### PR TITLE
Fix Env File Path Setup

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -49,9 +49,7 @@ class EnvGlobals {  // singleton
   TFilePath *m_dllRelativeDir;
   bool m_isPortable = false;
 
-  EnvGlobals() : m_stuffDir(0) {
-    setWorkingDirectory();
-  }
+  EnvGlobals() : m_stuffDir(0) { setWorkingDirectory(); }
 
 public:
   ~EnvGlobals() { delete m_stuffDir; }
@@ -188,7 +186,10 @@ public:
   }
   std::string getRootVarName() { return m_rootVarName; }
 
-  void setSystemVarPrefix(std::string prefix) { m_systemVarPrefix = prefix; }
+  void setSystemVarPrefix(std::string prefix) {
+    m_systemVarPrefix = prefix;
+    updateEnvFile();
+  }
   std::string getSystemVarPrefix() {
     if (getIsPortable()) return "";
     return m_systemVarPrefix;


### PR DESCRIPTION
You can set arbitrary path to  `$TOONZPROFILES` other than `$TOONZROOT\profiles` so that managing the user profiles can be flexible.
For now, this feature is broken regarding .env file because the path to the .env file ( `m_envFile` ) is not updated after setting `m_systemVarPrefix` to proper value. This PR will fix such problem.