### PR TITLE
Fix path to qt5 in OSX build script.

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -8,7 +8,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt55/5.5.1/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt@5.5/5.5.1/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make


### PR DESCRIPTION
Toravis said
> We agreed to the Qt opensource license for you.
> If this is unacceptable you should uninstall.
> This formula is keg-only, which means it was not symlinked into /usr/local.
> Older version of qt5
> Generally there are no consequences of this for you. If you build your
> own software and it requires this formula, you'll need to add to your
> build variables:
>     LDFLAGS:  -L/usr/local/opt/qt@5.5/lib
>     CPPFLAGS: -I/usr/local/opt/qt@5.5/include
>     PKG_CONFIG_PATH: /usr/local/opt/qt@5.5/lib/pkgconfig

Fixed above.