### PR TITLE
Use cmath instead of defining isnan (Linux build-fix)

### DIFF
--- a/toonz/sources/common/tapptools/tcolorutils.cpp
+++ b/toonz/sources/common/tapptools/tcolorutils.cpp
@@ -6,6 +6,7 @@
 
 #include <set>
 #include <list>
+#include <cmath>
 
 typedef float KEYER_FLOAT;
 
@@ -13,7 +14,6 @@ typedef float KEYER_FLOAT;
 #ifdef _WIN32
 #define ISNAN _isnan
 #else
-extern "C" int isnan(double);
 #define ISNAN isnan
 #endif
 

--- a/toonz/sources/stdfx/pins.cpp
+++ b/toonz/sources/stdfx/pins.cpp
@@ -6,11 +6,12 @@
 #include "tmathutil.h"
 #include "tofflinegl.h"
 
+#include <cmath>
+
 //------------------------------------------------------------------------------
 #ifdef _WIN32
 #define ISNAN _isnan
 #else
-extern "C" int isnan(double);
 #define ISNAN isnan
 #endif
 


### PR DESCRIPTION
Needed for building on Linux

Without this I get the error:

```
/dsk/src/opentoonz/toonz/sources/common/tapptools/tcolorutils.cpp:16:28: error: 'int isnan(double)' conflicts with a previous declaration
 extern "C" int isnan(double);
                            ^
In file included from /usr/include/c++/6.1.1/math.h:36:0,
                 from /dsk/src/opentoonz/toonz/sources/include/tutil.h:7,
                 from /dsk/src/opentoonz/toonz/sources/include/traster.h:6,
                 from /dsk/src/opentoonz/toonz/sources/include/tcolorutils.h:9,
                 from /dsk/src/opentoonz/toonz/sources/common/tapptools/tcolorutils.cpp:4:
/usr/include/c++/6.1.1/cmath:643:3: note: previous declaration 'constexpr bool std::isnan(double)'
   isnan(double __x)
   ^~~~~
```