### PR TITLE
Show Renamed Names in MacroFx

### DIFF
--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -2596,14 +2596,16 @@ FxSchematicNormalFxNode::FxSchematicNormalFxNode(FxSchematicScene *scene,
       std::vector<TFxP> macroFxs = macroFx->getFxs();
       int j;
       for (j = 0; j < (int)macroFxs.size(); j++) {
-        TFx *inMacroFx = macroFxs[j].getPointer();
+        TFx *inMacroFx      = macroFxs[j].getPointer();
+        std::wstring fxName = inMacroFx->getName();
+        QString qFxName     = QString::fromStdWString(fxName);
         if (inMacroFx->getFxId() == qInMacroFxId.toStdWString()) {
           int count = inMacroFx->getInputPortCount();
           if (count == 1)
-            qPortName = qInMacroFxId;
+            qPortName = qFxName;
           else {
             qPortName.remove(1, qPortName.size());
-            qPortName += ". " + qInMacroFxId;
+            qPortName += ". " + qFxName;
           }
         }
       }


### PR DESCRIPTION
![renamed](https://user-images.githubusercontent.com/4576381/28750619-b59c00ac-74ad-11e7-8882-73201b671f7a.JPG)


If a user has renamed a fx (ctrl + double click), the new name isn't used for the port name in macroFx.  The renamed name is probably more descriptive for the user than the generic name - if they have gone through the work of renaming it.  They can still see the original name/type by hovering over the port.