### PR TITLE
Fix Position of Style Shortcuts Label

### DIFF
--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -844,7 +844,9 @@ void PageViewer::paintEvent(QPaintEvent *e) {
         p.drawChord(ssRect, 0, -180 * 16);
         tmpFont.setPointSize(6);
         p.setFont(tmpFont);
-        p.drawText(ssRect.adjusted(0, 10, 0, 0), Qt::AlignCenter,
+        // make sure the text is visible with any font
+        static int rectTopAdjust = 19 - QFontMetrics(tmpFont).overlinePos();
+        p.drawText(ssRect.adjusted(0, rectTopAdjust, 0, 0), Qt::AlignCenter,
                    QString().setNum(shortcut));
       }
 


### PR DESCRIPTION
This fixes #1511 .
The baseline placement seems to vary between fonts and sometimes it becomes unwanted position with specific font size (6px, in this case). I added some offset based on the over line position of each font.

![image](https://user-images.githubusercontent.com/17974955/31369631-b62ef7bc-adc0-11e7-9c6f-84b0d13231d2.png)

I confirmed this solution works fine with "Segoe UI", "Arial", "Century" and "Meiryo UI".