### PR TITLE
[FIX] Plastictool: SuperLU non thirdparty issue on Linux.

### DIFF
--- a/toonz/cmake/FindSuperLU.cmake
+++ b/toonz/cmake/FindSuperLU.cmake
@@ -1,15 +1,4 @@
 # preferred homebrew's directories.
-find_path(
-    SUPERLU_INCLUDE_DIR
-    NAMES
-        slu_Cnames.h
-    HINTS
-        ${THIRDPARTY_LIBS_HINTS}
-    PATH_SUFFIXES
-        superlu43/4.3_1/include/superlu
-        superlu/SuperLU_4.1/include
-)
-
 find_library(
     SUPERLU_LIBRARY
     NAMES
@@ -22,6 +11,36 @@ find_library(
         superlu43/4.3_1/lib
         superlu
 )
+
+string(TOLOWER ${SUPERLU_LIBRARY} SUPERLU_LIB_CASE_INSENSITIVE)
+
+if (${SUPERLU_LIB_CASE_INSENSITIVE} MATCHES "thirdparty")
+    find_path(
+        SUPERLU_INCLUDE_DIR
+        NAMES
+            slu_Cnames.h
+        HINTS
+            ${THIRDPARTY_LIBS_HINTS}
+        PATH_SUFFIXES
+            superlu43/4.3_1/include/superlu
+            superlu/SuperLU_4.1/include
+    )
+else()
+    set(SUPERLU_NO_THIRDPARTY "true")
+    find_path(
+        SUPERLU_INCLUDE_DIR
+        NAMES
+            slu_Cnames.h
+        PATH_SUFFIXES
+            superlu
+    )
+    #Get the version of Superlu. We need >= 5.0.0
+    if (SUPERLU_INCLUDE_DIR)
+        file(STRINGS "${SUPERLU_INCLUDE_DIR}/slu_util.h" SUPERLU_VERSION REGEX "#define SUPERLU_MAJOR_VERSION.+[0-9]+")
+        string(REGEX MATCH "[0-9]+" SUPERLU_VERSION ${SUPERLU_VERSION})
+    endif()
+endif()
+
 
 message("***** SuperLU Header path:" ${SUPERLU_INCLUDE_DIR})
 message("***** SuperLU Library path:" ${SUPERLU_LIBRARY})

--- a/toonz/cmake/FindSuperLU.cmake
+++ b/toonz/cmake/FindSuperLU.cmake
@@ -37,7 +37,11 @@ else()
     #Get the version of Superlu. We need >= 5.0.0
     if (SUPERLU_INCLUDE_DIR)
         file(STRINGS "${SUPERLU_INCLUDE_DIR}/slu_util.h" SUPERLU_VERSION REGEX "#define SUPERLU_MAJOR_VERSION.+[0-9]+")
-        string(REGEX MATCH "[0-9]+" SUPERLU_VERSION ${SUPERLU_VERSION})
+        if(SUPERLU_VERSION)
+            string(REGEX MATCH "[0-9]+" SUPERLU_VERSION ${SUPERLU_VERSION})
+        else()
+            set(SUPERLU_VERSION "0")
+        endif()
     endif()
 endif()
 

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -288,8 +288,19 @@ elseif(UNIX)
     find_package(GLEW)
 
     find_package(SuperLU REQUIRED)
-    set(SUPERLU_INCLUDE_DIR ${SUPERLU_INCLUDE_DIR}/superlu)
+    set(SUPERLU_INCLUDE_DIR ${SUPERLU_INCLUDE_DIR})
     set(SUPERLU_LIB ${SUPERLU_LIBRARY})
+    set(SUPERLU_NO_THIRDPARTY ${SUPERLU_NO_THIRDPARTY})
+    set(SUPERLU_VERSION ${SUPERLU_VERSION})
+    if (SUPERLU_NO_THIRDPARTY)
+        #If we are using system (from upstream) SuperLU we need version >= 5
+        if (${SUPERLU_VERSION} VERSION_LESS "5")
+            message("[VERSION CHECK] SuperLU version 5.0.0 or greater required. Update your SuperLU package, thanks.")
+            return()
+        endif()
+        add_definitions(-DSUPERLU_NO_THIRDPARTY)
+    endif()
+
 
     find_package(JPEG REQUIRED)
 

--- a/toonz/sources/tnzext/tlin/tlin_superlu_wrap.cpp
+++ b/toonz/sources/tnzext/tlin/tlin_superlu_wrap.cpp
@@ -1,8 +1,13 @@
 
 
 extern "C" {
+#ifdef SUPERLU_NO_THIRDPARTY
+#include <slu_ddefs.h>
+#include <slu_util.h>
+#else
 #include "slu_ddefs.h"
 #include "slu_util.h"
+#endif
 }
 
 #include <algorithm>
@@ -308,8 +313,15 @@ void tlin::factorize(SuperMatrix *A, SuperFactors *&F, superlu_options_t *opt) {
   StatInit(&stat);
 
   int result;
+
+#ifdef SUPERLU_NO_THIRDPARTY
+  GlobalLU_t Glu;
+  dgstrf(opt, &AC, sp_ienv(1), sp_ienv(2), etree, NULL, 0, F->perm_c, F->perm_r,
+         F->L, F->U, &Glu, &stat, &result);
+#else
   dgstrf(opt, &AC, sp_ienv(1), sp_ienv(2), etree, NULL, 0, F->perm_c, F->perm_r,
          F->L, F->U, &stat, &result);
+#endif
 
   StatFree(&stat);
 


### PR DESCRIPTION
Hi.

This PR fixes the problem with using the non thirdparty SuperLU (the upstream). So, it close #623 issue.

Opentoonz are using a modified version of SuperLU(v.4.1) because multi threading issues with static variables (see https://github.com/opentoonz/opentoonz/blob/master/thirdparty/superlu/README.txt) . SuperLU >=5 becomes thread-safe, so it is safe use it instead of the thirdparty.

Anyway, SuperLU 5+ change the interface of the method used for factorizing, so it is not enough linking with the new library.


**What happens**:

Without this fix, in Linux box if the upstream SuperLU is used, you get a "Segmentation fault" (get it when select "Animate" before create the mesh and the bones) because the function has a mixing of parameters.

There is a mixing of the headers file, too. Always gets the headers of the thirdparty directory.


**What do the fix**:

_In build_:
	Change CMake configuration to get the correct header when you are using the thirdparty or the official upstream of SuperLU.
	Added a validation for correct version of SuperLU library (>=5) in casef you use non-thirdparty.

_In code_:

If using the non-thirdparty, it uses the new interface of the function of factorizing (dgstrf) with the new parameter.

If thirdparty used, do nothing. I've tried to make it the more transparent for non-Linux platforms, in case the thirdparty SuperLU wanted to be kept.




As said, the fix is only for Linux. Microsoft Windows and OSX are using still the thirdparty; although I think that it could be interesting use the official upstream SuperLU for all platforms ( @shun-iwasawa ). As it works in Linux, it must works fine in Windows and OSX, and it does the code more unified and easy to mantain. Anyway, as I can only test on Linux, I prefer that someone related with Microsoft Windows and OSX checks this.



This is my first time with CMake, so it is possible that are something missing or incorrect. Just comment it.  :)


Thanks.