### PR TITLE
FFmpeg timeout error fix

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -9,7 +9,7 @@
 #include <QRegExp>
 #include "toonz/preferences.h"
 #include "toonz/toonzfolders.h"
-#include "toonzqt/dvdialog.h"
+#include "tmsgcore.h"
 
 Ffmpeg::Ffmpeg() {
   m_ffmpegPath         = Preferences::instance()->getFfmpegPath();

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -9,6 +9,7 @@
 #include <QRegExp>
 #include "toonz/preferences.h"
 #include "toonz/toonzfolders.h"
+#include "toonzqt/dvdialog.h"
 
 Ffmpeg::Ffmpeg() {
   m_ffmpegPath         = Preferences::instance()->getFfmpegPath();
@@ -163,12 +164,19 @@ void Ffmpeg::runFfmpeg(QStringList preIArgs, QStringList postIArgs,
   // write the file
   QProcess ffmpeg;
   ffmpeg.start(m_ffmpegPath + "/ffmpeg", args);
-  ffmpeg.waitForFinished(m_ffmpegTimeout);
-  QString results = ffmpeg.readAllStandardError();
-  results += ffmpeg.readAllStandardOutput();
-  int exitCode = ffmpeg.exitCode();
-  ffmpeg.close();
-  std::string strResults = results.toStdString();
+  if (ffmpeg.waitForFinished(m_ffmpegTimeout)) {
+    QString results = ffmpeg.readAllStandardError();
+    results += ffmpeg.readAllStandardOutput();
+    int exitCode = ffmpeg.exitCode();
+    ffmpeg.close();
+    std::string strResults = results.toStdString();
+  } else {
+    DVGui::warning(
+        QObject::tr("FFmpeg timed out.\n"
+                    "Please check the file for errors.\n"
+                    "If the file doesn't play or is incomplete, \n"
+                    "Please try raising the FFmpeg timeout in Preferences."));
+  }
 }
 
 QString Ffmpeg::runFfprobe(QStringList args) {

--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -212,13 +212,17 @@ void MovieRenderer::Imp::prepareForStart() {
         // In case the raster specifics are different from those of a currently
         // existing movie, erase it
         try {
-          TLevelReaderP lr(fp);
-          lr->loadInfo();
+          if (fp.isFfmpegType()) {
+            TSystem::removeFileOrLevel(fp);
+          } else {
+            TLevelReaderP lr(fp);
+            lr->loadInfo();
 
-          const TImageInfo *info = lr->getImageInfo();
-          if (!info || info->m_lx != imageSize.lx ||
-              info->m_ly != imageSize.ly || fp.isFfmpegType())
-            TSystem::removeFileOrLevel(fp);  // nothrow
+            const TImageInfo *info = lr->getImageInfo();
+            if (!info || info->m_lx != imageSize.lx ||
+                info->m_ly != imageSize.ly)
+              TSystem::removeFileOrLevel(fp);  // nothrow
+          }
         } catch (...) {
           // Same if the level could not be read/opened
           TSystem::removeFileOrLevel(fp);  // nothrow


### PR DESCRIPTION
Fix for #955 

This removes the file info check on render for FFmpeg types and gives a warning dialog if FFmpeg times out, along with a reminder to raise the timeout in preferences.
