### PR TITLE
SoapBubbleIwaFx Update

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1183,6 +1183,8 @@
   <item>"STD_iwa_SoapBubbleFx.GGamma"	"G Gamma"	</item>
   <item>"STD_iwa_SoapBubbleFx.BGamma"	"B Gamma"	</item>
   <item>"STD_iwa_SoapBubbleFx.binarizeThresold"	"Threshold"	</item>
+  <item>"STD_iwa_SoapBubbleFx.multiSource"	"Multiple Bubbles in Shape Image"	</item>
+  <item>"STD_iwa_SoapBubbleFx.maskCenter"	"Mask Center of the Bubble"	</item>
   <item>"STD_iwa_SoapBubbleFx.shapeAspectRatio"	"Shape Aspect Ratio"	</item>
   <item>"STD_iwa_SoapBubbleFx.blurRadius"	"Blur Radius"	</item>
   <item>"STD_iwa_SoapBubbleFx.blurPower"	"Power"	</item>

--- a/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
@@ -13,6 +13,8 @@
     <vbox>
       <separator label="Shape"/>
       <control>binarizeThresold</control>
+      <control>multiSource</control>
+      <control>maskCenter</control>
       <control>shapeAspectRatio</control>
       <control>blurRadius</control>
       <control>blurPower</control>

--- a/toonz/sources/stdfx/iwa_soapbubblefx.h
+++ b/toonz/sources/stdfx/iwa_soapbubblefx.h
@@ -26,6 +26,8 @@ protected:
   TDoubleParamP m_shape_aspect_ratio;
   TDoubleParamP m_blur_radius;
   TDoubleParamP m_blur_power;
+  TBoolParamP m_multi_source;
+  TBoolParamP m_mask_center;
 
   // noise parameters
   TIntParamP m_normal_sample_distance;
@@ -38,24 +40,27 @@ protected:
   TDoubleParamP m_noise_thickness_mix_ratio;
 
   template <typename RASTER, typename PIXEL>
-  void convertToBrightness(const RASTER srcRas, float* dst, TDimensionI dim);
+  void convertToBrightness(const RASTER srcRas, float* dst, float* alpha,
+                           TDimensionI dim);
 
   template <typename RASTER, typename PIXEL>
   void convertToRaster(const RASTER ras, float* thickness_map_p,
-                       float* depth_map_p, TDimensionI dim,
+                       float* depth_map_p, float* alpha_map_p, TDimensionI dim,
                        float3* bubbleColor_p);
 
   void processShape(double frame, TTile& shape_tile, float* depth_map_p,
-                    TDimensionI dim, const TRenderSettings& settings);
+                    float* alpha_map_p, TDimensionI dim,
+                    const TRenderSettings& settings);
 
-  void do_binarize(TRaster32P srcRas, char* dst_p, float thres,
-                   float* distance_p, TDimensionI dim);
+  int do_binarize(TRaster32P srcRas, USHORT* dst_p, float thres,
+                  float* distance_p, float* alpha_map_p, TDimensionI dim);
 
   void do_createBlurFilter(float* dst_p, int size, float radius);
 
   void do_applyFilter(float* depth_map_p, TDimensionI dim, float* distace_p,
-                      char* binarized_p, float* blur_filter_p,
-                      int blur_filter_size, double frame);
+                      USHORT* binarized_p, float* blur_filter_p,
+                      int blur_filter_size, double frame,
+                      const TRenderSettings& settings);
 
   void processNoise(float* thickness_map_p, float* depth_map_p, TDimensionI dim,
                     double frame, const TRenderSettings& settings);
@@ -76,7 +81,15 @@ protected:
                  float* noise_map_p, float noise_thickness_mix_ratio,
                  float noise_depth_mix_ratio);
 
-  void do_distance_transform(float* dst_p, TDimensionI dim, double frame);
+  void do_distance_transform(float* dst_p, USHORT* binarized_p, int regionCount,
+                             TDimensionI dim, double frame);
+
+  // if the rendering process is canceled, release raster and return TRUE
+  bool checkCancelAndReleaseRaster(const QList<TRasterGR8P>&, TTile&,
+                                   const TRenderSettings&);
+
+  void applyDistanceToAlpha(float* distance_p, float* alpha_map_p,
+                            TDimensionI dim);
 
 public:
   Iwa_SoapBubbleFx();


### PR DESCRIPTION
This PR updates the SoapBubbleIwaFx as follows:

- The result becomes being masked with the Shape image.

- Added "Multiple Bubbles in Shape Image" option. With this option, the Shape image will be divided into each opaque region and computed separately so that it can render more than one bubble with various size.

- Added "Mask Center of the Bubble" option. With this option, the center of the bubble will be masked so that it can make the "wrinkles" of noise pattern less noticeable.

- Inserted a function which will check whether the current rendering process is cancelled. (For example, when fx parameter changed twice rapidly, the rendering process invoked by the first change will be cancelled.) When cancelled, it will immediately release the raster memory and return in mid-flow of the computation. 

<img src="https://cloud.githubusercontent.com/assets/17974955/23458092/06fb1048-febe-11e6-9230-e4fbe8497794.png" width=600>