### PR TITLE
Shift-Drag Keyframe fix

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1583,7 +1583,7 @@ void TCellSelection::pasteCells() {
       // Retrieves all keyframe positions from mime data and translates them by
       // (r0,c0)
       std::set<TKeyframeSelection::Position> positions;
-      int newC0;
+      int newC0 = c0;
       if (viewer && !viewer->orientation()->isVerticalTimeline())
         newC0 = c0 - keyframeData->getColumnSpanCount() + 1;
       positions.insert(TKeyframeSelection::Position(r0, newC0));
@@ -1792,7 +1792,7 @@ void TCellSelection::pasteKeyframesInto() {
       // (r0,c0)
       XsheetViewer *viewer = TApp::instance()->getCurrentXsheetViewer();
       std::set<TKeyframeSelection::Position> positions;
-      int newC0;
+      int newC0 = c0;
       if (viewer && !viewer->orientation()->isVerticalTimeline())
         newC0 = c0 - keyframeData->getColumnSpanCount() + 1;
       positions.insert(TKeyframeSelection::Position(r0, newC0));

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1583,7 +1583,10 @@ void TCellSelection::pasteCells() {
       // Retrieves all keyframe positions from mime data and translates them by
       // (r0,c0)
       std::set<TKeyframeSelection::Position> positions;
-      positions.insert(TKeyframeSelection::Position(r0, c0));
+      int newC0;
+      if (viewer && !viewer->orientation()->isVerticalTimeline())
+        newC0 = c0 - keyframeData->getColumnSpanCount() + 1;
+      positions.insert(TKeyframeSelection::Position(r0, newC0));
       keyframeData->getKeyframes(positions);
       selection.select(positions);
 
@@ -1787,8 +1790,12 @@ void TCellSelection::pasteKeyframesInto() {
     } else {
       // Retrieves all keyframe positions from mime data and translates them by
       // (r0,c0)
+      XsheetViewer *viewer = TApp::instance()->getCurrentXsheetViewer();
       std::set<TKeyframeSelection::Position> positions;
-      positions.insert(TKeyframeSelection::Position(r0, c0));
+      int newC0;
+      if (viewer && !viewer->orientation()->isVerticalTimeline())
+        newC0 = c0 - keyframeData->getColumnSpanCount() + 1;
+      positions.insert(TKeyframeSelection::Position(r0, newC0));
       keyframeData->getKeyframes(positions);
       selection.select(positions);
     }

--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -80,8 +80,6 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
   }
 
   XsheetViewer *viewer = TApp::instance()->getCurrentXsheetViewer();
-  if (viewer && !viewer->orientation()->isVerticalTimeline())
-    c0 -= m_columnSpanCount - 1;
 
   positions.clear();
   TStageObjectId cameraId = xsh->getStageObjectTree()->getCurrentCameraId();


### PR DESCRIPTION
This PR fixes #1671 

The logic for pasting keyframes in the flipped timeline was in the wrong spot.  Moved to where it needed to be so it only happened when actually pasting, and not when getting keyframes in general.