### PR TITLE
WIP - Linked styles enabled and style right click menu organized

### DIFF
--- a/toonz/sources/include/toonzqt/paletteviewergui.h
+++ b/toonz/sources/include/toonzqt/paletteviewergui.h
@@ -200,9 +200,6 @@ protected:
   void zoomOutChip();
 
 protected slots:
-
-  void toggleLink();
-  void eraseToggleLink();
   void removeLink();
 
 private:

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -12,6 +12,8 @@
 #define MI_PasteColors "MI_PasteColors"
 #define MI_PasteNames "MI_PasteNames"
 #define MI_GetColorFromStudioPalette "MI_GetColorFromStudioPalette"
+#define MI_ToggleLinkToStudioPalette "MI_ToggleLinkToStudioPalette"
+#define MI_RemoveReferenceToStudioPalette "MI_RemoveReferenceToStudioPalette"
 #define MI_Clear "MI_Clear"
 #define MI_SelectAll "MI_SelectAll"
 #define MI_InvertSelection "MI_InvertSelection"

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1611,7 +1611,7 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_ToggleLinkToStudioPalette,
                              tr("Toggle Link to Studio Palette"), "\\");
   createRightClickMenuAction(MI_RemoveReferenceToStudioPalette,
-                             tr("Remove Connection to Studio Palette"), "");
+                             tr("Remove Reference to Studio Palette"), "");
   createMenuEditAction(MI_Clear, tr("&Delete"), "Delete");
   createMenuEditAction(MI_Insert, tr("&Insert"), "Ins");
   createMenuEditAction(MI_Group, tr("&Group"), "Ctrl+G");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1608,6 +1608,10 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_PasteNames, tr("Paste Name"), "");
   createRightClickMenuAction(MI_GetColorFromStudioPalette,
                              tr("Get Color from Studio Palette"), "");
+  createRightClickMenuAction(MI_ToggleLinkToStudioPalette,
+                             tr("Toggle Link to Studio Palette"), "\\");
+  createRightClickMenuAction(MI_RemoveReferenceToStudioPalette,
+                             tr("Remove Connection to Studio Palette"), "");
   createMenuEditAction(MI_Clear, tr("&Delete"), "Delete");
   createMenuEditAction(MI_Insert, tr("&Insert"), "Ins");
   createMenuEditAction(MI_Group, tr("&Group"), "Ctrl+G");

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -1023,28 +1023,29 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   bool isLocked = m_page ? m_page->getPalette()->isLocked() : false;
 
   // remove links from studio palette
-  if (m_viewType == LEVEL_PALETTE && m_styleSelection &&
-      !m_styleSelection->isEmpty() && !isLocked) {
-    menu.addSeparator();
-    QAction *removeLinkAct = menu.addAction(tr("Remove Links"));
-    connect(removeLinkAct, SIGNAL(triggered()), this, SLOT(removeLink()));
-  }
+  //if (m_viewType == LEVEL_PALETTE && m_styleSelection &&
+  //    !m_styleSelection->isEmpty() && !isLocked) {
+  //  menu.addSeparator();
+  //  QAction *removeLinkAct = menu.addAction(tr("Remove Links"));
+  //  connect(removeLinkAct, SIGNAL(triggered()), this, SLOT(removeLink()));
+  //}
 
   if (((indexPage == 0 && index > 0) || (indexPage > 0 && index >= 0)) &&
       index < getChipCount() && !isLocked) {
-    // iwsw commented out temporarly
-    /*
-    wstring globalName = m_page->getStyle(index)->getGlobalName();
-    if (m_viewType != STUDIO_PALETTE &&
-            globalName != L"" &&
+    
+    std::wstring globalName = m_page->getStyle(index)->getGlobalName();
+    if (m_viewType != STUDIO_PALETTE && globalName != L"" &&
             (globalName[0] == L'-' || globalName[0] == L'+'))
     {
-            createMenuAction(menu, "MI_ToggleLinkToStudioPalette", tr("Toggle
-    Link to Studio Palette"), "toggleLink()");
-            createMenuAction(menu, "MI_RemoveReferenceToStudioPalette",
-    tr("Remove Reference to Studio Palette"), "eraseToggleLink()");
+		menu.addSeparator();
+		QAction *toggleStyleLink = cmd->getAction("MI_ToggleLinkToStudioPalette");
+		menu.addAction(toggleStyleLink);
+		QAction *removeStyleLink = cmd->getAction("MI_RemoveReferenceToStudioPalette");
+		menu.addAction(removeStyleLink);
+		QAction *getBackOriginalAct = cmd->getAction("MI_GetColorFromStudioPalette");
+		menu.addAction(getBackOriginalAct);
     }
-    */
+    
     if (pasteValueAct) pasteValueAct->setEnabled(true);
     if (pasteColorsAct) pasteColorsAct->setEnabled(true);
 
@@ -1062,29 +1063,18 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
     clearAct->setEnabled(false);
   }
 
-  // get color from the original studio palette
-  if (m_viewType == LEVEL_PALETTE && m_styleSelection &&
-      !m_styleSelection->isEmpty() && !isLocked) {
-    menu.addSeparator();
-    QAction *getBackOriginalAct =
-        cmd->getAction("MI_GetColorFromStudioPalette");
-    menu.addAction(getBackOriginalAct);
-  }
-
-  // iwsw commented out temporarly
-  /*
-  if (m_viewType != STUDIO_PALETTE)
-  {
-          menu.addSeparator();
-          menu.addAction(cmd->getAction(MI_EraseUnusedStyles));
-  }
-  */
   if (m_page) {
+	menu.addSeparator();
     QAction *newStyle = menu.addAction(tr("New Style"));
     connect(newStyle, SIGNAL(triggered()), SLOT(addNewColor()));
     QAction *newPage = menu.addAction(tr("New Page"));
     connect(newPage, SIGNAL(triggered()), SLOT(addNewPage()));
   }
+
+  if (m_viewType != STUDIO_PALETTE) {
+	  menu.addAction(cmd->getAction(MI_EraseUnusedStyles));
+  }
+
   menu.exec(event->globalPos());
 }
 
@@ -1371,25 +1361,6 @@ void PageViewer::onStyleRenamed() {
   PaletteCmd::renamePaletteStyle(getPaletteHandle(), newName);
 }
 
-//-----------------------------------------------------------------------------
-/*! Recall \b TStyleSelection::toggleLink() to current page style selection.
-*/
-void PageViewer::toggleLink() {
-  if (!m_page || !m_styleSelection || m_styleSelection->isEmpty()) return;
-  m_styleSelection->toggleLink();
-  update();
-  emit changeWindowTitleSignal();
-}
-
-//-----------------------------------------------------------------------------
-/*! Recall \b TStyleSelection::eraseToggleLink() to current page style
- * selection.
-*/
-void PageViewer::eraseToggleLink() {
-  if (!m_page || !m_styleSelection || m_styleSelection->isEmpty()) return;
-  m_styleSelection->eraseToggleLink();
-}
-
 //=============================================================================
 /*! \class PaletteViewerGUI::PaletteTabBar
                 \brief The PaletteTabBar class provides a bar with tab to show
@@ -1653,6 +1624,8 @@ void PageViewer::updateCommandLocks() {
   cmd->getAction("MI_BlendColors")->setEnabled(!isLocked);
   cmd->getAction("MI_PasteNames")->setEnabled(!isLocked);
   cmd->getAction("MI_GetColorFromStudioPalette")->setEnabled(!isLocked);
+  cmd->getAction("MI_ToggleLinkToStudioPalette")->setEnabled(!isLocked);
+  cmd->getAction("MI_RemoveReferenceToStudioPalette")->setEnabled(!isLocked);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -505,9 +505,15 @@ void TStyleSelection::enableCommands() {
     enableCommand(this, MI_PasteNames, &TStyleSelection::pasteStylesName);
 
     // available only for level palette
-    if (m_paletteHandle->getPalette()->getGlobalName() == L"")
-      enableCommand(this, MI_GetColorFromStudioPalette,
-                    &TStyleSelection::getBackOriginalStyle);
+	if (m_paletteHandle->getPalette()->getGlobalName() == L"") {
+		enableCommand(this, MI_GetColorFromStudioPalette,
+			&TStyleSelection::getBackOriginalStyle);
+		enableCommand(this, MI_ToggleLinkToStudioPalette,
+			&TStyleSelection::toggleLink);
+		enableCommand(this, MI_RemoveReferenceToStudioPalette,
+			&TStyleSelection::eraseToggleLink);
+		
+	}
   }
   enableCommand(this, MI_Clear, &TStyleSelection::deleteStyles);
   enableCommand(this, MI_EraseUnusedStyles, &TStyleSelection::eraseUnsedStyle);
@@ -1408,6 +1414,7 @@ public:
 void TStyleSelection::toggleLink() {
   TPalette *palette = getPalette();
   if (!palette || m_pageIndex < 0) return;
+  if (isEmpty() || palette->isLocked()) return;
   int n = m_styleIndicesInPage.size();
   if (n <= 0) return;
 
@@ -1460,6 +1467,7 @@ void TStyleSelection::toggleLink() {
 void TStyleSelection::eraseToggleLink() {
   TPalette *palette = getPalette();
   if (!palette || m_pageIndex < 0) return;
+  if (isEmpty() || palette->isLocked()) return;
   int n = m_styleIndicesInPage.size();
   if (n <= 0) return;
 


### PR DESCRIPTION
- Re-enabled linked styles - "Toggle Link to Studio Palette"
- Changed "Remove Links" to "Remove Reference to Studio Palette"
    - This sounds wordy, but it was to avoid confusion about toggling the link
- Re-enabled "Delete Unused Styles"
- Made toggle link and remove connection able to have shortcuts (Default for toggle link is \\)

To update linked colors, save the Studio Palette and now the option to update linked styles works.

![stylelink](https://cloud.githubusercontent.com/assets/4576381/16755341/ddf61d4e-47b8-11e6-9982-1e7171352411.png)
