### PR TITLE
isnan fixes

### DIFF
--- a/toonz/sources/common/tapptools/tcolorutils.cpp
+++ b/toonz/sources/common/tapptools/tcolorutils.cpp
@@ -14,7 +14,7 @@ typedef float KEYER_FLOAT;
 #ifdef _WIN32
 #define ISNAN _isnan
 #else
-#define ISNAN isnan
+#define ISNAN std::isnan
 #endif
 
 //------------------------------------------------------------------------------

--- a/toonz/sources/stdfx/pins.cpp
+++ b/toonz/sources/stdfx/pins.cpp
@@ -12,7 +12,7 @@
 #ifdef _WIN32
 #define ISNAN _isnan
 #else
-#define ISNAN isnan
+#define ISNAN std::isnan
 #endif
 
 namespace {


### PR DESCRIPTION
`isnan` was used without specifying namespace, yet it was coming from `<cmath>` header.