### PR TITLE
Fix clone levels not saving correctly

### DIFF
--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1292,6 +1292,7 @@ TXshSimpleLevel *CloneLevelUndo::cloneLevel(
     assert(palette);
 
     dstSl->setPalette(palette->clone());
+    dstSl->getPalette()->setDirtyFlag(true);
   }
 
   // The level clone shell was created. Now, clone the associated frames found
@@ -1305,6 +1306,8 @@ TXshSimpleLevel *CloneLevelUndo::cloneLevel(
 
     dstSl->setFrame(*ft, img->cloneImage());
   }
+
+  dstSl->setDirtyFlag(true);
 
   return dstSl;
 }


### PR DESCRIPTION
This PR is for the issue #843.

Save Level command will work on only levels with dirty flags being ON.
In this PR I modified the clone level command so that the cloned levels are set to "dirty".

Please note that with this modification will only turn on the dirty flag. You still need to Save Level / Save All in order to save them into files. (This behavior is same as Toonz Harlequin)