### PR TITLE
Enable to use template settings for preferences

### DIFF
--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -325,8 +325,11 @@ Preferences::Preferences()
   TFilePath layoutDir = ToonzFolder::getMyModuleDir();
   TFilePath savePath  = layoutDir + TFilePath("preferences.ini");
 
+  // If no personal settings found, then try to load template settings
+  TFilePath loadPath = ToonzFolder::getModuleFile(TFilePath("preferences.ini"));
+
   m_settings.reset(new QSettings(
-      QString::fromStdWString(savePath.getWideString()), QSettings::IniFormat));
+      QString::fromStdWString(loadPath.getWideString()), QSettings::IniFormat));
 
   getValue(*m_settings, "autoExposeEnabled", m_autoExposeEnabled);
   getValue(*m_settings, "autoCreateEnabled", m_autoCreateEnabled);
@@ -598,6 +601,16 @@ Preferences::Preferences()
            m_inputCellsWithoutDoubleClickingEnabled);
   getValue(*m_settings, "importPolicy", m_importPolicy);
   getValue(*m_settings, "watchFileSystemEnabled", m_watchFileSystem);
+
+  // in case there is no personal settings
+  if (savePath != loadPath) {
+    // copy the template settins to the personal one
+    if (TFileStatus(loadPath).doesExist())
+      TSystem::copyFile(savePath, loadPath);
+    m_settings.reset(
+        new QSettings(QString::fromStdWString(savePath.getWideString()),
+                      QSettings::IniFormat));
+  }
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
This feature is demanded by some Japanese animation studio.
In the studio, animators use OpenToonz only for pencil testing.
There are some preferable options for pencil testing in preferences, so they would like to introduce the template settings in order to cut out the need of initial customization for new users.

With this PR, if there is no `preferences.ini` in  `$TOONZPROFILES\layouts\settings.username` , then try to load the template settings `$TOONZPROFILES\layouts\settings\preferences.ini` .
Nothing is changed in behavior if there is no template settings.