### PR TITLE
Update Qt version for Appveyor (5.9.1->5.9.2)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
 
     mkdir %PLATFORM% && cd %PLATFORM%
 
-    cmake ..\sources -G "Visual Studio 14 2015 Win64" -DQT_PATH="C:\Qt\5.9.1\msvc2015_64" -DBOOST_ROOT="C:\Libraries\boost_1_60_0"
+    cmake ..\sources -G "Visual Studio 14 2015 Win64" -DQT_PATH="C:\Qt\5.9.2\msvc2015_64" -DBOOST_ROOT="C:\Libraries\boost_1_60_0"
 build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
   parallel: true


### PR DESCRIPTION
According to the [technical updates](https://www.appveyor.com/updates/) of Appveyor (November 18):

> Qt 5.9.1 ( `C:\Qt\5.9.1` ) has been replaced with Qt 5.9.2 ( `C:\Qt\5.9.2` ).