### PR TITLE
Fix crash on using the "skeleton mode" shortcut with the plastic tool 

### DIFF
--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -387,8 +387,10 @@ void PlasticToolOptionsBox::SkelIdsComboBox::updateCurrentSkeleton() {
 //****************************************************************************************
 
 PlasticToolOptionsBox::PlasticToolOptionsBox(QWidget *parent, TTool *tool,
-                                             TPaletteHandle *pltHandle)
-    : GenericToolOptionsBox(parent, tool, pltHandle, PlasticTool::MODES_COUNT)
+                                             TPaletteHandle *pltHandle,
+                                             ToolHandle *toolHandle)
+    : GenericToolOptionsBox(parent, tool, pltHandle, PlasticTool::MODES_COUNT,
+                            toolHandle)
     , m_tool(tool)
     , m_subToolbars(new GenericToolOptionsBox *[PlasticTool::MODES_COUNT])
 //, m_subToolbarActions(new QAction*[PlasticTool::MODES_COUNT])
@@ -721,8 +723,9 @@ ToolOptionsBox *PlasticTool::createOptionsBox() {
   // Create the options box
   TPaletteHandle *currPalette =
       TTool::getApplication()->getPaletteController()->getCurrentLevelPalette();
+  ToolHandle *currTool = m_application->getCurrentTool();
   PlasticToolOptionsBox *optionsBox =
-      new PlasticToolOptionsBox(0, this, currPalette);
+      new PlasticToolOptionsBox(0, this, currPalette, currTool);
 
   // Connect it to receive m_mode notifications
   m_mode.addListener(optionsBox);

--- a/toonz/sources/tnztools/plastictool.h
+++ b/toonz/sources/tnztools/plastictool.h
@@ -402,8 +402,8 @@ class PlasticToolOptionsBox final : public GenericToolOptionsBox,
   Q_OBJECT
 
 public:
-  PlasticToolOptionsBox(QWidget *parent, TTool *tool,
-                        TPaletteHandle *pltHandle);
+  PlasticToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
+                        ToolHandle *toolHandle);
 
 private:
   class SkelIdsComboBox;


### PR DESCRIPTION
This fixes #1065 , keeping the "Build Skeleton Mode" and the "Animate Mode" available.
The cause of crash was that the pointer to `ToolHandle` was missing in the `PlasticToolOptionsBox`. 
Thank you @BrundleThwaite for reporting the crash and @turtletooth for investigation of this matter!