### PR TITLE
Startup Popup: Highlight "Open Recent Scene" items on mouse hover

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -1370,3 +1370,10 @@ QDialog #dialogButtonFrame {
 #GearButton {
     qproperty-icon: url("@{image_url}/gear.png");
 }
+
+#StartupLabel {
+    padding: 3px;
+	&:hover {
+		.baseBG(light, 10%);
+	}    
+}

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -764,7 +764,7 @@ DvDirTreeView {
 /*---------------------------------------------------------------------------*/
 /* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
-#CleanupSettingsFrame, 
+#CleanupSettingsFrame,
 #LoadLevelFrame,
 #SolidLineFrame {
   border: 1px solid #e6e6e6;
@@ -1371,6 +1371,12 @@ QDialog #dialogButtonFrame {
 }
 #GearButton {
   qproperty-icon: url("../gray_072/imgs/gear.png");
+}
+#StartupLabel {
+  padding: 3px;
+}
+#StartupLabel:hover {
+  background-color: #4a4a4a;
 }
 
 //# sourceMappingURL=gray_048.qss.map

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -764,7 +764,7 @@ DvDirTreeView {
 /*---------------------------------------------------------------------------*/
 /* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
-#CleanupSettingsFrame, 
+#CleanupSettingsFrame,
 #LoadLevelFrame,
 #SolidLineFrame {
   border: 1px solid #e6e6e6;
@@ -1371,6 +1371,12 @@ QDialog #dialogButtonFrame {
 }
 #GearButton {
   qproperty-icon: url("../gray_072/imgs/gear.png");
+}
+#StartupLabel {
+  padding: 3px;
+}
+#StartupLabel:hover {
+  background-color: #4a4a4a;
 }
 
 //# sourceMappingURL=gray_048_mac.qss.map

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -1370,3 +1370,10 @@ QDialog #dialogButtonFrame {
 #GearButton {
     qproperty-icon: url("@{image_url}/gear.png");
 }
+
+#StartupLabel {
+    padding: 3px;
+	&:hover {
+		.baseBG(light, 10%);
+	}    
+}

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -764,7 +764,7 @@ DvDirTreeView {
 /*---------------------------------------------------------------------------*/
 /* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
-#CleanupSettingsFrame, 
+#CleanupSettingsFrame,
 #LoadLevelFrame,
 #SolidLineFrame {
   border: 1px solid #e6e6e6;
@@ -1371,6 +1371,12 @@ QDialog #dialogButtonFrame {
 }
 #GearButton {
   qproperty-icon: url("imgs/gear.png");
+}
+#StartupLabel {
+  padding: 3px;
+}
+#StartupLabel:hover {
+  background-color: #626262;
 }
 
 //# sourceMappingURL=gray_072.qss.map

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -764,7 +764,7 @@ DvDirTreeView {
 /*---------------------------------------------------------------------------*/
 /* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
-#CleanupSettingsFrame, 
+#CleanupSettingsFrame,
 #LoadLevelFrame,
 #SolidLineFrame {
   border: 1px solid #e6e6e6;
@@ -1371,6 +1371,12 @@ QDialog #dialogButtonFrame {
 }
 #GearButton {
   qproperty-icon: url("imgs/gear.png");
+}
+#StartupLabel {
+  padding: 3px;
+}
+#StartupLabel:hover {
+  background-color: #626262;
 }
 
 //# sourceMappingURL=gray_072_mac.qss.map

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -1195,3 +1195,10 @@ QDialog #dialogButtonFrame {
 #GearButton {
     qproperty-icon: url("@{image_url}/gear.png");
 }
+
+#StartupLabel {
+    padding: 3px;
+	&:hover {
+		.baseBG(light, 10%);
+	}    
+}

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -526,7 +526,7 @@ DvDirTreeView {
 /*---------------------------------------------------------------------------*/
 /* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
-#CleanupSettingsFrame, 
+#CleanupSettingsFrame,
 #LoadLevelFrame,
 #SolidLineFrame {
   border: 1px solid #141414;
@@ -1110,6 +1110,12 @@ QDialog #dialogButtonFrame {
 }
 #GearButton {
   qproperty-icon: url("imgs/gear.png");
+}
+#StartupLabel {
+  padding: 3px;
+}
+#StartupLabel:hover {
+  background-color: #9a9a9a;
 }
 
 //# sourceMappingURL=gray_128.qss.map

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -526,7 +526,7 @@ DvDirTreeView {
 /*---------------------------------------------------------------------------*/
 /* Cleanup Settings, LoadLevel, PsdSettingsPopup, FxSettingsPopup, RenameAsToonzPopup */
 /*---------------------------------------------------------------------------*/
-#CleanupSettingsFrame, 
+#CleanupSettingsFrame,
 #LoadLevelFrame,
 #SolidLineFrame {
   border: 1px solid #141414;
@@ -1110,6 +1110,12 @@ QDialog #dialogButtonFrame {
 }
 #GearButton {
   qproperty-icon: url("imgs/gear.png");
+}
+#StartupLabel {
+  padding: 3px;
+}
+#StartupLabel:hover {
+  background-color: #9a9a9a;
 }
 
 //# sourceMappingURL=gray_128_mac.qss.map

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -221,8 +221,8 @@ StartupPopup::StartupPopup()
     m_sceneBox->setLayout(newSceneLay);
     guiLay->addWidget(m_sceneBox, 2, 0, 4, 1, Qt::AlignLeft);
 
-    m_recentSceneLay->setMargin(8);
-    m_recentSceneLay->setSpacing(8);
+    m_recentSceneLay->setMargin(5);
+    m_recentSceneLay->setSpacing(2);
     {
       // Recent Scene List
       m_recentBox->setLayout(m_recentSceneLay);
@@ -367,6 +367,8 @@ void StartupPopup::showEvent(QShowEvent *) {
       if (i > 9) break;  // box can hold 10 scenes
       QString justName = QString::fromStdString(TFilePath(name).getName());
       m_recentNamesLabels[i] = new StartupLabel(justName, this, i);
+      m_recentNamesLabels[i]->setToolTip(
+          name.remove(0, name.indexOf(" ") + 1));  // remove "#. " prefix
       m_recentSceneLay->addWidget(m_recentNamesLabels[i], i, Qt::AlignTop);
       i++;
     }
@@ -901,6 +903,7 @@ void StartupPopup::updateSize() {
 StartupLabel::StartupLabel(const QString &text, QWidget *parent, int index)
     : QLabel(parent), m_index(index) {
   setText(text);
+  setObjectName("StartupLabel");
 }
 
 StartupLabel::~StartupLabel() {}


### PR DESCRIPTION
This PR modifies Startup Popup, changing background color of "Open Recent Scene" items on mouse hover in order to make it clear for users that they are clickable. Also added a tool tip showing the full scene path.

<img src="https://cloud.githubusercontent.com/assets/17974955/19433885/99a4f58e-949d-11e6-9136-1d9ce4698260.png" width=600>