### PR TITLE
Fix for arrow commands on brush tool

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -1572,7 +1572,7 @@ bool BrushTool::keyDown(int key, TUINT32 b, const TPoint &point) {
   if (key == TwConsts::TK_Esc) {
     resetFrameRange();
   }
-  return true;
+  return false;
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I broke the arrows for next frame and previous frame on a previous PR.  This fixes it.  One word can change a lot.