### PR TITLE
Fix crash on using preference template

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -362,6 +362,9 @@ void TSystem::copyFile(const TFilePath &dst, const TFilePath &src,
 
   if (dst == src) return;
 
+  // Create the containing folder before trying to copy or it will crash!
+  touchParentDir(dst);
+
   const QString &qDst = toQString(dst);
   if (overwrite && QFile::exists(qDst)) QFile::remove(qDst);
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -325,13 +325,19 @@ Preferences::Preferences()
   m_defLevelDpi    = camera.getDpi().x;
 
   TFilePath layoutDir = ToonzFolder::getMyModuleDir();
-  TFilePath savePath  = layoutDir + TFilePath("preferences.ini");
+  TFilePath prefPath  = layoutDir + TFilePath("preferences.ini");
 
-  // If no personal settings found, then try to load template settings
-  TFilePath loadPath = ToonzFolder::getModuleFile(TFilePath("preferences.ini"));
+  // In case the personal settings is not exist (for new users)
+  if (!TFileStatus(prefPath).doesExist()) {
+    TFilePath templatePath =
+        ToonzFolder::getTemplateModuleDir() + TFilePath("preferences.ini");
+    // If there is the template, copy it to the personal one
+    if (TFileStatus(templatePath).doesExist())
+      TSystem::copyFile(prefPath, templatePath);
+  }
 
   m_settings.reset(new QSettings(
-      QString::fromStdWString(loadPath.getWideString()), QSettings::IniFormat));
+      QString::fromStdWString(prefPath.getWideString()), QSettings::IniFormat));
 
   getValue(*m_settings, "autoExposeEnabled", m_autoExposeEnabled);
   getValue(*m_settings, "autoCreateEnabled", m_autoCreateEnabled);
@@ -606,16 +612,6 @@ Preferences::Preferences()
            m_inputCellsWithoutDoubleClickingEnabled);
   getValue(*m_settings, "importPolicy", m_importPolicy);
   getValue(*m_settings, "watchFileSystemEnabled", m_watchFileSystem);
-
-  // in case there is no personal settings
-  if (savePath != loadPath) {
-    // copy the template settins to the personal one
-    if (TFileStatus(loadPath).doesExist())
-      TSystem::copyFile(savePath, loadPath);
-    m_settings.reset(
-        new QSettings(QString::fromStdWString(savePath.getWideString()),
-                      QSettings::IniFormat));
-  }
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -610,10 +610,8 @@ Preferences::Preferences()
   // in case there is no personal settings
   if (savePath != loadPath) {
     // copy the template settins to the personal one
-    if (TFileStatus(loadPath).doesExist()) {
-      TSystem::mkDir(savePath.getParentDir());
+    if (TFileStatus(loadPath).doesExist())
       TSystem::copyFile(savePath, loadPath);
-    }
     m_settings.reset(
         new QSettings(QString::fromStdWString(savePath.getWideString()),
                       QSettings::IniFormat));

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -610,8 +610,10 @@ Preferences::Preferences()
   // in case there is no personal settings
   if (savePath != loadPath) {
     // copy the template settins to the personal one
-    if (TFileStatus(loadPath).doesExist())
+    if (TFileStatus(loadPath).doesExist()) {
+      TSystem::mkDir(savePath.getParentDir());
       TSystem::copyFile(savePath, loadPath);
+    }
     m_settings.reset(
         new QSettings(QString::fromStdWString(savePath.getWideString()),
                       QSettings::IniFormat));


### PR DESCRIPTION
This PR will fix crash when using template preference file store in `$TOONZPROFILES/layouts/settings/` .
Please do the following to reproduce the crash:

1. Create a folder `$TOONZPROFILES/layouts/settings/` and copy `$TOONZPROFILES/layouts/settings.username/preferences.ini` as a template preference file.

1. Remove or rename `$TOONZPROFILES/layouts/settings.username/` to pretend the situation that a new user lauch OpenToonz for the first time.

1. Lauch OpenToonz.

OpenToonz crashes for failing to copy the setting file because the parent directory is missing. Sorry for the unforced mistake in my previous PR.