### PR TITLE
Updated level export settings

### DIFF
--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -696,7 +696,7 @@ ExportLevelPopup::ExportOptions::ExportOptions(QWidget *parent)
 
     QLabel *bgColorLabel = new QLabel(tr("Background Color:"));
     m_bgColorField =
-        new DVGui::ColorField(0, false, TPixel32::Black, 35, false);
+        new DVGui::ColorField(0, false, TPixel32::White, 35, false);
     layout->addWidget(bgColorLabel, row, 1, Qt::AlignRight);
     layout->addWidget(m_bgColorField, row++, 2, Qt::AlignLeft);
 

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -389,8 +389,10 @@ void ColorField::setAlphaActive(bool active) {
     connect(m_alphaChannel, SIGNAL(valueChanged(int, bool)),
             SLOT(onAlphaChannelChanged(int, bool)));
     assert(m_color.m == 255);
-    // m_color.m = m_alphaChannel->getChannel();
-    // m_colorSample->setColor(m_color);
+    m_alphaChannel->setChannel(0);
+    m_color.m = 0;
+    m_colorSample->setColor(m_color);
+    emit colorChanged(m_color, false);
   } else if (!active && m_alphaChannel->isVisible()) {
     m_alphaChannel->hide();
     disconnect(m_alphaChannel, SIGNAL(valueChanged(int, bool)), this,


### PR DESCRIPTION
Levels that don't support transparency have a white background by default, and levels that do, have a transparent background by default.

#530 