### PR TITLE
Replace  'zanzo' with 'Afterimage' in current.txt

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1040,8 +1040,8 @@
   <item>"STD_inoMotionBlurFx.y2"	"Y2"	</item>
   <item>"STD_inoMotionBlurFx.scale"	"Scale"	</item>
   <item>"STD_inoMotionBlurFx.curve"	"Curve"	</item>
-  <item>"STD_inoMotionBlurFx.zanzo_length"	"Zanzo Length"	</item>
-  <item>"STD_inoMotionBlurFx.zanzo_power"	"Zanzo Power"	</item>
+  <item>"STD_inoMotionBlurFx.zanzo_length"	"Afterimage Length"	</item>
+  <item>"STD_inoMotionBlurFx.zanzo_power"	"Afterimage Power"	</item>
   <item>"STD_inoMotionBlurFx.alpha_rendering"	"Alpha Rendering"	</item>
   <item>"STD_inoMotionWindFx"	"Motion Wind Ino"	</item>
   <item>"STD_inoMotionWindFx.direction"	"Direction"	</item>
@@ -1127,7 +1127,7 @@
   <item>"STD_iwa_MotionBlurCompFx.startCurve" "Start Curve"	</item>
   <item>"STD_iwa_MotionBlurCompFx.endValue" "End Value"	</item>
   <item>"STD_iwa_MotionBlurCompFx.endCurve" "End Curve"	</item>
-  <item>"STD_iwa_MotionBlurCompFx.zanzoMode" "Zanzo Mode"	</item>
+  <item>"STD_iwa_MotionBlurCompFx.zanzoMode" "Afterimage Mode"	</item>
   <item>"STD_iwa_MotionBlurCompFx.premultiType" "Source Premultiply Type"	</item>
 
   <item>"STD_iwa_PerspectiveDistortFx"			"Perspective Distort Iwa"</item>


### PR DESCRIPTION
LIne 1043, 1044 and 1130 of current.txt updated with translation of term 'zanzo' to 'afterimage' in the dialog settings of Motion Blur Ino and Motion Blur Iwa.  This is a UI update only.   Occurrences of 'zanzo' in other locations are not effected.