### PR TITLE
Fix Tablet Behavior on OSX

### DIFF
--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -484,8 +484,7 @@ void EraserTool::startErase(
   m_indexes.resize(size);
   for (UINT i = 0; i < size; i++) m_indexes[i] = i;
 
-  assert(m_undo == 0);
-  delete m_undo;
+  if (m_undo) delete m_undo;
   TXshSimpleLevel *level =
       TTool::getApplication()->getCurrentLevel()->getSimpleLevel();
   m_undo        = new UndoEraser(level, getCurrentFid());

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -444,10 +444,7 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
     , m_mouseButton(Qt::NoButton)
     , m_foregroundDrawing(false)
     , m_tabletEvent(false)
-    , m_tabletActive(false)
     , m_tabletMove(false)
-    , m_tabletPressed(false)
-    , m_tabletReleased(false)
     , m_buttonClicked(false)
     , m_referenceMode(NORMAL_REFERENCE)
     , m_previewMode(NO_PREVIEW)
@@ -491,8 +488,10 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
   setFocusPolicy(Qt::StrongFocus);
   setAcceptDrops(true);
   this->setMouseTracking(true);
-  // to be introduced from Qt 5.9
-  // this->setTabletTracking(true);
+// introduced from Qt 5.9
+#if QT_VERSION >= 0x050900
+  this->setTabletTracking(true);
+#endif
 
   for (int i = 0; i < tArrayCount(m_viewAff); i++)
     setViewMatrix(getNormalZoomScale(), i);

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -69,8 +69,13 @@ class SceneViewer final : public GLWidgetForHighDpi,
   QPoint m_pos;
   Qt::MouseButton m_mouseButton;
   bool m_foregroundDrawing;
-  bool m_tabletEvent, m_tabletPressed, m_tabletReleased, m_tabletMove,
-      m_tabletActive;
+  bool m_tabletEvent, m_tabletMove;
+  enum TabletState {
+    None = 0,
+    Touched,
+    OnStroke,
+    Released
+  } m_tabletState = None;
   // used to handle wrong mouse drag events!
   bool m_buttonClicked, m_toolSwitched;
   bool m_shownOnce     = false;
@@ -310,6 +315,9 @@ protected:
   void onPress(const TMouseEvent &event);
   void onMove(const TMouseEvent &event);
   void onRelease(const TMouseEvent &event);
+  void onContextMenu(const QPoint &pos, const QPoint &globalPos);
+  void onEnter();
+  void onLeave();
 
   void wheelEvent(QWheelEvent *) override;
   void keyPressEvent(QKeyEvent *event) override;


### PR DESCRIPTION
(hopefully) fixed #756 

For now when using tablet on OSX, viewer seems to behave in a different way from Windows.
In particular, most of events such as `mousePressEvent`, `mouseMoveEvent`, `mouseReleaseEvent`, `contextMenuEvent`, `enterEvent` or `leaveEvent` seem NOT to be called properly. 
So, I tried to modify it by handling all of operations done in the above events in `tabletEvent` instead.
Also I fixed not to draw stroke if the tablet moves with 0 pressure.

Please note that the above changes are done only for OSX. I tried to keep the behavior in Windows and other OS unchanged.

I already notice that there are some problems remaining as follows:
- Instead of preventing the unwanted stroke, there is a case that a stroke cannot be drawn. Please just draw again in such case.
- Mouse cursor seems to fail to update properly when using tablet on OSX.

Anyway, I think I made it better than before.

After merging this, I would like to wait a few days before releasing the next version for verification since this will be quite a big change.