### PR TITLE
Fix png and spritesheet render (depremultiply)

### DIFF
--- a/toonz/sources/common/timage_io/timage_io.cpp
+++ b/toonz/sources/common/timage_io/timage_io.cpp
@@ -631,6 +631,9 @@ void TImageWriter::save(const TImageP &img) {
     writer->open(file, info);
 
     ras->lock();
+    if (m_path.getType() == "png") {
+      TRop::depremultiply(ras);
+    }
     if (writer->getRowOrder() == Tiio::BOTTOM2TOP) {
       if (bpp == 1 || bpp == 8 || bpp == 24 || bpp == 32 || bpp == 16)
         for (int i = 0; i < ras->getLy(); i++)

--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -404,6 +404,9 @@ std::pair<bool, int> MovieRenderer::Imp::saveFrame(
 
     // Flush images
     try {
+      if (m_fp.getType() == "spritesheet") {
+        TRop::depremultiply(rasterA);
+      }
       TRasterImageP imgA(rasterA);
       postProcessImage(imgA, has64bitOutputSupport, m_renderSettings.m_mark,
                        fid.getNumber());


### PR DESCRIPTION
fixes #1230 

Depremultiplies png and spritesheets during render.