### PR TITLE
update findlzo

### DIFF
--- a/toonz/cmake/FindLZO.cmake
+++ b/toonz/cmake/FindLZO.cmake
@@ -1,5 +1,5 @@
 find_path(LZO_INCLUDE_DIR NAMES lzoconf.h HINTS ${THIRDPARTY_LIBS_HINTS} PATH_SUFFIXES lzo/2.09/include/lzo lzo/2.03/include/lzo)
-find_library(LZO_LIBRARY NAMES liblzo2.a lzo2_64.lib HINTS ${THIRDPARTY_LIBS_HINTS} PATH_SUFFIXES lzo/2.09/lib lzo/2.03/lib/LZO_lib)
+find_library(LZO_LIBRARY NAMES liblzo2.a lzo2_64.lib liblzo2.so HINTS ${THIRDPARTY_LIBS_HINTS} PATH_SUFFIXES lzo/2.09/lib lzo/2.03/lib/LZO_lib)
 
 message("***** LZO Header path:" ${LZO_INCLUDE_DIR})
 message("***** LZO Library path:" ${LZO_LIBRARY})


### PR DESCRIPTION
A little bit missed from #452 

There's also still some weirdness in cmake for Linux, resulting in following:
```
[ 70%] Linking CXX executable .
/usr/bin/ld: cannot open output file .: Is a directory
collect2: error: ld returned 1 exit status
```

@ideasman42 can you inspect that?