### PR TITLE
Foreign letter and Apostrophe fix

### DIFF
--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -24,7 +24,12 @@ namespace {
 string escape(string v) {
   int i = 0;
   for (;;) {
+// Removing escaping of apostrophe from Windows and OSX as it's not needed and causes problems
+#ifdef LINUX
     i = v.find_first_of("\\\'\"", i);
+#else
+    i = v.find_first_of("\\\"", i);
+#endif
     if (i == (int)string::npos) break;
     string h = "\\" + v[i];
     v.insert(i, "\\");

--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -348,7 +348,10 @@ TOStream &TOStream::operator<<(string v) {
   }
   int i;
   for (i = 0; i < len; i++)
-    if (!iswalnum(v[i]) && v[i] != '_' && v[i] != '%') break;
+    if ((!iswalnum(v[i]) && v[i] != '_' && v[i] != '%')
+		|| v[i] < 32   // Less than ASCII for SPACE
+		|| v[i] > 126  // Greater than ASCII for ~
+		) break;
   if (i == len)
     os << v << " ";
   else {
@@ -373,7 +376,10 @@ TOStream &TOStream::operator<<(QString _v) {
   }
   int i;
   for (i = 0; i < len; i++)
-    if (!iswalnum(v[i]) && v[i] != '_' && v[i] != '%') break;
+	  if ((!iswalnum(v[i]) && v[i] != '_' && v[i] != '%')
+		  || v[i] < 32   // Less than ASCII for SPACE
+		  || v[i] > 126  // Greater than ASCII for ~
+		  ) break;
   if (i == len)
     os << v << " ";
   else {


### PR DESCRIPTION
This PR does the following:

1) fixes #666 

Problem: Foreign characters in Level names, when written to the .tnz file, can cause the scene not to load correctly later if the entire Level name is not double-quoted.

Resolution:  Inspect the characters in the string for anything outside the ASCII range 32 (space) and 126 (~) and force the entire string to be double-quoted.

2) fixes #1226

Problem: When an apostrophe is in a filename, an escape character (\\) is inserted before it.  Later when the scene loads, it cannot find the file because the backlash is being treated as part of the path.

Resolution: Windows and OSX builds do not need to have apostrophe's escaped.  Added logic so it only escapes apostrophes for LINUX builds.


These fixes will only prevents the issue going forward.  This does not fix existing .tnz files with these issues.

**These fixes were tested on a Windows build. Need someone to verify OSX and LINUX builds.**