### PR TITLE
Sound playback in the viewer

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -249,6 +249,7 @@ public:
   void enableButton(UINT button, bool enable, bool doShowHide = true);
   void showCurrentFrame();
   int getCurrentFrame() const { return m_currentFrame; }
+  int getCurrentFps() const { return m_fps; }
   void setChecked(UINT button, bool state);
   bool isChecked(UINT button) const;
   void setCurrentFrame(int frame, bool forceResetting = false);

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -619,7 +619,7 @@ void SceneViewerPanel::onFrameTypeChanged() {
 }
 
 void SceneViewerPanel::playAudioFrame(int frame) {
-	if (m_first) {
+  if (m_first) {
     m_first = false;
     m_fps   = TApp::instance()
                 ->getCurrentScene()
@@ -633,8 +633,10 @@ void SceneViewerPanel::playAudioFrame(int frame) {
   m_viewerFps = m_flipConsole->getCurrentFps();
   double s0 = frame * m_samplesPerFrame, s1 = s0 + m_samplesPerFrame;
 
-  // make the sound stop if the viewerfps is higher so the next sound can play on time.
-  if (m_fps < m_viewerFps) TApp::instance()->getCurrentXsheet()->getXsheet()->stopScrub();
+  // make the sound stop if the viewerfps is higher so the next sound can play
+  // on time.
+  if (m_fps < m_viewerFps)
+    TApp::instance()->getCurrentXsheet()->getXsheet()->stopScrub();
   TApp::instance()->getCurrentXsheet()->getXsheet()->play(m_sound, s0, s1,
                                                           false);
 }

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -442,6 +442,12 @@ void SceneViewerPanel::onXshLevelSwitched(TXshLevel *) { changeWindowTitle(); }
 //-----------------------------------------------------------------------------
 
 void SceneViewerPanel::onPlayingStatusChanged(bool playing) {
+  if (playing) {
+    m_playing = true;
+  } else {
+    m_playing = false;
+    m_first   = true;
+  }
   if (Preferences::instance()->getOnionSkinDuringPlayback()) return;
   OnionSkinMask osm =
       TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
@@ -452,15 +458,12 @@ void SceneViewerPanel::onPlayingStatusChanged(bool playing) {
       TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
       TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
     }
-    m_playing = true;
   } else {
     if (m_onionSkinActive) {
       osm.enable(true);
       TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
       TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
     }
-    m_playing = false;
-    m_first   = true;
   }
 }
 
@@ -549,7 +552,6 @@ void SceneViewerPanel::onSceneChanged() {
   updateFrameRange();
   updateFrameMarkers();
   changeWindowTitle();
-
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
   assert(scene);
@@ -559,6 +561,7 @@ void SceneViewerPanel::onSceneChanged() {
   int frameIndex = TApp::instance()->getCurrentFrame()->getFrameIndex();
   if (m_keyFrameButton->getCurrentFrame() != frameIndex)
     m_keyFrameButton->setCurrentFrame(frameIndex);
+  hasSoundtrack();
 }
 
 //-----------------------------------------------------------------------------
@@ -642,6 +645,11 @@ void SceneViewerPanel::playAudioFrame(int frame) {
 }
 
 bool SceneViewerPanel::hasSoundtrack() {
+  if (m_sound != NULL) {
+    m_sound         = NULL;
+    m_hasSoundtrack = false;
+    m_first         = true;
+  }
   TXsheetHandle *xsheetHandle    = TApp::instance()->getCurrentXsheet();
   TXsheet::SoundProperties *prop = new TXsheet::SoundProperties();
   m_sound                        = xsheetHandle->getXsheet()->makeSound(prop);

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -150,9 +150,9 @@ SceneViewerPanel::SceneViewerPanel(QWidget *parent, Qt::WFlags flags)
         connect(m_flipConsole, SIGNAL(buttonPressed(FlipConsole::EGadget)),
                 m_sceneViewer, SLOT(onButtonPressed(FlipConsole::EGadget)));
 
-  ret = ret &&
-	  connect(m_flipConsole, SIGNAL(buttonPressed(FlipConsole::EGadget)),
-		  this, SLOT(onButtonPressed(FlipConsole::EGadget)));
+  ret =
+      ret && connect(m_flipConsole, SIGNAL(buttonPressed(FlipConsole::EGadget)),
+                     this, SLOT(onButtonPressed(FlipConsole::EGadget)));
 
   ret = ret && connect(m_sceneViewer, SIGNAL(previewStatusChanged()), this,
                        SLOT(update()));
@@ -452,15 +452,15 @@ void SceneViewerPanel::onPlayingStatusChanged(bool playing) {
       TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
       TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
     }
-	m_playing = true;
+    m_playing = true;
   } else {
     if (m_onionSkinActive) {
       osm.enable(true);
       TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
       TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
     }
-	m_playing = false;
-	m_first = true;
+    m_playing = false;
+    m_first   = true;
   }
 }
 
@@ -588,12 +588,11 @@ void SceneViewerPanel::onFrameSwitched() {
     m_keyFrameButton->setCurrentFrame(frameIndex);
 
   if (m_playing && m_playSound) {
-	  if (m_first == true && hasSoundtrack()) {
-		  playAudioFrame(frameIndex);
-	  }
-	  else if (m_hasSoundtrack) {
-		  playAudioFrame(frameIndex);
-	  }
+    if (m_first == true && hasSoundtrack()) {
+      playAudioFrame(frameIndex);
+    } else if (m_hasSoundtrack) {
+      playAudioFrame(frameIndex);
+    }
   }
 }
 
@@ -620,34 +619,38 @@ void SceneViewerPanel::onFrameTypeChanged() {
 }
 
 void SceneViewerPanel::playAudioFrame(int frame) {
-	if (m_first) {
-		m_first = false;
-		m_fps =
-			TApp::instance()->getCurrentScene()->getScene()->getProperties()->getOutputProperties()->getFrameRate();
-		m_samplesPerFrame = m_sound->getSampleRate() / m_fps;
-	}
-	if (!m_sound) return;
+  if (m_first) {
+    m_first = false;
+    m_fps   = TApp::instance()
+                ->getCurrentScene()
+                ->getScene()
+                ->getProperties()
+                ->getOutputProperties()
+                ->getFrameRate();
+    m_samplesPerFrame = m_sound->getSampleRate() / m_fps;
+  }
+  if (!m_sound) return;
 
-	double s0 = frame * m_samplesPerFrame, s1 = s0 + m_samplesPerFrame;
-	TApp::instance()->getCurrentXsheet()->getXsheet()->play(m_sound, s0, s1, false);
+  double s0 = frame * m_samplesPerFrame, s1 = s0 + m_samplesPerFrame;
+  TApp::instance()->getCurrentXsheet()->getXsheet()->play(m_sound, s0, s1,
+                                                          false);
 }
 
 bool SceneViewerPanel::hasSoundtrack() {
-	TXsheetHandle *xsheetHandle = TApp::instance()->getCurrentXsheet();
-	TXsheet::SoundProperties *prop = new TXsheet::SoundProperties();
-	m_sound = xsheetHandle->getXsheet()->makeSound(prop);
-	if (m_sound == NULL) {
-		m_hasSoundtrack = false;
-		return false;
-	}
-	else {
-		m_hasSoundtrack = true;
-		return true;
-	}
+  TXsheetHandle *xsheetHandle    = TApp::instance()->getCurrentXsheet();
+  TXsheet::SoundProperties *prop = new TXsheet::SoundProperties();
+  m_sound                        = xsheetHandle->getXsheet()->makeSound(prop);
+  if (m_sound == NULL) {
+    m_hasSoundtrack = false;
+    return false;
+  } else {
+    m_hasSoundtrack = true;
+    return true;
+  }
 }
 
 void SceneViewerPanel::onButtonPressed(FlipConsole::EGadget button) {
-	if (button == FlipConsole::eSound) {
-		m_playSound = !m_playSound;
-	}
+  if (button == FlipConsole::eSound) {
+    m_playSound = !m_playSound;
+  }
 }

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -619,7 +619,7 @@ void SceneViewerPanel::onFrameTypeChanged() {
 }
 
 void SceneViewerPanel::playAudioFrame(int frame) {
-  if (m_first) {
+	if (m_first) {
     m_first = false;
     m_fps   = TApp::instance()
                 ->getCurrentScene()
@@ -627,11 +627,14 @@ void SceneViewerPanel::playAudioFrame(int frame) {
                 ->getProperties()
                 ->getOutputProperties()
                 ->getFrameRate();
-    m_samplesPerFrame = m_sound->getSampleRate() / m_fps;
+    m_samplesPerFrame = m_sound->getSampleRate() / abs(m_fps);
   }
   if (!m_sound) return;
-
+  m_viewerFps = m_flipConsole->getCurrentFps();
   double s0 = frame * m_samplesPerFrame, s1 = s0 + m_samplesPerFrame;
+
+  // make the sound stop if the viewerfps is higher so the next sound can play on time.
+  if (m_fps < m_viewerFps) TApp::instance()->getCurrentXsheet()->getXsheet()->stopScrub();
   TApp::instance()->getCurrentXsheet()->getXsheet()->play(m_sound, s0, s1,
                                                           false);
 }

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -43,8 +43,8 @@ class SceneViewerPanel final : public TPanel, public FlipConsoleOwner {
   double m_fps;
   int m_viewerFps;
   double m_samplesPerFrame;
-  bool m_first = true;
-  TSoundTrack *m_sound;
+  bool m_first         = true;
+  TSoundTrack *m_sound = NULL;
 
 public:
 #if QT_VERSION >= 0x050500

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -37,6 +37,13 @@ class SceneViewerPanel final : public TPanel, public FlipConsoleOwner {
   TPanelTitleBarButton *m_previewButton;
   TPanelTitleBarButton *m_subcameraPreviewButton;
   bool m_onionSkinActive = false;
+  bool m_playSound = true;
+  bool m_hasSoundtrack = false;
+  bool m_playing = false;
+  double m_fps;
+  double m_samplesPerFrame;
+  bool m_first = true;
+  TSoundTrack *m_sound;
 
 public:
 #if QT_VERSION >= 0x050500
@@ -48,7 +55,6 @@ public:
 
   void onDrawFrame(int frame,
                    const ImagePainter::VisualSettings &settings) override;
-
 protected:
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;
@@ -58,6 +64,8 @@ protected:
   void createPlayToolBar();
   void addColorMaskButton(QWidget *parent, const char *iconSVGName, int id);
   void enableFlipConsoleForCamerastand(bool on);
+  void playAudioFrame(int frame);
+  bool hasSoundtrack();
 
 public slots:
 
@@ -66,6 +74,7 @@ public slots:
   void onXshLevelSwitched(TXshLevel *);
   void updateFrameRange();
   void updateFrameMarkers();
+  void onButtonPressed(FlipConsole::EGadget button);
 
 protected slots:
 

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -41,6 +41,7 @@ class SceneViewerPanel final : public TPanel, public FlipConsoleOwner {
   bool m_hasSoundtrack   = false;
   bool m_playing         = false;
   double m_fps;
+  int m_viewerFps;
   double m_samplesPerFrame;
   bool m_first = true;
   TSoundTrack *m_sound;

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -37,9 +37,9 @@ class SceneViewerPanel final : public TPanel, public FlipConsoleOwner {
   TPanelTitleBarButton *m_previewButton;
   TPanelTitleBarButton *m_subcameraPreviewButton;
   bool m_onionSkinActive = false;
-  bool m_playSound = true;
-  bool m_hasSoundtrack = false;
-  bool m_playing = false;
+  bool m_playSound       = true;
+  bool m_hasSoundtrack   = false;
+  bool m_playing         = false;
   double m_fps;
   double m_samplesPerFrame;
   bool m_first = true;
@@ -55,6 +55,7 @@ public:
 
   void onDrawFrame(int frame,
                    const ImagePainter::VisualSettings &settings) override;
+
 protected:
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;


### PR DESCRIPTION
This is a fix for #133 
I added the ability to turn sound on and off in the viewer play bar - like the flipbook.
Now, playing the animation will let you hear the sound also.

Note- I only built this in the viewer, not the combo viewer.  From what I understand, the combo viewer was built in house by @shun-iwasawa at Studio Ghibli and I don't know if they want this.  I so, I don't mind adding it there too.
