### PR TITLE
Fix for gif reader not getting all frames

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -399,6 +399,26 @@ void Ffmpeg::getFramesFromMovie(int frame) {
   }
 }
 
+int Ffmpeg::getGifFrameCount() {
+  int frame               = 1;
+  QString ffmpegCachePath = getFfmpegCache().getQString();
+  QString tempPath        = ffmpegCachePath + "//" +
+                     QString::fromStdString(m_path.getName()) +
+                     QString::fromStdString(m_path.getType());
+  std::string tmpPath = tempPath.toStdString();
+  QString tempName    = "In%04d." + m_intermediateFormat;
+  tempName            = tempPath + tempName;
+  QString tempStart;
+  tempStart = "In0001." + m_intermediateFormat;
+  tempStart = tempPath + tempStart;
+  while (TSystem::doesExistFileOrLevel(TFilePath(tempStart))) {
+    frame++;
+    QString number = QString("%1").arg(frame, 4, 10, QChar('0'));
+    tempStart      = tempPath + "In" + number + "." + m_intermediateFormat;
+  }
+  return frame - 1;
+}
+
 void Ffmpeg::addToCleanUp(QString path) {
   if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
     m_cleanUpList.push_back(path);

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -41,6 +41,7 @@ public:
   TFilePath getFfmpegCache();
   ffmpegFileInfo getInfo();
   void disablePrecompute();
+  int getGifFrameCount();
 
 private:
   QString m_intermediateFormat, m_ffmpegPath, m_audioPath, m_audioFormat;

--- a/toonz/sources/image/ffmpeg/tiio_gif.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_gif.cpp
@@ -190,7 +190,7 @@ TLevelReaderGif::TLevelReaderGif(const TFilePath &path)
   m_ly                    = m_size.ly;
 
   ffmpegReader->getFramesFromMovie();
-
+  m_frameCount = ffmpegReader->getGifFrameCount();
   // set values
   m_info                   = new TImageInfo();
   m_info->m_frameRate      = fps;


### PR DESCRIPTION
Ffprobe was not returning the correct value for gif number of frames.  This counts the number of frames made from the conversion to png and sets that as the number of frames.

Found this error when I was playing with spritesheet generation.