### PR TITLE
fix #1156 which causes program to crash when expanding history

### DIFF
--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -1631,7 +1631,7 @@ void DvDirTreeView::getExpandedPathsRecursive(const QModelIndex &index,
 void DvDirTreeView::onExpanded(const QModelIndex &index) {
   QStringList paths;
   getExpandedPathsRecursive(index, paths);
-  paths.removeFirst();
+  if (paths.size()) paths.removeFirst();
   MyFileSystemWatcher::instance()->addPaths(paths);
 }
 


### PR DESCRIPTION
fix #1156 which causes program to crash when expanding history