### PR TITLE
Level settings and info for sound levels 

### DIFF
--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -1113,7 +1113,7 @@ public:
       cellSelection->getSelectedCells(r0, c0, r1, c1);
       for (int c = c0; c <= c1; c++) {
         for (int r = r0; r <= r1; r++) {
-          TXshLevel *lv = xsh->getCell(r, c).getSimpleLevel();
+          TXshLevel *lv = xsh->getCell(r, c).m_level.getPointer();
           if (!lv) continue;
           std::vector<TXshLevel *>::iterator lvIt =
               find(selectedLevels.begin(), selectedLevels.end(), lv);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2130,9 +2130,9 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
   }
 
   if (isCellSelected) {
-    if (!soundCellsSelected) {
-      menu.addAction(cmdManager->getAction(MI_LevelSettings));
+    menu.addAction(cmdManager->getAction(MI_LevelSettings));
 
+    if (!soundCellsSelected) {
       //- force reframe
       QMenu *reframeSubMenu = new QMenu(tr("Reframe"), this);
       {


### PR DESCRIPTION
For now, "Info" command triggered from right-click menu of the sound levels does nothing (for bug), so there is no easy way to know the file path and other information of them.
This PR fixes such problem, allowing to display the Level Settings and the Info Viewer for sound levels.