### PR TITLE
Fix OSX Menu Items

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1424,6 +1424,9 @@ QAction *MainWindow::createAction(const char *id, const QString &name,
   if (strcmp(id, MI_ShortcutPopup) == 0) {
     action->setMenuRole(QAction::NoRole);
   }
+  if (strcmp(id,MI_ExitGroup) == 0) {
+    action->setMenuRole(QAction::NoRole);
+  }
 #endif
   CommandManager::instance()->define(id, type, defaultShortcut.toStdString(),
                                      action);


### PR DESCRIPTION
This fixes #1874 and part of #618. 

Exit group was automatically replacing quit since exit is part of the name. This made it look like quit was there but disabled and like there was no exit group menu item. In fact, there was no visible quit item and a wrongly named exit group item. Giving exit group norole, returns both quit and exit group to behaving as is intended.