### PR TITLE
CMake: Test for endian instead of guessing based on the platform

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -312,6 +312,16 @@ elseif(UNIX)
 endif()
 
 
+include(TestBigEndian)
+test_big_endian(_SYSTEM_BIG_ENDIAN)
+if(_SYSTEM_BIG_ENDIAN)
+    add_definitions(-DTNZ_LITTLE_ENDIAN=0)
+else()
+    add_definitions(-DTNZ_LITTLE_ENDIAN=1)
+endif()
+unset(_SYSTEM_BIG_ENDIAN)
+
+
 set(C_WARNINGS)
 set(CXX_WARNINGS)
 

--- a/toonz/sources/include/tmachine.h
+++ b/toonz/sources/include/tmachine.h
@@ -4,19 +4,19 @@
 #define T_MACHINE_INCLUDED
 
 #if defined(_WIN32) || defined(i386)
-#define TNZ_LITTLE_ENDIAN 1
 #define TNZ_MACHINE_CHANNEL_ORDER_BGRM 1
 #elif defined(__sgi)
-#define TNZ_LITTLE_ENDIAN 0
 #define TNZ_MACHINE_CHANNEL_ORDER_MBGR 1
 #elif defined(LINUX)
-#define TNZ_LITTLE_ENDIAN 1
 #define TNZ_MACHINE_CHANNEL_ORDER_BGRM 1
 #elif defined(MACOSX)
-#define TNZ_LITTLE_ENDIAN 0
 #define TNZ_MACHINE_CHANNEL_ORDER_MRGB 1
 #else
 @UNKNOW PLATFORM @
+#endif
+
+#if !defined(TNZ_LITTLE_ENDIAN)
+#error "TNZ_LITTLE_ENDIAN not defined!"
 #endif
 
 #ifndef WIN32

--- a/toonz/sources/include/toonz4.6/machine.h
+++ b/toonz/sources/include/toonz4.6/machine.h
@@ -11,29 +11,22 @@
 #define SCANNER_DEVNAME "/dev/scanner"
 #define DDR_DEVNAME     "/dev/ddr"
 #endif
-
-
-#ifdef __sgi
-#define TNZ_LITTLE_ENDIAN 0
-#else
-#define TNZ_LITTLE_ENDIAN 1
-#endif
 */
 
 #if defined(_WIN32) || defined(i386)
-#define TNZ_LITTLE_ENDIAN 1
 #define TNZ_MACHINE_CHANNEL_ORDER_BGRM 1
 #elif defined(__sgi)
-#define TNZ_LITTLE_ENDIAN 0
 #define TNZ_MACHINE_CHANNEL_ORDER_MBGR 1
 #elif defined(LINUX)
-#define TNZ_LITTLE_ENDIAN 1
 #define TNZ_MACHINE_CHANNEL_ORDER_BGRM 1
 #elif defined(MACOSX)
-#define TNZ_LITTLE_ENDIAN 0
 #define TNZ_MACHINE_CHANNEL_ORDER_MRGB 1
 #else
 @UNKNOW PLATFORM @
+#endif
+
+#if !defined(TNZ_LITTLE_ENDIAN)
+#error "TNZ_LITTLE_ENDIAN not defined!"
 #endif
 
 /*


### PR DESCRIPTION
Setting endian was making an arbitrary guess, this sets the value correctly.