### PR TITLE
Fix Interrupted Brush Stroke When Using Tablet

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -87,8 +87,8 @@ public:
 
 public:
   TPoint m_pos;  //!< Mouse position in window coordinates, bottom-left origin.
-  int m_pressure;  //!< Pressure of the tablet pen, or 255 for pure mouse
-                   //! events.
+  double m_pressure;  //!< Pressure of the tablet pen (0.0 - 1.0) , or 1.0 for
+                      //! pure mouse events.
   ModifierMask m_modifiersMask;  //!< Bitmask specifying key modifiers applying
                                  //! on the event.
 
@@ -100,7 +100,7 @@ public:
 
 public:
   TMouseEvent()
-      : m_pressure(255)
+      : m_pressure(1.0)
       , m_modifiersMask(NO_KEY)
       , m_buttons(Qt::NoButton)
       , m_button(Qt::NoButton)

--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -543,11 +543,10 @@ public:
 
 //=========================================================================================================
 
-double computeThickness(int pressure, const TDoublePairProperty &property,
+double computeThickness(double pressure, const TDoublePairProperty &property,
                         bool isPath) {
   if (isPath) return 0.0;
-  double p                    = pressure / 255.0;
-  double t                    = p * p * p;
+  double t                    = pressure * pressure * pressure;
   double thick0               = property.getValue().first;
   double thick1               = property.getValue().second;
   if (thick1 < 0.0001) thick0 = thick1 = 0.0;
@@ -556,11 +555,10 @@ double computeThickness(int pressure, const TDoublePairProperty &property,
 
 //---------------------------------------------------------------------------------------------------------
 
-int computeThickness(int pressure, const TIntPairProperty &property,
+int computeThickness(double pressure, const TIntPairProperty &property,
                      bool isPath) {
   if (isPath) return 0.0;
-  double p   = pressure / 255.0;
-  double t   = p * p * p;
+  double t   = pressure * pressure * pressure;
   int thick0 = property.getValue().first;
   int thick1 = property.getValue().second;
   return tround(thick0 + (thick1 - thick0) * t);
@@ -1179,7 +1177,7 @@ void BrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
 
       /*--- ストロークの最初にMaxサイズの円が描かれてしまう不具合を防止する
        * ---*/
-      if (m_pressure.getValue() && e.m_pressure == 255)
+      if (m_pressure.getValue() && e.m_pressure == 1.0)
         thickness = m_rasThickness.getValue().first;
 
       TPointD halfThick(maxThick * 0.5, maxThick * 0.5);
@@ -1234,7 +1232,7 @@ void BrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
             : m_thickness.getValue().second * 0.5;
 
     /*--- ストロークの最初にMaxサイズの円が描かれてしまう不具合を防止する ---*/
-    if (m_pressure.getValue() && e.m_pressure == 255)
+    if (m_pressure.getValue() && e.m_pressure == 1.0)
       thickness     = m_rasThickness.getValue().first;
     m_currThickness = thickness;
     m_smoothStroke.beginStroke(m_smooth.getValue());
@@ -1698,7 +1696,7 @@ void BrushTool::flushTrackPoint() {
 /*!
  * ドラッグ中にツールが切り替わった場合に備え、onDeactivate時とMouseRelease時にと同じ終了処理を行う
 */
-void BrushTool::finishRasterBrush(const TPointD &pos, int pressureVal) {
+void BrushTool::finishRasterBrush(const TPointD &pos, double pressureVal) {
   TImageP image   = getImage(true);
   TToonzImageP ti = image;
   if (!ti) return;
@@ -1721,7 +1719,7 @@ void BrushTool::finishRasterBrush(const TPointD &pos, int pressureVal) {
             : m_rasThickness.getValue().second;
 
     /*--- ストロークの最初にMaxサイズの円が描かれてしまう不具合を防止する ---*/
-    if (m_pressure.getValue() && pressureVal == 255)
+    if (m_pressure.getValue() && pressureVal == 1.0)
       thickness = m_rasThickness.getValue().first;
 
     /*-- Pencilモードでなく、Hardness=100 の場合のブラシサイズを1段階下げる --*/
@@ -2080,8 +2078,8 @@ void BrushTool::checkGuideSnapping(bool beforeMousePress) {
         snapPoint.x = hGuide;
       }
       beforeMousePress ? m_foundFirstSnap = true : m_foundLastSnap = true;
-      beforeMousePress ? m_firstSnapPoint = snapPoint : m_lastSnapPoint =
-                                                            snapPoint;
+      beforeMousePress ? m_firstSnapPoint                          = snapPoint
+                       : m_lastSnapPoint                           = snapPoint;
     }
   }
 }
@@ -2420,16 +2418,16 @@ void BrushTool::addPreset(QString name) {
     preset.m_max = m_rasThickness.getValue().second;
   }
 
-  preset.m_acc             = m_accuracy.getValue();
-  preset.m_smooth          = m_smooth.getValue();
-  preset.m_hardness        = m_hardness.getValue();
-  preset.m_selective       = m_selective.getValue();
-  preset.m_pencil          = m_pencil.getValue();
-  preset.m_breakAngles     = m_breakAngles.getValue();
-  preset.m_pressure        = m_pressure.getValue();
-  preset.m_cap             = m_capStyle.getIndex();
-  preset.m_join            = m_joinStyle.getIndex();
-  preset.m_miter           = m_miterJoinLimit.getValue();
+  preset.m_acc         = m_accuracy.getValue();
+  preset.m_smooth      = m_smooth.getValue();
+  preset.m_hardness    = m_hardness.getValue();
+  preset.m_selective   = m_selective.getValue();
+  preset.m_pencil      = m_pencil.getValue();
+  preset.m_breakAngles = m_breakAngles.getValue();
+  preset.m_pressure    = m_pressure.getValue();
+  preset.m_cap         = m_capStyle.getIndex();
+  preset.m_join        = m_joinStyle.getIndex();
+  preset.m_miter       = m_miterJoinLimit.getValue();
 
   // Pass the preset to the manager
   m_presetsManager.addPreset(preset);

--- a/toonz/sources/tnztools/brushtool.h
+++ b/toonz/sources/tnztools/brushtool.h
@@ -34,13 +34,13 @@ class BluredBrush;
 struct BrushData final : public TPersist {
   PERSIST_DECLARATION(BrushData)
   // frameRange, snapSensitivity and snap are not included
-  // Those options are not really a part of the brush settings, 
-  //just the overall tool.
+  // Those options are not really a part of the brush settings,
+  // just the overall tool.
 
   std::wstring m_name;
   double m_min, m_max, m_acc, m_smooth, m_hardness, m_opacityMin, m_opacityMax;
-  bool m_selective, m_pencil, m_breakAngles, m_pressure; 
-  int m_cap, m_join, m_miter; 
+  bool m_selective, m_pencil, m_breakAngles, m_pressure;
+  int m_cap, m_join, m_miter;
   double m_modifierSize, m_modifierOpacity;
   bool m_modifierEraser, m_modifierLockAlpha;
 
@@ -152,7 +152,7 @@ public:
   void addPreset(QString name);
   void removePreset();
 
-  void finishRasterBrush(const TPointD &pos, int pressureVal);
+  void finishRasterBrush(const TPointD &pos, double pressureVal);
   // return true if the pencil mode is active in the Brush / PaintBrush / Eraser
   // Tools.
   bool isPencilModeActive() override;

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -314,8 +314,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
 
   TPointD rasCenter = ras->getCenterD();
   TPointD point(pos + rasCenter);
-  double pressure =
-      m_enabledPressure && e.isTablet() ? e.m_pressure / 255.0 : 0.5;
+  double pressure = m_enabledPressure && e.isTablet() ? e.m_pressure : 0.5;
 
   m_tileSet   = new TTileSetFullColor(ras->getSize());
   m_tileSaver = new TTileSaverFullColor(ras, m_tileSet);
@@ -353,8 +352,7 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
   TRasterP ras      = ri->getRaster();
   TPointD rasCenter = ras->getCenterD();
   TPointD point(pos + rasCenter);
-  double pressure =
-      m_enabledPressure && e.isTablet() ? e.m_pressure / 255.0 : 0.5;
+  double pressure = m_enabledPressure && e.isTablet() ? e.m_pressure : 0.5;
 
   m_strokeSegmentRect.empty();
   m_toonz_brush->strokeTo(point, pressure, restartBrushTimer());
@@ -383,8 +381,7 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   TRasterP ras      = ri->getRaster();
   TPointD rasCenter = ras->getCenterD();
   TPointD point(pos + rasCenter);
-  double pressure =
-      m_enabledPressure && e.isTablet() ? e.m_pressure / 255.0 : 0.5;
+  double pressure = m_enabledPressure && e.isTablet() ? e.m_pressure : 0.5;
 
   m_strokeSegmentRect.empty();
   m_toonz_brush->strokeTo(point, pressure, restartBrushTimer());

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -64,7 +64,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
                           public Previewer::Listener {
   Q_OBJECT
 
-  qreal m_pressure;
+  double m_pressure;
   QPoint m_lastMousePos;
   QPoint m_pos;
   Qt::MouseButton m_mouseButton;
@@ -73,6 +73,8 @@ class SceneViewer final : public GLWidgetForHighDpi,
   enum TabletState {
     None = 0,
     Touched,
+    StartStroke,  // this state is to detect the first call
+                  // of TabletMove just after TabletPress
     OnStroke,
     Released
   } m_tabletState = None;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -80,7 +80,7 @@ void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
   toonzEvent.m_pos = TPoint(event->pos().x() * devPixRatio,
                             widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
-  toonzEvent.m_pressure = 255;
+  toonzEvent.m_pressure = 1.0;
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
@@ -98,8 +98,7 @@ void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
   toonzEvent.m_pos = TPoint(event->pos().x() * devPixRatio,
                             widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
-  toonzEvent.m_pressure = int(255 * pressure);
-
+  toonzEvent.m_pressure = pressure;
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
                           event->modifiers() & Qt::ControlModifier);
@@ -276,7 +275,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     // work.
     if (e->button() == Qt::LeftButton) {
       TMouseEvent mouseEvent;
-      initToonzEvent(mouseEvent, e, height(), e->pressure(), getDevPixRatio());
+      initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
       m_tabletState = Touched;
       onPress(mouseEvent);
     } else
@@ -286,7 +285,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
   } break;
   case QEvent::TabletRelease: {
 #ifdef MACOSX
-    if (m_tabletState == OnStroke) m_tabletState = Released;
+    if (m_tabletState == StartStroke || m_tabletState == OnStroke)
+      m_tabletState = Released;
 
     TMouseEvent mouseEvent;
     initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
@@ -295,10 +295,10 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     if (TApp::instance()->getCurrentTool()->isToolBusy())
       TApp::instance()->getCurrentTool()->setToolBusy(false);
 #else
-    if (m_tabletState == OnStroke) {
+    if (m_tabletState == StartStroke || m_tabletState == OnStroke) {
       m_tabletState = Released;
       TMouseEvent mouseEvent;
-      initToonzEvent(mouseEvent, e, height(), e->pressure(), getDevPixRatio());
+      initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
       onRelease(mouseEvent);
     } else
       m_tabletEvent = false;
@@ -314,16 +314,11 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     if (isHoveringInsideViewer) onEnter();
 #else
     // for Windowsm, use tabletEvent only for the left Button
-    if (m_tabletState != OnStroke) {
+    if (m_tabletState != StartStroke && m_tabletState != OnStroke) {
       m_tabletEvent = false;
       break;
     }
 #endif
-    // cancel stroke to prevent drawing while floating
-    if (m_tabletState == OnStroke && m_pressure == 0.0) {
-      resetTabletStatus();
-      break;
-    }
     QPoint curPos = e->pos() * getDevPixRatio();
     // It seems that the tabletEvent is called more often than mouseMoveEvent.
     // So I fire the interval timer in order to limit the following process
@@ -332,9 +327,21 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       m_isBusyOnTabletMove = true;
       TMouseEvent mouseEvent;
       initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
-      m_tabletMove = true;
       QTimer::singleShot(20, this, SLOT(releaseBusyOnTabletMove()));
-      onMove(mouseEvent);
+      // cancel stroke to prevent drawing while floating
+      // 23/1/2018 There is a case that the pressure becomes zero at the start
+      // and the end of stroke. For such case, stroke should not be cancelled.
+      // So, added a process to finish stroke here instead of cancelling.
+      // This will be called only if the state is OnStroke so at the start
+      // of the stroke this condition will be passed.
+      if (m_tabletState == OnStroke && m_pressure == 0.0) {
+        m_tabletState       = Released;
+        mouseEvent.m_button = Qt::LeftButton;
+        onRelease(mouseEvent);
+      } else {
+        m_tabletMove = true;
+        onMove(mouseEvent);  // m_tabletState is set to OnStrole here
+      }
     }
 #ifdef MACOSX
     // call the fake leave event if the pen is hovering the viewer edge
@@ -447,48 +454,49 @@ void SceneViewer::onMove(const TMouseEvent &event) {
       cursorSet = true;
       setToolCursor(this, ToolCursor::ScaleVCursor);
     }
-  }
 
-  // control of the border handle when the "compare with snapshot" mode is
-  // activated
-  if (m_compareSettings.m_dragCompareX || m_compareSettings.m_dragCompareY) {
-    if (m_compareSettings.m_dragCompareX)
-      m_compareSettings.m_compareX +=
-          ((double)(curPos.x() - m_pos.x())) / width();
-    else if (m_compareSettings.m_dragCompareY)
-      m_compareSettings.m_compareY -=
-          ((double)(curPos.y() - m_pos.y())) / height();
-    m_compareSettings.m_compareX =
-        tcrop(m_compareSettings.m_compareX, 0.0, 1.0);
-    m_compareSettings.m_compareY =
-        tcrop(m_compareSettings.m_compareY, 0.0, 1.0);
+    // control of the border handle when the "compare with snapshot" mode is
+    // activated
+    if (m_compareSettings.m_dragCompareX || m_compareSettings.m_dragCompareY) {
+      if (m_compareSettings.m_dragCompareX)
+        m_compareSettings.m_compareX +=
+            ((double)(curPos.x() - m_pos.x())) / width();
+      else if (m_compareSettings.m_dragCompareY)
+        m_compareSettings.m_compareY -=
+            ((double)(curPos.y() - m_pos.y())) / height();
+      m_compareSettings.m_compareX =
+          tcrop(m_compareSettings.m_compareX, 0.0, 1.0);
+      m_compareSettings.m_compareY =
+          tcrop(m_compareSettings.m_compareY, 0.0, 1.0);
 
-    update();
+      update();
 
-    m_pos = curPos;
+      m_pos = curPos;
+    }
   } else if (m_mouseButton == Qt::NoButton || m_mouseButton == Qt::LeftButton) {
-    if (is3DView() && m_current3DDevice != NONE &&
-        m_mouseButton == Qt::LeftButton)
-      return;
-    else if (is3DView() && m_mouseButton == Qt::NoButton) {
-      TRectD rect = TRectD(TPointD(m_topRasterPos.x, m_topRasterPos.y),
-                           TDimensionD(20 * devPixRatio, 20 * devPixRatio));
-      if (rect.contains(TPointD(curPos.x(), curPos.y())))
-        m_current3DDevice = TOP_3D;
-      else {
-        rect = TRectD(TPointD(m_sideRasterPos.x, m_sideRasterPos.y),
-                      TDimensionD(20 * devPixRatio, 20 * devPixRatio));
-        if (rect.contains(TPointD(curPos.x(), curPos.y()))) {
-          if (m_phi3D > 0)
-            m_current3DDevice = SIDE_RIGHT_3D;
-          else
-            m_current3DDevice = SIDE_LEFT_3D;
-        } else
-          m_current3DDevice = NONE;
-      }
-      if (m_current3DDevice != NONE) {
-        cursorSet = true;
-        setToolCursor(this, ToolCursor::CURSOR_ARROW);
+    if (is3DView()) {
+      if (m_current3DDevice != NONE && m_mouseButton == Qt::LeftButton)
+        return;
+      else if (m_mouseButton == Qt::NoButton) {
+        TRectD rect = TRectD(TPointD(m_topRasterPos.x, m_topRasterPos.y),
+                             TDimensionD(20 * devPixRatio, 20 * devPixRatio));
+        if (rect.contains(TPointD(curPos.x(), curPos.y())))
+          m_current3DDevice = TOP_3D;
+        else {
+          rect = TRectD(TPointD(m_sideRasterPos.x, m_sideRasterPos.y),
+                        TDimensionD(20 * devPixRatio, 20 * devPixRatio));
+          if (rect.contains(TPointD(curPos.x(), curPos.y()))) {
+            if (m_phi3D > 0)
+              m_current3DDevice = SIDE_RIGHT_3D;
+            else
+              m_current3DDevice = SIDE_LEFT_3D;
+          } else
+            m_current3DDevice = NONE;
+        }
+        if (m_current3DDevice != NONE) {
+          cursorSet = true;
+          setToolCursor(this, ToolCursor::CURSOR_ARROW);
+        }
       }
     }
 
@@ -526,15 +534,18 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     //         << " buttonClicked=" << m_buttonClicked;
 
     // separate tablet events from mouse events
-    if (m_tabletEvent && m_tabletState == OnStroke && m_tabletMove) {
+    if (m_tabletEvent &&
+        (m_tabletState == OnStroke || m_tabletState == StartStroke) &&
+        m_tabletMove) {
       tool->leftButtonDrag(pos, event);
+      m_tabletState = OnStroke;
     }
 
     else if (m_mouseButton == Qt::LeftButton) {
       // sometimes the mousePressedEvent is postponed to a wrong  mouse move
       // event!
       if (m_buttonClicked && !m_toolSwitched) tool->leftButtonDrag(pos, event);
-    } else if (m_pressure == 0) {
+    } else if (m_pressure == 0.0) {
       tool->mouseMove(pos, event);
     }
     if (!cursorSet) setToolCursor(this, tool->getCursorId());
@@ -659,7 +670,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
   }
   // separate tablet and mouse events
   if (m_tabletEvent && m_tabletState == Touched) {
-    m_tabletState = OnStroke;
+    m_tabletState = StartStroke;
     tool->leftButtonDown(pos, event);
   } else if (m_mouseButton == Qt::LeftButton) {
     TApp::instance()->getCurrentTool()->setToolBusy(true);

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -670,6 +670,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
   }
   // separate tablet and mouse events
   if (m_tabletEvent && m_tabletState == Touched) {
+    TApp::instance()->getCurrentTool()->setToolBusy(true);
     m_tabletState = StartStroke;
     tool->leftButtonDown(pos, event);
   } else if (m_mouseButton == Qt::LeftButton) {


### PR DESCRIPTION
This will fix #1683 .

Replaced the cancelling stroke process by finishing of stroke when zero pressure is detected while tablet is moving.
Also refactored the source to handle pressure value as double (0.0-1.0).

It seems to solve the problem at least on Windows. I'll test on OSX from now.
Hope someone can check the modification on Linux.

**NOTE:**
To reproduce the issue, try using tablet with pressure as weak as possible. Some strokes were interrupted on my environment with Win7 + Wacom Intuos Art (CTH-690).