### PR TITLE
Project settings drop down now working and added default folders for new project.

### DIFF
--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -347,7 +347,7 @@ ProjectPopup::ProjectPopup(bool isModal)
 			FileField *ff = new FileField(0, qName);
 			m_folderFlds.append(qMakePair(name, ff));
 			upperLayout->addWidget(new QLabel("+" + qName, this), i + 2, 0, Qt::AlignRight | Qt::AlignVCenter);
-			upperLayout->addWidget(ff, i + 2, 1);
+			upperLayout->addWidget(ff, i + 2, 1);	
 		}
 		struct {
 			QString name;
@@ -464,6 +464,7 @@ void ProjectPopup::showEvent(QShowEvent *)
 	m_model->refreshFolderChild(index);
 	TProjectP currentProject = TProjectManager::instance()->getCurrentProject();
 	updateFieldsFromProject(currentProject.getPointer());
+	updateChooseProjectCombo();
 }
 
 //=============================================================================
@@ -647,8 +648,10 @@ void ProjectCreatePopup::createProject()
 void ProjectCreatePopup::showEvent(QShowEvent *)
 {
 	int i;
+	QString fldName;
 	for (i = 0; i < m_folderFlds.size(); i++) {
-		m_folderFlds[i].second->setPath("");
+		fldName = QString::fromStdString(m_folderFlds[i].first);
+		m_folderFlds[i].second->setPath(fldName);
 	}
 	for (i = 0; i < m_useScenePathCbs.size(); i++) {
 		CheckBox *cb = m_useScenePathCbs[i].second;


### PR DESCRIPTION
Previously the project settings project chooser drop down did not work.  This enables you to choose different projects through the drop down now.

I also added default folder names for the project folders to save people time getting their new projects up and running.  Before, if a person just made a new project without filling in folder names, a palettes folder would not be made and therefore the project palettes option was missing from the Studio Palettes window.  

If a user wants to get custom names for their folder, it is no more work than before- just tab through the window.

I think Project Palettes are very useful but they aren't an option if the folder doesn't exist.