### PR TITLE
Fix for ffmpeg named with sequence names

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -480,6 +480,7 @@ bool TFilePath::isRoot() const {
 // ritorna ""(niente tipo, niente punto), "." (file con tipo) o ".." (file con
 // tipo e frame)
 std::string TFilePath::getDots() const {
+  if (isFfmpegType()) return ".";
   int i            = getLastSlash(m_path);
   std::wstring str = m_path.substr(i + 1);
   // potrei anche avere a.b.c.d dove d e' l'estensione
@@ -561,7 +562,7 @@ std::string TFilePath::getLevelName() const {
 std::wstring TFilePath::getLevelNameW() const {
   int i            = getLastSlash(m_path);  // cerco l'ultimo slash
   std::wstring str = m_path.substr(i + 1);  // str e' m_path senza directory
-
+  if (isFfmpegType()) return str;
   int j = str.rfind(L".");                       // str[j..] = ".type"
   if (j == (int)std::wstring::npos) return str;  // no frame; no type
   i = str.substr(0, j).rfind(L'.');
@@ -597,6 +598,7 @@ TFilePath TFilePath::getParentDir() const  // noSlash!
 //-----------------------------------------------------------------------------
 
 bool TFilePath::isLevelName() const {
+  if (isFfmpegType()) return false;
   try {
     return getFrame() == TFrameId(TFrameId::EMPTY_FRAME);
   }
@@ -638,6 +640,15 @@ TFrameId TFilePath::getFrame() const {
 
 //-----------------------------------------------------------------------------
 
+bool TFilePath::isFfmpegType() const {
+  QString type = QString::fromStdString(getType()).toLower();
+  if (type == "gif" || type == "mp4" || type == "webm")
+    return true;
+  else
+    return false;
+}
+
+//-----------------------------------------------------------------------------
 TFilePath TFilePath::withType(const std::string &type) const {
   assert(type.length() < 2 || type.substr(0, 2) != "..");
   int i            = getLastSlash(m_path);  // cerco l'ultimo slash

--- a/toonz/sources/include/tfilepath.h
+++ b/toonz/sources/include/tfilepath.h
@@ -177,7 +177,7 @@ If the path is "<alpha>:" a slash will be added*/
   TFilePath getParentDir() const;  // noSlash!;
 
   TFrameId getFrame() const;
-
+  bool isFfmpegType() const;
   bool isLevelName()
       const;  //{return getFrame() == TFrameId(TFrameId::EMPTY_FRAME);};
   bool isAbsolute() const;


### PR DESCRIPTION
Fix for #767.  FFmpeg types with a name such as img.0001.gif or img_0001.mp4 will no longer crash when viewed in the browser or when trying to load.  