### PR TITLE
Shortcut Override for Tool-Specific Keys

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -441,6 +441,11 @@ return true if the method execution can have changed the current tool
     return 0;
   }  //!< Returns the type of cursor used by the tool.
 
+  // returns true if the pressed key is recognized and processed.
+  // used in SceneViewer::event(), reimplemented in SelectionTool
+  // and ControlPointEditorTool
+  virtual bool isEventAcceptable(QEvent *e) { return false; }
+
   TXsheet *getXsheet() const;  //!< Returns a pointer to the actual Xsheet.
 
   int getFrame();        //!< Returns the actual frame in use.

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -25,6 +25,7 @@
 
 // For Qt translation support
 #include <QCoreApplication>
+#include <QKeyEvent>
 
 using namespace ToolUtils;
 
@@ -196,6 +197,9 @@ public:
   void onDeactivate() override;
   void onImageChanged() override;
   int getCursorId() const override;
+
+  // returns true if the pressed key is recognized and processed.
+  bool isEventAcceptable(QEvent *e) override;
 
 } controlPointEditorTool;
 
@@ -888,6 +892,23 @@ int ControlPointEditorTool::getCursorId() const {
   default:
     return ToolCursor::SplineEditorCursor;
   }
+}
+
+//-----------------------------------------------------------------------------
+
+// returns true if the pressed key is recognized and processed in the tool
+// instead of triggering the shortcut command.
+bool ControlPointEditorTool::isEventAcceptable(QEvent *e) {
+  if (!isEnabled()) return false;
+  TVectorImageP vi(getImage(false));
+  if (!vi || (vi && m_selection.isEmpty())) return false;
+  // arrow keys will be used for moving the selected points
+  QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
+  // shift + arrow will not be recognized for now
+  if (keyEvent->modifiers() & Qt::ShiftModifier) return false;
+  int key = keyEvent->key();
+  return (key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left ||
+          key == Qt::Key_Right);
 }
 
 //=============================================================================

--- a/toonz/sources/tnztools/selectiontool.cpp
+++ b/toonz/sources/tnztools/selectiontool.cpp
@@ -12,6 +12,8 @@
 #include "toonz/tobjecthandle.h"
 #include "tw/keycodes.h"
 
+#include <QKeyEvent>
+
 using namespace ToolUtils;
 using namespace DragSelectionTool;
 
@@ -1378,4 +1380,18 @@ void SelectionTool::closePolyline(const TPointD &pos) {
   m_stroke = new TStroke(strokePoints);
   assert(m_stroke->getPoint(0) == m_stroke->getPoint(1));
   invalidate();
+}
+
+//-----------------------------------------------------------------------------
+
+// returns true if the pressed key is recognized and processed in the tool
+// instead of triggering the shortcut command.
+bool SelectionTool::isEventAcceptable(QEvent *e) {
+  if (!isEnabled()) return false;
+  if (isSelectionEmpty()) return false;
+  // arrow keys will be used for moving the selected region
+  QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
+  int key             = keyEvent->key();
+  return (key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left ||
+          key == Qt::Key_Right);
 }

--- a/toonz/sources/tnztools/selectiontool.h
+++ b/toonz/sources/tnztools/selectiontool.h
@@ -453,6 +453,9 @@ public:
   TPropertyGroup *getProperties(int targetType) override { return &m_prop; }
 
   bool onPropertyChanged(std::string propertyName) override;
+
+  // returns true if the pressed key is recognized and processed.
+  bool isEventAcceptable(QEvent *e) override;
 };
 
 #endif  // SELECTIONTOOL_INCLUDED

--- a/toonz/sources/tnztools/trackertool.cpp
+++ b/toonz/sources/tnztools/trackertool.cpp
@@ -34,6 +34,7 @@
 
 // For Qt translation support
 #include <QCoreApplication>
+#include <QKeyEvent>
 
 using namespace ToolUtils;
 
@@ -216,6 +217,9 @@ public:
   bool pick(int &hookIndex, const TPointD &pos);
 
   int getCursorId() const override;
+
+  // returns true if the pressed key is recognized and processed.
+  bool isEventAcceptable(QEvent *e) override;
 
 } trackerTool;
 
@@ -845,6 +849,29 @@ void TrackerTool::onActivate() {}
 void TrackerTool::onDeactivate() {
   // m_selection.selectNone();
   // TSelection::setCurrent(0);
+}
+
+//-----------------------------------------------------------------------------
+
+// returns true if the pressed key is recognized and processed in the tool
+// instead of triggering the shortcut command.
+bool TrackerTool::isEventAcceptable(QEvent *e) {
+  if (!isEnabled()) return false;
+  TXshLevel *xl = TTool::getApplication()->getCurrentLevel()->getLevel();
+  if (!xl) return false;
+  HookSet *hookSet = xl->getHookSet();
+  if (!hookSet) return false;
+  Hook *hook = hookSet->getHook(m_hookSelectedIndex);
+  if (!hook || hook->isEmpty()) return false;
+
+  QKeyEvent *keyEvent = static_cast<QKeyEvent *>(e);
+  // shift + arrow will not be recognized for now
+  if (keyEvent->modifiers() & Qt::ShiftModifier) return false;
+  int key = keyEvent->key();
+  return (key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left ||
+          key == Qt::Key_Right);
+  // no need to override page up & down keys since they cannot be
+  // used as shortcut key for now
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -802,6 +802,11 @@ bool SceneViewer::event(QEvent *e) {
     if (tool && tool->isEnabled() && tool->getName() == T_Type &&
         tool->isActive())
       e->accept();
+    // for other tools, check if the pressed keys should be catched instead of
+    // triggering the shortcut command actions
+    else if (tool && tool->isEventAcceptable(e)) {
+      e->accept();
+    }
     return true;
   }
   if (e->type() == QEvent::KeyRelease) {


### PR DESCRIPTION
For now, arrow keys (Up/Down/Right/Left) can be assigned as the command shortcut.
However, they are also defined as special command keys in some tools . For instance, in the Selection Tool arrow keys are used for moving selected region.

The command shortcuts  (processed as a `QAction` shortcut ) take priority of the tool-specific commands ( processed in `keyPressEvent` ) for now. Therefore, if any of arrow keys is assigned to some command ( such as assigning the Up arrow key for "Increase Brush Size" ),  such key cannot be used for tool-specific commands anymore.

In this PR I modified such behavior, preventing the shortcut action if the current tool will accept the pressed key.