### PR TITLE
Allow drawing substitution on subxsheet levels

### DIFF
--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -651,7 +651,9 @@ public:
                         ->getScene()
                         ->getXsheet()
                         ->getCell(m_row, m_col);
-    if (!cell.m_level || !cell.m_level->getSimpleLevel()) return;
+    if (!cell.m_level ||
+        !(cell.m_level->getSimpleLevel() || cell.m_level->getChildLevel()))
+      return;
 
     TFrameId id = cell.m_frameId;
 
@@ -660,7 +662,9 @@ public:
                             ->getScene()
                             ->getXsheet()
                             ->getCell(m_row + m_count, m_col);
-    if (!nextCell.m_level || !nextCell.m_level->getSimpleLevel()) return;
+    if (!cell.m_level ||
+        !(cell.m_level->getSimpleLevel() || cell.m_level->getChildLevel()))
+      return;
 
     TFrameId nextId = nextCell.m_frameId;
 
@@ -710,10 +714,15 @@ bool DrawingSubtitutionUndo::changeDrawing(int delta, int row, int col) {
   TXsheet *xsh            = app->getCurrentScene()->getScene()->getXsheet();
   TXshCell cell           = xsh->getCell(row, col);
 
-  if (!cell.m_level || !cell.m_level->getSimpleLevel()) return false;
+  if (!cell.m_level ||
+      !(cell.m_level->getSimpleLevel() || cell.m_level->getChildLevel()))
+    return false;
 
   std::vector<TFrameId> fids;
-  cell.m_level->getSimpleLevel()->getFids(fids);
+  if (cell.m_level->getSimpleLevel())
+    cell.m_level->getSimpleLevel()->getFids(fids);
+  if (cell.m_level->getChildLevel())
+    cell.m_level->getChildLevel()->getFids(fids);
   int n = fids.size();
 
   if (n < 2) return false;

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -651,11 +651,10 @@ private:
   int m_row;
   int m_col;
   int m_count;
-  bool m_isEmpty;
 
 public:
-  DrawingSubtitutionGroupUndo(int dir, int row, int col, bool isEmpty)
-      : m_direction(dir), m_col(col), m_row(row), m_isEmpty(isEmpty) {
+  DrawingSubtitutionGroupUndo(int dir, int row, int col)
+      : m_direction(dir), m_col(col), m_row(row) {
     m_count       = 1;
     TXshCell cell = TTool::getApplication()
                         ->getCurrentScene()
@@ -692,7 +691,6 @@ public:
   }
 
   void undo() const override {
-    if (m_isEmpty) return;
     int n = 1;
     DrawingSubtitutionUndo::changeDrawing(-m_direction, m_row, m_col);
     while (n < m_count) {
@@ -702,7 +700,6 @@ public:
   }
 
   void redo() const override {
-    if (m_isEmpty) return;
     int n = 1;
     DrawingSubtitutionUndo::changeDrawing(m_direction, m_row, m_col);
     while (n < m_count) {
@@ -817,8 +814,9 @@ static void drawingSubstituionGroup(int dir) {
       TApp::instance()->getCurrentScene()->getScene()->getXsheet()->getCell(
           row, col);
   bool isEmpty = cell.isEmpty();
+  if (isEmpty) return;
   DrawingSubtitutionGroupUndo *undo =
-      new DrawingSubtitutionGroupUndo(dir, row, col, isEmpty);
+      new DrawingSubtitutionGroupUndo(dir, row, col);
   TUndoManager::manager()->add(undo);
   undo->redo();
 }


### PR DESCRIPTION
Right now drawing substitution only works on drawing levels, this change allows drawing substitution on subxsheet levels also.  This is useful if mouth, face, etc. . . are actually made up of multiple levels.