### PR TITLE
CMake: initialize build type

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.8.11)
+
+set(CMAKE_BUILD_TYPE_INIT Release)
+
 project(OpenToonz)
 
 include(${CMAKE_SOURCE_DIR}/../cmake/util_compiler.cmake)


### PR DESCRIPTION
Avoid using an empty build type.

While supported, it means some settings aren't well defined.
better to default to Release.