### PR TITLE
Fix for Raster Level Tool Switch Crash

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -204,6 +204,7 @@ void FullColorBrushTool::onActivate() {
 //--------------------------------------------------------------------------------------------------
 
 void FullColorBrushTool::onDeactivate() {
+  if (m_mousePressed) leftButtonUp(m_mousePos, m_mouseEvent);
   m_workRaster = TRaster32P();
   m_backUpRas  = TRasterP();
 }
@@ -249,8 +250,9 @@ bool FullColorBrushTool::preLeftButtonDown() {
 void FullColorBrushTool::leftButtonDown(const TPointD &pos,
                                         const TMouseEvent &e) {
   m_brushPos = m_mousePos = pos;
-
-  Viewer *viewer = getViewer();
+  m_mousePressed          = true;
+  m_mouseEvent            = e;
+  Viewer *viewer          = getViewer();
   if (!viewer) return;
 
   TRasterImageP ri = (TRasterImageP)getImage(true);
@@ -308,8 +310,8 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
 void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
                                         const TMouseEvent &e) {
   m_brushPos = m_mousePos = pos;
-
-  TRasterImageP ri = (TRasterImageP)getImage(true);
+  m_mouseEvent            = e;
+  TRasterImageP ri        = (TRasterImageP)getImage(true);
   if (!ri) return;
 
   double maxThickness = m_thickness.getValue().second;
@@ -425,6 +427,7 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
 
   notifyImageChanged();
   m_strokeRect.empty();
+  m_mousePressed = false;
 }
 
 //---------------------------------------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -101,6 +101,8 @@ protected:
 
   bool m_presetsLoaded;
   bool m_firstTime;
+  bool m_mousePressed = false;
+  TMouseEvent m_mouseEvent;
 };
 
 //------------------------------------------------------------

--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -356,10 +356,11 @@ private:
   TRectD m_selectingRect, m_firstRect;
 
   TPointD m_mousePos, m_brushPos, m_firstPos;
-
+  TMouseEvent m_mouseEvent;
   double m_thick;
 
   bool m_firstTime, m_selecting, m_firstFrameSelected, m_isXsheetCell;
+  bool m_mousePressed = false;
 
 } fullColorEraser(T_Eraser);  // Tools are statically instantiated
 
@@ -431,15 +432,18 @@ void FullColorEraserTool::onActivate() {
 
 //--------------------------------------------------------------------------------------------------
 
-void FullColorEraserTool::onDeactivate() {}
+void FullColorEraserTool::onDeactivate() {
+  if (m_mousePressed) leftButtonUp(m_mousePos, m_mouseEvent);
+}
 
 //--------------------------------------------------------------------------------------------------
 
 void FullColorEraserTool::leftButtonDown(const TPointD &pos,
                                          const TMouseEvent &e) {
   m_brushPos = m_mousePos = pos;
-
-  TRasterImageP ri = (TRasterImageP)getImage(true);
+  m_mouseEvent            = e;
+  m_mousePressed          = true;
+  TRasterImageP ri        = (TRasterImageP)getImage(true);
   if (!ri) return;
   TRectD invalidateRect;
   TRasterP ras = ri->getRaster();
@@ -524,8 +528,8 @@ void FullColorEraserTool::leftButtonDown(const TPointD &pos,
 void FullColorEraserTool::leftButtonDrag(const TPointD &pos,
                                          const TMouseEvent &e) {
   m_brushPos = m_mousePos = pos;
-
-  double pixelSize2 = getPixelSize() * getPixelSize();
+  m_mouseEvent            = e;
+  double pixelSize2       = getPixelSize() * getPixelSize();
 
   TRasterImageP ri = (TRasterImageP)getImage(true);
   if (!ri) return;
@@ -786,6 +790,7 @@ void FullColorEraserTool::leftButtonUp(const TPointD &pos,
         invalidate(stroke->getBBox().enlarge(2));
     }
   }
+  m_mousePressed = false;
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -68,7 +68,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
   bool m_foregroundDrawing;
   bool m_tabletEvent;
   // used to handle wrong mouse drag events!
-  bool m_buttonClicked;
+  bool m_buttonClicked, m_toolSwitched;
   bool m_shownOnce = false;
   int m_referenceMode;
   int m_previewMode;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -379,7 +379,7 @@ void SceneViewer::mouseMoveEvent(QMouseEvent *event) {
     if ((m_tabletEvent && m_pressure > 0) || m_mouseButton == Qt::LeftButton) {
       // sometimes the mousePressedEvent is postponed to a wrong  mouse move
       // event!
-      if (m_buttonClicked) tool->leftButtonDrag(pos, toonzEvent);
+    if (m_buttonClicked && !m_toolSwitched) tool->leftButtonDrag(pos, toonzEvent);
     } else if (m_pressure == 0) {
       tool->mouseMove(pos, toonzEvent);
       // m_tabletEvent=false;
@@ -412,7 +412,7 @@ void SceneViewer::mousePressEvent(QMouseEvent *event) {
   // evita i press ripetuti
   if (m_buttonClicked) return;
   m_buttonClicked = true;
-
+  m_toolSwitched = false;
   if (m_freezedStatus != NO_FREEZED) return;
 
   if (m_mouseButton != Qt::NoButton) return;
@@ -554,7 +554,7 @@ void SceneViewer::mouseReleaseEvent(QMouseEvent *event) {
     }
 
     if (m_mouseButton == Qt::LeftButton) {
-      tool->leftButtonUp(pos, toonzEvent);
+      if (!m_toolSwitched)tool->leftButtonUp(pos, toonzEvent);
       TApp::instance()->getCurrentTool()->setToolBusy(false);
     }
   }
@@ -1117,7 +1117,7 @@ void SceneViewer::dropEvent(QDropEvent *e) {
 
 void SceneViewer::onToolSwitched() {
   m_forceGlFlush = true;
-
+  m_toolSwitched = true;
   invalidateToolStatus();
 
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -379,7 +379,8 @@ void SceneViewer::mouseMoveEvent(QMouseEvent *event) {
     if ((m_tabletEvent && m_pressure > 0) || m_mouseButton == Qt::LeftButton) {
       // sometimes the mousePressedEvent is postponed to a wrong  mouse move
       // event!
-    if (m_buttonClicked && !m_toolSwitched) tool->leftButtonDrag(pos, toonzEvent);
+      if (m_buttonClicked && !m_toolSwitched)
+        tool->leftButtonDrag(pos, toonzEvent);
     } else if (m_pressure == 0) {
       tool->mouseMove(pos, toonzEvent);
       // m_tabletEvent=false;
@@ -412,7 +413,7 @@ void SceneViewer::mousePressEvent(QMouseEvent *event) {
   // evita i press ripetuti
   if (m_buttonClicked) return;
   m_buttonClicked = true;
-  m_toolSwitched = false;
+  m_toolSwitched  = false;
   if (m_freezedStatus != NO_FREEZED) return;
 
   if (m_mouseButton != Qt::NoButton) return;
@@ -554,7 +555,7 @@ void SceneViewer::mouseReleaseEvent(QMouseEvent *event) {
     }
 
     if (m_mouseButton == Qt::LeftButton) {
-      if (!m_toolSwitched)tool->leftButtonUp(pos, toonzEvent);
+      if (!m_toolSwitched) tool->leftButtonUp(pos, toonzEvent);
       TApp::instance()->getCurrentTool()->setToolBusy(false);
     }
   }


### PR DESCRIPTION
#860 
I'm not sure this is the best fix, since the crash only happens on raster levels, but this seems to fix it.

I don't know if there will be residual effects since mouse up is not called on the tool before it is switched, but I don't know how to get the mouse position required in the function for leftbuttonup.