### PR TITLE
Fix crash loading levels

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -1246,7 +1246,7 @@ void LoadLevelPopup::updateBottomGUI() {
       TLevelReaderP lr(fp);
       TLevelP level;
       if (lr) level = lr->loadInfo();
-      if (!level.getPointer()) return;
+      if (!level.getPointer() || level->getTable()->size() == 0) return;
 
       firstFrame = level->begin()->first;
       lastFrame  = (--level->end())->first;


### PR DESCRIPTION
Effects Linux, but may apply to other systems too.

`--level->end()` resolved to an invalid pointer and crashes.

Simple to redo, load new levels and keep clicking on the "..", would crash after 2 clicks.