### PR TITLE
Remove hard-coded lines around panels

### DIFF
--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -212,7 +212,7 @@ FlipBook::FlipBook(QWidget *parent, QString viewerTitle,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(1);
+  mainLayout->setMargin(0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(fsWidget, 1);

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -460,7 +460,7 @@ SchematicViewer::SchematicViewer(QWidget *parent)
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(1);
+  mainLayout->setMargin(0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_viewer, 1);

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -2833,7 +2833,7 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
 
   /* ------- layout ------- */
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(1);
+  mainLayout->setMargin(0);
   mainLayout->setSpacing(0);
   {
     QHBoxLayout *hLayout = new QHBoxLayout;


### PR DESCRIPTION
This removes the hard-coded line around the style editor that @konero mentioned in #1043 

It doesn't show up as distinctly in the normal themes, but is very apparent in the new theme.