### PR TITLE
Fix Plastic Tool not to Create the Black Contour 

### DIFF
--- a/toonz/sources/include/trop.h
+++ b/toonz/sources/include/trop.h
@@ -291,6 +291,14 @@ DVAPI void premultiply(const TRasterP &ras);
 //! Make a depremultiply of all raster pixels
 DVAPI void depremultiply(const TRasterP &ras);
 
+// called from meshtexturizer in order to remove unwanted black contour
+// appears at the border of the plastic-deformed texture.
+// this function will "expand" color channels of the border pixels to
+// neighbor full-transparent pixels.
+// by doing this the linear interpolation at the border pixels will not
+// decay color info and can get ideal antialiased result
+DVAPI void expandColor(const TRaster32P &ras32, bool precise);
+
 //! all white pixels are set to transparent
 DVAPI void whiteTransp(const TRasterP &ras);
 

--- a/toonz/sources/tnzext/meshtexturizer.cpp
+++ b/toonz/sources/tnzext/meshtexturizer.cpp
@@ -15,6 +15,8 @@
 #include "tcg/tcg_list.h"
 #include "tcg/tcg_misc.h"
 
+#include "trop.h"
+
 #define COPIED_BORDER 1  // Amount of tile border from the original image
 #define TRANSP_BORDER 1  // Amount of transparent tile border
 #define NONPREM_BORDER                                                         \
@@ -106,6 +108,7 @@ GLuint MeshTexturizer::Imp::textureAlloc(const TRaster32P &ras,
       clearMatte(ras, ras->getLx() - border1, border1, ras->getLx() - border0,
                  ras->getLy() - border1);
     }
+
   };  // locals
 
   // Prepare the texture tile
@@ -125,9 +128,11 @@ GLuint MeshTexturizer::Imp::textureAlloc(const TRaster32P &ras,
   tex->clear();
   aux->extract(auxRect)->copy(ras->extract(rasRect));
 
-  if (!premultiplied && NONPREM_BORDER > 0)
-    locals::clearMatte_border(aux, TRANSP_BORDER - NONPREM_BORDER,
+  if (!premultiplied && NONPREM_BORDER > 0) {
+    locals::clearMatte_border(tex, TRANSP_BORDER - NONPREM_BORDER,
                               TRANSP_BORDER);
+    TRop::expandColor(tex, true);  // precise is always true for now
+  }
 
   // Pass the raster into VRAM
   GLuint texId;

--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -100,7 +100,7 @@ TRasterImageP getTexture(const TXshSimpleLevel *sl, const TFrameId &fid,
   TRasterImageP ri(ImageManager::instance()->getImage(
       id, ImageManager::dontPutInCache, &extData));
 
-  return ri;
+  return convert32(ri);
 }
 
 }  // namespace


### PR DESCRIPTION
This will fix #1249 . 

The problem was related to the linear interpolation of the plastic-deformed texture.
At the border of texture, interpolation between "colored-opac" pixels and "black-transparent" pixels was made and caused color decaying in the interpolated pixels.
I fixed this by "expanding" color information at the border pixels before storing it to the texture. By doing this, interpolation will be done between  "colored-opac" pixels and "**colored**-transparent" pixels which will not decay color and obtain ideal result.

I also fixed the problem that the vector semi-transparent level becomes darken in the camstand view  when it is applied plastic-deformation.

![fix_plastic_black_contour](https://user-images.githubusercontent.com/17974955/35131921-0f6d9f46-fd0c-11e7-9f8e-e436c2990925.png)
