### PR TITLE
[Fix] Crash in History Panel when a level is unlinked.

### DIFF
--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -2022,12 +2022,11 @@ QString DeleteLinksUndo::getHistoryString() {
 
   if (!m_terminalFxs.empty()) {
     str += QString("  :  ");
-    std::list<TFxP>::const_iterator it1;
     std::list<TFx *>::const_iterator ft;
     for (ft = m_terminalFxs.begin(); ft != m_terminalFxs.end(); ++ft) {
       if (ft != m_terminalFxs.begin()) str += QString(",  ");
-      str += QString("%1- -Xsheet")
-                 .arg(QString::fromStdWString((*it1)->getName()));
+      str +=
+          QString("%1- -Xsheet").arg(QString::fromStdWString((*ft)->getName()));
     }
   }
 


### PR DESCRIPTION
Hi. This PR closes #965 issue.

**How to reproduce**:

1) Select brush and draw something to get a new level.
2) Open History panel.
3) Open Schematic panel.
4) Toggle to FX schematic.
5) Select the link between the level (drawed in step 1) node and the XSheet node and delete it (press _supr_).
6) You'll get a crash.


**What happens**:

It is used an un-initialized iterator pointer for calling a method. Probably somebody was doing some test in code and forgot get back to a previous stage.


**What does the fix**:

Call the method from the right iterator.