### PR TITLE
Fix tconverter crash

### DIFF
--- a/toonz/sources/common/tipc/tipc.cpp
+++ b/toonz/sources/common/tipc/tipc.cpp
@@ -338,7 +338,8 @@ bool tipc::startSlaveServer(QString srvName, QString cmdline) {
   // the *MAIN* thread
   // in *this process* exits. So, if this is not the main thread, we must move
   // the socket there.
-  if (QThread::currentThread() != QCoreApplication::instance()->thread())
+  if (QCoreApplication::instance() &&
+      QThread::currentThread() != QCoreApplication::instance()->thread())
     dummySock->moveToThread(QCoreApplication::instance()->thread());
 
   // If a connection error takes place, release the dummy socket.


### PR DESCRIPTION
TO REPRODUCE THE CRASH:  

1. Prepare some source image ( say `srcimage.tif` )

1. Run `tconverter.exe srcimage.tif dstimage.png`.

This PR fixes the crash by adding null pointer check.
The `tconverter.exe` is still not well-functional, but it's better to make it available. 