### PR TITLE
Fix: level strip width is wrong when you start open toonz (#334)

### DIFF
--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1106,7 +1106,6 @@ public:
 	{
 		Filmstrip *filmstrip = new Filmstrip(panel);
 		panel->setWidget(filmstrip);
-		panel->setMinimumWidth(filmstrip->width() + 2 * panel->getFloatingMargin());
 		panel->setIsMaximizable(false);
 	}
 } filmStripFactory;


### PR DESCRIPTION
On the creation the docking panel of the level strip was assigned a minimum
width. This has no effect, but making the docking panel too big, because the
size of the underlying controls hasn't been calculated at this point.
Removing the line fixes the issue with the level strip size, without affecting
the docking window otherwise.