### PR TITLE
Skeleton Tool Tweaks

### DIFF
--- a/toonz/sources/tnztools/skeletontool.h
+++ b/toonz/sources/tnztools/skeletontool.h
@@ -56,7 +56,7 @@ class SkeletonTool : public TTool {
   TEnumProperty m_mode;
   TBoolProperty m_showOnlyActiveSkeleton;
   TBoolProperty m_globalKeyframes;
-
+  TDoubleProperty m_UIScale;
   TPropertyGroup m_prop;
 
   std::vector<SkeletonSubtools::MagicLink> m_magicLinks;
@@ -109,7 +109,7 @@ public:
   void drawIKBone(const TPointD &a, const TPointD &b);
   void drawMainGadget(const TPointD &center);
   void drawDrawingBrowser(const TXshCell &cell, const TPointD &center);
-
+  double getUIScale();
   void setParentProbe(const TPointD &parentProbe) {
     m_parentProbe        = parentProbe;
     m_parentProbeEnabled = true;


### PR DESCRIPTION
I ran into an issue with the skeleton tool.  I was using a character made outside OpenToonz with really large dimensions (overall 2000px by 3000px) and the parts saved as separate pngs.  I set the character up as a skeleton rig and scaled the parent node down to 15% scale.  With this, when you select a child node with the skeleton tool, the nodes are too big to be usable:
![before](https://user-images.githubusercontent.com/4576381/33237601-913f9468-d235-11e7-8b11-c68fd4317fd4.JPG)

This change makes a slider at the top to change the scale of the UI overlay:
![after](https://user-images.githubusercontent.com/4576381/33237603-a1fcfdea-d235-11e7-9f1b-c5246328cdd3.JPG)

It also makes the Skeleton Tool remember the mode of the tool between sessions and remember the status of "Show Only Active Skeleton" between sessions.