### PR TITLE
Revert refactoring for vector rendering

### DIFF
--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -1817,7 +1817,12 @@ void getClosingPoints(const TRectD &rect, double fac, const TVectorImageP &vi,
 			if (s2->getChunkCount() == 1)
 				continue;
 
+#ifdef NEW_REGION_FILL
+			double autoTol = 0;
+#else
 			double autoTol = vi->getAutocloseTolerance();
+#endif
+
 			double enlarge1 = (autoTol + 0.7) * (s1->getMaxThickness() > 0 ? s1->getMaxThickness() : 2.5) + fac;
 			double enlarge2 = (autoTol + 0.7) * (s2->getMaxThickness() > 0 ? s2->getMaxThickness() : 2.5) + fac;
 
@@ -2747,6 +2752,10 @@ void printStrokes1(vector<VIStroke *> &v, int size);
 // Trova le regioni in una TVectorImage
 int TVectorImage::Imp::computeRegions()
 {
+#ifdef NEW_REGION_FILL
+	return 0;
+#endif
+
 #if defined(_DEBUG) && !defined(MACOSX)
 	TStopWatch stopWatch;
 	stopWatch.start(true);

--- a/toonz/sources/common/tvectorimage/tvectorimage.cpp
+++ b/toonz/sources/common/tvectorimage/tvectorimage.cpp
@@ -86,7 +86,14 @@ TVectorImage::Imp: implementation of TVectorImage class
 
 TVectorImage::Imp::Imp(TVectorImage *vi)
 	: m_areValidRegions(false), m_notIntersectingStrokes(false), m_computeRegions(true), m_autocloseTolerance(c_newAutocloseTolerance), m_maxGroupId(1), m_maxGhostGroupId(1), m_mutex(new TThread::Mutex()), m_vi(vi), m_intersectionData(0), m_computedAlmostOnce(false), m_justLoaded(false), m_insideGroup(TGroupId()), m_minimizeEdges(true)
+#ifdef NEW_REGION_FILL
+	  ,
+	  m_regionFinder(0)
+#endif
 {
+#ifdef NEW_REGION_FILL
+	resetRegionFinder();
+#endif
 	initRegionsData();
 }
 
@@ -671,11 +678,13 @@ TRaster32P TVectorImage::render(bool onlyStrokes)
 
 TRegion *TVectorImage::getRegion(const TPointD &p)
 {
+#ifndef NEW_REGION_FILL
 	if (!isComputedRegionAlmostOnce())
 		return 0;
 
 	if (!m_imp->m_areValidRegions)
 		m_imp->computeRegions();
+#endif
 
 	return m_imp->getRegion(p);
 }
@@ -721,6 +730,15 @@ int TVectorImage::fillStrokes(const TPointD &p, int styleId)
 	return -1;
 }
 
+//-----------------------------------------------------------------------------
+
+#ifdef NEW_REGION_FILL
+
+void TVectorImage::resetRegionFinder()
+{
+	m_imp->resetRegionFinder();
+}
+#else
 //------------------------------------------------------------------
 
 int TVectorImage::fill(const TPointD &p, int newStyleId, bool onlyEmpty)
@@ -734,7 +752,41 @@ int TVectorImage::fill(const TPointD &p, int newStyleId, bool onlyEmpty)
 		m_imp->computeRegions();
 	return m_imp->fill(p, newStyleId);
 }
+#endif
 
+//-----------------------------------------------------------------------------
+/*
+void TVectorImage::autoFill(int styleId)
+{
+m_imp->autoFill(styleId, true);
+}
+
+void TVectorImage::Imp::autoFill(int styleId, bool oddLevel)
+{
+if (!m_areValidRegions)
+  computeRegions(); 
+for (UINT i = 0; i<m_regions.size(); i++)
+  {
+  if (oddLevel)
+    m_regions[i]->setStyle(styleId);
+  m_regions[i]->autoFill(styleId, !oddLevel);
+  }
+}
+*/
+//-----------------------------------------------------------------------------
+/*
+void TRegion::autoFill(int styleId, bool oddLevel)
+{
+for (UINT i = 0; i<getSubregionCount(); i++)
+  {
+  TRegion* r = getSubregion(i);
+  if (oddLevel)
+    r->setStyle(styleId);
+  r->autoFill(styleId, !oddLevel);
+  }
+
+}
+*/
 //-----------------------------------------------------------------------------
 
 int TVectorImage::Imp::fill(const TPointD &p, int styleId)
@@ -778,14 +830,12 @@ bool TVectorImage::Imp::selectFill(const TRectD &selArea, TStroke *s, int newSty
 		aux.findRegions();
 		for (UINT j = 0; j < aux.getRegionCount(); j++) {
 			TRegion *r0 = aux.getRegion(j);
-			if (fillAreas) {
+			if (fillAreas)
 				for (UINT i = 0; i < m_regions.size(); i++) {
 					TRegion *r1 = m_regions[i];
 
-					if ((m_insideGroup != TGroupId())
-						&& !m_insideGroup.isParentOf(m_strokes[r1->getEdge(0)->m_index]->m_groupId)) {
-							continue;
-					}
+					if (m_insideGroup != TGroupId() && !m_insideGroup.isParentOf(m_strokes[r1->getEdge(0)->m_index]->m_groupId))
+						continue;
 
 					if ((!onlyUnfilled || r1->getStyle() == 0) &&
 						r0->contains(*r1)) {
@@ -793,8 +843,7 @@ bool TVectorImage::Imp::selectFill(const TRectD &selArea, TStroke *s, int newSty
 						hitSome = true;
 					}
 				}
-			}
-			if (fillLines) {
+			if (fillLines)
 				for (UINT i = 0; i < m_strokes.size(); i++) {
 					if (!inCurrentGroup(i))
 						continue;
@@ -806,35 +855,40 @@ bool TVectorImage::Imp::selectFill(const TRectD &selArea, TStroke *s, int newSty
 						hitSome = true;
 					}
 				}
-			}
 		}
 		aux.removeStroke(0);
 		return hitSome;
 	}
 
 	// rect fill
-	if (fillAreas) {
-		for (std::size_t i = 0, size = m_regions.size(); i < size; i++) {
-			int index;
-			UINT j = 0;
 
-			do {
+	if (fillAreas)
+#ifndef NEW_REGION_FILL
+		for (UINT i = 0; i < m_regions.size(); i++) {
+			int index, j = 0;
+
+			do
 				index = m_regions[i]->getEdge(j++)->m_index;
-			}  while ((index < 0) && (j < m_regions[i]->getEdgeCount()));
-
-			// if index<0, means that the region is purely of autoclose strokes!
-			if ((m_insideGroup != TGroupId())
-				&& (index >= 0) && !m_insideGroup.isParentOf(m_strokes[index]->m_groupId)) {
+			while (index < 0 && j < (int)m_regions[i]->getEdgeCount());
+			//if index<0, means that the region is purely of autoclose strokes!
+			if (m_insideGroup != TGroupId() && index >= 0 && !m_insideGroup.isParentOf(m_strokes[index]->m_groupId))
 				continue;
-			}
-			if (onlyUnfilled && (m_regions[i]->getStyle() != 0)) {
-			} else {
+			if (!onlyUnfilled || m_regions[i]->getStyle() == 0)
 				hitSome |= m_regions[i]->selectFill(selArea, newStyleId);
-			}
 		}
-	}
+#else
 
-	if (fillLines) {
+		findRegions(selArea);
+
+	for (UINT i = 0; i < m_regions.size(); i++) {
+		if (m_insideGroup != TGroupId() && !m_insideGroup.isParentOf(m_strokes[m_regions[i]->getEdge(0)->m_index]->m_groupId))
+			continue;
+		if (!onlyUnfilled || m_regions[i]->getStyle() == 0)
+			hitSome |= m_regions[i]->selectFill(selArea, newStyleId);
+	}
+#endif
+
+	if (fillLines)
 		for (UINT i = 0; i < m_strokes.size(); i++) {
 			if (!inCurrentGroup(i))
 				continue;
@@ -846,8 +900,6 @@ bool TVectorImage::Imp::selectFill(const TRectD &selArea, TStroke *s, int newSty
 				hitSome = true;
 			}
 		}
-	}
-
 	return hitSome;
 }
 

--- a/toonz/sources/common/tvectorimage/tvectorimageP.h
+++ b/toonz/sources/common/tvectorimage/tvectorimageP.h
@@ -199,6 +199,11 @@ public:
 
 #endif
 
+#ifdef NEW_REGION_FILL
+	TRegionFinder *m_regionFinder;
+	void resetRegionFinder();
+#endif
+
 private:
 	void findRegions(const TRectD &rect);
 	int computeIntersections();

--- a/toonz/sources/include/ext/meshtexturizer.h
+++ b/toonz/sources/include/ext/meshtexturizer.h
@@ -117,7 +117,7 @@ private:
 
 struct MeshTexturizer::TextureData {
 	struct TileData //!  Data structure for a texture tile.
-	{
+		{
 		GLuint m_textureId;	//!< OpenGL texture identifier.
 		TRectD m_tileGeometry; //!< The tile's world geometry.
 	};
@@ -132,15 +132,15 @@ public:
 
 	~TextureData()
 	{
-		for (auto const& tile : m_tileDatas) {
-			glDeleteTextures(1, &tile.m_textureId);
-		}
+		int t, tilesCount = m_tileDatas.size();
+		for (t = 0; t < tilesCount; ++t)
+			glDeleteTextures(1, &m_tileDatas[t].m_textureId);
 	}
 
 private:
 	// Not copyable
-	TextureData(const TextureData &) = delete;
-	TextureData &operator=(const TextureData &) = delete;
+	TextureData(const TextureData &);
+	TextureData &operator=(const TextureData &);
 };
 
 #endif // MESHTEXTURIZER_H

--- a/toonz/sources/include/tgl.h
+++ b/toonz/sources/include/tgl.h
@@ -3,14 +3,16 @@
 #ifndef TGL_INCLUDED
 #define TGL_INCLUDED
 
+//#include "tgeometry.h"
 #include "tmachine.h"
 
 #ifdef _WIN32
 #include <windows.h>
+//#endif
+
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/glut.h>
-#include <GL/glext.h>
 #endif
 
 #ifdef MACOSX

--- a/toonz/sources/include/tgl.h
+++ b/toonz/sources/include/tgl.h
@@ -10,6 +10,7 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 #include <GL/glut.h>
+#include <GL/glext.h>
 #endif
 
 #ifdef MACOSX

--- a/toonz/sources/include/tpixelutils.h
+++ b/toonz/sources/include/tpixelutils.h
@@ -356,25 +356,25 @@ DVAPI inline void premult(TPixel32 &pix)
 
 DVAPI inline void premult(TPixel64 &pix)
 {
-	pix.r = static_cast<TPixel64::Channel>(pix.r * pix.m / 65535.0);
-	pix.g = static_cast<TPixel64::Channel>(pix.g * pix.m / 65535.0);
-	pix.b = static_cast<TPixel64::Channel>(pix.b * pix.m / 65535.0);
+	pix.r = pix.r * pix.m / 65535.0;
+	pix.g = pix.g * pix.m / 65535.0;
+	pix.b = pix.b * pix.m / 65535.0;
 }
 
 DVAPI inline void depremult(TPixel32 &pix)
 {
 	float fac = 255.0f / pix.m;
-	pix.r = static_cast<TPixel32::Channel>(tmin(pix.r * fac, 255.0f));
-	pix.g = static_cast<TPixel32::Channel>(tmin(pix.g * fac, 255.0f));
-	pix.b = static_cast<TPixel32::Channel>(tmin(pix.b * fac, 255.0f));
+	pix.r = tmin(pix.r * fac, 255.0f);
+	pix.g = tmin(pix.g * fac, 255.0f);
+	pix.b = tmin(pix.b * fac, 255.0f);
 }
 
 DVAPI inline void depremult(TPixel64 &pix)
 {
 	double fac = 65535.0 / pix.m;
-	pix.r = static_cast<TPixel64::Channel>(tmin(pix.r * fac, 65535.0));
-	pix.g = static_cast<TPixel64::Channel>(tmin(pix.g * fac, 65535.0));
-	pix.b = static_cast<TPixel64::Channel>(tmin(pix.b * fac, 65535.0));
+	pix.r = tmin(pix.r * fac, 65535.0);
+	pix.g = tmin(pix.g * fac, 65535.0);
+	pix.b = tmin(pix.b * fac, 65535.0);
 }
 
 //-----------------------------------------------------------------------------
@@ -402,27 +402,27 @@ DVAPI inline TPixel32 premultiply(const TPixel32 &pix)
 DVAPI inline TPixel64 premultiply(const TPixel64 &pix)
 {
 	return TPixel64(
-		static_cast<TPixel64::Channel>(pix.r * pix.m / 65535.0),
-		static_cast<TPixel64::Channel>(pix.g * pix.m / 65535.0),
-		static_cast<TPixel64::Channel>(pix.b * pix.m / 65535.0),
+		pix.r * pix.m / 65535.0,
+		pix.g * pix.m / 65535.0,
+		pix.b * pix.m / 65535.0,
 		pix.m);
 }
 
 DVAPI inline TPixel32 depremultiply(const TPixel32 &pix)
 {
 	return TPixel32(
-		static_cast<TPixel32::Channel>(pix.r * 255.0 / pix.m),
-		static_cast<TPixel32::Channel>(pix.g * 255.0 / pix.m),
-		static_cast<TPixel32::Channel>(pix.b * 255.0 / pix.m),
+		pix.r * 255.0 / pix.m,
+		pix.g * 255.0 / pix.m,
+		pix.b * 255.0 / pix.m,
 		pix.m);
 }
 
 DVAPI inline TPixel64 depremultiply(const TPixel64 &pix)
 {
 	return TPixel64(
-		static_cast<TPixel64::Channel>(pix.r * 65535.0 / pix.m),
-		static_cast<TPixel64::Channel>(pix.g * 65535.0 / pix.m),
-		static_cast<TPixel64::Channel>(pix.b * 65535.0 / pix.m),
+		pix.r * 65535.0 / pix.m,
+		pix.g * 65535.0 / pix.m,
+		pix.b * 65535.0 / pix.m,
 		pix.m);
 }
 

--- a/toonz/sources/include/tsmartpointer.h
+++ b/toonz/sources/include/tsmartpointer.h
@@ -167,12 +167,6 @@ public:
 
 	T *getPointer() const { return m_pointer; }
 
-	T* releasePointer() {
-		T* p = m_pointer;
-		m_pointer = nullptr;
-		return p;
-	}
-
 	bool operator!() const { return m_pointer == 0; }
 	operator bool() const { return m_pointer != 0; }
 

--- a/toonz/sources/include/tvectorimage.h
+++ b/toonz/sources/include/tvectorimage.h
@@ -21,6 +21,7 @@
 #define DVVAR DV_IMPORT_VAR
 #endif
 
+//#define NEW_REGION_FILL
 #define DISEGNO_OUTLINE 0
 
 //=============================================================================
@@ -349,6 +350,10 @@ public:
 #endif
 
 	void computeRegion(const TPointD &p, int styleId);
+
+#ifdef NEW_REGION_FILL
+	void resetRegionFinder();
+#endif
 
 private: //not implemented
 	TVectorImage(const TVectorImage &);

--- a/toonz/sources/tnzext/meshtexturizer.cpp
+++ b/toonz/sources/tnzext/meshtexturizer.cpp
@@ -158,16 +158,15 @@ void MeshTexturizer::Imp::allocateTextures(int groupIdx, const TRaster32P &ras, 
 
 	// Test the specified texture allocation
 	if (testTextureAlloc(textureLx, textureLy)) {
-		TPointD const scale(
-			data->m_geom.getLx() / ras->getLx(),
-			data->m_geom.getLy() / ras->getLy());
-		TRectD const tileGeom(
+		TPointD scale(data->m_geom.getLx() / (double)ras->getLx(),
+					  data->m_geom.getLy() / (double)ras->getLy());
+		TRectD tileGeom(
 			TRectD(
-				scale.x * (x             - TOTAL_BORDER), scale.y * (y             - TOTAL_BORDER),
+				scale.x * (x - TOTAL_BORDER), scale.y * (y - TOTAL_BORDER),
 				scale.x * (x + textureLx + TOTAL_BORDER), scale.y * (y + textureLy + TOTAL_BORDER)) +
 			data->m_geom.getP00());
 
-		GLuint const texId = textureAlloc(ras, aux, x, y, textureLx, textureLy, premultiplied);
+		GLuint texId = textureAlloc(ras, aux, x, y, textureLx, textureLy, premultiplied);
 
 		TextureData::TileData td = {texId, tileGeom};
 		data->m_tileDatas.push_back(td);

--- a/toonz/sources/tnzext/meshutils.cpp
+++ b/toonz/sources/tnzext/meshutils.cpp
@@ -320,7 +320,6 @@ void tglDraw(const TMeshImage &meshImage,
 			 const PlasticDeformerDataGroup &group)
 {
 #ifdef _WIN32
-	typedef void (*PFNGLBLENDFUNCSEPARATEPROC)(GLenum, GLenum, GLenum, GLenum);
 	static PFNGLBLENDFUNCSEPARATEPROC const glBlendFuncSeparate =
 		reinterpret_cast<PFNGLBLENDFUNCSEPARATEPROC>(::wglGetProcAddress("glBlendFuncSeparate"));
 #endif

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -330,9 +330,6 @@ void initToonzEnv()
 	if (cacheDir.isEmpty())
 		cacheDir = TEnv::getStuffDir() + "cache";
 	TImageCache::instance()->setRootDir(cacheDir);
-
-	DV_IMPORT_API void initializeImageRasterizer();
-	initializeImageRasterizer();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -330,6 +330,9 @@ void initToonzEnv()
 	if (cacheDir.isEmpty())
 		cacheDir = TEnv::getStuffDir() + "cache";
 	TImageCache::instance()->setRootDir(cacheDir);
+
+	DV_IMPORT_API void initializeImageRasterizer();
+	initializeImageRasterizer();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -26,8 +26,11 @@
 #include "toonz/fill.h"
 
 // Qt includes
-#include <QGLContext>
-#include <QGLPixelBuffer>
+#include <QImage>
+#include <QThread>
+#include <QOpenGLContext>
+#include <QOffscreenSurface>
+#include <QOpenGLFramebufferObject>
 
 #include "imagebuilders.h"
 
@@ -36,20 +39,6 @@
 //***************************************************************************************
 
 extern TOfflineGL *currentOfflineGL;
-
-//-----------------------------------------------------------------------------
-
-QGLPixelBuffer *imageRasterizerPixelBuffer = 0;
-
-void DV_EXPORT_API initializeImageRasterizer()
-{
-	assert(QGLPixelBuffer::hasOpenGLPbuffers());
-	if (!QGLPixelBuffer::hasOpenGLPbuffers()) {
-		imageRasterizerPixelBuffer = 0;
-	} else {
-		imageRasterizerPixelBuffer = new QGLPixelBuffer(QSize(1024, 1024));
-	}
-}
 
 //***************************************************************************************
 //    ImageLoader  implementation
@@ -281,54 +270,81 @@ TImageP ImageRasterizer::build(int imFlags, void *extData)
 
 			TGlContext oldContext = tglGetCurrentContext();
 
-			if (imageRasterizerPixelBuffer == 0) {
+			if (!QOpenGLFramebufferObject::hasOpenGLFramebufferObjects()) {
 				TRaster32P ras(d);
 				TRasterImageP ri(ras);
 				ri->setOffset(off + ras->getCenter());
 				return ri;
 			}
 
-			QGLPixelBuffer *gl = imageRasterizerPixelBuffer; // (QSize(d.lx, d.ly));
+			// this is too slow.
+			{
+				QSurfaceFormat format;
+				format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
-			gl->makeCurrent();
-			assert(glGetError() == 0);
+				std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
+				surface->setFormat(format);
+				surface->create();
 
-			glViewport(0, 0, 1024, 1024); // d.lx,d.ly);
-			glMatrixMode(GL_PROJECTION);
-			glLoadIdentity();
-			gluOrtho2D(0, d.lx, 0, d.ly);
-			glMatrixMode(GL_MODELVIEW);
-			glLoadIdentity();
-			glTranslatef(0.375, 0.375, 0.0);
-			glClearColor(0, 0, 0, 0);
-			glClear(GL_COLOR_BUFFER_BIT);
+				std::unique_ptr<QOpenGLContext> context(new QOpenGLContext());
+				context->moveToThread(QThread::currentThread());
+				context->makeCurrent(surface.get());
 
-			assert(glGetError() == 0);
-			tglDraw(rd, vi.getPointer());
-			assert(glGetError() == 0);
+				TRaster32P ras(d);
 
-			assert(glGetError() == 0);
-			glFlush();
-			assert(glGetError() == 0);
+				glPushAttrib(GL_ALL_ATTRIB_BITS);
+				glMatrixMode(GL_MODELVIEW), glPushMatrix();
+				glMatrixMode(GL_PROJECTION), glPushMatrix();
+				{
+					std::unique_ptr<QOpenGLFramebufferObject> fb(new QOpenGLFramebufferObject(d.lx, d.ly));
 
-			QImage img = gl->toImage().scaled(QSize(d.lx, d.ly), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
-			TRaster32P ras(d);
+					fb->bind();
+					assert(glGetError() == 0);
 
-			int wrap = ras->getLx() * sizeof(TPixel32);
-			uchar *srcPix = img.bits();
-			uchar *dstPix = ras->getRawData() + wrap * (d.ly - 1);
-			for (int y = 0; y < d.ly; y++) {
-				memcpy(dstPix, srcPix, wrap);
-				dstPix -= wrap;
-				srcPix += wrap;
+					glViewport(0, 0, d.lx, d.ly);
+					glClearColor(0, 0, 0, 0);
+					glClear(GL_COLOR_BUFFER_BIT);
+
+					glMatrixMode(GL_PROJECTION);
+					glLoadIdentity();
+					gluOrtho2D(0, d.lx, 0, d.ly);
+
+					glMatrixMode(GL_MODELVIEW);
+					glLoadIdentity();
+					glTranslatef(0.375, 0.375, 0.0);
+
+					assert(glGetError() == 0);
+					tglDraw(rd, vi.getPointer());
+					assert(glGetError() == 0);
+
+					assert(glGetError() == 0);
+					glFlush();
+					assert(glGetError() == 0);
+
+					QImage img = fb->toImage().scaled(QSize(d.lx, d.ly), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+
+					int wrap = ras->getLx() * sizeof(TPixel32);
+					uchar *srcPix = img.bits();
+					uchar *dstPix = ras->getRawData() + wrap * (d.ly - 1);
+					for (int y = 0; y < d.ly; y++) {
+						memcpy(dstPix, srcPix, wrap);
+						dstPix -= wrap;
+						srcPix += wrap;
+					}
+					fb->release();
+				}
+				glMatrixMode(GL_MODELVIEW), glPopMatrix();
+				glMatrixMode(GL_PROJECTION), glPopMatrix();
+
+				glPopAttrib();
+
+				context->doneCurrent();
+
+				TRasterImageP ri = TRasterImageP(ras);
+				ri->setOffset(off + ras->getCenter());
+
+				return ri;
 			}
-			gl->doneCurrent();
-
-			tglMakeCurrent(oldContext);
-
-			TRasterImageP ri = TRasterImageP(ras);
-			ri->setOffset(off + ras->getCenter());
-			return ri;
 		}
 	}
 

--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -29,6 +29,7 @@
 
 namespace
 {
+
 TRasterImageP convert32(const TImageP &img)
 {
 	struct locals {
@@ -95,10 +96,12 @@ TRasterImageP getTexture(const TXshSimpleLevel *sl, const TFrameId &fid, int sub
 	}
 
 	// Vector case
-	std::string const id = sl->getImageId(fid) + "_rasterized";
+	std::string id = sl->getImageId(fid) + "_rasterized";
 
 	ImageLoader::BuildExtData extData(sl, fid);
-	return ImageManager::instance()->getImage(id, ImageManager::dontPutInCache, &extData);
+	TRasterImageP ri(ImageManager::instance()->getImage(id, ImageManager::dontPutInCache, &extData));
+
+	return ri;
 }
 
 } // namespace
@@ -127,10 +130,10 @@ DrawableTextureDataP texture_utils::getTextureData(
 	TRaster32P ras(ri->getRaster());
 	assert(ras);
 
-	TRectD const geom
-		= TScale(ri->getSubsampling())
-		* TTranslation(convert(ri->getOffset()) - ras->getCenterD())
-		* TRectD(0, 0, ras->getLx(), ras->getLy());
+	TRectD geom(0, 0, ras->getLx(), ras->getLy());
+	geom = TScale(ri->getSubsampling()) *
+		   TTranslation(convert(ri->getOffset()) - ras->getCenterD()) *
+		   geom;
 
 	return TTexturesStorage::instance()->loadTexture(texId, ras, geom);
 }

--- a/toonz/sources/toonzqt/icongenerator.cpp
+++ b/toonz/sources/toonzqt/icongenerator.cpp
@@ -199,13 +199,16 @@ void makeChessBackground(const TRaster32P &ras)
 
 namespace
 {
-TRaster32P convertToIcon(TVectorImageP vimage, int frame,
-	TDimension const& iconSize, IconGenerator::Settings const& settings)
+TRaster32P convertToIcon(
+	TVectorImageP vimage,
+	int frame,
+	const TDimension &iconSize,
+	const IconGenerator::Settings &settings)
 {
 	if (!vimage)
 		return TRaster32P();
 
-	std::unique_ptr<TPalette> plt(vimage->getPalette()->clone());
+	TPalette *plt = vimage->getPalette()->clone();
 	if (!plt)
 		return TRaster32P();
 	plt->setFrame(frame);
@@ -234,31 +237,42 @@ TRaster32P convertToIcon(TVectorImageP vimage, int frame,
 	TAffine aff = TScale(sc).place(imageCenter, iconCenter);
 
 	// RenderData
-	TVectorRenderData rd(aff, TRect(iconSize), plt.get(), 0, true);
+	TVectorRenderData rd(
+		aff,
+		TRect(iconSize),
+		plt,
+		0, true);
+
 	rd.m_tcheckEnabled = settings.m_transparencyCheck;
 	rd.m_blackBgEnabled = settings.m_blackBgCheck;
 	rd.m_drawRegions = !settings.m_inksOnly;
-	rd.m_inkCheckEnabled = (settings.m_inkIndex != -1);
-	rd.m_paintCheckEnabled = (settings.m_paintIndex != -1);
+	rd.m_inkCheckEnabled = settings.m_inkIndex != -1;
+	rd.m_paintCheckEnabled = settings.m_paintIndex != -1;
 	rd.m_colorCheckIndex = rd.m_inkCheckEnabled ? settings.m_inkIndex : settings.m_paintIndex;
 	rd.m_isIcon = true;
 
 	// disegno l'immagine
 	glContext->makeCurrent();
-	glContext->clear(rd.m_blackBgEnabled ? TPixel32::Black : TPixel32::White);
+	glContext->clear(rd.m_blackBgEnabled ? TPixel::Black : TPixel32::White);
 	glContext->draw(vimage, rd);
 
 	TRaster32P ras(iconSize);
 	glContext->getRaster(ras);
+
 	glContext->doneCurrent();
+
+	delete plt;
 
 	return ras;
 }
 
 //-------------------------------------------------------------------------
 
-TRaster32P convertToIcon(TToonzImageP timage, int frame,
-	TDimension const& iconSize, IconGenerator::Settings const& settings)
+TRaster32P convertToIcon(
+	TToonzImageP timage,
+	int frame,
+	const TDimension &iconSize,
+	const IconGenerator::Settings &settings)
 {
 	if (!timage)
 		return TRaster32P();


### PR DESCRIPTION
Revert https://github.com/opentoonz/opentoonz/pull/248, because it breaks preview rendering for vector image; however this pr keeps modifications for `ImageRasterizer::build`.