### PR TITLE
Allow no trim on spritesheet

### DIFF
--- a/toonz/sources/image/sprite/tiio_sprite.h
+++ b/toonz/sources/image/sprite/tiio_sprite.h
@@ -38,6 +38,7 @@ private:
   std::vector<QImage *> m_images;
   std::vector<QImage> m_imagesResized;
   bool m_firstPass = true;
+  bool m_trim      = true;
   QString m_format;
   // void *m_buffer;
 };
@@ -53,6 +54,7 @@ public:
   TEnumProperty m_format;
   TIntProperty m_topPadding, m_bottomPadding, m_leftPadding, m_rightPadding;
   TIntProperty m_scale;
+  TBoolProperty m_trim;
   SpriteWriterProperties();
 };
 

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -400,13 +400,13 @@ void StartupPopup::onCreateButton() {
     return;
   }
 
-  if (m_widthFld->getValue() < 1) {
-    DVGui::warning(tr("The width must be 1 or more."));
+  if (m_widthFld->getValue() <= 0) {
+    DVGui::warning(tr("The width must be greater than zero."));
     m_widthFld->setFocus();
     return;
   }
-  if (m_heightFld->getValue() < 1) {
-    DVGui::warning(tr("The height must be 1 or more."));
+  if (m_heightFld->getValue() <= 0) {
+    DVGui::warning(tr("The height must be greater than zero."));
     m_heightFld->setFocus();
     return;
   }


### PR DESCRIPTION
This allows spritesheets to not have their empty space trimmed off so the user can set a predetermined width and height.

This also changes the startup popup to allow widths less than 120 pixels (one inch).