### PR TITLE
Style sheet for sound column

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -946,6 +946,12 @@ XsheetViewer {
 	qproperty-MeshColumnBorderColor: rgb(186,146,239);
 	qproperty-SelectedMeshColumnColor: rgb(138,117,162);
 	
+	qproperty-SoundColumnColor: rgb(101,116,86);
+	qproperty-SoundColumnBorderColor: rgb(160,175,125);
+	qproperty-SelectedSoundColumnColor: rgb(127,149,106);
+	qproperty-SoundColumnHlColor: rgb(52,254,94);
+	qproperty-SoundColumnTrackColor: rgb(182,194,157);
+	
 	qproperty-ColumnHeadPastelizer: rgb(0,0,0);
 	qproperty-SelectedColumnHead: rgb(80,96,130);
 

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -954,6 +954,11 @@ XsheetViewer {
   qproperty-MeshColumnColor: #684d86;
   qproperty-MeshColumnBorderColor: #ba92ef;
   qproperty-SelectedMeshColumnColor: #8a75a2;
+  qproperty-SoundColumnColor: #657456;
+  qproperty-SoundColumnBorderColor: #a0af7d;
+  qproperty-SelectedSoundColumnColor: #7f956a;
+  qproperty-SoundColumnHlColor: #34fe5e;
+  qproperty-SoundColumnTrackColor: #b6c29d;
   qproperty-ColumnHeadPastelizer: #000000;
   qproperty-SelectedColumnHead: #506082;
   qproperty-LightLightBGColor: #fafafa;

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -954,6 +954,11 @@ XsheetViewer {
   qproperty-MeshColumnColor: #684d86;
   qproperty-MeshColumnBorderColor: #ba92ef;
   qproperty-SelectedMeshColumnColor: #8a75a2;
+  qproperty-SoundColumnColor: #657456;
+  qproperty-SoundColumnBorderColor: #a0af7d;
+  qproperty-SelectedSoundColumnColor: #7f956a;
+  qproperty-SoundColumnHlColor: #34fe5e;
+  qproperty-SoundColumnTrackColor: #b6c29d;
   qproperty-ColumnHeadPastelizer: #000000;
   qproperty-SelectedColumnHead: #506082;
   qproperty-LightLightBGColor: #fafafa;

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -946,6 +946,12 @@ XsheetViewer {
 	qproperty-MeshColumnBorderColor: rgb(186,146,239);
 	qproperty-SelectedMeshColumnColor: rgb(138,117,162);
 	
+	qproperty-SoundColumnColor: rgb(101,116,86);
+	qproperty-SoundColumnBorderColor: rgb(160,175,125);
+	qproperty-SelectedSoundColumnColor: rgb(127,149,106);
+	qproperty-SoundColumnHlColor: rgb(52,254,94);
+	qproperty-SoundColumnTrackColor: rgb(182,194,157);
+	
 	qproperty-ColumnHeadPastelizer: rgb(0,0,0);
 	qproperty-SelectedColumnHead: rgb(80,96,130);
 

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -954,6 +954,11 @@ XsheetViewer {
   qproperty-MeshColumnColor: #684d86;
   qproperty-MeshColumnBorderColor: #ba92ef;
   qproperty-SelectedMeshColumnColor: #8a75a2;
+  qproperty-SoundColumnColor: #657456;
+  qproperty-SoundColumnBorderColor: #a0af7d;
+  qproperty-SelectedSoundColumnColor: #7f956a;
+  qproperty-SoundColumnHlColor: #34fe5e;
+  qproperty-SoundColumnTrackColor: #b6c29d;
   qproperty-ColumnHeadPastelizer: #000000;
   qproperty-SelectedColumnHead: #506082;
   qproperty-LightLightBGColor: #fafafa;

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -954,6 +954,11 @@ XsheetViewer {
   qproperty-MeshColumnColor: #684d86;
   qproperty-MeshColumnBorderColor: #ba92ef;
   qproperty-SelectedMeshColumnColor: #8a75a2;
+  qproperty-SoundColumnColor: #657456;
+  qproperty-SoundColumnBorderColor: #a0af7d;
+  qproperty-SelectedSoundColumnColor: #7f956a;
+  qproperty-SoundColumnHlColor: #34fe5e;
+  qproperty-SoundColumnTrackColor: #b6c29d;
   qproperty-ColumnHeadPastelizer: #000000;
   qproperty-SelectedColumnHead: #506082;
   qproperty-LightLightBGColor: #fafafa;

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -782,6 +782,12 @@ XsheetViewer {
 	qproperty-MeshColumnBorderColor: rgb(105,70,135);
 	qproperty-SelectedMeshColumnColor: rgb(216,180,245);
 	
+	qproperty-SoundColumnColor: rgb(179,193,135);
+	qproperty-SoundColumnBorderColor: rgb(99,120,86);
+	qproperty-SelectedSoundColumnColor: rgb(215,215,180);  
+	qproperty-SoundColumnHlColor: rgb(245,255,230);
+	qproperty-SoundColumnTrackColor: rgb(90,100,45);
+	
 	qproperty-ColumnHeadPastelizer: rgb(255,255,255);
 	qproperty-SelectedColumnHead: rgb(190,210,240);
 

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -701,6 +701,11 @@ XsheetViewer {
   qproperty-MeshColumnColor: #c882ff;
   qproperty-MeshColumnBorderColor: #694687;
   qproperty-SelectedMeshColumnColor: #d8b4f5;
+  qproperty-SoundColumnColor: #b3c187;
+  qproperty-SoundColumnBorderColor: #637856;
+  qproperty-SelectedSoundColumnColor: #d7d7b4;
+  qproperty-SoundColumnHlColor: #f5ffe6;
+  qproperty-SoundColumnTrackColor: #5a642d;
   qproperty-ColumnHeadPastelizer: #ffffff;
   qproperty-SelectedColumnHead: #bed2f0;
   qproperty-LightLightBGColor: #fafafa;

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -701,6 +701,11 @@ XsheetViewer {
   qproperty-MeshColumnColor: #c882ff;
   qproperty-MeshColumnBorderColor: #694687;
   qproperty-SelectedMeshColumnColor: #d8b4f5;
+  qproperty-SoundColumnColor: #b3c187;
+  qproperty-SoundColumnBorderColor: #637856;
+  qproperty-SelectedSoundColumnColor: #d7d7b4;
+  qproperty-SoundColumnHlColor: #f5ffe6;
+  qproperty-SoundColumnTrackColor: #5a642d;
   qproperty-ColumnHeadPastelizer: #ffffff;
   qproperty-SelectedColumnHead: #bed2f0;
   qproperty-LightLightBGColor: #fafafa;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -923,22 +923,34 @@ void CellArea::drawSoundCell(QPainter &p, int row, int col) {
   bool isSelected                   = cellSelection->isCellSelected(row, col) ||
                     columnSelection->isColumnSelected(col);
 
+  // get cell colors
+  QColor cellColor, sideColor;
+  int levelType;
+  m_viewer->getCellTypeAndColors(levelType, cellColor, sideColor, cell,
+                                 isSelected);
+
   // sfondo celle
   QRect backgroundRect = QRect(x + 1, y + 1, ColumnWidth - 1, RowHeight - 1);
-  p.fillRect(backgroundRect, QBrush((isSelected) ? SelectedSoundColumnColor
-                                                 : SoundColumnColor));
-  if (isLastRow) {
-    QPainterPath path(QPointF(x, y));
-    path.lineTo(QPointF(x + 6, y));
-    path.lineTo(QPointF(x + 6, y + 2));
-    path.lineTo(QPointF(x, y + RowHeight - 2));
-    p.fillPath(path, QBrush(SoundColumnBorderColor));
-  } else
-    p.fillRect(QRect(x, y, 6, RowHeight), QBrush(SoundColumnBorderColor));
+  p.fillRect(backgroundRect, cellColor);
+  p.fillRect(QRect(x, y, 7, RowHeight), QBrush(sideColor));
 
-  int x1    = rect.x() + 5;
+  // draw dot line if the column is locked
+  if (soundColumn->isLocked()) {
+    p.setPen(QPen(cellColor, 2, Qt::DotLine));
+    p.drawLine(x + 3, y, x + 3, y + RowHeight);
+  }
+  // draw "end of the level"
+  if (isLastRow) {
+    QPainterPath path(QPointF(x, y + RowHeight));
+    path.lineTo(QPointF(x + 7, y + RowHeight));
+    path.lineTo(QPointF(x + 7, y + RowHeight - 7));
+    path.lineTo(QPointF(x, y + RowHeight));
+    p.fillPath(path, QBrush(cellColor));
+  }
+
+  int x1    = rect.x() + 6;
   int x2    = rect.x() + rect.width();
-  int x1Bis = x2 - 6;
+  int x1Bis = x2 - 7;
 
   int offset  = row - cell.getFrameId().getNumber();
   int y0      = rect.y();
@@ -975,22 +987,22 @@ void CellArea::drawSoundCell(QPainter &p, int row, int col) {
     if (i != y0 || !isFirstRow) {
       // trattini a destra della colonna
       if (i % 2) {
-        p.setPen((isSelected) ? SelectedSoundColumnColor : SoundColumnColor);
+        p.setPen(cellColor);
         p.drawLine(x1, i, x1Bis, i);
       } else {
-        p.setPen(SoundColumnTrackColor);
+        p.setPen(m_viewer->getSoundColumnTrackColor());
         p.drawLine(x1Bis + 1, i, x2, i);
       }
     }
 
     if (scrub && i % 2) {
-      p.setPen(SoundColumnHlColor);
+      p.setPen(m_viewer->getSoundColumnHlColor());
       p.drawLine(x1Bis + 1, i, x2, i);
     }
 
     if (i != y0) {
       // "traccia audio" al centro della colonna
-      p.setPen(SoundColumnTrackColor);
+      p.setPen(m_viewer->getSoundColumnTrackColor());
       p.drawLine(lastMin, i, min, i);
       p.drawLine(lastMax, i, max, i);
     }

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -824,7 +824,11 @@ void ColumnArea::drawSoundColumnHead(QPainter &p, int col) {
   }
 
   QColor pastelizer(m_viewer->getColumnHeadPastelizer());
-  p.fillRect(rect, (isSelected) ? ColorSelection : pastelizer);
+  pastelizer.setAlpha(50);
+
+  QColor colorSelection(m_viewer->getSelectedColumnHead());
+  colorSelection.setAlpha(170);
+  p.fillRect(rect, (isSelected) ? colorSelection : pastelizer);
 
   int prevViewImgHeight = RowHeight - 5;
   int prevViewImgWidth  = prevViewImgHeight * 5 / 4;
@@ -881,7 +885,7 @@ void ColumnArea::drawSoundColumnHead(QPainter &p, int col) {
   QRect rr(rect.x() + 8, RowHeight * 2 + 3, rect.width() - 7, m_tabBox.y() - 3);
 
   // suddivisioni slider
-  p.setPen(Qt::black);
+  p.setPen(m_viewer->getTextColor());
   int xa = rr.x() + 7, ya = rr.y() + 4;
   int y = ya;
   for (int i = 0; i <= 20; i++, y += 3)

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -92,9 +92,9 @@ void XsheetViewer::getCellTypeAndColors(int &ltype, QColor &cellColor,
       sideColor = getChildColumnBorderColor();
       break;
     case SND_XSHLEVEL:
-      cellColor = (isSelected) ? XsheetGUI::SelectedSoundColumnColor
-                               : XsheetGUI::SoundColumnColor;
-      sideColor = XsheetGUI::SoundColumnBorderColor;
+      cellColor =
+          (isSelected) ? m_selectedSoundColumnColor : m_soundColumnColor;
+      sideColor = m_soundColumnBorderColor;
       break;
     case SND_TXT_XSHLEVEL:
       cellColor = XsheetGUI::SoundTextColumnColor;

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -287,6 +287,17 @@ class XsheetViewer final : public QFrame, public Spreadsheet::FrameScroller {
                  setMeshColumnBorderColor)
   Q_PROPERTY(QColor SelectedMeshColumnColor READ getSelectedMeshColumnColor
                  WRITE setSelectedMeshColumnColor)
+  // Sound column
+  QColor m_soundColumnColor;
+  QColor m_soundColumnBorderColor;
+  QColor m_selectedSoundColumnColor;
+  QColor m_soundColumnHlColor;
+  QColor m_soundColumnTrackColor;
+  Q_PROPERTY(QColor SoundColumnColor MEMBER m_soundColumnColor)
+  Q_PROPERTY(QColor SoundColumnBorderColor MEMBER m_soundColumnBorderColor)
+  Q_PROPERTY(QColor SelectedSoundColumnColor MEMBER m_selectedSoundColumnColor)
+  Q_PROPERTY(QColor SoundColumnHlColor MEMBER m_soundColumnHlColor)
+  Q_PROPERTY(QColor SoundColumnTrackColor MEMBER m_soundColumnTrackColor)
 
   // for making the column head lighter (255,255,255,50);
   QColor m_columnHeadPastelizer;
@@ -612,6 +623,9 @@ public:
   QColor getSelectedMeshColumnColor() const {
     return m_selectedMeshColumnColor;
   }
+  // Sound column
+  QColor getSoundColumnHlColor() const { return m_soundColumnHlColor; }
+  QColor getSoundColumnTrackColor() const { return m_soundColumnTrackColor; }
 
   void setColumnHeadPastelizer(const QColor &color) {
     m_columnHeadPastelizer = color;


### PR DESCRIPTION
This PR is for setting style sheet to sound column in Xsheet.

Recently some valuable PRs relevant to sound feature are posted by @turtletooth .
However, the sound column UI had been almost untouched since the sound feature was not used in Ghibli Edition.

<img src="https://cloud.githubusercontent.com/assets/17974955/18248481/6bea61a2-73b3-11e6-9f0b-052cebfcd5fa.png" width=600>
