### PR TITLE
New Geometry Icon

### DIFF
--- a/toonz/sources/toonz/Resources/geometric.svg
+++ b/toonz/sources/toonz/Resources/geometric.svg
@@ -1,63 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 10.0, SVG Export Plug-In . SVG Version: 3.0.0 Build 76)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN"    "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
-	<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">
-	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
-	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
-	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
-	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
-	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
-	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
-	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
-	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
-]>
-<svg 
-	 xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" i:viewOrigin="387 312" i:rulerOrigin="0 0" i:pageBounds="0 600 800 0"
-	 xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
-	 width="26" height="26.184" viewBox="0 0 26 26.184" overflow="visible" enable-background="new 0 0 26 26.184"
-	 xml:space="preserve">
-	<metadata>
-		<variableSets  xmlns="&ns_vars;">
-			<variableSet  varSetName="binding1" locked="none">
-				<variables></variables>
-				<v:sampleDataSets  xmlns="&ns_custom;" xmlns:v="&ns_vars;"></v:sampleDataSets>
-			</variableSet>
-		</variableSets>
-		<sfw  xmlns="&ns_sfw;">
-			<slices></slices>
-			<sliceSourceBounds  y="285.816" x="387" width="26" height="26.184" bottomLeftOrigin="true"></sliceSourceBounds>
-		</sfw>
-	</metadata>
-	<g id="Layer_1" i:layer="yes" i:dimmedPercent="50" i:rgbTrio="#4F008000FFFF">
-		<path i:knockout="Off" fill="none" d="M26,26H0V0h26V26z"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
-			c0,1.28-1.037,2.318-2.316,2.318s-2.318-1.038-2.318-2.318c0-1.279,1.039-2.317,2.318-2.317S19.251,5.655,19.251,6.934z"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
-			l-5.388,14.25"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
-			l5.389,14.25"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.55,11.911
-			l2.811,11.385"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.311,12.356
-			L11.5,23.74"/>
-		<path i:knockout="Off" fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
-			M21.518,16.74c-0.907,2.747-1.431,0.541-1.431,0.541l-2.707-7.161c0,0,0.463-0.791,1.431-0.542S22.425,13.992,21.518,16.74z"/>
-		<path i:knockout="Off" fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
-			M17.833,4.594h-1.799V0.622h1.799V4.594z"/>
-		<path i:knockout="Off" fill="#E6E6E6" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.637,22.992
-			l-3.55,2.691L0.609,11.828l3.55-2.692L14.637,22.992z"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M4.584,13.598l2.127-1.616"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M6.494,16.124l2.13-1.615"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M8.404,18.649l2.13-1.614"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M10.315,21.176l2.129-1.615"/>
-		<path i:knockout="Off" fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
-			M12.427,16.74c0.906,2.747,1.431,0.541,1.431,0.541l2.707-7.161c0,0-0.463-0.791-1.431-0.542
-			C14.165,9.828,11.52,13.992,12.427,16.74z"/>
-	</g>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="26px" height="26.184px" viewBox="0 0 26 26.184" enable-background="new 0 0 26 26.184" xml:space="preserve">
+<path fill="none" d="M26,26H0V0h26V26z"/>
+<path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
+	c0,1.28-1.037,2.318-2.315,2.318s-2.317-1.038-2.317-2.318c0-1.278,1.039-2.316,2.317-2.316S19.251,5.656,19.251,6.934z"/>
+<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M21.518,16.74
+	c-0.906,2.746-1.431,0.541-1.431,0.541L17.38,10.12c0,0,0.463-0.791,1.431-0.542C19.779,9.827,22.425,13.992,21.518,16.74z"/>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="M4.584,13.598
+	l2.127-1.616"/>
+<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M12.427,16.74
+	c0.906,2.746,1.433,0.541,1.433,0.541l2.707-7.161c0,0-0.465-0.791-1.433-0.542C14.165,9.828,11.52,13.992,12.427,16.74z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="4.5313" y1="28.0315" x2="17.9706" y2="8.838" gradientTransform="matrix(1 0 0 -1 0 27.1841)">
+	<stop  offset="0" style="stop-color:#FFFFFF"/>
+	<stop  offset="0.9086" style="stop-color:#2A2A2A"/>
+	<stop  offset="1" style="stop-color:#000000"/>
+</linearGradient>
+<rect x="1.417" y="1.333" fill="url(#SVGID_1_)" stroke="#000000" stroke-miterlimit="10" width="19.667" height="14.833"/>
+<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="13.4263" y1="16.384" x2="20.3329" y2="2.829" gradientTransform="matrix(1 0 0 -1 0 27.1841)">
+	<stop  offset="0" style="stop-color:#FFFFFF"/>
+	<stop  offset="0.2361" style="stop-color:#FDFDFD"/>
+	<stop  offset="0.3728" style="stop-color:#F4F4F4"/>
+	<stop  offset="0.4841" style="stop-color:#E6E6E6"/>
+	<stop  offset="0.5818" style="stop-color:#D2D2D2"/>
+	<stop  offset="0.6706" style="stop-color:#B8B8B8"/>
+	<stop  offset="0.7529" style="stop-color:#999999"/>
+	<stop  offset="0.8303" style="stop-color:#737373"/>
+	<stop  offset="0.9037" style="stop-color:#474747"/>
+	<stop  offset="0.9716" style="stop-color:#171717"/>
+	<stop  offset="1" style="stop-color:#000000"/>
+</linearGradient>
+<circle fill="url(#SVGID_2_)" stroke="#000000" stroke-miterlimit="10" cx="16.88" cy="17.578" r="7.605"/>
+<line fill="none" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" x1="5.25" y1="23.833" x2="24.484" y2="6.417"/>
 </svg>

--- a/toonz/sources/toonz/Resources/geometric.svg
+++ b/toonz/sources/toonz/Resources/geometric.svg
@@ -1,36 +1,88 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with PhotoLine 19.90B7 (www.pl32.com) -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="26px" height="26.184px" viewBox="0 0 26 26.184" enable-background="new 0 0 26 26.184" xml:space="preserve">
-<path fill="none" d="M26,26H0V0h26V26z"/>
-<path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
-	c0,1.28-1.037,2.318-2.315,2.318s-2.317-1.038-2.317-2.318c0-1.278,1.039-2.316,2.317-2.316S19.251,5.656,19.251,6.934z"/>
-<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M21.518,16.74
-	c-0.906,2.746-1.431,0.541-1.431,0.541L17.38,10.12c0,0,0.463-0.791,1.431-0.542C19.779,9.827,22.425,13.992,21.518,16.74z"/>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="M4.584,13.598
-	l2.127-1.616"/>
-<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M12.427,16.74
-	c0.906,2.746,1.433,0.541,1.433,0.541l2.707-7.161c0,0-0.465-0.791-1.433-0.542C14.165,9.828,11.52,13.992,12.427,16.74z"/>
-<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="4.5313" y1="28.0315" x2="17.9706" y2="8.838" gradientTransform="matrix(1 0 0 -1 0 27.1841)">
-	<stop  offset="0" style="stop-color:#FFFFFF"/>
-	<stop  offset="0.9086" style="stop-color:#2A2A2A"/>
-	<stop  offset="1" style="stop-color:#000000"/>
-</linearGradient>
-<rect x="1.417" y="1.333" fill="url(#SVGID_1_)" stroke="#000000" stroke-miterlimit="10" width="19.667" height="14.833"/>
-<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="13.4263" y1="16.384" x2="20.3329" y2="2.829" gradientTransform="matrix(1 0 0 -1 0 27.1841)">
-	<stop  offset="0" style="stop-color:#FFFFFF"/>
-	<stop  offset="0.2361" style="stop-color:#FDFDFD"/>
-	<stop  offset="0.3728" style="stop-color:#F4F4F4"/>
-	<stop  offset="0.4841" style="stop-color:#E6E6E6"/>
-	<stop  offset="0.5818" style="stop-color:#D2D2D2"/>
-	<stop  offset="0.6706" style="stop-color:#B8B8B8"/>
-	<stop  offset="0.7529" style="stop-color:#999999"/>
-	<stop  offset="0.8303" style="stop-color:#737373"/>
-	<stop  offset="0.9037" style="stop-color:#474747"/>
-	<stop  offset="0.9716" style="stop-color:#171717"/>
-	<stop  offset="1" style="stop-color:#000000"/>
-</linearGradient>
-<circle fill="url(#SVGID_2_)" stroke="#000000" stroke-miterlimit="10" cx="16.88" cy="17.578" r="7.605"/>
-<line fill="none" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" x1="5.25" y1="23.833" x2="24.484" y2="6.417"/>
+<svg width="26" height="26" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="grad0" x1="5.81" y1="1.67" x2="14.9" y2="18.65" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 1.01 -0 -0.02)">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.04" stop-color="#f3f3f3"/>
+      <stop offset="0.08" stop-color="#e7e7e7"/>
+      <stop offset="0.13" stop-color="#dadada"/>
+      <stop offset="0.17" stop-color="#cecece"/>
+      <stop offset="0.22" stop-color="#c1c1c1"/>
+      <stop offset="0.26" stop-color="#b4b4b4"/>
+      <stop offset="0.31" stop-color="#a7a7a7"/>
+      <stop offset="0.36" stop-color="#9b9b9b"/>
+      <stop offset="0.4" stop-color="#8e8e8e"/>
+      <stop offset="0.45" stop-color="#818181"/>
+      <stop offset="0.5" stop-color="#737373"/>
+      <stop offset="0.55" stop-color="#666666"/>
+      <stop offset="0.61" stop-color="#595959"/>
+      <stop offset="0.66" stop-color="#4b4b4b"/>
+      <stop offset="0.71" stop-color="#3d3d3d"/>
+      <stop offset="0.77" stop-color="#2f2f2f"/>
+      <stop offset="0.82" stop-color="#212121"/>
+      <stop offset="0.88" stop-color="#121212"/>
+      <stop offset="0.94" stop-color="#040404"/>
+      <stop offset="1" stop-color="#000000"/>
+    </linearGradient>
+    <linearGradient id="grad1" x1="16" y1="7.34" x2="21.37" y2="18.53" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 1.01 0 0.01)">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.15" stop-color="#f3f3f3"/>
+      <stop offset="0.27" stop-color="#e7e7e7"/>
+      <stop offset="0.38" stop-color="#dadada"/>
+      <stop offset="0.46" stop-color="#cecece"/>
+      <stop offset="0.53" stop-color="#c1c1c1"/>
+      <stop offset="0.59" stop-color="#b4b4b4"/>
+      <stop offset="0.65" stop-color="#a8a7a7"/>
+      <stop offset="0.69" stop-color="#9b9b9a"/>
+      <stop offset="0.74" stop-color="#8e8e8e"/>
+      <stop offset="0.77" stop-color="#818181"/>
+      <stop offset="0.81" stop-color="#737373"/>
+      <stop offset="0.84" stop-color="#666666"/>
+      <stop offset="0.86" stop-color="#595959"/>
+      <stop offset="0.89" stop-color="#4b4b4b"/>
+      <stop offset="0.91" stop-color="#3d3d3d"/>
+      <stop offset="0.93" stop-color="#2f2f2f"/>
+      <stop offset="0.95" stop-color="#212121"/>
+      <stop offset="0.97" stop-color="#121212"/>
+      <stop offset="0.98" stop-color="#040404"/>
+      <stop offset="1" stop-color="#000000"/>
+    </linearGradient>
+    <linearGradient id="grad2" x1="5.78" y1="16.5" x2="9.97" y2="27.16" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.09" stop-color="#f3f3f3"/>
+      <stop offset="0.18" stop-color="#e7e7e7"/>
+      <stop offset="0.26" stop-color="#dadada"/>
+      <stop offset="0.33" stop-color="#cecece"/>
+      <stop offset="0.4" stop-color="#c1c1c1"/>
+      <stop offset="0.46" stop-color="#b4b4b4"/>
+      <stop offset="0.51" stop-color="#a7a7a7"/>
+      <stop offset="0.57" stop-color="#9b9b9a"/>
+      <stop offset="0.62" stop-color="#8e8e8e"/>
+      <stop offset="0.66" stop-color="#818080"/>
+      <stop offset="0.71" stop-color="#737373"/>
+      <stop offset="0.75" stop-color="#666666"/>
+      <stop offset="0.78" stop-color="#595959"/>
+      <stop offset="0.82" stop-color="#4b4b4b"/>
+      <stop offset="0.85" stop-color="#3d3d3d"/>
+      <stop offset="0.89" stop-color="#2f2f2f"/>
+      <stop offset="0.92" stop-color="#212121"/>
+      <stop offset="0.95" stop-color="#121212"/>
+      <stop offset="0.97" stop-color="#040404"/>
+      <stop offset="1" stop-color="#000000"/>
+    </linearGradient>
+  </defs>
+  <g transform="matrix(0.862817 0 0 0.884851 2.477389 2.420494)">
+    <path transform="matrix(1.15898 0 0 1.122184 -2.871267 -2.716264)" stroke-miterlimit="10" fill="url(#grad0)" stroke="#000000" d="M3.7 3.61 L17 3.61 L17 16.83 L3.7 16.83 Z"/>
+  </g>
+  <g transform="matrix(0.777079 0 0 0.825974 5.566967 -1.58175)">
+    <path transform="matrix(1.286865 0 0 1.202187 -7.163997 1.901564)" stroke-miterlimit="10" fill="url(#grad1)" stroke="#000000" d="M12.77 13.04 C12.77 9.55 15.42 6.71 18.68 6.71 C21.94 6.71 24.59 9.55 24.59 13.04 C24.59 16.53 21.94 19.37 18.68 19.37 C15.42 19.37 12.77 16.53 12.77 13.04 Z"/>
+  </g>
+  <g id="Polygon" transform="matrix(-1 0 -0 -1 19.609518 29.303133)">
+    <path transform="matrix(-1 -0 0 -1 19.609516 29.303134)" stroke-miterlimit="10" fill="url(#grad2)" fill-rule="evenodd" stroke="#000000" d="M7.79 12.4 L1.15 23.41 L14.46 23.39 Z"/>
+  </g>
+  <g transform="matrix(0.457561 0.411204 -0.408314 0.454346 13.388488 23.659553)">
+    <path transform="matrix(1.209037 -1.086542 1.086543 1.209036 -41.894172 -14.058144)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" stroke="#080808" d="M5.99 36.72 L21.95 36.66"/>
+  </g>
 </svg>

--- a/toonz/sources/toonz/Resources/geometric_old.svg
+++ b/toonz/sources/toonz/Resources/geometric_old.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 10.0, SVG Export Plug-In . SVG Version: 3.0.0 Build 76)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN"    "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+	<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+]>
+<svg 
+	 xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" i:viewOrigin="387 312" i:rulerOrigin="0 0" i:pageBounds="0 600 800 0"
+	 xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
+	 width="26" height="26.184" viewBox="0 0 26 26.184" overflow="visible" enable-background="new 0 0 26 26.184"
+	 xml:space="preserve">
+	<metadata>
+		<variableSets  xmlns="&ns_vars;">
+			<variableSet  varSetName="binding1" locked="none">
+				<variables></variables>
+				<v:sampleDataSets  xmlns="&ns_custom;" xmlns:v="&ns_vars;"></v:sampleDataSets>
+			</variableSet>
+		</variableSets>
+		<sfw  xmlns="&ns_sfw;">
+			<slices></slices>
+			<sliceSourceBounds  y="285.816" x="387" width="26" height="26.184" bottomLeftOrigin="true"></sliceSourceBounds>
+		</sfw>
+	</metadata>
+	<g id="Layer_1" i:layer="yes" i:dimmedPercent="50" i:rgbTrio="#4F008000FFFF">
+		<path i:knockout="Off" fill="none" d="M26,26H0V0h26V26z"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
+			c0,1.28-1.037,2.318-2.316,2.318s-2.318-1.038-2.318-2.318c0-1.279,1.039-2.317,2.318-2.317S19.251,5.655,19.251,6.934z"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
+			l-5.388,14.25"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
+			l5.389,14.25"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.55,11.911
+			l2.811,11.385"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.311,12.356
+			L11.5,23.74"/>
+		<path i:knockout="Off" fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
+			M21.518,16.74c-0.907,2.747-1.431,0.541-1.431,0.541l-2.707-7.161c0,0,0.463-0.791,1.431-0.542S22.425,13.992,21.518,16.74z"/>
+		<path i:knockout="Off" fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
+			M17.833,4.594h-1.799V0.622h1.799V4.594z"/>
+		<path i:knockout="Off" fill="#E6E6E6" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.637,22.992
+			l-3.55,2.691L0.609,11.828l3.55-2.692L14.637,22.992z"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M4.584,13.598l2.127-1.616"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M6.494,16.124l2.13-1.615"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M8.404,18.649l2.13-1.614"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M10.315,21.176l2.129-1.615"/>
+		<path i:knockout="Off" fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
+			M12.427,16.74c0.906,2.747,1.431,0.541,1.431,0.541l2.707-7.161c0,0-0.463-0.791-1.431-0.542
+			C14.165,9.828,11.52,13.992,12.427,16.74z"/>
+	</g>
+</svg>

--- a/toonz/sources/toonz/Resources/geometric_rollover.svg
+++ b/toonz/sources/toonz/Resources/geometric_rollover.svg
@@ -1,63 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 10.0, SVG Export Plug-In . SVG Version: 3.0.0 Build 76)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN"    "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
-	<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">
-	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
-	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
-	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
-	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
-	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
-	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
-	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
-	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
-	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
-	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
-]>
-<svg 
-	 xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" i:viewOrigin="387 312" i:rulerOrigin="0 0" i:pageBounds="0 600 800 0"
-	 xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
-	 width="26" height="26.184" viewBox="0 0 26 26.184" overflow="visible" enable-background="new 0 0 26 26.184"
-	 xml:space="preserve">
-	<metadata>
-		<variableSets  xmlns="&ns_vars;">
-			<variableSet  varSetName="binding1" locked="none">
-				<variables></variables>
-				<v:sampleDataSets  xmlns="&ns_custom;" xmlns:v="&ns_vars;"></v:sampleDataSets>
-			</variableSet>
-		</variableSets>
-		<sfw  xmlns="&ns_sfw;">
-			<slices></slices>
-			<sliceSourceBounds  y="285.816" x="387" width="26" height="26.184" bottomLeftOrigin="true"></sliceSourceBounds>
-		</sfw>
-	</metadata>
-	<g id="Layer_1" i:layer="yes" i:dimmedPercent="50" i:rgbTrio="#4F008000FFFF">
-		<path i:knockout="Off" fill="none" d="M26,26H0V0h26V26z"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.55,11.911
-			l2.811,11.385"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.311,12.356
-			L11.5,23.74"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
-			c0,1.28-1.037,2.318-2.316,2.318s-2.318-1.038-2.318-2.318c0-1.279,1.039-2.317,2.318-2.317S19.251,5.655,19.251,6.934z"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
-			l-5.388,14.25"/>
-		<path i:knockout="Off" fill="#4479B3" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
-			M12.427,16.74c0.906,2.747,1.431,0.541,1.431,0.541l2.707-7.161c0,0-0.463-0.791-1.431-0.542
-			C14.165,9.828,11.52,13.992,12.427,16.74z"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
-			l5.389,14.25"/>
-		<path i:knockout="Off" fill="#4479B3" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
-			M21.518,16.74c-0.907,2.747-1.431,0.541-1.431,0.541l-2.707-7.161c0,0,0.463-0.791,1.431-0.542S22.425,13.992,21.518,16.74z"/>
-		<path i:knockout="Off" fill="#4479B3" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
-			M17.833,4.594h-1.799V0.622h1.799V4.594z"/>
-		<path i:knockout="Off" fill="#A9E6FF" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.637,22.992
-			l-3.55,2.691L0.609,11.828l3.55-2.692L14.637,22.992z"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M4.584,13.598l2.127-1.616"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M6.494,16.124l2.13-1.615"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M8.404,18.649l2.13-1.614"/>
-		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
-			M10.315,21.176l2.129-1.615"/>
-	</g>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="26px" height="26.184px" viewBox="0 0 26 26.184" enable-background="new 0 0 26 26.184" xml:space="preserve">
+<path fill="none" d="M26,26H0V0h26V26z"/>
+<path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
+	c0,1.28-1.037,2.318-2.316,2.318c-1.278,0-2.317-1.038-2.317-2.318c0-1.279,1.039-2.317,2.317-2.317
+	C18.214,4.617,19.251,5.655,19.251,6.934z"/>
+<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M21.518,16.74
+	c-0.906,2.747-1.431,0.541-1.431,0.541L17.38,10.12c0,0,0.463-0.791,1.431-0.542C19.779,9.827,22.425,13.992,21.518,16.74z"/>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="M4.584,13.598
+	l2.127-1.616"/>
+<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M12.427,16.74
+	c0.906,2.747,1.432,0.541,1.432,0.541l2.707-7.161c0,0-0.464-0.791-1.432-0.542C14.165,9.828,11.52,13.992,12.427,16.74z"/>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="4.0391" y1="3.7622" x2="20.214" y2="14.9497">
+	<stop  offset="0" style="stop-color:#FFFFFF"/>
+	<stop  offset="0.0725" style="stop-color:#FCD0D0"/>
+	<stop  offset="0.1534" style="stop-color:#FAA3A3"/>
+	<stop  offset="0.24" style="stop-color:#F87B7B"/>
+	<stop  offset="0.3312" style="stop-color:#F65A5A"/>
+	<stop  offset="0.4283" style="stop-color:#F53E3E"/>
+	<stop  offset="0.5332" style="stop-color:#F32929"/>
+	<stop  offset="0.6498" style="stop-color:#F31A1A"/>
+	<stop  offset="0.7877" style="stop-color:#F21212"/>
+	<stop  offset="1" style="stop-color:#F20F0F"/>
+</linearGradient>
+<rect x="1.417" y="1.333" fill="url(#SVGID_1_)" stroke="#000000" stroke-miterlimit="10" width="19.667" height="14.833"/>
+<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="13.1982" y1="12.085" x2="21.7404" y2="24.8303">
+	<stop  offset="0.0727" style="stop-color:#FFF100"/>
+	<stop  offset="0.2133" style="stop-color:#FCEE00"/>
+	<stop  offset="0.333" style="stop-color:#F1E400"/>
+	<stop  offset="0.4451" style="stop-color:#E0D300"/>
+	<stop  offset="0.5525" style="stop-color:#C7BC00"/>
+	<stop  offset="0.6566" style="stop-color:#A79E00"/>
+	<stop  offset="0.7583" style="stop-color:#7F7800"/>
+	<stop  offset="0.858" style="stop-color:#514C00"/>
+	<stop  offset="0.9537" style="stop-color:#1C1B00"/>
+	<stop  offset="1" style="stop-color:#000000"/>
+</linearGradient>
+<circle fill="url(#SVGID_2_)" stroke="#000000" stroke-miterlimit="10" cx="16.88" cy="17.578" r="7.605"/>
+<line fill="none" stroke="#001CBF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="5.25" y1="23.833" x2="24.485" y2="6.417"/>
 </svg>

--- a/toonz/sources/toonz/Resources/geometric_rollover.svg
+++ b/toonz/sources/toonz/Resources/geometric_rollover.svg
@@ -1,43 +1,88 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with PhotoLine 19.90B7 (www.pl32.com) -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="26px" height="26.184px" viewBox="0 0 26 26.184" enable-background="new 0 0 26 26.184" xml:space="preserve">
-<path fill="none" d="M26,26H0V0h26V26z"/>
-<path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
-	c0,1.28-1.037,2.318-2.316,2.318c-1.278,0-2.317-1.038-2.317-2.318c0-1.279,1.039-2.317,2.317-2.317
-	C18.214,4.617,19.251,5.655,19.251,6.934z"/>
-<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M21.518,16.74
-	c-0.906,2.747-1.431,0.541-1.431,0.541L17.38,10.12c0,0,0.463-0.791,1.431-0.542C19.779,9.827,22.425,13.992,21.518,16.74z"/>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="M4.584,13.598
-	l2.127-1.616"/>
-<path fill="#999999" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="M12.427,16.74
-	c0.906,2.747,1.432,0.541,1.432,0.541l2.707-7.161c0,0-0.464-0.791-1.432-0.542C14.165,9.828,11.52,13.992,12.427,16.74z"/>
-<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="4.0391" y1="3.7622" x2="20.214" y2="14.9497">
-	<stop  offset="0" style="stop-color:#FFFFFF"/>
-	<stop  offset="0.0725" style="stop-color:#FCD0D0"/>
-	<stop  offset="0.1534" style="stop-color:#FAA3A3"/>
-	<stop  offset="0.24" style="stop-color:#F87B7B"/>
-	<stop  offset="0.3312" style="stop-color:#F65A5A"/>
-	<stop  offset="0.4283" style="stop-color:#F53E3E"/>
-	<stop  offset="0.5332" style="stop-color:#F32929"/>
-	<stop  offset="0.6498" style="stop-color:#F31A1A"/>
-	<stop  offset="0.7877" style="stop-color:#F21212"/>
-	<stop  offset="1" style="stop-color:#F20F0F"/>
-</linearGradient>
-<rect x="1.417" y="1.333" fill="url(#SVGID_1_)" stroke="#000000" stroke-miterlimit="10" width="19.667" height="14.833"/>
-<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="13.1982" y1="12.085" x2="21.7404" y2="24.8303">
-	<stop  offset="0.0727" style="stop-color:#FFF100"/>
-	<stop  offset="0.2133" style="stop-color:#FCEE00"/>
-	<stop  offset="0.333" style="stop-color:#F1E400"/>
-	<stop  offset="0.4451" style="stop-color:#E0D300"/>
-	<stop  offset="0.5525" style="stop-color:#C7BC00"/>
-	<stop  offset="0.6566" style="stop-color:#A79E00"/>
-	<stop  offset="0.7583" style="stop-color:#7F7800"/>
-	<stop  offset="0.858" style="stop-color:#514C00"/>
-	<stop  offset="0.9537" style="stop-color:#1C1B00"/>
-	<stop  offset="1" style="stop-color:#000000"/>
-</linearGradient>
-<circle fill="url(#SVGID_2_)" stroke="#000000" stroke-miterlimit="10" cx="16.88" cy="17.578" r="7.605"/>
-<line fill="none" stroke="#001CBF" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" x1="5.25" y1="23.833" x2="24.485" y2="6.417"/>
+<svg width="26" height="26" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="grad0" x1="5.79" y1="1.16" x2="12.75" y2="15.65" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 1.01 -0 -0.01)">
+      <stop offset="0" stop-color="#f5785b"/>
+      <stop offset="0.1" stop-color="#e97156"/>
+      <stop offset="0.19" stop-color="#dd6b51"/>
+      <stop offset="0.27" stop-color="#d1654d"/>
+      <stop offset="0.34" stop-color="#c55f48"/>
+      <stop offset="0.41" stop-color="#b95943"/>
+      <stop offset="0.47" stop-color="#ad523e"/>
+      <stop offset="0.53" stop-color="#a04c39"/>
+      <stop offset="0.58" stop-color="#944534"/>
+      <stop offset="0.63" stop-color="#873f2f"/>
+      <stop offset="0.67" stop-color="#7b3829"/>
+      <stop offset="0.72" stop-color="#6e3224"/>
+      <stop offset="0.76" stop-color="#612c1f"/>
+      <stop offset="0.79" stop-color="#55251a"/>
+      <stop offset="0.83" stop-color="#481f14"/>
+      <stop offset="0.86" stop-color="#3a180f"/>
+      <stop offset="0.89" stop-color="#2d110a"/>
+      <stop offset="0.92" stop-color="#1f0a05"/>
+      <stop offset="0.95" stop-color="#110302"/>
+      <stop offset="0.98" stop-color="#040100"/>
+      <stop offset="1" stop-color="#000000"/>
+    </linearGradient>
+    <linearGradient id="grad1" x1="16" y1="7.34" x2="21.37" y2="18.53" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 1.01 0 0.01)">
+      <stop offset="0" stop-color="#fdf6d8"/>
+      <stop offset="0.15" stop-color="#f9f2d0"/>
+      <stop offset="0.27" stop-color="#f5eec9"/>
+      <stop offset="0.38" stop-color="#f1e9c1"/>
+      <stop offset="0.46" stop-color="#ede5b9"/>
+      <stop offset="0.53" stop-color="#e9e1b1"/>
+      <stop offset="0.59" stop-color="#e5dcaa"/>
+      <stop offset="0.65" stop-color="#e1d8a2"/>
+      <stop offset="0.69" stop-color="#ddd39a"/>
+      <stop offset="0.74" stop-color="#d9cf92"/>
+      <stop offset="0.77" stop-color="#d5ca8a"/>
+      <stop offset="0.81" stop-color="#d1c683"/>
+      <stop offset="0.84" stop-color="#cdc17b"/>
+      <stop offset="0.86" stop-color="#c9bd73"/>
+      <stop offset="0.89" stop-color="#c5b96b"/>
+      <stop offset="0.91" stop-color="#c2b463"/>
+      <stop offset="0.93" stop-color="#beaf5b"/>
+      <stop offset="0.95" stop-color="#baab53"/>
+      <stop offset="0.97" stop-color="#b6a64b"/>
+      <stop offset="0.98" stop-color="#b2a244"/>
+      <stop offset="1" stop-color="#ae9d3c"/>
+    </linearGradient>
+    <linearGradient id="grad2" x1="5.78" y1="16.5" x2="9.97" y2="27.16" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="0.09" stop-color="#f9f3fe"/>
+      <stop offset="0.18" stop-color="#f3e7fd"/>
+      <stop offset="0.26" stop-color="#eddafc"/>
+      <stop offset="0.33" stop-color="#e7cdfa"/>
+      <stop offset="0.4" stop-color="#e1c1f9"/>
+      <stop offset="0.46" stop-color="#dbb4f8"/>
+      <stop offset="0.51" stop-color="#d4a6f7"/>
+      <stop offset="0.57" stop-color="#ce99f6"/>
+      <stop offset="0.62" stop-color="#c88bf5"/>
+      <stop offset="0.66" stop-color="#c27df4"/>
+      <stop offset="0.71" stop-color="#bc6ef3"/>
+      <stop offset="0.75" stop-color="#b65ff1"/>
+      <stop offset="0.78" stop-color="#b04ef0"/>
+      <stop offset="0.82" stop-color="#aa3bef"/>
+      <stop offset="0.85" stop-color="#a422ee"/>
+      <stop offset="0.89" stop-color="#9e10ed"/>
+      <stop offset="0.92" stop-color="#9800ed"/>
+      <stop offset="0.95" stop-color="#9200ec"/>
+      <stop offset="0.97" stop-color="#8d00eb"/>
+      <stop offset="1" stop-color="#8700ea"/>
+    </linearGradient>
+  </defs>
+  <g transform="matrix(0.862817 0 0 0.884851 2.460168 1.914259)">
+    <path transform="matrix(1.15898 0 0 1.122184 -2.851308 -2.148173)" stroke-miterlimit="10" fill="url(#grad0)" stroke="#000000" d="M3.68 3.1 L16.98 3.1 L16.98 16.32 L3.68 16.32 Z"/>
+  </g>
+  <g transform="matrix(0.777079 0 0 0.825974 5.566967 -1.58175)">
+    <path transform="matrix(1.286865 0 0 1.202187 -7.163997 1.901564)" stroke-miterlimit="10" fill="url(#grad1)" stroke="#000000" d="M12.77 13.04 C12.77 9.55 15.42 6.71 18.68 6.71 C21.94 6.71 24.59 9.55 24.59 13.04 C24.59 16.53 21.94 19.37 18.68 19.37 C15.42 19.37 12.77 16.53 12.77 13.04 Z"/>
+  </g>
+  <g id="Polygon" transform="matrix(-1 0 -0 -1 19.609518 29.303133)">
+    <path transform="matrix(-1 -0 0 -1 19.609516 29.303134)" stroke-miterlimit="10" fill="url(#grad2)" fill-rule="evenodd" stroke="#000000" d="M7.79 12.4 L1.15 23.41 L14.46 23.39 Z"/>
+  </g>
+  <g transform="matrix(0.457561 0.411204 -0.408314 0.454346 13.388488 23.659553)">
+    <path transform="matrix(1.209037 -1.086542 1.086543 1.209036 -41.894172 -14.058144)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" stroke="#080808" d="M5.99 36.72 L21.95 36.66"/>
+  </g>
 </svg>

--- a/toonz/sources/toonz/Resources/geometric_rollover_old.svg
+++ b/toonz/sources/toonz/Resources/geometric_rollover_old.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 10.0, SVG Export Plug-In . SVG Version: 3.0.0 Build 76)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN"    "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+	<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+	<!ENTITY ns_svg "http://www.w3.org/2000/svg">
+	<!ENTITY ns_xlink "http://www.w3.org/1999/xlink">
+]>
+<svg 
+	 xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" i:viewOrigin="387 312" i:rulerOrigin="0 0" i:pageBounds="0 600 800 0"
+	 xmlns="&ns_svg;" xmlns:xlink="&ns_xlink;" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
+	 width="26" height="26.184" viewBox="0 0 26 26.184" overflow="visible" enable-background="new 0 0 26 26.184"
+	 xml:space="preserve">
+	<metadata>
+		<variableSets  xmlns="&ns_vars;">
+			<variableSet  varSetName="binding1" locked="none">
+				<variables></variables>
+				<v:sampleDataSets  xmlns="&ns_custom;" xmlns:v="&ns_vars;"></v:sampleDataSets>
+			</variableSet>
+		</variableSets>
+		<sfw  xmlns="&ns_sfw;">
+			<slices></slices>
+			<sliceSourceBounds  y="285.816" x="387" width="26" height="26.184" bottomLeftOrigin="true"></sliceSourceBounds>
+		</sfw>
+	</metadata>
+	<g id="Layer_1" i:layer="yes" i:dimmedPercent="50" i:rgbTrio="#4F008000FFFF">
+		<path i:knockout="Off" fill="none" d="M26,26H0V0h26V26z"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.55,11.911
+			l2.811,11.385"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.311,12.356
+			L11.5,23.74"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M19.251,6.934
+			c0,1.28-1.037,2.318-2.316,2.318s-2.318-1.038-2.318-2.318c0-1.279,1.039-2.317,2.318-2.317S19.251,5.655,19.251,6.934z"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
+			l-5.388,14.25"/>
+		<path i:knockout="Off" fill="#4479B3" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
+			M12.427,16.74c0.906,2.747,1.431,0.541,1.431,0.541l2.707-7.161c0,0-0.463-0.791-1.431-0.542
+			C14.165,9.828,11.52,13.992,12.427,16.74z"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M16.972,9.046
+			l5.389,14.25"/>
+		<path i:knockout="Off" fill="#4479B3" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
+			M21.518,16.74c-0.907,2.747-1.431,0.541-1.431,0.541l-2.707-7.161c0,0,0.463-0.791,1.431-0.542S22.425,13.992,21.518,16.74z"/>
+		<path i:knockout="Off" fill="#4479B3" stroke="#000000" stroke-width="0.5" stroke-linecap="round" stroke-linejoin="round" d="
+			M17.833,4.594h-1.799V0.622h1.799V4.594z"/>
+		<path i:knockout="Off" fill="#A9E6FF" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" d="M14.637,22.992
+			l-3.55,2.691L0.609,11.828l3.55-2.692L14.637,22.992z"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M4.584,13.598l2.127-1.616"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M6.494,16.124l2.13-1.615"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M8.404,18.649l2.13-1.614"/>
+		<path i:knockout="Off" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round" d="
+			M10.315,21.176l2.129-1.615"/>
+	</g>
+</svg>


### PR DESCRIPTION
Replaces the old icon that didn't actually show what the tool did.

Open to suggestions/submissions.  Bring on the art.

![geom_rollover](https://cloud.githubusercontent.com/assets/4576381/17454804/fd38bc96-5b60-11e6-8798-c3ba4fda4d73.jpg)

![geom_noroll](https://cloud.githubusercontent.com/assets/4576381/17454806/00c61192-5b61-11e6-8136-36266008f5c3.jpg)


Would it be better without the line? I wanted to show what the tool does, but the line is not quite right.