### PR TITLE
Add format string literal

### DIFF
--- a/toonz/sources/common/tsystem/tsystempd.cpp
+++ b/toonz/sources/common/tsystem/tsystempd.cpp
@@ -136,7 +136,7 @@ void TSystem::outputDebug(string s) {
   cerr << s << endl;
 #endif
 #else
-  qDebug(s.c_str());
+  qDebug("%s", s.c_str());
 #endif
 }
 

--- a/toonz/sources/toonzfarm/tfarm/tlog.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tlog.cpp
@@ -91,7 +91,7 @@ void notify(LEVEL level, const QString &msg) {
 
 #else
   std::string str = msg.toStdString();
-  syslog(Level2XPriority(level), str.c_str());
+  syslog(Level2XPriority(level), "%s", str.c_str());
 #endif
 }
 

--- a/toonz/sources/toonzlib/tlog.cpp
+++ b/toonz/sources/toonzlib/tlog.cpp
@@ -92,7 +92,7 @@ void notify(LEVEL level, const std::string &msg) {
   DeregisterEventSource(handle);
 
 #else
-  syslog(Level2XPriority(level), msg.c_str());
+  syslog(Level2XPriority(level), "%s", msg.c_str());
 #endif
 }
 


### PR DESCRIPTION
Prevents security issues when the string contains
format specifiers.
Fixes: warning: format not a string literal and
no format arguments [-Wformat-security]