### PR TITLE
Replace else() with elseif(APPLE) to ensure quicktime not built on unix.

### DIFF
--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -69,7 +69,7 @@ if(WIN32)
         mov/tiio_movW.cpp
         3gp/tiio_3gpW.cpp
     )
-else()
+elseif(APPLE)
     set(HEADERS ${HEADERS}
         mov/tiio_movM.h
         3gp/tiio_3gpM.h


### PR DESCRIPTION
While updating my openSUSE package i586 builds tried to build mov and 3gp. Perhaps an oversight of the Linux build support.

Unless it's some oddity of cmake that logic doesn't make a whole lot of sense.

```
if (WIN32)
else()
elseif(UNIX)
```