### PR TITLE
Fix invalid scene path when import scene from sandbox to another project

### DIFF
--- a/toonz/sources/toonzlib/sceneresources.cpp
+++ b/toonz/sources/toonzlib/sceneresources.cpp
@@ -540,9 +540,13 @@ ResourceImporter::ResourceImporter(ToonzScene *scene, TProject *dstProject,
     , m_dstScene(new ToonzScene())
     , m_importStrategy(importStrategy) {
   m_dstScene->setProject(dstProject);
-  TFilePath newFp =
-      dstProject->getScenesPath() +
-      (scene->getScenePath() - scene->getProject()->getScenesPath());
+  // scene file may not be in the "+scenes" path for the sandbox project.
+  // in such case, try to save as "+scenes/filename.tnz" on import.
+  TFilePath relativeScenePath =
+      scene->getScenePath() - scene->getProject()->getScenesPath();
+  if (relativeScenePath.isAbsolute())
+    relativeScenePath = scene->getScenePath().withoutParentDir();
+  TFilePath newFp     = dstProject->getScenesPath() + relativeScenePath;
   makeUnique(newFp);
   m_dstScene->setScenePath(newFp);
 }


### PR DESCRIPTION
This fixes the issue #1063.
When importing the scene, if the scene is in outside of the "+scenes" folder, it will be imported under the "+scenes" folder of the current project.