### PR TITLE
Fix Crash on Setting Negative Frame

### DIFF
--- a/toonz/sources/toonz/previewer.cpp
+++ b/toonz/sources/toonz/previewer.cpp
@@ -1139,6 +1139,7 @@ void Previewer::saveRenderedFrames() {
 /*! Restituisce un puntatore al raster randerizzato se il frame e' disponibile,
     altrimenti comincia a calcolarlo*/
 TRasterP Previewer::getRaster(int frame, bool renderIfNeeded) const {
+  if (frame < 0) return TRasterP();
   std::map<int, Imp::FrameInfo>::iterator it = m_imp->m_frames.find(frame);
   if (it != m_imp->m_frames.end()) {
     if (frame < m_imp->m_pbStatus.size()) {
@@ -1183,7 +1184,7 @@ TRasterP Previewer::getRaster(int frame, bool renderIfNeeded) const {
 
 //! Verifica se \b frame e' nella cache, cioe' se il frame e' disponibile
 bool Previewer::isFrameReady(int frame) const {
-  if (frame >= (int)m_imp->m_pbStatus.size()) return false;
+  if (frame < 0 || frame >= (int)m_imp->m_pbStatus.size()) return false;
 
   return m_imp->m_pbStatus[frame] == FlipSlider::PBFrameFinished;
 }

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -205,7 +205,7 @@ void SceneViewerPanel::onDrawFrame(
     }
   }
 
-  assert(frame >= 0);
+  // assert(frame >= 0); // frame can be negative in rare cases
   if (frame != frameHandle->getFrameIndex() + 1) {
     int oldFrame = frameHandle->getFrame();
     frameHandle->setCurrentFrame(frame);


### PR DESCRIPTION
In most cases, the current frame is positive. However, in some rare cases it can be negative such as users manually type the frame number in the console or move the current frame marker in the Function Curves panel.
When the preview mode is activated `Previewer` tries to obtain the frame status from `std::vector<UCHAR> Previewer::Imp::m_pbStatus[frame]` and for now if the current `frame` is negative the returned status becomes undefined and may causes crash.

I would like to keep availability of the negative frame itself because there may be a case that the animation key should starts from the negative frame in order to get ”midstream” movement at the first frame.