### PR TITLE
Allow to reset rooms without restarting

### DIFF
--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -67,8 +67,11 @@ class MainWindow final : public QMainWindow {
   Q_OBJECT
 
   bool m_saveSettingsOnQuit;
+  bool m_resetting;
+  bool m_resetDone;
   int m_oldRoomIndex;
   QString m_currentRoomsChoice;
+  QString m_argumentLayoutFileName;
   UpdateChecker *m_updateChecker;
 
   TopBar *m_topBar;
@@ -142,6 +145,7 @@ private:
   Room *createXsheetRoom();
   Room *createBatchesRoom();
   Room *createBrowserRoom();
+  Room *createBasicsRoom();
 
   QAction *createAction(const char *id, const QString &name,
                         const QString &defaultShortcut,


### PR DESCRIPTION
This rebuild the default rooms without restarting when a user selects reset rooms in menu.

This enables a user to get their rooms back in order without restarting if they mangle their rooms.
Note: the browser and farm room are not rebuilt without restarting.  Something about rebuilding them in the middle of running crashes OT.