### PR TITLE
Template Env File

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -171,6 +171,9 @@ public:
   }
 
   TFilePath getEnvFile() { return m_envFile; }
+  TFilePath getTemplateEnvFile() {
+    return m_envFile.getParentDir() + TFilePath("template.env");
+  }
 
   void setApplicationFullName(std::string applicationFullName) {
     m_applicationFullName = applicationFullName;
@@ -326,8 +329,11 @@ void VariableSet::load() {
 #endif
   TFilePath fp = EnvGlobals::instance()->getEnvFile();
   if (fp == TFilePath()) return;
+  // if the personal env is not found, then try to find the template
+  if (!TFileStatus(fp).doesExist())
+    fp = EnvGlobals::instance()->getTemplateEnvFile();
   Tifstream is(fp);
-  if (!is) return;
+  if (!is.isOpen()) return;
   char buffer[1024];
   while (is.getline(buffer, sizeof(buffer))) {
     char *s = buffer;


### PR DESCRIPTION
The user env file ( in `$TOONZPROFILES\env\username.env` ) is for storing the current state of the software in order to reproduce the same state on next launch.  The env file differs from the preferences in that, the preferences are manually modified via the Preferences popup, OTOH the env file is automatically saved on quitting the software.

Most of parameters stored in env file are "tend to fluctuate" on a short-term basis ( such as a size of brush tip ). But some of the parameters are more "stable" through production and obtaining default values from the template env file can avoid the trouble of having to setup such parameters for new users ( such as a current camera name and a current resolution set in the Camera Capture popup ). 

This PR will enable to use the template env file. If the personal env file is missing on launch ( i.e. the user firstly launch the software ), then the template env file ( `$TOONZPROFILES\env\template.env` ) will be loaded, if it exists.
This feature is demanded by some Japanese animation studio.