### PR TITLE
Fix mesh preview blackout on opening Create Mesh popup

### DIFF
--- a/toonz/sources/toonz/meshifypopup.cpp
+++ b/toonz/sources/toonz/meshifypopup.cpp
@@ -697,7 +697,7 @@ MeshifyPopup::MeshifyPopup()
   // Finally, acquire current selection
   onCellSwitched();
 
-  m_viewer->resize(0, 350);
+  m_viewer->resize(600, 350);
   resize(600, 700);
 }
 


### PR DESCRIPTION
Fixes #253 .
Changed initial size of the preview area in order to call `paintEvent()` on opening popup.