### PR TITLE
Cleanup: declare local functions static

### DIFF
--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -95,6 +95,7 @@ set(MOC_HEADERS
     scenesettingspopup.h
     sceneviewer.h
     sceneviewercontextmenu.h
+    sceneviewerevents.h
     scriptconsolepanel.h
     selectionutils.h
     shifttracetool.h

--- a/toonz/sources/toonz/batchserversviewer.cpp
+++ b/toonz/sources/toonz/batchserversviewer.cpp
@@ -246,8 +246,8 @@ void BatchServersViewer::onCurrentItemChanged(QListWidgetItem *_item) {
                 Inherits \b QFrame.
 */
 
-LineEdit *create(QGridLayout *layout, const QString &name, int &row,
-                 bool readOnly = true) {
+static LineEdit *create(QGridLayout *layout, const QString &name, int &row,
+                        bool readOnly = true) {
   layout->addWidget(new QLabel(name), row, 0, Qt::AlignRight);
   LineEdit *ret = new LineEdit();
   ret->setReadOnly(readOnly);

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1198,7 +1198,7 @@ void TCellSelection::copyCells() {
 
 //-----------------------------------------------------------------------------
 
-void pasteStrokesInCell(int row, int col, const StrokesData *strokesData) {
+static void pasteStrokesInCell(int row, int col, const StrokesData *strokesData) {
   PasteStrokesInCellUndo *undo =
       new PasteStrokesInCellUndo(row, col, strokesData);
   std::vector<int> indices;
@@ -1213,8 +1213,8 @@ void pasteStrokesInCell(int row, int col, const StrokesData *strokesData) {
 
 //-----------------------------------------------------------------------------
 
-void pasteRasterImageInCell(int row, int col,
-                            const RasterImageData *rasterImageData) {
+static void pasteRasterImageInCell(int row, int col,
+                                   const RasterImageData *rasterImageData) {
   TXsheet *xsh         = TApp::instance()->getCurrentXsheet()->getXsheet();
   TXshCell cell        = xsh->getCell(row, col);
   bool createdFrame    = false;
@@ -1557,7 +1557,7 @@ void TCellSelection::openTimeStretchPopup() {
 
 //-----------------------------------------------------------------------------
 
-bool operator<(const TXshCell &a, const TXshCell &b) {
+static bool operator<(const TXshCell &a, const TXshCell &b) {
   if (a.getSimpleLevel() < b.getSimpleLevel())
     return true;
   else if (a.getSimpleLevel() > b.getSimpleLevel())
@@ -1567,7 +1567,7 @@ bool operator<(const TXshCell &a, const TXshCell &b) {
 
 //-----------------------------------------------------------------------------
 
-void dRenumberCells(int col, int r0, int r1) {
+static void dRenumberCells(int col, int r0, int r1) {
   typedef std::vector<std::pair<TFrameId, TFrameId>> FramesMap;
   typedef std::map<TXshCell, TXshCell> CellsMap;
   typedef std::map<TXshSimpleLevel *, FramesMap> LevelsTable;
@@ -1709,7 +1709,7 @@ public:
 
 // TODO: spostare queste funzioni in un posto piu' generale e riutilizzabile
 
-int getLevelType(const TImageP &img) {
+static int getLevelType(const TImageP &img) {
   if (img->getType() == TImage::RASTER)
     return OVL_XSHLEVEL;
   else if (img->getType() == TImage::VECTOR)
@@ -1775,7 +1775,7 @@ void setNewDrawing(TXsheet *xsh, int row, int col, const TImageP &img)
 
 //-----------------------------------------------------------------------------
 
-void createNewDrawing(TXsheet *xsh, int row, int col, int preferredLevelType) {
+static void createNewDrawing(TXsheet *xsh, int row, int col, int preferredLevelType) {
   // search for the level
   TXshCell old = xsh->getCell(row, col);
   if (old.isEmpty()) {

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -756,7 +756,7 @@ void ColumnCmd::insertEmptyColumn(int index) {
 //    Copy Columns  Command
 //*************************************************************************
 
-void copyColumns_internal(const std::set<int> &indices) {
+static void copyColumns_internal(const std::set<int> &indices) {
   assert(!indices.empty());
 
   StageObjectsData *data = new StageObjectsData;
@@ -821,7 +821,7 @@ void ColumnCmd::deleteColumn(int index) {
 // cutColumns
 //-----------------------------------------------------------------------------
 
-void cutColumnsWithoutUndo(std::set<int> *indices) {
+static void cutColumnsWithoutUndo(std::set<int> *indices) {
   copyColumns_internal(*indices);
   deleteColumnsWithoutUndo(indices);
 }

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -98,7 +98,7 @@ void TColumnSelection::explodeChild() {
 
 //-----------------------------------------------------------------------------
 
-bool canMergeColumns(int column, int mColumn, bool forMatchlines) {
+static bool canMergeColumns(int column, int mColumn, bool forMatchlines) {
   TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
   int start, end;
   xsh->getCellRange(column, start, end);

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -471,7 +471,7 @@ void ClipListViewer::getSelectedClips(std::vector<TFilePath> &selectedClips) {
 
 //-----------------------------------------------------------------------------
 
-QByteArray packStringList(const QStringList &lst) {
+static QByteArray packStringList(const QStringList &lst) {
   QByteArray ba;
   QDataStream ds(&ba, QIODevice::WriteOnly);
   ds << (qint32)lst.size();
@@ -480,7 +480,7 @@ QByteArray packStringList(const QStringList &lst) {
   return ba;
 }
 
-QStringList unpackStringList(const QByteArray &ba) {
+static QStringList unpackStringList(const QByteArray &ba) {
   QStringList lst;
   QDataStream ds(ba);
   qint32 n = 0;

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -432,7 +432,7 @@ void FileSelection::duplicateFiles() {
 
 //------------------------------------------------------------------------
 
-int collectAssets(TFilePath scenePath) {
+static int collectAssets(TFilePath scenePath) {
   // bool dirtyFlag = TNotifier::instance()->getDirtyFlag();
   ToonzScene scene;
   scene.load(scenePath);
@@ -485,7 +485,7 @@ void FileSelection::collectAssets() {
 
 //------------------------------------------------------------------------
 
-int importScene(TFilePath scenePath) {
+static int importScene(TFilePath scenePath) {
   // bool dirtyFlag = TNotifier::instance()->getDirtyFlag();
   ToonzScene scene;
   try {

--- a/toonz/sources/toonz/floatingpanelcommand.cpp
+++ b/toonz/sources/toonz/floatingpanelcommand.cpp
@@ -18,7 +18,7 @@
 
 // mette il widget al centro dello schermo e lo fa diventare la finestra
 // corrente
-void activateWidget(QWidget *w) {
+static void activateWidget(QWidget *w) {
   QDesktopWidget *desktop = qApp->desktop();
   QRect screenRect        = desktop->screenGeometry(w);
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1951,9 +1951,9 @@ std::vector<int>
                           // Trovare un metodo alternativo.
 
 //! Returns the number of actually loaded levels
-int createSubXSheetFromPSDFolder(IoCmd::LoadResourceArguments &args,
-                                 TXsheet *xsh, int &col0, int psdLevelIndex,
-                                 PsdSettingsPopup *popup) {
+static int createSubXSheetFromPSDFolder(IoCmd::LoadResourceArguments &args,
+                                        TXsheet *xsh, int &col0, int psdLevelIndex,
+                                        PsdSettingsPopup *popup) {
   assert(popup->isFolder(psdLevelIndex));
 
   int row0  = 0;
@@ -2008,8 +2008,8 @@ int createSubXSheetFromPSDFolder(IoCmd::LoadResourceArguments &args,
 
 //  Load a psd file
 //! Returns the number of actually loaded levels
-int loadPSDResource(IoCmd::LoadResourceArguments &args, bool updateRecentFile,
-                    PsdSettingsPopup *popup) {
+static int loadPSDResource(IoCmd::LoadResourceArguments &args, bool updateRecentFile,
+                           PsdSettingsPopup *popup) {
   int &row0 = args.row0;
   int &col0 = args.col0;
   int &row1 = args.row1;

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -117,7 +117,7 @@ void qt_mac_set_menubar_merge(bool enable);
 #define NO_LICENSE
 //-----------------------------------------------------------------------------
 
-void fatalError(QString msg) {
+static void fatalError(QString msg) {
   DVGui::MsgBoxInPopup(
       CRITICAL, msg + "\n" +
                     QObject::tr("Installing %1 again could fix the problem.")
@@ -126,13 +126,13 @@ void fatalError(QString msg) {
 }
 //-----------------------------------------------------------------------------
 
-void lastWarningError(QString msg) {
+static void lastWarningError(QString msg) {
   DVGui::error(msg);
   // exit(0);
 }
 //-----------------------------------------------------------------------------
 
-void toonzRunOutOfContMemHandler(unsigned long size) {
+static void toonzRunOutOfContMemHandler(unsigned long size) {
 #ifdef _WIN32
   static bool firstTime = true;
   if (firstTime) {
@@ -156,7 +156,7 @@ DV_IMPORT_API void initColorFx();
     la stuffDir, controlla se la directory di outputs esiste (e provvede a
     crearla in caso contrario) verifica inoltre che stuffDir esista.
 */
-void initToonzEnv() {
+static void initToonzEnv() {
   StudioPalette::enable(true);
 
   TEnv::setApplication(applicationName, applicationVersion,

--- a/toonz/sources/toonz/matchline.cpp
+++ b/toonz/sources/toonz/matchline.cpp
@@ -995,8 +995,8 @@ void DeleteInkDialog::setRange(const QString &str) { m_frames->setText(str); }
          DeleteLinesコマンドから呼ばれる場合：chooseInkがtrue
 --*/
 
-void doDeleteMatchlines(TXshSimpleLevel *sl, const std::set<TFrameId> &fids,
-                        bool chooseInk) {
+static void doDeleteMatchlines(TXshSimpleLevel *sl, const std::set<TFrameId> &fids,
+                               bool chooseInk) {
   std::vector<int> indexes;
   // vector<TToonzImageP> images;
   std::vector<TFrameId> frames;

--- a/toonz/sources/toonz/mergecmapped.cpp
+++ b/toonz/sources/toonz/mergecmapped.cpp
@@ -321,7 +321,7 @@ TApp::instance()->getCurrentScene()->getScene();
 } //namespace
 */
 
-bool removeLevel(TXshLevel *level) {
+static bool removeLevel(TXshLevel *level) {
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
   // if(scene->getChildStack()->getTopXsheet()->isLevelUsed(level))

--- a/toonz/sources/toonz/pltgizmopopup.cpp
+++ b/toonz/sources/toonz/pltgizmopopup.cpp
@@ -34,8 +34,8 @@ using namespace DVGui;
 
 //-----------------------------------------------------------------------------
 
-void getStyles(std::vector<TColorStyle *> &styles,
-               const TStyleSelection &selection, TPaletteP palette) {
+static void getStyles(std::vector<TColorStyle *> &styles,
+                      const TStyleSelection &selection, TPaletteP palette) {
   styles.clear();
   int pageIndex        = selection.getPageIndex();
   TPalette::Page *page = palette->getPage(pageIndex);
@@ -50,7 +50,7 @@ void getStyles(std::vector<TColorStyle *> &styles,
 
 //-----------------------------------------------------------------------------
 
-void getStyleIds(std::vector<int> &styleIds, const TStyleSelection &selection) {
+static void getStyleIds(std::vector<int> &styleIds, const TStyleSelection &selection) {
   styleIds.clear();
   int pageIndex        = selection.getPageIndex();
   TPaletteP palette    = selection.getPalette();

--- a/toonz/sources/toonz/print.cpp
+++ b/toonz/sources/toonz/print.cpp
@@ -25,7 +25,7 @@
 #include <QPainter>
 #include <QApplication>
 
-void printCurrentFrame() {
+static void printCurrentFrame() {
   QPrinter printer;
   QPrintDialog dialog(&printer, 0);
   if (!dialog.exec()) return;

--- a/toonz/sources/toonz/psdsettingspopup.cpp
+++ b/toonz/sources/toonz/psdsettingspopup.cpp
@@ -39,7 +39,7 @@ QStringList modesDescription =
 // Costruisce la stringa delle info della psd da caricare che comparirà nel
 // popup:
 // Path, Dimensioni, numero di livelli, ecc..
-void doPSDInfo(TFilePath psdpath, QTreeWidget *psdTree) {
+static void doPSDInfo(TFilePath psdpath, QTreeWidget *psdTree) {
   psdTree->clear();
   try {
     TPSDReader *psdreader = new TPSDReader(psdpath);

--- a/toonz/sources/toonz/scanpopup.cpp
+++ b/toonz/sources/toonz/scanpopup.cpp
@@ -800,7 +800,7 @@ void MyScannerListener::cancelButtonPressed() {
 
 //=============================================================================
 //
-void doScan() {
+static void doScan() {
   if (!checkScannerDefinition()) return;
   ScanList scanList;
   if (scanList.areScannedFramesSelected()) {

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -314,7 +314,7 @@ void invalidateIcons() {
 
 //--------------------------------------------------------------
 
-void executeCheck(int checkType) {
+static void executeCheck(int checkType) {
   ToonzCheck::instance()->toggleCheck(checkType);
   invalidateIcons();
 }
@@ -1021,7 +1021,7 @@ void SceneViewer::drawBackground() {
   }
 }
 
-bool check_framebuffer_status() {
+static bool check_framebuffer_status() {
 #ifdef _WIN32
   PROC proc = wglGetProcAddress("glCheckFramebufferStatusEXT");
   if (proc == nullptr) return true;
@@ -1363,7 +1363,7 @@ void SceneViewer::drawOverlay() {
 
 //-----------------------------------------------------------------------------
 
-void drawFpsGraph(int t0, int t1) {
+static void drawFpsGraph(int t0, int t1) {
   glDisable(GL_BLEND);
   static std::deque<std::pair<int, int>> times;
   times.push_back(std::make_pair(t0, t1));

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -372,4 +372,8 @@ signals:
   void previewToggled();
 };
 
+// Functions
+
+void invalidateIcons();
+
 #endif  // SCENEVIEWER_H

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -39,8 +39,8 @@
 #include <QContextMenuEvent>
 #include <QSignalMapper>
 
-void addShowHideStageObjectCmd(QMenu *menu, const TStageObjectId &id,
-                               bool isShow) {
+static void addShowHideStageObjectCmd(QMenu *menu, const TStageObjectId &id,
+                                      bool isShow) {
   TXsheet *xsh         = TApp::instance()->getCurrentXsheet()->getXsheet();
   TStageObject *pegbar = xsh->getStageObject(id);
   QString cmdStr;
@@ -55,7 +55,7 @@ void addShowHideStageObjectCmd(QMenu *menu, const TStageObjectId &id,
   menu->addAction(showHideAction);
 }
 
-void onShowHideSelectObject(QAction *action) {
+static void onShowHideSelectObject(QAction *action) {
   TApp *app = TApp::instance();
   TStageObjectId id;
   id.setCode(action->data().toInt());
@@ -80,7 +80,7 @@ void onShowHideSelectObject(QAction *action) {
   }
 }
 
-int addShowHideStageObjectCmds(const std::vector<int> &columnIndexes,
+static int addShowHideStageObjectCmds(const std::vector<int> &columnIndexes,
                                QMenu *menu, bool isShow) {
   int ii, columnIndex = -1;
   bool flag = true;
@@ -238,7 +238,7 @@ void SceneViewerContextMenu::addEnterGroupCommands(const TPointD &pos) {
   assert(ret);
 }
 
-QString getName(TStageObject *obj) {
+static QString getName(TStageObject *obj) {
   return QString::fromStdString(obj->getFullName());
 }
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -6,6 +6,7 @@
 
 // Tnz6 includes
 #include "sceneviewer.h"
+#include "sceneviewerevents.h"
 #include "viewerpane.h"
 #include "tapp.h"
 #include "iocommand.h"

--- a/toonz/sources/toonz/sceneviewerevents.h
+++ b/toonz/sources/toonz/sceneviewerevents.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#ifndef SCENEVIEWEREVENTS_H
+#define SCENEVIEWEREVENTS_H
+
+bool changeFrameSkippingHolds(QKeyEvent *e);
+
+#endif  // SCENEVIEWEREVENTS_H

--- a/toonz/sources/toonz/scriptconsolepanel.cpp
+++ b/toonz/sources/toonz/scriptconsolepanel.cpp
@@ -24,7 +24,7 @@
 #include <QFile>
 #include <QTextStream>
 
-QScriptValue loadSceneFun(QScriptContext *context, QScriptEngine *engine) {
+static QScriptValue loadSceneFun(QScriptContext *context, QScriptEngine *engine) {
   if (context->argumentCount() > 0) {
     QString fpArg = context->argument(0).toString();
     TFilePath fp(fpArg.toStdWString());
@@ -33,7 +33,7 @@ QScriptValue loadSceneFun(QScriptContext *context, QScriptEngine *engine) {
   return QScriptValue();
 }
 
-QScriptValue saveSceneFun(QScriptContext *context, QScriptEngine *engine) {
+static QScriptValue saveSceneFun(QScriptContext *context, QScriptEngine *engine) {
   if (context->argumentCount() > 0) {
     QString fpArg = context->argument(0).toString();
     TFilePath fp(fpArg.toStdWString());
@@ -42,7 +42,7 @@ QScriptValue saveSceneFun(QScriptContext *context, QScriptEngine *engine) {
   return QScriptValue();
 }
 
-QScriptValue loadLevelFun(QScriptContext *context, QScriptEngine *engine) {
+static QScriptValue loadLevelFun(QScriptContext *context, QScriptEngine *engine) {
   if (context->argumentCount() > 0) {
     QString fpArg = context->argument(0).toString();
     TFilePath fp(fpArg.toStdWString());
@@ -68,11 +68,11 @@ QScriptValue loadLevelFun(QScriptContext *context, QScriptEngine *engine) {
   return QScriptValue();
 }
 
-QScriptValue dummyFun(QScriptContext *context, QScriptEngine *engine) {
+static QScriptValue dummyFun(QScriptContext *context, QScriptEngine *engine) {
   return QScriptValue(engine, 0);
 }
 
-QScriptValue viewFun(QScriptContext *context, QScriptEngine *engine) {
+static QScriptValue viewFun(QScriptContext *context, QScriptEngine *engine) {
   TScriptBinding::Image *image = 0;
   TScriptBinding::Level *level = 0;
 
@@ -101,8 +101,8 @@ QScriptValue viewFun(QScriptContext *context, QScriptEngine *engine) {
   return engine->globalObject().property("void");
 }
 
-QScriptValue evaluateOnMainThread(QScriptContext *context,
-                                  QScriptEngine *engine) {
+static QScriptValue evaluateOnMainThread(QScriptContext *context,
+                                         QScriptEngine *engine) {
   QScriptValue fun = context->callee().data();
   QObject *obj     = fun.data().toQObject();
   QString s        = fun.toString();
@@ -110,8 +110,8 @@ QScriptValue evaluateOnMainThread(QScriptContext *context,
   return se->evaluateOnMainThread(fun, context->argumentsObject());
 }
 
-void def(ScriptEngine *teng, const QString &name,
-         QScriptEngine::FunctionSignature fun) {
+static void def(ScriptEngine *teng, const QString &name,
+                QScriptEngine::FunctionSignature fun) {
   QScriptEngine *eng  = teng->getQScriptEngine();
   QScriptValue funVal = eng->newFunction(fun);
   funVal.setData(eng->newQObject(teng));

--- a/toonz/sources/toonz/shifttracetool.cpp
+++ b/toonz/sources/toonz/shifttracetool.cpp
@@ -24,8 +24,8 @@
 
 //=============================================================================
 
-bool circumCenter(TPointD &out, const TPointD &a, const TPointD &b,
-                  const TPointD &c) {
+static bool circumCenter(TPointD &out, const TPointD &a, const TPointD &b,
+                         const TPointD &c) {
   double d = 2 * (a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y));
   if (fabs(d) < 0.0001) {
     out = TPointD();

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -629,7 +629,7 @@ void TApp::onLevelColorStyleSwitched() {
 
 //-----------------------------------------------------------------------------
 
-void notifyPaletteChanged(TXshSimpleLevel *simpleLevel) {
+static void notifyPaletteChanged(TXshSimpleLevel *simpleLevel) {
   simpleLevel->onPaletteChanged();
   std::vector<TFrameId> fids;
   simpleLevel->getFids(fids);

--- a/toonz/sources/toonz/viewerdraw.cpp
+++ b/toonz/sources/toonz/viewerdraw.cpp
@@ -37,6 +37,9 @@
 
 TEnv::StringVar EnvSafeAreaName("SafeAreaName", "PR_safe");
 
+/* TODO, move to include */
+void getSafeAreaSizeList(QList<QList<double>> &_sizeList);
+
 //=============================================================================
 //=============================================================================
 // SafeAreaData

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -110,7 +110,7 @@ namespace XsheetGUI {
 
 //-----------------------------------------------------------------------------
 
-void getVolumeCursorRect(QRect &out, double volume, const QPoint &origin) {
+static void getVolumeCursorRect(QRect &out, double volume, const QPoint &origin) {
   int ly = 60;
   int v  = tcrop(0, ly, (int)(volume * ly));
   out.setX(origin.x() + 11);

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -203,7 +203,7 @@ void InsertSceneFrameUndo::doRemoveSceneFrame(int frame) {
 
 //-----------------------------------------------------------------------------
 
-void insertSceneFrame(int frame) {
+static void insertSceneFrame(int frame) {
   InsertSceneFrameUndo *undo = new InsertSceneFrameUndo(frame);
   TUndoManager::manager()->add(undo);
 
@@ -298,7 +298,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
-void removeSceneFrame(int frame) {
+static void removeSceneFrame(int frame) {
   RemoveSceneFrameUndo *undo = new RemoveSceneFrameUndo(frame);
   TUndoManager::manager()->add(undo);
 
@@ -443,7 +443,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
-void insertGlobalKeyframe(int frame) {
+static void insertGlobalKeyframe(int frame) {
   std::vector<int> columns;
   ::getColumns(columns);
 
@@ -536,7 +536,7 @@ public:
 
 //-----------------------------------------------------------------------------
 
-void removeGlobalKeyframe(int frame) {
+static void removeGlobalKeyframe(int frame) {
   std::vector<int> columns;
   ::getColumns(columns);
 
@@ -747,7 +747,7 @@ void DrawingSubtitutionUndo::setDrawing(const TFrameId &fid, int row, int col,
 
 //-----------------------------------------------------------------------------
 
-void drawingSubstituion(int dir) {
+static void drawingSubstituion(int dir) {
   // TTool::Application *app = TTool::getApplication();
   // TCellSelection *selection = dynamic_cast<TCellSelection
   // *>(app->getCurrentSelection()->getSelection());
@@ -769,7 +769,7 @@ void drawingSubstituion(int dir) {
   undo->redo();
 }
 
-void drawingSubstituionGroup(int dir) {
+static void drawingSubstituionGroup(int dir) {
   int row = TTool::getApplication()->getCurrentFrame()->getFrame();
   int col = TTool::getApplication()->getCurrentColumn()->getColumnIndex();
   DrawingSubtitutionGroupUndo *undo =
@@ -1744,7 +1744,7 @@ void XsheetWriter::write(ostream &os) {
   }
 }
 
-void makeHtml(TFilePath fp) {
+static void makeHtml(TFilePath fp) {
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
 

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1483,7 +1483,7 @@ XsheetGUI::DragTool *XsheetGUI::DragTool::makeColumnSelectionTool(
 // Column Movement
 //-----------------------------------------------------------------------------
 
-void moveColumns(const std::set<int> &indices, int delta) {
+static void moveColumns(const std::set<int> &indices, int delta) {
   if (indices.empty()) return;
   if (delta < 0 && *indices.begin() + delta < 0) delta = -*indices.begin();
   if (delta == 0) return;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1,6 +1,7 @@
 
 
 #include "xsheetviewer.h"
+#include "sceneviewerevents.h"
 #include "tapp.h"
 #include "floatingpanelcommand.h"
 #include "menubarcommandids.h"
@@ -398,7 +399,7 @@ void XsheetViewer::setAutoPanSpeed(const QPoint &speed) {
 
 //-----------------------------------------------------------------------------
 
-int getAutoPanSpeed(int pixels) {
+static int getAutoPanSpeed(int pixels) {
   int f = 40;
   return std::min(100, (f - 1 + pixels * f) / 100);
 }
@@ -771,7 +772,6 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
 
   } locals = {this};
 
-  extern bool changeFrameSkippingHolds(QKeyEvent * e);
   if (changeFrameSkippingHolds(event)) return;
 
   int frameCount = getXsheet()->getFrameCount();

--- a/toonz/sources/toonzfarm/tfarm/tfarmexecutor.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmexecutor.cpp
@@ -8,7 +8,7 @@ TFarmExecutor::TFarmExecutor(int port) : TTcpIpServer(port) {}
 
 //------------------------------------------------------------------------------
 
-int extractArgs(const QString &s, std::vector<QString> &argv) {
+static int extractArgs(const QString &s, std::vector<QString> &argv) {
   argv.clear();
   if (s == "") return 0;
 

--- a/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
@@ -375,7 +375,7 @@ QString toString(int value, int w, char c = ' ') {
 
 //------------------------------------------------------------------------------
 
-TFilePath getFilePath(const QStringList &l, int &i) {
+static TFilePath getFilePath(const QStringList &l, int &i) {
   QString outStr = l.at(i++);
   if (outStr.startsWith('"')) {
     outStr = outStr.remove(0, 1);

--- a/toonz/sources/toonzfarm/tfarm/ttcpipclient.cpp
+++ b/toonz/sources/toonzfarm/tfarm/ttcpipclient.cpp
@@ -200,7 +200,7 @@ int TTcpIpClient::send(int sock, const QString &data) {
 
 //------------------------------------------------------------------------------
 
-int readData(int sock, QString &data) {
+static int readData(int sock, QString &data) {
   int cnt = 0;
   char buff[1024];
   memset(buff, 0, sizeof(buff));

--- a/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
+++ b/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
@@ -424,7 +424,7 @@ void FarmServerProxy::removeTask(const QString &taskId) {
 
 //------------------------------------------------------------------------------
 
-bool doTestConnection(const QString &hostName, const QString &addr, int port) {
+static bool doTestConnection(const QString &hostName, const QString &addr, int port) {
   TTcpIpClient client;
 
   int sock;

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -683,7 +683,7 @@ int inline STRICMP(const char *a, const char *b) {
   return str.compare(QString(b), Qt::CaseSensitive);
 }
 
-bool loadServerData(const QString &hostname, QString &addr, int &port) {
+static bool loadServerData(const QString &hostname, QString &addr, int &port) {
   TFilePath rootDir = getGlobalRoot();
 
   TFilePath fp = rootDir + "config" + "servers.txt";

--- a/toonz/sources/toonzqt/addfxcontextmenu.cpp
+++ b/toonz/sources/toonzqt/addfxcontextmenu.cpp
@@ -207,7 +207,7 @@ void AddFxContextMenu::fillMenus() {
 
 //---------------------------------------------------
 
-void scan_all_plugins(const std::string &basedir, QObject *listener) {
+static void scan_all_plugins(const std::string &basedir, QObject *listener) {
   // clear_all_plugins();
   new PluginLoadController(basedir, listener);
 }

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -730,7 +730,7 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
 //------------------------------------------------------
 
 //! A region is empty, if contains no item and no children.
-bool isEmptyRegion(Region *r) {
+static bool isEmptyRegion(Region *r) {
   if ((!r->getItem()) && (r->getChildList().size() == 0)) {
     delete r;  // Be', e' un po' improprio, ma funziona...
     return true;
@@ -863,8 +863,8 @@ bool DockLayout::undockItem(DockWidget *item) {
 //! Search for the \b nearest n-ple from a \b target one, under conditions:
 //!\b 1) nearest elements belong to \b fixed \b intervals; \b 2) their \b sum is
 //!\b fixed too.
-void calculateNearest(std::vector<double> target, std::vector<double> &nearest,
-                      std::vector<std::pair<int, int>> intervals, double sum) {
+static void calculateNearest(std::vector<double> target, std::vector<double> &nearest,
+                             std::vector<std::pair<int, int>> intervals, double sum) {
   // Solving a small Lagrange multipliers problem to find solution on constraint
   // (2)
   assert(target.size() == intervals.size());

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -1500,8 +1500,8 @@ void FunctionPanel::fitRegion(double f0, double v0, double f1, double v1) {}
 
 //-----------------------------------------------------------------------------
 
-void setSegmentType(FunctionSelection *selection, TDoubleParam *curve,
-                    int segmentIndex, TDoubleKeyframe::Type type) {
+static void setSegmentType(FunctionSelection *selection, TDoubleParam *curve,
+                           int segmentIndex, TDoubleKeyframe::Type type) {
   selection->selectSegment(curve, segmentIndex);
   KeyframeSetter setter(curve, segmentIndex);
   setter.setType(type);

--- a/toonz/sources/toonzqt/functionsegmentviewer.cpp
+++ b/toonz/sources/toonzqt/functionsegmentviewer.cpp
@@ -41,7 +41,7 @@ using namespace DVGui;
 
 //-----------------------------------------------------------------------------
 
-LineEdit *createField() {
+static LineEdit *createField() {
   LineEdit *field = new LineEdit();
   /*
 field->setMaximumWidth(100);

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -110,13 +110,13 @@ namespace ImageUtils {
 // todo: spostare da qualche altra parte. rendere accessibile a tutti.
 // utilizzare
 // anche nella libreria dovunque si usi direttamente "_files"
-TFilePath getResourceFolder(const TFilePath &scenePath) {
+static TFilePath getResourceFolder(const TFilePath &scenePath) {
   return scenePath.getParentDir() + (scenePath.getName() + "_files");
 }
 
 //-----------------------------------------------------------------------------
 
-void copyScene(const TFilePath &dst, const TFilePath &src) {
+static void copyScene(const TFilePath &dst, const TFilePath &src) {
   TSystem::copyFile(dst, src);
   if (TProjectManager::instance()->isTabModeEnabled())
     TSystem::copyDir(getResourceFolder(dst), getResourceFolder(src));
@@ -337,11 +337,11 @@ void getStrokeStyleInformationInArea(
 }
 
 //--------------------------------------------------------------------
-void convertFromCM(const TLevelReaderP &lr, const TPaletteP &plt,
-                   const TLevelWriterP &lw, const std::vector<TFrameId> &frames,
-                   const TAffine &aff, const TRop::ResampleFilterType &resType,
-                   FrameTaskNotifier *frameNotifier, const TPixel &bgColor,
-                   bool removeDotBeforeFrameNumber = false) {
+static void convertFromCM(const TLevelReaderP &lr, const TPaletteP &plt,
+                          const TLevelWriterP &lw, const std::vector<TFrameId> &frames,
+                          const TAffine &aff, const TRop::ResampleFilterType &resType,
+                          FrameTaskNotifier *frameNotifier, const TPixel &bgColor,
+                          bool removeDotBeforeFrameNumber = false) {
   for (int i = 0; i < (int)frames.size(); i++) {
     if (frameNotifier->abortTask()) break;
     try {
@@ -402,10 +402,10 @@ void convertFromCM(const TLevelReaderP &lr, const TPaletteP &plt,
 
 //--------------------------------------------------------------------
 
-void convertFromVI(const TLevelReaderP &lr, const TPaletteP &plt,
-                   const TLevelWriterP &lw, const std::vector<TFrameId> &frames,
-                   const TRop::ResampleFilterType &resType, int width,
-                   FrameTaskNotifier *frameNotifier) {
+static void convertFromVI(const TLevelReaderP &lr, const TPaletteP &plt,
+                          const TLevelWriterP &lw, const std::vector<TFrameId> &frames,
+                          const TRop::ResampleFilterType &resType, int width,
+                          FrameTaskNotifier *frameNotifier) {
   QString msg;
   int i;
   std::vector<TVectorImageP> images;
@@ -457,13 +457,13 @@ void convertFromVI(const TLevelReaderP &lr, const TPaletteP &plt,
 
 //-----------------------------------------------------------------------
 
-void convertFromFullRaster(const TLevelReaderP &lr, const TLevelWriterP &lw,
-                           const std::vector<TFrameId> &_frames,
-                           const TAffine &aff,
-                           const TRop::ResampleFilterType &resType,
-                           FrameTaskNotifier *frameNotifier,
-                           const TPixel &bgColor,
-                           bool removeDotBeforeFrameNumber = false) {
+static void convertFromFullRaster(const TLevelReaderP &lr, const TLevelWriterP &lw,
+                                  const std::vector<TFrameId> &_frames,
+                                  const TAffine &aff,
+                                  const TRop::ResampleFilterType &resType,
+                                  FrameTaskNotifier *frameNotifier,
+                                  const TPixel &bgColor,
+                                  bool removeDotBeforeFrameNumber = false) {
   std::vector<TFrameId> frames = _frames;
   if (frames.empty() &&
       lr->loadInfo()->getFrameCount() ==
@@ -540,9 +540,9 @@ ConvertPopup での指定に合わせて、[レベル名].[フレーム番号].[
 
 //-----------------------------------------------------------------------
 
-void convertFromVector(const TLevelReaderP &lr, const TLevelWriterP &lw,
-                       const std::vector<TFrameId> &_frames,
-                       FrameTaskNotifier *frameNotifier) {
+static void convertFromVector(const TLevelReaderP &lr, const TLevelWriterP &lw,
+                              const std::vector<TFrameId> &_frames,
+                              FrameTaskNotifier *frameNotifier) {
   std::vector<TFrameId> frames = _frames;
   TLevelP lv                   = lr->loadInfo();
   if (frames.empty() &&

--- a/toonz/sources/toonzqt/pluginhost.cpp
+++ b/toonz/sources/toonzqt/pluginhost.cpp
@@ -669,7 +669,7 @@ static inline bool is_compatible(const toonz_if_version_t &v) {
   return v.major == compat_maj && v.minor == compat_min;
 }
 
-int check_base_sanity(const toonz_param_page_t *p) {
+static int check_base_sanity(const toonz_param_page_t *p) {
   int err = 0;
   if (!is_compatible<toonz_param_base_t_, 1, 0>(p->base))
     err |= TOONZ_PARAM_ERROR_VERSION;
@@ -678,7 +678,7 @@ int check_base_sanity(const toonz_param_page_t *p) {
   return err;
 }
 
-int check_base_sanity(const toonz_param_group_t *p) {
+static int check_base_sanity(const toonz_param_group_t *p) {
   int err = 0;
   if (!is_compatible<toonz_param_base_t_, 1, 0>(p->base))
     err |= TOONZ_PARAM_ERROR_VERSION;
@@ -688,7 +688,7 @@ int check_base_sanity(const toonz_param_group_t *p) {
   return err;
 }
 
-int check_base_sanity(const toonz_param_desc_t *p) {
+static int check_base_sanity(const toonz_param_desc_t *p) {
   int err = 0;
   if (!is_compatible<toonz_param_base_t_, 1, 0>(p->base))
     err |= TOONZ_PARAM_ERROR_VERSION;
@@ -1266,7 +1266,7 @@ T *interface_factory() {
   return interface_t<T, major, minor>::factory();
 }
 
-int query_interface(const UUID *uuid, void **interf) {
+static int query_interface(const UUID *uuid, void **interf) {
   typedef std::pair<const UUID *, int> uuid_dict_t;
   static const uuid_dict_t dict[] = {
       uuid_dict_t(&uuid_nodal_, 1), uuid_dict_t(&uuid_port_, 2),
@@ -1325,7 +1325,7 @@ int query_interface(const UUID *uuid, void **interf) {
   return TOONZ_OK;
 }
 
-void release_interface(void *interf) {
+static void release_interface(void *interf) {
   if (interf) delete interf;
 }
 
@@ -1357,9 +1357,9 @@ void Loader::walkDirectory_(const QString &path) {
 }
 
 #if defined(_WIN32) || defined(_CYGWIN_)
-void end_library(HMODULE mod) { FreeLibrary(mod); }
+static void end_library(HMODULE mod) { FreeLibrary(mod); }
 #else
-void end_library(void *mod) { dlclose(mod); }
+static void end_library(void *mod) { dlclose(mod); }
 #endif
 
 void Loader::doLoad(const QString &file) {

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -558,7 +558,7 @@ void SpreadsheetViewer::setAutoPanSpeed(const QPoint &speed) {
 
 //-----------------------------------------------------------------------------
 
-int getAutoPanSpeed(int pixels) {
+static int getAutoPanSpeed(int pixels) {
   int f = 40;
   return std::min(100, (f - 1 + pixels * f) / 100);
 }


### PR DESCRIPTION
Applies to toonz, toonzfarm, toonzqt.
Follow on from (#610).

Note that there was one function left as an `extern`, because of type declarations.
`getSafeAreaSizeList`.

Also added header `sceneviewerevents.h`.