### PR TITLE
Remove duplicate Cell Drag Behavior options

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1162,7 +1162,6 @@ PreferencesPopup::PreferencesPopup()
   CheckBox *replaceAfterSaveLevelAsCB =
       new CheckBox(tr("Replace Toonz Level after SaveLevelAs command"), this);
 
-  m_cellsDragBehaviour = new QComboBox();
   m_undoMemorySize =
       new DVGui::IntLineEdit(this, m_pref->getUndoMemorySize(), 0, 2000);
   m_levelsBackup = new CheckBox(tr("Backup Animation Levels when Saving"));
@@ -1433,10 +1432,6 @@ PreferencesPopup::PreferencesPopup()
   replaceAfterSaveLevelAsCB->setChecked(
       m_pref->isReplaceAfterSaveLevelAsEnabled());
 
-  QStringList dragCellsBehaviourList;
-  dragCellsBehaviourList << tr("Cells Only") << tr("Cells and Column Data");
-  m_cellsDragBehaviour->addItems(dragCellsBehaviourList);
-  m_cellsDragBehaviour->setCurrentIndex(m_pref->getDragCellsBehaviour());
   m_levelsBackup->setChecked(m_pref->isLevelsBackupEnabled());
   sceneNumberingCB->setChecked(m_pref->isSceneNumberingEnabled());
   watchFileSystemCB->setChecked(m_pref->isWatchFileSystemEnabled());


### PR DESCRIPTION
This PR removes the duplicate entries in the Cell Dragging behavior drop down on Xsheet Preferences tab.

It appears the preference was moved from the General tab to the Xsheet tab, but the code remained causing duplicates.

Other than there are duplicate entries, the duplicates need to be removed because only the 1st instance of "Cells and Column Data" actually triggers the behavior, the 2nd does nothing.