### PR TITLE
Fix the Flipbook's console to be updated when the "Blank Frame" option is changed in the Preferences

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -393,7 +393,7 @@ protected slots:
   void onFPSEdited();
 
 public slots:
-  void onPreferenceChanged();
+  void onPreferenceChanged(const QString &);
 
 private:
   friend class PlaybackExecutor;

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -786,10 +786,6 @@ bool ComboViewerPanel::isFrameAlreadyCached(int frame) {
 //-----------------------------------------------------------------------------
 
 void ComboViewerPanel::onPreferenceChanged(const QString &prefName) {
-  // if no name specified (on showEvent), then process all updates
-  if (prefName == "BlankCount" || prefName == "BlankColor" ||
-      prefName.isEmpty())
-    m_flipConsole->onPreferenceChanged();
-
+  m_flipConsole->onPreferenceChanged(prefName);
   StyleShortcutSwitchablePanel::onPreferenceChanged(prefName);
 }

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -1872,9 +1872,9 @@ void FlipBook::showEvent(QShowEvent *e) {
   connect(sceneHandle, SIGNAL(sceneChanged()), m_imageViewer, SLOT(update()));
   // for updating the blank frame button
   if (!m_imageViewer->isColorModel()) {
-    connect(sceneHandle, SIGNAL(preferenceChanged()), m_flipConsole,
-            SLOT(onPreferenceChanged()));
-    m_flipConsole->onPreferenceChanged();
+    connect(sceneHandle, SIGNAL(preferenceChanged(const QString &)),
+            m_flipConsole, SLOT(onPreferenceChanged(const QString &)));
+    m_flipConsole->onPreferenceChanged("");
   }
   m_flipConsole->setActive(true);
   m_imageViewer->update();
@@ -1886,6 +1886,10 @@ void FlipBook::hideEvent(QHideEvent *e) {
   TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
   disconnect(sceneHandle, SIGNAL(sceneChanged()), m_imageViewer,
              SLOT(update()));
+  if (!m_imageViewer->isColorModel()) {
+    disconnect(sceneHandle, SIGNAL(preferenceChanged(const QString &)),
+               m_flipConsole, SLOT(onPreferenceChanged(const QString &)));
+  }
   m_flipConsole->setActive(false);
 }
 

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -657,12 +657,7 @@ void SceneViewerPanel::onFrameTypeChanged() {
 //-----------------------------------------------------------------------------
 
 void SceneViewerPanel::onPreferenceChanged(const QString &prefName) {
-  // if no name specified (on StyleShortcutSelectivePanel::showEvent),
-  // then process all updates
-  if (prefName == "BlankCount" || prefName == "BlankColor" ||
-      prefName.isEmpty())
-    m_flipConsole->onPreferenceChanged();
-
+  m_flipConsole->onPreferenceChanged(prefName);
   StyleShortcutSwitchablePanel::onPreferenceChanged(prefName);
 }
 

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -1847,7 +1847,12 @@ const std::vector<UCHAR> *FlipConsole::getProgressBarStatus() const {
 
 //--------------------------------------------------------------------
 
-void FlipConsole::onPreferenceChanged() {
+void FlipConsole::onPreferenceChanged(const QString &prefName) {
+  // react only when related properties are changed
+  if (prefName != "BlankCount" && prefName != "BlankColor" &&
+      !prefName.isEmpty())
+    return;
+
   if (m_drawBlanksEnabled) {
     Preferences::instance()->getBlankValues(m_blanksCount, m_blankColor);
     if (m_blanksCount == 0) {


### PR DESCRIPTION
This PR fixes the Flipbook's console bug as follows.

**TO REPRODUCE:**

1. Open both the Viewer and the Flipbook.

1. Change the "Blank Frames" or "Blank Frames Color" in  Preferences > Preview category.

The Viewer will update the "blank button" at the right side of the frame slider, but the Flipbook won't.