### PR TITLE
Fix Raster Selection Tool Behavior

### DIFF
--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1242,6 +1242,4 @@ TRectD RasterSelection::getSelectionBbox() const {
 
 void RasterSelection::setSelectionBbox(const TRectD &rect) {
   m_selectionBbox = rect;
-  if (m_currentImage)
-    m_selectionBbox = intersection(m_selectionBbox, m_currentImage);
 }


### PR DESCRIPTION
fixes #1654 

It seems that the bounding box of floating selection should not be limited with the original image boundary.