### PR TITLE
Timeline bug fixes and tweeks

### DIFF
--- a/toonz/sources/toonz/keyframemover.cpp
+++ b/toonz/sources/toonz/keyframemover.cpp
@@ -330,10 +330,18 @@ void KeyframeMoverTool::rectSelect(int row, int col) {
 //-----------------------------------------------------------------------------
 
 bool KeyframeMoverTool::canMove(const TPoint &pos) {
-  TXsheet *xsh = getViewer()->getXsheet();
-  if (pos.x < 0) return false;
+  const Orientation *o = getViewer()->orientation();
+  TXsheet *xsh         = getViewer()->getXsheet();
 
-  int col      = pos.x;
+  TPoint usePos = pos;
+  if (!o->isVerticalTimeline()) {
+    usePos.x = pos.y;
+    usePos.y = pos.x;
+  }
+
+  if (usePos.x < 0) return false;
+
+  int col      = usePos.x;
   int startCol = getViewer()->xyToPosition(m_startPos).layer();
   if (col != startCol) return false;
 

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1101,6 +1101,7 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
       if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
           !m_viewer->orientation()->isVerticalTimeline() &&
           Preferences::instance()->isCurrentTimelineIndicatorEnabled()) {
+        row       = m_viewer->getCurrentRow();
         QPoint xy = m_viewer->positionToXY(CellPosition(row, col));
         int x     = xy.x();
         int y     = xy.y();
@@ -1110,7 +1111,7 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
           else
             xy.setX(xy.x() + 1);
         }
-        drawCurrentTimeIndicator(p, xy);
+        drawCurrentTimeIndicator(p, xy, true);
       }
       continue;
     }
@@ -1558,7 +1559,8 @@ void CellArea::drawLockedDottedLine(QPainter &p, bool isLocked,
   p.drawLine(dottedLine);
 }
 
-void CellArea::drawCurrentTimeIndicator(QPainter &p, const QPoint &xy) {
+void CellArea::drawCurrentTimeIndicator(QPainter &p, const QPoint &xy,
+                                        bool isFolded) {
   int frameAdj = m_viewer->getFrameZoomAdjustment();
   QRect cell =
       m_viewer->orientation()->rect(PredefinedRect::CELL).translated(xy);
@@ -1567,6 +1569,12 @@ void CellArea::drawCurrentTimeIndicator(QPainter &p, const QPoint &xy) {
   int cellMid    = cell.left() + (cell.width() / 2) - 1;
   int cellTop    = cell.top();
   int cellBottom = cell.bottom();
+
+  // Adjust left for 1st row
+  if (xy.x() <= 1) cellMid -= 1;
+
+  if (isFolded)
+    cellBottom = cell.top() + m_viewer->orientation()->foldedCellSize() - 1;
 
   p.setPen(Qt::red);
   p.drawLine(cellMid, cellTop, cellMid, cellBottom);

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -96,7 +96,8 @@ class CellArea final : public QWidget {
 
   void drawNotes(QPainter &p, const QRect toBeUpdated);
 
-  void drawCurrentTimeIndicator(QPainter &p, const QPoint &xy);
+  void drawCurrentTimeIndicator(QPainter &p, const QPoint &xy,
+                                bool isFolded = false);
 
   void drawFrameDot(QPainter &p, const QPoint &xy, bool isValid);
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -675,9 +675,9 @@ bool XsheetViewer::refreshContentSize(int dx, int dy) {
     contentSize = positionToXY(CellPosition(frameCount + 1, 0));
 
     ColumnFan *fan = xsh->getColumnFan(m_orientation);
-    contentSize.setY(contentSize.y() + (fan->isActive(0)
-                                            ? m_orientation->cellHeight()
-                                            : m_orientation->foldedCellSize()));
+    contentSize.setY(contentSize.y() + 1 +
+                     (fan->isActive(0) ? m_orientation->cellHeight()
+                                       : m_orientation->foldedCellSize()));
   }
 
   QSize actualSize(contentSize.x(), contentSize.y());
@@ -726,9 +726,9 @@ void XsheetViewer::updateAreeSize() {
       areaFilled = positionToXY(CellPosition(xsh->getFrameCount() + 1, 0));
 
       ColumnFan *fan = xsh->getColumnFan(m_orientation);
-      areaFilled.setY(areaFilled.y() + (fan->isActive(0)
-                                            ? o->cellHeight()
-                                            : o->foldedCellSize()));
+      areaFilled.setY(areaFilled.y() + 1 + (fan->isActive(0)
+                                                ? o->cellHeight()
+                                                : o->foldedCellSize()));
     }
   }
   if (viewArea.right() < areaFilled.x()) viewArea.setRight(areaFilled.x());
@@ -757,8 +757,9 @@ int XsheetViewer::colToTimelineLayerAxis(int layer) const {
   int yBottom = o->colToLayerAxis(layer, fan) +
                 (fan->isActive(layer) ? o->cellHeight() : o->foldedCellSize()) -
                 1;
-  int columnCount       = qMax(1, xsh->getColumnCount());
-  int layerHeightActual = o->colToLayerAxis(columnCount, fan) - 1;
+  int columnCount = qMax(1, xsh->getColumnCount());
+  int layerHeightActual =
+      m_columnArea->height() - 2;  // o->colToLayerAxis(columnCount, fan) - 1;
 
   return layerHeightActual - yBottom;
 }

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -949,10 +949,10 @@ LeftToRightOrientation::LeftToRightOrientation() {
 
   // Column viewer
   addRect(PredefinedRect::LAYER_HEADER,
-          QRect(1, 0, LAYER_HEADER_WIDTH - 3, CELL_HEIGHT));
+          QRect(1, 0, LAYER_HEADER_WIDTH - 2, CELL_HEIGHT));
   addRect(
       PredefinedRect::FOLDED_LAYER_HEADER,
-      QRect(1, 0, FOLDED_LAYER_HEADER_WIDTH - 3, FOLDED_LAYER_HEADER_HEIGHT));
+      QRect(1, 0, FOLDED_LAYER_HEADER_WIDTH - 2, FOLDED_LAYER_HEADER_HEIGHT));
   QRect columnName(ICONS_WIDTH + 2, 1,
                    LAYER_NAME_WIDTH + LAYER_NUMBER_WIDTH - 4, CELL_HEIGHT - 1);
   addRect(PredefinedRect::RENAME_COLUMN, columnName);


### PR DESCRIPTION
The PR fixes and tweeks the following Timeline issues:

1) Selected Keyframe move bug fix

When you Ctrl-Select cells with keyframes in them, the keyframe is selected and will move when the cell moves within the same column.  The original introduction of the timeline broke this feature by not allowing the cells to move due to the keyframes checking logic was incorrect.  This was not found until recently. This fix corrects it.

2) Timeline indicator tweeks

 - Timeline indicator in the 1st row is shifted to the right by 1 pixel.   Added logic to shift it back left for 1st row only
 - Timeline indicator was not being drawn over folded columns.  Added logic to corect
 - Timeline indicator was appearing in the 1st row when the bottom column was folded and did not move.  Corrected behavior.

3) Timeline border clipping fix

When there are fewer columns than what can be displayed in the xsheet area, Col1 is clipped at the bottom by 1 pixel due to the border.  It isn't obvious until you fold the column.  Adjusted logic to lower bottom of displayed columns by 1 pixel.
