### PR TITLE
Fix animate mode shortcut on plastic tool

### DIFF
--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -618,7 +618,8 @@ void ToolOptionCombo::doOnActivated(int index) {
     onActivated(index);
     setCurrentIndex(index);
     // for updating the cursor
-    m_toolHandle->notifyToolChanged();
+    std::string toolName = m_tool->getName();
+    if (toolName != "T_Plastic") m_toolHandle->notifyToolChanged();
     return;
   }
 


### PR DESCRIPTION
#1065 

I'm not sure why it was getting hung up on the notifyToolChanged signal, but this change seems to work.