### PR TITLE
Fix slow Toonz Raster brush on High DPI

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -1264,11 +1264,14 @@ void BrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
         m_tileSaver->save(m_rasterTrack->getLastRect());
         m_rasterTrack->generateLastPieceOfStroke(m_pencil.getValue());
 
-        m_smoothStroke.beginStroke(m_smooth.getValue());
-        m_smoothStroke.addPoint(thickPoint);
         std::vector<TThickPoint> pts;
-        m_smoothStroke.getSmoothPoints(
-            pts);  // skip first point because it has been outputted
+        if (m_smooth.getValue() == 0) {
+          pts.push_back(thickPoint);
+        } else {
+          m_smoothStroke.beginStroke(m_smooth.getValue());
+          m_smoothStroke.addPoint(thickPoint);
+          m_smoothStroke.getSmoothPoints(pts);
+        }
       } else {
         m_points.clear();
         TThickPoint point(pos + rasCenter, thickness);
@@ -1286,11 +1289,14 @@ void BrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
                                      m_styleId, drawOrder);
         m_lastRect = m_strokeRect;
 
-        m_smoothStroke.beginStroke(m_smooth.getValue());
-        m_smoothStroke.addPoint(point);
         std::vector<TThickPoint> pts;
-        m_smoothStroke.getSmoothPoints(
-            pts);  // skip first point because it has been outputted
+        if (m_smooth.getValue() == 0) {
+          pts.push_back(point);
+        } else {
+          m_smoothStroke.beginStroke(m_smooth.getValue());
+          m_smoothStroke.addPoint(point);
+          m_smoothStroke.getSmoothPoints(pts);
+        }
       }
       /*-- 作業中のFidを登録 --*/
       m_workingFrameId = getFrameId();
@@ -1343,9 +1349,13 @@ void BrushTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
       if (!m_pencil.getValue()) thickness -= 1.0;
 
       TThickPoint thickPoint(pos + rasCenter, thickness);
-      m_smoothStroke.addPoint(thickPoint);
       std::vector<TThickPoint> pts;
-      m_smoothStroke.getSmoothPoints(pts);
+      if (m_smooth.getValue() == 0) {
+        pts.push_back(thickPoint);
+      } else {
+        m_smoothStroke.addPoint(thickPoint);
+        m_smoothStroke.getSmoothPoints(pts);
+      }
       for (size_t i = 0; i < pts.size(); ++i) {
         const TThickPoint &thickPoint = pts[i];
         isAdded                       = m_rasterTrack->add(thickPoint);
@@ -1377,9 +1387,13 @@ void BrushTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
       // antialiased brush
       assert(m_workRas.getPointer() && m_backupRas.getPointer());
       TThickPoint thickPoint(pos + rasCenter, thickness);
-      m_smoothStroke.addPoint(thickPoint);
       std::vector<TThickPoint> pts;
-      m_smoothStroke.getSmoothPoints(pts);
+      if (m_smooth.getValue() == 0) {
+        pts.push_back(thickPoint);
+      } else {
+        m_smoothStroke.addPoint(thickPoint);
+        m_smoothStroke.getSmoothPoints(pts);
+      }
       bool rectUpdated = false;
       for (size_t i = 0; i < pts.size(); ++i) {
         TThickPoint old = m_points.back();
@@ -1800,10 +1814,14 @@ void BrushTool::finishRasterBrush(const TPointD &pos, double pressureVal) {
 
     TRectD invalidateRect;
     TThickPoint thickPoint(pos + rasCenter, thickness);
-    m_smoothStroke.addPoint(thickPoint);
-    m_smoothStroke.endStroke();
     std::vector<TThickPoint> pts;
-    m_smoothStroke.getSmoothPoints(pts);
+    if (m_smooth.getValue() == 0) {
+      pts.push_back(thickPoint);
+    } else {
+      m_smoothStroke.addPoint(thickPoint);
+      m_smoothStroke.endStroke();
+      m_smoothStroke.getSmoothPoints(pts);
+    }
     for (size_t i = 0; i < pts.size(); ++i) {
       const TThickPoint &thickPoint = pts[i];
       bool isAdded                  = m_rasterTrack->add(thickPoint);
@@ -1855,10 +1873,14 @@ void BrushTool::finishRasterBrush(const TPointD &pos, double pressureVal) {
       TRectD invalidateRect;
       bool rectUpdated = false;
       TThickPoint thickPoint(pos + rasCenter, thickness);
-      m_smoothStroke.addPoint(thickPoint);
-      m_smoothStroke.endStroke();
       std::vector<TThickPoint> pts;
-      m_smoothStroke.getSmoothPoints(pts);
+      if (m_smooth.getValue() == 0) {
+        pts.push_back(thickPoint);
+      } else {
+        m_smoothStroke.addPoint(thickPoint);
+        m_smoothStroke.endStroke();
+        m_smoothStroke.getSmoothPoints(pts);
+      }
       for (size_t i = 0; i < pts.size() - 1; ++i) {
         TThickPoint old = m_points.back();
         if (norm2(pos - old) < 4) continue;
@@ -2154,8 +2176,8 @@ void BrushTool::checkGuideSnapping(bool beforeMousePress) {
         snapPoint.x = hGuide;
       }
       beforeMousePress ? m_foundFirstSnap = true : m_foundLastSnap = true;
-      beforeMousePress ? m_firstSnapPoint                          = snapPoint
-                       : m_lastSnapPoint                           = snapPoint;
+      beforeMousePress ? m_firstSnapPoint = snapPoint : m_lastSnapPoint =
+                                                            snapPoint;
     }
   }
 }


### PR DESCRIPTION
I don't know if anyone else has this issue, but when I use Toonz Raster levels on my Surface Pro, the brush stalls at the beginning of a stroke.  It only happens on Toonz Raster levels, but anything that I drew for the first second is smoothed even with 0 smoothing.

I'm not sure if this is the best way to solve it, but I just bypassed the smoothing code completely if the smooth factor was set to 0.  This seems to make a significant improvement.

I suspect that the high dpi of the screen is messing with the delay before the smoothing will start outputting a stroke, but I couldn't find where that might be happening.

This change at least allows me to use an unsmoothed brush with good performance.