### PR TITLE
Fix crash when setting "Level Subsampling" to 0 

### DIFF
--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -134,7 +134,7 @@ LevelSettingsPopup::LevelSettingsPopup()
 
 	//subsampling
 	m_subsamplingLabel = new QLabel(tr("Subsampling:"));
-	m_subsamplingFld = new DVGui::IntLineEdit(this);
+	m_subsamplingFld = new DVGui::IntLineEdit(this,1,1);
 
 	m_doPremultiply = new CheckBox(tr("Premultiply"), this);
 


### PR DESCRIPTION
This fix is for the issue #222 
In this fix the minimum value of the "Level Subsampling" input box is set to 1.