### PR TITLE
Enable to Skip the Version Check

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -506,6 +506,12 @@ public:
   bool isAutomaticSVNFolderRefreshEnabled() const {
     return m_automaticSVNFolderRefreshEnabled;
   }
+
+  void enableLatestVersionCheck(bool on);
+  bool isLatestVersionCheckEnabled() const {
+    return m_latestVersionCheckEnabled;
+  }
+
   // Import Export Tab
 
   void setFfmpegPath(std::string path);
@@ -666,6 +672,9 @@ private:
   // map of [monitor name]-[path to the lut file].
   // for now non-Windows accepts only one lut path for all kinds of monitors
   QMap<QString, QString> m_colorCalibrationLutPaths;
+
+  // release version check
+  bool m_latestVersionCheckEnabled = true;
 
 private:
   Preferences();

--- a/toonz/sources/include/toonzqt/dvdialog.h
+++ b/toonz/sources/include/toonzqt/dvdialog.h
@@ -91,7 +91,8 @@ Dialog DVAPI *createMsgBox(MsgType type, const QString &text,
 
 MessageAndCheckboxDialog DVAPI *createMsgandCheckbox(
     MsgType type, const QString &text, const QString &checkBoxText,
-    const QStringList &buttons, int defaultButtonIndex, QWidget *parent = 0);
+    const QStringList &buttons, int defaultButtonIndex,
+    Qt::CheckState defaultCheckBoxState, QWidget *parent = 0);
 
 // void DVAPI error(const QString &msg);
 // void DVAPI info(const QString &msg);
@@ -261,8 +262,9 @@ class DVAPI MessageAndCheckboxDialog final : public DVGui::Dialog {
 
 public:
   MessageAndCheckboxDialog(QWidget *parent = 0, bool hasButton = false,
-                           bool hasFixedSize   = true,
-                           const QString &name = QString());
+                           bool hasFixedSize               = true,
+                           const QString &name             = QString(),
+                           Qt::CheckState checkButtonState = Qt::Unchecked);
   int getChecked() { return m_checked; }
 
 public slots:

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -156,7 +156,7 @@ public:
               << QObject::tr("Cancel");
       DVGui::MessageAndCheckboxDialog *importDialog =
           DVGui::createMsgandCheckbox(DVGui::QUESTION, label, checkBoxLabel,
-                                      buttons, 0);
+                                      buttons, 0, Qt::Unchecked);
       int ret     = importDialog->exec();
       int checked = importDialog->getChecked();
       importDialog->deleteLater();

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -591,7 +591,8 @@ int main(int argc, char *argv[]) {
 
   a.setQuitOnLastWindowClosed(false);
   // a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
-  w.checkForUpdates();
+  if (Preferences::instance()->isLatestVersionCheckEnabled())
+    w.checkForUpdates();
 
   w.show();
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1336,14 +1336,19 @@ void MainWindow::onUpdateCheckerDone(bool error) {
   int const latest_version =
       get_version_code_from(m_updateChecker->getLatestVersion().toStdString());
   if (software_version < latest_version) {
-    std::vector<QString> buttons;
+    QStringList buttons;
     buttons.push_back(QObject::tr("Visit Web Site"));
     buttons.push_back(QObject::tr("Cancel"));
-    int ret = DVGui::MsgBox(
+    DVGui::MessageAndCheckboxDialog *dialog = DVGui::createMsgandCheckbox(
         DVGui::INFORMATION,
         QObject::tr("An update is available for this software.\nVisit the Web "
                     "site for more information."),
-        buttons);
+        QObject::tr("Check for the latest version on launch."), buttons, 0,
+        Qt::Checked);
+    int ret = dialog->exec();
+    if (dialog->getChecked() == Qt::Unchecked)
+      Preferences::instance()->enableLatestVersionCheck(false);
+    dialog->deleteLater();
     if (ret == 1) {
       // Write the new last date to file
       QDesktopServices::openUrl(QObject::tr("https://opentoonz.github.io/e/"));
@@ -2392,9 +2397,9 @@ RecentFiles::~RecentFiles() {}
 
 void RecentFiles::addFilePath(QString path, FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) files.removeAt(i);
@@ -2519,9 +2524,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2548,9 +2553,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
-                                                        ? MI_ClearRecentLevel
-                                                        : MI_ClearRecentImage;
+        (fileType == Scene)
+            ? MI_ClearRecentScene
+            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -429,6 +429,12 @@ void PreferencesPopup::onAutomaticSVNRefreshChanged(int index) {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onCheckLatestVersionChanged(bool on) {
+  m_pref->enableLatestVersionCheck(on);
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onSVNEnabledChanged(int index) {
   bool enabled = index == Qt::Checked;
   if (enabled) {
@@ -1464,6 +1470,9 @@ PreferencesPopup::PreferencesPopup()
   CheckBox *autoRefreshFolderContentsCB =
       new CheckBox(tr("Automatically Refresh Folder Contents"), this);
 
+  CheckBox *checkForTheLatestVersionCB = new CheckBox(
+      tr("Check for the Latest Version of OpenToonz on Launch"), this);
+
   QLabel *note_version =
       new QLabel(tr("* Changes will take effect the next time you run Toonz"));
   note_version->setStyleSheet("font-size: 10px; font: italic;");
@@ -1794,6 +1803,7 @@ PreferencesPopup::PreferencesPopup()
   m_enableVersionControl->setChecked(m_pref->isSVNEnabled());
   autoRefreshFolderContentsCB->setChecked(
       m_pref->isAutomaticSVNFolderRefreshEnabled());
+  checkForTheLatestVersionCB->setChecked(m_pref->isLatestVersionCheckEnabled());
 
   /*--- layout ---*/
 
@@ -2486,6 +2496,8 @@ PreferencesPopup::PreferencesPopup()
                        Qt::AlignLeft | Qt::AlignVCenter);
       vcLay->addWidget(autoRefreshFolderContentsCB, 0,
                        Qt::AlignLeft | Qt::AlignVCenter);
+      vcLay->addWidget(checkForTheLatestVersionCB, 0,
+                       Qt::AlignLeft | Qt::AlignVCenter);
 
       vcLay->addStretch(1);
 
@@ -2805,7 +2817,8 @@ PreferencesPopup::PreferencesPopup()
                        SLOT(onSVNEnabledChanged(int)));
   ret = ret && connect(autoRefreshFolderContentsCB, SIGNAL(stateChanged(int)),
                        SLOT(onAutomaticSVNRefreshChanged(int)));
-
+  ret = ret && connect(checkForTheLatestVersionCB, SIGNAL(clicked(bool)),
+                       SLOT(onCheckLatestVersionChanged(bool)));
   assert(ret);
 }
 

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -203,6 +203,7 @@ private slots:
   void onShowCurrentTimelineChanged(int);
   void onColorCalibrationChanged(bool);
   void onLutPathChanged();
+  void onCheckLatestVersionChanged(bool);
 };
 
 //**********************************************************************************

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -678,6 +678,8 @@ Preferences::Preferences()
                                         it.value().toString());
     }
   }
+  getValue(*m_settings, "latestVersionCheckEnabled",
+           m_latestVersionCheckEnabled);
 }
 
 //-----------------------------------------------------------------
@@ -829,6 +831,13 @@ void Preferences::enableAutomaticSVNFolderRefresh(bool on) {
 void Preferences::enableSVN(bool on) {
   m_SVNEnabled = on;
   m_settings->setValue("SVNEnabled", on ? "1" : "0");
+}
+
+//-----------------------------------------------------------------
+
+void Preferences::enableLatestVersionCheck(bool on) {
+  m_latestVersionCheckEnabled = on;
+  m_settings->setValue("latestVersionCheckEnabled", on ? "1" : "0");
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -806,11 +806,11 @@ void Dialog::addButtonBarWidget(QWidget *first, QWidget *second, QWidget *third,
 
 //=============================================================================
 
-MessageAndCheckboxDialog::MessageAndCheckboxDialog(QWidget *parent,
-                                                   bool hasButton,
-                                                   bool hasFixedSize,
-                                                   const QString &name)
-    : Dialog(parent, hasButton, hasFixedSize, name) {}
+MessageAndCheckboxDialog::MessageAndCheckboxDialog(
+    QWidget *parent, bool hasButton, bool hasFixedSize, const QString &name,
+    Qt::CheckState checkButtonState)
+    : Dialog(parent, hasButton, hasFixedSize, name)
+    , m_checked(checkButtonState) {}
 
 //=============================================================================
 
@@ -1275,8 +1275,10 @@ Dialog *DVGui::createMsgBox(MsgType type, const QString &text,
 
 MessageAndCheckboxDialog *DVGui::createMsgandCheckbox(
     MsgType type, const QString &text, const QString &checkBoxText,
-    const QStringList &buttons, int defaultButtonIndex, QWidget *parent) {
-  MessageAndCheckboxDialog *dialog = new MessageAndCheckboxDialog(parent, true);
+    const QStringList &buttons, int defaultButtonIndex,
+    Qt::CheckState defaultCheckBoxState, QWidget *parent) {
+  MessageAndCheckboxDialog *dialog = new MessageAndCheckboxDialog(
+      parent, true, true, "", defaultCheckBoxState);
   dialog->setWindowFlags(dialog->windowFlags() | Qt::WindowStaysOnTopHint);
   dialog->setAlignment(Qt::AlignLeft);
   QString msgBoxTitle = getMsgBoxTitle(type);
@@ -1312,14 +1314,13 @@ MessageAndCheckboxDialog *DVGui::createMsgandCheckbox(
     buttonGroup->addButton(button, i + 1);
   }
 
-  QCheckBox *dialogCheckBox   = new QCheckBox(dialog);
+  QCheckBox *dialogCheckBox   = new QCheckBox(checkBoxText, dialog);
   QHBoxLayout *checkBoxLayout = new QHBoxLayout;
-  QLabel *checkBoxLabel       = new QLabel(checkBoxText, dialog);
   checkBoxLayout->addWidget(dialogCheckBox);
-  checkBoxLayout->addWidget(checkBoxLabel);
   checkBoxLayout->addStretch(0);
-
   dialog->addLayout(checkBoxLayout);
+
+  dialogCheckBox->setCheckState(defaultCheckBoxState);
 
   QObject::connect(dialogCheckBox, SIGNAL(stateChanged(int)), dialog,
                    SLOT(onCheckboxChanged(int)));


### PR DESCRIPTION
For now OT checks the latest version on launch and displays the notification popup if the newer version is available.
However, especially during production, users do not always want to update the software in order to maintain compatibility.
This PR enables to choose whether to execute such version check. Disabling this option will avoid the trouble of having to cancel the popup on launch.

This option is available in `Preferences > Version Control` and also in the popup.

![image](https://user-images.githubusercontent.com/17974955/36522921-68f152c4-17e2-11e8-98bd-bf810697bc0c.png)
