### PR TITLE
Fix Actual Pixel Size and Zoom Factor Reporting

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1836,12 +1836,12 @@ double SceneViewer::getDpiFactor() {
   else if (TApp::instance()->getCurrentFrame()->isEditingLevel()) {
     TXshSimpleLevel *sl;
     sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
-    if (!sl) return 1.;
-    if (sl->getType() == PLI_XSHLEVEL) return 1.;
+    if (!sl) return Stage::inch / Stage::standardDpi;
+    if (sl->getType() == PLI_XSHLEVEL) return Stage::inch / Stage::standardDpi;
     if (sl->getImageDpi() != TPointD())
       return Stage::inch / sl->getImageDpi().x;
     if (sl->getDpi() != TPointD()) return Stage::inch / sl->getDpi().x;
-    return 1.;
+    return Stage::inch / sl->getDpi().x;
   }
   // When the special case in the scene editing mode:
   // If the option "ActualPixelViewOnSceneEditingMode" is ON,
@@ -1852,16 +1852,16 @@ double SceneViewer::getDpiFactor() {
            !CameraTestCheck::instance()->isEnabled()) {
     TXshSimpleLevel *sl;
     sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
-    if (!sl) return 1.;
-    if (sl->getType() == PLI_XSHLEVEL) return 1.;
-    if (sl->getDpi() == TPointD()) return 1.;
+    if (!sl) return Stage::inch / Stage::standardDpi;
+    if (sl->getType() == PLI_XSHLEVEL) return Stage::inch / Stage::standardDpi;
+    if (sl->getDpi() == TPointD()) return Stage::inch / Stage::standardDpi;
     // use default value for the argument of getDpi() (=TFrameId::NO_FRAME）
     // so that the dpi of the first frame in the level will be returned.
     return Stage::inch / sl->getDpi().x;
   }
   // When the scene editing mode without any option, don't think about DPI
   else {
-    return 1.;
+    return Stage::inch / Stage::standardDpi;
   }
 }
 

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1819,29 +1819,31 @@ void SceneViewer::zoomQt(bool forward, bool reset) {
 */
 double SceneViewer::getDpiFactor() {
   // When the current unit is "pixels", always use a standard dpi
+  double cameraDpi = TApp::instance()
+                         ->getCurrentScene()
+                         ->getScene()
+                         ->getCurrentCamera()
+                         ->getDpi()
+                         .x;
   if (Preferences::instance()->getPixelsOnly()) {
     return Stage::inch / Stage::standardDpi;
   }
+
   // When preview mode, use a camera DPI
   else if (isPreviewEnabled()) {
-    return Stage::inch /
-           TApp::instance()
-               ->getCurrentScene()
-               ->getScene()
-               ->getCurrentCamera()
-               ->getDpi()
-               .x;
+    return Stage::inch / cameraDpi;
   }
   // When level editing mode, use an image DPI
   else if (TApp::instance()->getCurrentFrame()->isEditingLevel()) {
     TXshSimpleLevel *sl;
     sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
-    if (!sl) return Stage::inch / Stage::standardDpi;
-    if (sl->getType() == PLI_XSHLEVEL) return Stage::inch / Stage::standardDpi;
+    if (!sl) return Stage::inch / cameraDpi;
+    if (sl->getType() == PLI_XSHLEVEL) return Stage::inch / cameraDpi;
     if (sl->getImageDpi() != TPointD())
       return Stage::inch / sl->getImageDpi().x;
     if (sl->getDpi() != TPointD()) return Stage::inch / sl->getDpi().x;
-    return Stage::inch / sl->getDpi().x;
+    // no valid dpi, use camera dpi
+    return Stage::inch / cameraDpi;
   }
   // When the special case in the scene editing mode:
   // If the option "ActualPixelViewOnSceneEditingMode" is ON,
@@ -1852,16 +1854,16 @@ double SceneViewer::getDpiFactor() {
            !CameraTestCheck::instance()->isEnabled()) {
     TXshSimpleLevel *sl;
     sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
-    if (!sl) return Stage::inch / Stage::standardDpi;
-    if (sl->getType() == PLI_XSHLEVEL) return Stage::inch / Stage::standardDpi;
-    if (sl->getDpi() == TPointD()) return Stage::inch / Stage::standardDpi;
+    if (!sl) return Stage::inch / cameraDpi;
+    if (sl->getType() == PLI_XSHLEVEL) return Stage::inch / cameraDpi;
+    if (sl->getDpi() == TPointD()) return Stage::inch / cameraDpi;
     // use default value for the argument of getDpi() (=TFrameId::NO_FRAME）
     // so that the dpi of the first frame in the level will be returned.
     return Stage::inch / sl->getDpi().x;
   }
-  // When the scene editing mode without any option, don't think about DPI
+  // When the scene editing mode without any option, use the camera dpi
   else {
-    return Stage::inch / Stage::standardDpi;
+    return Stage::inch / cameraDpi;
   }
 }
 


### PR DESCRIPTION
![traster](https://user-images.githubusercontent.com/4576381/33536127-b326b01c-d86f-11e7-9005-90759a5e43d7.JPG)

The above picture is a Toonz Raster layer at 1920 x 1080 resolution on a 1080p screen.  Notice the zoom factor says 100%, actual 100% display is reported as 225%.

The default return on getDpiFactor is currently 1 which worked well before the introduction of Stage::standardDpi.  

Turning on "Enable Actual Pixel View on Scene Editing Mode" in preferences fixes this for Toonz Raster and Raster levels, but the problem persists on vector levels.  I realize that vector levels have no actual dpi, but I think it is reasonable for a user to expect clicking actual pixel size to show the output size based on the camera settings.