### PR TITLE
Revert "Use QOpenGLWidget instead of QGLWidget"

### DIFF
--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -32,8 +32,7 @@
 #include <QSlider>
 #include <QToolButton>
 #include <QScrollArea>
-#include <QOpenGLWidget>
-#include <QOpenGLFunctions_3_0>
+#include <QGLWidget>
 #include <QMouseEvent>
 #include <QPointF>
 
@@ -142,7 +141,7 @@ enum CurrentWheel {
 	rightTriangle
 };
 
-class DVAPI HexagonalColorWheel : public QOpenGLWidget, private QOpenGLFunctions_3_0
+class DVAPI HexagonalColorWheel : public QGLWidget
 {
 	Q_OBJECT
 
@@ -176,17 +175,17 @@ public:
 	QColor getBGColor() const { return m_bgColor; }
 
 protected:
-	void initializeGL() override;
-	void resizeGL(int width, int height) override;
-	void paintGL() override;
+	void initializeGL();
+	void resizeGL(int width, int height);
+	void paintGL();
 	QSize SizeHint() const
 	{
 		return QSize(300, 200);
 	};
 
-	void mousePressEvent(QMouseEvent *event) override;
-	void mouseMoveEvent(QMouseEvent *event) override;
-	void mouseReleaseEvent(QMouseEvent *event) override;
+	void mousePressEvent(QMouseEvent *event);
+	void mouseMoveEvent(QMouseEvent *event);
+	void mouseReleaseEvent(QMouseEvent *event);
 
 signals:
 	void colorChanged(const ColorModel &color, bool isDragging);

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -143,7 +143,9 @@ set(MOC_HEADERS
     metnum.h
     ObjectTracker.h
     predict3d.h
-    processor.h)
+    processor.h
+    viewer.h
+    writer.h)
 
 set(HEADERS ${MOC_HEADERS})
 
@@ -298,7 +300,9 @@ set(SOURCES
     dummyprocessor.cpp
     metnum.cpp
     ObjectTracker.cpp
-    predict3d.cpp)
+    predict3d.cpp
+    viewer.cpp
+    writer.cpp)
 
 add_translation(toonz ${HEADERS} ${SOURCES})
 

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -1894,7 +1894,7 @@ void FlipBook::showEvent(QShowEvent *e)
 		m_flipConsole->onPreferenceChanged();
 	}
 	m_flipConsole->setActive(true);
-	m_imageViewer->update();
+	m_imageViewer->updateGL();
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -3,10 +3,12 @@
 #ifndef IMAGEVIEWER_INCLUDE
 #define IMAGEVIEWER_INCLUDE
 
+//iwsw commented out temporarily
+//#include "toonzqt/ghibli_3dlut_util.h"
+
 #include "toonz/imagepainter.h"
 
-#include <QOpenGLWidget>
-#include <QOpenGLFunctions_3_0>
+#include <QGLWidget>
 
 //-----------------------------------------------------------------------------
 
@@ -20,7 +22,7 @@ class HistogramPopup;
 //    ImageViewer
 //--------------------
 
-class ImageViewer : public QOpenGLWidget, private QOpenGLFunctions_3_0
+class ImageViewer : public QGLWidget
 {
 	Q_OBJECT
 	enum DragType { eNone,
@@ -56,6 +58,9 @@ class ImageViewer : public QOpenGLWidget, private QOpenGLFunctions_3_0
 	//a flipbook shows a red border line before the rendered result is shown.
 	bool m_isRemakingPreviewFx;
 
+	//iwsw commented out temporarily
+	//Ghibli3DLutUtil * m_ghibli3DLutUtil;
+
 	int getDragType(const TPoint &pos, const TRect &loadBox);
 	void updateLoadbox(const TPoint &curPos);
 	void updateCursor(const TPoint &curPos);
@@ -67,6 +72,7 @@ class ImageViewer : public QOpenGLWidget, private QOpenGLFunctions_3_0
 
 public:
 	ImageViewer(QWidget *parent, FlipBook *flipbook, bool showHistogram);
+	~ImageViewer();
 
 	void setIsColorModel(bool isColorModel) { m_isColorModel = isColorModel; }
 	bool isColorModel() { return m_isColorModel; }
@@ -100,21 +106,28 @@ public:
 	void adaptView(const TRect &imgRect, const TRect &viewRect);
 	void adaptView(const QRect &viewerRect);
 
-	void doSwapBuffers();
-	void changeSwapBehavior(bool enable);
+	void doSwapBuffers()
+	{
+		swapBuffers();
+		glFlush();
+	}
+	void changeSwapBehavior(bool enable) { setAutoBufferSwap(enable); }
+
+	//iwsw commented out temporarily
+	//Ghibli3DLutUtil* get3DLutUtil(){ return m_ghibli3DLutUtil; }
 
 protected:
-	void contextMenuEvent(QContextMenuEvent *event) override;
-	void initializeGL() override;
-	void resizeGL(int width, int height) override;
-	void paintGL() override;
+	void contextMenuEvent(QContextMenuEvent *event);
+	void initializeGL();
+	void resizeGL(int width, int height);
+	void paintGL();
 
-	void mouseMoveEvent(QMouseEvent *event) override;
-	void mousePressEvent(QMouseEvent *event) override;
-	void mouseReleaseEvent(QMouseEvent *event) override;
-	void keyPressEvent(QKeyEvent *event) override;
-	void mouseDoubleClickEvent(QMouseEvent *event) override;
-	void wheelEvent(QWheelEvent *) override;
+	void mouseMoveEvent(QMouseEvent *event);
+	void mousePressEvent(QMouseEvent *event);
+	void mouseReleaseEvent(QMouseEvent *event);
+	void keyPressEvent(QKeyEvent *event);
+	void mouseDoubleClickEvent(QMouseEvent *event);
+	void wheelEvent(QWheelEvent *);
 
 	void panQt(const QPoint &delta);
 	void zoomQt(const QPoint &center, double factor);

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -258,11 +258,6 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
-	QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-
 	QApplication a(argc, argv);
 
 #ifdef Q_OS_WIN

--- a/toonz/sources/toonz/viewer.cpp
+++ b/toonz/sources/toonz/viewer.cpp
@@ -1,0 +1,83 @@
+
+
+#include <QPainter>
+#include "tgl.h"
+#include "viewer.h"
+#include "processor.h"
+
+//=============================================================================
+// Viewer
+//-----------------------------------------------------------------------------
+
+Viewer::Viewer(QWidget *parent)
+	: QGLWidget(parent), m_raster(0), m_processor(0), update_frame(true)
+{
+}
+
+//-----------------------------------------------------------------------------
+
+Viewer::~Viewer()
+{
+}
+
+//-----------------------------------------------------------------------------
+
+void Viewer::initializeGL()
+{
+	glClearColor(1.0f, 1.0f, 1.0f, 0.0f);
+}
+
+//-----------------------------------------------------------------------------
+
+void Viewer::resizeGL(int width, int height)
+{
+	glViewport(0, 0, width, height);
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
+	glOrtho(0, width, 0, height, -1, 1);
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
+	// To maintain pixel accuracy
+	glTranslated(0.375, 0.375, 0.0);
+}
+
+//-----------------------------------------------------------------------------
+
+void Viewer::paintGL()
+{
+	glClear(GL_COLOR_BUFFER_BIT);
+	if (m_raster) {
+		glRasterPos2d(0, 0);
+		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0); // ras->getWrap());
+		glDrawPixels(m_raster->getLx(), m_raster->getLy(), TGL_FMT, TGL_TYPE, m_raster->getRawData());
+	}
+	if (m_processor) {
+		m_processor->draw();
+	}
+
+	if (m_message != "") {
+		glColor3d(0, 0, 0);
+		glPushMatrix();
+		const double sc = 5;
+		glScaled(sc, sc, sc);
+		tglDrawText(TPointD(5, 5), m_message);
+		glPopMatrix();
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+void Viewer::setRaster(TRaster32P raster)
+{
+	m_raster = raster;
+	if (update_frame)
+		update();
+}
+
+//-----------------------------------------------------------------------------
+
+void Viewer::setMessage(std::string msg)
+{
+	m_message = msg;
+	update();
+}

--- a/toonz/sources/toonz/viewer.h
+++ b/toonz/sources/toonz/viewer.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifndef VIEWER_H
+#define VIEWER_H
+
+#include <QGLWidget>
+#include "traster.h"
+
+class Processor;
+
+//! OpenGL Widget that display the movie
+class Viewer : public QGLWidget
+{
+	//! Raster that store the current Frame of the Movie.
+	TRaster32P m_raster;
+	Q_OBJECT;
+	//! String used to display "loading" text while the movie is being loaded
+	std::string m_message;
+	//! Pointer to a Processor to process the frame drawing OpenGL primitive over it.
+	Processor *m_processor;
+
+public:
+	bool update_frame;
+
+	//! Construct a QGLWidget object which is a child of parent.
+	Viewer(QWidget *parent = 0);
+	//! Destroys the widget
+	~Viewer();
+
+	//! Set the raster to draw
+	void setRaster(TRaster32P raster);
+	//! Returns the raster
+	const TRaster32P &getRaster() const { return m_raster; }
+
+	//! Set the Processor to draw over the current frame
+	void setProcessor(Processor *processor) { m_processor = processor; }
+	//! Set the message. This message is displayed for every frame (if is a non-empty string).
+	void setMessage(std::string msg);
+
+protected:
+	void initializeGL();
+	void paintGL();
+	void resizeGL(int width, int height);
+};
+
+#endif // VIEWER_H

--- a/toonz/sources/toonz/writer.cpp
+++ b/toonz/sources/toonz/writer.cpp
@@ -1,0 +1,60 @@
+
+
+#include <QPainter>
+#include "tgl.h"
+#include "writer.h"
+#include "processor.h"
+#include "trasterimage.h"
+
+//=============================================================================
+// Writer
+//----------------------------------------------------------------------------
+
+Writer::Writer(const TFilePath &outputFile, int lx, int ly)
+	: m_pixmap(lx, ly), m_context(0), m_levelWriter(outputFile), m_frameCount(0), m_raster(lx, ly)
+{
+	QGLFormat glFormat;
+	m_context = new QGLContext(glFormat, &m_pixmap);
+	m_context->makeCurrent();
+
+	glViewport(0, 0, lx, ly);
+	glMatrixMode(GL_PROJECTION);
+	glLoadIdentity();
+	glOrtho(0, lx, 0, ly, -1, 1);
+	glMatrixMode(GL_MODELVIEW);
+	glLoadIdentity();
+	// To maintain pixel accuracy
+	glTranslated(0.375, 0.375, 0.0);
+	glClearColor(1.0f, 1.0f, 1.0f, 0.0f);
+}
+
+//-----------------------------------------------------------------------------
+
+Writer::~Writer()
+{
+	delete m_context;
+}
+
+//-----------------------------------------------------------------------------
+
+void Writer::write(const TRaster32P &ras, Processor *processor)
+{
+	m_context->makeCurrent();
+	glClear(GL_COLOR_BUFFER_BIT);
+	if (ras) {
+		glRasterPos2d(0, 0);
+		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0); // ras->getWrap());
+		glDrawPixels(ras->getLx(), ras->getLy(), TGL_FMT, TGL_TYPE, ras->getRawData());
+	}
+	if (processor) {
+		processor->draw();
+	}
+	glRasterPos2d(0, 0);
+	glPixelStorei(GL_UNPACK_ROW_LENGTH, 0); // ras->getWrap());
+	glReadPixels(0, 0, m_raster->getLx(), m_raster->getLy(), TGL_FMT, TGL_TYPE, m_raster->getRawData());
+
+	TImageP img = TRasterImageP(m_raster);
+	m_levelWriter->getFrameWriter(++m_frameCount)->save(img);
+}
+
+//-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/writer.h
+++ b/toonz/sources/toonz/writer.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#ifndef WRITER_H
+#define WRITER_H
+
+#include <QGLWidget>
+#include "traster.h"
+#include "tfilepath.h"
+#include "tlevel_io.h"
+
+class Processor;
+
+//! Draw the frame (with the processing) before saving it.
+class Writer
+{
+	//! QPaintDevice used only to initialize the QGLContext
+	QPixmap m_pixmap;
+	//! Offline OpenGL context that draw directly to a QPaintDevice (in this case a QPixmap)
+	QGLContext *m_context;
+	//! Class to write the level to file
+	TLevelWriterP m_levelWriter;
+	//! Frame counter
+	int m_frameCount;
+	//! Current Raster
+	TRaster32P m_raster;
+
+public:
+	//! Constructor
+	/*!
+    \param &outputFile filename of the output movie
+    \param lx an integer contains the width of the movie
+    \param ly an integer contains the height of the movie
+   */
+	Writer(const TFilePath &outputFile, int lx, int ly);
+	//! Destructor
+	~Writer();
+
+	/*! Write the raster, using the processor to the GL Context,
+      then read the context to store it in the m_raster. 
+      Hence write m_raster to the movie file using TLevelWriter
+  */
+	void write(const TRaster32P &ras, Processor *processor);
+
+protected:
+};
+
+#endif // WRITER_H

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -587,29 +587,49 @@ QPixmap makeSquareShading(
 //*****************************************************************************
 
 HexagonalColorWheel::HexagonalColorWheel(QWidget *parent)
-	: QOpenGLWidget(parent)
-	, m_bgColor(128, 128, 128) //defaul value in case this value does not set in the style sheet
+	: QGLWidget(parent), m_bgColor(128, 128, 128) //defaul value in case this value does not set in the style sheet
+												  //, m_ghibli3DLutUtil(0)//iwsw commented out temporarily
 {
 	setObjectName("HexagonalColorWheel");
 	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	setFocusPolicy(Qt::NoFocus);
 	m_currentWheel = none;
+
+	//iwsw commented out temporarily
+	/*
+	if(Preferences::instance()->isDoColorCorrectionByUsing3DLutEnabled() && Ghibli3DLutUtil::m_isValid)
+	{
+	m_ghibli3DLutUtil = new Ghibli3DLutUtil();
+	m_ghibli3DLutUtil->setInvert();
+	}
+	*/
 }
 
 //-----------------------------------------------------------------------------
 
 HexagonalColorWheel::~HexagonalColorWheel()
 {
+	//iwsw commented out temporarily
+	/*
+	if(m_ghibli3DLutUtil)
+	{
+	m_ghibli3DLutUtil->onEnd();
+	delete m_ghibli3DLutUtil;
+	}
+	*/
 }
 
 //-----------------------------------------------------------------------------
 
 void HexagonalColorWheel::initializeGL()
 {
-	initializeOpenGLFunctions();
+	qglClearColor(getBGColor());
 
-	QColor color = getBGColor();
-	glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+	//iwsw commented out temporarily
+	/*
+	if(Preferences::instance()->isDoColorCorrectionByUsing3DLutEnabled() && m_ghibli3DLutUtil)
+	m_ghibli3DLutUtil->onInit();
+	*/
 }
 
 //-----------------------------------------------------------------------------
@@ -659,16 +679,28 @@ void HexagonalColorWheel::resizeGL(int width, int height)
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	glOrtho(0.0, (GLdouble)width, (GLdouble)height, 0.0, 1.0, -1.0);
+
+	//iwsw commented out temporarily
+	/*
+	if(Preferences::instance()->isDoColorCorrectionByUsing3DLutEnabled() && m_ghibli3DLutUtil)
+	m_ghibli3DLutUtil->onResize(width,height);
+	*/
 }
 
 //-----------------------------------------------------------------------------
 
 void HexagonalColorWheel::paintGL()
 {
-	QColor color = getBGColor();
-	glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+	//call ClearColor() here in order to update bg color when the stylesheet is switched
+	qglClearColor(getBGColor());
 
 	glMatrixMode(GL_MODELVIEW);
+
+	//iwsw commented out temporarily
+	/*
+	if(Preferences::instance()->isDoColorCorrectionByUsing3DLutEnabled() && m_ghibli3DLutUtil)
+	m_ghibli3DLutUtil->startDraw();
+	*/
 
 	glClear(GL_COLOR_BUFFER_BIT);
 
@@ -714,6 +746,12 @@ void HexagonalColorWheel::paintGL()
 	drawCurrentColorMark();
 
 	glPopMatrix();
+
+	//iwsw commented out temporarily
+	/*
+	if(Preferences::instance()->isDoColorCorrectionByUsing3DLutEnabled() && m_ghibli3DLutUtil)
+	m_ghibli3DLutUtil->endDraw();
+	*/
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Reverts opentoonz/opentoonz#315.

In OSX environment, #315 caused fatal error (`EXC_BAD_ACCESS`) at

```
inline void QOpenGLFunctions_3_0::glClearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha)
{
    d_1_0_Core->ClearColor(red, green, blue, alpha);
```

So it must be reverted and we will wait merging it until the error will be fixed.