### PR TITLE
CMake: add WITH_SYSTEM_LZO option

### DIFF
--- a/toonz/cmake/FindLZO.cmake
+++ b/toonz/cmake/FindLZO.cmake
@@ -1,12 +1,36 @@
+
+if(WITH_SYSTEM_LZO)
+    # depend on CMake's defaults
+    set(_header_hints)
+    set(_header_suffixes
+        lzo
+    )
+    set(_lib_suffixes)
+else()
+    set(_header_hints
+        ${THIRDPARTY_LIBS_HINTS}
+    )
+    set(_header_suffixes
+        lzo/2.09/include/lzo
+        lzo/2.03/include/lzo
+    )
+    set(_lib_hints
+        ${THIRDPARTY_LIBS_HINTS}
+    )
+    set(_lib_suffixes
+        lzo/2.09/lib
+        lzo/2.03/lib/LZO_lib
+    )
+endif()
+
 find_path(
     LZO_INCLUDE_DIR
     NAMES
         lzoconf.h
     HINTS
-        ${THIRDPARTY_LIBS_HINTS}
+        ${_header_hints}
     PATH_SUFFIXES
-        lzo/2.09/include/lzo
-        lzo/2.03/include/lzo
+        ${_header_suffixes}
 )
 
 find_library(
@@ -16,10 +40,9 @@ find_library(
         lzo2_64.lib
         liblzo2.so
     HINTS
-        ${THIRDPARTY_LIBS_HINTS}
+        ${_lib_hints}
     PATH_SUFFIXES
-        lzo/2.09/lib
-        lzo/2.03/lib/LZO_lib
+        ${_lib_suffixes}
 )
 
 message("***** LZO Header path:" ${LZO_INCLUDE_DIR})
@@ -39,3 +62,8 @@ mark_as_advanced(
     LZO_LIBRARY
     LZO_INCLUDE_DIR
 )
+
+unset(_header_hints)
+unset(_header_suffixes)
+unset(_lib_hints)
+unset(_lib_suffixes)

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -4,6 +4,60 @@ set(CMAKE_BUILD_TYPE_INIT Release)
 
 project(OpenToonz)
 
+
+#-----------------------------------------------------------------------------
+# Platform Specific Defaults
+
+# list of var-names
+set(_init_vars)
+
+# initialize to ON
+macro(option_defaults_init)
+    foreach(_var ${ARGV})
+        set(${_var} ON)
+        list(APPEND _init_vars "${_var}")
+    endforeach()
+    unset(_var)
+endmacro()
+
+# remove from namespace
+macro(option_defaults_clear)
+    foreach(_var ${_init_vars})
+        unset(${_var})
+    endforeach()
+    unset(_var)
+    unset(_init_vars)
+endmacro()
+
+# values to initialize WITH_****
+option_defaults_init(
+    _init_SYSTEM_LZO
+)
+
+# customize...
+if(WIN32)
+    set(_init_SYSTEM_LZO                     OFF)
+elseif(APPLE)
+    set(_init_SYSTEM_LZO                     OFF)
+elseif(UNIX)
+    set(_init_SYSTEM_LZO                     ON)
+endif()
+
+
+#-----------------------------------------------------------------------------
+# Build Options
+
+option(WITH_SYSTEM_LZO "Use the system LZO library instead of 'thirdpary'" ${_init_SYSTEM_LZO})
+
+# avoid using again
+option_defaults_clear()
+
+# end option(...)
+
+
+#-----------------------------------------------------------------------------
+# Third Party & System Libs
+
 include(${CMAKE_SOURCE_DIR}/../cmake/util_compiler.cmake)
 
 get_filename_component(SDKROOT ../../thirdparty/ ABSOLUTE)


### PR DESCRIPTION
Allows to easily switch between using thirdparty libs, this patch:

- Adds the option `WITH_SYSTEM_LZO`
- Sets `WITH_SYSTEM_LZO` **off** for Apple and Win32, **on** for Linux.
- Defines reusable utility functions for defining initial options based on platforms.
- This fixes an error using thirdparty headers on Linux, see below.

---

There is a problem currently where building on Linux will default to using the `thirdparty` headers with the system libraries.

This is dangerous since there may be differences (the same issue caused crashes with SuperLU).
This is a complete solution for the change proposed in #1004

----


If accepted, we can add `WITH_SYSTEM_SUPERLU` and eventually `WITH_SYSTEM_TIFF`,

Regarding option initialization - it may seem odd for a single option, see Blender's [CMakeLists.txt](https://developer.blender.org/diffusion/B/browse/master/CMakeLists.txt;ddf99214dc0677542d6ca300c3ee49549e6514bc$128-537) to see how this can be useful.
