### PR TITLE
fixes warnings when library and fxs folders don't exist

### DIFF
--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -484,6 +484,14 @@ if [ ! -d \$HOME/.config/OpenToonz/stuff ]; then
     cp -r \$OPENTOONZ_BASE/share/opentoonz/stuff \$HOME/.config/OpenToonz
 fi
 
+if [ ! -d \$HOME/.config/OpenToonz/stuff/projects/library ]; then
+    mkdir -p \$HOME/.config/OpenToonz/stuff/projects/library
+fi
+
+if [ ! -d \$HOME/.config/OpenToonz/stuff/projects/fxs ]; then
+    mkdir -p \$HOME/.config/OpenToonz/stuff/projects/fxs
+fi
+
 if [ ! -e \$HOME/.config/OpenToonz/SystemVar.ini ]; then
     cat << EOF > $HOME/.config/OpenToonz/SystemVar.ini
 [General]


### PR DESCRIPTION
If $HOME/.config/OpenToonz/stuff/projects/library or $HOME/.config/OpenToonz/stuff/projects/fxs folders don't exist then a warning will be displayed in the console each time opentoonz is launched on linux.