### PR TITLE
Make functions static, ensure declarations match headers

### DIFF
--- a/toonz/sources/include/toonz/tcolumnfx.h
+++ b/toonz/sources/include/toonz/tcolumnfx.h
@@ -281,4 +281,11 @@ private:
   TOutputFx &operator=(const TOutputFx &);
 };
 
+//*******************************************************************************************
+//    TColumnFx functions
+//*******************************************************************************************
+
+bool isSubsheetChainOnColumn0(TXsheet *topXsheet, TXsheet *subsheet,
+                              int frame);
+
 #endif  // TCOLUMNFX_H

--- a/toonz/sources/include/traster.h
+++ b/toonz/sources/include/traster.h
@@ -452,6 +452,13 @@ typedef TRasterPT<TPixelCY> TRasterYUV422P;
 
 //=========================================================
 
+// functions
+
+// trastercentroid.cpp
+TPoint computeCentroid(const TRaster32P &r);
+
+//=========================================================
+
 //=========================================================
 
 #endif  //__T_RASTER_INCLUDED

--- a/toonz/sources/toonzlib/autoclose.cpp
+++ b/toonz/sources/toonzlib/autoclose.cpp
@@ -549,7 +549,7 @@ void TAutocloser::Imp::findMeetingPoints(
 
 /*------------------------------------------------------------------------*/
 
-bool allMarked(const std::vector<bool> &marks, int index) {
+static bool allMarked(const std::vector<bool> &marks, int index) {
   int i;
 
   for (i = index + 1; i < (int)marks.size(); i++)

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -456,11 +456,11 @@ void fill(const TRaster32P &ras, const TRaster32P &ref,
 
 //-----------------------------------------------------------------------------
 
-void rectFill(const TRaster32P &ras, const TRect &r, const TPixel32 &color) {}
+static void rectFill(const TRaster32P &ras, const TRect &r, const TPixel32 &color) {}
 
 //-----------------------------------------------------------------------------
 
-TPoint nearestInk(const TRasterCM32P &r, const TPoint &p, int ray) {
+static TPoint nearestInk(const TRasterCM32P &r, const TPoint &p, int ray) {
   int i, j;
   TPixelCM32 *buf = (TPixelCM32 *)r->getRawData();
 

--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -2036,8 +2036,8 @@ QString DeleteLinksUndo::getHistoryString() {
 
 //=============================================================
 
-void deleteLinks(const std::list<TFxCommand::Link> &links,
-                 TXsheetHandle *xshHandle) {
+static void deleteLinks(const std::list<TFxCommand::Link> &links,
+                        TXsheetHandle *xshHandle) {
   std::auto_ptr<FxCommandUndo> undo(new DeleteLinksUndo(links, xshHandle));
   if (undo->isConsistent()) {
     undo->redo();
@@ -2298,8 +2298,8 @@ QString DeleteFxOrColumnUndo::getHistoryString() {
 
 //=============================================================
 
-void deleteFxs(const std::list<TFxP> &fxs, TXsheetHandle *xshHandle,
-               TFxHandle *fxHandle) {
+static void deleteFxs(const std::list<TFxP> &fxs, TXsheetHandle *xshHandle,
+                      TFxHandle *fxHandle) {
   TUndoManager *undoManager = TUndoManager::manager();
   TXsheet *xsh              = xshHandle->getXsheet();
 
@@ -2345,8 +2345,8 @@ void TFxCommand::removeOutputFx(TFx *fx, TXsheetHandle *xshHandle,
 //    Delete Columns  command
 //**********************************************************************
 
-void deleteColumns(const std::list<int> &columns, TXsheetHandle *xshHandle,
-                   TFxHandle *fxHandle) {
+static void deleteColumns(const std::list<int> &columns, TXsheetHandle *xshHandle,
+                          TFxHandle *fxHandle) {
   TUndoManager *undoManager = TUndoManager::manager();
 
   undoManager->beginBlock();

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -919,7 +919,7 @@ void Preferences::setViewValues(int shrink, int step) {
 
 //-----------------------------------------------------------------
 
-void setCurrentUnits(std::string measureName, std::string units) {
+static void setCurrentUnits(std::string measureName, std::string units) {
   TMeasure *m = TMeasureManager::instance()->get(measureName);
   if (!m) return;
   TUnit *u = m->getUnit(::to_wstring(units));

--- a/toonz/sources/toonzlib/sandor_fxs/CIL.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/CIL.cpp
@@ -76,7 +76,7 @@ void CCIL::strToColorIndex(const char *s, CCIL &cil, const int maxIndex) {
   }
 }
 
-int cilCompare(const void *a, const void *b) {
+static int cilCompare(const void *a, const void *b) {
   int *aa;
   int *bb;
   aa = (int *)a;

--- a/toonz/sources/toonzlib/sandor_fxs/CallCircle.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/CallCircle.cpp
@@ -15,7 +15,7 @@
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-int callcircle_xydwCompare(const void *a, const void *b) {
+static int callcircle_xydwCompare(const void *a, const void *b) {
   SXYDW *aa = (SXYDW *)a;
   SXYDW *bb = (SXYDW *)b;
 

--- a/toonz/sources/toonzlib/sandor_fxs/EraseContour.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/EraseContour.cpp
@@ -132,7 +132,7 @@ void CEraseContour::eraseInkColors() {
       }
 }
 
-int erasecontour_xydwCompare(const void *a, const void *b) {
+static int erasecontour_xydwCompare(const void *a, const void *b) {
   SXYDW *aa = (SXYDW *)a;
   SXYDW *bb = (SXYDW *)b;
 

--- a/toonz/sources/toonzlib/sandor_fxs/PatternPosition.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/PatternPosition.cpp
@@ -32,7 +32,7 @@ bool CPatternPosition::isInSet(const int nbSet, const int *set, const int val) {
   return false;
 }
 
-int pp_intCompare(const void *a, const void *b) {
+static int pp_intCompare(const void *a, const void *b) {
   int *aa = (int *)a;
   int *bb = (int *)b;
 

--- a/toonz/sources/toonzlib/sandor_fxs/SDirection.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/SDirection.cpp
@@ -255,7 +255,7 @@ void CSDirection::equalizeDir(UCHAR *sel, const int d) {
     }
 }
 
-UCHAR getRadius(const double angle, const double r[4]) {
+static UCHAR getRadius(const double angle, const double r[4]) {
   double p, q;
   if (angle >= 0.0 && angle < 45.0) {
     q = angle / 45.0;

--- a/toonz/sources/toonzlib/sandor_fxs/YOMBInputParam.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/YOMBInputParam.cpp
@@ -94,7 +94,7 @@ void CYOMBInputParam::strToColorIndex(const char *s, COLOR_INDEX_LIST &cil,
   }
 }
 
-int ushortCompare(const void *a, const void *b) {
+static int ushortCompare(const void *a, const void *b) {
   unsigned short *aa;
   unsigned short *bb;
   aa = (unsigned short *)a;

--- a/toonz/sources/toonzlib/sandor_fxs/blend.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/blend.cpp
@@ -303,9 +303,9 @@ inline void getFactors(int tone, double &inkFactor, double &paintFactor) {
 //---------------------------------------------------------------------------------
 
 // Copies the cmIn paint and ink colors to the output rasters.
-void buildLayers(const TRasterCM32P &cmIn,
-                 const std::vector<TPixel32> &palColors, TRaster32P &inkRaster,
-                 TRaster32P &paintRaster) {
+static void buildLayers(const TRasterCM32P &cmIn,
+                        const std::vector<TPixel32> &palColors, TRaster32P &inkRaster,
+                        TRaster32P &paintRaster) {
   // Separate cmIn by copying the ink & paint colors directly to the layer
   // rasters.
   TPixelCM32 *cmPix, *cmBegin = (TPixelCM32 *)cmIn->getRawData();

--- a/toonz/sources/toonzlib/sandor_fxs/calligraph.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/calligraph.cpp
@@ -39,9 +39,9 @@ extern "C" {
                  inr->ly - border - 1, 0, 0)
 
 // ----- CALLIGRAPH for UCHAR pixels (range 0-255) --------------------------
-void calligraphUC(const RASTER *inr, RASTER *outr, CCallParam &par,
-                  const int border,
-                  bool isOutBorder)  // throw(SMemAllocError,SWriteRasterError)
+static void calligraphUC(const RASTER *inr, RASTER *outr, CCallParam &par,
+                         const int border,
+                         bool isOutBorder)  // throw(SMemAllocError,SWriteRasterError)
 {
   try {
     SRECT rect = {border, border, inr->lx - border - 1, inr->ly - border - 1};
@@ -90,9 +90,9 @@ void calligraphUC(const RASTER *inr, RASTER *outr, CCallParam &par,
 }
 
 // ----- CALLIGRAPH for USHORT pixels (range 0-65535) ------------------------
-void calligraphUS(const RASTER *inr, RASTER *outr, CCallParam &par,
-                  const int border,
-                  bool isOutBorder)  // throw(SMemAllocError,SWriteRasterError)
+static void calligraphUS(const RASTER *inr, RASTER *outr, CCallParam &par,
+                         const int border,
+                         bool isOutBorder)  // throw(SMemAllocError,SWriteRasterError)
 {
   try {
     SRECT rect = {border, border, inr->lx - border - 1, inr->ly - border - 1};

--- a/toonz/sources/toonzlib/sandor_fxs/calligraph.h
+++ b/toonz/sources/toonzlib/sandor_fxs/calligraph.h
@@ -3,7 +3,15 @@
 #ifndef __CALLIGRAPH_H_
 #define __CALLIGRAPH_H_
 
-int calligraph(RASTER *, RASTER *, const int border, int argc,
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int calligraph(const RASTER *inr, RASTER *outr, const int border, int argc,
                const char *argv[], const int shrink, bool isOutBorder);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/toonz/sources/toonzlib/sandor_fxs/patternmap.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/patternmap.cpp
@@ -31,7 +31,6 @@
 using namespace std;
 
 #ifdef __cplusplus
-
 extern "C" {
 #endif
 
@@ -44,10 +43,9 @@ extern "C" {
 
 // ----- PatternMapping for UCHAR pixels (range 0-255)
 // --------------------------
-void patternmapUC(
+static void patternmapUC(
     const RASTER *iras, RASTER *oras, CPatternMapParam &pmP, const int border,
-    RASTER
-        *imgContour)  // throw (SMemAllocError,SWriteRasterError,SFileReadError)
+    RASTER *imgContour)  // throw (SMemAllocError,SWriteRasterError,SFileReadError)
 {
   try {
     SRECT rect = {border, border, iras->lx - border - 1, iras->ly - border - 1};
@@ -125,10 +123,9 @@ void patternmapUC(
 
 // ----- PatternMapping for USHORT pixels (range 0-255)
 // --------------------------
-void patternmapUS(
+static void patternmapUS(
     const RASTER *iras, RASTER *oras, CPatternMapParam &pmP, const int border,
-    RASTER
-        *imgContour)  // throw (SMemAllocError,SWriteRasterError,SFileReadError)
+    RASTER *imgContour)  // throw (SMemAllocError,SWriteRasterError,SFileReadError)
 {
   try {
     SRECT rect = {border, border, iras->lx - border - 1, iras->ly - border - 1};

--- a/toonz/sources/toonzlib/sandor_fxs/patternmap.h
+++ b/toonz/sources/toonzlib/sandor_fxs/patternmap.h
@@ -3,7 +3,15 @@
 #ifndef __PATTERNMAP_H_
 #define __PATTERNMAP_H_
 
-int patternmap(RASTER *, RASTER *, const int border, int argc,
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int patternmap(const RASTER *, RASTER *, const int border, int argc,
                const char *argv[], const int shrink, RASTER *imgContour);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -318,8 +318,8 @@ bool getColumnPlacement(TAffine &aff, TXsheet *xsh, double row, int col,
 
 //-------------------------------------------------------------------
 
-bool getColumnPlacement(PlacedFx &pf, TXsheet *xsh, double row, int col,
-                        bool isPreview) {
+static bool getColumnPlacement(PlacedFx &pf, TXsheet *xsh, double row, int col,
+                               bool isPreview) {
   if (col < 0) return false;
   TStageObject *pegbar = xsh->getStageObject(TStageObjectId::ColumnId(col));
   TAffine objAff       = pegbar->getPlacement(row);
@@ -344,8 +344,8 @@ bool getColumnPlacement(PlacedFx &pf, TXsheet *xsh, double row, int col,
 
 //-------------------------------------------------------------------
 /*-- Objectの位置を得る --*/
-bool getStageObjectPlacement(TAffine &aff, TXsheet *xsh, double row,
-                             TStageObjectId &id, bool isPreview) {
+static bool getStageObjectPlacement(TAffine &aff, TXsheet *xsh, double row,
+                                    TStageObjectId &id, bool isPreview) {
   TStageObject *pegbar = xsh->getStageObjectTree()->getStageObject(id, false);
   if (!pegbar) return false;
 
@@ -398,7 +398,7 @@ TStageObjectId getMotionObjectId(MotionObjectType type, int index) {
 
 //-------------------------------------------------------------------
 
-TPointD getColumnSpeed(TXsheet *xsh, double row, int col, bool isPreview) {
+static TPointD getColumnSpeed(TXsheet *xsh, double row, int col, bool isPreview) {
   TAffine aff;
   TPointD a, b;
   const double h = 0.001;
@@ -427,10 +427,10 @@ TPointD getColumnSpeed(TXsheet *xsh, double row, int col, bool isPreview) {
 /*-- オブジェクトの軌跡を、基準点との差分で得る
         objectId: 移動の参考にするオブジェクト。自分自身の場合はNoneId
 --*/
-QList<TPointD> getColumnMotionPoints(TXsheet *xsh, double row, int col,
-                                     TStageObjectId &objectId, bool isPreview,
-                                     double shutterStart, double shutterEnd,
-                                     int traceResolution) {
+static QList<TPointD> getColumnMotionPoints(TXsheet *xsh, double row, int col,
+                                            TStageObjectId &objectId, bool isPreview,
+                                            double shutterStart, double shutterEnd,
+                                            int traceResolution) {
   /*-- 前後フレームが共に０なら空のリストを返す --*/
   if (shutterStart == 0.0 && shutterEnd == 0.0) return QList<TPointD>();
 

--- a/toonz/sources/toonzlib/scriptbinding.cpp
+++ b/toonz/sources/toonzlib/scriptbinding.cpp
@@ -137,7 +137,7 @@ public:
   }
 };
 
-void deffoo(QScriptEngine &engine) {
+static void deffoo(QScriptEngine &engine) {
   QScriptValue f = engine.newFunction(
       Dummy<ToonzRasterConverter, &ToonzRasterConverter::convert>::dummy);
   engine.globalObject()

--- a/toonz/sources/toonzlib/scriptbinding_outline_vectorizer.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_outline_vectorizer.cpp
@@ -22,9 +22,9 @@ QScriptValue OutlineVectorizer::ctor(QScriptContext *context,
   return create(engine, new OutlineVectorizer());
 }
 
-QScriptValue vectorizeImage(QScriptContext *context, QScriptEngine *engine,
-                            const TImageP &src, TPalette *palette,
-                            NewOutlineConfiguration *parameters) {
+static QScriptValue vectorizeImage(QScriptContext *context, QScriptEngine *engine,
+                                   const TImageP &src, TPalette *palette,
+                                   NewOutlineConfiguration *parameters) {
   VectorizerCore vc;
   TAffine dpiAff;
   double factor = Stage::inch;

--- a/toonz/sources/toonzlib/scriptbinding_rasterizer.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_rasterizer.cpp
@@ -27,9 +27,9 @@ QScriptValue Rasterizer::ctor(QScriptContext *context, QScriptEngine *engine) {
   return create(engine, new Rasterizer());
 }
 
-TToonzImageP vectorToToonzRaster(const TVectorImageP &vi,
-                                 const TDimension &size, const TAffine &aff,
-                                 const TPointD &dpi) {
+static TToonzImageP vectorToToonzRaster(const TVectorImageP &vi,
+                                        const TDimension &size, const TAffine &aff,
+                                        const TPointD &dpi) {
   /*
 TScale sc(dpi.x/Stage::inch, dpi.y/Stage::inch);
 TRectD bbox = sc*vi->getBBox();
@@ -47,9 +47,9 @@ TDimension size(bbox.getLx(), bbox.getLy());
   return ti;
 }
 
-TImageP renderVectorImage(TOfflineGL *glContext, const TVectorRenderData &rd,
-                          const TPointD &dpi, const TImageP &img,
-                          const TPixel32 &color) {
+static TImageP renderVectorImage(TOfflineGL *glContext, const TVectorRenderData &rd,
+                                 const TPointD &dpi, const TImageP &img,
+                                 const TPixel32 &color) {
   glContext->clear(color);
   glContext->draw(img, rd);
   TRasterImageP rimg(glContext->getRaster());
@@ -57,8 +57,8 @@ TImageP renderVectorImage(TOfflineGL *glContext, const TVectorRenderData &rd,
   return rimg;
 }
 
-void setFrame(QScriptEngine *engine, QScriptValue &level, const TFrameId &fid,
-              const TImageP &drawing) {
+static void setFrame(QScriptEngine *engine, QScriptValue &level, const TFrameId &fid,
+                     const TImageP &drawing) {
   QScriptValueList args;
   args << QString::fromStdString(fid.expand())
        << Wrapper::create(engine, new Image(drawing.getPointer()));

--- a/toonz/sources/toonzlib/scriptbinding_renderer.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_renderer.cpp
@@ -21,8 +21,8 @@ namespace TScriptBinding {
 
 //=======================================================
 
-QScriptValue getScene(QScriptContext *context, const QScriptValue &sceneArg,
-                      Scene *&scene) {
+static QScriptValue getScene(QScriptContext *context, const QScriptValue &sceneArg,
+                             Scene *&scene) {
   scene = qscriptvalue_cast<Scene *>(sceneArg);
   if (!scene)
     return context->throwError(
@@ -33,7 +33,7 @@ QScriptValue getScene(QScriptContext *context, const QScriptValue &sceneArg,
   return QScriptValue();
 }
 
-void valueToIntList(const QScriptValue &arr, QList<int> &list) {
+static void valueToIntList(const QScriptValue &arr, QList<int> &list) {
   list.clear();
   if (arr.isArray()) {
     int length = arr.property("length").toInteger();

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -453,8 +453,8 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
 
 //-----------------------------------------------------------------------------
 
-bool alreadyAdded(TXsheet *xsh, int row, int index,
-                  const std::vector<int> &rows, int col) {
+static bool alreadyAdded(TXsheet *xsh, int row, int index,
+                         const std::vector<int> &rows, int col) {
   int i;
   for (i = 0; i < index; i++)
     if (xsh->getCell(rows[i], col) == xsh->getCell(rows[index], col))

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -31,6 +31,7 @@
 #include "toonz/stageplayer.h"
 #include "toonz/stage.h"
 #include "toonz/stage2.h"
+#include "toonz/tcolumnfx.h"
 #include "toonz/txsheet.h"
 #include "toonz/txshsimplelevel.h"
 #include "toonz/txshchildlevel.h"
@@ -681,9 +682,9 @@ void RasterPainter::drawRasterImages(QPainter &p, QPolygon cameraPol) {
   m_nodes.clear();
 }
 
-void buildAutocloseImage(TVectorImage *vaux, TVectorImage *vi,
-                         const std::vector<std::pair<int, double>> &startPoints,
-                         const std::vector<std::pair<int, double>> &endPoints) {
+static void buildAutocloseImage(TVectorImage *vaux, TVectorImage *vi,
+                                const std::vector<std::pair<int, double>> &startPoints,
+                                const std::vector<std::pair<int, double>> &endPoints) {
   for (UINT i = 0; i < startPoints.size(); i++) {
     TThickPoint p1 = vi->getStroke(startPoints[i].first)
                          ->getThickPoint(startPoints[i].second);
@@ -702,7 +703,7 @@ void buildAutocloseImage(TVectorImage *vaux, TVectorImage *vi,
 
 TEnv::DoubleVar AutocloseFactor("InknpaintAutocloseFactor", 4.0);
 
-void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
+static void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
   static TPalette *plt = 0;
   if (!plt) {
     plt = new TPalette();
@@ -861,9 +862,6 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
   delete cf;
 }
 
-//-----------------------------------------------------------------------------
-
-bool isSubsheetChainOnColumn0(TXsheet *topXsheet, TXsheet *subsheet, int frame);
 
 //-----------------------------------------------------
 

--- a/toonz/sources/toonzlib/studiopalette.cpp
+++ b/toonz/sources/toonzlib/studiopalette.cpp
@@ -218,7 +218,7 @@ TFilePath StudioPalette::getProjectPalettesRoot() {
 
 //-------------------------------------------------------------------
 
-bool loadRefImg(TPalette *palette, TFilePath dir) {
+static bool loadRefImg(TPalette *palette, TFilePath dir) {
   assert(palette);
   TFilePath fp = palette->getRefImgPath();
   if (fp == TFilePath() || !TSystem::doesExistFileOrLevel(fp)) return false;
@@ -463,7 +463,7 @@ TFilePath StudioPalette::importPalette(const TFilePath &dstFolder,
 
 //-------------------------------------------------------------------
 
-void foobar(std::wstring paletteId) { table.erase(paletteId); }
+static void foobar(std::wstring paletteId) { table.erase(paletteId); }
 
 TFilePath StudioPalette::getPalettePath(std::wstring paletteId) {
   std::map<std::wstring, TFilePath>::iterator it = table.find(paletteId);

--- a/toonz/sources/toonzlib/tcenterlineadjustments.cpp
+++ b/toonz/sources/toonzlib/tcenterlineadjustments.cpp
@@ -270,7 +270,7 @@ inline void findRoads(const Sequence &s) {
 //--------------------------------------------------------------------------
 
 // Find the 'roads' of the current Graph.
-void findRoads(const JointSequenceGraph &JSGraph) {
+static void findRoads(const JointSequenceGraph &JSGraph) {
   unsigned int i, j;
 
   // For all Sequence of currGraph, extract roads

--- a/toonz/sources/toonzlib/tcenterlinecolors.cpp
+++ b/toonz/sources/toonzlib/tcenterlinecolors.cpp
@@ -38,7 +38,7 @@ namespace boost_c = boost::container;
 
 //--------------------------------------------------------------------------
 
-TPixelCM32 pixel(const TRasterCM32 &ras, int x, int y) {
+static TPixelCM32 pixel(const TRasterCM32 &ras, int x, int y) {
   // Seems that raster access was not very much double-checked at the time
   // I wrote this. Too bad. Enforcing it now.
 
@@ -47,9 +47,9 @@ TPixelCM32 pixel(const TRasterCM32 &ras, int x, int y) {
 
 //--------------------------------------------------------------------------
 
-T3DPointD firstInkChangePosition(const TRasterCM32P &ras,
-                                 const T3DPointD &start, const T3DPointD &end,
-                                 int threshold) {
+static T3DPointD firstInkChangePosition(const TRasterCM32P &ras,
+                                        const T3DPointD &start, const T3DPointD &end,
+                                        int threshold) {
   double dist = norm(end - start);
 
   int sampleMax = tceil(dist), sampleCount = sampleMax + 1;
@@ -114,8 +114,8 @@ T3DPointD firstInkChangePosition(const TRasterCM32P &ras,
 // NOTA: La struttura a grafo J-S 'superiore' non viene alterata qui dentro.
 // Eventualm. da fare fuori.
 
-void sampleColor(const TRasterCM32P &ras, int threshold, Sequence &seq,
-                 Sequence &seqOpposite, SequenceList &singleSequences) {
+static void sampleColor(const TRasterCM32P &ras, int threshold, Sequence &seq,
+                        Sequence &seqOpposite, SequenceList &singleSequences) {
   SkeletonGraph *currGraph = seq.m_graphHolder;
 
   // Calculate sequence parametrization
@@ -469,8 +469,8 @@ inline void applyStrokeIndices(VectorizerCoreGlobals *globals) {
 //--------------------------------------------------------------------------
 
 // Find predominant ink color in a circle of given radius and center
-int getInkPredominance(const TRasterCM32P &ras, TPalette *palette, int x, int y,
-                       int radius, int threshold) {
+static int getInkPredominance(const TRasterCM32P &ras, TPalette *palette, int x, int y,
+                              int radius, int threshold) {
   int i, j;
   int mx, my, Mx, My;
   std::vector<int> inksFound(palette->getStyleCount());
@@ -511,8 +511,8 @@ int getInkPredominance(const TRasterCM32P &ras, TPalette *palette, int x, int y,
             input graph node.
   \return   The predominant branch color if found, \p -1 otherwise.
 */
-int getBranchPredominance(const TRasterCM32P &ras, TPalette *palette,
-                          JointSequenceGraph::Node &node) {
+static int getBranchPredominance(const TRasterCM32P &ras, TPalette *palette,
+                                 JointSequenceGraph::Node &node) {
   struct locals {
     static inline bool valueLess(const std::pair<int, int> &a,
                                  const std::pair<int, int> &b) {
@@ -548,9 +548,9 @@ int getBranchPredominance(const TRasterCM32P &ras, TPalette *palette,
 
 // NOTA: Da implementare una versione in grado di ordinare *pienamente* la
 // vector image.
-void sortJS(JointSequenceGraph *js,
-            std::vector<std::pair<int, TStroke *>> &toOrder,
-            const TRasterCM32P &ras, TPalette *palette) {
+static void sortJS(JointSequenceGraph *js,
+                   std::vector<std::pair<int, TStroke *>> &toOrder,
+                   const TRasterCM32P &ras, TPalette *palette) {
   enum { SORTED = 0x10 };
 
   std::vector<std::pair<unsigned int, int>> nodesToDo;

--- a/toonz/sources/toonzlib/tcenterlinepolygonizer.cpp
+++ b/toonz/sources/toonzlib/tcenterlinepolygonizer.cpp
@@ -304,8 +304,8 @@ inline void setSignature(Signaturemap &ras, const RawBorder &border, int val) {
 // Keeping B on the right of our path-seeking direction, we may either turn
 // left or right at these points.
 
-RawBorder *extractPath(Signaturemap &ras, int x0, int y0, int pathType,
-                       int xOuterPixel, int despeckling) {
+static RawBorder *extractPath(Signaturemap &ras, int x0, int y0, int pathType,
+                              int xOuterPixel, int despeckling) {
   RawBorder *path = new RawBorder;
   int x, y;
   short dirX, dirY;
@@ -389,8 +389,8 @@ RawBorder *extractPath(Signaturemap &ras, int x0, int y0, int pathType,
 
 //--------------------------------------------------------------------------
 
-BorderList *extractBorders(const TRasterP &ras, int threshold,
-                           int despeckling) {
+static BorderList *extractBorders(const TRasterP &ras, int threshold,
+                                  int despeckling) {
   Signaturemap byteImage(ras, threshold);
 
   BorderList *borderHierarchy = new BorderList;

--- a/toonz/sources/toonzlib/tcenterlineskeletonizer.cpp
+++ b/toonz/sources/toonzlib/tcenterlineskeletonizer.cpp
@@ -1653,9 +1653,9 @@ inline void Event::processSpecialEvent() {
 //    Straight Skeleton mains
 //-------------------------------
 
-SkeletonGraph *skeletonize(ContourFamily &regionContours,
-                           VectorizationContext &context,
-                           VectorizerCore *thisVectorizer) {
+static SkeletonGraph *skeletonize(ContourFamily &regionContours,
+                                  VectorizationContext &context,
+                                  VectorizerCore *thisVectorizer) {
   SkeletonGraph *output = context.m_output = new SkeletonGraph;
 
   context.prepareContours(regionContours);

--- a/toonz/sources/toonzlib/tcenterlinevectorizer.cpp
+++ b/toonz/sources/toonzlib/tcenterlinevectorizer.cpp
@@ -64,7 +64,7 @@ inline void deleteSkeletonList(SkeletonList *skeleton) {
 
 //========================================================================
 
-TVectorImageP copyStrokes(std::vector<TStroke *> &strokes) {
+static TVectorImageP copyStrokes(std::vector<TStroke *> &strokes) {
   unsigned int i;
   TVectorImageP result = new TVectorImage;
 
@@ -88,7 +88,7 @@ inline TThickPoint randomized(const TThickPoint &P) {
 //------------------------------------------------------------------------
 
 // Give stroke extremities a random shake. May help for region computing.
-void randomizeExtremities(TVectorImageP vi) {
+static void randomizeExtremities(TVectorImageP vi) {
   unsigned int i;
   for (i = 0; i < vi->getStrokeCount(); ++i) {
     TThickPoint P = vi->getStroke(i)->getControlPoint(0);

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -183,7 +183,7 @@ std::string getAlias(TXsheet *xsh, double frame, const TRenderSettings &info) {
 //    Local namespace  -  Colormap (Sandor) Fxs stuff
 //****************************************************************************************
 
-bool vectorMustApplyCmappedFx(const std::vector<TRasterFxRenderDataP> &fxs) {
+static bool vectorMustApplyCmappedFx(const std::vector<TRasterFxRenderDataP> &fxs) {
   std::vector<TRasterFxRenderDataP>::const_iterator ft, fEnd(fxs.end());
   for (ft = fxs.begin(); ft != fEnd; ++ft) {
     PaletteFilterFxRenderData *paletteFilterData =
@@ -220,7 +220,7 @@ Will have to inquire further, though...
 
 //-------------------------------------------------------------------
 
-bool mustApplySandorFx(const std::vector<TRasterFxRenderDataP> &fxs) {
+static bool mustApplySandorFx(const std::vector<TRasterFxRenderDataP> &fxs) {
   std::vector<TRasterFxRenderDataP>::const_iterator ft, fEnd(fxs.end());
   for (ft = fxs.begin(); ft != fEnd; ++ft) {
     SandorFxRenderData *sandorData =
@@ -233,7 +233,7 @@ bool mustApplySandorFx(const std::vector<TRasterFxRenderDataP> &fxs) {
 
 //-------------------------------------------------------------------
 
-int getEnlargement(const std::vector<TRasterFxRenderDataP> &fxs, double scale) {
+static int getEnlargement(const std::vector<TRasterFxRenderDataP> &fxs, double scale) {
   int enlargement = 1;
 
   std::vector<TRasterFxRenderDataP>::const_iterator ft, fEnd(fxs.end());
@@ -287,8 +287,8 @@ int getEnlargement(const std::vector<TRasterFxRenderDataP> &fxs, double scale) {
 
 //-------------------------------------------------------------------
 
-void applyPaletteFilter(TPalette *&plt, bool keep, const set<int> &colors,
-                        const TPalette *srcPlt) {
+static void applyPaletteFilter(TPalette *&plt, bool keep, const set<int> &colors,
+                               const TPalette *srcPlt) {
   if (colors.empty()) return;
 
   if (!plt) plt = srcPlt->clone();
@@ -309,7 +309,7 @@ void applyPaletteFilter(TPalette *&plt, bool keep, const set<int> &colors,
 
 //-------------------------------------------------------------------
 
-TPalette *getPliPalette(const TFilePath &path) {
+static TPalette *getPliPalette(const TFilePath &path) {
   TLevelReaderP levelReader = TLevelReaderP(path);
   if (!levelReader.getPointer()) return 0;
 
@@ -348,7 +348,7 @@ inline void sortCmappedFxs(std::vector<TRasterFxRenderDataP> &fxs) {
 
 //-------------------------------------------------------------------
 
-std::vector<int> getAllBut(std::vector<int> &colorIds) {
+static std::vector<int> getAllBut(std::vector<int> &colorIds) {
   assert(TPixelCM32::getMaxInk() == TPixelCM32::getMaxPaint());
 
   std::vector<int> curColorIds;
@@ -378,9 +378,9 @@ std::vector<int> getAllBut(std::vector<int> &colorIds) {
 //! that of
 //! optimizing memory usage, please avoid copying the entire image buffer...
 
-TImageP applyCmappedFx(TToonzImageP &ti,
-                       const std::vector<TRasterFxRenderDataP> &fxs, int frame,
-                       double scale) {
+static TImageP applyCmappedFx(TToonzImageP &ti,
+                              const std::vector<TRasterFxRenderDataP> &fxs, int frame,
+                              double scale) {
   TImageP result = ti;
   TTile resultTile;  // Just a quick wrapper to the ImageCache
   TPalette *inPalette, *tempPlt;
@@ -671,8 +671,8 @@ TImageP applyCmappedFx(TToonzImageP &ti,
 
 //-------------------------------------------------------------------
 
-void applyCmappedFx(TVectorImageP &vi,
-                    const std::vector<TRasterFxRenderDataP> &fxs, int frame) {
+static void applyCmappedFx(TVectorImageP &vi,
+                           const std::vector<TRasterFxRenderDataP> &fxs, int frame) {
   TRasterP ras;
   bool keep = false;
   TPaletteP modPalette;

--- a/toonz/sources/toonzlib/tcolumnfxset.cpp
+++ b/toonz/sources/toonzlib/tcolumnfxset.cpp
@@ -113,7 +113,7 @@ void TFxSet::loadData(TIStream &is) {
   }
 }
 
-TFx *getActualFx(TFx *fx) {
+static TFx *getActualFx(TFx *fx) {
   // Zerary fxs and zerary COLUMN fxs are separate, and fx port connections
   // are stored in the actual zerary fx.
   // It's sad - couldn't we do something about it?

--- a/toonz/sources/toonzlib/toonzimageutils.cpp
+++ b/toonz/sources/toonzlib/toonzimageutils.cpp
@@ -202,10 +202,10 @@ TRectD ToonzImageUtils::convertRasterToWorld(const TRect area,
 
 // overlaying inks, blend inks always "lose" on normal inks
 
-TRect fastAddInkStroke(const TToonzImageP &ti, TStroke *stroke, int inkId,
-                       bool selective, bool filled, TRectD clip,
-                       bool doAntialiasing       = true,
-                       const set<int> &blendInks = set<int>()) {
+static TRect fastAddInkStroke(const TToonzImageP &ti, TStroke *stroke, int inkId,
+                              bool selective, bool filled, TRectD clip,
+                              bool doAntialiasing       = true,
+                              const set<int> &blendInks = set<int>()) {
   TRasterCM32P ras = ti->getRaster();
   TOfflineGL *gl   = 0;
 

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -283,7 +283,7 @@ void fixBiancoProblem(ToonzScene *scene, TXsheet *xsh) {
 
 //=============================================================================
 
-void deleteAllUntitledScenes() {
+static void deleteAllUntitledScenes() {
   TFilePath tempDir = getUntitledScenesDir();
   try {
     if (TFileStatus(tempDir).isDirectory()) {
@@ -948,7 +948,7 @@ struct LevelType {
 
 //-----------------------------------------------------------------------------
 
-LevelType getLevelType(const TFilePath &fp) {
+static LevelType getLevelType(const TFilePath &fp) {
   LevelType ret;
   ret.m_ltype        = UNKNOWN_XSHLEVEL;
   ret.m_oldLevelFlag = false;

--- a/toonz/sources/toonzlib/toutlinevectorizer.cpp
+++ b/toonz/sources/toonzlib/toutlinevectorizer.cpp
@@ -128,7 +128,7 @@ public:
 
 //---------------------------------------------------------
 
-double computeDistance2(Node *na, Node *nb) {
+static double computeDistance2(Node *na, Node *nb) {
   assert(na->m_pixel);
   assert(nb->m_pixel);
   TPointD d = convert(na->m_pixel->m_pos - nb->m_pixel->m_pos);
@@ -137,7 +137,7 @@ double computeDistance2(Node *na, Node *nb) {
 
 //---------------------------------------------------------
 
-void renormalizeImage(TVectorImage *vi) {
+static void renormalizeImage(TVectorImage *vi) {
   int i, j;
   int n = vi->getStrokeCount();
   std::vector<ControlPoint> points;
@@ -832,7 +832,7 @@ TVectorImageP VectorizerCore::outlineVectorize(
 
 //=========================================================
 
-bool isPointInRegion(TPointD p, TRegion *r) {
+static bool isPointInRegion(TPointD p, TRegion *r) {
   int i;
   for (i = 0; i < 5; i++) {
     double stepX = i * 0.2;
@@ -856,9 +856,9 @@ bool isPointInRegion(TPointD p, TRegion *r) {
 
 //(Daniele) Aggiunti controlli per evitare uscite dai bounds
 
-bool isNearestInkOrPaintInRegion(bool findInk, const TRasterCM32P &ras,
-                                 TRegion *r, const TAffine &aff,
-                                 const TPoint &p) {
+static bool isNearestInkOrPaintInRegion(bool findInk, const TRasterCM32P &ras,
+                                        TRegion *r, const TAffine &aff,
+                                        const TPoint &p) {
   bool isTheLastSquare = false;
   int mx, my, Mx, My;
   int i;

--- a/toonz/sources/toonzlib/trastercentroid.cpp
+++ b/toonz/sources/toonzlib/trastercentroid.cpp
@@ -271,7 +271,7 @@ static int find_next_seed(const TRasterGR8P &r, int first_seed, UCHAR *&seed,
 
 /*------------------------------------------------------------------------*/
 
-void doComputeCentroid(const TRasterGR8P &r, TPoint &cp) {
+static void doComputeCentroid(const TRasterGR8P &r, TPoint &cp) {
   int preseed, displ, prewalker, code;
   UCHAR *seed, *walker;
   int x_num = 0, y_num = 0, den = 0;

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -46,7 +46,7 @@ using namespace std;
 #ifdef _WIN32
 #pragma optimize("", off)
 #endif
-TAffine makeRotation(double ang) { return TRotation(ang); }
+static TAffine makeRotation(double ang) { return TRotation(ang); }
 #ifdef _WIN32
 #pragma optimize("", on)
 #endif

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1013,7 +1013,7 @@ void getLoadingLevelRange(TFrameId &fromFid, TFrameId &toFid) {
   toFid   = loadingLevelRange.m_toFid;
 }
 
-TFilePath getLevelPathAndSetNameWithPsdLevelName(TXshSimpleLevel *xshLevel) {
+static TFilePath getLevelPathAndSetNameWithPsdLevelName(TXshSimpleLevel *xshLevel) {
   TFilePath retfp = xshLevel->getPath();
 
   QString name     = QString::fromStdWString(retfp.getWideName());
@@ -1358,7 +1358,7 @@ void TXshSimpleLevel::save() {
 
 //-----------------------------------------------------------------------------
 
-void saveBackup(TFilePath path) {
+static void saveBackup(TFilePath path) {
   try {
     TFilePath backup = path.withName(path.getName() + "_backup");
     if (TSystem::doesExistFileOrLevel(backup))


### PR DESCRIPTION
This patch used `-Wmissing-declarations` to show functions and symbols that had no declarations, and either make them static or declare in headers.

This helps avoid possibility that declarations and functions get out of sync. _(which can cause hard to track down crashes which may only happen on some configurations)_
And ensures all source files reference headers correctly.

This ensures functions declared in `extern "C"`, do so in the header too.
An error found in `calligraph.h` while writing this patch.

It helps with refactoring code, when its obvious that functions are only ever used locally, theres no need to double check if they're called from other files, or forget to and cause bugs.

The compiler may also do a better job optimizing the code it knows isn't used elsewhere _(inline static calls, fold branches when called with constant arguments)_.

This has been applied to `toonzlib`, to avoid making very large global changes.
If accepted, other modules could have similar changes made and `-Wmissing-declarations` added to CMake.