### PR TITLE
Fix crash in initializing

### DIFF
--- a/toonz/sources/image/avi/tiio_avi.cpp
+++ b/toonz/sources/image/avi/tiio_avi.cpp
@@ -1061,11 +1061,19 @@ Tiio::AviWriterProperties::AviWriterProperties()
 				if (!rc)
 					break;
 				HIC hic = 0;
+#ifdef _MSC_VER
+				[&](){
+					__try {
+						hic = ICOpen(icinfo.fccType, icinfo.fccHandler, ICMODE_QUERY);
+					} __except (EXCEPTION_EXECUTE_HANDLER) {
+					}
+				}();
+#else
 				try {
 					hic = ICOpen(icinfo.fccType, icinfo.fccHandler, ICMODE_QUERY);
 				} catch (...) {
-					continue;
 				}
+#endif
 				if (hic) {
 					if (ICGetInfo(hic, &icinfo, sizeof(ICINFO)) == 0) // Find out the compressor name
 					{


### PR DESCRIPTION
In some enviroment, access violations occures in ICOpen.
Althogh this code seems to intended to handle SEH, structured exceptions are not catched in current configulation.

Thank you, Laura.
https://groups.google.com/d/msg/opentoonz_en/-3ajuxOjAGA/vbJhSvlADwAJ

#46, #50