### PR TITLE
Add project name to startup

### DIFF
--- a/toonz/sources/include/toonz/tproject.h
+++ b/toonz/sources/include/toonz/tproject.h
@@ -146,6 +146,8 @@ public:
   TFilePath projectNameToProjectPath(const TFilePath &projectName);
   TFilePath projectFolderToProjectPath(const TFilePath &projectFolder);
   TFilePath getProjectPathByName(const TFilePath &projectName);
+  TFilePath getProjectNameByScenePath(const TFilePath &scenePath);
+  TFilePath getProjectPathByScenePath(const TFilePath &scenePath);
 
   TProjectP loadSceneProject(const TFilePath &scenePath);
   void getFolderNames(std::vector<std::string> &names);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2380,9 +2380,9 @@ RecentFiles::~RecentFiles() {}
 
 void RecentFiles::addFilePath(QString path, FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) files.removeAt(i);
@@ -2505,18 +2505,23 @@ void RecentFiles::saveRecentFiles() {
 
 //-----------------------------------------------------------------------------
 
-QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
+QList<QString> RecentFiles::getFilesNameList(FileType fileType,
+                                             bool withNumber) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
     TFilePath path(files.at(i).toStdWString());
     QString str, number;
-    names.append(number.number(i + 1) + QString(". ") +
-                 str.fromStdWString(path.getWideString()));
+    if (withNumber) {
+      names.append(number.number(i + 1) + QString(". ") +
+                   str.fromStdWString(path.getWideString()));
+    } else {
+      names.append(str.fromStdWString(path.getWideString()));
+    }
   }
   return names;
 }
@@ -2536,9 +2541,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene)
-            ? MI_ClearRecentScene
-            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
+        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
+                                                        ? MI_ClearRecentLevel
+                                                        : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -239,7 +239,7 @@ public:
 
 protected:
   void refreshRecentFilesMenu(FileType fileType);
-  QList<QString> getFilesNameList(FileType fileType);
+  QList<QString> getFilesNameList(FileType fileType, bool withNumber = true);
 };
 
 #endif  // TESTCUSTOMTAB_H

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -416,7 +416,7 @@ void StartupPopup::refreshRecentScenes() {
               ->getProjectNameByScenePath(TFilePath(name))
               .getName());
       if (projectName.length() > 0)
-        justName             = justName + " (" + projectName + ")";
+        justName             = justName + " - " + projectName;
       m_recentNamesLabels[i] = new StartupLabel(justName, this, i);
       m_recentNamesLabels[i]->setToolTip(
           name.remove(0, name.indexOf(" ") + 1));  // remove "#. " prefix

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -398,7 +398,8 @@ void StartupPopup::refreshRecentScenes() {
   removeAll(m_recentSceneLay);
 
   m_sceneNames.clear();
-  m_sceneNames = RecentFiles::instance()->getFilesNameList(RecentFiles::Scene);
+  m_sceneNames =
+      RecentFiles::instance()->getFilesNameList(RecentFiles::Scene, false);
   m_recentNamesLabels.clear();
   m_recentNamesLabels = QVector<StartupLabel *>(m_sceneNames.count());
 
@@ -409,7 +410,13 @@ void StartupPopup::refreshRecentScenes() {
     int i = 0;
     for (QString name : m_sceneNames) {
       if (i > 9) break;  // box can hold 10 scenes
-      QString justName = QString::fromStdString(TFilePath(name).getName());
+      QString justName    = QString::fromStdString(TFilePath(name).getName());
+      QString projectName = QString::fromStdString(
+          TProjectManager::instance()
+              ->getProjectNameByScenePath(TFilePath(name))
+              .getName());
+      if (projectName.length() > 0)
+        justName             = justName + " (" + projectName + ")";
       m_recentNamesLabels[i] = new StartupLabel(justName, this, i);
       m_recentNamesLabels[i]->setToolTip(
           name.remove(0, name.indexOf(" ") + 1));  // remove "#. " prefix

--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -942,12 +942,20 @@ TProjectP TProjectManager::getCurrentProject() {
 }
 
 //-------------------------------------------------------------------
-/*! Returns the TProjectP in which the specified \b scenePath is saved.\n
-        Returns 0 if \b scenePath isn't a valid scene, or isn't saved in a valid
-   folder of a project root.
-        \note \b scenePath must be an absolute path.\n
-        Creates a new TProject. The caller gets ownership.*/
-TProjectP TProjectManager::loadSceneProject(const TFilePath &scenePath) {
+
+TFilePath TProjectManager::getProjectNameByScenePath(
+    const TFilePath &scenePath) {
+  TFilePath projectPath = getProjectPathByScenePath(scenePath);
+  if (projectPath.isEmpty())
+    return TFilePath();
+  else
+    return projectPathToProjectName(projectPath);
+}
+
+//-------------------------------------------------------------------
+
+TFilePath TProjectManager::getProjectPathByScenePath(
+    const TFilePath &scenePath) {
   // cerca il file scenes.xml nella stessa directory della scena
   // oppure in una
   // directory superiore
@@ -992,7 +1000,7 @@ TProjectP TProjectManager::loadSceneProject(const TFilePath &scenePath) {
 
     } catch (...) {
     }
-    if (projectPath == TFilePath()) return 0;
+    if (projectPath == TFilePath()) return TFilePath();
   } else
     projectPath = getSandboxProjectPath();
 
@@ -1001,10 +1009,21 @@ TProjectP TProjectManager::loadSceneProject(const TFilePath &scenePath) {
     if (!projectPath.isAbsolute())
       projectPath = getProjectPathByName(projectPath);
     else
-      return 0;
+      return TFilePath();
   }
-  if (!TFileStatus(projectPath).doesExist()) return 0;
+  if (!TFileStatus(projectPath).doesExist()) return TFilePath();
+  return projectPath;
+}
 
+//-------------------------------------------------------------------
+/*! Returns the TProjectP in which the specified \b scenePath is saved.\n
+        Returns 0 if \b scenePath isn't a valid scene, or isn't saved in a valid
+   folder of a project root.
+        \note \b scenePath must be an absolute path.\n
+        Creates a new TProject. The caller gets ownership.*/
+TProjectP TProjectManager::loadSceneProject(const TFilePath &scenePath) {
+  TFilePath projectPath = getProjectPathByScenePath(scenePath);
+  if (projectPath == TFilePath()) return 0;
   TProject *project = new TProject();
   project->load(projectPath);
   return project;


### PR DESCRIPTION
fixes #1553 

This adds the project name to the end of the scene name in the startup popup.

scene name - project name

Note: there is already a tool tip if you hover.  This just makes it easier to quickly scan the list.