### PR TITLE
Improvement of direct inputting feature in Xsheet

### DIFF
--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -8,6 +8,7 @@
 #include <set>
 
 class TimeStretchPopup;
+class TXshCell;
 
 //=============================================================================
 // TCellSelection
@@ -97,6 +98,8 @@ public:
   void reframe2Cells() { reframeCells(2); }
   void reframe3Cells() { reframeCells(3); }
   void reframe4Cells() { reframeCells(4); }
+
+  void renameCells(TXshCell &cell);
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -1567,3 +1567,14 @@ TRectD TXsheet::getBBox(int r) const {
 
   return bbox;
 }
+
+//-----------------------------------------------------------------------
+
+bool TXsheet::isRectEmpty(int r0, int c0, int r1, int c1) const {
+  for (int r = r0; r <= r1; r++) {
+    for (int c = c0; c <= c1; c++) {
+      if (!getCell(r, c).isEmpty()) return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
This PR is to improve the feature for defining animation level directly in xsheet cell. ( Issue #721 ) 

- For now all the selected cells are input at a time. In order to use this feature, press shift key on double-clicking the cell in order to avoid releasing the cell selection.
- When inputting number into the empty cell, if the next upper cell is empty, search upper cells and use the nearest level.
- Enabled to type '0' which makes the target cell empty.