### PR TITLE
Fix of the file browser and popups hierarchy

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -144,6 +144,10 @@ protected slots:
   virtual void onFilePathsSelected(
       const std::set<TFilePath> &paths,
       const std::list<std::vector<TFrameId>> &fIds);
+
+  // utility function
+public:
+  static void setModalBrowserToParent(QWidget *widget);
 };
 
 //********************************************************************************

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -183,7 +183,6 @@ public:
     return str;
   }
 };
-
 //-----------------------------------------------------------------------------
 }
 
@@ -354,6 +353,7 @@ void FileSelection::viewFileInfo() {
       infoViewer = new InfoViewer();
       m_infoViewers.append(infoViewer);
     }
+    FileBrowserPopup::setModalBrowserToParent(infoViewer);
     infoViewer->setItem(0, 0, files[j]);
   }
 }
@@ -371,8 +371,12 @@ void FileSelection::viewFile() {
         (files[i].getType() == "mov" || files[i].getType() == "avi" ||
          files[i].getType() == "3gp"))
       QDesktopServices::openUrl(QUrl("file:///" + toQString(files[i])));
-    else
-      ::viewFile(files[i]);
+    else {
+      FlipBook *fb = ::viewFile(files[i]);
+      if (fb) {
+        FileBrowserPopup::setModalBrowserToParent(fb->parentWidget());
+      }
+    }
   }
 }
 

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -2177,9 +2177,10 @@ void FlipBook::loadAndCacheAllTlvImages(Level level, int fromFrame,
 //! some additional random access information may be retrieved (i.e. images may
 //! map
 //! to specific frames).
-void viewFile(const TFilePath &path, int from, int to, int step, int shrink,
-              TSoundTrack *snd, FlipBook *flipbook, bool append,
-              bool isToonzOutput) {
+// returns pointer to the opened flipbook to control modality.
+FlipBook *viewFile(const TFilePath &path, int from, int to, int step,
+                   int shrink, TSoundTrack *snd, FlipBook *flipbook,
+                   bool append, bool isToonzOutput) {
   // In case the step and shrink informations are invalid, load them from
   // preferences
   if (step == -1 || shrink == -1) {
@@ -2195,11 +2196,11 @@ void viewFile(const TFilePath &path, int from, int to, int step, int shrink,
       path.isLevelName()) {
     DVGui::warning(QObject::tr("%1  has an invalid extension format.")
                        .arg(QString::fromStdString(path.getLevelName())));
-    return;
+    return NULL;
   }
 
   // Windows Screen Saver - avoid
-  if (path.getType() == "scr") return;
+  if (path.getType() == "scr") return NULL;
 
   // Avi and movs may be viewed by an external viewer, depending on preferences
   if (path.getType() == "mov" || path.getType() == "avi" && !flipbook) {
@@ -2207,7 +2208,7 @@ void viewFile(const TFilePath &path, int from, int to, int step, int shrink,
     QSettings().value("generatedMovieViewEnabled", str);
     if (str.toInt() != 0) {
       TSystem::showDocument(path);
-      return;
+      return NULL;
     }
   }
 
@@ -2220,6 +2221,7 @@ void viewFile(const TFilePath &path, int from, int to, int step, int shrink,
   // Assign the passed level with associated infos
   flipbook->setLevel(path, 0, from, to, step, shrink, snd, append,
                      isToonzOutput);
+  return flipbook;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/flipbook.h
+++ b/toonz/sources/toonz/flipbook.h
@@ -298,9 +298,11 @@ public slots:
 };
 
 // utility
+// returns pointer to the opened flipbook to control modality.
 
-void viewFile(const TFilePath &fp, int from = -1, int to = -1, int step = -1,
-              int shrink = -1, TSoundTrack *snd = 0, FlipBook *flipbook = 0,
-              bool append = false, bool isToonzOutput = false);
+FlipBook *viewFile(const TFilePath &fp, int from = -1, int to = -1,
+                   int step = -1, int shrink = -1, TSoundTrack *snd = 0,
+                   FlipBook *flipbook = 0, bool append = false,
+                   bool isToonzOutput = false);
 
 #endif  // FLIPBOOK_H

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -1193,10 +1193,16 @@ public:
     for (i = 0; i < simpleLevels.size(); i++) {
       TFilePath path = simpleLevels[i]->getPath();
       path           = simpleLevels[i]->getScene()->decodeFilePath(path);
+      FlipBook *fb;
       if (TSystem::doesExistFileOrLevel(path))
-        ::viewFile(path);
-      else
-        FlipBookPool::instance()->pop()->setLevel(simpleLevels[i]);
+        fb = ::viewFile(path);
+      else {
+        fb = FlipBookPool::instance()->pop();
+        fb->setLevel(simpleLevels[i]);
+      }
+      if (fb) {
+        FileBrowserPopup::setModalBrowserToParent(fb->parentWidget());
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes #1231 .

I think I found the proper solution regarding the modal file browser and other popups (such as the info viewer and the flipbook) open from it.
I changed the strategy done in #1214, I introduced an utility function `FileBrowserPopup::setModalBrowserToParent()` instead. This function will set the modal file browser to parent of the popup, in order to allow it controllable with leaving the browser modal.