### PR TITLE
Fix: Allow negative frame id in scene.setCell (scripting).

### DIFF
--- a/toonz/sources/toonzlib/scriptbinding_level.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_level.cpp
@@ -228,7 +228,7 @@ TFrameId Level::getFid(const QScriptValue &arg, QString &err)
 {
 	if (arg.isNumber() || arg.isString()) {
 		QString s = arg.toString();
-		QRegExp re("(\\d+)(\\w?)");
+		QRegExp re("(-?\\d+)(\\w?)");
 		if (re.exactMatch(s)) {
 			int d = re.cap(1).toInt();
 			QString c = re.cap(2);


### PR DESCRIPTION
This fix is necessary for creating animations in Javascript from raster images
with only one frame. For this Opentoonz expects a frame id of -2.
A frame id of -1 is an empty frame.
The original implementation only allows positive numbers.

I'm planning to release a converter from Papagayo to Opentoonz script. The script will create a new level with all the mouth shapes. But without this patch the script won't work.