### PR TITLE
Travis Linux job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: cpp
 sudo: required
 dist: trusty
-before_install:
-    - sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
-    - sudo apt-get update
 install:
-    - sudo apt-get install -y liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libsdl2-dev libglew-dev freeglut3-dev qt55script libsuperlu3-dev libpng-dev qt55svg qt55tools wget libusb-1.0-0-dev libboost-all-dev liblzma-dev
-    # someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
-    - wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb
-    - wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-dev_0.0~r131-2ubuntu2_amd64.deb -O liblz4-dev.deb
-    - sudo dpkg -i liblz4.deb liblz4-dev.deb
+    - if [[ $TRAVIS_OS_NAME == "osx" ]];   then bash ci-scripts/osx/travis-install.sh; fi
+    - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash ci-scripts/linux/travis-install.sh; fi
 script:
-    - pushd thirdparty/tiff-4.0.3
-    - CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig && make
-    - popd
-    - cd toonz && mkdir build && cd build
-    - source /opt/qt55/bin/qt55-env.sh
-    - cmake ../sources
-    - make -j 2
+    - if [[ $TRAVIS_OS_NAME == "osx" ]];   then bash ci-scripts/osx/travis-build.sh; fi
+    - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash ci-scripts/linux/travis-build.sh; fi
+
+matrix:
+    include:
+        - os: linux
+        - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     - sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
     - sudo apt-get update
 install:
-    - sudo apt-get install -y liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libsdl2-dev libglew-dev freeglut3-dev qt55script libsuperlu3-dev libpng-dev qt55svg qt55tools wget libusb-1.0-0-dev libboost-all-dev
+    - sudo apt-get install -y liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libsdl2-dev libglew-dev freeglut3-dev qt55script libsuperlu3-dev libpng-dev qt55svg qt55tools wget libusb-1.0-0-dev libboost-all-dev liblzma-dev
     # someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
     - wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb
     - wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-dev_0.0~r131-2ubuntu2_amd64.deb -O liblz4-dev.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
-os: osx
 language: cpp
-compiler: clang
+sudo: required
+dist: trusty
 before_install:
-    - brew update
+    - sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
+    - sudo apt-get update
 install:
-    - brew install qt55 glew lz4 lzo libusb
+    - sudo apt-get install -y liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libsdl2-dev libglew-dev freeglut3-dev qt55script libsuperlu3-dev libpng-dev qt55svg qt55tools wget libusb-1.0-0-dev libboost-all-dev
+    # someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
+    - wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb
+    - wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-dev_0.0~r131-2ubuntu2_amd64.deb -O liblz4-dev.deb
+    - sudo dpkg -i liblz4.deb liblz4-dev.deb
 script:
     - pushd thirdparty/tiff-4.0.3
-    - ./configure && make
+    - CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig && make
     - popd
     - cd toonz && mkdir build && cd build
+    - source /opt/qt55/bin/qt55-env.sh
     - cmake ../sources
-          -DQT_PATH=/usr/local/Cellar/qt55/5.5.1/lib/
-          -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/
-          -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
-    - make
+    - make -j 2

--- a/ci-scripts/linux/travis-build.sh
+++ b/ci-scripts/linux/travis-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+pushd thirdparty/tiff-4.0.3
+CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig && make
+popd
+cd toonz && mkdir build && cd build
+source /opt/qt55/bin/qt55-env.sh
+cmake ../sources
+# according to https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+# travis can offer up to 2 cores in burst, try using that
+make -j 2

--- a/ci-scripts/linux/travis-install.sh
+++ b/ci-scripts/linux/travis-install.sh
@@ -1,0 +1,7 @@
+sudo add-apt-repository --yes ppa:beineri/opt-qt551-trusty
+sudo apt-get update
+sudo apt-get install -y liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libsdl2-dev libglew-dev freeglut3-dev qt55script libsuperlu3-dev libpng-dev qt55svg qt55tools wget libusb-1.0-0-dev libboost-all-dev liblzma-dev
+# someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
+wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb
+wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-dev_0.0~r131-2ubuntu2_amd64.deb -O liblz4-dev.deb
+sudo dpkg -i liblz4.deb liblz4-dev.deb

--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+pushd thirdparty/tiff-4.0.3
+./configure && make
+popd
+cd toonz && mkdir build && cd build
+cmake ../sources \
+      -DQT_PATH=/usr/local/Cellar/qt55/5.5.1/lib/ \
+      -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
+      -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
+make

--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+brew update
+brew install qt55 glew lz4 lzo libusb

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -230,7 +230,6 @@ elseif(UNIX)
     find_library(Z_LIB z)
 
     find_package(TIFF REQUIRED)
-    set(TIFF_LIB ${TIFF_LIBRARY})
     find_package(PNG REQUIRED)
     set(PNG_LIB ${PNG_LIBRARY})
     message("******* libpng:" ${PNG_LIB})
@@ -244,6 +243,12 @@ elseif(UNIX)
 
     # the libraries have .pc
     find_package(PkgConfig)
+
+    # This is not required for OpenToonz itself, but libtiff will pick it up if
+    # present and libimage won't be aware causing linker to fail
+    pkg_check_modules(LZMA liblzma)
+    set(TIFF_LIB ${TIFF_LIBRARY} ${LZMA_LIBRARIES})
+
     if(GLEW-NOTFOUND)
         pkg_check_modules(GLEW REQUIRED glew)
     endif()

--- a/toonz/sources/common/tapptools/tcolorutils.cpp
+++ b/toonz/sources/common/tapptools/tcolorutils.cpp
@@ -14,7 +14,7 @@ typedef float KEYER_FLOAT;
 #ifdef _WIN32
 #define ISNAN _isnan
 #else
-#define ISNAN isnan
+#define ISNAN std::isnan
 #endif
 
 //------------------------------------------------------------------------------

--- a/toonz/sources/image/png/tiio_png.cpp
+++ b/toonz/sources/image/png/tiio_png.cpp
@@ -28,7 +28,36 @@ void tnz_error_fun(png_structp pngPtr, png_const_charp error_message) {
 }
 
 #if !defined(TNZ_LITTLE_ENDIAN)
-TNZ_LITTLE_ENDIAN undefined !!
+#error "TNZ_LITTLE_ENDIAN undefined !!"
+#endif
+
+//=========================================================
+/* Check for the older version of libpng */
+
+#if defined(PNG_LIBPNG_VER)
+#if (PNG_LIBPNG_VER < 10527)
+extern "C" {
+static png_uint_32 png_get_current_row_number(const png_structp png_ptr)
+{
+       /* See the comments in png.h - this is the sub-image row when reading and
+        * interlaced image.
+        */
+       if (png_ptr != NULL)
+               return png_ptr->row_number;
+
+       return PNG_UINT_32_MAX; /* help the app not to fail silently */
+}
+
+static png_byte png_get_current_pass_number(const png_structp png_ptr)
+{
+       if (png_ptr != NULL)
+               return png_ptr->pass;
+       return 8; /* invalid */
+}
+}
+#endif
+#else
+#error "PNG_LIBPNG_VER undefined, libpng too old?"
 #endif
 
     //=========================================================
@@ -108,8 +137,12 @@ public:
                                        tnz_error_fun, 0);
     if (!m_png_ptr) return;
 
+#if defined(PNG_LIBPNG_VER)
+#if (PNG_LIBPNG_VER >= 10527)
     png_set_longjmp_fn(m_png_ptr, tnz_abort,
                        sizeof(jmp_buf)); /* ignore all fatal errors */
+#endif // (PNG_LIBPNG_VER >= 10527)
+#endif // defined(PNG_LIBPNG_VER)
 
     m_canDelete = 1;
     m_info_ptr  = png_create_info_struct(m_png_ptr);
@@ -149,7 +182,7 @@ public:
 
     int rowBytes = png_get_rowbytes(m_png_ptr, m_info_ptr);
 
-    TUINT32 lx = 0, ly = 0;
+    png_uint_32 lx = 0, ly = 0;
     png_get_IHDR(m_png_ptr, m_info_ptr, &lx, &ly, &m_bit_depth, &m_color_type,
                  &m_interlace_type, &m_compression_type, &m_filter_type);
     m_info.m_lx = lx;

--- a/toonz/sources/stdfx/pins.cpp
+++ b/toonz/sources/stdfx/pins.cpp
@@ -12,7 +12,7 @@
 #ifdef _WIN32
 #define ISNAN _isnan
 #else
-#define ISNAN isnan
+#define ISNAN std::isnan
 #endif
 
 namespace {


### PR DESCRIPTION
Adds Linux travis job.

Travis uses Ubuntu 12.04 by default, which does not have all the required packages, so I made it use a slightly newer version, 14.04. It still has improperly packaged `liblz4`, so I used a package from current LTS version, 16.04.

I also had to use external PPA, as Ubuntu 14.04 only has Qt 5.2 available.

There are two caveats with regards to `libtiff`:
* it will pick up `liblzma`, which is already installed on Ubuntu and link to it, but `libimage` is not aware of that, so I added optional dependency on `liblzma` and if found, it will be used to link `libimage`,
* similarly, `libjbig` will also get picked up by `libtiff`, but since it offers no `pkg-config` module, I simply disabled it for travis builds.

The only source changes are already contained in #553 and #554, so I think there's no need to test in on jenkins, I will rebase this PR once the other two are merged.