### PR TITLE
Fix Camera Capture feature crash on OS X with Qt5.6

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -4,7 +4,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt@5.5/5.5.1_1/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt5/5.6.1-1/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make

--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 brew update
-brew install qt55 glew lz4 lzo libusb libmypaint
+brew install qt56 glew lz4 lzo libusb libmypaint
 brew tap tcr/tcr
 brew install clang-format

--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 brew update
-brew install qt56 glew lz4 lzo libusb libmypaint
+brew install glew lz4 lzo libusb libmypaint
 brew tap tcr/tcr
 brew install clang-format
+# obtain qt5.6 from the previous version of the formula
+curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/fdfc724dd532345f5c6cdf47dc43e99654e6a5fd/Formula/qt5.rb
+brew install ./qt5.rb

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -245,6 +245,7 @@ find_package(Qt5 REQUIRED
     PrintSupport
     LinguistTools
     Multimedia
+    MultimediaWidgets
 )
 
 set(QT_MINIMUM_VERSION 5.5.0)

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -409,7 +409,7 @@ elseif(BUILD_ENV_APPLE)
 
     target_link_libraries(OpenToonz_${VERSION}
         Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
-        Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia
+        Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::MultimediaWidgets
         ${GL_LIB} ${GLUT_LIB}
         ${COCOA_LIB} ${EXTRA_LIBS} mousedragfilter
     )

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -45,6 +45,7 @@
 #include <QCamera>
 #include <QCameraImageCapture>
 #include <QCameraViewfinderSettings>
+#include <QCameraViewfinder>
 
 #include <QComboBox>
 #include <QPushButton>
@@ -944,6 +945,10 @@ PencilTestPopup::PencilTestPopup()
 
   QPushButton* subfolderButton = new QPushButton(tr("Subfolder"), this);
 
+#ifdef MACOSX
+  m_dummyViewFinder = new QCameraViewfinder(this);
+  m_dummyViewFinder->hide();
+#endif
   //----
 
   m_resolutionCombo->setMaximumWidth(fontMetrics().width("0000 x 0000") + 25);
@@ -1297,6 +1302,12 @@ void PencilTestPopup::onCameraListComboActivated(int comboIndex) {
                this, SLOT(onImageCaptured(int, const QImage&)));
     delete m_cameraImageCapture;
   }
+
+#ifdef MACOSX
+  // this line is needed only in macosx
+  m_currentCamera->setViewfinder(m_dummyViewFinder);
+#endif
+
   m_cameraImageCapture = new QCameraImageCapture(m_currentCamera, this);
   /* Capturing to buffer currently seems not to be supported on Windows */
   // if
@@ -1367,6 +1378,10 @@ void PencilTestPopup::onResolutionComboActivated(const QString& itemText) {
   imageEncoderSettings.setResolution(newResolution);
   m_cameraImageCapture->setEncodingSettings(imageEncoderSettings);
   m_cameraViewfinder->updateSize();
+
+#ifdef MACOSX
+  m_dummyViewFinder->resize(newResolution);
+#endif
 
   // reset white bg
   m_whiteBGImg = QImage();

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -45,7 +45,9 @@
 #include <QCamera>
 #include <QCameraImageCapture>
 #include <QCameraViewfinderSettings>
+#ifdef MACOSX
 #include <QCameraViewfinder>
+#endif
 
 #include <QComboBox>
 #include <QPushButton>

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -22,6 +22,9 @@ class QTimer;
 class QIntValidator;
 class QRegExpValidator;
 class QPushButton;
+#ifdef MACOSX
+class QCameraViewfinder;
+#endif
 
 namespace DVGui {
 class FileField;
@@ -182,6 +185,10 @@ class PencilTestPopup : public DVGui::Dialog {
   PencilTestSaveInFolderPopup* m_saveInFolderPopup;
 
   CameraCaptureLevelControl* m_camCapLevelControl;
+
+#ifdef MACOSX
+  QCameraViewfinder* m_dummyViewFinder;
+#endif
 
   int m_timerId;
   QString m_cacheImagePath;


### PR DESCRIPTION
This PR will fix the problem that using the Camera Capture feature crashes the software, on OS X version built with Qt 5.6.

According to [the comment posted in QTBUG-49170](https://bugreports.qt.io/browse/QTBUG-49170?focusedCommentId=297714&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-297714), it seems that calling `QCamera::setViewfinder()` is needed only on OS X.

Since the crash can be avoided with this fix, I changed Qt version from 5.5 to 5.6 in Travis CI.
I'll update the OSX installer to use Qt5.6 as well, as soon as this fix will be merged.