### PR TITLE
Fix popup locations

### DIFF
--- a/toonz/sources/include/toonzqt/dvdialog.h
+++ b/toonz/sources/include/toonzqt/dvdialog.h
@@ -173,6 +173,7 @@ class DVAPI Dialog : public QDialog {
   // If the dialog has button then is modal too.
   bool m_hasButton;
   QString m_name;
+  int m_currentScreen = -1;
   // gmt. rendo m_buttonLayout protected per ovviare ad un problema
   // sull'addButtonBarWidget(). cfr filebrowserpopup.cpp.
   // Dobbiamo discutere di Dialog.

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -362,8 +362,13 @@ void StartupPopup::showEvent(QShowEvent *) {
   // clear items if they exist first
   refreshRecentScenes();
   // center window
-  this->move(QApplication::desktop()->screen()->rect().center() -
-             this->rect().center());
+  int currentScreen =
+      QApplication::desktop()->screenNumber(TApp::instance()->getMainWindow());
+  QPoint activeMonitorCenter =
+      QApplication::desktop()->availableGeometry(currentScreen).center();
+  QPoint thisPopupCenter         = this->rect().center();
+  QPoint centeredOnActiveMonitor = activeMonitorCenter - thisPopupCenter;
+  this->move(centeredOnActiveMonitor);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This is a fix for #1283 
If a popup gets  moved off screen, this moves it back.

This also puts the startup popup on the screen OpenToonz is on, not just the primary monitor.