### PR TITLE
Add audio toggle back to flipbook for Mac

### DIFF
--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -672,9 +672,6 @@ protected:
 //-----------------------------------------------------------------------------
 
 void FlipConsole::enableButton(UINT button, bool enable, bool doShowHide) {
-#if defined(MACOSX)  // on mac, the sound playback in flip is broken..
-  if (button == eSound) enable = false;
-#endif
 
   if (!m_playToolBar) return;
 


### PR DESCRIPTION
This fixes #1725. The audio button was deliberately disabled on macOS in flipconsole.cpp due to broken sound playback on macOS. Since @turtletooth fixed the playback issues for Mac, disabling the button is no longer necessary.