### PR TITLE
Paste Numbers Command

### DIFF
--- a/toonz/sources/include/toonz/txshlevelcolumn.h
+++ b/toonz/sources/include/toonz/txshlevelcolumn.h
@@ -85,6 +85,9 @@ Return \b TFx.
 */
   TFx *getFx() const override;
 
+  // Used in TCellData::getNumbers
+  bool setNumbers(int row, int rowCount, const TXshCell cells[]);
+
 private:
   // not implemented
   TXshLevelColumn(const TXshLevelColumn &);

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -36,5 +36,6 @@
 #define MI_Collapse "MI_Collapse"
 #define MI_ExplodeChild "MI_ExplodeChild"
 #define MI_ToggleEditInPlace "MI_ToggleEditInPlace"
+#define MI_PasteNumbers "MI_PasteNumbers"
 
 #endif

--- a/toonz/sources/toonz/celldata.h
+++ b/toonz/sources/toonz/celldata.h
@@ -47,6 +47,11 @@ If skipEmptyCells == false do not skip setting empty cells in data*/
                 bool insert = true, bool doZeraryClone = true,
                 bool skipEmptyCells = true) const;
 
+  // Paste only cell numbers.
+  // As a special behavior, enable to copy one column and paste into
+  // multiple columns.
+  bool getNumbers(TXsheet *xsh, int r0, int c0, int &r1, int &c1) const;
+
   //! Return true if cell in TCellData can be set in \b xsh xsheet.
   bool canChange(TXsheet *xsh, int c0) const;
 

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -50,6 +50,8 @@ public:
 
   /*- セルの上書きペースト -*/
   void overWritePasteCells();
+  // paste cell numbers only
+  void overwritePasteNumbers();
 
   //! \note: puo' anche essere r0>r1 o c0>c1
   void selectCells(int r0, int c0, int r1, int c1);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1869,6 +1869,7 @@ void MainWindow::defineActions() {
                         "");
 
   createRightClickMenuAction(MI_SetKeyframes, tr("&Set Key"), "Z");
+  createRightClickMenuAction(MI_PasteNumbers, tr("&Paste Numbers"), "");
 
   createToggle(MI_ViewCamera, tr("&Camera Box"), "",
                ViewCameraToggleAction ? 1 : 0, MenuViewCommandType);
@@ -2357,9 +2358,9 @@ RecentFiles::~RecentFiles() {}
 
 void RecentFiles::addFilePath(QString path, FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) files.removeAt(i);
@@ -2484,9 +2485,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2513,9 +2514,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
-                                                        ? MI_ClearRecentLevel
-                                                        : MI_ClearRecentImage;
+        (fileType == Scene)
+            ? MI_ClearRecentScene
+            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2629,9 +2629,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
       menu.addAction(cmdManager->getAction(MI_Autorenumber));
     }
     menu.addAction(cmdManager->getAction(MI_ReplaceLevel));
-
     menu.addAction(cmdManager->getAction(MI_ReplaceParentDirectory));
-
     {
       // replace with another level in scene cast
       std::vector<TXshLevel *> levels;
@@ -2693,6 +2691,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
   menu.addSeparator();
   if (!soundCellsSelected)
     menu.addAction(cmdManager->getAction(MI_ImportMagpieFile));
+  menu.addAction(cmdManager->getAction(MI_PasteNumbers));
 }
 //-----------------------------------------------------------------------------
 /*! replace level with another level in the cast


### PR DESCRIPTION
This PR will introduce a new command "Paste Numbers" . This feature is demanded by some Japanese animation studio.

- This command works when the xsheet cells are copied in the clipboard.
- Unlike normal "Paste" command, it will paste only numbers of copied cells, keeping the level unchanged.
- This command will overwrite the cells. No matter how many cells are selected on trigger this command, it will paste numbers of all the copied cells starting from the upper-left corner of the selected cell region.  
- If the destination cell is empty, search upper and lower cells in the column and use the level of occupied neighbor cell. This command will do nothing to empty column or columns without cell numbers.
- As a special option, this command can paste single column to multiple columns. In such case, the same number sequence will be duplicated to the selected columns.

For now this command is tentatively added to the end of the right-click menu of the xsheet cell area. The command position will be modified after merging #1516 . 