### PR TITLE
Pixels Only Mode: Fixed preset dropdown, dpi lock, labels, decimals

### DIFF
--- a/toonz/sources/include/toonzqt/camerasettingswidget.h
+++ b/toonz/sources/include/toonzqt/camerasettingswidget.h
@@ -86,6 +86,7 @@ class DVAPI CameraSettingsWidget final : public QFrame {
   QLabel *m_dpiLabel;
   QLabel *m_resLabel;
   QLabel *m_xLabel;
+  QLabel *m_unitLabel;
 
   QPushButton *m_fspChk;  // Force Squared Pixel => dpix == dpiy
 

--- a/toonz/sources/include/toonzqt/cleanupcamerasettingswidget.h
+++ b/toonz/sources/include/toonzqt/cleanupcamerasettingswidget.h
@@ -60,7 +60,7 @@ public:
   void setCameraPresetListFile(const TFilePath &fp);
 
   // CleanupParameters => CleanupCameraSettingsWidget fields
-  void setFields(const CleanupParameters *cleanupParameters);
+  void setFields(CleanupParameters *cleanupParameters);
 
   // CleanupCameraSettingsWidget fields => CleanupParameters
   void getFields(CleanupParameters *cleanupParameters);

--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -33,6 +33,7 @@
 #include "toonz/stage2.h"
 #include "toonz/txshsimplelevel.h"
 #include "toonz/txshleveltypes.h"
+#include "toonz/preferences.h"
 
 // TnzCore includes
 #include "tconvert.h"
@@ -241,6 +242,10 @@ void CameraSettingsPopup::updateFields() {
   if (!cameraObject) return;  // it should never happen
   m_nameFld->setText(QString(cameraObject->getName().c_str()));
   TCamera *camera = cameraObject->getCamera();
+  if (Preferences::instance()->getPixelsOnly()) {
+	  TDimension res = camera->getRes();
+	  camera->setSize(TDimensionD(res.lx / Stage::inch, res.ly / Stage::inch));
+  }
   if (camera) m_cameraSettingsWidget->setFields(camera);
 }
 

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -338,9 +338,13 @@ void LevelCreatePopup::showEvent(QShowEvent *) {
   if (Preferences::instance()->getUnits() == "pixel") {
     m_dpiFld->hide();
     m_dpiLabel->hide();
+    m_widthFld->setDecimals(0);
+    m_heightFld->setDecimals(0);
   } else {
     m_dpiFld->show();
     m_dpiLabel->show();
+    m_widthFld->setDecimals(4);
+    m_heightFld->setDecimals(4);
   }
 }
 

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -329,8 +329,8 @@ void LevelSettingsPopup::showEvent(QShowEvent *e) {
     m_imageDpiLabel->hide();
     m_imageDpiTitle->hide();
     m_cameraDpiTitle->hide();
-    m_imageResTitle->hide();
-    m_imageResLabel->hide();
+    m_widthFld->setDecimals(0);
+    m_heightFld->setDecimals(0);
   } else {
     m_dpiTypeOm->show();
     m_dpiLabel->show();
@@ -343,6 +343,8 @@ void LevelSettingsPopup::showEvent(QShowEvent *e) {
     m_cameraDpiTitle->show();
     m_imageResTitle->show();
     m_imageResLabel->show();
+    m_widthFld->setDecimals(4);
+    m_heightFld->setDecimals(4);
   }
 }
 

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -21,6 +21,7 @@
 #include "toonz/txshsimplelevel.h"
 #include "toonz/txshleveltypes.h"
 #include "toonz/preferences.h"
+#include "toonz/stage.h"
 
 // TnzCore includes
 #include "tconvert.h"
@@ -193,7 +194,11 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
   m_yResFld = new DVGui::IntLineEdit();
   m_xDpiFld = new DoubleLineEdit();
   m_yDpiFld = new DoubleLineEdit();
-
+  m_unitLabel = new QLabel();
+  if (Preferences::instance()->getPixelsOnly())
+	  m_unitLabel->setText("Pixels");
+  else
+	  m_unitLabel->setText(Preferences::instance()->getCameraUnits());
   m_dpiLabel = new QLabel(tr("DPI"));
   m_resLabel = new QLabel(tr("Pixels"));
   m_xLabel   = new QLabel(tr("x"));
@@ -282,8 +287,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
       gridLay->addWidget(m_yPrev, 0, 4, Qt::AlignCenter);
 
       gridLay->addWidget(m_inchPrev, 1, 0, Qt::AlignRight | Qt::AlignVCenter);
-      QString units = Preferences::instance()->getCameraUnits();
-      gridLay->addWidget(new QLabel(units), 1, 1,
+      gridLay->addWidget(m_unitLabel, 1, 1,
                          Qt::AlignRight | Qt::AlignVCenter);
       gridLay->addWidget(m_lxFld, 1, 2);
       gridLay->addWidget(new QLabel("x"), 1, 3, Qt::AlignCenter);
@@ -380,6 +384,8 @@ void CameraSettingsWidget::showEvent(QShowEvent *e) {
     m_yDpiFld->hide();
     m_fspChk->hide();
     m_dotPrev->hide();
+    m_lxFld->setDecimals(0);
+    m_lyFld->setDecimals(0);
   } else {
     m_resLabel->show();
     m_dpiLabel->show();
@@ -390,7 +396,13 @@ void CameraSettingsWidget::showEvent(QShowEvent *e) {
     m_yDpiFld->show();
     m_fspChk->show();
     m_dotPrev->show();
+    m_lxFld->setDecimals(4);
+    m_lyFld->setDecimals(4);
   }
+  if (Preferences::instance()->getPixelsOnly())
+	  m_unitLabel->setText("Pixels");
+  else
+	  m_unitLabel->setText(Preferences::instance()->getCameraUnits());
 }
 
 void CameraSettingsWidget::loadPresetList() {
@@ -662,13 +674,13 @@ void CameraSettingsWidget::computeYRes() {
 // lx,xres => xdpi
 void CameraSettingsWidget::computeXDpi() {
   if (m_lxFld->getValue() == 0.0) return;  // non dovrebbe mai succedere
-  m_xDpiFld->setValue(m_xResFld->getValue() / m_lxFld->getValue());
+	m_xDpiFld->setValue(m_xResFld->getValue() / m_lxFld->getValue());
 }
 
 // ly,yres => ydpi
 void CameraSettingsWidget::computeYDpi() {
   if (m_lyFld->getValue() == 0.0) return;  // non dovrebbe mai succedere
-  m_yDpiFld->setValue(m_yResFld->getValue() / m_lyFld->getValue());
+	m_yDpiFld->setValue(m_yResFld->getValue() / m_lyFld->getValue());
 }
 
 // set A/R field, assign m_arValue and compute a nice string representation for
@@ -747,7 +759,11 @@ void CameraSettingsWidget::onYResChanged() {
 }
 
 void CameraSettingsWidget::onXDpiChanged() {
-  if (m_fspChk->isChecked()) m_yDpiFld->setValue(m_xDpiFld->getValue());
+	if (Preferences::instance()->getPixelsOnly()) {
+		m_xDpiFld->setValue(Stage::inch);
+		m_yDpiFld->setValue(Stage::inch);
+	}
+  else if (m_fspChk->isChecked()) m_yDpiFld->setValue(m_xDpiFld->getValue());
 
   if (m_dotPrev->isChecked()) {
     vComputeLx();
@@ -765,7 +781,11 @@ void CameraSettingsWidget::onXDpiChanged() {
 }
 
 void CameraSettingsWidget::onYDpiChanged() {
-  if (m_fspChk->isChecked()) m_xDpiFld->setValue(m_yDpiFld->getValue());
+	if (Preferences::instance()->getPixelsOnly()) {
+		m_xDpiFld->setValue(Stage::inch);
+		m_yDpiFld->setValue(Stage::inch);
+	}
+	else if (m_fspChk->isChecked()) m_xDpiFld->setValue(m_yDpiFld->getValue());
 
   if (m_dotPrev->isChecked()) {
     vComputeLy();
@@ -829,6 +849,11 @@ void CameraSettingsWidget::onPresetSelected(const QString &str) {
       else
         hComputeLx();
     }
+
+	if (Preferences::instance()->getPixelsOnly()) {
+		m_lxFld->setValue(xres / Stage::inch);
+		m_lyFld->setValue(yres / Stage::inch);
+	}
 
     if (m_forCleanup && m_offsX && m_offsY && !xoffset.isEmpty() &&
         !yoffset.isEmpty()) {

--- a/toonz/sources/toonzqt/cleanupcamerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/cleanupcamerasettingswidget.cpp
@@ -3,6 +3,8 @@
 #include "toonzqt/cleanupcamerasettingswidget.h"
 #include "toonzqt/camerasettingswidget.h"
 #include "toonz/cleanupparameters.h"
+#include "toonz/preferences.h"
+#include "toonz/stage.h"
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QGridLayout>
@@ -89,7 +91,12 @@ void CleanupCameraSettingsWidget::setCameraPresetListFile(const TFilePath &fp) {
 }
 
 void CleanupCameraSettingsWidget::setFields(
-    const CleanupParameters *cleanupParameters) {
+    CleanupParameters *cleanupParameters) {
+	if (Preferences::instance()->getPixelsOnly()) {
+		TDimension res = cleanupParameters->m_camera.getRes();
+		cleanupParameters->m_camera.setSize(TDimensionD(
+			res.lx / Stage::inch, res.ly / Stage::inch));
+	}
   m_cameraWidget->setFields(&cleanupParameters->m_camera);
   m_offsX->setValue(cleanupParameters->m_offx);
   m_offsY->setValue(cleanupParameters->m_offy);


### PR DESCRIPTION
Misc fixes for pixels only mode:
- Labels now update without a restart
- Fixed resolution presets not working as expected
- Fixed issue where dpi wasn't locked at Stage::inch in camera settings
- Pixel values now don't show a decimal in all camera settings, new level, and level settings
- Restored the resolution label to level settings to make it clear that changing the width and height only scales the image- not actually resizes it. 

Level Settings screenshot:
![level_settings_pixels](https://cloud.githubusercontent.com/assets/4576381/17086327/144c8502-51ac-11e6-8231-873a50f6e0e4.jpg)


This addresses #670 
