### PR TITLE
Fix level placement when the option "Show Appendix to the Frame Number" is activated

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -1269,6 +1269,15 @@ void LoadLevelPopup::updateBottomGUI() {
     // six letters of the scene name from the level name
     m_levelName->setText(getLevelNameWithoutSceneNumber(fp.getName()));
 
+    // If the option "Show "ABC" Appendix to the Frame Number in Xsheet Cell" is
+    // ON, frame numbers normally increment at interval of 10.
+    // Placing such level with "Auto" step option will cause unwanted
+    // spacing between frames in Xsheet. Setting the step to "1" can prevent
+    // such problem.
+    if (Preferences::instance()->isShowFrameNumberWithLettersEnabled() &&
+        m_stepCombo->currentIndex() == 0)
+      m_stepCombo->setCurrentIndex(1);
+
     m_arrangementFrame->setEnabled(true);
   }
   updatePosTo();


### PR DESCRIPTION
The preference option  "Show "ABC" Appendix to the Frame Number in Xsheet Cell" was introduced for inserting drawings when pencil testing using the camera capture feature.

If this option is activated, ones place digit of frame numbers are converted to "ABC" appendix (10 > 1,  11>1A, 12>1B and so on) and captured image will normally increment frame number at interval of 10.
  
When placing such level with "Load Level" command, with the option "Arrangement in Xsheet>step" is set to "Auto" in the popup, it will cause unwanted spacing between frames in Xsheet:

![level_placement](https://cloud.githubusercontent.com/assets/17974955/24955940/6a1cffc4-1fc0-11e7-896e-3ba3069c5034.png)

This PR will fix such problem, by setting the step to "1" in such case.