### PR TITLE
Fix "Replace Parent Directory" Command Fails on the First Call

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -398,9 +398,10 @@ class ReplaceParentDirectoryPopup final : public FileBrowserPopup {
 
 public:
   ReplaceParentDirectoryPopup();
-  void show();
   bool execute() override;
   void initFolder() override;
+  void setRange(TCellSelection::Range &range, std::set<int> &columnRange,
+                bool &replaceCells);
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the problem as follows:

"Replace Parent Directory" always fails when you use the command for the first time after launching the software. It fails with an error message `Nothing to replace: no cells or columns selected` even if you surely select cells or columns before using this command.
It works properly from the second use of this command.

This problem occurs because the current selection is cleared on constructing the File Browser. In this PR I made a command handler specially used for this command and obtain the selection information before making the browser window.