### PR TITLE
Fix Crash on Launch with Flipbook

### DIFF
--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -1486,6 +1486,8 @@ void FlipConsole::doButtonPressed(UINT button) {
     return;
 
   case ePause:
+    if (!m_playbackExecutor.isRunning() && !m_isLinkedPlaying) return;
+
     m_isLinkedPlaying = false;
 
     if (m_playbackExecutor.isRunning()) m_playbackExecutor.abort();


### PR DESCRIPTION
This PR will fix both of the following problems:

- OT crashes on launch if the Flipbook panel is embedded in the room.
- Each time you click the Pause button in console, redundant and unwanted signal-slot connections are made. (You can observe the current connection information by calling `QObject::dumpObjectInfo()` in Debug mode.)

I fixed the behavior of the Pause button, not to proceed if it is not playing.