### PR TITLE
Fix Fill Behavior on Toonz Raster

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -27,6 +27,7 @@ public:
   bool m_shiftFill;
   TPoint m_p;
   TPalette *m_palette;
+  bool m_prevailing;
 
   FillParameters()
       : m_styleId(0)
@@ -37,7 +38,8 @@ public:
       , m_maxFillDepth(0)
       , m_p()
       , m_shiftFill(false)
-      , m_palette(0) {}
+      , m_palette(0)
+      , m_prevailing(true) {}
   FillParameters(const FillParameters &params)
       : m_styleId(params.m_styleId)
       , m_fillType(params.m_fillType)
@@ -47,7 +49,8 @@ public:
       , m_maxFillDepth(params.m_maxFillDepth)
       , m_p(params.m_p)
       , m_shiftFill(params.m_shiftFill)
-      , m_palette(params.m_palette) {}
+      , m_palette(params.m_palette)
+      , m_prevailing(params.m_prevailing) {}
 };
 
 //=============================================================================

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -52,11 +52,14 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
     if (tone == 0) break;
     // prevent fill area from protruding behind the colored line
     if (tone > oldtone) {
+      // not-yet-colored line case
       if (!pix->isPurePaint() && pix->getInk() != pix->getPaint()) break;
       while (pix != pix0) {
         // iterate back in order to leave the pixel with the lowest tone
         // unpainted
         pix--;
+        // make the one-pixel-width semi-transparent line to be painted
+        if (pix->getInk() != pix->getPaint()) break;
         if (pix->getTone() > oldtone) {
           // check if the current pixel is NOT with the lowest tone among the
           // vertical neighbors as well
@@ -98,11 +101,14 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
     if (tone == 0) break;
     // prevent fill area from protruding behind the colored line
     if (tone > oldtone) {
+      // not-yet-colored line case
       if (!pix->isPurePaint() && pix->getInk() != pix->getPaint()) break;
       while (pix != pix0) {
         // iterate forward in order to leave the pixel with the lowest tone
         // unpainted
         pix++;
+        // make the one-pixel-width semi-transparent line to be painted
+        if (pix->getInk() != pix->getPaint()) break;
         if (pix->getTone() > oldtone) {
           // check if the current pixel is NOT with the lowest tone among the
           // vertical neighbors as well

--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -69,6 +69,8 @@ void fillArea(const TRasterCM32P &ras, TRegion *r, int colorId,
 void restoreColors(const TRasterCM32P &r,
                    const std::vector<std::pair<TPoint, int>> &seeds) {
   FillParameters params;
+  // in order to make the paint to protlude behind the line
+  params.m_prevailing = false;
   for (UINT i = 0; i < seeds.size(); i++) {
     params.m_p       = seeds[i].first;
     params.m_styleId = seeds[i].second;
@@ -232,6 +234,8 @@ void AreaFiller::rectFill(const TRect &rect, int color, bool onlyUnfilled,
   // fillate.
   count1 = 0;
   FillParameters params;
+  // in order to make the paint to protlude behind the line
+  params.m_prevailing = false;
   if (r.x0 > 0)
     for (y = r.y0; y <= r.y1; y++) {
       params.m_p       = TPoint(r.x0, y);


### PR DESCRIPTION
This PR fixes the problem when painting on Toonz Raster levels as follows:

When you draw some character which has light and dark parts, usually the self-colored line is drawn at the border, with the "Autopaint Lines" option activated. Conventionally, the self-colored lines are to be painted with a color of the dark area. So the workflow would be as follows:

1. Prepare an unpainted drawing. The self-colored line (red line) is drawn with the style with the "Autopaint Lines" option being ON.
1. Fill the dark area. The self-colored line is automatically painted with the dark color.
1. Fill the light area.

<img src="https://user-images.githubusercontent.com/17974955/31993434-1167b544-b9b8-11e7-9254-8c7c14d994b3.png" width=400>

However, for now the result of the above procedure causes unwanted artifacts - which is because the light color protrudes too much, behind the center of the line. ( as seen in the left figure below )
To prevent such artifacts, for now you need to do quite troublesome way - first, fill the light area with the "Autopaint Lines" option being OFF, secondly activate the "Autopaint Lines" option, then finally fill the dark area. ( the result is in the right figure below ) 

![autopaint_comparison](https://user-images.githubusercontent.com/17974955/31993922-b04c1bea-b9b9-11e7-8bc6-fb2a5cfc72a0.png)

This PR will solve such issue.
With this PR, when filling the area the paint will not protrude the center of self-colored line anymore, as illustrated as follows:

![fix_fill_behavior](https://user-images.githubusercontent.com/17974955/31994088-6b65b85a-b9ba-11e7-9cc4-7130576635db.png)

I set this PR as WIP because I need some time to test this modification by some Japanese animation studio who demanded this fix.