### PR TITLE
Eraser and Lock Alpha options for MyPaint brushes

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -2489,7 +2489,9 @@ BrushData::BrushData()
     , m_join(0)
     , m_miter(0)
     , m_modifierSize(0.0)
-    , m_modifierOpacity(0.0) {}
+    , m_modifierOpacity(0.0)
+    , m_modifierEraser(0.0)
+    , m_modifierLockAlpha(0.0) {}
 
 //----------------------------------------------------------------------------------------------------------
 
@@ -2510,7 +2512,9 @@ BrushData::BrushData(const std::wstring &name)
     , m_join(0)
     , m_miter(0)
     , m_modifierSize(0.0)
-    , m_modifierOpacity(0.0) {}
+    , m_modifierOpacity(0.0)
+    , m_modifierEraser(0.0)
+    , m_modifierLockAlpha(0.0) {}
 
 //----------------------------------------------------------------------------------------------------------
 
@@ -2560,6 +2564,12 @@ void BrushData::saveData(TOStream &os) {
   os.openChild("Modifier_Opacity");
   os << m_modifierOpacity;
   os.closeChild();
+  os.openChild("Modifier_Eraser");
+  os << (int)m_modifierEraser;
+  os.closeChild();
+  os.openChild("Modifier_LockAlpha");
+  os << (int)m_modifierLockAlpha;
+  os.closeChild();
 }
 
 //----------------------------------------------------------------------------------------------------------
@@ -2599,6 +2609,10 @@ void BrushData::loadData(TIStream &is) {
       is >> m_modifierSize, is.matchEndTag();
     else if (tagName == "Modifier_Opacity")
       is >> m_modifierOpacity, is.matchEndTag();
+    else if (tagName == "Modifier_Eraser")
+      is >> val, m_modifierEraser = val, is.matchEndTag();
+    else if (tagName == "Modifier_LockAlpha")
+      is >> val, m_modifierLockAlpha = val, is.matchEndTag();
     else
       is.skipCurrentTag();
   }

--- a/toonz/sources/tnztools/brushtool.h
+++ b/toonz/sources/tnztools/brushtool.h
@@ -42,6 +42,7 @@ struct BrushData final : public TPersist {
   bool m_selective, m_pencil, m_breakAngles, m_pressure; 
   int m_cap, m_join, m_miter; 
   double m_modifierSize, m_modifierOpacity;
+  bool m_modifierEraser, m_modifierLockAlpha;
 
   BrushData();
   BrushData(const std::wstring &name);

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -88,6 +88,8 @@ protected:
   TDoubleProperty m_hardness;
   TDoubleProperty m_modifierSize;
   TDoubleProperty m_modifierOpacity;
+  TBoolProperty m_modifierEraser;
+  TBoolProperty m_modifierLockAlpha;
   TEnumProperty m_preset;
 
   TPixel32 m_currentColor;


### PR DESCRIPTION
This patch adds "Eraser" and "Lock Alpha" options into brush toolbar for MyPaint brushes like in Krita and MyPaint.

As described here: https://github.com/blackwarthog/opentoonz/issues/5

![2017-10-16 23-47-18](https://user-images.githubusercontent.com/5143743/31624589-6fdf3670-b2cd-11e7-8ddf-91ff68db2427.png)
