### PR TITLE
[Feature] Set auto markers

### DIFF
--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -30,6 +30,8 @@ class RowArea final : public QWidget {
     Mos
   } m_showOnionToSet;  // TODO:明日はこれをFos,Mosどちらをハイライトしているのか判定させる！！！！
 
+  enum Direction { up = 0, down };
+
   // Play ranges
   int m_r0;
   int m_r1;
@@ -50,6 +52,12 @@ class RowArea final : public QWidget {
 
   DragTool *getDragTool() const;
   void setDragTool(DragTool *dragTool);
+
+  // Return when the item-menu setAutoMarkers can be enabled.
+  bool canSetAutoMarkers();
+  // Return the number of the last non-empty cell finded. You can set the
+  // direction of the search.
+  int getNonEmptyCell(int row, int column, Direction);
 
 public:
 #if QT_VERSION >= 0x050500
@@ -76,6 +84,9 @@ protected slots:
   void onSetStartMarker();
   void onSetStopMarker();
   void onRemoveMarkers();
+
+  // Set start and end marker automatically respect the current row and column.
+  void onSetAutoMarkers();
 
   // set both the from and to markers at the specified row
   void onPreviewThis();


### PR DESCRIPTION
Hi.

This adding closes #572 issue request.

**What the new feature adds?**

It adds a new item (_Set Auto Markers_)  in the popup of the frame number column.  When the item is selected (if there is a cell non-empty in the current column and row) the start and finish markers are positioned in the first and last continuous cell.

The current row is where the user right click to get the popup. The current column is the selected column.


Here is a video with simples testings: https://youtu.be/X9ATeUelUao