### PR TITLE
Don't allow throw() in destructors

### DIFF
--- a/toonz/sources/image/3gp/tiio_3gp_proxy.cpp
+++ b/toonz/sources/image/3gp/tiio_3gp_proxy.cpp
@@ -138,8 +138,6 @@ TLevelWriter3gp::~TLevelWriter3gp() {
   QString res;
 
   stream << (msg << QString("$closeLW3gp") << m_id);
-  if (tipc::readMessage(stream, msg) != "ok")
-    throw TException("Unable to write file");
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/image/mov/tiio_mov_proxy.cpp
+++ b/toonz/sources/image/mov/tiio_mov_proxy.cpp
@@ -206,8 +206,6 @@ TLevelWriterMov::~TLevelWriterMov() {
   QString res;
 
   stream << (msg << QString("$closeLWMov") << m_id);
-  if (tipc::readMessage(stream, msg) != "ok")
-    throw TException("Unable to write file");
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
Destructors are incapable of deducing whether they are being called in the context of normal destruction or stack unwinding.  Throwing in a destructor can lead to multiple exceptions being thrown, inadvertent process termination, or worse.  Furthermore, even if the destructor is adequately handled without process termination, its object's memory might not be properly deallocated.

For such reasons, in C++11/14/17, destructors default to `noexcept(true)` and all instances of `throw()` become calls to `std::terminate()`.  This however changes the original intent of the code which was to throw an exception to be handled outside of its immediate scope.

Forcing such pre-C++11 throwing behavior in such destructors (`TLevelWriter3gp::~TLevelWriter3gp()` and `TLevelWriterMov::~TLevelWriterMov()`) by explicitly marking them `noexcept(false)` wouldn't be enough since they are virtual and more base destructors aren't allowed more lax exception specification than exist in more derived classes.  Some even derive from QT classes (via multiple inheritance) and would render such an endeavor impossible.

In both offending instances, an exception is thrown based on the state of a stream object instantiated in the destructor.  Either, such a scenario is so serious as to warrant an explicit call to `std::exit()` or `std::terminate()`, or it should be benign enough to be ignored (at least in the context of an object's destruction).

This PR assumes the latter.
It also resolves issues of [compiling with `-Wno-error=terminate`](https://github.com/opentoonz/opentoonz/issues/1161).