### PR TITLE
Moved ffmpeg temp files to cache folder

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -100,7 +100,8 @@ void Ffmpeg::setPath(TFilePath path) { m_path = path; }
 
 void Ffmpeg::createIntermediateImage(const TImageP &img, int frameIndex) {
   m_frameCount++;
-  QString tempPath = m_path.getQString() + "tempOut" +
+  QString tempPath = getFfmpegCache().getQString() + "//" +
+                     QString::fromStdString(m_path.getName()) + "tempOut" +
                      QString::number(m_frameCount) + "." + m_intermediateFormat;
   std::string saveStatus = "";
   TRasterImageP tempImage(img);
@@ -137,8 +138,9 @@ void Ffmpeg::createIntermediateImage(const TImageP &img, int frameIndex) {
 void Ffmpeg::runFfmpeg(QStringList preIArgs, QStringList postIArgs,
                        bool includesInPath, bool includesOutPath,
                        bool overWriteFiles) {
-  QString tempName = "tempOut%d." + m_intermediateFormat;
-  tempName         = m_path.getQString() + tempName;
+  QString tempName = "//" + QString::fromStdString(m_path.getName()) +
+                     "tempOut%d." + m_intermediateFormat;
+  tempName = getFfmpegCache().getQString() + tempName;
 
   QStringList args;
   args = args + preIArgs;
@@ -189,7 +191,8 @@ void Ffmpeg::saveSoundTrack(TSoundTrack *st) {
   int bufSize         = st->getSampleCount() * st->getSampleSize();
   const UCHAR *buffer = st->getRawData();
 
-  m_audioPath   = m_path.getQString() + "tempOut.raw";
+  m_audioPath = getFfmpegCache().getQString() + "//" +
+                QString::fromStdString(m_path.getName()) + "tempOut.raw";
   m_audioFormat = "s" + QString::number(m_bitsPerSample);
   if (m_bitsPerSample > 8) m_audioFormat = m_audioFormat + "le";
   std::string strPath                    = m_audioPath.toStdString();

--- a/toonz/sources/image/ffmpeg/tiio_gif.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_gif.cpp
@@ -74,7 +74,8 @@ TLevelWriterGif::~TLevelWriterGif() {
   QString filters = "scale=" + QString::number(outLx) + ":-1:flags=lanczos";
   QString paletteFilters = filters + " [x]; [x][1:v] paletteuse";
   if (m_palette) {
-    palette = m_path.getQString() + "palette.png";
+    palette = ffmpegWriter->getFfmpegCache().getQString() + "//" +
+              QString::fromStdString(m_path.getName()) + "palette.png";
     palettePreIArgs << "-v";
     palettePreIArgs << "warning";
 


### PR DESCRIPTION
#918 
This saves the temp export files to the cache folder so they don't clutter up output folders if OT crashes during export before the cleanup command runs.