### PR TITLE
Use Precise Pen Position

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -86,7 +86,7 @@ public:
   };
 
 public:
-  TPoint m_pos;  //!< Mouse position in window coordinates, bottom-left origin.
+  TPointD m_pos;  //!< Mouse position in window coordinates, bottom-left origin.
   int m_pressure;  //!< Pressure of the tablet pen, or 255 for pure mouse
                    //! events.
   ModifierMask m_modifiersMask;  //!< Bitmask specifying key modifiers applying
@@ -94,8 +94,8 @@ public:
 
   Qt::MouseButtons m_buttons;
   Qt::MouseButton m_button;
-  QPoint m_mousePos;  // mouse position obtained with QMouseEvent::pos() or
-                      // QTabletEvent::pos()
+  QPointF m_mousePos;  // mouse position obtained with QMouseEvent::pos() or
+                       // QTabletEvent::pos()
   bool m_isTablet;
 
 public:
@@ -113,7 +113,7 @@ public:
   bool isLeftButtonPressed() const { return (m_buttons & Qt::LeftButton) != 0; }
   Qt::MouseButtons buttons() const { return m_buttons; }
   Qt::MouseButton button() const { return m_button; }
-  QPoint mousePos() const { return m_mousePos; }
+  QPointF mousePos() const { return m_mousePos; }
   bool isTablet() const { return m_isTablet; }
 
   void setModifiers(bool shiftPressed, bool altPressed, bool ctrlPressed) {
@@ -368,7 +368,7 @@ public:
           restrict drawing to a small regionaround \p p of the viewport.
           Retuns -1 if no object's view has been changed.
   */
-  int pick(const TPoint &p);
+  int pick(const TPointD &p);
   bool isPicking() const { return m_picking; }
 
   virtual void updateTranslation(){};
@@ -603,32 +603,32 @@ public:
 
   //! return the column index of the drawing intersecting point \b p
   //! (window coordinate, pixels, bottom-left origin)
-  virtual int posToColumnIndex(const TPoint &p, double distance,
+  virtual int posToColumnIndex(const TPointD &p, double distance,
                                bool includeInvisible = true) const = 0;
-  virtual void posToColumnIndexes(const TPoint &p, std::vector<int> &indexes,
+  virtual void posToColumnIndexes(const TPointD &p, std::vector<int> &indexes,
                                   double distance,
                                   bool includeInvisible = true) const = 0;
 
   //! return the row of the drawing intersecting point \b p (used with
   //! onionskins)
   //! (window coordinate, pixels, bottom-left origin)
-  virtual int posToRow(const TPoint &p, double distance,
+  virtual int posToRow(const TPointD &p, double distance,
                        bool includeInvisible = true) const = 0;
 
   //! return pos in pixel, bottom-left origin
-  virtual TPoint worldToPos(const TPointD &worldPos) const = 0;
+  virtual TPointD worldToPos(const TPointD &worldPos) const = 0;
 
   //! return the OpenGL nameId of the object intersecting point \b p
   //! (window coordinate, pixels, bottom-left origin)
-  virtual int pick(const TPoint &point) = 0;
+  virtual int pick(const TPointD &point) = 0;
 
   // note: winPos in pixel, top-left origin;
   // when no camera movements have been defined then worldPos = 0 at camera
   // center
-  virtual TPointD winToWorld(const TPoint &winPos) const = 0;
+  virtual TPointD winToWorld(const TPointD &winPos) const = 0;
 
   // delta.x: right panning, pixels; delta.y: down panning, pixels
-  virtual void pan(const TPoint &delta) = 0;
+  virtual void pan(const TPointD &delta) = 0;
 
   // center: window coordinates, pixels, bottomleft origin
   virtual void zoom(const TPointD &center, double scaleFactor) = 0;
@@ -639,7 +639,7 @@ public:
   virtual bool getIsFlippedX() const = 0;
   virtual bool getIsFlippedY() const = 0;
 
-  virtual double projectToZ(const TPoint &delta) = 0;
+  virtual double projectToZ(const TPointD &delta) = 0;
 
   virtual TPointD getDpiScale() const = 0;
   virtual int getVGuideCount()        = 0;

--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -568,7 +568,7 @@ public:
 //-----------------------------------------------------------------------------
 
 class DragZTool final : public DragChannelTool {
-  TPoint m_lastPos;
+  TPointD m_lastPos;
   TTool::Viewer *m_viewer;
   double m_dz;
 

--- a/toonz/sources/tnztools/pinchtool.cpp
+++ b/toonz/sources/tnztools/pinchtool.cpp
@@ -378,7 +378,7 @@ void PinchTool::onImageChanged() {
   m_deformation->reset();
 
   double w        = 0;
-  TStroke *stroke = getClosestStroke(convert(m_lastMouseEvent.m_pos), w);
+  TStroke *stroke = getClosestStroke(m_lastMouseEvent.m_pos, w);
   if (stroke) {
     // set parameters from sliders
     updateInterfaceStatus(m_lastMouseEvent);

--- a/toonz/sources/tnztools/rgbpickertool.cpp
+++ b/toonz/sources/tnztools/rgbpickertool.cpp
@@ -330,10 +330,10 @@ void RGBPickerTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
     invalidate();
     return;
   } else if (m_pickType.getValue() == FREEHAND_PICK) {
-    startFreehand(pos, convert(e.m_pos));
+    startFreehand(pos, e.m_pos);
     return;
   } else if (m_pickType.getValue() == POLYLINE_PICK) {
-    addPointPolyline(pos, convert(e.m_pos));
+    addPointPolyline(pos, e.m_pos);
     return;
   } else {  // NORMAL_PICK
     m_mousePixelPosition = e.m_pos;
@@ -354,7 +354,7 @@ void RGBPickerTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     invalidate();
     return;
   } else if (m_pickType.getValue() == FREEHAND_PICK) {
-    freehandDrag(pos, convert(e.m_pos));
+    freehandDrag(pos, e.m_pos);
     invalidate();
   }
 }
@@ -380,7 +380,7 @@ void RGBPickerTool::leftButtonDoubleClick(const TPointD &pos,
                                           const TMouseEvent &e) {
   if (m_currentStyleId == 0) return;
   if (m_pickType.getValue() == POLYLINE_PICK) {
-    closePolyline(pos, convert(e.m_pos));
+    closePolyline(pos, e.m_pos);
     std::vector<TThickPoint> strokePoints;
     for (UINT i = 0; i < m_workingPolyline.size() - 1; i++) {
       strokePoints.push_back(TThickPoint(m_workingPolyline[i], 1));

--- a/toonz/sources/tnztools/rgbpickertool.h
+++ b/toonz/sources/tnztools/rgbpickertool.h
@@ -37,7 +37,7 @@ class RGBPickerTool final : public TTool {
   std::vector<TPointD> m_workingPolyline;
   bool m_makePick;
 
-  TPoint m_mousePixelPosition;
+  TPointD m_mousePixelPosition;
 
 public:
   RGBPickerTool();

--- a/toonz/sources/tnztools/skeletonsubtools.h
+++ b/toonz/sources/tnztools/skeletonsubtools.h
@@ -112,7 +112,7 @@ public:
 
 class ParentChangeTool final : public DragTool {
   TTool::Viewer *m_viewer;
-  TPoint m_firstWinPos;
+  TPointD m_firstWinPos;
   TPointD m_lastPos, m_lastPos2;
   TPointD m_center;
   int m_index;

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -1037,7 +1037,7 @@ void SkeletonTool::drawHooks() {
     currentColumnHooks.push_back(HookData(xsh, col, hookId, m_parentProbe));
 
     // otherColumn = "picked" column not connected
-    TPoint parentProbePos = getViewer()->worldToPos(m_parentProbe);
+    TPointD parentProbePos = getViewer()->worldToPos(m_parentProbe);
     std::vector<int> indexes;
     getViewer()->posToColumnIndexes(parentProbePos, indexes,
                                     getPixelSize() * 10, false);

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -498,7 +498,7 @@ void TTool::invalidate(const TRectD &rect) {
 
 //-----------------------------------------------------------------------------
 
-int TTool::pick(const TPoint &p) {
+int TTool::pick(const TPointD &p) {
   if (!m_viewer) return 0;
 
   m_picking = true;

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -1531,7 +1531,7 @@ void ToolUtils::drawBalloon(const TPointD &pos, std::string text,
       double d  = pixelSize * 5;
       glRectd(x0 - d, y0 - d, x1 + d, y1 + d);
     } else {
-      TPoint posBalloon = viewer->worldToPos(pos);
+      TPointD posBalloon = viewer->worldToPos(pos);
 
       double d  = 5;
       double x0 = posBalloon.x + textRect.left() - d;
@@ -1539,10 +1539,10 @@ void ToolUtils::drawBalloon(const TPointD &pos, std::string text,
       double x1 = x0 + textRect.width() + d;
       double y1 = y0 + textRect.height() + d;
 
-      TPoint p1(x0, y0);
-      TPoint p2(x1, y0);
-      TPoint p3(x0, y1);
-      TPoint p4(x1, y1);
+      TPointD p1(x0, y0);
+      TPointD p2(x1, y0);
+      TPointD p3(x0, y1);
+      TPointD p4(x1, y1);
 
       TPointD w1(viewer->winToWorld(p1));
       TPointD w2(viewer->winToWorld(p2));

--- a/toonz/sources/tnztools/viewtools.cpp
+++ b/toonz/sources/tnztools/viewtools.cpp
@@ -62,7 +62,7 @@ public:
   void draw() override {
     if (!m_dragging) return;
 
-    TPointD center   = m_viewer->winToWorld(TPoint(m_center.x, m_center.y));
+    TPointD center   = m_viewer->winToWorld(m_center);
     double pixelSize = getPixelSize();
     double unit      = pixelSize;
     glPushMatrix();
@@ -91,7 +91,7 @@ public:
 
 class HandTool final : public TTool {
   TStopWatch m_sw;
-  TPoint m_oldPos;
+  TPointD m_oldPos;
 
 public:
   HandTool() : TTool("T_Hand") { bind(TTool::AllTargets); }
@@ -111,8 +111,8 @@ public:
     if (m_sw.getTotalTime() < 10) return;
     m_sw.stop();
     m_sw.start(true);
-    TPoint delta = e.m_pos - m_oldPos;
-    delta.y      = -delta.y;
+    TPointD delta = e.m_pos - m_oldPos;
+    delta.y       = -delta.y;
     m_viewer->pan(delta);
     m_oldPos = e.m_pos;
   }
@@ -136,7 +136,7 @@ class RotateTool final : public TTool {
   TPointD m_center;
   bool m_dragging;
   double m_angle;
-  TPoint m_oldMousePos;
+  TPointD m_oldMousePos;
   TBoolProperty m_cameraCentered;
   TPropertyGroup m_prop;
 
@@ -179,7 +179,7 @@ public:
     m_sw.start(true);
     TPointD p = pos;
     if (m_viewer->is3DView()) {
-      TPoint d      = e.m_pos - m_oldMousePos;
+      TPointD d     = e.m_pos - m_oldMousePos;
       m_oldMousePos = e.m_pos;
       double factor = 0.5;
       m_viewer->rotate3D(factor * d.x, -factor * d.y);

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -65,8 +65,8 @@ class SceneViewer final : public GLWidgetForHighDpi,
   Q_OBJECT
 
   qreal m_pressure;
-  QPoint m_lastMousePos;
-  QPoint m_pos;
+  QPointF m_lastMousePos;
+  QPointF m_pos;
   Qt::MouseButton m_mouseButton;
   bool m_foregroundDrawing;
   bool m_tabletEvent, m_tabletMove;
@@ -226,7 +226,7 @@ public:
   TPointD getPan3D() const { return m_pan3D; }
   double getZoomScale3D() const { return m_zoomScale3D; }
 
-  double projectToZ(const TPoint &delta) override;
+  double projectToZ(const TPointD &delta) override;
 
   TPointD getDpiScale() const override { return m_dpiScale; }
   void zoomQt(bool forward, bool reset);
@@ -264,10 +264,10 @@ public:
 
 public:
   // SceneViewer's gadget public functions
-  TPointD winToWorld(const QPoint &pos) const;
-  TPointD winToWorld(const TPoint &winPos) const override;
+  TPointD winToWorld(const QPointF &pos) const;
+  TPointD winToWorld(const TPointD &winPos) const override;
 
-  TPoint worldToPos(const TPointD &worldPos) const override;
+  TPointD worldToPos(const TPointD &worldPos) const override;
 
 protected:
   // Paint vars
@@ -328,13 +328,13 @@ protected:
   bool event(QEvent *event) override;
 
   // delta.x: right panning, pixel; delta.y: down panning, pixel
-  void panQt(const QPoint &delta);
+  void panQt(const QPointF &delta);
 
   // center: window coordinate, pixels, topleft origin
   void zoomQt(const QPoint &center, double scaleFactor);
 
   // overriden from TTool::Viewer
-  void pan(const TPoint &delta) override { panQt(QPoint(delta.x, delta.y)); }
+  void pan(const TPointD &delta) override { panQt(QPointF(delta.x, delta.y)); }
 
   // overriden from TTool::Viewer
   void zoom(const TPointD &center, double factor) override;
@@ -345,20 +345,20 @@ protected:
 
   //! return the column index of the drawing intersecting point \b p
   //! (window coordinate, pixels, bottom-left origin)
-  int pick(const TPoint &point) override;
+  int pick(const TPointD &point) override;
 
   //! return the column indexes of the drawings intersecting point \b p
   //! (window coordinate, pixels, bottom-left origin)
-  int posToColumnIndex(const TPoint &p, double distance,
+  int posToColumnIndex(const TPointD &p, double distance,
                        bool includeInvisible = true) const override;
-  void posToColumnIndexes(const TPoint &p, std::vector<int> &indexes,
+  void posToColumnIndexes(const TPointD &p, std::vector<int> &indexes,
                           double distance,
                           bool includeInvisible = true) const override;
 
   //! return the row of the drawings intersecting point \b p (used with onion
   //! skins)
   //! (window coordinate, pixels, bottom-left origin)
-  int posToRow(const TPoint &p, double distance,
+  int posToRow(const TPointD &p, double distance,
                bool includeInvisible = true) const override;
 
   void dragEnterEvent(QDragEnterEvent *event) override;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -77,8 +77,8 @@ int modifiers = 0;
 
 void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
                     int widgetHeight, double pressure, int devPixRatio) {
-  toonzEvent.m_pos = TPoint(event->pos().x() * devPixRatio,
-                            widgetHeight - 1 - event->pos().y() * devPixRatio);
+  toonzEvent.m_pos = TPointD(event->pos().x() * devPixRatio,
+                             widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
   toonzEvent.m_pressure = 255;
 
@@ -95,9 +95,10 @@ void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
 
 void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
                     int widgetHeight, double pressure, int devPixRatio) {
-  toonzEvent.m_pos = TPoint(event->pos().x() * devPixRatio,
-                            widgetHeight - 1 - event->pos().y() * devPixRatio);
-  toonzEvent.m_mousePos = event->pos();
+  toonzEvent.m_pos = TPointD(
+      event->posF().x() * (float)devPixRatio,
+      (float)widgetHeight - 1.0f - event->posF().y() * (float)devPixRatio);
+  toonzEvent.m_mousePos = event->posF();
   toonzEvent.m_pressure = int(255 * pressure);
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
@@ -112,8 +113,8 @@ void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
 //-----------------------------------------------------------------------------
 
 void initToonzEvent(TMouseEvent &toonzEvent, QKeyEvent *event) {
-  toonzEvent.m_pos      = TPoint();
-  toonzEvent.m_mousePos = QPoint();
+  toonzEvent.m_pos      = TPointD();
+  toonzEvent.m_mousePos = QPointF();
   toonzEvent.m_pressure = 0;
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
@@ -427,7 +428,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
   if (m_freezedStatus != NO_FREEZED) return;
 
   int devPixRatio = getDevPixRatio();
-  QPoint curPos   = event.mousePos() * devPixRatio;
+  QPointF curPos  = event.mousePos() * devPixRatio;
   bool cursorSet  = false;
   m_lastMousePos  = curPos;
 
@@ -495,8 +496,8 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     // if the middle mouse button is pressed while dragging, then do panning
     if (event.buttons() & Qt::MidButton) {
       // panning
-      QPoint p = curPos - m_pos;
-      if (m_pos == QPoint(0, 0) && p.manhattanLength() > 300) return;
+      QPointF p = curPos - m_pos;
+      if (m_pos == QPointF() && p.manhattanLength() > 300) return;
       panQt(curPos - m_pos);
       m_pos = curPos;
       return;
@@ -731,7 +732,7 @@ void SceneViewer::onRelease(const TMouseEvent &event) {
     goto quit;
   }
 
-  m_pos = QPoint(0, 0);
+  m_pos = QPointF();
   if (!tool || !tool->isEnabled()) goto quit;
 
   tool->setViewer(this);
@@ -1195,8 +1196,8 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
     // cambiare subito la forma del cursore, senza aspettare il prossimo move
     TMouseEvent toonzEvent;
     initToonzEvent(toonzEvent, event);
-    toonzEvent.m_pos =
-        TPoint(m_lastMousePos.x(), height() - 1 - m_lastMousePos.y());
+    toonzEvent.m_pos = TPointD(m_lastMousePos.x(),
+                               (double)(height() - 1) - m_lastMousePos.y());
 
     TPointD pos = tool->getMatrix().inv() * winToWorld(m_lastMousePos);
 
@@ -1352,8 +1353,8 @@ void SceneViewer::keyReleaseEvent(QKeyEvent *event) {
     // cambiare subito la forma del cursore, senza aspettare il prossimo move
     TMouseEvent toonzEvent;
     initToonzEvent(toonzEvent, event);
-    toonzEvent.m_pos =
-        TPoint(m_lastMousePos.x(), height() - 1 - m_lastMousePos.y());
+    toonzEvent.m_pos = TPointD(m_lastMousePos.x(),
+                               (double)(height() - 1) - m_lastMousePos.y());
 
     TPointD pos = tool->getMatrix().inv() * winToWorld(m_lastMousePos);
 

--- a/toonz/sources/toonz/subcameramanager.cpp
+++ b/toonz/sources/toonz/subcameramanager.cpp
@@ -87,7 +87,7 @@ TRectD PreviewSubCameraManager::getEditingCameraInterestStageRect() const {
 //-----------------------------------------------------------------------------
 
 TPointD PreviewSubCameraManager::winToCamera(SceneViewer *viewer,
-                                             const QPoint &pos) const {
+                                             const QPointF &pos) const {
   TPointD worldPos(viewer->winToWorld(pos));
 
   TApp *app = TApp::instance();
@@ -100,8 +100,8 @@ TPointD PreviewSubCameraManager::winToCamera(SceneViewer *viewer,
 
 //-----------------------------------------------------------------------------
 
-TPoint PreviewSubCameraManager::cameraToWin(SceneViewer *viewer,
-                                            const TPointD &cameraPos) const {
+TPointD PreviewSubCameraManager::cameraToWin(SceneViewer *viewer,
+                                             const TPointD &cameraPos) const {
   TApp *app = TApp::instance();
   TAffine stageToWorldRef(app->getCurrentXsheet()->getXsheet()->getCameraAff(
       app->getCurrentFrame()->getFrame()));
@@ -133,7 +133,7 @@ bool PreviewSubCameraManager::mousePressEvent(SceneViewer *viewer,
 bool PreviewSubCameraManager::mouseMoveEvent(SceneViewer *viewer,
                                              const TMouseEvent &event) {
   if (viewer->is3DView()) return true;
-  QPoint curPos(event.mousePos() * getDevPixRatio());
+  QPointF curPos(event.mousePos() * getDevPixRatio());
   if (event.buttons() == Qt::LeftButton) {
     if (!bitwiseContains(m_dragType, INNER)) {
       if (abs(curPos.x() - m_mousePressPos.x()) > 10 ||
@@ -261,17 +261,17 @@ bool PreviewSubCameraManager::mouseReleaseEvent(SceneViewer *viewer) {
 
 //! Builds the drag enum and camera distance for subcamera refinement drags.
 UCHAR PreviewSubCameraManager::getSubCameraDragEnum(SceneViewer *viewer,
-                                                    const QPoint &mousePos) {
+                                                    const QPointF &mousePos) {
   TCamera *camera =
       TApp::instance()->getCurrentScene()->getScene()->getCurrentCamera();
   TRect subCamera = camera->getInterestRect();
 
   if (subCamera.getLx() <= 0 || subCamera.getLy() <= 0) return NODRAG;
 
-  TPointD cameraPosL(winToCamera(viewer, mousePos - QPoint(10, 0)));
-  TPointD cameraPosR(winToCamera(viewer, mousePos + QPoint(10, 0)));
-  TPointD cameraPosT(winToCamera(viewer, mousePos - QPoint(0, 10)));
-  TPointD cameraPosB(winToCamera(viewer, mousePos + QPoint(0, 10)));
+  TPointD cameraPosL(winToCamera(viewer, mousePos - QPointF(10, 0)));
+  TPointD cameraPosR(winToCamera(viewer, mousePos + QPointF(10, 0)));
+  TPointD cameraPosT(winToCamera(viewer, mousePos - QPointF(0, 10)));
+  TPointD cameraPosB(winToCamera(viewer, mousePos + QPointF(0, 10)));
 
   TRectD cameraPosBox(
       std::min({cameraPosL.x, cameraPosR.x, cameraPosT.x, cameraPosB.x}),
@@ -302,7 +302,7 @@ UCHAR PreviewSubCameraManager::getSubCameraDragEnum(SceneViewer *viewer,
 //-----------------------------------------------------------------------------
 
 TPoint PreviewSubCameraManager::getSubCameraDragDistance(
-    SceneViewer *viewer, const QPoint &mousePos) {
+    SceneViewer *viewer, const QPointF &mousePos) {
   // Build the camera drag distance
   if (m_clickAndDrag) return TPoint();
 

--- a/toonz/sources/toonz/subcameramanager.h
+++ b/toonz/sources/toonz/subcameramanager.h
@@ -60,7 +60,7 @@ class PreviewSubCameraManager final : public SceneViewerInteractiveGadget {
   UCHAR m_dragType;
   bool m_clickAndDrag;
 
-  QPoint m_mousePressPos;
+  QPointF m_mousePressPos;
   TPointD m_cameraMousePressPos;
   bool m_mousePressed;
 
@@ -106,11 +106,11 @@ public:
   void deleteSubCamera(SceneViewer *viewer);
 
 private:
-  TPointD winToCamera(SceneViewer *viewer, const QPoint &pos) const;
-  TPoint cameraToWin(SceneViewer *viewer, const TPointD &cameraPos) const;
+  TPointD winToCamera(SceneViewer *viewer, const QPointF &pos) const;
+  TPointD cameraToWin(SceneViewer *viewer, const TPointD &cameraPos) const;
 
-  UCHAR getSubCameraDragEnum(SceneViewer *viewer, const QPoint &mousePos);
-  TPoint getSubCameraDragDistance(SceneViewer *viewer, const QPoint &mousePos);
+  UCHAR getSubCameraDragEnum(SceneViewer *viewer, const QPointF &mousePos);
+  TPoint getSubCameraDragDistance(SceneViewer *viewer, const QPointF &mousePos);
 };
 
 #endif  // SUBCAMERAMANAGER_INCLUDED


### PR DESCRIPTION
This PR will enhance the brush stroke quality when using pen tablet for both the Toonz Raster / Raster levels.

I changed the mouse position to be handled in fractional number which can be obtained via pen tablet.
This enhancement can be found more obvious when you draw on the viewer with zoom scale lower than 100%.

I believe (hope) that this change will not slow the computation since the mouse position had already been converted to fractional number in many part of the software before introducing this PR.

The following image shows a comparison of strokes drawn on the left Viewer pane, with 50% zoom scale.

![precise_pen_position](https://user-images.githubusercontent.com/17974955/35145171-3b6f6a50-fd4a-11e7-99f6-c7d0de6027f3.png)

