### PR TITLE
Fix for Scrubbing Shortcuts

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -1645,7 +1645,7 @@ void BrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   // locals.addMinMax(
   //  TToonzImageP(getImage(false, 1)) ? m_rasThickness : m_thickness, add);
   //} else
-  if (e.isCtrlPressed() && e.isAltPressed()) {
+  if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed()) {
     const TPointD &diff = pos - m_mousePos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;
@@ -2007,8 +2007,7 @@ BrushData::BrushData()
     , m_join(0)
     , m_miter(0)
     , m_modifierSize(0.0)
-    , m_modifierOpacity(0.0)
-    {}
+    , m_modifierOpacity(0.0) {}
 
 //----------------------------------------------------------------------------------------------------------
 
@@ -2029,8 +2028,7 @@ BrushData::BrushData(const std::wstring &name)
     , m_join(0)
     , m_miter(0)
     , m_modifierSize(0.0)
-    , m_modifierOpacity(0.0)
-    {}
+    , m_modifierOpacity(0.0) {}
 
 //----------------------------------------------------------------------------------------------------------
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -489,7 +489,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
   } else if (m_mouseButton == Qt::MidButton) {
     if ((event.buttons() & Qt::MidButton) == 0) m_mouseButton = Qt::NoButton;
     // scrub with shift and middle click
-    else if (event.isShiftPressed()) {
+    else if (event.isShiftPressed() && event.isCtrlPressed()) {
       if (curPos.x() > m_pos.x()) {
         CommandManager::instance()->execute("MI_NextFrame");
       } else if (curPos.x() < m_pos.x()) {
@@ -727,7 +727,10 @@ void SceneViewer::wheelEvent(QWheelEvent *event) {
   int delta = 0;
   switch (event->source()) {
   case Qt::MouseEventNotSynthesized: {
-    delta = event->angleDelta().y();
+    if (event->modifiers() & Qt::AltModifier)
+      delta = event->angleDelta().x();
+    else
+      delta = event->angleDelta().y();
     break;
   }
 
@@ -756,20 +759,23 @@ void SceneViewer::wheelEvent(QWheelEvent *event) {
 
   if (abs(delta) > 0) {
     // scrub with mouse wheel
-    if ((event->modifiers() & Qt::ControlModifier) &&
-        (event->modifiers() & Qt::ShiftModifier)) {
+    if ((event->modifiers() & Qt::AltModifier) &&
+        (event->modifiers() & Qt::ShiftModifier) &&
+        (event->modifiers() & Qt::ControlModifier)) {
       if (delta < 0) {
         CommandManager::instance()->execute("MI_NextStep");
       } else if (delta > 0) {
         CommandManager::instance()->execute("MI_PrevStep");
       }
-    } else if (event->modifiers() & Qt::ShiftModifier) {
+    } else if ((event->modifiers() & Qt::ControlModifier) &&
+               (event->modifiers() & Qt::ShiftModifier)) {
       if (delta < 0) {
         CommandManager::instance()->execute("MI_NextFrame");
       } else if (delta > 0) {
         CommandManager::instance()->execute("MI_PrevFrame");
       }
-    } else if (event->modifiers() & Qt::ControlModifier) {
+    } else if ((event->modifiers() & Qt::ShiftModifier) &&
+               (event->modifiers() & Qt::AltModifier)) {
       if (delta < 0) {
         CommandManager::instance()->execute("MI_NextDrawing");
       } else if (delta > 0) {


### PR DESCRIPTION
This is a fix for the mouse scrubbing shortcuts that was requested in #1307.
The previous shortcuts were to easy to accidentally trigger.
The new shortcuts are:
ctrl + shift + drag = next/prev frames
ctrl + shift + scroll = next/prev frames
alt + shift + scroll = next/prev drawings
ctrl + shift + alt = next/prev step

I couldn't do ctrl + alt as suggested as that is the shortcut for changing brush sizes.