### PR TITLE
Fix Opentoonz Filebrowser crash when a sequence has a frame with a  malformed named.

### DIFF
--- a/toonz/sources/common/timage_io/tlevel_io.cpp
+++ b/toonz/sources/common/timage_io/tlevel_io.cpp
@@ -5,6 +5,7 @@
 #include "tiio.h"
 #include "tcontenthistory.h"
 #include "tconvert.h"
+#include "tmsgcore.h"
 
 // STD includes
 #include <map>
@@ -118,8 +119,13 @@ TLevelP TLevelReader::loadInfo() {
       try {
         level->setFrame(it->getFrame(), TImageP());
         data.push_back(*it);
-      } catch (string msg) {
-        throw msg;
+      } catch (TMalformedFrameException tmfe) {
+        // skip frame named incorrectly warning to the user in the message
+        // center.
+        DVGui::warning(QString::fromStdWString(
+            tmfe.getMessage() + L": " +
+            QObject::tr("Skipping frame.").toStdWString()));
+        continue;
       }
     }
   }

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -24,6 +24,9 @@ const char wauxslash = '\\';
 #include <cctype>
 #include <sstream>
 
+// QT
+#include <QObject>
+
 bool TFilePath::m_underscoreFormatAllowed = true;
 
 namespace {
@@ -634,7 +637,10 @@ TFrameId TFilePath::getFrame() const {
   if (iswalpha(str[k])) letter = str[k++] + ('a' - L'a');
 
   if (number == 0 || k < i)  // || letter!='\0')
-    throw(::to_string(m_path) + ": malformed frame name.");
+    throw TMalformedFrameException(
+        *this,
+        str + L": " + QObject::tr("Malformed frame name").toStdWString());
+
   return TFrameId(number, letter);
 }
 

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -599,6 +599,18 @@ void FileBrowser::refreshCurrentFolderItems() {
     m_multiFileItemMap.clear();
 
     for (it = all_files.begin(); it != all_files.end(); it++) {
+      TFrameId tFrameId;
+      try {
+        tFrameId = it->getFrame();
+      } catch (TMalformedFrameException tmfe) {
+        // Incorrect frame name sequence. Warning to the user in the message
+        // center.
+        DVGui::warning(QString::fromStdWString(
+            tmfe.getMessage() + L": " +
+            QObject::tr("Skipping frame.").toStdWString()));
+        continue;
+      }
+
       TFilePath levelName(it->getLevelName());
 
       if (levelName.isLevelName()) {
@@ -618,7 +630,7 @@ void FileBrowser::refreshCurrentFolderItems() {
         levelItem.m_fileSize += fileInfo.size();
 
         // store frameId
-        levelItem.m_frameIds.push_back(it->getFrame());
+        levelItem.m_frameIds.push_back(tFrameId);
 
         levelItem.m_frameCount++;
       }


### PR DESCRIPTION
Hi.

This PR close partially #469 issue: only fix de crash.

**What happen**:

Opentoonz file browse crash when enter in a directory with a file name that start a sequence with 0 (file.0000.png, for example) or have letters (except a final "a") file.0wre.png.

That's because for Opentoonz a sequence can not start in 0 or contain letters (except "a". I suppose that this a feature for alpha images... but I really don't know).

This is really bad because an user can have a file named that way and it just crash Opentoonz.


**How reproduce this**:

Create a image file named file.0000.png. Navigate with file browser to the file created. You'll get a crash.

**What do this fix**:

This fix throws and capture exception more gentle avoiding the crash. If it find a file with a malformed name, it skips that frame, showing warning messages in the message center.