### PR TITLE
Use #error directive instead of explicit syntax error

### DIFF
--- a/toonz/sources/common/tgl/tgl.cpp
+++ b/toonz/sources/common/tgl/tgl.cpp
@@ -536,8 +536,8 @@ void tglDraw(const TRectD &rect, const TRaster32P &tex, bool blending)
 #elif TNZ_MACHINE_CHANNEL_ORDER_MRGB
 		GL_BGRA;
 #else
-		@unknow channel order
 //   Error  PLATFORM NOT SUPPORTED
+#error "unknown channel order!"
 #endif
 
 	// Generate a texture id and bind it.
@@ -709,8 +709,8 @@ void tglDoneCurrent(TGlContext context)
 		reinterpret_cast<QGLContext *>(context)->doneCurrent();
 }
 
-#elif @unknow platform !
-
+#else
+#error "unknown platform!"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/image/png/tiio_png.cpp
+++ b/toonz/sources/image/png/tiio_png.cpp
@@ -127,7 +127,7 @@ public:
 #elif defined(TNZ_MACHINE_CHANNEL_ORDER_MRGB)
 		png_set_swap_alpha(m_png_ptr);
 #elif !defined(TNZ_MACHINE_CHANNEL_ORDER_RGBM)
-		@unknow channel order
+#error	"unknown channel order"
 #endif
 
 		png_read_info(m_png_ptr, m_info_ptr);
@@ -192,7 +192,7 @@ public:
 			png_set_swap_alpha(m_png_ptr);
 		}
 #elif !defined(TNZ_MACHINE_CHANNEL_ORDER_RGBM) && !defined(TNZ_MACHINE_CHANNEL_ORDER_MRGB)
-		@unknow channel order
+#error	"unknown channel order"
 #endif
 
 		if (m_color_type == PNG_COLOR_TYPE_GRAY ||
@@ -344,7 +344,7 @@ public:
 					pix[j].g = m_rowBuffer[i = i + 2];
 					pix[j].r = m_rowBuffer[i = i + 2];
 #else
-					@unknow channel order
+#error				"unknown channel order"
 #endif
 				}
 			} else {
@@ -372,7 +372,7 @@ public:
 					pix[j].g = m_rowBuffer[i++];
 					pix[j].r = m_rowBuffer[i++];
 #else
-					@unknow channel order
+#error				"unknown channel order"
 #endif
 				}
 			}
@@ -391,7 +391,7 @@ public:
 					pix[j].g = m_rowBuffer[i = i + 2];
 					pix[j].r = m_rowBuffer[i = i + 2];
 #else
-					@unknow channel order
+#error				"unknown channel order"
 #endif
 					pix[j].m = 255;
 				}
@@ -408,7 +408,7 @@ public:
 					pix[j].g = m_rowBuffer[i++];
 					pix[j].r = m_rowBuffer[i++];
 #else
-					@unknow channel order
+#error				"unknown channel order"
 #endif
 					pix[j].m = 255;
 				}
@@ -434,7 +434,7 @@ public:
 				pix[j].r = mySwap(m_rowBuffer[i = i + 2]);
 				pix[j].m = mySwap(m_rowBuffer[i = i + 2]);
 #else
-				@unknow channel order
+#error			"unknown channel order"
 #endif
 				//pix[j].m = 255;
 			}
@@ -452,7 +452,7 @@ public:
 				pix[j].g = mySwap(m_rowBuffer[i = i + 2]);
 				pix[j].r = mySwap(m_rowBuffer[i = i + 2]);
 #else
-				@unknow channel order
+#error			"unknown channel order"
 #endif
 				pix[j].m = mySwap(255);
 			}
@@ -800,7 +800,7 @@ void PngWriter::open(FILE *file, const TImageInfo &info)
 #elif defined(TNZ_MACHINE_CHANNEL_ORDER_MRGB)
 	png_set_swap_alpha(m_png_ptr);
 #elif !defined(TNZ_MACHINE_CHANNEL_ORDER_RGBM)
-	@unknow channel order
+#error	"unknownchannel order"
 #endif
 
 	png_write_info(m_png_ptr, m_info_ptr);
@@ -844,7 +844,7 @@ void PngWriter::writeLine(short *buffer)
 			tmp[k++] = mySwap(pix->g);
 			tmp[k++] = mySwap(pix->r);
 #else
-			@unknow channel order
+#error		"unknown channel order"
 #endif
 			if (m_matte)
 				tmp[k++] = mySwap(pix->m);
@@ -882,7 +882,7 @@ void PngWriter::writeLine(char *buffer)
 			tmp[k++] = pix->g;
 			tmp[k++] = pix->r;
 #else
-			@unknow channel order
+#error		"unknown channel order"
 #endif
 
 			++pix;

--- a/toonz/sources/tnztools/stylepicker.cpp
+++ b/toonz/sources/tnztools/stylepicker.cpp
@@ -179,8 +179,8 @@ TPixel32 getAverageColor(const TRect &rect)
 #elif TNZ_MACHINE_CHANNEL_ORDER_MRGB
 		GL_BGRA;
 #else
-		@unknow channel order
 //   Error  PLATFORM NOT SUPPORTED
+#error	"unknown channel order!"
 #endif
 	UINT r = 0, g = 0, b = 0, m = 0;
 	vector<TPixel32> buffer(rect.getLx() * rect.getLy());
@@ -209,8 +209,8 @@ TPixel32 getAverageColor(TStroke *stroke)
 #elif TNZ_MACHINE_CHANNEL_ORDER_MRGB
 		GL_BGRA;
 #else
-		@unknow channel order
 //   Error  PLATFORM NOT SUPPORTED
+#error	"unknown channel order"
 #endif
 
 	//leggo il buffer e mi prendo i pixels


### PR DESCRIPTION
We had a report (that I can't confirm), that this caused errors.
Best to use `error` here.

See report on the problem: https://github.com/ideasman42/opentoonz/pull/7