### PR TITLE
Fix crash of lzocompres and lzodecompress

### DIFF
--- a/thirdparty/lzo/driver/lzocompress.c
+++ b/thirdparty/lzo/driver/lzocompress.c
@@ -15,6 +15,10 @@
 
 
 #include <stdio.h>
+#include <stdlib.h>
+#if defined(_WIN32)
+#include <io.h>
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/thirdparty/lzo/driver/lzodecompress.c
+++ b/thirdparty/lzo/driver/lzodecompress.c
@@ -17,6 +17,10 @@
 
 #include <stdio.h>
 #include <fcntl.h>
+#include <stdlib.h>
+#if defined(_WIN32)
+#include <io.h>
+#endif
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Without stdlib.h malloc is assumed to return int, which is not compatible with void * in x64.
#91 