### PR TITLE
Fix Loading Note Level with Non-ASCII Text

### DIFF
--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -436,7 +436,8 @@ bool LevelCreatePopup::apply() {
 
   bool validColumn = true;
   if (xsh->getColumn(col))
-    validColumn = xsh->getColumn(col)->getColumnType() == 0;
+    validColumn =
+        xsh->getColumn(col)->getColumnType() == TXshColumn::eLevelType;
 
   int from   = (int)m_fromFld->getValue();
   int to     = (int)m_toFld->getValue();

--- a/toonz/sources/toonzlib/txshsoundtextlevel.cpp
+++ b/toonz/sources/toonzlib/txshsoundtextlevel.cpp
@@ -56,9 +56,9 @@ void TXshSoundTextLevel::loadData(TIStream &is) {
       if (v == "textSound") type = SND_TXT_XSHLEVEL;
       is.matchEndTag();
     } else if (tagName == "frame") {
-      QString text;
+      std::wstring text;
       is >> text;
-      m_framesText.push_back(text);
+      m_framesText.push_back(QString::fromStdWString(text));
       is.matchEndTag();
     } else
       throw TException("unexpected tag " + tagName);


### PR DESCRIPTION
This PR will fix the problem that the note level ( just added by #1322 ) with non-ASCII text fails to be loaded properly. Also refactored `levelcreatepopup.cpp` in order to clarify.

An image on the left-below is the original scene for example and the right-below is the loaded scene with the current master.

![image](https://user-images.githubusercontent.com/17974955/32881699-6bb10930-caf5-11e7-9202-0ff29c0fe817.png)
