### PR TITLE
Fix const enum which is an error with GCC5.3

### DIFF
--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -36,7 +36,7 @@
 
 using namespace DVGui;
 
-const enum StyleType {
+enum StyleType {
 	NORMALSTYLE,
 	STUDIOSTYLE,
 	LINKEDSTYLE


### PR DESCRIPTION
This gives an error with GCC, and has no useful meaning with other compilers, see: 
http://stackoverflow.com/questions/17805427