### PR TITLE
Fix cell selection behavior

### DIFF
--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -384,7 +384,7 @@ void FilmstripFrames::hideEvent(QHideEvent *) {
   TApp *app = TApp::instance();
 
   // cambiamenti al livello
-  disconnect(app->getCurrentLevel());
+  disconnect(app->getCurrentLevel(), 0, this, 0);
 
   // al frame corrente
   disconnect(app->getCurrentFrame(), SIGNAL(frameSwitched()), this,
@@ -1007,7 +1007,9 @@ void FilmstripFrames::onFrameSwitched() {
   if (index >= 0) {
     exponeFrame(index);
     // clear selection and select only the destination frame
-    select(index, ONLY_SELECT);
+    TFilmstripSelection *fsSelection =
+        dynamic_cast<TFilmstripSelection *>(TSelection::getCurrent());
+    if (fsSelection) select(index, ONLY_SELECT);
   }
   update();
 }


### PR DESCRIPTION
This PR fixes a niche, but very very frustrating behavior in the software as follows:

"Sometimes the xsheet cell selection released on right-click. "

After investigation, I found that this behavior happens when the Level Strip panel is opened along with the Xsheet. Right-clicking on the xsheet causes unwanted change of the current selection to the `TFilmStripSelection` which causes the cell selection's release.

Also I fixed in this PR the incorrect disconnection done in `FilmstripFrames::hideEvent()` .

 