### PR TITLE
Fix to save the column icon loading policy properly on the non-English environment

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -671,7 +671,7 @@ void PreferencesPopup::setChessboardColor2(const TPixel32 &color,
 //-----------------------------------------------------------------------------
 
 void PreferencesPopup::onColumnIconChange(const QString &value) {
-  m_pref->setColumnIconLoadingPolicy(value == QString("At Once")
+  m_pref->setColumnIconLoadingPolicy(value == tr("At Once")
                                          ? Preferences::LoadAtOnce
                                          : Preferences::LoadOnDemand);
 }


### PR DESCRIPTION
This PR fixes the problem as follows:
For now the `Preferences -> Loading -> Column Icon` option is not saved properly on non-English environment.