### PR TITLE
Fix crash on editing curve with control point tool

### DIFF
--- a/toonz/sources/tnztools/controlpointselection.cpp
+++ b/toonz/sources/tnztools/controlpointselection.cpp
@@ -873,7 +873,7 @@ void ControlPointEditorStroke::moveSegment(int beforeIndex, int nextIndex,
       m_controlPoints[beforeIndex].m_isCusp = true;
   } else if (!isSpeedOutLinear(beforeIndex) && !isSpeedInLinear(beforeIndex) &&
              !isCusp(beforeIndex)) {
-    t = 1 - abs(w - w0) / abs(w4 - w0);
+    t = 1 - fabs(w - w0) / fabs(w4 - w0);
     moveSingleControlPoint(beforeIndex, t * delta);
     t = 1 - t;
   }
@@ -887,7 +887,7 @@ void ControlPointEditorStroke::moveSegment(int beforeIndex, int nextIndex,
       m_controlPoints[nextIndex].m_isCusp = true;
   } else if (!isSpeedInLinear(nextIndex) && !isSpeedOutLinear(nextIndex) &&
              !isCusp(nextIndex)) {
-    s = 1 - abs(w4 - w) / abs(w4 - w0);
+    s = 1 - fabs(w4 - w) / fabs(w4 - w0);
     moveSingleControlPoint(nextIndex, s * delta);
     s = 1 - s;
   }


### PR DESCRIPTION
OpenToonz crashes when directly manipulating curves via the lines
themselves, unless the curve was initialized as a straight line.

Depending on the build environment, a calculation interprets doubles
as ints, resulting in a divison by zero.

 -Explicitly specify the use of floating point abs() - fabs()

Resolves: #858, #919