### PR TITLE
Prevent the Camera Capture popup from being at outside of the screen

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -569,17 +569,16 @@ void LevelNameLineEdit::onEditingFinished() {
 //=============================================================================
 
 PencilTestPopup::PencilTestPopup()
-    : Dialog(TApp::instance()->getMainWindow(), false, false, "PencilTest")
-    , m_currentCamera(NULL)
-    , m_cameraImageCapture(NULL)
-    , m_captureWhiteBGCue(false)
-    , m_captureCue(false) {
+    // set the parent 0 in order to enable the popup behind the main window
+    : Dialog(0, false, false, "PencilTest"),
+      m_currentCamera(NULL),
+      m_cameraImageCapture(NULL),
+      m_captureWhiteBGCue(false),
+      m_captureCue(false) {
   setWindowTitle(tr("Camera Capture"));
 
   // add maximize button to the dialog
-  Qt::WindowFlags flags = windowFlags();
-  flags |= Qt::WindowMaximizeButtonHint;
-  setWindowFlags(flags);
+  setWindowFlags(windowFlags() | Qt::WindowMaximizeButtonHint);
 
   layout()->setSizeConstraint(QLayout::SetNoConstraint);
 
@@ -1241,6 +1240,7 @@ void PencilTestPopup::hideEvent(QHideEvent* event) {
     if (m_currentCamera->state() == QCamera::LoadedState)
       m_currentCamera->unload();
   }
+  Dialog::hideEvent(event);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -25,6 +25,7 @@
 #include <QPainter>
 #include <QRadioButton>
 #include <QThread>
+#include <QDesktopWidget>
 
 // boost includes
 #include <boost/algorithm/cxx11/any_of.hpp>
@@ -286,8 +287,16 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
   if (geo != QString()) {
     QStringList values = geo.split(" ");
     assert(values.size() == 4);
-    setGeometry(values.at(0).toInt(), std::max(30, values.at(1).toInt()),
-                values.at(2).toInt(), values.at(3).toInt());
+    // Ensure that the dialog is visible in the screen.
+    // The dialog opens with some offset to bottom-right direction
+    // if a flag Qt::WindowMaximizeButtonHint is set. (e.g. PencilTestPopup)
+    // Therefore, if the dialog is moved to the bottom-end of the screen,
+    // it will be got out of the screen on the next launch.
+    // The following position adjustment will also prevent such behavior.
+    QRect screen = QApplication::desktop()->screenGeometry();
+    int x        = std::min(values.at(0).toInt(), screen.width() - 50);
+    int y = std::min(std::max(30, values.at(1).toInt()), screen.height() - 90);
+    setGeometry(x, y, values.at(2).toInt(), values.at(3).toInt());
   }
 }
 


### PR DESCRIPTION
This PR is for the issue #915 
Although it is not clear why the flag `Qt::WindowMaximizeButtonHint` makes the popup to move to right-bottom direction, I added a "safeguard" in order to prevent the popup not to go out of the screen.
This fix will also take care when you are temporary using screen with low resolution (such as XGA projector), you will not lose the popup outside of the screen.

Also I changed the `parent` of `PencilTestPopup` from `TApp::instance()->getMainWindow()` to `0`, in order to enable the popup to be behind the main window.