### PR TITLE
Hint NVIDIA and AMD GPU usage

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -230,6 +230,17 @@ project->setUseScenePath(TProject::Extras, false);
 }
 
 //-----------------------------------------------------------------------------
+#if defined(WIN32) || defined(_WIN32)
+extern "C" {
+__declspec(dllexport) DWORD NvOptimusEnablement                = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#else
+extern "C" {
+int NvOptimusEnablement                  = 1;
+int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
 
 int main(int argc, char *argv[]) {
 #ifdef Q_OS_WIN


### PR DESCRIPTION
This PR adds logic to hint to NVIDIA and AMD cards that it should use the card's GPU.

OT currently does not automatically trigger GPU usage on NVIDIA and AMD cards. This causes OT to perform poorly on lower end machines because it uses CPU even though it may have a graphics card with a more powerful GPU.

Typically, NVIDIA and AMD cards have to be told that certain applications are to use its GPU.  OT is not one that is typically detected by default since it doesn't have a manufacturer's predefined profile in the card's settings. Users need to go into the card's properties and set up a profile for it in order to be used.

This change exports a setting that the cards scan for when OT starts up.  Once detected, it will force the use of the GPU unless an existing profile already exists.

NOTE: This may solve some performance problems with OT, but it does not resolve all issues due to lack of GPU usage.

Case in point...Currently without either an NVIDIA profile or this hint, when I run V 1.2, the viewers are blank.  Explicitly creating a NVIDIA profile fixes my problems, however, if I just run V 1.2 with this hint enabled, I can verify it is using GPU but I still have a blank viewer.
