### PR TITLE
add clean-up at the end of SceneViewer::contextMenuEvent for OSX

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -982,6 +982,13 @@ void SceneViewer::contextMenuEvent(QContextMenuEvent *e)
 
 	menu->exec(e->globalPos());
 	delete menu;
+#ifdef MACOSX
+	m_mouseButton = Qt::NoButton;
+	m_tabletEvent = false;
+	m_pressure = 0;
+	m_buttonClicked = false;
+#endif
+
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -957,6 +957,15 @@ using namespace ImageUtils;
 
 void SceneViewer::contextMenuEvent(QContextMenuEvent *e)
 {
+
+#ifdef MACOSX
+        //cleaning-up mousePressedEvent on MacOSX instead of mouseReleaseEvent called
+	m_mouseButton = Qt::NoButton;
+	m_tabletEvent = false;
+	m_pressure = 0;
+	m_buttonClicked = false;
+#endif
+
 	if (m_freezedStatus != NO_FREEZED)
 		return;
 
@@ -982,13 +991,6 @@ void SceneViewer::contextMenuEvent(QContextMenuEvent *e)
 
 	menu->exec(e->globalPos());
 	delete menu;
-#ifdef MACOSX
-	m_mouseButton = Qt::NoButton;
-	m_tabletEvent = false;
-	m_pressure = 0;
-	m_buttonClicked = false;
-#endif
-
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
fixed problem reported in https://github.com/opentoonz/opentoonz/issues/115 and https://github.com/opentoonz/opentoonz/issues/73 .