### PR TITLE
CMake: Conditionally add warnings when supported

### DIFF
--- a/toonz/cmake/util_compiler.cmake
+++ b/toonz/cmake/util_compiler.cmake
@@ -1,0 +1,33 @@
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+
+function(ADD_CHECK_C_COMPILER_FLAG
+	_CFLAGS
+	_CACHE_VAR
+	_FLAG
+	)
+
+	CHECK_C_COMPILER_FLAG("${_FLAG}" "${_CACHE_VAR}")
+	if(${_CACHE_VAR})
+		# message(STATUS "Using CFLAG: ${_FLAG}")
+		set(${_CFLAGS} "${${_CFLAGS}} ${_FLAG}" PARENT_SCOPE)
+	else()
+		message(STATUS "Unsupported CFLAG: ${_FLAG}")
+	endif()
+endfunction()
+
+function(ADD_CHECK_CXX_COMPILER_FLAG
+	_CXXFLAGS
+	_CACHE_VAR
+	_FLAG
+	)
+
+	CHECK_CXX_COMPILER_FLAG("${_FLAG}" "${_CACHE_VAR}")
+	if(${_CACHE_VAR})
+		# message(STATUS "Using CXXFLAG: ${_FLAG}")
+		set(${_CXXFLAGS} "${${_CXXFLAGS}} ${_FLAG}" PARENT_SCOPE)
+	else()
+		message(STATUS "Unsupported CXXFLAG: ${_FLAG}")
+	endif()
+endfunction()
+

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.11)
 project(OpenToonz)
 
+include(${CMAKE_SOURCE_DIR}/../cmake/util_compiler.cmake)
+
 get_filename_component(SDKROOT ../../thirdparty/ ABSOLUTE)
 message("SDK Root:" ${SDKROOT})
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
@@ -309,6 +311,19 @@ elseif(UNIX)
     pkg_check_modules(SDL_LIB REQUIRED sdl2)
 endif()
 
+
+set(C_WARNINGS)
+set(CXX_WARNINGS)
+
+if(CMAKE_COMPILER_IS_GNUCC)
+    ADD_CHECK_C_COMPILER_FLAG(C_WARNINGS C_WARN_WRITE_STRINGS -Wwrite-strings)
+    ADD_CHECK_C_COMPILER_FLAG(C_WARNINGS C_WARN_UNDEF -Wundef)
+
+    ADD_CHECK_CXX_COMPILER_FLAG(CXX_WARNINGS CXX_WARN_WRITE_STRINGS -Wwrite-strings)
+    ADD_CHECK_CXX_COMPILER_FLAG(CXX_WARNINGS CXX_WARN_UNDEF -Wundef)
+endif()
+
+
 include_directories(
     BEFORE
     ${TIFF_INCLUDE_DIR}
@@ -393,6 +408,9 @@ function(add_translation module)
     set_target_properties("translation_${module}" PROPERTIES
         EXCLUDE_FROM_DEFAULT_BUILD TRUE)
 endfunction()
+
+set(CMAKE_C_FLAGS "${C_WARNINGS} ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CXX_WARNINGS} ${CMAKE_CXX_FLAGS}")
 
 add_subdirectory(tnzcore)
 add_subdirectory(tnzbase)


### PR DESCRIPTION
This adds utility functions to conditionally add compiler flags (when they're supported by the compiler),

allowing warnings from newer compiler versions to be used without
causing a lot of noise for users of older compilers.

Using `C/CXX_WARNINGS` also makes it easier to configure warnings based on different compilers instead of platforms, Clang/GCC on OSX and Linux can use the same warnings for example.