### PR TITLE
Modification in Camera Capture : Increment Alphabet on Capture

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1777,7 +1777,10 @@ void PencilTestPopup::onImageCaptured(int id, const QImage& image) {
       m_cameraViewfinder->setPreviousImage(procImg);
       if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
         int f = m_frameNumberEdit->getValue();
-        m_frameNumberEdit->setValue(((int)(f / 10) + 1) * 10);
+        if (f % 10 == 0)  // next number
+          m_frameNumberEdit->setValue(((int)(f / 10) + 1) * 10);
+        else  // next alphabet
+          m_frameNumberEdit->setValue(f + 1);
       } else
         m_frameNumberEdit->setValue(m_frameNumberEdit->getValue() + 1);
 


### PR DESCRIPTION
This modification is demanded by some Japanese animation studio.

It changes behavior of the frame number field of the Camera Capture popup, with the preferences option `Show "ABC" Appendix to the Frame Number in Xsheet Cell` being ON.
In the current implementation, the frame number field will always be incremented to the next "number" without alphabet appendix.
(i.e. if the frame is "001" or "001A" or "001B" before capturing, the next frame will become "2" in all cases.)

I changed the behavior, to be incremented to the next "alphabet" if the previous frame has the alphabet appendix (i.e. "001A" -> "001B", "001B" -> "001C", "001I" -> "002", "001" -> "002"), because it is more frequent to do so.