### PR TITLE
Fix crash on applying shortcut preset

### DIFF
--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -527,6 +527,7 @@ void ShortcutPopup::setPresetShortcuts(TFilePath fp) {
     QByteArray ba      = id.toLatin1();
     const char *charId = ba.data();
     action = CommandManager::instance()->getAction((CommandId)charId);
+    if (!action) continue;
     CommandManager::instance()->setShortcut(
         action, preset.value(id).toString().toStdString(), false);
   }


### PR DESCRIPTION
To reproduce crash:

1. Open "Configure Shortcuts" popup.

1. In Preset combobox, select "OpenToonz" and press "Apply" button.

The software crashes while setting the shortcuts.


For now, in OpenToonz shortcut preset there is a setting with ID "MI_ReloadStyle", corresponding to ”Reload qss” command which is only available in debug build. 
In the release build the software crashes because no action is obtained with such ID.