### PR TITLE
Handle more then 3 peg holes

### DIFF
--- a/toonz/sources/toonzlib/autopos.cpp
+++ b/toonz/sources/toonzlib/autopos.cpp
@@ -1607,7 +1607,7 @@ static int compare_dots(DOT const dots[], int ndots, DOT reference[], int ref_do
 	int toll;
 	float tolld;
 	int i, j, k;
-	short *dot_ok = 0;
+	bool *dot_ok = 0;
 	float *ref_dis = 0, dx, dy;
 	float vmin, v, dist_i_j, dist_i_k, dist_j_k, del1, del2;
 	float ref_dis_0_1, ref_dis_1_2;
@@ -1623,7 +1623,7 @@ static int compare_dots(DOT const dots[], int ndots, DOT reference[], int ref_do
 	}
 
 	/* controllo quanti dots sono realmente buoni per il confronto */
-	dot_ok = (short *)calloc(ndots, sizeof(short));
+	dot_ok = (bool *)calloc(ndots, sizeof(bool));
 	found = 0;
 
 	for (i = 0; i < ndots; i++) {

--- a/toonz/sources/toonzlib/autopos.cpp
+++ b/toonz/sources/toonzlib/autopos.cpp
@@ -1083,8 +1083,8 @@ static int find_dots_rgb(const TRaster32P &img, int strip_width, PEGS_SIDE pegs_
 				if (Npix < max_area * 3 / 2 &&
 					dot_lx > 3 && dot_lx < (xsize >> 1) &&
 					dot_ly > 3 && dot_ly < (ysize >> 1) &&
-					Xmin > x0 && Xmax < xlast &&
-					Ymin > y0 && Ymax < ylast) {
+					Xmin > x0 && Xmax <= xlast &&
+					Ymin > y0 && Ymax <= ylast) {
 					dot_x = (float)(BIG_TO_DOUBLE(Xsum) / BIG_TO_DOUBLE(Weightsum));
 					dot_y = (float)(BIG_TO_DOUBLE(Ysum) / BIG_TO_DOUBLE(Weightsum));
 					if (vertical) {

--- a/toonz/sources/toonzlib/autopos.cpp
+++ b/toonz/sources/toonzlib/autopos.cpp
@@ -1486,6 +1486,7 @@ static void visit_rgb(int i, int j, int x, int y, TPixel32 *pix)
 
 #endif
 
+#define PERCENT (40.0 / 100.0)
 /*---------------------------------------------------------------------------*/
 /*
  * Attenzione: tutti i controlli e i calcoli vengono fatti in pixel.
@@ -1504,7 +1505,7 @@ int get_image_rotation_and_center(const TRasterP &img, int strip_width,
 	DOT _dotarray[MAX_DOT];
 	DOT *dotarray = _dotarray;
 	int ndot, central;
-	int max_area;
+	int max_area, min_area;
 
 	*p_ang = 0.0;
 
@@ -1516,9 +1517,21 @@ int get_image_rotation_and_center(const TRasterP &img, int strip_width,
 	}
 
 	max_area = 0;
+	if (ref_dot > 0)
+	{
+	  min_area = ref[0].area;
+	}
 	for (i = 0; i < ref_dot; i++)
+	{
 		if (ref[i].area > max_area)
+		{
 			max_area = ref[i].area;
+		}
+		if (ref[i].area < min_area)
+		{
+			min_area = ref[i].area;
+		}
+	}
 
 	ndot = find_dots(img, strip_width, pegs_side, dotarray, MAX_DOT, max_area);
 	if (Debug_flag)
@@ -1527,7 +1540,7 @@ int get_image_rotation_and_center(const TRasterP &img, int strip_width,
 	i = 0;
 	while (i < ndot) //elimino i dots troppo piccoli
 	{
-		if (dotarray[i].area < 500) {
+		if (dotarray[i].area < min_area * PERCENT) {
 			for (int j = i; j < ndot - 1; j++)
 				dotarray[j] = dotarray[j + 1];
 			ndot--;
@@ -1576,7 +1589,6 @@ int get_image_rotation_and_center(const TRasterP &img, int strip_width,
 }
 
 /*---------------------------------------------------------------------------*/
-#define PERCENT (40.0 / 100.0)
 #define MIN_V 100.0
 
 static int compare_dots(DOT dots[], int *ndots,

--- a/toonz/sources/toonzlib/cleanupparameters.cpp
+++ b/toonz/sources/toonzlib/cleanupparameters.cpp
@@ -135,8 +135,8 @@ void FdgManager::loadFieldGuideInfo()
 					sscanf(arg, "%d", &cnt);
 					if (cnt >= (int)fdg_info.dots.size()) {
 						// tmsg_error("load field guide info error: bad hole number");
-						break;
 						//        return FALSE;
+						fdg_info.dots.push_back(CleanupTypes::DOT());
 					}
 				} else if (STR_EQ(label, "X0"))
 					sscanf(arg, "%d", &fdg_info.dots[cnt].x1);


### PR DESCRIPTION
I added support to use pegbars with more than three holes. Due to the poor availability of paper for traditional pegbars I use a puncher for a filing system with six round holes and a custom built pegbar.

The code assumed the pegbar specification to have exactly three holes. The auto center code didn't work when a peg hole was at the top border of the paper (I scanned a bit poorly) and when there are more then three holes the original code centered the page at the middle hole of the three best matching holes.

I think I could also get the code to work with only two peg holes, but have not tried yet. It might help people try out toonz (a pegbar can be easily created with a 3d-printer), but it would be also quite hard to draw and keep the pages aligned, so don't know if it is worth the try.