### PR TITLE
Fix crash on unfreeze preview

### DIFF
--- a/toonz/sources/toonz/previewfxmanager.cpp
+++ b/toonz/sources/toonz/previewfxmanager.cpp
@@ -1327,6 +1327,7 @@ void PreviewFxManager::unfreeze(FlipBook *flipbook) {
 
     // Also any associated pb status
     delete flipbook->getProgressBarStatus();
+    flipbook->setProgressBarStatus(NULL);
 
     previewInstance->addFlipbook(flipbook);
     previewInstance->refreshViewRects();


### PR DESCRIPTION
**To reproduce the bug:**
1. Create simple scene with some fx node, like as follows:
![crash_sample](https://cloud.githubusercontent.com/assets/17974955/21979987/a81ac688-dc24-11e6-98f9-7a6be7981cf8.png)

1.  Preview the scene. (Flipbook window opens.)
1. Click the freeze button in the upper-right corner of flipbook.
1. Modify the fx parameter.
1. Unfreeze the flipbook by clicking the freeze button again.

In my test, OpenToonz crashes once I try to unfreeze the flipbook.

**About the fix:**
The cause of this crash was related to refreshing of the frame slider status on unfreezing.
It is once deleted, but for now it seems to be accessed from `FlipSlider::paintEvent()`  before re-creating.
This PR fixes such problem by clearing the pointer to the frame slider status stored in `FlipSlider` just after its deletion.