### PR TITLE
Fix Template Room Path

### DIFF
--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -535,7 +535,7 @@ Preferences::Preferences()
   bool roomsExist = false;
   rooms           = m_settings->value("CurrentRoomChoice").toString();
 
-  TFilePath room_path(TEnv::getStuffDir() + "profiles/layouts/rooms");
+  TFilePath room_path(ToonzFolder::getRoomsDir());
   TFilePathSet room_fpset;
   try {
     TSystem::readDirectory(room_fpset, room_path, true, false);


### PR DESCRIPTION
This will fix the problem as follows:

The rooms template cannot be loaded properly if `$TOONZPROFILES` is not set to `$TOONZROOT/profiles` .