### PR TITLE
Modified: Linked styles enabled and style right click menu organized by turtletooth

### DIFF
--- a/toonz/sources/include/toonzqt/paletteviewergui.h
+++ b/toonz/sources/include/toonzqt/paletteviewergui.h
@@ -199,9 +199,6 @@ protected:
   void zoomInChip();
   void zoomOutChip();
 
-protected slots:
-  void removeLink();
-
 private:
   DVGui::LineEdit *m_renameTextField;
   QPoint m_dragStartPosition;

--- a/toonz/sources/include/toonzqt/styleselection.h
+++ b/toonz/sources/include/toonzqt/styleselection.h
@@ -98,6 +98,8 @@ public:
   void removeLink();
   // get back the style from the studio palette (if linked)
   void getBackOriginalStyle();
+  // return true if there is at least one linked style in the selection
+  bool hasLinkedStyle();
 };
 
 #endif  // STYLESELECTION_INCLUDED

--- a/toonz/sources/include/toonzqt/styleselection.h
+++ b/toonz/sources/include/toonzqt/styleselection.h
@@ -95,7 +95,7 @@ public:
   void toggleKeyframe(int frame);
 
   // remove link from the studio palette (if linked)
-  bool removeLink();
+  void removeLink();
   // get back the style from the studio palette (if linked)
   void getBackOriginalStyle();
 };

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1614,7 +1614,7 @@ bool IoCmd::saveAll() {
 
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
-
+  bool untitled     = scene->isUntitled();
   SceneResources resources(scene, 0);
   resources.save(scene->getScenePath());
   resources.updatePaths();
@@ -1622,7 +1622,7 @@ bool IoCmd::saveAll() {
   // for update title bar
   app->getCurrentLevel()->notifyLevelTitleChange();
   app->getCurrentPalette()->notifyPaletteTitleChanged();
-
+  if (untitled) scene->setUntitled();
   return result;
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1640,7 +1640,7 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_GetColorFromStudioPalette,
                              tr("Get Color from Studio Palette"), "");
   createRightClickMenuAction(MI_ToggleLinkToStudioPalette,
-                             tr("Toggle Link to Studio Palette"), "\\");
+                             tr("Toggle Link to Studio Palette"), "");
   createRightClickMenuAction(MI_RemoveReferenceToStudioPalette,
                              tr("Remove Reference to Studio Palette"), "");
   createMenuEditAction(MI_Clear, tr("&Delete"), "Delete");

--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -501,7 +501,11 @@ void StudioPaletteCmd::loadIntoCurrentPalette(TPaletteHandle *paletteHandle,
   // keep the color model path unchanged
   TFilePath oldRefImagePath = current->getRefImgPath();
 
+  std::wstring oldGlobalName = current->getGlobalName();
   current->assign(palette, true);
+  // keep global name unchanged
+  current->setGlobalName(oldGlobalName);
+
   current->setDirtyFlag(true);
 
   current->setRefImgPath(oldRefImagePath);

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -911,10 +911,7 @@ void PaletteViewer::saveStudioPalette() {
     if (ret == 2 || ret == 0) return;
     sp->setPalette(fp, getPalette(), false);
 
-    question = "Do you want to update all linked styles in current scene ?";
-    ret      = DVGui::MsgBox(question, tr("Update"), tr("Don't Update"), 0);
-    if (ret == 1)
-      StudioPaletteCmd::updateAllLinkedStyles(m_paletteHandle, m_xsheetHandle);
+    StudioPaletteCmd::updateAllLinkedStyles(m_paletteHandle, m_xsheetHandle);
 
     palette->setDirtyFlag(false);
   }

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -1022,29 +1022,21 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   bool isLocked = m_page ? m_page->getPalette()->isLocked() : false;
 
   // remove links from studio palette
-  //if (m_viewType == LEVEL_PALETTE && m_styleSelection &&
-  //    !m_styleSelection->isEmpty() && !isLocked) {
-  //  menu.addSeparator();
-  //  QAction *removeLinkAct = menu.addAction(tr("Remove Links"));
-  //  connect(removeLinkAct, SIGNAL(triggered()), this, SLOT(removeLink()));
-  //}
+  if (m_viewType == LEVEL_PALETTE && m_styleSelection &&
+      !m_styleSelection->isEmpty() && !isLocked) {
+    menu.addSeparator();
+    QAction *toggleStyleLink = cmd->getAction("MI_ToggleLinkToStudioPalette");
+    menu.addAction(toggleStyleLink);
+    QAction *removeStyleLink =
+        cmd->getAction("MI_RemoveReferenceToStudioPalette");
+    menu.addAction(removeStyleLink);
+    QAction *getBackOriginalAct =
+        cmd->getAction("MI_GetColorFromStudioPalette");
+    menu.addAction(getBackOriginalAct);
+  }
 
   if (((indexPage == 0 && index > 0) || (indexPage > 0 && index >= 0)) &&
       index < getChipCount() && !isLocked) {
-    
-    std::wstring globalName = m_page->getStyle(index)->getGlobalName();
-    if (m_viewType != STUDIO_PALETTE && globalName != L"" &&
-            (globalName[0] == L'-' || globalName[0] == L'+'))
-    {
-		menu.addSeparator();
-		QAction *toggleStyleLink = cmd->getAction("MI_ToggleLinkToStudioPalette");
-		menu.addAction(toggleStyleLink);
-		QAction *removeStyleLink = cmd->getAction("MI_RemoveReferenceToStudioPalette");
-		menu.addAction(removeStyleLink);
-		QAction *getBackOriginalAct = cmd->getAction("MI_GetColorFromStudioPalette");
-		menu.addAction(getBackOriginalAct);
-    }
-    
     if (pasteValueAct) pasteValueAct->setEnabled(true);
     if (pasteColorsAct) pasteColorsAct->setEnabled(true);
 
@@ -1063,16 +1055,18 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   }
 
   if (m_page) {
-	menu.addSeparator();
+    menu.addSeparator();
     QAction *newStyle = menu.addAction(tr("New Style"));
     connect(newStyle, SIGNAL(triggered()), SLOT(addNewColor()));
     QAction *newPage = menu.addAction(tr("New Page"));
     connect(newPage, SIGNAL(triggered()), SLOT(addNewPage()));
   }
 
+  /*
   if (m_viewType != STUDIO_PALETTE) {
-	  menu.addAction(cmd->getAction(MI_EraseUnusedStyles));
+          menu.addAction(cmd->getAction(MI_EraseUnusedStyles));
   }
+  */
 
   menu.exec(event->globalPos());
 }
@@ -1625,13 +1619,4 @@ void PageViewer::updateCommandLocks() {
   cmd->getAction("MI_GetColorFromStudioPalette")->setEnabled(!isLocked);
   cmd->getAction("MI_ToggleLinkToStudioPalette")->setEnabled(!isLocked);
   cmd->getAction("MI_RemoveReferenceToStudioPalette")->setEnabled(!isLocked);
-}
-
-//-----------------------------------------------------------------------------
-/*! remove link and revert to the normal style
-*/
-void PageViewer::removeLink() {
-  if (!m_page || !m_styleSelection || m_styleSelection->isEmpty()) return;
-
-  if (m_styleSelection->removeLink()) emit changeWindowTitleSignal();
 }

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -1023,7 +1023,8 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
 
   // remove links from studio palette
   if (m_viewType == LEVEL_PALETTE && m_styleSelection &&
-      !m_styleSelection->isEmpty() && !isLocked) {
+      !m_styleSelection->isEmpty() && !isLocked &&
+      m_styleSelection->hasLinkedStyle()) {
     menu.addSeparator();
     QAction *toggleStyleLink = cmd->getAction("MI_ToggleLinkToStudioPalette");
     menu.addAction(toggleStyleLink);

--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -497,6 +497,7 @@ void StudioPaletteTreeViewer::onCurrentItemChanged(QTreeWidgetItem *current,
   m_currentPalette = StudioPalette::instance()->getPalette(newPath, false);
   m_studioPaletteHandle->setPalette(m_currentPalette.getPointer());
   m_studioPaletteHandle->notifyPaletteSwitched();
+  StudioPaletteCmd::updateAllLinkedStyles(m_levelPaletteHandle, m_xsheetHandle);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -1794,3 +1794,26 @@ void TStyleSelection::getBackOriginalStyle() {
   } else
     delete undo;
 }
+
+//-----------------------------------------------------------------------------
+/*! return true if there is at least one linked style in the selection
+*/
+
+bool TStyleSelection::hasLinkedStyle() {
+  TPalette *palette = getPalette();
+  if (!palette || m_pageIndex < 0 || isEmpty()) return false;
+  if (m_styleIndicesInPage.size() <= 0) return false;
+
+  TPalette::Page *page = palette->getPage(m_pageIndex);
+  assert(page);
+
+  // for each selected style
+  for (std::set<int>::iterator it = m_styleIndicesInPage.begin();
+       it != m_styleIndicesInPage.end(); ++it) {
+    TColorStyle *cs    = page->getStyle(*it);
+    std::wstring gname = cs->getGlobalName();
+    // if the style has link, return true
+    if (gname != L"" && (gname[0] == L'-' || gname[0] == L'+')) return true;
+  }
+  return false;
+}

--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -505,15 +505,14 @@ void TStyleSelection::enableCommands() {
     enableCommand(this, MI_PasteNames, &TStyleSelection::pasteStylesName);
 
     // available only for level palette
-	if (m_paletteHandle->getPalette()->getGlobalName() == L"") {
-		enableCommand(this, MI_GetColorFromStudioPalette,
-			&TStyleSelection::getBackOriginalStyle);
-		enableCommand(this, MI_ToggleLinkToStudioPalette,
-			&TStyleSelection::toggleLink);
-		enableCommand(this, MI_RemoveReferenceToStudioPalette,
-			&TStyleSelection::eraseToggleLink);
-		
-	}
+    if (m_paletteHandle->getPalette()->getGlobalName() == L"") {
+      enableCommand(this, MI_GetColorFromStudioPalette,
+                    &TStyleSelection::getBackOriginalStyle);
+      enableCommand(this, MI_ToggleLinkToStudioPalette,
+                    &TStyleSelection::toggleLink);
+      enableCommand(this, MI_RemoveReferenceToStudioPalette,
+                    &TStyleSelection::removeLink);
+    }
   }
   enableCommand(this, MI_Clear, &TStyleSelection::deleteStyles);
   enableCommand(this, MI_EraseUnusedStyles, &TStyleSelection::eraseUnsedStyle);
@@ -1421,8 +1420,8 @@ void TStyleSelection::toggleLink() {
   std::vector<std::pair<int, std::wstring>> oldColorStylesLinked;
   std::vector<std::pair<int, std::wstring>> newColorStylesLinked;
 
-  bool somethingHasBeenLinked = false;
-
+  bool somethingHasBeenLinked    = false;
+  bool somethingChanged          = false;
   bool currentStyleIsInSelection = false;
 
   TPalette::Page *page = palette->getPage(m_pageIndex);
@@ -1442,6 +1441,7 @@ void TStyleSelection::toggleLink() {
       name[0] = name[0] == L'-' ? L'+' : L'-';
       cs->setGlobalName(name);
       if (name[0] == L'+') somethingHasBeenLinked = true;
+      somethingChanged                            = true;
     }
     undo->setColorStyle(index, oldCs, name);
 
@@ -1449,6 +1449,13 @@ void TStyleSelection::toggleLink() {
         palette->getPage(m_pageIndex)->search(m_paletteHandle->getStyleIndex()))
       currentStyleIsInSelection = true;
   }
+
+  // if nothing changed, do not set dirty flag, nor register undo
+  if (!somethingChanged) {
+    delete undo;
+    return;
+  }
+
   if (somethingHasBeenLinked)
     StudioPalette::instance()->updateLinkedColors(palette);
 
@@ -1583,7 +1590,7 @@ public:
   int getSize() const override { return sizeof(*this); }
 
   QString getHistoryString() override {
-    return QObject::tr("Remove Link  in Palette : %1")
+    return QObject::tr("Remove Reference  in Palette : %1")
         .arg(QString::fromStdWString(m_palette->getPaletteName()));
   }
   int getHistoryType() override { return HistoryType::Palette; }
@@ -1593,11 +1600,11 @@ public:
 /*! remove link from studio palette. Delete the global and the orginal names.
  * return true if something changed
 */
-bool TStyleSelection::removeLink() {
+void TStyleSelection::removeLink() {
   TPalette *palette = getPalette();
-  if (!palette || m_pageIndex < 0) return false;
+  if (!palette || m_pageIndex < 0) return;
   int n = m_styleIndicesInPage.size();
-  if (n <= 0) return false;
+  if (n <= 0) return;
 
   TPalette::Page *page = palette->getPage(m_pageIndex);
   assert(page);
@@ -1622,12 +1629,10 @@ bool TStyleSelection::removeLink() {
   }
 
   if (somethingChanged) {
-    palette->setDirtyFlag(true);
+    m_paletteHandle->notifyColorStyleChanged(false);
     TUndoManager::manager()->add(undo);
   } else
     delete undo;
-
-  return somethingChanged;
 }
 
 //=============================================================================


### PR DESCRIPTION
This PR is for the issue #520 and based on the PR #628 by @turtletooth 

@turtletooth did almost everything so I just modified minor parts as follows:

- Use TStyleSelection::removeLink() instead of TStyleSelection::eraseToggleLink(). The former function takes care of removal of "original name" which is newly added from Ghibli Edition.
- Show these commands without right-clicking the linked style. Which makes easier to apply these commands to all styles in the palette.
- Removed default shortcut for "Toggle Link to Studio Palette" as it can be added by users afterwards.
- Removed confirmation dialog on save studio palette, asking whether to update linked styles.