### PR TITLE
modification of style sheet problem 

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -2,8 +2,7 @@
 /* LESS Definitions */
 
 /*Image URL*/
-@base_url: "qss/gray_072";
-@image_url: "@{base_url}/imgs";
+@image_url: "../gray_072/imgs";
 
 /*Text Color*/
 @m_baseTxtColor: rgb(230,230,230);
@@ -274,19 +273,21 @@ QPushButton {
 	.base_outset;
 	border-width: 1px;
  	border-radius: 4px;
-   	.set_padding(20px, 3px);
-	
+   	.set_padding(15px, 3px);
+	&:checked {
+		.base_inset(light, 10%);
+	}
 	/*lighten lilttle bit when hover*/
 	&:hover {
 		.base_outset(light, 10%);
 		&:pressed {
 		    .base_inset(light, 10%);
 	    }
+    	&:checked {
+    		.base_inset(light, 5%);
+	    }
 	}
 	/*lighten lilttle bit when pressed*/
-	&:checked {
-		.base_inset(light, 10%);
-	}
 	&:disabled{
 		.base_outset(light, 5%);
 		color: rgb(80,80,80);

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -121,10 +121,10 @@ QToolBar {
   border-image: none;
 }
 QToolBar::separator:horizontal {
-  image: url("qss/gray_072/imgs/bottomseparator.png");
+  image: url("../gray_072/imgs/bottomseparator.png");
 }
 QToolBar::separator:vertical {
-  image: url("qss/gray_072/imgs/separator.png");
+  image: url("../gray_072/imgs/separator.png");
 }
 QToolBar QToolButton {
   background-color: #303030;
@@ -134,11 +134,11 @@ QToolBar QToolButton {
   border-image: none;
 }
 QToolBar QToolButton:hover {
-  border-image: url("qss/gray_072/imgs/over.png") 2;
+  border-image: url("../gray_072/imgs/over.png") 2;
 }
 QToolBar QToolButton:checked,
 QToolBar QToolButton:pressed {
-  border-image: url("qss/gray_072/imgs/click.png") 2;
+  border-image: url("../gray_072/imgs/click.png") 2;
 }
 QToolBar QToolButton:disabled {
   background-color: #3d3d3d;
@@ -214,7 +214,7 @@ QComboBox::drop-down:on {
   border-bottom-color: #6c6c6c;
 }
 QComboBox::down-arrow {
-  image: url("qss/gray_072/imgs/combo_down_arrow.png");
+  image: url("../gray_072/imgs/combo_down_arrow.png");
 }
 QComboBox:disabled {
   background-color: #4a4a4a;
@@ -234,12 +234,20 @@ QPushButton {
   border-bottom-color: #000000;
   border-width: 1px;
   border-radius: 4px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 15px;
+  padding-right: 15px;
   padding-top: 3px;
   padding-bottom: 3px;
   /*lighten lilttle bit when hover*/
   /*lighten lilttle bit when pressed*/
+}
+QPushButton:checked {
+  background-color: #4a4a4a;
+  border-style: inset;
+  border-left-color: #262626;
+  border-top-color: #1a1a1a;
+  border-right-color: #727272;
+  border-bottom-color: #868686;
 }
 QPushButton:hover {
   background-color: #4a4a4a;
@@ -257,13 +265,13 @@ QPushButton:hover:pressed {
   border-right-color: #727272;
   border-bottom-color: #868686;
 }
-QPushButton:checked {
-  background-color: #4a4a4a;
+QPushButton:hover:checked {
+  background-color: #3d3d3d;
   border-style: inset;
-  border-left-color: #262626;
-  border-top-color: #1a1a1a;
-  border-right-color: #727272;
-  border-bottom-color: #868686;
+  border-left-color: #191919;
+  border-top-color: #0d0d0d;
+  border-right-color: #656565;
+  border-bottom-color: #797979;
 }
 QPushButton:disabled {
   background-color: #3d3d3d;
@@ -304,10 +312,10 @@ QCheckBox::indicator:disabled {
   border-bottom-color: #797979;
 }
 QCheckBox::indicator:checked {
-  image: url("qss/gray_072/imgs/check_indicator.png");
+  image: url("../gray_072/imgs/check_indicator.png");
 }
 QCheckBox::indicator:checked:disabled {
-  image: url("qss/gray_072/imgs/check_indicator_disabled.png");
+  image: url("../gray_072/imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
   background-color: #161616;
@@ -444,13 +452,13 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   /* if there is only one tab, we don't want overlapping margins */
 }
 #PaletteLockButton:hover {
-  border-image: url("qss/gray_072/imgs/over_yellow.png") 2;
+  border-image: url("../gray_072/imgs/over_yellow.png") 2;
 }
 #PaletteLockButton:checked {
-  border-image: url("qss/gray_072/imgs/click_pink.png") 2;
+  border-image: url("../gray_072/imgs/click_pink.png") 2;
 }
 #PaletteLockButton:checked:hover {
-  border-image: url("qss/gray_072/imgs/over_pressed_yellow.png") 2;
+  border-image: url("../gray_072/imgs/over_pressed_yellow.png") 2;
 }
 #PageViewer {
   qproperty-TextColor: #e6e6e6;
@@ -520,23 +528,23 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
 }
 #colorSliderAddButton,
 #colorSliderSubButton {
-  border-image: url("qss/gray_072/imgs/colorslider_button_bg.png") 2;
+  border-image: url("../gray_072/imgs/colorslider_button_bg.png") 2;
   padding: 0px;
   margin: 0px;
   border: 2px;
   image-position: center center;
 }
 #colorSliderAddButton {
-  image: url("qss/gray_072/imgs/colorslider_add.png");
+  image: url("../gray_072/imgs/colorslider_add.png");
 }
 #colorSliderAddButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_add_pressed.png");
+  image: url("../gray_072/imgs/colorslider_add_pressed.png");
 }
 #colorSliderSubButton {
-  image: url("qss/gray_072/imgs/colorslider_sub.png");
+  image: url("../gray_072/imgs/colorslider_sub.png");
 }
 #colorSliderSubButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_sub_pressed.png");
+  image: url("../gray_072/imgs/colorslider_sub_pressed.png");
 }
 #PlainColorPageParts {
   background-color: #303030;
@@ -575,19 +583,19 @@ DvScrollWidget > QPushButton:pressed {
   max-width: 15px;
 }
 #ScrollLeftButton {
-  image: url("qss/gray_072/imgs/left_arrow_black.png");
+  image: url("../gray_072/imgs/left_arrow_black.png");
   border-right: 1px solid black;
 }
 #ScrollRightButton {
-  image: url("qss/gray_072/imgs/right_arrow_black.png");
+  image: url("../gray_072/imgs/right_arrow_black.png");
   border-left: 1px solid black;
 }
 #ScrollUpButton {
-  image: url("qss/gray_072/imgs/up_arrow_black.png");
+  image: url("../gray_072/imgs/up_arrow_black.png");
   border-bottom: 1px solid black;
 }
 #ScrollDownButton {
-  image: url("qss/gray_072/imgs/down_arrow_black.png");
+  image: url("../gray_072/imgs/down_arrow_black.png");
   border-top: 1px solid black;
 }
 /* ------ Viewer, Flipbook ------ */
@@ -621,30 +629,30 @@ FlipBook #ToolBarContainer {
   height: 21px;
 }
 #ViewerFpsSlider::handle {
-  border-image: url("qss/gray_072/imgs/handle_border.png") 6;
+  border-image: url("../gray_072/imgs/handle_border.png") 6;
   border-width: 6px;
   image: none;
   min-width: 5px;
 }
 #ViewerFpsSlider::add-line {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow.png");
+  image: url("../gray_072/imgs/fpssb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::add-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow_pressed.png");
+  image: url("../gray_072/imgs/fpssb_g_rarrow_pressed.png");
 }
 #ViewerFpsSlider::sub-line {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow.png");
+  image: url("../gray_072/imgs/fpssb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::sub-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow_pressed.png");
+  image: url("../gray_072/imgs/fpssb_g_larrow_pressed.png");
 }
 #FlipConsolePlayToolBar {
   border: none;
@@ -654,8 +662,8 @@ FlipBook #ToolBarContainer {
 }
 FlipSlider {
   qproperty-PBHeight: 20;
-  qproperty-PBOverlay: url("qss/gray_072/imgs/flipslider.png");
-  qproperty-PBMarker: url("qss/gray_072/imgs/flipmarker.png");
+  qproperty-PBOverlay: url("../gray_072/imgs/flipslider.png");
+  qproperty-PBMarker: url("../gray_072/imgs/flipmarker.png");
   qproperty-PBColorMarginLeft: 1;
   qproperty-PBColorMarginTop: 1;
   qproperty-PBColorMarginRight: 1;
@@ -698,29 +706,29 @@ Ruler {
   margin: 0px;
 }
 #DirTreeView::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-end.png") 0;
+  border-image: url("../gray_072/imgs/tree_branch-end.png") 0;
 }
 #DirTreeView::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree_vline.png") 0;
+  border-image: url("../gray_072/imgs/tree_vline.png") 0;
 }
 #DirTreeView::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-more.png") 0;
+  border-image: url("../gray_072/imgs/tree_branch-more.png") 0;
 }
 #DirTreeView::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed_nosib.png");
+  image: url("../gray_072/imgs/tree_branch-closed_nosib.png");
 }
 #DirTreeView::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open_nosib.png");
+  image: url("../gray_072/imgs/tree_branch-open_nosib.png");
 }
 #DirTreeView::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed.png");
+  image: url("../gray_072/imgs/tree_branch-closed.png");
 }
 #DirTreeView::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open.png");
+  image: url("../gray_072/imgs/tree_branch-open.png");
 }
 DvItemViewerPanel {
   qproperty-TextColor: #e6e6e6;
@@ -764,14 +772,14 @@ DvDirTreeView {
   border-width: 2px;
   padding: 0px;
   margin: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("../gray_072/imgs/handle_border.png") 5;
+  image: url("../gray_072/imgs/plus.png");
   image-position: center center;
 }
 #CleanupSettingsShowButton:checked,
 #LoadLevelShowButton:checked,
 #FxSettingsPreviewShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("../gray_072/imgs/minus.png");
 }
 ParamsPage {
   qproperty-TextColor: #e6e6e6;
@@ -845,52 +853,52 @@ ParamsPage {
   image-position: center center;
 }
 #XsheetScrollBar::handle:vertical {
-  border-image: url("qss/gray_072/imgs/sb_g_vhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_vline.png");
+  border-image: url("../gray_072/imgs/sb_g_vhandle.png") 4;
+  image: url("../gray_072/imgs/sb_g_vline.png");
   min-height: 40px;
 }
 #XsheetScrollBar::handle:horizontal {
-  border-image: url("qss/gray_072/imgs/sb_g_hhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_hline.png");
+  border-image: url("../gray_072/imgs/sb_g_hhandle.png") 4;
+  image: url("../gray_072/imgs/sb_g_hline.png");
   min-width: 40px;
 }
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::add-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_downarrow.png");
+  image: url("../gray_072/imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
 #XsheetScrollBar::add-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_downarrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_downarrow_pressed.png");
 }
 #XsheetScrollBar::add-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_rarrow.png");
+  image: url("../gray_072/imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
 #XsheetScrollBar::add-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_rarrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_rarrow_pressed.png");
 }
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::sub-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_uparrow.png");
+  image: url("../gray_072/imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
 #XsheetScrollBar::sub-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_uparrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_uparrow_pressed.png");
 }
 #XsheetScrollBar::sub-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_larrow.png");
+  image: url("../gray_072/imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
 #XsheetScrollBar::sub-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_larrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_larrow_pressed.png");
 }
 #XsheetScrollBar::add-page {
   background: none;
@@ -957,35 +965,35 @@ XsheetViewer {
 }
 #FunctionEditorTree::branch:adjoins-item,
 #ShortcutTree::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-end.png") 0;
+  border-image: url("../gray_072/imgs/tree17_branch-end.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings,
 #ShortcutTree::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree17_vline.png") 0;
+  border-image: url("../gray_072/imgs/tree17_vline.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings:adjoins-item,
 #ShortcutTree::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-more.png") 0;
+  border-image: url("../gray_072/imgs/tree17_branch-more.png") 0;
 }
 #FunctionEditorTree::branch:has-children:closed,
 #ShortcutTree::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed_nosib.png");
+  image: url("../gray_072/imgs/tree17_branch-closed_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:open,
 #ShortcutTree::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open_nosib.png");
+  image: url("../gray_072/imgs/tree17_branch-open_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:closed,
 #ShortcutTree::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed.png");
+  image: url("../gray_072/imgs/tree17_branch-closed.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:open,
 #ShortcutTree::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open.png");
+  image: url("../gray_072/imgs/tree17_branch-open.png");
 }
 FunctionPanel {
   qproperty-BGColor: #303030;
@@ -1039,7 +1047,7 @@ SpreadsheetViewer {
 #FunctionSegmentViewerLinkButton {
   border: 2px;
   margin: 0px;
-  background-image: url("qss/gray_072/imgs/segment_unlinked.png");
+  background-image: url("../gray_072/imgs/segment_unlinked.png");
   background-color: #636363;
   border-style: outset;
   border-left-color: #8b8b8b;
@@ -1048,7 +1056,7 @@ SpreadsheetViewer {
   border-bottom-color: #333333;
 }
 #FunctionSegmentViewerLinkButton:checked {
-  background-image: url("qss/gray_072/imgs/segment_linked.png");
+  background-image: url("../gray_072/imgs/segment_linked.png");
   background-color: #636363;
   border-style: inset;
   border-left-color: #3f3f3f;
@@ -1057,7 +1065,7 @@ SpreadsheetViewer {
   border-bottom-color: #9f9f9f;
 }
 #FunctionSegmentViewerLinkButton:disabled {
-  background-image: url("qss/gray_072/imgs/segment_disabled.png");
+  background-image: url("../gray_072/imgs/segment_disabled.png");
   background-color: #4a4a4a;
   border-style: outset;
   border-left-color: #727272;
@@ -1099,13 +1107,13 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("../gray_072/imgs/cam_lock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("../gray_072/imgs/cam_unlock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("../gray_072/imgs/cam_lock_hover.png");
 }
 #CameraSettingsDPI {
   color: #a8bee7;
@@ -1118,25 +1126,25 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton_Small::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock_small.png");
+  image: url("../gray_072/imgs/cam_lock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock_small.png");
+  image: url("../gray_072/imgs/cam_unlock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover_small.png");
+  image: url("../gray_072/imgs/cam_lock_hover_small.png");
 }
 #ForceSquaredPixelButton {
   border: none;
   border-radius: 0px;
   padding: 0px;
-  image: url("qss/gray_072/imgs/fsp_released.png");
+  image: url("../gray_072/imgs/fsp_released.png");
 }
 #ForceSquaredPixelButton:hover {
-  image: url("qss/gray_072/imgs/fsp_hover.png");
+  image: url("../gray_072/imgs/fsp_hover.png");
 }
 #ForceSquaredPixelButton:checked {
-  image: url("qss/gray_072/imgs/fsp_pressed.png");
+  image: url("../gray_072/imgs/fsp_pressed.png");
 }
 /*------ Tool Options Bar------*/
 #EditToolLockButton {
@@ -1149,16 +1157,16 @@ SpreadsheetViewer {
   height: 21px;
 }
 #EditToolLockButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("../gray_072/imgs/cam_unlock.png");
 }
 #EditToolLockButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_unlock_hover.png");
+  image: url("../gray_072/imgs/cam_unlock_hover.png");
 }
 #EditToolLockButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("../gray_072/imgs/cam_lock.png");
 }
 #EditToolLockButton::indicator:checked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("../gray_072/imgs/cam_lock_hover.png");
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
@@ -1175,7 +1183,7 @@ SpreadsheetViewer {
   padding: 0px;
 }
 #TopBarTab {
-  border-image: url("qss/gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
+  border-image: url("../gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
   /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
   border: 0px;
   padding: 0px;
@@ -1262,21 +1270,21 @@ QDialog #dialogButtonFrame {
 #OutputSettingsShowButton {
   border: 2px;
   padding: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("../gray_072/imgs/handle_border.png") 5;
+  image: url("../gray_072/imgs/plus.png");
   image-position: center center;
 }
 #OutputSettingsShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("../gray_072/imgs/minus.png");
 }
 #IntPairField,
 #DoublePairField {
   qproperty-LightLineColor: #9b9b9b;
   qproperty-DarkLineColor: #2f2f2f;
-  qproperty-HandleLeftPixmap: url("qss/gray_072/imgs/h_slider_left.png");
-  qproperty-HandleRightPixmap: url("qss/gray_072/imgs/h_slider_right.png");
-  qproperty-HandleLeftGrayPixmap: url("qss/gray_072/imgs/h_slider_left_disabled.png");
-  qproperty-HandleRightGrayPixmap: url("qss/gray_072/imgs/h_slider_right_disabled.png");
+  qproperty-HandleLeftPixmap: url("../gray_072/imgs/h_slider_left.png");
+  qproperty-HandleRightPixmap: url("../gray_072/imgs/h_slider_right.png");
+  qproperty-HandleLeftGrayPixmap: url("../gray_072/imgs/h_slider_left_disabled.png");
+  qproperty-HandleRightGrayPixmap: url("../gray_072/imgs/h_slider_right_disabled.png");
 }
 #FxSettingsLabel {
   color: #a0e680;

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -121,10 +121,10 @@ QToolBar {
   border-image: none;
 }
 QToolBar::separator:horizontal {
-  image: url("qss/gray_072/imgs/bottomseparator.png");
+  image: url("../gray_072/imgs/bottomseparator.png");
 }
 QToolBar::separator:vertical {
-  image: url("qss/gray_072/imgs/separator.png");
+  image: url("../gray_072/imgs/separator.png");
 }
 QToolBar QToolButton {
   background-color: #303030;
@@ -134,11 +134,11 @@ QToolBar QToolButton {
   border-image: none;
 }
 QToolBar QToolButton:hover {
-  border-image: url("qss/gray_072/imgs/over.png") 2;
+  border-image: url("../gray_072/imgs/over.png") 2;
 }
 QToolBar QToolButton:checked,
 QToolBar QToolButton:pressed {
-  border-image: url("qss/gray_072/imgs/click.png") 2;
+  border-image: url("../gray_072/imgs/click.png") 2;
 }
 QToolBar QToolButton:disabled {
   background-color: #3d3d3d;
@@ -214,7 +214,7 @@ QComboBox::drop-down:on {
   border-bottom-color: #6c6c6c;
 }
 QComboBox::down-arrow {
-  image: url("qss/gray_072/imgs/combo_down_arrow.png");
+  image: url("../gray_072/imgs/combo_down_arrow.png");
 }
 QComboBox:disabled {
   background-color: #4a4a4a;
@@ -234,12 +234,20 @@ QPushButton {
   border-bottom-color: #000000;
   border-width: 1px;
   border-radius: 4px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 15px;
+  padding-right: 15px;
   padding-top: 3px;
   padding-bottom: 3px;
   /*lighten lilttle bit when hover*/
   /*lighten lilttle bit when pressed*/
+}
+QPushButton:checked {
+  background-color: #4a4a4a;
+  border-style: inset;
+  border-left-color: #262626;
+  border-top-color: #1a1a1a;
+  border-right-color: #727272;
+  border-bottom-color: #868686;
 }
 QPushButton:hover {
   background-color: #4a4a4a;
@@ -257,21 +265,13 @@ QPushButton:hover:pressed {
   border-right-color: #727272;
   border-bottom-color: #868686;
 }
-QPushButton:pressed {
-  background-color: #4a4a4a;
+QPushButton:hover:checked {
+  background-color: #3d3d3d;
   border-style: inset;
-  border-left-color: #262626;
-  border-top-color: #1a1a1a;
-  border-right-color: #727272;
-  border-bottom-color: #868686;
-}
-QPushButton:checked {
-  background-color: #4a4a4a;
-  border-style: inset;
-  border-left-color: #262626;
-  border-top-color: #1a1a1a;
-  border-right-color: #727272;
-  border-bottom-color: #868686;
+  border-left-color: #191919;
+  border-top-color: #0d0d0d;
+  border-right-color: #656565;
+  border-bottom-color: #797979;
 }
 QPushButton:disabled {
   background-color: #3d3d3d;
@@ -312,10 +312,10 @@ QCheckBox::indicator:disabled {
   border-bottom-color: #797979;
 }
 QCheckBox::indicator:checked {
-  image: url("qss/gray_072/imgs/check_indicator.png");
+  image: url("../gray_072/imgs/check_indicator.png");
 }
 QCheckBox::indicator:checked:disabled {
-  image: url("qss/gray_072/imgs/check_indicator_disabled.png");
+  image: url("../gray_072/imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
   background-color: #161616;
@@ -452,13 +452,13 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   /* if there is only one tab, we don't want overlapping margins */
 }
 #PaletteLockButton:hover {
-  border-image: url("qss/gray_072/imgs/over_yellow.png") 2;
+  border-image: url("../gray_072/imgs/over_yellow.png") 2;
 }
 #PaletteLockButton:checked {
-  border-image: url("qss/gray_072/imgs/click_pink.png") 2;
+  border-image: url("../gray_072/imgs/click_pink.png") 2;
 }
 #PaletteLockButton:checked:hover {
-  border-image: url("qss/gray_072/imgs/over_pressed_yellow.png") 2;
+  border-image: url("../gray_072/imgs/over_pressed_yellow.png") 2;
 }
 #PageViewer {
   qproperty-TextColor: #e6e6e6;
@@ -528,23 +528,23 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
 }
 #colorSliderAddButton,
 #colorSliderSubButton {
-  border-image: url("qss/gray_072/imgs/colorslider_button_bg.png") 2;
+  border-image: url("../gray_072/imgs/colorslider_button_bg.png") 2;
   padding: 0px;
   margin: 0px;
   border: 2px;
   image-position: center center;
 }
 #colorSliderAddButton {
-  image: url("qss/gray_072/imgs/colorslider_add.png");
+  image: url("../gray_072/imgs/colorslider_add.png");
 }
 #colorSliderAddButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_add_pressed.png");
+  image: url("../gray_072/imgs/colorslider_add_pressed.png");
 }
 #colorSliderSubButton {
-  image: url("qss/gray_072/imgs/colorslider_sub.png");
+  image: url("../gray_072/imgs/colorslider_sub.png");
 }
 #colorSliderSubButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_sub_pressed.png");
+  image: url("../gray_072/imgs/colorslider_sub_pressed.png");
 }
 #PlainColorPageParts {
   background-color: #303030;
@@ -583,19 +583,19 @@ DvScrollWidget > QPushButton:pressed {
   max-width: 15px;
 }
 #ScrollLeftButton {
-  image: url("qss/gray_072/imgs/left_arrow_black.png");
+  image: url("../gray_072/imgs/left_arrow_black.png");
   border-right: 1px solid black;
 }
 #ScrollRightButton {
-  image: url("qss/gray_072/imgs/right_arrow_black.png");
+  image: url("../gray_072/imgs/right_arrow_black.png");
   border-left: 1px solid black;
 }
 #ScrollUpButton {
-  image: url("qss/gray_072/imgs/up_arrow_black.png");
+  image: url("../gray_072/imgs/up_arrow_black.png");
   border-bottom: 1px solid black;
 }
 #ScrollDownButton {
-  image: url("qss/gray_072/imgs/down_arrow_black.png");
+  image: url("../gray_072/imgs/down_arrow_black.png");
   border-top: 1px solid black;
 }
 /* ------ Viewer, Flipbook ------ */
@@ -629,30 +629,30 @@ FlipBook #ToolBarContainer {
   height: 21px;
 }
 #ViewerFpsSlider::handle {
-  border-image: url("qss/gray_072/imgs/handle_border.png") 6;
+  border-image: url("../gray_072/imgs/handle_border.png") 6;
   border-width: 6px;
   image: none;
   min-width: 5px;
 }
 #ViewerFpsSlider::add-line {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow.png");
+  image: url("../gray_072/imgs/fpssb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::add-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow_pressed.png");
+  image: url("../gray_072/imgs/fpssb_g_rarrow_pressed.png");
 }
 #ViewerFpsSlider::sub-line {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow.png");
+  image: url("../gray_072/imgs/fpssb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::sub-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow_pressed.png");
+  image: url("../gray_072/imgs/fpssb_g_larrow_pressed.png");
 }
 #FlipConsolePlayToolBar {
   border: none;
@@ -662,8 +662,8 @@ FlipBook #ToolBarContainer {
 }
 FlipSlider {
   qproperty-PBHeight: 20;
-  qproperty-PBOverlay: url("qss/gray_072/imgs/flipslider.png");
-  qproperty-PBMarker: url("qss/gray_072/imgs/flipmarker.png");
+  qproperty-PBOverlay: url("../gray_072/imgs/flipslider.png");
+  qproperty-PBMarker: url("../gray_072/imgs/flipmarker.png");
   qproperty-PBColorMarginLeft: 1;
   qproperty-PBColorMarginTop: 1;
   qproperty-PBColorMarginRight: 1;
@@ -706,29 +706,29 @@ Ruler {
   margin: 0px;
 }
 #DirTreeView::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-end.png") 0;
+  border-image: url("../gray_072/imgs/tree_branch-end.png") 0;
 }
 #DirTreeView::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree_vline.png") 0;
+  border-image: url("../gray_072/imgs/tree_vline.png") 0;
 }
 #DirTreeView::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-more.png") 0;
+  border-image: url("../gray_072/imgs/tree_branch-more.png") 0;
 }
 #DirTreeView::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed_nosib.png");
+  image: url("../gray_072/imgs/tree_branch-closed_nosib.png");
 }
 #DirTreeView::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open_nosib.png");
+  image: url("../gray_072/imgs/tree_branch-open_nosib.png");
 }
 #DirTreeView::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed.png");
+  image: url("../gray_072/imgs/tree_branch-closed.png");
 }
 #DirTreeView::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open.png");
+  image: url("../gray_072/imgs/tree_branch-open.png");
 }
 DvItemViewerPanel {
   qproperty-TextColor: #e6e6e6;
@@ -772,14 +772,14 @@ DvDirTreeView {
   border-width: 2px;
   padding: 0px;
   margin: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("../gray_072/imgs/handle_border.png") 5;
+  image: url("../gray_072/imgs/plus.png");
   image-position: center center;
 }
 #CleanupSettingsShowButton:checked,
 #LoadLevelShowButton:checked,
 #FxSettingsPreviewShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("../gray_072/imgs/minus.png");
 }
 ParamsPage {
   qproperty-TextColor: #e6e6e6;
@@ -853,52 +853,52 @@ ParamsPage {
   image-position: center center;
 }
 #XsheetScrollBar::handle:vertical {
-  border-image: url("qss/gray_072/imgs/sb_g_vhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_vline.png");
+  border-image: url("../gray_072/imgs/sb_g_vhandle.png") 4;
+  image: url("../gray_072/imgs/sb_g_vline.png");
   min-height: 40px;
 }
 #XsheetScrollBar::handle:horizontal {
-  border-image: url("qss/gray_072/imgs/sb_g_hhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_hline.png");
+  border-image: url("../gray_072/imgs/sb_g_hhandle.png") 4;
+  image: url("../gray_072/imgs/sb_g_hline.png");
   min-width: 40px;
 }
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::add-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_downarrow.png");
+  image: url("../gray_072/imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
 #XsheetScrollBar::add-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_downarrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_downarrow_pressed.png");
 }
 #XsheetScrollBar::add-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_rarrow.png");
+  image: url("../gray_072/imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
 #XsheetScrollBar::add-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_rarrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_rarrow_pressed.png");
 }
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::sub-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_uparrow.png");
+  image: url("../gray_072/imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
 #XsheetScrollBar::sub-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_uparrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_uparrow_pressed.png");
 }
 #XsheetScrollBar::sub-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_larrow.png");
+  image: url("../gray_072/imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
 #XsheetScrollBar::sub-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_larrow_pressed.png");
+  image: url("../gray_072/imgs/sb_g_larrow_pressed.png");
 }
 #XsheetScrollBar::add-page {
   background: none;
@@ -965,35 +965,35 @@ XsheetViewer {
 }
 #FunctionEditorTree::branch:adjoins-item,
 #ShortcutTree::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-end.png") 0;
+  border-image: url("../gray_072/imgs/tree17_branch-end.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings,
 #ShortcutTree::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree17_vline.png") 0;
+  border-image: url("../gray_072/imgs/tree17_vline.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings:adjoins-item,
 #ShortcutTree::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-more.png") 0;
+  border-image: url("../gray_072/imgs/tree17_branch-more.png") 0;
 }
 #FunctionEditorTree::branch:has-children:closed,
 #ShortcutTree::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed_nosib.png");
+  image: url("../gray_072/imgs/tree17_branch-closed_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:open,
 #ShortcutTree::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open_nosib.png");
+  image: url("../gray_072/imgs/tree17_branch-open_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:closed,
 #ShortcutTree::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed.png");
+  image: url("../gray_072/imgs/tree17_branch-closed.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:open,
 #ShortcutTree::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open.png");
+  image: url("../gray_072/imgs/tree17_branch-open.png");
 }
 FunctionPanel {
   qproperty-BGColor: #303030;
@@ -1047,7 +1047,7 @@ SpreadsheetViewer {
 #FunctionSegmentViewerLinkButton {
   border: 2px;
   margin: 0px;
-  background-image: url("qss/gray_072/imgs/segment_unlinked.png");
+  background-image: url("../gray_072/imgs/segment_unlinked.png");
   background-color: #636363;
   border-style: outset;
   border-left-color: #8b8b8b;
@@ -1056,7 +1056,7 @@ SpreadsheetViewer {
   border-bottom-color: #333333;
 }
 #FunctionSegmentViewerLinkButton:checked {
-  background-image: url("qss/gray_072/imgs/segment_linked.png");
+  background-image: url("../gray_072/imgs/segment_linked.png");
   background-color: #636363;
   border-style: inset;
   border-left-color: #3f3f3f;
@@ -1065,7 +1065,7 @@ SpreadsheetViewer {
   border-bottom-color: #9f9f9f;
 }
 #FunctionSegmentViewerLinkButton:disabled {
-  background-image: url("qss/gray_072/imgs/segment_disabled.png");
+  background-image: url("../gray_072/imgs/segment_disabled.png");
   background-color: #4a4a4a;
   border-style: outset;
   border-left-color: #727272;
@@ -1107,13 +1107,13 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("../gray_072/imgs/cam_lock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("../gray_072/imgs/cam_unlock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("../gray_072/imgs/cam_lock_hover.png");
 }
 #CameraSettingsDPI {
   color: #a8bee7;
@@ -1126,25 +1126,25 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton_Small::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock_small.png");
+  image: url("../gray_072/imgs/cam_lock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock_small.png");
+  image: url("../gray_072/imgs/cam_unlock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover_small.png");
+  image: url("../gray_072/imgs/cam_lock_hover_small.png");
 }
 #ForceSquaredPixelButton {
   border: none;
   border-radius: 0px;
   padding: 0px;
-  image: url("qss/gray_072/imgs/fsp_released.png");
+  image: url("../gray_072/imgs/fsp_released.png");
 }
 #ForceSquaredPixelButton:hover {
-  image: url("qss/gray_072/imgs/fsp_hover.png");
+  image: url("../gray_072/imgs/fsp_hover.png");
 }
 #ForceSquaredPixelButton:checked {
-  image: url("qss/gray_072/imgs/fsp_pressed.png");
+  image: url("../gray_072/imgs/fsp_pressed.png");
 }
 /*------ Tool Options Bar------*/
 #EditToolLockButton {
@@ -1157,16 +1157,16 @@ SpreadsheetViewer {
   height: 21px;
 }
 #EditToolLockButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("../gray_072/imgs/cam_unlock.png");
 }
 #EditToolLockButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_unlock_hover.png");
+  image: url("../gray_072/imgs/cam_unlock_hover.png");
 }
 #EditToolLockButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("../gray_072/imgs/cam_lock.png");
 }
 #EditToolLockButton::indicator:checked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("../gray_072/imgs/cam_lock_hover.png");
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
@@ -1183,7 +1183,7 @@ SpreadsheetViewer {
   padding: 0px;
 }
 #TopBarTab {
-  border-image: url("qss/gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
+  border-image: url("../gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
   /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
   border: 0px;
   padding: 0px;
@@ -1270,21 +1270,21 @@ QDialog #dialogButtonFrame {
 #OutputSettingsShowButton {
   border: 2px;
   padding: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("../gray_072/imgs/handle_border.png") 5;
+  image: url("../gray_072/imgs/plus.png");
   image-position: center center;
 }
 #OutputSettingsShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("../gray_072/imgs/minus.png");
 }
 #IntPairField,
 #DoublePairField {
   qproperty-LightLineColor: #9b9b9b;
   qproperty-DarkLineColor: #2f2f2f;
-  qproperty-HandleLeftPixmap: url("qss/gray_072/imgs/h_slider_left.png");
-  qproperty-HandleRightPixmap: url("qss/gray_072/imgs/h_slider_right.png");
-  qproperty-HandleLeftGrayPixmap: url("qss/gray_072/imgs/h_slider_left_disabled.png");
-  qproperty-HandleRightGrayPixmap: url("qss/gray_072/imgs/h_slider_right_disabled.png");
+  qproperty-HandleLeftPixmap: url("../gray_072/imgs/h_slider_left.png");
+  qproperty-HandleRightPixmap: url("../gray_072/imgs/h_slider_right.png");
+  qproperty-HandleLeftGrayPixmap: url("../gray_072/imgs/h_slider_left_disabled.png");
+  qproperty-HandleRightGrayPixmap: url("../gray_072/imgs/h_slider_right_disabled.png");
 }
 #FxSettingsLabel {
   color: #a0e680;

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -1,8 +1,7 @@
 /* LESS Definitions */
 
 /*Image URL*/
-@base_url: "qss/gray_072";
-@image_url: "@{base_url}/imgs";
+@image_url: "imgs";
 
 /*Text Color*/
 @m_baseTxtColor: rgb(230,230,230);
@@ -273,19 +272,21 @@ QPushButton {
 	.base_outset;
 	border-width: 1px;
  	border-radius: 4px;
-   	.set_padding(20px, 3px);
-	
+   	.set_padding(15px, 3px);
+	&:checked {
+		.base_inset(light, 10%);
+	}
 	/*lighten lilttle bit when hover*/
 	&:hover {
 		.base_outset(light, 10%);
 		&:pressed {
 		    .base_inset(light, 10%);
 	    }
+    	&:checked {
+    		.base_inset(light, 5%);
+	    }
 	}
 	/*lighten lilttle bit when pressed*/
-	&:checked {
-		.base_inset(light, 10%);
-	}
 	&:disabled{
 		.base_outset(light, 5%);
 		color: rgb(80,80,80);

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -121,10 +121,10 @@ QToolBar {
   border-image: none;
 }
 QToolBar::separator:horizontal {
-  image: url("qss/gray_072/imgs/bottomseparator.png");
+  image: url("imgs/bottomseparator.png");
 }
 QToolBar::separator:vertical {
-  image: url("qss/gray_072/imgs/separator.png");
+  image: url("imgs/separator.png");
 }
 QToolBar QToolButton {
   background-color: #484848;
@@ -134,11 +134,11 @@ QToolBar QToolButton {
   border-image: none;
 }
 QToolBar QToolButton:hover {
-  border-image: url("qss/gray_072/imgs/over.png") 2;
+  border-image: url("imgs/over.png") 2;
 }
 QToolBar QToolButton:checked,
 QToolBar QToolButton:pressed {
-  border-image: url("qss/gray_072/imgs/click.png") 2;
+  border-image: url("imgs/click.png") 2;
 }
 QToolBar QToolButton:disabled {
   background-color: #555555;
@@ -214,7 +214,7 @@ QComboBox::drop-down:on {
   border-bottom-color: #808080;
 }
 QComboBox::down-arrow {
-  image: url("qss/gray_072/imgs/combo_down_arrow.png");
+  image: url("imgs/combo_down_arrow.png");
 }
 QComboBox:disabled {
   background-color: #626262;
@@ -234,12 +234,20 @@ QPushButton {
   border-bottom-color: #000000;
   border-width: 1px;
   border-radius: 4px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 15px;
+  padding-right: 15px;
   padding-top: 3px;
   padding-bottom: 3px;
   /*lighten lilttle bit when hover*/
   /*lighten lilttle bit when pressed*/
+}
+QPushButton:checked {
+  background-color: #626262;
+  border-style: inset;
+  border-left-color: #3a3a3a;
+  border-top-color: #1a1a1a;
+  border-right-color: #868686;
+  border-bottom-color: #9a9a9a;
 }
 QPushButton:hover {
   background-color: #626262;
@@ -257,13 +265,13 @@ QPushButton:hover:pressed {
   border-right-color: #868686;
   border-bottom-color: #9a9a9a;
 }
-QPushButton:checked {
-  background-color: #626262;
+QPushButton:hover:checked {
+  background-color: #555555;
   border-style: inset;
-  border-left-color: #3a3a3a;
-  border-top-color: #1a1a1a;
-  border-right-color: #868686;
-  border-bottom-color: #9a9a9a;
+  border-left-color: #2d2d2d;
+  border-top-color: #0d0d0d;
+  border-right-color: #797979;
+  border-bottom-color: #8d8d8d;
 }
 QPushButton:disabled {
   background-color: #555555;
@@ -304,10 +312,10 @@ QCheckBox::indicator:disabled {
   border-bottom-color: #8d8d8d;
 }
 QCheckBox::indicator:checked {
-  image: url("qss/gray_072/imgs/check_indicator.png");
+  image: url("imgs/check_indicator.png");
 }
 QCheckBox::indicator:checked:disabled {
-  image: url("qss/gray_072/imgs/check_indicator_disabled.png");
+  image: url("imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
   background-color: #2f2f2f;
@@ -444,13 +452,13 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   /* if there is only one tab, we don't want overlapping margins */
 }
 #PaletteLockButton:hover {
-  border-image: url("qss/gray_072/imgs/over_yellow.png") 2;
+  border-image: url("imgs/over_yellow.png") 2;
 }
 #PaletteLockButton:checked {
-  border-image: url("qss/gray_072/imgs/click_pink.png") 2;
+  border-image: url("imgs/click_pink.png") 2;
 }
 #PaletteLockButton:checked:hover {
-  border-image: url("qss/gray_072/imgs/over_pressed_yellow.png") 2;
+  border-image: url("imgs/over_pressed_yellow.png") 2;
 }
 #PageViewer {
   qproperty-TextColor: #e6e6e6;
@@ -520,23 +528,23 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
 }
 #colorSliderAddButton,
 #colorSliderSubButton {
-  border-image: url("qss/gray_072/imgs/colorslider_button_bg.png") 2;
+  border-image: url("imgs/colorslider_button_bg.png") 2;
   padding: 0px;
   margin: 0px;
   border: 2px;
   image-position: center center;
 }
 #colorSliderAddButton {
-  image: url("qss/gray_072/imgs/colorslider_add.png");
+  image: url("imgs/colorslider_add.png");
 }
 #colorSliderAddButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_add_pressed.png");
+  image: url("imgs/colorslider_add_pressed.png");
 }
 #colorSliderSubButton {
-  image: url("qss/gray_072/imgs/colorslider_sub.png");
+  image: url("imgs/colorslider_sub.png");
 }
 #colorSliderSubButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_sub_pressed.png");
+  image: url("imgs/colorslider_sub_pressed.png");
 }
 #PlainColorPageParts {
   background-color: #484848;
@@ -575,19 +583,19 @@ DvScrollWidget > QPushButton:pressed {
   max-width: 15px;
 }
 #ScrollLeftButton {
-  image: url("qss/gray_072/imgs/left_arrow_black.png");
+  image: url("imgs/left_arrow_black.png");
   border-right: 1px solid black;
 }
 #ScrollRightButton {
-  image: url("qss/gray_072/imgs/right_arrow_black.png");
+  image: url("imgs/right_arrow_black.png");
   border-left: 1px solid black;
 }
 #ScrollUpButton {
-  image: url("qss/gray_072/imgs/up_arrow_black.png");
+  image: url("imgs/up_arrow_black.png");
   border-bottom: 1px solid black;
 }
 #ScrollDownButton {
-  image: url("qss/gray_072/imgs/down_arrow_black.png");
+  image: url("imgs/down_arrow_black.png");
   border-top: 1px solid black;
 }
 /* ------ Viewer, Flipbook ------ */
@@ -621,30 +629,30 @@ FlipBook #ToolBarContainer {
   height: 21px;
 }
 #ViewerFpsSlider::handle {
-  border-image: url("qss/gray_072/imgs/handle_border.png") 6;
+  border-image: url("imgs/handle_border.png") 6;
   border-width: 6px;
   image: none;
   min-width: 5px;
 }
 #ViewerFpsSlider::add-line {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow.png");
+  image: url("imgs/fpssb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::add-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow_pressed.png");
+  image: url("imgs/fpssb_g_rarrow_pressed.png");
 }
 #ViewerFpsSlider::sub-line {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow.png");
+  image: url("imgs/fpssb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::sub-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow_pressed.png");
+  image: url("imgs/fpssb_g_larrow_pressed.png");
 }
 #FlipConsolePlayToolBar {
   border: none;
@@ -654,8 +662,8 @@ FlipBook #ToolBarContainer {
 }
 FlipSlider {
   qproperty-PBHeight: 20;
-  qproperty-PBOverlay: url("qss/gray_072/imgs/flipslider.png");
-  qproperty-PBMarker: url("qss/gray_072/imgs/flipmarker.png");
+  qproperty-PBOverlay: url("imgs/flipslider.png");
+  qproperty-PBMarker: url("imgs/flipmarker.png");
   qproperty-PBColorMarginLeft: 1;
   qproperty-PBColorMarginTop: 1;
   qproperty-PBColorMarginRight: 1;
@@ -698,29 +706,29 @@ Ruler {
   margin: 0px;
 }
 #DirTreeView::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-end.png") 0;
+  border-image: url("imgs/tree_branch-end.png") 0;
 }
 #DirTreeView::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree_vline.png") 0;
+  border-image: url("imgs/tree_vline.png") 0;
 }
 #DirTreeView::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-more.png") 0;
+  border-image: url("imgs/tree_branch-more.png") 0;
 }
 #DirTreeView::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed_nosib.png");
+  image: url("imgs/tree_branch-closed_nosib.png");
 }
 #DirTreeView::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open_nosib.png");
+  image: url("imgs/tree_branch-open_nosib.png");
 }
 #DirTreeView::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed.png");
+  image: url("imgs/tree_branch-closed.png");
 }
 #DirTreeView::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open.png");
+  image: url("imgs/tree_branch-open.png");
 }
 DvItemViewerPanel {
   qproperty-TextColor: #e6e6e6;
@@ -764,14 +772,14 @@ DvDirTreeView {
   border-width: 2px;
   padding: 0px;
   margin: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #CleanupSettingsShowButton:checked,
 #LoadLevelShowButton:checked,
 #FxSettingsPreviewShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 ParamsPage {
   qproperty-TextColor: #e6e6e6;
@@ -845,52 +853,52 @@ ParamsPage {
   image-position: center center;
 }
 #XsheetScrollBar::handle:vertical {
-  border-image: url("qss/gray_072/imgs/sb_g_vhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_vline.png");
+  border-image: url("imgs/sb_g_vhandle.png") 4;
+  image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
 #XsheetScrollBar::handle:horizontal {
-  border-image: url("qss/gray_072/imgs/sb_g_hhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_hline.png");
+  border-image: url("imgs/sb_g_hhandle.png") 4;
+  image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::add-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_downarrow.png");
+  image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
 #XsheetScrollBar::add-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_downarrow_pressed.png");
+  image: url("imgs/sb_g_downarrow_pressed.png");
 }
 #XsheetScrollBar::add-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_rarrow.png");
+  image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
 #XsheetScrollBar::add-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_rarrow_pressed.png");
+  image: url("imgs/sb_g_rarrow_pressed.png");
 }
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::sub-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_uparrow.png");
+  image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
 #XsheetScrollBar::sub-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_uparrow_pressed.png");
+  image: url("imgs/sb_g_uparrow_pressed.png");
 }
 #XsheetScrollBar::sub-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_larrow.png");
+  image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
 #XsheetScrollBar::sub-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_larrow_pressed.png");
+  image: url("imgs/sb_g_larrow_pressed.png");
 }
 #XsheetScrollBar::add-page {
   background: none;
@@ -957,35 +965,35 @@ XsheetViewer {
 }
 #FunctionEditorTree::branch:adjoins-item,
 #ShortcutTree::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-end.png") 0;
+  border-image: url("imgs/tree17_branch-end.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings,
 #ShortcutTree::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree17_vline.png") 0;
+  border-image: url("imgs/tree17_vline.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings:adjoins-item,
 #ShortcutTree::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-more.png") 0;
+  border-image: url("imgs/tree17_branch-more.png") 0;
 }
 #FunctionEditorTree::branch:has-children:closed,
 #ShortcutTree::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed_nosib.png");
+  image: url("imgs/tree17_branch-closed_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:open,
 #ShortcutTree::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open_nosib.png");
+  image: url("imgs/tree17_branch-open_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:closed,
 #ShortcutTree::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed.png");
+  image: url("imgs/tree17_branch-closed.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:open,
 #ShortcutTree::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open.png");
+  image: url("imgs/tree17_branch-open.png");
 }
 FunctionPanel {
   qproperty-BGColor: #303030;
@@ -1039,7 +1047,7 @@ SpreadsheetViewer {
 #FunctionSegmentViewerLinkButton {
   border: 2px;
   margin: 0px;
-  background-image: url("qss/gray_072/imgs/segment_unlinked.png");
+  background-image: url("imgs/segment_unlinked.png");
   background-color: #7b7b7b;
   border-style: outset;
   border-left-color: #9f9f9f;
@@ -1048,7 +1056,7 @@ SpreadsheetViewer {
   border-bottom-color: #333333;
 }
 #FunctionSegmentViewerLinkButton:checked {
-  background-image: url("qss/gray_072/imgs/segment_linked.png");
+  background-image: url("imgs/segment_linked.png");
   background-color: #7b7b7b;
   border-style: inset;
   border-left-color: #535353;
@@ -1057,7 +1065,7 @@ SpreadsheetViewer {
   border-bottom-color: #b3b3b3;
 }
 #FunctionSegmentViewerLinkButton:disabled {
-  background-image: url("qss/gray_072/imgs/segment_disabled.png");
+  background-image: url("imgs/segment_disabled.png");
   background-color: #626262;
   border-style: outset;
   border-left-color: #868686;
@@ -1099,13 +1107,13 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 #CameraSettingsDPI {
   color: #a8bee7;
@@ -1118,25 +1126,25 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton_Small::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock_small.png");
+  image: url("imgs/cam_lock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock_small.png");
+  image: url("imgs/cam_unlock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover_small.png");
+  image: url("imgs/cam_lock_hover_small.png");
 }
 #ForceSquaredPixelButton {
   border: none;
   border-radius: 0px;
   padding: 0px;
-  image: url("qss/gray_072/imgs/fsp_released.png");
+  image: url("imgs/fsp_released.png");
 }
 #ForceSquaredPixelButton:hover {
-  image: url("qss/gray_072/imgs/fsp_hover.png");
+  image: url("imgs/fsp_hover.png");
 }
 #ForceSquaredPixelButton:checked {
-  image: url("qss/gray_072/imgs/fsp_pressed.png");
+  image: url("imgs/fsp_pressed.png");
 }
 /*------ Tool Options Bar------*/
 #EditToolLockButton {
@@ -1149,16 +1157,16 @@ SpreadsheetViewer {
   height: 21px;
 }
 #EditToolLockButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #EditToolLockButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_unlock_hover.png");
+  image: url("imgs/cam_unlock_hover.png");
 }
 #EditToolLockButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #EditToolLockButton::indicator:checked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
@@ -1175,7 +1183,7 @@ SpreadsheetViewer {
   padding: 0px;
 }
 #TopBarTab {
-  border-image: url("qss/gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
+  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
   /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
   border: 0px;
   padding: 0px;
@@ -1262,21 +1270,21 @@ QDialog #dialogButtonFrame {
 #OutputSettingsShowButton {
   border: 2px;
   padding: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #OutputSettingsShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 #IntPairField,
 #DoublePairField {
   qproperty-LightLineColor: #9b9b9b;
   qproperty-DarkLineColor: #2f2f2f;
-  qproperty-HandleLeftPixmap: url("qss/gray_072/imgs/h_slider_left.png");
-  qproperty-HandleRightPixmap: url("qss/gray_072/imgs/h_slider_right.png");
-  qproperty-HandleLeftGrayPixmap: url("qss/gray_072/imgs/h_slider_left_disabled.png");
-  qproperty-HandleRightGrayPixmap: url("qss/gray_072/imgs/h_slider_right_disabled.png");
+  qproperty-HandleLeftPixmap: url("imgs/h_slider_left.png");
+  qproperty-HandleRightPixmap: url("imgs/h_slider_right.png");
+  qproperty-HandleLeftGrayPixmap: url("imgs/h_slider_left_disabled.png");
+  qproperty-HandleRightGrayPixmap: url("imgs/h_slider_right_disabled.png");
 }
 #FxSettingsLabel {
   color: #a0e680;

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -121,10 +121,10 @@ QToolBar {
   border-image: none;
 }
 QToolBar::separator:horizontal {
-  image: url("qss/gray_072/imgs/bottomseparator.png");
+  image: url("imgs/bottomseparator.png");
 }
 QToolBar::separator:vertical {
-  image: url("qss/gray_072/imgs/separator.png");
+  image: url("imgs/separator.png");
 }
 QToolBar QToolButton {
   background-color: #484848;
@@ -134,11 +134,11 @@ QToolBar QToolButton {
   border-image: none;
 }
 QToolBar QToolButton:hover {
-  border-image: url("qss/gray_072/imgs/over.png") 2;
+  border-image: url("imgs/over.png") 2;
 }
 QToolBar QToolButton:checked,
 QToolBar QToolButton:pressed {
-  border-image: url("qss/gray_072/imgs/click.png") 2;
+  border-image: url("imgs/click.png") 2;
 }
 QToolBar QToolButton:disabled {
   background-color: #555555;
@@ -214,7 +214,7 @@ QComboBox::drop-down:on {
   border-bottom-color: #808080;
 }
 QComboBox::down-arrow {
-  image: url("qss/gray_072/imgs/combo_down_arrow.png");
+  image: url("imgs/combo_down_arrow.png");
 }
 QComboBox:disabled {
   background-color: #626262;
@@ -234,12 +234,20 @@ QPushButton {
   border-bottom-color: #000000;
   border-width: 1px;
   border-radius: 4px;
-  padding-left: 20px;
-  padding-right: 20px;
+  padding-left: 15px;
+  padding-right: 15px;
   padding-top: 3px;
   padding-bottom: 3px;
   /*lighten lilttle bit when hover*/
   /*lighten lilttle bit when pressed*/
+}
+QPushButton:checked {
+  background-color: #626262;
+  border-style: inset;
+  border-left-color: #3a3a3a;
+  border-top-color: #1a1a1a;
+  border-right-color: #868686;
+  border-bottom-color: #9a9a9a;
 }
 QPushButton:hover {
   background-color: #626262;
@@ -257,13 +265,13 @@ QPushButton:hover:pressed {
   border-right-color: #868686;
   border-bottom-color: #9a9a9a;
 }
-QPushButton:checked {
-  background-color: #626262;
+QPushButton:hover:checked {
+  background-color: #555555;
   border-style: inset;
-  border-left-color: #3a3a3a;
-  border-top-color: #1a1a1a;
-  border-right-color: #868686;
-  border-bottom-color: #9a9a9a;
+  border-left-color: #2d2d2d;
+  border-top-color: #0d0d0d;
+  border-right-color: #797979;
+  border-bottom-color: #8d8d8d;
 }
 QPushButton:disabled {
   background-color: #555555;
@@ -304,10 +312,10 @@ QCheckBox::indicator:disabled {
   border-bottom-color: #8d8d8d;
 }
 QCheckBox::indicator:checked {
-  image: url("qss/gray_072/imgs/check_indicator.png");
+  image: url("imgs/check_indicator.png");
 }
 QCheckBox::indicator:checked:disabled {
-  image: url("qss/gray_072/imgs/check_indicator_disabled.png");
+  image: url("imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
   background-color: #2f2f2f;
@@ -444,13 +452,13 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   /* if there is only one tab, we don't want overlapping margins */
 }
 #PaletteLockButton:hover {
-  border-image: url("qss/gray_072/imgs/over_yellow.png") 2;
+  border-image: url("imgs/over_yellow.png") 2;
 }
 #PaletteLockButton:checked {
-  border-image: url("qss/gray_072/imgs/click_pink.png") 2;
+  border-image: url("imgs/click_pink.png") 2;
 }
 #PaletteLockButton:checked:hover {
-  border-image: url("qss/gray_072/imgs/over_pressed_yellow.png") 2;
+  border-image: url("imgs/over_pressed_yellow.png") 2;
 }
 #PageViewer {
   qproperty-TextColor: #e6e6e6;
@@ -520,23 +528,23 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
 }
 #colorSliderAddButton,
 #colorSliderSubButton {
-  border-image: url("qss/gray_072/imgs/colorslider_button_bg.png") 2;
+  border-image: url("imgs/colorslider_button_bg.png") 2;
   padding: 0px;
   margin: 0px;
   border: 2px;
   image-position: center center;
 }
 #colorSliderAddButton {
-  image: url("qss/gray_072/imgs/colorslider_add.png");
+  image: url("imgs/colorslider_add.png");
 }
 #colorSliderAddButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_add_pressed.png");
+  image: url("imgs/colorslider_add_pressed.png");
 }
 #colorSliderSubButton {
-  image: url("qss/gray_072/imgs/colorslider_sub.png");
+  image: url("imgs/colorslider_sub.png");
 }
 #colorSliderSubButton:pressed {
-  image: url("qss/gray_072/imgs/colorslider_sub_pressed.png");
+  image: url("imgs/colorslider_sub_pressed.png");
 }
 #PlainColorPageParts {
   background-color: #484848;
@@ -575,19 +583,19 @@ DvScrollWidget > QPushButton:pressed {
   max-width: 15px;
 }
 #ScrollLeftButton {
-  image: url("qss/gray_072/imgs/left_arrow_black.png");
+  image: url("imgs/left_arrow_black.png");
   border-right: 1px solid black;
 }
 #ScrollRightButton {
-  image: url("qss/gray_072/imgs/right_arrow_black.png");
+  image: url("imgs/right_arrow_black.png");
   border-left: 1px solid black;
 }
 #ScrollUpButton {
-  image: url("qss/gray_072/imgs/up_arrow_black.png");
+  image: url("imgs/up_arrow_black.png");
   border-bottom: 1px solid black;
 }
 #ScrollDownButton {
-  image: url("qss/gray_072/imgs/down_arrow_black.png");
+  image: url("imgs/down_arrow_black.png");
   border-top: 1px solid black;
 }
 /* ------ Viewer, Flipbook ------ */
@@ -621,30 +629,30 @@ FlipBook #ToolBarContainer {
   height: 21px;
 }
 #ViewerFpsSlider::handle {
-  border-image: url("qss/gray_072/imgs/handle_border.png") 6;
+  border-image: url("imgs/handle_border.png") 6;
   border-width: 6px;
   image: none;
   min-width: 5px;
 }
 #ViewerFpsSlider::add-line {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow.png");
+  image: url("imgs/fpssb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::add-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_rarrow_pressed.png");
+  image: url("imgs/fpssb_g_rarrow_pressed.png");
 }
 #ViewerFpsSlider::sub-line {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow.png");
+  image: url("imgs/fpssb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::sub-line:pressed {
-  image: url("qss/gray_072/imgs/fpssb_g_larrow_pressed.png");
+  image: url("imgs/fpssb_g_larrow_pressed.png");
 }
 #FlipConsolePlayToolBar {
   border: none;
@@ -654,8 +662,8 @@ FlipBook #ToolBarContainer {
 }
 FlipSlider {
   qproperty-PBHeight: 20;
-  qproperty-PBOverlay: url("qss/gray_072/imgs/flipslider.png");
-  qproperty-PBMarker: url("qss/gray_072/imgs/flipmarker.png");
+  qproperty-PBOverlay: url("imgs/flipslider.png");
+  qproperty-PBMarker: url("imgs/flipmarker.png");
   qproperty-PBColorMarginLeft: 1;
   qproperty-PBColorMarginTop: 1;
   qproperty-PBColorMarginRight: 1;
@@ -698,29 +706,29 @@ Ruler {
   margin: 0px;
 }
 #DirTreeView::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-end.png") 0;
+  border-image: url("imgs/tree_branch-end.png") 0;
 }
 #DirTreeView::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree_vline.png") 0;
+  border-image: url("imgs/tree_vline.png") 0;
 }
 #DirTreeView::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree_branch-more.png") 0;
+  border-image: url("imgs/tree_branch-more.png") 0;
 }
 #DirTreeView::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed_nosib.png");
+  image: url("imgs/tree_branch-closed_nosib.png");
 }
 #DirTreeView::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open_nosib.png");
+  image: url("imgs/tree_branch-open_nosib.png");
 }
 #DirTreeView::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-closed.png");
+  image: url("imgs/tree_branch-closed.png");
 }
 #DirTreeView::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree_branch-open.png");
+  image: url("imgs/tree_branch-open.png");
 }
 DvItemViewerPanel {
   qproperty-TextColor: #e6e6e6;
@@ -764,14 +772,14 @@ DvDirTreeView {
   border-width: 2px;
   padding: 0px;
   margin: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #CleanupSettingsShowButton:checked,
 #LoadLevelShowButton:checked,
 #FxSettingsPreviewShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 ParamsPage {
   qproperty-TextColor: #e6e6e6;
@@ -845,52 +853,52 @@ ParamsPage {
   image-position: center center;
 }
 #XsheetScrollBar::handle:vertical {
-  border-image: url("qss/gray_072/imgs/sb_g_vhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_vline.png");
+  border-image: url("imgs/sb_g_vhandle.png") 4;
+  image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
 #XsheetScrollBar::handle:horizontal {
-  border-image: url("qss/gray_072/imgs/sb_g_hhandle.png") 4;
-  image: url("qss/gray_072/imgs/sb_g_hline.png");
+  border-image: url("imgs/sb_g_hhandle.png") 4;
+  image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::add-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_downarrow.png");
+  image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
 #XsheetScrollBar::add-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_downarrow_pressed.png");
+  image: url("imgs/sb_g_downarrow_pressed.png");
 }
 #XsheetScrollBar::add-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_rarrow.png");
+  image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
 #XsheetScrollBar::add-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_rarrow_pressed.png");
+  image: url("imgs/sb_g_rarrow_pressed.png");
 }
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::sub-line:vertical {
-  image: url("qss/gray_072/imgs/sb_g_uparrow.png");
+  image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
 #XsheetScrollBar::sub-line:vertical:pressed {
-  image: url("qss/gray_072/imgs/sb_g_uparrow_pressed.png");
+  image: url("imgs/sb_g_uparrow_pressed.png");
 }
 #XsheetScrollBar::sub-line:horizontal {
-  image: url("qss/gray_072/imgs/sb_g_larrow.png");
+  image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
 #XsheetScrollBar::sub-line:horizontal:pressed {
-  image: url("qss/gray_072/imgs/sb_g_larrow_pressed.png");
+  image: url("imgs/sb_g_larrow_pressed.png");
 }
 #XsheetScrollBar::add-page {
   background: none;
@@ -957,35 +965,35 @@ XsheetViewer {
 }
 #FunctionEditorTree::branch:adjoins-item,
 #ShortcutTree::branch:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-end.png") 0;
+  border-image: url("imgs/tree17_branch-end.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings,
 #ShortcutTree::branch:has-siblings {
-  border-image: url("qss/gray_072/imgs/tree17_vline.png") 0;
+  border-image: url("imgs/tree17_vline.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings:adjoins-item,
 #ShortcutTree::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_072/imgs/tree17_branch-more.png") 0;
+  border-image: url("imgs/tree17_branch-more.png") 0;
 }
 #FunctionEditorTree::branch:has-children:closed,
 #ShortcutTree::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed_nosib.png");
+  image: url("imgs/tree17_branch-closed_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:open,
 #ShortcutTree::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open_nosib.png");
+  image: url("imgs/tree17_branch-open_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:closed,
 #ShortcutTree::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-closed.png");
+  image: url("imgs/tree17_branch-closed.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:open,
 #ShortcutTree::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_072/imgs/tree17_branch-open.png");
+  image: url("imgs/tree17_branch-open.png");
 }
 FunctionPanel {
   qproperty-BGColor: #303030;
@@ -1039,7 +1047,7 @@ SpreadsheetViewer {
 #FunctionSegmentViewerLinkButton {
   border: 2px;
   margin: 0px;
-  background-image: url("qss/gray_072/imgs/segment_unlinked.png");
+  background-image: url("imgs/segment_unlinked.png");
   background-color: #7b7b7b;
   border-style: outset;
   border-left-color: #9f9f9f;
@@ -1048,7 +1056,7 @@ SpreadsheetViewer {
   border-bottom-color: #333333;
 }
 #FunctionSegmentViewerLinkButton:checked {
-  background-image: url("qss/gray_072/imgs/segment_linked.png");
+  background-image: url("imgs/segment_linked.png");
   background-color: #7b7b7b;
   border-style: inset;
   border-left-color: #535353;
@@ -1057,7 +1065,7 @@ SpreadsheetViewer {
   border-bottom-color: #b3b3b3;
 }
 #FunctionSegmentViewerLinkButton:disabled {
-  background-image: url("qss/gray_072/imgs/segment_disabled.png");
+  background-image: url("imgs/segment_disabled.png");
   background-color: #626262;
   border-style: outset;
   border-left-color: #868686;
@@ -1099,13 +1107,13 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 #CameraSettingsDPI {
   color: #a8bee7;
@@ -1118,25 +1126,25 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton_Small::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock_small.png");
+  image: url("imgs/cam_lock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock_small.png");
+  image: url("imgs/cam_unlock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover_small.png");
+  image: url("imgs/cam_lock_hover_small.png");
 }
 #ForceSquaredPixelButton {
   border: none;
   border-radius: 0px;
   padding: 0px;
-  image: url("qss/gray_072/imgs/fsp_released.png");
+  image: url("imgs/fsp_released.png");
 }
 #ForceSquaredPixelButton:hover {
-  image: url("qss/gray_072/imgs/fsp_hover.png");
+  image: url("imgs/fsp_hover.png");
 }
 #ForceSquaredPixelButton:checked {
-  image: url("qss/gray_072/imgs/fsp_pressed.png");
+  image: url("imgs/fsp_pressed.png");
 }
 /*------ Tool Options Bar------*/
 #EditToolLockButton {
@@ -1149,16 +1157,16 @@ SpreadsheetViewer {
   height: 21px;
 }
 #EditToolLockButton::indicator:unchecked {
-  image: url("qss/gray_072/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #EditToolLockButton::indicator:unchecked:hover {
-  image: url("qss/gray_072/imgs/cam_unlock_hover.png");
+  image: url("imgs/cam_unlock_hover.png");
 }
 #EditToolLockButton::indicator:checked {
-  image: url("qss/gray_072/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #EditToolLockButton::indicator:checked:hover {
-  image: url("qss/gray_072/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
@@ -1175,7 +1183,7 @@ SpreadsheetViewer {
   padding: 0px;
 }
 #TopBarTab {
-  border-image: url("qss/gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
+  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
   /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
   border: 0px;
   padding: 0px;
@@ -1262,21 +1270,21 @@ QDialog #dialogButtonFrame {
 #OutputSettingsShowButton {
   border: 2px;
   padding: 0px;
-  border-image: url("qss/gray_072/imgs/handle_border.png") 5;
-  image: url("qss/gray_072/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #OutputSettingsShowButton:checked {
-  image: url("qss/gray_072/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 #IntPairField,
 #DoublePairField {
   qproperty-LightLineColor: #9b9b9b;
   qproperty-DarkLineColor: #2f2f2f;
-  qproperty-HandleLeftPixmap: url("qss/gray_072/imgs/h_slider_left.png");
-  qproperty-HandleRightPixmap: url("qss/gray_072/imgs/h_slider_right.png");
-  qproperty-HandleLeftGrayPixmap: url("qss/gray_072/imgs/h_slider_left_disabled.png");
-  qproperty-HandleRightGrayPixmap: url("qss/gray_072/imgs/h_slider_right_disabled.png");
+  qproperty-HandleLeftPixmap: url("imgs/h_slider_left.png");
+  qproperty-HandleRightPixmap: url("imgs/h_slider_right.png");
+  qproperty-HandleLeftGrayPixmap: url("imgs/h_slider_left_disabled.png");
+  qproperty-HandleRightGrayPixmap: url("imgs/h_slider_right_disabled.png");
 }
 #FxSettingsLabel {
   color: #a0e680;

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -1,8 +1,7 @@
 /* LESS Definitions */
 
 /*Image URL*/
-@base_url: "qss/gray_128";
-@image_url: "@{base_url}/imgs";
+@image_url: "imgs";
 
 @m_baseBG: 	rgb(128,128,128);
 @m_base_lightH: rgb(230,230,230);

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -80,10 +80,10 @@ QToolBar::separator:horizontal {
   margin_top: 1px;
   margin_left: 2px;
   margin_right: 2px;
-  image: url("qss/gray_128/imgs/bottomseparator.png");
+  image: url("imgs/bottomseparator.png");
 }
 QToolBar::separator:vertical {
-  image: url("qss/gray_128/imgs/separator.png");
+  image: url("imgs/separator.png");
 }
 QToolBar QToolButton {
   background-color: #808080;
@@ -94,11 +94,11 @@ QToolBar QToolButton {
   border-image: none;
 }
 QToolBar QToolButton:hover {
-  border-image: url("qss/gray_128/imgs/over.png") 2;
+  border-image: url("imgs/over.png") 2;
 }
 QToolBar QToolButton:checked,
 QToolBar QToolButton:pressed {
-  border-image: url("qss/gray_128/imgs/click.png") 2;
+  border-image: url("imgs/click.png") 2;
 }
 QToolBar QToolButton:disabled {
   border-image: none;
@@ -210,13 +210,13 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   /* if there is only one tab, we don't want overlapping margins */
 }
 #PaletteLockButton:hover {
-  border-image: url("qss/gray_128/imgs/over_yellow.png") 2;
+  border-image: url("imgs/over_yellow.png") 2;
 }
 #PaletteLockButton:checked {
-  border-image: url("qss/gray_128/imgs/click_pink.png") 2;
+  border-image: url("imgs/click_pink.png") 2;
 }
 #PaletteLockButton:checked:hover {
-  border-image: url("qss/gray_128/imgs/over_pressed_yellow.png") 2;
+  border-image: url("imgs/over_pressed_yellow.png") 2;
 }
 #PageViewer {
   qproperty-TextColor: black;
@@ -286,23 +286,23 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
 }
 #colorSliderAddButton,
 #colorSliderSubButton {
-  border-image: url("qss/gray_128/imgs/colorslider_button_bg.png") 2;
+  border-image: url("imgs/colorslider_button_bg.png") 2;
   padding: 0px;
   margin: 0px;
   border: 2px;
   image-position: center center;
 }
 #colorSliderAddButton {
-  image: url("qss/gray_128/imgs/colorslider_add.png");
+  image: url("imgs/colorslider_add.png");
 }
 #colorSliderAddButton:pressed {
-  image: url("qss/gray_128/imgs/colorslider_add_pressed.png");
+  image: url("imgs/colorslider_add_pressed.png");
 }
 #colorSliderSubButton {
-  image: url("qss/gray_128/imgs/colorslider_sub.png");
+  image: url("imgs/colorslider_sub.png");
 }
 #colorSliderSubButton:pressed {
-  image: url("qss/gray_128/imgs/colorslider_sub_pressed.png");
+  image: url("imgs/colorslider_sub_pressed.png");
 }
 #PlainColorPageParts {
   border-width: 0px;
@@ -336,19 +336,19 @@ DvScrollWidget > QPushButton:pressed {
   max-width: 15px;
 }
 #ScrollLeftButton {
-  image: url("qss/gray_128/imgs/left_arrow_black.png");
+  image: url("imgs/left_arrow_black.png");
   border-right: 1px solid black;
 }
 #ScrollRightButton {
-  image: url("qss/gray_128/imgs/right_arrow_black.png");
+  image: url("imgs/right_arrow_black.png");
   border-left: 1px solid black;
 }
 #ScrollUpButton {
-  image: url("qss/gray_128/imgs/up_arrow_black.png");
+  image: url("imgs/up_arrow_black.png");
   border-bottom: 1px solid black;
 }
 #ScrollDownButton {
-  image: url("qss/gray_128/imgs/down_arrow_black.png");
+  image: url("imgs/down_arrow_black.png");
   border-top: 1px solid black;
 }
 /* ------ Viewer, Flipbook ------ */
@@ -382,30 +382,30 @@ FlipBook #ToolBarContainer {
   height: 21px;
 }
 #ViewerFpsSlider::handle {
-  border-image: url("qss/gray_128/imgs/handle_border.png") 6;
+  border-image: url("imgs/handle_border.png") 6;
   border-width: 6px;
   image: none;
   min-width: 5px;
 }
 #ViewerFpsSlider::add-line {
-  image: url("qss/gray_128/imgs/fpssb_g_rarrow.png");
+  image: url("imgs/fpssb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::add-line:pressed {
-  image: url("qss/gray_128/imgs/fpssb_g_rarrow_pressed.png");
+  image: url("imgs/fpssb_g_rarrow_pressed.png");
 }
 #ViewerFpsSlider::sub-line {
-  image: url("qss/gray_128/imgs/fpssb_g_larrow.png");
+  image: url("imgs/fpssb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::sub-line:pressed {
-  image: url("qss/gray_128/imgs/fpssb_g_larrow_pressed.png");
+  image: url("imgs/fpssb_g_larrow_pressed.png");
 }
 #FlipConsolePlayToolBar {
   border: none;
@@ -415,8 +415,8 @@ FlipBook #ToolBarContainer {
 }
 FlipSlider {
   qproperty-PBHeight: 20;
-  qproperty-PBOverlay: url("qss/gray_128/imgs/flipslider.png");
-  qproperty-PBMarker: url("qss/gray_128/imgs/flipmarker.png");
+  qproperty-PBOverlay: url("imgs/flipslider.png");
+  qproperty-PBMarker: url("imgs/flipmarker.png");
   qproperty-PBColorMarginLeft: 1;
   qproperty-PBColorMarginTop: 1;
   qproperty-PBColorMarginRight: 1;
@@ -457,29 +457,29 @@ Ruler {
   margin: 0px;
 }
 #DirTreeView::branch:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree_branch-end.png") 0;
+  border-image: url("imgs/tree_branch-end.png") 0;
 }
 #DirTreeView::branch:has-siblings {
-  border-image: url("qss/gray_128/imgs/tree_vline.png") 0;
+  border-image: url("imgs/tree_vline.png") 0;
 }
 #DirTreeView::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree_branch-more.png") 0;
+  border-image: url("imgs/tree_branch-more.png") 0;
 }
 #DirTreeView::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-closed_nosib.png");
+  image: url("imgs/tree_branch-closed_nosib.png");
 }
 #DirTreeView::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-open_nosib.png");
+  image: url("imgs/tree_branch-open_nosib.png");
 }
 #DirTreeView::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-closed.png");
+  image: url("imgs/tree_branch-closed.png");
 }
 #DirTreeView::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-open.png");
+  image: url("imgs/tree_branch-open.png");
 }
 DvItemViewerPanel {
   qproperty-TextColor: black;
@@ -523,14 +523,14 @@ DvDirTreeView {
   border-width: 2px;
   padding: 0px;
   margin: 0px;
-  border-image: url("qss/gray_128/imgs/handle_border.png") 5;
-  image: url("qss/gray_128/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #CleanupSettingsShowButton:checked,
 #LoadLevelShowButton:checked,
 #FxSettingsPreviewShowButton:checked {
-  image: url("qss/gray_128/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 ParamsPage {
   qproperty-TextColor: black;
@@ -592,52 +592,52 @@ ParamsPage {
   image-position: center center;
 }
 #XsheetScrollBar::handle:vertical {
-  border-image: url("qss/gray_128/imgs/sb_g_vhandle.png") 4;
-  image: url("qss/gray_128/imgs/sb_g_vline.png");
+  border-image: url("imgs/sb_g_vhandle.png") 4;
+  image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
 #XsheetScrollBar::handle:horizontal {
-  border-image: url("qss/gray_128/imgs/sb_g_hhandle.png") 4;
-  image: url("qss/gray_128/imgs/sb_g_hline.png");
+  border-image: url("imgs/sb_g_hhandle.png") 4;
+  image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::add-line:vertical {
-  image: url("qss/gray_128/imgs/sb_g_downarrow.png");
+  image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
 #XsheetScrollBar::add-line:vertical:pressed {
-  image: url("qss/gray_128/imgs/sb_g_downarrow_pressed.png");
+  image: url("imgs/sb_g_downarrow_pressed.png");
 }
 #XsheetScrollBar::add-line:horizontal {
-  image: url("qss/gray_128/imgs/sb_g_rarrow.png");
+  image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
 #XsheetScrollBar::add-line:horizontal:pressed {
-  image: url("qss/gray_128/imgs/sb_g_rarrow_pressed.png");
+  image: url("imgs/sb_g_rarrow_pressed.png");
 }
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::sub-line:vertical {
-  image: url("qss/gray_128/imgs/sb_g_uparrow.png");
+  image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
 #XsheetScrollBar::sub-line:vertical:pressed {
-  image: url("qss/gray_128/imgs/sb_g_uparrow_pressed.png");
+  image: url("imgs/sb_g_uparrow_pressed.png");
 }
 #XsheetScrollBar::sub-line:horizontal {
-  image: url("qss/gray_128/imgs/sb_g_larrow.png");
+  image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
 #XsheetScrollBar::sub-line:horizontal:pressed {
-  image: url("qss/gray_128/imgs/sb_g_larrow_pressed.png");
+  image: url("imgs/sb_g_larrow_pressed.png");
 }
 #XsheetScrollBar::add-page {
   background: none;
@@ -704,35 +704,35 @@ XsheetViewer {
 }
 #FunctionEditorTree::branch:adjoins-item,
 #ShortcutTree::branch:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree17_branch-end.png") 0;
+  border-image: url("imgs/tree17_branch-end.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings,
 #ShortcutTree::branch:has-siblings {
-  border-image: url("qss/gray_128/imgs/tree17_vline.png") 0;
+  border-image: url("imgs/tree17_vline.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings:adjoins-item,
 #ShortcutTree::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree17_branch-more.png") 0;
+  border-image: url("imgs/tree17_branch-more.png") 0;
 }
 #FunctionEditorTree::branch:has-children:closed,
 #ShortcutTree::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-closed_nosib.png");
+  image: url("imgs/tree17_branch-closed_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:open,
 #ShortcutTree::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-open_nosib.png");
+  image: url("imgs/tree17_branch-open_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:closed,
 #ShortcutTree::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-closed.png");
+  image: url("imgs/tree17_branch-closed.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:open,
 #ShortcutTree::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-open.png");
+  image: url("imgs/tree17_branch-open.png");
 }
 FunctionPanel {
   qproperty-BGColor: #e1e1e1;
@@ -784,7 +784,7 @@ SpreadsheetViewer {
 #FunctionSegmentViewerLinkButton {
   border: 2px;
   margin: 0px;
-  image: url("qss/gray_128/imgs/segment_unlinked.png");
+  image: url("imgs/segment_unlinked.png");
   background-color: #b3b3b3;
   border-style: outset;
   border-left-color: #ffffff;
@@ -793,7 +793,7 @@ SpreadsheetViewer {
   border-bottom-color: #737373;
 }
 #FunctionSegmentViewerLinkButton:checked {
-  image: url("qss/gray_128/imgs/segment_linked.png");
+  image: url("imgs/segment_linked.png");
   background-color: #b3b3b3;
   border-style: inset;
   border-left-color: #737373;
@@ -802,7 +802,7 @@ SpreadsheetViewer {
   border-bottom-color: #ffffff;
 }
 #FunctionSegmentViewerLinkButton:disabled {
-  image: url("qss/gray_128/imgs/segment_disabled.png");
+  image: url("imgs/segment_disabled.png");
   background-color: #9a9a9a;
   border-style: outset;
   border-left-color: #ffffff;
@@ -844,13 +844,13 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton::indicator:checked {
-  image: url("qss/gray_128/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked {
-  image: url("qss/gray_128/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked:hover {
-  image: url("qss/gray_128/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 #CameraSettingsDPI {
   color: #004000;
@@ -863,25 +863,25 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton_Small::indicator:checked {
-  image: url("qss/gray_128/imgs/cam_lock_small.png");
+  image: url("imgs/cam_lock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked {
-  image: url("qss/gray_128/imgs/cam_unlock_small.png");
+  image: url("imgs/cam_unlock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked:hover {
-  image: url("qss/gray_128/imgs/cam_lock_hover_small.png");
+  image: url("imgs/cam_lock_hover_small.png");
 }
 #ForceSquaredPixelButton {
   border: none;
   border-radius: 0px;
   padding: 0px;
-  image: url("qss/gray_128/imgs/fsp_released.png");
+  image: url("imgs/fsp_released.png");
 }
 #ForceSquaredPixelButton:hover {
-  image: url("qss/gray_128/imgs/fsp_hover.png");
+  image: url("imgs/fsp_hover.png");
 }
 #ForceSquaredPixelButton:checked {
-  image: url("qss/gray_128/imgs/fsp_pressed.png");
+  image: url("imgs/fsp_pressed.png");
 }
 /*------ Tool Options Bar------*/
 #EditToolLockButton {
@@ -894,16 +894,16 @@ SpreadsheetViewer {
   height: 21px;
 }
 #EditToolLockButton::indicator:unchecked {
-  image: url("qss/gray_128/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #EditToolLockButton::indicator:unchecked:hover {
-  image: url("qss/gray_128/imgs/cam_unlock_hover.png");
+  image: url("imgs/cam_unlock_hover.png");
 }
 #EditToolLockButton::indicator:checked {
-  image: url("qss/gray_128/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #EditToolLockButton::indicator:checked:hover {
-  image: url("qss/gray_128/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
@@ -920,7 +920,7 @@ SpreadsheetViewer {
   padding: 0px;
 }
 #TopBarTab {
-  border-image: url("qss/gray_128/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
+  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
   /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
   border: 0px;
   padding: 0px;
@@ -1004,21 +1004,21 @@ QDialog #dialogButtonFrame {
 #OutputSettingsShowButton {
   border: 2px;
   padding: 0px;
-  border-image: url("qss/gray_128/imgs/handle_border.png") 5;
-  image: url("qss/gray_128/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #OutputSettingsShowButton:checked {
-  image: url("qss/gray_128/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 #IntPairField,
 #DoublePairField {
   qproperty-LightLineColor: white;
   qproperty-DarkLineColor: #808080;
-  qproperty-HandleLeftPixmap: url("qss/gray_128/imgs/h_slider_left.png");
-  qproperty-HandleRightPixmap: url("qss/gray_128/imgs/h_slider_right.png");
-  qproperty-HandleLeftGrayPixmap: url("qss/gray_128/imgs/h_slider_left_disabled.png");
-  qproperty-HandleRightGrayPixmap: url("qss/gray_128/imgs/h_slider_right_disabled.png");
+  qproperty-HandleLeftPixmap: url("imgs/h_slider_left.png");
+  qproperty-HandleRightPixmap: url("imgs/h_slider_right.png");
+  qproperty-HandleLeftGrayPixmap: url("imgs/h_slider_left_disabled.png");
+  qproperty-HandleRightGrayPixmap: url("imgs/h_slider_right_disabled.png");
 }
 #FxSettingsLabel {
   color: #004000;

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -80,10 +80,10 @@ QToolBar::separator:horizontal {
   margin_top: 1px;
   margin_left: 2px;
   margin_right: 2px;
-  image: url("qss/gray_128/imgs/bottomseparator.png");
+  image: url("imgs/bottomseparator.png");
 }
 QToolBar::separator:vertical {
-  image: url("qss/gray_128/imgs/separator.png");
+  image: url("imgs/separator.png");
 }
 QToolBar QToolButton {
   background-color: #808080;
@@ -94,11 +94,11 @@ QToolBar QToolButton {
   border-image: none;
 }
 QToolBar QToolButton:hover {
-  border-image: url("qss/gray_128/imgs/over.png") 2;
+  border-image: url("imgs/over.png") 2;
 }
 QToolBar QToolButton:checked,
 QToolBar QToolButton:pressed {
-  border-image: url("qss/gray_128/imgs/click.png") 2;
+  border-image: url("imgs/click.png") 2;
 }
 QToolBar QToolButton:disabled {
   border-image: none;
@@ -210,13 +210,13 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   /* if there is only one tab, we don't want overlapping margins */
 }
 #PaletteLockButton:hover {
-  border-image: url("qss/gray_128/imgs/over_yellow.png") 2;
+  border-image: url("imgs/over_yellow.png") 2;
 }
 #PaletteLockButton:checked {
-  border-image: url("qss/gray_128/imgs/click_pink.png") 2;
+  border-image: url("imgs/click_pink.png") 2;
 }
 #PaletteLockButton:checked:hover {
-  border-image: url("qss/gray_128/imgs/over_pressed_yellow.png") 2;
+  border-image: url("imgs/over_pressed_yellow.png") 2;
 }
 #PageViewer {
   qproperty-TextColor: black;
@@ -286,23 +286,23 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
 }
 #colorSliderAddButton,
 #colorSliderSubButton {
-  border-image: url("qss/gray_128/imgs/colorslider_button_bg.png") 2;
+  border-image: url("imgs/colorslider_button_bg.png") 2;
   padding: 0px;
   margin: 0px;
   border: 2px;
   image-position: center center;
 }
 #colorSliderAddButton {
-  image: url("qss/gray_128/imgs/colorslider_add.png");
+  image: url("imgs/colorslider_add.png");
 }
 #colorSliderAddButton:pressed {
-  image: url("qss/gray_128/imgs/colorslider_add_pressed.png");
+  image: url("imgs/colorslider_add_pressed.png");
 }
 #colorSliderSubButton {
-  image: url("qss/gray_128/imgs/colorslider_sub.png");
+  image: url("imgs/colorslider_sub.png");
 }
 #colorSliderSubButton:pressed {
-  image: url("qss/gray_128/imgs/colorslider_sub_pressed.png");
+  image: url("imgs/colorslider_sub_pressed.png");
 }
 #PlainColorPageParts {
   border-width: 0px;
@@ -336,19 +336,19 @@ DvScrollWidget > QPushButton:pressed {
   max-width: 15px;
 }
 #ScrollLeftButton {
-  image: url("qss/gray_128/imgs/left_arrow_black.png");
+  image: url("imgs/left_arrow_black.png");
   border-right: 1px solid black;
 }
 #ScrollRightButton {
-  image: url("qss/gray_128/imgs/right_arrow_black.png");
+  image: url("imgs/right_arrow_black.png");
   border-left: 1px solid black;
 }
 #ScrollUpButton {
-  image: url("qss/gray_128/imgs/up_arrow_black.png");
+  image: url("imgs/up_arrow_black.png");
   border-bottom: 1px solid black;
 }
 #ScrollDownButton {
-  image: url("qss/gray_128/imgs/down_arrow_black.png");
+  image: url("imgs/down_arrow_black.png");
   border-top: 1px solid black;
 }
 /* ------ Viewer, Flipbook ------ */
@@ -382,30 +382,30 @@ FlipBook #ToolBarContainer {
   height: 21px;
 }
 #ViewerFpsSlider::handle {
-  border-image: url("qss/gray_128/imgs/handle_border.png") 6;
+  border-image: url("imgs/handle_border.png") 6;
   border-width: 6px;
   image: none;
   min-width: 5px;
 }
 #ViewerFpsSlider::add-line {
-  image: url("qss/gray_128/imgs/fpssb_g_rarrow.png");
+  image: url("imgs/fpssb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::add-line:pressed {
-  image: url("qss/gray_128/imgs/fpssb_g_rarrow_pressed.png");
+  image: url("imgs/fpssb_g_rarrow_pressed.png");
 }
 #ViewerFpsSlider::sub-line {
-  image: url("qss/gray_128/imgs/fpssb_g_larrow.png");
+  image: url("imgs/fpssb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
   subcontrol-origin: margin;
   margin: 0px;
 }
 #ViewerFpsSlider::sub-line:pressed {
-  image: url("qss/gray_128/imgs/fpssb_g_larrow_pressed.png");
+  image: url("imgs/fpssb_g_larrow_pressed.png");
 }
 #FlipConsolePlayToolBar {
   border: none;
@@ -415,8 +415,8 @@ FlipBook #ToolBarContainer {
 }
 FlipSlider {
   qproperty-PBHeight: 20;
-  qproperty-PBOverlay: url("qss/gray_128/imgs/flipslider.png");
-  qproperty-PBMarker: url("qss/gray_128/imgs/flipmarker.png");
+  qproperty-PBOverlay: url("imgs/flipslider.png");
+  qproperty-PBMarker: url("imgs/flipmarker.png");
   qproperty-PBColorMarginLeft: 1;
   qproperty-PBColorMarginTop: 1;
   qproperty-PBColorMarginRight: 1;
@@ -457,29 +457,29 @@ Ruler {
   margin: 0px;
 }
 #DirTreeView::branch:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree_branch-end.png") 0;
+  border-image: url("imgs/tree_branch-end.png") 0;
 }
 #DirTreeView::branch:has-siblings {
-  border-image: url("qss/gray_128/imgs/tree_vline.png") 0;
+  border-image: url("imgs/tree_vline.png") 0;
 }
 #DirTreeView::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree_branch-more.png") 0;
+  border-image: url("imgs/tree_branch-more.png") 0;
 }
 #DirTreeView::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-closed_nosib.png");
+  image: url("imgs/tree_branch-closed_nosib.png");
 }
 #DirTreeView::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-open_nosib.png");
+  image: url("imgs/tree_branch-open_nosib.png");
 }
 #DirTreeView::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-closed.png");
+  image: url("imgs/tree_branch-closed.png");
 }
 #DirTreeView::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree_branch-open.png");
+  image: url("imgs/tree_branch-open.png");
 }
 DvItemViewerPanel {
   qproperty-TextColor: black;
@@ -523,14 +523,14 @@ DvDirTreeView {
   border-width: 2px;
   padding: 0px;
   margin: 0px;
-  border-image: url("qss/gray_128/imgs/handle_border.png") 5;
-  image: url("qss/gray_128/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #CleanupSettingsShowButton:checked,
 #LoadLevelShowButton:checked,
 #FxSettingsPreviewShowButton:checked {
-  image: url("qss/gray_128/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 ParamsPage {
   qproperty-TextColor: black;
@@ -592,52 +592,52 @@ ParamsPage {
   image-position: center center;
 }
 #XsheetScrollBar::handle:vertical {
-  border-image: url("qss/gray_128/imgs/sb_g_vhandle.png") 4;
-  image: url("qss/gray_128/imgs/sb_g_vline.png");
+  border-image: url("imgs/sb_g_vhandle.png") 4;
+  image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
 #XsheetScrollBar::handle:horizontal {
-  border-image: url("qss/gray_128/imgs/sb_g_hhandle.png") 4;
-  image: url("qss/gray_128/imgs/sb_g_hline.png");
+  border-image: url("imgs/sb_g_hhandle.png") 4;
+  image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::add-line:vertical {
-  image: url("qss/gray_128/imgs/sb_g_downarrow.png");
+  image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
 #XsheetScrollBar::add-line:vertical:pressed {
-  image: url("qss/gray_128/imgs/sb_g_downarrow_pressed.png");
+  image: url("imgs/sb_g_downarrow_pressed.png");
 }
 #XsheetScrollBar::add-line:horizontal {
-  image: url("qss/gray_128/imgs/sb_g_rarrow.png");
+  image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
 #XsheetScrollBar::add-line:horizontal:pressed {
-  image: url("qss/gray_128/imgs/sb_g_rarrow_pressed.png");
+  image: url("imgs/sb_g_rarrow_pressed.png");
 }
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
 #XsheetScrollBar::sub-line:vertical {
-  image: url("qss/gray_128/imgs/sb_g_uparrow.png");
+  image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
 #XsheetScrollBar::sub-line:vertical:pressed {
-  image: url("qss/gray_128/imgs/sb_g_uparrow_pressed.png");
+  image: url("imgs/sb_g_uparrow_pressed.png");
 }
 #XsheetScrollBar::sub-line:horizontal {
-  image: url("qss/gray_128/imgs/sb_g_larrow.png");
+  image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
 #XsheetScrollBar::sub-line:horizontal:pressed {
-  image: url("qss/gray_128/imgs/sb_g_larrow_pressed.png");
+  image: url("imgs/sb_g_larrow_pressed.png");
 }
 #XsheetScrollBar::add-page {
   background: none;
@@ -704,35 +704,35 @@ XsheetViewer {
 }
 #FunctionEditorTree::branch:adjoins-item,
 #ShortcutTree::branch:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree17_branch-end.png") 0;
+  border-image: url("imgs/tree17_branch-end.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings,
 #ShortcutTree::branch:has-siblings {
-  border-image: url("qss/gray_128/imgs/tree17_vline.png") 0;
+  border-image: url("imgs/tree17_vline.png") 0;
 }
 #FunctionEditorTree::branch:has-siblings:adjoins-item,
 #ShortcutTree::branch:has-siblings:adjoins-item {
-  border-image: url("qss/gray_128/imgs/tree17_branch-more.png") 0;
+  border-image: url("imgs/tree17_branch-more.png") 0;
 }
 #FunctionEditorTree::branch:has-children:closed,
 #ShortcutTree::branch:has-children:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-closed_nosib.png");
+  image: url("imgs/tree17_branch-closed_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:open,
 #ShortcutTree::branch:has-children:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-open_nosib.png");
+  image: url("imgs/tree17_branch-open_nosib.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:closed,
 #ShortcutTree::branch:has-children:has-siblings:closed {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-closed.png");
+  image: url("imgs/tree17_branch-closed.png");
 }
 #FunctionEditorTree::branch:has-children:has-siblings:open,
 #ShortcutTree::branch:has-children:has-siblings:open {
   border-image: none;
-  image: url("qss/gray_128/imgs/tree17_branch-open.png");
+  image: url("imgs/tree17_branch-open.png");
 }
 FunctionPanel {
   qproperty-BGColor: #e1e1e1;
@@ -784,7 +784,7 @@ SpreadsheetViewer {
 #FunctionSegmentViewerLinkButton {
   border: 2px;
   margin: 0px;
-  image: url("qss/gray_128/imgs/segment_unlinked.png");
+  image: url("imgs/segment_unlinked.png");
   background-color: #b3b3b3;
   border-style: outset;
   border-left-color: #ffffff;
@@ -793,7 +793,7 @@ SpreadsheetViewer {
   border-bottom-color: #737373;
 }
 #FunctionSegmentViewerLinkButton:checked {
-  image: url("qss/gray_128/imgs/segment_linked.png");
+  image: url("imgs/segment_linked.png");
   background-color: #b3b3b3;
   border-style: inset;
   border-left-color: #737373;
@@ -802,7 +802,7 @@ SpreadsheetViewer {
   border-bottom-color: #ffffff;
 }
 #FunctionSegmentViewerLinkButton:disabled {
-  image: url("qss/gray_128/imgs/segment_disabled.png");
+  image: url("imgs/segment_disabled.png");
   background-color: #9a9a9a;
   border-style: outset;
   border-left-color: #ffffff;
@@ -844,13 +844,13 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton::indicator:checked {
-  image: url("qss/gray_128/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked {
-  image: url("qss/gray_128/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #CameraSettingsRadioButton::indicator:unchecked:hover {
-  image: url("qss/gray_128/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 #CameraSettingsDPI {
   color: #004000;
@@ -863,25 +863,25 @@ SpreadsheetViewer {
   height: 21px;
 }
 #CameraSettingsRadioButton_Small::indicator:checked {
-  image: url("qss/gray_128/imgs/cam_lock_small.png");
+  image: url("imgs/cam_lock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked {
-  image: url("qss/gray_128/imgs/cam_unlock_small.png");
+  image: url("imgs/cam_unlock_small.png");
 }
 #CameraSettingsRadioButton_Small::indicator:unchecked:hover {
-  image: url("qss/gray_128/imgs/cam_lock_hover_small.png");
+  image: url("imgs/cam_lock_hover_small.png");
 }
 #ForceSquaredPixelButton {
   border: none;
   border-radius: 0px;
   padding: 0px;
-  image: url("qss/gray_128/imgs/fsp_released.png");
+  image: url("imgs/fsp_released.png");
 }
 #ForceSquaredPixelButton:hover {
-  image: url("qss/gray_128/imgs/fsp_hover.png");
+  image: url("imgs/fsp_hover.png");
 }
 #ForceSquaredPixelButton:checked {
-  image: url("qss/gray_128/imgs/fsp_pressed.png");
+  image: url("imgs/fsp_pressed.png");
 }
 /*------ Tool Options Bar------*/
 #EditToolLockButton {
@@ -894,16 +894,16 @@ SpreadsheetViewer {
   height: 21px;
 }
 #EditToolLockButton::indicator:unchecked {
-  image: url("qss/gray_128/imgs/cam_unlock.png");
+  image: url("imgs/cam_unlock.png");
 }
 #EditToolLockButton::indicator:unchecked:hover {
-  image: url("qss/gray_128/imgs/cam_unlock_hover.png");
+  image: url("imgs/cam_unlock_hover.png");
 }
 #EditToolLockButton::indicator:checked {
-  image: url("qss/gray_128/imgs/cam_lock.png");
+  image: url("imgs/cam_lock.png");
 }
 #EditToolLockButton::indicator:checked:hover {
-  image: url("qss/gray_128/imgs/cam_lock_hover.png");
+  image: url("imgs/cam_lock_hover.png");
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
@@ -920,7 +920,7 @@ SpreadsheetViewer {
   padding: 0px;
 }
 #TopBarTab {
-  border-image: url("qss/gray_128/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
+  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
   /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
   border: 0px;
   padding: 0px;
@@ -1004,21 +1004,21 @@ QDialog #dialogButtonFrame {
 #OutputSettingsShowButton {
   border: 2px;
   padding: 0px;
-  border-image: url("qss/gray_128/imgs/handle_border.png") 5;
-  image: url("qss/gray_128/imgs/plus.png");
+  border-image: url("imgs/handle_border.png") 5;
+  image: url("imgs/plus.png");
   image-position: center center;
 }
 #OutputSettingsShowButton:checked {
-  image: url("qss/gray_128/imgs/minus.png");
+  image: url("imgs/minus.png");
 }
 #IntPairField,
 #DoublePairField {
   qproperty-LightLineColor: white;
   qproperty-DarkLineColor: #808080;
-  qproperty-HandleLeftPixmap: url("qss/gray_128/imgs/h_slider_left.png");
-  qproperty-HandleRightPixmap: url("qss/gray_128/imgs/h_slider_right.png");
-  qproperty-HandleLeftGrayPixmap: url("qss/gray_128/imgs/h_slider_left_disabled.png");
-  qproperty-HandleRightGrayPixmap: url("qss/gray_128/imgs/h_slider_right_disabled.png");
+  qproperty-HandleLeftPixmap: url("imgs/h_slider_left.png");
+  qproperty-HandleRightPixmap: url("imgs/h_slider_right.png");
+  qproperty-HandleLeftGrayPixmap: url("imgs/h_slider_left_disabled.png");
+  qproperty-HandleRightGrayPixmap: url("imgs/h_slider_right_disabled.png");
 }
 #FxSettingsLabel {
   color: #004000;

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -599,11 +599,7 @@ int main(int argc, char *argv[])
 
 	// Carico lo styleSheet
 	QString currentStyle = Preferences::instance()->getCurrentStyleSheet();
-	QFile file(currentStyle);
-	file.open(QFile::ReadOnly);
-	QString styleSheet = QString(file.readAll());
-	a.setStyleSheet(styleSheet);
-	file.close();
+	a.setStyleSheet(currentStyle);
 
 	TApp::instance()->setMainWindow(&w);
 	w.setWindowTitle(applicationFullName);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -642,11 +642,7 @@ void PreferencesPopup::onStyleSheetTypeChanged(int index)
 	m_pref->setCurrentStyleSheet(index);
 	QApplication::setOverrideCursor(Qt::WaitCursor);
 	QString currentStyle = m_pref->getCurrentStyleSheet();
-	QFile file(currentStyle);
-	file.open(QFile::ReadOnly);
-	QString styleSheet = QString(file.readAll());
-	qApp->setStyleSheet(styleSheet);
-	file.close();
+	qApp->setStyleSheet(currentStyle);
 	QApplication::restoreOverrideCursor();
 }
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -389,7 +389,7 @@ Preferences::Preferences()
 #endif
 			if (fpName == QString("standard"))
 				m_currentStyleSheet = i;
-			m_styleSheetMaps[i] = path.getQString() + "/" + string;
+			m_styleSheetMaps[i] = "file:///" + path.getQString() + "/" + string;
 		}
 	} catch (...) {
 	}


### PR DESCRIPTION
qssがstuffに移動したために、画像が読めなくなった不具合を修正しました。
具体的には、setStyleSheet()にスタイルシートの内容ではなくファイルパスを入れるという方法を取り、
その副産物的な効果で画像が（カレントディレクトリからでなく）スタイルシートファイルからの相対パスで
読めるようにしています。
