### PR TITLE
Fix Right Click Crash - Audio Popup

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2973,7 +2973,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
     } else if (selectionContainTlvImage(m_viewer->getCellSelection(),
                                         m_viewer->getXsheet()))
       menu.addAction(cmdManager->getAction(MI_CanvasSize));
-      if (sl || TApp::instance()->getCurrentLevel()->getLevel()->getChildLevel())
+      if (sl || (TApp::instance()->getCurrentLevel()->getLevel() && TApp::instance()->getCurrentLevel()->getLevel()->getChildLevel()))
       menu.addAction(cmdManager->getAction(MI_LipSyncPopup));
   }
   menu.addSeparator();


### PR DESCRIPTION
If you have a scene set up like this:

![crash2](https://user-images.githubusercontent.com/4576381/32972269-b39b5d36-cbae-11e7-90b5-f04e32831ee8.PNG)

And select all 3 columns and then right click in column 2 - it will crash.