### PR TITLE
Level Settings Popup: removed name unchanged warning and set focus on other errors

### DIFF
--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -659,13 +659,13 @@ void LevelSettingsPopup::onNameChanged() {
     error("The name " + text +
           " you entered for the level is not valid.\n Please enter a different "
           "name.");
-	m_nameFld->setFocus();
+    m_nameFld->setFocus();
     return;
   }
 
   /*-- Level名に変更がない場合 --*/
   if (level->getName() == text.toStdWString()) {
-  // warning("Level name unchanged.");
+    // warning("Level name unchanged.");
     return;
   }
 
@@ -676,7 +676,7 @@ void LevelSettingsPopup::onNameChanged() {
     error("The name " + text +
           " you entered for the level is already used.\nPlease enter a "
           "different name.");
-	m_nameFld->setFocus();
+    m_nameFld->setFocus();
     return;
   }
 

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -659,14 +659,15 @@ void LevelSettingsPopup::onNameChanged() {
     error("The name " + text +
           " you entered for the level is not valid.\n Please enter a different "
           "name.");
+	m_nameFld->setFocus();
     return;
   }
 
   /*-- Level名に変更がない場合 --*/
-  if (level->getName() == text.toStdWString()) {
-    warning("Level name unchanged.");
-    return;
-  }
+  //if (level->getName() == text.toStdWString()) {
+  //  warning("Level name unchanged.");
+  //  return;
+  //}
 
   TLevelSet *levelSet =
       TApp::instance()->getCurrentScene()->getScene()->getLevelSet();
@@ -675,6 +676,7 @@ void LevelSettingsPopup::onNameChanged() {
     error("The name " + text +
           " you entered for the level is already used.\nPlease enter a "
           "different name.");
+	m_nameFld->setFocus();
     return;
   }
 

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -664,10 +664,10 @@ void LevelSettingsPopup::onNameChanged() {
   }
 
   /*-- Level名に変更がない場合 --*/
-  //if (level->getName() == text.toStdWString()) {
-  //  warning("Level name unchanged.");
-  //  return;
-  //}
+  if (level->getName() == text.toStdWString()) {
+  // warning("Level name unchanged.");
+    return;
+  }
 
   TLevelSet *levelSet =
       TApp::instance()->getCurrentScene()->getScene()->getLevelSet();


### PR DESCRIPTION
This removes the warning that the name is unchanged on the level settings popup.  Is it necessary to warn users that they left the name the same?  

It also sets the focus back to the name box for other name errors- makes it more usable.