### PR TITLE
Moved xsheetChanged event and scene setDirty call outside loop

### DIFF
--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -639,18 +639,16 @@ public:
         }
         if (found) {
           r++;
-          TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-          TApp::instance()->getCurrentScene()->setDirtyFlag(true);
           continue;
         }
         changeDrawing(-m_direction, row, col);
-        TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-		TApp::instance()->getCurrentScene()->setDirtyFlag(true);
         r++;
       }
       r = m_range.m_r0;
       c++;
     }
+	TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   void redo() const override {

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -619,6 +619,8 @@ public:
 
     if (!m_selected) {
       changeDrawing(-m_direction, m_row, m_col);
+      TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+      TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
       return;
     }
     int col, row;
@@ -642,6 +644,8 @@ public:
           continue;
         }
         changeDrawing(-m_direction, row, col);
+        TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+		TApp::instance()->getCurrentScene()->setDirtyFlag(true);
         r++;
       }
       r = m_range.m_r0;
@@ -652,6 +656,8 @@ public:
   void redo() const override {
     if (!m_selected) {
       changeDrawing(m_direction, m_row, m_col);
+      TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+	  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
       return;
     }
 
@@ -668,6 +674,8 @@ public:
       r = m_range.m_r0;
       c++;
     }
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   int getSize() const override { return sizeof(*this); }
@@ -742,6 +750,8 @@ public:
       DrawingSubtitutionUndo::changeDrawing(-m_direction, m_row + n, m_col);
       n++;
     }
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   void redo() const override {
@@ -751,6 +761,8 @@ public:
       DrawingSubtitutionUndo::changeDrawing(m_direction, m_row + n, m_col);
       n++;
     }
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   int getSize() const override { return sizeof(*this); }
@@ -853,8 +865,6 @@ void DrawingSubtitutionUndo::setDrawing(const TFrameId &fid, int row, int col,
   TStageObject *pegbar = xsh->getStageObject(TStageObjectId::ColumnId(col));
   pegbar->setOffset(pegbar->getOffset());
 
-  app->getCurrentXsheet()->notifyXsheetChanged();
-  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -647,15 +647,15 @@ public:
       r = m_range.m_r0;
       c++;
     }
-	TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   void redo() const override {
     if (!m_selected) {
       changeDrawing(m_direction, m_row, m_col);
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-	  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+      TApp::instance()->getCurrentScene()->setDirtyFlag(true);
       return;
     }
 
@@ -673,7 +673,7 @@ public:
       c++;
     }
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   int getSize() const override { return sizeof(*this); }
@@ -749,7 +749,7 @@ public:
       n++;
     }
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   void redo() const override {
@@ -760,7 +760,7 @@ public:
       n++;
     }
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
-	TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
   int getSize() const override { return sizeof(*this); }
@@ -862,7 +862,6 @@ void DrawingSubtitutionUndo::setDrawing(const TFrameId &fid, int row, int col,
   xsh->setCell(row, col, cell);
   TStageObject *pegbar = xsh->getStageObject(TStageObjectId::ColumnId(col));
   pegbar->setOffset(pegbar->getOffset());
-
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
In complex cutout animation scenes, these two events being called from within loops in the "Similar Drawing Substitution" commands were causing those commands to take as long as 90 seconds to complete (iterating over 200 frames and updating the scene & xsheet per-frame).

Moved the events outside all calls to the internal changeDrawing/setDrawing functions, so that they won't be caught up in the multi-frame loop. The scene and xsheet display only needs to be updated at the end of the command, not for each frame it alters.

This change drops the time for the command to complete to realtime, even in large/complex files.