### PR TITLE
Fix Crash on Closing Scene with Floating Selection Remained

### DIFF
--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -101,6 +101,7 @@ void ToolUtils::updateSaveBox(const TXshSimpleLevelP &sl, const TFrameId &fid) {
 
   TImageP img = sl->getFrame(fid, true);  // The image will be modified (it
                                           // should already have been, though)
+  if (!img) return;
   // Observe that the returned image will forcedly have subsampling 1
   ::updateSaveBox(img);
 


### PR DESCRIPTION
fix #1650 

In line 102 of `ToolUtils::updateSaveBox()`, `TImageP img` seems to be obtained in most cases except when closing and opening the scenes.