### PR TITLE
Quiet GCC -Wparentheses warning with assignment

### DIFF
--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -1775,15 +1775,15 @@ void getClosingSegments(TL2LAutocloser &l2lautocloser, double facMin, double fac
 		return;
 
 	if (!s1->isSelfLoop() && !s2->isSelfLoop()) {
-		if (ret1 = isCloseEnoughP2P(facMin, facMax, s1, 0.0, s2, 1.0))
+		if ((ret1 = isCloseEnoughP2P(facMin, facMax, s1, 0.0, s2, 1.0)))
 			segments.push_back(std::pair<double, double>(0.0, 1.0));
 
 		if (s1 != s2) {
-			if (ret2 = isCloseEnoughP2P(facMin, facMax, s1, 0.0, s2, 0.0))
+			if ((ret2 = isCloseEnoughP2P(facMin, facMax, s1, 0.0, s2, 0.0)))
 				segments.push_back(std::pair<double, double>(0.0, 0.0));
-			if (ret3 = isCloseEnoughP2P(facMin, facMax, s1, 1.0, s2, 0.0))
+			if ((ret3 = isCloseEnoughP2P(facMin, facMax, s1, 1.0, s2, 0.0)))
 				segments.push_back(std::pair<double, double>(1.0, 0.0));
-			if (ret4 = isCloseEnoughP2P(facMin, facMax, s1, 1.0, s2, 1.0))
+			if ((ret4 = isCloseEnoughP2P(facMin, facMax, s1, 1.0, s2, 1.0)))
 				segments.push_back(std::pair<double, double>(1.0, 1.0));
 		}
 	}

--- a/toonz/sources/image/tzp/avl.c
+++ b/toonz/sources/image/tzp/avl.c
@@ -154,7 +154,7 @@ static void *new_memory(uint size)
 		*(void **)base = Free_List[NODE_LIST];
 		Free_List[NODE_LIST] = (void *)base;
 	}
-	if (Avail_Base = (char *)malloc(MALLOC_SIZE)) {
+	if ((Avail_Base = (char *)malloc(MALLOC_SIZE))) {
 		Avail_Size = MALLOC_SIZE - size;
 		return (void *)(Avail_Base + Avail_Size);
 	} else {
@@ -904,7 +904,7 @@ void *avl_locate_first(TREE *tree)
 	node = tree->root;
 	if (!node)
 		return NIL;
-	while (leftnode = node->left)
+	while ((leftnode = node->left))
 		node = leftnode;
 	return node->data;
 }
@@ -918,7 +918,7 @@ void *avl_locate_last(TREE *tree)
 	node = tree->root;
 	if (!node)
 		return NIL;
-	while (rightnode = node->right)
+	while ((rightnode = node->right))
 		node = rightnode;
 	return node->data;
 }
@@ -1280,7 +1280,7 @@ void *avl_first(TREE *tree)
 	*++pathnode = NIL;
 	*++pathright = FALSE;
 	*++pathnode = node = tree->root;
-	while (node = node->left) {
+	while ((node = node->left)) {
 		*++pathright = FALSE;
 		*++pathnode = node;
 	}
@@ -1315,7 +1315,7 @@ void *avl_last(TREE *tree)
 	*++pathnode = NIL;
 	*++pathright = TRUE;
 	*++pathnode = node = tree->root;
-	while (node = node->right) {
+	while ((node = node->right)) {
 		*++pathright = TRUE;
 		*++pathnode = node;
 	}
@@ -1328,7 +1328,7 @@ void *avl_last(TREE *tree)
 
 #define DOWN_RIGHT_OR_BREAK(node, pathright, pathnode) \
 	{                                                  \
-		if (node = node->right) {                      \
+		if ((node = node->right)) {                    \
 			*++pathright = TRUE;                       \
 			*++pathnode = node;                        \
 		} else                                         \
@@ -1337,7 +1337,7 @@ void *avl_last(TREE *tree)
 
 #define DOWN_LEFT_OR_BREAK(node, pathright, pathnode) \
 	{                                                 \
-		if (node = node->left) {                      \
+		if ((node = node->left)) {                    \
 			*++pathright = FALSE;                     \
 			*++pathnode = node;                       \
 		} else                                        \
@@ -1541,10 +1541,10 @@ void *avl_next(TREE *tree)
 		return NIL;
 	pathright = path->pathright;
 	pathnode = path->pathnode;
-	if (node = (*pathnode)->right) {
+	if ((node = (*pathnode)->right)) {
 		*++pathright = TRUE;
 		*++pathnode = node;
-		while (node = node->left) {
+		while ((node = node->left)) {
 			*++pathright = FALSE;
 			*++pathnode = node;
 		}
@@ -1580,10 +1580,10 @@ void *avl_prev(TREE *tree)
 		return NIL;
 	pathright = path->pathright;
 	pathnode = path->pathnode;
-	if (node = (*pathnode)->left) {
+	if ((node = (*pathnode)->left)) {
 		*++pathright = FALSE;
 		*++pathnode = node;
-		while (node = node->right) {
+		while ((node = node->right)) {
 			*++pathright = TRUE;
 			*++pathnode = node;
 		}

--- a/toonz/sources/toonz/binarizepopup.cpp
+++ b/toonz/sources/toonz/binarizepopup.cpp
@@ -310,7 +310,7 @@ int BinarizePopup::getSelectedFrames()
 	TCellSelection *cellSelection;
 	TFilmstripSelection *filmstripSelection;
 	int count = 0;
-	if (cellSelection = dynamic_cast<TCellSelection *>(selection)) {
+	if ((cellSelection = dynamic_cast<TCellSelection *>(selection))) {
 		std::set<TRasterImage *> images;
 		int r0, c0, r1, c1;
 		cellSelection->getSelectedCells(r0, c0, r1, c1);
@@ -331,7 +331,7 @@ int BinarizePopup::getSelectedFrames()
 				}
 			}
 		}
-	} else if (filmstripSelection = dynamic_cast<TFilmstripSelection *>(selection)) {
+	} else if ((filmstripSelection = dynamic_cast<TFilmstripSelection *>(selection))) {
 		TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
 		if (sl) {
 			std::set<TFrameId> fids = filmstripSelection->getSelectedFids();

--- a/toonz/sources/toonz/meshifypopup.cpp
+++ b/toonz/sources/toonz/meshifypopup.cpp
@@ -746,7 +746,7 @@ void MeshifyPopup::acquirePreview()
 			m_cell = xsh->getCell(m_r, childId.getIndex());
 	}
 
-	if (sl = m_cell.getSimpleLevel()) {
+	if ((sl = m_cell.getSimpleLevel())) {
 		// Standard image case
 		m_viewer->m_img = sl->getFullsampledFrame(m_cell.getFrameId(), ImageManager::dontPutInCache);
 

--- a/toonz/sources/toonzlib/tcenterlinepolygonizer.cpp
+++ b/toonz/sources/toonzlib/tcenterlinepolygonizer.cpp
@@ -418,7 +418,7 @@ BorderList *extractBorders(const TRasterP &ras, int threshold, int despeckling)
 
 				if ((signature = byteImage.getSignature(x, y)) == none) {
 					//We've found a border
-					if (foundPath = extractPath(byteImage, x, y, !enteredRegionType, xOuterPixel, despeckling))
+					if ((foundPath = extractPath(byteImage, x, y, !enteredRegionType, xOuterPixel, despeckling)))
 						if (enteredRegionType == outer)
 							innerBorders.push_back(foundPath);
 						else

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -703,7 +703,7 @@ void CleanupColorField::updateColor()
 		if ((bs = dynamic_cast<TBlackCleanupStyle *>(m_cleanupStyle)) && !m_greyMode) {
 			m_cThresholdChannel->setChannel(bs->getColorThreshold());
 			m_wThresholdChannel->setChannel(bs->getWhiteThreshold());
-		} else if (cs = dynamic_cast<TColorCleanupStyle *>(m_cleanupStyle)) {
+		} else if ((cs = dynamic_cast<TColorCleanupStyle *>(m_cleanupStyle))) {
 			m_hRangeChannel->setChannel(cs->getHRange());
 			m_lineWidthChannel->setChannel(cs->getLineWidth());
 		}

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -1416,7 +1416,7 @@ bool DockLayout::restoreState(const State &state)
 
 	//Docked widgets are found in hierarchy
 	for (j = 0; j < m_regions.size(); ++j)
-		if (item = m_regions[j]->m_item) {
+		if ((item = m_regions[j]->m_item)) {
 			item->setWindowFlags(Qt::SubWindow);
 			item->setDockedAppearance();
 			item->m_floating = false;

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -219,7 +219,7 @@ void DockWidget::hoverMoveEvent(QHoverEvent *he)
 	if (m_floating && !m_resizing && !m_undocking) {
 		QCursor newCursor = Qt::ArrowCursor;
 
-		if (m_marginType = isResizeGrip(he->pos())) {
+		if ((m_marginType = isResizeGrip(he->pos()))) {
 			//Hovering a margin - update cursor shape
 			if (m_marginType & leftMargin) {
 				if (m_marginType & topMargin)
@@ -254,7 +254,7 @@ void DockWidget::hoverMoveEvent(QHoverEvent *he)
 //!b)  Trigger a window drag if press is over a drag grip
 void DockWidget::mousePressEvent(QMouseEvent *me)
 {
-	if (m_marginType = m_floating ? isResizeGrip(me->pos()) : 0) {
+	if ((m_marginType = m_floating ? isResizeGrip(me->pos()) : 0)) {
 		//Resize begins
 
 		//NOTE: It is better to assume that resize grips dominate over drag grips: this ensures
@@ -613,7 +613,7 @@ DockPlaceholder *DockPlaceholder::parentPlaceholder()
 	if (!m_region || !m_region->getParent())
 		return this;
 
-	if (grandParent = m_region->getParent()->getParent()) {
+	if ((grandParent = m_region->getParent()->getParent())) {
 		//Good, we finally have to search in grandParent's region our direct parent.
 		unsigned int idx = grandParent->find(m_region->getParent());
 

--- a/toonz/sources/toonzqt/dvscrollwidget.cpp
+++ b/toonz/sources/toonzqt/dvscrollwidget.cpp
@@ -180,7 +180,7 @@ void DvScrollWidget::setWidget(QWidget *widget)
 
 void DvScrollWidget::setOrientation(Qt::Orientation orientation)
 {
-	if (m_horizontal = (orientation == Qt::Horizontal)) {
+	if ((m_horizontal = (orientation == Qt::Horizontal))) {
 		setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
 		m_scrollBackward->setObjectName("ScrollLeftButton");

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -814,7 +814,7 @@ void FullScreenWidget::setWidget(QWidget *widget)
 	QLayout *layout = this->layout();
 
 	delete layout->takeAt(0);
-	if (m_widget = widget)
+	if ((m_widget = widget))
 		layout->addWidget(m_widget);
 }
 

--- a/toonz/sources/toonzqt/pluginhost.cpp
+++ b/toonz/sources/toonzqt/pluginhost.cpp
@@ -171,7 +171,7 @@ static int create_param_view(toonz_node_handle_t node, toonz_param_view_handle_t
 			return TOONZ_ERROR_INVALID_HANDLE;
 		}
 
-		if (p = fx->createParamView()) {
+		if ((p = fx->createParamView())) {
 			*view = p;
 		} else {
 			printf("create_param_view: invalid param name");
@@ -311,7 +311,7 @@ static int add_preference(toonz_node_handle_t node, const char *name, toonz_ui_p
 			return TOONZ_ERROR_INVALID_HANDLE;
 		}
 
-		if (p = fx->createUIPage(name)) {
+		if ((p = fx->createUIPage(name))) {
 			*ui = p;
 		} else {
 			printf("add_preference: failed to get UIPage\n");
@@ -335,7 +335,7 @@ static int add_param(toonz_node_handle_t node, const char *name, int type, toonz
 			return TOONZ_ERROR_INVALID_HANDLE;
 		}
 
-		if (p = fx->createParam(name, toonz_param_type_enum(type))) {
+		if ((p = fx->createParam(name, toonz_param_type_enum(type)))) {
 			*param = p;
 		} else {
 			printf("add_param: invalid type");


### PR DESCRIPTION
These warnings are helpful to avoid accidentally writing `==` as `=`.

A mistake which looks like is made in `dvdialog.cpp`, `DVGui::MsgBox`.
so I made this an alternate PR (now merged, see #311).