### PR TITLE
[WIP] Travis CI Fix (testing another approach)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: cpp
 sudo: required
 dist: trusty
+env:
+  global:
+    TRAVIS=true
 install:
     - if [[ $TRAVIS_OS_NAME == "osx" ]];   then bash ci-scripts/osx/travis-install.sh; fi
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash ci-scripts/linux/travis-install.sh; fi

--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -2,4 +2,8 @@
 brew update
 brew install qt55 glew lz4 lzo libusb
 brew tap tcr/tcr
-brew install clang-format
+# Use older version of clang-format 
+brew tap homebrew/versions
+brew search clang-format
+brew install homebrew/versions/clang-format38
+# brew install clang-format

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -43,7 +43,12 @@ elseif(APPLE)
     set(_init_SYSTEM_SUPERLU                 OFF)
 elseif(UNIX)
     set(_init_SYSTEM_LZO                     ON)
-    set(_init_SYSTEM_SUPERLU                 ON)
+# Travis CI only provides old version of SuperLU 
+    if(DEFINED ENV{TRAVIS})
+        set(_init_SYSTEM_SUPERLU                 OFF)
+    else()
+        set(_init_SYSTEM_SUPERLU                 ON)
+    endif()
 endif()
 
 
@@ -158,7 +163,7 @@ elseif(UNIX)
 
     set(CMAKE_CXX_STANDARD 11)
 
-    find_package(Qt5Widgets)
+    #find_package(Qt5Widgets)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -lstdc++ -std=c++11")
 else()


### PR DESCRIPTION
This PR is to fix Travis CI, using different approach from #1041 .
Travis CI uses clang-format version 4.0.0, recently it changes some setting from (tags/google/stable/2016-12-09) to (tags/google/testing/2016-08-03). It causes unwanted format collections in many part of source.
I try to use older version of clang-format (v3.8) in Travis, hoping to avoiding such behavior.