### PR TITLE
Fix pinch tool crash

### DIFF
--- a/toonz/sources/tnztools/pinchtool.cpp
+++ b/toonz/sources/tnztools/pinchtool.cpp
@@ -549,7 +549,8 @@ bool PinchTool::keyDown(int key,
 						TUINT32 flags,
 						const TPoint &pos)
 {
-	m_deformation->reset();
+	if (!m_active)
+		m_deformation->reset();
 
 #if 0
   char c = (char)key;


### PR DESCRIPTION
This fix is for the issue #199 
I changed the source not to reset tool by pressing modifier key while the mouse button is down (=dragging).