### PR TITLE
Fix style removal problem on Convert to Painted TLV from non AA source

### DIFF
--- a/toonz/sources/include/toonz/Naa2TlvConverter.h
+++ b/toonz/sources/include/toonz/Naa2TlvConverter.h
@@ -146,12 +146,13 @@ public:
       return -1;
   }
 
-  TToonzImageP makeTlv(bool transparentSyntheticInks,
-                       bool removeUnusedStyles = false);
+  TToonzImageP makeTlv(bool transparentSyntheticInks, QList<int> &usedStyleIds);
 
   TVectorImageP vectorize(const TToonzImageP &ti);
   TVectorImageP vectorize(const TRaster32P &ras);
   TVectorImageP vectorize();
+
+  void removeUnusedStyles(const QList<int> &styleIds);
 };
 
 #endif

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -784,6 +784,7 @@ void ConvertPopup::setFiles(const std::vector<TFilePath> &fps) {
   // if (m_unpaintedFolder->getPath()==SameAsPainted)
   //   m_unpaintedFolder->setPath(toQString(fps[0].getParentDir()));
   m_palettePath->setPath(CreateNewPalette);
+  m_removeUnusedStyles->setEnabled(false);
 
   // m_fileFormat->setCurrentIndex(areFullcolor?0:m_fileFormat->findText("tif"));
 }

--- a/toonz/sources/toonzlib/tcenterlinevectorizer.cpp
+++ b/toonz/sources/toonzlib/tcenterlinevectorizer.cpp
@@ -176,7 +176,8 @@ TVectorImageP VectorizerCore::centerlineVectorize(
       converter.process(ras32);
       converter.setPalette(palette);
 
-      if (ti = converter.makeTlv(true))  // Transparent synthetic inks
+      QList<int> dummy;
+      if (ti = converter.makeTlv(true, dummy))  // Transparent synthetic inks
       {
         image = ti;
         ras   = ti->getRaster();

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -652,6 +652,8 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
   Naa2TlvConverter converter;
   converter.setPalette(palette);
 
+  QList<int> usedStyleIds({0});
+
   int f, fCount = int(frames.size());
   for (f = 0; f != fCount; ++f) {
     if (frameNotifier->abortTask()) break;
@@ -672,8 +674,8 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
 
       converter.process(raster);
 
-      if (TToonzImageP dstImg = converter.makeTlv(
-              false, removeUnusedStyles))  // Opaque synthetic inks
+      if (TToonzImageP dstImg =
+              converter.makeTlv(false, usedStyleIds))  // Opaque synthetic inks
       {
         if (converter.getPalette() == 0)
           converter.setPalette(dstImg->getPalette());
@@ -693,6 +695,8 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
 
     frameNotifier->notifyFrameCompleted(100 * (f + 1) / frames.size());
   }
+
+  if (removeUnusedStyles) converter.removeUnusedStyles(usedStyleIds);
 }
 
 //=============================================================================


### PR DESCRIPTION
This PR fixes the problem on Covert to Painted TLV from raster images.

For now, the "Remove Unused Styles from Input Palette" option has a problem - the style removal operation executed for each frame. As a result, only styles used in every frames are left, but styles appears in the part of frames will be removed.

I modified this problem by changing the removal operation to be done once in the end of the conversion of whole frames.

Also, I changed the conversion rule, to make the closed regions (= regions not touching image border) can be background if they are painted in white.