### PR TITLE
(WIP) Filenaming:  Sequence can start in 0 not only 1

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -20,6 +20,7 @@ const char wauxslash = '\\';
 
 #include "tfilepath.h"
 #include "tconvert.h"
+#include "toonz/preferences.h"
 #include <cmath>
 #include <cctype>
 #include <sstream>
@@ -633,7 +634,9 @@ TFrameId TFilePath::getFrame() const {
   char letter                  = '\0';
   if (iswalpha(str[k])) letter = str[k++] + ('a' - L'a');
 
-  if (k < i)  // || letter!='\0')
+  // Check if user wants to start a sequence in 0
+  if ((!Preferences::instance()->isSequenceCanStartWith0() && number == 0) ||
+      k < i)  // || letter!='\0')
     throw(::to_string(m_path) + ": malformed frame name.");
   return TFrameId(number, letter);
 }

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -633,7 +633,7 @@ TFrameId TFilePath::getFrame() const {
   char letter                  = '\0';
   if (iswalpha(str[k])) letter = str[k++] + ('a' - L'a');
 
-  if (number == 0 || k < i)  // || letter!='\0')
+  if (k < i)  // || letter!='\0')
     throw(::to_string(m_path) + ": malformed frame name.");
   return TFrameId(number, letter);
 }

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -20,7 +20,6 @@ const char wauxslash = '\\';
 
 #include "tfilepath.h"
 #include "tconvert.h"
-#include "toonz/preferences.h"
 #include <cmath>
 #include <cctype>
 #include <sstream>
@@ -29,6 +28,7 @@ const char wauxslash = '\\';
 #include <QObject>
 
 bool TFilePath::m_underscoreFormatAllowed = true;
+bool TFilePath::m_sequenceCanStartWith0   = false;
 
 namespace {
 
@@ -638,8 +638,7 @@ TFrameId TFilePath::getFrame() const {
   if (iswalpha(str[k])) letter = str[k++] + ('a' - L'a');
 
   // Check if user wants to start a sequence in 0
-  if ((!Preferences::instance()->isSequenceCanStartWith0() && number == 0) ||
-      k < i)  // || letter!='\0')
+  if ((!m_sequenceCanStartWith0 && number == 0) || k < i)  // || letter!='\0')
     throw TMalformedFrameException(
         *this,
         str + L": " + QObject::tr("Malformed frame name").toStdWString());

--- a/toonz/sources/include/tfilepath.h
+++ b/toonz/sources/include/tfilepath.h
@@ -100,6 +100,7 @@ inline std::ostream &operator<<(std::ostream &out, const TFrameId &f) {
    constructor.*/
 class DVAPI TFilePath {
   static bool m_underscoreFormatAllowed;
+  static bool m_sequenceCanStartWith0;
   std::wstring m_path;
   void setPath(std::wstring path);
 
@@ -108,6 +109,10 @@ public:
    * pippo_0001.tif (represented  always as pippo..tif) */
   static void setUnderscoreFormatAllowed(bool state) {
     m_underscoreFormatAllowed = state;
+  }
+
+  static void setSequenceCanStartWith0(bool state) {
+    m_sequenceCanStartWith0 = state;
   }
 
   /*!This constructor creates a string removing redundances ('//', './',etc.)

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -234,6 +234,9 @@ public:
   void enableSubsceneFolder(bool on);
   bool isSubsceneFolderEnabled() const { return m_subsceneFolderEnabled; }
 
+  void enableSequenceCanStartWith0(bool on);
+  bool isSequenceCanStartWith0() const { return m_sequenceCanStartWith0; }
+
   int addLevelFormat(const LevelFormat &format);  //!< Inserts a new level
                                                   //! format.  \return  The
   //! associated format index.
@@ -475,12 +478,12 @@ private:
       m_dragCellsBehaviour, m_lineTestFpsCapture, m_defLevelType, m_xsheetStep,
       m_shmmax, m_shmseg, m_shmall, m_shmmni;
 
-  bool m_autoExposeEnabled, m_autoCreateEnabled, m_subsceneFolderEnabled,
-      m_generatedMovieViewEnabled, m_xsheetAutopanEnabled,
-      m_ignoreAlphaonColumn1Enabled, m_previewAlwaysOpenNewFlipEnabled,
-      m_rewindAfterPlaybackEnabled, m_fitToFlipbookEnabled, m_autosaveEnabled,
-      m_autosaveSceneEnabled, m_autosaveOtherFilesEnabled,
-      m_defaultViewerEnabled, m_pixelsOnly;
+  bool m_autoExposeEnabled, m_autoCreateEnabled, m_sequenceCanStartWith0,
+      m_subsceneFolderEnabled, m_generatedMovieViewEnabled,
+      m_xsheetAutopanEnabled, m_ignoreAlphaonColumn1Enabled,
+      m_previewAlwaysOpenNewFlipEnabled, m_rewindAfterPlaybackEnabled,
+      m_fitToFlipbookEnabled, m_autosaveEnabled, m_autosaveSceneEnabled,
+      m_autosaveOtherFilesEnabled, m_defaultViewerEnabled, m_pixelsOnly;
   bool m_rasterOptimizedMemory, m_saveUnpaintedInCleanup,
       m_askForOverrideRender, m_automaticSVNFolderRefreshEnabled, m_SVNEnabled,
       m_levelsBackupEnabled, m_minimizeSaveboxAfterEditing,

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -452,8 +452,13 @@ TImage *TTool::touchImage() {
     m_isLevelCreated = true;
 
     // create the drawing
-    TFrameId fid = animationSheetEnabled ? getNewFrameId(sl, row) : TFrameId(1);
-    TImageP img  = sl->createEmptyFrame();
+    // we check if user wants start sequences with 0
+    TFrameId fid =
+        animationSheetEnabled
+            ? getNewFrameId(sl, row)
+            : TFrameId(Preferences::instance()->isSequenceCanStartWith0() ? 0
+                                                                          : 1);
+    TImageP img      = sl->createEmptyFrame();
     m_isFrameCreated = true;
     sl->setFrame(fid, img);
     cell = TXshCell(sl, fid);

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -165,9 +165,11 @@ LevelCreatePopup::LevelCreatePopup()
     : Dialog(TApp::instance()->getMainWindow(), true, true, "LevelCreate") {
   setWindowTitle(tr("New Level"));
 
-  m_nameFld     = new LineEdit(this);
-  m_fromFld     = new DVGui::IntLineEdit(this);
-  m_toFld       = new DVGui::IntLineEdit(this);
+  m_nameFld = new LineEdit(this);
+  m_fromFld = new DVGui::IntLineEdit(
+      this, Preferences::instance()->isSequenceCanStartWith0() ? 0 : 1);
+  m_toFld = new DVGui::IntLineEdit(
+      this, Preferences::instance()->isSequenceCanStartWith0() ? 0 : 1);
   m_stepFld     = new DVGui::IntLineEdit(this);
   m_incFld      = new DVGui::IntLineEdit(this);
   m_levelTypeOm = new QComboBox();

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -470,6 +470,12 @@ void PreferencesPopup::onSubsceneFolderChanged(int index) {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onSequenceCanStartWith0Changed(int index) {
+  m_pref->enableSequenceCanStartWith0(index == Qt::Checked);
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onViewGeneratedMovieChanged(int index) {
   m_pref->enableGeneratedMovieView(index == Qt::Checked);
 }
@@ -1162,6 +1168,8 @@ PreferencesPopup::PreferencesPopup()
       new CheckBox(tr("Ignore Alpha Channel on Levels in Column 1"), this);
   CheckBox *showKeyframesOnCellAreaCB =
       new CheckBox(tr("Show Keyframes on Cell Area"), this);
+  m_sequenceCanStartWith0CB =
+      new CheckBox(tr("A sequence can start with 0"), this);
 
   //--- Animation ------------------------------
   categoryList->addItem(tr("Animation"));
@@ -1416,6 +1424,7 @@ PreferencesPopup::PreferencesPopup()
   ignoreAlphaonColumn1CB->setChecked(m_pref->isIgnoreAlphaonColumn1Enabled());
   showKeyframesOnCellAreaCB->setChecked(
       m_pref->isShowKeyframesOnXsheetCellAreaEnabled());
+  m_sequenceCanStartWith0CB->setChecked(m_pref->isSequenceCanStartWith0());
 
   //--- Animation ------------------------------
   QStringList list;
@@ -1856,11 +1865,12 @@ PreferencesPopup::PreferencesPopup()
 
       xsheetFrameLay->addWidget(ignoreAlphaonColumn1CB, 3, 0, 1, 2);
       xsheetFrameLay->addWidget(showKeyframesOnCellAreaCB, 4, 0, 1, 2);
+      xsheetFrameLay->addWidget(m_sequenceCanStartWith0CB, 5, 0, 1, 2);
     }
     xsheetFrameLay->setColumnStretch(0, 0);
     xsheetFrameLay->setColumnStretch(1, 0);
     xsheetFrameLay->setColumnStretch(2, 1);
-    xsheetFrameLay->setRowStretch(5, 1);
+    xsheetFrameLay->setRowStretch(6, 1);
     xsheetBox->setLayout(xsheetFrameLay);
     stackedWidget->addWidget(xsheetBox);
 
@@ -2188,6 +2198,8 @@ PreferencesPopup::PreferencesPopup()
                        SLOT(onDragCellsBehaviourChanged(int)));
   ret = ret && connect(showKeyframesOnCellAreaCB, SIGNAL(stateChanged(int)),
                        this, SLOT(onShowKeyframesOnCellAreaChanged(int)));
+  ret = ret && connect(m_sequenceCanStartWith0CB, SIGNAL(stateChanged(int)),
+                       this, SLOT(onSequenceCanStartWith0Changed(int)));
 
   //--- Animation ----------------------
   ret = ret && connect(m_keyframeType, SIGNAL(currentIndexChanged(int)),

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -74,6 +74,8 @@ private:
       *m_onionSkinDuringPlayback, *m_autoSaveSceneCB, *m_autoSaveOtherFilesCB,
       *m_useNumpadForSwitchingStyles;
 
+  DVGui::CheckBox *m_sequenceCanStartWith0CB;
+
   DVGui::FileField *m_customProjectRootFileField;
 
   DVGui::FileField *m_ffmpegPathFileFld, *m_fastRenderPathFileField;
@@ -99,6 +101,7 @@ private slots:
   void onViewValuesChanged();
   void onAutoExposeChanged(int index);
   void onSubsceneFolderChanged(int index);
+  void onSequenceCanStartWith0Changed(int index);
   void onViewGeneratedMovieChanged(int index);
   void onXsheetStepChanged();
   void onXsheetAutopanChanged(int index);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1049,6 +1049,16 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
   TXshCell cell = xsh->getCell(row, col);
   TXshCell prevCell;
 
+  // If the user change the option to start a sequence with 0 to 1 in-live, we
+  // delete all cell and frame 0 of the actual Xsheet
+  if (!Preferences::instance()->isSequenceCanStartWith0() &&
+      cell.getFrameId().getNumber() == 0) {
+    cell.getSimpleLevel()->eraseFrame(TFrameId(0));
+    xsh->clearCells(row, col);
+    cell.getSimpleLevel()->setDirtyFlag(true);
+    return;
+  }
+
   TCellSelection *cellSelection     = m_viewer->getCellSelection();
   TColumnSelection *columnSelection = m_viewer->getColumnSelection();
   bool isSelected                   = cellSelection->isCellSelected(row, col) ||

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -528,7 +528,13 @@ void RenameCellField::showInRowCol(int row, int col) {
                         m_viewer->getFrameNumberWithLetters(fid.getNumber()));
     else {
       std::string frameNumber("");
-      if (fid.getNumber() >= 0) frameNumber = std::to_string(fid.getNumber());
+      // Check if the user wants a sequence starting with 0
+      if ((Preferences::instance()->isSequenceCanStartWith0() &&
+           fid.getNumber() >= 0) ||
+          (!Preferences::instance()->isSequenceCanStartWith0() &&
+           fid.getNumber() > 0)) {
+        frameNumber = std::to_string(fid.getNumber());
+      }
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       setText((frameNumber.empty())
                   ? QString::fromStdWString(levelName)
@@ -637,7 +643,14 @@ void RenameCellField::renameCell() {
 
   TXshCell cell(xl, fid);
 
-  cellSelection->renameCells(cell);
+  if (!Preferences::instance()->isSequenceCanStartWith0() &&
+      (fid.getNumber() == 0)) {
+    TCellSelection::Range range = cellSelection->getSelectedCells();
+    cellSelection->deleteCells();
+    // revert cell selection
+    cellSelection->selectCells(range.m_r0, range.m_c0, range.m_r1, range.m_c1);
+  } else
+    cellSelection->renameCells(cell);
 }
 
 //-----------------------------------------------------------------------------
@@ -1169,7 +1182,13 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
     else {
       std::string frameNumber("");
       // set number
-      if (fid.getNumber() >= 0) frameNumber = std::to_string(fid.getNumber());
+      // Check if the user wants a sequence starting with 0
+      if ((Preferences::instance()->isSequenceCanStartWith0() &&
+           fid.getNumber() >= 0) ||
+          (!Preferences::instance()->isSequenceCanStartWith0() &&
+           fid.getNumber() > 0)) {
+        frameNumber = std::to_string(fid.getNumber());
+      }
       // add letter
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       p.drawText(nameRect, Qt::AlignRight, QString::fromStdString(frameNumber));

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -528,7 +528,7 @@ void RenameCellField::showInRowCol(int row, int col) {
                         m_viewer->getFrameNumberWithLetters(fid.getNumber()));
     else {
       std::string frameNumber("");
-      if (fid.getNumber() > 0) frameNumber = std::to_string(fid.getNumber());
+      if (fid.getNumber() >= 0) frameNumber = std::to_string(fid.getNumber());
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       setText((frameNumber.empty())
                   ? QString::fromStdWString(levelName)
@@ -637,13 +637,7 @@ void RenameCellField::renameCell() {
 
   TXshCell cell(xl, fid);
 
-  if (fid.getNumber() == 0) {
-    TCellSelection::Range range = cellSelection->getSelectedCells();
-    cellSelection->deleteCells();
-    // revert cell selection
-    cellSelection->selectCells(range.m_r0, range.m_c0, range.m_r1, range.m_c1);
-  } else
-    cellSelection->renameCells(cell);
+  cellSelection->renameCells(cell);
 }
 
 //-----------------------------------------------------------------------------
@@ -1175,7 +1169,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
     else {
       std::string frameNumber("");
       // set number
-      if (fid.getNumber() > 0) frameNumber = std::to_string(fid.getNumber());
+      if (fid.getNumber() >= 0) frameNumber = std::to_string(fid.getNumber());
       // add letter
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       p.drawText(nameRect, Qt::AlignRight, QString::fromStdString(frameNumber));

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -247,6 +247,7 @@ Preferences::Preferences()
     , m_defLevelType(0)
     , m_autocreationType(1)
     , m_autoExposeEnabled(true)
+    , m_sequenceCanStartWith0(false)
     , m_autoCreateEnabled(true)
     , m_subsceneFolderEnabled(true)
     , m_generatedMovieViewEnabled(true)
@@ -311,6 +312,7 @@ Preferences::Preferences()
       QString::fromStdWString(savePath.getWideString()), QSettings::IniFormat));
 
   getValue(*m_settings, "autoExposeEnabled", m_autoExposeEnabled);
+  getValue(*m_settings, "sequenceCanStartWith0", m_sequenceCanStartWith0);
   getValue(*m_settings, "autoCreateEnabled", m_autoCreateEnabled);
   getValue(*m_settings, "subsceneFolderEnabled", m_subsceneFolderEnabled);
   getValue(*m_settings, "generatedMovieViewEnabled",
@@ -591,6 +593,13 @@ Preferences *Preferences::instance() {
 void Preferences::enableAutoExpose(bool on) {
   m_autoExposeEnabled = on;
   m_settings->setValue("autoExposeEnabled", on ? "1" : "0");
+}
+
+//-----------------------------------------------------------------
+
+void Preferences::enableSequenceCanStartWith0(bool on) {
+  m_sequenceCanStartWith0 = on;
+  m_settings->setValue("sequenceCanStartWith0", on ? "1" : "0");
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -313,6 +313,7 @@ Preferences::Preferences()
 
   getValue(*m_settings, "autoExposeEnabled", m_autoExposeEnabled);
   getValue(*m_settings, "sequenceCanStartWith0", m_sequenceCanStartWith0);
+  TFilePath::setSequenceCanStartWith0(m_sequenceCanStartWith0);
   getValue(*m_settings, "autoCreateEnabled", m_autoCreateEnabled);
   getValue(*m_settings, "subsceneFolderEnabled", m_subsceneFolderEnabled);
   getValue(*m_settings, "generatedMovieViewEnabled",
@@ -600,6 +601,7 @@ void Preferences::enableAutoExpose(bool on) {
 void Preferences::enableSequenceCanStartWith0(bool on) {
   m_sequenceCanStartWith0 = on;
   m_settings->setValue("sequenceCanStartWith0", on ? "1" : "0");
+  TFilePath::setSequenceCanStartWith0(on);
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
Hi.

This PR close #469. (See #966, too)

**What happen**:

Opentoonz not accept sequence starting with 0. This is explicitaly prohibed in code. One reason is that "0" frame is used to delete a cell.

I suppose that starting with 1 is a industry standard, but I think that it must be possible for the user start with 0 (if he wants it).

**What do this fix**:

Activate the use of 0 frame to start a sequence.

**What problem with enter this fix**:

As said, setting a cell with 0 frame is used to delete. I suppose that this feature is used (as is programmed), but I really don't know.

If deleting is not used, this fix could be considered as is.

if deleting is used and, of course, is prefered continuing with this, I could make an options in preference configuration that let to the user select if he wants start with 0 or continue as now (this will be the default option).

I accept other suggestion (including forgot this  :)).