### PR TITLE
SoapBubbleFxIwa Improvement

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1177,6 +1177,7 @@
   <item>"STD_iwa_PNPerspectiveFx.waveHeight"		"Wave Height"</item>
   
   <item>"STD_iwa_SoapBubbleFx"	"SoapBubble Iwa"	</item>
+  <item>"STD_iwa_SoapBubbleFx.renderMode"	"Render Mode"	</item>
   <item>"STD_iwa_SoapBubbleFx.intensity"	"Intensity"	</item>
   <item>"STD_iwa_SoapBubbleFx.refractiveIndex"	"Refractive Index"	</item>
   <item>"STD_iwa_SoapBubbleFx.thickMax"	"Thick Max"	</item>

--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1143,6 +1143,8 @@
   <item>"STD_iwa_SpectrumFx.RGamma"	"R Gamma"	</item>
   <item>"STD_iwa_SpectrumFx.GGamma"	"G Gamma"	</item>
   <item>"STD_iwa_SpectrumFx.BGamma"	"B Gamma"	</item>
+  <item>"STD_iwa_SpectrumFx.loopSpectrumFadeWidth"	"Loop Spectrum Fade Width"	</item>
+  <item>"STD_iwa_SpectrumFx.spectrumShift"	"Spectrum Shift"	</item>
   <item>"STD_iwa_SpectrumFx.lensFactor"	"Lens Factor"	</item>
   <item>"STD_iwa_SpectrumFx.lightThres"	"Light Threshod"</item>
   <item>"STD_iwa_SpectrumFx.lightIntensity"	"Light Intensity"</item>
@@ -1182,6 +1184,8 @@
   <item>"STD_iwa_SoapBubbleFx.RGamma"	"R Gamma"	</item>
   <item>"STD_iwa_SoapBubbleFx.GGamma"	"G Gamma"	</item>
   <item>"STD_iwa_SoapBubbleFx.BGamma"	"B Gamma"	</item>
+  <item>"STD_iwa_SoapBubbleFx.loopSpectrumFadeWidth"	"Loop Spectrum Fade Width"	</item>
+  <item>"STD_iwa_SoapBubbleFx.spectrumShift"	"Spectrum Shift"	</item>
   <item>"STD_iwa_SoapBubbleFx.binarizeThresold"	"Threshold"	</item>
   <item>"STD_iwa_SoapBubbleFx.multiSource"	"Multiple Bubbles in Shape Image"	</item>
   <item>"STD_iwa_SoapBubbleFx.maskCenter"	"Mask Center of the Bubble"	</item>

--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1185,6 +1185,8 @@
   <item>"STD_iwa_SoapBubbleFx.binarizeThresold"	"Threshold"	</item>
   <item>"STD_iwa_SoapBubbleFx.multiSource"	"Multiple Bubbles in Shape Image"	</item>
   <item>"STD_iwa_SoapBubbleFx.maskCenter"	"Mask Center of the Bubble"	</item>
+  <item>"STD_iwa_SoapBubbleFx.centerOpacity"	"Opacity of Bubble's Center"	</item>
+  <item>"STD_iwa_SoapBubbleFx.fitThickness"	"Fit Thickness Image to Each Bubble"	</item>
   <item>"STD_iwa_SoapBubbleFx.shapeAspectRatio"	"Shape Aspect Ratio"	</item>
   <item>"STD_iwa_SoapBubbleFx.blurRadius"	"Blur Radius"	</item>
   <item>"STD_iwa_SoapBubbleFx.blurPower"	"Power"	</item>

--- a/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
@@ -1,6 +1,7 @@
 <fxlayout>
   <page name="Color and Shape">
     <vbox>
+      <control>renderMode</control>
       <separator label="Bubble Color"/>
       <control>intensity</control>
       <control>refractiveIndex</control>

--- a/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
@@ -14,7 +14,8 @@
       <separator label="Shape"/>
       <control>binarizeThresold</control>
       <control>multiSource</control>
-      <control>maskCenter</control>
+      <control>centerOpacity</control>
+      <control>fitThickness</control>
       <control>shapeAspectRatio</control>
       <control>blurRadius</control>
       <control>blurPower</control>

--- a/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_SoapBubbleFx.xml
@@ -9,6 +9,8 @@
       <control>RGamma</control>
       <control>GGamma</control>
       <control>BGamma</control>
+		  <control>loopSpectrumFadeWidth</control>
+		  <control>spectrumShift</control>
     </vbox>
     <vbox>
       <separator label="Shape"/>

--- a/stuff/profiles/layouts/fxs/STD_iwa_SpectrumFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_SpectrumFx.xml
@@ -8,6 +8,8 @@
 		<control>RGamma</control>
 		<control>GGamma</control>
 		<control>BGamma</control>
+		<control>loopSpectrumFadeWidth</control>
+		<control>spectrumShift</control>
 		<control>lensFactor</control>
 		<control>lightThres</control>
 		<control>lightIntensity</control>

--- a/toonz/sources/common/tparam/tparamcontainer.cpp
+++ b/toonz/sources/common/tparam/tparamcontainer.cpp
@@ -67,12 +67,17 @@ const TParamVar *TParamContainer::getParamVar(int index) const {
 }
 
 TParam *TParamContainer::getParam(std::string name) const {
+  TParamVar *var = getParamVar(name);
+  return (var) ? var->getParam() : 0;
+}
+
+TParamVar *TParamContainer::getParamVar(std::string name) const {
   std::map<std::string, TParamVar *>::const_iterator it;
   it = m_imp->m_nameTable.find(name);
   if (it == m_imp->m_nameTable.end())
     return 0;
   else
-    return it->second->getParam();
+    return it->second;
 }
 
 void TParamContainer::unlink() {

--- a/toonz/sources/include/tfx.h
+++ b/toonz/sources/include/tfx.h
@@ -499,6 +499,10 @@ public:
   virtual void callEndRenderFrameHandler(const TRenderSettings *rs,
                                          double frame) {}
 
+  // This function will be called in TFx::loadData whenever the obsolete
+  // parameter is loaded. Do nothing by default.
+  virtual void onObsoleteParamLoaded(const std::string &paramName) {}
+
 public:
   // Id-related functions
 
@@ -539,6 +543,7 @@ inline std::string TFx::getFxType() const { return getDeclaration()->getId(); }
 //-------------------------------------------------------------------
 
 #define FX_DECLARATION(T)                                                      \
+  \
 public:                                                                        \
   const TPersistDeclaration *getDeclaration() const override;
 

--- a/toonz/sources/include/tfxparam.h
+++ b/toonz/sources/include/tfxparam.h
@@ -9,8 +9,9 @@
 #include "tparamcontainer.h"
 
 template <class T>
-void bindParam(TFx *fx, std::string name, T &var, bool hidden = false) {
-  fx->getParams()->add(new TParamVarT<T>(name, var, hidden));
+void bindParam(TFx *fx, std::string name, T &var, bool hidden = false,
+               bool obsolete = false) {
+  fx->getParams()->add(new TParamVarT<T>(name, var, hidden, obsolete));
   var->addObserver(fx);
 }
 

--- a/toonz/sources/stdfx/iwa_soapbubblefx.cpp
+++ b/toonz/sources/stdfx/iwa_soapbubblefx.cpp
@@ -10,9 +10,12 @@ Inherits Iwa_SpectrumFx.
 #include "iwa_cie_d65.h"
 #include "iwa_xyz.h"
 
+#include "trop.h"
+
 #include <QList>
 #include <QPoint>
 #include <QSize>
+#include <QRect>
 
 namespace {
 const float PI = 3.14159265f;
@@ -68,7 +71,9 @@ Iwa_SoapBubbleFx::Iwa_SoapBubbleFx()
     , m_blur_radius(5.0)
     , m_blur_power(0.5)
     , m_multi_source(false)
-    , m_mask_center(false)
+    , m_mask_center(false)  // obsolete
+    , m_center_opacity(1.0)
+    , m_fit_thickness(false)
     , m_normal_sample_distance(1)
     , m_noise_sub_depth(3)
     , m_noise_resolution_s(18.0)
@@ -88,7 +93,9 @@ Iwa_SoapBubbleFx::Iwa_SoapBubbleFx()
   bindParam(this, "blurRadius", m_blur_radius);
   bindParam(this, "blurPower", m_blur_power);
   bindParam(this, "multiSource", m_multi_source);
-  bindParam(this, "maskCenter", m_mask_center);
+  bindParam(this, "maskCenter", m_mask_center, false, true);  // obsolete
+  bindParam(this, "centerOpacity", m_center_opacity);
+  bindParam(this, "fitThickness", m_fit_thickness);
   bindParam(this, "normalSampleDistance", m_normal_sample_distance);
   bindParam(this, "noiseSubDepth", m_noise_sub_depth);
   bindParam(this, "noiseResolutionS", m_noise_resolution_s);
@@ -103,6 +110,7 @@ Iwa_SoapBubbleFx::Iwa_SoapBubbleFx()
   m_blur_radius->setMeasureName("fxLength");
   m_blur_radius->setValueRange(0.0, 25.0);
   m_blur_power->setValueRange(0.01, 5.0);
+  m_center_opacity->setValueRange(0.0, 1.0);
 
   m_normal_sample_distance->setValueRange(1, 20);
   m_noise_sub_depth->setValueRange(1, 5);
@@ -145,6 +153,14 @@ void Iwa_SoapBubbleFx::doCompute(TTile& tile, double frame,
   allocatedRasList.append(alpha_map_ras);
   float* alpha_map_p = (float*)alpha_map_ras->getRawData();
 
+  /* region indices */
+  TRasterGR8P regionIds_ras(sizeof(USHORT) * dim.lx * dim.ly, 1);
+  regionIds_ras->lock();
+  regionIds_ras->clear();
+  allocatedRasList.append(regionIds_ras);
+  USHORT* regionIds_p = (USHORT*)regionIds_ras->getRawData();
+  QList<QRect> regionBoundingRects;
+
   /* if the depth image is connected, use it */
   if (m_depth.isConnected()) {
     TTile depth_tile;
@@ -167,6 +183,9 @@ void Iwa_SoapBubbleFx::doCompute(TTile& tile, double frame,
                                                   alpha_map_p, dim);
     }
     depthRas->unlock();
+
+    // set one region covering whole camera rect
+    regionBoundingRects.append(QRect(0, 0, dim.lx, dim.ly));
   }
   /* or, use the shape image to obtain pseudo depth */
   else { /* m_shape.isConnected */
@@ -180,24 +199,48 @@ void Iwa_SoapBubbleFx::doCompute(TTile& tile, double frame,
 
     if (checkCancelAndReleaseRaster(allocatedRasList, tile, settings)) return;
 
-    processShape(frame, shape_tile, depth_map_p, alpha_map_p, dim, settings);
+    processShape(frame, shape_tile, depth_map_p, alpha_map_p, regionIds_p,
+                 regionBoundingRects, dim, settings);
   }
 
   if (checkCancelAndReleaseRaster(allocatedRasList, tile, settings)) return;
 
-  /* compute the thickness input and temporarily store to the tile */
-  m_input->compute(tile, frame, settings);
-
-  if (checkCancelAndReleaseRaster(allocatedRasList, tile, settings)) return;
-
+  // conpute thickness
   TRasterGR8P thickness_map_ras(sizeof(float) * dim.lx * dim.ly, 1);
   thickness_map_ras->lock();
   allocatedRasList.append(thickness_map_ras);
   float* thickness_map_p = (float*)thickness_map_ras->getRawData();
-  TRasterP thicknessRas  = tile.getRaster();
-  TRaster32P ras32       = (TRaster32P)thicknessRas;
-  TRaster64P ras64       = (TRaster64P)thicknessRas;
-  {
+
+  TRasterP tileRas = tile.getRaster();
+  TRaster32P ras32 = (TRaster32P)tileRas;
+  TRaster64P ras64 = (TRaster64P)tileRas;
+
+  if (m_fit_thickness->getValue()) {
+    // Get the original bbox of thickness image
+    TRectD thickBBox;
+    m_input->getBBox(frame, thickBBox, settings);
+    if (thickBBox == TConsts::infiniteRectD)
+      thickBBox = TRectD(tile.m_pos, TDimensionD(tile.getRaster()->getLx(),
+                                                 tile.getRaster()->getLy()));
+    // Compute the thickenss tile.
+    TTile thicknessTile;
+    TDimension thickDim(static_cast<int>(thickBBox.getLx() + 0.5),
+                        static_cast<int>(thickBBox.getLy() + 0.5));
+    m_input->allocateAndCompute(thicknessTile, thickBBox.getP00(), thickDim,
+                                tile.getRaster(), frame, settings);
+
+    if (checkCancelAndReleaseRaster(allocatedRasList, tile, settings)) return;
+
+    TRasterP thickRas = thicknessTile.getRaster();
+
+    fitThicknessPatches(thickRas, thickDim, thickness_map_p, dim, regionIds_p,
+                        regionBoundingRects);
+  } else {
+    /* compute the thickness input and temporarily store to the tile */
+    m_input->compute(tile, frame, settings);
+
+    if (checkCancelAndReleaseRaster(allocatedRasList, tile, settings)) return;
+
     if (ras32)
       convertToBrightness<TRaster32P, TPixel32>(ras32, thickness_map_p, nullptr,
                                                 dim);
@@ -260,7 +303,9 @@ void Iwa_SoapBubbleFx::convertToRaster(const RASTER ras, float* thickness_map_p,
     PIXEL* pix = ras->pixels(j);
     for (int i = 0; i < dim.lx;
          i++, depth_p++, thickness_p++, alpha_p++, pix++) {
-      float alpha = (*alpha_p) * (float)pix->m / (float)PIXEL::maxChannelValue;
+      float alpha = (*alpha_p);
+      if (!m_fit_thickness->getValue())
+        alpha *= (float)pix->m / (float)PIXEL::maxChannelValue;
       if (alpha == 0.0f) { /* no change for the transparent pixels */
         pix->m = (typename PIXEL::Channel)0;
         continue;
@@ -331,15 +376,12 @@ void Iwa_SoapBubbleFx::convertToRaster(const RASTER ras, float* thickness_map_p,
 
 void Iwa_SoapBubbleFx::processShape(double frame, TTile& shape_tile,
                                     float* depth_map_p, float* alpha_map_p,
+                                    USHORT* regionIds_p,
+                                    QList<QRect>& regionBoundingRects,
                                     TDimensionI dim,
                                     const TRenderSettings& settings) {
   TRaster32P shapeRas = shape_tile.getRaster();
   shapeRas->lock();
-
-  /* binarize the shape image */
-  TRasterGR8P binarized_ras(sizeof(USHORT) * dim.lx * dim.ly, 1);
-  binarized_ras->lock();
-  USHORT* binarized_p = (USHORT*)binarized_ras->getRawData();
 
   TRasterGR8P distance_ras(sizeof(float) * dim.lx * dim.ly, 1);
   distance_ras->lock();
@@ -347,27 +389,27 @@ void Iwa_SoapBubbleFx::processShape(double frame, TTile& shape_tile,
 
   float binarize_thres = (float)m_binarize_threshold->getValue(frame);
 
-  int regionCount = do_binarize(shapeRas, binarized_p, binarize_thres,
-                                distance_p, alpha_map_p, dim);
+  int regionCount =
+      do_binarize(shapeRas, regionIds_p, binarize_thres, distance_p,
+                  alpha_map_p, regionBoundingRects, dim);
 
   shapeRas->unlock();
 
   if (settings.m_isCanceled && *settings.m_isCanceled) {
-    binarized_ras->unlock();
     distance_ras->unlock();
     return;
   }
 
-  do_distance_transform(distance_p, binarized_p, regionCount, dim, frame);
+  do_distance_transform(distance_p, regionIds_p, regionCount, dim, frame);
 
   if (settings.m_isCanceled && *settings.m_isCanceled) {
-    binarized_ras->unlock();
     distance_ras->unlock();
     return;
   }
 
-  if (m_mask_center->getValue())
-    applyDistanceToAlpha(distance_p, alpha_map_p, dim);
+  float center_opacity = (float)m_center_opacity->getValue(frame);
+  if (center_opacity != 1.0f)
+    applyDistanceToAlpha(distance_p, alpha_map_p, dim, center_opacity);
 
   /* create blur filter */
   float blur_radius = (float)m_blur_radius->getValue(frame) *
@@ -378,16 +420,15 @@ void Iwa_SoapBubbleFx::processShape(double frame, TTile& shape_tile,
     float power      = (float)m_blur_power->getValue(frame);
     float* tmp_depth = depth_map_p;
     float* tmp_dist  = distance_p;
-    USHORT* bin_p    = binarized_p;
+    USHORT* rid_p    = regionIds_p;
     for (int i = 0; i < dim.lx * dim.ly;
-         i++, tmp_depth++, tmp_dist++, bin_p++) {
-      if (*bin_p == 0)
+         i++, tmp_depth++, tmp_dist++, rid_p++) {
+      if (*rid_p == 0)
         *tmp_depth = 0.0f;
       else
         *tmp_depth = 1.0f - std::pow(*tmp_dist, power);
     }
     distance_ras->unlock();
-    binarized_ras->unlock();
     return;
   }
 
@@ -401,17 +442,15 @@ void Iwa_SoapBubbleFx::processShape(double frame, TTile& shape_tile,
 
   if (settings.m_isCanceled && *settings.m_isCanceled) {
     blur_filter_ras->unlock();
-    binarized_ras->unlock();
     distance_ras->unlock();
     return;
   }
 
   /* blur filtering, normarize & power */
-  do_applyFilter(depth_map_p, dim, distance_p, binarized_p, blur_filter_p,
+  do_applyFilter(depth_map_p, dim, distance_p, regionIds_p, blur_filter_p,
                  blur_filter_size, frame, settings);
 
   distance_ras->unlock();
-  binarized_ras->unlock();
   blur_filter_ras->unlock();
 }
 
@@ -419,6 +458,7 @@ void Iwa_SoapBubbleFx::processShape(double frame, TTile& shape_tile,
 
 int Iwa_SoapBubbleFx::do_binarize(TRaster32P srcRas, USHORT* dst_p, float thres,
                                   float* distance_p, float* alpha_map_p,
+                                  QList<QRect>& regionBoundingRects,
                                   TDimensionI dim) {
   TPixel32::Channel channelThres =
       (TPixel32::Channel)(thres * (float)TPixel32::maxChannelValue);
@@ -435,7 +475,27 @@ int Iwa_SoapBubbleFx::do_binarize(TRaster32P srcRas, USHORT* dst_p, float thres,
   }
 
   // label regions when multi bubble option is on
-  if (!m_multi_source->getValue()) return 1;
+  if (!m_multi_source->getValue()) {
+    if (m_fit_thickness->getValue()) {
+      regionBoundingRects.append(QRect());
+      // calc boundingRect of the bubble
+      QPoint topLeft(dim.lx, dim.ly);
+      QPoint bottomRight(0, 0);
+      USHORT* tmp_p = dst_p;
+      for (int j = 0; j < dim.ly; j++) {
+        for (int i = 0; i < dim.lx; i++, tmp_p++) {
+          if ((*tmp_p) == 0) continue;
+          if (topLeft.x() > i) topLeft.setX(i);
+          if (bottomRight.x() < i) bottomRight.setX(i);
+          if (topLeft.y() > j) topLeft.setY(j);
+          if (bottomRight.y() < j) bottomRight.setY(j);
+        }
+      }
+      regionBoundingRects.append(QRect(topLeft, bottomRight));
+    }
+
+    return 1;
+  }
 
   QList<int> lut;
   for (int i      = 0; i < 65536; i++) lut.append(i);
@@ -481,13 +541,43 @@ int Iwa_SoapBubbleFx::do_binarize(TRaster32P srcRas, USHORT* dst_p, float thres,
     lut[convIndex.at(i)] = lut.at(lut.at(convIndex.at(i)));
 
   // apply lut
-  tmp_p = dst_p;
+  int maxRegionIndex = 0;
+  tmp_p              = dst_p;
   for (int j = 0; j < dim.ly; j++) {
     for (int i = 0; i < dim.lx; i++, tmp_p++) {
-      (*tmp_p) = lut[*tmp_p];
+      (*tmp_p)                                      = lut[*tmp_p];
+      if (maxRegionIndex < (*tmp_p)) maxRegionIndex = (*tmp_p);
     }
   }
-  return regionCount;
+
+  // compute bounding boxes of each bubble
+  if (m_fit_thickness->getValue()) {
+    regionBoundingRects.append(QRect());
+    USHORT* tmp_p = dst_p;
+    for (int j = 0; j < dim.ly; j++) {
+      for (int i = 0; i < dim.lx; i++, tmp_p++) {
+        int rId = (*tmp_p);
+        if (rId == 0) continue;
+        while (regionBoundingRects.size() <= rId)
+          regionBoundingRects.append(QRect());
+
+        if (regionBoundingRects.at(rId).isNull())
+          regionBoundingRects[rId].setRect(i, j, 1, 1);
+        else {
+          if (regionBoundingRects[rId].left() > i)
+            regionBoundingRects[rId].setLeft(i);
+          if (regionBoundingRects[rId].right() < i)
+            regionBoundingRects[rId].setRight(i);
+          if (regionBoundingRects[rId].top() > j)
+            regionBoundingRects[rId].setTop(j);
+          if (regionBoundingRects[rId].bottom() < j)
+            regionBoundingRects[rId].setBottom(j);
+        }
+      }
+    }
+  }
+
+  return maxRegionIndex;
 }
 
 //------------------------------------
@@ -859,12 +949,83 @@ bool Iwa_SoapBubbleFx::checkCancelAndReleaseRaster(
 //------------------------------------
 
 void Iwa_SoapBubbleFx::applyDistanceToAlpha(float* distance_p,
-                                            float* alpha_map_p,
-                                            TDimensionI dim) {
+                                            float* alpha_map_p, TDimensionI dim,
+                                            float center_opacity) {
+  float da   = 1.0f - center_opacity;
   float* d_p = distance_p;
   float* a_p = alpha_map_p;
-  for (int i = 0; i < dim.lx * dim.ly; i++, d_p++, a_p++)
-    (*a_p) *= 1.0f - (*d_p);
+  for (int i = 0; i < dim.lx * dim.ly; i++, d_p++, a_p++) {
+    (*a_p) *= 1.0f - (*d_p) * da;
+  }
+}
+
+//------------------------------------
+// This will be called in TFx::loadData when obsolete "mask center" value is
+// loaded
+void Iwa_SoapBubbleFx::onObsoleteParamLoaded(const std::string& paramName) {
+  if (paramName != "maskCenter") return;
+  // if "mask center" was ON, set a key frame to the center opacity in order to
+  // get the same result.
+  if (m_mask_center->getValue()) m_center_opacity->setValue(0.0, 0.0);
+}
+
+//------------------------------------
+// patch the thickness images to each bounding box of the bubble
+void Iwa_SoapBubbleFx::fitThicknessPatches(TRasterP thickRas,
+                                           TDimensionI thickDim,
+                                           float* thickness_map_p,
+                                           TDimensionI dim, USHORT* regionIds_p,
+                                           QList<QRect>& regionBoundingRects) {
+  int regionCount = regionBoundingRects.size() - 1;
+
+  // compute resized thickness rasters
+  QList<TRasterGR16P> resizedThicks;
+  resizedThicks.append(TRasterGR16P());
+  for (int r = 1; r <= regionCount; r++) {
+    QRect regionRect = regionBoundingRects.at(r);
+    TRaster64P resizedThickness(
+        TDimension(regionRect.width(), regionRect.height()));
+    resizedThickness->lock();
+
+    TAffine aff = TScale((double)regionRect.width() / (double)thickDim.lx,
+                         (double)regionRect.height() / (double)thickDim.ly);
+
+    // resample the thickenss
+    TRop::resample(resizedThickness, thickRas, aff);
+
+    for (int ry = 0; ry < regionRect.height(); ry++) {
+      TPixel64* p = resizedThickness->pixels(ry);
+      for (int rx = 0; rx < regionRect.width(); rx++, p++) {
+        double val = (double)((*p).r) / (double)(TPixel64::maxChannelValue);
+      }
+    }
+
+    TRasterGR16P thickRas_gray(
+        TDimension(regionRect.width(), regionRect.height()));
+    thickRas_gray->lock();
+    TRop::convert(thickRas_gray, resizedThickness);
+
+    resizedThickness->unlock();
+    resizedThicks.append(thickRas_gray);
+  }
+
+  float* out_p  = thickness_map_p;
+  USHORT* rId_p = regionIds_p;
+  for (int j = 0; j < dim.ly; j++) {
+    for (int i = 0; i < dim.lx; i++, out_p++, rId_p++) {
+      if ((*rId_p) == 0) {
+        (*out_p) = 0.0f;
+        continue;
+      }
+      QRect regionBBox = regionBoundingRects.at((int)(*rId_p));
+      QPoint coordInRegion(i - regionBBox.left(), j - regionBBox.top());
+      TPixelGR16 pix = resizedThicks.at((int)(*rId_p))
+                           ->pixels(coordInRegion.y())[coordInRegion.x()];
+      (*out_p) = (float)pix.value / (float)TPixelGR16::maxChannelValue;
+    }
+  }
+
+  for (int r = 1; r <= regionCount; r++) resizedThicks.at(r)->unlock();
 }
 
 //==============================================================================

--- a/toonz/sources/stdfx/iwa_soapbubblefx.h
+++ b/toonz/sources/stdfx/iwa_soapbubblefx.h
@@ -27,7 +27,10 @@ protected:
   TDoubleParamP m_blur_radius;
   TDoubleParamP m_blur_power;
   TBoolParamP m_multi_source;
-  TBoolParamP m_mask_center;
+  TBoolParamP
+      m_mask_center;  // obsolete parameter. to be conerted to m_center_opacity
+  TDoubleParamP m_center_opacity;
+  TBoolParamP m_fit_thickness;
 
   // noise parameters
   TIntParamP m_normal_sample_distance;
@@ -49,11 +52,13 @@ protected:
                        float3* bubbleColor_p);
 
   void processShape(double frame, TTile& shape_tile, float* depth_map_p,
-                    float* alpha_map_p, TDimensionI dim,
+                    float* alpha_map_p, USHORT* regionIds_p,
+                    QList<QRect>& regionBoundingRects, TDimensionI dim,
                     const TRenderSettings& settings);
 
   int do_binarize(TRaster32P srcRas, USHORT* dst_p, float thres,
-                  float* distance_p, float* alpha_map_p, TDimensionI dim);
+                  float* distance_p, float* alpha_map_p,
+                  QList<QRect>& regionBoundingRects, TDimensionI dim);
 
   void do_createBlurFilter(float* dst_p, int size, float radius);
 
@@ -89,13 +94,22 @@ protected:
                                    const TRenderSettings&);
 
   void applyDistanceToAlpha(float* distance_p, float* alpha_map_p,
-                            TDimensionI dim);
+                            TDimensionI dim, float center_opacity);
+
+  void fitThicknessPatches(TRasterP thickRas, TDimensionI thickDim,
+                           float* thickness_map_p, TDimensionI dim,
+                           USHORT* regionIds_p,
+                           QList<QRect>& regionBoundingRects);
 
 public:
   Iwa_SoapBubbleFx();
 
   void doCompute(TTile& tile, double frame,
                  const TRenderSettings& settings) override;
+
+  // This will be called in TFx::loadData when obsolete "mask center" value is
+  // loaded
+  void onObsoleteParamLoaded(const std::string& paramName) override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_soapbubblefx.h
+++ b/toonz/sources/stdfx/iwa_soapbubblefx.h
@@ -21,16 +21,19 @@ protected:
   TRasterFxPort m_shape;
   /* another option, to input a depth map directly */
   TRasterFxPort m_depth;
+  // rendering mode
+  TIntEnumParamP m_renderMode;
   // shape parameters
   TDoubleParamP m_binarize_threshold;
   TDoubleParamP m_shape_aspect_ratio;
   TDoubleParamP m_blur_radius;
   TDoubleParamP m_blur_power;
   TBoolParamP m_multi_source;
-  TBoolParamP
-      m_mask_center;  // obsolete parameter. to be conerted to m_center_opacity
   TDoubleParamP m_center_opacity;
   TBoolParamP m_fit_thickness;
+
+  // obsolete parameter. to be conerted to m_center_opacity
+  TBoolParamP m_mask_center;
 
   // noise parameters
   TIntParamP m_normal_sample_distance;
@@ -41,6 +44,8 @@ protected:
   TDoubleParamP m_noise_evolution;
   TDoubleParamP m_noise_depth_mix_ratio;
   TDoubleParamP m_noise_thickness_mix_ratio;
+
+  enum { RENDER_MODE_BUBBLE, RENDER_MODE_THICKNESS, RENDER_MODE_DEPTH };
 
   template <typename RASTER, typename PIXEL>
   void convertToBrightness(const RASTER srcRas, float* dst, float* alpha,

--- a/toonz/sources/stdfx/iwa_spectrumfx.h
+++ b/toonz/sources/stdfx/iwa_spectrumfx.h
@@ -35,6 +35,10 @@ protected:
   TDoubleParamP m_RGamma;
   TDoubleParamP m_GGamma;
   TDoubleParamP m_BGamma;
+
+  TDoubleParamP m_loopSpectrumFadeWidth;
+  TDoubleParamP m_spectrumShift;
+
   TDoubleParamP m_lensFactor;
   TDoubleParamP m_lightThres;
   TDoubleParamP m_lightIntensity;


### PR DESCRIPTION
This PR will improve SoapBubbleIwaFx by adding several features as written below.
All of these features were requested by some Japanese animation studio.

Please note in advance that all example images here were rendered with the input images as follows:
![soapbubble01](https://cloud.githubusercontent.com/assets/17974955/25434256/8a48869a-2ac6-11e7-99ae-327972fecb02.png)

 ## 1. Fit Thickness to Each Bubble option
This option will automatically resize the thickness image in order to fit with the bounding box of each bubble. With this option you don't need to adjust the thickness image according to the size & movement of bubbles.
![soapbubble02](https://cloud.githubusercontent.com/assets/17974955/25434358/fbd14a0e-2ac6-11e7-85bf-87b5a5a6ef71.png)

## 2. Opacity of Bubble's Center is now adjustable
Added a new parameter "Opacity of Bubble's Center", which allows to have semi-transparent center of the bubble. It is replacement of "Mask Center of the Bubble" checkbox so I set the "Mask Center of the Bubble" parameter as OBSOLETE. If you load the scene saved with older version, the "Mask Center of the Bubble" value will automatically converted to "Opacity of Bubble's Center" parameter in order to get the same rendering result.
![soapbubble03](https://cloud.githubusercontent.com/assets/17974955/25434591/d7a37fa2-2ac7-11e7-9287-9afaac01a317.png)

## 3. Loop and Shift the spectrum
Although this feature is not physically correct, it can obtain somewhat nice result...
Added two new parameters, "Loop Spectrum Fade Width" and "Spectrum Shift".
Consider that the bubble spectrum pattern is "looped" outside of the range between "Thickness Min" and "Thickness Max". The "Loop Spectrum Fade Width" specifies the width of fading around the border:
<img src="https://cloud.githubusercontent.com/assets/17974955/25434909/20f25c68-2ac9-11e7-9d44-d4ace9a3200e.png" width=500>

And the "Spectrum Shift" can shift the looped spectrum pattern. By animating this parameter you can easily get the following result:
![soapbubble05](https://cloud.githubusercontent.com/assets/17974955/25435040/b086b626-2ac9-11e7-8c73-b3bf5ce365d1.gif)

## 4. "Thickness" and "Depth" render modes
These render modes will render thickness and depth pattern used for calculating bubble color. 
![soapbubble06](https://cloud.githubusercontent.com/assets/17974955/25435310/8d304452-2aca-11e7-99e0-3f0f835c1375.png)

Although the new option "Fit Thickness to Each Bubble" is useful, it has some disadvantage; if you render multiple bubbles, the appearance of bubbles becomes very identical since the same thickness images are used in all bubbles.
In order to vary them, you can do some trick as follows: 1. Render the bubble with "Thickness" render mode. 2. Composite it with some noise pattern. 3. Use it as "Thickness" image for ANOTHER SoapBubbleFx.  By doing this, you can obtain "similar, but not identical" appearance in each bubble.
![soapbubble07](https://cloud.githubusercontent.com/assets/17974955/25435447/fd6917f8-2aca-11e7-9dc6-809d8c53c179.png)
 
