### PR TITLE
Temporary Use the Previous Image of Trusty in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: cpp
 sudo: required
 dist: trusty
+group: deprecated-2017Q4 # temporary uses the previous version
 install:
     - if [[ $TRAVIS_OS_NAME == "osx" ]];   then bash ci-scripts/osx/travis-install.sh; fi
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash ci-scripts/linux/travis-install.sh; fi


### PR DESCRIPTION
This is for temporary fixing the Travis CI error due to the [update on last Tuesday](https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch).
The updated clang claims an error with a bug to be fixed after merging #1663 .

I modified the Travis settings to temporary use the previous image, until #1663 will be merged.

