### PR TITLE
Add add_dependencies Command to CMake for OSX

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -7,4 +7,4 @@ cmake ../sources \
       -DQT_PATH=/usr/local/Cellar/qt/5.9.2/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
-make
+make -j 2

--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 brew update
-brew install glew lz4 lzo libusb libmypaint qt
+brew install glew lz4 lzo libusb libmypaint
 brew tap tcr/tcr
 brew install clang-format
+# obtain qt5.9.2 from the previous version of the formula
+curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/9bc1bdd8d26747cffd7a18c31975f86cd0a97bc3/Formula/qt.rb
+brew install ./qt.rb

--- a/toonz/sources/colorfx/CMakeLists.txt
+++ b/toonz/sources/colorfx/CMakeLists.txt
@@ -27,6 +27,7 @@ add_definitions(
 
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libcolorfx.dylib")
+    add_dependencies(colorfx tnzcore tnzbase)
 endif()
 
 message("subdir: colorfx")

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -100,6 +100,7 @@ add_definitions(
 
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libimage.dylib")
+    add_dependencies(image tnzcore tnzbase toonzlib)
 endif()
 
 message("subdir: image")

--- a/toonz/sources/sound/CMakeLists.txt
+++ b/toonz/sources/sound/CMakeLists.txt
@@ -23,6 +23,7 @@ add_definitions(
 
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libsound.dylib")
+    add_dependencies(sound tnzcore tnzbase toonzlib)
 endif()
 
 message("subdir: sound")

--- a/toonz/sources/stdfx/CMakeLists.txt
+++ b/toonz/sources/stdfx/CMakeLists.txt
@@ -267,6 +267,7 @@ add_definitions(
 
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnzstdfx.dylib")
+    add_dependencies(tnzstdfx tnzcore tnzbase toonzlib)
 endif()
 
 message("subdir: tnzstdfx")

--- a/toonz/sources/tnzbase/CMakeLists.txt
+++ b/toonz/sources/tnzbase/CMakeLists.txt
@@ -166,6 +166,7 @@ add_library(tnzbase SHARED ${HEADERS} ${SOURCES} ${OBJCSOURCES})
 
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnzbase.dylib")
+    add_dependencies(tnzbase tnzcore)
 endif()
 
 add_definitions(

--- a/toonz/sources/tnzext/CMakeLists.txt
+++ b/toonz/sources/tnzext/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(tnzext SHARED ${HEADERS} ${SOURCES} ${OBJCSOURCES})
 
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnzext.dylib")
+    add_dependencies(tnzext tnzcore tnzbase)
 endif()
 
 add_definitions(

--- a/toonz/sources/tnztools/CMakeLists.txt
+++ b/toonz/sources/tnztools/CMakeLists.txt
@@ -111,6 +111,7 @@ add_definitions(
 
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnztools.dylib")
+    add_dependencies(tnztools tnzcore tnzbase tnzext toonzlib toonzqt)
 endif()
 
 message("subdir: tnztools")

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -416,6 +416,7 @@ elseif(BUILD_ENV_APPLE)
     # 変なところにライブラリ生成するカスども
     set(EXTRA_LIBS ${EXTRA_LIBS} "$<TARGET_FILE:tnzstdfx>" "$<TARGET_FILE:tfarm>")
 
+    add_dependencies(OpenToonz_${VERSION} tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm)
 
     target_link_libraries(OpenToonz_${VERSION}
         Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml

--- a/toonz/sources/toonzfarm/tfarm/CMakeLists.txt
+++ b/toonz/sources/toonzfarm/tfarm/CMakeLists.txt
@@ -49,13 +49,13 @@ elseif(BUILD_ENV_APPLE)
         ${CMAKE_CURRENT_BINARY_DIR}/../../tnzbase/libtnzbase.dylib
         ${CMAKE_CURRENT_BINARY_DIR}/../../toonzlib/libtoonzlib.dylib
     )
+    add_dependencies(tfarm tnzcore tnzbase toonzlib tnzext)
 elseif(BUILD_ENV_UNIXLIKE)
     _find_toonz_library(EXTRA_LIBS "tnzcore;tnzbase;toonzlib;tnzext")
     if(BUILD_TARGET_WIN)
         set(EXTRA_LIBS ${EXTRA_LIBS} -lws2_32)
     endif()
 endif()
-
 target_link_libraries(tfarm
     Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Network
     ${GLUT_LIB} ${GL_LIB} ${EXTRA_LIBS}

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -332,6 +332,7 @@ qt5_wrap_cpp(SOURCES ${MOC_HEADERS})
 add_library(toonzlib SHARED ${HEADERS} ${SOURCES})
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtoonzlib.dylib")
+    add_dependencies(toonzlib tnzcore tnzbase tnzext)
 endif()
 
 add_definitions(

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -215,6 +215,7 @@ qt5_wrap_cpp(SOURCES ${MOC_HEADERS} OPTIONS ${incs})
 add_library(toonzqt SHARED ${HEADERS} ${SOURCES} ${RESOURCES})
 if(BUILD_ENV_APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtoonzqt.dylib")
+    add_dependencies(toonzqt tnzcore tnzbase tnzext toonzlib sound)
 endif()
 
 add_definitions(


### PR DESCRIPTION
This PR will add `add_dependencies` command to CMake settings for OSX.
I recently started to use CLion for OSX development and this commands are needed to solve build errors due to inappropriate build order.

**UPDATE**

This PR will also fix Travis CI scripts, obtaining the proper Qt version and introducing `make -j 2` in order to enhance the build speed. (According to @damies13 's advice. Thanks!)