### PR TITLE
Update Appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.3.{build}
+version: 1.2.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
@@ -25,14 +25,14 @@ install:
 
     mkdir %PLATFORM% && cd %PLATFORM%
 
-    cmake ..\sources -G "Visual Studio 14 2015 Win64" -DQT_PATH="C:\Qt\5.9.2\msvc2015_64" -DBOOST_ROOT="C:\Libraries\boost_1_60_0"
+    cmake ..\sources -G "Visual Studio 14 2015 Win64" -DQT_PATH="C:\Qt\5.9.3\msvc2015_64" -DBOOST_ROOT="C:\Libraries\boost_1_60_0"
 build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
   parallel: true
   verbosity: minimal
 after_build:
 - cmd: >-
-    C:\Qt\5.6\msvc2013_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz_1.2.exe
+    C:\Qt\5.9.3\msvc2015_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz_1.2.exe
 
     copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%
 


### PR DESCRIPTION
Change Qt version used in Appveyor, reflecting [the yesterday update](https://github.com/appveyor/ci/issues/1949). 
The Qt path available in Appveyor is listed in [here](https://www.appveyor.com/docs/build-environment/#qt) .

Also updated version number of the software to 1.2.0