### PR TITLE
Fix problem : the info viewer and the flipbook becomes impossible to close.

### DIFF
--- a/toonz/sources/include/toonzqt/infoviewer.h
+++ b/toonz/sources/include/toonzqt/infoviewer.h
@@ -25,7 +25,6 @@ class InfoViewerImp;
 class DVAPI InfoViewer final : public DVGui::Dialog {
   Q_OBJECT
   std::unique_ptr<InfoViewerImp> m_imp;
-  QWidget *m_parent;
 
 public:
   InfoViewer(QWidget *parent = 0);
@@ -33,7 +32,6 @@ public:
 
 protected:
   void hideEvent(QHideEvent *) override;
-  void showEvent(QShowEvent *) override;
 protected slots:
   void onSliderChanged(bool);
 public slots:

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -376,6 +376,11 @@ void FileBrowserPopup::showEvent(QShowEvent *) {
     m_nameField->setFocus();
   }
   resize(m_dialogSize);
+
+  // Set all the file browsers non-modal (even if opened with exec())
+  // in order to handle the info viewer and the flipbook which are opened
+  // with "Info..." and "View..." commands respectively.
+  setWindowModality(Qt::NonModal);
 }
 
 //***********************************************************************************
@@ -399,6 +404,14 @@ bool GenericLoadFilePopup::execute() {
 //-----------------------------------------------------------------------------
 
 TFilePath GenericLoadFilePopup::getPath() {
+  // In case that this function is called twice before closing the popup.
+  // Note that the file browser popup will be always non-modal even if opened
+  // with exec().
+  // see FileBrowserPopup::showEvent()
+  if (isVisible()) {
+    activateWindow();
+    return TFilePath();
+  }
   return (exec() == QDialog::Rejected) ? TFilePath() : *m_selectedPaths.begin();
 }
 
@@ -450,6 +463,14 @@ bool GenericSaveFilePopup::execute() {
 //-----------------------------------------------------------------------------
 
 TFilePath GenericSaveFilePopup::getPath() {
+  // In case that this function is called twice before closing the popup.
+  // Note that the file browser popup will be always non-modal even if opened
+  // with exec().
+  // see FileBrowserPopup::showEvent()
+  if (isVisible()) {
+    activateWindow();
+    return TFilePath();
+  }
   return (exec() == QDialog::Rejected) ? TFilePath() : *m_selectedPaths.begin();
 }
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -62,9 +62,6 @@
 #include <QCoreApplication>
 #include <QMainWindow>
 
-QWidget *CurrentOpenedBrowser =
-    0;  // not nice....it is used to get rid of blocking modality
-
 //***********************************************************************************
 //    FileBrowserPopup  implementation
 //***********************************************************************************
@@ -353,7 +350,6 @@ void FileBrowserPopup::setOkText(const QString &text) {
 //-----------------------------------------------------------------------------
 
 void FileBrowserPopup::hideEvent(QHideEvent *e) {
-  CurrentOpenedBrowser = 0;
   TSelectionHandle::getCurrent()->popSelection();
   m_dialogSize = size();
   move(pos());
@@ -363,7 +359,6 @@ void FileBrowserPopup::hideEvent(QHideEvent *e) {
 //-----------------------------------------------------------------------------
 
 void FileBrowserPopup::showEvent(QShowEvent *) {
-  CurrentOpenedBrowser = this;
   TSelectionHandle::getCurrent()->pushSelection();
   m_selectedPaths.clear();
   m_currentFIdsSet.clear();
@@ -377,7 +372,7 @@ void FileBrowserPopup::showEvent(QShowEvent *) {
   }
   resize(m_dialogSize);
 
-  // Set all the file browsers non-modal (even if opened with exec())
+  // Set ALL the file browsers non-modal (even if opened with exec())
   // in order to handle the info viewer and the flipbook which are opened
   // with "Info..." and "View..." commands respectively.
   setWindowModality(Qt::NonModal);

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -336,8 +336,6 @@ void FileSelection::showFolderContents() {
 
 //------------------------------------------------------------------------
 
-extern QWidget *CurrentOpenedBrowser;
-
 void FileSelection::viewFileInfo() {
   std::vector<TFilePath> files;
   getSelectedFiles(files);
@@ -353,7 +351,7 @@ void FileSelection::viewFileInfo() {
       break;
     }
     if (!infoViewer) {
-      infoViewer = new InfoViewer(CurrentOpenedBrowser);
+      infoViewer = new InfoViewer();
       m_infoViewers.append(infoViewer);
     }
     infoViewer->setItem(0, 0, files[j]);

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -35,7 +35,6 @@ extern TEnv::StringVar EnvSafeAreaName;
 //=============================================================================
 // TPanel
 //-----------------------------------------------------------------------------
-extern QWidget *CurrentOpenedBrowser;
 
 TPanel::TPanel(QWidget *parent, Qt::WindowFlags flags,
                TDockWidget::Orientation orientation)
@@ -57,20 +56,6 @@ TPanel::TPanel(QWidget *parent, Qt::WindowFlags flags,
   connect(m_panelTitleBar, SIGNAL(closeButtonPressed()), this,
           SLOT(onCloseButtonPressed()));
   setOrientation(orientation);
-}
-
-void TPanel::hideEvent(QHideEvent *) {
-  if (CurrentOpenedBrowser) {
-    CurrentOpenedBrowser->setWindowModality(Qt::ApplicationModal);
-    // setWindowModality(Qt::NonModal);
-  }
-}
-
-void TPanel::showEvent(QShowEvent *) {
-  if (CurrentOpenedBrowser) {
-    CurrentOpenedBrowser->setWindowModality(Qt::NonModal);
-    // setWindowModality(Qt::WindowModal);
-  }
 }
 
 //-----------------------------------------------------------------------------
@@ -467,7 +452,7 @@ TPanelFactory::~TPanelFactory() { tableInstance().remove(m_panelType); }
 
 //-----------------------------------------------------------------------------
 
-QMap<QString, TPanelFactory *>& TPanelFactory::tableInstance() {
+QMap<QString, TPanelFactory *> &TPanelFactory::tableInstance() {
   static QMap<QString, TPanelFactory *> table;
   return table;
 }

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -230,8 +230,6 @@ public:
 
 protected:
   void paintEvent(QPaintEvent *) override;
-  void showEvent(QShowEvent *) override;
-  void hideEvent(QHideEvent *) override;
   void enterEvent(QEvent *) override;
   void leaveEvent(QEvent *) override;
 
@@ -258,7 +256,7 @@ signals:
 
 class TPanelFactory {
   QString m_panelType;
-  static QMap<QString, TPanelFactory *>& tableInstance();
+  static QMap<QString, TPanelFactory *> &tableInstance();
 
 public:
   TPanelFactory(QString panelType);

--- a/toonz/sources/toonzqt/infoviewer.cpp
+++ b/toonz/sources/toonzqt/infoviewer.cpp
@@ -112,12 +112,11 @@ public slots:
 
 //----------------------------------------------------------------
 
-InfoViewer::InfoViewer(QWidget *parent) : Dialog(), m_imp(new InfoViewerImp()) {
+InfoViewer::InfoViewer(QWidget *parent)
+    : Dialog(parent), m_imp(new InfoViewerImp()) {
   setWindowTitle(tr("File Info"));
   setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
   // setAttribute(Qt::WA_DeleteOnClose);
-
-  m_parent = parent;
 
   int i;
   for (i = 0; i < (int)m_imp->m_labels.size(); i++) {
@@ -140,21 +139,7 @@ InfoViewer::~InfoViewer() {}
 
 //----------------------------------------------------------------
 
-void InfoViewer::hideEvent(QHideEvent *) {
-  m_imp->m_level = TLevelP();
-
-  if (m_parent) {
-    m_parent->setWindowModality(Qt::ApplicationModal);
-    // setWindowModality(Qt::NonModal);
-  }
-}
-
-void InfoViewer::showEvent(QShowEvent *) {
-  if (m_parent) {
-    m_parent->setWindowModality(Qt::NonModal);
-    // setWindowModality(Qt::WindowModal);
-  }
-}
+void InfoViewer::hideEvent(QHideEvent *) { m_imp->m_level = TLevelP(); }
 
 //----------------------------------------------------------------
 void InfoViewer::onSliderChanged(bool) { m_imp->onSliderChanged(); }


### PR DESCRIPTION
This PR fixes #1056 and #1208 .
The problem can occur not only in the info viewer opened from "Run Script" browser, but also in any popup/panes opened from any file browser popup.

In the previous version, they tried to avoid this problem by setting the modal file browser to non-modal as soon as the info popup is shown ( it is the same resolution as Toonz Harlequin ). However for now it seems not to work properly for unknown reasons. I struggled to restore it but failed.
 
Finally I decided to set all the file browser popup to non-modal even if they are opened with `exec()` function. It will make the software less user-inductive, but I think it is better than freezing the interface... 