### PR TITLE
CMake: differentiate system includes

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -142,6 +142,7 @@ find_package(Qt5 REQUIRED
 
 if(WIN32)
     include_directories(
+        SYSTEM
         ${SDKROOT}/glut/3.7.6/include
         ${SDKROOT}/zlib-1.2.8
         ${SDKROOT}/LibJPEG/jpeg-9
@@ -335,6 +336,7 @@ endif()
 
 
 include_directories(
+    SYSTEM
     BEFORE
     ${TIFF_INCLUDE_DIR}
     ${PNG_INCLUDE_DIRS}
@@ -363,6 +365,7 @@ else()
 endif()
 
 include_directories(
+    SYSTEM
     ${Boost_INCLUDE_DIR}
     ${LZ4_LIB_INCLUDE_DIRS}
     ${USB_LIB_INCLUDE_DIRS}

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -88,12 +88,21 @@ message("subdir: image")
 message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 
 include_directories(
+    SYSTEM
     ${TIFF_INCLUDE_DIR}
-    ${SDKROOT}/LibJPEG/jpeg-9)
+    ${SDKROOT}/LibJPEG/jpeg-9
+)
+
 if(WIN32)
-    include_directories(${SDKROOT}/libpng-1.6.21)
+    include_directories(
+        SYSTEM
+        ${SDKROOT}/libpng-1.6.21
+    )
     if(PLATFORM EQUAL 32)
-        include_directories(${SDKROOT}/quicktime/QT73SDK/CIncludes)
+        include_directories(
+            SYSTEM
+            ${SDKROOT}/quicktime/QT73SDK/CIncludes
+        )
     endif()
 endif()
 

--- a/toonz/sources/stdfx/CMakeLists.txt
+++ b/toonz/sources/stdfx/CMakeLists.txt
@@ -261,9 +261,15 @@ message("subdir: tnzstdfx")
 message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 
 if(GLEW_FOUND)
-    include_directories(${GLEW_INCLUDE_DIRS})
+    include_directories(
+        SYSTEM
+        ${GLEW_INCLUDE_DIRS}
+    )
 else()
-    include_directories(${SDKROOT}/glew/glew-1.9.0/include)
+    include_directories(
+        SYSTEM
+        ${SDKROOT}/glew/glew-1.9.0/include
+    )
 endif()
 
 _find_toonz_library(TNZLIBS "tnzcore;tnzbase;toonzlib")

--- a/toonz/sources/t32bitsrv/CMakeLists.txt
+++ b/toonz/sources/t32bitsrv/CMakeLists.txt
@@ -8,7 +8,10 @@ add_executable(t32bitsrv
     t32movmsg.h)
 
 if(WIN32)
-    include_directories(${SDKROOT}/quicktime/QT73SDK/CIncludes)
+    include_directories(
+        SYSTEM
+        ${SDKROOT}/quicktime/QT73SDK/CIncludes
+    )
 endif()
 
 target_link_libraries(t32bitsrv

--- a/toonz/sources/tnzbase/CMakeLists.txt
+++ b/toonz/sources/tnzbase/CMakeLists.txt
@@ -174,7 +174,11 @@ message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 #message("Exe: " ${EXECUTABLE_OUTPUT_PATH})
 #message("Sources:" ${SOURCES})
 
-include_directories(../common/flash ${SDKROOT}/libusb/libusb-1.0.9/include)
+include_directories(
+    SYSTEM
+    ../common/flash
+    ${SDKROOT}/libusb/libusb-1.0.9/include
+)
 
 if(WIN32)
     set(EXTRA_LIBS
@@ -197,7 +201,10 @@ elseif(UNIX)
     set(EXTRA_LIBS ${EXTRA_LIBS}
         ${SDL_LIB_LIBRARIES})
 
-	include_directories(${SDL_LIB_INCLUDE_DIRS})
+    include_directories(
+        SYSTEM
+        ${SDL_LIB_INCLUDE_DIRS}
+    )
     target_link_libraries(tnzbase Qt5::Core Qt5::Gui)
 endif()
 

--- a/toonz/sources/tnzcore/CMakeLists.txt
+++ b/toonz/sources/tnzcore/CMakeLists.txt
@@ -291,12 +291,19 @@ add_definitions(
 )
 
 message("subdir: tnzcore")
-message("Sources:" ${SOURCES})
+#message("Sources:" ${SOURCES})
 
-include_directories(../common/flash ${SDKROOT}/Lz4/Lz4_131/lib/)
+include_directories(
+    SYSTEM
+    ../common/flash
+    ${SDKROOT}/Lz4/Lz4_131/lib/
+)
 if(WIN32)
     if(PLATFORM EQUAL 32)
-        include_directories(${SDKROOT}/quicktime/QT73SDK/CIncludes)
+        include_directories(
+            SYSTEM
+            ${SDKROOT}/quicktime/QT73SDK/CIncludes
+        )
     endif()
 endif()
 
@@ -318,7 +325,10 @@ elseif(APPLE)
         ${CARBON_LIB})
 elseif(UNIX)
     set(QT_LIB)  # avoid warning
-    include_directories(${FREETYPE_INCLUDE_DIRS})
+    include_directories(
+        SYSTEM
+        ${FREETYPE_INCLUDE_DIRS}
+    )
     set(EXTRA_LIBS
         ${GLU_LIB})
 endif()

--- a/toonz/sources/tnzext/CMakeLists.txt
+++ b/toonz/sources/tnzext/CMakeLists.txt
@@ -92,7 +92,10 @@ if(APPLE)
     find_library(ACCE_LIB Accelerate)
 endif()
 
-include_directories(${SDKROOT}/superlu/SuperLU_4.1/SRC)
+include_directories(
+    SYSTEM
+    ${SDKROOT}/superlu/SuperLU_4.1/SRC
+)
 
 if(WIN32)
     target_link_libraries(tnzext

--- a/toonz/sources/tnztools/CMakeLists.txt
+++ b/toonz/sources/tnztools/CMakeLists.txt
@@ -110,7 +110,13 @@ endif()
 message("subdir: tnztools")
 message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 
-include_directories(../include/tools ${SDKROOT}/superlu/SupperLU_4.1/SRC)
+include_directories(
+    SYSTEM
+    ${SDKROOT}/superlu/SupperLU_4.1/SRC
+)
+include_directories(
+    ../include/tools
+)
 
 _find_toonz_library(EXTRA_LIBS "tnzcore;tnzbase;tnzext;toonzlib;toonzqt")
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -349,11 +349,17 @@ message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 #message("Exe: " ${EXECUTABLE_OUTPUT_PATH})
 #message("Sources:" ${SOURCES})
 
-include_directories(../../sources/toonzfarm/include)
-include_directories(../../sources/toonzqt)
+include_directories(
+    ../../sources/toonzfarm/include
+    ../../sources/toonzqt
+)
+
 if(WIN32)
     if(PLATFORM EQUAL 32)
-        include_directories(${SDKROOT}/quicktime/QT73SDK/CIncludes)
+        include_directories(
+            SYSTEM
+            ${SDKROOT}/quicktime/QT73SDK/CIncludes
+        )
     endif()
 endif()
 

--- a/toonz/sources/toonzfarm/tfarm/CMakeLists.txt
+++ b/toonz/sources/toonzfarm/tfarm/CMakeLists.txt
@@ -32,7 +32,9 @@ endif()
 message("subdir: tfarm")
 message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 
-include_directories(../include)
+include_directories(
+    ../include
+)
 
 if(WIN32)
     set(EXTRA_LIBS

--- a/toonz/sources/toonzfarm/tfarmcontroller/CMakeLists.txt
+++ b/toonz/sources/toonzfarm/tfarmcontroller/CMakeLists.txt
@@ -1,4 +1,6 @@
-include_directories(../include)
+include_directories(
+    ../include
+)
 
 add_executable(tfarmcontroller
     tfarmcontroller.cpp)

--- a/toonz/sources/toonzfarm/tfarmserver/CMakeLists.txt
+++ b/toonz/sources/toonzfarm/tfarmserver/CMakeLists.txt
@@ -1,4 +1,6 @@
-include_directories(../include)
+include_directories(
+    ../include
+)
 
 add_executable(tfarmserver
     tfarmserver.cpp)

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -332,9 +332,12 @@ message("subdir: toonzlib")
 message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 
 include_directories(
+    SYSTEM
+    ${SDKROOT}/libusb/libusb-1.0.9/include
+)
+include_directories(
     ../toonzfarm/include
-    ${SDKROOT}/libusb/libusb-1.0.9/include)
-
+)
 
 if(WIN32)
     target_link_libraries(toonzlib


### PR DESCRIPTION
Use system includes where supported.

With GCC and Clang this passes includes as `-isystem` to the compiler.
This suppresses some warnings in system headers which are maintained externally.