### PR TITLE
libtiff/Makefile.am: add tif_getimage_64.c

### DIFF
--- a/thirdparty/tiff-4.0.3/libtiff/Makefile.am
+++ b/thirdparty/tiff-4.0.3/libtiff/Makefile.am
@@ -74,6 +74,7 @@ libtiff_la_SOURCES = \
 	tif_fax3sm.c \
 	tif_flush.c \
 	tif_getimage.c \
+	tif_getimage_64.c \
 	tif_jbig.c \
 	tif_jpeg.c \
 	tif_jpeg_12.c \


### PR DESCRIPTION
Fixes automake for the vendored libtiff.
