### PR TITLE
Improved convert command from non AA raster images to painted tlv

### DIFF
--- a/toonz/sources/include/toonz/Naa2TlvConverter.h
+++ b/toonz/sources/include/toonz/Naa2TlvConverter.h
@@ -146,7 +146,8 @@ public:
       return -1;
   }
 
-  TToonzImageP makeTlv(bool transparentSyntheticInks);
+  TToonzImageP makeTlv(bool transparentSyntheticInks,
+                       bool removeUnusedStyles = false);
 
   TVectorImageP vectorize(const TToonzImageP &ti);
   TVectorImageP vectorize(const TRaster32P &ras);

--- a/toonz/sources/include/toonzqt/filefield.h
+++ b/toonz/sources/include/toonzqt/filefield.h
@@ -53,6 +53,8 @@ class DVAPI FileField : public QWidget {
   QStringList m_filters;
   QFileDialog::FileMode m_fileMode;
   QString m_windowTitle;
+  QString m_descriptionText;  // if the initial text is not path, set the string
+                              // here and prevent browsing
 
 protected:  // used in the child class for CleanupSettings
   QPushButton *m_fileBrowseButton;
@@ -73,7 +75,7 @@ public:
   static BrowserPopupController *m_browserPopupController;
 
   FileField(QWidget *parent = 0, QString path = QString(),
-            bool readOnly = false);
+            bool readOnly = false, bool doNotBrowseInitialPath = false);
   ~FileField() {}
 
   /*! Set what the user may select in the file dialog:

--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -111,8 +111,10 @@ void DVAPI convertNaa2Tlv(
     FrameTaskNotifier
         *frameNotifier,  //!< Observer class for frame success notifications.
     TPalette *palette =
-        0);  //!< Special conversion function from an antialiased level to tlv.
-             //!  \sa  Function ImageUtils::convert().
+        0,  //!< Special conversion function from an antialiased level to tlv.
+            //!  \sa  Function ImageUtils::convert().
+    bool removeUnusedStyles =
+        false);  //! Remove unused styles from input palette.
 
 double DVAPI getQuantizedZoomFactor(double zf, bool forward);
 

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -529,7 +529,7 @@ QFrame *ConvertPopup::createTlvSettings() {
   m_tlvMode              = new QComboBox();
   m_unpaintedFolderLabel = new QLabel(tr("Unpainted File Folder:"));
   m_unpaintedFolder =
-      new DVGui::FileField(0, QString(tr("Same as Painted")), true);
+      new DVGui::FileField(0, QString(tr("Same as Painted")), true, true);
   m_suffixLabel     = new QLabel(tr(" Unpainted File Suffix:"));
   m_unpaintedSuffix = new DVGui::LineEdit("_np");
   m_applyAutoclose  = new QCheckBox(tr("Apply Autoclose"));
@@ -538,8 +538,9 @@ QFrame *ConvertPopup::createTlvSettings() {
   m_appendDefaultPalette = new QCheckBox(tr("Append Default Palette"));
   m_antialias            = new QComboBox();
   m_antialiasIntensity   = new DVGui::IntLineEdit(0, 50, 0, 100);
-  m_palettePath = new DVGui::FileField(0, QString(CreateNewPalette), true);
-  m_tolerance   = new DVGui::IntLineEdit(0, 0, 0, 255);
+  m_palettePath =
+      new DVGui::FileField(0, QString(CreateNewPalette), true, true);
+  m_tolerance = new DVGui::IntLineEdit(0, 0, 0, 255);
 
   m_removeUnusedStyles =
       new QCheckBox(tr("Remove Unused Styles from Input Palette"));

--- a/toonz/sources/toonz/convertpopup.h
+++ b/toonz/sources/toonz/convertpopup.h
@@ -87,6 +87,7 @@ public slots:
   void onLevelConverted(const TFilePath &fullPath);
 
   void onFormatChanged(const QString &);
+  void onPalettePathChanged();
 
 protected:
   Convert2Tlv *makeTlvConverter(const TFilePath &sourceFilePath);
@@ -104,7 +105,7 @@ private:
   DVGui::ColorField *m_bgColorField;
   QFrame *m_tlvFrame;
   QCheckBox *m_applyAutoclose, *m_removeDotBeforeFrameNumber,
-      *m_saveBackupToNopaint, *m_appendDefaultPalette;
+      *m_saveBackupToNopaint, *m_appendDefaultPalette, *m_removeUnusedStyles;
   DVGui::CheckBox *m_skip;
   QComboBox *m_antialias, *m_tlvMode, *m_fileFormat;
   QLabel *m_bgColorLabel, *m_suffixLabel, *m_unpaintedFolderLabel,

--- a/toonz/sources/toonzqt/filefield.cpp
+++ b/toonz/sources/toonzqt/filefield.cpp
@@ -18,7 +18,8 @@ FileField::BrowserPopupController *FileField::m_browserPopupController = 0;
 // FileField
 //-----------------------------------------------------------------------------
 
-FileField::FileField(QWidget *parent, QString path, bool readOnly)
+FileField::FileField(QWidget *parent, QString path, bool readOnly,
+                     bool doNotBrowseInitialPath)
     : QWidget(parent)
     , m_filters(QStringList())
     , m_fileMode(QFileDialog::DirectoryOnly)
@@ -32,6 +33,9 @@ FileField::FileField(QWidget *parent, QString path, bool readOnly)
 
   m_fileBrowseButton->setMinimumSize(20, WidgetHeight);
   m_fileBrowseButton->setObjectName("PushButton_NoPadding");
+
+  // if the initial text is not path, set the string here and prevent browsing
+  if (doNotBrowseInitialPath) m_descriptionText = path;
 
   QHBoxLayout *mainLayout = new QHBoxLayout();
   mainLayout->setMargin(0);
@@ -90,7 +94,7 @@ void FileField::browseDirectory() {
   if (!m_browserPopupController) return;
   m_browserPopupController->openPopup(
       m_filters, (m_fileMode == QFileDialog::DirectoryOnly),
-      m_lastSelectedPath);
+      (m_lastSelectedPath == m_descriptionText) ? "" : m_lastSelectedPath);
   if (m_browserPopupController->isExecute())
     directory = m_browserPopupController->getPath();
 

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -632,7 +632,8 @@ void convert(const TFilePath &source, const TFilePath &dest,
 
 void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
                     const TFrameId &from, const TFrameId &to,
-                    FrameTaskNotifier *frameNotifier, TPalette *palette) {
+                    FrameTaskNotifier *frameNotifier, TPalette *palette,
+                    bool removeUnusedStyles) {
   std::string dstExt = dest.getType(), srcExt = source.getType();
 
   // Load source level structure
@@ -671,8 +672,8 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
 
       converter.process(raster);
 
-      if (TToonzImageP dstImg =
-              converter.makeTlv(false))  // Opaque synthetic inks
+      if (TToonzImageP dstImg = converter.makeTlv(
+              false, removeUnusedStyles))  // Opaque synthetic inks
       {
         if (converter.getPalette() == 0)
           converter.setPalette(dstImg->getPalette());


### PR DESCRIPTION
This PR is for the issue #852 and is improving "Convert" command which can be triggered from the right-click menu of File Browser.

- Enabled to input palette when "Painted tlv from non AA source" option.
- Added an option to remove unused styles from input palette.