### PR TITLE
Cleanup: gcc's -Wwrite-strings warning

### DIFF
--- a/toonz/sources/common/psdlib/psd.h
+++ b/toonz/sources/common/psdlib/psd.h
@@ -136,7 +136,7 @@ struct TPSDHeaderInfo {
 
 struct dictentry {
 	int id;
-	char *key, *tag, *desc;
+	const char *key, *tag, *desc;
 	void (*func)(FILE *f, struct dictentry *dict, TPSDLayerInfo *li);
 };
 

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -762,7 +762,7 @@ TFilePath TFilePath::withFrame(const TFrameId &frame, TFrameId::FrameFormat form
 	std::wstring str = m_path.substr(i + 1); // str e' il path senza parentdir
 	assert(str != dot && str != dotDot);
 	int j = str.rfind(L'.');
-	char *ch = ".";
+	const char *ch = ".";
 	if (m_underscoreFormatAllowed &&
 		(format == TFrameId::UNDERSCORE_FOUR_ZEROS || format == TFrameId::UNDERSCORE_NO_PAD))
 		ch = "_";

--- a/toonz/sources/stdfx/igs_line_blur.cpp
+++ b/toonz/sources/stdfx/igs_line_blur.cpp
@@ -30,7 +30,7 @@ extern void pri_funct_cv_start(int32_t i32_ys);
 extern void pri_funct_cv_run(int32_t i32_y);
 extern void pri_funct_cv_end(void);
 
-extern void pri_funct_set_cp_title(char *cp_title);
+extern void pri_funct_set_cp_title(const char *cp_title);
 extern void pri_funct_msg_ttvr(const char *fmt, ...);
 extern void pri_funct_msg_vr(const char *fmt, ...);
 extern void pri_funct_err_bttvr(const char *fmt, ...);
@@ -114,9 +114,9 @@ void pri_funct_cv_end(void)
 #define vsnprintf(buf, len, fmt, ap) _vsnprintf(buf, len, fmt, ap)
 #endif
 
-static char *pri_param_cp_com_name = "#";
+static const char *pri_param_cp_com_name = "#";
 
-void pri_funct_set_cp_title(char *cp_title)
+void pri_funct_set_cp_title(const char *cp_title)
 {
 	pri_param_cp_com_name = cp_title;
 }
@@ -438,7 +438,7 @@ public:
 	void set_subpixel_value(int32_t i32_x_sub, int32_t i32_y_sub);
 	void set_pixel_value(void);
 
-	int save(double d_xp, double d_yp, char *cp_fname);
+	int save(double d_xp, double d_yp, const char *cp_fname);
 	void debug_print(void);
 
 private:
@@ -640,7 +640,7 @@ void brush_curve_blur::set_pixel_value(void)
 
 #include "igs_line_blur.h" // "pri.h" "brush_curve_blur.h"
 
-int brush_curve_blur::save(double d_xp, double d_yp, char *cp_fname)
+int brush_curve_blur::save(double d_xp, double d_yp, const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -1423,7 +1423,7 @@ public:
 	pixel_point_node *append(pixel_point_node *clp_previous);
 
 	/* for debug */
-	int save(char *cp_fname);
+	int save(const char *cp_fname);
 
 	void mem_free(void);
 
@@ -1530,7 +1530,7 @@ int pixel_point_root::alloc_mem_and_list_node(int32_t i32_xs, int32_t i32_ys, ui
 	return OK;
 }
 
-int pixel_point_root::save(char *cp_fname)
+int pixel_point_root::save(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -2913,16 +2913,16 @@ public:
 	void exec10_smooth_expand(void);
 	void exec11_set_bbox(void);
 
-	int save_not_include(pixel_point_root *clp_pixel_point_root, char *cp_fname);
-	int save_lines(char *cp_fname);
-	int save_one_point(char *cp_fname);
-	int save_middle_point(char *cp_fname);
-	int save_another_point(char *cp_fname);
+	int save_not_include(pixel_point_root *clp_pixel_point_root, const char *cp_fname);
+	int save_lines(const char *cp_fname);
+	int save_one_point(const char *cp_fname);
+	int save_middle_point(const char *cp_fname);
+	int save_another_point(const char *cp_fname);
 
-	int save_expand_lines(char *cp_fname);
-	int save_one_expand_point(char *cp_fname);
-	int save_another_expand_point(char *cp_fname);
-	int save_expand_vector(char *cp_fname);
+	int save_expand_lines(const char *cp_fname);
+	int save_one_expand_point(const char *cp_fname);
+	int save_another_expand_point(const char *cp_fname);
+	int save_expand_vector(const char *cp_fname);
 
 	void mem_free(void);
 
@@ -3692,7 +3692,7 @@ void pixel_line_root::mem_free(void)
 
 #include "igs_line_blur.h" // "pri.h" "pixel_line_root.h"
 
-int pixel_line_root::save_not_include(pixel_point_root *clp_pixel_point_root, char *cp_fname)
+int pixel_line_root::save_not_include(pixel_point_root *clp_pixel_point_root, const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3751,7 +3751,7 @@ int pixel_line_root::save_not_include(pixel_point_root *clp_pixel_point_root, ch
 
 /********************************************************************/
 
-int pixel_line_root::save_lines(char *cp_fname)
+int pixel_line_root::save_lines(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3816,7 +3816,7 @@ int pixel_line_root::save_lines(char *cp_fname)
 
 /********************************************************************/
 
-int pixel_line_root::save_one_point(char *cp_fname)
+int pixel_line_root::save_one_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3868,7 +3868,7 @@ int pixel_line_root::save_one_point(char *cp_fname)
 	return OK;
 }
 
-int pixel_line_root::save_middle_point(char *cp_fname)
+int pixel_line_root::save_middle_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3920,7 +3920,7 @@ int pixel_line_root::save_middle_point(char *cp_fname)
 	return OK;
 }
 
-int pixel_line_root::save_another_point(char *cp_fname)
+int pixel_line_root::save_another_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3974,7 +3974,7 @@ int pixel_line_root::save_another_point(char *cp_fname)
 
 #include "igs_line_blur.h" // "pri.h" "pixel_line_root.h"
 
-int pixel_line_root::save_expand_lines(char *cp_fname)
+int pixel_line_root::save_expand_lines(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4039,7 +4039,7 @@ int pixel_line_root::save_expand_lines(char *cp_fname)
 
 /********************************************************************/
 
-int pixel_line_root::save_one_expand_point(char *cp_fname)
+int pixel_line_root::save_one_expand_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4091,7 +4091,7 @@ int pixel_line_root::save_one_expand_point(char *cp_fname)
 	return OK;
 }
 
-int pixel_line_root::save_another_expand_point(char *cp_fname)
+int pixel_line_root::save_another_expand_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4145,7 +4145,7 @@ int pixel_line_root::save_another_expand_point(char *cp_fname)
 
 #include "igs_line_blur.h" // "pri.h" "pixel_line_root.h"
 
-int pixel_line_root::save_expand_vector(char *cp_fname)
+int pixel_line_root::save_expand_vector(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4264,7 +4264,7 @@ public:
 	/******void exec( double d_xp, double d_yp, pixel_line_node *clp_line_first, int32_t i32_count, int32_t i32_blur_count, double d_effect_length_radius );******/
 	int get_line(int32_t i32_blur_count, double *dp_xv, double *dp_yv);
 
-	int save(double d_xp, double d_yp, int32_t i32_blur_count, char *cp_fname);
+	int save(double d_xp, double d_yp, int32_t i32_blur_count, const char *cp_fname);
 
 	void mem_free(void);
 
@@ -4599,7 +4599,7 @@ int pixel_select_curve_blur_root::get_line(int32_t i32_blur_count, double *dp_xv
 
 #include "igs_line_blur.h" // "pri.h" "pixel_select_curve_blur.h"
 
-int pixel_select_curve_blur_root::save(double d_xp, double d_yp, int32_t i32_blur_count, char *cp_fname)
+int pixel_select_curve_blur_root::save(double d_xp, double d_yp, int32_t i32_blur_count, const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii, jj;

--- a/toonz/sources/stdfx/ino_line_blur.cpp
+++ b/toonz/sources/stdfx/ino_line_blur.cpp
@@ -102,7 +102,7 @@ extern void pri_funct_cv_start( int32_t i32_ys );
 extern void pri_funct_cv_run( int32_t i32_y );
 extern void pri_funct_cv_end( void );
 
-extern void pri_funct_set_cp_title( char *cp_title );
+extern void pri_funct_set_cp_title(const char *cp_title );
 extern void pri_funct_msg_ttvr( const char* fmt, ...);
 extern void pri_funct_msg_vr( const char* fmt, ...);
 extern void pri_funct_err_bttvr( const char* fmt, ...);
@@ -187,9 +187,9 @@ void pri_funct_cv_end(void)
 #define vsnprintf(buf, len, fmt, ap) _vsnprintf(buf, len, fmt, ap)
 #endif
 
-static char *pri_param_cp_com_name = "#";
+static const char *pri_param_cp_com_name = "#";
 
-void pri_funct_set_cp_title(char *cp_title)
+void pri_funct_set_cp_title(const char *cp_title)
 {
 	pri_param_cp_com_name = cp_title;
 }
@@ -510,7 +510,7 @@ public:
 	void set_subpixel_value(int32_t i32_x_sub, int32_t i32_y_sub);
 	void set_pixel_value(void);
 
-	int save(double d_xp, double d_yp, char *cp_fname);
+	int save(double d_xp, double d_yp, const char *cp_fname);
 	void debug_print(void);
 
 private:
@@ -712,7 +712,7 @@ void brush_curve_blur::set_pixel_value(void)
 
 #include "igs_line_blur.h" // "pri.h" "brush_curve_blur.h"
 
-int brush_curve_blur::save(double d_xp, double d_yp, char *cp_fname)
+int brush_curve_blur::save(double d_xp, double d_yp, const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -1495,7 +1495,7 @@ public:
 	pixel_point_node *append(pixel_point_node *clp_previous);
 
 	/* for debug */
-	int save(char *cp_fname);
+	int save(const char *cp_fname);
 
 	void mem_free(void);
 
@@ -1602,7 +1602,7 @@ int pixel_point_root::alloc_mem_and_list_node(int32_t i32_xs, int32_t i32_ys, ui
 	return OK;
 }
 
-int pixel_point_root::save(char *cp_fname)
+int pixel_point_root::save(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -2985,16 +2985,16 @@ public:
 	void exec10_smooth_expand(void);
 	void exec11_set_bbox(void);
 
-	int save_not_include(pixel_point_root *clp_pixel_point_root, char *cp_fname);
-	int save_lines(char *cp_fname);
-	int save_one_point(char *cp_fname);
-	int save_middle_point(char *cp_fname);
-	int save_another_point(char *cp_fname);
+	int save_not_include(pixel_point_root *clp_pixel_point_root, const char *cp_fname);
+	int save_lines(const char *cp_fname);
+	int save_one_point(const char *cp_fname);
+	int save_middle_point(const char *cp_fname);
+	int save_another_point(const char *cp_fname);
 
-	int save_expand_lines(char *cp_fname);
-	int save_one_expand_point(char *cp_fname);
-	int save_another_expand_point(char *cp_fname);
-	int save_expand_vector(char *cp_fname);
+	int save_expand_lines(const char *cp_fname);
+	int save_one_expand_point(const char *cp_fname);
+	int save_another_expand_point(const char *cp_fname);
+	int save_expand_vector(const char *cp_fname);
 
 	void mem_free(void);
 
@@ -3764,7 +3764,7 @@ void pixel_line_root::mem_free(void)
 
 #include "igs_line_blur.h" // "pri.h" "pixel_line_root.h"
 
-int pixel_line_root::save_not_include(pixel_point_root *clp_pixel_point_root, char *cp_fname)
+int pixel_line_root::save_not_include(pixel_point_root *clp_pixel_point_root, const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3823,7 +3823,7 @@ int pixel_line_root::save_not_include(pixel_point_root *clp_pixel_point_root, ch
 
 /********************************************************************/
 
-int pixel_line_root::save_lines(char *cp_fname)
+int pixel_line_root::save_lines(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3888,7 +3888,7 @@ int pixel_line_root::save_lines(char *cp_fname)
 
 /********************************************************************/
 
-int pixel_line_root::save_one_point(char *cp_fname)
+int pixel_line_root::save_one_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3940,7 +3940,7 @@ int pixel_line_root::save_one_point(char *cp_fname)
 	return OK;
 }
 
-int pixel_line_root::save_middle_point(char *cp_fname)
+int pixel_line_root::save_middle_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -3992,7 +3992,7 @@ int pixel_line_root::save_middle_point(char *cp_fname)
 	return OK;
 }
 
-int pixel_line_root::save_another_point(char *cp_fname)
+int pixel_line_root::save_another_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4046,7 +4046,7 @@ int pixel_line_root::save_another_point(char *cp_fname)
 
 #include "igs_line_blur.h" // "pri.h" "pixel_line_root.h"
 
-int pixel_line_root::save_expand_lines(char *cp_fname)
+int pixel_line_root::save_expand_lines(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4111,7 +4111,7 @@ int pixel_line_root::save_expand_lines(char *cp_fname)
 
 /********************************************************************/
 
-int pixel_line_root::save_one_expand_point(char *cp_fname)
+int pixel_line_root::save_one_expand_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4163,7 +4163,7 @@ int pixel_line_root::save_one_expand_point(char *cp_fname)
 	return OK;
 }
 
-int pixel_line_root::save_another_expand_point(char *cp_fname)
+int pixel_line_root::save_another_expand_point(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4217,7 +4217,7 @@ int pixel_line_root::save_another_expand_point(char *cp_fname)
 
 #include "igs_line_blur.h" // "pri.h" "pixel_line_root.h"
 
-int pixel_line_root::save_expand_vector(char *cp_fname)
+int pixel_line_root::save_expand_vector(const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii;
@@ -4336,7 +4336,7 @@ public:
 	/******void exec( double d_xp, double d_yp, pixel_line_node *clp_line_first, int32_t i32_count, int32_t i32_blur_count, double d_effect_length_radius );******/
 	int get_line(int32_t i32_blur_count, double *dp_xv, double *dp_yv);
 
-	int save(double d_xp, double d_yp, int32_t i32_blur_count, char *cp_fname);
+	int save(double d_xp, double d_yp, int32_t i32_blur_count, const char *cp_fname);
 
 	void mem_free(void);
 
@@ -4671,7 +4671,7 @@ int pixel_select_curve_blur_root::get_line(int32_t i32_blur_count, double *dp_xv
 
 #include "igs_line_blur.h" // "pri.h" "pixel_select_curve_blur.h"
 
-int pixel_select_curve_blur_root::save(double d_xp, double d_yp, int32_t i32_blur_count, char *cp_fname)
+int pixel_select_curve_blur_root::save(double d_xp, double d_yp, int32_t i32_blur_count, const char *cp_fname)
 {
 	FILE *fp;
 	int32_t ii, jj;

--- a/toonz/sources/toonzlib/autoadjust.cpp
+++ b/toonz/sources/toonzlib/autoadjust.cpp
@@ -553,7 +553,7 @@ void build_gr_lut(int ref_cum[256], int cum[256], UCHAR lut[256])
 /*===========================================================================*/
 
 struct edge_config {
-	char *str;
+	const char *str;
 	int val;
 };
 
@@ -820,7 +820,7 @@ static struct edge_config Edge_base[] =
 static int Edge_value[256];
 static int Edge_init_done = 0;
 
-static int edge_int(char x[8]);
+static int edge_int(const char x[8]);
 static void edge_rotate(char x[8]);
 static void edge_mirror(char x[8]);
 
@@ -829,7 +829,7 @@ static void edge_mirror(char x[8]);
 static void edge_init(void)
 {
 	int b;
-	char *str;
+	const char *str;
 	int val;
 	char x[8];
 
@@ -867,7 +867,7 @@ static void edge_init(void)
 
 /*---------------------------------------------------------------------------*/
 
-static int edge_int(char x[8])
+static int edge_int(const char x[8])
 {
 	return (x[0] != ' ') << 7 |
 		   (x[1] != ' ') << 6 |

--- a/toonz/sources/toonzlib/sandor_fxs/SError.h
+++ b/toonz/sources/toonzlib/sandor_fxs/SError.h
@@ -23,7 +23,7 @@ protected:
 
 public:
 	SError() : m_msg(""){};
-	SError(char *s) : m_msg(s){};
+	SError(const char *s) : m_msg(s){};
 	virtual ~SError(){};
 	virtual void debug_print() const
 	{
@@ -38,7 +38,7 @@ class SMemAllocError : public SError
 {
 public:
 	SMemAllocError() : SError(""){};
-	SMemAllocError(char *s) : SError(s){};
+	SMemAllocError(const char *s) : SError(s){};
 	virtual ~SMemAllocError(){};
 	void debug_print() const
 	{
@@ -53,7 +53,7 @@ class SWriteRasterError : public SError
 {
 public:
 	SWriteRasterError() : SError(""){};
-	SWriteRasterError(char *s) : SError(s){};
+	SWriteRasterError(const char *s) : SError(s){};
 	virtual ~SWriteRasterError(){};
 	void debug_print() const
 	{
@@ -68,7 +68,7 @@ class SBlurMatrixError : public SError
 {
 public:
 	SBlurMatrixError() : SError(""){};
-	SBlurMatrixError(char *s) : SError(s){};
+	SBlurMatrixError(const char *s) : SError(s){};
 	virtual ~SBlurMatrixError(){};
 	void debug_print() const
 	{
@@ -83,7 +83,7 @@ class SFileReadError : public SError
 {
 public:
 	SFileReadError() : SError(""){};
-	SFileReadError(char *s) : SError(s){};
+	SFileReadError(const char *s) : SError(s){};
 	virtual ~SFileReadError(){};
 	void debug_print() const
 	{


### PR DESCRIPTION
Quiets `-Wwrite-strings` warning.
*Can cause bugs, though in this case not - just quiet the warnings, so improper use alerts us in future.*

```
toonz/sources/stdfx/igs_line_blur.cpp:117:38: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6635:66: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6639:68: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6643:76: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6647:96: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6656:74: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6676:76: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6684:78: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6694:74: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6698:82: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/stdfx/igs_line_blur.cpp:6702:90: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/CallCircle.cpp:44:39: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/CallCircle.h:136:42: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SDirection.cpp:322:42: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SDirection.cpp:33:43: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SDirection.cpp:378:42: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SDirection.cpp:402:42: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SDirection.cpp:59:43: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SError.h:40:30: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SError.h:55:33: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SError.h:70:32: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/SError.h:85:30: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/STColSelPic.h:55:50: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/STPic.h:130:38: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/STPic.h:543:47: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/STPic.h:564:47: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
toonz/sources/toonzlib/sandor_fxs/STPic.h:606:47: warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings]
```