### PR TITLE
Remove can't save warning on untitled autosave

### DIFF
--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -673,13 +673,6 @@ void TApp::autosave() {
   } else
     m_autosaveSuspended = false;
 
-  if (scene->isUntitled() &&
-      Preferences::instance()->isAutosaveSceneEnabled()) {
-    DVGui::warning(
-        tr("It is not possible to automatically save an untitled scene."));
-    return;
-  }
-
   DVGui::ProgressDialog pb(
       "Autosaving scene..." + toQString(scene->getScenePath()), 0, 0, 1);
   pb.show();


### PR DESCRIPTION
This fixes #777.  This removes the can't save warning if a scene is untitled during autosave and just brings up the save dialog.  