### PR TITLE
Fix "Replace Level..." Command Fails on the First Call

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -332,9 +332,10 @@ public:
   ReplaceLevelPopup();
 
   bool execute() override;
-  void show();
 
   void initFolder() override;
+  void setRange(TCellSelection::Range &range, std::set<int> &columnRange,
+                bool &replaceCells);
 
 protected slots:
   void onSelectionChanged(TSelection *selection);


### PR DESCRIPTION
Please refer to the previous fix #1626 . 

>"Replace Parent Directory" always fails when you use the command for the first time after launching the software. It fails with an error message `Nothing to replace: no cells or columns selected` even if you surely select cells or columns before using this command.

It was found that the same problem occurs with "Replace Level..." command as well.

The problem was fixed just in the same manner.
I made a class template `OpenReplaceFilePopupHandler` in order to be used by both commands.