### PR TITLE
(Partially) fix vector shapes unfillable

### DIFF
--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -2582,7 +2582,7 @@ public:
     m_quasiArea += (p2.y + p1.y) * (p1.x - p2.x);
   }
 
-  bool isClockwise() { return m_quasiArea > 0.5; }
+  bool isClockwise() { return m_quasiArea > 0.1; }
 };
 
 //----------------------------------------------------------------------------------------------

--- a/toonz/sources/image/pli/tiio_pli.cpp
+++ b/toonz/sources/image/pli/tiio_pli.cpp
@@ -420,6 +420,8 @@ TImageP TImageReaderPli::doLoad() {
   outVectImage->checkIntersections();
 #endif
 
+  outVectImage->findRegions();
+
   return TImageP(outVectImage);
 }
 

--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -374,6 +374,12 @@ static void addStroke(TTool::Application *application, const TVectorImageP &vi,
                                                 frameCreated, levelCreated));
   }
 
+  // Update regions. It will call roundStroke() in
+  // TVectorImage::Imp::findIntersections().
+  // roundStroke() will slightly modify all the stroke positions.
+  // It is needed to update information for Fill Check.
+  vi->findRegions();
+
   for (int k = 0; k < (int)strokes.size(); k++) delete strokes[k];
   strokes.clear();
 


### PR DESCRIPTION
This PR fixes issue reported in #1007 , ~~and hopefully fixes other "unfillable vector" problems.~~ ( Unfortunately, the third problem still remains. )

As far as I noticed, there were ~~two~~ three (I found one more, now) separate problems related to the "unfillable vector" as follows:

1. Fill Check information are not properly updated in some shape. Confirmed with the sample  [gorilla_test.zip](https://github.com/opentoonz/opentoonz/files/734154/gorilla_test.zip) provided by @mcjadski . Also he reported that the Fill Check fails to detect the last stroke. (Thank you @mcjadski for the "random fish" test!)

1. Very small region could not be filled. For now, an area less than approx. 0.0001 square inch (= 1.26 square pixel in 120dpi scene) could not be filled.

1. Other unfillable shapes like this. [unfillable.zip](https://github.com/opentoonz/opentoonz/files/816428/unfillable.zip)

The cause of the problem 1 is related to the timing of calling the function `void roundStroke(TStroke *s)` at the [line 50 of tcomputeregions.cpp](https://github.com/opentoonz/opentoonz/blob/master/toonz/sources/common/tvectorimage/tcomputeregions.cpp#L50). In this function, all points of vector strokes are slightly moved to discrete positions. If the Fill Check is processed before calling this function, the check will be failed because of as follows: The Fill Check does rectangular fill with the bounding box of whole strokes. Without calling `roundStroke()`, it will be called  "in the middle" of Fill Check procedure and the strokes will be moved and may run off the box. 
In this PR I added `TVectorImage::findRegions()` on loading PLI file and on adding a stroke with brush tool. `TVectorImage::findRegions()` will be followed by `roundStroke()`. 

The cause of the problem 2 was not a bug, there was some threshold of area size [here](https://github.com/opentoonz/opentoonz/blob/master/toonz/sources/common/tvectorimage/tcomputeregions.cpp#L2585). 
For now the value is 0.5 (unit is a square of 1/53.33333 inch). Which means that the rectangular with less than approx. 1.125 * 1.125 pixel size will be unfillable in 120dpi scene. I reduced this threshold to 0.1 in order to fill small region comparable to a single pixel.

Actually I just enabled to reproduce the problem 3 now. I'll investigate this.