### PR TITLE
Fixed changing name on change level type - new level popup

### DIFF
--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -329,7 +329,9 @@ bool LevelCreatePopup::levelExists(std::wstring levelName) {
   TLevelSet *levelSet =
       TApp::instance()->getCurrentScene()->getScene()->getLevelSet();
 
-  fp       = scene->getDefaultLevelPath(getLevelType(), levelName);
+  TFilePath parentDir(m_pathFld->getPath().toStdWString());
+  fp = scene->getDefaultLevelPath(getLevelType(), levelName)
+           .withParentDir(parentDir);
   actualFp = scene->decodeFilePath(fp);
 
   if (levelSet->getLevel(levelName) != 0 ||

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -304,26 +304,15 @@ void LevelCreatePopup::updatePath() {
 void LevelCreatePopup::nextName() {
   const std::unique_ptr<NameBuilder> nameBuilder(NameBuilder::getBuilder(L""));
 
-  TLevelSet *levelSet =
-      TApp::instance()->getCurrentScene()->getScene()->getLevelSet();
-  ToonzScene *scene      = TApp::instance()->getCurrentScene()->getScene();
   std::wstring levelName = L"";
 
   // Select a different unique level name in case it already exists (either in
   // scene or on disk)
-  TFilePath fp;
-  TFilePath actualFp;
+
   for (;;) {
     levelName = nameBuilder->getNext();
 
-    if (levelSet->getLevel(levelName) != 0) continue;
-
-    fp       = scene->getDefaultLevelPath(getLevelType(), levelName);
-    actualFp = scene->decodeFilePath(fp);
-
-    if (TSystem::doesExistFileOrLevel(actualFp)) {
-      continue;
-    }
+    if (levelExists(levelName)) continue;
 
     break;
   }
@@ -331,6 +320,26 @@ void LevelCreatePopup::nextName() {
   m_nameFld->setText(QString::fromStdWString(levelName));
 }
 
+//-----------------------------------------------------------------------------
+
+bool LevelCreatePopup::levelExists(std::wstring levelName) {
+  TFilePath fp;
+  TFilePath actualFp;
+  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+  TLevelSet *levelSet =
+      TApp::instance()->getCurrentScene()->getScene()->getLevelSet();
+
+  fp       = scene->getDefaultLevelPath(getLevelType(), levelName);
+  actualFp = scene->decodeFilePath(fp);
+
+  if (levelSet->getLevel(levelName) != 0 ||
+      TSystem::doesExistFileOrLevel(actualFp)) {
+    return true;
+  } else
+    return false;
+}
+
+//-----------------------------------------------------------------------------
 void LevelCreatePopup::showEvent(QShowEvent *) {
   nextName();
   update();
@@ -382,7 +391,15 @@ void LevelCreatePopup::onLevelTypeChanged(const QString &text) {
   else
     setSizeWidgetEnable(false);
   updatePath();
-  nextName();
+
+  std::wstring levelName = m_nameFld->text().toStdWString();
+  // check if the name already exists or if it is a 1 letter name
+  // one letter names are most likely created automatically so
+  // this makes sure that automatically created names
+  // don't skip a letter.
+  if (levelExists(levelName) || levelName.length() == 1) {
+    nextName();
+  }
   m_nameFld->setFocus();
 }
 

--- a/toonz/sources/toonz/levelcreatepopup.h
+++ b/toonz/sources/toonz/levelcreatepopup.h
@@ -48,6 +48,7 @@ protected:
   void updatePath();
   void nextName();
   void showEvent(QShowEvent *) override;
+  bool levelExists(std::wstring levelName);
 
 public slots:
   void onLevelTypeChanged(const QString &text);


### PR DESCRIPTION
This is a fix for #1006 

If a level name has been typed in the new level popup and the level type is changed, this checks to see if the level exists before getting an automatically created name.

Note: if a name is 1 letter long, the odds are greater that the name is automatically created, so I let it replace the name with the next name sequentially for that level type to avoid automatically created names being out of order.