### PR TITLE
Add "Autopaint for Lines" indicator on Palette 

### DIFF
--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -769,6 +769,14 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       p.setBrush(Qt::white);
       p.drawRect(indexRect);
       p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
+
+      //draw "Autopaint for lines" indicator
+      if (style->getFlags() != 0) {
+        QRect aflRect(chipRect.bottomLeft() + QPoint(0,-14), QSize(12,15));
+        p.drawRect(aflRect);
+        p.drawText(aflRect, Qt::AlignCenter, "A");
+      }
+
       // revert font set
       p.setFont(preFont);
       // revert brush


### PR DESCRIPTION
This PR is for the issue #433 
I added a small letter "A" on the bottom-left corner of the style chip, exactly looks like @konero 's mock up.
The indicator appears in Large, Medium and Small chip view mode. In the List view mode I did nothing in this PR as it already shows the text (autopaint) next to the style name.
 
![autopaint_indicator_on_palette](https://cloud.githubusercontent.com/assets/17974955/16268495/a46e243e-38c9-11e6-8c12-0f4816af0ab5.png)
