### PR TITLE
Fixed removed scene from startup

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2278,6 +2278,16 @@ void RecentFiles::moveFilePath(int fromIndex, int toIndex, FileType fileType) {
 
 //-----------------------------------------------------------------------------
 
+void RecentFiles::removeFilePath(int index, FileType fileType) {
+  if (fileType == Scene)
+    m_recentScenes.removeAt(index);
+  else if (fileType == Level)
+    m_recentLevels.removeAt(index);
+  saveRecentFiles();
+}
+
+//-----------------------------------------------------------------------------
+
 QString RecentFiles::getFilePath(int index, FileType fileType) const {
   return (fileType == Scene)
              ? m_recentScenes[index]

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -228,6 +228,7 @@ public:
 
   void addFilePath(QString path, FileType fileType);
   void moveFilePath(int fromIndex, int toIndex, FileType fileType);
+  void removeFilePath(int fromIndex, FileType fileType);
   QString getFilePath(int index, FileType fileType) const;
   void clearRecentFilesList(FileType fileType);
   void loadRecentFiles();

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -52,6 +52,20 @@ namespace {
 // the first value in the preset list
 const QString custom = QObject::tr("<custom>");
 
+void removeAll(QLayout *layout) {
+  QLayoutItem *child;
+  while (layout->count() != 0) {
+    child = layout->takeAt(0);
+    if (child->layout() != 0) {
+      removeAll(child->layout());
+    } else if (child->widget() != 0) {
+      delete child->widget();
+    }
+
+    delete child;
+  }
+}
+
 QString removeZeros(QString srcStr) {
   if (!srcStr.contains('.')) return srcStr;
 
@@ -346,16 +360,20 @@ void StartupPopup::showEvent(QShowEvent *) {
 
   // update recent scenes
   // clear items if they exist first
+  refreshRecentScenes();
+  // center window
+  this->move(QApplication::desktop()->screen()->rect().center() -
+             this->rect().center());
+}
 
-  if (m_recentSceneLay->count() > 0) {
-    QLayoutItem *child;
-    while (m_recentSceneLay->count() != 0) {
-      child = m_recentSceneLay->takeAt(0);
-      delete child;
-    }
-  }
+//-----------------------------------------------------------------------------
 
+void StartupPopup::refreshRecentScenes() {
+  removeAll(m_recentSceneLay);
+
+  m_sceneNames.clear();
   m_sceneNames = RecentFiles::instance()->getFilesNameList(RecentFiles::Scene);
+  m_recentNamesLabels.clear();
   m_recentNamesLabels = QVector<StartupLabel *>(m_sceneNames.count());
 
   if (m_sceneNames.count() <= 0) {
@@ -369,21 +387,17 @@ void StartupPopup::showEvent(QShowEvent *) {
       m_recentNamesLabels[i] = new StartupLabel(justName, this, i);
       m_recentNamesLabels[i]->setToolTip(
           name.remove(0, name.indexOf(" ") + 1));  // remove "#. " prefix
-      m_recentSceneLay->addWidget(m_recentNamesLabels[i], i, Qt::AlignTop);
+      m_recentSceneLay->addWidget(m_recentNamesLabels[i], 0, Qt::AlignTop);
       i++;
     }
-    m_recentSceneLay->addStretch(100);
   }
-
   bool ret = true;
   for (int i = 0; i < m_recentNamesLabels.count() && i < 7; i++) {
     ret = ret && connect(m_recentNamesLabels[i], SIGNAL(wasClicked(int)), this,
                          SLOT(onRecentSceneClicked(int)));
   }
   assert(ret);
-  // center window
-  this->move(QApplication::desktop()->screen()->rect().center() -
-             this->rect().center());
+  m_recentSceneLay->addStretch(1);
 }
 
 //-----------------------------------------------------------------------------
@@ -804,10 +818,21 @@ void StartupPopup::onRecentSceneClicked(int index) {
   if (index < 0) return;
   QString path =
       RecentFiles::instance()->getFilePath(index, RecentFiles::Scene);
-  IoCmd::loadScene(TFilePath(path.toStdWString()), false);
-  RecentFiles::instance()->moveFilePath(index, 0, RecentFiles::Scene);
-  RecentFiles::instance()->refreshRecentFilesMenu(RecentFiles::Scene);
-  hide();
+  if (!TSystem::doesExistFileOrLevel(TFilePath(path.toStdWString()))) {
+    RecentFiles::instance()->removeFilePath(index, RecentFiles::Scene);
+    RecentFiles::instance()->refreshRecentFilesMenu(RecentFiles::Scene);
+    for (int i = 0; i < m_recentNamesLabels.count() && i < 7; i++) {
+      disconnect(m_recentNamesLabels[i]);
+    }
+    QString msg = QObject::tr("The selected scene could not be found.");
+    DVGui::warning(msg);
+    refreshRecentScenes();
+  } else {
+    IoCmd::loadScene(TFilePath(path.toStdWString()), false);
+    RecentFiles::instance()->moveFilePath(index, 0, RecentFiles::Scene);
+    RecentFiles::instance()->refreshRecentFilesMenu(RecentFiles::Scene);
+    hide();
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -392,7 +392,8 @@ void StartupPopup::refreshRecentScenes() {
     }
   }
   bool ret = true;
-  for (int i = 0; i < m_recentNamesLabels.count() && i < 10; i++) {
+  for (int i = 0;
+       i < m_recentNamesLabels.count() && i < RECENT_SCENES_MAX_COUNT; i++) {
     ret = ret && connect(m_recentNamesLabels[i], SIGNAL(wasClicked(int)), this,
                          SLOT(onRecentSceneClicked(int)));
   }
@@ -821,7 +822,8 @@ void StartupPopup::onRecentSceneClicked(int index) {
   if (!TSystem::doesExistFileOrLevel(TFilePath(path.toStdWString()))) {
     RecentFiles::instance()->removeFilePath(index, RecentFiles::Scene);
     RecentFiles::instance()->refreshRecentFilesMenu(RecentFiles::Scene);
-    for (int i = 0; i < m_recentNamesLabels.count() && i < 7; i++) {
+    for (int i = 0;
+         i < m_recentNamesLabels.count() && i < RECENT_SCENES_MAX_COUNT; i++) {
       disconnect(m_recentNamesLabels[i]);
     }
     QString msg = QObject::tr("The selected scene could not be found.");

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -392,7 +392,7 @@ void StartupPopup::refreshRecentScenes() {
     }
   }
   bool ret = true;
-  for (int i = 0; i < m_recentNamesLabels.count() && i < 7; i++) {
+  for (int i = 0; i < m_recentNamesLabels.count() && i < 10; i++) {
     ret = ret && connect(m_recentNamesLabels[i], SIGNAL(wasClicked(int)), this,
                          SLOT(onRecentSceneClicked(int)));
   }

--- a/toonz/sources/toonz/startuppopup.h
+++ b/toonz/sources/toonz/startuppopup.h
@@ -67,6 +67,7 @@ protected:
   void showEvent(QShowEvent *) override;
   void loadPresetList();
   void savePresetList();
+  void refreshRecentScenes();
   QString aspectRatioValueToString(double value, int width = 0, int height = 0);
   double aspectRatioStringToValue(const QString &s);
   bool parsePresetString(const QString &str, QString &name, int &xres,

--- a/toonz/sources/toonz/startuppopup.h
+++ b/toonz/sources/toonz/startuppopup.h
@@ -52,7 +52,8 @@ class StartupPopup final : public DVGui::Dialog {
   CameraSettingsWidget *m_cameraSettingsWidget;
   double m_dpi;
   int m_xRes, m_yRes;
-  bool m_updating = false;
+  const int RECENT_SCENES_MAX_COUNT = 10;
+  bool m_updating                   = false;
   QString m_presetListFile;
   QGroupBox *m_projectBox;
   QGroupBox *m_sceneBox;


### PR DESCRIPTION
Fix for #997 

Before attempting to open a recent scene it checks to see if it exists.  If it doesn't it gives a warning and the popup stays open with the scene list updated.

Note:  didn't check to see if the scenes in the list exist when first populating based on the warning from @ideasman42 in #997