### PR TITLE
エフェクトファイルを含むシーンファイルを 2 回連続で開くと落ちるバグを修正

### DIFF
--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -110,13 +110,13 @@ bool get_and_check(toonz::node_handle_t node, const char *nm, double frame, doub
 
 	int type = 0;
 	int cnt = 0;
-	pif->get_type(p1, frame, &type, &cnt);
+	pif->get_type(node, p1, frame, &type, &cnt);
 	printf("parameter(ret:%d): name:%s (type:%d count:%d) expect:(type:%d) typesize:%ld\n", ret, nm, type, cnt, T::E, sizeof(typename T::iovaluetype));
 	if (type != T::E)
 		return false;
 
 	typename T::iovaluetype v;
-	ret = pif->get_value(p1, frame, &cnt, &v);
+	ret = pif->get_value(node, p1, frame, &cnt, &v);
 	printf("get_value: ret:%d count:%d\n", ret, cnt);
 	dump_value<typename T::iovaluetype>(v);
 	return true;
@@ -134,13 +134,13 @@ bool get_and_check<toonz_param_traits_string_t>(toonz::node_handle_t node, const
 
 	int type = 0;
 	int cnt = 0;
-	ret = pif->get_type(p1, frame, &type, &cnt);
+	ret = pif->get_type(node, p1, frame, &type, &cnt);
 	printf("parameter(ret:%d): name:%s (type:%d count:%d) expect:(type:%d) typesize:-\n", ret, nm, type, cnt, toonz_param_traits_string_t::E);
 	if (type != toonz_param_traits_string_t::E)
 		return false;
 
 	std::vector<toonz_param_traits_string_t::iovaluetype> v(cnt);
-	ret = pif->get_value(p1, frame, &cnt, v.data());
+	ret = pif->get_value(node, p1, frame, &cnt, v.data());
 	printf("get_value: ret:%d count:%d\n", ret, cnt);
 	//dump_value< toonz_param_traits_string_t::iovaluetype* >(v);
 	printf("value: type:%s {%s}\n", typeid(toonz_param_traits_string_t::iovaluetype).name(), v.begin());
@@ -158,14 +158,14 @@ bool get_and_check<toonz_param_traits_spectrum_t>(toonz::node_handle_t node, con
 	printf("get_param(%s): ret:%d\n", nm, ret);
 	int type = 0;
 	int cnt = 0;
-	ret = pif->get_type(p1, frame, &type, &cnt);
+	ret = pif->get_type(node, p1, frame, &type, &cnt);
 	printf("parameter(ret:%d): name:%s (type:%d count:%d) expect:(type:%d) typesize:-\n", ret, nm, type, cnt, toonz_param_traits_spectrum_t::E);
 	if (type != toonz_param_traits_spectrum_t::E)
 		return false;
 
 	toonz_param_traits_spectrum_t::iovaluetype v;
 	v.w = opt;
-	ret = pif->get_value(p1, frame, &cnt, &v);
+	ret = pif->get_value(node, p1, frame, &cnt, &v);
 	printf("get_value: ret:%d count:%d\n", ret, cnt);
 	dump_value<toonz_param_traits_spectrum_t::iovaluetype>(v);
 	return true;
@@ -183,13 +183,13 @@ bool get_and_check<toonz_param_traits_tonecurve_t>(toonz::node_handle_t node, co
 
 	int type = 0;
 	int cnt = 0;
-	ret = pif->get_type(p1, frame, &type, &cnt);
+	ret = pif->get_type(node, p1, frame, &type, &cnt);
 	printf("parameter)(ret:%d): name:%s (type:%d count:%d) expect:(type:%d) sz:-\n", ret, nm, type, cnt, toonz_param_traits_tonecurve_t::E);
 	if (type != toonz_param_traits_tonecurve_t::E)
 		return false;
 
 	std::vector<toonz_param_traits_tonecurve_t::iovaluetype> v(cnt);
-	ret = pif->get_value(p1, frame, &cnt, v.data());
+	ret = pif->get_value(node, p1, frame, &cnt, v.data());
 	printf("get_value: ret:%d count:%d\n", ret, cnt);
 	for (int i = 0; i < cnt; i++) {
 		dump_value<toonz_param_traits_tonecurve_t::iovaluetype>(v[i]);
@@ -232,21 +232,21 @@ void do_compute(toonz::node_handle_t node, const toonz::rendering_setting_t *rs,
 			auto pif = grab_interf<toonz::param_interface_t>(TOONZ_UUID_PARAM);
 			if (pif) {
 				int t, l;
-				pif->get_type(str, frame, &t, &l);
+				pif->get_type(node, str, frame, &t, &l);
 				int sz;
 				std::vector<char> shortage_buf(l / 2 + 1);
-				int ret = pif->get_string_value(str, &sz, l / 2 + 1, shortage_buf.data());
+				int ret = pif->get_string_value(node, str, &sz, l / 2 + 1, shortage_buf.data());
 				printf("get_string_value(string): {%s} (length:%d) ret:%d\n", shortage_buf.data(), sz, ret);
 
-				ret = pif->get_string_value(notstr, &sz, l / 2 + 1, shortage_buf.data()); // must be error
+				ret = pif->get_string_value(node, notstr, &sz, l / 2 + 1, shortage_buf.data()); // must be error
 				printf("get_string_value(not string): sz:%d ret:%d\n", sz, ret);		  // size must be not changed
 
-				pif->get_type(spec, frame, &t, &l);
+				pif->get_type(node, spec, frame, &t, &l);
 				toonz_param_spectrum_t spc;
-				ret = pif->get_spectrum_value(spec, frame, 0, &spc);
+				ret = pif->get_spectrum_value(node, spec, frame, 0, &spc);
 				printf("get_spectrum_value(spec): ret:%d\n", ret);
 				dump_value(spc);
-				ret = pif->get_spectrum_value(str, frame, 0, &spc);
+				ret = pif->get_spectrum_value(node, str, frame, 0, &spc);
 				printf("get_spectrum_value(str): ret:%d\n", ret); // must be error
 			}
 		}

--- a/plugins/geom/geom.cpp
+++ b/plugins/geom/geom.cpp
@@ -49,10 +49,10 @@ void do_compute(toonz::node_handle_t node, const toonz::rendering_setting_t *rs,
 			auto pif = grab_interf<toonz::param_interface_t>(TOONZ_UUID_PARAM);
 			if (pif) {
 				int type, counts;
-				pif->get_type(param, frame, &type, &counts);
+				pif->get_type(node, param, frame, &type, &counts);
 				printf("do_compute: get value type:%d\n", type);
 				toonz_param_traits_point_t::iovaluetype v;
-				pif->get_value(param, frame, &counts, &v);
+				pif->get_value(node, param, frame, &counts, &v);
 
 				printf("do_compute: value:[%g, %g]\n", v.x, v.y);
 			}

--- a/toonz/sources/toonzqt/plugin_param_interface.cpp
+++ b/toonz/sources/toonzqt/plugin_param_interface.cpp
@@ -32,176 +32,6 @@ enum toonz_value_unit_enum {
 
 static int set_value_unit(TDoubleParamP param, toonz_value_unit_enum unit);
 
-int hint_default_value(toonz_param_handle_t param, int size_in_bytes, const void *default_value)
-{
-	if (Param *_ = reinterpret_cast<Param *>(param)) {
-		TParamP param = _->param();
-
-		if (TDoubleParamP p = param) {
-			if (size_in_bytes != sizeof(double)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const double *values = reinterpret_cast<const double *>(default_value);
-			p->setDefaultValue(values[0]);
-		} else if (TRangeParamP p = param) {
-			if (size_in_bytes != sizeof(double) * 2) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const double *values = reinterpret_cast<const double *>(default_value);
-			p->setDefaultValue(std::make_pair(values[0], values[1]));
-		} else if (TPixelParamP p = param) {
-			if (size_in_bytes != sizeof(double) * 4) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const double *values = reinterpret_cast<const double *>(default_value);
-			p->setDefaultValue(toPixel32(
-				TPixelD(values[0], values[1], values[2], values[3])));
-		} else if (TPointParamP p = param) {
-			if (size_in_bytes != sizeof(double) * 2) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const double *values = reinterpret_cast<const double *>(default_value);
-			p->setDefaultValue(TPointD(values[0], values[1]));
-		} else if (TIntEnumParamP p = param) {
-			if (size_in_bytes != sizeof(int)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const int *values = reinterpret_cast<const int *>(default_value);
-			p->setDefaultValue(values[0]);
-		} else if (TIntParamP p = param) {
-			if (size_in_bytes != sizeof(int)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const int *values = reinterpret_cast<const int *>(default_value);
-			p->setDefaultValue(values[0]);
-		} else if (TBoolParamP p = param) {
-			if (size_in_bytes != sizeof(int)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const int *values = reinterpret_cast<const int *>(default_value);
-			p->setDefaultValue(values[0]);
-		} else if (TSpectrumParamP p = param) {
-			const double *values = reinterpret_cast<const double *>(default_value);
-			const int count = size_in_bytes / (sizeof(double) * 5);
-			std::vector<TSpectrum::ColorKey> keys(count);
-			for (int i = 0; i < count; i++) {
-				keys[i].first = values[5 * i + 0];
-				keys[i].second = toPixel32(TPixelD(
-					values[5 * i + 1], values[5 * i + 2],
-					values[5 * i + 3], values[5 * i + 4]));
-			}
-			p->setDefaultValue(TSpectrum(count, keys.data()));
-		} else if (TStringParamP p = param) {
-			if (size_in_bytes < 1) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const char *values = reinterpret_cast<const char *>(default_value);
-			p->setDefaultValue(QString::fromStdString(values).toStdWString());
-		} else if (TToneCurveParamP p = param) {
-			const double *values = reinterpret_cast<const double *>(default_value);
-			const int count = size_in_bytes / (sizeof(double) * 2);
-			QList<TPointD> list;
-			for (int i = 0; i < count; ++i) {
-				list.push_back(TPointD(values[2 * i + 0], values[2 * i + 1]));
-			}
-			p->setDefaultValue(list);
-		} else {
-			return TOONZ_ERROR_NOT_IMPLEMENTED;
-		}
-	} else {
-		return TOONZ_ERROR_INVALID_HANDLE;
-	}
-
-	return TOONZ_OK;
-}
-
-int hint_value_range(toonz_param_handle_t param, const void *minvalue, const void *maxvalue)
-{
-	if (Param *_ = reinterpret_cast<Param *>(param)) {
-		TParamP param = _->param();
-
-		if (TDoubleParamP p = param) {
-			p->setValueRange(
-				*reinterpret_cast<const double *>(minvalue),
-				*reinterpret_cast<const double *>(maxvalue));
-		} else if (TRangeParamP p = param) {
-			const double minv = *reinterpret_cast<const double *>(minvalue);
-			const double maxv = *reinterpret_cast<const double *>(maxvalue);
-			p->getMin()->setValueRange(minv, maxv);
-			p->getMax()->setValueRange(minv, maxv);
-		} else if (TPointParamP p = param) {
-			const double minv = *reinterpret_cast<const double *>(minvalue);
-			const double maxv = *reinterpret_cast<const double *>(maxvalue);
-			p->getX()->setValueRange(minv, maxv);
-			p->getY()->setValueRange(minv, maxv);
-		} else if (TIntParamP p = param) {
-			p->setValueRange(
-				*reinterpret_cast<const int *>(minvalue),
-				*reinterpret_cast<const int *>(maxvalue));
-		} else {
-			return TOONZ_ERROR_NOT_IMPLEMENTED;
-		}
-	} else {
-		return TOONZ_ERROR_INVALID_HANDLE;
-	}
-
-	return TOONZ_OK;
-}
-
-int hint_unit(toonz_param_handle_t param, int unit)
-{
-	if (Param *_ = reinterpret_cast<Param *>(param)) {
-		TParamP param = _->param();
-
-		if (TDoubleParamP p = param) {
-			return set_value_unit(p, toonz_value_unit_enum(unit));
-		} else if (TRangeParamP p = param) {
-			if (const int retval = set_value_unit(p->getMin(), toonz_value_unit_enum(unit))) {
-				return retval;
-			}
-			return set_value_unit(p->getMax(), toonz_value_unit_enum(unit));
-		} else if (TPointParamP p = param) {
-			if (const int retval = set_value_unit(p->getX(), toonz_value_unit_enum(unit))) {
-				return retval;
-			}
-			return set_value_unit(p->getY(), toonz_value_unit_enum(unit));
-		} else {
-			return TOONZ_ERROR_NOT_IMPLEMENTED;
-		}
-	} else {
-		return TOONZ_ERROR_INVALID_HANDLE;
-	}
-}
-
-int hint_item(toonz_param_handle_t param, int item, const char *caption)
-{
-	if (Param *_ = reinterpret_cast<Param *>(param)) {
-		TParamP param = _->param();
-
-		if (TIntEnumParamP p = param) {
-			p->addItem(item, caption);
-		} else {
-			return TOONZ_ERROR_NOT_IMPLEMENTED;
-		}
-	} else {
-		return TOONZ_ERROR_INVALID_HANDLE;
-	}
-
-	return TOONZ_OK;
-}
-
-int set_description(toonz_param_handle_t param, const char *description)
-{
-	if (Param *_ = reinterpret_cast<Param *>(param)) {
-		TParamP param = _->param();
-		param->setDescription(description);
-	} else {
-		return TOONZ_ERROR_INVALID_HANDLE;
-	}
-
-	return TOONZ_OK;
-}
-
 static int set_value_unit(TDoubleParamP param, toonz_value_unit_enum unit)
 {
 	switch (unit) {
@@ -236,64 +66,26 @@ static int set_value_unit(TDoubleParamP param, toonz_value_unit_enum unit)
 	return TOONZ_OK;
 }
 
-int get_value_type(toonz_param_handle_t param, int *pvalue_type)
-{
-	if (!pvalue_type) {
-		return TOONZ_ERROR_NULL;
-	}
-
-	if (Param *_ = reinterpret_cast<Param *>(param)) {
-		TParamP param = _->param();
-
-		if (TDoubleParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_DOUBLE;
-		} else if (TRangeParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_DOUBLE;
-		} else if (TPixelParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_DOUBLE;
-		} else if (TPointParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_DOUBLE;
-		} else if (TIntEnumParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_INT;
-		} else if (TIntParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_INT;
-		} else if (TBoolParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_INT;
-		} else if (TSpectrumParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_DOUBLE;
-		} else if (TStringParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_CHAR;
-		} else if (TToneCurveParamP p = param) {
-			*pvalue_type = TOONZ_PARAM_VALUE_TYPE_DOUBLE;
-		} else {
-			return TOONZ_ERROR_NOT_IMPLEMENTED;
-		}
-	} else {
-		return TOONZ_ERROR_INVALID_HANDLE;
-	}
-
-	return TOONZ_OK;
-}
-
-int get_type(toonz_param_handle_t param, double frame, int *ptype, int *pcount)
+int get_type(toonz_node_handle_t node, toonz_param_handle_t param, double frame, int *ptype, int *pcount)
 {
 	/* size はほとんどの型で自明なので返さなくてもいいよね? */
-	if (!ptype || !pcount)
+	if (!node || !ptype || !pcount)
 		return TOONZ_ERROR_NULL;
 
+	TFx* fx = reinterpret_cast<TFx *>(node);
 	if (Param *p = reinterpret_cast<Param *>(param)) {
 		toonz_param_type_enum e = toonz_param_type_enum(p->desc()->traits_tag);
 		if (e >= TOONZ_PARAM_TYPE_NB)
 			return TOONZ_ERROR_NOT_IMPLEMENTED;
 		size_t v;
-		if (parameter_type_check(p->param().getPointer(), p->desc(), v)) {
+		if (parameter_type_check(p->param(fx).getPointer(), p->desc(), v)) {
 			*ptype = p->desc()->traits_tag;
 			if (e == TOONZ_PARAM_TYPE_STRING) {
-				TStringParam *r = reinterpret_cast<TStringParam *>(p->param().getPointer());
+				TStringParam *r = reinterpret_cast<TStringParam *>(p->param(fx).getPointer());
 				const std::string str = QString::fromStdWString(r->getValue()).toStdString();
 				*pcount = str.length() + 1;
 			} else if (e == TOONZ_PARAM_TYPE_TONECURVE) {
-				TToneCurveParam *r = reinterpret_cast<TToneCurveParam *>(p->param().getPointer());
+				TToneCurveParam *r = reinterpret_cast<TToneCurveParam *>(p->param(fx).getPointer());
 				auto lst = r->getValue(frame);
 				*pcount = lst.size();
 			} else {
@@ -306,24 +98,25 @@ int get_type(toonz_param_handle_t param, double frame, int *ptype, int *pcount)
 	return TOONZ_ERROR_INVALID_HANDLE;
 }
 
-int get_value(toonz_param_handle_t param, double frame, int *psize_in_bytes, void *pvalue)
+int get_value(toonz_node_handle_t node, toonz_param_handle_t param, double frame, int *psize_in_bytes, void *pvalue)
 {
-	if (!psize_in_bytes) {
+	if (!node || !psize_in_bytes) {
 		return TOONZ_ERROR_NULL;
 	}
 
 	if (!pvalue) {
 		int type = 0;
-		return get_type(param, frame, &type, psize_in_bytes);
+		return get_type(node, param, frame, &type, psize_in_bytes);
 	}
 
+	TFx* fx = reinterpret_cast<TFx *>(node);
 	if (Param *p = reinterpret_cast<Param *>(param)) {
 		toonz_param_type_enum e = toonz_param_type_enum(p->desc()->traits_tag);
 		if (e >= TOONZ_PARAM_TYPE_NB)
 			return TOONZ_ERROR_NOT_IMPLEMENTED;
 		size_t v;
 		int icounts = *psize_in_bytes;
-		if (parameter_read_value(p->param().getPointer(), p->desc(), pvalue, frame, icounts, v)) {
+		if (parameter_read_value(p->param(fx).getPointer(), p->desc(), pvalue, frame, icounts, v)) {
 			*psize_in_bytes = v;
 			return TOONZ_OK;
 		} else
@@ -332,15 +125,17 @@ int get_value(toonz_param_handle_t param, double frame, int *psize_in_bytes, voi
 	return TOONZ_ERROR_INVALID_HANDLE;
 }
 
-int get_string_value(toonz_param_handle_t param, int *wholesize, int rcvbufsize, char *pvalue)
+int get_string_value(toonz_node_handle_t node, toonz_param_handle_t param, int *wholesize, int rcvbufsize, char *pvalue)
 {
-	if (!pvalue)
+	if (!node || !pvalue)
 		return TOONZ_ERROR_NULL;
+
+	TFx* fx = reinterpret_cast<TFx *>(node);
 	if (Param *p = reinterpret_cast<Param *>(param)) {
 		const toonz_param_desc_t *desc = p->desc();
 		toonz_param_type_enum e = toonz_param_type_enum(desc->traits_tag);
 		size_t vsz;
-		TParam *pp = p->param().getPointer();
+		TParam *pp = p->param(fx).getPointer();
 		if (param_type_check_<tpbind_str_t>(pp, desc, vsz)) {
 			size_t isize = rcvbufsize;
 			size_t osize = 0;
@@ -354,15 +149,17 @@ int get_string_value(toonz_param_handle_t param, int *wholesize, int rcvbufsize,
 	return TOONZ_ERROR_INVALID_HANDLE;
 }
 
-int get_spectrum_value(toonz_param_handle_t param, double frame, double x, toonz_param_spectrum_t *pvalue)
+int get_spectrum_value(toonz_node_handle_t node, toonz_param_handle_t param, double frame, double x, toonz_param_spectrum_t *pvalue)
 {
-	if (!pvalue)
+	if (!node || !pvalue)
 		return TOONZ_ERROR_NULL;
+
+	TFx* fx = reinterpret_cast<TFx *>(node);
 	if (Param *p = reinterpret_cast<Param *>(param)) {
 		const toonz_param_desc_t *desc = p->desc();
 		toonz_param_type_enum e = toonz_param_type_enum(desc->traits_tag);
 		size_t vsz;
-		TParam *pp = p->param().getPointer();
+		TParam *pp = p->param(fx).getPointer();
 		if (param_type_check_<tpbind_spc_t>(pp, desc, vsz)) {
 			size_t isize = 1;
 			size_t osize = 0;
@@ -375,80 +172,3 @@ int get_spectrum_value(toonz_param_handle_t param, double frame, double x, toonz
 	return TOONZ_ERROR_INVALID_HANDLE;
 }
 
-int set_value(toonz_param_handle_t param, double frame, int size_in_bytes, const void *pvalue)
-{
-	if (Param *_ = reinterpret_cast<Param *>(param)) {
-		TParamP param = _->param();
-
-		if (TDoubleParamP p = param) {
-			if (size_in_bytes != sizeof(double)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			p->setValue(frame, *reinterpret_cast<const double *>(pvalue));
-		} else if (TRangeParamP p = param) {
-			if (size_in_bytes != sizeof(double) * 2) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const double *const pvalues = reinterpret_cast<const double *>(pvalue);
-			p->setValue(frame, std::make_pair(pvalues[0], pvalues[1]));
-		} else if (TPixelParamP p = param) {
-			if (size_in_bytes != sizeof(double) * 4) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const double *const pvalues = reinterpret_cast<const double *>(pvalue);
-			p->setValueD(frame, TPixelD(pvalues[0], pvalues[1], pvalues[2], pvalues[3]));
-		} else if (TPointParamP p = param) {
-			if (size_in_bytes != sizeof(double) * 2) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const double *const pvalues = reinterpret_cast<const double *>(pvalue);
-			p->setValue(frame, TPointD(pvalues[0], pvalues[1]));
-		} else if (TIntEnumParamP p = param) {
-			if (size_in_bytes != sizeof(int)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			p->setValue(*reinterpret_cast<const int *>(pvalue));
-		} else if (TIntParamP p = param) {
-			if (size_in_bytes != sizeof(int)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			p->setValue(*reinterpret_cast<const int *>(pvalue));
-		} else if (TBoolParamP p = param) {
-			if (size_in_bytes != sizeof(int)) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			p->setValue(*reinterpret_cast<const int *>(pvalue) != 0);
-		} else if (TSpectrumParamP p = param) {
-			const double *values = reinterpret_cast<const double *>(pvalue);
-			const int count = size_in_bytes / (sizeof(double) * 5);
-			std::vector<TSpectrum::ColorKey> keys(count);
-			for (int i = 0; i < count; i++) {
-				keys[i].first = values[5 * i + 0];
-				keys[i].second = toPixel32(TPixelD(
-					values[5 * i + 1], values[5 * i + 2],
-					values[5 * i + 3], values[5 * i + 4]));
-			}
-			p->setValue(frame, TSpectrum(count, keys.data()));
-		} else if (TStringParamP p = param) {
-			if (size_in_bytes < 1) {
-				return TOONZ_ERROR_INVALID_SIZE;
-			}
-			const char *values = reinterpret_cast<const char *>(pvalue);
-			p->setValue(QString::fromStdString(values).toStdWString());
-		} else if (TToneCurveParamP p = param) {
-			const double *values = reinterpret_cast<const double *>(pvalue);
-			const int count = size_in_bytes / (sizeof(double) * 2);
-			QList<TPointD> list;
-			for (int i = 0; i < count; ++i) {
-				list.push_back(TPointD(values[2 * i + 0], values[2 * i + 1]));
-			}
-			p->setValue(frame, list);
-		} else {
-			return TOONZ_ERROR_NOT_IMPLEMENTED;
-		}
-	} else {
-		return TOONZ_ERROR_INVALID_HANDLE;
-	}
-
-	return TOONZ_OK;
-}

--- a/toonz/sources/toonzqt/plugin_param_interface.h
+++ b/toonz/sources/toonzqt/plugin_param_interface.h
@@ -19,8 +19,8 @@ class Param
 public:
 	//inline Param(TFx* fx, const std::string& name, toonz_param_type_enum type, std::shared_ptr< toonz_param_desc_t >&& desc)
 	//	: fx_(fx), name_(name), type_(type), desc_(std::move(desc)) {
-	inline Param(TFx *fx, const std::string &name, toonz_param_type_enum type, const toonz_param_desc_t *desc)
-		: fx_(fx), name_(name), type_(type), desc_(const_cast<toonz_param_desc_t *>(desc))
+	inline Param(const std::string &name, toonz_param_type_enum type, const toonz_param_desc_t *desc)
+		: name_(name), type_(type), desc_(const_cast<toonz_param_desc_t *>(desc))
 	{
 	}
 
@@ -34,9 +34,9 @@ public:
 		return type_;
 	}
 
-	inline TParamP param() const
+	inline TParamP param(TFx* fx) const
 	{
-		return fx_->getParams()->getParam(name_);
+		return fx->getParams()->getParam(name_);
 	}
 
 	inline const toonz_param_desc_t *desc() const { return desc_; }
@@ -49,12 +49,12 @@ int hint_unit(toonz_param_handle_t param, int unit);
 int hint_item(toonz_param_handle_t param, int item, const char *caption);
 int set_description(toonz_param_handle_t param, const char *description);
 
-int get_type(toonz_param_handle_t param, double, int *, int *);
+int get_type(toonz_node_handle_t node, toonz_param_handle_t param, double, int *, int *);
 int get_value_type(toonz_param_handle_t param, int *pvalue_type);
-int get_value(toonz_param_handle_t param, double frame, int *psize_in_bytes, void *pvalue);
+int get_value(toonz_node_handle_t node, toonz_param_handle_t param, double frame, int *psize_in_bytes, void *pvalue);
 int set_value(toonz_param_handle_t param, double frame, int size_in_bytes, const void *pvalue);
 
-int get_string_value(toonz_param_handle_t param, int *wholesize, int rcvbufsize, char *pvalue);
-int get_spectrum_value(toonz_param_handle_t param, double frame, double x, toonz_param_spectrum_t *pvalue);
+int get_string_value(toonz_node_handle_t node, toonz_param_handle_t param, int *wholesize, int rcvbufsize, char *pvalue);
+int get_spectrum_value(toonz_node_handle_t node, toonz_param_handle_t param, double frame, double x, toonz_param_spectrum_t *pvalue);
 
 #endif

--- a/toonz/sources/toonzqt/plugin_param_traits.h
+++ b/toonz/sources/toonzqt/plugin_param_traits.h
@@ -104,9 +104,9 @@ struct set_param_range_t {
 /* ranged complextype */
 template <typename Bind>
 struct set_param_range_t<Bind, std::true_type, 1> {
-	static bool set_param_range(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_range(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		typename Bind::realtype *p = reinterpret_cast<typename Bind::realtype *>(smartptr.getPointer());
 		if (p) {
 			const typename Bind::traittype &t = *reinterpret_cast<const typename Bind::traittype *>(&desc->traits.d);
@@ -131,9 +131,9 @@ struct set_param_range_t<Bind, std::true_type, 1> {
    このため range に対しても特殊版を用意するハメになった. */
 template <>
 struct set_param_range_t<tpbind_rng_t, std::true_type, 1> {
-	static bool set_param_range(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_range(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		tpbind_rng_t::realtype *p = reinterpret_cast<tpbind_rng_t::realtype *>(smartptr.getPointer());
 		if (p) {
 			const tpbind_rng_t::traittype &t = desc->traits.rd;
@@ -176,11 +176,11 @@ struct set_param_range_t< tpbind_pnt_t, std::true_type, 1 >  {
 /* ranged primitive: */
 template <typename Bind>
 struct set_param_range_t<Bind, std::false_type, 1> {
-	static bool set_param_range(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_range(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
 		if (!is_type_of<typename Bind::traittype>(desc))
 			return false;
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		typename Bind::realtype *p = reinterpret_cast<typename Bind::realtype *>(smartptr.getPointer());
 		if (p) {
 			const typename Bind::traittype &t = *reinterpret_cast<const typename Bind::traittype *>(&desc->traits.d);
@@ -192,16 +192,16 @@ struct set_param_range_t<Bind, std::false_type, 1> {
 };
 
 template <typename Bind>
-bool set_param_range(Param *param, const toonz_param_desc_t *desc)
+bool set_param_range(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 {
 	if (!is_type_of<typename Bind::traittype>(desc))
 		return false;
-	return set_param_range_t<Bind>::set_param_range(param, desc);
+	return set_param_range_t<Bind>::set_param_range(fx, param, desc);
 }
 
 template <typename Bind, typename Comp = typename std::is_compound<typename Bind::valuetype>::type>
 struct set_param_default_t {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
 		return false;
 	}
@@ -211,9 +211,9 @@ struct set_param_default_t {
 /* Point/Range */
 template <typename Bind>
 struct set_param_default_t<Bind, std::true_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		typename Bind::realtype *p = reinterpret_cast<typename Bind::realtype *>(smartptr.getPointer());
 		if (p) {
 			const typename Bind::traittype &t = *reinterpret_cast<const typename Bind::traittype *>(&desc->traits.d);
@@ -232,9 +232,9 @@ struct set_param_default_t<Bind, std::true_type> {
 /* Default Color */
 template <>
 struct set_param_default_t<tpbind_col_t, std::true_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		tpbind_col_t::realtype *p = reinterpret_cast<tpbind_col_t::realtype *>(smartptr.getPointer());
 		if (p) {
 			const tpbind_col_t::traittype &t = *reinterpret_cast<const tpbind_col_t::traittype *>(&desc->traits.d);
@@ -247,9 +247,9 @@ struct set_param_default_t<tpbind_col_t, std::true_type> {
 /* Default String */
 template <>
 struct set_param_default_t<tpbind_str_t, std::true_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		tpbind_str_t::realtype *p = reinterpret_cast<tpbind_str_t::realtype *>(smartptr.getPointer());
 		if (p) {
 			const tpbind_str_t::traittype &t = *reinterpret_cast<const tpbind_str_t::traittype *>(&desc->traits.d);
@@ -265,7 +265,7 @@ struct set_param_default_t<tpbind_str_t, std::true_type> {
 /* Default Spectrum */
 template <>
 struct set_param_default_t<tpbind_spc_t, std::true_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
 		/* unfortunatly, TSpectrumParam's default values must be set within the constructor, for now.
 		 see param_factory_< TSpectrumParam >() */
@@ -276,7 +276,7 @@ struct set_param_default_t<tpbind_spc_t, std::true_type> {
 /* Default ToneCurve */
 template <>
 struct set_param_default_t<tpbind_tcv_t, std::true_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
 		/*
 		auto smartptr = param->param();
@@ -298,9 +298,9 @@ struct set_param_default_t<tpbind_tcv_t, std::true_type> {
 /* primitive: TDoubleParam */
 template <>
 struct set_param_default_t<tpbind_dbl_t, std::false_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		tpbind_dbl_t::realtype *p = reinterpret_cast<tpbind_dbl_t::realtype *>(smartptr.getPointer());
 		if (p) {
 			const tpbind_dbl_t::traittype &t = *reinterpret_cast<const tpbind_dbl_t::traittype *>(&desc->traits.d);
@@ -314,9 +314,9 @@ struct set_param_default_t<tpbind_dbl_t, std::false_type> {
 /* primitive: TNotAnimatableParam */
 template <typename Bind>
 struct set_param_default_t<Bind, std::false_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		typename Bind::realtype *p = reinterpret_cast<typename Bind::realtype *>(smartptr.getPointer());
 		if (p) {
 			const typename Bind::traittype &t = *reinterpret_cast<const typename Bind::traittype *>(&desc->traits.d);
@@ -331,9 +331,9 @@ struct set_param_default_t<Bind, std::false_type> {
 /* Default Enum */
 template <>
 struct set_param_default_t<tpbind_enm_t, std::false_type> {
-	static bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+	static bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 	{
-		auto smartptr = param->param();
+		auto smartptr = param->param(fx);
 		tpbind_enm_t::realtype *p = reinterpret_cast<tpbind_enm_t::realtype *>(smartptr.getPointer());
 		if (p) {
 			const tpbind_enm_t::traittype &t = *reinterpret_cast<const tpbind_enm_t::traittype *>(&desc->traits.d);
@@ -347,11 +347,11 @@ struct set_param_default_t<tpbind_enm_t, std::false_type> {
 };
 
 template <typename Bind>
-bool set_param_default(Param *param, const toonz_param_desc_t *desc)
+bool set_param_default(TFx* fx, Param *param, const toonz_param_desc_t *desc)
 {
 	if (!is_type_of<typename Bind::traittype>(desc))
 		return false;
-	return set_param_default_t<Bind>::set_param_default(param, desc);
+	return set_param_default_t<Bind>::set_param_default(fx, param, desc);
 }
 
 template <typename T>

--- a/toonz/sources/toonzqt/pluginhost.cpp
+++ b/toonz/sources/toonzqt/pluginhost.cpp
@@ -639,7 +639,7 @@ Param *RasterFxPluginHost::createParam(const toonz_param_desc_t *desc, bool from
 		}
 		if (!param) {
 			pi_->params_.push_back(nullptr);
-			pi_->params_.back() = new Param(this, desc->key, toonz_param_type_enum(desc->traits_tag), desc);
+			pi_->params_.back() = new Param(desc->key, toonz_param_type_enum(desc->traits_tag), desc);
 			param = pi_->params_.back();
 		}
 		return param;
@@ -925,21 +925,21 @@ void RasterFxPluginHost::createParamsByDesc()
 
 					r = bind_param(page, p, v);
 
-					set_param_default<tpbind_dbl_t>(p, desc);
-					set_param_default<tpbind_int_t>(p, desc);
-					set_param_default<tpbind_rng_t>(p, desc);
-					set_param_default<tpbind_pnt_t>(p, desc);
-					set_param_default<tpbind_enm_t>(p, desc);
-					set_param_default<tpbind_col_t>(p, desc);
-					set_param_default<tpbind_bool_t>(p, desc);
-					set_param_default<tpbind_str_t>(p, desc);
-					set_param_default<tpbind_spc_t>(p, desc);
-					set_param_default<tpbind_tcv_t>(p, desc);
+					set_param_default<tpbind_dbl_t>(this, p, desc);
+					set_param_default<tpbind_int_t>(this, p, desc);
+					set_param_default<tpbind_rng_t>(this, p, desc);
+					set_param_default<tpbind_pnt_t>(this, p, desc);
+					set_param_default<tpbind_enm_t>(this, p, desc);
+					set_param_default<tpbind_col_t>(this, p, desc);
+					set_param_default<tpbind_bool_t>(this, p, desc);
+					set_param_default<tpbind_str_t>(this, p, desc);
+					set_param_default<tpbind_spc_t>(this, p, desc);
+					set_param_default<tpbind_tcv_t>(this, p, desc);
 
-					set_param_range<tpbind_dbl_t>(p, desc);
-					set_param_range<tpbind_int_t>(p, desc);
-					set_param_range<tpbind_rng_t>(p, desc);
-					set_param_range<tpbind_pnt_t>(p, desc);
+					set_param_range<tpbind_dbl_t>(this, p, desc);
+					set_param_range<tpbind_int_t>(this, p, desc);
+					set_param_range<tpbind_rng_t>(this, p, desc);
+					set_param_range<tpbind_pnt_t>(this, p, desc);
 
 					printf("RasterFxPluginHost::createParam: bind_param: r:0x%x\n", r);
 				}

--- a/toonz/sources/toonzqt/toonz_hostif.h
+++ b/toonz/sources/toonzqt/toonz_hostif.h
@@ -48,15 +48,17 @@ struct toonz_rect_t_ {
 
 typedef struct toonz_rect_t_ toonz_rect_t;
 
+typedef void *toonz_node_handle_t;
+
 typedef void *toonz_param_handle_t;
 
 struct toonz_param_interface_t_ {
 	toonz_if_version_t ver;
-	int (*get_type)(toonz_param_handle_t param, double frame, int *type, int *counts);
-	int (*get_value)(toonz_param_handle_t param, double frame, int *pcounts, void *pvalue);
-	int (*set_value)(toonz_param_handle_t param, double frame, int counts, const void *pvalue);
-	int (*get_string_value)(toonz_param_handle_t param, int *wholesize, int rcvbufsize, char *pvalue);
-	int (*get_spectrum_value)(toonz_param_handle_t param, double frame, double x, toonz_param_spectrum_t *pvalue);
+	int (*get_type)(toonz_node_handle_t node, toonz_param_handle_t param, double frame, int *type, int *counts);
+	int (*get_value)(toonz_node_handle_t node, toonz_param_handle_t param, double frame, int *pcounts, void *pvalue);
+	int (*set_value)(toonz_node_handle_t node, toonz_param_handle_t param, double frame, int counts, const void *pvalue);
+	int (*get_string_value)(toonz_node_handle_t node, toonz_param_handle_t param, int *wholesize, int rcvbufsize, char *pvalue);
+	int (*get_spectrum_value)(toonz_node_handle_t node, toonz_param_handle_t param, double frame, double x, toonz_param_spectrum_t *pvalue);
 } TOONZ_PACK;
 
 typedef toonz_param_interface_t_ toonz_param_interface_t;
@@ -102,8 +104,6 @@ enum {
 	TOONZ_TILE_TYPE_GRDP,
 	TOONZ_TILE_TYPE_YUV422P,
 };
-
-typedef void *toonz_node_handle_t;
 
 struct toonz_node_interface_t_ {
 	toonz_if_version_t ver;


### PR DESCRIPTION
**原因**
1. `Param` は `TFx*` を保存するようになっていた (インスタンスに依存していた)
2. `params_` を `PluginInformation` に置くようになった (すべてのエフェクトインスタンスで共通化された)
3. エフェクトが削除された場合、不正な値を持つようになっていた

**対応**
1. `Param` から `TFx*` を削除
2. `Param` の `TFx*` を利用していた `toonz_param_interface_t` の第一引数に `toonz_node_handle_t` を追加
3. `set_param_range` と `set_param_default` も同様に対応
4. インタフェース修正に伴って、サンプルプラグインも修正
