### PR TITLE
Sound Scrubbing in Combo Viewer and Missing Updates in Scene Viewer by turtletooth (Removed unused source)

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -245,7 +245,7 @@ public:
   void getFrameRange(int &from, int &to, int &step) const {
     from = m_from, to = m_to, step = m_step;
   }
-  void setFrameRate(int rate);
+  void setFrameRate(int rate, bool forceUpdate = true);
   // if doShowHide==true, applies set visible, otherwise applies setEnabled
   void enableButton(UINT button, bool enable, bool doShowHide = true);
   void showCurrentFrame();
@@ -331,7 +331,7 @@ private:
   ImagePainter::VisualSettings m_settings;
 
   bool m_isPlay;
-  int m_fps;
+  int m_fps, m_sceneFps;
   bool m_reverse;
   int m_markerFrom, m_markerTo;
   bool m_drawBlanksEnabled;

--- a/toonz/sources/include/toonzqt/flipconsoleowner.h
+++ b/toonz/sources/include/toonzqt/flipconsoleowner.h
@@ -18,8 +18,6 @@ public:
   virtual void onDrawFrame(int frame,
                            const ImagePainter::VisualSettings &settings) = 0;
 
-  // return true if the frmae is in cache. reimplemented only in Flipbook
-  virtual bool isFrameAlreadyCached(int frame) { return true; };
   virtual void swapBuffers(){};
   virtual void changeSwapBehavior(bool enable){};
 };

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -714,6 +714,14 @@ void ComboViewerPanel::onSceneChanged() {
   int frameIndex    = fh->getFrameIndex();
   int maxFrameIndex = fh->getMaxFrameIndex();
   if (frameIndex > maxFrameIndex) maxFrameIndex = frameIndex;
+  // update fps only when the scene settings is changed
+  m_flipConsole->setFrameRate(TApp::instance()
+                                  ->getCurrentScene()
+                                  ->getScene()
+                                  ->getProperties()
+                                  ->getOutputProperties()
+                                  ->getFrameRate(),
+                              false);
   // update the frame slider's range with new frameHandle
   m_flipConsole->setFrameRange(1, maxFrameIndex + 1, 1, frameIndex + 1);
 
@@ -736,7 +744,6 @@ void ComboViewerPanel::onSceneSwitched() {
   enableFlipConsoleForCamerastand(false);
   m_sceneViewer->enablePreview(SceneViewer::NO_PREVIEW);
   m_flipConsole->setChecked(FlipConsole::eDefineSubCamera, false);
-  // set the FPS for new scene
   m_flipConsole->setFrameRate(TApp::instance()
                                   ->getCurrentScene()
                                   ->getScene()

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -411,35 +411,12 @@ void ComboViewerPanel::showEvent(QShowEvent *event) {
 
 void ComboViewerPanel::hideEvent(QHideEvent *event) {
   StyleShortcutSwitchablePanel::hideEvent(event);
-  TApp *app                    = TApp::instance();
-  TFrameHandle *frameHandle    = app->getCurrentFrame();
-  TSceneHandle *sceneHandle    = app->getCurrentScene();
-  TXshLevelHandle *levelHandle = app->getCurrentLevel();
-  TObjectHandle *objectHandle  = app->getCurrentObject();
-  TXsheetHandle *xshHandle     = app->getCurrentXsheet();
-
-  disconnect(xshHandle, SIGNAL(xsheetChanged()), this, SLOT(onSceneChanged()));
-
-  disconnect(sceneHandle, SIGNAL(sceneChanged()), this, SLOT(onSceneChanged()));
-  disconnect(sceneHandle, SIGNAL(nameSceneChanged()), this,
-             SLOT(changeWindowTitle()));
-  disconnect(sceneHandle, SIGNAL(sceneSwitched()), this,
-             SLOT(onSceneChanged()));
-  disconnect(levelHandle, SIGNAL(xshLevelSwitched(TXshLevel *)), this,
-             SLOT(onXshLevelSwitched(TXshLevel *)));
-  disconnect(levelHandle, SIGNAL(xshLevelChanged()), this,
-             SLOT(changeWindowTitle()));
-  disconnect(levelHandle, SIGNAL(xshLevelTitleChanged()), this,
-             SLOT(changeWindowTitle()));
-  disconnect(levelHandle, SIGNAL(xshLevelChanged()), this,
-             SLOT(updateFrameRange()));
-
-  disconnect(frameHandle, SIGNAL(frameSwitched()), this,
-             SLOT(changeWindowTitle()));
-  disconnect(frameHandle, SIGNAL(frameSwitched()), this,
-             SLOT(onFrameChanged()));
-  disconnect(frameHandle, SIGNAL(frameTypeChanged()), this,
-             SLOT(onFrameTypeChanged()));
+  TApp *app = TApp::instance();
+  disconnect(app->getCurrentFrame(), 0, this, 0);
+  disconnect(app->getCurrentScene(), 0, this, 0);
+  disconnect(app->getCurrentLevel(), 0, this, 0);
+  disconnect(app->getCurrentObject(), 0, this, 0);
+  disconnect(app->getCurrentXsheet(), 0, this, 0);
 
   disconnect(app->getCurrentTool(), SIGNAL(toolSwitched()), m_sceneViewer,
              SLOT(onToolSwitched()));
@@ -737,14 +714,6 @@ void ComboViewerPanel::onSceneChanged() {
   int frameIndex    = fh->getFrameIndex();
   int maxFrameIndex = fh->getMaxFrameIndex();
   if (frameIndex > maxFrameIndex) maxFrameIndex = frameIndex;
-
-  // set the FPS for new scene
-  m_flipConsole->setFrameRate(TApp::instance()
-                                  ->getCurrentScene()
-                                  ->getScene()
-                                  ->getProperties()
-                                  ->getOutputProperties()
-                                  ->getFrameRate());
   // update the frame slider's range with new frameHandle
   m_flipConsole->setFrameRange(1, maxFrameIndex + 1, 1, frameIndex + 1);
 
@@ -767,6 +736,13 @@ void ComboViewerPanel::onSceneSwitched() {
   enableFlipConsoleForCamerastand(false);
   m_sceneViewer->enablePreview(SceneViewer::NO_PREVIEW);
   m_flipConsole->setChecked(FlipConsole::eDefineSubCamera, false);
+  // set the FPS for new scene
+  m_flipConsole->setFrameRate(TApp::instance()
+                                  ->getCurrentScene()
+                                  ->getScene()
+                                  ->getProperties()
+                                  ->getOutputProperties()
+                                  ->getFrameRate());
   m_sceneViewer->setEditPreviewSubcamera(false);
   onSceneChanged();
 }
@@ -815,16 +791,6 @@ void ComboViewerPanel::onFrameTypeChanged() {
   // if in the level editing mode, ignore the preview marker
   else
     m_flipConsole->setMarkers(0, -1);
-}
-
-//-----------------------------------------------------------------------------
-
-bool ComboViewerPanel::isFrameAlreadyCached(int frame) {
-  if (m_sceneViewer->isPreviewEnabled()) {
-    class Previewer *pr = Previewer::instance();
-    return pr->isFrameReady(frame - 1);
-  } else
-    return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/comboviewerpane.h
+++ b/toonz/sources/toonz/comboviewerpane.h
@@ -89,9 +89,6 @@ public:
   void onDrawFrame(int frame,
                    const ImagePainter::VisualSettings &settings) override;
 
-  // reimplementation of FlipConsoleOwner::isFrameAlreadyCached
-  bool isFrameAlreadyCached(int frame) override;
-
 protected:
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -600,12 +600,6 @@ void SceneViewerPanel::onSceneChanged() {
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
   assert(scene);
-  m_flipConsole->setFrameRate(TApp::instance()
-                                  ->getCurrentScene()
-                                  ->getScene()
-                                  ->getProperties()
-                                  ->getOutputProperties()
-                                  ->getFrameRate());
   // vinz: perche veniva fatto?
   // m_flipConsole->updateCurrentFPS(scene->getProperties()->getOutputProperties()->getFrameRate());
 
@@ -623,6 +617,12 @@ void SceneViewerPanel::onSceneSwitched() {
   enableFlipConsoleForCamerastand(false);
   m_sceneViewer->enablePreview(SceneViewer::NO_PREVIEW);
   m_flipConsole->setChecked(FlipConsole::eDefineSubCamera, false);
+  m_flipConsole->setFrameRate(TApp::instance()
+                                  ->getCurrentScene()
+                                  ->getScene()
+                                  ->getProperties()
+                                  ->getOutputProperties()
+                                  ->getFrameRate());
   m_sceneViewer->setEditPreviewSubcamera(false);
   onSceneChanged();
 }
@@ -664,16 +664,6 @@ void SceneViewerPanel::onFrameTypeChanged() {
 
   updateFrameRange();
   updateFrameMarkers();
-}
-
-//-----------------------------------------------------------------------------
-
-bool SceneViewerPanel::isFrameAlreadyCached(int frame) {
-  if (m_sceneViewer->isPreviewEnabled()) {
-    class Previewer *pr = Previewer::instance();
-    return pr->isFrameReady(frame - 1);
-  } else
-    return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -600,6 +600,14 @@ void SceneViewerPanel::onSceneChanged() {
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
   assert(scene);
+  // update fps only when the scene settings is changed
+  m_flipConsole->setFrameRate(TApp::instance()
+                                  ->getCurrentScene()
+                                  ->getScene()
+                                  ->getProperties()
+                                  ->getOutputProperties()
+                                  ->getFrameRate(),
+                              false);
   // vinz: perche veniva fatto?
   // m_flipConsole->updateCurrentFPS(scene->getProperties()->getOutputProperties()->getFrameRate());
 

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -60,8 +60,6 @@ public:
   bool widgetInThisPanelIsFocused() override {
     return m_sceneViewer->hasFocus();
   }
-  // reimplementation of FlipConsoleOwner::isFrameAlreadyCached
-  bool isFrameAlreadyCached(int frame) override;
 
 protected:
   void showEvent(QShowEvent *) override;

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -443,6 +443,7 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, UINT gadgetsMask,
     , m_framesCount(1)
     , m_settings()
     , m_fps(24)
+    , m_sceneFps(24)
     , m_isPlay(false)
     , m_reverse(false)
     , m_doubleRed(0)
@@ -841,10 +842,13 @@ void FlipConsole::updateCurrentFPS(int val) {
 
 //-----------------------------------------------------------------------------
 
-void FlipConsole::setFrameRate(int val) {
-  if (!m_fpsSlider) return;
-  m_fpsSlider->setValue(val);
-  setCurrentFPS(val);
+void FlipConsole::setFrameRate(int val, bool forceUpdate) {
+  if (m_sceneFps != val || forceUpdate) {
+    if (!m_fpsSlider) return;
+    m_fpsSlider->setValue(val);
+    setCurrentFPS(val);
+  }
+  m_sceneFps = val;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR is based on #1260 by @turtletooth , just revised slightly as follows:

- Removed unnecessary code `isFrameAlreadyCached`.
- Moved the timing of resetting the console's frame rate from changing the scene to switching the scene.
- Simplified `ComboViewerPanel::hideEvent`

Again, thank you @turtletooth for the fix!