### PR TITLE
Improvements to Vector Snap

### DIFF
--- a/toonz/sources/tnztools/brushtool.h
+++ b/toonz/sources/tnztools/brushtool.h
@@ -162,8 +162,8 @@ public:
   bool doFrameRangeStrokes(TFrameId firstFrameId, TStroke *firstStroke,
                            TFrameId lastFrameId, TStroke *lastStroke,
                            bool drawFirstStroke = true);
-  void checkGuideSnapping(bool beforeMousePress);
-  void checkStrokeSnapping(bool beforeMousePress);
+  void checkGuideSnapping(bool beforeMousePress, bool invertCheck);
+  void checkStrokeSnapping(bool beforeMousePress, bool invertCheck);
 
 protected:
   TPropertyGroup m_prop[2];


### PR DESCRIPTION
This makes two changes to Vector snapping
You can now snap to the starting point of a brush stroke.
Holding alt while drawing will invert whether snapping is on or off.  This will help if you only need snapping occasionally or if you want to quickly disable it.