### PR TITLE
Show pinned center keys on Xsheet row area 

### DIFF
--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -49,6 +49,7 @@ class RowArea : public QWidget
 	void drawPlayRange(QPainter &p, int r0, int r1);
 	void drawCurrentRowGadget(QPainter &p, int r0, int r1);
 	void drawOnionSkinSelection(QPainter &p);
+	void drawPinnedCenterKeys(QPainter &p, int r0, int r1);
 
 	DragTool *getDragTool() const;
 	void setDragTool(DragTool *dragTool);


### PR DESCRIPTION
This PR is for the issue #282 
On the frames where the pinned center of the current skeleton is changed from the previous frame (= pinned center keyframes), blue square are displayed in the Xsheet row area.
Look and feel of this feature is based on @psychoanima 's proposal in the issue #282 but I made some changes as follows:
- This UI is displayed whenever the skeleton tool is selected, regardless of the current mode. 
- Index of the column which contains the pinned center object is displayed in the squares.
- Tooltip is set for this UI.

Since the row area is limited, this UI may obscure the frame numbers if the display mode of frame numbers is set to other than "Frame". This inconvenience might be another issue.

![pinned_center_keys](https://cloud.githubusercontent.com/assets/17974955/15564798/9d648694-2350-11e6-9581-8cad0c88a769.png)
