### PR TITLE
Allow enter to end polyline

### DIFF
--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -1517,6 +1517,11 @@ void MultiLinePrimitive::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 //-----------------------------------------------------------------------------
 
 bool MultiLinePrimitive::keyDown(int key, const TPoint &point) {
+  if (key == TwConsts::TK_Return) {
+    endLine();
+    return true;
+  }
+
   if (key != TwConsts::TK_Esc || !m_isEditing) return false;
 
   UINT size = m_vertex.size();

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -860,7 +860,7 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
     flags = TwConsts::TK_CapsLock;
   else if (key == Qt::Key_Backspace)
     key = TwConsts::TK_Backspace;
-  else if (key == Qt::Key_Return)
+  else if (key == Qt::Key_Return || key == Qt::Key_Enter)
     key = TwConsts::TK_Return;
   else if (key == Qt::Key_Left && !shiftButton)
     key = TwConsts::TK_LeftArrow;


### PR DESCRIPTION
This is for #1094 

Allowing enter to end a polyline is somewhat expected behavior from other vector software.