### PR TITLE
Fix to show result on mov rendering

### DIFF
--- a/toonz/sources/image/3gp/tiio_3gp_proxy.cpp
+++ b/toonz/sources/image/3gp/tiio_3gp_proxy.cpp
@@ -9,6 +9,7 @@
 #include "timageinfo.h"
 #include "trop.h"
 #include "tsound.h"
+#include "tmsgcore.h"
 
 // tipc includes
 #include "tipc.h"
@@ -138,6 +139,8 @@ TLevelWriter3gp::~TLevelWriter3gp() {
   QString res;
 
   stream << (msg << QString("$closeLW3gp") << m_id);
+  if (tipc::readMessage(stream, msg) != "ok")
+    DVGui::warning("Unable to write file");
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/image/mov/tiio_mov_proxy.cpp
+++ b/toonz/sources/image/mov/tiio_mov_proxy.cpp
@@ -9,6 +9,7 @@
 #include "timageinfo.h"
 #include "trop.h"
 #include "tsound.h"
+#include "tmsgcore.h"
 
 // tipc includes
 #include "tipc.h"
@@ -206,6 +207,8 @@ TLevelWriterMov::~TLevelWriterMov() {
   QString res;
 
   stream << (msg << QString("$closeLWMov") << m_id);
+  if (tipc::readMessage(stream, msg) != "ok")
+    DVGui::warning("Unable to write file");
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the problem as follows (in windows version):

1. Set "Preferences>Interface>Open Flipbook after Rendering" to ON.

1. Set the output file format to "mov".

1. Render the scene.

In my environment, flipbook fails to show the rendered mov file and becomes blank.

It seems that `tipc::readMessage(stream, msg)` (removed in #1182) was needed in the `TLevelWriterMov` destructor. I reverted it without throwing exception.