### PR TITLE
パレット上書きの確認ダイアログに関する修正

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1600,7 +1600,7 @@ bool IoCmd::saveLevel(const TFilePath &fp, TXshSimpleLevel *sl, bool overwrite)
 	if (sl->getPalette() &&
 		sl->getPalette()->getAskOverwriteFlag() &&
 		sl->getPath().getType() != "pli") {
-		/*--  --*/
+		/*-- ファイルが存在しない場合はパレットも必ず保存する --*/
 		if (!fileDoesExist)
 			overwritePalette = true;
 		else


### PR DESCRIPTION
Level保存時に、Paletteにも変更があった場合に、Paletteも上書き保存するかどうかの確認ダイアログが表示されます。しかし、Levelを別名で保存する場合、既存のファイルが無い保存先にPaletteを保存することは自明です。（しかも、確認ダイアログは「『上書き』しますか？」と表示されるので混乱してしまいます。）

そこで、Level保存先に既存のファイルが無い場合、ダイアログは開かず、自動的にパレットも保存することにしました。
