### PR TITLE
Fix Rename Cell in Empty Column Crash

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2764,7 +2764,7 @@ void CellArea::mouseDoubleClickEvent(QMouseEvent *event) {
   if ((Preferences::instance()->isAnimationSheetEnabled() &&
        m_viewer->getXsheet()->getCell(row, col).isEmpty()))
     return;
-
+  if (m_viewer->getXsheet()->isColumnEmpty(col)) return;
   int colCount = m_viewer->getCellSelection()->getSelectedCells().getColCount();
 
   m_renameCell->showInRowCol(row, col, colCount > 1);


### PR DESCRIPTION
If you try and rename a cell in an empty column, OpenToonz will crash.  This fixes it.

To test:
- Double click a cell
- Enter text
- Hit Enter