### PR TITLE
Changes needed to build OpenGL files with Linux

### DIFF
--- a/toonz/sources/common/tvrender/qtofflinegl.cpp
+++ b/toonz/sources/common/tvrender/qtofflinegl.cpp
@@ -153,6 +153,10 @@ void QtOfflineGL::createContext(TDimension rasterSize,
   fmt.setPlane(0);
   fmt.setDirectRendering(false);
 #endif
+#elif LINUX
+  fmt = QGLFormat::defaultFormat();
+  // printf("GL Version: %s\n",glGetString(GL_VERSION));
+  fmt.setVersion(2, 1); /* XXX? */
 #endif
 
   QSurfaceFormat format;
@@ -286,6 +290,16 @@ SPECIFICHE  MAC = depth_size 24, stencil_size 8, alpha_size 1
   fmt.setAccum(false);
   fmt.setPlane(0);
 #elif MACOSX
+  fmt.setAlphaBufferSize(1);
+  fmt.setAlpha(false);
+  fmt.setRgba(true);
+  fmt.setDepthBufferSize(24);
+  fmt.setDepth(true);
+  fmt.setStencilBufferSize(8);
+  fmt.setStencil(true);
+  fmt.setAccum(false);
+  fmt.setPlane(0);
+#elif LINUX
   fmt.setAlphaBufferSize(1);
   fmt.setAlpha(false);
   fmt.setRgba(true);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1,4 +1,7 @@
 
+#ifdef LINUX
+#define GL_GLEXT_PROTOTYPES
+#endif
 
 // Toonz includes
 #include "tapp.h"


### PR DESCRIPTION
Minor changes needed for building OpenGL related files.

Needed to define `GL_GLEXT_PROTOTYPES` so `glCheckFramebufferStatus` is declared.