### PR TITLE
Fix Function Editor to be scrolled synchronously with Xsheet 

### DIFF
--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -94,13 +94,18 @@ void adjustScrollbar(QScrollBar *scrollBar, int add);
 
 void FrameScroller::onScroll(const CellPositionRatio &ratio) {
   QPoint offset = orientation()->positionRatioToXY(ratio);
+  // scroll area should be resized before moving down the scroll bar.
+  // SpreadsheetViewer::onPrepareToScrollOffset() will be invoked immediately
+  // since the receiver is in the same thread.
+  // when moving up the scroll bar, resizing will be done in
+  // SpreadsheetViewer::onVSliderChanged().
+  if (offset.x() > 0 || offset.y() > 0) emit prepareToScrollOffset(offset);
   if (offset.x())
     adjustScrollbar(m_scrollArea->horizontalScrollBar(), offset.x());
   if (offset.y())
     adjustScrollbar(m_scrollArea->verticalScrollBar(), offset.y());
-
-  emit prepareToScrollOffset(offset);
 }
+
 void adjustScrollbar(QScrollBar *scrollBar, int add) {
   scrollBar->setValue(scrollBar->value() + add);
 }


### PR DESCRIPTION
This PR will fix the problem as follows:

The function editor does not scroll synchronously with the Xsheet, especially it is obvious when using the mouse wheel.
- When wheel-down, it does not start scroll when the scroll bar is at the top.
- When wheel-up, it scrolls double.

![wheel_bug](https://user-images.githubusercontent.com/17974955/28412610-b4f83a10-6d7f-11e7-9507-20b0e84995ec.gif)


