### PR TITLE
Fix Rename Cell in Empty Column Crash (modified)

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -11,6 +11,7 @@
 class XsheetViewer;
 class QMenu;
 class TXsheetHandle;
+class TXshSoundTextColumn;
 
 namespace XsheetGUI {
 
@@ -41,6 +42,7 @@ protected:
   void hideEvent(QHideEvent *) override;
 
   void renameCell();
+  void renameSoundTextColumn(TXshSoundTextColumn *sndTextCol, const QString &s);
 
 protected slots:
   void onReturnPressed();


### PR DESCRIPTION
This will fix the crash issue mentioned in #1619 but in another approach, retaining the availability to insert a level into empty column.
Also I moved the renaming process for note levels to separate function to clarify.
Thank you @turtletooth for finding the problem!