### PR TITLE
Mark TTileSet destructor as virtual

### DIFF
--- a/toonz/sources/include/toonz/ttileset.h
+++ b/toonz/sources/include/toonz/ttileset.h
@@ -51,7 +51,7 @@ protected:
 
 public:
   TTileSet(const TDimension &dim) : m_srcImageSize(dim) {}
-  ~TTileSet();
+  virtual ~TTileSet();
 
   int getMemorySize() const;
 


### PR DESCRIPTION
This class gets inherited, yet the destructor is not marked as virtual.