### PR TITLE
Fix uninitialized variable use

### DIFF
--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -427,6 +427,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
     TObjectHandle *objHandle, TXsheetHandle *xshHandle, ToolHandle *toolHandle)
     : ToolOptionsBox(parent)
     , m_pg(pg)
+    , m_splined(false)
     , m_tool(tool)
     , m_frameHandle(frameHandle)
     , m_objHandle(objHandle)

--- a/toonz/sources/toonz/previewer.cpp
+++ b/toonz/sources/toonz/previewer.cpp
@@ -241,6 +241,7 @@ Previewer::Imp::Imp(Previewer *owner)
     , m_renderer(TSystem::getProcessorCount())
     , m_computingFrameCount(0)
     , m_currentFrameToSave(0)
+    , m_subcamera(false)
     , m_lw() {
   // Precomputing (ie predictive cache) is disabled in this case. This is due to
   // current TFxCacheManager's


### PR DESCRIPTION
Both these variables are read before being initialized.

```
./toonz/sources/toonz/previewer.cpp:315:  if (m_subcamera && subCameraRect.getLx() > 0 && subCameraRect.getLy() > 0) {

```

```
./toonz/sources/tnztools/tooloptions.cpp:581:  if (splined != m_splined) m_splined = splined;
```