### PR TITLE
Create zerary fx node at right-clicked position in the fx schematic

### DIFF
--- a/toonz/sources/toonzqt/addfxcontextmenu.cpp
+++ b/toonz/sources/toonzqt/addfxcontextmenu.cpp
@@ -15,6 +15,8 @@
 #include "toonz/txsheet.h"
 #include "toonz/fxdag.h"
 #include "toonz/tapplication.h"
+#include "toonz/txshzeraryfxcolumn.h"
+#include "toonz/tcolumnfx.h"
 #include "tw/stringtable.h"
 
 // TnzBase includes
@@ -25,6 +27,7 @@
 // TnzCore includes
 #include "tstream.h"
 #include "tsystem.h"
+#include "tconst.h"
 
 // Qt includes
 #include <QMenu>
@@ -557,6 +560,18 @@ void AddFxContextMenu::onAddFx(QAction *action) {
     TFxCommand::addFx(fx, fxs, m_app,
                       m_app->getCurrentColumn()->getColumnIndex(),
                       m_app->getCurrentFrame()->getFrameIndex());
+
+    // move the zerary fx node to the clicked position
+    if (fx->isZerary() &&
+        fx->getAttributes()->getDagNodePos() != TConst::nowhere) {
+      TXsheet *xsh = m_app->getCurrentXsheet()->getXsheet();
+      TXshZeraryFxColumn *column =
+          xsh->getColumn(m_app->getCurrentColumn()->getColumnIndex())
+              ->getZeraryFxColumn();
+      if (column)
+        column->getZeraryColumnFx()->getAttributes()->setDagNodePos(
+            fx->getAttributes()->getDagNodePos());
+    }
 
     m_app->getCurrentXsheet()->notifyXsheetChanged();
     // memorize the latest operation


### PR DESCRIPTION
This PR will modify the behavior when right-click on the fx schematic and create a zerary fx with "Add Fx" command.
Compared to non-zerary (normal) fxs, the created zerary fx node does not placed at the right-clicked postion and placed at next to the xsheet node. It is troublesome especially in the complicated scene with large schematic tree.
With this PR, zerary fx nodes will be placed at the right-clicked position as well as other fx nodes.

![addfx](https://cloud.githubusercontent.com/assets/17974955/25895220/fda77cba-35b9-11e7-9581-8f720460f08b.gif)
