### PR TITLE
Camera Capture Enhancements

### DIFF
--- a/toonz/sources/include/toonzqt/filefield.h
+++ b/toonz/sources/include/toonzqt/filefield.h
@@ -69,7 +69,8 @@ public:
     virtual ~BrowserPopupController() {}
     virtual bool isExecute() { return true; };
     virtual QString getPath() { return QString(); };
-    virtual void openPopup(QStringList, bool, QString){};
+    virtual void openPopup(QStringList, bool, QString,
+                           const QWidget * = NULL){};
   };
 
   static BrowserPopupController *m_browserPopupController;

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -2072,7 +2072,8 @@ BrowserPopupController::BrowserPopupController() : m_browserPopup() {
 
 void BrowserPopupController::openPopup(QStringList filters,
                                        bool isDirectoryOnly,
-                                       QString lastSelectedPath) {
+                                       QString lastSelectedPath,
+                                       const QWidget *parentWidget) {
   if (!m_browserPopup) m_browserPopup = new BrowserPopup();
   m_browserPopup->setWindowTitle(QString(""));
 
@@ -2083,6 +2084,19 @@ void BrowserPopupController::openPopup(QStringList filters,
                                      : QString(QObject::tr("File Browser")));
   m_browserPopup->initFolder(TFilePath(lastSelectedPath.toStdWString()));
   m_browserPopup->setFileMode(isDirectoryOnly);
+
+  if (parentWidget) {
+    QWidget *pwidget = NULL;
+    foreach (pwidget, QApplication::topLevelWidgets()) {
+      if (pwidget->isWindow() && pwidget->isVisible() &&
+          pwidget->isAncestorOf(parentWidget)) {
+        Qt::WindowFlags flags = m_browserPopup->windowFlags();
+        m_browserPopup->setParent(pwidget);
+        m_browserPopup->setWindowFlags(flags);
+        break;
+      }
+    }
+  }
 
   if (isDirectoryOnly)
     m_browserPopup->setFilename(TFilePath(lastSelectedPath.toStdWString()));

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -433,8 +433,11 @@ public:
   BrowserPopupController();
 
   bool isExecute() override { return m_isExecute; }
+  // if parentWidget is non-zero, then check if the any modal dialog is ancestor
+  // of it.
   void openPopup(QStringList filters, bool isDirectoryOnly,
-                 QString lastSelectedPath) override;
+                 QString lastSelectedPath,
+                 const QWidget *parentWidget = NULL) override;
   QString getPath() override;
 };
 

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -138,11 +138,13 @@ class PencilTestSaveInFolderPopup : public DVGui::Dialog {
 public:
   PencilTestSaveInFolderPopup(QWidget* parent = 0);
   QString getPath();
+  QString getParentPath();
 
 protected slots:
   void updateSubFolderName();
   void onAutoSubNameCBClicked(bool);
   void onShowPopupOnLaunchCBClicked(bool);
+  void onSetAsDefaultBtnPressed();
   void onOkPressed();
 };
 

--- a/toonz/sources/toonzqt/filefield.cpp
+++ b/toonz/sources/toonzqt/filefield.cpp
@@ -94,7 +94,8 @@ void FileField::browseDirectory() {
   if (!m_browserPopupController) return;
   m_browserPopupController->openPopup(
       m_filters, (m_fileMode == QFileDialog::DirectoryOnly),
-      (m_lastSelectedPath == m_descriptionText) ? "" : m_lastSelectedPath);
+      (m_lastSelectedPath == m_descriptionText) ? "" : m_lastSelectedPath,
+      this);
   if (m_browserPopupController->isExecute())
     directory = m_browserPopupController->getPath();
 


### PR DESCRIPTION
This PR enhances & modifies the camera capture feature, which was requested by some Japanese animation studio.

- Enabled to set the current "Save In" folder as default by pressing "Set as Default" button in the subfolder popup.
- Fixed the bug : When clicking "..." (open browser) button next to the Save In field, the camera capture window unexpectedly moves to the behind of the main window.
- Fixed the bug : Changing the "Auto Format" combo box in the subfolder popup does not update the "Subfolder Name" field.