### PR TITLE
Fix for initial preference saving issues

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -362,6 +362,9 @@ void TSystem::copyFile(const TFilePath &dst, const TFilePath &src,
 
   if (dst == src) return;
 
+  // Create the containing folder before trying to copy or it will crash!
+  touchParentDir(dst);
+
   const QString &qDst = toQString(dst);
   if (overwrite && QFile::exists(qDst)) QFile::remove(qDst);
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -327,11 +327,18 @@ Preferences::Preferences()
   TFilePath layoutDir = ToonzFolder::getMyModuleDir();
   TFilePath savePath  = layoutDir + TFilePath("preferences.ini");
 
-  // If no personal settings found, then try to load template settings
-  TFilePath loadPath = ToonzFolder::getModuleFile(TFilePath("preferences.ini"));
+  bool existingUser = true;
+
+  // If there is no personal settings file, this is the user's first time use.
+  if (!TFileStatus(savePath).doesExist())
+  {
+	  // create the user's settings directory if it isn't there already
+	  TSystem::touchParentDir(savePath);
+	  existingUser = false;
+  }
 
   m_settings.reset(new QSettings(
-      QString::fromStdWString(loadPath.getWideString()), QSettings::IniFormat));
+      QString::fromStdWString(savePath.getWideString()), QSettings::IniFormat));
 
   getValue(*m_settings, "autoExposeEnabled", m_autoExposeEnabled);
   getValue(*m_settings, "autoCreateEnabled", m_autoCreateEnabled);
@@ -607,16 +614,8 @@ Preferences::Preferences()
   getValue(*m_settings, "importPolicy", m_importPolicy);
   getValue(*m_settings, "watchFileSystemEnabled", m_watchFileSystem);
 
-  // in case there is no personal settings
-  if (savePath != loadPath) {
-    // copy the template settins to the personal one
-	// Save file to directory if it doesn't already exist.
-	if (!TFileStatus(loadPath).doesExist()) m_settings->sync();
-    TSystem::copyFile(savePath, loadPath);
-    m_settings.reset(
-        new QSettings(QString::fromStdWString(savePath.getWideString()),
-                      QSettings::IniFormat));
-  }
+  // Save settings to directory now, just in case
+  m_settings->sync();
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -610,8 +610,11 @@ Preferences::Preferences()
   // in case there is no personal settings
   if (savePath != loadPath) {
     // copy the template settins to the personal one
-    if (TFileStatus(loadPath).doesExist())
-      TSystem::copyFile(savePath, loadPath);
+	// Save file to directory if it doesn't already exist.
+	if (!TFileStatus(loadPath).doesExist()) m_settings->sync();
+	// Create the settings.user folder before trying to copy or we will crash!
+	TSystem::touchParentDir(savePath);
+    TSystem::copyFile(savePath, loadPath);
     m_settings.reset(
         new QSettings(QString::fromStdWString(savePath.getWideString()),
                       QSettings::IniFormat));

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -612,8 +612,6 @@ Preferences::Preferences()
     // copy the template settins to the personal one
 	// Save file to directory if it doesn't already exist.
 	if (!TFileStatus(loadPath).doesExist()) m_settings->sync();
-	// Create the settings.user folder before trying to copy or we will crash!
-	TSystem::touchParentDir(savePath);
     TSystem::copyFile(savePath, loadPath);
     m_settings.reset(
         new QSettings(QString::fromStdWString(savePath.getWideString()),


### PR DESCRIPTION
This PR fixes the following scenarios

1) Initial/default preferences for user not set correctly in preferences.ini file.

In this scenario, the C:\OpenToonz 1.1 stuff\profiles\layouts\setting directory is missing or the preferences.ini is missing AND the C:\OpenToonz 1.1 stuff\profiles\layouts\setting.user directory is missing completely.  This scenario may be likely on a fresh install of OT.

Result: The setting.user\preferences.ini is created, but does not contain the default information found in setting\preferences.ini

Fix: Performed a QSettings sync() which forces the data to be written out.  Afterwards, it can be copied to settings.user and reloaded properly.

NOTE: This issue is probably not really noticed since the next time they open OT, the defaults get loaded again and saved properly in the setting.user\preferences.ini.

2) setting directory exists but setting.user does not leads to a crash

In this scenario, the C:\OpenToonz 1.1 stuff\profiles\layouts\setting\preferences.ini file exists, however the setting.user directory is missing completely.  This may be likely if OT is already loaded on the system and either another user of the machine has logged in and is using it for the first time or the user has somehow deleted their setting.user directory.

Result: When it tries to copy the file from setting to setting.user, since the directory is not there, it crashes.  If the directory is there but does not have preferences.ini it will work as normal.

Fix: Prior to copying, create the parent directory if it isn't already there.  Fix was done in copyFile() so it fixes potential crashes due to this issue.
