### PR TITLE
Fix crash with 3DLUT feature

### DIFF
--- a/toonz/sources/include/toonzqt/lutcalibrator.h
+++ b/toonz/sources/include/toonzqt/lutcalibrator.h
@@ -24,11 +24,11 @@ class QOpenGLShader;
 class QOpenGLShaderProgram;
 class QOpenGLFramebufferObject;
 class QOpenGLTexture;
+class QOpenGLContext;
 
 class QColor;
 
-class DVAPI LutCalibrator : public QOpenGLFunctions  // sigleton
-{
+class DVAPI LutCalibrator : public QOpenGLFunctions {
   bool m_isValid = false;
 
   struct LutTextureShader {
@@ -42,37 +42,57 @@ class DVAPI LutCalibrator : public QOpenGLFunctions  // sigleton
     int texCoordAttrib            = -1;
   } m_shader;
 
-  struct Lut {
-    int meshSize;
-    float* data         = NULL;
-    QOpenGLTexture* tex = NULL;
-  } m_lut;
+  QOpenGLTexture* m_lutTex = NULL;
 
   QOpenGLBuffer m_viewerVBO;
-  LutCalibrator() {}
 
   bool initializeLutTextureShader();
   void createViewerVBO();
-  bool loadLutFile(const QString& path);
   void assignLutTexture();
 
 public:
-  static LutCalibrator* instance();
+  // static LutCalibrator* instance();
+  LutCalibrator() {}
 
   // to be computed once through the software
   void initialize();
-  void finalize();
+
   bool isValid() { return m_isValid; }
 
-  ~LutCalibrator() { finalize(); }
+  ~LutCalibrator() {}
 
   void onEndDraw(QOpenGLFramebufferObject*);
 
-  QString& getMonitorName() const;
+  void cleanup();
+};
+
+class DVAPI LutManager  // singleton
+{
+  bool m_isValid = false;
+
+  LutManager();
+
+  struct Lut {
+    int meshSize;
+    float* data = NULL;
+  } m_lut;
+
+public:
+  static LutManager* instance();
+
+  ~LutManager();
+
+  bool isValid() { return m_isValid; }
+  int meshSize() const { return m_lut.meshSize; }
+  float* data() const { return m_lut.data; }
+
+  bool loadLutFile(const QString& fp);
 
   void convert(float&, float&, float&);
   void convert(QColor&);
   void convert(TPixel32&);
+
+  QString& getMonitorName() const;
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -70,6 +70,7 @@ class ColorSquaredWheel;
 class TabBarContainter;
 class StyleChooser;
 class StyleEditor;
+class LutCalibrator;
 
 //=============================================
 
@@ -149,6 +150,7 @@ class DVAPI HexagonalColorWheel final : public GLWidgetForHighDpi {
 
   // used for color calibration with 3DLUT
   QOpenGLFramebufferObject *m_fbo = NULL;
+  LutCalibrator *m_lutCalibrator  = NULL;
 
 private:
   void drawCurrentColorMark();
@@ -176,6 +178,9 @@ protected:
 
 signals:
   void colorChanged(const ColorModel &color, bool isDragging);
+
+public slots:
+  void onContextAboutToBeDestroyed();
 };
 
 //=============================================================================

--- a/toonz/sources/tnztools/rgbpickertool.cpp
+++ b/toonz/sources/tnztools/rgbpickertool.cpp
@@ -418,11 +418,11 @@ void RGBPickerTool::passivePick() {
 
   StylePicker picker(image);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->bindFBO();
+  if (LutManager::instance()->isValid()) m_viewer->bindFBO();
 
   TPixel32 pix = picker.pickColor(area);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->releaseFBO();
+  if (LutManager::instance()->isValid()) m_viewer->releaseFBO();
 
   QColor col((int)pix.r, (int)pix.g, (int)pix.b);
 
@@ -446,11 +446,11 @@ void RGBPickerTool::pick() {
                        m_mousePixelPosition.x + 1, m_mousePixelPosition.y + 1);
   StylePicker picker(image, palette);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->bindFBO();
+  if (LutManager::instance()->isValid()) m_viewer->bindFBO();
 
   m_currentValue = picker.pickColor(area);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->releaseFBO();
+  if (LutManager::instance()->isValid()) m_viewer->releaseFBO();
 
   TXshSimpleLevel *level = app->getCurrentLevel()->getSimpleLevel();
   UndoPickRGBM *cmd = new UndoPickRGBM(palette, styleId, m_currentValue, level);
@@ -491,11 +491,11 @@ void RGBPickerTool::pickRect() {
   if (area.getLx() <= 1 || area.getLy() <= 1) return;
   StylePicker picker(image, palette);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->bindFBO();
+  if (LutManager::instance()->isValid()) m_viewer->bindFBO();
 
   m_currentValue = picker.pickColor(area);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->releaseFBO();
+  if (LutManager::instance()->isValid()) m_viewer->releaseFBO();
 }
 
 //---------------------------------------------------------
@@ -512,11 +512,11 @@ void RGBPickerTool::pickStroke() {
   StylePicker picker(image, palette);
   TStroke *stroke = new TStroke(*m_stroke);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->bindFBO();
+  if (LutManager::instance()->isValid()) m_viewer->bindFBO();
 
   m_currentValue = picker.pickColor(stroke);
 
-  if (LutCalibrator::instance()->isValid()) m_viewer->releaseFBO();
+  if (LutManager::instance()->isValid()) m_viewer->releaseFBO();
 
   if (!(m_pickType.getValue() == POLYLINE_PICK)) {
     TXshSimpleLevel *level = app->getCurrentLevel()->getSimpleLevel();

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2278,9 +2278,9 @@ protected:
     QPainter p(this);
     p.setPen(Qt::NoPen);
 
-    if (LutCalibrator::instance()->isValid()) {
+    if (LutManager::instance()->isValid()) {
       QColor convertedColor(m_color);
-      LutCalibrator::instance()->convert(convertedColor);
+      LutManager::instance()->convert(convertedColor);
       p.setBrush(convertedColor);
     } else
       p.setBrush(m_color);

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -28,6 +28,7 @@
 #include "toonz/sceneproperties.h"
 #include "toonz/palettecontroller.h"
 #include "toonz/tpalettehandle.h"
+#include "toonz/preferences.h"
 
 // TnzCore includes
 #include "tgl.h"
@@ -228,6 +229,9 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
 
   if (m_isHistogramEnable)
     m_histogramPopup = new HistogramPopup(tr("Flipbook Histogram"));
+
+  if (Preferences::instance()->isColorCalibrationEnabled())
+    m_lutCalibrator = new LutCalibrator();
 }
 
 //-----------------------------------------------------------------------------
@@ -413,7 +417,11 @@ void ImageViewer::initializeGL() {
   initializeOpenGLFunctions();
 
   // to be computed once through the software
-  LutCalibrator::instance()->initialize();
+  if (m_lutCalibrator) {
+    m_lutCalibrator->initialize();
+    connect(context(), SIGNAL(aboutToBeDestroyed()), this,
+            SLOT(onContextAboutToBeDestroyed()));
+  }
 
   // glClearColor(1.0,1.0,1.0,1);
   glClear(GL_COLOR_BUFFER_BIT);
@@ -437,7 +445,7 @@ void ImageViewer::resizeGL(int w, int h) {
   glTranslated(w * 0.5, h * 0.5, 0);
 
   // remake fbo with new size
-  if (LutCalibrator::instance()->isValid()) {
+  if (m_lutCalibrator && m_lutCalibrator->isValid()) {
     if (m_fbo) delete m_fbo;
     m_fbo = new QOpenGLFramebufferObject(w, h);
   }
@@ -446,7 +454,7 @@ void ImageViewer::resizeGL(int w, int h) {
 //-----------------------------------------------------------------------------
 
 void ImageViewer::paintGL() {
-  if (LutCalibrator::instance()->isValid()) m_fbo->bind();
+  if (m_lutCalibrator && m_lutCalibrator->isValid()) m_fbo->bind();
 
   TDimension viewerSize(width(), height());
   TAffine aff = m_viewAff;
@@ -503,8 +511,8 @@ void ImageViewer::paintGL() {
   }
 
   if (!m_image) {
-    if (LutCalibrator::instance()->isValid())
-      LutCalibrator::instance()->onEndDraw(m_fbo);
+    if (m_lutCalibrator && m_lutCalibrator->isValid())
+      m_lutCalibrator->onEndDraw(m_fbo);
     return;
   }
 
@@ -582,8 +590,8 @@ void ImageViewer::paintGL() {
     }
   }
 
-  if (LutCalibrator::instance()->isValid())
-    LutCalibrator::instance()->onEndDraw(m_fbo);
+  if (m_lutCalibrator && m_lutCalibrator->isValid())
+    m_lutCalibrator->onEndDraw(m_fbo);
 }
 
 //------------------------------------------------------------------------------
@@ -841,11 +849,11 @@ void ImageViewer::pickColor(QMouseEvent *event, bool putValueToStyleEditor) {
   TPoint mousePos = TPoint(curPos.x(), height() - 1 - curPos.y());
   TRectD area     = TRectD(mousePos.x, mousePos.y, mousePos.x, mousePos.y);
 
-  if (LutCalibrator::instance()->isValid()) m_fbo->bind();
+  if (m_lutCalibrator && m_lutCalibrator->isValid()) m_fbo->bind();
 
   const TPixel32 pix = picker.pickColor(area);
 
-  if (LutCalibrator::instance()->isValid()) m_fbo->release();
+  if (m_lutCalibrator && m_lutCalibrator->isValid()) m_fbo->release();
 
   QPoint viewP = mapFrom(this, curPos);
   TPointD pos  = getViewAff().inv() *
@@ -883,11 +891,11 @@ void ImageViewer::rectPickColor(bool putValueToStyleEditor) {
     return;
   }
 
-  if (LutCalibrator::instance()->isValid() && m_fbo) m_fbo->bind();
+  if (m_lutCalibrator && m_lutCalibrator->isValid() && m_fbo) m_fbo->bind();
 
   const TPixel32 pix = picker.pickColor(area.enlarge(-1, -1));
 
-  if (LutCalibrator::instance()->isValid() && m_fbo) m_fbo->release();
+  if (m_lutCalibrator && m_lutCalibrator->isValid() && m_fbo) m_fbo->release();
 
   // throw the picked color to the histogram
   m_histogramPopup->updateAverageColor(pix);
@@ -1148,6 +1156,15 @@ void ImageViewer::keyPressEvent(QKeyEvent *event) {
   if (FlipZoomer(this).exec(event)) return;
 
   ImageViewerShortcutReceiver(m_flipbook).exec(event);
+}
+
+//-----------------------------------------------------------------------------
+
+void ImageViewer::onContextAboutToBeDestroyed() {
+  if (!m_lutCalibrator) return;
+  makeCurrent();
+  m_lutCalibrator->cleanup();
+  doneCurrent();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -12,6 +12,7 @@
 class FlipBook;
 class HistogramPopup;
 class QOpenGLFramebufferObject;
+class LutCalibrator;
 
 //-----------------------------------------------------------------------------
 
@@ -57,6 +58,7 @@ class ImageViewer final : public GLWidgetForHighDpi {
 
   // used for color calibration with 3DLUT
   QOpenGLFramebufferObject *m_fbo = NULL;
+  LutCalibrator *m_lutCalibrator  = NULL;
 
   int getDragType(const TPoint &pos, const TRect &loadBox);
   void updateLoadbox(const TPoint &curPos);
@@ -132,6 +134,7 @@ public slots:
   void fitView();
   void showHistogram();
   void swapCompared();
+  void onContextAboutToBeDestroyed();
 };
 
 #endif  // IMAGEVIEWER_INCLUDE

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1155,9 +1155,8 @@ void PreferencesPopup::onColorCalibrationChanged(bool on) {
 //-----------------------------------------------------------------------------
 
 void PreferencesPopup::onLutPathChanged() {
-  m_pref->setColorCalibrationLutPath(
-      LutCalibrator::instance()->getMonitorName(),
-      m_lutPathFileField->getPath());
+  m_pref->setColorCalibrationLutPath(LutManager::instance()->getMonitorName(),
+                                     m_lutPathFileField->getPath());
 }
 
 //**********************************************************************************
@@ -1606,7 +1605,7 @@ PreferencesPopup::PreferencesPopup()
   m_colorCalibration->setCheckable(true);
   m_colorCalibration->setChecked(m_pref->isColorCalibrationEnabled());
   QString lutPath = m_pref->getColorCalibrationLutPath(
-      LutCalibrator::instance()->getMonitorName());
+      LutManager::instance()->getMonitorName());
   if (!lutPath.isEmpty()) m_lutPathFileField->setPath(lutPath);
   m_lutPathFileField->setFileMode(QFileDialog::ExistingFile);
   QStringList lutFileTypes;
@@ -2021,7 +2020,7 @@ PreferencesPopup::PreferencesPopup()
       {
         lutLayout->addWidget(
             new QLabel(tr("3DLUT File for [%1] *:")
-                           .arg(LutCalibrator::instance()->getMonitorName()),
+                           .arg(LutManager::instance()->getMonitorName()),
                        this),
             0);
         lutLayout->addWidget(m_lutPathFileField, 1);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -506,6 +506,9 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
   grabGesture(Qt::SwipeGesture);
   grabGesture(Qt::PanGesture);
   grabGesture(Qt::PinchGesture);
+
+  if (Preferences::instance()->isColorCalibrationEnabled())
+    m_lutCalibrator = new LutCalibrator();
 }
 
 //-----------------------------------------------------------------------------
@@ -818,7 +821,11 @@ void SceneViewer::initializeGL() {
   initializeOpenGLFunctions();
 
   // to be computed once through the software
-  LutCalibrator::instance()->initialize();
+  if (m_lutCalibrator) {
+    m_lutCalibrator->initialize();
+    connect(context(), SIGNAL(aboutToBeDestroyed()), this,
+            SLOT(onContextAboutToBeDestroyed()));
+  }
 
   // glClearColor(1.0,1.0,1.0,1);
   glClear(GL_COLOR_BUFFER_BIT);
@@ -847,7 +854,7 @@ void SceneViewer::resizeGL(int w, int h) {
   if (m_previewMode != NO_PREVIEW) requestTimedRefresh();
 
   // remake fbo with new size
-  if (LutCalibrator::instance()->isValid()) {
+  if (m_lutCalibrator && m_lutCalibrator->isValid()) {
     if (m_fbo) delete m_fbo;
     m_fbo = new QOpenGLFramebufferObject(w, h);
   }
@@ -1373,7 +1380,8 @@ void SceneViewer::paintGL() {
   time.start();
 #endif
 
-  if (!m_isPicking && LutCalibrator::instance()->isValid()) m_fbo->bind();
+  if (!m_isPicking && m_lutCalibrator && m_lutCalibrator->isValid())
+    m_fbo->bind();
 
   if (m_hRuler && m_vRuler) {
     if (!viewRulerToggle.getStatus() &&
@@ -1403,8 +1411,8 @@ void SceneViewer::paintGL() {
     glPopMatrix();
     m_viewGrabImage->unlock();
 
-    if (!m_isPicking && LutCalibrator::instance()->isValid())
-      LutCalibrator::instance()->onEndDraw(m_fbo);
+    if (!m_isPicking && m_lutCalibrator && m_lutCalibrator->isValid())
+      m_lutCalibrator->onEndDraw(m_fbo);
 
     return;
   }
@@ -1447,8 +1455,8 @@ void SceneViewer::paintGL() {
 #endif
   // TOfflineGL::setContextManager(0);
 
-  if (!m_isPicking && LutCalibrator::instance()->isValid())
-    LutCalibrator::instance()->onEndDraw(m_fbo);
+  if (!m_isPicking && m_lutCalibrator && m_lutCalibrator->isValid())
+    m_lutCalibrator->onEndDraw(m_fbo);
 }
 
 //-----------------------------------------------------------------------------
@@ -2546,4 +2554,13 @@ void SceneViewer::bindFBO() {
 
 void SceneViewer::releaseFBO() {
   if (m_fbo) m_fbo->release();
+}
+
+//-----------------------------------------------------------------------------
+
+void SceneViewer::onContextAboutToBeDestroyed() {
+  if (!m_lutCalibrator) return;
+  makeCurrent();
+  m_lutCalibrator->cleanup();
+  doneCurrent();
 }

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -35,6 +35,7 @@ class LocatorPopup;
 class QGestureEvent;
 class QTouchEvent;
 class QOpenGLFramebufferObject;
+class LutCalibrator;
 
 namespace ImageUtils {
 class FullScreenWidget;
@@ -148,6 +149,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
 
   // used for color calibration with 3DLUT
   QOpenGLFramebufferObject *m_fbo = NULL;
+  LutCalibrator *m_lutCalibrator  = NULL;
 
   enum Device3D {
     NONE,
@@ -412,6 +414,7 @@ public slots:
 
   void releaseBusyOnTabletMove() { m_isBusyOnTabletMove = false; }
 
+  void onContextAboutToBeDestroyed();
 signals:
 
   void onZoomChanged();

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -96,8 +96,7 @@ void StyleSample::setStyle(TColorStyle &style) {
 */
 void StyleSample::setColor(const TPixel32 &pixel) {
   QColor color(pixel.r, pixel.g, pixel.b, pixel.m);
-  if (LutCalibrator::instance()->isValid())
-    LutCalibrator::instance()->convert(color);
+  if (LutManager::instance()->isValid()) LutManager::instance()->convert(color);
 
   m_samplePixmap.fill(color.rgba());
   update();

--- a/toonz/sources/toonzqt/combohistogram.cpp
+++ b/toonz/sources/toonzqt/combohistogram.cpp
@@ -322,9 +322,9 @@ void ComboHistoRGBLabel::paintEvent(QPaintEvent *pe) {
     return;
   }
 
-  if (LutCalibrator::instance()->isValid()) {
+  if (LutManager::instance()->isValid()) {
     QColor convertedColor(m_color);
-    LutCalibrator::instance()->convert(convertedColor);
+    LutManager::instance()->convert(convertedColor);
     p.setBrush(convertedColor);
   } else
     p.setBrush(m_color);

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -430,8 +430,20 @@ QSize PageViewer::getChipSize() const {
 */
 void PageViewer::drawColorChip(QPainter &p, QRect &chipRect,
                                TColorStyle *style) {
-  TRaster32P icon = style->getIcon(qsize2Dimension(chipRect.size()));
-  p.drawPixmap(chipRect.left(), chipRect.top(), rasterToQPixmap(icon, false));
+  // draw with MainColor for TSolidColorStyle(3), TColorCleanupStyle(2001)
+  // and TBlackCleanupStyle(2002)
+  if (style->getTagId() == 3 || style->getTagId() == 2001 ||
+      style->getTagId() == 2002) {
+    QColor styleColor((int)style->getMainColor().r,
+                      (int)style->getMainColor().g,
+                      (int)style->getMainColor().b);
+    if (LutManager::instance()->isValid())
+      LutManager::instance()->convert(styleColor);
+    p.fillRect(chipRect, QBrush(styleColor));
+  } else {
+    TRaster32P icon = style->getIcon(qsize2Dimension(chipRect.size()));
+    p.drawPixmap(chipRect.left(), chipRect.top(), rasterToQPixmap(icon, false));
+  }
   p.drawRect(chipRect);
 }
 
@@ -682,8 +694,8 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       // and TBlackCleanupStyle(2002)
       if (style->getTagId() == 3 || style->getTagId() == 2001 ||
           style->getTagId() == 2002) {
-        if (LutCalibrator::instance()->isValid())
-          LutCalibrator::instance()->convert(styleColor);
+        if (LutManager::instance()->isValid())
+          LutManager::instance()->convert(styleColor);
 
         p.fillRect(chipRect, QBrush(styleColor));
 


### PR DESCRIPTION
#1862 

Since the global shared OpenGL context is disabled, I made 3DLUT-related resources (`LutCalibrator`) to be held by each GL widget individually.
The LUT array data itself is loaded once and held in `LutManager` in order to share it between widgets. 