### PR TITLE
Revert "Remove strstream"

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -624,18 +624,20 @@ istream &operator>>(istream &is, TRect &rect)
 template <class T>
 string toString2(T value)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << value << '\0';
 	string s(ss.str());
+	ss.freeze(false);
 	return s;
 }
 
 template <>
 string toString2(TRect value)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << value.x0 << " " << value.y0 << " " << value.x1 << " " << value.y1 << '\0';
 	string s = ss.str();
+	ss.freeze(false);
 	return s;
 }
 
@@ -644,7 +646,7 @@ void fromString(string s, T &value)
 {
 	if (s.empty())
 		return;
-	istringstream is(s.c_str());
+	istrstream is(s.c_str(), s.size());
 	is >> value;
 }
 

--- a/toonz/sources/common/tcore/tstopwatch.cpp
+++ b/toonz/sources/common/tcore/tstopwatch.cpp
@@ -352,9 +352,9 @@ TUINT32 TStopWatch::getSystemTime()
 TStopWatch::operator string()
 {
 	char buffer[256];
-	ostringstream out(buffer);
+	ostrstream out(buffer, sizeof(buffer));
 	out << m_name.c_str() << ": " << (int)getTotalTime() << " u" << (int)getUserTime() << " s" << (TINT32)getSystemTime();
-	return string(buffer);
+	return string(buffer, out.pcount());
 }
 
 //------------------------------------------------------------

--- a/toonz/sources/common/tcore/tstring.cpp
+++ b/toonz/sources/common/tcore/tstring.cpp
@@ -75,25 +75,28 @@ wstring toWideString(int x)
 
 string toString(int value)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << value << '\0';
 	string s = ss.str();
+	ss.freeze(false);
 	return s;
 }
 
 string toString(unsigned long value)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << value << '\0';
 	string s = ss.str();
+	ss.freeze(false);
 	return s;
 }
 
 string toString(unsigned long long value)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << value << '\0';
 	string s = ss.str();
+	ss.freeze(false);
 	return s;
 }
 
@@ -105,20 +108,22 @@ string toString(unsigned long long value)
 
 string toString(double value, int prec)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss.setf(std::ios_base::fixed, std::ios_base::floatfield);
 	if (prec >= 0)
 		ss.precision(prec);
 	ss << value << '\0';
 	string s = ss.str();
+	ss.freeze(0);
 	return s;
 }
 
 string toString(void *p)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << p << '\0';
 	string s = ss.str();
+	ss.freeze(false);
 	return s;
 }
 
@@ -184,7 +189,7 @@ bool isDouble(wstring s) { return isDouble(toString(s)); }
 double toDouble(string str)
 {
 	double value;
-	istringstream ss(str.c_str());
+	istrstream ss(str.c_str(), (std::streamsize)str.length());
 	ss >> value;
 	return value;
 }

--- a/toonz/sources/common/trasterimage/tcachedlevel.cpp
+++ b/toonz/sources/common/trasterimage/tcachedlevel.cpp
@@ -169,7 +169,7 @@ private:
 
 			default:
 				char *sysErr = strerror(errorCode);
-				ostringstream os;
+				ostrstream os;
 				os << errorCode << '\0';
 				os.freeze(false);
 				return string(sysErr) + "(" + os.str() + ")";

--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -222,7 +222,7 @@ public:
 	ostream *m_os;
 	bool m_chanOwner;
 	bool m_compressed;
-	ostringstream m_ostringstream;
+	ostrstream m_ostrstream;
 
 	vector<string> m_tagStack;
 	int m_tab;
@@ -243,7 +243,7 @@ TOStream::TOStream(const TFilePath &fp, bool compressed)
 	m_imp->m_filepath = fp;
 
 	if (compressed) {
-		m_imp->m_os = &m_imp->m_ostringstream;
+		m_imp->m_os = &m_imp->m_ostrstream;
 		m_imp->m_compressed = true;
 		m_imp->m_chanOwner = false;
 	} else {
@@ -288,7 +288,7 @@ TOStream::~TOStream()
 			m_imp->m_justStarted = true;
 		} else {
 			if (m_imp->m_compressed) {
-				const void *in = (const void *)m_imp->m_ostringstream.str().c_str();
+				const void *in = (const void *)m_imp->m_ostrstream.str();
 				size_t in_len = strlen((char *)in);
 
 				size_t out_len = LZ4F_compressFrameBound(in_len, NULL);
@@ -307,6 +307,8 @@ TOStream::~TOStream()
 					v = out_len;
 					os.write((char *)&v, sizeof v);
 					os.write((char *)out, out_len);
+
+					m_imp->m_ostrstream.freeze(0);
 				}
 
 				free(out);
@@ -956,7 +958,7 @@ TIStream::TIStream(const TFilePath &fp)
 		if (check_len != out_len)
 			throw TException("corrupted file");
 
-		m_imp->m_is = new istringstream((char *)out);
+		m_imp->m_is = new istrstream((char *)out, out_len);
 	}
 
 	m_imp->m_chanOwner = true;
@@ -1326,7 +1328,7 @@ bool TIStream::getTagParam(string paramName, int &value)
 	string svalue;
 	if (!getTagParam(paramName, svalue))
 		return false;
-	istringstream is(svalue.c_str());
+	istrstream is(svalue.c_str(), svalue.length());
 	value = 0;
 	is >> value;
 	return true;

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -51,7 +51,7 @@ string TFrameId::expand(FrameFormat format) const
 	else if (m_frame == NO_FRAME)
 		return "-";
 	char buffer[80];
-	ostringstream o_buff(buffer);
+	ostrstream o_buff(buffer, sizeof(buffer));
 	if (format == FOUR_ZEROS || format == UNDERSCORE_FOUR_ZEROS) {
 		o_buff.fill('0');
 		o_buff.width(4);
@@ -62,7 +62,7 @@ string TFrameId::expand(FrameFormat format) const
 	}
 	if (m_letter != '\0')
 		o_buff << m_letter;
-	int len = o_buff.tellp();
+	int len = o_buff.pcount();
 	return string(buffer, len);
 }
 
@@ -184,7 +184,7 @@ void append(string &out, wchar_t c)
   else if(c=='&') out.append("&amp;");
   else 
     {
-     ostringstream ss;
+     ostrstream ss;
      ss << "&#" <<  c << ";" << '\0';
      out += ss.str();
      ss.freeze(0);

--- a/toonz/sources/common/ttest/ttest.cpp
+++ b/toonz/sources/common/ttest/ttest.cpp
@@ -172,7 +172,7 @@ void TTest::runTests(string name)
 	cout << "Test file : '" << testFile << "'" << endl;
 	char buffer[1024];
 	while (is.getline(buffer, sizeof(buffer))) {
-		istringstream ss(buffer);
+		istrstream ss(buffer);
 		while (ss) {
 			string s;
 			ss >> s;

--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -2735,7 +2735,7 @@ void printStrokes1(vector<VIStroke *> &v, int size)
 #ifdef _DEBUG
 static void printTime(TStopWatch &sw, string name)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << name << " : ";
 	sw.print(ss);
 	ss << '\n' << '\0';

--- a/toonz/sources/common/tvectorimage/tregionutil.cpp
+++ b/toonz/sources/common/tvectorimage/tregionutil.cpp
@@ -2022,7 +2022,7 @@ void printStrokes1(vector<VIStroke *> &v, int size)
 #ifdef _DEBUG
 static void printTime(TStopWatch &sw, string name)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << name << " : ";
 	sw.print(ss);
 	ss << '\n' << '\0';

--- a/toonz/sources/common/tvectorimage/tstroke.cpp
+++ b/toonz/sources/common/tvectorimage/tstroke.cpp
@@ -415,7 +415,7 @@ void printContainer(const T &c, int maxRow = MAX_ROW)
     
     typename T::const_iterator cit;
     cit = c.begin();
-    ostringstream  oss1;
+    ostrstream  oss1;
     oss1<<'['<<c.size()<<']'<<"=\n";
     TSystem::outputDebug( oss1.str() );
     oss1.freeze(false);
@@ -423,7 +423,7 @@ void printContainer(const T &c, int maxRow = MAX_ROW)
     int counter = 0;
     for( ; cit != c.end(); ++cit)
     {
-      ostringstream  oss;
+      ostrstream  oss;
       if( ++counter == maxRow-1)
       {
         oss<<'\n';

--- a/toonz/sources/include/tcommon.h
+++ b/toonz/sources/include/tcommon.h
@@ -24,7 +24,7 @@
 #endif
 
 #include <string>
-#include <sstream>
+#include <strstream>
 #include <iostream>
 #include <fstream>
 #include <algorithm>
@@ -68,8 +68,8 @@ using std::wstring;
 using std::ostream;
 using std::istream;
 using std::iostream;
-using std::ostringstream;
-using std::istringstream;
+using std::ostrstream;
+using std::istrstream;
 using std::fstream;
 
 #if 0 && defined(__GNUC__)

--- a/toonz/sources/stdfx/iwa_particlesengine.cpp
+++ b/toonz/sources/stdfx/iwa_particlesengine.cpp
@@ -35,7 +35,7 @@ QMutex mutex;
 
 void printTime(TStopWatch &sw, string name)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << name << " : ";
 	sw.print(ss);
 	ss << '\n' << '\0';

--- a/toonz/sources/stdfx/particlesengine.cpp
+++ b/toonz/sources/stdfx/particlesengine.cpp
@@ -35,7 +35,7 @@ Particles_Engine::Particles_Engine(ParticlesFx *parent, double frame)
 
 void printTime(TStopWatch &sw, string name)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << name << " : ";
 	sw.print(ss);
 	ss << '\n' << '\0';

--- a/toonz/sources/tnzbase/tscanner/TScannerIO/TUSBScannerIO_M.cpp
+++ b/toonz/sources/tnzbase/tscanner/TScannerIO/TUSBScannerIO_M.cpp
@@ -48,7 +48,7 @@ TUSBScannerIOPD::TUSBScannerIOPD()
 
 namespace
 {
-void buf2printable(const unsigned char *buffer, const int size, ostringstream &os)
+void buf2printable(const unsigned char *buffer, const int size, ostrstream &os)
 {
 	int i = 0;
 	if ((size == 2) && (buffer[0] == 0x1b)) {
@@ -166,7 +166,7 @@ int TUSBScannerIO::receive(unsigned char *buffer, int size)
 	count = usb_bulk_read(m_data->m_handle, m_data->m_epR, (char *)buffer, size, 30 * 1000);
 
 	if (m_data->m_trace) {
-		ostringstream os;
+		ostrstream os;
 		os.freeze(false);
 		os << "receive: size=" << size << " got = " << count << " buf=";
 		buf2printable(buffer, count, os);
@@ -195,7 +195,7 @@ int TUSBScannerIO::send(unsigned char *buffer, int size)
 
 	count = usb_bulk_write(m_data->m_handle, m_data->m_epW, (char *)buffer, size, 30 * 1000);
 	if (m_data->m_trace) {
-		ostringstream os;
+		ostrstream os;
 		os.freeze(false);
 		os << "send: size=" << size << " wrote = " << count << " buf=";
 		buf2printable(buffer, size, os);

--- a/toonz/sources/tnzbase/tscanner/TScannerIO/TUSBScannerIO_W.cpp
+++ b/toonz/sources/tnzbase/tscanner/TScannerIO/TUSBScannerIO_W.cpp
@@ -19,7 +19,7 @@ public:
 //-----------------------------------------------------------------------------
 namespace
 {
-void buf2printable(const unsigned char *buffer, const int size, ostringstream &os)
+void buf2printable(const unsigned char *buffer, const int size, ostrstream &os)
 {
 	int i = 0;
 	if ((size == 2) && (buffer[0] == 0x1b)) {
@@ -95,7 +95,8 @@ int TUSBScannerIO::receive(unsigned char *buffer, int size)
 		ReadFile(m_data->m_handle, ptr, bytesToRead, &count, &overlapped);
 		DWORD waitRC = WaitForSingleObject(overlapped.hEvent, INFINITE);
 		if (m_data->m_trace) {
-			ostringstream os;
+			ostrstream os;
+			os.freeze(false);
 			os << "receive: size=" << size << " got = " << count << " buf=";
 			buf2printable(ptr, count, os);
 			os << '\n' << '\0';
@@ -126,7 +127,8 @@ int TUSBScannerIO::send(unsigned char *buffer, int size)
 		WriteFile(m_data->m_handle, buffer, bytesToWrite, &count, 0);
 
 		if (m_data->m_trace) {
-			ostringstream os;
+			ostrstream os;
+			os.freeze(false);
 			os << "send: size=" << size << " wrote = " << count << " buf=";
 			buf2printable(buffer, size, os);
 			os << '\n' << '\0';

--- a/toonz/sources/tnzbase/tscanner/tscannerepson.cpp
+++ b/toonz/sources/tnzbase/tscanner/tscannerepson.cpp
@@ -322,7 +322,7 @@ void TScannerEpson::acquire(const TScannerParameters &params, int paperCount)
 
 			bytes_to_read = lines * counter;
 			if (stx != 0x02) {
-				ostringstream os;
+				ostrstream os;
 				os << "header corrupted (" << std::hex << stx << ")" << '\0';
 				throw TException(os.str());
 			}
@@ -651,7 +651,7 @@ if (!resetScanner())
 
 #ifdef _DEBUG
 	memcpy(&status, &(buffer2[1]), 1);
-	ostringstream os;
+	ostrstream os;
 	os.freeze(false);
 	os << "stx = " << stx << " status = " << status << " counter=" << counter << '\n' << '\0';
 #endif
@@ -777,7 +777,7 @@ bool TScannerEpson::expectACK()
 
 #ifdef _DEBUG
 	if (ack != ACK) {
-		ostringstream os;
+		ostrstream os;
 		os.freeze(false);
 		os << "ack fails ret = 0x" << std::hex << (int)ack << '\n' << '\0';
 		TSystem::outputDebug(os.str());
@@ -963,7 +963,7 @@ void TScannerEpson::ESCI_readLineData(unsigned char &stx, unsigned char &status,
 	status = buffer[1];
 
 #ifdef _DEBUG
-	ostringstream os;
+	ostrstream os;
 	os.freeze(false);
 
 	os << "fatal=" << fatalError;
@@ -999,7 +999,7 @@ void TScannerEpson::ESCI_readLineData2(unsigned char &stx, unsigned char &status
 	status = buffer[1];
 
 #ifdef _DEBUG
-	ostringstream os;
+	ostrstream os;
 	os.freeze(false);
 
 	os << "fatal=" << fatalError;

--- a/toonz/sources/toonzfarm/tfarm/tfarmcontroller_c.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmcontroller_c.cpp
@@ -526,7 +526,7 @@ void loadControllerData(const TFilePath &fp, ControllerData &data)
 		is.getline(line, 1024);
 
 		if (line[0] != '#' && QString(line) != "") {
-			istringstream iss(line);
+			istrstream iss(line);
 
 			char hostName[512];
 			char ipAddr[80];

--- a/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
+++ b/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
@@ -751,7 +751,7 @@ void FarmController::loadServersData(const TFilePath &globalRoot)
 		is.getline(line, 80);
 
 		if (line[0] != '#' && QString(line) != "") {
-			istringstream iss(line);
+			istrstream iss(line);
 
 			char hostName[512];
 			char ipAddr[80];

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -519,9 +519,10 @@ FarmServer::~FarmServer()
 
 inline string toString(unsigned long value)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << value << '\0';
 	string s = ss.str();
+	ss.freeze(false);
 	return s;
 }
 
@@ -805,7 +806,7 @@ bool loadServerData(const QString &hostname, QString &addr, int &port)
     is.getline(line, 256);
     */
 		string line = getLine(is);
-		istringstream iss(line.c_str());
+		istrstream iss(line.c_str());
 
 		char name[80];
 		char ipAddress[80];
@@ -976,7 +977,7 @@ void FarmServerService::onStart(int argc, char *argv[])
   while (!isAppCfgFile.eof())
   {
     string line = getLine(isAppCfgFile);
-    istringstream iss(line.c_str());
+    istrstream iss(line.c_str());
     TFilePath appPath = TFilePath(line);
     appPaths.push_back(appPath);
   }

--- a/toonz/sources/toonzfarm/tnzcore_stuff/tfilepath.cpp
+++ b/toonz/sources/toonzfarm/tnzcore_stuff/tfilepath.cpp
@@ -22,7 +22,7 @@ string TFrameId::expand(FrameFormat format) const
 	else if (m_frame == NO_FRAME)
 		return "-";
 	char buffer[80];
-	ostringstream o_buff(buffer, sizeof(buffer));
+	ostrstream o_buff(buffer, sizeof(buffer));
 	if (format == FOUR_ZEROS) {
 		o_buff.fill('0');
 		o_buff.width(4);

--- a/toonz/sources/toonzfarm/tnzcore_stuff/tsystem.cpp
+++ b/toonz/sources/toonzfarm/tnzcore_stuff/tsystem.cpp
@@ -406,7 +406,7 @@ string TTime::getDate() const
 string TTime::getTime() const
 { // hh:mm:ss
 	char buffer[10];
-	ostringstream buff_s(buffer, sizeof(buffer));
+	ostrstream buff_s(buffer, sizeof(buffer));
 	buff_s << "." << m_msec << '\0';
 	return getFormattedString("%X") + buffer;
 }
@@ -451,7 +451,7 @@ string TFileStatus::getGroup() const
 		return string(grp->gr_name);
 #endif
 	char buffer[1024];
-	ostringstream buff(buffer, sizeof(buffer));
+	ostrstream buff(buffer, sizeof(buffer));
 	buff << m_fStatus.st_gid;
 	return string(buffer, buff.pcount());
 }
@@ -466,7 +466,7 @@ string TFileStatus::getUser() const
 		return string(pw->pw_name);
 #endif
 	char buffer[1024];
-	ostringstream buff(buffer, sizeof(buffer));
+	ostrstream buff(buffer, sizeof(buffer));
 	buff << m_fStatus.st_uid;
 	return string(buffer, buff.pcount());
 }

--- a/toonz/sources/toonzlib/autopos.cpp
+++ b/toonz/sources/toonzlib/autopos.cpp
@@ -775,8 +775,9 @@ static int find_dots_bw(const TRasterP &img, int strip_width, PEGS_SIDE pegs_sid
 		vertical = TRUE;
 
 	DEFAULT : {
-		ostringstream os;
+		ostrstream os;
 		os << "find dots internal error: pegs_side = " << std::hex << pegs_side << '\0';
+		os.freeze(false);
 		throw TCleanupException(os.str());
 		x0 = y0 = xsize = ysize = vertical = 0;
 	}
@@ -903,9 +904,10 @@ static int find_dots_gr8(const TRasterGR8P &img, int strip_width, PEGS_SIDE pegs
 		vertical = TRUE;
 
 	DEFAULT : {
-		ostringstream os;
+		ostrstream os;
 		os << "find dots internal error: pegs_side = " << std::hex << pegs_side << '\0';
-		throw TCleanupException(os.str().c_str());
+		os.freeze(false);
+		throw TCleanupException(os.str());
 		x0 = y0 = xsize = ysize = vertical = 0;
 	}
 	}
@@ -1027,9 +1029,10 @@ static int find_dots_rgb(const TRaster32P &img, int strip_width, PEGS_SIDE pegs_
 		vertical = TRUE;
 
 	DEFAULT : {
-		ostringstream os;
+		ostrstream os;
 		os << "find dots internal error: pegs_side = " << std::hex << pegs_side << '\0';
-		throw TCleanupException(os.str().c_str());
+		os.freeze(false);
+		throw TCleanupException(os.str());
 		x0 = y0 = xsize = ysize = vertical = 0;
 	}
 	}

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -719,7 +719,7 @@ void StageBuilder::visit(PlayerSet &players, Visitor &visitor, bool isPlaying)
 // debug
 class DummyVisitor : public Visitor
 {
-	ostringstream m_ss;
+	ostrstream m_ss;
 
 public:
 	void onImage(const Stage::Player &data) { m_ss << "img "; }

--- a/toonz/sources/toonzlib/tcenterlinevectorizerOld.cpp
+++ b/toonz/sources/toonzlib/tcenterlinevectorizerOld.cpp
@@ -2547,7 +2547,7 @@ void CenterLineVectorizer::vectorize()
 #ifdef DEBUG
 void printTime(TStopWatch &sw, string name)
 {
-	ostringstream ss;
+	ostrstream ss;
 	ss << name << " : ";
 	sw.print(ss);
 	ss << '\n' << '\0';

--- a/toonz/sources/toonzlib/texturemanager.cpp
+++ b/toonz/sources/toonzlib/texturemanager.cpp
@@ -55,7 +55,7 @@ TDimensionI TextureManager::getMaxSize(bool isRGBM)
 			glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_COMPONENTS, &cmpt);
 
 			if (outX && outY) {
-				ostringstream os;
+				ostrstream os;
 				os << "texture size = " << outX << "x" << outY << " fmt " << intFmt << " cmpt# " << cmpt << " " << rSize << "," << gSize << "," << bSize << "," << aSize << '\n' << '\0';
 				TSystem::outputDebug(os.str());
 				os.freeze(false);


### PR DESCRIPTION
Reverts opentoonz/opentoonz#169

Because it will crush when I tried clean installation. Maybe it fails to save `rooms` in startup.