### PR TITLE
Fix Load Scene popup to initialize correctly

### DIFF
--- a/toonz/sources/include/toonz/tproject.h
+++ b/toonz/sources/include/toonz/tproject.h
@@ -57,7 +57,7 @@ public:
   bool isConstantFolder(int index) const;
 
   TFilePath getFolder(int index) const;
-  TFilePath getFolder(std::string name) const;
+  TFilePath getFolder(std::string name, bool absolute = false) const;
 
   TFilePath getScenesPath() const;
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -485,17 +485,15 @@ bool LoadScenePopup::execute() {
 void LoadScenePopup::initFolder() { setInitialFolderByCurrentRoom(); }
 
 void LoadScenePopup::setInitialFolderByCurrentRoom() {
-  QString roomName = TApp::instance()->getCurrentRoomName();
+  QString roomName  = TApp::instance()->getCurrentRoomName();
+  TProjectP project = TProjectManager::instance()->getCurrentProject();
   TFilePath scenePath;
   if (roomName == "Cleanup" || roomName == "InknPaint")
-    scenePath = TProjectManager::instance()->getCurrentProject()->getFolder(
-        TProject::Drawings);
+    scenePath = project->getFolder(TProject::Drawings, true);
   else if (roomName == "PltEdit")
-    scenePath = TProjectManager::instance()->getCurrentProject()->getFolder(
-        TProject::Palettes);
+    scenePath = project->getFolder(TProject::Palettes, true);
   else
-    scenePath = TProjectManager::instance()->getCurrentProject()->getFolder(
-        TProject::Scenes);
+    scenePath = project->getFolder(TProject::Scenes, true);
   setFolder(scenePath);
 }
 

--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -298,13 +298,15 @@ void TProject::setFolder(string name) { setFolder(name, TFilePath(name)); }
 //-------------------------------------------------------------------
 /*! Returns the path of the folder named with \b name.\n
         Returns TFilePath() if there isn't a folder named with \b name.
-        \note The returned path could be a relative path.
+        \note The returned path could be a relative path if \b absolute is
+   false.
 */
-TFilePath TProject::getFolder(string name) const {
+TFilePath TProject::getFolder(string name, bool absolute) const {
   std::map<std::string, TFilePath>::const_iterator it;
   it = m_folders.find(name);
   if (it != m_folders.end())
-    return it->second;
+    return (absolute) ? makeAbsolute(getProjectFolder(), it->second)
+                      : it->second;
   else
     return TFilePath();
 }


### PR DESCRIPTION
This PR is for the issue #867 
Now the Load Scene popup can locate correct initial position even if the "+scenes" project folder path is relative.