### PR TITLE
Allow Mesh Icon On Demand

### DIFF
--- a/toonz/sources/include/toonz/txshmeshcolumn.h
+++ b/toonz/sources/include/toonz/txshmeshcolumn.h
@@ -22,7 +22,12 @@
 class DVAPI TXshMeshColumn final : public TXshCellColumn {
   PERSIST_DECLARATION(TXshMeshColumn)
 
+  bool m_iconVisible;
+
 public:
+  bool isIconVisible() { return m_iconVisible; }
+  void setIconVisible(bool visible) { m_iconVisible = visible; }
+
   TXshMeshColumn();
 
   TXshColumn::ColumnType getColumnType() const override { return eMeshType; }

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -44,6 +44,7 @@
 #include "toonz/preferences.h"
 #include "toonz/childstack.h"
 #include "toonz/txshlevelcolumn.h"
+#include "toonz/txshmeshcolumn.h"
 #include "toonz/tfxhandle.h"
 
 // TnzCore includes
@@ -936,18 +937,22 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
     p.setFont(lastfont);
   } else {
     TXshLevelColumn *levelColumn = column->getLevelColumn();
+    TXshMeshColumn *meshColumn   = column->getMeshColumn();
 
-    if (levelColumn &&
-        Preferences::instance()->getColumnIconLoadingPolicy() ==
+    if (Preferences::instance()->getColumnIconLoadingPolicy() ==
             Preferences::LoadOnDemand &&
-        !levelColumn->isIconVisible()) {
+        ((levelColumn && !levelColumn->isIconVisible()) ||
+         (meshColumn && !meshColumn->isIconVisible()))) {
       // display nothing
     } else {
       if (!iconPixmap.isNull()) {
         p.drawPixmap(thumbnailImageRect, iconPixmap);
       }
       // notify that the column icon is already shown
-      if (levelColumn) levelColumn->setIconVisible(true);
+      if (levelColumn)
+        levelColumn->setIconVisible(true);
+      else if (meshColumn)
+        meshColumn->setIconVisible(true);
     }
   }
 }
@@ -1498,8 +1503,17 @@ QPixmap ColumnArea::getColumnIcon(int columnIndex) {
   else {
     bool onDemand = false;
     if (Preferences::instance()->getColumnIconLoadingPolicy() ==
-        Preferences::LoadOnDemand)
+        Preferences::LoadOnDemand) {
       onDemand = m_viewer->getCurrentColumn() != columnIndex;
+      if (!onDemand) {
+        TXshColumn *column           = xsh->getColumn(columnIndex);
+        TXshLevelColumn *levelColumn = column->getLevelColumn();
+        TXshMeshColumn *meshColumn   = column->getMeshColumn();
+        if ((levelColumn && !levelColumn->isIconVisible()) ||
+            (meshColumn && !meshColumn->isIconVisible()))
+          return QPixmap();
+      }
+    }
     QPixmap icon =
         IconGenerator::instance()->getIcon(xl, cell.m_frameId, false, onDemand);
     QRect thumbnailImageRect = o->rect(PredefinedRect::THUMBNAIL);
@@ -1877,19 +1891,22 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
 
         // toggle columnIcon visibility with alt+click
         TXshLevelColumn *levelColumn = column->getLevelColumn();
-        if (levelColumn &&
-            Preferences::instance()->getColumnIconLoadingPolicy() ==
+        TXshMeshColumn *meshColumn   = column->getMeshColumn();
+        if (Preferences::instance()->getColumnIconLoadingPolicy() ==
                 Preferences::LoadOnDemand &&
             (event->modifiers() & Qt::AltModifier)) {
-          levelColumn->setIconVisible(!levelColumn->isIconVisible());
+          if (levelColumn)
+            levelColumn->setIconVisible(!levelColumn->isIconVisible());
+          else if (meshColumn)
+            meshColumn->setIconVisible(!meshColumn->isIconVisible());
         }
       }
       // synchronize the current column and the current fx
       TApp::instance()->getCurrentFx()->setFx(column->getFx());
     } else if (m_col >= 0) {
-		if (m_viewer->getColumnSelection()->isColumnSelected(m_col) &&
-			event->button() == Qt::RightButton)
-			return;
+      if (m_viewer->getColumnSelection()->isColumnSelected(m_col) &&
+          event->button() == Qt::RightButton)
+        return;
       setDragTool(XsheetGUI::DragTool::makeColumnSelectionTool(m_viewer));
       TApp::instance()->getCurrentFx()->setFx(0);
     }

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -51,7 +51,7 @@ TFrameId qstringToFrameId(QString str) {
 //    TXshMeshColumn  implementation
 //*******************************************************************************
 
-TXshMeshColumn::TXshMeshColumn() : TXshCellColumn() {}
+TXshMeshColumn::TXshMeshColumn() : TXshCellColumn(), m_iconVisible(false) {}
 
 //------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds the ability to load mesh icons on demand.

Currently if the "Column Icons" preference setting is set to "On Demand", when a scene loads the mesh columns have no icons like most other columns (excluding palettes and note levels).  However, the moment you select the mesh column, the icon immediately loads without any way to turn it off or on as desired.
