### PR TITLE
Fix non-printable null character is xsheet cell with "ABC" appendix.

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1196,7 +1196,7 @@ QString XsheetViewer::getFrameNumberWithLetters(int frame) {
   } else
     number = "0";
 
-  return number.append(letter);
+  return (QChar(letter).isNull()) ? number : number.append(letter);
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Hi.

This PR fix a print "non-printable" '\0' character in cells of the x-sheet.

I really don't know if this issue is only related with GNU/Linux (or a unique configuration), but I think that this fix is safest for all platforms and configurations.


**What happens**:

Opentoonz appends a null non-printable '\0' to a number frame when "ABC" appendix format is used in the 10, 20, 30, ... frames intead of the 0 in the units.

The problem is that character is visible.

You can see mark in red:

![character_non_printable_with_abc_notation](https://cloud.githubusercontent.com/assets/13252762/21239628/fdd25a72-c307-11e6-8c93-49c5963fb32d.png)


**How to reproduce**:

Open a sequence as a level (it must have 10 frames or more).

Go to preference/interface and check on "Show "ABC" appendix to the frame number in XSheet cell". Close the preference window.

The frames 10, 20, 30,... instead of 1, 2, 3, are showed with a null non-printable character append to the number.


**What do the fix**:

Don't append any non-printable character to the number, as (I think) is not neccesary.
