### PR TITLE
Fixes on convert feature from NAA raster images to TLV

### DIFF
--- a/toonz/sources/include/convert2tlv.h
+++ b/toonz/sources/include/convert2tlv.h
@@ -39,6 +39,8 @@ private:
   bool m_isUnpaintedFromNAA;
   bool m_appendDefaultPalette;
 
+  double m_dpi;
+
   void buildToonzRaster(TRasterCM32P &rout, const TRasterP &rin1,
                         const TRasterP &rin2);
   void doFill(TRasterCM32P &rout, const TRaster32P &rin);
@@ -66,7 +68,7 @@ public:
               const TFilePath &outFolder, const QString &outName, int from,
               int to, bool doAutoclose, const TFilePath &palettePath,
               int colorTolerance, int antialiasType, int antialiasValue,
-              bool isUnpaintedFromNAA, bool appendDefaultPalette);
+              bool isUnpaintedFromNAA, bool appendDefaultPalette, double dpi);
 
   bool init(std::string &errorMessage);
   int getFramesToConvertCount();

--- a/toonz/sources/include/toonz/Naa2TlvConverter.h
+++ b/toonz/sources/include/toonz/Naa2TlvConverter.h
@@ -146,7 +146,8 @@ public:
       return -1;
   }
 
-  TToonzImageP makeTlv(bool transparentSyntheticInks, QList<int> &usedStyleIds);
+  TToonzImageP makeTlv(bool transparentSyntheticInks, QList<int> &usedStyleIds,
+                       double dpi = 0.0);
 
   TVectorImageP vectorize(const TToonzImageP &ti);
   TVectorImageP vectorize(const TRaster32P &ras);

--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -113,8 +113,8 @@ void DVAPI convertNaa2Tlv(
     TPalette *palette =
         0,  //!< Special conversion function from an antialiased level to tlv.
             //!  \sa  Function ImageUtils::convert().
-    bool removeUnusedStyles =
-        false);  //! Remove unused styles from input palette.
+    bool removeUnusedStyles = false,
+    double dpi = 0.0);  //! Remove unused styles from input palette.
 
 double DVAPI getQuantizedZoomFactor(double zf, bool forward);
 

--- a/toonz/sources/toonz/convertpopup.h
+++ b/toonz/sources/toonz/convertpopup.h
@@ -35,6 +35,7 @@ class LineEdit;
 class ColorField;
 class ProgressDialog;
 class CheckBox;
+class DoubleLineEdit;
 }
 
 namespace ImageUtils {
@@ -89,6 +90,8 @@ public slots:
   void onFormatChanged(const QString &);
   void onPalettePathChanged();
 
+  void onDpiModeSelected(int index);
+
 protected:
   Convert2Tlv *makeTlvConverter(const TFilePath &sourceFilePath);
   bool checkParameters() const;
@@ -112,6 +115,10 @@ private:
       *m_antialiasLabel;
 
   QPushButton *m_okBtn, *m_cancelBtn, *m_formatOptions;
+
+  QComboBox *m_dpiMode;
+  DVGui::DoubleLineEdit *m_dpiFld;
+  double m_imageDpi;
 
   class Converter;
   Converter *m_converter;

--- a/toonz/sources/toonzlib/Naa2TlvConverter.cpp
+++ b/toonz/sources/toonzlib/Naa2TlvConverter.cpp
@@ -1012,7 +1012,7 @@ int Naa2TlvConverter::measureThickness(int x0, int y0) {
 //-----------------------------------------------------------------------------
 
 TToonzImageP Naa2TlvConverter::makeTlv(bool transparentSyntheticInks,
-                                       QList<int> &usedStyleIds) {
+                                       QList<int> &usedStyleIds, double dpi) {
   if (!m_valid || m_colors.empty() || m_regions.empty() || !m_regionRas)
     return TToonzImageP();
   int lx                = m_regionRas->getLx();
@@ -1119,7 +1119,11 @@ TToonzImageP Naa2TlvConverter::makeTlv(bool transparentSyntheticInks,
 
   TToonzImageP ti = new TToonzImage(ras, ras->getBounds());
   ti->setPalette(palette);
-  ti->setDpi(72, 72);
+
+  if (dpi > 0.0)  // for now, accept only square pixel
+    ti->setDpi(dpi, dpi);
+  else
+    ti->setDpi(72, 72);
 
   return ti;
 }

--- a/toonz/sources/toonzlib/Naa2TlvConverter.cpp
+++ b/toonz/sources/toonzlib/Naa2TlvConverter.cpp
@@ -744,6 +744,14 @@ void Naa2TlvConverter::addBorderInks()  // add syntethic inks: lines between two
   m_syntheticInkRas = new WorkRaster<unsigned char>(lx, ly);
   for (int i = 0; i < lx * ly; i++) m_syntheticInkRas->pixels(0)[i] = 0;
 
+  // calculate brightness of all colors in order to decide the region on which
+  // the border to be added
+  QList<int> colorsBrightness;
+  QVector<TPixel32>::iterator c;
+  for (c = m_colors.begin(); c != m_colors.end(); ++c)
+    colorsBrightness.append((int)(*c).r * 30 + (int)(*c).g * 59 +
+                            (int)(*c).b * 11);
+
   int borderInkColorIndex = m_colors.count();
   m_colors.append(TPixel32(255, 0, 0));
 
@@ -778,7 +786,9 @@ void Naa2TlvConverter::addBorderInks()  // add syntethic inks: lines between two
             // OLD: note: we consider only regions with a lower index, to avoid
             // to create double border strokes
             // NEW: we put syntetic ink pixels in larger regions
-            if (m_regions[c1].pixelCount < m_regions[c].pixelCount) {
+            // UPDATE 2017/5/12 : we put ink on darker style
+            if (colorsBrightness[m_regions[c1].colorIndex] >
+                colorsBrightness[m_regions[c].colorIndex]) {
               touchesOtherRegion = true;
               break;
             }
@@ -1053,11 +1063,59 @@ TToonzImageP Naa2TlvConverter::makeTlv(bool transparentSyntheticInks,
         outScanLine[x] = TPixelCM32(styleId, 0, 0);
       else if (m_syntheticInkRas->pixels(y)[x] == 1)
         outScanLine[x] =
-            TPixelCM32(transparentSyntheticInks ? 0 : styleId, styleId, 0);
+            TPixelCM32(transparentSyntheticInks ? 0 : styleId, 0, 0);
       else
         outScanLine[x] = TPixelCM32(0, styleId, 255);
     }
   }
+
+  struct locals {
+    static bool compare(const QPair<int, int> &p1, const QPair<int, int> &p2) {
+      return p1.second > p2.second;
+    }
+
+    static void addPaint(QList<QPair<int, int>> &list, const int paintId) {
+      if (paintId == 0) return;
+      for (int i = 0; i < list.size(); i++)
+        if (list[i].first == paintId) {
+          list[i].second += 1;
+          return;
+        }
+      list.append(QPair<int, int>(paintId, 1));
+    }
+  };  // locals
+
+  // Here, expand paint area under the solid ink pixel in order to prevent the
+  // gap appears when the "Add Antialiasing" option is activated.
+  TRasterCM32P copiedRas = ras->clone();
+  copiedRas->lock();
+  for (int y = 0; y < ly; y++) {
+    TPixelCM32 *topScanLine    = copiedRas->pixels((y == 0) ? y : y - 1);
+    TPixelCM32 *middleScanLine = copiedRas->pixels(y);
+    TPixelCM32 *bottomScanLine = copiedRas->pixels((y == ly - 1) ? y : y + 1);
+    TPixelCM32 *outScanLine    = ras->pixels(y);
+    for (int x = 0; x < lx; x++) {
+      if (!middleScanLine[x].isPureInk() || middleScanLine[x].getPaint() != 0)
+        continue;
+
+      int prev_x = (x == 0) ? x : x - 1;
+      int next_x = (x == lx - 1) ? x : x + 1;
+      QList<QPair<int, int>> neighborPaints;
+      locals::addPaint(neighborPaints, topScanLine[prev_x].getPaint());
+      locals::addPaint(neighborPaints, topScanLine[x].getPaint());
+      locals::addPaint(neighborPaints, topScanLine[next_x].getPaint());
+      locals::addPaint(neighborPaints, middleScanLine[prev_x].getPaint());
+      locals::addPaint(neighborPaints, middleScanLine[next_x].getPaint());
+      locals::addPaint(neighborPaints, bottomScanLine[prev_x].getPaint());
+      locals::addPaint(neighborPaints, bottomScanLine[x].getPaint());
+      locals::addPaint(neighborPaints, bottomScanLine[next_x].getPaint());
+      qSort(neighborPaints.begin(), neighborPaints.end(), locals::compare);
+
+      if (!neighborPaints.isEmpty())
+        outScanLine[x].setPaint(neighborPaints[0].first);
+    }
+  }
+  copiedRas->unlock();
 
   TToonzImageP ti = new TToonzImage(ras, ras->getBounds());
   ti->setPalette(palette);

--- a/toonz/sources/toonzlib/convert2tlv.cpp
+++ b/toonz/sources/toonzlib/convert2tlv.cpp
@@ -643,7 +643,8 @@ Convert2Tlv::Convert2Tlv(const TFilePath &filepath1, const TFilePath &filepath2,
                          int from, int to, bool doAutoclose,
                          const TFilePath &palettePath, int colorTolerance,
                          int antialiasType, int antialiasValue,
-                         bool isUnpaintedFromNAA, bool appendDefaultPalette)
+                         bool isUnpaintedFromNAA, bool appendDefaultPalette,
+                         double dpi)
     : m_size(0, 0)
     , m_level1()
     , m_levelIn1()
@@ -660,7 +661,8 @@ Convert2Tlv::Convert2Tlv(const TFilePath &filepath1, const TFilePath &filepath2,
     , m_antialiasType(antialiasType)
     , m_antialiasValue(antialiasValue)
     , m_isUnpaintedFromNAA(isUnpaintedFromNAA)
-    , m_appendDefaultPalette(appendDefaultPalette) {
+    , m_appendDefaultPalette(appendDefaultPalette)
+    , m_dpi(dpi) {
   if (filepath1 != TFilePath()) {
     m_levelIn1 = filepath1.getParentDir() + filepath1.getLevelName();
     if (outFolder != TFilePath())
@@ -886,10 +888,13 @@ bool Convert2Tlv::convertNext(std::string &errorMessage) {
   TRop::computeBBox(rout, bbox);
   timg->setSavebox(bbox);
 
-  double dpix, dpiy;
-
-  imgIn1->getDpi(dpix, dpiy);
-  timg->setDpi(dpix, dpiy);
+  if (m_dpi > 0.0)  // specify dpi in the convert popup
+    timg->setDpi(m_dpi, m_dpi);
+  else {
+    double dpix, dpiy;
+    imgIn1->getDpi(dpix, dpiy);
+    timg->setDpi(dpix, dpiy);
+  }
 
   TLevel::Iterator itaux = m_it;
   itaux++;

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -633,7 +633,7 @@ void convert(const TFilePath &source, const TFilePath &dest,
 void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
                     const TFrameId &from, const TFrameId &to,
                     FrameTaskNotifier *frameNotifier, TPalette *palette,
-                    bool removeUnusedStyles) {
+                    bool removeUnusedStyles, double dpi) {
   std::string dstExt = dest.getType(), srcExt = source.getType();
 
   // Load source level structure
@@ -674,8 +674,8 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
 
       converter.process(raster);
 
-      if (TToonzImageP dstImg =
-              converter.makeTlv(false, usedStyleIds))  // Opaque synthetic inks
+      if (TToonzImageP dstImg = converter.makeTlv(
+              false, usedStyleIds, dpi))  // Opaque synthetic inks
       {
         if (converter.getPalette() == 0)
           converter.setPalette(dstImg->getPalette());


### PR DESCRIPTION
This PR will modify the convert feature, especially for NAA (non-antialiased) raster images converting to TLV. This feature is mainly used for handling RETAS-compatible TGA drawings. 

I've introduced 3 modifications as follows:

- In the previous version, if you enable the "Add Antialiasing" option in the level settings, the unwanted gap appears in the converted TLV at boundaries between lines and filled areas. I modified this problem by setting the style indices at the line pixels properly.

- In the previous version, the one-pixel-width border lines of color regions are generated always at the "larger" region. I modified this behavior in order to generate the border line always at the "darker" regions. As it is more consistent with the rules of animation production. 

- In the previous version, the DPI of converted TLV is always set to 72. I added the option to set the dpi of the result, which can be selected from "Image DPI", "Camera DPI" and "Custom DPI". Please note that if the source image does not contain dpi information, the current camera DPI will be used.

![naa_tga_to_tlv](https://cloud.githubusercontent.com/assets/17974955/26092602/c72b585e-3a4c-11e7-9bf8-d29cd15c84a9.png)
