### PR TITLE
Fix Saving PLI file's AutoClose Value

### DIFF
--- a/toonz/sources/image/pli/pli_io.cpp
+++ b/toonz/sources/image/pli/pli_io.cpp
@@ -2509,7 +2509,7 @@ bool ParsedPliImp::writePli(const TFilePath &filename) {
   double absAutoClose = fabs(m_autocloseTolerance);
   s                   = tsign(m_autocloseTolerance) + 1;
   i                   = (UCHAR)((int)absAutoClose);
-  d                   = (UCHAR)((int)((absAutoClose - i) * 100));
+  d                   = (UCHAR)((int)round((absAutoClose - i) * 100));
   *m_oChan << s;
   *m_oChan << i;
   *m_oChan << d;


### PR DESCRIPTION
This PR will fix saving fractional portion of the Auto Close Tolerance value of Toonz Vector Level.
After merging #1317 this value will be used for identifying the file version. If this value is not equal to the default ( `1.15` ), PLI will be identified as new version (v120) which will have no backward compatibility.

In my environment of Win7, due to the value precision the default value of `m_autocloseTolerance` is set as `1.14999...` . So it should be rounded off before saving the fractional portion or it is saved as `1.14` .