### PR TITLE
Default to Toonz Raster Level

### DIFF
--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -313,7 +313,9 @@ Preferences::Preferences()
     , m_importPolicy(0)
     , m_watchFileSystem(true) {
   TCamera camera;
-  m_defLevelType   = PLI_XSHLEVEL;
+  // Change while vector level fill is still unreliable. 05/2017 JCB
+  // m_defLevelType   = PLI_XSHLEVEL;
+  m_defLevelType   = TZP_XSHLEVEL;
   m_defLevelWidth  = camera.getSize().lx;
   m_defLevelHeight = camera.getSize().ly;
   m_defLevelDpi    = camera.getDpi().x;


### PR DESCRIPTION
This is probably a controversial PR.  And I don't mind closing it if the consensus opposes it.

This is for #1105 

Right now, vector fill is unreliable to the point of driving people crazy.  But vector is most everyone's first impression with painting in OT.  

I would prefer to keep vector the default since it gives greater flexibility for scale and camera movements, but I don't know anything about vector graphics and it doesn't seem that vector fill is being worked on.

I'm torn, but I thought I would throw this out there.