### PR TITLE
Change brush default to rounded

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -45,7 +45,7 @@ using namespace ToolUtils;
 
 TEnv::DoubleVar VectorBrushMinSize("InknpaintVectorBrushMinSize", 1);
 TEnv::DoubleVar VectorBrushMaxSize("InknpaintVectorBrushMaxSize", 5);
-TEnv::IntVar VectorCapStyle("InknpaintVectorCapStyle", 0);
+TEnv::IntVar VectorCapStyle("InknpaintVectorCapStyle", 1);
 TEnv::IntVar VectorJoinStyle("InknpaintVectorJoinStyle", 0);
 TEnv::IntVar VectorMiterValue("InknpaintVectorMiterValue", 4);
 TEnv::DoubleVar RasterBrushMinSize("InknpaintRasterBrushMinSize", 1);


### PR DESCRIPTION
The default flat end brush cap is sometimes harsh.  I think using rounded as the default would be nicer and easier to work with.  

#766