### PR TITLE
[Enhacement] Add "aif" extension to AIFF sound list

### DIFF
--- a/toonz/sources/sound/tsio.cpp
+++ b/toonz/sources/sound/tsio.cpp
@@ -21,6 +21,10 @@ void initSoundIo() {
   TSoundTrackWriter::define("aiff", TSoundTrackWriterAiff::create);
   TFileType::declare("aiff", TFileType::AUDIO_LEVEL);
 
+  TSoundTrackReader::define("aif", TSoundTrackReaderAiff::create);
+  TSoundTrackWriter::define("aif", TSoundTrackWriterAiff::create);
+  TFileType::declare("aif", TFileType::AUDIO_LEVEL);
+
   TSoundTrackReader::define("raw", TSoundTrackReaderRaw::create);
   TSoundTrackWriter::define("raw", TSoundTrackWriterRaw::create);
   TFileType::declare("raw", TFileType::AUDIO_LEVEL);


### PR DESCRIPTION
Hi.

This PR adds the Microsoft old-style (three letters) file extension **_aif_** to load and save AIFF sound files.

As there are a lot of sound files that have the short AIFF extension (and it is an standard extension, too) I think it is good to have listed, too.