### PR TITLE
Fix Boolean Tool Options Behavior with Shortcuts

### DIFF
--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -306,8 +306,10 @@ void ToolOptionControlBuilder::visit(TBoolProperty *p) {
     std::string actionName = "A_ToolOption_" + p->getId();
     QAction *a = CommandManager::instance()->getAction(actionName.c_str());
     if (a) {
+      a->setCheckable(true);
       control->addAction(a);
-      QObject::connect(a, SIGNAL(triggered()), control, SLOT(doClick()));
+      QObject::connect(a, SIGNAL(triggered(bool)), control,
+                       SLOT(doClick(bool)));
     }
   }
   hLayout()->addSpacing(5);
@@ -553,10 +555,11 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
     m_lockNSCenterCheckbox =
         new ToolOptionCheckbox(m_tool, lockProp, toolHandle, this);
 
-  TBoolProperty *prop =
+  TBoolProperty *globalKeyProp =
       dynamic_cast<TBoolProperty *>(m_pg->getProperty("Global Key"));
-  if (prop)
-    m_globalKey = new ToolOptionCheckbox(m_tool, prop, toolHandle, this);
+  if (globalKeyProp)
+    m_globalKey =
+        new ToolOptionCheckbox(m_tool, globalKeyProp, toolHandle, this);
 
   m_lockEWPosCheckbox->setObjectName("EditToolLockButton");
   m_lockNSPosCheckbox->setObjectName("EditToolLockButton");
@@ -811,6 +814,16 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
             SLOT(onScaleTypeChanged(int)));
     connect(m_maintainCombo, SIGNAL(currentIndexChanged(int)), m_scaleVField,
             SLOT(onScaleTypeChanged(int)));
+  }
+
+  if (globalKeyProp) {
+    std::string actionName = "A_ToolOption_" + globalKeyProp->getId();
+    QAction *a = CommandManager::instance()->getAction(actionName.c_str());
+    if (a) {
+      a->setCheckable(true);
+      m_globalKey->addAction(a);
+      connect(a, SIGNAL(triggered(bool)), m_globalKey, SLOT(doClick(bool)));
+    }
   }
 }
 

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -102,6 +102,11 @@ ToolOptionCheckbox::ToolOptionCheckbox(TTool *tool, TBoolProperty *property,
 
 void ToolOptionCheckbox::updateStatus() {
   bool check = m_property->getValue();
+
+  if (!actions().isEmpty() && actions()[0]->isCheckable() &&
+      actions()[0]->isChecked() != check)
+    actions()[0]->setChecked(check);
+
   if (isChecked() == check) return;
 
   setCheckState(check ? Qt::Checked : Qt::Unchecked);
@@ -109,19 +114,16 @@ void ToolOptionCheckbox::updateStatus() {
 
 //-----------------------------------------------------------------------------
 
-void ToolOptionCheckbox::nextCheckState() {
-  QAbstractButton::nextCheckState();
-  m_property->setValue(checkState() == Qt::Checked);
-  notifyTool();
-}
-
-//-----------------------------------------------------------------------------
-
-void ToolOptionCheckbox::doClick() {
+void ToolOptionCheckbox::doClick(bool checked) {
   if (m_toolHandle && m_toolHandle->getTool() != m_tool) return;
   // active only if the belonging combo-viewer is visible
   if (!isInVisibleViewer(this)) return;
-  click();
+
+  if (isChecked() == checked) return;
+
+  setChecked(checked);
+  m_property->setValue(checked);
+  notifyTool();
 }
 
 //=============================================================================

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -93,10 +93,7 @@ public:
                      ToolHandle *toolHandle = 0, QWidget *parent = 0);
   void updateStatus() override;
 public slots:
-  void doClick();
-
-protected:
-  void nextCheckState() override;
+  void doClick(bool);
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following two problem regarding the boolean (checkbox) tool options:

- The `Global Key` option of the Edit tool does not accept shortcut key control.

- Any of the boolean options do not change via shortcut key control, if even number of tool option bars are opened.