### PR TITLE
Fix random crashes after saving meshes

### DIFF
--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -222,7 +222,7 @@ public:
 	ostream *m_os;
 	bool m_chanOwner;
 	bool m_compressed;
-	ostrstream m_ostrstream;
+        ostringstream m_ostringstream;
 
 	vector<std::string> m_tagStack;
 	int m_tab;
@@ -243,7 +243,7 @@ TOStream::TOStream(const TFilePath &fp, bool compressed)
 	m_imp->m_filepath = fp;
 
 	if (compressed) {
-		m_imp->m_os = &m_imp->m_ostrstream;
+		m_imp->m_os = &m_imp->m_ostringstream;
 		m_imp->m_compressed = true;
 		m_imp->m_chanOwner = false;
 	} else {
@@ -304,7 +304,9 @@ TOStream::~TOStream()
 			m_imp->m_justStarted = true;
 		} else {
 			if (m_imp->m_compressed) {
-				const void *in = (const void *)m_imp->m_ostrstream.str();
+			        std::string tmp = m_imp->m_ostringstream.str();
+			        const void *in = (const void *)tmp.c_str();
+
 				size_t in_len = strlen((char *)in);
 
 				size_t out_len = LZ4F_compressFrameBound(in_len, NULL);
@@ -323,8 +325,6 @@ TOStream::~TOStream()
 					v = out_len;
 					os.write((char *)&v, sizeof v);
 					os.write((char *)out, out_len);
-
-					m_imp->m_ostrstream.freeze(0);
 				}
 
 				free(out);
@@ -434,7 +434,7 @@ TOStream &TOStream::operator<<(std::wstring v)
   int len = v.length();
   if(len==0)
   {
-    os << "\"" << "\"" << " "; 
+    os << "\"" << "\"" << " ";
     m_imp->m_justStarted = false;
     return *this;
   }
@@ -459,7 +459,7 @@ TOStream &TOStream::operator<<(std::wstring v)
          os << "\\n";
        else if(iswprint(v[i]))
          os << v[i];
-       else 
+       else
          {os.put('\\'); os << (int)v[i];}
      os << "\" ";
     }
@@ -634,7 +634,7 @@ bool TOStream::checkStatus() const
 }
 
 //===============================================================
-/*! 
+/*!
 	This class contains TIStream's attributes.
 	It is created by memory allocation in the TIStream's constructor.
 */
@@ -974,7 +974,7 @@ TIStream::TIStream(const TFilePath &fp)
 		if (check_len != out_len)
 			throw TException("corrupted file");
 
-		m_imp->m_is = new istrstream((char *)out, out_len);
+		m_imp->m_is = new istringstream((char *)out, out_len);
 	}
 
 	m_imp->m_chanOwner = true;
@@ -1344,7 +1344,7 @@ bool TIStream::getTagParam(string paramName, int &value)
 	string svalue;
 	if (!getTagParam(paramName, svalue))
 		return false;
-	istrstream is(svalue.c_str(), svalue.length());
+	istringstream is(svalue.c_str(), svalue.length());
 	value = 0;
 	is >> value;
 	return true;


### PR DESCRIPTION
This PR is related to https://github.com/opentoonz/opentoonz/issues/397
Legacy strstream library might have caused crashes after saving meshes.
Replaced strstream with stringstream in tstream.cpp.