### PR TITLE
Fix #1639 by Removing Unused StyleId Check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 sudo: required
 dist: trusty
-group: deprecated-2017Q4 # temporary uses the previous version
 install:
     - if [[ $TRAVIS_OS_NAME == "osx" ]];   then bash ci-scripts/osx/travis-install.sh; fi
     - if [[ $TRAVIS_OS_NAME == "linux" ]]; then bash ci-scripts/linux/travis-install.sh; fi

--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -91,18 +91,13 @@ bool pasteStylesDataWithoutUndo(TPalette *palette, TPaletteHandle *pltHandle,
       break;
     }
 
-    if (palette->getStylePage(styleId) < 0) {
-      // styleId non e' utilizzato: uso quello
-      // (cut/paste utilizzato per spostare stili)
+    // For now styles will be inserted regardless the styleId of copied styles
+    // are already used in the target palette or not.
+    styleId = palette->getFirstUnpagedStyle();
+    if (styleId >= 0)
       palette->setStyle(styleId, style);
-    } else {
-      // styleId e' gia' utilizzato. ne devo prendere un altro
-      styleId = palette->getFirstUnpagedStyle();
-      if (styleId >= 0)
-        palette->setStyle(styleId, style);
-      else
-        styleId = palette->addStyle(style);
-    }
+    else
+      styleId = palette->addStyle(style);
 
     // check the type of the original(copied) style
     // If the original is NormalStyle


### PR DESCRIPTION
This will fix #1639 

On pasting styles, there was wrong conditional inequality expression, comparing `TPalette::Page *` and zero.
It causes an error on recent Travis CI on Linux.

This bug has been existed from Toonz Harlequin. It seems to be originally intended to change pasting behavior according to the condition that the styleId of copied style is already in the paste destination palette. i.e. if there already are styles with the same styleId as the copied ones, then overwrite them.
But for now the condition expression is broken and the styles will always be inserted, regardless of the styleId.

@damies13 has been tackled with this issue to make it working properly. (in #1640 and #1663. Thanks @damies13 !)

However, I came to think that it would better to maintain the current behavior - pasted styles with "Insert Paste" command should always be inserted. It's more clear and we already have "Paste Color" and "Paste Color and Name" command as alternative.
So, this PR will remove unused 'if' condition at all. The pasting behavior will not change and will solve the Travis errors.
