### PR TITLE
Fix Studio Palette not to delete palette file unexpectedly

### DIFF
--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -1050,6 +1050,8 @@ void StudioPaletteTreeViewer::dropEvent(QDropEvent *event) {
 
   resetDropItem();
 
+  if (newPath.isEmpty()) return;
+
   const QMimeData *mimeData      = event->mimeData();
   const PaletteData *paletteData = dynamic_cast<const PaletteData *>(mimeData);
   if (paletteData) {


### PR DESCRIPTION
This PR is for the issue #887

 This problem occurs when the `m_dropItem` is NULL because the mouse released without certain length of mouse move and `dragMoveEvent()` was not executed before `dropEvent()`.
In such case, `newPath` (= drop destination) becomes empty which causes unexpected deletion of the selected palette item.