### PR TITLE
Linux support for tsound (SDL2) and tfont (Qt), from pr #51

### DIFF
--- a/toonz/sources/common/tsound/tsound_sdl.cpp
+++ b/toonz/sources/common/tsound/tsound_sdl.cpp
@@ -1,0 +1,563 @@
+
+#include "tsound_t.h"
+#include "texception.h"
+#include "tthread.h"
+#include "tthreadmessage.h"
+
+#include <errno.h>
+#include <unistd.h>
+#include <queue>
+#include <set>
+
+#include <SDL2/SDL.h>
+using namespace std;
+
+//==============================================================================
+namespace {
+TThread::Mutex MutexOut;
+}
+
+namespace {
+
+struct MyData {
+  char *entireFileBuffer;
+
+  int totalPacketCount;
+  int fileByteCount;
+  // UInt32 maxPacketSize;
+  // UInt64 packetOffset;
+  int byteOffset;
+  bool m_doNotify;
+
+  void *sourceBuffer;
+  // AudioConverterRef converter;
+  TSoundOutputDeviceImp *imp;
+  bool isLooping;
+  MyData()
+      : entireFileBuffer(0)
+      , totalPacketCount(0)
+      , fileByteCount(0)
+      , /*maxPacketSize(0), packetOffset(0),*/ byteOffset(0)
+      , sourceBuffer(0)
+      , isLooping(false)
+      , imp(0)
+      , m_doNotify(true) {}
+};
+}
+
+class TSoundOutputDeviceImp {
+public:
+  bool m_isPlaying;
+  bool m_looped;
+  TSoundTrackFormat m_currentFormat;
+  std::set<int> m_supportedRate;
+  bool m_opened;
+  struct MyData *m_data;
+  int m_volume;
+
+  TSoundOutputDeviceImp()
+      : m_isPlaying(false)
+      , m_looped(false)
+      , m_supportedRate()
+      , m_opened(false)
+      , m_data(NULL)
+      , m_volume(SDL_MIX_MAXVOLUME){};
+
+  std::set<TSoundOutputDeviceListener *> m_listeners;
+
+  ~TSoundOutputDeviceImp(){};
+
+  bool doOpenDevice(const TSoundTrackFormat &format);
+  bool doStopDevice();
+  void play(const TSoundTrackP &st, TINT32 s0, TINT32 s1, bool loop,
+            bool scrubbing);
+};
+
+//-----------------------------------------------------------------------------
+namespace {
+
+class PlayCompletedMsg : public TThread::Message {
+  std::set<TSoundOutputDeviceListener *> m_listeners;
+  MyData *m_data;
+
+public:
+  PlayCompletedMsg(MyData *data) : m_data(data) {}
+
+  TThread::Message *clone() const { return new PlayCompletedMsg(*this); }
+
+  void onDeliver() {
+    if (m_data->imp) {
+      if (m_data->m_doNotify == false) return;
+      m_data->m_doNotify = false;
+      if (m_data->imp->m_isPlaying) m_data->imp->doStopDevice();
+      std::set<TSoundOutputDeviceListener *>::iterator it =
+          m_data->imp->m_listeners.begin();
+      for (; it != m_data->imp->m_listeners.end(); ++it)
+        (*it)->onPlayCompleted();
+    }
+  }
+};
+}
+
+#define checkStatus(err)                                                       \
+  if (err) {                                                                   \
+    printf("Error: 0x%x ->  %s: %d\n", (int)err, __FILE__, __LINE__);          \
+    fflush(stdout);                                                            \
+  }
+
+extern "C" {
+
+void sdl_fill_audio(void *udata, Uint8 *stream, int len) {
+  TSoundOutputDeviceImp *_this = (TSoundOutputDeviceImp *)udata;
+  MyData *myData               = _this->m_data;
+
+  /* Only play if we have data left */
+  if (myData == NULL) return;
+  {
+    // TThread::ScopedLock sl(MutexOut);
+    if (myData->imp->m_isPlaying == false) return;
+  }
+
+  int audio_len = myData->fileByteCount - myData->byteOffset;
+  if (audio_len <= 0) {
+    delete[] myData->entireFileBuffer;
+    myData->entireFileBuffer = 0;
+#if 0
+		{
+			TThread::ScopedLock sl(MutexOut);
+			*(myData->isPlaying) = false;   //questo lo faccio nel main thread
+		}
+#endif
+    PlayCompletedMsg(myData).send();
+    return;
+  }
+
+  /* Mix as much data as possible */
+  len = (len > audio_len ? audio_len : len);
+  SDL_MixAudio(stream, (Uint8 *)myData->entireFileBuffer + myData->byteOffset,
+               len, _this->m_volume);
+  myData->byteOffset += len;
+}
+
+}  // extern "C"
+
+bool TSoundOutputDeviceImp::doOpenDevice(const TSoundTrackFormat &format) {
+  SDL_AudioSpec wanted;
+
+  static bool first = true;  // TODO: should be shared with InputDevice
+  if (first) {
+    SDL_Init(SDL_INIT_AUDIO);
+    first = false;
+  }
+
+  if (m_opened) {
+    SDL_CloseAudio();
+    // we'll just reopen right away
+  }
+
+  wanted.freq = format.m_sampleRate;
+  switch (format.m_bitPerSample) {
+  case 8:
+    wanted.format = AUDIO_S8;
+    break;
+  case 16:
+    wanted.format = AUDIO_S16;
+    break;
+  default:
+    throw TSoundDeviceException(TSoundDeviceException::UnableOpenDevice,
+                                "invalid bits per sample");
+    return false;
+  }
+  wanted.channels = format.m_channelCount; /* 1 = mono, 2 = stereo */
+  wanted.samples  = 1024; /* Good low-latency value for callback */
+  wanted.callback = sdl_fill_audio;
+  wanted.userdata = this;
+
+  /* Open the audio device, forcing the desired format */
+  if (SDL_OpenAudio(&wanted, NULL) < 0) {
+    std::string msg("Couldn't open audio: ");
+    msg += SDL_GetError();
+    throw TSoundDeviceException(TSoundDeviceException::UnableOpenDevice, msg);
+    return false;
+  }
+
+  m_opened = true;
+  return m_opened;
+}
+
+//==============================================================================
+
+TSoundOutputDevice::TSoundOutputDevice() : m_imp(new TSoundOutputDeviceImp) {
+#if 0
+	try {
+		supportsVolume();
+	} catch (TSoundDeviceException &e) {
+		throw TSoundDeviceException(e.getType(), e.getMessage());
+	}
+#endif
+}
+
+//------------------------------------------------------------------------------
+
+TSoundOutputDevice::~TSoundOutputDevice() {
+  stop();
+  close();
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::installed() { return true; }
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::open(const TSoundTrackP &st) {
+  if (!m_imp->doOpenDevice(st->getFormat()))
+    throw TSoundDeviceException(
+        TSoundDeviceException::UnableOpenDevice,
+        "Problem to open the output device setting some params");
+  return true;
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::close() {
+  stop();
+  m_imp->m_opened = false;
+  return true;
+}
+
+//------------------------------------------------------------------------------
+
+void TSoundOutputDevice::play(const TSoundTrackP &st, TINT32 s0, TINT32 s1,
+                              bool loop, bool scrubbing) {
+  // TThread::ScopedLock sl(MutexOut);
+  int lastSample = st->getSampleCount() - 1;
+  notLessThan(0, s0);
+  notLessThan(0, s1);
+
+  notMoreThan(lastSample, s0);
+  notMoreThan(lastSample, s1);
+
+  if (s0 > s1) {
+#ifdef DEBUG
+    cout << "s0 > s1; reorder" << endl;
+#endif
+    swap(s0, s1);
+  }
+
+  if (isPlaying()) {
+#ifdef DEBUG
+    cout << "is playing, stop it!" << endl;
+#endif
+    stop();
+  }
+  m_imp->play(st, s0, s1, loop, scrubbing);
+}
+
+//------------------------------------------------------------------------------
+
+void TSoundOutputDeviceImp::play(const TSoundTrackP &st, TINT32 s0, TINT32 s1,
+                                 bool loop, bool scrubbing) {
+  if (!doOpenDevice(st->getFormat())) return;
+
+  MyData *myData = new MyData();
+
+  myData->imp              = this;
+  myData->totalPacketCount = s1 - s0;
+  myData->fileByteCount    = (s1 - s0) * st->getSampleSize();
+  myData->entireFileBuffer = new char[myData->fileByteCount];
+
+#if defined(i386)
+  // XXX: let's see if that's needed for SDL
+  if (st->getBitPerSample() == 16) {
+    int i;
+    USHORT *dst = (USHORT *)(myData->entireFileBuffer);
+    USHORT *src = (USHORT *)(st->getRawData() + s0 * st->getSampleSize());
+
+    for (i = 0; i < myData->fileByteCount / 2; i++) *dst++ = swapUshort(*src++);
+  } else
+    memcpy(myData->entireFileBuffer,
+           st->getRawData() + s0 * st->getSampleSize(), myData->fileByteCount);
+#else
+  memcpy(myData->entireFileBuffer, st->getRawData() + s0 * st->getSampleSize(),
+         myData->fileByteCount);
+#endif
+
+  //	myData->maxPacketSize = fileASBD.mFramesPerPacket *
+  //fileASBD.mBytesPerFrame;
+  {
+    // TThread::ScopedLock sl(MutexOut);
+    m_isPlaying = true;
+  }
+  myData->isLooping = loop;
+
+  // cout << "total packet count = " << myData->totalPacketCount <<endl;
+  // cout << "filebytecount " << myData->fileByteCount << endl;
+
+  m_data = myData;
+  SDL_PauseAudio(0);
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDeviceImp::doStopDevice() {
+  SDL_PauseAudio(1);
+  m_isPlaying = false;
+  delete m_data;
+  m_data = NULL;
+  SDL_CloseAudio();
+  m_opened = false;
+  return true;
+}
+
+//------------------------------------------------------------------------------
+
+void TSoundOutputDevice::stop() {
+  // TThread::ScopedLock sl(MutexOut);
+  if (m_imp->m_opened == false) return;
+
+  // TThread::ScopedLock sl(MutexOut);
+  m_imp->doStopDevice();
+}
+
+//------------------------------------------------------------------------------
+
+void TSoundOutputDevice::attach(TSoundOutputDeviceListener *listener) {
+  m_imp->m_listeners.insert(listener);
+}
+
+//------------------------------------------------------------------------------
+
+void TSoundOutputDevice::detach(TSoundOutputDeviceListener *listener) {
+  m_imp->m_listeners.erase(listener);
+}
+
+#if 0
+//------------------------------------------------------------------------------
+
+double TSoundOutputDevice::getVolume()
+{
+	if (!m_imp->m_opened)
+		m_imp->doOpenDevice();
+
+	double vol = m_volume / SDL_MIX_MAXVOLUME;
+
+	return (vol < 0. ? 0. : vol);
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::setVolume(double volume)
+{
+	Float32 vol = volume;
+
+	m_imp->m_volume = (int)(volume * SDL_MIX_MAXVOLUME);
+	return true;
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::supportsVolume()
+{
+	return true;
+}
+
+#endif
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::isPlaying() const {
+  // TThread::ScopedLock sl(MutexOut);
+  // TODO: handle actually queuing items?
+  return m_imp->m_isPlaying;
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::isAllQueuedItemsPlayed() {
+  // TThread::ScopedLock sl(MutexOut);
+  return m_imp->m_data == NULL;
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundOutputDevice::isLooping() {
+  // TThread::ScopedLock sl(MutexOut);
+  return m_imp->m_looped;
+}
+
+//------------------------------------------------------------------------------
+
+void TSoundOutputDevice::setLooping(bool loop) {
+  // TThread::ScopedLock sl(MutexOut);
+  m_imp->m_looped = loop;
+}
+
+//------------------------------------------------------------------------------
+
+TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(TUINT32 sampleRate,
+                                                         int channelCount,
+                                                         int bitPerSample) {
+  if (bitPerSample > 16) bitPerSample = 16;
+  // not sure SDL supports more than 2 channels
+  if (channelCount > 2) channelCount = 2;
+  TSoundTrackFormat fmt(sampleRate, bitPerSample, channelCount, true);
+  return fmt;
+}
+
+//------------------------------------------------------------------------------
+
+TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(
+    const TSoundTrackFormat &format) {
+#if 0
+	try {
+#endif
+  return getPreferredFormat(format.m_sampleRate, format.m_channelCount,
+                            format.m_bitPerSample);
+#if 0
+	}
+	catch (TSoundDeviceException &e) {
+		throw TSoundDeviceException( e.getType(), e.getMessage());
+	}
+#endif
+}
+
+//==============================================================================
+//==============================================================================
+//                REGISTRAZIONE
+//==============================================================================
+//==============================================================================
+
+class TSoundInputDeviceImp {
+public:
+  // ALport m_port;
+  bool m_stopped;
+  bool m_isRecording;
+  bool m_oneShotRecording;
+
+  long m_recordedSampleCount;
+
+  TSoundTrackFormat m_currentFormat;
+  TSoundTrackP m_st;
+  std::set<int> m_supportedRate;
+
+  TThread::Executor m_executor;
+
+  TSoundInputDeviceImp()
+      : m_stopped(false)
+      , m_isRecording(false)
+      //   , m_port(NULL)
+      , m_oneShotRecording(false)
+      , m_recordedSampleCount(0)
+      , m_st(0)
+      , m_supportedRate(){};
+
+  ~TSoundInputDeviceImp(){};
+
+  bool doOpenDevice(const TSoundTrackFormat &format,
+                    TSoundInputDevice::Source devType);
+};
+
+bool TSoundInputDeviceImp::doOpenDevice(const TSoundTrackFormat &format,
+                                        TSoundInputDevice::Source devType) {
+  return true;
+}
+
+//==============================================================================
+
+class RecordTask : public TThread::Runnable {
+public:
+  TSoundInputDeviceImp *m_devImp;
+  int m_ByteToSample;
+
+  RecordTask(TSoundInputDeviceImp *devImp, int numByte)
+      : TThread::Runnable(), m_devImp(devImp), m_ByteToSample(numByte){};
+
+  ~RecordTask(){};
+
+  void run();
+};
+
+void RecordTask::run() {}
+
+//==============================================================================
+
+TSoundInputDevice::TSoundInputDevice() : m_imp(new TSoundInputDeviceImp) {}
+
+//------------------------------------------------------------------------------
+
+TSoundInputDevice::~TSoundInputDevice() {
+#if 0
+	if(m_imp->m_port)
+		alClosePort(m_imp->m_port);
+	delete m_imp;
+#endif
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundInputDevice::installed() {
+#if 0
+	if (alQueryValues(AL_SYSTEM, AL_DEFAULT_INPUT, 0, 0, 0, 0) <= 0)
+		return false;
+#endif
+  return true;
+}
+
+//------------------------------------------------------------------------------
+
+void TSoundInputDevice::record(const TSoundTrackFormat &format,
+                               TSoundInputDevice::Source type) {}
+
+//------------------------------------------------------------------------------
+
+void TSoundInputDevice::record(const TSoundTrackP &st,
+                               TSoundInputDevice::Source type) {}
+
+//------------------------------------------------------------------------------
+
+TSoundTrackP TSoundInputDevice::stop() {
+  TSoundTrackP st;
+  return st;
+}
+
+//------------------------------------------------------------------------------
+
+double TSoundInputDevice::getVolume() { return 0.0; }
+
+//------------------------------------------------------------------------------
+
+bool TSoundInputDevice::setVolume(double volume) { return true; }
+
+//------------------------------------------------------------------------------
+
+bool TSoundInputDevice::supportsVolume() { return true; }
+
+//------------------------------------------------------------------------------
+
+TSoundTrackFormat TSoundInputDevice::getPreferredFormat(TUINT32 sampleRate,
+                                                        int channelCount,
+                                                        int bitPerSample) {
+  TSoundTrackFormat fmt;
+  return fmt;
+}
+
+//------------------------------------------------------------------------------
+
+TSoundTrackFormat TSoundInputDevice::getPreferredFormat(
+    const TSoundTrackFormat &format) {
+#if 0
+	try {
+#endif
+  return getPreferredFormat(format.m_sampleRate, format.m_channelCount,
+                            format.m_bitPerSample);
+#if 0
+	}
+	catch (TSoundDeviceException &e) {
+		throw TSoundDeviceException( e.getType(), e.getMessage());
+	}
+#endif
+}
+
+//------------------------------------------------------------------------------
+
+bool TSoundInputDevice::isRecording() { return m_imp->m_isRecording; }

--- a/toonz/sources/common/tvrender/tfont_qt.cpp
+++ b/toonz/sources/common/tvrender/tfont_qt.cpp
@@ -1,0 +1,471 @@
+
+
+// character_manager.cpp: implementation of the TFont class
+// for FreeType 2.
+//
+//////////////////////////////////////////////////////////////////////
+
+//#include <ft2build.h>
+//#include FT_FREETYPE_H
+
+#include <QStringList>
+#include <QFont>
+#include <QFontDatabase>
+#include <QFontMetrics>
+#include <QImage>
+#include <QPainterPath>
+#include <QRawFont>
+
+#include <vector>
+#include <iostream>
+#include <string>
+
+#include "tpixelgr.h"
+#include "tfont.h"
+#include "tstroke.h"
+#include "tcurves.h"
+#include "traster.h"
+#include <vector>
+#include <iostream>
+#include <string>
+//#include <tstring.h>
+#include <tmathutil.h>
+//#include <tdebugmessage.h>
+#include "tvectorimage.h"
+using namespace std;
+
+//=============================================================================
+
+struct TFont::Impl {
+  bool m_hasKerning;
+  int m_hasVertical;
+  QFont m_font;
+  // XXX:cache a QFontMetrics m_metrics; ?
+  // XXX:cache a QRawFont m_raw; ?
+
+  //  KerningPairs m_kerningPairs;
+
+  /*
+          ATSUStyle m_style;
+          ATSUFontID m_fontId;
+          ATSUTextLayout m_layout;
+          Fixed m_size;
+          int m_ascender;
+          int m_descender;
+  */
+
+  Impl(const QString &family, const QString &style, int size);
+  ~Impl();
+
+  // void getChar();
+};
+
+//-----------------------------------------------------------------------------
+
+TFont::TFont(const wstring family, const wstring face, int size) {
+  m_pimpl = new Impl(QString::fromStdWString(family),
+                     QString::fromStdWString(face), size);
+}
+
+//-----------------------------------------------------------------------------
+
+TFont::~TFont() { delete m_pimpl; }
+
+//-----------------------------------------------------------------------------
+
+TFont::Impl::Impl(const QString &family, const QString &style, int size) {
+  m_font = QFont(family, size);
+  m_font.setStyleName(style);
+}
+
+//-----------------------------------------------------------------------------
+
+TFont::Impl::~Impl() {}
+
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+
+TPoint TFont::drawChar(TVectorImageP &image, wchar_t charcode,
+                       wchar_t nextCharCode) const {
+  QRawFont raw(QRawFont::fromFont(m_pimpl->m_font));
+
+  QChar chars[2] = {charcode, nextCharCode};
+  quint32 indices[2];
+  int count = 2;
+
+  if (!raw.glyphIndexesForChars(chars, 2, indices, &count) || count < 1)
+    return TPoint(0, 0);
+  QPainterPath path = raw.pathForGlyph(indices[0]);
+
+  // empty glyph, nothing to do
+  if (path.elementCount() < 1) return getDistance(charcode, nextCharCode);
+
+  // force closing the last path
+  if (path.elementAt(path.elementCount() - 1).type !=
+      QPainterPath::MoveToElement)
+    path.moveTo(0.0, 0.0);
+
+  int i, n = path.elementCount();
+  int strokes = 0;
+  std::vector<TThickPoint> points;
+
+  TThickPoint pts[4];
+  int nCubicPts = 0;
+
+  for (i = 0; i < n; i++) {
+    QPainterPath::Element e = path.elementAt(i);
+    e.y                     = -e.y;
+
+    switch (e.type) {
+    case QPainterPath::MoveToElement:
+      if (!points.empty()) {
+        if (points.back() != points.front()) {
+          points.push_back(0.5 * (points.back() + points.front()));
+          points.push_back(points.front());
+        }
+
+        TStroke *stroke = new TStroke(points);
+        stroke->setSelfLoop(true);
+        image->addStroke(stroke);
+        strokes++;
+        points.clear();
+      }
+      points.push_back(TThickPoint(e.x, e.y, 0));
+      break;
+    case QPainterPath::LineToElement: {
+      TThickPoint p0 = points.back();
+      TThickPoint p1 = TThickPoint(e.x, e.y, 0);
+      points.push_back((p0 + p1) * 0.5);
+      points.push_back(p1);
+      break;
+    }
+    case QPainterPath::CurveToElement:
+      pts[0]    = points.back();
+      pts[1]    = TThickPoint(e.x, e.y, 0);
+      nCubicPts = 2;
+      break;
+    case QPainterPath::CurveToDataElement:
+      pts[nCubicPts++] = TThickPoint(e.x, e.y, 0);
+      if (nCubicPts == 4) {
+        vector<TThickQuadratic *> chunkArray;
+        computeQuadraticsFromCubic(pts[0], pts[1], pts[2], pts[3], 0.09,
+                                   chunkArray);
+
+        for (int j = 0; j < chunkArray.size(); j++) {
+          points.push_back(chunkArray[j]->getP1());
+          points.push_back(chunkArray[j]->getP2());
+        }
+        nCubicPts = 0;
+      }
+      break;
+    }
+  }
+
+  if (strokes > 1) image->group(0, strokes);
+
+  return getDistance(charcode, nextCharCode);
+}
+
+//-----------------------------------------------------------------------------
+
+TPoint TFont::drawChar(TRasterGR8P &outImage, TPoint &unused, wchar_t charcode,
+                       wchar_t nextCharCode) const {
+  QRawFont raw(QRawFont::fromFont(m_pimpl->m_font));
+
+  QChar chars[2] = {charcode, nextCharCode};
+  quint32 indices[2];
+  int count = 2;
+
+  if (!raw.glyphIndexesForChars(chars, 2, indices, &count) || count < 1)
+    return TPoint(0, 0);
+
+  QImage image(raw.alphaMapForGlyph(indices[0], QRawFont::PixelAntialiasing));
+
+  if (image.format() != QImage::Format_Indexed8)
+    throw TException(L"bad QImage format " + image.format());
+
+  int height = image.height();
+  int width  = image.width();
+
+  outImage = TRasterGR8P(width, height);
+
+  /*
+          TPixelGR8 bgp;
+          bgp.value = 255;
+          outImage->fill(bgp);
+  */
+  void *data = outImage->getRawData();
+
+  memcpy(data, image.bits(), image.byteCount());
+
+  return getDistance(charcode, nextCharCode);
+}
+
+//-----------------------------------------------------------------------------
+
+TPoint TFont::drawChar(TRasterCM32P &outImage, TPoint &unused, int inkId,
+                       wchar_t charcode, wchar_t nextCharCode) const {
+  TRasterGR8P grayAppImage;
+  this->drawChar(grayAppImage, unused, charcode, nextCharCode);
+
+  int lx = grayAppImage->getLx();
+  int ly = grayAppImage->getLy();
+
+  outImage = TRasterCM32P(lx, ly);
+
+  assert(TPixelCM32::getMaxTone() == 255);
+  TPixelCM32 bgColor(0, 0, TPixelCM32::getMaxTone());
+  grayAppImage->lock();
+  outImage->lock();
+  int ty = 0;
+  for (int gy = ly - 1; gy >= 0; --gy, ++ty) {
+    TPixelGR8 *srcPix  = grayAppImage->pixels(gy);
+    TPixelCM32 *tarPix = outImage->pixels(ty);
+    for (int x = 0; x < lx; ++x) {
+      int tone = srcPix->value;
+
+      if (tone == 255)
+        *tarPix = bgColor;
+      else
+        *tarPix = TPixelCM32(inkId, 0, tone);
+
+      ++srcPix;
+      ++tarPix;
+    }
+  }
+  grayAppImage->unlock();
+  outImage->unlock();
+
+  return getDistance(charcode, nextCharCode);
+}
+
+//-----------------------------------------------------------------------------
+
+TPoint TFont::getDistance(wchar_t firstChar, wchar_t secondChar) const {
+  QRawFont raw(QRawFont::fromFont(m_pimpl->m_font));
+  QChar chars[2] = {firstChar, secondChar};
+  quint32 indices[2];
+  QPointF advances[2];
+  int count = 2;
+
+  if (!raw.glyphIndexesForChars(chars, 2, indices, &count) || count != 2)
+    return TPoint(0, 0);
+
+  if (!raw.advancesForGlyphIndexes(indices, advances, 2,
+                                   QRawFont::KernedAdvances))
+    return TPoint(0, 0);
+
+  int advance = (int)(advances[0].x());
+
+  return TPoint(advance, 0);
+}
+
+//-----------------------------------------------------------------------------
+
+int TFont::getMaxHeight() const {
+  QFontMetrics metrics(m_pimpl->m_font);
+  return metrics.ascent() - metrics.descent();
+}
+
+//-----------------------------------------------------------------------------
+
+int TFont::getMaxWidth() const {
+  QFontMetrics metrics(m_pimpl->m_font);
+  return metrics.maxWidth();
+}
+//-----------------------------------------------------------------------------
+
+int TFont::getLineAscender() const {
+  QFontMetrics metrics(m_pimpl->m_font);
+  return metrics.ascent();
+}
+
+//-----------------------------------------------------------------------------
+
+int TFont::getLineDescender() const {
+  QFontMetrics metrics(m_pimpl->m_font);
+  return metrics.descent();
+}
+
+//-----------------------------------------------------------------------------
+
+bool TFont::hasKerning() const { return m_pimpl->m_font.kerning(); }
+
+//-----------------------------------------------------------------------------
+
+bool TFont::hasVertical() const {
+  // FIXME
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+
+//=============================================================================
+//====================      TFontManager  =====================================
+//=============================================================================
+
+//---------------------------------------------------------
+
+struct TFontManager::Impl {
+  QFontDatabase *m_qfontdb;
+  bool m_loaded;
+
+  TFont *m_currentFont;
+  wstring m_currentFamily;
+  wstring m_currentTypeface;
+  int m_size;
+
+  // this option is set by library user when he wants to write vertically.
+  // In this implementation, if m_vertical is true and the font
+  // has the @-version, the library use it.
+  bool m_vertical;
+
+  Impl()
+      : m_qfontdb(NULL)
+      , m_loaded(false)
+      , m_currentFont(0)
+      , m_size(0)
+      , m_vertical(false) {}
+  ~Impl() { delete m_qfontdb; }
+};
+
+//---------------------------------------------------------
+
+TFontManager::TFontManager() { m_pimpl = new TFontManager::Impl(); }
+
+//---------------------------------------------------------
+
+TFontManager::~TFontManager() { delete m_pimpl; }
+
+//---------------------------------------------------------
+
+TFontManager *TFontManager::instance() {
+  static TFontManager theManager;
+  return &theManager;
+}
+
+//---------------------------------------------------------
+
+void TFontManager::loadFontNames() {
+  if (m_pimpl->m_loaded) return;
+
+  m_pimpl->m_qfontdb = new QFontDatabase;
+
+  if (m_pimpl->m_qfontdb->families().empty()) throw TFontLibraryLoadingError();
+
+  m_pimpl->m_loaded = true;
+}
+
+//---------------------------------------------------------
+
+void TFontManager::setFamily(const wstring family) {
+  if (m_pimpl->m_currentFamily == family) return;
+
+  QString qFamily      = QString::fromStdWString(family);
+  QStringList families = m_pimpl->m_qfontdb->families();
+  if (!families.contains(qFamily)) throw TFontCreationError();
+
+  m_pimpl->m_currentFamily = family;
+
+  // XXX: if current style is not valid for family, reset it?
+  // doing so asserts when chosing a font in the GUI
+  /*
+          QStringList styles = m_pimpl->m_qfontdb->styles(qFamily);
+          if
+     (styles.contains(QString::fromStdWString(m_pimpl->m_currentTypeface)))
+                  m_pimpl->m_currentTypeface = L"";
+  */
+  delete m_pimpl->m_currentFont;
+  m_pimpl->m_currentFont = new TFont(
+      m_pimpl->m_currentFamily, m_pimpl->m_currentTypeface, m_pimpl->m_size);
+}
+
+//---------------------------------------------------------
+
+void TFontManager::setTypeface(const wstring typeface) {
+  if (m_pimpl->m_currentTypeface == typeface) return;
+
+  QString qTypeface  = QString::fromStdWString(typeface);
+  QStringList styles = m_pimpl->m_qfontdb->styles(
+      QString::fromStdWString(m_pimpl->m_currentFamily));
+  if (!styles.contains(qTypeface)) throw TFontCreationError();
+
+  m_pimpl->m_currentTypeface = typeface;
+
+  delete m_pimpl->m_currentFont;
+  m_pimpl->m_currentFont = new TFont(
+      m_pimpl->m_currentFamily, m_pimpl->m_currentTypeface, m_pimpl->m_size);
+}
+
+//---------------------------------------------------------
+
+void TFontManager::setSize(int size) {
+  if (m_pimpl->m_size == size) return;
+  m_pimpl->m_size = size;
+  delete m_pimpl->m_currentFont;
+  m_pimpl->m_currentFont = new TFont(
+      m_pimpl->m_currentFamily, m_pimpl->m_currentTypeface, m_pimpl->m_size);
+}
+
+//---------------------------------------------------------
+
+wstring TFontManager::getCurrentFamily() const {
+  return m_pimpl->m_currentFamily;
+}
+
+//---------------------------------------------------------
+
+wstring TFontManager::getCurrentTypeface() const {
+  return m_pimpl->m_currentTypeface;
+}
+
+//---------------------------------------------------------
+
+TFont *TFontManager::getCurrentFont() {
+  if (m_pimpl->m_currentFont) return m_pimpl->m_currentFont;
+
+  if (!m_pimpl->m_currentFont) loadFontNames();
+
+  assert(!m_pimpl->m_qfontdb->families().empty());
+  setFamily(m_pimpl->m_qfontdb->families().first().toStdWString());
+
+  return m_pimpl->m_currentFont;
+}
+
+//---------------------------------------------------------
+
+void TFontManager::getAllFamilies(vector<wstring> &families) const {
+  QStringList qFamilies = m_pimpl->m_qfontdb->families();
+
+  families.clear();
+  families.reserve(qFamilies.count());
+
+  QStringList::const_iterator it = qFamilies.begin();
+  for (; it != qFamilies.end(); ++it) {
+    families.push_back(it->toStdWString());
+  }
+}
+
+//---------------------------------------------------------
+
+void TFontManager::getAllTypefaces(vector<wstring> &typefaces) const {
+  typefaces.clear();
+
+  QStringList qStyles = m_pimpl->m_qfontdb->styles(
+      QString::fromStdWString(m_pimpl->m_currentFamily));
+
+  if (qStyles.empty()) return;
+
+  typefaces.reserve(qStyles.count());
+  QStringList::const_iterator it_typeface = qStyles.begin();
+  for (; it_typeface != qStyles.end(); ++it_typeface) {
+    typefaces.push_back(it_typeface->toStdWString());
+  }
+}
+
+//---------------------------------------------------------
+
+void TFontManager::setVertical(bool vertical) {}
+
+//---------------------------------------------------------


### PR DESCRIPTION
Linux support for tsound (SDL2) and tfont (Qt), from pr #51 

Note that these files don't have license headers, but neither do OSX and Windows files here.

Credit goes to François Revol for this work.