### PR TITLE
Camera Capture enhancement : Added the information label and the previous level button

### DIFF
--- a/toonz/sources/include/toonz/namebuilder.h
+++ b/toonz/sources/include/toonz/namebuilder.h
@@ -33,7 +33,9 @@ public:
 //-------------------------------------------------------------------
 
 // NameCreator genera la sequenza 'A', 'B', ...
-class DVAPI NameCreator final : public NameBuilder {
+// inherited by FlexibleNameCreator
+class DVAPI NameCreator : public NameBuilder {
+protected:
   std::vector<int> m_s;
 
 public:

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -2301,7 +2301,7 @@ void PencilTestPopup::refreshFrameInfo() {
       // if the saved images has not the same resolution as the current camera
       // resolution
       if (camRes != dim) {
-        tooltipStr += tr("\nWARNING : Image size mismatch. The saved image "
+        tooltipStr += tr("WARNING : Image size mismatch. The saved image "
                          "size is %1 x %2.")
                           .arg(dim.lx)
                           .arg(dim.ly);
@@ -2318,16 +2318,16 @@ void PencilTestPopup::refreshFrameInfo() {
                             .arg(fidsToString(fids, letterOptionEnabled));
         // if the frame exists, then it will be overwritten
         if (frameExist) {
-          labelStr += tr("OVERWRITE");
+          labelStr += tr("OVERWRITE one of");
           infoType = OVERWRITE;
         } else {
-          labelStr += tr("ADD");
+          labelStr += tr("ADD to");
           infoType = ADD;
         }
         if (frameCount == 1)
-          labelStr += tr(" : %1 frame exists").arg(frameCount);
+          labelStr += tr(" %1 frame").arg(frameCount);
         else
-          labelStr += tr(" : %1 frames exist").arg(frameCount);
+          labelStr += tr(" %1 frames").arg(frameCount);
       }
     }
     // If no level exists in the file system, then it will be a new level
@@ -2378,18 +2378,18 @@ void PencilTestPopup::refreshFrameInfo() {
       }
       // If there is already the frame then it will be overwritten
       if (hasFrame) {
-        labelStr += tr("OVERWRITE");
+        labelStr += tr("OVERWRITE one of");
         infoType = OVERWRITE;
       }
       // Or, the frame will be added to the level
       else {
-        labelStr += tr("ADD");
+        labelStr += tr("ADD to");
         infoType = ADD;
       }
       if (frameCount == 1)
-        labelStr += tr(" : %1 frame exists").arg(frameCount);
+        labelStr += tr(" %1 frame").arg(frameCount);
       else
-        labelStr += tr(" : %1 frames exist").arg(frameCount);
+        labelStr += tr(" %1 frames").arg(frameCount);
     }
   }
   // ### CASE 3 ###
@@ -2398,7 +2398,7 @@ void PencilTestPopup::refreshFrameInfo() {
     if (level_sameName) {
       TFilePath anotherPath = level_sameName->getPath();
       tooltipStr +=
-          tr("\nWARNING : Level name conflicts. There already is the level %1 in the scene with the path\
+          tr("WARNING : Level name conflicts. There already is a level %1 in the scene with the path\
                         \n          %2.")
               .arg(QString::fromStdWString(levelName))
               .arg(toQString(anotherPath));
@@ -2417,8 +2417,9 @@ void PencilTestPopup::refreshFrameInfo() {
     }
     if (level_samePath) {
       std::wstring anotherName = level_samePath->getName();
+      if (!tooltipStr.isEmpty()) tooltipStr += QString("\n");
       tooltipStr +=
-          tr("\nWARNING : Level path conflicts. There already is the level with the path %1\
+          tr("WARNING : Level path conflicts. There already is a level with the path %1\
                         \n          in the scene with the name %2.")
               .arg(toQString(levelFp))
               .arg(QString::fromStdWString(anotherName));

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -5,6 +5,7 @@
 
 #include "toonzqt/dvdialog.h"
 #include "toonzqt/lineedit.h"
+#include "toonz/namebuilder.h"
 
 #include <QFrame>
 
@@ -127,6 +128,18 @@ signals:
 };
 
 //=============================================================================
+// FlexibleNameCreator
+// Inherits NameCreator, added function for obtaining the previous name and
+// setting the current name.
+
+class FlexibleNameCreator final : public NameCreator {
+public:
+  FlexibleNameCreator() {}
+  std::wstring getPrevious();
+  bool setCurrent(std::wstring name);
+};
+
+//=============================================================================
 // PencilTestSaveInFolderPopup
 //-----------------------------------------------------------------------------
 
@@ -188,6 +201,8 @@ class PencilTestPopup : public DVGui::Dialog {
 
   QLabel* m_frameInfoLabel;
 
+  QToolButton* m_previousLevelButton;
+
 #ifdef MACOSX
   QCameraViewfinder* m_dummyViewFinder;
 #endif
@@ -199,6 +214,9 @@ class PencilTestPopup : public DVGui::Dialog {
 
   void processImage(QImage& procImage);
   bool importImage(QImage& image);
+
+  void setToNextNewLevel();
+  void updateLevelNameAndFrame(std::wstring levelName);
 
 public:
   PencilTestPopup();
@@ -218,6 +236,7 @@ protected slots:
   void onFileFormatOptionButtonPressed();
   void onLevelNameEdited();
   void onNextName();
+  void onPreviousName();
   void onColorTypeComboChanged(int index);
   void onImageCaptured(int, const QImage&);
   void onCaptureWhiteBGButtonPressed();

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -186,6 +186,8 @@ class PencilTestPopup : public DVGui::Dialog {
 
   CameraCaptureLevelControl* m_camCapLevelControl;
 
+  QLabel* m_frameInfoLabel;
+
 #ifdef MACOSX
   QCameraViewfinder* m_dummyViewFinder;
 #endif
@@ -228,6 +230,8 @@ protected slots:
 
   void onCaptureButtonClicked(bool);
   void onCaptureFilterSettingsBtnPressed();
+
+  void refreshFrameInfo();
 
 public slots:
   void openSaveInFolderPopup();


### PR DESCRIPTION
This PR enhances the Camera Capture feature in following 3 points: 

* Added the information label below the level name field, which indicates how many frames exist in the level and what will happen when you hit the capture button with the current parameters. It shows one of the following 4 status:
  * NEW - The captured frame will be the first frame of the newly-created level.
  * ADD - The captured frame will be added to the existing level.
  * OVERWRITE - The captured frame will overwrite the existing frame.
  * WARNING - The frame cannot be captured for some reasons.
Furthermore, you can see the detailed information in the tool tip of the information label.

* Added a button to select the previous level name on the left side of the level name field.

* Modified the cell placement behavior after the image captured.

These features were requested by some Japanese animation studio.

![camcap_frameinfo](https://user-images.githubusercontent.com/17974955/29361946-b0d5482e-82c4-11e7-934f-e2b4ba4bb5b3.png)
