### PR TITLE
Fix Double Fields to Update Correctly When Input Values

### DIFF
--- a/toonz/sources/toonzqt/doublefield.cpp
+++ b/toonz/sources/toonzqt/doublefield.cpp
@@ -145,8 +145,8 @@ void DoubleValueField::setRange(double minValue, double maxValue) {
   m_roller->setRange(minValue, maxValue);
 
   int dicimal   = m_lineEdit->getDecimals();
-  int sliderMax = maxValue * pow(10., dicimal);
-  int sliderMin = minValue * pow(10., dicimal);
+  int sliderMax = (int)round(maxValue * pow(10., dicimal));
+  int sliderMin = (int)round(minValue * pow(10., dicimal));
 
   m_slider->setRange(sliderMin, sliderMax);
 
@@ -161,7 +161,7 @@ void DoubleValueField::setValue(double value) {
   m_roller->setValue(value);
 
   int dicimal     = m_lineEdit->getDecimals();
-  int sliderValue = value * pow(10., dicimal);
+  int sliderValue = (int)round(value * pow(10., dicimal));
 
   m_slider->setValue(sliderValue);
   // forzo il repaint... non sempre si aggiorna e l'update non sembra risolvere
@@ -237,12 +237,12 @@ void DoubleValueField::onSliderChanged(int value) {
 //-----------------------------------------------------------------------------
 
 void DoubleValueField::onLineEditValueChanged() {
-  double value       = m_lineEdit->getValue();
-  int dicimal        = m_lineEdit->getDecimals();
-  double sliderValue = value * pow(10., dicimal);
+  double value    = m_lineEdit->getValue();
+  int dicimal     = m_lineEdit->getDecimals();
+  int sliderValue = (int)round(value * pow(10., dicimal));
 
-  // Controllo necessario per evitare che il segnale di cambiamento venga emesso
-  // piu' volte.
+  // Control necessary to prevent the change signal from being emitted more than
+  // once.
   if ((m_slider->value() == sliderValue && m_slider->isVisible()) ||
       (m_roller->getValue() == value && m_roller->isVisible()))
     return;


### PR DESCRIPTION
To reproduce the problem:

- Create a vector level.
- Choose Brush tool.
- Try to set the `Smooth` parameter to `1.14` by manually typing in the field in Tool Option.

![doublefield](https://user-images.githubusercontent.com/17974955/36956299-fe7af32c-2070-11e8-9c51-3f46280092b9.gif)

On my environment, the value is changed to `1.13` as soon as the editing is finished.
This small shift may become critical, especially for the `Maximum Gap` parameter to be introduced with #1317 , since it will lose backward compatibility once the value is changed from the initial value of `1.15` .

This PR will fix such problem. It was due to the precision difference between the field and the slider in `DoubleValueField` .