### PR TITLE
WIP: Update Stage::inch to more practical value

### DIFF
--- a/toonz/sources/common/tunit/tunit.cpp
+++ b/toonz/sources/common/tunit/tunit.cpp
@@ -347,7 +347,7 @@ TMeasureManager::TMeasureManager() {
   m->add(cameraYFld.clone());
   add(m);
 
-  const double stage_inch = 53.33333;  // Consider changing to 120 or 160
+  const double stage_inch = 120;  // Consider changing to 120 or 160 (old value 53.33333)
 
   TUnit fxLength(L"fxLength"),
       fxInch(L"in", new TSimpleUnitConverter(1 / stage_inch)),

--- a/toonz/sources/include/toonz/tcamera.h
+++ b/toonz/sources/include/toonz/tcamera.h
@@ -39,9 +39,9 @@ class DVAPI TCamera {
 public:
   /*!
 Constructs TCamera with default value, size (12,9) and resolution (768,576).
-  Constructs TCamera with default value, size (36, 20.25) and resolution
+  Constructs TCamera with default value, size (16, 9) and resolution
 (1920,1080).
-- 05/31/16
+- 07/25/16
 */
   TCamera();
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1257,8 +1257,8 @@ bool IoCmd::saveSceneIfNeeded(QString msg) {
 void IoCmd::newScene() {
   RenderingSuspender suspender;
   TApp *app        = TApp::instance();
-  double cameraDpi = 53.33333;  // used to be 64, consider changing to 120 or
-                                // 160
+  double cameraDpi = Stage::inch;  // used to be 64, consider changing to 120 or
+                                // 160 (old = 53.33333)
   if (!saveSceneIfNeeded(QApplication::tr("New Scene"))) return;
 
   IconGenerator::instance()->clearRequests();
@@ -1281,7 +1281,6 @@ void IoCmd::newScene() {
 
   TCamera *camera = scene->getCurrentCamera();
   TDimension res(1920, 1080);
-  // TDimension res(768, 576);
   camera->setRes(res);
   camera->setSize(
       TDimensionD((double)res.lx / cameraDpi, (double)res.ly / cameraDpi));

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -27,6 +27,7 @@
 #include "toonz/tcamera.h"
 #include "toonz/levelproperties.h"
 #include "toonz/tonionskinmaskhandle.h"
+#include "toonz/stage.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -217,20 +218,20 @@ Preferences::LevelFormat PreferencesPopup::FormatProperties::levelFormat()
 void PreferencesPopup::onPixelsOnlyChanged(int index) {
   bool enabled = index == Qt::Checked;
   if (enabled) {
-    m_pref->setDefLevelDpi(53.33333);
+	  m_pref->setDefLevelDpi(Stage::inch);
     m_pref->setPixelsOnly(true);
     TCamera *camera;
     camera =
         TApp::instance()->getCurrentScene()->getScene()->getCurrentCamera();
     TDimension camRes = camera->getRes();
     TDimensionD camSize;
-    camSize.lx = camRes.lx / 53.33333;
-    camSize.ly = camRes.ly / 53.33333;
+	camSize.lx = camRes.lx / Stage::inch;
+	camSize.ly = camRes.ly / Stage::inch;
     camera->setSize(camSize);
     TDimension cleanupRes = CleanupSettingsModel::instance()->getCurrentParameters()->m_camera.getRes();
     TDimensionD cleanupSize;
-    cleanupSize.lx = cleanupRes.lx / 53.33333;
-    cleanupSize.ly = cleanupRes.ly / 53.33333;
+	cleanupSize.lx = cleanupRes.lx / Stage::inch;
+	cleanupSize.ly = cleanupRes.ly / Stage::inch;
     CleanupSettingsModel::instance()->getCurrentParameters()->m_camera.setSize(cleanupSize);
 	m_pref->storeOldUnits();
     if (m_unitOm->currentIndex() != 4) m_unitOm->setCurrentIndex(4);
@@ -238,7 +239,7 @@ void PreferencesPopup::onPixelsOnlyChanged(int index) {
     m_unitOm->setDisabled(true);
     m_cameraUnitOm->setDisabled(true);
     m_defLevelDpi->setDisabled(true);
-    m_defLevelDpi->setValue(53.33333);
+	m_defLevelDpi->setValue(Stage::inch);
     m_defLevelWidth->setMeasure("camera.lx");
     m_defLevelHeight->setMeasure("camera.ly");
     m_defLevelWidth->setValue(m_pref->getDefLevelWidth());

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -69,8 +69,8 @@ typedef std::vector<Player> PlayerSet;
    thickness of
                 images .pli.
 */
-const double Stage::inch      = 53.33333;  // consider changing to 120 or 160
-const double Stage::vectorDpi = 53.3333;
+const double Stage::inch      = 120;  // consider changing to 120 or 160
+const double Stage::vectorDpi = 53.33333;
 
 namespace {
 void updateOnionSkinSize(const PlayerSet &players) {

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -77,7 +77,7 @@ using namespace Stage;
    thickness of
                 images .pli.
 */
-// const double Stage::inch = 53.33333;
+// const double Stage::inch = 120 (old = 53.33333);
 
 //**********************************************************************************************
 //    Local namespace

--- a/toonz/sources/toonzlib/tcamera.cpp
+++ b/toonz/sources/toonzlib/tcamera.cpp
@@ -10,7 +10,7 @@
 
 TCamera::TCamera()
     //: m_size(12, 9), m_res(768, 576), m_xPrevalence(true)
-    : m_size(36, 20.25),
+    : m_size(16, 9),
       m_res(1920, 1080),
       m_xPrevalence(true) {}
 


### PR DESCRIPTION
This makes Stage::inch = 120.  (I'm fine with 160 too).
The new default level size is 16 x 9 inches (still 1920 x 1080)

@shun-iwasawa I know that Stage::inch also affects vector sizes, and should be set to Stage::vectorDpi, but I can't find where that is happening.  I have looked a long time.  It's probably something very simple, but I don't see it.