### PR TITLE
Fix Plastic Mesh on SubXsheet for OSX

### DIFF
--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -192,14 +192,7 @@ DrawableTextureDataP texture_utils::getTextureData(const TXsheet *xsh,
   bbox = (cameraAff.inv() * bbox).enlarge(1.0);
 
   // Render the xsheet on the specified bbox
-
-  // The call below will change context (I know, it's a shame :( )
-  TGlContext currentContext = tglGetCurrentContext();
-  {
-    tglDoneCurrent(currentContext);
-    xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());
-    tglMakeCurrent(currentContext);
-  }
+  xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());
 
   TRop::depremultiply(tex);  // Stored textures are rendered nonpremultiplied
 

--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -191,8 +191,18 @@ DrawableTextureDataP texture_utils::getTextureData(const TXsheet *xsh,
       xsh->getPlacement(xsh->getStageObjectTree()->getCurrentCameraId(), frame);
   bbox = (cameraAff.inv() * bbox).enlarge(1.0);
 
-  // Render the xsheet on the specified bbox
+// Render the xsheet on the specified bbox
+#ifdef MACOSX
   xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());
+#else
+  // The call below will change context (I know, it's a shame :( )
+  TGlContext currentContext = tglGetCurrentContext();
+  {
+    tglDoneCurrent(currentContext);
+    xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());
+    tglMakeCurrent(currentContext);
+  }
+#endif
 
   TRop::depremultiply(tex);  // Stored textures are rendered nonpremultiplied
 

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -763,6 +763,11 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 //! placedRect,
 //! with known world/placed reference change - and returns the result in a
 //! 32-bit raster.
+
+#include <QSurfaceFormat>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
 void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
                              const TRectD &placedRect,
                              const TAffine &worldToPlacedAff) const {
@@ -781,11 +786,33 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 
   TRect clipRect(ras->getBounds());
 
-  TOfflineGL ogl(ras->getSize());
-  currentOfflineGL = &ogl;
+  QSurfaceFormat format;
+  format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
-  ogl.makeCurrent();
+  std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
+  surface->setFormat(format);
+  // Enabling Qt::AA_ShareOpenGLContexts attribute in main()
+  surface->setScreen(QOpenGLContext::globalShareContext()->screen());
+  surface->create();
+
+  glPushAttrib(GL_ALL_ATTRIB_BITS);
+  glMatrixMode(GL_MODELVIEW), glPushMatrix();
+  glMatrixMode(GL_PROJECTION), glPushMatrix();
   {
+    std::unique_ptr<QOpenGLFramebufferObject> fb(
+        new QOpenGLFramebufferObject(ras->getLx(), ras->getLy()));
+
+    fb->bind();
+    assert(glGetError() == GL_NO_ERROR);
+
+    glViewport(0, 0, ras->getLx(), ras->getLy());
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    gluOrtho2D(0, ras->getLx(), 0, ras->getLy());
+
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
     glTranslated(0.5 * ras->getLx(), 0.5 * ras->getLy(), 0.0);
 
     glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
@@ -802,11 +829,25 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
     painter.flushRasterImages();
     glFlush();
 
-    TRop::over(ras, ogl.getRaster());
-  }
-  ogl.doneCurrent();
+    QImage img =
+        fb->toImage().scaled(QSize(ras->getLx(), ras->getLy()),
+                             Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
-  currentOfflineGL = 0;
+    int wrap      = ras->getLx() * sizeof(TPixel32);
+    uchar *srcPix = img.bits();
+    uchar *dstPix = ras->getRawData() + wrap * (ras->getLy() - 1);
+    for (int y = 0; y < ras->getLy(); y++) {
+      memcpy(dstPix, srcPix, wrap);
+      dstPix -= wrap;
+      srcPix += wrap;
+    }
+    fb->release();
+    assert(glGetError() == GL_NO_ERROR);
+  }
+  glMatrixMode(GL_MODELVIEW), glPopMatrix();
+  glMatrixMode(GL_PROJECTION), glPopMatrix();
+
+  glPopAttrib();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This is a dirty fix for #1676 .

I used `ImageRasterizer::build()` in `imagebuilders.cpp` as a reference.
The fix was applied only for OSX since OpenGL error arises with this on Windows debug.
Further modification is needed regarding GL-related part. I post this as a quick fix, 