### PR TITLE
Fix SDL includes in tnzbase

### DIFF
--- a/toonz/sources/common/tapptools/ttimer.cpp
+++ b/toonz/sources/common/tapptools/ttimer.cpp
@@ -124,8 +124,8 @@ void CALLBACK ElapsedTimeCB(UINT uID, UINT uMsg, DWORD dwUser, DWORD dw1,
 };
 #elif LINUX
 
-#include <SDL/SDL_timer.h>
-#include <SDL/SDL.h>
+#include <SDL_timer.h>
+#include <SDL.h>
 #include "tthread.h"
 namespace {
 Uint32 ElapsedTimeCB(Uint32 interval, void *param);

--- a/toonz/sources/tnzbase/CMakeLists.txt
+++ b/toonz/sources/tnzbase/CMakeLists.txt
@@ -190,6 +190,7 @@ elseif(UNIX)
     set(EXTRA_LIBS ${EXTRA_LIBS}
         ${SDL_LIB_LIBRARIES})
 
+	include_directories(${SDL_LIB_INCLUDE_DIRS})
     target_link_libraries(tnzbase Qt5::Core Qt5::Gui)
 endif()
 


### PR DESCRIPTION
SDL headers are installed to /usr/include/SDL2 which was in conflict
with explicit way they were included previously.