### PR TITLE
Only the First Click to Select All

### DIFF
--- a/toonz/sources/include/toonzqt/doublefield.h
+++ b/toonz/sources/include/toonzqt/doublefield.h
@@ -33,7 +33,10 @@ class DVAPI DoubleValueLineEdit : public LineEdit {
   Q_OBJECT
 
   int m_xMouse;
+
+protected:
   bool m_mouseDragEditing = false;
+  bool m_isTyping         = false;
 
 public:
   DoubleValueLineEdit(QWidget *parent = 0) : LineEdit(parent) {}
@@ -227,8 +230,7 @@ class DVAPI MeasuredDoubleLineEdit : public DoubleValueLineEdit {
   int m_errorHighlightingTimerId;
   int m_decimals;
   int m_xMouse;
-  bool m_labelClicked     = false;
-  bool m_mouseDragEditing = false;
+  bool m_labelClicked = false;
 
 public:
   MeasuredDoubleLineEdit(QWidget *parent = 0);

--- a/toonz/sources/include/toonzqt/intfield.h
+++ b/toonz/sources/include/toonzqt/intfield.h
@@ -88,6 +88,7 @@ class DVAPI IntLineEdit : public LineEdit {
   int m_showedDigits;
   int m_xMouse;
   bool m_mouseDragEditing = false;
+  bool m_isTyping         = false;
 
 public:
   IntLineEdit(QWidget *parent = 0, int value = 1,

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1071,8 +1071,13 @@ void MeasuredValueField::mousePressEvent(QMouseEvent *e) {
     m_xMouse        = e->x();
     m_mouseEdit     = true;
     m_originalValue = m_value->getValue(TMeasuredValue::CurrentUnit);
-  } else
+  } else {
     QLineEdit::mousePressEvent(e);
+    if (!m_isTyping) {  // only the first click will select all
+      selectAll();
+      m_isTyping = true;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1105,10 +1110,18 @@ void MeasuredValueField::mouseReleaseEvent(QMouseEvent *e) {
     setText(QString::fromStdWString(m_value->toWideString(m_precision)));
     emit measuredValueChanged(m_value, true);
     clearFocus();
-  } else {
-    if (!hasSelectedText()) selectAll();
-  }
+  } else
+    QLineEdit::mouseReleaseEvent(e);
 }
+
+//-----------------------------------------------------------------------------
+
+void MeasuredValueField::focusOutEvent(QFocusEvent *e) {
+  DVGui::LineEdit::focusOutEvent(e);
+  m_isTyping = false;
+}
+
+//-----------------------------------------------------------------------------
 
 void MeasuredValueField::receiveMousePress(QMouseEvent *e) {
   m_labelClicked = true;

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -332,6 +332,7 @@ class DVAPI MeasuredValueField : public DVGui::LineEdit {
   bool m_mouseEdit    = false;
   bool m_labelClicked = false;
   double m_originalValue;
+  bool m_isTyping = false;
 
 protected:
   bool m_isGlobalKeyframe;
@@ -340,6 +341,7 @@ protected:
   void mousePressEvent(QMouseEvent *) override;
   void mouseMoveEvent(QMouseEvent *) override;
   void mouseReleaseEvent(QMouseEvent *) override;
+  void focusOutEvent(QFocusEvent *) override;
 
 public:
   MeasuredValueField(QWidget *parent, QString name = "numfield");

--- a/toonz/sources/toonzqt/doublefield.cpp
+++ b/toonz/sources/toonzqt/doublefield.cpp
@@ -37,6 +37,7 @@ void DoubleValueLineEdit::focusOutEvent(QFocusEvent *e) {
     emit editingFinished();
   }
   QLineEdit::focusOutEvent(e);
+  m_isTyping = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -45,8 +46,13 @@ void DoubleValueLineEdit::mousePressEvent(QMouseEvent *e) {
   if (e->buttons() == Qt::MiddleButton) {
     m_xMouse           = e->x();
     m_mouseDragEditing = true;
-  } else
+  } else {
     QLineEdit::mousePressEvent(e);
+    if (!m_isTyping) {  // only the first click will select all
+      selectAll();
+      m_isTyping = true;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -66,10 +72,8 @@ void DoubleValueLineEdit::mouseReleaseEvent(QMouseEvent *e) {
   if ((e->buttons() == Qt::NoButton && m_mouseDragEditing)) {
     m_mouseDragEditing = false;
     clearFocus();
-  } else {
-    if (!hasSelectedText()) selectAll();
+  } else
     QLineEdit::mouseReleaseEvent(e);
-  }
 }
 
 //=============================================================================
@@ -500,8 +504,13 @@ void MeasuredDoubleLineEdit::mousePressEvent(QMouseEvent *e) {
   if ((e->buttons() == Qt::MiddleButton) || m_labelClicked) {
     m_xMouse           = e->x();
     m_mouseDragEditing = true;
-  } else
+  } else {
     QLineEdit::mousePressEvent(e);
+    if (!m_isTyping) {  // only the first click will select all
+      selectAll();
+      m_isTyping = true;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -528,10 +537,8 @@ void MeasuredDoubleLineEdit::mouseReleaseEvent(QMouseEvent *e) {
     m_mouseDragEditing = false;
     m_labelClicked     = false;
 
-  } else {
-    if (!hasSelectedText()) selectAll();
+  } else
     QLineEdit::mouseReleaseEvent(e);
-  }
 }
 
 void MeasuredDoubleLineEdit::receiveMousePress(QMouseEvent *e) {

--- a/toonz/sources/toonzqt/intfield.cpp
+++ b/toonz/sources/toonzqt/intfield.cpp
@@ -191,6 +191,7 @@ void IntLineEdit::focusOutEvent(QFocusEvent *e) {
   if (e->lostFocus()) setValue(value);
 
   QLineEdit::focusOutEvent(e);
+  m_isTyping = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -211,8 +212,13 @@ void IntLineEdit::mousePressEvent(QMouseEvent *e) {
   if (e->buttons() == Qt::MiddleButton) {
     m_xMouse           = e->x();
     m_mouseDragEditing = true;
-  } else
+  } else {
     QLineEdit::mousePressEvent(e);
+    if (!m_isTyping) {  // only the first click will select all
+      selectAll();
+      m_isTyping = true;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -231,10 +237,8 @@ void IntLineEdit::mouseReleaseEvent(QMouseEvent *e) {
   if ((e->buttons() == Qt::NoButton && m_mouseDragEditing)) {
     m_mouseDragEditing = false;
     clearFocus();
-  } else {
-    if (!hasSelectedText()) selectAll();
+  } else
     QLineEdit::mouseReleaseEvent(e);
-  }
 }
 
 //=============================================================================


### PR DESCRIPTION
This PR is a modification related to #1362 .
For now anytime you click on the numeric input fields, it causes selection of all the texts.
It is useful for inputting the numbers from scratch, but is difficult to edit by inserting numbers.

I modified such behavior, to select all the texts only when firstly clicking (i.e. clicking and focusing in) the field.