### PR TITLE
Fix for pixels only mode conflict too easily.

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1892,8 +1892,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   // check if the output dpi is incompatible with pixels only mode
   if (Preferences::instance()->getPixelsOnly()) {
     TPointD dpi = scene->getCurrentCamera()->getDpi();
-    if (!areAlmostEqual(dpi.x, Stage::standardDpi) ||
-        !areAlmostEqual(dpi.y, Stage::standardDpi)) {
+    if (!areAlmostEqual(dpi.x, Stage::standardDpi, 0.1) ||
+        !areAlmostEqual(dpi.y, Stage::standardDpi, 0.1)) {
       QString question = QObject::tr(
           "This scene is incompatible with pixels only mode of the current "
           "OpenToonz version.\nWhat would you like to do?");


### PR DESCRIPTION
Right now, it is too easy to trigger the warning about scene incompatibility with pixels only mode.  I have made several scenes in pixels only mode and am later told they are incompatible.

This eases the comparison so that any dpi within .1 of 120 is allowed to work in pixels only mode.
