### PR TITLE
Tool Option crash fixes

### DIFF
--- a/toonz/sources/common/tunit/tunit.cpp
+++ b/toonz/sources/common/tunit/tunit.cpp
@@ -457,7 +457,7 @@ void TMeasuredValue::setMeasure(std::string measureName) {
 //-------------------------------------------------------------------
 
 bool TMeasuredValue::setValue(std::wstring s, int *pErr) {
-  if (s == L"") {
+  if (s == L"" || s == L"-") {
     if (pErr) *pErr = -1;
     return false;
   }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1663,7 +1663,7 @@ void FillToolOptionsBox::updateStatus() {
 void FillToolOptionsBox::onColorModeChanged() {
   bool enabled = m_colorMode->currentText() != QString("Lines");
   m_selectiveMode->setEnabled(enabled);
-  m_autopaintMode->setEnabled(enabled);
+  if(m_autopaintMode) m_autopaintMode->setEnabled(enabled);
   if (m_fillDepthLabel && m_fillDepthField) {
     m_fillDepthLabel->setEnabled(enabled);
     m_fillDepthField->setEnabled(enabled);


### PR DESCRIPTION
This PR fixes #1600 

A new Autopaint Lines tools option was recently added for Toonz Raster levels, but is not available for Toonz Vectors levels.  The control is not loaded for vectors but tries to disable it and crashes.  Fixed to skip the new control if not loaded.

This PR fixes #1599 

In tool option bars with measured field settings (i.e Edit Tool's E/W, N/S, etc.), if you enter just a minus sign (-) and leave the box, OT crashes.  Modified logic to error out like any normal invalid value.