### PR TITLE
Fix crash when viewing audio levels in Scene Cast

### DIFF
--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -725,6 +725,7 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
   bool audioSelected       = false;
   bool paletteSelected     = false;
   bool vectorLevelSelected = false;
+  bool meshLevelSelected   = false;
   bool otherFileSelected   = false;
   int levelSelectedCount   = 0;
   for (it = indices.begin(); it != indices.end(); ++it) {
@@ -742,6 +743,8 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
     levelSelectedCount++;
     if (sl->getType() == PLI_XSHLEVEL)
       vectorLevelSelected = true;
+	else if(sl->getType() == MESH_XSHLEVEL)
+	  meshLevelSelected = true;
     else
       otherFileSelected = true;
   }
@@ -752,7 +755,7 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
 
   menu->addAction(cm->getAction(MI_ExposeResource));
   menu->addAction(cm->getAction(MI_ShowFolderContents));
-  if(!audioSelected && !paletteSelected)
+  if(!audioSelected && !paletteSelected && !meshLevelSelected)
 	  menu->addAction(cm->getAction(MI_ViewFile));
   menu->addAction(cm->getAction(MI_FileInfo));
 

--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -752,11 +752,12 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
 
   menu->addAction(cm->getAction(MI_ExposeResource));
   menu->addAction(cm->getAction(MI_ShowFolderContents));
-  menu->addAction(cm->getAction(MI_ViewFile));
+  if(!audioSelected && !paletteSelected)
+	  menu->addAction(cm->getAction(MI_ViewFile));
   menu->addAction(cm->getAction(MI_FileInfo));
-  if (audioSelected && !paletteSelected && !vectorLevelSelected &&
-      !otherFileSelected)
-    return menu;
+//  if (audioSelected && !paletteSelected && !vectorLevelSelected &&
+//      !otherFileSelected)
+//    return menu;
 
   // MI_EditLevel solo se e' stato selezionato un singolo diverso da livelli
   // palette a livelli audio

--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -755,9 +755,6 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
   if(!audioSelected && !paletteSelected)
 	  menu->addAction(cm->getAction(MI_ViewFile));
   menu->addAction(cm->getAction(MI_FileInfo));
-//  if (audioSelected && !paletteSelected && !vectorLevelSelected &&
-//      !otherFileSelected)
-//    return menu;
 
   // MI_EditLevel solo se e' stato selezionato un singolo diverso da livelli
   // palette a livelli audio

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -1191,6 +1191,8 @@ public:
 
     if (!simpleLevels.size()) return;
     for (i = 0; i < simpleLevels.size(); i++) {
+	  if (!(simpleLevels[i]->getType() & LEVELCOLUMN_XSHLEVEL)) continue;
+
       TFilePath path = simpleLevels[i]->getPath();
       path           = simpleLevels[i]->getScene()->decodeFilePath(path);
       FlipBook *fb;


### PR DESCRIPTION
This PR fixes #1240 

The "View" menu item does not support Audio and Palette level types.  Disabled this option if either of those types are selected to prevent crashing.

Additionally allowed "Remove Level" and "Remove All Unused Levels" to be options when selecting Audio level types as these are still valid actions.