### PR TITLE
"Save All" menu which saves current scene and all the levels.

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1658,6 +1658,74 @@ bool IoCmd::saveLevel(TXshSimpleLevel *sl)
 }
 
 //===========================================================================
+// IoCmd::saveAll() save current scene and all of its levels
+//---------------------------------------------------------------------------
+
+bool IoCmd::saveAll()
+{
+#ifdef BRAVODEMO
+    return false;
+#else
+    // try to save as much as possible
+    // if anything is wrong, return false
+    bool result = true;
+    // save scene
+    if (!saveScene())
+    {
+        result = false;
+    }
+
+    TApp *app = TApp::instance();
+    ToonzScene* scene = app->getCurrentScene()->getScene();
+    TLevelSet* levelSet = scene->getLevelSet();
+    int numLevels = levelSet->getLevelCount();
+    // save levels of scene
+    for (int i = 0; i < numLevels; ++i)
+    {
+        TXshLevel* level = levelSet->getLevel(i);
+        TXshSimpleLevel *sl = level->getSimpleLevel();
+        if (sl)
+        {
+            if (sl->getPath() == TFilePath())
+            {
+                result = false;
+                continue;
+            }
+                
+            TFilePath path = scene->decodeFilePath(sl->getPath());
+            if (path == TFilePath())
+            {
+                result = false;
+                continue;
+            }
+            if (path.getWideString()[0] == L'+')
+            {
+                result = false;
+                continue;
+            }
+            if (!path.isAbsolute())
+            {
+                result = false;
+                continue;
+            }
+            if (!saveLevel(path, sl, true))
+            {
+                result = false;
+                continue;
+            }
+            sl->setDirtyFlag(false);
+        }
+    }
+
+    // for update title bar
+    // should we call this for all the levels?
+    app->getCurrentLevel()->notifyLevelChange();
+    
+    return result;
+#endif
+}
+
+//===========================================================================
 // IoCmd::saveSound(soundPath, soundColumn, overwrite)
 //---------------------------------------------------------------------------
 
@@ -2829,3 +2897,21 @@ public:
 		TApp::instance()->getPaletteController()->getCurrentLevelPalette()->notifyPaletteDirtyFlagChanged();
 	}
 } overwritePaletteCommandHandler;
+
+
+//=============================================================================
+// Save scene and levels
+//-----------------------------------------------------------------------------
+class SaveAllCommandHandler : public MenuItemHandler
+{
+public:
+    SaveAllCommandHandler() : MenuItemHandler(MI_SaveAll) {}
+    void execute()
+    {
+#ifdef BRAVODEMO
+        DVGui::featureNotAvelaible();
+#else
+        IoCmd::saveAll();
+#endif
+    }
+} saveAllCommandHandler;

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -174,6 +174,8 @@ bool saveLevel();
 bool saveLevel(const TFilePath &fp, TXshSimpleLevel *sl, bool overwrite);
 bool saveLevel(TXshSimpleLevel *sl);
 
+bool saveAll();
+
 bool saveSound(const TFilePath &fp, TXshSoundLevel *sc, bool overwrite);
 bool saveSound(TXshSoundLevel *sc);
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1552,6 +1552,7 @@ void MainWindow::defineActions()
 	createMenuFileAction(MI_LoadScene, tr("&Load Scene..."), "Ctrl+L");
 	createMenuFileAction(MI_SaveScene, tr("&Save Scene"), "Ctrl+S");
 	createMenuFileAction(MI_SaveSceneAs, tr("&Save Scene As..."), "Ctrl+Shift+S");
+    createMenuFileAction(MI_SaveAll, tr("&Save All"), "");
 	createMenuFileAction(MI_RevertScene, tr("&Revert Scene"), "");
 
 	QAction *act = CommandManager::instance()->getAction(MI_RevertScene);

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -100,6 +100,7 @@ void StackedMenuBar::createCleanupMenuBar()
 	addMenuItem(filesMenu, MI_LoadScene);
 	addMenuItem(filesMenu, MI_SaveScene);
 	addMenuItem(filesMenu, MI_SaveSceneAs);
+    addMenuItem(filesMenu, MI_SaveAll);
 	addMenuItem(filesMenu, MI_OpenRecentScene);
 	addMenuItem(filesMenu, MI_RevertScene);
 	filesMenu->addSeparator();
@@ -233,6 +234,7 @@ void StackedMenuBar::createPltEditMenuBar()
 	addMenuItem(filesMenu, MI_LoadScene);
 	addMenuItem(filesMenu, MI_SaveScene);
 	addMenuItem(filesMenu, MI_SaveSceneAs);
+    addMenuItem(filesMenu, MI_SaveAll);
 	addMenuItem(filesMenu, MI_OpenRecentScene);
 	addMenuItem(filesMenu, MI_RevertScene);
 	filesMenu->addSeparator();
@@ -406,6 +408,7 @@ void StackedMenuBar::createInknPaintMenuBar()
 	addMenuItem(filesMenu, MI_LoadScene);
 	addMenuItem(filesMenu, MI_SaveScene);
 	addMenuItem(filesMenu, MI_SaveSceneAs);
+    addMenuItem(filesMenu, MI_SaveAll);
 	addMenuItem(filesMenu, MI_OpenRecentScene);
 	filesMenu->addSeparator();
 	addMenuItem(filesMenu, MI_NewScene);
@@ -557,6 +560,7 @@ void StackedMenuBar::createXsheetMenuBar()
 	addMenuItem(xsheetMenu, MI_LoadScene);
 	addMenuItem(xsheetMenu, MI_SaveScene);
 	addMenuItem(xsheetMenu, MI_SaveSceneAs);
+    addMenuItem(xsheetMenu, MI_SaveAll);
 	addMenuItem(xsheetMenu, MI_OpenRecentScene);
 	addMenuItem(xsheetMenu, MI_RevertScene);
 	xsheetMenu->addSeparator();
@@ -811,6 +815,7 @@ void StackedMenuBar::createFullMenuBar()
 	addMenuItem(fileMenu, MI_NewScene);
 	addMenuItem(fileMenu, MI_LoadScene);
 	addMenuItem(fileMenu, MI_SaveScene);
+    addMenuItem(fileMenu, MI_SaveAll);
 	addMenuItem(fileMenu, MI_SaveSceneAs);
 	addMenuItem(fileMenu, MI_OpenRecentScene);
 	addMenuItem(fileMenu, MI_RevertScene);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -15,6 +15,7 @@
 #define MI_LoadScene "MI_LoadScene"
 #define MI_SaveScene "MI_SaveScene"
 #define MI_SaveSceneAs "MI_SaveSceneAs"
+#define MI_SaveAll "MI_SaveAll"
 #define MI_RevertScene "MI_RevertScene"
 #define MI_LoadSubSceneFile "MI_LoadSubSceneFile"
 


### PR DESCRIPTION
The "Save All" menu which saves the scene and all its levels. I've tested raster, toonz raster/vector and scan. It looks no data lost. The code is mainly copied from saveLevel() function.

I'm not quite familiar with the file components so please tell me if I missed anything.

Users who needs this can redirect "Ctrl+S" shortcut to this menu, instead of "Save Scene".