### PR TITLE
Remove Hyphens in Fx Parameter Expression

### DIFF
--- a/toonz/sources/toonzlib/txsheetexpr.cpp
+++ b/toonz/sources/toonzlib/txsheetexpr.cpp
@@ -304,10 +304,10 @@ public:
       TParam *param         = fx->getParams()->getParam(i);
       std::string paramName = ::to_string(
           TStringTable::translate(fx->getFxType() + "." + param->getName()));
-      int i = paramName.find(" ");
+      int i = paramName.find_first_of(" -");
       while (i != std::string::npos) {
         paramName.erase(i, 1);
-        i = paramName.find(" ");
+        i = paramName.find_first_of(" -");
       }
       std::string paramNameToCheck = token.getText();
       if (paramName == paramNameToCheck ||

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -680,9 +680,12 @@ QString FunctionTreeModel::Channel::getExprRefName() const {
     return stageGroup->getIdName() + QString(".") + tmpName;
   }
 
-  /*--- Fxパラメータの場合 ---*/
+  // expression for fx parameters
+  // see txsheetexpr.cpp for generation of actual tokens
+
   tmpName.remove(QChar(' '), Qt::CaseInsensitive);
   tmpName.remove(QChar('/'));
+  tmpName.remove(QChar('-'));
   tmpName = tmpName.toLower();
 
   FunctionTreeModel::ChannelGroup *parentGroup =


### PR DESCRIPTION
This PR solves the following problem:
 
`On-Focus Distance` parameter in the `Bokeh Iwa` and `Bokeh Ref Iwa` Fxs cannot be referred by expression, since the expression `fx.bokehrefiwa01.on-focusdistance` is recognized as separated at hyphen.

I fixed it by removing hyphens from the parameter name when obtaining the text for expression variable.
Now `On-Focus Distance` can be referred with `fx.bokehrefiwa01.onfocusdistance` .