### PR TITLE
Fix to include cmath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Debug Library/
 Release/
 Release Library/
 ipch/
+.idea

--- a/toonz/sources/include/toonzqt/functionpanel.h
+++ b/toonz/sources/include/toonzqt/functionpanel.h
@@ -8,6 +8,7 @@
 
 #include <QDialog>
 #include <set>
+#include <cmath>
 
 #undef DVAPI
 #undef DVVAR


### PR DESCRIPTION
This fixes commit#6dca1d3a6d64f6b55d5545fd209acc0f81aab9ec
In OSX, we need to include `cmath` to use `std::abs(float)`