### PR TITLE
Disable Tools for Hidden Columns

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -802,13 +802,18 @@ QString TTool::updateEnabled() {
     if (column->isLocked())
       return (enable(false), QObject::tr("The current column is locked."));
 
+    else if (!column->isCamstandVisible())
+      return (enable(false), QObject::tr("The current column is hidden."));
+
     else if (column->getSoundColumn())
       return (enable(false),
               QObject::tr("It is not possible to edit the audio column."));
 
     else if (column->getSoundTextColumn())
-      return (enable(false),
-              QObject::tr("It is not possible to edit the Magpie column."));
+      return (
+          enable(false),
+          QObject::tr(
+              "Note columns can only be edited in the xsheet or timeline."));
 
     if (toolType == TTool::ColumnTool) {
       // Check column target


### PR DESCRIPTION
If a column is hidden, this disables using tools on the column in xsheet view.
fixes #1559 