### PR TITLE
Render Button added to Output Settings

### DIFF
--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -165,7 +165,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     showOtherSettingsButton = new QPushButton("", this);
     otherSettingsLabel      = new QLabel(tr("Other Settings"), this);
     otherSettingsFrame      = new QFrame(this);
-
+    m_renderButton          = new QPushButton(tr("Render"), this);
     // Gamma
     m_gammaFld = new DVGui::DoubleLineEdit();
     // Dominant Field
@@ -503,7 +503,9 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     }
     fileSettingsBox->setLayout(fileSetBoxLay);
     m_topLayout->addWidget(fileSettingsBox, 0);
-
+    if (!isPreview) {
+      m_topLayout->addWidget(m_renderButton);
+    }
     m_topLayout->addStretch(1);
   }
 
@@ -520,6 +522,8 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
                   SLOT(onFormatChanged(const QString &)));
     ret = ret && connect(m_fileFormatButton, SIGNAL(pressed()), this,
                          SLOT(openSettingsPopup()));
+    ret = ret && connect(m_renderButton, SIGNAL(pressed()), this,
+                         SLOT(onRenderClicked()));
   }
   ret = ret &&
         connect(m_outputCameraOm, SIGNAL(currentIndexChanged(const QString &)),
@@ -650,6 +654,12 @@ void OutputSettingsPopup::onApplyShrinkChecked(int state) {
 
 void OutputSettingsPopup::onSubcameraChecked(int state) {
   getProperties()->setSubcameraPreview(state == Qt::Checked);
+}
+
+//-----------------------------------------------------------------------------
+
+void OutputSettingsPopup::onRenderClicked() {
+  CommandManager::instance()->execute("MI_Render");
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -49,6 +49,7 @@ class OutputSettingsPopup : public DVGui::Dialog {
 
   DVGui::DoubleLineEdit *m_frameRateFld;
   QPushButton *m_fileFormatButton;
+  QPushButton *m_renderButton;
   CameraSettingsPopup *m_cameraSettings;
   QComboBox *m_presetCombo;
 
@@ -86,6 +87,7 @@ protected slots:
   void onRasterGranularityChanged(int type);
   void onStereoChecked(int);
   void onStereoChanged();
+  void onRenderClicked();
 
   /*-- OutputSettingsのPreset登録/削除/選択 --*/
   void onAddPresetButtonPressed();


### PR DESCRIPTION
#795

Added a render button to the bottom of output settings.  This makes it easier to set the settings and render from the same place.

![renderinoutputsettings](https://cloud.githubusercontent.com/assets/4576381/19573935/6f4eefd6-96c5-11e6-97a3-45d6238b3b39.png)
