### PR TITLE
Allow building with a newer version of Boost (up to 1.60.0).

### DIFF
--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -12,7 +12,7 @@
   - http://download.qt.io/official_releases/qt/5.5/5.5.1/
     - qt-opensource-mac-x64-clang-5.5.1.dmg
 - boost
-  - http://www.boost.org/users/history/version_1_55_0.html
+  - http://www.boost.org/users/history/version_1_55_0.html (or later, though only 1.55.0 is supported)
 
 ## Building on MacOSX
 

--- a/doc/how_to_build_win.md
+++ b/doc/how_to_build_win.md
@@ -33,10 +33,12 @@ They will have to be installed seperately as follows.
   - qt-opensource-windows-x86-msvc2013_64-5.5.1.exe
 
 ### boost
+- boost 1.55.0 or later is required (tested up to 1.60.0), but the support build is using 1.55.0 exactly.
 - http://www.boost.org/users/history/version_1_55_0.html
 - Download boost_1_55_0.zip from the above link.  Extract all contents to the '$opentoonz/thirdparty/boost' directory.
 - Install the following path for Visual Studio 2013
   - https://svn.boost.org/trac/boost/attachment/ticket/9369/vc12_fix_has_member_function_callable_with.patch
+
 
 ## Building
 

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -186,8 +186,10 @@ endif()
 
 include_directories(BEFORE ${TIFF_INCLUDE_DIR} ${PNG_INCLUDE_DIRS})
 
-find_path(BOOST_ROOT include/boost boost HINTS ${THIRDPARTY_LIBS_HINTS} PATH_SUFFIXES boost155/1.55.0_1 boost/boost_1_55_0/)
-find_package(Boost 1.55 EXACT REQUIRED)
+find_path(BOOST_ROOT include/boost boost HINTS ${THIRDPARTY_LIBS_HINTS}
+	PATH_SUFFIXES boost/boost_1_60_0/ boost/boost_1_59_0/
+	boost/boost_1_58_0/ boost/boost_1_57_0/ boost/boost_1_56_0/ boost155/1.55.0_1/ boost/boost_1_55_0/ )
+find_package(Boost 1.55 REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIR} ${LZ4_LIB_INCLUDE_DIRS} ${USB_LIB_INCLUDE_DIRS} ${SUPERLU_INCLUDE_DIR} ${JPEG_INCLUDE_DIR})
 


### PR DESCRIPTION
The instructions for both OSX and Windows still say to use 1.55.0, but cmake will allow up to 1.60.0.
Using a later version will also mean the additional patch for VS2013 is not required.