### PR TITLE
Keep the consistency of mesh image addr, after save operation

### DIFF
--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -154,6 +154,9 @@ bool ImageLoader::isImageCompatible(int imFlags, void *extData)
 
 	BuildExtData *data = static_cast<BuildExtData *>(extData);
 	const TXshSimpleLevel *sl = data->m_sl;
+
+	// NOTE: Vector and Mesh dont care about sub sampling rate and bit depth compatibility.
+	//       They are property of Raster.
 	if (sl->getType() == PLI_XSHLEVEL || sl->getType() == MESH_XSHLEVEL)
 		return true;
 
@@ -162,7 +165,11 @@ bool ImageLoader::isImageCompatible(int imFlags, void *extData)
 	if (m_subsampling <= 0 || subsampling != m_subsampling)
 		return false;
 
-	return (m_64bitCompatible || !(imFlags & ImageManager::is64bitEnabled));
+	if (m_64bitCompatible || !(imFlags & ImageManager::is64bitEnabled)){
+                return true;
+	}else{
+	        return false;
+	}
 }
 
 //-------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -154,7 +154,7 @@ bool ImageLoader::isImageCompatible(int imFlags, void *extData)
 
 	BuildExtData *data = static_cast<BuildExtData *>(extData);
 	const TXshSimpleLevel *sl = data->m_sl;
-	if (sl->getType() == PLI_XSHLEVEL)
+	if (sl->getType() == PLI_XSHLEVEL || sl->getType() == MESH_XSHLEVEL)
 		return true;
 
 	int subsampling = buildSubsampling(imFlags, data);


### PR DESCRIPTION
Change the mesh image to be isImageCompatible true, when it is already loaded. 
This PR is related to issue https://github.com/opentoonz/opentoonz/issues/379