### PR TITLE
Move level palette lines to qss

### DIFF
--- a/stuff/config/qss/gray_048/gray_048.less
+++ b/stuff/config/qss/gray_048/gray_048.less
@@ -411,6 +411,8 @@ PaletteViewer #ToolBarContainer
     }
 }
 #TabBarContainer{
+	qproperty-BottomAboveLineColor: rgb(120, 120, 120);
+	qproperty-BottomBelowLineColor: rgb(255, 255, 255);
 	.baseBG(15%);
 	& #ScrollLeftButton,
 	& #ScrollRightButton{

--- a/stuff/config/qss/gray_048/gray_048.qss
+++ b/stuff/config/qss/gray_048/gray_048.qss
@@ -409,6 +409,8 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   border: 0px;
 }
 #TabBarContainer {
+  qproperty-BottomAboveLineColor: #787878;
+  qproperty-BottomBelowLineColor: #ffffff;
   background-color: #0a0a0a;
 }
 #TabBarContainer #ScrollLeftButton,

--- a/stuff/config/qss/gray_048/gray_048_mac.qss
+++ b/stuff/config/qss/gray_048/gray_048_mac.qss
@@ -409,6 +409,8 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   border: 0px;
 }
 #TabBarContainer {
+  qproperty-BottomAboveLineColor: #787878;
+  qproperty-BottomBelowLineColor: #ffffff;
   background-color: #0a0a0a;
 }
 #TabBarContainer #ScrollLeftButton,

--- a/stuff/config/qss/gray_072/gray_072.less
+++ b/stuff/config/qss/gray_072/gray_072.less
@@ -408,6 +408,8 @@ PaletteViewer #ToolBarContainer
     }
 }
 #TabBarContainer{
+	qproperty-BottomAboveLineColor: rgb(120, 120, 120);
+	qproperty-BottomBelowLineColor: rgb(255, 255, 255);
 	.baseBG(15%);
 	& #ScrollLeftButton,
 	& #ScrollRightButton{

--- a/stuff/config/qss/gray_072/gray_072.qss
+++ b/stuff/config/qss/gray_072/gray_072.qss
@@ -409,6 +409,8 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   border: 0px;
 }
 #TabBarContainer {
+  qproperty-BottomAboveLineColor: #787878;
+  qproperty-BottomBelowLineColor: #ffffff;
   background-color: #222222;
 }
 #TabBarContainer #ScrollLeftButton,

--- a/stuff/config/qss/gray_072/gray_072_mac.qss
+++ b/stuff/config/qss/gray_072/gray_072_mac.qss
@@ -409,6 +409,8 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   border: 0px;
 }
 #TabBarContainer {
+  qproperty-BottomAboveLineColor: #787878;
+  qproperty-BottomBelowLineColor: #ffffff;
   background-color: #222222;
 }
 #TabBarContainer #ScrollLeftButton,

--- a/stuff/config/qss/gray_128/gray_128.less
+++ b/stuff/config/qss/gray_128/gray_128.less
@@ -248,6 +248,8 @@ PaletteViewer #ToolBarContainer
     }
 }
 #TabBarContainer{
+	qproperty-BottomAboveLineColor: rgb(120, 120, 120);
+	qproperty-BottomBelowLineColor: rgb(255, 255, 255);
 	.baseBG(15%);
 	& #ScrollLeftButton,
 	& #ScrollRightButton{

--- a/stuff/config/qss/gray_128/gray_128.qss
+++ b/stuff/config/qss/gray_128/gray_128.qss
@@ -167,6 +167,8 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   border: 0px;
 }
 #TabBarContainer {
+  qproperty-BottomAboveLineColor: #787878;
+  qproperty-BottomBelowLineColor: #ffffff;
   background-color: #5a5a5a;
 }
 #TabBarContainer #ScrollLeftButton,

--- a/stuff/config/qss/gray_128/gray_128_mac.qss
+++ b/stuff/config/qss/gray_128/gray_128_mac.qss
@@ -167,6 +167,8 @@ PaletteViewer #ToolBarContainer #keyFrameNavigator {
   border: 0px;
 }
 #TabBarContainer {
+  qproperty-BottomAboveLineColor: #787878;
+  qproperty-BottomBelowLineColor: #ffffff;
   background-color: #5a5a5a;
 }
 #TabBarContainer #ScrollLeftButton,

--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -155,11 +155,25 @@ QPainterPath DVAPI strokeToPainterPath(TStroke *stroke);
 // It is also used to take 6px on the left before the tabBar
 
 class DVAPI TabBarContainter final : public QFrame {
+  Q_OBJECT
 public:
   TabBarContainter(QWidget *parent = 0);
 
 protected:
+  QColor m_bottomBelowLineColor, m_bottomAboveLineColor;
+  Q_PROPERTY(QColor BottomBelowLineColor READ getBottomBelowLineColor WRITE
+                 setBottomBelowLineColor);
+  Q_PROPERTY(QColor BottomAboveLineColor READ getBottomAboveLineColor WRITE
+                 setBottomAboveLineColor);
   void paintEvent(QPaintEvent *event) override;
+  void setBottomBelowLineColor(const QColor &color) {
+    m_bottomBelowLineColor = color;
+  }
+  QColor getBottomBelowLineColor() const { return m_bottomBelowLineColor; }
+  void setBottomAboveLineColor(const QColor &color) {
+    m_bottomAboveLineColor = color;
+  }
+  QColor getBottomAboveLineColor() const { return m_bottomAboveLineColor; }
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -374,9 +374,9 @@ TabBarContainter::TabBarContainter(QWidget *parent) : QFrame(parent) {
 
 void TabBarContainter::paintEvent(QPaintEvent *event) {
   QPainter p(this);
-  p.setPen(QColor(120, 120, 120));
+  p.setPen(getBottomAboveLineColor());
   p.drawLine(0, height() - 2, width(), height() - 2);
-  p.setPen(Qt::white);
+  p.setPen(getBottomBelowLineColor());
   p.drawLine(0, height() - 1, width(), height() - 1);
 }
 


### PR DESCRIPTION
#883

Lines below the tabs on the style editor and palettes was not accessible via qss.  This fixes that.