### PR TITLE
Travis CI Fix - Stopped clang-format check in Travis temporarily

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
-pushd toonz/sources
-clang-format --version
-git ls-files | egrep \\.\(c\|cpp\|h\|hpp\)$ | xargs clang-format -i && git diff --exit-code || exit 1
-popd
 pushd thirdparty/tiff-4.0.3
 ./configure && make
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt@5.5/5.5.1/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt@5.5/5.5.1_1/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make


### PR DESCRIPTION
This PR is for fixing the the Travis CI failures in recent PRs.
It seems that there are two separate problems in Linux and OSX respectively.
One is regarding SuperLU library, the other one is regarding clang-format version changes in Travis.

This is WIP, trying to fix Linux test first... I have no confidence with this fix yet.

## UPDATE

Finally I managed to make Travis CI back to normal.
### WHAT'S HAPPENED
There were several problems as follows:

**OS X**
-  Travis CI is using clang-format version 4.0.0. Some setting used in clang-format was recently changed from (tags/google/testing/2016-08-03) to (tags/google/stable/2016-12-09) . It caused unwanted format collections in many part of source code for unknown reasons.
- Library path for Qt5.5 was changed from `/usr/local/Cellar/qt@5.5/5.5.1/lib/` to `/usr/local/Cellar/qt@5.5/5.5.1_1/lib/` (again, for unknown reasons).
- `toonz/cmake/FindSuperLU.cmake` failed to find SuperLU library.

**Linux**
- After [the previous modification](https://github.com/opentoonz/opentoonz/commit/cead1bb2cae97c48b833bec28588646d4bc9a693) in `CMakeLists.txt` , Linux build started to use system's SuperLU library instead of one in `thirdparty`. However, Travis CI seems to support only older version of SuperLU library (v3).

## UPDATE AGAIN

### WHAT I DID
- Considering keeping the development efficiency, I decided to stop `clang-format` in Travis CI temporarily, until the version inconsistency in Travis will be fixed somehow.
- Fixed `ci-scripts/osx/travis-build.sh` in order to use correct path for Qt5.5.
- Fixed `toonz/cmake/FindSuperLU.cmake` in order to find the SuperLU library.

### NOTICE
Since the `clang-format` check in CI will be stopped after this PR, please make sure to apply  `clang-format` before push your fixes for the future.