### PR TITLE
Fixes for abs()

### DIFF
--- a/toonz/sources/include/ext/plasticvisualsettings.h
+++ b/toonz/sources/include/ext/plasticvisualsettings.h
@@ -33,4 +33,4 @@ public:
 		: m_applyPlasticDeformation(true), m_showOriginalColumn(), m_drawMeshesWireframe(true), m_drawRigidity(false), m_drawSO(false) {}
 };
 
-#endif PLASTICVISUALSETTINGS_H
+#endif //PLASTICVISUALSETTINGS_H

--- a/toonz/sources/include/toonz/doubleparamcmd.h
+++ b/toonz/sources/include/toonz/doubleparamcmd.h
@@ -109,4 +109,4 @@ public:
 	static void enableCycle(TDoubleParam *curve, bool enabled);
 };
 
-#endif;
+#endif

--- a/toonz/sources/include/toonz/ikengine.h
+++ b/toonz/sources/include/toonz/ikengine.h
@@ -69,4 +69,4 @@ private:
 };
 
 //#endif
-#endif IKENGINE_H
+#endif //IKENGINE_H

--- a/toonz/sources/include/toonz/ikjacobian.h
+++ b/toonz/sources/include/toonz/ikjacobian.h
@@ -736,4 +736,4 @@ private:
 	static const double BaseMaxTargetDist;
 };
 
-#endif JACOBIAN_H
+#endif //JACOBIAN_H

--- a/toonz/sources/include/toonz/iknode.h
+++ b/toonz/sources/include/toonz/iknode.h
@@ -98,4 +98,4 @@ private:
 	bool freezed; // Se vero l'angolo è blocccato
 };
 
-#endif IKNODE_H
+#endif //IKNODE_H

--- a/toonz/sources/include/toonz/ikskeleton.h
+++ b/toonz/sources/include/toonz/ikskeleton.h
@@ -89,4 +89,4 @@ private:
 	void computeSkeleton(IKNode *);
 };
 
-#endif IKSKELETON_H
+#endif //IKSKELETON_H

--- a/toonz/sources/include/toonzqt/styleindexlineedit.h
+++ b/toonz/sources/include/toonzqt/styleindexlineedit.h
@@ -40,4 +40,4 @@ protected:
 };
 } //namspace
 
-#endif;
+#endif

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -150,7 +150,7 @@ void Ruler::compute()
 	// and m_labelPeriod (number of ticks between two adjacent labels)
 
 	// the distance (world units) between two labels must be >= minLabelWorldDistance
-	const double absUnit = abs(m_unit);
+	const double absUnit = std::abs(m_unit);
 	const double minLabelWorldDistance = m_minLabelDistance / absUnit;
 	const double minWorldDistance = m_minDistance / absUnit;
 
@@ -363,7 +363,7 @@ int FunctionPanel::getCurveDistance(TDoubleParam *curve, const QPoint &winPos)
 	double frame = xToFrame(winPos.x());
 	double value = curve->getValue(frame);
 	double curveY = valueToY(curve, value);
-	return abs(curveY - winPos.y());
+	return std::abs(curveY - winPos.y());
 }
 
 //-----------------------------------------------------------------------------
@@ -1308,7 +1308,7 @@ void FunctionPanel::mouseMoveEvent(QMouseEvent *e)
 		}
 
 		double currentFrame = m_frameHandle ? m_frameHandle->getFrame() : 0;
-		if (m_highlighted.handle == None && abs(e->pos().x() - frameToX(currentFrame)) < 5)
+		if (m_highlighted.handle == None && std::abs(e->pos().x() - frameToX(currentFrame)) < 5)
 			m_currentFrameStatus = 1;
 		else
 			m_currentFrameStatus = 0;


### PR DESCRIPTION
abs() only returns integer values, while arguments and results are real
in the cases fixed.

Also fixes some unexpected tokens after `#endif`.