### PR TITLE
Function Curves Window Usability - Option 2

### DIFF
--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -246,7 +246,7 @@ FunctionPanel::FunctionPanel(QWidget *parent)
     , m_currentFrameStatus(0)
     , m_selection(0)
     , m_curveShape(SMOOTH) {
-  setWindowTitle(tr("Function Curves - Use Ctrl Key to Modify Positions"));
+  setWindowTitle(tr("Function Curves - Use Control Key to Modify Positions"));
 
   m_viewTransform.translate(50, 200);
   m_viewTransform.scale(5, -1);

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -246,7 +246,7 @@ FunctionPanel::FunctionPanel(QWidget *parent)
     , m_currentFrameStatus(0)
     , m_selection(0)
     , m_curveShape(SMOOTH) {
-  setWindowTitle(tr("Function Curves"));
+  setWindowTitle(tr("Function Curves - Use Ctrl Key to Modify Positions"));
 
   m_viewTransform.translate(50, 200);
   m_viewTransform.scale(5, -1);


### PR DESCRIPTION
This option changes the functions curves window title to "Function Curves - Use Control Key to Modify Positions".  I don't think this is as user friendly as option 1, many users don't read the title bars of windows.  (Does the title bar for this window show up on Mac?)  

But at the very least this might give users a chance to find out how to change the values.
#159