### PR TITLE
(incompletely) Fix crash on using Shader Fx 

### DIFF
--- a/toonz/sources/include/toonzqt/planeviewer.h
+++ b/toonz/sources/include/toonzqt/planeviewer.h
@@ -9,7 +9,7 @@
 #include "timage.h"
 
 // Qt includes
-#include <QOpenGLWidget>
+#include <QGLWidget>
 
 #undef DVAPI
 #undef DVVAR
@@ -51,7 +51,13 @@ class TVectorImageP;
             efficient image-drawing functions for all Toonz image types.
 */
 
-class DVAPI PlaneViewer : public QOpenGLWidget {
+/*
+CAUTION : Changing PlaneViewer to inherit QOpenGLWidget causes crash bug with 
+shader fx for some unknown reasons. So I will reluctantly keep using the 
+obsolete class until the shader fx being overhauled. 2016/6/22 Shun
+*/
+
+class DVAPI PlaneViewer : public QGLWidget {
 public:
   PlaneViewer(QWidget *parent);
 

--- a/toonz/sources/toonzqt/planeviewer.cpp
+++ b/toonz/sources/toonzqt/planeviewer.cpp
@@ -55,7 +55,7 @@ bool PlaneViewerZoomer::zoom(bool zoomin, bool resetZoom) {
 //=========================================================================================
 
 PlaneViewer::PlaneViewer(QWidget *parent)
-    : QOpenGLWidget(parent)
+    : QGLWidget(parent)
     , m_firstResize(true)
     , m_xpos(0)
     , m_ypos(0)
@@ -186,7 +186,7 @@ void PlaneViewer::wheelEvent(QWheelEvent *event) {
 void PlaneViewer::keyPressEvent(QKeyEvent *event) {
   if (PlaneViewerZoomer(this).exec(event)) return;
 
-  QOpenGLWidget::keyPressEvent(event);
+  QGLWidget::keyPressEvent(event);
 }
 
 //------------------------------------------------------


### PR DESCRIPTION
This PR is for the issue #451, but it is still incomplete.

In OpenToonz we introduced a new version of Qt (v.5.5 and 5.6) and it seems that the usage of OpenGL context becomes severe. In this PR I reluctantly revert some code to the old one - which uses obsolete class, but enables us to render the shader fx somehow... but only for single frame.

Please note this quick-fix is provisional and incomplete. The shader fx is still very unstable and it crashes with only rendering multi frames. It still needs to be overhauled.