### PR TITLE
Revert autocenter options to Cleanup Settings panel

### DIFF
--- a/toonz/sources/toonz/cleanupsettingspane.h
+++ b/toonz/sources/toonz/cleanupsettingspane.h
@@ -18,6 +18,7 @@ class QComboBox;
 class QLabel;
 class QCheckBox;
 class CleanupPaletteViewer;
+class QGroupBox;
 
 namespace DVGui {
 
@@ -47,6 +48,9 @@ public:
   CleanupCameraSettingsWidget *m_cameraWidget;
 
 private:
+  //----Autocenter
+  QGroupBox *m_autocenterBox;
+  QComboBox *m_pegHolesOm, *m_fieldGuideOm;
   //----Rotate & Flip
   QComboBox *m_rotateOm;
   QCheckBox *m_flipX;


### PR DESCRIPTION
This PR is for the issue #361.
Please note that I just reverted interface for the autocenter option and the autocenter feature itself is virtually unchanged from Toonz Harlequin. This option was hidden in Toonz Ghibli Edition since we did not use automatic sheet feeder for scanning the drawings in order to protect animation papers from a paper jam.

<img src="https://cloud.githubusercontent.com/assets/17974955/18466014/bdb7efdc-79d4-11e6-8876-974af4604def.png" width=270>
