### PR TITLE
Revert behavior when double clicking on styles to open the style editor (and some fixes)

### DIFF
--- a/toonz/sources/toonzlib/palettecontroller.cpp
+++ b/toonz/sources/toonzlib/palettecontroller.cpp
@@ -7,7 +7,12 @@
 #include "toonz/txshlevelhandle.h"
 #include "toonz/txshlevel.h"
 
+// TnzBase includes
+#include "tenv.h"
+
 #include "toonz/palettecontroller.h"
+
+TEnv::IntVar PaletteControllerAutoApplyState("PaletteControllerAutoApplyState", 1);
 
 PaletteController::PaletteController()
     : QObject()
@@ -15,7 +20,7 @@ PaletteController::PaletteController()
     , m_currentCleanupPalette(0)
     , m_originalCurrentPalette(0)
     , m_currentPalette(0)
-    , m_colorAutoApplyEnabled(true)
+    , m_colorAutoApplyEnabled( PaletteControllerAutoApplyState != 0 )
     , m_colorSample() {
   m_currentLevelPalette   = new TPaletteHandle;
   m_currentCleanupPalette = new TPaletteHandle;
@@ -89,6 +94,7 @@ void PaletteController::editCleanupPalette() {
 void PaletteController::enableColorAutoApply(bool enabled) {
   if (m_colorAutoApplyEnabled != enabled) {
     m_colorAutoApplyEnabled = enabled;
+    PaletteControllerAutoApplyState = (enabled) ? 1 : 0;
     emit colorAutoApplyEnabled(m_colorAutoApplyEnabled);
   }
 }

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -580,6 +580,7 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       if (getCurrentStyleIndex() == styleIndex) currentStyleIndexInPage = i;
 
       QRect chipRect = getColorChipRect(i);
+      p.setPen(Qt::black);
       drawColorChip(p, chipRect, style);
 
       // name, index and shortcut
@@ -942,14 +943,13 @@ void PageViewer::mouseDoubleClickEvent(QMouseEvent *e) {
       fld->show();
       fld->selectAll();
       fld->setFocus(Qt::OtherFocusReason);
-      fld->setAlignment(Qt::AlignCenter);
+      fld->setAlignment((m_viewMode == List) ? Qt::AlignLeft : Qt::AlignCenter);
       return;
     }
   }
 
-  m_styleNameEditor->show();
-  m_styleNameEditor->raise();
-  m_styleNameEditor->activateWindow();
+  CommandManager::instance()->execute("MI_OpenStyleControl");
+
 }
 
 //-----------------------------------------------------------------------------
@@ -1008,6 +1008,12 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   menu.addAction(openPltGizmoAct);
   QAction *openStyleControlAct = cmd->getAction("MI_OpenStyleControl");
   menu.addAction(openStyleControlAct);
+  QAction *openStyleNameEditorAct = menu.addAction(tr("Name Editor"));
+  connect(openStyleNameEditorAct, &QAction::triggered, [&]() {
+    m_styleNameEditor->show();
+    m_styleNameEditor->raise();
+    m_styleNameEditor->activateWindow();
+  });
 
   // Verifica se lo stile e' link.
   // Abilita e disabilita le voci di menu' in base a dove si e' cliccato.

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -2880,7 +2880,6 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
   assert(ret);
 
   /* ------- initial conditions ------- */
-  autoCheckChanged(false);
   enable(false, false, false);
   // set to the empty page
   m_styleChooser->setCurrentIndex(6);
@@ -2912,12 +2911,12 @@ QFrame *StyleEditor::createBottomWidget() {
   bottomWidget->setObjectName("bottomWidget");
   bottomWidget->setContentsMargins(0, 0, 0, 0);
   m_applyButton->setToolTip(tr("Apply changes to current style"));
-  m_applyButton->setDisabled(true);
+  m_applyButton->setDisabled(m_paletteController->isColorAutoApplyEnabled());
   m_applyButton->setFocusPolicy(Qt::NoFocus);
 
   m_autoButton->setCheckable(true);
   m_autoButton->setToolTip(tr("Automatically update style changes"));
-  m_autoButton->setChecked(false);
+  m_autoButton->setChecked(m_paletteController->isColorAutoApplyEnabled());
   m_autoButton->setFocusPolicy(Qt::NoFocus);
 
   m_oldColor->setToolTip(tr("Return To Previous Style"));
@@ -3225,7 +3224,7 @@ void StyleEditor::enable(bool enabled, bool enabledOnlyFirstTab,
       m_autoButton->setEnabled(false);
     } else  // when the palette is unlocked
     {
-      m_applyButton->setEnabled(true);
+      m_applyButton->setDisabled(m_autoButton->isChecked());
       m_autoButton->setEnabled(true);
     }
   }
@@ -3268,14 +3267,11 @@ void StyleEditor::applyButtonClicked() {
 //-----------------------------------------------------------------------------
 
 void StyleEditor::autoCheckChanged(bool value) {
-  m_paletteController->enableColorAutoApply(!!value);
+  m_paletteController->enableColorAutoApply(value);
 
   if (!m_enabled) return;
 
-  if (value != 0)
-    m_applyButton->setDisabled(true);
-  else
-    m_applyButton->setDisabled(false);
+  m_applyButton->setDisabled(value);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR is for the issue #543
- Now the style editor will open when double clicking the style chip other than the style name region.
- The name editor popup is still available, you can open it from the context menu of the palette.
- Text alignment of the rename field is changed to leftward when the "List" view mode.

--- and also contains some fixes as follows:
- Modified frame color of the style chip of the palette in the "List" view mode.
- The "Auto Apply" toggle state will be saved in user's env file so that it can reproduce the previous state on launching the software. Note that the initial state of this toggle is set to "ON" (= Auto Apply is activated) reflecting the comments by @blurymind and @turtletooth in the issue #428