### PR TITLE
Fix use after free error

### DIFF
--- a/toonz/sources/include/toonzqt/treemodel.h
+++ b/toonz/sources/include/toonzqt/treemodel.h
@@ -130,6 +130,7 @@ public slots:
 
 protected:
   void setRootItem(Item *rootItem);
+  void setRootItem_NoFree(Item *rootItem);
   Item *getRootItem() const { return m_rootItem; }
 
 private:

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -1215,7 +1215,10 @@ void FunctionTreeModel::resetAll() {
   beginResetModel();
 #endif
   m_activeChannels.clear();
-  setRootItem(0);
+
+  TreeModel::Item *root_item = getRootItem();
+  setRootItem_NoFree(NULL);
+
   m_stageObjects = 0;
   m_fxs          = 0;
 #if QT_VERSION < 0x050000
@@ -1225,6 +1228,10 @@ void FunctionTreeModel::resetAll() {
   beginRefresh();
   refreshActiveChannels();
   endRefresh();
+
+  // postpone until after refresh,
+  // since its members are used for reference.
+  delete root_item;
 
   m_currentChannel = 0;
 

--- a/toonz/sources/toonzqt/treemodel.cpp
+++ b/toonz/sources/toonzqt/treemodel.cpp
@@ -310,6 +310,13 @@ void TreeModel::setRootItem(Item *rootItem) {
   if (m_rootItem) m_rootItem->setModel(this);
 }
 
+// postpone freeing, so existing items can be referenced while refreshing.
+void TreeModel::setRootItem_NoFree(Item *rootItem) {
+  if (rootItem == m_rootItem) return;
+  m_rootItem = rootItem;
+  if (m_rootItem) m_rootItem->setModel(this);
+}
+
 //---------------------------------------------------------------------------------------------------------------
 
 void TreeModel::setRowHidden(int row, const QModelIndex &parent, bool hide) {


### PR DESCRIPTION
The tree-view was freed, then while refreshing, freed items would be accessed.

This fixes #892 

See: [error.txt](https://github.com/opentoonz/opentoonz/files/560042/error.txt) for cause of error.