### PR TITLE
Add Camera Capture command to full menu bar (OSX)

### DIFF
--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1171,6 +1171,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(scanCleanupMenu, MI_CameraTest);
   addMenuItem(scanCleanupMenu, MI_Cleanup);
   scanCleanupMenu->addSeparator();
+  addMenuItem(scanCleanupMenu, MI_PencilTest);
 #endif
 
   // Menu' LEVEL


### PR DESCRIPTION
This PR adds Camera Capture command to the full menu bar which is used in OSX version.