### PR TITLE
Allow Imported Images to Use Camera DPI

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -272,6 +272,9 @@ public:
   void setDefaultImportPolicy(int policy);
   int getDefaultImportPolicy() { return m_importPolicy; }
 
+  void setIgnoreImageDpi(bool on);
+  bool isIgnoreImageDpiEnabled() const { return m_ignoreImageDpi; }
+
   // Drawing  tab
 
   void setScanLevelType(std::string s);
@@ -510,7 +513,7 @@ private:
       m_sceneNumberingEnabled, m_animationSheetEnabled, m_inksOnly,
       m_startupPopupEnabled;
   bool m_fillOnlySavebox, m_show0ThickLines, m_regionAntialias;
-  bool m_onionSkinDuringPlayback;
+  bool m_onionSkinDuringPlayback, m_ignoreImageDpi;
   TPixel32 m_viewerBGColor, m_previewBGColor, m_chessboardColor1,
       m_chessboardColor2;
   bool m_showRasterImagesDarkenBlendedInViewer,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -478,6 +478,12 @@ void PreferencesPopup::onAutoExposeChanged(int index) {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onIgnoreImageDpiChanged(int index) {
+  m_pref->setIgnoreImageDpi(index == Qt::Checked);
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onSubsceneFolderChanged(int index) {
   m_pref->enableSubsceneFolder(index == Qt::Checked);
 }
@@ -1159,6 +1165,8 @@ PreferencesPopup::PreferencesPopup()
       new CheckBox(tr("Expose Loaded Levels in Xsheet"), this);
   CheckBox *createSubfolderCB =
       new CheckBox(tr("Create Sub-folder when Importing Sub-xsheet"), this);
+  CheckBox *m_ignoreImageDpiCB =
+      new CheckBox(tr("Use Camera DPI for All Imported Images"), this);
   // Column Icon
   m_columnIconOm                                   = new QComboBox(this);
   QComboBox *initialLoadTlvCachingBehaviorComboBox = new QComboBox(this);
@@ -1383,6 +1391,7 @@ PreferencesPopup::PreferencesPopup()
 
   //--- Loading ------------------------------
   exposeLoadedLevelsCB->setChecked(m_pref->isAutoExposeEnabled());
+  m_ignoreImageDpiCB->setChecked(m_pref->isIgnoreImageDpiEnabled());
   QStringList behaviors;
   behaviors << tr("On Demand") << tr("All Icons") << tr("All Icons & Images");
   initialLoadTlvCachingBehaviorComboBox->addItems(behaviors);
@@ -1771,6 +1780,8 @@ PreferencesPopup::PreferencesPopup()
       loadingFrameLay->addWidget(createSubfolderCB, 0,
                                  Qt::AlignLeft | Qt::AlignVCenter);
       loadingFrameLay->addWidget(removeSceneNumberFromLoadedLevelNameCB, 0,
+                                 Qt::AlignLeft | Qt::AlignVCenter);
+      loadingFrameLay->addWidget(m_ignoreImageDpiCB, 0,
                                  Qt::AlignLeft | Qt::AlignVCenter);
 
       QGridLayout *cacheLay = new QGridLayout();
@@ -2226,6 +2237,8 @@ PreferencesPopup::PreferencesPopup()
   //--- Loading ----------------------
   ret = ret && connect(exposeLoadedLevelsCB, SIGNAL(stateChanged(int)), this,
                        SLOT(onAutoExposeChanged(int)));
+  ret = ret && connect(m_ignoreImageDpiCB, SIGNAL(stateChanged(int)), this,
+                       SLOT(onIgnoreImageDpiChanged(int)));
   ret = ret && connect(initialLoadTlvCachingBehaviorComboBox,
                        SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onInitialLoadTlvCachingBehaviorChanged(int)));

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -72,7 +72,8 @@ private:
       *m_onionSkinVisibility, *m_pixelsOnlyCB, *m_projectRootDocuments,
       *m_projectRootDesktop, *m_projectRootCustom, *m_projectRootStuff,
       *m_onionSkinDuringPlayback, *m_autoSaveSceneCB, *m_autoSaveOtherFilesCB,
-      *m_useNumpadForSwitchingStyles, *m_expandFunctionHeader;
+      *m_useNumpadForSwitchingStyles, *m_expandFunctionHeader,
+      *m_ignoreImageDpiCB;
 
   DVGui::FileField *m_customProjectRootFileField;
 
@@ -140,6 +141,7 @@ private slots:
   void onRemoveLevelFormat();
   void onEditLevelFormat();
   void onLevelFormatEdited();
+  void onIgnoreImageDpiChanged(int index);
   void onShow0ThickLinesChanged(int);
   void onRegionAntialiasChanged(int);
   void onImportPolicyChanged(int);

--- a/toonz/sources/toonzlib/levelproperties.cpp
+++ b/toonz/sources/toonzlib/levelproperties.cpp
@@ -10,7 +10,7 @@
 //**********************************************************************************
 
 LevelOptions::LevelOptions()
-    : m_dpi(Stage::inch)
+    : m_dpi(Stage::standardDpi)
     , m_subsampling(1)
     , m_antialias(0)
     , m_dpiPolicy(DP_ImageDpi)

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -313,6 +313,7 @@ Preferences::Preferences()
     , m_useArrowKeyToShiftCellSelection(false)
     , m_inputCellsWithoutDoubleClickingEnabled(false)
     , m_importPolicy(0)
+    , m_ignoreImageDpi(false)
     , m_watchFileSystem(true) {
   TCamera camera;
   m_defLevelType   = PLI_XSHLEVEL;
@@ -545,7 +546,7 @@ Preferences::Preferences()
   getValue(*m_settings, "DefLevelWidth", m_defLevelWidth);
   getValue(*m_settings, "DefLevelHeight", m_defLevelHeight);
   getValue(*m_settings, "DefLevelDpi", m_defLevelDpi);
-
+  getValue(*m_settings, "IgnoreImageDpi", m_ignoreImageDpi);
   getValue(*m_settings, "viewerBGColor", m_viewerBGColor);
   getValue(*m_settings, "previewBGColor", m_previewBGColor);
   getValue(*m_settings, "chessboardColor1", m_chessboardColor1);
@@ -1268,6 +1269,13 @@ void Preferences::setDefLevelHeight(double height) {
 void Preferences::setDefLevelDpi(double dpi) {
   m_defLevelDpi = dpi;
   m_settings->setValue("DefLevelDpi", dpi);
+}
+
+//-----------------------------------------------------------------
+
+void Preferences::setIgnoreImageDpi(bool on) {
+  m_ignoreImageDpi = on;
+  m_settings->setValue("IgnoreImageDpi", on ? "1" : "0");
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1177,7 +1177,8 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
       const TPointD &imageDpi = xl->getImageDpi();
 
       if (imageDpi == TPointD() ||
-          Preferences::instance()->getUnits() == "pixel") {
+          Preferences::instance()->getUnits() == "pixel" ||
+          Preferences::instance()->isIgnoreImageDpiEnabled()) {
         // Change to "Custom Dpi" policy and use camera dpi
         TStageObjectId cameraId =
             getXsheet()->getStageObjectTree()->getCurrentCameraId();


### PR DESCRIPTION
This creates a new setting in preferences to allow OpenToonz to ignore an images built in DPI and use the current camera dpi.  

It also corrects an error where images without a built in dpi were getting the stage::inch as a default instead of stage::standarddpi.