### PR TITLE
Fix: User facing typos throughout application

### DIFF
--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -2477,13 +2477,13 @@ void FilmstripCmd::moveToScene(TXshSoundLevel *sl)
 }
 
 //=============================================================================
-// UndoInbeteween
+// UndoInbetween
 //-----------------------------------------------------------------------------
 
 namespace
 {
 
-class UndoInbeteween : public TUndo
+class UndoInbetween : public TUndo
 {
 	TXshSimpleLevelP m_level;
 	vector<TFrameId> m_fids;
@@ -2491,7 +2491,7 @@ class UndoInbeteween : public TUndo
 	FilmstripCmd::InbetweenInterpolation m_interpolation;
 
 public:
-	UndoInbeteween(
+	UndoInbetween(
 		TXshSimpleLevel *xl,
 		std::vector<TFrameId> fids,
 		FilmstripCmd::InbetweenInterpolation interpolation)
@@ -2530,7 +2530,7 @@ public:
 
 	QString getHistoryString()
 	{
-		QString str = QObject::tr("Inbeteween  : Level %1,  ")
+		QString str = QObject::tr("Inbetween  : Level %1,  ")
 						  .arg(QString::fromStdWString(m_level->getName()));
 		switch (m_interpolation) {
 		case FilmstripCmd::II_Linear:
@@ -2631,7 +2631,7 @@ void FilmstripCmd::inbetween(TXshSimpleLevel *sl,
 			fids.push_back(*it);
 	}
 
-	TUndoManager::manager()->add(new UndoInbeteween(sl, fids, interpolation));
+	TUndoManager::manager()->add(new UndoInbetween(sl, fids, interpolation));
 
 	inbetweenWithoutUndo(sl, fid0, fid1, interpolation);
 	TApp::instance()->getCurrentScene()->setDirtyFlag(true);

--- a/toonz/sources/toonz/inbetweencommand.cpp
+++ b/toonz/sources/toonz/inbetweencommand.cpp
@@ -124,13 +124,13 @@ TVectorImageP MyInbetweener::tween(double t)
 }
 
 //=============================================================================
-// UndoInbeteween
+// UndoInbetween
 //-----------------------------------------------------------------------------
 
 namespace
 {
 
-class UndoInbeteween : public TUndo
+class UndoInbetween : public TUndo
 {
 	TXshSimpleLevelP m_level;
 	vector<TFrameId> m_fids;
@@ -138,7 +138,7 @@ class UndoInbeteween : public TUndo
 	FilmstripCmd::InbetweenInterpolation m_interpolation;
 
 public:
-	UndoInbeteween(
+	UndoInbetween(
 		TXshSimpleLevel *xl,
 		std::vector<TFrameId> fids,
 		FilmstripCmd::InbetweenInterpolation interpolation)
@@ -252,7 +252,7 @@ void FilmstripCmd::inbetween(TXshSimpleLevel *sl,
 			fids.push_back(*it);
 	}
 
-	TUndoManager::manager()->add(new UndoInbeteween(sl, fids, interpolation));
+	TUndoManager::manager()->add(new UndoInbetween(sl, fids, interpolation));
 
 	inbetweenWithoutUndo(sl, fid0, fid1, interpolation);
 	TApp::instance()->getCurrentScene()->setDirtyFlag(true);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1850,7 +1850,7 @@ void MainWindow::defineActions()
 
 	createMenuWindowsAction(MI_ResetRoomLayout, tr("&Reset to Default Rooms"), "");
 
-	createMenuWindowsAction(MI_About, tr("&Abount OpenToonz..."), "");
+	createMenuWindowsAction(MI_About, tr("&About OpenToonz..."), "");
 
 	createRightClickMenuAction(MI_BlendColors, tr("&Blend colors"), "");
 

--- a/toonz/sources/toonz/matchlinecommand.cpp
+++ b/toonz/sources/toonz/matchlinecommand.cpp
@@ -137,7 +137,7 @@ public:
 		std::set<int> indices = selection->getIndices();
 
 		if (indices.size() != 2) {
-			MsgBox(WARNING, tr("It is not possible to apply the match lines because two columns have to be seleted."));
+			MsgBox(WARNING, tr("It is not possible to apply the match lines because two columns have to be selected."));
 			return;
 		}
 

--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -907,7 +907,7 @@ TaskSheet::TaskSheet(TasksViewer *owner)
 	//m_stepCount->setMaximumWidth(38);
 	::create(m_failedSteps, layout, tr("Failed Steps:"), row++);
 	// m_failedSteps->setMaximumWidth(38);
-	::create(m_succSteps, layout, tr("Successfull Steps:"), row++);
+	::create(m_succSteps, layout, tr("Successful Steps:"), row++);
 	// m_succSteps->setMaximumWidth(38);
 	::create(m_priority, layout, tr("Priority:"), row++);
 	// m_priority->setMaximumWidth(40);

--- a/toonz/sources/toonz/trackerpopup.cpp
+++ b/toonz/sources/toonz/trackerpopup.cpp
@@ -793,7 +793,7 @@ QString Tracker::getErrorMessage(int errorCode)
 		errorMessage = QObject::tr("It is not possible to track specified regions:\nthe level has to be saved first.");
 		break;
 	default:
-		errorMessage = QObject::tr("It is not possible to track the level:\nundefinied error.");
+		errorMessage = QObject::tr("It is not possible to track the level:\nundefined error.");
 	}
 	return errorMessage;
 }

--- a/toonz/sources/translations/french/toonz.ts
+++ b/toonz/sources/translations/french/toonz.ts
@@ -112,8 +112,8 @@
         <translation>Il n&apos;est pas possible d&apos;appliquer les lignes de correspondance, car aucune colonne a été sélectionné.</translation>
     </message>
     <message>
-        <source>It is not possible to apply the match lines because two columns have to be seleted.</source>
-        <translation>Il n&apos;est pas possible d&apos;appliquer les lignes de match parce que les deux colonnesdoivent être seleted.</translation>
+        <source>It is not possible to apply the match lines because two columns have to be selected.</source>
+        <translation>Il n&apos;est pas possible d&apos;appliquer les lignes de match parce que les deux colonnes doivent être sélectionnés.</translation>
     </message>
 </context>
 <context>
@@ -5804,7 +5804,7 @@ le niveau doit être enregistré d&apos;abord.</translation>
     </message>
     <message>
         <source>It is not possible to track the level:
-undefinied error.</source>
+undefined error.</source>
         <translation>Il n&apos;est pas possible de tracer le niveau:
 erreur indéfini.</translation>
     </message>
@@ -6634,7 +6634,7 @@ Are you sure to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbeteween  : Level %1,  </source>
+        <source>Inbetween  : Level %1,  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6824,10 +6824,6 @@ Are you sure to </source>
     </message>
     <message>
         <source>Combo Viewer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cleeanup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8425,7 +8421,7 @@ Cliquez sur le bouton fléché pour créer un nouveau sub-xsheet</translation>
         <translation>Pas Échoués:</translation>
     </message>
     <message>
-        <source>Successfull Steps:</source>
+        <source>Successful Steps:</source>
         <translation>Pas réussis:</translation>
     </message>
     <message>

--- a/toonz/sources/translations/italian/toonz.ts
+++ b/toonz/sources/translations/italian/toonz.ts
@@ -112,7 +112,7 @@
         <translation>Impossibile applicare le match lines poichè non è stata selezionata nessuna colonna.</translation>
     </message>
     <message>
-        <source>It is not possible to apply the match lines because two columns have to be seleted.</source>
+        <source>It is not possible to apply the match lines because two columns have to be selected.</source>
         <translation>Impossibile applicare le match lines poichè devono essere selezionate due colonne.</translation>
     </message>
 </context>
@@ -5805,7 +5805,7 @@ il livello deve essere prima salvato.</translation>
     </message>
     <message>
         <source>It is not possible to track the level:
-undefinied error.</source>
+undefined error.</source>
         <translation>Non è possibile tracciare il livello:
 errore indefinito.</translation>
     </message>
@@ -6636,7 +6636,7 @@ Are you sure to </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Inbeteween  : Level %1,  </source>
+        <source>Inbetween  : Level %1,  </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6826,10 +6826,6 @@ Are you sure to </source>
     </message>
     <message>
         <source>Combo Viewer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cleeanup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8427,7 +8423,7 @@ Clicca la freccia per creare un nuovo sub-xsheet</translation>
         <translation>Passi Falliti:</translation>
     </message>
     <message>
-        <source>Successfull Steps:</source>
+        <source>Successful Steps:</source>
         <translation>Passi Portati a termine con Successo:</translation>
     </message>
     <message>

--- a/toonz/sources/translations/japanese/toonz.ts
+++ b/toonz/sources/translations/japanese/toonz.ts
@@ -113,7 +113,7 @@
         <translation>列が選択されていないので、マッチラインを合成できません。</translation>
     </message>
     <message>
-        <source>It is not possible to apply the match lines because two columns have to be seleted.</source>
+        <source>It is not possible to apply the match lines because two columns have to be selected.</source>
         <translation>二つの列が選択されていないので、マッチラインを合成できません。</translation>
     </message>
 </context>
@@ -4209,7 +4209,7 @@ Do you want to create it?</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <source>&amp;Abount OpenToonz...</source>
+        <source>&amp;About OpenToonz...</source>
         <translation>OpenToonzについて (&amp;A)...</translation>
     </message>
     <message>
@@ -5895,7 +5895,7 @@ the level has to be saved first.</source>
     </message>
     <message>
         <source>It is not possible to track the level:
-undefinied error.</source>
+undefined error.</source>
         <translation>レベルを追跡できません：
 未定義のエラー。</translation>
     </message>
@@ -6710,7 +6710,7 @@ Are you sure to </source>
         <translation>レベルをシーンに移動 : レベル %1</translation>
     </message>
     <message>
-        <source>Inbeteween  : Level %1,  </source>
+        <source>Inbetween  : Level %1,  </source>
         <translation>中割り : レベル %1</translation>
     </message>
     <message>
@@ -6902,10 +6902,6 @@ Are you sure to </source>
     <message>
         <source>Combo Viewer</source>
         <translation>メインビューア</translation>
-    </message>
-    <message>
-        <source>Cleeanup Settings</source>
-        <translation type="vanished">トレース設定</translation>
     </message>
     <message>
         <source>Move Level to Cast Folder</source>
@@ -8522,7 +8518,7 @@ Click the arrow button to create a new sub-xsheet</source>
         <translation>失敗ステップ数：</translation>
     </message>
     <message>
-        <source>Successfull Steps:</source>
+        <source>Successful Steps:</source>
         <translation>成功ステップ数：</translation>
     </message>
     <message>


### PR DESCRIPTION
- inbeteween -> inbetween
- abount -> about
- seleted -> selected
- successfull -> successful
- undefinied -> undefined
- colonnesdoivent (fr) -> colonnes doivent
- seleted (fr) -> sélectionnés
- cleeanup -> removed from translations,
  wasn't translated anyway and
  was removed from english codebase