### PR TITLE
Add lzo to cmake include path suffixes.

### DIFF
--- a/toonz/cmake/FindLZO.cmake
+++ b/toonz/cmake/FindLZO.cmake
@@ -7,6 +7,7 @@ find_path(
     PATH_SUFFIXES
         lzo/2.09/include/lzo
         lzo/2.03/include/lzo
+        lzo
 )
 
 find_library(


### PR DESCRIPTION
Building against openSUSE `lzo-devel` does not work without `lzo` path suffix in cmake.