### PR TITLE
Updated table/disc size for new default resolution

### DIFF
--- a/toonz/sources/toonz/viewerdraw.cpp
+++ b/toonz/sources/toonz/viewerdraw.cpp
@@ -765,7 +765,7 @@ unsigned int ViewerDraw::createDiskDisplayList() {
       sinCosTable[i].y = sin(ang);
     }
   }
-  double r = 10 * Stage::inch;
+  double r = 20 * Stage::inch;
   glNewList(id, GL_COMPILE);
   glColor3d(.6, .65, .7);
   glBegin(GL_POLYGON);


### PR DESCRIPTION
The drawing table/disc was totally covered by the new default resolution.  I updated it to fit.  
Here it is with default settings (1920 x 1080)
![table](https://cloud.githubusercontent.com/assets/4576381/17087025/f9120d54-51bd-11e6-927e-ee045cc31dfc.jpg)

Here it is for 1280 x 720 at the same dpi.
![table720](https://cloud.githubusercontent.com/assets/4576381/17087038/153617f0-51be-11e6-87d9-fa1ab6cb362a.jpg)

