### PR TITLE
Refactor Topbar Style

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -1,10 +1,10 @@
 
-/* LESS Definitions */
+// LESS Definitions
 
-/*Image URL*/
+// Image URL
 @image_url: "../gray_072/imgs";
 
-/*Text Color*/
+// Text Color
 @m_baseTxtColor: rgb(230,230,230);
 @m_disabledTxtColor: rgb(128,128,128);
 
@@ -14,24 +14,24 @@
 @m_base_darkH: 	rgb(12,12,12);
 @m_base_darkV: 	rgb(0,0,0);
 
-/*Used in Dialog border*/
+// Used in Dialog Border
 @m_dialog_border_color:	rgb(0,0,0);
 
-/*Color for Selected Item*/
+// Color for Selected Item
 @m_selectedBG:	rgb(128,160,220);
 
-/*Color for title texts*/
+// Color for Title Text
 @m_titleTxtColor: lighten(@m_selectedBG, 10%);
 
-/* color adjustable by delta */
-.baseBG(@dark: 0%){
+// Color Adjustable by Delta
+.baseBG(@dark: 0%) {
 	background-color: darken(@m_baseBG, @dark);
 }
-.baseBG(light, @light: 0%){
+.baseBG(light, @light: 0%) {
 	background-color: lighten(@m_baseBG, @light);
 }
 
-.base_inset(@dark: 0%){
+.base_inset(@dark: 0%) {
 	.baseBG(@dark);
 	border-style: inset;
 	border-left-color: 	darken(@m_base_darkH, @dark);
@@ -39,7 +39,7 @@
 	border-right-color: 	darken(@m_base_lightH, @dark);
 	border-bottom-color: 	darken(@m_base_lightV, @dark);
 }
-.base_inset(light, @light: 0%){
+.base_inset(light, @light: 0%) {
 	.baseBG(light, @light);
 	border-style: inset;
 	border-left-color: 	lighten(@m_base_darkH, @light);
@@ -48,7 +48,7 @@
 	border-bottom-color: 	lighten(@m_base_lightV, @light);
 }
 
-.base_outset(@dark: 0%){
+.base_outset(@dark: 0%) {
 	.baseBG(@dark);
 	border-style: outset;
 	border-left-color: 	darken(@m_base_lightH, @dark);
@@ -56,7 +56,7 @@
 	border-right-color: 	darken(@m_base_darkH, @dark);
 	border-bottom-color: 	darken(@m_base_darkV, @dark);
 }
-.base_outset(light, @light: 0%){
+.base_outset(light, @light: 0%) {
 	.baseBG(light, @light);
 	border-style: outset;
 	border-left-color: 	lighten(@m_base_lightH, @light);
@@ -65,14 +65,14 @@
 	border-bottom-color: 	lighten(@m_base_darkV, @light);
 }
 
-/*set padding*/
-.set_padding(@hPad: 0px, @vPad: 0px){
+// Set Padding
+.set_padding(@hPad: 0px, @vPad: 0px) {
    	padding-left: 	@hPad;
    	padding-right: 	@hPad;
    	padding-top: 	@vPad;
    	padding-bottom: @vPad;	
 }
-/*set margin*/
+// Set Margin
 .set_margin(@hMgn: 0px, @vMgn: 0px) {
    	margin-left: 	@hMgn;
    	margin-right: 	@hMgn;
@@ -143,38 +143,38 @@ QStatusBar {
 		.set_padding( 3px, 1px );
 	}
 }
-QMenuBar
-{
+
+QMenuBar {
 	.baseBG(5%);
-	&::item:selected{
+	
+	&::item:selected {
 		.base_inset(5%);
 		border-width: 1px;
 	}
 }
 
-QMenu
-{
+QMenu {
 	.baseBG(5%);
 	
 	&::item {
-		&:selected{
+		&:selected {
 			background: @m_selectedBG;
-			color: black;
+			color: #000;
 		}
-		&:disabled{
+		&:disabled {
 			.baseBG(light, 5%);
 			color: @m_disabledTxtColor;
 		}
-		&:disabled:selected{
+		&:disabled:selected {
 			background: rgb(108,118,128);
 		}
 	}
 	
 	&::separator {
 		.base_inset(10%);
-		.set_margin(5px,2px);
 		border-width: 1px;
-		height: 0px;
+		height: 0;
+		margin: 2px 5px;
 	}
 }
 
@@ -1231,28 +1231,29 @@ PopupButton {
 /*------ Topbar and Menubar of the MainWindow ------*/
 
 #TopBar {
-	height: 22px;
 	.baseBG(5%);
-	margin: 0px;
-	border: 0px;
-	padding: 0px;
+	border: 0;
+	height: 22px;
+	margin: 0;
+	padding: 0;
 }
 #TopBarTabContainer {
-	.baseBG;
-	margin: 0px;
-	border: 0px;
-	padding: 0px;
+	.baseBG(5%);
+	border: 0;
+	margin: 0;
+	padding: 0;
 }
 #TopBarTab {
-    border-image: url("@{image_url}/topbar_bg.png") 0 0 0 0 stretch stretch;
-	/*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-	border: 0px;
-	padding: 0px;
+	background: ~"qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #232323, stop: 0.5 #131313)";
+	border: 0;
+	padding: 0;
+	
 	&::tab {
-		.set_margin(5px, 1px);
-		.set_padding(8px, 1px);
-	    .baseBG( light, 5% );
-	    border: 1px solid white; 
+		.baseBG(light, 5%);
+		border: 1px solid #fff; 
+		margin: 1px 5px;
+		padding: 1px 8px;
+	    
 		&:selected {
 		    background-color: rgb(90,140,120);
 		}

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -1,12 +1,3 @@
-/* LESS Definitions */
-/*Image URL*/
-/*Text Color*/
-/*Used in Dialog border*/
-/*Color for Selected Item*/
-/*Color for title texts*/
-/* color adjustable by delta */
-/*set padding*/
-/*set margin*/
 /* ------ Qt Widgets Common Difinitions ------ */
 QWidget {
   color: #e6e6e6;
@@ -85,7 +76,7 @@ QMenu {
 }
 QMenu::item:selected {
   background: #80a0dc;
-  color: black;
+  color: #000;
 }
 QMenu::item:disabled {
   background-color: #3d3d3d;
@@ -101,12 +92,9 @@ QMenu::separator {
   border-top-color: #000000;
   border-right-color: #3f3f3f;
   border-bottom-color: #525252;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 2px;
-  margin-bottom: 2px;
   border-width: 1px;
-  height: 0px;
+  height: 0;
+  margin: 2px 5px;
 }
 QToolBar {
   background-color: #303030;
@@ -1234,35 +1222,28 @@ PopupButton::menu-indicator:disabled {
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
-  height: 22px;
   background-color: #232323;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  border: 0;
+  height: 22px;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTabContainer {
-  background-color: #303030;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  background-color: #232323;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTab {
-  border-image: url("../gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
-  /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-  border: 0px;
-  padding: 0px;
+  background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #232323, stop: 0.5 #131313);
+  border: 0;
+  padding: 0;
 }
 #TopBarTab::tab {
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 1px;
-  margin-bottom: 1px;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
   background-color: #3d3d3d;
-  border: 1px solid white;
+  border: 1px solid #fff;
+  margin: 1px 5px;
+  padding: 1px 8px;
 }
 #TopBarTab::tab:selected {
   background-color: #5a8c78;
@@ -1378,5 +1359,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #4a4a4a;
 }
-
-//# sourceMappingURL=gray_048.qss.map

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -1,12 +1,3 @@
-/* LESS Definitions */
-/*Image URL*/
-/*Text Color*/
-/*Used in Dialog border*/
-/*Color for Selected Item*/
-/*Color for title texts*/
-/* color adjustable by delta */
-/*set padding*/
-/*set margin*/
 /* ------ Qt Widgets Common Difinitions ------ */
 QWidget {
   color: #e6e6e6;
@@ -85,7 +76,7 @@ QMenu {
 }
 QMenu::item:selected {
   background: #80a0dc;
-  color: black;
+  color: #000;
 }
 QMenu::item:disabled {
   background-color: #3d3d3d;
@@ -101,12 +92,9 @@ QMenu::separator {
   border-top-color: #000000;
   border-right-color: #3f3f3f;
   border-bottom-color: #525252;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 2px;
-  margin-bottom: 2px;
   border-width: 1px;
-  height: 0px;
+  height: 0;
+  margin: 2px 5px;
 }
 QToolBar {
   background-color: #303030;
@@ -1234,35 +1222,28 @@ PopupButton::menu-indicator:disabled {
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
-  height: 22px;
   background-color: #232323;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  border: 0;
+  height: 22px;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTabContainer {
-  background-color: #303030;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  background-color: #232323;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTab {
-  border-image: url("../gray_072/imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
-  /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-  border: 0px;
-  padding: 0px;
+  background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #232323, stop: 0.5 #131313);
+  border: 0;
+  padding: 0;
 }
 #TopBarTab::tab {
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 1px;
-  margin-bottom: 1px;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
   background-color: #3d3d3d;
-  border: 1px solid white;
+  border: 1px solid #fff;
+  margin: 1px 5px;
+  padding: 1px 8px;
 }
 #TopBarTab::tab:selected {
   background-color: #5a8c78;
@@ -1378,5 +1359,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #4a4a4a;
 }
-
-//# sourceMappingURL=gray_048_mac.qss.map

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -1,9 +1,10 @@
-/* LESS Definitions */
 
-/*Image URL*/
+// LESS Definitions
+
+// Image URL
 @image_url: "imgs";
 
-/*Text Color*/
+// Text Color
 @m_baseTxtColor: rgb(230,230,230);
 @m_disabledTxtColor: rgb(128,128,128);
 
@@ -13,24 +14,24 @@
 @m_base_darkH: 	rgb(32,32,32);
 @m_base_darkV: 	rgb(0,0,0);
 
-/*Used in Dialog border*/
+// Used in Dialog Border
 @m_dialog_border_color:	rgb(32,32,32);
 
-/*Color for Selected Item*/
+// Color for Selected Item
 @m_selectedBG:	rgb(128,160,220);
 
-/*Color for title texts*/
+// Color for Title Text
 @m_titleTxtColor: lighten(@m_selectedBG, 10%);
 
-/* color adjustable by delta */
-.baseBG(@dark: 0%){
+// Color Adjustable by Delta
+.baseBG(@dark: 0%) {
 	background-color: darken(@m_baseBG, @dark);
 }
-.baseBG(light, @light: 0%){
+.baseBG(light, @light: 0%) {
 	background-color: lighten(@m_baseBG, @light);
 }
 
-.base_inset(@dark: 0%){
+.base_inset(@dark: 0%) {
 	.baseBG(@dark);
 	border-style: inset;
 	border-left-color: 	darken(@m_base_darkH, @dark);
@@ -38,7 +39,7 @@
 	border-right-color: 	darken(@m_base_lightH, @dark);
 	border-bottom-color: 	darken(@m_base_lightV, @dark);
 }
-.base_inset(light, @light: 0%){
+.base_inset(light, @light: 0%) {
 	.baseBG(light, @light);
 	border-style: inset;
 	border-left-color: 	lighten(@m_base_darkH, @light);
@@ -47,7 +48,7 @@
 	border-bottom-color: 	lighten(@m_base_lightV, @light);
 }
 
-.base_outset(@dark: 0%){
+.base_outset(@dark: 0%) {
 	.baseBG(@dark);
 	border-style: outset;
 	border-left-color: 	darken(@m_base_lightH, @dark);
@@ -55,7 +56,7 @@
 	border-right-color: 	darken(@m_base_darkH, @dark);
 	border-bottom-color: 	darken(@m_base_darkV, @dark);
 }
-.base_outset(light, @light: 0%){
+.base_outset(light, @light: 0%) {
 	.baseBG(light, @light);
 	border-style: outset;
 	border-left-color: 	lighten(@m_base_lightH, @light);
@@ -64,14 +65,14 @@
 	border-bottom-color: 	lighten(@m_base_darkV, @light);
 }
 
-/*set padding*/
-.set_padding(@hPad: 0px, @vPad: 0px){
+// Set Padding
+.set_padding(@hPad: 0px, @vPad: 0px) {
    	padding-left: 	@hPad;
    	padding-right: 	@hPad;
    	padding-top: 	@vPad;
    	padding-bottom: @vPad;	
 }
-/*set margin*/
+// Set Margin
 .set_margin(@hMgn: 0px, @vMgn: 0px) {
    	margin-left: 	@hMgn;
    	margin-right: 	@hMgn;
@@ -142,38 +143,38 @@ QStatusBar {
 		.set_padding( 3px, 1px );
 	}
 }
-QMenuBar
-{
+
+QMenuBar {
 	.baseBG(5%);
-	&::item:selected{
+	
+	&::item:selected {
 		.base_inset(5%);
 		border-width: 1px;
 	}
 }
 
-QMenu
-{
+QMenu {
 	.baseBG(5%);
 	
 	&::item {
-		&:selected{
+		&:selected {
 			background: @m_selectedBG;
-			color: black;
+			color: #000;
 		}
-		&:disabled{
+		&:disabled {
 			.baseBG(light, 5%);
 			color: @m_disabledTxtColor;
 		}
-		&:disabled:selected{
+		&:disabled:selected {
 			background: rgb(108,118,128);
 		}
 	}
 	
 	&::separator {
 		.base_inset(10%);
-		.set_margin(5px,2px);
 		border-width: 1px;
-		height: 0px;
+		height: 0;
+		margin: 2px 5px;
 	}
 }
 
@@ -1231,28 +1232,31 @@ PopupButton {
 /*------ Topbar and Menubar of the MainWindow ------*/
 
 #TopBar {
-	height: 22px;
 	.baseBG(5%);
-	margin: 0px;
 	border: 0px;
-	padding: 0px;
+	height: 22px;
+	margin: 0;
+	padding: 0;
 }
+
 #TopBarTabContainer {
-	.baseBG;
-	margin: 0px;
-	border: 0px;
-	padding: 0px;
+	.baseBG(5%);
+	border: 0;
+	margin: 0;
+	padding: 0;
 }
+
 #TopBarTab {
-    border-image: url("@{image_url}/topbar_bg.png") 0 0 0 0 stretch stretch;
-	/*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-	border: 0px;
-	padding: 0px;
+	background: ~"qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #3b3b3b, stop: 0.5 #262626)";
+	border: 0;
+	padding: 0;
+	
 	&::tab {
-		.set_margin(5px, 1px);
-		.set_padding(8px, 1px);
-	    .baseBG( light, 5% );
-	    border: 1px solid white; 
+		.baseBG(light, 5%);
+		border: 1px solid #fff; 
+		margin: 1px 5px;
+		padding: 1px 8px;
+	    
 		&:selected {
 		    background-color: rgb(90,140,120);
 		}

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -1,12 +1,3 @@
-/* LESS Definitions */
-/*Image URL*/
-/*Text Color*/
-/*Used in Dialog border*/
-/*Color for Selected Item*/
-/*Color for title texts*/
-/* color adjustable by delta */
-/*set padding*/
-/*set margin*/
 /* ------ Qt Widgets Common Difinitions ------ */
 QWidget {
   color: #e6e6e6;
@@ -85,7 +76,7 @@ QMenu {
 }
 QMenu::item:selected {
   background: #80a0dc;
-  color: black;
+  color: #000;
 }
 QMenu::item:disabled {
   background-color: #555555;
@@ -101,12 +92,9 @@ QMenu::separator {
   border-top-color: #000000;
   border-right-color: #525252;
   border-bottom-color: #676767;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 2px;
-  margin-bottom: 2px;
   border-width: 1px;
-  height: 0px;
+  height: 0;
+  margin: 2px 5px;
 }
 QToolBar {
   background-color: #484848;
@@ -1234,35 +1222,28 @@ PopupButton::menu-indicator:disabled {
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
-  height: 22px;
   background-color: #3b3b3b;
-  margin: 0px;
   border: 0px;
-  padding: 0px;
+  height: 22px;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTabContainer {
-  background-color: #484848;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  background-color: #3b3b3b;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTab {
-  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
-  /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-  border: 0px;
-  padding: 0px;
+  background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #3b3b3b, stop: 0.5 #262626);
+  border: 0;
+  padding: 0;
 }
 #TopBarTab::tab {
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 1px;
-  margin-bottom: 1px;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
   background-color: #555555;
-  border: 1px solid white;
+  border: 1px solid #fff;
+  margin: 1px 5px;
+  padding: 1px 8px;
 }
 #TopBarTab::tab:selected {
   background-color: #5a8c78;
@@ -1378,5 +1359,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #626262;
 }
-
-//# sourceMappingURL=gray_072.qss.map

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -1,12 +1,3 @@
-/* LESS Definitions */
-/*Image URL*/
-/*Text Color*/
-/*Used in Dialog border*/
-/*Color for Selected Item*/
-/*Color for title texts*/
-/* color adjustable by delta */
-/*set padding*/
-/*set margin*/
 /* ------ Qt Widgets Common Difinitions ------ */
 QWidget {
   color: #e6e6e6;
@@ -85,7 +76,7 @@ QMenu {
 }
 QMenu::item:selected {
   background: #80a0dc;
-  color: black;
+  color: #000;
 }
 QMenu::item:disabled {
   background-color: #555555;
@@ -101,12 +92,9 @@ QMenu::separator {
   border-top-color: #000000;
   border-right-color: #525252;
   border-bottom-color: #676767;
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 2px;
-  margin-bottom: 2px;
   border-width: 1px;
-  height: 0px;
+  height: 0;
+  margin: 2px 5px;
 }
 QToolBar {
   background-color: #484848;
@@ -1234,35 +1222,28 @@ PopupButton::menu-indicator:disabled {
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
-  height: 22px;
   background-color: #3b3b3b;
-  margin: 0px;
   border: 0px;
-  padding: 0px;
+  height: 22px;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTabContainer {
-  background-color: #484848;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  background-color: #3b3b3b;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTab {
-  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
-  /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-  border: 0px;
-  padding: 0px;
+  background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #3b3b3b, stop: 0.5 #262626);
+  border: 0;
+  padding: 0;
 }
 #TopBarTab::tab {
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 1px;
-  margin-bottom: 1px;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
   background-color: #555555;
-  border: 1px solid white;
+  border: 1px solid #fff;
+  margin: 1px 5px;
+  padding: 1px 8px;
 }
 #TopBarTab::tab:selected {
   background-color: #5a8c78;
@@ -1378,5 +1359,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #626262;
 }
-
-//# sourceMappingURL=gray_072_mac.qss.map

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -1,6 +1,7 @@
-/* LESS Definitions */
 
-/*Image URL*/
+// LESS Definitions
+
+// Image URL
 @image_url: "imgs";
 
 @m_baseBG: 	rgb(128,128,128);
@@ -9,15 +10,15 @@
 @m_base_darkH: 	rgb(64,64,64);
 @m_base_darkV: 	rgb(64,64,64);
 
-/* color adjustable by delta */
-.baseBG(@dark: 0%){
+// Color Adjustable by Delta
+.baseBG(@dark: 0%) {
 	background-color: darken(@m_baseBG, @dark);
 }
-.baseBG(light, @light: 0%){
+.baseBG(light, @light: 0%) {
 	background-color: lighten(@m_baseBG, @light);
 }
 
-.base_inset(@dark: 0%){
+.base_inset(@dark: 0%) {
 	.baseBG(@dark);
 	border-style: inset;
 	border-left-color: 	darken(@m_base_darkH, @dark);
@@ -25,7 +26,7 @@
 	border-right-color: 	darken(@m_base_lightH, @dark);
 	border-bottom-color: 	darken(@m_base_lightV, @dark);
 }
-.base_inset(light, @light: 0%){
+.base_inset(light, @light: 0%) {
 	.baseBG(light, @light);
 	border-style: inset;
 	border-left-color: 	lighten(@m_base_darkH, @light);
@@ -34,7 +35,7 @@
 	border-bottom-color: 	lighten(@m_base_lightV, @light);
 }
 
-.base_outset(@dark: 0%){
+.base_outset(@dark: 0%) {
 	.baseBG(@dark);
 	border-style: outset;
 	border-left-color: 	darken(@m_base_lightH, @dark);
@@ -42,7 +43,7 @@
 	border-right-color: 	darken(@m_base_darkH, @dark);
 	border-bottom-color: 	darken(@m_base_darkV, @dark);
 }
-.base_outset(light, @light: 0%){
+.base_outset(light, @light: 0%) {
 	.baseBG(light, @light);
 	border-style: outset;
 	border-left-color: 	lighten(@m_base_lightH, @light);
@@ -51,14 +52,14 @@
 	border-bottom-color: 	lighten(@m_base_darkV, @light);
 }
 
-/*set padding*/
+// Set Padding
 .set_padding(@hPad: 0px, @vPad: 0px){
    	padding-left: 	@hPad;
    	padding-right: 	@hPad;
    	padding-top: 	@vPad;
    	padding-bottom: @vPad;	
 }
-/*set margin*/
+// Set Margin
 .set_margin(@hMgn: 0px, @vMgn: 0px) {
    	margin-left: 	@hMgn;
    	margin-right: 	@hMgn;
@@ -113,19 +114,18 @@ QStatusBar {
 		.set_padding( 3px, 1px );
 	}
 }
-QMenuBar
-{
-	background: rgb(160,160,160);
-	color: black;
+
+QMenuBar {
+	.baseBG(light, 8%);
+	color: #000;
 }
 
-QMenu
-{
+QMenu {
 	background: rgb(160,160,160);
-	&::item:selected
-	{
+	
+	&::item:selected {
 		background: rgb(0,0,128);
-		color: white;	
+		color: #fff;	
 	}
 }
 
@@ -1064,36 +1064,40 @@ PopupButton {
 /*------ Topbar and Menubar of the MainWindow ------*/
 
 #TopBar {
-	height: 22px;
 	background-color: rgb(192,192,192);
-	margin: 0px;
-	border: 0px;
-	padding: 0px;
+	border: 0;
+	height: 22px;
+	margin: 0;
+	padding: 0;
 }
+
 #TopBarTabContainer {
-	background: rgb(160,160,160);
-	margin: 0px;
-	border: 0px;
-	padding: 0px;
+	.baseBG(light, 8%);
+	border: 0;
+	margin: 0;
+	padding: 0;
 }
+
 #TopBarTab {
-    border-image: url("@{image_url}/topbar_bg.png") 0 0 0 0 stretch stretch;
-	/*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-	border: 0px;
-	padding: 0px;
+	background: ~"qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #949494, stop: 0.5 #5a5a5a)";
+	border: 0;
+	padding: 0;
+	
 	&::tab {
-		.set_margin(5px, 1px);
-		.set_padding(8px, 1px);
-		border: 1px solid black; 
-		background-color: rgb(160,160,160);
+		background: rgb(160,160,160);
+		border: 1px solid #000; 
+		margin: 1px 5px;
+		padding: 1px 8px;
+		
 		&:selected {
-			background-color: rgb(205,220,192);
+			background: rgb(205,220,192);
 		}
 		&:hover {
-			background-color: rgb(192,192,192);
+			background: rgb(192,192,192);
 		}
 	}
 }
+
 #StackedMenuBar
 {
 	background: rgb(160,160,160);

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -1,8 +1,3 @@
-/* LESS Definitions */
-/*Image URL*/
-/* color adjustable by delta */
-/*set padding*/
-/*set margin*/
 /* ------ Qt Widgets Common Difinitions ------ */
 QFrame {
   background-color: #808080;
@@ -54,15 +49,15 @@ QStatusBar #StatusBarLabel {
   padding-bottom: 1px;
 }
 QMenuBar {
-  background: #a0a0a0;
-  color: black;
+  background-color: #949494;
+  color: #000;
 }
 QMenu {
   background: #a0a0a0;
 }
 QMenu::item:selected {
   background: #000080;
-  color: white;
+  color: #fff;
 }
 QToolBar {
   background-color: #808080;
@@ -978,41 +973,34 @@ PopupButton::menu-indicator:disabled {
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
-  height: 22px;
   background-color: #c0c0c0;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  border: 0;
+  height: 22px;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTabContainer {
-  background: #a0a0a0;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  background-color: #949494;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTab {
-  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
-  /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-  border: 0px;
-  padding: 0px;
+  background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #949494, stop: 0.5 #5a5a5a);
+  border: 0;
+  padding: 0;
 }
 #TopBarTab::tab {
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 1px;
-  margin-bottom: 1px;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  border: 1px solid black;
-  background-color: #a0a0a0;
+  background: #a0a0a0;
+  border: 1px solid #000;
+  margin: 1px 5px;
+  padding: 1px 8px;
 }
 #TopBarTab::tab:selected {
-  background-color: #cddcc0;
+  background: #cddcc0;
 }
 #TopBarTab::tab:hover {
-  background-color: #c0c0c0;
+  background: #c0c0c0;
 }
 #StackedMenuBar {
   background: #a0a0a0;
@@ -1117,5 +1105,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #9a9a9a;
 }
-
-//# sourceMappingURL=gray_128.qss.map

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -1,8 +1,3 @@
-/* LESS Definitions */
-/*Image URL*/
-/* color adjustable by delta */
-/*set padding*/
-/*set margin*/
 /* ------ Qt Widgets Common Difinitions ------ */
 QFrame {
   background-color: #808080;
@@ -54,15 +49,15 @@ QStatusBar #StatusBarLabel {
   padding-bottom: 1px;
 }
 QMenuBar {
-  background: #a0a0a0;
-  color: black;
+  background-color: #949494;
+  color: #000;
 }
 QMenu {
   background: #a0a0a0;
 }
 QMenu::item:selected {
   background: #000080;
-  color: white;
+  color: #fff;
 }
 QToolBar {
   background-color: #808080;
@@ -978,41 +973,34 @@ PopupButton::menu-indicator:disabled {
 }
 /*------ Topbar and Menubar of the MainWindow ------*/
 #TopBar {
-  height: 22px;
   background-color: #c0c0c0;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  border: 0;
+  height: 22px;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTabContainer {
-  background: #a0a0a0;
-  margin: 0px;
-  border: 0px;
-  padding: 0px;
+  background-color: #949494;
+  border: 0;
+  margin: 0;
+  padding: 0;
 }
 #TopBarTab {
-  border-image: url("imgs/topbar_bg.png") 0 0 0 0 stretch stretch;
-  /*background: qlineargradient(x1: 0,y1: 0, x2: 1, y2: 0, stop: 0 #a0a0a0, stop: 0.5 #404040);*/
-  border: 0px;
-  padding: 0px;
+  background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #949494, stop: 0.5 #5a5a5a);
+  border: 0;
+  padding: 0;
 }
 #TopBarTab::tab {
-  margin-left: 5px;
-  margin-right: 5px;
-  margin-top: 1px;
-  margin-bottom: 1px;
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  border: 1px solid black;
-  background-color: #a0a0a0;
+  background: #a0a0a0;
+  border: 1px solid #000;
+  margin: 1px 5px;
+  padding: 1px 8px;
 }
 #TopBarTab::tab:selected {
-  background-color: #cddcc0;
+  background: #cddcc0;
 }
 #TopBarTab::tab:hover {
-  background-color: #c0c0c0;
+  background: #c0c0c0;
 }
 #StackedMenuBar {
   background: #a0a0a0;
@@ -1117,5 +1105,3 @@ QDialog #dialogButtonFrame {
 #StartupLabel:hover {
   background-color: #9a9a9a;
 }
-
-//# sourceMappingURL=gray_128_mac.qss.map


### PR DESCRIPTION
I noticed in the code `#TopBarTab` was set to use `qlineargradient` but was replaced instead with a bitmap and blocked out. I imagine _(correct me if I'm mistaken)_ it was for compile reasons since it wasn't escaped. I rewrote it with an escaped version so it should compile now.

Also switched comments referring to less variables to inline so they don't bloat the qss files.
