### PR TITLE
Cell Input Feature Fixes

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1591,7 +1591,12 @@ void TCellSelection::deleteCells() {
       new DeleteCellsUndo(new TCellSelection(m_range), data);
 
   deleteCellsWithoutUndo(r0, c0, r1, c1);
-  selectNone();
+  // emit selectionChanged() signal so that the rename field will update
+  // accordingly
+  if (Preferences::instance()->isUseArrowKeyToShiftCellSelectionEnabled())
+    TApp::instance()->getCurrentSelection()->notifySelectionChanged();
+  else
+    selectNone();
 
   TUndoManager::manager()->add(undo);
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
@@ -1616,7 +1621,12 @@ void TCellSelection::cutCells(bool withoutCopy) {
   cutCellsWithoutUndo(r0, c0, r1, c1);
 
   TUndoManager::manager()->add(undo);
-  selectNone();
+  // cutCellsWithoutUndo will clear the selection, so select cells again
+  if (Preferences::instance()->isUseArrowKeyToShiftCellSelectionEnabled()) {
+    selectCells(r0, c0, r1, c1);
+    TApp::instance()->getCurrentSelection()->notifySelectionChanged();
+  } else
+    selectNone();
 
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
 }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1652,7 +1652,7 @@ void MainWindow::defineActions() {
                              tr("Toggle Link to Studio Palette"), "");
   createRightClickMenuAction(MI_RemoveReferenceToStudioPalette,
                              tr("Remove Reference to Studio Palette"), "");
-  createMenuEditAction(MI_Clear, tr("&Delete"), "Delete");
+  createMenuEditAction(MI_Clear, tr("&Delete"), "Del");
   createMenuEditAction(MI_Insert, tr("&Insert"), "Ins");
   createMenuEditAction(MI_Group, tr("&Group"), "Ctrl+G");
   createMenuEditAction(MI_Ungroup, tr("&Ungroup"), "Ctrl+Shift+G");

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -36,10 +36,14 @@ protected:
   void keyPressEvent(QKeyEvent *event) override;
   bool eventFilter(QObject *, QEvent *) override;
 
+  void showEvent(QShowEvent *) override;
+  void hideEvent(QHideEvent *) override;
+
   void renameCell();
 
 protected slots:
   void onReturnPressed();
+  void onXsheetChanged();
 };
 
 //=============================================================================
@@ -98,6 +102,7 @@ public:
   void showRenameField(int row, int col, bool multiColumnSelected = false) {
     m_renameCell->showInRowCol(row, col, multiColumnSelected);
   }
+  void hideRenameField() { m_renameCell->hide(); }
 
 protected:
   void paintEvent(QPaintEvent *) override;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1034,7 +1034,9 @@ void XsheetViewer::onSelectionChanged(TSelection *selection) {
     changeWindowTitle();
     if (Preferences::instance()->isInputCellsWithoutDoubleClickingEnabled()) {
       TCellSelection *cellSel = getCellSelection();
-      if (!cellSel->isEmpty())
+      if (cellSel->isEmpty())
+        m_cellArea->hideRenameField();
+      else
         m_cellArea->showRenameField(
             cellSel->getSelectedCells().m_r0, cellSel->getSelectedCells().m_c0,
             cellSel->getSelectedCells().getColCount() > 1);


### PR DESCRIPTION
This PR fixes the issue #1014.

- Changed the default shortcut string for `MI_Clear` command from "Delete" to "Del", in order to keep consistency with `QKeySequence::toString(SequenceFormat format)`  which is used with the default argument value of  _format_ = PortableText and the "Delete" is handled as "Del" in many parts of the sources. By this modification, `CommandManager::getActionFromShortcut()` can properly find the `MI_Clear` command from "Del" shortcut key.

- The rename cell field is decreased in width so that the field may not cover over the side bar of the cell.

- Enabled `Undo` and `Redo` commands even when the field is shown.

- Now `Cut` and `Delete` commands will not clear cell selection, if the `Use Arrow Key to Shift Cell Selection` option is ON.