### PR TITLE
Fix brush tool crash

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -1398,15 +1398,9 @@ bool BrushTool::onPropertyChanged(string propertyName)
 
 			m_minThick = m_thickness.getValue().first;
 			m_maxThick = m_thickness.getValue().second;
-		}
-
-		if (m_preset.getValue() != CUSTOM_WSTR)
-			m_preset.setValue(CUSTOM_WSTR);
-
+		}		
 	} else if (propertyName == m_accuracy.getName()) {
 		BrushAccuracy = m_accuracy.getValue();
-		if (m_preset.getValue() != CUSTOM_WSTR)
-			m_preset.setValue(CUSTOM_WSTR);
 	} else if (propertyName == m_preset.getName()) {
 		loadPreset();
 		notifyTool = true;
@@ -1441,7 +1435,7 @@ bool BrushTool::onPropertyChanged(string propertyName)
 		}
 	}
 
-	if (m_preset.getValue() != CUSTOM_WSTR) {
+	if (propertyName != m_preset.getName() && m_preset.getValue() != CUSTOM_WSTR) {
 		m_preset.setValue(CUSTOM_WSTR);
 		notifyTool = true;
 	}

--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -573,6 +573,7 @@ BrushTool::BrushTool(string name, int targetType)
 #ifndef STUDENT
 	m_prop[0].bind(m_preset);
 	m_preset.setId("BrushPreset");
+	m_preset.addValue(CUSTOM_WSTR);
 #endif
 	m_pressure.setId("PressureSensibility");
 
@@ -1207,6 +1208,8 @@ void BrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e)
 
 		void addMinMax(TDoublePairProperty &prop, double add)
 		{
+			if (add == 0.0)
+				return;
 			const TDoublePairProperty::Range &range = prop.getRange();
 
 			TDoublePairProperty::Value value = prop.getValue();
@@ -1397,13 +1400,13 @@ bool BrushTool::onPropertyChanged(string propertyName)
 			m_maxThick = m_thickness.getValue().second;
 		}
 
-		if (m_preset.getValue() != L"<custom>")
-			m_preset.setValue(L"<custom>");
+		if (m_preset.getValue() != CUSTOM_WSTR)
+			m_preset.setValue(CUSTOM_WSTR);
 
 	} else if (propertyName == m_accuracy.getName()) {
 		BrushAccuracy = m_accuracy.getValue();
-		if (m_preset.getValue() != L"<custom>")
-			m_preset.setValue(L"<custom>");
+		if (m_preset.getValue() != CUSTOM_WSTR)
+			m_preset.setValue(CUSTOM_WSTR);
 	} else if (propertyName == m_preset.getName()) {
 		loadPreset();
 		notifyTool = true;


### PR DESCRIPTION
This fix is for the issue #59.
This problem happens when the brush tool is selected and "Alt" key is pressed while Tool Option Bar is hidden. 
In this fix, an item "<custom>" is added to brush preset property at constructor in order to avoid crash at BrushTool::onPropertyChanged() because of failure to find any items in the preset property.