### PR TITLE
XSheetToolbar Fixes and New Pane

### DIFF
--- a/stuff/config/qss/Astral_048_VeryDark/Astral_048_VeryDark.qss
+++ b/stuff/config/qss/Astral_048_VeryDark/Astral_048_VeryDark.qss
@@ -1489,7 +1489,7 @@ FxSettings QToolBar QToolBar {
    Tool Options
 ----------------------------------------------------------------------------- */
 #ToolOptions TPanelTitleBar,
-#XSheetToolBar TPanelTitleBar {
+#CommandBar TPanelTitleBar {
   background-color: #303030;
   background-image: url('../Astral_072_Dark/imgs/white/title_grip_vertical.svg');
   background-repeat: no-repeat;
@@ -1551,6 +1551,15 @@ PopupButton::menu-indicator:disabled {
 }
 #XSheetToolbar #XSheetToolbarLevelButton {
   padding: 2;
+}
+#CommandBar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#CommandBar::separator:horizontal {
+  margin-right: 3;
+  margin-left: 3;
 }
 QToolBar#MediumPaddingToolBar QToolButton {
   padding-left: 3;

--- a/stuff/config/qss/Astral_048_VeryDark/Astral_048_VeryDark.qss
+++ b/stuff/config/qss/Astral_048_VeryDark/Astral_048_VeryDark.qss
@@ -1488,7 +1488,8 @@ FxSettings QToolBar QToolBar {
 /* -----------------------------------------------------------------------------
    Tool Options
 ----------------------------------------------------------------------------- */
-#ToolOptions TPanelTitleBar {
+#ToolOptions TPanelTitleBar,
+#XSheetToolBar TPanelTitleBar {
   background-color: #303030;
   background-image: url('../Astral_072_Dark/imgs/white/title_grip_vertical.svg');
   background-repeat: no-repeat;

--- a/stuff/config/qss/Astral_072_Dark/Astral_072_Dark.qss
+++ b/stuff/config/qss/Astral_072_Dark/Astral_072_Dark.qss
@@ -1489,7 +1489,7 @@ FxSettings QToolBar QToolBar {
    Tool Options
 ----------------------------------------------------------------------------- */
 #ToolOptions TPanelTitleBar,
-#XSheetToolBar TPanelTitleBar {
+#CommandBar TPanelTitleBar {
   background-color: #484848;
   background-image: url('imgs/white/title_grip_vertical.svg');
   background-repeat: no-repeat;
@@ -1551,6 +1551,15 @@ PopupButton::menu-indicator:disabled {
 }
 #XSheetToolbar #XSheetToolbarLevelButton {
   padding: 2;
+}
+#CommandBar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#CommandBar::separator:horizontal {
+  margin-right: 3;
+  margin-left: 3;
 }
 QToolBar#MediumPaddingToolBar QToolButton {
   padding-left: 3;

--- a/stuff/config/qss/Astral_072_Dark/Astral_072_Dark.qss
+++ b/stuff/config/qss/Astral_072_Dark/Astral_072_Dark.qss
@@ -1488,7 +1488,8 @@ FxSettings QToolBar QToolBar {
 /* -----------------------------------------------------------------------------
    Tool Options
 ----------------------------------------------------------------------------- */
-#ToolOptions TPanelTitleBar {
+#ToolOptions TPanelTitleBar,
+#XSheetToolBar TPanelTitleBar {
   background-color: #484848;
   background-image: url('imgs/white/title_grip_vertical.svg');
   background-repeat: no-repeat;

--- a/stuff/config/qss/Astral_072_Dark/less/layouts/toolbar.less
+++ b/stuff/config/qss/Astral_072_Dark/less/layouts/toolbar.less
@@ -29,7 +29,7 @@
    Tool Options
 ----------------------------------------------------------------------------- */
 
-#ToolOptions, #XSheetToolBar {
+#ToolOptions, #CommandBar {
   & TPanelTitleBar {
     // Use grip handles for title bar
     background-color: @bg;
@@ -111,6 +111,16 @@ PopupButton {
     &:extend(.button-tool all);
     padding: 2; 
   }
+}
+
+#CommandBar {
+	margin: 0;
+	padding: 0;
+	border: 0;
+		&::separator:horizontal {
+		margin-right: 3;
+		margin-left: 3;
+	}
 }
 
 QToolBar#MediumPaddingToolBar { //Schematic Toolbars

--- a/stuff/config/qss/Astral_072_Dark/less/layouts/toolbar.less
+++ b/stuff/config/qss/Astral_072_Dark/less/layouts/toolbar.less
@@ -29,7 +29,7 @@
    Tool Options
 ----------------------------------------------------------------------------- */
 
-#ToolOptions {
+#ToolOptions, #XSheetToolBar {
   & TPanelTitleBar {
     // Use grip handles for title bar
     background-color: @bg;

--- a/stuff/config/qss/Astral_128_Neutral/Astral_128_Neutral.qss
+++ b/stuff/config/qss/Astral_128_Neutral/Astral_128_Neutral.qss
@@ -1489,7 +1489,7 @@ FxSettings QToolBar QToolBar {
    Tool Options
 ----------------------------------------------------------------------------- */
 #ToolOptions TPanelTitleBar,
-#XSheetToolBar TPanelTitleBar {
+#CommandBar TPanelTitleBar {
   background-color: #808080;
   background-image: url('../Astral_072_Dark/imgs/black/title_grip_vertical.svg');
   background-repeat: no-repeat;
@@ -1551,6 +1551,15 @@ PopupButton::menu-indicator:disabled {
 }
 #XSheetToolbar #XSheetToolbarLevelButton {
   padding: 2;
+}
+#CommandBar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#CommandBar::separator:horizontal {
+  margin-right: 3;
+  margin-left: 3;
 }
 QToolBar#MediumPaddingToolBar QToolButton {
   padding-left: 3;

--- a/stuff/config/qss/Astral_128_Neutral/Astral_128_Neutral.qss
+++ b/stuff/config/qss/Astral_128_Neutral/Astral_128_Neutral.qss
@@ -1488,7 +1488,8 @@ FxSettings QToolBar QToolBar {
 /* -----------------------------------------------------------------------------
    Tool Options
 ----------------------------------------------------------------------------- */
-#ToolOptions TPanelTitleBar {
+#ToolOptions TPanelTitleBar,
+#XSheetToolBar TPanelTitleBar {
   background-color: #808080;
   background-image: url('../Astral_072_Dark/imgs/black/title_grip_vertical.svg');
   background-repeat: no-repeat;

--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -226,6 +226,7 @@
     <command>MI_OpenTasks</command>
     <command>MI_OpenTMessage</command>
     <command>MI_OpenToolbar</command>
+    <command>MI_OpenCommandToolbar</command>
     <command>MI_OpenToolOptionBar</command>
     <command>MI_OpenLevelView</command>
     <command>MI_OpenComboViewer</command>

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -29,6 +29,7 @@ set(MOC_HEADERS
     colormodelviewer.h
     columncommand.h
     columnselection.h
+    commandbar.h
     convertpopup.h
     curveio.h
     drawingdata.h
@@ -163,6 +164,7 @@ set(HEADERS ${MOC_HEADERS})
 set(SOURCES
     floatingpanelcommand.cpp
     canvassizepopup.cpp
+    commandbar.cpp
     history.cpp
     loadfoldercommand.cpp
     loadfolderpopup.cpp

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -1,9 +1,8 @@
 
 
-#include "xshtoolbar.h"
+#include "commandbar.h"
 
 // Tnz6 includes
-#include "xsheetviewer.h"
 #include "tapp.h"
 #include "menubarcommandids.h"
 // TnzQt includes
@@ -15,27 +14,22 @@
 #include "toonzqt/menubarcommand.h"
 
 // Qt includes
-#include <QPushButton>
 #include <QWidgetAction>
 
-//=============================================================================
-
-namespace XsheetGUI {
 
 //=============================================================================
 // Toolbar
 //-----------------------------------------------------------------------------
 
 #if QT_VERSION >= 0x050500
-XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WindowFlags flags,
+CommandBar::CommandBar(QWidget *parent, Qt::WindowFlags flags,
                              bool isCollapsible)
 #else
-XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WFlags flags)
+CommandBar::CommandBar(XsheetViewer *parent, Qt::WFlags flags)
 #endif
-    : QToolBar(parent), m_viewer(parent), m_isCollapsible(isCollapsible) {
+    : QToolBar(parent), m_isCollapsible(isCollapsible) {
   setObjectName("cornerWidget");
-  setFixedHeight(30);
-  setObjectName("XSheetToolbar");
+  setObjectName("CommandBar");
 
   TApp *app        = TApp::instance();
   m_keyFrameButton = new ViewerKeyframeNavigator(this, app->getCurrentFrame());
@@ -80,47 +74,11 @@ XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WFlags flags)
 
     addSeparator();
     addAction(keyFrameAction);
-
-    if (!Preferences::instance()->isShowXSheetToolbarEnabled() &&
-        m_isCollapsible) {
-      hide();
-    }
   }
 }
 
-//-----------------------------------------------------------------------------
 
-void XSheetToolbar::showToolbar(bool show) {
-  if (!m_isCollapsible) return;
-  show ? this->show() : this->hide();
-}
 
-//-----------------------------------------------------------------------------
 
-void XSheetToolbar::toggleXSheetToolbar() {
-  bool toolbarEnabled = Preferences::instance()->isShowXSheetToolbarEnabled();
-  Preferences::instance()->enableShowXSheetToolbar(!toolbarEnabled);
-  TApp::instance()->getCurrentScene()->notifyPreferenceChanged("XSheetToolbar");
-}
 
-//-----------------------------------------------------------------------------
 
-void XSheetToolbar::showEvent(QShowEvent *e) {
-  if (Preferences::instance()->isShowXSheetToolbarEnabled() || !m_isCollapsible)
-    show();
-  else
-    hide();
-  emit updateVisibility();
-}
-
-//============================================================
-
-class ToggleXSheetToolbarCommand final : public MenuItemHandler {
-public:
-  ToggleXSheetToolbarCommand() : MenuItemHandler(MI_ToggleXSheetToolbar) {}
-  void execute() override { XSheetToolbar::toggleXSheetToolbar(); }
-} ToggleXSheetToolbarCommand;
-
-//============================================================
-
-}  // namespace XsheetGUI;

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifndef XSHTOOLBAR_H
-#define XSHTOOLBAR_H
+#ifndef COMMANDBAR_H
+#define COMMANDBAR_H
 
 #include <memory>
 
@@ -9,7 +9,6 @@
 #include "toonz/txshleveltypes.h"
 #include "toonzqt/keyframenavigator.h"
 
-#include <QFrame>
 #include <QToolBar>
 
 //-----------------------------------------------------------------------------
@@ -18,37 +17,28 @@
 class XsheetViewer;
 class QPushButton;
 
-//-----------------------------------------------------------------------------
-
-namespace XsheetGUI {
-
 //=============================================================================
 // XSheet Toolbar
 //-----------------------------------------------------------------------------
 
-class XSheetToolbar final : public QToolBar {
+class CommandBar final : public QToolBar {
   Q_OBJECT
 
-  XsheetViewer *m_viewer;
+  //XsheetViewer *m_viewer;
   ViewerKeyframeNavigator *m_keyFrameButton;
   bool m_isCollapsible;
 
 public:
 #if QT_VERSION >= 0x050500
-  XSheetToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0,
+  CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = 0,
                 bool isCollapsible = false);
 #else
-  XSheetToolbar(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
+  CommandBar(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
 #endif
-  static void toggleXSheetToolbar();
-  void showToolbar(bool show);
+  
 signals:
   void updateVisibility();
-
-protected:
-  void showEvent(QShowEvent *e) override;
+ 
 };
 
-}  // namespace XsheetGUI;
-
-#endif  // XSHTOOLBAR_H
+#endif  // COMMANDBAR_H

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -446,6 +446,12 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_MaximizePanel, this, &MainWindow::maximizePanel);
   setCommandHandler(MI_FullScreenWindow, this, &MainWindow::fullScreenWindow);
+  setCommandHandler("MI_NewVectorLevel", this,
+                    &MainWindow::onNewVectorLevelButtonPressed);
+  setCommandHandler("MI_NewToonzRasterLevel", this,
+                    &MainWindow::onNewToonzRasterLevelButtonPressed);
+  setCommandHandler("MI_NewRasterLevel", this,
+                    &MainWindow::onNewRasterLevelButtonPressed);
   // remove ffmpegCache if still exists from crashed exit
   QString ffmpegCachePath =
       ToonzFolder::getCacheRootFolder().getQString() + "//ffmpeg";
@@ -2263,6 +2269,33 @@ void MainWindow::togglePickStyleAreas() {
 void MainWindow::togglePickStyleLines() {
   CommandManager::instance()->getAction(T_StylePicker)->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Mode:Lines")->trigger();
+}
+
+//-----------------------------------------------------------------------------
+
+void MainWindow::onNewVectorLevelButtonPressed() {
+  int defaultLevelType = Preferences::instance()->getDefLevelType();
+  Preferences::instance()->setDefLevelType(PLI_XSHLEVEL);
+  CommandManager::instance()->execute("MI_NewLevel");
+  Preferences::instance()->setDefLevelType(defaultLevelType);
+}
+
+//-----------------------------------------------------------------------------
+
+void MainWindow::onNewToonzRasterLevelButtonPressed() {
+  int defaultLevelType = Preferences::instance()->getDefLevelType();
+  Preferences::instance()->setDefLevelType(TZP_XSHLEVEL);
+  CommandManager::instance()->execute("MI_NewLevel");
+  Preferences::instance()->setDefLevelType(defaultLevelType);
+}
+
+//-----------------------------------------------------------------------------
+
+void MainWindow::onNewRasterLevelButtonPressed() {
+  int defaultLevelType = Preferences::instance()->getDefLevelType();
+  Preferences::instance()->setDefLevelType(OVL_XSHLEVEL);
+  CommandManager::instance()->execute("MI_NewLevel");
+  Preferences::instance()->setDefLevelType(defaultLevelType);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1949,6 +1949,7 @@ void MainWindow::defineActions() {
   createMenuWindowsAction(MI_OpenStyleControl, tr("&Style Editor"), "");
   createMenuWindowsAction(MI_OpenToolbar, tr("&Toolbar"), "");
   createMenuWindowsAction(MI_OpenToolOptionBar, tr("&Tool Option Bar"), "");
+  createMenuWindowsAction(MI_OpenXSheetToolbar, tr("&XSheet Toolbar"), "");
   createMenuWindowsAction(MI_OpenLevelView, tr("&Viewer"), "");
 #ifdef LINETEST
   createMenuWindowsAction(MI_OpenLineTestCapture, tr("&LineTest Capture"), "");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -307,8 +307,9 @@ void Room::load(const TFilePath &fp) {
     QVariant name = settings.value("name");
     if (name.canConvert(QVariant::String)) {
       // Allocate panel
-      paneObjectName = name.toString();
-      pane           = TPanelFactory::createPanel(this, paneObjectName);
+      paneObjectName          = name.toString();
+      std::string paneStrName = paneObjectName.toStdString();
+      pane = TPanelFactory::createPanel(this, paneObjectName);
       if (SaveLoadQSettings *persistent =
               dynamic_cast<SaveLoadQSettings *>(pane->widget()))
         persistent->load(settings);
@@ -1595,6 +1596,20 @@ void MainWindow::defineActions() {
   createMenuFileAction(MI_ClearRecentLevel, tr("&Clear Recent level File List"),
                        "");
   createMenuFileAction(MI_NewLevel, tr("&New Level..."), "Alt+N");
+
+  QAction *newVectorLevelAction =
+      createMenuFileAction(MI_NewVectorLevel, tr("&New Vector Level"), "");
+  newVectorLevelAction->setIconText(tr("New Vector Level"));
+  newVectorLevelAction->setIcon(createQIconPNG("new_vector_level"));
+  QAction *newToonzRasterLevelAction = createMenuFileAction(
+      MI_NewToonzRasterLevel, tr("&New Toonz Raster Level"), "");
+  newToonzRasterLevelAction->setIconText(tr("New Toonz Raster Level"));
+  newToonzRasterLevelAction->setIcon(createQIconPNG("new_toonz_raster_level"));
+  QAction *newRasterLevelAction =
+      createMenuFileAction(MI_NewRasterLevel, tr("&New Raster Level"), "");
+  newRasterLevelAction->setIconText(tr("New Raster Level"));
+  newRasterLevelAction->setIcon(createQIconPNG("new_raster_level"));
+
   createMenuFileAction(MI_LoadLevel, tr("&Load Level..."), "");
   createMenuFileAction(MI_SaveLevel, tr("&Save Level"), "");
   createMenuFileAction(MI_SaveAllLevels, tr("&Save All Levels"), "");
@@ -1949,7 +1964,7 @@ void MainWindow::defineActions() {
   createMenuWindowsAction(MI_OpenStyleControl, tr("&Style Editor"), "");
   createMenuWindowsAction(MI_OpenToolbar, tr("&Toolbar"), "");
   createMenuWindowsAction(MI_OpenToolOptionBar, tr("&Tool Option Bar"), "");
-  createMenuWindowsAction(MI_OpenXSheetToolbar, tr("&XSheet Toolbar"), "");
+  createMenuWindowsAction(MI_OpenCommandToolbar, tr("&Command Bar"), "");
   createMenuWindowsAction(MI_OpenLevelView, tr("&Viewer"), "");
 #ifdef LINETEST
   createMenuWindowsAction(MI_OpenLineTestCapture, tr("&LineTest Capture"), "");
@@ -2288,9 +2303,9 @@ RecentFiles::~RecentFiles() {}
 
 void RecentFiles::addFilePath(QString path, FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) files.removeAt(i);
@@ -2415,9 +2430,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2444,9 +2459,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene)
-            ? MI_ClearRecentScene
-            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
+        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
+                                                        ? MI_ClearRecentLevel
+                                                        : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -118,6 +118,9 @@ public:
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   void togglePickStyleAreas();
   void togglePickStyleLines();
+  void onNewVectorLevelButtonPressed();
+  void onNewToonzRasterLevelButtonPressed();
+  void onNewRasterLevelButtonPressed();
 
   QString getLayoutName() { return m_layoutName; }
 

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1335,7 +1335,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(windowsMenu, MI_OpenTasks);
   addMenuItem(windowsMenu, MI_OpenTMessage);
   addMenuItem(windowsMenu, MI_OpenToolbar);
-  addMenuItem(windowsMenu, MI_OpenXSheetToolbar);
+  addMenuItem(windowsMenu, MI_OpenCommandToolbar);
   addMenuItem(windowsMenu, MI_OpenToolOptionBar);
   addMenuItem(windowsMenu, MI_OpenLevelView);
   addMenuItem(windowsMenu, MI_OpenComboViewer);

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1335,6 +1335,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(windowsMenu, MI_OpenTasks);
   addMenuItem(windowsMenu, MI_OpenTMessage);
   addMenuItem(windowsMenu, MI_OpenToolbar);
+  addMenuItem(windowsMenu, MI_OpenXSheetToolbar);
   addMenuItem(windowsMenu, MI_OpenToolOptionBar);
   addMenuItem(windowsMenu, MI_OpenLevelView);
   addMenuItem(windowsMenu, MI_OpenComboViewer);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -86,6 +86,7 @@
 #define MI_OpenFileBrowser2 "MI_OpenFileBrowser2"
 #define MI_OpenStyleControl "MI_OpenStyleControl"
 #define MI_OpenToolbar "MI_OpenToolbar"
+#define MI_OpenXSheetToolbar "MI_OpenXSheetToolbar"
 #define MI_OpenToolOptionBar "MI_OpenToolOptionBar"
 #define MI_OpenLevelView "MI_OpenLevelView"
 #ifdef LINETEST

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -26,6 +26,9 @@
 #define MI_ClearRecentLevel "MI_ClearRecentLevel"
 #define MI_PrintXsheet "MI_PrintXsheet"
 #define MI_NewLevel "MI_NewLevel"
+#define MI_NewVectorLevel "MI_NewVectorLevel"
+#define MI_NewToonzRasterLevel "MI_NewToonzRasterLevel"
+#define MI_NewRasterLevel "MI_NewRasterLevel"
 #define MI_LoadLevel "MI_LoadLevel"
 #define MI_LoadFolder "MI_LoadFolder"
 #define MI_SaveLevel "MI_SaveLevel"
@@ -86,7 +89,7 @@
 #define MI_OpenFileBrowser2 "MI_OpenFileBrowser2"
 #define MI_OpenStyleControl "MI_OpenStyleControl"
 #define MI_OpenToolbar "MI_OpenToolbar"
-#define MI_OpenXSheetToolbar "MI_OpenXSheetToolbar"
+#define MI_OpenCommandToolbar "MI_OpenCommandToolbar"
 #define MI_OpenToolOptionBar "MI_OpenToolOptionBar"
 #define MI_OpenLevelView "MI_OpenLevelView"
 #ifdef LINETEST

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -14,6 +14,7 @@
 #include "xsheetviewer.h"
 #include "sceneviewer.h"
 #include "toolbar.h"
+#include "xshtoolbar.h"
 #include "flipbook.h"
 #include "castviewer.h"
 #include "filebrowser.h"
@@ -859,6 +860,53 @@ public:
     panel->setWindowTitle(QString(""));
   }
 } toolbarFactory;
+
+//-----------------------------------------------------------------------------
+XSheetToolbarPanel::XSheetToolbarPanel(QWidget *parent)
+	: TPanel(parent, 0, TDockWidget::horizontal) {
+	TApp *app = TApp::instance();
+	//m_toolOption = new ToolOptions;
+	XsheetGUI::XSheetToolbar *xsheetToolbar = new XsheetGUI::XSheetToolbar();
+	setWidget(xsheetToolbar);
+	setIsMaximizable(false);
+	setFixedHeight(36);
+}
+
+
+//class XSheetToolbarFactory final : public TPanelFactory {
+//public:
+//	XSheetToolbarFactory() : TPanelFactory("XSheetToolBar") {}
+//	void initialize(TPanel *panel) override {
+//		XsheetGUI::XSheetToolbar *xsheetToolbar = new XsheetGUI::XSheetToolbar();
+//		xsheetToolbar->setParent(panel);
+//		panel->setWidget(xsheetToolbar);
+//		panel->setIsMaximizable(false);
+//		// panel->setAllowedAreas(Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea);
+//		panel->setFixedHeight(30);  // 35
+//		xsheetToolbar->setFixedHeight(30);
+//		panel->setWindowTitle(QString(""));
+//	}
+//} xsheetToolbarFactory;
+
+class XSheetToolbarFactory final : public TPanelFactory {
+	TPanel *m_panel;
+
+public:
+	XSheetToolbarFactory() : TPanelFactory("XSheetToolBar") {}
+	TPanel *createPanel(QWidget *parent) override {
+		TPanel *panel = new ToolOptionPanel(parent);
+		panel->setObjectName(getPanelType());
+		panel->setWindowTitle(getPanelType());
+		panel->resize(600, panel->height());
+		return panel;
+	}
+	void initialize(TPanel *panel) override { assert(0); }
+} xsheetToolbarFactory;
+
+//=============================================================================
+OpenFloatingPanel openXSheetToolbarCommand(MI_OpenXSheetToolbar, "XSheetToolbar",
+	QObject::tr("XSheet Toolbar"));
+//-----------------------------------------------------------------------------
 
 //=========================================================
 // ToolOptionPanel

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -14,7 +14,7 @@
 #include "xsheetviewer.h"
 #include "sceneviewer.h"
 #include "toolbar.h"
-#include "xshtoolbar.h"
+#include "commandbar.h"
 #include "flipbook.h"
 #include "castviewer.h"
 #include "filebrowser.h"
@@ -862,33 +862,32 @@ public:
 } toolbarFactory;
 
 //=========================================================
-// XSheet Toolbar/Command Bar Panel
+// Command Bar Panel
 //---------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-XSheetToolbarPanel::XSheetToolbarPanel(QWidget *parent)
+CommandBarPanel::CommandBarPanel(QWidget *parent)
     : TPanel(parent, 0, TDockWidget::horizontal) {
-  XsheetGUI::XSheetToolbar *xsheetToolbar = new XsheetGUI::XSheetToolbar();
+  CommandBar *xsheetToolbar = new CommandBar();
   setWidget(xsheetToolbar);
   setIsMaximizable(false);
   setFixedHeight(36);
 }
 
-class XSheetToolbarFactory final : public TPanelFactory {
+class CommandBarFactory final : public TPanelFactory {
 public:
-  XSheetToolbarFactory() : TPanelFactory("XSheetToolBar") {}
+  CommandBarFactory() : TPanelFactory("CommandBar") {}
   TPanel *createPanel(QWidget *parent) override {
-    TPanel *panel = new XSheetToolbarPanel(parent);
+    TPanel *panel = new CommandBarPanel(parent);
     panel->setObjectName(getPanelType());
     return panel;
   }
   void initialize(TPanel *panel) override {}
-} xsheetToolbarFactory;
+} commandBarFactory;
 
 //=============================================================================
-OpenFloatingPanel openXSheetToolbarCommand(MI_OpenCommandToolbar,
-                                           "XSheetToolBar",
-                                           QObject::tr("XSheet Toolbar"));
+OpenFloatingPanel openCommandBarCommand(MI_OpenCommandToolbar, "CommandBar",
+                                        QObject::tr("Command Bar"));
 //-----------------------------------------------------------------------------
 
 //=========================================================

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -861,51 +861,34 @@ public:
   }
 } toolbarFactory;
 
+//=========================================================
+// XSheet Toolbar/Command Bar Panel
+//---------------------------------------------------------
+
 //-----------------------------------------------------------------------------
 XSheetToolbarPanel::XSheetToolbarPanel(QWidget *parent)
-	: TPanel(parent, 0, TDockWidget::horizontal) {
-	TApp *app = TApp::instance();
-	//m_toolOption = new ToolOptions;
-	XsheetGUI::XSheetToolbar *xsheetToolbar = new XsheetGUI::XSheetToolbar();
-	setWidget(xsheetToolbar);
-	setIsMaximizable(false);
-	setFixedHeight(36);
+    : TPanel(parent, 0, TDockWidget::horizontal) {
+  XsheetGUI::XSheetToolbar *xsheetToolbar = new XsheetGUI::XSheetToolbar();
+  setWidget(xsheetToolbar);
+  setIsMaximizable(false);
+  setFixedHeight(36);
 }
 
-
-//class XSheetToolbarFactory final : public TPanelFactory {
-//public:
-//	XSheetToolbarFactory() : TPanelFactory("XSheetToolBar") {}
-//	void initialize(TPanel *panel) override {
-//		XsheetGUI::XSheetToolbar *xsheetToolbar = new XsheetGUI::XSheetToolbar();
-//		xsheetToolbar->setParent(panel);
-//		panel->setWidget(xsheetToolbar);
-//		panel->setIsMaximizable(false);
-//		// panel->setAllowedAreas(Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea);
-//		panel->setFixedHeight(30);  // 35
-//		xsheetToolbar->setFixedHeight(30);
-//		panel->setWindowTitle(QString(""));
-//	}
-//} xsheetToolbarFactory;
-
 class XSheetToolbarFactory final : public TPanelFactory {
-	TPanel *m_panel;
-
 public:
-	XSheetToolbarFactory() : TPanelFactory("XSheetToolBar") {}
-	TPanel *createPanel(QWidget *parent) override {
-		TPanel *panel = new ToolOptionPanel(parent);
-		panel->setObjectName(getPanelType());
-		panel->setWindowTitle(getPanelType());
-		panel->resize(600, panel->height());
-		return panel;
-	}
-	void initialize(TPanel *panel) override { assert(0); }
+  XSheetToolbarFactory() : TPanelFactory("XSheetToolBar") {}
+  TPanel *createPanel(QWidget *parent) override {
+    TPanel *panel = new XSheetToolbarPanel(parent);
+    panel->setObjectName(getPanelType());
+    return panel;
+  }
+  void initialize(TPanel *panel) override {}
 } xsheetToolbarFactory;
 
 //=============================================================================
-OpenFloatingPanel openXSheetToolbarCommand(MI_OpenXSheetToolbar, "XSheetToolbar",
-	QObject::tr("XSheet Toolbar"));
+OpenFloatingPanel openXSheetToolbarCommand(MI_OpenCommandToolbar,
+                                           "XSheetToolBar",
+                                           QObject::tr("XSheet Toolbar"));
 //-----------------------------------------------------------------------------
 
 //=========================================================

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -210,14 +210,13 @@ public:
   ToolOptionPanel(QWidget *parent);
 };
 
-
 class XSheetToolbarPanel final : public TPanel {
-	Q_OBJECT
+  Q_OBJECT
 
-		//ToolOptions *m_toolOption;
+  // ToolOptions *m_toolOption;
 
 public:
-	XSheetToolbarPanel(QWidget *parent);
+  XSheetToolbarPanel(QWidget *parent);
 };
 
 //=========================================================

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -210,13 +210,13 @@ public:
   ToolOptionPanel(QWidget *parent);
 };
 
-class XSheetToolbarPanel final : public TPanel {
+class CommandBarPanel final : public TPanel {
   Q_OBJECT
 
   // ToolOptions *m_toolOption;
 
 public:
-  XSheetToolbarPanel(QWidget *parent);
+  CommandBarPanel(QWidget *parent);
 };
 
 //=========================================================

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -210,6 +210,16 @@ public:
   ToolOptionPanel(QWidget *parent);
 };
 
+
+class XSheetToolbarPanel final : public TPanel {
+	Q_OBJECT
+
+		//ToolOptions *m_toolOption;
+
+public:
+	XSheetToolbarPanel(QWidget *parent);
+};
+
 //=========================================================
 // FlipbookPanel
 //---------------------------------------------------------

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -169,13 +169,13 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WFlags flags)
       TApp::instance()->getCurrentXsheet());
 
   m_toolbarScrollArea = new XsheetScrollArea(this);
-  m_toolbarScrollArea->setFixedSize(m_orientation->cellWidth() * 12,
-                                    XsheetGUI::TOOLBAR_HEIGHT);
+  //m_toolbarScrollArea->setFixedSize(m_orientation->cellWidth() * 12,
+                                    //XsheetGUI::TOOLBAR_HEIGHT);
   m_toolbarScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_toolbarScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  m_toolbar = new XsheetGUI::Toolbar(this);
-  m_toolbar->setFixedSize(m_orientation->cellWidth() * 12,
-                          XsheetGUI::TOOLBAR_HEIGHT);
+  m_toolbar = new XsheetGUI::XSheetToolbar(this);
+  //m_toolbar->setFixedSize(m_orientation->cellWidth() * 12,
+                         //XsheetGUI::TOOLBAR_HEIGHT);
   m_toolbarScrollArea->setWidget(m_toolbar);
 
   QRect noteArea(0, 0, 75, 120);
@@ -316,7 +316,7 @@ void XsheetViewer::positionSections() {
 
     int w = geometry().size().width();
     m_toolbarScrollArea->setGeometry(0, 0, w, XsheetGUI::TOOLBAR_HEIGHT);
-
+	m_toolbar->setMaximumWidth(300);
     if (o->isVerticalTimeline()) {
       headerFrame = headerFrame.adjusted(XsheetGUI::TOOLBAR_HEIGHT,
                                          XsheetGUI::TOOLBAR_HEIGHT);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -169,13 +169,9 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WFlags flags)
       TApp::instance()->getCurrentXsheet());
 
   m_toolbarScrollArea = new XsheetScrollArea(this);
-  //m_toolbarScrollArea->setFixedSize(m_orientation->cellWidth() * 12,
-                                    //XsheetGUI::TOOLBAR_HEIGHT);
   m_toolbarScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_toolbarScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  m_toolbar = new XsheetGUI::XSheetToolbar(this);
-  //m_toolbar->setFixedSize(m_orientation->cellWidth() * 12,
-                         //XsheetGUI::TOOLBAR_HEIGHT);
+  m_toolbar = new XsheetGUI::XSheetToolbar(this, 0, true);
   m_toolbarScrollArea->setWidget(m_toolbar);
 
   QRect noteArea(0, 0, 75, 120);
@@ -215,6 +211,8 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WFlags flags)
 
   connect(this, &XsheetViewer::orientationChanged, this,
           &XsheetViewer::onOrientationChanged);
+  connect(m_toolbar, SIGNAL(updateVisibility()), this,
+          SLOT(positionSections()));
 
   emit orientationChanged(orientation());
 }
@@ -313,10 +311,9 @@ void XsheetViewer::positionSections() {
 
   if (Preferences::instance()->isShowXSheetToolbarEnabled()) {
     m_toolbar->showToolbar(true);
-
-    int w = geometry().size().width();
+    int w = visibleRegion().boundingRect().width() - 5;
     m_toolbarScrollArea->setGeometry(0, 0, w, XsheetGUI::TOOLBAR_HEIGHT);
-	m_toolbar->setMaximumWidth(300);
+    m_toolbar->setFixedWidth(w);
     if (o->isVerticalTimeline()) {
       headerFrame = headerFrame.adjusted(XsheetGUI::TOOLBAR_HEIGHT,
                                          XsheetGUI::TOOLBAR_HEIGHT);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -698,7 +698,6 @@ protected:
   void wheelEvent(QWheelEvent *event) override;
   void timerEvent(QTimerEvent *) override;
 
-  void positionSections();
   void disconnectScrollBars();
   void connectScrollBars();
   void connectOrDisconnectScrollBars(bool toConnect);
@@ -708,6 +707,7 @@ signals:
   void orientationChanged(const Orientation *newOrientation);
 
 public slots:
+  void positionSections();
   void onSceneSwitched();
   void onXsheetChanged();
   void onCurrentFrameSwitched();

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -325,7 +325,7 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   XsheetGUI::RowArea *m_rowArea;
   XsheetGUI::CellArea *m_cellArea;
   XsheetGUI::NoteArea *m_noteArea;
-  XsheetGUI::Toolbar *m_toolbar;
+  XsheetGUI::XSheetToolbar *m_toolbar;
 
   Spreadsheet::FrameScroller m_frameScroller;
 

--- a/toonz/sources/toonz/xshtoolbar.cpp
+++ b/toonz/sources/toonz/xshtoolbar.cpp
@@ -15,6 +15,7 @@
 
 // Qt includes
 #include <QPushButton>
+#include <QWidgetAction>
 
 //=============================================================================
 
@@ -25,16 +26,16 @@ namespace XsheetGUI {
 //-----------------------------------------------------------------------------
 
 #if QT_VERSION >= 0x050500
-Toolbar::Toolbar(XsheetViewer *parent, Qt::WindowFlags flags)
+	XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WindowFlags flags)
 #else
-Toolbar::Toolbar(XsheetViewer *parent, Qt::WFlags flags)
+	XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WFlags flags)
 #endif
-    : QFrame(parent), m_viewer(parent) {
-  setFrameStyle(QFrame::StyledPanel);
+    : QToolBar(parent), m_viewer(parent) {
+  //setFrameStyle(QFrame::StyledPanel);
   setObjectName("cornerWidget");
-  m_toolbar = new QToolBar();
-  m_toolbar->setFixedHeight(30);
-  m_toolbar->setObjectName("XSheetToolbar");
+  //m_toolbar = new QToolBar();
+  setFixedHeight(30);
+  setObjectName("XSheetToolbar");
 
   m_newVectorLevelButton = new QPushButton(this);
   m_newVectorLevelButton->setIconSize(QSize(18, 18));
@@ -62,56 +63,66 @@ Toolbar::Toolbar(XsheetViewer *parent, Qt::WFlags flags)
   m_keyFrameButton->setObjectHandle(app->getCurrentObject());
   m_keyFrameButton->setXsheetHandle(app->getCurrentXsheet());
 
-  QVBoxLayout *mainLay = new QVBoxLayout();
-  mainLay->setMargin(0);
-  mainLay->setSpacing(5);
+  //QWidgetAction *newVectorAction = new QWidgetAction(m_newVectorLevelButton);
+  //QWidgetAction *newToonzRasterAction = new QWidgetAction(m_newToonzRasterLevelButton);
+  //QWidgetAction *newRasterAction = new QWidgetAction(m_newRasterLevelButton);
+  //QWidgetAction *keyFrameAction = new QWidgetAction(m_keyFrameButton);
+
+  //QVBoxLayout *mainLay = new QVBoxLayout();
+  //mainLay->setMargin(0);
+  //mainLay->setSpacing(5);
   {
-    mainLay->addStretch(1);
-    QHBoxLayout *toolbarLayout = new QHBoxLayout();
-    toolbarLayout->setSpacing(2);
-    toolbarLayout->setMargin(0);
+    //mainLay->addStretch(1);
+    //QHBoxLayout *toolbarLayout = new QHBoxLayout();
+    //toolbarLayout->setSpacing(2);
+    //toolbarLayout->setMargin(0);
     {
-      m_toolbar->addWidget(m_newVectorLevelButton);
-      m_toolbar->addWidget(m_newToonzRasterLevelButton);
-      m_toolbar->addWidget(m_newRasterLevelButton);
-      m_toolbar->addSeparator();
+      addWidget(m_newVectorLevelButton);
+      addWidget(m_newToonzRasterLevelButton);
+      addWidget(m_newRasterLevelButton);
+	  //addAction(newVectorAction);
+	  //addAction(newToonzRasterAction);
+	  //addAction(newRasterAction);
+
+      addSeparator();
       QAction *reframeOnes =
           CommandManager::instance()->getAction("MI_Reframe1");
-      m_toolbar->addAction(reframeOnes);
+      addAction(reframeOnes);
       QAction *reframeTwos =
           CommandManager::instance()->getAction("MI_Reframe2");
-      m_toolbar->addAction(reframeTwos);
+      addAction(reframeTwos);
       QAction *reframeThrees =
           CommandManager::instance()->getAction("MI_Reframe3");
-      m_toolbar->addAction(reframeThrees);
+      addAction(reframeThrees);
 
-      m_toolbar->addSeparator();
+      addSeparator();
 
       QAction *repeat = CommandManager::instance()->getAction("MI_Dup");
-      m_toolbar->addAction(repeat);
+      addAction(repeat);
 
-      m_toolbar->addSeparator();
+      addSeparator();
 
       QAction *collapse = CommandManager::instance()->getAction("MI_Collapse");
-      m_toolbar->addAction(collapse);
+      addAction(collapse);
       QAction *open = CommandManager::instance()->getAction("MI_OpenChild");
-      m_toolbar->addAction(open);
+      addAction(open);
       QAction *leave = CommandManager::instance()->getAction("MI_CloseChild");
-      m_toolbar->addAction(leave);
+      addAction(leave);
 
-      m_toolbar->addSeparator();
-      m_toolbar->addWidget(m_keyFrameButton);
-      toolbarLayout->addWidget(m_toolbar);
-      toolbarLayout->addStretch(0);
+      addSeparator();
+      addWidget(m_keyFrameButton);
+	  //addAction(keyFrameAction);
+      //toolbarLayout->addWidget(m_toolbar);
+      //toolbarLayout->addStretch(0);
     }
-    mainLay->addLayout(toolbarLayout, 0);
+    //mainLay->addLayout(toolbarLayout, 0);
     if (!Preferences::instance()->isShowXSheetToolbarEnabled()) {
-      m_toolbar->hide();
+      //m_toolbar->hide();
     }
 
-    mainLay->addStretch(1);
+    //mainLay->addStretch(1);
   }
-  setLayout(mainLay);
+  //setLayout(mainLay);
 
   // signal-slot connections
   bool ret = true;
@@ -128,7 +139,7 @@ Toolbar::Toolbar(XsheetViewer *parent, Qt::WFlags flags)
 
 //-----------------------------------------------------------------------------
 
-void Toolbar::onNewVectorLevelButtonPressed() {
+void XSheetToolbar::onNewVectorLevelButtonPressed() {
   int defaultLevelType = Preferences::instance()->getDefLevelType();
   Preferences::instance()->setDefLevelType(PLI_XSHLEVEL);
   CommandManager::instance()->execute("MI_NewLevel");
@@ -137,7 +148,7 @@ void Toolbar::onNewVectorLevelButtonPressed() {
 
 //-----------------------------------------------------------------------------
 
-void Toolbar::onNewToonzRasterLevelButtonPressed() {
+void XSheetToolbar::onNewToonzRasterLevelButtonPressed() {
   int defaultLevelType = Preferences::instance()->getDefLevelType();
   // Preferences::instance()->setOldDefLevelType(defaultLevelType);
   Preferences::instance()->setDefLevelType(TZP_XSHLEVEL);
@@ -147,7 +158,7 @@ void Toolbar::onNewToonzRasterLevelButtonPressed() {
 
 //-----------------------------------------------------------------------------
 
-void Toolbar::onNewRasterLevelButtonPressed() {
+void XSheetToolbar::onNewRasterLevelButtonPressed() {
   int defaultLevelType = Preferences::instance()->getDefLevelType();
   Preferences::instance()->setDefLevelType(OVL_XSHLEVEL);
   CommandManager::instance()->execute("MI_NewLevel");
@@ -156,13 +167,13 @@ void Toolbar::onNewRasterLevelButtonPressed() {
 
 //-----------------------------------------------------------------------------
 
-void Toolbar::showToolbar(bool show) {
-  show ? m_toolbar->show() : m_toolbar->hide();
+void XSheetToolbar::showToolbar(bool show) {
+  //show ? m_toolbar->show() : m_toolbar->hide();
 }
 
 //-----------------------------------------------------------------------------
 
-void Toolbar::toggleXSheetToolbar() {
+void XSheetToolbar::toggleXSheetToolbar() {
   bool toolbarEnabled = Preferences::instance()->isShowXSheetToolbarEnabled();
   Preferences::instance()->enableShowXSheetToolbar(!toolbarEnabled);
   TApp::instance()->getCurrentScene()->notifyPreferenceChanged("XSheetToolbar");
@@ -175,7 +186,7 @@ void Toolbar::toggleXSheetToolbar() {
 class ToggleXSheetToolbarCommand final : public MenuItemHandler {
 public:
   ToggleXSheetToolbarCommand() : MenuItemHandler(MI_ToggleXSheetToolbar) {}
-  void execute() override { Toolbar::toggleXSheetToolbar(); }
+  void execute() override { XSheetToolbar::toggleXSheetToolbar(); }
 } ToggleXSheetToolbarCommand;
 
 //============================================================

--- a/toonz/sources/toonz/xshtoolbar.cpp
+++ b/toonz/sources/toonz/xshtoolbar.cpp
@@ -12,6 +12,7 @@
 // TnzLib includes
 #include "toonz/preferences.h"
 #include "toonz/tscenehandle.h"
+#include "toonzqt/menubarcommand.h"
 
 // Qt includes
 #include <QPushButton>
@@ -26,115 +27,72 @@ namespace XsheetGUI {
 //-----------------------------------------------------------------------------
 
 #if QT_VERSION >= 0x050500
-	XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WindowFlags flags)
+XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WindowFlags flags,
+                             bool isCollapsible)
 #else
-	XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WFlags flags)
+XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WFlags flags)
 #endif
-    : QToolBar(parent), m_viewer(parent) {
-  //setFrameStyle(QFrame::StyledPanel);
+    : QToolBar(parent), m_viewer(parent), m_isCollapsible(isCollapsible) {
   setObjectName("cornerWidget");
-  //m_toolbar = new QToolBar();
   setFixedHeight(30);
   setObjectName("XSheetToolbar");
-
-  m_newVectorLevelButton = new QPushButton(this);
-  m_newVectorLevelButton->setIconSize(QSize(18, 18));
-  QIcon newVectorIcon = createQIconPNG("new_vector_level");
-  m_newVectorLevelButton->setIcon(newVectorIcon);
-  m_newVectorLevelButton->setObjectName("XSheetToolbarLevelButton");
-  m_newVectorLevelButton->setToolTip(tr("New Vector Level"));
-
-  m_newToonzRasterLevelButton = new QPushButton(this);
-  m_newToonzRasterLevelButton->setIconSize(QSize(18, 18));
-  QIcon newToonzRasterIcon = createQIconPNG("new_toonz_raster_level");
-  m_newToonzRasterLevelButton->setIcon(newToonzRasterIcon);
-  m_newToonzRasterLevelButton->setObjectName("XSheetToolbarLevelButton");
-  m_newToonzRasterLevelButton->setToolTip(tr("New Toonz Raster Level"));
-
-  m_newRasterLevelButton = new QPushButton(this);
-  m_newRasterLevelButton->setIconSize(QSize(18, 18));
-  QIcon newRasterIcon = createQIconPNG("new_raster_level");
-  m_newRasterLevelButton->setIcon(newRasterIcon);
-  m_newRasterLevelButton->setObjectName("XSheetToolbarLevelButton");
-  m_newRasterLevelButton->setToolTip(tr("New Raster Level"));
 
   TApp *app        = TApp::instance();
   m_keyFrameButton = new ViewerKeyframeNavigator(this, app->getCurrentFrame());
   m_keyFrameButton->setObjectHandle(app->getCurrentObject());
   m_keyFrameButton->setXsheetHandle(app->getCurrentXsheet());
 
-  //QWidgetAction *newVectorAction = new QWidgetAction(m_newVectorLevelButton);
-  //QWidgetAction *newToonzRasterAction = new QWidgetAction(m_newToonzRasterLevelButton);
-  //QWidgetAction *newRasterAction = new QWidgetAction(m_newRasterLevelButton);
-  //QWidgetAction *keyFrameAction = new QWidgetAction(m_keyFrameButton);
+  QWidgetAction *keyFrameAction = new QWidgetAction(this);
+  keyFrameAction->setDefaultWidget(m_keyFrameButton);
 
-  //QVBoxLayout *mainLay = new QVBoxLayout();
-  //mainLay->setMargin(0);
-  //mainLay->setSpacing(5);
   {
-    //mainLay->addStretch(1);
-    //QHBoxLayout *toolbarLayout = new QHBoxLayout();
-    //toolbarLayout->setSpacing(2);
-    //toolbarLayout->setMargin(0);
-    {
-      addWidget(m_newVectorLevelButton);
-      addWidget(m_newToonzRasterLevelButton);
-      addWidget(m_newRasterLevelButton);
-	  //addAction(newVectorAction);
-	  //addAction(newToonzRasterAction);
-	  //addAction(newRasterAction);
+    QAction *newVectorLevel =
+        CommandManager::instance()->getAction("MI_NewVectorLevel");
+    addAction(newVectorLevel);
+    QAction *newToonzRasterLevel =
+        CommandManager::instance()->getAction("MI_NewToonzRasterLevel");
+    addAction(newToonzRasterLevel);
+    QAction *newRasterLevel =
+        CommandManager::instance()->getAction("MI_NewRasterLevel");
+    addAction(newRasterLevel);
+    addSeparator();
+    QAction *reframeOnes = CommandManager::instance()->getAction("MI_Reframe1");
+    addAction(reframeOnes);
+    QAction *reframeTwos = CommandManager::instance()->getAction("MI_Reframe2");
+    addAction(reframeTwos);
+    QAction *reframeThrees =
+        CommandManager::instance()->getAction("MI_Reframe3");
+    addAction(reframeThrees);
 
-      addSeparator();
-      QAction *reframeOnes =
-          CommandManager::instance()->getAction("MI_Reframe1");
-      addAction(reframeOnes);
-      QAction *reframeTwos =
-          CommandManager::instance()->getAction("MI_Reframe2");
-      addAction(reframeTwos);
-      QAction *reframeThrees =
-          CommandManager::instance()->getAction("MI_Reframe3");
-      addAction(reframeThrees);
+    addSeparator();
 
-      addSeparator();
+    QAction *repeat = CommandManager::instance()->getAction("MI_Dup");
+    addAction(repeat);
 
-      QAction *repeat = CommandManager::instance()->getAction("MI_Dup");
-      addAction(repeat);
+    addSeparator();
 
-      addSeparator();
+    QAction *collapse = CommandManager::instance()->getAction("MI_Collapse");
+    addAction(collapse);
+    QAction *open = CommandManager::instance()->getAction("MI_OpenChild");
+    addAction(open);
+    QAction *leave = CommandManager::instance()->getAction("MI_CloseChild");
+    addAction(leave);
 
-      QAction *collapse = CommandManager::instance()->getAction("MI_Collapse");
-      addAction(collapse);
-      QAction *open = CommandManager::instance()->getAction("MI_OpenChild");
-      addAction(open);
-      QAction *leave = CommandManager::instance()->getAction("MI_CloseChild");
-      addAction(leave);
+    addSeparator();
+    addAction(keyFrameAction);
 
-      addSeparator();
-      addWidget(m_keyFrameButton);
-	  //addAction(keyFrameAction);
-      //toolbarLayout->addWidget(m_toolbar);
-      //toolbarLayout->addStretch(0);
+    if (!Preferences::instance()->isShowXSheetToolbarEnabled() &&
+        m_isCollapsible) {
+      hide();
     }
-    //mainLay->addLayout(toolbarLayout, 0);
-    if (!Preferences::instance()->isShowXSheetToolbarEnabled()) {
-      //m_toolbar->hide();
-    }
-
-    //mainLay->addStretch(1);
   }
-  //setLayout(mainLay);
 
-  // signal-slot connections
-  bool ret = true;
-  ret      = ret && connect(m_newVectorLevelButton, SIGNAL(released()), this,
-                       SLOT(onNewVectorLevelButtonPressed()));
-  ret = ret && connect(m_newToonzRasterLevelButton, SIGNAL(released()), this,
-                       SLOT(onNewToonzRasterLevelButtonPressed()));
-  ret = ret && connect(m_newRasterLevelButton, SIGNAL(released()), this,
-                       SLOT(onNewRasterLevelButtonPressed()));
-  assert(ret);
-
-  // m_leaveSubButton->hide();
+  setCommandHandler("MI_NewVectorLevel", this,
+                    &XSheetToolbar::onNewVectorLevelButtonPressed);
+  setCommandHandler("MI_NewToonzRasterLevel", this,
+                    &XSheetToolbar::onNewToonzRasterLevelButtonPressed);
+  setCommandHandler("MI_NewRasterLevel", this,
+                    &XSheetToolbar::onNewRasterLevelButtonPressed);
 }
 
 //-----------------------------------------------------------------------------
@@ -150,7 +108,6 @@ void XSheetToolbar::onNewVectorLevelButtonPressed() {
 
 void XSheetToolbar::onNewToonzRasterLevelButtonPressed() {
   int defaultLevelType = Preferences::instance()->getDefLevelType();
-  // Preferences::instance()->setOldDefLevelType(defaultLevelType);
   Preferences::instance()->setDefLevelType(TZP_XSHLEVEL);
   CommandManager::instance()->execute("MI_NewLevel");
   Preferences::instance()->setDefLevelType(defaultLevelType);
@@ -168,7 +125,8 @@ void XSheetToolbar::onNewRasterLevelButtonPressed() {
 //-----------------------------------------------------------------------------
 
 void XSheetToolbar::showToolbar(bool show) {
-  //show ? m_toolbar->show() : m_toolbar->hide();
+  if (!m_isCollapsible) return;
+  show ? this->show() : this->hide();
 }
 
 //-----------------------------------------------------------------------------
@@ -180,6 +138,14 @@ void XSheetToolbar::toggleXSheetToolbar() {
 }
 
 //-----------------------------------------------------------------------------
+
+void XSheetToolbar::showEvent(QShowEvent *e) {
+  if (Preferences::instance()->isShowXSheetToolbarEnabled() || !m_isCollapsible)
+    show();
+  else
+    hide();
+  emit updateVisibility();
+}
 
 //============================================================
 

--- a/toonz/sources/toonz/xshtoolbar.h
+++ b/toonz/sources/toonz/xshtoolbar.h
@@ -26,7 +26,7 @@ namespace XsheetGUI {
 // XSheet Toolbar
 //-----------------------------------------------------------------------------
 
-class Toolbar final : public QFrame {
+class XSheetToolbar final : public QToolBar {
   Q_OBJECT
 
   XsheetViewer *m_viewer;
@@ -35,13 +35,13 @@ class Toolbar final : public QFrame {
   QPushButton *m_newToonzRasterLevelButton;
   QPushButton *m_newRasterLevelButton;
   ViewerKeyframeNavigator *m_keyFrameButton;
-  QToolBar *m_toolbar;
+  //QToolBar *m_toolbar;
 
 public:
 #if QT_VERSION >= 0x050500
-  Toolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0);
+	XSheetToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0);
 #else
-  Toolbar(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
+	XSheetToolbar(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
 #endif
   static void toggleXSheetToolbar();
   void showToolbar(bool show);

--- a/toonz/sources/toonz/xshtoolbar.h
+++ b/toonz/sources/toonz/xshtoolbar.h
@@ -30,22 +30,23 @@ class XSheetToolbar final : public QToolBar {
   Q_OBJECT
 
   XsheetViewer *m_viewer;
-
-  QPushButton *m_newVectorLevelButton;
-  QPushButton *m_newToonzRasterLevelButton;
-  QPushButton *m_newRasterLevelButton;
   ViewerKeyframeNavigator *m_keyFrameButton;
-  //QToolBar *m_toolbar;
+  bool m_isCollapsible;
 
 public:
 #if QT_VERSION >= 0x050500
-	XSheetToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0);
+  XSheetToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0,
+                bool isCollapsible = false);
 #else
-	XSheetToolbar(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
+  XSheetToolbar(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
 #endif
   static void toggleXSheetToolbar();
   void showToolbar(bool show);
+signals:
+  void updateVisibility();
 
+protected:
+  void showEvent(QShowEvent *e) override;
 protected slots:
   void onNewVectorLevelButtonPressed();
   void onNewToonzRasterLevelButtonPressed();


### PR DESCRIPTION
This does a few things:
It fixes the xsheet toolbar not showing a dropdown arrow when not all icons are visible.
It also makes a new panel out of the xsheet toolbar that can be docked anywhere.  The normal xsheet toolbar is still available, the panel is a duplicate just for the flexibility of having it where you want it.

Note:
 - A side effect of this is that I had to make the new vector, new toonz raster and new raster level buttons an actual command, or they also didn't show up in the dropdown.  That means you can map them to shortcuts if you wish.
 - The keyframe commands don't show up in the dropdown because the widget they use isn't recognized as an action to add to the dropdown.

 - The new panel is called the Command Bar since XSheet Toolbar wouldn't be a good name since it can be docked anywhere.

Here is the new panel above the viewer:
![anywhere](https://user-images.githubusercontent.com/4576381/29551862-11ac5d3e-86d2-11e7-843c-a8a5a3ccc983.JPG)

Here is the dropdown:
![drop](https://user-images.githubusercontent.com/4576381/29551867-17a56c76-86d2-11e7-8350-e6af639b7ff4.JPG)
