### PR TITLE
Tidy GroupBox Styles

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -347,7 +347,7 @@ QGroupBox {
 		subcontrol-origin: margin;
 		left: 15px;
 		margin-top: -2px;
-		.set_padding(5px, 0px);
+		.set_padding(3px, 0px);
 	}
 	&::indicator {
 		&:extend(QCheckBox::indicator all);

--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -341,13 +341,13 @@ QSlider {
 QGroupBox {
 	border: 1px solid @m_baseTxtColor;
 	margin: 6px 0 0 0;
-	.set_padding(3px, 5px);
+	padding: 5px 3px;
 	
 	&::title {
 		subcontrol-origin: margin;
 		left: 15px;
-		margin-top: -2px;
-		.set_padding(3px, 0px);
+		margin: -2px 0 0 0;
+		padding: 0 3px;
 	}
 	&::indicator {
 		&:extend(QCheckBox::indicator all);

--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -340,14 +340,17 @@ QSlider {
 
 QGroupBox {
 	border: 1px solid @m_baseTxtColor;
-	.set_margin( 5px, 5px );
-	.set_padding( 3px, 5px );
+	margin: 6px 0 0 0;
+	.set_padding(3px, 5px);
+	
 	&::title {
 		subcontrol-origin: margin;
-		padding: 0px;
-		margin-top: -4px;
-		/*bottom: 3px;*/
 		left: 15px;
+		margin-top: -2px;
+		.set_padding(5px, 0px);
+	}
+	&::indicator {
+		&:extend(QCheckBox::indicator all);
 	}
 }
 

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -355,19 +355,13 @@ QSlider::handle:horizontal {
 QGroupBox {
   border: 1px solid #e6e6e6;
   margin: 6px 0 0 0;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 3px;
 }
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
-  margin-top: -2px;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 0px;
-  padding-bottom: 0px;
+  margin: -2px 0 0 0;
+  padding: 0 3px;
 }
 QSplitter::handle {
   background-color: #707070;

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -364,8 +364,8 @@ QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
   padding-top: 0px;
   padding-bottom: 0px;
 }

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -302,7 +302,8 @@ QCheckBox:hover {
 QCheckBox:disabled {
   color: #808080;
 }
-QCheckBox::indicator {
+QCheckBox::indicator,
+QGroupBox::indicator {
   background-color: #161616;
   border-style: inset;
   border-left-color: #000000;
@@ -311,7 +312,8 @@ QCheckBox::indicator {
   border-bottom-color: #525252;
   border-width: 2px;
 }
-QCheckBox::indicator:disabled {
+QCheckBox::indicator:disabled,
+QGroupBox::indicator:disabled {
   background-color: #3d3d3d;
   border-style: inset;
   border-left-color: #191919;
@@ -319,10 +321,12 @@ QCheckBox::indicator:disabled {
   border-right-color: #656565;
   border-bottom-color: #797979;
 }
-QCheckBox::indicator:checked {
+QCheckBox::indicator:checked,
+QGroupBox::indicator:checked {
   image: url("../gray_072/imgs/check_indicator.png");
 }
-QCheckBox::indicator:checked:disabled {
+QCheckBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
   image: url("../gray_072/imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
@@ -350,10 +354,7 @@ QSlider::handle:horizontal {
 }
 QGroupBox {
   border: 1px solid #e6e6e6;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin: 6px 0 0 0;
   padding-left: 3px;
   padding-right: 3px;
   padding-top: 5px;
@@ -361,10 +362,12 @@ QGroupBox {
 }
 QGroupBox::title {
   subcontrol-origin: margin;
-  padding: 0px;
-  margin-top: -4px;
-  /*bottom: 3px;*/
   left: 15px;
+  margin-top: -2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 QSplitter::handle {
   background-color: #707070;
@@ -1378,5 +1381,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #4a4a4a;
 }
-
-//# sourceMappingURL=gray_048.qss.map

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -355,19 +355,13 @@ QSlider::handle:horizontal {
 QGroupBox {
   border: 1px solid #e6e6e6;
   margin: 6px 0 0 0;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 3px;
 }
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
-  margin-top: -2px;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 0px;
-  padding-bottom: 0px;
+  margin: -2px 0 0 0;
+  padding: 0 3px;
 }
 QSplitter::handle {
   background-color: #707070;

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -364,8 +364,8 @@ QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
   padding-top: 0px;
   padding-bottom: 0px;
 }

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -302,7 +302,8 @@ QCheckBox:hover {
 QCheckBox:disabled {
   color: #808080;
 }
-QCheckBox::indicator {
+QCheckBox::indicator,
+QGroupBox::indicator {
   background-color: #161616;
   border-style: inset;
   border-left-color: #000000;
@@ -311,7 +312,8 @@ QCheckBox::indicator {
   border-bottom-color: #525252;
   border-width: 2px;
 }
-QCheckBox::indicator:disabled {
+QCheckBox::indicator:disabled,
+QGroupBox::indicator:disabled {
   background-color: #3d3d3d;
   border-style: inset;
   border-left-color: #191919;
@@ -319,10 +321,12 @@ QCheckBox::indicator:disabled {
   border-right-color: #656565;
   border-bottom-color: #797979;
 }
-QCheckBox::indicator:checked {
+QCheckBox::indicator:checked,
+QGroupBox::indicator:checked {
   image: url("../gray_072/imgs/check_indicator.png");
 }
-QCheckBox::indicator:checked:disabled {
+QCheckBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
   image: url("../gray_072/imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
@@ -350,10 +354,7 @@ QSlider::handle:horizontal {
 }
 QGroupBox {
   border: 1px solid #e6e6e6;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin: 6px 0 0 0;
   padding-left: 3px;
   padding-right: 3px;
   padding-top: 5px;
@@ -361,10 +362,12 @@ QGroupBox {
 }
 QGroupBox::title {
   subcontrol-origin: margin;
-  padding: 0px;
-  margin-top: -4px;
-  /*bottom: 3px;*/
   left: 15px;
+  margin-top: -2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 QSplitter::handle {
   background-color: #707070;
@@ -1378,5 +1381,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #4a4a4a;
 }
-
-//# sourceMappingURL=gray_048_mac.qss.map

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -346,7 +346,7 @@ QGroupBox {
 		subcontrol-origin: margin;
 		left: 15px;
 		margin-top: -2px;
-		.set_padding(5px, 0px);
+		.set_padding(3px, 0px);
 	}
 	&::indicator {
 		&:extend(QCheckBox::indicator all);

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -340,13 +340,13 @@ QSlider {
 QGroupBox {
 	border: 1px solid @m_baseTxtColor;
 	margin: 6px 0 0 0;
-	.set_padding(3px, 5px);
+	padding: 5px 3px;
 	
 	&::title {
 		subcontrol-origin: margin;
 		left: 15px;
-		margin-top: -2px;
-		.set_padding(3px, 0px);
+		margin: -2px 0 0 0;
+		padding: 0 3px;
 	}
 	&::indicator {
 		&:extend(QCheckBox::indicator all);

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -339,14 +339,17 @@ QSlider {
 
 QGroupBox {
 	border: 1px solid @m_baseTxtColor;
-	.set_margin( 5px, 5px );
-	.set_padding( 3px, 5px );
+	margin: 6px 0 0 0;
+	.set_padding(3px, 5px);
+	
 	&::title {
 		subcontrol-origin: margin;
-		padding: 0px;
-		margin-top: -4px;
-		/*bottom: 3px;*/
 		left: 15px;
+		margin-top: -2px;
+		.set_padding(5px, 0px);
+	}
+	&::indicator {
+		&:extend(QCheckBox::indicator all);
 	}
 }
 

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -364,8 +364,8 @@ QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
   padding-top: 0px;
   padding-bottom: 0px;
 }

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -355,19 +355,13 @@ QSlider::handle:horizontal {
 QGroupBox {
   border: 1px solid #e6e6e6;
   margin: 6px 0 0 0;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 3px;
 }
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
-  margin-top: -2px;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 0px;
-  padding-bottom: 0px;
+  margin: -2px 0 0 0;
+  padding: 0 3px;
 }
 QSplitter::handle {
   background-color: #888888;

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -302,7 +302,8 @@ QCheckBox:hover {
 QCheckBox:disabled {
   color: #505050;
 }
-QCheckBox::indicator {
+QCheckBox::indicator,
+QGroupBox::indicator {
   background-color: #2f2f2f;
   border-style: inset;
   border-left-color: #060606;
@@ -311,7 +312,8 @@ QCheckBox::indicator {
   border-bottom-color: #676767;
   border-width: 2px;
 }
-QCheckBox::indicator:disabled {
+QCheckBox::indicator:disabled,
+QGroupBox::indicator:disabled {
   background-color: #555555;
   border-style: inset;
   border-left-color: #2d2d2d;
@@ -319,10 +321,12 @@ QCheckBox::indicator:disabled {
   border-right-color: #797979;
   border-bottom-color: #8d8d8d;
 }
-QCheckBox::indicator:checked {
+QCheckBox::indicator:checked,
+QGroupBox::indicator:checked {
   image: url("imgs/check_indicator.png");
 }
-QCheckBox::indicator:checked:disabled {
+QCheckBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
   image: url("imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
@@ -350,10 +354,7 @@ QSlider::handle:horizontal {
 }
 QGroupBox {
   border: 1px solid #e6e6e6;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin: 6px 0 0 0;
   padding-left: 3px;
   padding-right: 3px;
   padding-top: 5px;
@@ -361,10 +362,12 @@ QGroupBox {
 }
 QGroupBox::title {
   subcontrol-origin: margin;
-  padding: 0px;
-  margin-top: -4px;
-  /*bottom: 3px;*/
   left: 15px;
+  margin-top: -2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 QSplitter::handle {
   background-color: #888888;
@@ -1378,5 +1381,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #626262;
 }
-
-//# sourceMappingURL=gray_072.qss.map

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -364,8 +364,8 @@ QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
   padding-top: 0px;
   padding-bottom: 0px;
 }

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -355,19 +355,13 @@ QSlider::handle:horizontal {
 QGroupBox {
   border: 1px solid #e6e6e6;
   margin: 6px 0 0 0;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 3px;
 }
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
-  margin-top: -2px;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 0px;
-  padding-bottom: 0px;
+  margin: -2px 0 0 0;
+  padding: 0 3px;
 }
 QSplitter::handle {
   background-color: #888888;

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -302,7 +302,8 @@ QCheckBox:hover {
 QCheckBox:disabled {
   color: #505050;
 }
-QCheckBox::indicator {
+QCheckBox::indicator,
+QGroupBox::indicator {
   background-color: #2f2f2f;
   border-style: inset;
   border-left-color: #060606;
@@ -311,7 +312,8 @@ QCheckBox::indicator {
   border-bottom-color: #676767;
   border-width: 2px;
 }
-QCheckBox::indicator:disabled {
+QCheckBox::indicator:disabled,
+QGroupBox::indicator:disabled {
   background-color: #555555;
   border-style: inset;
   border-left-color: #2d2d2d;
@@ -319,10 +321,12 @@ QCheckBox::indicator:disabled {
   border-right-color: #797979;
   border-bottom-color: #8d8d8d;
 }
-QCheckBox::indicator:checked {
+QCheckBox::indicator:checked,
+QGroupBox::indicator:checked {
   image: url("imgs/check_indicator.png");
 }
-QCheckBox::indicator:checked:disabled {
+QCheckBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
   image: url("imgs/check_indicator_disabled.png");
 }
 QSlider::groove:horizontal {
@@ -350,10 +354,7 @@ QSlider::handle:horizontal {
 }
 QGroupBox {
   border: 1px solid #e6e6e6;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin: 6px 0 0 0;
   padding-left: 3px;
   padding-right: 3px;
   padding-top: 5px;
@@ -361,10 +362,12 @@ QGroupBox {
 }
 QGroupBox::title {
   subcontrol-origin: margin;
-  padding: 0px;
-  margin-top: -4px;
-  /*bottom: 3px;*/
   left: 15px;
+  margin-top: -2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 QSplitter::handle {
   background-color: #888888;
@@ -1378,5 +1381,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #626262;
 }
-
-//# sourceMappingURL=gray_072_mac.qss.map

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -1,3 +1,4 @@
+
 /* LESS Definitions */
 
 /*Image URL*/
@@ -198,13 +199,13 @@ QCheckBox {
 QGroupBox {
 	border: 1px solid;
 	margin: 6px 0 0 0;
-	.set_padding(3px, 5px);
+	padding: 5px 3px;
 	
 	&::title {
 		subcontrol-origin: margin;
 		left: 15px;
 		margin-top: -2px;
-		.set_padding(3px, 0px);
+		padding: 0 3px;
 	}
 }
 

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -204,7 +204,7 @@ QGroupBox {
 	&::title {
 		subcontrol-origin: margin;
 		left: 15px;
-		margin-top: -2px;
+		margin: -2px 0 0 0;
 		padding: 0 3px;
 	}
 }

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -197,14 +197,14 @@ QCheckBox {
 
 QGroupBox {
 	border: 1px solid;
-	.set_margin( 5px, 5px );
-	.set_padding( 3px, 5px );
+	margin: 6px 0 0 0;
+	.set_padding(3px, 5px);
+	
 	&::title {
 		subcontrol-origin: margin;
-		padding: 0px;
-		margin-top: -4px;
-		/*bottom: 3px;*/
 		left: 15px;
+		margin-top: -2px;
+		.set_padding(5px, 0px);
 	}
 }
 

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -204,7 +204,7 @@ QGroupBox {
 		subcontrol-origin: margin;
 		left: 15px;
 		margin-top: -2px;
-		.set_padding(5px, 0px);
+		.set_padding(3px, 0px);
 	}
 }
 

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -135,8 +135,8 @@ QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
   padding-top: 0px;
   padding-bottom: 0px;
 }

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -125,10 +125,7 @@ QCheckBox:disabled {
 }
 QGroupBox {
   border: 1px solid;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin: 6px 0 0 0;
   padding-left: 3px;
   padding-right: 3px;
   padding-top: 5px;
@@ -136,10 +133,12 @@ QGroupBox {
 }
 QGroupBox::title {
   subcontrol-origin: margin;
-  padding: 0px;
-  margin-top: -4px;
-  /*bottom: 3px;*/
   left: 15px;
+  margin-top: -2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 /* ------ Toonz Classes Difinitions ------ */
 /* ------ TPanel ------ */
@@ -1117,5 +1116,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #9a9a9a;
 }
-
-//# sourceMappingURL=gray_128.qss.map

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -126,19 +126,13 @@ QCheckBox:disabled {
 QGroupBox {
   border: 1px solid;
   margin: 6px 0 0 0;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 3px;
 }
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 0px;
-  padding-bottom: 0px;
+  padding: 0 3px;
 }
 /* ------ Toonz Classes Difinitions ------ */
 /* ------ TPanel ------ */

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -131,7 +131,7 @@ QGroupBox {
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
-  margin-top: -2px;
+  margin: -2px 0 0 0;
   padding: 0 3px;
 }
 /* ------ Toonz Classes Difinitions ------ */

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -135,8 +135,8 @@ QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
   padding-top: 0px;
   padding-bottom: 0px;
 }

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -125,10 +125,7 @@ QCheckBox:disabled {
 }
 QGroupBox {
   border: 1px solid;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin: 6px 0 0 0;
   padding-left: 3px;
   padding-right: 3px;
   padding-top: 5px;
@@ -136,10 +133,12 @@ QGroupBox {
 }
 QGroupBox::title {
   subcontrol-origin: margin;
-  padding: 0px;
-  margin-top: -4px;
-  /*bottom: 3px;*/
   left: 15px;
+  margin-top: -2px;
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 /* ------ Toonz Classes Difinitions ------ */
 /* ------ TPanel ------ */
@@ -1117,5 +1116,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #9a9a9a;
 }
-
-//# sourceMappingURL=gray_128_mac.qss.map

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -126,19 +126,13 @@ QCheckBox:disabled {
 QGroupBox {
   border: 1px solid;
   margin: 6px 0 0 0;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding: 5px 3px;
 }
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
   margin-top: -2px;
-  padding-left: 3px;
-  padding-right: 3px;
-  padding-top: 0px;
-  padding-bottom: 0px;
+  padding: 0 3px;
 }
 /* ------ Toonz Classes Difinitions ------ */
 /* ------ TPanel ------ */

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -131,7 +131,7 @@ QGroupBox {
 QGroupBox::title {
   subcontrol-origin: margin;
   left: 15px;
-  margin-top: -2px;
+  margin: -2px 0 0 0;
   padding: 0 3px;
 }
 /* ------ Toonz Classes Difinitions ------ */


### PR DESCRIPTION
#881 Adjusts alignment and adds styling to the indicator.

![qgroupbox_fix](https://cloud.githubusercontent.com/assets/19820721/19621015/ca5f5aa2-9880-11e6-9f98-29d9c90c31b3.PNG)

I don't know why left and right margin was added to the box, let me know if there was a good reason for that.

Why is a source map added to the themes? On my end that line breaks some styles, removing it reveals or unblocks them. Since I used WinLess it removed that line.
