### PR TITLE
Fix Lip Sync Popup

### DIFF
--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -518,7 +518,6 @@ void LipSyncPopup::paintEvent(QPaintEvent *) {
       m_pixmaps[i] = QPixmap::fromImage(placeHolder);
       m_imageLabels[i]->setPixmap(m_pixmaps[i]);
     }
-    hide();
   }
 }
 


### PR DESCRIPTION
This will fix #1577 .
If any invalid column is selected, `hide()` is called in `paintEvent()` , followed by `raise()` and `activateWindow()` . It seems to occur malfunction of window modality.
