### PR TITLE
Add & to "Scan Cleanup" menu item (#440)

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -73,7 +73,7 @@
     <command>MI_SendBack</command>
     <command>MI_SendBackward</command>
   </menu>
-  <menu title="Scan &amp; Cleanup">
+  <menu title="Scan &amp;&amp; Cleanup">
     <command>MI_DefineScanner</command>
     <command>MI_ScanSettings</command>
     <command>MI_Scan</command>

--- a/stuff/profiles/layouts/rooms/StudioGhibli/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/StudioGhibli/menubar_template.xml
@@ -73,7 +73,7 @@
     <command>MI_SendBack</command>
     <command>MI_SendBackward</command>
   </menu>
-  <menu title="Scan &amp; Cleanup">
+  <menu title="Scan &amp;&amp; Cleanup">
     <command>MI_DefineScanner</command>
     <command>MI_ScanSettings</command>
     <command>MI_Scan</command>


### PR DESCRIPTION
On Windows platform, there is missing a "&" in menu item "Scan & Cleanup"  for both Default and StudioGhibli