### PR TITLE
Fix letter case in CMakeLists.txt

### DIFF
--- a/toonz/sources/tnzbase/CMakeLists.txt
+++ b/toonz/sources/tnzbase/CMakeLists.txt
@@ -86,7 +86,7 @@ set(SOURCES
     ../common/txsheet/tcolumnset.cpp
     ../common/tfx/binaryFx.cpp
     texternfx.cpp
-    ../common/TFx/tfx.cpp
+    ../common/tfx/tfx.cpp
     ../common/tfx/tfxcachemanager.cpp
     ../common/tfx/tcacheresource.cpp
     ../common/tfx/tcacheresourcepool.cpp
@@ -98,7 +98,7 @@ set(SOURCES
     trasterfx.cpp
     ../common/tfx/trenderer.cpp
     ../common/tfx/trenderresourcemanager.cpp
-    ../common/TFx/ttzpimagefx.cpp
+    ../common/tfx/ttzpimagefx.cpp
     ../common/tfx/unaryFx.cpp
     ../common/tfx/zeraryFx.cpp
     ../common/tapptools/tcli.cpp

--- a/toonz/sources/tnztools/CMakeLists.txt
+++ b/toonz/sources/tnztools/CMakeLists.txt
@@ -69,7 +69,7 @@ set(SOURCES
     rastererasertool.cpp
     rastertapetool.cpp
     rasterselectiontool.cpp
-    RGBpickertool.cpp
+    rgbpickertool.cpp
     selectiontool.cpp
     setsaveboxtool.cpp
     skeletonsubtools.cpp


### PR DESCRIPTION
These make build fail on case sensitive filesystem since actual directory and file names are different.