### PR TITLE
Update version numbers for tcleanupper, tcomposer and tconverter

### DIFF
--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -63,8 +63,8 @@ inline ostream &operator<<(ostream &out, const TFilePath &fp) {
 namespace {
 
 const char *applicationName     = "OpenToonz";
-const char *applicationVersion  = "1.0";
-const char *applicationFullName = "OpenToonz 1.0";
+const char *applicationVersion  = "1.1";
+const char *applicationFullName = "OpenToonz 1.1";
 const char *rootVarName         = "TOONZROOT";
 const char *systemVarPrefix     = "TOONZ";
 
@@ -625,6 +625,14 @@ int main(int argc, char *argv[]) {
   /*-- CleanupSettingsファイルパスを直接入力した場合 --*/
   else {
     try {
+      TProjectManager *pm    = TProjectManager::instance();
+      TProjectP sceneProject = pm->loadSceneProject(fp);
+      if (!sceneProject) {
+        cerr << "can't open project." << endl;
+        return -3;
+      }
+      scene->setProject(sceneProject.getPointer());
+
       /*- CleanupSettingsファイルに対応するTIFファイルが有るかチェック -*/
       TFilePath tifImagePath = fp.withType("tif");
       std::wcout << L"tifImagePath : " << tifImagePath.getWideString()

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -104,8 +104,8 @@ namespace {
 //
 
 const char *applicationName     = "OpenToonz";
-const char *applicationVersion  = "1.0";
-const char *applicationFullName = "OpenToonz 1.0";
+const char *applicationVersion  = "1.1";
+const char *applicationFullName = "OpenToonz 1.1";
 const char *rootVarName         = "TOONZROOT";
 const char *systemVarPrefix     = "TOONZ";
 

--- a/toonz/sources/tconverter/tconverter.cpp
+++ b/toonz/sources/tconverter/tconverter.cpp
@@ -37,7 +37,7 @@ typedef QualifierT<TFilePath> FilePathQualifier;
 
 #define RENDER_LICENSE_NOT_FOUND 888
 
-const char *applicationVersion = "1.0";
+const char *applicationVersion = "1.1";
 const char *applicationName    = "OpenToonz";
 const char *rootVarName        = "TOONZROOT";
 const char *systemVarPrefix    = "TOONZ";


### PR DESCRIPTION
For now the batch render or batch cleanup are unavailable, with the following error popup appears:

<img src="https://cloud.githubusercontent.com/assets/17974955/18462092/0bc53538-79ba-11e6-855c-fe53a30f7eff.png">

This PR fixes such problem by updating version numbers for each batch executable - tcleanupper, tcomposer and tconverter.

This also fixes another bug as follows:

> When executing tcleanupper with .cln file as input argument, if some project folder alias (such as "+drawings") is used in "Save in" path, output file is saved in wrong place.
