### PR TITLE
Fix OSX crash on vector animation rendering

### DIFF
--- a/toonz/sources/common/tvrender/qtofflinegl.cpp
+++ b/toonz/sources/common/tvrender/qtofflinegl.cpp
@@ -190,14 +190,13 @@ void QtOfflineGL::makeCurrent() {
     m_context->moveToThread(QThread::currentThread());
     m_context->makeCurrent(m_surface.get());
   }
-  // else
-  //  m_oldContext = 0;
 }
 
 //-----------------------------------------------------------------------------
 
 void QtOfflineGL::doneCurrent() {
   if (m_context) {
+    m_context->moveToThread(0);
     m_context->doneCurrent();
   }
 }

--- a/toonz/sources/stdfx/particlesfx.cpp
+++ b/toonz/sources/stdfx/particlesfx.cpp
@@ -448,6 +448,7 @@ void ParticlesFx::doCompute(TTile &tile, double frame,
     partLevel[0]->setName("particles");
     TDimension vecsize(10, 10);
     TOfflineGL *offlineGlContext = new TOfflineGL(vecsize);
+    offlineGlContext->makeCurrent();
     offlineGlContext->clear(TPixel32(0, 0, 0, 0));
 
     TStroke *stroke;
@@ -459,7 +460,7 @@ void ParticlesFx::doCompute(TTile &tile, double frame,
     vectmp->setPalette(plt);
     vectmp->addStroke(stroke);
     TVectorRenderData rd(AffI, TRect(vecsize), plt, 0, true, true);
-    offlineGlContext->makeCurrent();
+
     offlineGlContext->draw(vectmp, rd);
 
     partLevel[0]->setFrame(

--- a/toonz/sources/toonzlib/trasterimageutils.cpp
+++ b/toonz/sources/toonzlib/trasterimageutils.cpp
@@ -87,6 +87,7 @@ void rasterizeWholeStroke(TOfflineGL *&gl, TStroke *stroke, TPalette *palette,
   }
   glDisable(GL_ALPHA_TEST);
   glFinish();
+  gl->doneCurrent();
 }
 
 //--------------------------------------------------------------------------
@@ -142,6 +143,7 @@ TRect rasterizeRegion(TOfflineGL *&gl, TRect rasBounds, TRegion *region,
     glPopAttrib();
 
     glFinish();
+    gl->doneCurrent();
   }
   return rect;
 }

--- a/toonz/sources/toonzqt/icongenerator.cpp
+++ b/toonz/sources/toonzqt/icongenerator.cpp
@@ -584,7 +584,10 @@ TRaster32P SplineIconRenderer::generateRaster(
 
   const TStroke *stroke = m_spline->getStroke();
   assert(stroke);
-  if (!stroke) return TRaster32P();
+  if (!stroke) {
+    glContext->doneCurrent();
+    return TRaster32P();
+  }
   TRectD sbbox = stroke->getBBox();
 
   glColor3d(0, 0, 0);


### PR DESCRIPTION
This PR is related to #381.
In qtofflinegl.cpp, call moveToThread(0) to abandone the ownership of the GLContext before doneCurrent(), and add doneCurrent() at the end of some stdfx functions.