### PR TITLE
Add a standard issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,10 +1,11 @@
-**(Try to follow this template as much as possible. Also, please note that feature requests should instead be posted in the [official forums](https://groups.google.com/forum/#!categories/opentoonz_en/feature-requests). Thank you!)**
+**(Try to fill in this template as much as possible. Also, please note that troubleshooting and feature requests should instead be posted in the [official forums](https://groups.google.com/forum/#!categories/opentoonz_en). Thank you!)**
 
 ### Prerequisites
 
 * [ ] Can you reproduce the problem?
 * [ ] Are you running the [latest version](https://github.com/opentoonz/opentoonz/releases/latest)? (You can also try the [latest nightly](https://github.com/opentoonz/opentoonz/releases/tag/nightly), which includes cutting-edge features and fixes.)
 * [ ] Does your computer meet the [minimum system requirements](https://opentoonz.github.io/)?
+* [ ] Is your computer up-to-date, including your device drivers?
 * [ ] Did you perform a [cursory search](https://github.com/opentoonz/opentoonz/issues)?
 
 ### Description
@@ -23,12 +24,16 @@
 
 ### Environment
 
-**OpenToonz version:**
-
-**Operating system:**
-
-**Computer specifications:** [Try to include your CPU, GPU, RAM, and remaining hard disk space, as well as graphic tablet model if applicable.]
+- **OpenToonz version:**
+- **Operating system:**
+- **Computer specifications:**
+  - Desktop or laptop model, if applicable:
+  - CPU:
+  - RAM:
+  - GPU:
+  - Hard disk and remaining space:
+  - Graphic tablet model, if applicable:
 
 ### Screenshot, Screencast, or Crash Logs
 
-[GitHub supports [basic file sharing](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/).]
+[GitHub supports [basic file sharing](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/). You can also link to a third-party service.]

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -9,7 +9,7 @@
 
 ### Description
 
-[Description of the bug or feature]
+[Description of the bug]
 
 ### Steps to Reproduce
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -24,7 +24,9 @@
 ### Environment
 
 **OpenToonz version:**
+
 **Operating system:**
+
 **Computer specifications:** [Try to include your CPU, GPU, RAM, and remaining hard disk space, as well as graphic tablet model if applicable.]
 
 ### Screenshot, Screencast, or Crash Logs

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+**(Try to follow this template as much as possible. Also, please note that feature requests should instead be posted in the [official forums](https://groups.google.com/forum/#!categories/opentoonz_en/feature-requests). Thank you!)**
+
+### Prerequisites
+
+* [ ] Can you reproduce the problem?
+* [ ] Are you running the [latest version](https://github.com/opentoonz/opentoonz/releases/latest)? (You can also try the [latest nightly](https://github.com/opentoonz/opentoonz/releases/tag/nightly), which includes cutting-edge features and fixes.)
+* [ ] Does your computer meet the [minimum system requirements](https://opentoonz.github.io/)?
+* [ ] Did you perform a [cursory search](https://github.com/opentoonz/opentoonz/issues)?
+
+### Description
+
+[Description of the bug or feature]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expected to happen]
+
+**Actual behavior:** [What actually happened]
+
+### Environment
+
+**OpenToonz version:**
+**Operating system:**
+**Computer specifications:** [Try to include your CPU, GPU, RAM, and remaining hard disk space, as well as graphic tablet model if applicable.]
+
+### Screenshot, Screencast, or Crash Logs
+
+[GitHub supports [basic file sharing](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/).]


### PR DESCRIPTION
This will appear every time someone opens a new issue. It will hopefully make it easier for people to create meaningful bug reports. The documentation is here: https://help.github.com/articles/creating-an-issue-template-for-your-repository/.