### PR TITLE
Fix the Line-shaped Artifacts on Semi-transparent Deformed Image with Plastic Tool

### DIFF
--- a/toonz/sources/include/toonz/imagepainter.h
+++ b/toonz/sources/include/toonz/imagepainter.h
@@ -66,6 +66,7 @@ public:
   bool m_recomputeIfNeeded;
   bool m_drawBlankFrame;
   bool m_useChecks;  //!< whether to consider  paint check and ink check
+  bool m_forSceneIcon = false;  // whether it is redered for the scene icons
 public:
   VisualSettings();
 

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -9,6 +9,7 @@
 // TnzBase includes
 #include "tfx.h"
 #include "trasterfxrenderdata.h"
+#include <QOffscreenSurface>
 
 #undef DVAPI
 #undef DVVAR
@@ -150,6 +151,12 @@ public:
   TRectD m_cameraBox;
   /*-- 途中でPreview計算がキャンセルされたときのフラグ --*/
   int *m_isCanceled;
+
+  // pointer to QOffscreenSurface which is created on
+  // TRendererImp::startRendering()
+  // for offscreen rendering to be done in non-GUI thread.
+  // For now it is used only in the plasticDeformerFx.
+  std::shared_ptr<QOffscreenSurface> m_offScreenSurface;
 
 public:
   TRenderSettings();

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -403,7 +403,7 @@ static std::pair<int, int> generateMovie(ToonzScene *scene, const TFilePath &fp,
   r0 = r0 - 1;
   r1 = r1 - 1;
 
-  if (r0 < 0) r0 = 0;
+  if (r0 < 0) r0                                 = 0;
   if (r1 < 0 || r1 >= scene->getFrameCount()) r1 = scene->getFrameCount() - 1;
   string msg;
   assert(r1 >= r0);
@@ -564,6 +564,7 @@ static std::pair<int, int> generateMovie(ToonzScene *scene, const TFilePath &fp,
 DV_IMPORT_API void initStdFx();
 DV_IMPORT_API void initColorFx();
 int main(int argc, char *argv[]) {
+  QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
   QApplication app(argc, argv);
 
   // Create a QObject destroyed just before app - see Tnz6's main.cpp for
@@ -661,8 +662,8 @@ int main(int argc, char *argv[]) {
   TVectorBrushStyle::setRootDir(libraryFolder);
   TPalette::setRootDir(libraryFolder);
   TImageStyle::setLibraryDir(libraryFolder);
-  TFilePath cacheRoot = ToonzFolder::getCacheRootFolder();
-  if (cacheRoot.isEmpty()) cacheRoot= TEnv::getStuffDir() + "cache";
+  TFilePath cacheRoot                = ToonzFolder::getCacheRootFolder();
+  if (cacheRoot.isEmpty()) cacheRoot = TEnv::getStuffDir() + "cache";
   TImageCache::instance()->setRootDir(cacheRoot);
   // #endif
 
@@ -947,8 +948,8 @@ int main(int argc, char *argv[]) {
     DVGui::info(QString::fromStdString(msg));
     TImageCache::instance()->clear(true);
   } catch (TException &e) {
-    msg = "Untrapped exception: " + ::to_string(e.getMessage()),
-    cout << msg << endl;
+    msg = "Untrapped exception: " + ::to_string(e.getMessage()), cout << msg
+                                                                      << endl;
     m_userLog->error(msg);
     TImageCache::instance()->clear(true);
   } catch (...) {

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -291,7 +291,6 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
               new QOpenGLFramebufferObject(d.lx, d.ly));
 
           fb->bind();
-          assert(glGetError() == 0);
 
           glViewport(0, 0, d.lx, d.ly);
           glClearColor(0, 0, 0, 0);
@@ -305,13 +304,9 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
           glLoadIdentity();
           glTranslatef(0.375, 0.375, 0.0);
 
-          assert(glGetError() == 0);
           tglDraw(rd, vi.getPointer());
-          assert(glGetError() == 0);
 
-          assert(glGetError() == 0);
           glFlush();
-          assert(glGetError() == 0);
 
           QImage img =
               fb->toImage().scaled(QSize(d.lx, d.ly), Qt::IgnoreAspectRatio,
@@ -334,6 +329,8 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
 
         TRasterImageP ri = TRasterImageP(ras);
         ri->setOffset(off + ras->getCenter());
+
+        assert(glGetError() == 0);
 
         return ri;
       }

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -749,9 +749,12 @@ void RasterPainter::onImage(const Stage::Player &player) {
   // QOffscreenSurface is created outside the gui thread.
   // As a quick workaround, ignore the deformation if this is called from
   // non-gui thread (i.e. icon generator thread)
+  // 12/1/2018 Now the scene icon is rendered without deformation either
+  // since it causes unknown error with opengl contexts..
   TStageObject *obj =
       ::plasticDeformedObj(player, m_vs.m_plasticVisualSettings);
-  if (obj && QThread::currentThread() == qGuiApp->thread()) {
+  if (obj && QThread::currentThread() == qGuiApp->thread() &&
+      !m_vs.m_forSceneIcon) {
     flushRasterImages();
     ::onPlasticDeformedImage(obj, player, m_vs, m_viewAff);
   } else {
@@ -1540,6 +1543,7 @@ void onPlasticDeformedImage(TStageObject *playerObj,
 
   glDisable(GL_LINE_SMOOTH);
   glDisable(GL_BLEND);
+  assert(glGetError() == GL_NO_ERROR);
 }
 
 }  // namespace

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -741,6 +741,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 
     ImagePainter::VisualSettings vs;
     vs.m_plasticVisualSettings.m_drawMeshesWireframe = false;
+    vs.m_forSceneIcon                                = true;
 
     Stage::RasterPainter painter(ras->getSize(), viewAff, clipRect, vs,
                                  checkFlags);


### PR DESCRIPTION
#1620 

This fix will enlarge the texture tile size from 512 to 2048 and minimize the occurrence of line-shaped artifacts which will appear at the border of the tiles.

**NOTE 1**
As a bad side effect of this fix, I changed the scene icon not to show the deformed image in order to avoid an unknown problem related to OpenGL context which I couldn't resolve. The icon will become non-deformed, just like a column icon of subxsheet.

**NOTE 2**
I set this PR to "WIP" state as I haven't test this fix on OSX yet. I'll post an update on next week.