### PR TITLE
Fix saving/loading an angle unit (degree sign) used in expression

### DIFF
--- a/toonz/sources/common/tparam/tdoublekeyframe.cpp
+++ b/toonz/sources/common/tparam/tdoublekeyframe.cpp
@@ -48,6 +48,9 @@ void TDoubleKeyframe::saveData(TOStream &os) const
 		break;
 	}
 	std::string unitName = m_unitName != "" ? m_unitName : "default";
+	// Dirty resolution. Because the degree sign is converted to unexpected string...
+	if (QString::fromStdWString(L"\u00b0").toStdString() == unitName)
+		unitName = "\\u00b0";
 	switch (m_type) {
 	case Constant:
 	case Exponential:


### PR DESCRIPTION
This fix is for the issue #237 
With this modification, the degree sign will be saved as "\u00b0" instead of  "°" in the scene file.
This fix will keep the compatibility between Toonz Harlequin's scene file.
Please note that this fix will not enable to load the scene file saved with the previous version of OpenToonz.