### PR TITLE
Fix crash when clicking on/off button in palette viewer

### DIFF
--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -160,7 +160,7 @@ void PaletteViewer::setPaletteHandle(TPaletteHandle *paletteHandle)
 
 	bool ret = true;
 	if (m_paletteHandle)
-		ret = ret && disconnect(m_paletteHandle);
+		ret = ret && disconnect(m_paletteHandle,0,this,0);
 
 	m_paletteHandle = paletteHandle;
 


### PR DESCRIPTION
This fix is for the issue #75
It was mistake of usage of disconnect().