### PR TITLE
Fix dangling stack pointer use when inserting a keyframe

### DIFF
--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -1184,11 +1184,14 @@ void FunctionTreeModel::onChange(const TParamChange &tpc) {
 
     struct Func final : public TFunctorInvoker::BaseFunctor {
       FunctionTreeModel *m_obj;
-      const TParamChange *m_tpc;
+      // Use a copy of 'TParamChange' since callers declare
+      // and free this value on the stack,
+      // so we can't ensure its valid later on when the notifier executes.
+      const TParamChange m_tpc;
 
       Func(FunctionTreeModel *obj, const TParamChange *tpc)
-          : m_obj(obj), m_tpc(tpc) {}
-      void operator()() override { m_obj->onParamChange(m_tpc->m_dragging); }
+          : m_obj(obj), m_tpc(*tpc) {}
+      void operator()() override { m_obj->onParamChange(m_tpc.m_dragging); }
     };
 
     QMetaObject::invokeMethod(TFunctorInvoker::instance(), "invoke",


### PR DESCRIPTION
Typical usage, eg: `m_imp->notify(TParamChange(this, 0, 0, true, false, false));`

Would create `TParamChange` and free it (double checked and `TParamChange`'s virtual free function runs here).
However the notifier would run later on (via Qt's event loop),
accessing freed stack memory and often crashing when `override { m_obj->onParamChange(m_tpc->m_dragging); }` ran.

Since this class is quite small,
I think it's not a problem to make a copy here.

See output from Valgrind: [keyframe_crash_valgrind.txt](https://github.com/opentoonz/opentoonz/files/463195/keyframe_crash_valgrind.txt)

----


Note, surprising no bug reports on this, however `TParamChange` is used elsewhere too, so its possible this resolves other reported crashes.