### PR TITLE
Do not attempt to clone a palette when it is NULL.

### DIFF
--- a/toonz/sources/toonz/cleanuppopup.cpp
+++ b/toonz/sources/toonz/cleanuppopup.cpp
@@ -935,7 +935,7 @@ QString CleanupPopup::setupLevel()
 
 		/*--- Cleanup後にPaletteを元に戻すため、Paletteを保持しておく ---*/
 		if (m_keepOriginalPalette) {
-			if (sl->getType() == TZP_XSHLEVEL || sl->getType() == TZI_XSHLEVEL)
+			if ((sl->getType() == TZP_XSHLEVEL || sl->getType() == TZI_XSHLEVEL) && sl->getPalette() != NULL)
 				m_originalPalette = sl->getPalette()->clone();
 			else /*--- 既にCleanup済みだが、再びTIFファイルからCleanupを行う場合 ---*/
 			{


### PR DESCRIPTION
When a scanned strip was cleaned up and then without storing the scene cleaned up again and the query to overwrite the old files was answered with overwrite all, the program crashed.