### PR TITLE
[WIP] Fix libpng for msvc2015_x86

### DIFF
--- a/thirdparty/libpng-1.6.21/lib/libpng16_2015.lib
+++ b/thirdparty/libpng-1.6.21/lib/libpng16_2015.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d6be973caafd36b6dcf9b8fcb2d030ad2e0c3c523527fad7bbf7da9f9ba5b6e
-size 56118
+oid sha256:e005a1c28ab5a1f8ed57793a79c883f0b44cd5d2b25152544e3dca5fbdd616bc
+size 374568

--- a/thirdparty/libpng-1.6.21/lib/libpng16_2015d.lib
+++ b/thirdparty/libpng-1.6.21/lib/libpng16_2015d.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:be7784d0f86cf87b9dd965a32707e1a999b059d57fbeddb4066a033200e0fbc9
-size 56118
+oid sha256:f61acffbae2925d60a61bd11b6d5b09502843c89c8b3f20b89f240e050a1e916
+size 858596


### PR DESCRIPTION
This PR is for the issue #821 

We are migrating Jenkins to new computer with larger storage.
At the same time, we decided to start using MSVC2015 on it.

We noticed that the libpng library files for MSVC2015-32bit was not static ones 
and which may be cause of the launch failure of t32bitsrv.exe.

_Please do not merge this PR until we confirm that Jenkins builds proper binary._