### PR TITLE
Fix compile error on clang

### DIFF
--- a/toonz/sources/toonz/loadfoldercommand.cpp
+++ b/toonz/sources/toonz/loadfoldercommand.cpp
@@ -440,7 +440,7 @@ struct import_Locals {
 void import(const ToonzScene &scene, std::vector<Resource> &resources,
 			IoCmd::LoadResourceArguments::ScopedBlock &sb)
 {
-	import_Locals locals = {scene};
+	import_Locals locals = {scene, std::auto_ptr<OverwriteDialog>()};
 
 	// Setup import GUI
 	int r, rCount = resources.size();


### PR DESCRIPTION
Avoid 'chosen constructor is explicit in copy-initialization' error.

```
/Users/brly1/projects/opentoonz/toonz/sources/toonz/loadfoldercommand.cpp:444:31: error: chosen
      constructor is explicit in copy-initialization
        import_Locals locals = {scene};
                                     ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:1890:40: note: 
      constructor declared here
    _LIBCPP_INLINE_VISIBILITY explicit auto_ptr(_Tp* __p = 0) throw() : __ptr_(__p) {}
                                       ^
/Users/brly1/projects/opentoonz/toonz/sources/toonz/loadfoldercommand.cpp:382:33: note: in implicit
      initialization of field 'm_overwriteDialog' with omitted initializer
        std::auto_ptr<OverwriteDialog> m_overwriteDialog;
                                       ^
5 warnings and 1 error generated.
```

```
$ clang --version
Apple LLVM version 7.0.2 (clang-700.1.81)
Target: x86_64-apple-darwin14.5.0
Thread model: posix
```