### PR TITLE
Fix cmake to be able to search custom libpng include path

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -184,7 +184,7 @@ else()
     message("LZO:" ${LZO_INCLUDE_DIR})
 endif()
 
-include_directories(BEFORE ${TIFF_INCLUDE_DIR})
+include_directories(BEFORE ${TIFF_INCLUDE_DIR} ${PNG_INCLUDE_DIRS})
 
 find_path(BOOST_ROOT include/boost boost HINTS ${THIRDPARTY_LIBS_HINTS} PATH_SUFFIXES boost155/1.55.0_1 boost/boost_1_55_0/)
 find_package(Boost 1.55 EXACT REQUIRED)


### PR DESCRIPTION
This PR is similar approach as https://github.com/opentoonz/opentoonz/pull/85 .

I bumped into the problem discussed in https://github.com/opentoonz/opentoonz/issues/79 . With this fix and some cmake option, I could finally build OpenToonz successfully.

Here's my cmake options

```bash
cd toonz/build
CMAKE_PREFIX_PATH=~/Qt5.5.1/5.5/clang_64 cmake \
  -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
  -DPNG_PNG_INCLUDE_DIR=../../thirdparty/libpng-1.6.21/  \
  ../sources
make
```