### PR TITLE
Fix Vector Level Disappearing with Plastic Tool in OSX

### DIFF
--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -270,8 +270,6 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
       TVectorRenderData rd(TTranslation(-off.x, -off.y), TRect(TPoint(0, 0), d),
                            vpalette, 0, true, true);
 
-      TGlContext oldContext = tglGetCurrentContext();
-
       // this is too slow.
       {
         QSurfaceFormat format;
@@ -279,11 +277,9 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
 
         std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
         surface->setFormat(format);
+        // Enabling Qt::AA_ShareOpenGLContexts attribute in main()
+        surface->setScreen(QOpenGLContext::globalShareContext()->screen());
         surface->create();
-
-        std::unique_ptr<QOpenGLContext> context(new QOpenGLContext());
-        context->create();
-        context->makeCurrent(surface.get());
 
         TRaster32P ras(d);
 
@@ -335,9 +331,6 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
         glMatrixMode(GL_PROJECTION), glPopMatrix();
 
         glPopAttrib();
-
-        context->doneCurrent();
-        tglMakeCurrent(oldContext);
 
         TRasterImageP ri = TRasterImageP(ras);
         ri->setOffset(off + ras->getCenter());


### PR DESCRIPTION
This PR fixes #1543 

![image](https://user-images.githubusercontent.com/17974955/32596009-3582e070-c575-11e7-87eb-2d2f932da6f7.png)

It seems to be OpenGL context related problem. I modified it by using global-shared context which is available with `Qt::AA_ShareOpenGLContexts` attribute.
