### PR TITLE
Note level zoom out update

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1919,13 +1919,15 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
   QString text =
       cell.getSoundTextLevel()->getFrameText(cell.m_frameId.getNumber() - 1);
 
+  QFontMetrics metric(font);
+
   if (text.size() && text != "" && m_viewer->getFrameZoomFactor() <= 50) {
-    drawFrameDot(p, xy, false);
-    return;
+    text          = text[0];
+    int charWidth = metric.width(text, 1);
+    if (charWidth > nameRect.width()) nameRect.adjust(-2, 0, 4, 0);
   }
 
 #if QT_VERSION >= 0x050500
-  QFontMetrics metric(font);
   QString elidaName = elideText(text, metric, nameRect.width(), "~");
 #else
   QString elidaName   = elideText(text, font, nameRect.width(), "~");

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1561,6 +1561,17 @@ void CellArea::drawCurrentTimeIndicator(QPainter &p, const QPoint &xy) {
   p.drawLine(cellMid, cellTop, cellMid, cellBottom);
 }
 
+void CellArea::drawFrameDot(QPainter &p, const QPoint &xy, bool isValid) {
+  int frameAdj = m_viewer->getFrameZoomAdjustment();
+  QRect dotRect =
+      m_viewer->orientation()->rect(PredefinedRect::FRAME_DOT).translated(xy);
+  p.setPen(Qt::black);
+  p.setBrush(isValid ? QColor(230, 100, 100) : m_viewer->getTextColor());
+  dotRect.adjust(-frameAdj / 2, 0, -frameAdj / 2, 0);
+  p.drawEllipse(dotRect);
+  p.setBrush(Qt::NoBrush);
+}
+
 //-----------------------------------------------------------------------------
 
 void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
@@ -1739,14 +1750,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
   // draw frame number
   else {
     if (m_viewer->getFrameZoomFactor() <= 50) {
-      p.setPen(Qt::black);
-      p.setBrush(isRed ? QColor(230, 100, 100) : m_viewer->getTextColor());
-      QRect dotRect = m_viewer->orientation()
-                          ->rect(PredefinedRect::FRAME_DOT)
-                          .translated(QPoint(x, y));
-      dotRect.adjust(-frameAdj / 2, 0, -frameAdj / 2, 0);
-      p.drawEllipse(dotRect);
-      p.setBrush(Qt::NoBrush);
+      drawFrameDot(p, QPoint(x, y), isRed);
       return;
     }
 
@@ -1914,6 +1918,11 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
 
   QString text =
       cell.getSoundTextLevel()->getFrameText(cell.m_frameId.getNumber() - 1);
+
+  if (text.size() && text != "" && m_viewer->getFrameZoomFactor() <= 50) {
+    drawFrameDot(p, xy, false);
+    return;
+  }
 
 #if QT_VERSION >= 0x050500
   QFontMetrics metric(font);
@@ -2600,14 +2609,17 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
   TXsheet *xsh = m_viewer->getXsheet();
 
   // Verifico se e' una colonna sound
-  TXshColumn *column  = xsh->getColumn(col);
-  bool isSoundColumn  = false;
-  bool isZeraryColumn = false;
+  TXshColumn *column     = xsh->getColumn(col);
+  bool isSoundColumn     = false;
+  bool isZeraryColumn    = false;
+  bool isSoundTextColumn = false;
   if (column) {
-    TXshSoundColumn *soundColumn     = column->getSoundColumn();
-    isSoundColumn                    = (!soundColumn) ? false : true;
-    TXshZeraryFxColumn *zeraryColumn = column->getZeraryFxColumn();
-    isZeraryColumn                   = (!zeraryColumn) ? false : true;
+    TXshSoundColumn *soundColumn         = column->getSoundColumn();
+    isSoundColumn                        = (!soundColumn) ? false : true;
+    TXshZeraryFxColumn *zeraryColumn     = column->getZeraryFxColumn();
+    isZeraryColumn                       = (!zeraryColumn) ? false : true;
+    TXshSoundTextColumn *soundTextColumn = column->getSoundTextColumn();
+    isSoundTextColumn                    = (!soundTextColumn) ? false : true;
   }
 
   TStageObject *pegbar = xsh->getStageObject(m_viewer->getObjectId(col));
@@ -2660,7 +2672,10 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
 
     // convert the last one digit of the frame number to alphabet
     // Ex.  12 -> 1B    21 -> 2A   30 -> 3
-    if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
+    if (isSoundTextColumn)
+      m_tooltip = cell.getSoundTextLevel()->getFrameText(
+          cell.m_frameId.getNumber() - 1);
+    else if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
       m_tooltip =
           (fid.isEmptyFrame() || fid.isNoFrame())
               ? QString::fromStdWString(levelName)

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1921,11 +1921,8 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
 
   QFontMetrics metric(font);
 
-  if (text.size() && text != "" && m_viewer->getFrameZoomFactor() <= 50) {
-    text          = text[0];
-    int charWidth = metric.width(text, 1);
-    if (charWidth > nameRect.width()) nameRect.adjust(-2, 0, 4, 0);
-  }
+  int charWidth = metric.width(text, 1);
+  if ((charWidth * 2) > nameRect.width()) nameRect.adjust(-2, 0, 4, 0);
 
 #if QT_VERSION >= 0x050500
   QString elidaName = elideText(text, metric, nameRect.width(), "~");

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -96,6 +96,8 @@ class CellArea final : public QWidget {
 
   void drawCurrentTimeIndicator(QPainter &p, const QPoint &xy);
 
+  void drawFrameDot(QPainter &p, const QPoint &xy, bool isValid);
+
   // Restistusce true
   bool getEaseHandles(int r0, int r1, double e0, double e1, int &rh0, int &rh1);
 


### PR DESCRIPTION
This PR updates the zoom out behavior for Note levels similar to other levels.

This does the following:

1) Replaces the text with a frame dot when zoomed out more than 50% like other levels.
2) Zoomed out or not, the tool tip for the cell displays the contents of the cell instead of the frame number.

![image](https://user-images.githubusercontent.com/19245851/33376427-a172cc3a-d4db-11e7-99b6-e2a1e9bb6a87.png)
