### PR TITLE
Unify all scrollbars to same style and fix background

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -1,4 +1,4 @@
-
+// out: gray_048.qss
 /* LESS Definitions */
 
 /*Image URL*/
@@ -821,7 +821,7 @@ ParamsPage {
 	}
 }
 /* Customize QScrollBar  vertical*/
-#XsheetScrollBar {
+QScrollBar, #XsheetScrollBar {
 	.baseBG(light, 10%);
 	border: 1px solid black;
 
@@ -890,7 +890,7 @@ ParamsPage {
 		}
 	}
 
-	&::add-page {
+	&::add-page, &::sub-page {
 		background: none;
 	}
 }

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -841,11 +841,13 @@ ParamsPage {
   background-color: #000080;
 }
 /* Customize QScrollBar  vertical*/
+QScrollBar,
 #XsheetScrollBar {
   background-color: #4a4a4a;
   border: 1px solid black;
   /* buttons */
 }
+QScrollBar:vertical,
 #XsheetScrollBar:vertical {
   width: 18px;
   margin-left: 0px;
@@ -853,6 +855,7 @@ ParamsPage {
   margin-top: 20px;
   margin-bottom: 20px;
 }
+QScrollBar:horizontal,
 #XsheetScrollBar:horizontal {
   height: 18px;
   margin-left: 20px;
@@ -860,59 +863,75 @@ ParamsPage {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+QScrollBar::handle,
 #XsheetScrollBar::handle {
   border-width: 4;
   image-position: center center;
 }
+QScrollBar::handle:vertical,
 #XsheetScrollBar::handle:vertical {
   border-image: url("../gray_072/imgs/sb_g_vhandle.png") 4;
   image: url("../gray_072/imgs/sb_g_vline.png");
   min-height: 40px;
 }
+QScrollBar::handle:horizontal,
 #XsheetScrollBar::handle:horizontal {
   border-image: url("../gray_072/imgs/sb_g_hhandle.png") 4;
   image: url("../gray_072/imgs/sb_g_hline.png");
   min-width: 40px;
 }
+QScrollBar::add-line,
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
+QScrollBar::add-line:vertical,
 #XsheetScrollBar::add-line:vertical {
   image: url("../gray_072/imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
+QScrollBar::add-line:vertical:pressed,
 #XsheetScrollBar::add-line:vertical:pressed {
   image: url("../gray_072/imgs/sb_g_downarrow_pressed.png");
 }
+QScrollBar::add-line:horizontal,
 #XsheetScrollBar::add-line:horizontal {
   image: url("../gray_072/imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
+QScrollBar::add-line:horizontal:pressed,
 #XsheetScrollBar::add-line:horizontal:pressed {
   image: url("../gray_072/imgs/sb_g_rarrow_pressed.png");
 }
+QScrollBar::sub-line,
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
+QScrollBar::sub-line:vertical,
 #XsheetScrollBar::sub-line:vertical {
   image: url("../gray_072/imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
+QScrollBar::sub-line:vertical:pressed,
 #XsheetScrollBar::sub-line:vertical:pressed {
   image: url("../gray_072/imgs/sb_g_uparrow_pressed.png");
 }
+QScrollBar::sub-line:horizontal,
 #XsheetScrollBar::sub-line:horizontal {
   image: url("../gray_072/imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
+QScrollBar::sub-line:horizontal:pressed,
 #XsheetScrollBar::sub-line:horizontal:pressed {
   image: url("../gray_072/imgs/sb_g_larrow_pressed.png");
 }
-#XsheetScrollBar::add-page {
+QScrollBar::add-page,
+#XsheetScrollBar::add-page,
+QScrollBar::sub-page,
+#XsheetScrollBar::sub-page {
   background: none;
 }
 #noteTextEdit {

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -841,11 +841,13 @@ ParamsPage {
   background-color: #000080;
 }
 /* Customize QScrollBar  vertical*/
+QScrollBar,
 #XsheetScrollBar {
   background-color: #4a4a4a;
   border: 1px solid black;
   /* buttons */
 }
+QScrollBar:vertical,
 #XsheetScrollBar:vertical {
   width: 18px;
   margin-left: 0px;
@@ -853,6 +855,7 @@ ParamsPage {
   margin-top: 20px;
   margin-bottom: 20px;
 }
+QScrollBar:horizontal,
 #XsheetScrollBar:horizontal {
   height: 18px;
   margin-left: 20px;
@@ -860,59 +863,75 @@ ParamsPage {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+QScrollBar::handle,
 #XsheetScrollBar::handle {
   border-width: 4;
   image-position: center center;
 }
+QScrollBar::handle:vertical,
 #XsheetScrollBar::handle:vertical {
   border-image: url("../gray_072/imgs/sb_g_vhandle.png") 4;
   image: url("../gray_072/imgs/sb_g_vline.png");
   min-height: 40px;
 }
+QScrollBar::handle:horizontal,
 #XsheetScrollBar::handle:horizontal {
   border-image: url("../gray_072/imgs/sb_g_hhandle.png") 4;
   image: url("../gray_072/imgs/sb_g_hline.png");
   min-width: 40px;
 }
+QScrollBar::add-line,
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
+QScrollBar::add-line:vertical,
 #XsheetScrollBar::add-line:vertical {
   image: url("../gray_072/imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
+QScrollBar::add-line:vertical:pressed,
 #XsheetScrollBar::add-line:vertical:pressed {
   image: url("../gray_072/imgs/sb_g_downarrow_pressed.png");
 }
+QScrollBar::add-line:horizontal,
 #XsheetScrollBar::add-line:horizontal {
   image: url("../gray_072/imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
+QScrollBar::add-line:horizontal:pressed,
 #XsheetScrollBar::add-line:horizontal:pressed {
   image: url("../gray_072/imgs/sb_g_rarrow_pressed.png");
 }
+QScrollBar::sub-line,
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
+QScrollBar::sub-line:vertical,
 #XsheetScrollBar::sub-line:vertical {
   image: url("../gray_072/imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
+QScrollBar::sub-line:vertical:pressed,
 #XsheetScrollBar::sub-line:vertical:pressed {
   image: url("../gray_072/imgs/sb_g_uparrow_pressed.png");
 }
+QScrollBar::sub-line:horizontal,
 #XsheetScrollBar::sub-line:horizontal {
   image: url("../gray_072/imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
+QScrollBar::sub-line:horizontal:pressed,
 #XsheetScrollBar::sub-line:horizontal:pressed {
   image: url("../gray_072/imgs/sb_g_larrow_pressed.png");
 }
-#XsheetScrollBar::add-page {
+QScrollBar::add-page,
+#XsheetScrollBar::add-page,
+QScrollBar::sub-page,
+#XsheetScrollBar::sub-page {
   background: none;
 }
 #noteTextEdit {

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -821,7 +821,7 @@ ParamsPage {
 	}
 }
 /* Customize QScrollBar  vertical*/
-#XsheetScrollBar {
+QScrollBar, #XsheetScrollBar {
 	.baseBG(light, 10%);
 	border: 1px solid black;
 
@@ -890,7 +890,7 @@ ParamsPage {
 		}
 	}
 
-	&::add-page {
+	&::add-page, &::sub-page {
 		background: none;
 	}
 }

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -841,11 +841,13 @@ ParamsPage {
   background-color: #000080;
 }
 /* Customize QScrollBar  vertical*/
+QScrollBar,
 #XsheetScrollBar {
   background-color: #626262;
   border: 1px solid black;
   /* buttons */
 }
+QScrollBar:vertical,
 #XsheetScrollBar:vertical {
   width: 18px;
   margin-left: 0px;
@@ -853,6 +855,7 @@ ParamsPage {
   margin-top: 20px;
   margin-bottom: 20px;
 }
+QScrollBar:horizontal,
 #XsheetScrollBar:horizontal {
   height: 18px;
   margin-left: 20px;
@@ -860,59 +863,75 @@ ParamsPage {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+QScrollBar::handle,
 #XsheetScrollBar::handle {
   border-width: 4;
   image-position: center center;
 }
+QScrollBar::handle:vertical,
 #XsheetScrollBar::handle:vertical {
   border-image: url("imgs/sb_g_vhandle.png") 4;
   image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
+QScrollBar::handle:horizontal,
 #XsheetScrollBar::handle:horizontal {
   border-image: url("imgs/sb_g_hhandle.png") 4;
   image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
+QScrollBar::add-line,
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
+QScrollBar::add-line:vertical,
 #XsheetScrollBar::add-line:vertical {
   image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
+QScrollBar::add-line:vertical:pressed,
 #XsheetScrollBar::add-line:vertical:pressed {
   image: url("imgs/sb_g_downarrow_pressed.png");
 }
+QScrollBar::add-line:horizontal,
 #XsheetScrollBar::add-line:horizontal {
   image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
+QScrollBar::add-line:horizontal:pressed,
 #XsheetScrollBar::add-line:horizontal:pressed {
   image: url("imgs/sb_g_rarrow_pressed.png");
 }
+QScrollBar::sub-line,
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
+QScrollBar::sub-line:vertical,
 #XsheetScrollBar::sub-line:vertical {
   image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
+QScrollBar::sub-line:vertical:pressed,
 #XsheetScrollBar::sub-line:vertical:pressed {
   image: url("imgs/sb_g_uparrow_pressed.png");
 }
+QScrollBar::sub-line:horizontal,
 #XsheetScrollBar::sub-line:horizontal {
   image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
+QScrollBar::sub-line:horizontal:pressed,
 #XsheetScrollBar::sub-line:horizontal:pressed {
   image: url("imgs/sb_g_larrow_pressed.png");
 }
-#XsheetScrollBar::add-page {
+QScrollBar::add-page,
+#XsheetScrollBar::add-page,
+QScrollBar::sub-page,
+#XsheetScrollBar::sub-page {
   background: none;
 }
 #noteTextEdit {

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -841,11 +841,13 @@ ParamsPage {
   background-color: #000080;
 }
 /* Customize QScrollBar  vertical*/
+QScrollBar,
 #XsheetScrollBar {
   background-color: #626262;
   border: 1px solid black;
   /* buttons */
 }
+QScrollBar:vertical,
 #XsheetScrollBar:vertical {
   width: 18px;
   margin-left: 0px;
@@ -853,6 +855,7 @@ ParamsPage {
   margin-top: 20px;
   margin-bottom: 20px;
 }
+QScrollBar:horizontal,
 #XsheetScrollBar:horizontal {
   height: 18px;
   margin-left: 20px;
@@ -860,59 +863,75 @@ ParamsPage {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+QScrollBar::handle,
 #XsheetScrollBar::handle {
   border-width: 4;
   image-position: center center;
 }
+QScrollBar::handle:vertical,
 #XsheetScrollBar::handle:vertical {
   border-image: url("imgs/sb_g_vhandle.png") 4;
   image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
+QScrollBar::handle:horizontal,
 #XsheetScrollBar::handle:horizontal {
   border-image: url("imgs/sb_g_hhandle.png") 4;
   image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
+QScrollBar::add-line,
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
+QScrollBar::add-line:vertical,
 #XsheetScrollBar::add-line:vertical {
   image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
+QScrollBar::add-line:vertical:pressed,
 #XsheetScrollBar::add-line:vertical:pressed {
   image: url("imgs/sb_g_downarrow_pressed.png");
 }
+QScrollBar::add-line:horizontal,
 #XsheetScrollBar::add-line:horizontal {
   image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
+QScrollBar::add-line:horizontal:pressed,
 #XsheetScrollBar::add-line:horizontal:pressed {
   image: url("imgs/sb_g_rarrow_pressed.png");
 }
+QScrollBar::sub-line,
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
+QScrollBar::sub-line:vertical,
 #XsheetScrollBar::sub-line:vertical {
   image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
+QScrollBar::sub-line:vertical:pressed,
 #XsheetScrollBar::sub-line:vertical:pressed {
   image: url("imgs/sb_g_uparrow_pressed.png");
 }
+QScrollBar::sub-line:horizontal,
 #XsheetScrollBar::sub-line:horizontal {
   image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
+QScrollBar::sub-line:horizontal:pressed,
 #XsheetScrollBar::sub-line:horizontal:pressed {
   image: url("imgs/sb_g_larrow_pressed.png");
 }
-#XsheetScrollBar::add-page {
+QScrollBar::add-page,
+#XsheetScrollBar::add-page,
+QScrollBar::sub-page,
+#XsheetScrollBar::sub-page {
   background: none;
 }
 #noteTextEdit {

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -1,3 +1,4 @@
+// out: gray_128.qss
 /* LESS Definitions */
 
 /*Image URL*/
@@ -661,7 +662,7 @@ ParamsPage {
 	}
 }
 /* Customize QScrollBar  vertical*/
-#XsheetScrollBar {
+QScrollBar, #XsheetScrollBar {
 	background-color: rgb(160,160,160);
 	border: 1px solid black;
 
@@ -730,7 +731,7 @@ ParamsPage {
 		}
 	}
 
-	&::add-page {
+	&::add-page, &::sub-page {
 		background: none;
 	}
 }

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -591,11 +591,13 @@ ParamsPage {
   background-color: #000080;
 }
 /* Customize QScrollBar  vertical*/
+QScrollBar,
 #XsheetScrollBar {
   background-color: #a0a0a0;
   border: 1px solid black;
   /* buttons */
 }
+QScrollBar:vertical,
 #XsheetScrollBar:vertical {
   width: 18px;
   margin-left: 0px;
@@ -603,6 +605,7 @@ ParamsPage {
   margin-top: 20px;
   margin-bottom: 20px;
 }
+QScrollBar:horizontal,
 #XsheetScrollBar:horizontal {
   height: 18px;
   margin-left: 20px;
@@ -610,59 +613,75 @@ ParamsPage {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+QScrollBar::handle,
 #XsheetScrollBar::handle {
   border-width: 4;
   image-position: center center;
 }
+QScrollBar::handle:vertical,
 #XsheetScrollBar::handle:vertical {
   border-image: url("imgs/sb_g_vhandle.png") 4;
   image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
+QScrollBar::handle:horizontal,
 #XsheetScrollBar::handle:horizontal {
   border-image: url("imgs/sb_g_hhandle.png") 4;
   image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
+QScrollBar::add-line,
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
+QScrollBar::add-line:vertical,
 #XsheetScrollBar::add-line:vertical {
   image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
+QScrollBar::add-line:vertical:pressed,
 #XsheetScrollBar::add-line:vertical:pressed {
   image: url("imgs/sb_g_downarrow_pressed.png");
 }
+QScrollBar::add-line:horizontal,
 #XsheetScrollBar::add-line:horizontal {
   image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
+QScrollBar::add-line:horizontal:pressed,
 #XsheetScrollBar::add-line:horizontal:pressed {
   image: url("imgs/sb_g_rarrow_pressed.png");
 }
+QScrollBar::sub-line,
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
+QScrollBar::sub-line:vertical,
 #XsheetScrollBar::sub-line:vertical {
   image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
+QScrollBar::sub-line:vertical:pressed,
 #XsheetScrollBar::sub-line:vertical:pressed {
   image: url("imgs/sb_g_uparrow_pressed.png");
 }
+QScrollBar::sub-line:horizontal,
 #XsheetScrollBar::sub-line:horizontal {
   image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
+QScrollBar::sub-line:horizontal:pressed,
 #XsheetScrollBar::sub-line:horizontal:pressed {
   image: url("imgs/sb_g_larrow_pressed.png");
 }
-#XsheetScrollBar::add-page {
+QScrollBar::add-page,
+#XsheetScrollBar::add-page,
+QScrollBar::sub-page,
+#XsheetScrollBar::sub-page {
   background: none;
 }
 XsheetViewer {

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -591,11 +591,13 @@ ParamsPage {
   background-color: #000080;
 }
 /* Customize QScrollBar  vertical*/
+QScrollBar,
 #XsheetScrollBar {
   background-color: #a0a0a0;
   border: 1px solid black;
   /* buttons */
 }
+QScrollBar:vertical,
 #XsheetScrollBar:vertical {
   width: 18px;
   margin-left: 0px;
@@ -603,6 +605,7 @@ ParamsPage {
   margin-top: 20px;
   margin-bottom: 20px;
 }
+QScrollBar:horizontal,
 #XsheetScrollBar:horizontal {
   height: 18px;
   margin-left: 20px;
@@ -610,59 +613,75 @@ ParamsPage {
   margin-top: 0px;
   margin-bottom: 0px;
 }
+QScrollBar::handle,
 #XsheetScrollBar::handle {
   border-width: 4;
   image-position: center center;
 }
+QScrollBar::handle:vertical,
 #XsheetScrollBar::handle:vertical {
   border-image: url("imgs/sb_g_vhandle.png") 4;
   image: url("imgs/sb_g_vline.png");
   min-height: 40px;
 }
+QScrollBar::handle:horizontal,
 #XsheetScrollBar::handle:horizontal {
   border-image: url("imgs/sb_g_hhandle.png") 4;
   image: url("imgs/sb_g_hline.png");
   min-width: 40px;
 }
+QScrollBar::add-line,
 #XsheetScrollBar::add-line {
   subcontrol-origin: margin;
 }
+QScrollBar::add-line:vertical,
 #XsheetScrollBar::add-line:vertical {
   image: url("imgs/sb_g_downarrow.png");
   height: 20px;
   subcontrol-position: bottom;
 }
+QScrollBar::add-line:vertical:pressed,
 #XsheetScrollBar::add-line:vertical:pressed {
   image: url("imgs/sb_g_downarrow_pressed.png");
 }
+QScrollBar::add-line:horizontal,
 #XsheetScrollBar::add-line:horizontal {
   image: url("imgs/sb_g_rarrow.png");
   width: 20px;
   subcontrol-position: right;
 }
+QScrollBar::add-line:horizontal:pressed,
 #XsheetScrollBar::add-line:horizontal:pressed {
   image: url("imgs/sb_g_rarrow_pressed.png");
 }
+QScrollBar::sub-line,
 #XsheetScrollBar::sub-line {
   subcontrol-origin: margin;
 }
+QScrollBar::sub-line:vertical,
 #XsheetScrollBar::sub-line:vertical {
   image: url("imgs/sb_g_uparrow.png");
   height: 20px;
   subcontrol-position: top;
 }
+QScrollBar::sub-line:vertical:pressed,
 #XsheetScrollBar::sub-line:vertical:pressed {
   image: url("imgs/sb_g_uparrow_pressed.png");
 }
+QScrollBar::sub-line:horizontal,
 #XsheetScrollBar::sub-line:horizontal {
   image: url("imgs/sb_g_larrow.png");
   width: 20px;
   subcontrol-position: left;
 }
+QScrollBar::sub-line:horizontal:pressed,
 #XsheetScrollBar::sub-line:horizontal:pressed {
   image: url("imgs/sb_g_larrow_pressed.png");
 }
-#XsheetScrollBar::add-page {
+QScrollBar::add-page,
+#XsheetScrollBar::add-page,
+QScrollBar::sub-page,
+#XsheetScrollBar::sub-page {
   background: none;
 }
 XsheetViewer {


### PR DESCRIPTION
The scrollbar in the xsheet and the rest of the UI were not consistent.  This unifies the scrollbars and takes care of the checkered background on the scrollbars mentioned in #754

![scrollbars](https://cloud.githubusercontent.com/assets/4576381/19572799/eccea820-96c0-11e6-9e8d-ae6e775b6604.png)

Note: There is still discussion to be had regarding theme colors, flattening, etc, but I think that should be its own PR/issue.
