### PR TITLE
Fix Palette Titlebar to be Updated When Loading Color Model 

### DIFF
--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -975,7 +975,10 @@ int PaletteCmd::loadReferenceImage(TPaletteHandle *paletteHandle,
 
   // when choosing replace(Keep the destination palette), dirty flag is
   // unchanged
-  if (pltBehavior != ReplaceColorModelPlt) levelPalette->setDirtyFlag(true);
+  if (pltBehavior != ReplaceColorModelPlt) {
+    levelPalette->setDirtyFlag(true);
+    paletteHandle->notifyPaletteDirtyFlagChanged();
+  }
 
   return 0;
 }


### PR DESCRIPTION
This small will fix a problem as follows.

When loading a color model with "Overwrite the destination palette" option, level palette will be overwritten by the color model's palette. However, asterisk "*" ( a sign indicating the palette is changed ) is not shown on the palette's titlebar.