### PR TITLE
Fix number+letter filename save and detection

### DIFF
--- a/toonz/sources/common/timage_io/tlevel_io.cpp
+++ b/toonz/sources/common/timage_io/tlevel_io.cpp
@@ -139,6 +139,11 @@ TLevelP TLevelReader::loadInfo() {
         m_frameFormat = TFrameId::FOUR_ZEROS;
       else
         m_frameFormat = TFrameId::UNDERSCORE_FOUR_ZEROS;
+    } else if (ws.rfind(L'0') == 1) {  // leads with any number of zeros
+      if (ws.rfind(L'_') == (int)wstring::npos)
+        m_frameFormat = TFrameId::CUSTOM_PAD;
+      else
+        m_frameFormat = TFrameId::UNDERSCORE_CUSTOM_PAD;
     } else {
       if (ws.rfind(L'_') == (int)wstring::npos)
         m_frameFormat = TFrameId::NO_PAD;

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -811,7 +811,7 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
   if (!isFfmpegType() && checkForSeqNum(type) && isNumbers(str, k, j))
     hasValidFrameNum = true;
   std::string frameString;
-  if (frame.isNoFrame() || !hasValidFrameNum) {
+  if (frame.isNoFrame() || (!frame.isEmptyFrame() && !hasValidFrameNum)) {
     if (k != (int)std::wstring::npos) {
       std::wstring wstr = str.substr(k, j - k);
       std::string str2(wstr.begin(), wstr.end());

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -73,7 +73,8 @@ bool isNumbers(std::wstring str, int fromSeg, int toSeg) {
 }
 
 bool checkForSeqNum(QString type) {
-  if (type == "myb") return false;
+  if (type == "myb" || type == "tlv" || type == "pli" || type == "tpl")
+    return false;
   return true;
 }
 };
@@ -792,7 +793,7 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
   int j          = str.rfind(L'.');
   const char *ch = ".";
   // Override format input because it may be wrong.
-  format = frame.getCurrentFormat();
+  if (!isFfmpegType() && !checkForSeqNum(type)) format = frame.getCurrentFormat();
   if (m_underscoreFormatAllowed && (format == TFrameId::UNDERSCORE_FOUR_ZEROS ||
                                     format == TFrameId::UNDERSCORE_NO_PAD ||
                                     format == TFrameId::UNDERSCORE_CUSTOM_PAD))

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -793,7 +793,8 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
   int j          = str.rfind(L'.');
   const char *ch = ".";
   // Override format input because it may be wrong.
-  if (!isFfmpegType() && !checkForSeqNum(type)) format = frame.getCurrentFormat();
+  if (!isFfmpegType() && checkForSeqNum(type))
+    format = frame.getCurrentFormat();
   if (m_underscoreFormatAllowed && (format == TFrameId::UNDERSCORE_FOUR_ZEROS ||
                                     format == TFrameId::UNDERSCORE_NO_PAD ||
                                     format == TFrameId::UNDERSCORE_CUSTOM_PAD))

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -616,7 +616,7 @@ std::wstring TFilePath::getLevelNameW() const {
   if (j == i || j - i == 1)  // prova.tif o prova..tif
     return str;
 
-  if (checkForSeqNum(type) && !isNumbers(str, i, j)) return str;
+  if (!checkForSeqNum(type) || !isNumbers(str, i, j)) return str;
   // prova.0001.tif
   return str.erase(i + 1, j - i - 1);
 }
@@ -671,7 +671,7 @@ TFrameId TFilePath::getFrame() const {
 
   /*-- 間が数字でない場合（ファイル名にまぎれた"_" や "."がある場合）を除外する
    * --*/
-  if (checkForSeqNum(type) && !isNumbers(str, j, i))
+  if (!checkForSeqNum(type) || !isNumbers(str, j, i))
     return TFrameId(TFrameId::NO_FRAME);
 
   int k, number = 0;
@@ -756,7 +756,7 @@ TFilePath TFilePath::withName(const std::wstring &name) const {
 
   if (k == (int)(std::wstring::npos))
     k = j;
-  else if (k != j - 1 && checkForSeqNum(type) && !isNumbers(str, k, j))
+  else if (k != j - 1 && (!checkForSeqNum(type) || !isNumbers(str, k, j)))
     k = j;
 
   return TFilePath(m_path.substr(0, i + 1) + name + str.substr(k));

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -35,11 +35,43 @@ namespace {
  * toSeg位置は含まず、それらの間に挟まれている文字列が「数字4ケタ」ならtrueを返す
  * --*/
 bool isNumbers(std::wstring str, int fromSeg, int toSeg) {
+/*
   if (toSeg - fromSeg != 5) return false;
   for (int pos = fromSeg + 1; pos < toSeg; pos++) {
     if (str[pos] < '0' || str[pos] > '9') return false;
   }
-  return true;
+*/
+	// Let's check if it follows the format ####A (i.e 00001 or 00001a)
+	int numDigits = 0, numLetters = 0;
+	for (int pos = fromSeg + 1; pos < toSeg; pos++) {
+
+		if ((str[pos] >= 'A' && str[pos] <= 'Z')
+			|| (str[pos] >= 'a' && str[pos] <= 'z')) {
+
+			// Not the right format if we ran into a letter without first finding a number
+			if (!numDigits) return false;
+			
+			// We'll keep track of the number of letters we find.
+			// NOTE: From here on out we should only see letters
+			numLetters++;
+		}
+		else if (str[pos] >= '0' && str[pos] <= '9') {
+			// Not the right format if we ran into a number that followed a letter.
+			// This format is not something we expect currently
+			if (numLetters) return false; // not right format
+
+			// We'll keep track of the number of digits we find.
+			numDigits++;
+		}
+		else // Not the right format if we found something we didn't expect
+			return false;
+	}
+
+	// Not the right format if we see too many letters.
+	// At the time of this logic, we only expect 1 letter.  Can expand to 2 or more later, if we want.
+	if (numLetters > 1) return false;
+
+	return true; // We're good!
 }
 };
 

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -532,16 +532,14 @@ std::string TFilePath::getDots() const {
   i = str.rfind(L".");
   if (i == (int)std::wstring::npos || str == L"..") return "";
 
-  if (str.substr(0, i).rfind(L".") != std::wstring::npos)
-    return "..";
-  else if (m_underscoreFormatAllowed) {
-    int j = str.substr(0, i).rfind(L"_");
-    /*-- j == i-1は、フレーム番号を抜いて"A_.tga"のような場合の条件 --*/
-    return (j != (int)std::wstring::npos &&
-            (j == i - 1 || (checkForSeqNum(type) && isNumbers(str, j, i))))
-               ? ".."
-               : ".";
-  } else
+  int j = str.substr(0, i).rfind(L".");
+  if (j == (int)std::wstring::npos && m_underscoreFormatAllowed)
+    j = str.substr(0, i).rfind(L"_");
+
+  if (j != (int)std::wstring::npos)
+    return (j == i - 1 || (checkForSeqNum(type) && isNumbers(str, j, i))) ? ".."
+                                                                          : ".";
+  else
     return ".";
 }
 
@@ -811,7 +809,8 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
   if (!isFfmpegType() && checkForSeqNum(type) && isNumbers(str, k, j))
     hasValidFrameNum = true;
   std::string frameString;
-  if (frame.isNoFrame() || (!frame.isEmptyFrame() && !hasValidFrameNum)) {
+  if (frame.isNoFrame() ||
+      (!frame.isEmptyFrame() && getDots() != "." && !hasValidFrameNum)) {
     if (k != (int)std::wstring::npos) {
       std::wstring wstr = str.substr(k, j - k);
       std::string str2(wstr.begin(), wstr.end());

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -605,7 +605,9 @@ void FilmstripFrames::paintEvent(QPaintEvent *evt) {
       }
       // for sequencial frame
       else {
-        text = QString::number(fid.getNumber()).rightJustified(4, '0');
+        char letter = fid.getLetter();
+        text        = QString::number(fid.getNumber()).rightJustified(4, '0') +
+               (letter != '\0' ? QString(letter) : "");
       }
       p.drawText(tmp_frameRect.adjusted(0, 0, -3, 2), text,
                  QTextOption(Qt::AlignRight | Qt::AlignBottom));


### PR DESCRIPTION
This PR fixes #1693 

The original function for checking the sequence number format was not accounting for the optional letter at the end.  As such it treated these files in an odd way resulting in either the file being deleted while saving or loading as a separate level when brought into OT.

I corrected it to make sure the sequence number followed the format "####[a]" (4-digit number + optional letter). 

This PR also fixes #1382 

I added a new function to skip checking for sequence number in file names for specified file types.  Currently that is only for .myb files used by mypaint brushes and OT's .tpl, .plt and .tlv types..  Additional file types can be added as needed, when discovered

This PR also fixes #1761 

Added logic to better detect and keep track of sequence numbers in filenames. There can be 0-to-many leading zeros. Default for new files is still 4. It is still expected that sequence numbers are between '..' or '_.'. (i.e A.001.tif, A_001.tif - Note, these are considered 2 separate levels)

Additionally updated level strip to show frame letters.

This PR also fixes #1768 

Added a dialog box that pops up when it detects a file in the dragged/dropped file list (another file in the same level sequence) will cause a duplicate of the same level to be created. This gives the user the option to allow it or not. 

This PR also fixes #235, #1809 

This really wasn't an issue of multiple dots. The problem became what was between those dots.  OT only expected a frame number between the last 2 dots, but found regular text instead and didn't handle the filename properly from there.  It would take out the frame number for some operations and then couldn't find anything.

Corrected to only strip frame numbers from filenames in which the text between the last 2 dots is a valid frame number format.  Otherwise it retains the text.