### PR TITLE
Fix use-after free on render

### DIFF
--- a/toonz/sources/common/tfx/trenderer.cpp
+++ b/toonz/sources/common/tfx/trenderer.cpp
@@ -1107,6 +1107,7 @@ void RenderTask::onFinished(TThread::RunnableP) {
 
   // Update the render instance status
   bool instanceExpires = false;
+  bool isCanceled = false;
   {
     QMutexLocker sl(&rendererImp->m_renderInstancesMutex);
     std::map<unsigned long, TRendererImp::RenderInstanceInfos>::iterator it =
@@ -1115,14 +1116,15 @@ void RenderTask::onFinished(TThread::RunnableP) {
     if (it != rendererImp->m_activeInstances.end() &&
         (--it->second.m_activeTasks) <= 0) {
       instanceExpires = true;
+      isCanceled = (m_info.m_isCanceled && *m_info.m_isCanceled);
       rendererImp->m_activeInstances.erase(m_renderId);
+      // m_info is freed, don't access further!
     }
   }
 
   // If the render instance has just expired
   if (instanceExpires) {
     /*-- キャンセルされた場合はm_overallRenderedRegionの更新をしない --*/
-    bool isCanceled = (m_info.m_isCanceled && *m_info.m_isCanceled);
 
     // Inform the render ports
     rendererImp->notifyRenderFinished(isCanceled);


### PR DESCRIPTION
m_info was used after being freed, see: [asan.txt](https://github.com/opentoonz/opentoonz/files/355651/asan.txt) for details.
