### PR TITLE
Fix New Level Name for Vector Level

### DIFF
--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -343,8 +343,8 @@ bool LevelCreatePopup::levelExists(std::wstring levelName) {
 
 //-----------------------------------------------------------------------------
 void LevelCreatePopup::showEvent(QShowEvent *) {
-  nextName();
   update();
+  nextName();
   m_nameFld->setFocus();
   if (Preferences::instance()->getUnits() == "pixel") {
     m_dpiFld->hide();
@@ -480,6 +480,7 @@ bool LevelCreatePopup::apply() {
     error(
         tr("The level name specified is already used: please choose a "
            "different level name"));
+    m_nameFld->selectAll();
     return false;
   }
 
@@ -492,6 +493,7 @@ bool LevelCreatePopup::apply() {
     error(
         tr("The level name specified is already used: please choose a "
            "different level name"));
+    m_nameFld->selectAll();
     return false;
   }
   parentDir = scene->decodeFilePath(parentDir);
@@ -617,7 +619,7 @@ void LevelCreatePopup::update() {
     break;
   }
   if (index >= 0) m_levelTypeOm->setCurrentIndex(index);
-
+  
   /*
 (old behaviour)
 TCamera* camera = scene->getCurrentCamera();


### PR DESCRIPTION
This PR does two things:

When the first level created is a vector level, the level create popup doesn't correctly set a new name - it gets A (only the first time, but this isn't as it should be).

To recreate:
Open OT
Click the new vector level button in the xsheet toolbar 
Notice the level name is A whether a level A exists already or not.

This PR also selects all text in the new level name field if the warning that the level name already exists, giving the user the chance to give a totally new name without having to backspace or select all.