### PR TITLE
Enable Vector Selection Right-click Menus in All Section Modes

### DIFF
--- a/toonz/sources/tnztools/imagegrouping.cpp
+++ b/toonz/sources/tnztools/imagegrouping.cpp
@@ -216,7 +216,15 @@ public:
 
   int getSize() const override { return sizeof(*this); }
 
-  QString getToolName() override { return QObject::tr("Move Group"); }
+  QString getToolName() override {
+    static QMap<int, QString> commandTypeStrMap{
+        {TGroupCommand::FRONT, QObject::tr(" to Front")},
+        {TGroupCommand::FORWARD, QObject::tr(" to Forward")},
+        {TGroupCommand::BACK, QObject::tr(" to Back")},
+        {TGroupCommand::BACKWARD, QObject::tr(" to Backward")}};
+
+    return QObject::tr("Move Group") + commandTypeStrMap.value(m_moveType);
+  }
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -338,6 +338,7 @@ private:
     void selectNone() override {
       LevelSelection::selectNone(), m_strokeSelection.selectNone();
     }
+    void enableCommands() override { m_strokeSelection.enableCommands(); }
   };
 
 private:


### PR DESCRIPTION
For now, some right-click menu commands of Vector Selection Tool such as `Group`, `Bring to Front`, `Send Back`, etc. are available only when the `Mode` option is set to `Standard` .

This fix will modify it so that all commands can be used in any selection mode.
Please note that for now these commands are applied to the selected strokes only in the current frame even if you are selecting strokes across multiple frames by using `... on Selected Frames` or `... on Whole Level` mode.

Also I modified the undo text for `MoveGroupsUndo` , adding the type of movement.

![image](https://user-images.githubusercontent.com/17974955/37146860-5631a392-2308-11e8-8ebf-67b44e636509.png)
