### PR TITLE
Fix filmstrip renumber issues

### DIFF
--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -83,8 +83,8 @@ void makeSpaceForFids(TXshSimpleLevel *sl,
   }
   if (!touchedFids.empty()) {
     sl->renumber(fids);
-    invalidateIcons(sl, touchedFids);
-    sl->setDirtyFlag(true);
+//	invalidateIcons(sl, touchedFids);
+	sl->setDirtyFlag(true);
   }
 }
 
@@ -917,6 +917,7 @@ public:
     if (m_setType == DrawingData::INSERT) {
       assert(m_sl->getFrameCount() == m_oldLevelFrameId.size());
       m_sl->renumber(m_oldLevelFrameId);
+	  m_sl->setDirtyFlag(true);
       TApp::instance()
           ->getPaletteController()
           ->getCurrentLevelPalette()
@@ -1120,7 +1121,7 @@ public:
   void undo() const override {
     removeFramesWithoutUndo(m_level, m_insertedFids);
     m_level->renumber(m_oldFids);
-    invalidateIcons(m_level.getPointer(), m_oldFids);
+//    invalidateIcons(m_level.getPointer(), m_oldFids);
     m_level->setDirtyFlag(true);
 
     TApp *app = TApp::instance();
@@ -1222,8 +1223,9 @@ public:
     m_level->renumber(fids);
     TSelection *selection = TSelection::getCurrent();
     if (selection) selection->selectNone();
-    invalidateIcons(m_level.getPointer(), fids);
-    TApp::instance()->getCurrentLevel()->notifyLevelChange();
+//    invalidateIcons(m_level.getPointer(), fids);
+	m_level->setDirtyFlag(true);
+	TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
   void undo() const override {
     std::vector<TFrameId> fids;
@@ -1308,9 +1310,8 @@ void FilmstripCmd::renumber(
 
   TUndoManager::manager()->add(new RenumberUndo(sl, fids));
   sl->renumber(fids);
-  sl->setDirtyFlag(true);
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-  invalidateIcons(sl, fids);
+//  invalidateIcons(sl, fids);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
 
   /*
@@ -1381,7 +1382,7 @@ void FilmstripCmd::renumber(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
   assert(frames.size() == newFrames.size());
   frames.swap(newFrames);
 
-  invalidateIcons(sl, fids);
+//  invalidateIcons(sl, fids);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
 }
 
@@ -1643,7 +1644,8 @@ public:
     removeFramesWithoutUndo(m_level, m_frames);
     assert(m_oldFrames.size() == m_level->getFrameCount());
     m_level->renumber(m_oldFrames);
-    invalidateIcons(m_level.getPointer(), m_oldFrames);
+//    invalidateIcons(m_level.getPointer(), m_oldFrames);
+	m_level->setDirtyFlag(true);
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
 
@@ -1720,7 +1722,7 @@ void performReverse(const TXshSimpleLevelP &sl,
   sl->renumber(fids);
   sl->setDirtyFlag(true);
   //  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-  invalidateIcons(sl.getPointer(), frames);
+//  invalidateIcons(sl.getPointer(), frames);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
 }
 
@@ -1887,6 +1889,7 @@ void stepFilmstripFrames(const TXshSimpleLevelP &sl,
     }
   }
   invalidateIcons(sl.getPointer(), changedFids);
+  sl->setDirtyFlag(true);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
 }
 
@@ -1917,7 +1920,8 @@ public:
     m_level->renumber(m_oldFrames);
     TSelection *selection = TSelection::getCurrent();
     if (selection) selection->selectNone();
-    invalidateIcons(m_level.getPointer(), m_oldFrames);
+//    invalidateIcons(m_level.getPointer(), m_oldFrames);
+	m_level->setDirtyFlag(true);
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
   void redo() const override {
@@ -2074,7 +2078,8 @@ public:
     assert(m_level);
     removeFramesWithoutUndo(m_level, m_frameInserted);
     m_level->renumber(m_oldFrames);
-    invalidateIcons(m_level.getPointer(), m_oldFrames);
+//    invalidateIcons(m_level.getPointer(), m_oldFrames);
+	m_level->setDirtyFlag(true);
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
   void redo() const override {
@@ -2416,6 +2421,7 @@ void FilmstripCmd::renumberDrawing(TXshSimpleLevel *sl, const TFrameId &oldFid,
   }
   *it = newFid;
   sl->renumber(fids);
+  sl->setDirtyFlag(true);
 
   TXshCell oldCell(sl, oldFid);
   TXshCell newCell(sl, newFid);

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -83,7 +83,6 @@ void makeSpaceForFids(TXshSimpleLevel *sl,
   }
   if (!touchedFids.empty()) {
     sl->renumber(fids);
-//	invalidateIcons(sl, touchedFids);
 	sl->setDirtyFlag(true);
   }
 }
@@ -1121,7 +1120,6 @@ public:
   void undo() const override {
     removeFramesWithoutUndo(m_level, m_insertedFids);
     m_level->renumber(m_oldFids);
-//    invalidateIcons(m_level.getPointer(), m_oldFids);
     m_level->setDirtyFlag(true);
 
     TApp *app = TApp::instance();
@@ -1223,7 +1221,6 @@ public:
     m_level->renumber(fids);
     TSelection *selection = TSelection::getCurrent();
     if (selection) selection->selectNone();
-//    invalidateIcons(m_level.getPointer(), fids);
 	m_level->setDirtyFlag(true);
 	TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
@@ -1311,7 +1308,6 @@ void FilmstripCmd::renumber(
   TUndoManager::manager()->add(new RenumberUndo(sl, fids));
   sl->renumber(fids);
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-//  invalidateIcons(sl, fids);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
 
   /*
@@ -1382,7 +1378,6 @@ void FilmstripCmd::renumber(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
   assert(frames.size() == newFrames.size());
   frames.swap(newFrames);
 
-//  invalidateIcons(sl, fids);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
 }
 
@@ -1644,7 +1639,6 @@ public:
     removeFramesWithoutUndo(m_level, m_frames);
     assert(m_oldFrames.size() == m_level->getFrameCount());
     m_level->renumber(m_oldFrames);
-//    invalidateIcons(m_level.getPointer(), m_oldFrames);
 	m_level->setDirtyFlag(true);
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
@@ -1722,7 +1716,6 @@ void performReverse(const TXshSimpleLevelP &sl,
   sl->renumber(fids);
   sl->setDirtyFlag(true);
   //  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-//  invalidateIcons(sl.getPointer(), frames);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
 }
 
@@ -1920,7 +1913,6 @@ public:
     m_level->renumber(m_oldFrames);
     TSelection *selection = TSelection::getCurrent();
     if (selection) selection->selectNone();
-//    invalidateIcons(m_level.getPointer(), m_oldFrames);
 	m_level->setDirtyFlag(true);
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }
@@ -2078,7 +2070,6 @@ public:
     assert(m_level);
     removeFramesWithoutUndo(m_level, m_frameInserted);
     m_level->renumber(m_oldFrames);
-//    invalidateIcons(m_level.getPointer(), m_oldFrames);
 	m_level->setDirtyFlag(true);
     TApp::instance()->getCurrentLevel()->notifyLevelChange();
   }

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1960,22 +1960,26 @@ void TXshSimpleLevel::renumber(const std::vector<TFrameId> &fids) {
   }
 
   ImageManager *im = ImageManager::instance();
+  TImageCache *ic = TImageCache::instance();
 
   std::map<TFrameId, TFrameId>::iterator jt;
 
   {
     for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i) {
       std::string Id = getImageId(jt->first);
-      im->rebind(Id, "^" + std::to_string(i));
-      TImageCache::instance()->remap("^icon:" + std::to_string(i),
-                                     "icon:" + Id);
+	  ImageLoader::BuildExtData extData(this, jt->first);
+	  TImageP img = im->getImage(Id, ImageManager::none, &extData);
+	  ic->add(getIconId(jt->first), img, false);
+	  im->rebind(Id, "^" + std::to_string(i));
+	  ic->remap("^icon:" + std::to_string(i),
+                                     getIconId(jt->first));
     }
 
     for (i = 0, jt = table.begin(); jt != table.end(); ++jt, ++i) {
       std::string Id = getImageId(jt->second);
       im->rebind("^" + std::to_string(i), Id);
-      TImageCache::instance()->remap("icon:" + Id,
-                                     "^icon:" + std::to_string(i));
+	  ic->remap(getIconId(jt->second),
+                                    "^icon:" + std::to_string(i));
       im->renumber(Id, jt->second);
     }
   }


### PR DESCRIPTION
This PR fixes #1581 

There were 2 issues contributing to this issue:

1) The simplelevel->renumber() automatically updates the icon image cache so when an invalidateIcons() was called, it removed the updated image from the cache. Later when it loads, since the image was not in the cache, it went to the original level file for the image, thus loading the wrong one.

FIX: Removeed unnecessary calls to invalidateIcons() that followed a simplelevel->renumber();

2) When renumbering an image that was not cached, nothing would happen, so when loading the image later, it went to the original level file for the image and loaded the wrong one.

FIX: Attempt to pre-load the icon image before renumbering to ensure it is there.
