### PR TITLE
Fix crash saving an AIFF level missed

### DIFF
--- a/toonz/sources/sound/aiff/tsio_aiff.cpp
+++ b/toonz/sources/sound/aiff/tsio_aiff.cpp
@@ -457,7 +457,9 @@ TSoundTrackWriterAiff::TSoundTrackWriterAiff(const TFilePath &fp)
 //------------------------------------------------------------------------------
 
 bool TSoundTrackWriterAiff::save(const TSoundTrackP &st) {
-  assert(st);
+  if (!st)
+    throw TException(L"Unable to save the soundtrack: " +
+                     m_path.getWideString());
 
   TSoundTrackP sndtrack;
   if (st->getBitPerSample() == 8 && !st->isSampleSigned())

--- a/toonz/sources/toonzlib/sceneresources.cpp
+++ b/toonz/sources/toonzlib/sceneresources.cpp
@@ -14,6 +14,8 @@
 #include "toonz/preferences.h"
 #include "tpalette.h"
 
+#include "tmsgcore.h"
+
 #include "tconvert.h"
 #include "tlogger.h"
 #include "tsystem.h"
@@ -429,7 +431,8 @@ void SceneSound::save() {
       TSystem::copyFile(actualFp, m_oldActualPath);
     }
   } catch (...) {
-    TLogger::error() << "Can't save " << actualFp;
+    DVGui::warning(QObject::tr("Can't save") +
+                   QString::fromStdWString(L": " + actualFp.getLevelNameW()));
   }
 }
 


### PR DESCRIPTION
Hi. This PR closes #957 issue.

**How to reproduce**:

1) Create a scene
2) Add an AIFF level sound.
3) Save all.
4) Change the name, move or delete the file name of the AIFF sound.
5) If you didn't close the scene before step 4, close now or change to a new scene.
6) Open the scene created in step 1.
7) Save all (or save all levels).
8) You'll get a crash.


**What does the fix**:

It checks that the AIFF data sound is valid, throwing a message to the user (to Message Center) if the save cannot be possible.


**Comment to this fix**:

This probably must be controled in an upper stage (at resource stage), but that should require a deeper refactor. So, as a quick fix, this should works.