### PR TITLE
Fix cleanup problem when the source image has no DPI

### DIFF
--- a/toonz/sources/include/toonz/tcleanupper.h
+++ b/toonz/sources/include/toonz/tcleanupper.h
@@ -57,7 +57,7 @@ public:
 
 class DVAPI TCleanupper {
   CleanupParameters *m_parameters;
-  TPointD m_customDpi;
+  TPointD m_sourceDpi;
 
 private:
   TCleanupper()
@@ -101,8 +101,8 @@ time, to unlock a possibly useful memory block.
   TRasterImageP autocenterOnly(const TRasterImageP &image, bool isCameraTest,
                                bool &autocentered);
 
-  TPointD getCustomDpi() const { return m_customDpi; }
-  void setCustomDpi(const TPointD &dpi) { m_customDpi = dpi; }
+  TPointD getSourceDpi() const { return m_sourceDpi; }
+  void setSourceDpi(const TPointD &dpi) { m_sourceDpi = dpi; }
 
 private:
   // process phase

--- a/toonz/sources/toonz/cleanupsettingsmodel.cpp
+++ b/toonz/sources/toonz/cleanupsettingsmodel.cpp
@@ -420,10 +420,10 @@ void CleanupSettingsModel::processFrame(TXshSimpleLevel *sl, TFrameId fid) {
   bool doCameraTest = (m_cameraTestsCount > 0);
 
   // Retrieve new image dpi
-  double dpix, dpiy;
-  imageToCleanup->getDpi(dpix, dpiy);
-  cl->setCustomDpi((dpix == 0 && dpiy == 0) ? sl->getProperties()->getDpi()
-                                            : TPointD());
+  TPointD dpi;
+  imageToCleanup->getDpi(dpi.x, dpi.y);
+  if (dpi.x == 0 && dpi.y == 0) dpi = sl->getProperties()->getDpi();
+  cl->setSourceDpi(dpi);
 
   // Perform primary cleanup processing
   if (doProcessing) {

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1332,13 +1332,13 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
   if (yetToCleanupCell)  // ORIENTATION: what's this?
   {
     if (o->isVerticalTimeline())
-      p.fillRect(
-          rect.adjusted(rect.width() / 2, 0, 0, 0),
-          (isSelected) ? SelectedFullcolorColumnColor : FullcolorColumnColor);
+      p.fillRect(rect.adjusted(rect.width() / 2, 0, 0, 0),
+                 (isSelected) ? m_viewer->getSelectedFullcolorColumnColor()
+                              : m_viewer->getFullcolorColumnColor());
     else
-      p.fillRect(
-          rect.adjusted(0, rect.height() / 2, 0, 0),
-          (isSelected) ? SelectedFullcolorColumnColor : FullcolorColumnColor);
+      p.fillRect(rect.adjusted(0, rect.height() / 2, 0, 0),
+                 (isSelected) ? m_viewer->getSelectedFullcolorColumnColor()
+                              : m_viewer->getFullcolorColumnColor());
   }
 
   bool isLastRow = nextCell.isEmpty() ||

--- a/toonz/sources/toonzlib/tcleanupper.cpp
+++ b/toonz/sources/toonzlib/tcleanupper.cpp
@@ -416,11 +416,11 @@ bool TCleanupper::getResampleValues(const TRasterImageP &image, TAffine &aff,
        saveBox.getLy() > 0 && saveBox.getLy() < rasterLy))
     raster_is_savebox = false;
 
-  image->getDpi(dpi.x, dpi.y);
-  if (dpi == TPointD()) {
-    dpi                         = getCustomDpi();
-    if (dpi == TPointD()) dpi.x = dpi.y = 65.0;  // using 65.0 as default DPI
-  } else if (!dpi.x)
+  // Use the same source dpi throughout the level
+  dpi = getSourceDpi();
+  if (dpi == TPointD())
+    dpi.x = dpi.y = 65.0;  // using 65.0 as default DPI //??????WHY
+  else if (!dpi.x)
     dpi.x = dpi.y;
   else if (!dpi.y)
     dpi.y = dpi.x;


### PR DESCRIPTION
This PR fixes the following problem which is reported by some Japanese animation production:

#### PROBLEM
When cleanup raster levels which has no dpi (for instance, non-antialiased TGA images), the first frame looks OK, but the following frames change its size irregularly and the images are not resampled nor smoothed. 
This problem does NOT occur if the source raster level has dpi information in its file format  (such as TIF images).

#### CAUSE OF THE PROBLEM
For now, in cleanup procedure the dpi of source image is obtained for each frame. 
If the source raster level has no image dpi, then the custom dpi in the level settings is retrieved as the source image dpi. 
However, just after processing the first frame, the custom dpi will be overwritten by the dpi of cleanup camera. This is why the second and the following frames becomes wrong size.

I fixed this behavior to use always the dpi of the first frame throughout the level.

In this PR I also fixed the following cleanup-related problems:
- Added missing `m_firstLevelFrame` initialization in the `CleanupPopup` constructor.
- Fixed color of cells of "partially cleanupped" level.

#### CAUTION
Cleanup of the raster levels with no dpi still has issues, in the case you cleanup partial frames and then cleanup the rest later.
Even if you cleanup the level partially, the level's dpi will be overwritten by the cleanup camera's dpi. So you need to revert the custom dpi before you start cleanup of the remaining frames.