### PR TITLE
Revert formatting changes to tif_getimage_64.c

### DIFF
--- a/thirdparty/tiff-4.0.3/libtiff/tif_getimage_64.c
+++ b/thirdparty/tiff-4.0.3/libtiff/tif_getimage_64.c
@@ -43,15 +43,15 @@ typedef void (*tileContigRoutine_64)(TIFFRGBAImage *, uint64 *, uint32, uint32, 
 typedef void (*tileSeparateRoutine_64)(TIFFRGBAImage *, uint64 *, uint32, uint32, uint32, uint32, int32, int32,
 									   unsigned char *, unsigned char *, unsigned char *, unsigned char *);
 
-static int gtTileContig(TIFFRGBAImage *, uint64 *, uint32, uint32);
-static int gtTileSeparate(TIFFRGBAImage *, uint64 *, uint32, uint32);
-static int gtStripContig(TIFFRGBAImage *, uint64 *, uint32, uint32);
-static int gtStripSeparate(TIFFRGBAImage *, uint64 *, uint32, uint32);
-static int PickContigCase(TIFFRGBAImage *);
-static int PickSeparateCase(TIFFRGBAImage *);
+static int gtTileContig(TIFFRGBAImage*, uint64*, uint32, uint32);
+static int gtTileSeparate(TIFFRGBAImage*, uint64*, uint32, uint32);
+static int gtStripContig(TIFFRGBAImage*, uint64*, uint32, uint32);
+static int gtStripSeparate(TIFFRGBAImage*, uint64*, uint32, uint32);
+static int PickContigCase(TIFFRGBAImage*);
+static int PickSeparateCase(TIFFRGBAImage*);
 
-static int BuildMapUaToAa(TIFFRGBAImage *img);
-static int BuildMapBitdepth16To8(TIFFRGBAImage *img);
+static int BuildMapUaToAa(TIFFRGBAImage* img);
+static int BuildMapBitdepth16To8(TIFFRGBAImage* img);
 
 static const char photoTag[] = "PhotometricInterpretation";
 
@@ -66,38 +66,32 @@ static const char photoTag[] = "PhotometricInterpretation";
  */
 
 static const TIFFDisplay display_sRGB = {
-	{/* XYZ -> luminance matrix */
-	 {3.2410F, -1.5374F, -0.4986F},
-	 {-0.9692F, 1.8760F, 0.0416F},
-	 {0.0556F, -0.2040F, 1.0570F}},
-	100.0F,
-	100.0F,
-	100.0F, /* Light o/p for reference white */
-	255,
-	255,
-	255, /* Pixel values for ref. white */
-	1.0F,
-	1.0F,
-	1.0F, /* Residual light o/p for black pixel */
-	2.4F,
-	2.4F,
-	2.4F, /* Gamma values for the three guns */
+	{			/* XYZ -> luminance matrix */
+		{  3.2410F, -1.5374F, -0.4986F },
+		{  -0.9692F, 1.8760F, 0.0416F },
+		{  0.0556F, -0.2040F, 1.0570F }
+	},	
+	100.0F, 100.0F, 100.0F,	/* Light o/p for reference white */
+	255, 255, 255,		/* Pixel values for ref. white */
+	1.0F, 1.0F, 1.0F,	/* Residual light o/p for black pixel */
+	2.4F, 2.4F, 2.4F,	/* Gamma values for the three guns */
 };
 
 static int
-isCCITTCompression(TIFF *tif)
+isCCITTCompression(TIFF* tif)
 {
-	uint16 compress;
-	TIFFGetField(tif, TIFFTAG_COMPRESSION, &compress);
-	return (compress == COMPRESSION_CCITTFAX3 ||
-			compress == COMPRESSION_CCITTFAX4 ||
-			compress == COMPRESSION_CCITTRLE ||
-			compress == COMPRESSION_CCITTRLEW);
+    uint16 compress;
+    TIFFGetField(tif, TIFFTAG_COMPRESSION, &compress);
+    return (compress == COMPRESSION_CCITTFAX3 ||
+	    compress == COMPRESSION_CCITTFAX4 ||
+	    compress == COMPRESSION_CCITTRLE ||
+	    compress == COMPRESSION_CCITTRLEW);
 }
 
-int TIFFRGBAImageBegin_64(TIFFRGBAImage *img, TIFF *tif, int stop, char emsg[1024])
+int
+TIFFRGBAImageBegin_64(TIFFRGBAImage* img, TIFF* tif, int stop, char emsg[1024])
 {
-	uint16 *sampleinfo;
+	uint16* sampleinfo;
 	uint16 extrasamples;
 	uint16 planarconfig;
 	uint16 compress;
@@ -111,45 +105,49 @@ int TIFFRGBAImageBegin_64(TIFFRGBAImage *img, TIFF *tif, int stop, char emsg[102
 	img->redcmap = NULL;
 	img->greencmap = NULL;
 	img->bluecmap = NULL;
-	img->req_orientation = ORIENTATION_BOTLEFT; /* It is the default */
+	img->req_orientation = ORIENTATION_BOTLEFT;     /* It is the default */
 
 	img->tif = tif;
 	img->stoponerr = stop;
 	TIFFGetFieldDefaulted(tif, TIFFTAG_BITSPERSAMPLE, &img->bitspersample);
 	switch (img->bitspersample) {
-	case 1:
-	case 2:
-	case 4:
-	case 8:
-	case 16:
-		break;
-	default:
-		sprintf(emsg, "Sorry, can not handle images with %d-bit samples",
-				img->bitspersample);
-		goto fail_return;
+		case 1:
+		case 2:
+		case 4:
+		case 8:
+		case 16:
+			break;
+		default:
+			sprintf(emsg, "Sorry, can not handle images with %d-bit samples",
+			    img->bitspersample);
+			goto fail_return;
 	}
 	img->alpha = 0;
 	TIFFGetFieldDefaulted(tif, TIFFTAG_SAMPLESPERPIXEL, &img->samplesperpixel);
 	TIFFGetFieldDefaulted(tif, TIFFTAG_EXTRASAMPLES,
-						  &extrasamples, &sampleinfo);
-	if (extrasamples >= 1) {
+	    &extrasamples, &sampleinfo);
+	if (extrasamples >= 1)
+	{
 		switch (sampleinfo[0]) {
-		case EXTRASAMPLE_UNSPECIFIED:	 /* Workaround for some images without */
-			if (img->samplesperpixel > 3) /* correct info about alpha channel */
-				img->alpha = EXTRASAMPLE_ASSOCALPHA;
-			break;
-		case EXTRASAMPLE_ASSOCALPHA: /* data is pre-multiplied */
-		case EXTRASAMPLE_UNASSALPHA: /* data is not pre-multiplied */
-			img->alpha = sampleinfo[0];
-			break;
+			case EXTRASAMPLE_UNSPECIFIED:          /* Workaround for some images without */
+				if (img->samplesperpixel > 3)  /* correct info about alpha channel */
+					img->alpha = EXTRASAMPLE_ASSOCALPHA;
+				break;
+			case EXTRASAMPLE_ASSOCALPHA:           /* data is pre-multiplied */
+			case EXTRASAMPLE_UNASSALPHA:           /* data is not pre-multiplied */
+				img->alpha = sampleinfo[0];
+				break;
 		}
 	}
 
 #ifdef DEFAULT_EXTRASAMPLE_AS_ALPHA
-	if (!TIFFGetField(tif, TIFFTAG_PHOTOMETRIC, &img->photometric))
+	if( !TIFFGetField(tif, TIFFTAG_PHOTOMETRIC, &img->photometric))
 		img->photometric = PHOTOMETRIC_MINISWHITE;
 
-	if (extrasamples == 0 && img->samplesperpixel == 4 && img->photometric == PHOTOMETRIC_RGB) {
+	if( extrasamples == 0
+	    && img->samplesperpixel == 4
+	    && img->photometric == PHOTOMETRIC_RGB )
+	{
 		img->alpha = EXTRASAMPLE_ASSOCALPHA;
 		extrasamples = 1;
 	}
@@ -160,133 +158,137 @@ int TIFFRGBAImageBegin_64(TIFFRGBAImage *img, TIFF *tif, int stop, char emsg[102
 	TIFFGetFieldDefaulted(tif, TIFFTAG_PLANARCONFIG, &planarconfig);
 	if (!TIFFGetField(tif, TIFFTAG_PHOTOMETRIC, &img->photometric)) {
 		switch (colorchannels) {
-		case 1:
-			if (isCCITTCompression(tif))
-				img->photometric = PHOTOMETRIC_MINISWHITE;
-			else
-				img->photometric = PHOTOMETRIC_MINISBLACK;
-			break;
-		case 3:
-			img->photometric = PHOTOMETRIC_RGB;
-			break;
-		default:
-			sprintf(emsg, "Missing needed %s tag", photoTag);
-			goto fail_return;
+			case 1:
+				if (isCCITTCompression(tif))
+					img->photometric = PHOTOMETRIC_MINISWHITE;
+				else
+					img->photometric = PHOTOMETRIC_MINISBLACK;
+				break;
+			case 3:
+				img->photometric = PHOTOMETRIC_RGB;
+				break;
+			default:
+				sprintf(emsg, "Missing needed %s tag", photoTag);
+                                goto fail_return;
 		}
 	}
 	switch (img->photometric) {
-	case PHOTOMETRIC_PALETTE:
-		if (!TIFFGetField(tif, TIFFTAG_COLORMAP,
-						  &red_orig, &green_orig, &blue_orig)) {
-			sprintf(emsg, "Missing required \"Colormap\" tag");
-			goto fail_return;
-		}
+		case PHOTOMETRIC_PALETTE:
+			if (!TIFFGetField(tif, TIFFTAG_COLORMAP,
+			    &red_orig, &green_orig, &blue_orig)) {
+				sprintf(emsg, "Missing required \"Colormap\" tag");
+                                goto fail_return;
+			}
 
-		/* copy the colormaps so we can modify them */
-		n_color = (1L << img->bitspersample);
-		img->redcmap = (uint16 *)_TIFFmalloc(sizeof(uint16) * n_color);
-		img->greencmap = (uint16 *)_TIFFmalloc(sizeof(uint16) * n_color);
-		img->bluecmap = (uint16 *)_TIFFmalloc(sizeof(uint16) * n_color);
-		if (!img->redcmap || !img->greencmap || !img->bluecmap) {
-			sprintf(emsg, "Out of memory for colormap copy");
-			goto fail_return;
-		}
+			/* copy the colormaps so we can modify them */
+			n_color = (1L << img->bitspersample);
+			img->redcmap = (uint16 *) _TIFFmalloc(sizeof(uint16)*n_color);
+			img->greencmap = (uint16 *) _TIFFmalloc(sizeof(uint16)*n_color);
+			img->bluecmap = (uint16 *) _TIFFmalloc(sizeof(uint16)*n_color);
+			if( !img->redcmap || !img->greencmap || !img->bluecmap ) {
+				sprintf(emsg, "Out of memory for colormap copy");
+                                goto fail_return;
+			}
 
-		_TIFFmemcpy(img->redcmap, red_orig, n_color * 2);
-		_TIFFmemcpy(img->greencmap, green_orig, n_color * 2);
-		_TIFFmemcpy(img->bluecmap, blue_orig, n_color * 2);
+			_TIFFmemcpy( img->redcmap, red_orig, n_color * 2 );
+			_TIFFmemcpy( img->greencmap, green_orig, n_color * 2 );
+			_TIFFmemcpy( img->bluecmap, blue_orig, n_color * 2 );
 
-	/* fall thru... */
-	case PHOTOMETRIC_MINISWHITE:
-	case PHOTOMETRIC_MINISBLACK:
-		if (planarconfig == PLANARCONFIG_CONTIG && img->samplesperpixel != 1 && img->bitspersample < 8) {
-			sprintf(emsg,
-					"Sorry, can not handle contiguous data with %s=%d, "
-					"and %s=%d and Bits/Sample=%d",
-					photoTag, img->photometric,
-					"Samples/pixel", img->samplesperpixel,
-					img->bitspersample);
-			goto fail_return;
-		}
-		break;
-	case PHOTOMETRIC_YCBCR:
-		/* It would probably be nice to have a reality check here. */
-		if (planarconfig == PLANARCONFIG_CONTIG)
-			/* can rely on libjpeg to convert to RGB */
-			/* XXX should restore current state on exit */
-			switch (compress) {
-			case COMPRESSION_JPEG:
-				/*
+			/* fall thru... */
+		case PHOTOMETRIC_MINISWHITE:
+		case PHOTOMETRIC_MINISBLACK:
+			if (planarconfig == PLANARCONFIG_CONTIG
+			    && img->samplesperpixel != 1
+			    && img->bitspersample < 8 ) {
+				sprintf(emsg,
+				    "Sorry, can not handle contiguous data with %s=%d, "
+				    "and %s=%d and Bits/Sample=%d",
+				    photoTag, img->photometric,
+				    "Samples/pixel", img->samplesperpixel,
+				    img->bitspersample);
+                                goto fail_return;
+			}
+			break;
+		case PHOTOMETRIC_YCBCR:
+			/* It would probably be nice to have a reality check here. */
+			if (planarconfig == PLANARCONFIG_CONTIG)
+				/* can rely on libjpeg to convert to RGB */
+				/* XXX should restore current state on exit */
+				switch (compress) {
+					case COMPRESSION_JPEG:
+						/*
 						 * TODO: when complete tests verify complete desubsampling
 						 * and YCbCr handling, remove use of TIFFTAG_JPEGCOLORMODE in
 						 * favor of tif_getimage.c native handling
 						 */
-				TIFFSetField(tif, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
-				img->photometric = PHOTOMETRIC_RGB;
-				break;
-			default:
-				/* do nothing */;
-				break;
-			}
-		/*
+						TIFFSetField(tif, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
+						img->photometric = PHOTOMETRIC_RGB;
+						break;
+					default:
+						/* do nothing */;
+						break;
+				}
+			/*
 			 * TODO: if at all meaningful and useful, make more complete
 			 * support check here, or better still, refactor to let supporting
 			 * code decide whether there is support and what meaningfull
 			 * error to return
 			 */
-		break;
-	case PHOTOMETRIC_RGB:
-		if (colorchannels < 3) {
-			sprintf(emsg, "Sorry, can not handle RGB image with %s=%d",
-					"Color channels", colorchannels);
-			goto fail_return;
-		}
-		break;
-	case PHOTOMETRIC_SEPARATED: {
-		uint16 inkset;
-		TIFFGetFieldDefaulted(tif, TIFFTAG_INKSET, &inkset);
-		if (inkset != INKSET_CMYK) {
-			sprintf(emsg, "Sorry, can not handle separated image with %s=%d",
-					"InkSet", inkset);
-			goto fail_return;
-		}
-		if (img->samplesperpixel < 4) {
-			sprintf(emsg, "Sorry, can not handle separated image with %s=%d",
-					"Samples/pixel", img->samplesperpixel);
-			goto fail_return;
-		}
-	} break;
-	case PHOTOMETRIC_LOGL:
-		if (compress != COMPRESSION_SGILOG) {
-			sprintf(emsg, "Sorry, LogL data must have %s=%d",
-					"Compression", COMPRESSION_SGILOG);
-			goto fail_return;
-		}
-		TIFFSetField(tif, TIFFTAG_SGILOGDATAFMT, SGILOGDATAFMT_8BIT);
-		img->photometric = PHOTOMETRIC_MINISBLACK; /* little white lie */
-		img->bitspersample = 8;
-		break;
-	case PHOTOMETRIC_LOGLUV:
-		if (compress != COMPRESSION_SGILOG && compress != COMPRESSION_SGILOG24) {
-			sprintf(emsg, "Sorry, LogLuv data must have %s=%d or %d",
-					"Compression", COMPRESSION_SGILOG, COMPRESSION_SGILOG24);
-			goto fail_return;
-		}
-		if (planarconfig != PLANARCONFIG_CONTIG) {
-			sprintf(emsg, "Sorry, can not handle LogLuv images with %s=%d",
-					"Planarconfiguration", planarconfig);
-			return (0);
-		}
-		TIFFSetField(tif, TIFFTAG_SGILOGDATAFMT, SGILOGDATAFMT_8BIT);
-		img->photometric = PHOTOMETRIC_RGB; /* little white lie */
-		img->bitspersample = 8;
-		break;
-	case PHOTOMETRIC_CIELAB:
-		break;
-	default:
-		sprintf(emsg, "Sorry, can not handle image with %s=%d",
-				photoTag, img->photometric);
-		goto fail_return;
+			break;
+		case PHOTOMETRIC_RGB:
+			if (colorchannels < 3) {
+				sprintf(emsg, "Sorry, can not handle RGB image with %s=%d",
+				    "Color channels", colorchannels);
+                                goto fail_return;
+			}
+			break;
+		case PHOTOMETRIC_SEPARATED:
+			{
+				uint16 inkset;
+				TIFFGetFieldDefaulted(tif, TIFFTAG_INKSET, &inkset);
+				if (inkset != INKSET_CMYK) {
+					sprintf(emsg, "Sorry, can not handle separated image with %s=%d",
+					    "InkSet", inkset);
+                                        goto fail_return;
+				}
+				if (img->samplesperpixel < 4) {
+					sprintf(emsg, "Sorry, can not handle separated image with %s=%d",
+					    "Samples/pixel", img->samplesperpixel);
+                                        goto fail_return;
+				}
+			}
+			break;
+		case PHOTOMETRIC_LOGL:
+			if (compress != COMPRESSION_SGILOG) {
+				sprintf(emsg, "Sorry, LogL data must have %s=%d",
+				    "Compression", COMPRESSION_SGILOG);
+                                goto fail_return;
+			}
+			TIFFSetField(tif, TIFFTAG_SGILOGDATAFMT, SGILOGDATAFMT_8BIT);
+			img->photometric = PHOTOMETRIC_MINISBLACK;	/* little white lie */
+			img->bitspersample = 8;
+			break;
+		case PHOTOMETRIC_LOGLUV:
+			if (compress != COMPRESSION_SGILOG && compress != COMPRESSION_SGILOG24) {
+				sprintf(emsg, "Sorry, LogLuv data must have %s=%d or %d",
+				    "Compression", COMPRESSION_SGILOG, COMPRESSION_SGILOG24);
+                                goto fail_return;
+			}
+			if (planarconfig != PLANARCONFIG_CONTIG) {
+				sprintf(emsg, "Sorry, can not handle LogLuv images with %s=%d",
+				    "Planarconfiguration", planarconfig);
+				return (0);
+			}
+			TIFFSetField(tif, TIFFTAG_SGILOGDATAFMT, SGILOGDATAFMT_8BIT);
+			img->photometric = PHOTOMETRIC_RGB;		/* little white lie */
+			img->bitspersample = 8;
+			break;
+		case PHOTOMETRIC_CIELAB:
+			break;
+		default:
+			sprintf(emsg, "Sorry, can not handle image with %s=%d",
+			    photoTag, img->photometric);
+                        goto fail_return;
 	}
 	img->Map = NULL;
 	img->BWmap = NULL;
@@ -299,7 +301,7 @@ int TIFFRGBAImageBegin_64(TIFFRGBAImage *img, TIFF *tif, int stop, char emsg[102
 	TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &img->height);
 	TIFFGetFieldDefaulted(tif, TIFFTAG_ORIENTATION, &img->orientation);
 	img->isContig =
-		!(planarconfig == PLANARCONFIG_SEPARATE && img->samplesperpixel > 1);
+	    !(planarconfig == PLANARCONFIG_SEPARATE && img->samplesperpixel > 1);
 	if (img->isContig) {
 		if (!PickContigCase(img)) {
 			sprintf(emsg, "Sorry, can not handle image");
@@ -313,93 +315,94 @@ int TIFFRGBAImageBegin_64(TIFFRGBAImage *img, TIFF *tif, int stop, char emsg[102
 	}
 	return 1;
 
-fail_return:
-	_TIFFfree(img->redcmap);
-	_TIFFfree(img->greencmap);
-	_TIFFfree(img->bluecmap);
-	img->redcmap = img->greencmap = img->bluecmap = NULL;
-	return 0;
+  fail_return:
+        _TIFFfree( img->redcmap );
+        _TIFFfree( img->greencmap );
+        _TIFFfree( img->bluecmap );
+        img->redcmap = img->greencmap = img->bluecmap = NULL;
+        return 0;
 }
 
-int TIFFRGBAImageGet_64(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
+int
+TIFFRGBAImageGet_64(TIFFRGBAImage* img, uint64* raster, uint32 w, uint32 h)
 {
 	gtFunc_64 get = (gtFunc_64)img->get;
 
-	if (img->get == NULL) {
+    if (img->get == NULL) {
 		TIFFErrorExt(img->tif->tif_clientdata, TIFFFileName(img->tif), "No \"get\" routine setup");
 		return (0);
 	}
 	if (img->put.any == NULL) {
 		TIFFErrorExt(img->tif->tif_clientdata, TIFFFileName(img->tif),
-					 "No \"put\" routine setupl; probably can not handle image format");
+		"No \"put\" routine setupl; probably can not handle image format");
 		return (0);
-	}
+    }
 
-	// Casting between 2 function pointers is allowed in and C++ and works as expected
-	// if re-casted back.
-	// See C 6.3.2.3 (8) and 5.2.10 (6)
+    // Casting between 2 function pointers is allowed in and C++ and works as expected
+    // if re-casted back.
+    // See C 6.3.2.3 (8) and 5.2.10 (6)
 
-	return (*get)(img, raster, w, h);
+    return (*get)(img, raster, w, h);
 }
 
-static int
-setorientation(TIFFRGBAImage *img)
+static int 
+setorientation(TIFFRGBAImage* img)
 {
 	switch (img->orientation) {
-	case ORIENTATION_TOPLEFT:
-	case ORIENTATION_LEFTTOP:
-		if (img->req_orientation == ORIENTATION_TOPRIGHT ||
-			img->req_orientation == ORIENTATION_RIGHTTOP)
-			return FLIP_HORIZONTALLY;
-		else if (img->req_orientation == ORIENTATION_BOTRIGHT ||
-				 img->req_orientation == ORIENTATION_RIGHTBOT)
-			return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
-		else if (img->req_orientation == ORIENTATION_BOTLEFT ||
-				 img->req_orientation == ORIENTATION_LEFTBOT)
-			return FLIP_VERTICALLY;
-		else
+		case ORIENTATION_TOPLEFT:
+		case ORIENTATION_LEFTTOP:
+			if (img->req_orientation == ORIENTATION_TOPRIGHT ||
+			    img->req_orientation == ORIENTATION_RIGHTTOP)
+				return FLIP_HORIZONTALLY;
+			else if (img->req_orientation == ORIENTATION_BOTRIGHT ||
+			    img->req_orientation == ORIENTATION_RIGHTBOT)
+				return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
+			else if (img->req_orientation == ORIENTATION_BOTLEFT ||
+			    img->req_orientation == ORIENTATION_LEFTBOT)
+				return FLIP_VERTICALLY;
+			else
+				return 0;
+		case ORIENTATION_TOPRIGHT:
+		case ORIENTATION_RIGHTTOP:
+			if (img->req_orientation == ORIENTATION_TOPLEFT ||
+			    img->req_orientation == ORIENTATION_LEFTTOP)
+				return FLIP_HORIZONTALLY;
+			else if (img->req_orientation == ORIENTATION_BOTRIGHT ||
+			    img->req_orientation == ORIENTATION_RIGHTBOT)
+				return FLIP_VERTICALLY;
+			else if (img->req_orientation == ORIENTATION_BOTLEFT ||
+			    img->req_orientation == ORIENTATION_LEFTBOT)
+				return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
+			else
+				return 0;
+		case ORIENTATION_BOTRIGHT:
+		case ORIENTATION_RIGHTBOT:
+			if (img->req_orientation == ORIENTATION_TOPLEFT ||
+			    img->req_orientation == ORIENTATION_LEFTTOP)
+				return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
+			else if (img->req_orientation == ORIENTATION_TOPRIGHT ||
+			    img->req_orientation == ORIENTATION_RIGHTTOP)
+				return FLIP_VERTICALLY;
+			else if (img->req_orientation == ORIENTATION_BOTLEFT ||
+			    img->req_orientation == ORIENTATION_LEFTBOT)
+				return FLIP_HORIZONTALLY;
+			else
+				return 0;
+		case ORIENTATION_BOTLEFT:
+		case ORIENTATION_LEFTBOT:
+			if (img->req_orientation == ORIENTATION_TOPLEFT ||
+			    img->req_orientation == ORIENTATION_LEFTTOP)
+				return FLIP_VERTICALLY;
+			else if (img->req_orientation == ORIENTATION_TOPRIGHT ||
+			    img->req_orientation == ORIENTATION_RIGHTTOP)
+				return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
+			else if (img->req_orientation == ORIENTATION_BOTRIGHT ||
+			    img->req_orientation == ORIENTATION_RIGHTBOT)
+				return FLIP_HORIZONTALLY;
+			else
+				return 0;
+		default:	/* NOTREACHED */
 			return 0;
-	case ORIENTATION_TOPRIGHT:
-	case ORIENTATION_RIGHTTOP:
-		if (img->req_orientation == ORIENTATION_TOPLEFT ||
-			img->req_orientation == ORIENTATION_LEFTTOP)
-			return FLIP_HORIZONTALLY;
-		else if (img->req_orientation == ORIENTATION_BOTRIGHT ||
-				 img->req_orientation == ORIENTATION_RIGHTBOT)
-			return FLIP_VERTICALLY;
-		else if (img->req_orientation == ORIENTATION_BOTLEFT ||
-				 img->req_orientation == ORIENTATION_LEFTBOT)
-			return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
-		else
-			return 0;
-	case ORIENTATION_BOTRIGHT:
-	case ORIENTATION_RIGHTBOT:
-		if (img->req_orientation == ORIENTATION_TOPLEFT ||
-			img->req_orientation == ORIENTATION_LEFTTOP)
-			return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
-		else if (img->req_orientation == ORIENTATION_TOPRIGHT ||
-				 img->req_orientation == ORIENTATION_RIGHTTOP)
-			return FLIP_VERTICALLY;
-		else if (img->req_orientation == ORIENTATION_BOTLEFT ||
-				 img->req_orientation == ORIENTATION_LEFTBOT)
-			return FLIP_HORIZONTALLY;
-		else
-			return 0;
-	case ORIENTATION_BOTLEFT:
-	case ORIENTATION_LEFTBOT:
-		if (img->req_orientation == ORIENTATION_TOPLEFT ||
-			img->req_orientation == ORIENTATION_LEFTTOP)
-			return FLIP_VERTICALLY;
-		else if (img->req_orientation == ORIENTATION_TOPRIGHT ||
-				 img->req_orientation == ORIENTATION_RIGHTTOP)
-			return FLIP_HORIZONTALLY | FLIP_VERTICALLY;
-		else if (img->req_orientation == ORIENTATION_BOTRIGHT ||
-				 img->req_orientation == ORIENTATION_RIGHTBOT)
-			return FLIP_HORIZONTALLY;
-		else
-			return 0;
-	default: /* NOTREACHED */
-		return 0;
 	}
 }
 
@@ -408,86 +411,92 @@ setorientation(TIFFRGBAImage *img)
  *	PlanarConfiguration contiguous if SamplesPerPixel > 1
  * or
  *	SamplesPerPixel == 1
- */
+ */	
 static int
-gtTileContig(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
+gtTileContig(TIFFRGBAImage* img, uint64* raster, uint32 w, uint32 h)
 {
-	TIFF *tif = img->tif;
-	tileContigRoutine_64 put = (tileContigRoutine_64)img->put.contig;
-	uint32 col, row, y, rowstoread;
-	tmsize_t pos;
-	uint32 tw, th;
-	unsigned char *buf;
-	int32 fromskew, toskew;
-	uint32 nrow;
-	int ret = 1, flip;
+    TIFF* tif = img->tif;
+    tileContigRoutine_64 put = (tileContigRoutine_64)img->put.contig;
+    uint32 col, row, y, rowstoread;
+    tmsize_t pos;
+    uint32 tw, th;
+    unsigned char* buf;
+    int32 fromskew, toskew;
+    uint32 nrow;
+    int ret = 1, flip;
 
-	buf = (unsigned char *)_TIFFmalloc(TIFFTileSize(tif));
-	if (buf == 0) {
+    buf = (unsigned char*) _TIFFmalloc(TIFFTileSize(tif));
+    if (buf == 0) {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", "No space for tile buffer");
 		return (0);
-	}
-	_TIFFmemset(buf, 0, TIFFTileSize(tif));
-	TIFFGetField(tif, TIFFTAG_TILEWIDTH, &tw);
-	TIFFGetField(tif, TIFFTAG_TILELENGTH, &th);
+    }
+    _TIFFmemset(buf, 0, TIFFTileSize(tif));
+    TIFFGetField(tif, TIFFTAG_TILEWIDTH, &tw);
+    TIFFGetField(tif, TIFFTAG_TILELENGTH, &th);
 
-	flip = setorientation(img);
-	if (flip & FLIP_VERTICALLY) {
-		y = h - 1;
-		toskew = -(int32)(tw + w);
-	} else {
-		y = 0;
-		toskew = -(int32)(tw - w);
-	}
+    flip = setorientation(img);
+    if (flip & FLIP_VERTICALLY) {
+	    y = h - 1;
+	    toskew = -(int32)(tw + w);
+    }
+    else {
+	    y = 0;
+	    toskew = -(int32)(tw - w);
+    }
+     
+    for (row = 0; row < h; row += nrow)
+    {
+        rowstoread = th - (row + img->row_offset) % th;
+    	nrow = (row + rowstoread > h ? h - row : rowstoread);
+	for (col = 0; col < w; col += tw) 
+        {
+	    if (TIFFReadTile(tif, buf, col+img->col_offset,  
+			     row+img->row_offset, 0, 0)==(tmsize_t)(-1) && img->stoponerr)
+            {
+                ret = 0;
+                break;
+            }
+	    
+	    pos = ((row+img->row_offset) % th) * TIFFTileRowSize(tif);  
 
-	for (row = 0; row < h; row += nrow) {
-		rowstoread = th - (row + img->row_offset) % th;
-		nrow = (row + rowstoread > h ? h - row : rowstoread);
-		for (col = 0; col < w; col += tw) {
-			if (TIFFReadTile(tif, buf, col + img->col_offset,
-							 row + img->row_offset, 0, 0) == (tmsize_t)(-1) &&
-				img->stoponerr) {
-				ret = 0;
-				break;
-			}
-
-			pos = ((row + img->row_offset) % th) * TIFFTileRowSize(tif);
-
-			if (col + tw > w) {
-				/*
+    	    if (col + tw > w) 
+            {
+                /*
                  * Tile is clipped horizontally.  Calculate
                  * visible portion and skewing factors.
                  */
-				uint32 npix = w - col;
-				fromskew = tw - npix;
-				(*put)(img, raster + y * w + col, col, y,
-					   npix, nrow, fromskew, toskew + fromskew, buf + pos);
-			} else {
-				(*put)(img, raster + y * w + col, col, y, tw, nrow, 0, toskew, buf + pos);
-			}
-		}
+                uint32 npix = w - col;
+                fromskew = tw - npix;
+                (*put)(img, raster+y*w+col, col, y,
+                       npix, nrow, fromskew, toskew + fromskew, buf + pos);
+            }
+            else 
+            {
+                (*put)(img, raster+y*w+col, col, y, tw, nrow, 0, toskew, buf + pos);
+            }
+        }
 
-		y += (flip & FLIP_VERTICALLY ? -(int32)nrow : (int32)nrow);
-	}
-	_TIFFfree(buf);
+        y += (flip & FLIP_VERTICALLY ? -(int32) nrow : (int32) nrow);
+    }
+    _TIFFfree(buf);
 
-	if (flip & FLIP_HORIZONTALLY) {
-		uint32 line;
+    if (flip & FLIP_HORIZONTALLY) {
+	    uint32 line;
 
-		for (line = 0; line < h; line++) {
-			uint64 *left = raster + (line * w);
-			uint64 *right = left + w - 1;
+	    for (line = 0; line < h; line++) {
+		    uint64 *left = raster + (line * w);
+		    uint64 *right = left + w - 1;
+		    
+		    while ( left < right ) {
+			    uint64 temp = *left;
+			    *left = *right;
+			    *right = temp;
+			    left++, right--;
+		    }
+	    }
+    }
 
-			while (left < right) {
-				uint64 temp = *left;
-				*left = *right;
-				*right = temp;
-				left++, right--;
-			}
-		}
-	}
-
-	return (ret);
+    return (ret);
 }
 
 /*
@@ -495,35 +504,35 @@ gtTileContig(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
  *	 SamplesPerPixel > 1
  *	 PlanarConfiguration separated
  * We assume that all such images are RGB.
- */
+ */	
 static int
-gtTileSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
+gtTileSeparate(TIFFRGBAImage* img, uint64* raster, uint32 w, uint32 h)
 {
-	TIFF *tif = img->tif;
+	TIFF* tif = img->tif;
 	tileSeparateRoutine_64 put = (tileSeparateRoutine_64)img->put.separate;
 	uint32 col, row, y, rowstoread;
 	tmsize_t pos;
 	uint32 tw, th;
-	unsigned char *buf;
-	unsigned char *p0;
-	unsigned char *p1;
-	unsigned char *p2;
-	unsigned char *pa;
+	unsigned char* buf;
+	unsigned char* p0;
+	unsigned char* p1;
+	unsigned char* p2;
+	unsigned char* pa;
 	tmsize_t tilesize;
 	tmsize_t bufsize;
 	int32 fromskew, toskew;
 	int alpha = img->alpha;
 	uint32 nrow;
 	int ret = 1, flip;
-	int colorchannels;
+        int colorchannels;
 
-	tilesize = TIFFTileSize(tif);
-	bufsize = TIFFSafeMultiply(tmsize_t, alpha ? 4 : 3, tilesize);
+	tilesize = TIFFTileSize(tif);  
+	bufsize = TIFFSafeMultiply(tmsize_t,alpha?4:3,tilesize);
 	if (bufsize == 0) {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "Integer overflow in %s", "gtTileSeparate");
 		return (0);
 	}
-	buf = (unsigned char *)_TIFFmalloc(bufsize);
+	buf = (unsigned char*) _TIFFmalloc(bufsize);
 	if (buf == 0) {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", "No space for tile buffer");
 		return (0);
@@ -532,7 +541,7 @@ gtTileSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 	p0 = buf;
 	p1 = p0 + tilesize;
 	p2 = p1 + tilesize;
-	pa = (alpha ? (p2 + tilesize) : NULL);
+	pa = (alpha?(p2+tilesize):NULL);
 	TIFFGetField(tif, TIFFTAG_TILEWIDTH, &tw);
 	TIFFGetField(tif, TIFFTAG_TILELENGTH, &th);
 
@@ -540,66 +549,83 @@ gtTileSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 	if (flip & FLIP_VERTICALLY) {
 		y = h - 1;
 		toskew = -(int32)(tw + w);
-	} else {
+	}
+	else {
 		y = 0;
 		toskew = -(int32)(tw - w);
 	}
 
-	switch (img->photometric) {
-	case PHOTOMETRIC_MINISWHITE:
-	case PHOTOMETRIC_MINISBLACK:
-	case PHOTOMETRIC_PALETTE:
-		colorchannels = 1;
-		p2 = p1 = p0;
-		break;
+        switch( img->photometric )
+        {
+          case PHOTOMETRIC_MINISWHITE:
+          case PHOTOMETRIC_MINISBLACK:
+          case PHOTOMETRIC_PALETTE:
+            colorchannels = 1;
+            p2 = p1 = p0;
+            break;
 
-	default:
-		colorchannels = 3;
-		break;
-	}
+          default:
+            colorchannels = 3;
+            break;
+        }
 
-	for (row = 0; row < h; row += nrow) {
+	for (row = 0; row < h; row += nrow)
+	{
 		rowstoread = th - (row + img->row_offset) % th;
 		nrow = (row + rowstoread > h ? h - row : rowstoread);
-		for (col = 0; col < w; col += tw) {
-			if (TIFFReadTile(tif, p0, col + img->col_offset,
-							 row + img->row_offset, 0, 0) == (tmsize_t)(-1) &&
-				img->stoponerr) {
+		for (col = 0; col < w; col += tw)
+		{
+			if (TIFFReadTile(tif, p0, col+img->col_offset,  
+			    row+img->row_offset,0,0)==(tmsize_t)(-1) && img->stoponerr)
+			{
 				ret = 0;
 				break;
 			}
-			if (colorchannels > 1 && TIFFReadTile(tif, p1, col + img->col_offset, row + img->row_offset, 0, 1) == (tmsize_t)(-1) && img->stoponerr) {
+			if (colorchannels > 1 
+                            && TIFFReadTile(tif, p1, col+img->col_offset,  
+                                            row+img->row_offset,0,1) == (tmsize_t)(-1) 
+                            && img->stoponerr)
+			{
 				ret = 0;
 				break;
 			}
-			if (colorchannels > 1 && TIFFReadTile(tif, p2, col + img->col_offset, row + img->row_offset, 0, 2) == (tmsize_t)(-1) && img->stoponerr) {
+			if (colorchannels > 1 
+                            && TIFFReadTile(tif, p2, col+img->col_offset,  
+                                            row+img->row_offset,0,2) == (tmsize_t)(-1) 
+                            && img->stoponerr)
+			{
 				ret = 0;
 				break;
 			}
-			if (alpha && TIFFReadTile(tif, pa, col + img->col_offset, row + img->row_offset, 0, colorchannels) == (tmsize_t)(-1) && img->stoponerr) {
-				ret = 0;
-				break;
+			if (alpha
+                            && TIFFReadTile(tif,pa,col+img->col_offset,  
+                                            row+img->row_offset,0,colorchannels) == (tmsize_t)(-1) 
+                            && img->stoponerr)
+                        {
+                            ret = 0;
+                            break;
 			}
 
-			pos = ((row + img->row_offset) % th) * TIFFTileRowSize(tif);
+			pos = ((row+img->row_offset) % th) * TIFFTileRowSize(tif);  
 
-			if (col + tw > w) {
+			if (col + tw > w)
+			{
 				/*
 				 * Tile is clipped horizontally.  Calculate
 				 * visible portion and skewing factors.
 				 */
 				uint32 npix = w - col;
 				fromskew = tw - npix;
-				(*put)(img, raster + y * w + col, col, y,
-					   npix, nrow, fromskew, toskew + fromskew,
-					   p0 + pos, p1 + pos, p2 + pos, (alpha ? (pa + pos) : NULL));
+				(*put)(img, raster+y*w+col, col, y,
+				    npix, nrow, fromskew, toskew + fromskew,
+				    p0 + pos, p1 + pos, p2 + pos, (alpha?(pa+pos):NULL));
 			} else {
-				(*put)(img, raster + y * w + col, col, y,
-					   tw, nrow, 0, toskew, p0 + pos, p1 + pos, p2 + pos, (alpha ? (pa + pos) : NULL));
+				(*put)(img, raster+y*w+col, col, y,
+				    tw, nrow, 0, toskew, p0 + pos, p1 + pos, p2 + pos, (alpha?(pa+pos):NULL));
 			}
 		}
 
-		y += (flip & FLIP_VERTICALLY ? -(int32)nrow : (int32)nrow);
+		y += (flip & FLIP_VERTICALLY ?-(int32) nrow : (int32) nrow);
 	}
 
 	if (flip & FLIP_HORIZONTALLY) {
@@ -609,7 +635,7 @@ gtTileSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 			uint64 *left = raster + (line * w);
 			uint64 *right = left + w - 1;
 
-			while (left < right) {
+			while ( left < right ) {
 				uint64 temp = *left;
 				*left = *right;
 				*right = temp;
@@ -627,23 +653,23 @@ gtTileSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
  *	PlanarConfiguration contiguous if SamplesPerPixel > 1
  * or
  *	SamplesPerPixel == 1
- */
+ */	
 static int
-gtStripContig(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
+gtStripContig(TIFFRGBAImage* img, uint64* raster, uint32 w, uint32 h)
 {
-	TIFF *tif = img->tif;
+	TIFF* tif = img->tif;
 	tileContigRoutine_64 put = (tileContigRoutine_64)img->put.contig;
 	uint32 row, y, nrow, nrowsub, rowstoread;
 	tmsize_t pos;
-	unsigned char *buf;
+	unsigned char* buf;
 	uint32 rowsperstrip;
-	uint16 subsamplinghor, subsamplingver;
+	uint16 subsamplinghor,subsamplingver;
 	uint32 imagewidth = img->width;
 	tmsize_t scanline;
 	int32 fromskew, toskew;
 	int ret = 1, flip;
 
-	buf = (unsigned char *)_TIFFmalloc(TIFFStripSize(tif));
+	buf = (unsigned char*) _TIFFmalloc(TIFFStripSize(tif));
 	if (buf == 0) {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "No space for strip buffer");
 		return (0);
@@ -663,24 +689,26 @@ gtStripContig(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 	TIFFGetFieldDefaulted(tif, TIFFTAG_YCBCRSUBSAMPLING, &subsamplinghor, &subsamplingver);
 	scanline = TIFFScanlineSize(tif);
 	fromskew = (w < imagewidth ? imagewidth - w : 0);
-	for (row = 0; row < h; row += nrow) {
+	for (row = 0; row < h; row += nrow)
+	{
 		rowstoread = rowsperstrip - (row + img->row_offset) % rowsperstrip;
 		nrow = (row + rowstoread > h ? h - row : rowstoread);
 		nrowsub = nrow;
-		if ((nrowsub % subsamplingver) != 0)
-			nrowsub += subsamplingver - nrowsub % subsamplingver;
+		if ((nrowsub%subsamplingver)!=0)
+			nrowsub+=subsamplingver-nrowsub%subsamplingver;
 		if (TIFFReadEncodedStrip(tif,
-								 TIFFComputeStrip(tif, row + img->row_offset, 0),
-								 buf,
-								 ((row + img->row_offset) % rowsperstrip + nrowsub) * scanline) == (tmsize_t)(-1) &&
-			img->stoponerr) {
+		    TIFFComputeStrip(tif,row+img->row_offset, 0),
+		    buf,
+		    ((row + img->row_offset)%rowsperstrip + nrowsub) * scanline)==(tmsize_t)(-1)
+		    && img->stoponerr)
+		{
 			ret = 0;
 			break;
 		}
 
 		pos = ((row + img->row_offset) % rowsperstrip) * scanline;
-		(*put)(img, raster + y * w, 0, y, w, nrow, fromskew, toskew, buf + pos);
-		y += (flip & FLIP_VERTICALLY ? -(int32)nrow : (int32)nrow);
+		(*put)(img, raster+y*w, 0, y, w, nrow, fromskew, toskew, buf + pos);
+		y += (flip & FLIP_VERTICALLY ? -(int32) nrow : (int32) nrow);
 	}
 
 	if (flip & FLIP_HORIZONTALLY) {
@@ -690,7 +718,7 @@ gtStripContig(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 			uint64 *left = raster + (line * w);
 			uint64 *right = left + w - 1;
 
-			while (left < right) {
+			while ( left < right ) {
 				uint64 temp = *left;
 				*left = *right;
 				*right = temp;
@@ -710,9 +738,9 @@ gtStripContig(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
  * We assume that all such images are RGB.
  */
 static int
-gtStripSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
+gtStripSeparate(TIFFRGBAImage* img, uint64* raster, uint32 w, uint32 h)
 {
-	TIFF *tif = img->tif;
+	TIFF* tif = img->tif;
 	tileSeparateRoutine_64 put = (tileSeparateRoutine_64)img->put.separate;
 	unsigned char *buf;
 	unsigned char *p0, *p1, *p2, *pa;
@@ -727,8 +755,8 @@ gtStripSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 	int alpha = img->alpha;
 	int ret = 1, flip, colorchannels;
 
-	stripsize = TIFFStripSize(tif);
-	bufsize = TIFFSafeMultiply(tmsize_t, alpha ? 4 : 3, stripsize);
+	stripsize = TIFFStripSize(tif);  
+	bufsize = TIFFSafeMultiply(tmsize_t,alpha?4:3,stripsize);
 	if (bufsize == 0) {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "Integer overflow in %s", "gtStripSeparate");
 		return (0);
@@ -741,64 +769,78 @@ gtStripSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 	_TIFFmemset(buf, 0, bufsize);
 	p1 = p0 + stripsize;
 	p2 = p1 + stripsize;
-	pa = (alpha ? (p2 + stripsize) : NULL);
+	pa = (alpha?(p2+stripsize):NULL);
 
 	flip = setorientation(img);
 	if (flip & FLIP_VERTICALLY) {
 		y = h - 1;
 		toskew = -(int32)(w + w);
-	} else {
+	}
+	else {
 		y = 0;
 		toskew = -(int32)(w - w);
 	}
 
-	switch (img->photometric) {
-	case PHOTOMETRIC_MINISWHITE:
-	case PHOTOMETRIC_MINISBLACK:
-	case PHOTOMETRIC_PALETTE:
-		colorchannels = 1;
-		p2 = p1 = p0;
-		break;
+        switch( img->photometric )
+        {
+          case PHOTOMETRIC_MINISWHITE:
+          case PHOTOMETRIC_MINISBLACK:
+          case PHOTOMETRIC_PALETTE:
+            colorchannels = 1;
+            p2 = p1 = p0;
+            break;
 
-	default:
-		colorchannels = 3;
-		break;
-	}
+          default:
+            colorchannels = 3;
+            break;
+        }
 
 	TIFFGetFieldDefaulted(tif, TIFFTAG_ROWSPERSTRIP, &rowsperstrip);
-	scanline = TIFFScanlineSize(tif);
+	scanline = TIFFScanlineSize(tif);  
 	fromskew = (w < imagewidth ? imagewidth - w : 0);
-	for (row = 0; row < h; row += nrow) {
+	for (row = 0; row < h; row += nrow)
+	{
 		rowstoread = rowsperstrip - (row + img->row_offset) % rowsperstrip;
 		nrow = (row + rowstoread > h ? h - row : rowstoread);
 		offset_row = row + img->row_offset;
 		if (TIFFReadEncodedStrip(tif, TIFFComputeStrip(tif, offset_row, 0),
-								 p0, ((row + img->row_offset) % rowsperstrip + nrow) * scanline) == (tmsize_t)(-1) &&
-			img->stoponerr) {
+		    p0, ((row + img->row_offset)%rowsperstrip + nrow) * scanline)==(tmsize_t)(-1)
+		    && img->stoponerr)
+		{
 			ret = 0;
 			break;
 		}
-		if (colorchannels > 1 && TIFFReadEncodedStrip(tif, TIFFComputeStrip(tif, offset_row, 1), p1, ((row + img->row_offset) % rowsperstrip + nrow) * scanline) == (tmsize_t)(-1) && img->stoponerr) {
+		if (colorchannels > 1 
+                    && TIFFReadEncodedStrip(tif, TIFFComputeStrip(tif, offset_row, 1),
+                                            p1, ((row + img->row_offset)%rowsperstrip + nrow) * scanline) == (tmsize_t)(-1)
+		    && img->stoponerr)
+		{
 			ret = 0;
 			break;
 		}
-		if (colorchannels > 1 && TIFFReadEncodedStrip(tif, TIFFComputeStrip(tif, offset_row, 2), p2, ((row + img->row_offset) % rowsperstrip + nrow) * scanline) == (tmsize_t)(-1) && img->stoponerr) {
+		if (colorchannels > 1 
+                    && TIFFReadEncodedStrip(tif, TIFFComputeStrip(tif, offset_row, 2),
+                                            p2, ((row + img->row_offset)%rowsperstrip + nrow) * scanline) == (tmsize_t)(-1)
+		    && img->stoponerr)
+		{
 			ret = 0;
 			break;
 		}
-		if (alpha) {
+		if (alpha)
+		{
 			if (TIFFReadEncodedStrip(tif, TIFFComputeStrip(tif, offset_row, colorchannels),
-									 pa, ((row + img->row_offset) % rowsperstrip + nrow) * scanline) == (tmsize_t)(-1) &&
-				img->stoponerr) {
+			    pa, ((row + img->row_offset)%rowsperstrip + nrow) * scanline)==(tmsize_t)(-1)
+			    && img->stoponerr)
+			{
 				ret = 0;
 				break;
 			}
 		}
 
 		pos = ((row + img->row_offset) % rowsperstrip) * scanline;
-		(*put)(img, raster + y * w, 0, y, w, nrow, fromskew, toskew, p0 + pos, p1 + pos,
-			   p2 + pos, (alpha ? (pa + pos) : NULL));
-		y += (flip & FLIP_VERTICALLY ? -(int32)nrow : (int32)nrow);
+		(*put)(img, raster+y*w, 0, y, w, nrow, fromskew, toskew, p0 + pos, p1 + pos,
+		    p2 + pos, (alpha?(pa+pos):NULL));
+		y += (flip & FLIP_VERTICALLY ? -(int32) nrow : (int32) nrow);
 	}
 
 	if (flip & FLIP_HORIZONTALLY) {
@@ -808,7 +850,7 @@ gtStripSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
 			uint64 *left = raster + (line * w);
 			uint64 *right = left + w - 1;
 
-			while (left < right) {
+			while ( left < right ) {
 				uint64 temp = *left;
 				*left = *right;
 				*right = temp;
@@ -831,134 +873,97 @@ gtStripSeparate(TIFFRGBAImage *img, uint64 *raster, uint32 w, uint32 h)
  * PickSeparateCase analyze the parameters and select
  * the appropriate "get" and "put" routine to use.
  */
-#define REPEAT8(op) \
-	REPEAT4(op);    \
-	REPEAT4(op)
-#define REPEAT4(op) \
-	REPEAT2(op);    \
-	REPEAT2(op)
-#define REPEAT2(op) \
-	op;             \
-	op
-#define CASE8(x, op) \
-	switch (x) {     \
-	case 7:          \
-		op;          \
-	case 6:          \
-		op;          \
-	case 5:          \
-		op;          \
-	case 4:          \
-		op;          \
-	case 3:          \
-		op;          \
-	case 2:          \
-		op;          \
-	case 1:          \
-		op;          \
-	}
-#define CASE4(x, op) \
-	switch (x) {     \
-	case 3:          \
-		op;          \
-	case 2:          \
-		op;          \
-	case 1:          \
-		op;          \
-	}
-#define NOP
+#define	REPEAT8(op)	REPEAT4(op); REPEAT4(op)
+#define	REPEAT4(op)	REPEAT2(op); REPEAT2(op)
+#define	REPEAT2(op)	op; op
+#define	CASE8(x,op)			\
+    switch (x) {			\
+    case 7: op; case 6: op; case 5: op;	\
+    case 4: op; case 3: op; case 2: op;	\
+    case 1: op;				\
+    }
+#define	CASE4(x,op)	switch (x) { case 3: op; case 2: op; case 1: op; }
+#define	NOP
 
-#define UNROLL8(w, op1, op2)             \
-	{                                    \
-		uint32 _x;                       \
-		for (_x = w; _x >= 8; _x -= 8) { \
-			op1;                         \
-			REPEAT8(op2);                \
-		}                                \
-		if (_x > 0) {                    \
-			op1;                         \
-			CASE8(_x, op2);              \
-		}                                \
-	}
-#define UNROLL4(w, op1, op2)             \
-	{                                    \
-		uint64 _x;                       \
-		for (_x = w; _x >= 4; _x -= 4) { \
-			op1;                         \
-			REPEAT4(op2);                \
-		}                                \
-		if (_x > 0) {                    \
-			op1;                         \
-			CASE4(_x, op2);              \
-		}                                \
-	}
-#define UNROLL2(w, op1, op2)             \
-	{                                    \
-		uint64 _x;                       \
-		for (_x = w; _x >= 2; _x -= 2) { \
-			op1;                         \
-			REPEAT2(op2);                \
-		}                                \
-		if (_x) {                        \
-			op1;                         \
-			op2;                         \
-		}                                \
-	}
-
-#define SKEW(r, g, b, skew) \
-	{                       \
-		r += skew;          \
-		g += skew;          \
-		b += skew;          \
-	}
-#define SKEW4(r, g, b, a, skew) \
-	{                           \
-		r += skew;              \
-		g += skew;              \
-		b += skew;              \
-		a += skew;              \
-	}
+#define	UNROLL8(w, op1, op2) {		\
+    uint32 _x;				\
+    for (_x = w; _x >= 8; _x -= 8) {	\
+	op1;				\
+	REPEAT8(op2);			\
+    }					\
+    if (_x > 0) {			\
+	op1;				\
+	CASE8(_x,op2);			\
+    }					\
+}
+#define	UNROLL4(w, op1, op2) {		\
+    uint64 _x;				\
+    for (_x = w; _x >= 4; _x -= 4) {	\
+	op1;				\
+	REPEAT4(op2);			\
+    }					\
+    if (_x > 0) {			\
+	op1;				\
+	CASE4(_x,op2);			\
+    }					\
+}
+#define	UNROLL2(w, op1, op2) {		\
+    uint64 _x;				\
+    for (_x = w; _x >= 2; _x -= 2) {	\
+	op1;				\
+	REPEAT2(op2);			\
+    }					\
+    if (_x) {				\
+	op1;				\
+	op2;				\
+    }					\
+}
+    
+#define	SKEW(r,g,b,skew)	{ r += skew; g += skew; b += skew; }
+#define	SKEW4(r,g,b,a,skew)	{ r += skew; g += skew; b += skew; a+= skew; }
 
 #define A1 (((uint64)0xffffL) << 48)
 #define PACK_32(r, g, b) \
 	((uint32)(r) | ((uint32)(g) << 8) | ((uint32)(b) << 16) | (0xff << 24))
-#define PACK(r, g, b) \
+#define	PACK(r,g,b)	\
 	((uint64)(r) | ((uint64)(g) << 16) | ((uint64)(b) << 32) | A1)
-#define PACK4(r, g, b, a) \
+#define	PACK4(r,g,b,a)	\
 	((uint64)(r) | ((uint64)(g) << 16) | ((uint64)(b) << 32) | ((uint64)(a) << 48))
 #define W2B(v) (((v) >> 16) & 0xffff)
 /* TODO: PACKW should have be made redundant in favor of Bitdepth16To8 LUT */
-#define PACKW(r, g, b) \
+#define	PACKW(r,g,b)	\
 	((uint64)W2B(r) | ((uint64)W2B(g) << 16) | ((uint64)W2B(b) << 32) | A1)
-#define PACKW4(r, g, b, a) \
+#define	PACKW4(r,g,b,a)	\
 	((uint64)W2B(r) | ((uint64)W2B(g) << 16) | ((uint64)W2B(b) << 32) | ((uint64)W2B(a) << 48))
 
-#define DECLAREContigPutFunc(name)    \
-	static void name(                 \
-		TIFFRGBAImage *img,           \
-		uint64 *cp,                   \
-		uint32 x, uint32 y,           \
-		uint32 w, uint32 h,           \
-		int32 fromskew, int32 toskew, \
-		unsigned char *pp)
+#define	DECLAREContigPutFunc(name) \
+static void name(\
+    TIFFRGBAImage* img, \
+    uint64* cp, \
+    uint32 x, uint32 y, \
+    uint32 w, uint32 h, \
+    int32 fromskew, int32 toskew, \
+    unsigned char* pp \
+)
 
 /*
  * 8-bit greyscale => colormap/RGB
  */
 DECLAREContigPutFunc(putgreytile)
 {
-	int samplesperpixel = img->samplesperpixel;
-	uint64 **BWmap = (uint64 **)img->BWmap;
+    int samplesperpixel = img->samplesperpixel;
+    uint64** BWmap = (uint64 **)img->BWmap;
 
-	(void)y;
-	while (h-- > 0) {
-		for (x = w; x-- > 0;) {
-			*cp++ = BWmap[*pp][0];
-			pp += samplesperpixel;
-		}
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) y;
+    while (h-- > 0) {
+	for (x = w; x-- > 0;)
+        {
+	    *cp++ = BWmap[*pp][0];
+            pp += samplesperpixel;
+        }
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -966,18 +971,19 @@ DECLAREContigPutFunc(putgreytile)
  */
 DECLAREContigPutFunc(putagreytile)
 {
-	int samplesperpixel = img->samplesperpixel;
-	uint64 **BWmap = (uint64 **)img->BWmap;
+    int samplesperpixel = img->samplesperpixel;
+    uint64** BWmap = (uint64 **)img->BWmap;
 
-	(void)y;
-	while (h-- > 0) {
-		for (x = w; x-- > 0;) {
-			*cp++ = BWmap[*pp][0] & ((uint64) * (pp + 1) << 48 | ~A1);
-			pp += samplesperpixel;
-		}
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) y;
+    while (h-- > 0) {
+	for (x = w; x-- > 0;)
+        {
+            *cp++ = BWmap[*pp][0] & ((uint64) *(pp + 1) << 48 | ~A1);
+            pp += samplesperpixel;
+        }
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -985,23 +991,24 @@ DECLAREContigPutFunc(putagreytile)
  */
 DECLAREContigPutFunc(put16bitbwtile)
 {
-	int samplesperpixel = img->samplesperpixel;
-	uint64 **BWmap = (uint64 **)img->BWmap;
+    int samplesperpixel = img->samplesperpixel;
+    uint64** BWmap = (uint64 **)img->BWmap;
 
-	(void)y;
-	while (h-- > 0) {
-		uint16 *wp = (uint16 *)pp;
+    (void) y;
+    while (h-- > 0) {
+        uint16 *wp = (uint16 *) pp;
 
-		for (x = w; x-- > 0;) {
-			/* use high order byte of 16bit value */
+	for (x = w; x-- > 0;)
+        {
+            /* use high order byte of 16bit value */
 
-			*cp++ = BWmap[*wp >> 8][0];
-			pp += 2 * samplesperpixel;
-			wp += samplesperpixel;
-		}
-		cp += toskew;
-		pp += fromskew;
-	}
+	    *cp++ = BWmap[*wp >> 8][0];
+            pp += 2 * samplesperpixel;
+            wp += samplesperpixel;
+        }
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -1009,17 +1016,16 @@ DECLAREContigPutFunc(put16bitbwtile)
  */
 DECLAREContigPutFunc(put1bitbwtile)
 {
-	uint64 **BWmap = (uint64 **)img->BWmap;
+    uint64** BWmap = (uint64 **)img->BWmap;
 
-	(void)x;
-	(void)y;
-	fromskew /= 8;
-	while (h-- > 0) {
-		uint64 *bw;
-		UNROLL8(w, bw = BWmap[*pp++], *cp++ = *bw++);
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) x; (void) y;
+    fromskew /= 8;
+    while (h-- > 0) {
+	uint64* bw;
+	UNROLL8(w, bw = BWmap[*pp++], *cp++ = *bw++);
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -1027,17 +1033,16 @@ DECLAREContigPutFunc(put1bitbwtile)
  */
 DECLAREContigPutFunc(put2bitbwtile)
 {
-	uint64 **BWmap = (uint64 **)img->BWmap;
+    uint64** BWmap = (uint64 **)img->BWmap;
 
-	(void)x;
-	(void)y;
-	fromskew /= 4;
-	while (h-- > 0) {
-		uint64 *bw;
-		UNROLL4(w, bw = BWmap[*pp++], *cp++ = *bw++);
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) x; (void) y;
+    fromskew /= 4;
+    while (h-- > 0) {
+	uint64* bw;
+	UNROLL4(w, bw = BWmap[*pp++], *cp++ = *bw++);
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -1045,17 +1050,16 @@ DECLAREContigPutFunc(put2bitbwtile)
  */
 DECLAREContigPutFunc(put4bitbwtile)
 {
-	uint64 **BWmap = (uint64 **)img->BWmap;
+    uint64** BWmap = (uint64 **)img->BWmap;
 
-	(void)x;
-	(void)y;
-	fromskew /= 2;
-	while (h-- > 0) {
-		uint64 *bw;
-		UNROLL2(w, bw = BWmap[*pp++], *cp++ = *bw++);
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) x; (void) y;
+    fromskew /= 2;
+    while (h-- > 0) {
+	uint64* bw;
+	UNROLL2(w, bw = BWmap[*pp++], *cp++ = *bw++);
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -1063,18 +1067,17 @@ DECLAREContigPutFunc(put4bitbwtile)
  */
 DECLAREContigPutFunc(putRGBcontig8bittile)
 {
-	int samplesperpixel = img->samplesperpixel;
+    int samplesperpixel = img->samplesperpixel;
 
-	(void)x;
-	(void)y;
-	fromskew *= samplesperpixel;
-	while (h-- > 0) {
-		UNROLL8(w, NOP,
-					   *cp++ = PACK(pp[0] << 8, pp[1] << 8, pp[2] << 8);
-				pp += samplesperpixel);
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) x; (void) y;
+    fromskew *= samplesperpixel;
+    while (h-- > 0) {
+	UNROLL8(w, NOP,
+	    *cp++ = PACK(pp[0] << 8, pp[1] << 8, pp[2] << 8);
+	    pp += samplesperpixel);
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -1083,18 +1086,17 @@ DECLAREContigPutFunc(putRGBcontig8bittile)
  */
 DECLAREContigPutFunc(putRGBAAcontig8bittile)
 {
-	int samplesperpixel = img->samplesperpixel;
+    int samplesperpixel = img->samplesperpixel;
 
-	(void)x;
-	(void)y;
-	fromskew *= samplesperpixel;
-	while (h-- > 0) {
-		UNROLL8(w, NOP,
-					   *cp++ = PACK4(pp[0] << 8, pp[1] << 8, pp[2] << 8, pp[3] << 8);
-				pp += samplesperpixel);
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) x; (void) y;
+    fromskew *= samplesperpixel;
+    while (h-- > 0) {
+	UNROLL8(w, NOP,
+	    *cp++ = PACK4(pp[0] << 8, pp[1] << 8, pp[2] << 8, pp[3] << 8);
+	    pp += samplesperpixel);
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -1104,7 +1106,7 @@ DECLAREContigPutFunc(putRGBcontig16bittile)
 {
 	int samplesperpixel = img->samplesperpixel;
 	uint16 *wp = (uint16 *)pp;
-	(void)y;
+	(void) y;
 	fromskew *= samplesperpixel;
 	while (h-- > 0) {
 		for (x = w; x-- > 0;) {
@@ -1124,7 +1126,7 @@ DECLAREContigPutFunc(putRGBAAcontig16bittile)
 {
 	int samplesperpixel = img->samplesperpixel;
 	uint16 *wp = (uint16 *)pp;
-	(void)y;
+	(void) y;
 	fromskew *= samplesperpixel;
 	while (h-- > 0) {
 		for (x = w; x-- > 0;) {
@@ -1143,23 +1145,22 @@ DECLAREContigPutFunc(putRGBAAcontig16bittile)
  */
 DECLAREContigPutFunc(putRGBcontig8bitCMYKtile)
 {
-	int samplesperpixel = img->samplesperpixel;
-	uint16 r, g, b, k;
+    int samplesperpixel = img->samplesperpixel;
+    uint16 r, g, b, k;
 
-	(void)x;
-	(void)y;
-	fromskew *= samplesperpixel;
-	while (h-- > 0) {
-		UNROLL8(w, NOP,
-				k = 255 - pp[3];
-				r = (k * (255 - pp[0]));
-				g = (k * (255 - pp[1]));
-				b = (k * (255 - pp[2]));
-					*cp++ = PACK(r, g, b);
-				pp += samplesperpixel);
-		cp += toskew;
-		pp += fromskew;
-	}
+    (void) x; (void) y;
+    fromskew *= samplesperpixel;
+    while (h-- > 0) {
+	UNROLL8(w, NOP,
+	    k = 255 - pp[3];
+	    r = (k*(255-pp[0]));
+	    g = (k*(255-pp[1]));
+	    b = (k*(255-pp[2]));
+	    *cp++ = PACK(r, g, b);
+	    pp += samplesperpixel);
+	cp += toskew;
+	pp += fromskew;
+    }
 }
 
 /*
@@ -1169,49 +1170,47 @@ DECLAREContigPutFunc(putRGBcontig8bitCMYKtile)
  */
 DECLAREContigPutFunc(putRGBcontig8bitCMYKMaptile)
 {
-	int samplesperpixel = img->samplesperpixel;
-	TIFFRGBValue *Map = img->Map;
-	uint16 r, g, b, k;
+    int samplesperpixel = img->samplesperpixel;
+    TIFFRGBValue* Map = img->Map;
+    uint16 r, g, b, k;
 
-	(void)y;
-	fromskew *= samplesperpixel;
-	while (h-- > 0) {
-		for (x = w; x-- > 0;) {
-			k = 255 - pp[3];
-			r = (k * (255 - pp[0])) / 255;
-			g = (k * (255 - pp[1])) / 255;
-			b = (k * (255 - pp[2])) / 255;
-			*cp++ = PACK(Map[r] << 8, Map[g] << 8, Map[b] << 8);
-			pp += samplesperpixel;
-		}
-		pp += fromskew;
-		cp += toskew;
+    (void) y;
+    fromskew *= samplesperpixel;
+    while (h-- > 0) {
+	for (x = w; x-- > 0;) {
+	    k = 255 - pp[3];
+	    r = (k*(255-pp[0]))/255;
+	    g = (k*(255-pp[1]))/255;
+	    b = (k*(255-pp[2]))/255;
+	    *cp++ = PACK(Map[r] << 8, Map[g] << 8, Map[b] << 8);
+	    pp += samplesperpixel;
 	}
+	pp += fromskew;
+	cp += toskew;
+    }
 }
 
-#define DECLARESepPutFunc(name)       \
-	static void name(                 \
-		TIFFRGBAImage *img,           \
-		uint64 *cp,                   \
-		uint32 x, uint32 y,           \
-		uint32 w, uint32 h,           \
-		int32 fromskew, int32 toskew, \
-		unsigned char *r, unsigned char *g, unsigned char *b, unsigned char *a)
+#define	DECLARESepPutFunc(name) \
+static void name(\
+    TIFFRGBAImage* img,\
+    uint64* cp,\
+    uint32 x, uint32 y, \
+    uint32 w, uint32 h,\
+    int32 fromskew, int32 toskew,\
+    unsigned char* r, unsigned char* g, unsigned char* b, unsigned char* a\
+)
 
 /*
  * 8-bit unpacked samples => RGB
  */
 DECLARESepPutFunc(putRGBseparate8bittile)
 {
-	(void)img;
-	(void)x;
-	(void)y;
-	(void)a;
-	while (h-- > 0) {
-		UNROLL8(w, NOP, *cp++ = PACK(*r++ << 8, *g++ << 8, *b++ << 8));
-		SKEW(r, g, b, fromskew);
-		cp += toskew;
-	}
+    (void) img; (void) x; (void) y; (void) a;
+    while (h-- > 0) {
+	UNROLL8(w, NOP, *cp++ = PACK(*r++ << 8, *g++ << 8, *b++ << 8));
+	SKEW(r, g, b, fromskew);
+	cp += toskew;
+    }
 }
 
 /*
@@ -1219,9 +1218,7 @@ DECLARESepPutFunc(putRGBseparate8bittile)
  */
 DECLARESepPutFunc(putRGBAAseparate8bittile)
 {
-	(void)img;
-	(void)x;
-	(void)y;
+	(void) img; (void) x; (void) y; 
 	while (h-- > 0) {
 		UNROLL8(w, NOP, *cp++ = PACK4(*r++ << 8, *g++ << 8, *b++ << 8, *a++ << 8));
 		SKEW4(r, g, b, a, fromskew);
@@ -1234,16 +1231,15 @@ DECLARESepPutFunc(putRGBAAseparate8bittile)
  */
 DECLARESepPutFunc(putCMYKseparate8bittile)
 {
-	(void)img;
-	(void)y;
+	(void) img; (void) y;
 	while (h-- > 0) {
 		uint32 rv, gv, bv, kv;
 		for (x = w; x-- > 0;) {
 			kv = 255 - *a++;
-			rv = (kv * (255 - *r++));
-			gv = (kv * (255 - *g++));
-			bv = (kv * (255 - *b++));
-			*cp++ = PACK4(rv, gv, bv, 65535);
+			rv = (kv*(255-*r++));
+			gv = (kv*(255-*g++));
+			bv = (kv*(255-*b++));
+			*cp++ = PACK4(rv,gv,bv,65535);
 		}
 		SKEW4(r, g, b, a, fromskew);
 		cp += toskew;
@@ -1255,12 +1251,10 @@ DECLARESepPutFunc(putCMYKseparate8bittile)
  */
 DECLARESepPutFunc(putRGBseparate16bittile)
 {
-	uint16 *wr = (uint16 *)r;
-	uint16 *wg = (uint16 *)g;
-	uint16 *wb = (uint16 *)b;
-	(void)img;
-	(void)y;
-	(void)a;
+	uint16 *wr = (uint16*) r;
+	uint16 *wg = (uint16*) g;
+	uint16 *wb = (uint16*) b;
+	(void) img; (void) y; (void) a;
 	while (h-- > 0) {
 		for (x = 0; x < w; x++)
 			*cp++ = PACK(*wr++, *wg++, *wb++);
@@ -1274,12 +1268,11 @@ DECLARESepPutFunc(putRGBseparate16bittile)
  */
 DECLARESepPutFunc(putRGBAAseparate16bittile)
 {
-	uint16 *wr = (uint16 *)r;
-	uint16 *wg = (uint16 *)g;
-	uint16 *wb = (uint16 *)b;
-	uint16 *wa = (uint16 *)a;
-	(void)img;
-	(void)y;
+	uint16 *wr = (uint16*) r;
+	uint16 *wg = (uint16*) g;
+	uint16 *wb = (uint16*) b;
+	uint16 *wa = (uint16*) a;
+	(void) img; (void) y;
 	while (h-- > 0) {
 		for (x = 0; x < w; x++)
 			*cp++ = PACK4(*wr++, *wg++, *wb++, *wa++);
@@ -1295,15 +1288,15 @@ DECLAREContigPutFunc(putcontig8bitCIELab)
 {
 	float X, Y, Z;
 	uint32 r, g, b;
-	(void)y;
+	(void) y;
 	fromskew *= 3;
 	while (h-- > 0) {
 		for (x = w; x-- > 0;) {
 			TIFFCIELabToXYZ(img->cielab,
-							(unsigned char)pp[0],
-							(signed char)pp[1],
-							(signed char)pp[2],
-							&X, &Y, &Z);
+					(unsigned char)pp[0],
+					(signed char)pp[1],
+					(signed char)pp[2],
+					&X, &Y, &Z);
 			TIFFXYZToRGB(img->cielab, X, Y, Z, &r, &g, &b);
 			*cp++ = PACK(r << 8, g << 8, b << 8);
 			pp += 3;
@@ -1317,129 +1310,107 @@ DECLAREContigPutFunc(putcontig8bitCIELab)
  * YCbCr -> RGB conversion and packing routines.
  */
 
-#define YCbCrtoRGB(dst, Y)                                                \
-	{                                                                     \
-		uint32 r, g, b;                                                   \
-		TIFFYCbCrtoRGB(img->ycbcr, (Y), Cb, Cr, &r, &g, &b);              \
-		dst = PACK(((uint64)r) << 8, ((uint64)g) << 8, ((uint64)b) << 8); \
-	}
+#define	YCbCrtoRGB(dst, Y) {						\
+	uint32 r, g, b;							\
+	TIFFYCbCrtoRGB(img->ycbcr, (Y), Cb, Cr, &r, &g, &b);		\
+	dst = PACK(((uint64)r) << 8, ((uint64)g) << 8, ((uint64)b) << 8); \
+}
 
 /*
  * 8-bit packed YCbCr samples w/ 4,4 subsampling => RGB
  */
 DECLAREContigPutFunc(putcontig8bitYCbCr44tile)
 {
-	uint64 *cp1 = cp + w + toskew;
-	uint64 *cp2 = cp1 + w + toskew;
-	uint64 *cp3 = cp2 + w + toskew;
-	int32 incr = 3 * w + 4 * toskew;
+    uint64* cp1 = cp+w+toskew;
+    uint64* cp2 = cp1+w+toskew;
+    uint64* cp3 = cp2+w+toskew;
+    int32 incr = 3*w+4*toskew;
 
-	(void)y;
-	/* adjust fromskew */
-	fromskew = (fromskew * 18) / 4;
-	if ((h & 3) == 0 && (w & 3) == 0) {
-		for (; h >= 4; h -= 4) {
-			x = w >> 2;
-			do {
-				int32 Cb = pp[16];
-				int32 Cr = pp[17];
+    (void) y;
+    /* adjust fromskew */
+    fromskew = (fromskew * 18) / 4;
+    if ((h & 3) == 0 && (w & 3) == 0) {				        
+        for (; h >= 4; h -= 4) {
+            x = w>>2;
+            do {
+                int32 Cb = pp[16];
+                int32 Cr = pp[17];
 
-				YCbCrtoRGB(cp[0], pp[0]);
-				YCbCrtoRGB(cp[1], pp[1]);
-				YCbCrtoRGB(cp[2], pp[2]);
-				YCbCrtoRGB(cp[3], pp[3]);
-				YCbCrtoRGB(cp1[0], pp[4]);
-				YCbCrtoRGB(cp1[1], pp[5]);
-				YCbCrtoRGB(cp1[2], pp[6]);
-				YCbCrtoRGB(cp1[3], pp[7]);
-				YCbCrtoRGB(cp2[0], pp[8]);
-				YCbCrtoRGB(cp2[1], pp[9]);
-				YCbCrtoRGB(cp2[2], pp[10]);
-				YCbCrtoRGB(cp2[3], pp[11]);
-				YCbCrtoRGB(cp3[0], pp[12]);
-				YCbCrtoRGB(cp3[1], pp[13]);
-				YCbCrtoRGB(cp3[2], pp[14]);
-				YCbCrtoRGB(cp3[3], pp[15]);
+                YCbCrtoRGB(cp [0], pp[ 0]);
+                YCbCrtoRGB(cp [1], pp[ 1]);
+                YCbCrtoRGB(cp [2], pp[ 2]);
+                YCbCrtoRGB(cp [3], pp[ 3]);
+                YCbCrtoRGB(cp1[0], pp[ 4]);
+                YCbCrtoRGB(cp1[1], pp[ 5]);
+                YCbCrtoRGB(cp1[2], pp[ 6]);
+                YCbCrtoRGB(cp1[3], pp[ 7]);
+                YCbCrtoRGB(cp2[0], pp[ 8]);
+                YCbCrtoRGB(cp2[1], pp[ 9]);
+                YCbCrtoRGB(cp2[2], pp[10]);
+                YCbCrtoRGB(cp2[3], pp[11]);
+                YCbCrtoRGB(cp3[0], pp[12]);
+                YCbCrtoRGB(cp3[1], pp[13]);
+                YCbCrtoRGB(cp3[2], pp[14]);
+                YCbCrtoRGB(cp3[3], pp[15]);
 
-				cp += 4, cp1 += 4, cp2 += 4, cp3 += 4;
-				pp += 18;
-			} while (--x);
-			cp += incr, cp1 += incr, cp2 += incr, cp3 += incr;
-			pp += fromskew;
-		}
-	} else {
-		while (h > 0) {
-			for (x = w; x > 0;) {
-				int32 Cb = pp[16];
-				int32 Cr = pp[17];
-				switch (x) {
-				default:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp3[3], pp[15]); /* FALLTHROUGH */
-					case 3:
-						YCbCrtoRGB(cp2[3], pp[11]); /* FALLTHROUGH */
-					case 2:
-						YCbCrtoRGB(cp1[3], pp[7]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[3], pp[3]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				case 3:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp3[2], pp[14]); /* FALLTHROUGH */
-					case 3:
-						YCbCrtoRGB(cp2[2], pp[10]); /* FALLTHROUGH */
-					case 2:
-						YCbCrtoRGB(cp1[2], pp[6]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[2], pp[2]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				case 2:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp3[1], pp[13]); /* FALLTHROUGH */
-					case 3:
-						YCbCrtoRGB(cp2[1], pp[9]); /* FALLTHROUGH */
-					case 2:
-						YCbCrtoRGB(cp1[1], pp[5]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[1], pp[1]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				case 1:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp3[0], pp[12]); /* FALLTHROUGH */
-					case 3:
-						YCbCrtoRGB(cp2[0], pp[8]); /* FALLTHROUGH */
-					case 2:
-						YCbCrtoRGB(cp1[0], pp[4]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[0], pp[0]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				}
-				if (x < 4) {
-					cp += x;
-					cp1 += x;
-					cp2 += x;
-					cp3 += x;
-					x = 0;
-				} else {
-					cp += 4;
-					cp1 += 4;
-					cp2 += 4;
-					cp3 += 4;
-					x -= 4;
-				}
-				pp += 18;
-			}
-			if (h <= 4)
-				break;
-			h -= 4;
-			cp += incr, cp1 += incr, cp2 += incr, cp3 += incr;
-			pp += fromskew;
-		}
-	}
+                cp += 4, cp1 += 4, cp2 += 4, cp3 += 4;
+                pp += 18;
+            } while (--x);
+            cp += incr, cp1 += incr, cp2 += incr, cp3 += incr;
+            pp += fromskew;
+        }
+    } else {
+        while (h > 0) {
+            for (x = w; x > 0;) {
+                int32 Cb = pp[16];
+                int32 Cr = pp[17];
+                switch (x) {
+                default:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp3[3], pp[15]); /* FALLTHROUGH */
+                    case 3:  YCbCrtoRGB(cp2[3], pp[11]); /* FALLTHROUGH */
+                    case 2:  YCbCrtoRGB(cp1[3], pp[ 7]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [3], pp[ 3]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                case 3:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp3[2], pp[14]); /* FALLTHROUGH */
+                    case 3:  YCbCrtoRGB(cp2[2], pp[10]); /* FALLTHROUGH */
+                    case 2:  YCbCrtoRGB(cp1[2], pp[ 6]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [2], pp[ 2]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                case 2:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp3[1], pp[13]); /* FALLTHROUGH */
+                    case 3:  YCbCrtoRGB(cp2[1], pp[ 9]); /* FALLTHROUGH */
+                    case 2:  YCbCrtoRGB(cp1[1], pp[ 5]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [1], pp[ 1]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                case 1:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp3[0], pp[12]); /* FALLTHROUGH */
+                    case 3:  YCbCrtoRGB(cp2[0], pp[ 8]); /* FALLTHROUGH */
+                    case 2:  YCbCrtoRGB(cp1[0], pp[ 4]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [0], pp[ 0]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                }
+                if (x < 4) {
+                    cp += x; cp1 += x; cp2 += x; cp3 += x;
+                    x = 0;
+                }
+                else {
+                    cp += 4; cp1 += 4; cp2 += 4; cp3 += 4;
+                    x -= 4;
+                }
+                pp += 18;
+            }
+            if (h <= 4)
+                break;
+            h -= 4;
+            cp += incr, cp1 += incr, cp2 += incr, cp3 += incr;
+            pp += fromskew;
+        }
+    }
 }
 
 /*
@@ -1447,86 +1418,77 @@ DECLAREContigPutFunc(putcontig8bitYCbCr44tile)
  */
 DECLAREContigPutFunc(putcontig8bitYCbCr42tile)
 {
-	uint64 *cp1 = cp + w + toskew;
-	int32 incr = 2 * toskew + w;
+    uint64* cp1 = cp+w+toskew;
+    int32 incr = 2*toskew+w;
 
-	(void)y;
-	fromskew = (fromskew * 10) / 4;
-	if ((h & 3) == 0 && (w & 1) == 0) {
-		for (; h >= 2; h -= 2) {
-			x = w >> 2;
-			do {
-				int32 Cb = pp[8];
-				int32 Cr = pp[9];
-
-				YCbCrtoRGB(cp[0], pp[0]);
-				YCbCrtoRGB(cp[1], pp[1]);
-				YCbCrtoRGB(cp[2], pp[2]);
-				YCbCrtoRGB(cp[3], pp[3]);
-				YCbCrtoRGB(cp1[0], pp[4]);
-				YCbCrtoRGB(cp1[1], pp[5]);
-				YCbCrtoRGB(cp1[2], pp[6]);
-				YCbCrtoRGB(cp1[3], pp[7]);
-
-				cp += 4, cp1 += 4;
-				pp += 10;
-			} while (--x);
-			cp += incr, cp1 += incr;
-			pp += fromskew;
-		}
-	} else {
-		while (h > 0) {
-			for (x = w; x > 0;) {
-				int32 Cb = pp[8];
-				int32 Cr = pp[9];
-				switch (x) {
-				default:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp1[3], pp[7]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[3], pp[3]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				case 3:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp1[2], pp[6]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[2], pp[2]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				case 2:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp1[1], pp[5]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[1], pp[1]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				case 1:
-					switch (h) {
-					default:
-						YCbCrtoRGB(cp1[0], pp[4]); /* FALLTHROUGH */
-					case 1:
-						YCbCrtoRGB(cp[0], pp[0]); /* FALLTHROUGH */
-					}							  /* FALLTHROUGH */
-				}
-				if (x < 4) {
-					cp += x;
-					cp1 += x;
-					x = 0;
-				} else {
-					cp += 4;
-					cp1 += 4;
-					x -= 4;
-				}
-				pp += 10;
-			}
-			if (h <= 2)
-				break;
-			h -= 2;
-			cp += incr, cp1 += incr;
-			pp += fromskew;
-		}
-	}
+    (void) y;
+    fromskew = (fromskew * 10) / 4;
+    if ((h & 3) == 0 && (w & 1) == 0) {
+        for (; h >= 2; h -= 2) {
+            x = w>>2;
+            do {
+                int32 Cb = pp[8];
+                int32 Cr = pp[9];
+                
+                YCbCrtoRGB(cp [0], pp[0]);
+                YCbCrtoRGB(cp [1], pp[1]);
+                YCbCrtoRGB(cp [2], pp[2]);
+                YCbCrtoRGB(cp [3], pp[3]);
+                YCbCrtoRGB(cp1[0], pp[4]);
+                YCbCrtoRGB(cp1[1], pp[5]);
+                YCbCrtoRGB(cp1[2], pp[6]);
+                YCbCrtoRGB(cp1[3], pp[7]);
+                
+                cp += 4, cp1 += 4;
+                pp += 10;
+            } while (--x);
+            cp += incr, cp1 += incr;
+            pp += fromskew;
+        }
+    } else {
+        while (h > 0) {
+            for (x = w; x > 0;) {
+                int32 Cb = pp[8];
+                int32 Cr = pp[9];
+                switch (x) {
+                default:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp1[3], pp[ 7]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [3], pp[ 3]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                case 3:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp1[2], pp[ 6]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [2], pp[ 2]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                case 2:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp1[1], pp[ 5]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [1], pp[ 1]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                case 1:
+                    switch (h) {
+                    default: YCbCrtoRGB(cp1[0], pp[ 4]); /* FALLTHROUGH */
+                    case 1:  YCbCrtoRGB(cp [0], pp[ 0]); /* FALLTHROUGH */
+                    }                                    /* FALLTHROUGH */
+                }
+                if (x < 4) {
+                    cp += x; cp1 += x;
+                    x = 0;
+                }
+                else {
+                    cp += 4; cp1 += 4;
+                    x -= 4;
+                }
+                pp += 10;
+            }
+            if (h <= 2)
+                break;
+            h -= 2;
+            cp += incr, cp1 += incr;
+            pp += fromskew;
+        }
+    }
 }
 
 /*
@@ -1534,45 +1496,43 @@ DECLAREContigPutFunc(putcontig8bitYCbCr42tile)
  */
 DECLAREContigPutFunc(putcontig8bitYCbCr41tile)
 {
-	(void)y;
-	/* XXX adjust fromskew */
+    (void) y;
+    /* XXX adjust fromskew */
+    do {
+	x = w>>2;
 	do {
-		x = w >> 2;
-		do {
-			int32 Cb = pp[4];
-			int32 Cr = pp[5];
+	    int32 Cb = pp[4];
+	    int32 Cr = pp[5];
 
-			YCbCrtoRGB(cp[0], pp[0]);
-			YCbCrtoRGB(cp[1], pp[1]);
-			YCbCrtoRGB(cp[2], pp[2]);
-			YCbCrtoRGB(cp[3], pp[3]);
+	    YCbCrtoRGB(cp [0], pp[0]);
+	    YCbCrtoRGB(cp [1], pp[1]);
+	    YCbCrtoRGB(cp [2], pp[2]);
+	    YCbCrtoRGB(cp [3], pp[3]);
 
-			cp += 4;
-			pp += 6;
-		} while (--x);
+	    cp += 4;
+	    pp += 6;
+	} while (--x);
 
-		if ((w & 3) != 0) {
-			int32 Cb = pp[4];
-			int32 Cr = pp[5];
+        if( (w&3) != 0 )
+        {
+	    int32 Cb = pp[4];
+	    int32 Cr = pp[5];
 
-			switch ((w & 3)) {
-			case 3:
-				YCbCrtoRGB(cp[2], pp[2]);
-			case 2:
-				YCbCrtoRGB(cp[1], pp[1]);
-			case 1:
-				YCbCrtoRGB(cp[0], pp[0]);
-			case 0:
-				break;
-			}
+            switch( (w&3) ) {
+              case 3: YCbCrtoRGB(cp [2], pp[2]);
+              case 2: YCbCrtoRGB(cp [1], pp[1]);
+              case 1: YCbCrtoRGB(cp [0], pp[0]);
+              case 0: break;
+            }
 
-			cp += (w & 3);
-			pp += 6;
-		}
+            cp += (w&3);
+            pp += 6;
+        }
 
-		cp += toskew;
-		pp += fromskew;
-	} while (--h);
+	cp += toskew;
+	pp += fromskew;
+    } while (--h);
+
 }
 
 /*
@@ -1580,14 +1540,14 @@ DECLAREContigPutFunc(putcontig8bitYCbCr41tile)
  */
 DECLAREContigPutFunc(putcontig8bitYCbCr22tile)
 {
-	uint64 *cp2;
-	int32 incr = 2 * toskew + w;
-	(void)y;
+	uint64* cp2;
+	int32 incr = 2*toskew+w;
+	(void) y;
 	fromskew = (fromskew / 2) * 6;
-	cp2 = cp + w + toskew;
-	while (h >= 2) {
+	cp2 = cp+w+toskew;
+	while (h>=2) {
 		x = w;
-		while (x >= 2) {
+		while (x>=2) {
 			uint32 Cb = pp[4];
 			uint32 Cr = pp[5];
 			YCbCrtoRGB(cp[0], pp[0]);
@@ -1599,23 +1559,23 @@ DECLAREContigPutFunc(putcontig8bitYCbCr22tile)
 			pp += 6;
 			x -= 2;
 		}
-		if (x == 1) {
+		if (x==1) {
 			uint32 Cb = pp[4];
 			uint32 Cr = pp[5];
 			YCbCrtoRGB(cp[0], pp[0]);
 			YCbCrtoRGB(cp2[0], pp[2]);
-			cp++;
-			cp2++;
+			cp ++ ;
+			cp2 ++ ;
 			pp += 6;
 		}
 		cp += incr;
 		cp2 += incr;
 		pp += fromskew;
-		h -= 2;
+		h-=2;
 	}
-	if (h == 1) {
+	if (h==1) {
 		x = w;
-		while (x >= 2) {
+		while (x>=2) {
 			uint32 Cb = pp[4];
 			uint32 Cr = pp[5];
 			YCbCrtoRGB(cp[0], pp[0]);
@@ -1625,7 +1585,7 @@ DECLAREContigPutFunc(putcontig8bitYCbCr22tile)
 			pp += 6;
 			x -= 2;
 		}
-		if (x == 1) {
+		if (x==1) {
 			uint32 Cb = pp[4];
 			uint32 Cr = pp[5];
 			YCbCrtoRGB(cp[0], pp[0]);
@@ -1638,10 +1598,10 @@ DECLAREContigPutFunc(putcontig8bitYCbCr22tile)
  */
 DECLAREContigPutFunc(putcontig8bitYCbCr21tile)
 {
-	(void)y;
+	(void) y;
 	fromskew = (fromskew * 4) / 2;
 	do {
-		x = w >> 1;
+		x = w>>1;
 		do {
 			int32 Cb = pp[2];
 			int32 Cr = pp[3];
@@ -1653,7 +1613,8 @@ DECLAREContigPutFunc(putcontig8bitYCbCr21tile)
 			pp += 4;
 		} while (--x);
 
-		if ((w & 1) != 0) {
+		if( (w&1) != 0 )
+		{
 			int32 Cb = pp[2];
 			int32 Cr = pp[3];
 
@@ -1673,34 +1634,34 @@ DECLAREContigPutFunc(putcontig8bitYCbCr21tile)
  */
 DECLAREContigPutFunc(putcontig8bitYCbCr12tile)
 {
-	uint64 *cp2;
-	int32 incr = 2 * toskew + w;
-	(void)y;
+	uint64* cp2;
+	int32 incr = 2*toskew+w;
+	(void) y;
 	fromskew = (fromskew / 2) * 4;
-	cp2 = cp + w + toskew;
-	while (h >= 2) {
+	cp2 = cp+w+toskew;
+	while (h>=2) {
 		x = w;
 		do {
 			uint32 Cb = pp[2];
 			uint32 Cr = pp[3];
 			YCbCrtoRGB(cp[0], pp[0]);
 			YCbCrtoRGB(cp2[0], pp[1]);
-			cp++;
-			cp2++;
+			cp ++;
+			cp2 ++;
 			pp += 4;
 		} while (--x);
 		cp += incr;
 		cp2 += incr;
 		pp += fromskew;
-		h -= 2;
+		h-=2;
 	}
-	if (h == 1) {
+	if (h==1) {
 		x = w;
 		do {
 			uint32 Cb = pp[2];
 			uint32 Cr = pp[3];
 			YCbCrtoRGB(cp[0], pp[0]);
-			cp++;
+			cp ++;
 			pp += 4;
 		} while (--x);
 	}
@@ -1711,7 +1672,7 @@ DECLAREContigPutFunc(putcontig8bitYCbCr12tile)
  */
 DECLAREContigPutFunc(putcontig8bitYCbCr11tile)
 {
-	(void)y;
+	(void) y;
 	fromskew *= 3;
 	do {
 		x = w; /* was x = w>>1; patched 2000/09/25 warmerda@home.com */
@@ -1733,15 +1694,15 @@ DECLAREContigPutFunc(putcontig8bitYCbCr11tile)
  */
 DECLARESepPutFunc(putseparate8bitYCbCr11tile)
 {
-	(void)y;
-	(void)a;
+	(void) y;
+	(void) a;
 	/* TODO: naming of input vars is still off, change obfuscating declaration inside define, or resolve obfuscation */
 	while (h-- > 0) {
 		x = w;
 		do {
 			uint32 dr, dg, db;
-			TIFFYCbCrtoRGB(img->ycbcr, *r++, *g++, *b++, &dr, &dg, &db);
-			*cp++ = PACK(dr, dg, db);
+			TIFFYCbCrtoRGB(img->ycbcr,*r++,*g++,*b++,&dr,&dg,&db);
+			*cp++ = PACK(dr,dg,db);
 		} while (--x);
 		SKEW(r, g, b, fromskew);
 		cp += toskew;
@@ -1750,44 +1711,48 @@ DECLARESepPutFunc(putseparate8bitYCbCr11tile)
 #undef YCbCrtoRGB
 
 static int
-initYCbCrConversion(TIFFRGBAImage *img)
+initYCbCrConversion(TIFFRGBAImage* img)
 {
 	static const char module[] = "initYCbCrConversion";
 
 	float *luma, *refBlackWhite;
 
 	if (img->ycbcr == NULL) {
-		img->ycbcr = (TIFFYCbCrToRGB *)_TIFFmalloc(
-			TIFFroundup_32(sizeof(TIFFYCbCrToRGB), sizeof(long)) + 4 * 256 * sizeof(TIFFRGBValue) + 2 * 256 * sizeof(int) + 3 * 256 * sizeof(int32));
+		img->ycbcr = (TIFFYCbCrToRGB*) _TIFFmalloc(
+		    TIFFroundup_32(sizeof (TIFFYCbCrToRGB), sizeof (long))  
+		    + 4*256*sizeof (TIFFRGBValue)
+		    + 2*256*sizeof (int)
+		    + 3*256*sizeof (int32)
+		    );
 		if (img->ycbcr == NULL) {
 			TIFFErrorExt(img->tif->tif_clientdata, module,
-						 "No space for YCbCr->RGB conversion state");
+			    "No space for YCbCr->RGB conversion state");
 			return (0);
 		}
 	}
 
 	TIFFGetFieldDefaulted(img->tif, TIFFTAG_YCBCRCOEFFICIENTS, &luma);
 	TIFFGetFieldDefaulted(img->tif, TIFFTAG_REFERENCEBLACKWHITE,
-						  &refBlackWhite);
+	    &refBlackWhite);
 	if (TIFFYCbCrToRGBInit(img->ycbcr, luma, refBlackWhite) < 0)
-		return (0);
+		return(0);
 	return (1);
 }
 
 static tileContigRoutine_64
-initCIELabConversion(TIFFRGBAImage *img)
+initCIELabConversion(TIFFRGBAImage* img)
 {
 	static const char module[] = "initCIELabConversion";
 
-	float *whitePoint;
-	float refWhite[3];
+	float   *whitePoint;
+	float   refWhite[3];
 
 	if (!img->cielab) {
 		img->cielab = (TIFFCIELabToRGB *)
 			_TIFFmalloc(sizeof(TIFFCIELabToRGB));
 		if (!img->cielab) {
 			TIFFErrorExt(img->tif->tif_clientdata, module,
-						 "No space for CIE L*a*b*->RGB conversion state.");
+			    "No space for CIE L*a*b*->RGB conversion state.");
 			return NULL;
 		}
 	}
@@ -1795,10 +1760,11 @@ initCIELabConversion(TIFFRGBAImage *img)
 	TIFFGetFieldDefaulted(img->tif, TIFFTAG_WHITEPOINT, &whitePoint);
 	refWhite[1] = 100.0F;
 	refWhite[0] = whitePoint[0] / whitePoint[1] * refWhite[1];
-	refWhite[2] = (1.0F - whitePoint[0] - whitePoint[1]) / whitePoint[1] * refWhite[1];
+	refWhite[2] = (1.0F - whitePoint[0] - whitePoint[1])
+		      / whitePoint[1] * refWhite[1];
 	if (TIFFCIELabToRGBInit(img->cielab, &display_sRGB, refWhite) < 0) {
 		TIFFErrorExt(img->tif->tif_clientdata, module,
-					 "Failed to initialize CIE L*a*b*->RGB conversion state.");
+		    "Failed to initialize CIE L*a*b*->RGB conversion state.");
 		_TIFFfree(img->cielab);
 		return NULL;
 	}
@@ -1814,134 +1780,134 @@ initCIELabConversion(TIFFRGBAImage *img)
  * number.
  */
 static int
-makebwmap(TIFFRGBAImage *img)
+makebwmap(TIFFRGBAImage* img)
 {
-	TIFFRGBValue *Map = img->Map;
-	int bitspersample = img->bitspersample;
-	int nsamples = 8 / bitspersample;
-	int i;
-	uint64 *p;
+    TIFFRGBValue* Map = img->Map;
+    int bitspersample = img->bitspersample;
+    int nsamples = 8 / bitspersample;
+    int i;
+    uint64* p;
 
-	if (nsamples == 0)
-		nsamples = 1;
+    if( nsamples == 0 )
+        nsamples = 1;
 
-	img->BWmap = (uint32 **)_TIFFmalloc(
-		256 * sizeof(uint32 *) + (256 * nsamples * sizeof(uint64)));
-	if (img->BWmap == NULL) {
+    img->BWmap = (uint32**) _TIFFmalloc(
+	256*sizeof(uint32 *)+(256*nsamples*sizeof(uint64)));
+    if (img->BWmap == NULL) {
 		TIFFErrorExt(img->tif->tif_clientdata, TIFFFileName(img->tif), "No space for B&W mapping table");
 		return (0);
-	}
-	p = (uint64 *)(img->BWmap + 256);
-	for (i = 0; i < 256; i++) {
-		TIFFRGBValue c;
-		img->BWmap[i] = (uint32 *)p;
-		switch (bitspersample) {
+    }
+    p = (uint64*)(img->BWmap + 256);
+    for (i = 0; i < 256; i++) {
+	TIFFRGBValue c;
+	img->BWmap[i] = (uint32 *)p;
+	switch (bitspersample) {
 #define GREY(x) \
 	c = Map[x]; \
 	*p++ = PACK(c << 8, c << 8, c << 8);
-		case 1:
-			GREY(i >> 7);
-			GREY((i >> 6) & 1);
-			GREY((i >> 5) & 1);
-			GREY((i >> 4) & 1);
-			GREY((i >> 3) & 1);
-			GREY((i >> 2) & 1);
-			GREY((i >> 1) & 1);
-			GREY(i & 1);
-			break;
-		case 2:
-			GREY(i >> 6);
-			GREY((i >> 4) & 3);
-			GREY((i >> 2) & 3);
-			GREY(i & 3);
-			break;
-		case 4:
-			GREY(i >> 4);
-			GREY(i & 0xf);
-			break;
-		case 8:
-		case 16:
-			GREY(i);
-			break;
-		}
-#undef GREY
+	case 1:
+	    GREY(i>>7);
+	    GREY((i>>6)&1);
+	    GREY((i>>5)&1);
+	    GREY((i>>4)&1);
+	    GREY((i>>3)&1);
+	    GREY((i>>2)&1);
+	    GREY((i>>1)&1);
+	    GREY(i&1);
+	    break;
+	case 2:
+	    GREY(i>>6);
+	    GREY((i>>4)&3);
+	    GREY((i>>2)&3);
+	    GREY(i&3);
+	    break;
+	case 4:
+	    GREY(i>>4);
+	    GREY(i&0xf);
+	    break;
+	case 8:
+        case 16:
+	    GREY(i);
+	    break;
 	}
-	return (1);
+#undef	GREY
+    }
+    return (1);
 }
 
 /*
  * Construct a mapping table to convert from the range
  * of the data samples to [0,255] --for display.  This
  * process also handles inverting B&W images when needed.
- */
+ */ 
 static int
-setupMap(TIFFRGBAImage *img)
+setupMap(TIFFRGBAImage* img)
 {
-	int32 x, range;
+    int32 x, range;
 
-	range = (int32)((1L << img->bitspersample) - 1);
+    range = (int32)((1L<<img->bitspersample)-1);
+    
+    /* treat 16 bit the same as eight bit */
+    if( img->bitspersample == 16 )
+        range = (int32) 255;
 
-	/* treat 16 bit the same as eight bit */
-	if (img->bitspersample == 16)
-		range = (int32)255;
-
-	img->Map = (TIFFRGBValue *)_TIFFmalloc((range + 1) * sizeof(TIFFRGBValue));
-	if (img->Map == NULL) {
+    img->Map = (TIFFRGBValue*) _TIFFmalloc((range+1) * sizeof (TIFFRGBValue));
+    if (img->Map == NULL) {
 		TIFFErrorExt(img->tif->tif_clientdata, TIFFFileName(img->tif),
-					 "No space for photometric conversion table");
+			"No space for photometric conversion table");
 		return (0);
-	}
-	if (img->photometric == PHOTOMETRIC_MINISWHITE) {
-		for (x = 0; x <= range; x++)
-			img->Map[x] = (TIFFRGBValue)(((range - x) * 255) / range);
-	} else {
-		for (x = 0; x <= range; x++)
-			img->Map[x] = (TIFFRGBValue)((x * 255) / range);
-	}
-	if (img->bitspersample <= 16 &&
-		(img->photometric == PHOTOMETRIC_MINISBLACK ||
-		 img->photometric == PHOTOMETRIC_MINISWHITE)) {
-		/*
+    }
+    if (img->photometric == PHOTOMETRIC_MINISWHITE) {
+	for (x = 0; x <= range; x++)
+	    img->Map[x] = (TIFFRGBValue) (((range - x) * 255) / range);
+    } else {
+	for (x = 0; x <= range; x++)
+	    img->Map[x] = (TIFFRGBValue) ((x * 255) / range);
+    }
+    if (img->bitspersample <= 16 &&
+	(img->photometric == PHOTOMETRIC_MINISBLACK ||
+	 img->photometric == PHOTOMETRIC_MINISWHITE)) {
+	/*
 	 * Use photometric mapping table to construct
 	 * unpacking tables for samples <= 8 bits.
 	 */
-		if (!makebwmap(img))
-			return (0);
-		/* no longer need Map, free it */
-		_TIFFfree(img->Map), img->Map = NULL;
-	}
-	return (1);
+	if (!makebwmap(img))
+	    return (0);
+	/* no longer need Map, free it */
+	_TIFFfree(img->Map), img->Map = NULL;
+    }
+    return (1);
 }
 
 static int
-checkcmap(TIFFRGBAImage *img)
+checkcmap(TIFFRGBAImage* img)
 {
-	uint16 *r = img->redcmap;
-	uint16 *g = img->greencmap;
-	uint16 *b = img->bluecmap;
-	long n = 1L << img->bitspersample;
+    uint16* r = img->redcmap;
+    uint16* g = img->greencmap;
+    uint16* b = img->bluecmap;
+    long n = 1L<<img->bitspersample;
 
-	while (n-- > 0)
-		if (*r++ >= 256 || *g++ >= 256 || *b++ >= 256)
-			return (16);
-	return (8);
+    while (n-- > 0)
+	if (*r++ >= 256 || *g++ >= 256 || *b++ >= 256)
+	    return (16);
+    return (8);
 }
 
 static void
-cvtcmap(TIFFRGBAImage *img)
+cvtcmap(TIFFRGBAImage* img)
 {
-	uint16 *r = img->redcmap;
-	uint16 *g = img->greencmap;
-	uint16 *b = img->bluecmap;
-	long i;
+    uint16* r = img->redcmap;
+    uint16* g = img->greencmap;
+    uint16* b = img->bluecmap;
+    long i;
 
-	for (i = (1L << img->bitspersample) - 1; i >= 0; i--) {
-#define CVT(x) ((uint16)((x) >> 8))
-		r[i] = CVT(r[i]);
-		g[i] = CVT(g[i]);
-		b[i] = CVT(b[i]);
-#undef CVT
-	}
+    for (i = (1L<<img->bitspersample)-1; i >= 0; i--) {
+#define	CVT(x)		((uint16)((x)>>8))
+	r[i] = CVT(r[i]);
+	g[i] = CVT(g[i]);
+	b[i] = CVT(b[i]);
+#undef	CVT
+    }
 }
 
 /*
@@ -1952,57 +1918,55 @@ cvtcmap(TIFFRGBAImage *img)
  * number.
  */
 static int
-makecmap(TIFFRGBAImage *img)
+makecmap(TIFFRGBAImage* img)
 {
-	int bitspersample = img->bitspersample;
-	int nsamples = 8 / bitspersample;
-	uint16 *r = img->redcmap;
-	uint16 *g = img->greencmap;
-	uint16 *b = img->bluecmap;
-	uint32 *p;
-	int i;
+    int bitspersample = img->bitspersample;
+    int nsamples = 8 / bitspersample;
+    uint16* r = img->redcmap;
+    uint16* g = img->greencmap;
+    uint16* b = img->bluecmap;
+    uint32 *p;
+    int i;
 
-	img->PALmap = (uint32 **)_TIFFmalloc(
-		256 * sizeof(uint32 *) + (256 * nsamples * sizeof(uint32)));
-	if (img->PALmap == NULL) {
+    img->PALmap = (uint32**) _TIFFmalloc(
+	256*sizeof (uint32 *)+(256*nsamples*sizeof(uint32)));
+    if (img->PALmap == NULL) {
 		TIFFErrorExt(img->tif->tif_clientdata, TIFFFileName(img->tif), "No space for Palette mapping table");
 		return (0);
 	}
-	p = (uint32 *)(img->PALmap + 256);
-	for (i = 0; i < 256; i++) {
-		TIFFRGBValue c;
-		img->PALmap[i] = p;
-#define CMAP(x)          \
-	c = (TIFFRGBValue)x; \
-	*p++ = PACK_32(r[c] & 0xff, g[c] & 0xff, b[c] & 0xff);
-		switch (bitspersample) {
-		case 1:
-			CMAP(i >> 7);
-			CMAP((i >> 6) & 1);
-			CMAP((i >> 5) & 1);
-			CMAP((i >> 4) & 1);
-			CMAP((i >> 3) & 1);
-			CMAP((i >> 2) & 1);
-			CMAP((i >> 1) & 1);
-			CMAP(i & 1);
-			break;
-		case 2:
-			CMAP(i >> 6);
-			CMAP((i >> 4) & 3);
-			CMAP((i >> 2) & 3);
-			CMAP(i & 3);
-			break;
-		case 4:
-			CMAP(i >> 4);
-			CMAP(i & 0xf);
-			break;
-		case 8:
-			CMAP(i);
-			break;
-		}
-#undef CMAP
+    p = (uint32*)(img->PALmap + 256);
+    for (i = 0; i < 256; i++) {
+	TIFFRGBValue c;
+	img->PALmap[i] = p;
+#define	CMAP(x)	c = (TIFFRGBValue) x; *p++ = PACK_32(r[c]&0xff, g[c]&0xff, b[c]&0xff);
+	switch (bitspersample) {
+	case 1:
+	    CMAP(i>>7);
+	    CMAP((i>>6)&1);
+	    CMAP((i>>5)&1);
+	    CMAP((i>>4)&1);
+	    CMAP((i>>3)&1);
+	    CMAP((i>>2)&1);
+	    CMAP((i>>1)&1);
+	    CMAP(i&1);
+	    break;
+	case 2:
+	    CMAP(i>>6);
+	    CMAP((i>>4)&3);
+	    CMAP((i>>2)&3);
+	    CMAP(i&3);
+	    break;
+	case 4:
+	    CMAP(i>>4);
+	    CMAP(i&0xf);
+	    break;
+	case 8:
+	    CMAP(i);
+	    break;
 	}
-	return (1);
+#undef CMAP
+    }
+    return (1);
 }
 
 /* 
@@ -2010,107 +1974,109 @@ makecmap(TIFFRGBAImage *img)
  * by the associated put routine.
  */
 static int
-buildMap(TIFFRGBAImage *img)
+buildMap(TIFFRGBAImage* img)
 {
-	switch (img->photometric) {
-	case PHOTOMETRIC_RGB:
-	case PHOTOMETRIC_YCBCR:
-	case PHOTOMETRIC_SEPARATED:
-		if (img->bitspersample == 8)
-			break;
+    switch (img->photometric) {
+    case PHOTOMETRIC_RGB:
+    case PHOTOMETRIC_YCBCR:
+    case PHOTOMETRIC_SEPARATED:
+	if (img->bitspersample == 8)
+	    break;
 	/* fall thru... */
-	case PHOTOMETRIC_MINISBLACK:
-	case PHOTOMETRIC_MINISWHITE:
-		if (!setupMap(img))
-			return (0);
-		break;
-	case PHOTOMETRIC_PALETTE:
-		/*
+    case PHOTOMETRIC_MINISBLACK:
+    case PHOTOMETRIC_MINISWHITE:
+	if (!setupMap(img))
+	    return (0);
+	break;
+    case PHOTOMETRIC_PALETTE:
+	/*
 	 * Convert 16-bit colormap to 8-bit (unless it looks
 	 * like an old-style 8-bit colormap).
 	 */
-		if (checkcmap(img) == 16)
-			cvtcmap(img);
-		else
-			TIFFWarningExt(img->tif->tif_clientdata, TIFFFileName(img->tif), "Assuming 8-bit colormap");
-		/*
+	if (checkcmap(img) == 16)
+	    cvtcmap(img);
+	else
+	    TIFFWarningExt(img->tif->tif_clientdata, TIFFFileName(img->tif), "Assuming 8-bit colormap");
+	/*
 	 * Use mapping table and colormap to construct
 	 * unpacking tables for samples < 8 bits.
 	 */
-		if (img->bitspersample <= 8 && !makecmap(img))
-			return (0);
-		break;
-	}
-	return (1);
+	if (img->bitspersample <= 8 && !makecmap(img))
+	    return (0);
+	break;
+    }
+    return (1);
 }
 
 /*
  * Select the appropriate conversion routine for packed data.
  */
 static int
-PickContigCase(TIFFRGBAImage *img)
+PickContigCase(TIFFRGBAImage* img)
 {
 	img->get = (gtFunc_32)(TIFFIsTiled(img->tif) ? gtTileContig : gtStripContig);
 	img->put.contig = NULL;
 	switch (img->photometric) {
-	case PHOTOMETRIC_RGB:
-		switch (img->bitspersample) {
-		case 8:
-			if (img->alpha != EXTRASAMPLE_UNSPECIFIED)
-				img->put.contig = (tileContigRoutine)putRGBAAcontig8bittile;
-			else
-				img->put.contig = (tileContigRoutine)putRGBcontig8bittile;
-			break;
-		case 16:
-			if (img->alpha != EXTRASAMPLE_UNSPECIFIED)
-				img->put.contig = (tileContigRoutine)putRGBAAcontig16bittile;
-			else {
-				if (BuildMapBitdepth16To8(img))
-					img->put.contig = (tileContigRoutine)putRGBcontig16bittile;
-			}
-			break;
-		}
-		break;
-	case PHOTOMETRIC_SEPARATED:
-		if (buildMap(img)) {
-			if (img->bitspersample == 8) {
-				if (!img->Map)
-					img->put.contig = (tileContigRoutine)putRGBcontig8bitCMYKtile;
-				else
-					img->put.contig = (tileContigRoutine)putRGBcontig8bitCMYKMaptile;
-			}
-		}
-		break;
-	case PHOTOMETRIC_PALETTE:
-	case PHOTOMETRIC_MINISWHITE:
-	case PHOTOMETRIC_MINISBLACK:
-		if (buildMap(img)) {
+		case PHOTOMETRIC_RGB:
 			switch (img->bitspersample) {
-			case 16:
-				img->put.contig = (tileContigRoutine)put16bitbwtile;
-				break;
-			case 8:
-				if (img->alpha && img->samplesperpixel == 2)
-					img->put.contig = (tileContigRoutine)putagreytile;
-				else
-					img->put.contig = (tileContigRoutine)putgreytile;
-				break;
-			case 4:
-				img->put.contig = (tileContigRoutine)put4bitbwtile;
-				break;
-			case 2:
-				img->put.contig = (tileContigRoutine)put2bitbwtile;
-				break;
-			case 1:
-				img->put.contig = (tileContigRoutine)put1bitbwtile;
-				break;
+				case 8:
+					if (img->alpha != EXTRASAMPLE_UNSPECIFIED)
+					img->put.contig = (tileContigRoutine)putRGBAAcontig8bittile;
+					else
+						img->put.contig = (tileContigRoutine)putRGBcontig8bittile;
+					break;
+				case 16:
+					if (img->alpha != EXTRASAMPLE_UNSPECIFIED)
+						img->put.contig = (tileContigRoutine)putRGBAAcontig16bittile;
+					else {
+						if (BuildMapBitdepth16To8(img))
+							img->put.contig = (tileContigRoutine)putRGBcontig16bittile;
+					}
+					break;
 			}
-		}
-		break;
-	case PHOTOMETRIC_YCBCR:
-		if ((img->bitspersample == 8) && (img->samplesperpixel == 3)) {
-			if (initYCbCrConversion(img) != 0) {
-				/*
+			break;
+		case PHOTOMETRIC_SEPARATED:
+			if (buildMap(img)) {
+				if (img->bitspersample == 8) {
+					if (!img->Map)
+						img->put.contig = (tileContigRoutine)putRGBcontig8bitCMYKtile;
+					else
+						img->put.contig = (tileContigRoutine)putRGBcontig8bitCMYKMaptile;
+				}
+			}
+			break;
+		case PHOTOMETRIC_PALETTE:
+		case PHOTOMETRIC_MINISWHITE:
+		case PHOTOMETRIC_MINISBLACK:
+			if (buildMap(img)) {
+				switch (img->bitspersample) {
+					case 16:
+						img->put.contig = (tileContigRoutine)put16bitbwtile;
+						break;
+					case 8:
+						if (img->alpha && img->samplesperpixel == 2)
+							img->put.contig = (tileContigRoutine)putagreytile;
+						else
+							img->put.contig = (tileContigRoutine)putgreytile;
+						break;
+					case 4:
+						img->put.contig = (tileContigRoutine)put4bitbwtile;
+						break;
+					case 2:
+						img->put.contig = (tileContigRoutine)put2bitbwtile;
+						break;
+					case 1:
+						img->put.contig = (tileContigRoutine)put1bitbwtile;
+						break;
+				}
+			}
+			break;
+		case PHOTOMETRIC_YCBCR:
+			if ((img->bitspersample==8) && (img->samplesperpixel==3))
+			{
+				if (initYCbCrConversion(img)!=0)
+				{
+					/*
 					 * The 6.0 spec says that subsampling must be
 					 * one of 1, 2, or 4, and that vertical subsampling
 					 * must always be <= horizontal subsampling; so
@@ -2119,43 +2085,43 @@ PickContigCase(TIFFRGBAImage *img)
 					 * Joris: added support for the [1,2] case, nonetheless, to accomodate
 					 * some OJPEG files
 					 */
-				uint16 SubsamplingHor;
-				uint16 SubsamplingVer;
-				TIFFGetFieldDefaulted(img->tif, TIFFTAG_YCBCRSUBSAMPLING, &SubsamplingHor, &SubsamplingVer);
-				switch ((SubsamplingHor << 4) | SubsamplingVer) {
-				case 0x44:
-					img->put.contig = (tileContigRoutine)putcontig8bitYCbCr44tile;
-					break;
-				case 0x42:
-					img->put.contig = (tileContigRoutine)putcontig8bitYCbCr42tile;
-					break;
-				case 0x41:
-					img->put.contig = (tileContigRoutine)putcontig8bitYCbCr41tile;
-					break;
-				case 0x22:
-					img->put.contig = (tileContigRoutine)putcontig8bitYCbCr22tile;
-					break;
-				case 0x21:
-					img->put.contig = (tileContigRoutine)putcontig8bitYCbCr21tile;
-					break;
-				case 0x12:
-					img->put.contig = (tileContigRoutine)putcontig8bitYCbCr12tile;
-					break;
-				case 0x11:
-					img->put.contig = (tileContigRoutine)putcontig8bitYCbCr11tile;
-					break;
+					uint16 SubsamplingHor;
+					uint16 SubsamplingVer;
+					TIFFGetFieldDefaulted(img->tif, TIFFTAG_YCBCRSUBSAMPLING, &SubsamplingHor, &SubsamplingVer);
+					switch ((SubsamplingHor<<4)|SubsamplingVer) {
+						case 0x44:
+							img->put.contig = (tileContigRoutine)putcontig8bitYCbCr44tile;
+							break;
+						case 0x42:
+							img->put.contig = (tileContigRoutine)putcontig8bitYCbCr42tile;
+							break;
+						case 0x41:
+							img->put.contig = (tileContigRoutine)putcontig8bitYCbCr41tile;
+							break;
+						case 0x22:
+							img->put.contig = (tileContigRoutine)putcontig8bitYCbCr22tile;
+							break;
+						case 0x21:
+							img->put.contig = (tileContigRoutine)putcontig8bitYCbCr21tile;
+							break;
+						case 0x12:
+							img->put.contig = (tileContigRoutine)putcontig8bitYCbCr12tile;
+							break;
+						case 0x11:
+							img->put.contig = (tileContigRoutine)putcontig8bitYCbCr11tile;
+							break;
+					}
 				}
 			}
-		}
-		break;
-	case PHOTOMETRIC_CIELAB:
-		if (buildMap(img)) {
-			if (img->bitspersample == 8)
-				img->put.contig = (tileContigRoutine)initCIELabConversion(img);
 			break;
-		}
+		case PHOTOMETRIC_CIELAB:
+			if (buildMap(img)) {
+				if (img->bitspersample == 8)
+					img->put.contig = (tileContigRoutine)initCIELabConversion(img);
+				break;
+			}
 	}
-	return ((img->get != NULL) && (img->put.contig != NULL));
+	return ((img->get!=NULL) && (img->put.contig!=NULL));
 }
 
 /*
@@ -2165,14 +2131,14 @@ PickContigCase(TIFFRGBAImage *img)
  *	 to the "packed routines.
  */
 static int
-PickSeparateCase(TIFFRGBAImage *img)
+PickSeparateCase(TIFFRGBAImage* img)
 {
 	img->get = (gtFunc_32)(TIFFIsTiled(img->tif) ? gtTileSeparate : gtStripSeparate);
 	img->put.separate = NULL;
 	switch (img->photometric) {
 	case PHOTOMETRIC_MINISWHITE:
 	case PHOTOMETRIC_MINISBLACK:
-	/* greyscale images processed pretty much as RGB by gtTileSeparate */
+		/* greyscale images processed pretty much as RGB by gtTileSeparate */
 	case PHOTOMETRIC_RGB:
 		switch (img->bitspersample) {
 		case 8:
@@ -2193,17 +2159,20 @@ PickSeparateCase(TIFFRGBAImage *img)
 		}
 		break;
 	case PHOTOMETRIC_SEPARATED:
-		if (img->bitspersample == 8 && img->samplesperpixel == 4) {
+		if (img->bitspersample == 8 && img->samplesperpixel == 4)
+		{
 			img->alpha = 1; // Not alpha, but seems like the only way to get 4th band
 			img->put.separate = (tileSeparateRoutine)putCMYKseparate8bittile;
 		}
 		break;
 	case PHOTOMETRIC_YCBCR:
-		if ((img->bitspersample == 8) && (img->samplesperpixel == 3)) {
-			if (initYCbCrConversion(img) != 0) {
+		if ((img->bitspersample==8) && (img->samplesperpixel==3))
+		{
+			if (initYCbCrConversion(img)!=0)
+			{
 				uint16 hs, vs;
 				TIFFGetFieldDefaulted(img->tif, TIFFTAG_YCBCRSUBSAMPLING, &hs, &vs);
-				switch ((hs << 4) | vs) {
+				switch ((hs<<4)|vs) {
 				case 0x11:
 					img->put.separate = (tileSeparateRoutine)putseparate8bitYCbCr11tile;
 					break;
@@ -2213,26 +2182,28 @@ PickSeparateCase(TIFFRGBAImage *img)
 		}
 		break;
 	}
-	return ((img->get != NULL) && (img->put.separate != NULL));
+	return ((img->get!=NULL) && (img->put.separate!=NULL));
 }
 
 static int
-BuildMapBitdepth16To8(TIFFRGBAImage *img)
+BuildMapBitdepth16To8(TIFFRGBAImage* img)
 {
-	static const char module[] = "BuildMapBitdepth16To8";
-	uint8 *m;
+	static const char module[]="BuildMapBitdepth16To8";
+	uint8* m;
 	uint32 n;
-	assert(img->Bitdepth16To8 == NULL);
-	img->Bitdepth16To8 = _TIFFmalloc(65536);
-	if (img->Bitdepth16To8 == NULL) {
-		TIFFErrorExt(img->tif->tif_clientdata, module, "Out of memory");
-		return (0);
+	assert(img->Bitdepth16To8==NULL);
+	img->Bitdepth16To8=_TIFFmalloc(65536);
+	if (img->Bitdepth16To8==NULL)
+	{
+		TIFFErrorExt(img->tif->tif_clientdata,module,"Out of memory");
+		return(0);
 	}
-	m = img->Bitdepth16To8;
-	for (n = 0; n < 65536; n++)
-		*m++ = (n + 128) / 257;
-	return (1);
+	m=img->Bitdepth16To8;
+	for (n=0; n<65536; n++)
+		*m++=(n+128)/257;
+	return(1);
 }
+
 
 /*
  * Read a whole strip off data from the file, and convert to RGBA form.
@@ -2241,46 +2212,50 @@ BuildMapBitdepth16To8(TIFFRGBAImage *img)
  * organized in bottom to top form.
  */
 
-int TIFFReadRGBAStrip_64(TIFF *tif, uint32 row, uint64 *raster)
+
+int
+TIFFReadRGBAStrip_64(TIFF* tif, uint32 row, uint64 * raster )
 
 {
-	char emsg[1024] = "";
-	TIFFRGBAImage img;
-	int ok;
-	uint32 rowsperstrip, rows_to_read;
+    char 	emsg[1024] = "";
+    TIFFRGBAImage img;
+    int 	ok;
+    uint32	rowsperstrip, rows_to_read;
 
-	if (TIFFIsTiled(tif)) {
+    if( TIFFIsTiled( tif ) )
+    {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif),
-					 "Can't use TIFFReadRGBAStrip() with tiled file.");
-		return (0);
-	}
-
-	TIFFGetFieldDefaulted(tif, TIFFTAG_ROWSPERSTRIP, &rowsperstrip);
-	if ((row % rowsperstrip) != 0) {
+                  "Can't use TIFFReadRGBAStrip() with tiled file.");
+	return (0);
+    }
+    
+    TIFFGetFieldDefaulted(tif, TIFFTAG_ROWSPERSTRIP, &rowsperstrip);
+    if( (row % rowsperstrip) != 0 )
+    {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif),
-					 "Row passed to TIFFReadRGBAStrip() must be first in a strip.");
+				"Row passed to TIFFReadRGBAStrip() must be first in a strip.");
 		return (0);
-	}
+    }
 
-	if (TIFFRGBAImageOK(tif, emsg) && TIFFRGBAImageBegin_64(&img, tif, 0, emsg)) {
+    if (TIFFRGBAImageOK(tif, emsg) && TIFFRGBAImageBegin_64(&img, tif, 0, emsg)) {
 
-		img.row_offset = row;
-		img.col_offset = 0;
+        img.row_offset = row;
+        img.col_offset = 0;
 
-		if (row + rowsperstrip > img.height)
-			rows_to_read = img.height - row;
-		else
-			rows_to_read = rowsperstrip;
-
-		ok = TIFFRGBAImageGet_64(&img, raster, img.width, rows_to_read);
-
-		TIFFRGBAImageEnd(&img);
-	} else {
+        if( row + rowsperstrip > img.height )
+            rows_to_read = img.height - row;
+        else
+            rows_to_read = rowsperstrip;
+        
+	ok = TIFFRGBAImageGet_64(&img, raster, img.width, rows_to_read );
+        
+	TIFFRGBAImageEnd(&img);
+    } else {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", emsg);
 		ok = 0;
-	}
-
-	return (ok);
+    }
+    
+    return (ok);
 }
 
 /*
@@ -2289,74 +2264,78 @@ int TIFFReadRGBAStrip_64(TIFF *tif, uint32 row, uint64 *raster)
  * and may include zeroed areas if the tile extends off the image.
  */
 
-int TIFFReadRGBATile_64(TIFF *tif, uint32 col, uint32 row, uint64 *raster)
+int
+TIFFReadRGBATile_64(TIFF* tif, uint32 col, uint32 row, uint64 * raster)
 
 {
-	char emsg[1024] = "";
-	TIFFRGBAImage img;
-	int ok;
-	uint32 tile_xsize, tile_ysize;
-	uint32 read_xsize, read_ysize;
-	uint32 i_row;
+    char 	emsg[1024] = "";
+    TIFFRGBAImage img;
+    int 	ok;
+    uint32	tile_xsize, tile_ysize;
+    uint32	read_xsize, read_ysize;
+    uint32	i_row;
 
-	/*
+    /*
      * Verify that our request is legal - on a tile file, and on a
      * tile boundary.
      */
-
-	if (!TIFFIsTiled(tif)) {
+    
+    if( !TIFFIsTiled( tif ) )
+    {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif),
-					 "Can't use TIFFReadRGBATile() with stripped file.");
+				  "Can't use TIFFReadRGBATile() with stripped file.");
 		return (0);
-	}
-
-	TIFFGetFieldDefaulted(tif, TIFFTAG_TILEWIDTH, &tile_xsize);
-	TIFFGetFieldDefaulted(tif, TIFFTAG_TILELENGTH, &tile_ysize);
-	if ((col % tile_xsize) != 0 || (row % tile_ysize) != 0) {
+    }
+    
+    TIFFGetFieldDefaulted(tif, TIFFTAG_TILEWIDTH, &tile_xsize);
+    TIFFGetFieldDefaulted(tif, TIFFTAG_TILELENGTH, &tile_ysize);
+    if( (col % tile_xsize) != 0 || (row % tile_ysize) != 0 )
+    {
 		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif),
-					 "Row/col passed to TIFFReadRGBATile() must be top"
-					 "left corner of a tile.");
-		return (0);
-	}
+                  "Row/col passed to TIFFReadRGBATile() must be top"
+                  "left corner of a tile.");
+	return (0);
+    }
 
-	/*
+    /*
      * Setup the RGBA reader.
      */
+    
+    if (!TIFFRGBAImageOK(tif, emsg) 
+	|| !TIFFRGBAImageBegin_64(&img, tif, 0, emsg)) {
+	    TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", emsg);
+	    return( 0 );
+    }
 
-	if (!TIFFRGBAImageOK(tif, emsg) || !TIFFRGBAImageBegin_64(&img, tif, 0, emsg)) {
-		TIFFErrorExt(tif->tif_clientdata, TIFFFileName(tif), "%s", emsg);
-		return (0);
-	}
-
-	/*
+    /*
      * The TIFFRGBAImageGet() function doesn't allow us to get off the
      * edge of the image, even to fill an otherwise valid tile.  So we
      * figure out how much we can read, and fix up the tile buffer to
      * a full tile configuration afterwards.
      */
 
-	if (row + tile_ysize > img.height)
-		read_ysize = img.height - row;
-	else
-		read_ysize = tile_ysize;
+    if( row + tile_ysize > img.height )
+        read_ysize = img.height - row;
+    else
+        read_ysize = tile_ysize;
+    
+    if( col + tile_xsize > img.width )
+        read_xsize = img.width - col;
+    else
+        read_xsize = tile_xsize;
 
-	if (col + tile_xsize > img.width)
-		read_xsize = img.width - col;
-	else
-		read_xsize = tile_xsize;
-
-	/*
+    /*
      * Read the chunk of imagery.
      */
+    
+    img.row_offset = row;
+    img.col_offset = col;
 
-	img.row_offset = row;
-	img.col_offset = col;
+    ok = TIFFRGBAImageGet_64(&img, raster, read_xsize, read_ysize );
+        
+    TIFFRGBAImageEnd(&img);
 
-	ok = TIFFRGBAImageGet_64(&img, raster, read_xsize, read_ysize);
-
-	TIFFRGBAImageEnd(&img);
-
-	/*
+    /*
      * If our read was incomplete we will need to fix up the tile by
      * shifting the data around as if a full tile of data is being returned.
      *
@@ -2364,23 +2343,23 @@ int TIFFReadRGBATile_64(TIFF *tif, uint32 col, uint32 row, uint64 *raster)
      * bottom to top format. 
      */
 
-	if (read_xsize == tile_xsize && read_ysize == tile_ysize)
-		return (ok);
+    if( read_xsize == tile_xsize && read_ysize == tile_ysize )
+        return( ok );
 
-	for (i_row = 0; i_row < read_ysize; i_row++) {
-		memmove(raster + (tile_ysize - i_row - 1) * tile_xsize,
-				raster + (read_ysize - i_row - 1) * read_xsize,
-				read_xsize * sizeof(uint64));
-		_TIFFmemset(raster + (tile_ysize - i_row - 1) * tile_xsize + read_xsize,
-					0, sizeof(uint64) * (tile_xsize - read_xsize));
-	}
+    for( i_row = 0; i_row < read_ysize; i_row++ ) {
+        memmove( raster + (tile_ysize - i_row - 1) * tile_xsize,
+                 raster + (read_ysize - i_row - 1) * read_xsize,
+                 read_xsize * sizeof(uint64) );
+        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize+read_xsize,
+                     0, sizeof(uint64) * (tile_xsize - read_xsize) );
+    }
 
-	for (i_row = read_ysize; i_row < tile_ysize; i_row++) {
-		_TIFFmemset(raster + (tile_ysize - i_row - 1) * tile_xsize,
-					0, sizeof(uint64) * tile_xsize);
-	}
+    for( i_row = read_ysize; i_row < tile_ysize; i_row++ ) {
+        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize,
+                     0, sizeof(uint64) * tile_xsize );
+    }
 
-	return (ok);
+    return (ok);
 }
 
 /* vim: set ts=8 sts=8 sw=8 noet: */


### PR DESCRIPTION
This reverts all the formatting changes made to `tif_getimage_64.c` when compared to `tif_getimage.c`. This should make the code easier to get upstream at some point, or apply fixes to.

This change is refactoring only, it should have no functional effect.