### PR TITLE
Added menu item 'Toggle Edit in Place' (with small modification)

### DIFF
--- a/stuff/profiles/layouts/OpenToonz/room4_menubar.xml
+++ b/stuff/profiles/layouts/OpenToonz/room4_menubar.xml
@@ -23,6 +23,7 @@
     <command>MI_LoadSubSceneFile</command>
     <command>MI_CloneChild</command>
     <command>MI_ExplodeChild</command>
+    <command>MI_ToggleEditInPlace</command>
   </menu>
   <menu title="Levels">
     <command>MI_LoadLevel</command>

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -33,5 +33,6 @@
 #define MI_CloseChild "MI_CloseChild"
 #define MI_Collapse "MI_Collapse"
 #define MI_ExplodeChild "MI_ExplodeChild"
+#define MI_ToggleEditInPlace "MI_ToggleEditInPlace"
 
 #endif

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1728,6 +1728,7 @@ void MainWindow::defineActions()
 	createMenuXsheetAction(MI_CloseChild, tr("&Close Sub-xsheet"), "");
 	createMenuXsheetAction(MI_ExplodeChild, tr("Explode Sub-xsheet"), "");
 	createMenuXsheetAction(MI_Collapse, tr("Collapse"), "");
+	createMenuXsheetAction(MI_ToggleEditInPlace, tr("Toggle Edit in Place"), "");
 	createMenuXsheetAction(MI_SaveSubxsheetAs, tr("&Save Sub-xsheet As..."), "");
 	createMenuXsheetAction(MI_Resequence, tr("Resequence"), "");
 	createMenuXsheetAction(MI_CloneChild, tr("Clone Sub-xsheet"), "");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -876,6 +876,7 @@ QMenuBar* StackedMenuBar::createXsheetMenuBar()
 	addMenuItem(subxsheetMenu, MI_OpenChild);
 	addMenuItem(subxsheetMenu, MI_CloseChild);
 	addMenuItem(subxsheetMenu, MI_Collapse);
+	addMenuItem(subxsheetMenu, MI_ToggleEditInPlace);
 	addMenuItem(subxsheetMenu, MI_Resequence);
 	addMenuItem(subxsheetMenu, MI_SaveSubxsheetAs);
 	addMenuItem(subxsheetMenu, MI_LoadSubSceneFile);

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -1089,6 +1089,16 @@ void closeSubXsheet(int dlevel)
 	changeSaveSubXsheetAsCommand();
 }
 
+void toggleEditInPlace()
+{
+	TApp *app = TApp::instance();
+	ToonzScene *scene = app->getCurrentScene()->getScene();
+	int ancestorCount = scene->getChildStack()->getAncestorCount();
+	if (ancestorCount == 0)
+		return;
+	scene->getChildStack()->setEditInPlace(!scene->getChildStack()->getEditInPlace());
+}
+
 //=============================================================================
 
 void bringPegbarsInsideChildXsheet(TXsheet *xsh, TXsheet *childXsh)
@@ -2154,6 +2164,13 @@ public:
 	CloseChildCommand() : MenuItemHandler(MI_CloseChild) {}
 	void execute() { closeSubXsheet(1); }
 } closeChildCommand;
+
+class ToggleEditInPlaceCommand : public MenuItemHandler
+{
+public:
+	ToggleEditInPlaceCommand() : MenuItemHandler(MI_ToggleEditInPlace) {}
+	void execute() { toggleEditInPlace(); }
+} toggleEditInPlaceCommand;
 
 //=============================================================================
 // collapseColumns

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -1089,6 +1089,8 @@ void closeSubXsheet(int dlevel)
 	changeSaveSubXsheetAsCommand();
 }
 
+//=============================================================================
+
 void toggleEditInPlace()
 {
 	TApp *app = TApp::instance();
@@ -1097,6 +1099,8 @@ void toggleEditInPlace()
 	if (ancestorCount == 0)
 		return;
 	scene->getChildStack()->setEditInPlace(!scene->getChildStack()->getEditInPlace());
+	/*- Notify the change in order to update the viewer -*/
+	app->instance()->getCurrentXsheet()->notifyXsheetChanged();
 }
 
 //=============================================================================
@@ -2164,6 +2168,10 @@ public:
 	CloseChildCommand() : MenuItemHandler(MI_CloseChild) {}
 	void execute() { closeSubXsheet(1); }
 } closeChildCommand;
+
+//=============================================================================
+// ToggleEditInPlaceCommand
+//-----------------------------------------------------------------------------
 
 class ToggleEditInPlaceCommand : public MenuItemHandler
 {


### PR DESCRIPTION
This PR is for the issue #264 and is based on Banbury's modification https://github.com/opentoonz/opentoonz/pull/304

Here is Banbury's comment on his original PR:
> This readds the ability to edit Sub-XSheets in place. The menu item has to be
added to the menu of a room, before it can be used.

I just added a line to his code for notification of the change of the state in order to update the viewer.
And also I added this command to the default menubar of Xsheet Room.

Thank you very much, @Banbury!