### PR TITLE
Remove Are You Sure? when closing without unsaved content.

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1225,17 +1225,17 @@ bool IoCmd::saveSceneIfNeeded(QString msg) {
 
     //--- If both the level and scene is clean, then open the quit confirmation
     // dialog
-    if (!isLevelOrSceneIsDirty && msg == "Quit") {
-      QString question("Are you sure ?");
-      int ret =
-          DVGui::MsgBox(question, QObject::tr("OK"), QObject::tr("Cancel"), 0);
-      if (ret == 0 || ret == 2) {
-        // cancel (or closed message box window)
-        return false;
-      } else if (ret == 1) {
-        // ok
-      }
-    }
+    //if (!isLevelOrSceneIsDirty && msg == "Quit") {
+    //  QString question("Are you sure ?");
+    //  int ret =
+    //      DVGui::MsgBox(question, QObject::tr("OK"), QObject::tr("Cancel"), 0);
+    //  if (ret == 0 || ret == 2) {
+    //    // cancel (or closed message box window)
+    //    return false;
+    //  } else if (ret == 1) {
+    //    // ok
+    //  }
+    //}
 
     RenderingSuspender suspender;
 


### PR DESCRIPTION
If there is a good reason to ask "Are you sure?" when closing, I don't mind closing this, but I can't think of any other software that asks this when there is nothing to save.
