### PR TITLE
Camera capture improvement - supporting "Show ABC Appendix to the Frame Number in Xsheet Cell" option

### DIFF
--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -34,6 +34,7 @@
 #include "toonz/tscenehandle.h"
 #include "toonz/toonzscene.h"
 #include "toonz/levelset.h"
+#include "toonz/preferences.h"
 
 // TnzCore includes
 #include "tpalette.h"
@@ -48,6 +49,46 @@
 #include <QMainWindow>
 #include <QMimeData>
 #include <QDrag>
+
+namespace {
+QString fidToFrameNumberWithLetter(int f) {
+  QString str = QString::number((int)(f / 10));
+  while (str.length() < 3) str.push_front("0");
+  switch (f % 10) {
+  case 1:
+    str.append('A');
+    break;
+  case 2:
+    str.append('B');
+    break;
+  case 3:
+    str.append('C');
+    break;
+  case 4:
+    str.append('D');
+    break;
+  case 5:
+    str.append('E');
+    break;
+  case 6:
+    str.append('F');
+    break;
+  case 7:
+    str.append('G');
+    break;
+  case 8:
+    str.append('H');
+    break;
+  case 9:
+    str.append('I');
+    break;
+  default:
+    str.append(' ');
+    break;
+  }
+  return str;
+}
+}  // namespace
 
 //=============================================================================
 // Filmstrip
@@ -538,17 +579,21 @@ void FilmstripFrames::paintEvent(QPaintEvent *evt) {
 
       p.setBrush(Qt::NoBrush);
       // for single frame
+      QString text;
       if (fid.getNumber() == TFrameId::EMPTY_FRAME ||
           fid.getNumber() == TFrameId::NO_FRAME) {
-        p.drawText(tmp_frameRect.adjusted(0, 0, -3, 2), "Single Frame",
-                   QTextOption(Qt::AlignRight | Qt::AlignBottom));
+        text = QString("Single Frame");
+      }
+      // for sequencial frame (with letter)
+      else if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
+        text = fidToFrameNumberWithLetter(fid.getNumber());
       }
       // for sequencial frame
       else {
-        p.drawText(tmp_frameRect.adjusted(0, 0, -3, 2),
-                   QString().setNum(fid.getNumber()).rightJustified(4, '0'),
-                   QTextOption(Qt::AlignRight | Qt::AlignBottom));
+        text = QString::number(fid.getNumber()).rightJustified(4, '0');
       }
+      p.drawText(tmp_frameRect.adjusted(0, 0, -3, 2), text,
+                 QTextOption(Qt::AlignRight | Qt::AlignBottom));
       p.setPen(Qt::NoPen);
 
       // Read-only frames (lock)

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -4,6 +4,7 @@
 #define PENCILTESTPOPUP_H
 
 #include "toonzqt/dvdialog.h"
+#include "toonzqt/lineedit.h"
 
 #include <QFrame>
 
@@ -18,10 +19,11 @@ class QCheckBox;
 class QPushButton;
 class QVideoFrame;
 class QTimer;
+class QIntValidator;
+class QRegExpValidator;
 
 namespace DVGui {
 class FileField;
-class IntLineEdit;
 class IntField;
 }
 
@@ -67,6 +69,37 @@ protected slots:
 };
 
 //=============================================================================
+// FrameNumberLineEdit
+// a special Line Edit which accepts imputting alphabets if the preference
+// option
+// "Show ABC Appendix to the Frame Number in Xsheet Cell" is active.
+//-----------------------------------------------------------------------------
+
+class FrameNumberLineEdit : public DVGui::LineEdit {
+  Q_OBJECT
+  /* having two validators and switch them according to the preferences*/
+  QIntValidator* m_intValidator;
+  QRegExpValidator* m_regexpValidator;
+
+  void updateValidator();
+
+public:
+  FrameNumberLineEdit(QWidget* parent = 0, int value = 1);
+  ~FrameNumberLineEdit() {}
+
+  /*! Set text in field to \b value. */
+  void setValue(int value);
+  /*! Return an integer with text field value. */
+  int getValue();
+
+protected:
+  /*! If focus is lost and current text value is out of range emit signal
+  \b editingFinished.*/
+  void focusOutEvent(QFocusEvent*) override;
+  void showEvent(QShowEvent* event) override { updateValidator(); }
+};
+
+//=============================================================================
 // PencilTestPopup
 //-----------------------------------------------------------------------------
 
@@ -85,7 +118,7 @@ class PencilTestPopup : public DVGui::Dialog {
   QPushButton *m_fileFormatOptionButton, *m_captureWhiteBGButton,
       *m_captureButton;
   DVGui::FileField* m_saveInFileFld;
-  DVGui::IntLineEdit* m_frameNumberEdit;
+  FrameNumberLineEdit* m_frameNumberEdit;
   DVGui::IntField *m_thresholdFld, *m_contrastFld, *m_brightnessFld,
       *m_bgReductionFld, *m_onionOpacityFld, *m_timerIntervalFld;
 


### PR DESCRIPTION
This PR is updates of the camera capture feature listed in #626.

- Fixed the bug that the countdown number flips when the "Upside Down" check box is active.

- Supported the preferences option "Show ABC Appendix to the Frame Number in Xsheet Cell".

With this option OpenToonz accepts an alphabet modifier after the frame number as follows:
<img src="https://cloud.githubusercontent.com/assets/17974955/17096935/929102b8-5296-11e6-9073-ec45a2b343f0.png" width=600>
Please note that it just changes the display mode for frame number. For example, the actual frame numbers stored in the first column in the above image are; 10, 20, 21, 30, 31, 32, 33, 40 and 50. Please see my comment in #626 for details.