### PR TITLE
Fix white xsheet vertical line

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -1,4 +1,4 @@
-
+// out: gray_048.qss
 /* LESS Definitions */
 
 /*Image URL*/
@@ -904,6 +904,8 @@ XsheetViewer {
 	qproperty-BGColor: rgb(72,72,72);
 	qproperty-LightLineColor: rgb(32,32,32);
 	qproperty-MarkerLineColor: rgb(30, 150, 196);
+	qproperty-VerticalLineColor: rgb(120,120,120);
+	qproperty-VerticalLineHeadColor: rgb(160,160,160);
 	qproperty-PreviewFrameTextColor: rgb(150, 230, 230);
 	qproperty-CurrentRowBgColor: rgb(80,96,130);
 

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -923,6 +923,8 @@ XsheetViewer {
   qproperty-BGColor: #484848;
   qproperty-LightLineColor: #202020;
   qproperty-MarkerLineColor: #1e96c4;
+  qproperty-VerticalLineColor: #787878;
+  qproperty-VerticalLineHeadColor: #a0a0a0;
   qproperty-PreviewFrameTextColor: #96e6e6;
   qproperty-CurrentRowBgColor: #506082;
   qproperty-EmptyColumnHeadColor: #606060;

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -923,6 +923,8 @@ XsheetViewer {
   qproperty-BGColor: #484848;
   qproperty-LightLineColor: #202020;
   qproperty-MarkerLineColor: #1e96c4;
+  qproperty-VerticalLineColor: #787878;
+  qproperty-VerticalLineHeadColor: #a0a0a0;
   qproperty-PreviewFrameTextColor: #96e6e6;
   qproperty-CurrentRowBgColor: #506082;
   qproperty-EmptyColumnHeadColor: #606060;

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -1,3 +1,4 @@
+// out: gray_072.qss
 /* LESS Definitions */
 
 /*Image URL*/
@@ -904,6 +905,8 @@ XsheetViewer {
 	qproperty-BGColor: rgb(72,72,72);
 	qproperty-LightLineColor: rgb(32,32,32);
 	qproperty-MarkerLineColor: rgb(30, 150, 196);
+	qproperty-VerticalLineColor: rgb(120,120,120);
+	qproperty-VerticalLineHeadColor: rgb(160,160,160);
 	qproperty-PreviewFrameTextColor: rgb(150, 230, 230);
 	qproperty-CurrentRowBgColor: rgb(80,96,130);
 

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -923,6 +923,8 @@ XsheetViewer {
   qproperty-BGColor: #484848;
   qproperty-LightLineColor: #202020;
   qproperty-MarkerLineColor: #1e96c4;
+  qproperty-VerticalLineColor: #787878;
+  qproperty-VerticalLineHeadColor: #a0a0a0;
   qproperty-PreviewFrameTextColor: #96e6e6;
   qproperty-CurrentRowBgColor: #506082;
   qproperty-EmptyColumnHeadColor: #606060;

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -923,6 +923,8 @@ XsheetViewer {
   qproperty-BGColor: #484848;
   qproperty-LightLineColor: #202020;
   qproperty-MarkerLineColor: #1e96c4;
+  qproperty-VerticalLineColor: #787878;
+  qproperty-VerticalLineHeadColor: #a0a0a0;
   qproperty-PreviewFrameTextColor: #96e6e6;
   qproperty-CurrentRowBgColor: #506082;
   qproperty-EmptyColumnHeadColor: #606060;

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -1,3 +1,4 @@
+// out: gray_128.qss
 /* LESS Definitions */
 
 /*Image URL*/
@@ -740,6 +741,8 @@ XsheetViewer {
 	qproperty-BGColor: rgb(164,164,164);
 	qproperty-LightLineColor: rgb(146,144,146);
 	qproperty-MarkerLineColor: rgb(0, 255, 246);
+	qproperty-VerticalLineColor: rgb(0, 0, 0);
+	qproperty-VerticalLineHeadColor: rgb(0, 0, 0);
 	qproperty-PreviewFrameTextColor: rgb(0, 0, 255);
 	qproperty-CurrentRowBgColor: rgb(210,210,210);
 

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -670,6 +670,8 @@ XsheetViewer {
   qproperty-BGColor: #a4a4a4;
   qproperty-LightLineColor: #929092;
   qproperty-MarkerLineColor: #00fff6;
+  qproperty-VerticalLineColor: #000000;
+  qproperty-VerticalLineHeadColor: #000000;
   qproperty-PreviewFrameTextColor: #0000ff;
   qproperty-CurrentRowBgColor: #d2d2d2;
   qproperty-EmptyColumnHeadColor: #c8c8c8;

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -670,6 +670,8 @@ XsheetViewer {
   qproperty-BGColor: #a4a4a4;
   qproperty-LightLineColor: #929092;
   qproperty-MarkerLineColor: #00fff6;
+  qproperty-VerticalLineColor: #000000;
+  qproperty-VerticalLineHeadColor: #000000;
   qproperty-PreviewFrameTextColor: #0000ff;
   qproperty-CurrentRowBgColor: #d2d2d2;
   qproperty-EmptyColumnHeadColor: #c8c8c8;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -830,10 +830,8 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
     x1 = m_viewer->columnToX(col + 1);
 
     // draw vertical lines
-    p.setPen(Qt::black);
+    p.setPen(m_viewer->getVerticalLineColor());
     if (x > 0) p.drawLine(x, y0, x, y1);
-    p.setPen(Qt::white);
-    if (x > 1) p.drawLine(x - 1, y0, x - 1, y1);
 
     for (row = r0; row <= r1; row++) {
       // draw horizontal lines
@@ -1605,7 +1603,7 @@ void CellArea::paintEvent(QPaintEvent *event) {
   int col    = m_viewer->getCurrentColumn();
   int x      = m_viewer->columnToX(col);
   int y      = m_viewer->rowToY(row);
-  QRect rect = QRect(x + 1, y + 1, ColumnWidth - 3, RowHeight - 2);
+  QRect rect = QRect(x + 1, y + 1, ColumnWidth - 2, RowHeight - 2);
   p.setPen(Qt::black);
   p.setBrush(Qt::NoBrush);
   p.drawRect(rect);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -642,10 +642,8 @@ void ColumnArea::drawLevelColumnHead(QPainter &p, int col) {
   if (isEmpty || col < 0) {
     p.fillRect(rect, m_viewer->getEmptyColumnHeadColor());
 
-    p.setPen(Qt::black);
+    p.setPen(m_viewer->getVerticalLineHeadColor());
     p.drawLine(x0, y0, x0, y1);
-    p.setPen(Qt::white);
-    p.drawLine(x1, y0, x1, y1);
   } else {
     QColor columnColor, sideColor;
     if (usage == Reference) {
@@ -804,10 +802,8 @@ void ColumnArea::drawSoundColumnHead(QPainter &p, int col) {
   // base color
   if (isEmpty || col < 0) {
     p.fillRect(rect, EmptyColumnHeadColor);
-    p.setPen(Qt::black);
+    p.setPen(m_viewer->getVerticalLineHeadColor());
     p.drawLine(x0, y0, x0, y1);
-    p.setPen(Qt::white);
-    p.drawLine(x1, y0, x1, y1);
   } else {
     QColor columnColor, sideColor;
 
@@ -985,10 +981,8 @@ void ColumnArea::drawPaletteColumnHead(QPainter &p, int col) {
   // fill base color
   if (isEmpty || col < 0) {
     p.fillRect(rect, EmptyColumnHeadColor);
-    p.setPen(Qt::black);
+    p.setPen(m_viewer->getVerticalLineHeadColor());
     p.drawLine(x0, y0, x0, y1);
-    p.setPen(Qt::white);
-    p.drawLine(x1, y0, x1, y1);
   } else {
     QColor columnColor, sideColor;
     if (usage == Reference) {

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -176,12 +176,18 @@ class XsheetViewer final : public QFrame, public Spreadsheet::FrameScroller {
   // Row
   QColor m_currentRowBgColor;      // current frame / column (210,210,210)
   QColor m_markerLineColor;        // marker lines (0, 255, 246)
+  QColor m_verticalLineColor;      // vertical lines
+  QColor m_verticalLineHeadColor;  // vertical lines in column head
   QColor m_textColor;              // text color (black)
   QColor m_previewFrameTextColor;  // frame number in preview range (blue)
   Q_PROPERTY(QColor CurrentRowBgColor READ getCurrentRowBgColor WRITE
                  setCurrentRowBgColor)
   Q_PROPERTY(
       QColor MarkerLineColor READ getMarkerLineColor WRITE setMarkerLineColor)
+  Q_PROPERTY(QColor VerticalLineColor READ getVerticalLineColor WRITE
+                 setVerticalLineColor)
+  Q_PROPERTY(QColor VerticalLineHeadColor READ getVerticalLineHeadColor WRITE
+                 setVerticalLineHeadColor)
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
   Q_PROPERTY(QColor PreviewFrameTextColor READ getPreviewFrameTextColor WRITE
                  setPreviewFrameTextColor)
@@ -476,6 +482,14 @@ public:
   QColor getCurrentRowBgColor() const { return m_currentRowBgColor; }
   void setMarkerLineColor(const QColor &color) { m_markerLineColor = color; }
   QColor getMarkerLineColor() const { return m_markerLineColor; }
+  void setVerticalLineColor(const QColor &color) {
+    m_verticalLineColor = color;
+  }
+  QColor getVerticalLineColor() const { return m_verticalLineColor; }
+  void setVerticalLineHeadColor(const QColor &color) {
+    m_verticalLineHeadColor = color;
+  }
+  QColor getVerticalLineHeadColor() const { return m_verticalLineHeadColor; }
   void setTextColor(const QColor &color) { m_textColor = color; }
   QColor getTextColor() const { return m_textColor; }
   void setPreviewFrameTextColor(const QColor &color) {


### PR DESCRIPTION
This is a fix for #857 

The vertical line in the xsheet was actually two lines- a black and a white line.  The white line was an accent while the black line actually was in the correct place for a cell divider.  This removes the white line and moves the black line to qss for styling.  I set the value of the black line to the color of the vertical lines in the function viewer for each theme.

Two new properties are available in the qss (example from gray_048):
qproperty-VerticalLineColor: rgb(120,120,120);
qproperty-VerticalLineHeadColor: rgb(160,160,160);

The first one is the color of the vertical line in the xsheet itself.  The second one is the color of the vertical line in the column header.  Since column headers are not the same color as the main xsheet, I found that some adjustment was needed to maintain contrast.

![xsheetvertical](https://cloud.githubusercontent.com/assets/4576381/19579981/941f75cc-96e0-11e6-9ae6-0187a943626c.png)
