### PR TITLE
Move AutoClose Value to TEnv

### DIFF
--- a/toonz/sources/common/tvectorimage/tl2lautocloser.cpp
+++ b/toonz/sources/common/tvectorimage/tl2lautocloser.cpp
@@ -3,11 +3,13 @@
 #include "tl2lautocloser.h"
 
 #include "tgl.h"
-
+#include "tenv.h"
 #include "tvectorimage.h"
 #include "tstroke.h"
 
 #include <QDebug>
+
+TEnv::DoubleVar VectorCloseValue("VectorCloseValue", 5);
 
 //=============================================================================
 #ifdef _WIN32
@@ -107,7 +109,7 @@ struct StrokePointSet {
   TStroke *stroke;
   std::vector<StrokePoint> points;
   StrokePointSet(TStroke *stroke_ = 0) : stroke(stroke_) {
-    const double inc = 5;
+    const double inc = VectorCloseValue;
     if (stroke_) {
       double length = stroke->getLength();
       double s      = 0;


### PR DESCRIPTION
This moves the inc value in tl2lautocloser.cpp to TEnv.  This doesn't actually change the value but allows the user to set it by hand.  I wouldn't recommend that most users mess with this, but I think having it in TEnv will allow for some troubleshooting.

I didn't put this in preferences for 2 reasons:
Preferences isn't accessible in this file. (Good reason)
This value isn't something people should generally mess with.  

