### PR TITLE
Correct Preview and Camera toggle for Sound columns

### DIFF
--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -841,6 +841,7 @@ bool ComboViewerPanel::hasSoundtrack() {
   }
   TXsheetHandle *xsheetHandle    = TApp::instance()->getCurrentXsheet();
   TXsheet::SoundProperties *prop = new TXsheet::SoundProperties();
+  if(!m_sceneViewer->isPreviewEnabled()) prop->m_isPreview = true;
   m_sound                        = xsheetHandle->getXsheet()->makeSound(prop);
   if (m_sound == NULL) {
     m_hasSoundtrack = false;

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -716,6 +716,7 @@ bool SceneViewerPanel::hasSoundtrack() {
   }
   TXsheetHandle *xsheetHandle    = TApp::instance()->getCurrentXsheet();
   TXsheet::SoundProperties *prop = new TXsheet::SoundProperties();
+  if (!m_sceneViewer->isPreviewEnabled()) prop->m_isPreview = true;
   m_sound                        = xsheetHandle->getXsheet()->makeSound(prop);
   if (m_sound == NULL) {
     m_hasSoundtrack = false;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -996,7 +996,7 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
       if (!isColumn) continue;
       // Cells appearance depending on the type of column
       if (isSoundColumn)
-        drawSoundCell(p, row, col);
+        drawSoundCell(p, row, col, isReference);
       else if (isPaletteColumn)
         drawPaletteCell(p, row, col, isReference);
       else if (isSoundTextColumn)
@@ -1127,7 +1127,7 @@ void CellArea::drawExtenderHandles(QPainter &p) {
 
 //-----------------------------------------------------------------------------
 
-void CellArea::drawSoundCell(QPainter &p, int row, int col) {
+void CellArea::drawSoundCell(QPainter &p, int row, int col, bool isReference) {
   const Orientation *o = m_viewer->orientation();
   TXshSoundColumn *soundColumn =
       m_viewer->getXsheet()->getColumn(col)->getSoundColumn();
@@ -1164,8 +1164,14 @@ void CellArea::drawSoundCell(QPainter &p, int row, int col) {
   // get cell colors
   QColor cellColor, sideColor;
   int levelType;
-  m_viewer->getCellTypeAndColors(levelType, cellColor, sideColor, cell,
-                                 isSelected);
+  if (isReference) {
+	  cellColor = (isSelected) ? m_viewer->getSelectedReferenceColumnColor()
+		  : m_viewer->getReferenceColumnColor();
+	  sideColor = m_viewer->getReferenceColumnBorderColor();
+  }
+  else
+	  m_viewer->getCellTypeAndColors(levelType, cellColor, sideColor, cell,
+		  isSelected);
 
   // cells background
   p.fillRect(rect, QBrush(cellColor));

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -86,7 +86,7 @@ class CellArea final : public QWidget {
 
   void drawLevelCell(QPainter &p, int row, int col, bool isReference = false);
   void drawSoundTextCell(QPainter &p, int row, int col);
-  void drawSoundCell(QPainter &p, int row, int col);
+  void drawSoundCell(QPainter &p, int row, int col, bool isReference = false);
   void drawPaletteCell(QPainter &p, int row, int col, bool isReference = false);
 
   void drawKeyframe(QPainter &p, const QRect toBeUpdated);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -607,7 +607,7 @@ void ColumnArea::DrawHeader::levelColors(QColor &columnColor,
 }
 void ColumnArea::DrawHeader::soundColors(QColor &columnColor,
                                          QColor &dragColor) const {
-  m_viewer->getColumnColor(columnColor, dragColor, col, xsh);
+    m_viewer->getColumnColor(columnColor, dragColor, col, xsh);
 }
 void ColumnArea::DrawHeader::paletteColors(QColor &columnColor,
                                            QColor &dragColor) const {
@@ -1207,7 +1207,8 @@ void ColumnArea::drawSoundColumnHead(QPainter &p, int col) {  // AREA
   DrawHeader drawHeader(this, p, col);
   drawHeader.prepare();
   QColor columnColor, dragColor;
-  drawHeader.soundColors(columnColor, dragColor);
+//  drawHeader.soundColors(columnColor, dragColor);
+  drawHeader.levelColors(columnColor, dragColor);
   drawHeader.drawBaseFill(columnColor, dragColor);
   drawHeader.drawEye();
   drawHeader.drawPreviewToggle(255);
@@ -1845,7 +1846,7 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
     if (m_doOnRelease == ToggleTransparency &&
         (!m_columnTransparencyPopup || m_columnTransparencyPopup->isHidden())) {
       column->setCamstandVisible(!column->isCamstandVisible());
-      app->getCurrentXsheet()->notifyXsheetSoundChanged();
+	  if (column->getSoundColumn()) app->getCurrentXsheet()->notifyXsheetSoundChanged();
     } else if (m_doOnRelease == TogglePreviewVisible)
       column->setPreviewVisible(!column->isPreviewVisible());
     else if (m_doOnRelease == ToggleLock)

--- a/toonz/sources/toonzlib/tframehandle.cpp
+++ b/toonz/sources/toonzlib/tframehandle.cpp
@@ -338,7 +338,7 @@ bool TFrameHandle::scrub(int r0, int r1, double framePerSecond) {
     m_audioColumn->scrub(r0, r1);
   else if (m_xsheet) {
     int i;
-    for (i = r0; i <= r1; i++) m_xsheet->scrub(i);
+    for (i = r0; i <= r1; i++) m_xsheet->scrub(i, true);
   }
 
   if (onlyOneFrame) return false;

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -469,10 +469,12 @@ TXshColumn::ColumnType TXshColumn::toColumnType(int levelType) {
 }
 
 //-----------------------------------------------------------------------------
-
 bool TXshColumn::isRendered() const {
-  if (!getXsheet() || !getFx()) return false;
-  if (!isPreviewVisible()) return false;
+//  if (!getXsheet() || !getFx()) return false;
+//  if (!isPreviewVisible()) return false;
+  if (!getXsheet() || !isPreviewVisible()) return false;
+  if (getColumnType() == eSoundType) return true;
+  if (!getFx()) return false;
   return getXsheet()->getFxDag()->isRendered(getFx());
 }
 

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -1395,8 +1395,8 @@ void searchAudioColumn(TXsheet *xsh, std::vector<TXshSoundColumn *> &sounds,
     TXshColumn *column = xsh->getColumn(i);
     if (column) {
       TXshSoundColumn *soundCol = column->getSoundColumn();
-      if (soundCol && ((isPreview && soundCol->isPreviewVisible()) ||
-                       (!isPreview && soundCol->isCamstandVisible()))) {
+      if (soundCol && ((isPreview && soundCol->isCamstandVisible()) ||
+                       (!isPreview && soundCol->isPreviewVisible()))) {
         sounds.push_back(soundCol);
         continue;
       }


### PR DESCRIPTION
This PR fixes #1462 

Current behavior: 

Preview Toggle has no impact to rendering or playback of Sound Columns. The Camera Visibility Toggle does both.  This is not in line with other columns

New behavior for when sound is played based on Preview/Camera toggle combinations:
<!DOCTYPE html>
<html>
<body>
<table style="width:100%">
  <tr>
    <th rowspan="2">Preview Toggle</th>
    <th rowspan="2">Camera Toggle</th>
    <th colspan="2">Viewer/ComboViewer</th> 
    <th rowspan="2">Preview/Render</th>
    <th rowspan="2">Xsheet Scrub</th>
  </tr>
  <tr>
    <th>Preview</th> 
    <th>NoPreview</th> 
  </tr>
  <tr>
    <td>On</td>
    <td>On</td>
    <td>Yes</td> 
    <td>Yes</td>
    <td>Yes</td>
    <td>Yes</td>
  </tr>
  <tr>
    <td>Off</td>
    <td>On</td>
    <td>No</td> 
    <td>Yes</td>
    <td>No</td>
    <td>Yes</td>
  </tr>
  <tr>
    <td>On</td>
    <td>Off</td>
    <td>Yes</td> 
    <td>No</td>
    <td>Yes</td>
    <td>No</td>
  </tr>
  <tr>
    <td>Off</td>
    <td>Off</td>
    <td>No</td> 
    <td>No</td> 
    <td>No</td>
    <td>No</td>
  </tr> 
</table>
</body>
</html>
