### PR TITLE
Fix text color in the Script console and the Rename popup 

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -732,7 +732,7 @@ DvDirTreeView {
 }
 
 /*---------------------------------------------------------------------------*/ 
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame, 
 #LoadLevelFrame,
@@ -744,7 +744,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel, 
 #PsdSettingsHeadLabel, 
 #PsdSettingsGroupBox::title, 
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel{
 	color: @m_titleTxtColor;
 }
 
@@ -1170,6 +1171,15 @@ SpreadsheetViewer {
 			}
 		}
 	}
+}
+
+/*------ Script Console ------*/
+
+#ScriptConsole {
+	border: 1px inset;
+    background-color: rgb(220,220,220);
+    color: black;
+    font-family: "Courier";
 }
 
 /*------ Topbar and Menubar of the MainWindow ------*/

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -746,7 +746,7 @@ DvDirTreeView {
   alternate-background-color: #3d3d3d;
 }
 /*---------------------------------------------------------------------------*/
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame,
 #LoadLevelFrame,
@@ -757,7 +757,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel,
 #PsdSettingsHeadLabel,
 #PsdSettingsGroupBox::title,
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
   color: #a8bee7;
 }
 #PsdSettingsGroupBox {
@@ -1173,6 +1174,13 @@ SpreadsheetViewer {
 }
 #EditToolLockButton::indicator:checked:hover {
   image: url("../gray_072/imgs/cam_lock_hover.png");
+}
+/*------ Script Console ------*/
+#ScriptConsole {
+  border: 1px inset;
+  background-color: #dcdcdc;
+  color: black;
+  font-family: "Courier";
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -746,7 +746,7 @@ DvDirTreeView {
   alternate-background-color: #3d3d3d;
 }
 /*---------------------------------------------------------------------------*/
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame,
 #LoadLevelFrame,
@@ -757,7 +757,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel,
 #PsdSettingsHeadLabel,
 #PsdSettingsGroupBox::title,
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
   color: #a8bee7;
 }
 #PsdSettingsGroupBox {
@@ -1173,6 +1174,13 @@ SpreadsheetViewer {
 }
 #EditToolLockButton::indicator:checked:hover {
   image: url("../gray_072/imgs/cam_lock_hover.png");
+}
+/*------ Script Console ------*/
+#ScriptConsole {
+  border: 1px inset;
+  background-color: #dcdcdc;
+  color: black;
+  font-family: "Courier";
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -731,7 +731,7 @@ DvDirTreeView {
 }
 
 /*---------------------------------------------------------------------------*/ 
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame, 
 #LoadLevelFrame,
@@ -743,7 +743,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel, 
 #PsdSettingsHeadLabel, 
 #PsdSettingsGroupBox::title, 
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
 	color: @m_titleTxtColor;
 }
 
@@ -1169,6 +1170,15 @@ SpreadsheetViewer {
 			}
 		}
 	}
+}
+
+/*------ Script Console ------*/
+
+#ScriptConsole {
+	border: 1px inset;
+    background-color: rgb(220,220,220);
+    color: black;
+    font-family: "Courier";
 }
 
 /*------ Topbar and Menubar of the MainWindow ------*/

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -746,7 +746,7 @@ DvDirTreeView {
   alternate-background-color: #555555;
 }
 /*---------------------------------------------------------------------------*/
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame,
 #LoadLevelFrame,
@@ -757,7 +757,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel,
 #PsdSettingsHeadLabel,
 #PsdSettingsGroupBox::title,
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
   color: #a8bee7;
 }
 #PsdSettingsGroupBox {
@@ -1173,6 +1174,13 @@ SpreadsheetViewer {
 }
 #EditToolLockButton::indicator:checked:hover {
   image: url("imgs/cam_lock_hover.png");
+}
+/*------ Script Console ------*/
+#ScriptConsole {
+  border: 1px inset;
+  background-color: #dcdcdc;
+  color: black;
+  font-family: "Courier";
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -746,7 +746,7 @@ DvDirTreeView {
   alternate-background-color: #555555;
 }
 /*---------------------------------------------------------------------------*/
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame,
 #LoadLevelFrame,
@@ -757,7 +757,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel,
 #PsdSettingsHeadLabel,
 #PsdSettingsGroupBox::title,
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
   color: #a8bee7;
 }
 #PsdSettingsGroupBox {
@@ -1173,6 +1174,13 @@ SpreadsheetViewer {
 }
 #EditToolLockButton::indicator:checked:hover {
   image: url("imgs/cam_lock_hover.png");
+}
+/*------ Script Console ------*/
+#ScriptConsole {
+  border: 1px inset;
+  background-color: #dcdcdc;
+  color: black;
+  font-family: "Courier";
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -568,7 +568,7 @@ DvDirTreeView {
 }
 
 /*---------------------------------------------------------------------------*/ 
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame, 
 #LoadLevelFrame,
@@ -580,7 +580,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel, 
 #PsdSettingsHeadLabel, 
 #PsdSettingsGroupBox::title, 
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
 	color: rgb(0,0,64);
 }
 
@@ -993,6 +994,16 @@ SpreadsheetViewer {
 			}
 		}
 	}
+}
+
+
+/*------ Script Console ------*/
+
+#ScriptConsole {
+	border: 1px inset;
+    background-color: rgb(220,220,220);
+    color: black;
+    font-family: "Courier";
 }
 
 /*------ Topbar and Menubar of the MainWindow ------*/

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -497,7 +497,7 @@ DvDirTreeView {
   alternate-background-color: #8d8d8d;
 }
 /*---------------------------------------------------------------------------*/
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame,
 #LoadLevelFrame,
@@ -508,7 +508,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel,
 #PsdSettingsHeadLabel,
 #PsdSettingsGroupBox::title,
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
   color: #000040;
 }
 #PsdSettingsGroupBox {
@@ -907,6 +908,13 @@ SpreadsheetViewer {
 }
 #EditToolLockButton::indicator:checked:hover {
   image: url("imgs/cam_lock_hover.png");
+}
+/*------ Script Console ------*/
+#ScriptConsole {
+  border: 1px inset;
+  background-color: #dcdcdc;
+  color: black;
+  font-family: "Courier";
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -497,7 +497,7 @@ DvDirTreeView {
   alternate-background-color: #8d8d8d;
 }
 /*---------------------------------------------------------------------------*/
-/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup */
+/* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
 #CleanupSettingsFrame,
 #LoadLevelFrame,
@@ -508,7 +508,8 @@ DvDirTreeView {
 #LoadLevelHeadLabel,
 #PsdSettingsHeadLabel,
 #PsdSettingsGroupBox::title,
-#FxSettingsPreviewShowLabel {
+#FxSettingsPreviewShowLabel,
+#RenameAsToonzPopupLabel {
   color: #000040;
 }
 #PsdSettingsGroupBox {
@@ -907,6 +908,13 @@ SpreadsheetViewer {
 }
 #EditToolLockButton::indicator:checked:hover {
   image: url("imgs/cam_lock_hover.png");
+}
+/*------ Script Console ------*/
+#ScriptConsole {
+  border: 1px inset;
+  background-color: #dcdcdc;
+  color: black;
+  font-family: "Courier";
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -1607,7 +1607,7 @@ RenameAsToonzPopup::RenameAsToonzPopup(const QString name, int frames)
     lbl = new QLabel(
         QString(tr("Creating an animation level of %1 frames").arg(frames)));
   lbl->setFixedHeight(20);
-  lbl->setStyleSheet("color:rgb(0, 0, 190)");
+  lbl->setObjectName("RenameAsToonzPopupLabel");
 
   m_name = new LineEdit(frames == -1 ? "" : name);
   m_name->setFixedHeight(20);

--- a/toonz/sources/toonzqt/scriptconsole.cpp
+++ b/toonz/sources/toonzqt/scriptconsole.cpp
@@ -9,6 +9,11 @@
 
 ScriptConsole::ScriptConsole(QWidget *parent)
     : QTextEdit(parent), m_commandIndex(0) {
+  
+  setObjectName("ScriptConsole");
+  //setStyleSheet("background-color: rgb(220,220,220); color: black;");
+ // setTextColor(Qt::black);
+
   m_prompt = ">> ";
 
   append(m_prompt);

--- a/toonz/sources/toonzqt/scriptconsole.cpp
+++ b/toonz/sources/toonzqt/scriptconsole.cpp
@@ -11,8 +11,6 @@ ScriptConsole::ScriptConsole(QWidget *parent)
     : QTextEdit(parent), m_commandIndex(0) {
   
   setObjectName("ScriptConsole");
-  //setStyleSheet("background-color: rgb(220,220,220); color: black;");
- // setTextColor(Qt::black);
 
   m_prompt = ">> ";
 


### PR DESCRIPTION
This PR is for the issues #442 and #449 .
I applied style sheet to both UI. For the Script console, I set the background color to light-gray regardless of the current style, and also set monospace font (Courier).