### PR TITLE
Renumber crash fix

### DIFF
--- a/toonz/sources/include/toonz/imagemanager.h
+++ b/toonz/sources/include/toonz/imagemanager.h
@@ -288,7 +288,7 @@ protected:
                                           std::vector<TFrameId>,
                                           std::vector<std::string>, bool){};
 
-  virtual void setFid(const TFrameId &fid) {};
+  virtual void setFid(const TFrameId &fid){};
 
   //! Clears the builder's cached data.
   virtual void invalidate() {

--- a/toonz/sources/include/toonz/imagemanager.h
+++ b/toonz/sources/include/toonz/imagemanager.h
@@ -141,6 +141,8 @@ Binding an id to 0 is equivalent to unbinding it.
   //! succeeded.
   bool rebind(const std::string &srcId, const std::string &dstId);
 
+  bool renumber(const std::string &srcId, const TFrameId &fid);
+
   //! Unbinds all known identifiers, resetting the image manager to its empty
   //! state.
   void clear();
@@ -285,6 +287,8 @@ protected:
   virtual void buildAllIconsAndPutInCache(TXshSimpleLevel *,
                                           std::vector<TFrameId>,
                                           std::vector<std::string>, bool){};
+
+  virtual void setFid(const TFrameId &fid) {};
 
   //! Clears the builder's cached data.
   virtual void invalidate() {

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -450,8 +450,8 @@ public:
         for (int i = 0; i < n; i++) {
           std::map<TXshCell, TXshCell>::const_iterator it =
               table.find(cells[i]);
-          if (it != table.end())
-            cells[i] = it->second, changed = it->first != it->second;
+          if (it != table.end() && it->first != it->second)
+            cells[i] = it->second, changed = true;
         }
         if (changed) xsh->setCells(r0, c, n, &cells[0]);
       }

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -182,8 +182,8 @@ void TPanelTitleBarButton::setPressed(bool pressed) {
 void TPanelTitleBarButton::paintEvent(QPaintEvent *event) {
   QPainter painter(this);
   painter.drawPixmap(
-      0, 0, m_pressed ? m_pressedPixmap
-                      : m_rollover ? m_rolloverPixmap : m_standardPixmap);
+      0, 0, m_pressed ? m_pressedPixmap : m_rollover ? m_rolloverPixmap
+                                                     : m_standardPixmap);
   painter.end();
 }
 

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1424,7 +1424,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
 #ifdef _WIN32
     fontName = "Arial";
 #else
-    fontName          = "Helvetica";
+    fontName = "Helvetica";
 #endif
   }
   static QFont font(fontName, -1, QFont::Normal);

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -231,6 +231,10 @@ void ImageLoader::buildAllIconsAndPutInCache(TXshSimpleLevel *level,
   }
 }
 
+void ImageLoader::setFid(const TFrameId &fid) {
+	m_fid = fid;
+}
+
 //***************************************************************************************
 //    ImageRasterizer  implementation
 //***************************************************************************************

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -231,9 +231,7 @@ void ImageLoader::buildAllIconsAndPutInCache(TXshSimpleLevel *level,
   }
 }
 
-void ImageLoader::setFid(const TFrameId &fid) {
-	m_fid = fid;
-}
+void ImageLoader::setFid(const TFrameId &fid) { m_fid = fid; }
 
 //***************************************************************************************
 //    ImageRasterizer  implementation

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -59,6 +59,10 @@ public:
                                   std::vector<std::string> iconIds,
                                   bool cacheImagesAsWell) override;
 
+  /* Exposed to allow Fid to be updated due to a renumber operation
+  */
+  void setFid(const TFrameId &fid);
+
 protected:
   bool getInfo(TImageInfo &info, int imFlags, void *extData) override;
   TImageP build(int imFlags, void *extData) override;

--- a/toonz/sources/toonzlib/imagemanager.cpp
+++ b/toonz/sources/toonzlib/imagemanager.cpp
@@ -246,7 +246,7 @@ bool ImageManager::rebind(const std::string &srcId, const std::string &dstId) {
   m_imp->m_builders.erase(st);
   m_imp->m_builders[dstId] = builder;
 
-  m_imp->m_builders[dstId]->m_cached = true;
+  m_imp->m_builders[dstId]->m_cached   = true;
   m_imp->m_builders[dstId]->m_modified = true;
 
   TImageCache::instance()->remap(dstId, srcId);
@@ -255,13 +255,13 @@ bool ImageManager::rebind(const std::string &srcId, const std::string &dstId) {
 }
 
 bool ImageManager::renumber(const std::string &srcId, const TFrameId &fid) {
-	std::map<std::string, ImageBuilderP>::iterator st =
-		m_imp->m_builders.find(srcId);
-	if (st == m_imp->m_builders.end()) return false;
+  std::map<std::string, ImageBuilderP>::iterator st =
+      m_imp->m_builders.find(srcId);
+  if (st == m_imp->m_builders.end()) return false;
 
-	m_imp->m_builders[srcId]->setFid(fid);
+  m_imp->m_builders[srcId]->setFid(fid);
 
-	return true;
+  return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/imagemanager.cpp
+++ b/toonz/sources/toonzlib/imagemanager.cpp
@@ -251,6 +251,16 @@ bool ImageManager::rebind(const std::string &srcId, const std::string &dstId) {
   return true;
 }
 
+bool ImageManager::renumber(const std::string &srcId, const TFrameId &fid) {
+	std::map<std::string, ImageBuilderP>::iterator st =
+		m_imp->m_builders.find(srcId);
+	if (st == m_imp->m_builders.end()) return false;
+
+	m_imp->m_builders[srcId]->setFid(fid);
+
+	return true;
+}
+
 //-----------------------------------------------------------------------------
 
 void ImageManager::clear() {

--- a/toonz/sources/toonzlib/imagemanager.cpp
+++ b/toonz/sources/toonzlib/imagemanager.cpp
@@ -246,6 +246,9 @@ bool ImageManager::rebind(const std::string &srcId, const std::string &dstId) {
   m_imp->m_builders.erase(st);
   m_imp->m_builders[dstId] = builder;
 
+  m_imp->m_builders[dstId]->m_cached = true;
+  m_imp->m_builders[dstId]->m_modified = true;
+
   TImageCache::instance()->remap(dstId, srcId);
 
   return true;

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1964,13 +1964,19 @@ void TXshSimpleLevel::renumber(const std::vector<TFrameId> &fids) {
   std::map<TFrameId, TFrameId>::iterator jt;
 
   {
-    for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
-      im->rebind(getImageId(jt->first), "^" + std::to_string(i));
+	  for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
+	  {
+		  std::string Id = getImageId(jt->first);
+		  im->rebind(Id, "^" + std::to_string(i));
+		  TImageCache::instance()->remap("^icon:" + std::to_string(i), "icon:" + Id);
+	  }
 
 	for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
 	{
-		im->rebind("^" + std::to_string(i), getImageId(jt->second));
-		im->renumber(getImageId(jt->second), jt->second);
+		std::string Id = getImageId(jt->second);
+		im->rebind("^" + std::to_string(i), Id);
+		TImageCache::instance()->remap("icon:" + Id, "^icon:" + std::to_string(i));
+		im->renumber(Id, jt->second);
 	}
   }
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1967,8 +1967,11 @@ void TXshSimpleLevel::renumber(const std::vector<TFrameId> &fids) {
     for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
       im->rebind(getImageId(jt->first), "^" + std::to_string(i));
 
-    for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
-      im->rebind("^" + std::to_string(i), getImageId(jt->second));
+	for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
+	{
+		im->rebind("^" + std::to_string(i), getImageId(jt->second));
+		im->renumber(getImageId(jt->second), jt->second);
+	}
   }
 
   if (getType() == PLI_XSHLEVEL) {

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1964,20 +1964,20 @@ void TXshSimpleLevel::renumber(const std::vector<TFrameId> &fids) {
   std::map<TFrameId, TFrameId>::iterator jt;
 
   {
-	  for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
-	  {
-		  std::string Id = getImageId(jt->first);
-		  im->rebind(Id, "^" + std::to_string(i));
-		  TImageCache::instance()->remap("^icon:" + std::to_string(i), "icon:" + Id);
-	  }
+    for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i) {
+      std::string Id = getImageId(jt->first);
+      im->rebind(Id, "^" + std::to_string(i));
+      TImageCache::instance()->remap("^icon:" + std::to_string(i),
+                                     "icon:" + Id);
+    }
 
-	for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i)
-	{
-		std::string Id = getImageId(jt->second);
-		im->rebind("^" + std::to_string(i), Id);
-		TImageCache::instance()->remap("icon:" + Id, "^icon:" + std::to_string(i));
-		im->renumber(Id, jt->second);
-	}
+    for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i) {
+      std::string Id = getImageId(jt->second);
+      im->rebind("^" + std::to_string(i), Id);
+      TImageCache::instance()->remap("icon:" + Id,
+                                     "^icon:" + std::to_string(i));
+      im->renumber(Id, jt->second);
+    }
   }
 
   if (getType() == PLI_XSHLEVEL) {
@@ -2187,9 +2187,8 @@ TFilePath TXshSimpleLevel::getExistingHookFile(
   }
 
   assert(h >= 0);
-  return (h < 0) ? TFilePath()
-                 : decodedLevelPath.getParentDir() +
-                       TFilePath(hookFiles[h].toStdWString());
+  return (h < 0) ? TFilePath() : decodedLevelPath.getParentDir() +
+                                     TFilePath(hookFiles[h].toStdWString());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #1312

The main cause of the crash in this scenario is the disappearing drawing(s) when trying to display something that was renumbered. This crash appears only to happen with Toonz Raster and normal Raster levels that have been renumbered.

In a nutshell, when you perform a Renumber (Auto or manual), there are a few places internally where the image-to-frame (level strip, not xsheet) relationship is not being updated properly.

The issue usually isn't obvious until you actually save the level/scene because it changes where it might be pulling the images from, cache or file. Depending on what you are doing you may or may not notice a drawing has disappeared. Once the drawing disappears like that, it could crash OT depending on which internal structure is being referenced to display it.

NOTE: Technically this Renumber bug also impacts Toonz Vector levels, but because of the way Vector level images are saved and displayed, the discrepancy of internal dependencies has almost negligable impact.
