### PR TITLE
Set premultiply option and choose level name type on loading PSD layer levels

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1242,10 +1242,11 @@ bool IoCmd::saveSceneIfNeeded(QString msg) {
 
     //--- If both the level and scene is clean, then open the quit confirmation
     // dialog
-    //if (!isLevelOrSceneIsDirty && msg == "Quit") {
+    // if (!isLevelOrSceneIsDirty && msg == "Quit") {
     //  QString question("Are you sure ?");
     //  int ret =
-    //      DVGui::MsgBox(question, QObject::tr("OK"), QObject::tr("Cancel"), 0);
+    //      DVGui::MsgBox(question, QObject::tr("OK"), QObject::tr("Cancel"),
+    //      0);
     //  if (ret == 0 || ret == 2) {
     //    // cancel (or closed message box window)
     //    return false;
@@ -2122,6 +2123,7 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
     } else {
       TFilePath psdpath = popup->getPsdPath(i);
       TXshLevel *xl     = 0;
+
       try {
         xl = ::loadResource(scene, psdpath, args.castFolder, row0, col0, row1,
                             col1, !popup->subxsheet());
@@ -2129,6 +2131,9 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
         error(QString::fromStdWString(e.getMessage()));
       }
       if (xl) {
+        if (xl->getSimpleLevel())  // just in case
+          xl->getSimpleLevel()->getProperties()->setDoPremultiply(true);
+
         // lo importo nell'xsheet
         if (popup->subxsheet() && childXsh) {
           childXsh->exposeLevel(0, subCol0, xl);

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2131,9 +2131,6 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
         error(QString::fromStdWString(e.getMessage()));
       }
       if (xl) {
-        if (xl->getSimpleLevel())  // just in case
-          xl->getSimpleLevel()->getProperties()->setDoPremultiply(true);
-
         // lo importo nell'xsheet
         if (popup->subxsheet() && childXsh) {
           childXsh->exposeLevel(0, subCol0, xl);

--- a/toonz/sources/toonz/psdsettingspopup.cpp
+++ b/toonz/sources/toonz/psdsettingspopup.cpp
@@ -169,8 +169,18 @@ PsdSettingsPopup::PsdSettingsPopup()
   m_createSubXSheet->setMaximumHeight(WidgetHeight);
   m_createSubXSheet->setEnabled(false);
 
+  m_levelNameType = new QComboBox();
+  QStringList types;
+  types << tr("FileName#LayerName") << tr("LayerName");
+  m_levelNameType->addItems(types);
+  m_levelNameType->setFixedHeight(WidgetHeight);
+  m_levelNameType->setEnabled(false);
+
   QLabel *modeLbl = new QLabel(tr("Load As:"));
   modeLbl->setObjectName("TitleTxtLabel");
+
+  QLabel *levelNameLbl = new QLabel(tr("Level Name:"));
+  levelNameLbl->setObjectName("TitleTxtLabel");
 
   QGridLayout *gridMode = new QGridLayout();
   gridMode->setColumnMinimumWidth(0, 65);
@@ -179,6 +189,8 @@ PsdSettingsPopup::PsdSettingsPopup()
   gridMode->addWidget(m_loadMode, 0, 1, Qt::AlignLeft);
   gridMode->addWidget(m_modeDescription, 1, 1, Qt::AlignLeft);
   gridMode->addWidget(m_createSubXSheet, 2, 1, Qt::AlignLeft);
+  gridMode->addWidget(levelNameLbl, 3, 0, Qt::AlignRight);
+  gridMode->addWidget(m_levelNameType, 3, 1, Qt::AlignLeft);
   QHBoxLayout *modeLayout = new QHBoxLayout;
   modeLayout->addLayout(gridMode);
   modeLayout->addStretch();
@@ -247,11 +259,16 @@ bool PsdSettingsPopup::subxsheet() {
   return (m_createSubXSheet->isEnabled() && m_createSubXSheet->isChecked());
 }
 
+int PsdSettingsPopup::levelNameType() {
+  return m_levelNameType->currentIndex();
+}
+
 void PsdSettingsPopup::onModeChanged(const QString &mode) {
   if (mode == "Single Image") {
     m_mode = FLAT;
     m_modeDescription->setText(modesDescription[0]);
     m_createSubXSheet->setEnabled(false);
+    m_levelNameType->setEnabled(false);
     QList<QAbstractButton *> buttons = m_psdFolderOptions->buttons();
     while (!buttons.isEmpty()) {
       QAbstractButton *btn = buttons.takeFirst();
@@ -261,6 +278,7 @@ void PsdSettingsPopup::onModeChanged(const QString &mode) {
     m_mode = FRAMES;
     m_modeDescription->setText(modesDescription[1]);
     m_createSubXSheet->setEnabled(false);
+    m_levelNameType->setEnabled(false);
     QList<QAbstractButton *> buttons = m_psdFolderOptions->buttons();
     while (!buttons.isEmpty()) {
       QAbstractButton *btn = buttons.takeFirst();
@@ -274,6 +292,7 @@ void PsdSettingsPopup::onModeChanged(const QString &mode) {
       m_mode = COLUMNS;
     m_modeDescription->setText(modesDescription[2]);
     m_createSubXSheet->setEnabled(true);
+    m_levelNameType->setEnabled(true);
     QList<QAbstractButton *> buttons = m_psdFolderOptions->buttons();
     while (!buttons.isEmpty()) {
       QAbstractButton *btn = buttons.takeFirst();
@@ -342,7 +361,10 @@ void PsdSettingsPopup::doPsdParser() {
       int layerId      = m_psdparser->getLevelId(i);
       std::string name = m_path.getName();
       if (layerId > 0 && m_mode != FRAMES) {
-        name += "#" + std::to_string(layerId);
+        if (m_levelNameType->currentIndex() == 0)  // FileName#LevelName
+          name += "#" + std::to_string(layerId);
+        else  // LevelName
+          name += "##" + std::to_string(layerId);
       }
       if (mode != "") name += mode;
       name += m_path.getDottedType();

--- a/toonz/sources/toonz/psdsettingspopup.h
+++ b/toonz/sources/toonz/psdsettingspopup.h
@@ -44,7 +44,7 @@ class PsdSettingsPopup final : public DVGui::Dialog {
   Mode m_mode;
   QPushButton *m_okBtn;
   QPushButton *m_cancelBtn;
-  QComboBox *m_loadMode;
+  QComboBox *m_loadMode, *m_levelNameType;
   DVGui::CheckBox *m_createSubXSheet;
   QButtonGroup *m_psdFolderOptions;
 
@@ -70,6 +70,7 @@ public:
   bool isFolder(int levelIndex);
   bool isSubFolder(int levelIndex, int frameIndex);
   bool subxsheet();
+  int levelNameType();
 
   int getFolderOption();
   int getSubfolderLevelIndex(int psdLevelIndex, int frameIndex);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -103,7 +103,7 @@ inline bool formatLess(const Preferences::LevelFormat &a,
 //=================================================================
 
 void getDefaultLevelFormats(LevelFormatVector &lfv) {
-  lfv.resize(1);
+  lfv.resize(2);
   {
     LevelFormat &lf = lfv[0];
 
@@ -111,6 +111,11 @@ void getDefaultLevelFormats(LevelFormatVector &lfv) {
     lf.m_pathFormat = QRegExp(".+[0-9]{4,4}\\.tga", Qt::CaseInsensitive);
     lf.m_options.m_whiteTransp = true;
     lf.m_options.m_antialias   = 70;
+
+    // for all PSD files, set the premultiply options to layers
+    lfv[1].m_name                  = Preferences::tr("Adobe Photoshop");
+    lfv[1].m_pathFormat            = QRegExp("..*\\.psd", Qt::CaseInsensitive);
+    lfv[1].m_options.m_premultiply = true;
   }
 }
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1017,8 +1017,13 @@ static TFilePath getLevelPathAndSetNameWithPsdLevelName(
     TXshSimpleLevel *xshLevel) {
   TFilePath retfp = xshLevel->getPath();
 
-  QString name     = QString::fromStdWString(retfp.getWideName());
-  QStringList list = name.split("#");
+  QString name        = QString::fromStdWString(retfp.getWideName());
+  bool removeFileName = name.contains("##");
+  if (removeFileName) {
+    retfp = TFilePath(
+        QString::fromStdWString(retfp.getWideString()).replace("##", "#"));
+  }
+  QStringList list = name.split("#", QString::SkipEmptyParts);
 
   if (list.size() >= 2 && list.at(1) != "frames") {
     bool hasLayerId;
@@ -1036,6 +1041,8 @@ static TFilePath getLevelPathAndSetNameWithPsdLevelName(
       list[1]                 = layerNameCodec->toUnicode(levelName.c_str());
       std::wstring wLevelName = list.join("#").toStdWString();
       retfp                   = retfp.withName(wLevelName);
+
+      if (removeFileName) wLevelName = list[1].toStdWString();
 
       TLevelSet *levelSet = xshLevel->getScene()->getLevelSet();
       if (levelSet &&


### PR DESCRIPTION
This feature was demanded by some Japanese animation studio.
Modified the PSD file loading feature in two points as follows:

1.   Each layer level will be set the premultiply option on loading in order to obtain the same appearance as the original.

1.  When loading PSD files as "Columns", now it is available to select the level name type from two options; `FileName#LayerName` (an existing naming rule) and `LayerName` (a new option). the second option will shorten the level name so that it can be shown in the xsheet cell.