### PR TITLE
New option for Toonz Raster Brush Tool : Draw Order - Palette Order

### DIFF
--- a/toonz/sources/include/toonz/rasterstrokegenerator.h
+++ b/toonz/sources/include/toonz/rasterstrokegenerator.h
@@ -35,8 +35,8 @@ class DVAPI RasterStrokeGenerator {
   int m_selectedStyle;
   bool m_keepAntiAlias;
   bool m_doAnArc;
-  bool m_useStyleOrder;  // Used in the Selective option of Brush Tool,
-                         // use style order to define line stacking order
+  bool m_isPaletteOrder;  // Used in the Draw Order option of Brush Tool,
+                          // use style order to define line stacking order
   QSet<int> m_aboveStyleIds;
 
   // Ricalcola i punti in un nuovo sistema di riferimento
@@ -51,14 +51,14 @@ public:
   RasterStrokeGenerator(const TRasterCM32P &raster, Tasks task,
                         ColorType colorType, int styleId, const TThickPoint &p,
                         bool selective, int selectedStyle, bool keepAntialias,
-                        bool useStyleOrder = false);
+                        bool isPaletteOrder = false);
   ~RasterStrokeGenerator();
   void setRaster(const TRasterCM32P &ras) { m_raster = ras; }
   void setStyle(int styleId) { m_styleId = styleId; }
   int getStyleId() const { return m_styleId; }
   bool isSelective() { return m_selective; }
 
-  bool useStyleOrder() { return m_useStyleOrder; }
+  bool isPaletteOrder() { return m_isPaletteOrder; }
   void setAboveStyleIds(QSet<int> &ids) { m_aboveStyleIds = ids; }
 
   // Inserisce un punto in "m_points"

--- a/toonz/sources/include/toonz/rasterstrokegenerator.h
+++ b/toonz/sources/include/toonz/rasterstrokegenerator.h
@@ -4,6 +4,7 @@
 #include "ttilesaver.h"
 #include "tstopwatch.h"
 #include <fstream>
+#include <QSet>
 #undef DVAPI
 #undef DVVAR
 #ifdef TOONZLIB_EXPORTS
@@ -34,6 +35,9 @@ class DVAPI RasterStrokeGenerator {
   int m_selectedStyle;
   bool m_keepAntiAlias;
   bool m_doAnArc;
+  bool m_useStyleOrder;  // Used in the Selective option of Brush Tool,
+                         // use style order to define line stacking order
+  QSet<int> m_aboveStyleIds;
 
   // Ricalcola i punti in un nuovo sistema di riferimento
   void translatePoints(std::vector<TThickPoint> &points,
@@ -46,12 +50,16 @@ class DVAPI RasterStrokeGenerator {
 public:
   RasterStrokeGenerator(const TRasterCM32P &raster, Tasks task,
                         ColorType colorType, int styleId, const TThickPoint &p,
-                        bool selective, int selectedStyle, bool keepAntialias);
+                        bool selective, int selectedStyle, bool keepAntialias,
+                        bool useStyleOrder = false);
   ~RasterStrokeGenerator();
   void setRaster(const TRasterCM32P &ras) { m_raster = ras; }
   void setStyle(int styleId) { m_styleId = styleId; }
   int getStyleId() const { return m_styleId; }
   bool isSelective() { return m_selective; }
+
+  bool useStyleOrder() { return m_useStyleOrder; }
+  void setAboveStyleIds(QSet<int> &ids) { m_aboveStyleIds = ids; }
 
   // Inserisce un punto in "m_points"
   bool add(const TThickPoint &p);

--- a/toonz/sources/tnztools/bluredbrush.cpp
+++ b/toonz/sources/tnztools/bluredbrush.cpp
@@ -25,13 +25,13 @@ QImage rasterToQImage(const TRasterP &ras, bool premultiplied = false) {
 }
 
 //----------------------------------------------------------------------------------
-
+// selectiveMode : 0=OFF, 1=Always, 2=StyleOrder
 void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
-                   bool selective) {
+                   int selectiveMode, const QSet<int> &aboveStyleIds) {
   if (!out.getPointer() || !in.getPointer()) return;
   assert(out->getSize() == in->getSize());
   int x, y;
-  if (!selective) {
+  if (selectiveMode == 0) {  // OFF
     for (y = 0; y < out->getLy(); y++) {
       for (x = 0; x < out->getLx(); x++) {
 #ifdef _DEBUG
@@ -44,16 +44,17 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         if (inPix->m == 0) continue;
         TPixelCM32 *outPix = &out->pixels(y)[x];
         bool sameStyleId   = styleId == outPix->getInk();
+        // line with the same style : multiply tones
+        // line with different style : pick darker tone
         int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
-                               : outPix->getTone();
+                               : std::min(255 - inPix->m, outPix->getTone());
         int ink = !sameStyleId && outPix->getTone() < 255 - inPix->m
                       ? outPix->getInk()
                       : styleId;
-        *outPix =
-            TPixelCM32(ink, outPix->getPaint(), std::min(255 - inPix->m, tone));
+        *outPix = TPixelCM32(ink, outPix->getPaint(), tone);
       }
     }
-  } else {
+  } else if (selectiveMode == 1) {  // Always
     for (y = 0; y < out->getLy(); y++) {
       for (x = 0; x < out->getLx(); x++) {
 #ifdef _DEBUG
@@ -66,14 +67,32 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         if (inPix->m == 0) continue;
         TPixelCM32 *outPix = &out->pixels(y)[x];
         bool sameStyleId   = styleId == outPix->getInk();
+        // line with the same style : multiply tones
+        // line with different style : pick darker tone
         int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
-                               : outPix->getTone();
-        int ink = outPix->getTone() < 255 && !sameStyleId &&
-                          outPix->getTone() <= 255 - inPix->m
+                               : std::min(255 - inPix->m, outPix->getTone());
+        int ink = !sameStyleId && outPix->getTone() <= 255 - inPix->m
                       ? outPix->getInk()
                       : styleId;
-        *outPix =
-            TPixelCM32(ink, outPix->getPaint(), std::min(255 - inPix->m, tone));
+        *outPix = TPixelCM32(ink, outPix->getPaint(), tone);
+      }
+    }
+  } else {  // Style Order
+    for (y = 0; y < out->getLy(); y++) {
+      for (x = 0; x < out->getLx(); x++) {
+        TPixel32 *inPix = &in->pixels(y)[x];
+        if (inPix->m == 0) continue;
+        TPixelCM32 *outPix = &out->pixels(y)[x];
+        bool sameStyleId   = styleId == outPix->getInk();
+        // line with the same style : multiply tones
+        // line with different style : pick darker tone
+        int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
+                               : std::min(255 - inPix->m, outPix->getTone());
+        bool chooseOutPixInk = outPix->getTone() < 255 - inPix->m ||
+                               (outPix->getTone() == 255 - inPix->m &&
+                                aboveStyleIds.contains(outPix->getInk()));
+        int ink = !sameStyleId && chooseOutPixInk ? outPix->getInk() : styleId;
+        *outPix = TPixelCM32(ink, outPix->getPaint(), tone);
       }
     }
   }
@@ -346,7 +365,7 @@ void BluredBrush::eraseDrawing(const TRasterP ras, const TRasterP rasBackup,
 void BluredBrush::updateDrawing(const TRasterCM32P rasCM,
                                 const TRasterCM32P rasBackupCM,
                                 const TRect &bbox, int styleId,
-                                bool selective) const {
+                                int selectiveMode) const {
   if (!rasCM) return;
 
   TRect rasRect    = rasCM->getBounds();
@@ -355,7 +374,7 @@ void BluredBrush::updateDrawing(const TRasterCM32P rasCM,
 
   rasCM->copy(rasBackupCM->extract(targetRect), targetRect.getP00());
   putOnRasterCM(rasCM->extract(targetRect), m_ras->extract(targetRect), styleId,
-                selective);
+                selectiveMode, m_aboveStyleIds);
 }
 
 //----------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/bluredbrush.cpp
+++ b/toonz/sources/tnztools/bluredbrush.cpp
@@ -25,13 +25,13 @@ QImage rasterToQImage(const TRasterP &ras, bool premultiplied = false) {
 }
 
 //----------------------------------------------------------------------------------
-// selectiveMode : 0=OFF, 1=Always, 2=StyleOrder
+// drawOrderMode : 0=OverAll, 1=UnderAll, 2=PaletteOrder
 void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
-                   int selectiveMode, const QSet<int> &aboveStyleIds) {
+                   int drawOrderMode, const QSet<int> &aboveStyleIds) {
   if (!out.getPointer() || !in.getPointer()) return;
   assert(out->getSize() == in->getSize());
   int x, y;
-  if (selectiveMode == 0) {  // OFF
+  if (drawOrderMode == 0) {  // OverAll
     for (y = 0; y < out->getLy(); y++) {
       for (x = 0; x < out->getLx(); x++) {
 #ifdef _DEBUG
@@ -54,7 +54,7 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         *outPix = TPixelCM32(ink, outPix->getPaint(), tone);
       }
     }
-  } else if (selectiveMode == 1) {  // Always
+  } else if (drawOrderMode == 1) {  // UnderAll
     for (y = 0; y < out->getLy(); y++) {
       for (x = 0; x < out->getLx(); x++) {
 #ifdef _DEBUG
@@ -77,7 +77,7 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         *outPix = TPixelCM32(ink, outPix->getPaint(), tone);
       }
     }
-  } else {  // Style Order
+  } else {  // PaletteOrder
     for (y = 0; y < out->getLy(); y++) {
       for (x = 0; x < out->getLx(); x++) {
         TPixel32 *inPix = &in->pixels(y)[x];
@@ -365,7 +365,7 @@ void BluredBrush::eraseDrawing(const TRasterP ras, const TRasterP rasBackup,
 void BluredBrush::updateDrawing(const TRasterCM32P rasCM,
                                 const TRasterCM32P rasBackupCM,
                                 const TRect &bbox, int styleId,
-                                int selectiveMode) const {
+                                int drawOrderMode) const {
   if (!rasCM) return;
 
   TRect rasRect    = rasCM->getBounds();
@@ -374,7 +374,7 @@ void BluredBrush::updateDrawing(const TRasterCM32P rasCM,
 
   rasCM->copy(rasBackupCM->extract(targetRect), targetRect.getP00());
   putOnRasterCM(rasCM->extract(targetRect), m_ras->extract(targetRect), styleId,
-                selectiveMode, m_aboveStyleIds);
+                drawOrderMode, m_aboveStyleIds);
 }
 
 //----------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/bluredbrush.h
+++ b/toonz/sources/tnztools/bluredbrush.h
@@ -8,6 +8,7 @@
 #include "tcurves.h"
 #include <QPainter>
 #include <QImage>
+#include <QSet>
 
 //=======================================================
 //
@@ -24,6 +25,8 @@ class BluredBrush {
   double m_oldOpacity;
   bool m_enableDinamicOpacity;
 
+  QSet<int> m_aboveStyleIds;
+
   double getNextPadPosition(const TThickQuadratic &q, double t) const;
 
 public:
@@ -37,10 +40,12 @@ public:
   TRect getBoundFromPoints(const std::vector<TThickPoint> &points) const;
   // colormapped
   void updateDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
-                     const TRect &bbox, int styleId, bool selective) const;
+                     const TRect &bbox, int styleId, int selectiveMode) const;
   void eraseDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
                     const TRect &bbox, bool selective, int selectedStyleId,
                     const std::wstring &mode) const;
+
+  void setAboveStyleIds(QSet<int> &ids) { m_aboveStyleIds = ids; }
 
   // fullcolor
   void updateDrawing(const TRasterP ras, const TRasterP rasBackup,

--- a/toonz/sources/tnztools/bluredbrush.h
+++ b/toonz/sources/tnztools/bluredbrush.h
@@ -40,7 +40,7 @@ public:
   TRect getBoundFromPoints(const std::vector<TThickPoint> &points) const;
   // colormapped
   void updateDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
-                     const TRect &bbox, int styleId, int selectiveMode) const;
+                     const TRect &bbox, int styleId, int drawOrderMode) const;
   void eraseDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
                     const TRect &bbox, bool selective, int selectedStyleId,
                     const std::wstring &mode) const;

--- a/toonz/sources/tnztools/brushtool.h
+++ b/toonz/sources/tnztools/brushtool.h
@@ -39,8 +39,8 @@ struct BrushData final : public TPersist {
 
   std::wstring m_name;
   double m_min, m_max, m_acc, m_smooth, m_hardness, m_opacityMin, m_opacityMax;
-  bool m_selective, m_pencil, m_breakAngles, m_pressure;
-  int m_cap, m_join, m_miter;
+  bool m_pencil, m_breakAngles, m_pressure;
+  int m_cap, m_join, m_miter, m_selective;
   double m_modifierSize, m_modifierOpacity;
   bool m_modifierEraser, m_modifierLockAlpha;
 
@@ -174,7 +174,7 @@ protected:
   TDoubleProperty m_smooth;
   TDoubleProperty m_hardness;
   TEnumProperty m_preset;
-  TBoolProperty m_selective;
+  TEnumProperty m_selective;
   TBoolProperty m_breakAngles;
   TBoolProperty m_pencil;
   TBoolProperty m_pressure;

--- a/toonz/sources/tnztools/brushtool.h
+++ b/toonz/sources/tnztools/brushtool.h
@@ -40,7 +40,7 @@ struct BrushData final : public TPersist {
   std::wstring m_name;
   double m_min, m_max, m_acc, m_smooth, m_hardness, m_opacityMin, m_opacityMax;
   bool m_pencil, m_breakAngles, m_pressure;
-  int m_cap, m_join, m_miter, m_selective;
+  int m_cap, m_join, m_miter, m_drawOrder;
   double m_modifierSize, m_modifierOpacity;
   bool m_modifierEraser, m_modifierLockAlpha;
 
@@ -174,7 +174,7 @@ protected:
   TDoubleProperty m_smooth;
   TDoubleProperty m_hardness;
   TEnumProperty m_preset;
-  TEnumProperty m_selective;
+  TEnumProperty m_drawOrder;
   TBoolProperty m_breakAngles;
   TBoolProperty m_pencil;
   TBoolProperty m_pressure;

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1620,7 +1620,8 @@ void MainWindow::defineActions() {
   QAction *newToonzRasterLevelAction = createMenuFileAction(
       MI_NewToonzRasterLevel, tr("&New Toonz Raster Level"), "");
   newToonzRasterLevelAction->setIconText(tr("New Toonz Raster Level"));
-  newToonzRasterLevelAction->setIcon(QIcon(":Resources/new_toonz_raster_level.svg"));
+  newToonzRasterLevelAction->setIcon(
+      QIcon(":Resources/new_toonz_raster_level.svg"));
   QAction *newRasterLevelAction =
       createMenuFileAction(MI_NewRasterLevel, tr("&New Raster Level"), "");
   newRasterLevelAction->setIconText(tr("New Raster Level"));
@@ -2208,6 +2209,8 @@ void MainWindow::defineActions() {
                           tr("Pressure Sensitivity"), "Shift+P");
   createToolOptionsAction("A_ToolOption_SegmentInk", tr("Segment Ink"), "F8");
   createToolOptionsAction("A_ToolOption_Selective", tr("Selective"), "F7");
+  createToolOptionsAction("A_ToolOption_DrawOrder",
+                          tr("Brush Tool - Draw Order"), "");
   createToolOptionsAction("A_ToolOption_Smooth", tr("Smooth"), "");
   createToolOptionsAction("A_ToolOption_Snap", tr("Snap"), "");
   createToolOptionsAction("A_ToolOption_AutoSelectDrawing",
@@ -2392,9 +2395,9 @@ RecentFiles::~RecentFiles() {}
 
 void RecentFiles::addFilePath(QString path, FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) files.removeAt(i);
@@ -2519,9 +2522,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2548,9 +2551,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
-                                                        ? MI_ClearRecentLevel
-                                                        : MI_ClearRecentImage;
+        (fileType == Scene)
+            ? MI_ClearRecentScene
+            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -10,7 +10,7 @@ RasterStrokeGenerator::RasterStrokeGenerator(const TRasterCM32P &raster,
                                              int styleId, const TThickPoint &p,
                                              bool selective, int selectedStyle,
                                              bool keepAntialias,
-                                             bool useStyleOrder)
+                                             bool isPaletteOrder)
     : m_raster(raster)
     , m_boxOfRaster(TRect(raster->getSize()))
     , m_styleId(styleId)
@@ -21,7 +21,7 @@ RasterStrokeGenerator::RasterStrokeGenerator(const TRasterCM32P &raster,
     , m_selectedStyle(selectedStyle)
     , m_keepAntiAlias(keepAntialias)
     , m_doAnArc(false)
-    , m_useStyleOrder(useStyleOrder) {
+    , m_isPaletteOrder(isPaletteOrder) {
   TThickPoint pp = p;
   m_points.push_back(pp);
   if (task == ERASE) m_styleId = m_eraseStyle;
@@ -194,7 +194,7 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
           continue;
         }
         if (outPix->isPureInk() && m_selective) {
-          if (!m_useStyleOrder || m_aboveStyleIds.contains(outPix->getInk())) {
+          if (!m_isPaletteOrder || m_aboveStyleIds.contains(outPix->getInk())) {
             *outPix = TPixelCM32(outPix->getInk(), outPix->getPaint(), outTone);
             continue;
           }

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -9,7 +9,8 @@ RasterStrokeGenerator::RasterStrokeGenerator(const TRasterCM32P &raster,
                                              Tasks task, ColorType colorType,
                                              int styleId, const TThickPoint &p,
                                              bool selective, int selectedStyle,
-                                             bool keepAntialias)
+                                             bool keepAntialias,
+                                             bool useStyleOrder)
     : m_raster(raster)
     , m_boxOfRaster(TRect(raster->getSize()))
     , m_styleId(styleId)
@@ -19,7 +20,8 @@ RasterStrokeGenerator::RasterStrokeGenerator(const TRasterCM32P &raster,
     , m_eraseStyle(4095)
     , m_selectedStyle(selectedStyle)
     , m_keepAntiAlias(keepAntialias)
-    , m_doAnArc(false) {
+    , m_doAnArc(false)
+    , m_useStyleOrder(useStyleOrder) {
   TThickPoint pp = p;
   m_points.push_back(pp);
   if (task == ERASE) m_styleId = m_eraseStyle;
@@ -192,8 +194,10 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
           continue;
         }
         if (outPix->isPureInk() && m_selective) {
-          *outPix = TPixelCM32(outPix->getInk(), outPix->getPaint(), outTone);
-          continue;
+          if (!m_useStyleOrder || m_aboveStyleIds.contains(outPix->getInk())) {
+            *outPix = TPixelCM32(outPix->getInk(), outPix->getPaint(), outTone);
+            continue;
+          }
         }
         if (inTone <= outTone) {
           *outPix = TPixelCM32(inPix->getInk(), outPix->getPaint(), inTone);


### PR DESCRIPTION
This PR will introduce a new option to Toonz Raster Brush - ~~"Selective : Style Order".~~
**UPDATE:** This item is renamed to "Draw Order", with 3 options `Over All` , `Under All` and `Palette Order` .

We already have "Selective" option for the Toonz Raster Brush tool, which allows the drawing operation without affecting already drawn lines.
**UPDATE:** `Over All` and `Under All` options correspond to deactivate and activate the conventional "Selective" option, respectively.

The ~~"Style Order"~~ "Palette Order" option will be added to it. If the ~~"Style Order"~~ "Palette Order" is selected, stacking order of the stroke will be the same as the order of the styles in the palette. Therefore, style order in the palette will act as pseudo-layers.

Please note that the "style order" means the order in the palette page, regardless of the style index.
Which means that you can control the stacking order of the new stroke by moving the current style in the page before drawing.

This option is useful especially for drawing with switching between solid (black) ink and self-colored (red/blue) inks. You can draw solid lines always on top without any care of "Selective" option.
This feature was requested by some Japanese animation studio.

![style_order](https://user-images.githubusercontent.com/17974955/37094822-8425afd4-2257-11e8-8623-7c7e981b5a6c.gif)
