### PR TITLE
Resolve Warnings in Timeline View

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1503,6 +1503,7 @@ QPixmap ColumnArea::getColumnIcon(int columnIndex) {
     QPixmap icon =
         IconGenerator::instance()->getIcon(xl, cell.m_frameId, false, onDemand);
     QRect thumbnailImageRect = o->rect(PredefinedRect::THUMBNAIL);
+    if (thumbnailImageRect.isEmpty()) return QPixmap();
     return scalePixmapKeepingAspectRatio(icon, thumbnailImageRect.size());
   }
 }


### PR DESCRIPTION
This is a refactor PR.
In my environment of MSVC2015, many lines of warning saying `QPainter::begin: Paint device returned engine == 0, type: 2` appears in the console while displaying the Timeline.
For now Timeline has no thumbnails. The warning appears when OT tries to scale the thumbnail to invalid (=empty) size.