### PR TITLE
Fix Animate Tool Control with Tool Options

### DIFF
--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1215,6 +1215,7 @@ void PegbarChannelField::onChange(TMeasuredValue *fld, bool addToUndo) {
   // and only for the first drag
   // This should always fire if addToUndo is true
   if (!m_firstMouseDrag) {
+    m_before = TStageObjectValues();
     m_before.setFrameHandle(m_frameHandle);
     m_before.setObjectHandle(m_objHandle);
     m_before.setXsheetHandle(m_xshHandle);


### PR DESCRIPTION
fix #1646

In #1362 `PegbarChannelField` started to hold `TStageObjectValues m_before` to keep the values before dragging for undo.
However, since `m_before` is not initialized on each calling of `onChange()`, only the first object you changed will be stored in `TStageObjectValues::m_objectId` . (when `TStageObjectValues::updateValues()` is called, `m_objectId` will be set if it is not specified)

`m_before` is copied to `after`, and then the value is set to the wrong object when `after.applyValues()` is called.

I added a line to initialize the `TStageObjectValues` each time using `m_before`.