### PR TITLE
Fix crash on level strip arrow key presses

### DIFF
--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -875,7 +875,7 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
     return;
 
   m_selection->selectNone();
-  m_selection->select(fh->getFid());
+  if (getLevel()) m_selection->select(fh->getFid());
   int index = fid2index(fh->getFid());
   if (index >= 0) exponeFrame(index);
 }


### PR DESCRIPTION
#1026 
This checks to see if a level is null before trying to select