### PR TITLE
Allow border on docks- use QFrame

### DIFF
--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -163,7 +163,7 @@ private:
 
   \sa DockLayout and DockPlaceholder classes.
 */
-class DVAPI DockWidget : public QWidget {
+class DVAPI DockWidget : public QFrame {
   friend class DockLayout;  // DockLayout is granted access to placeholders'
                             // privates
   friend class DockPlaceholder;  // As above.

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -105,7 +105,7 @@ inline void DockLayout::update() {
 //! (i.e. not docked
 //! into the layout).
 DockWidget::DockWidget(QWidget *parent, Qt::WindowFlags flags)
-    : QWidget(parent, flags)
+    : QFrame(parent, flags)
     , m_dragging(false)
     , m_resizing(false)
     , m_floating(true)


### PR DESCRIPTION
This changes the dock widgets from QWidget to QFrame.  Since QDockWidgets weren't used, styling the border of the widgets was unavailable.  

Thanks @konero for the suggestion.