### PR TITLE
Fixed redundant condition check in in initToonzEnv

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -166,15 +166,16 @@ static void initToonzEnv() {
 
   /*-- TOONZROOTのPathの確認 --*/
   // controllo se la xxxroot e' definita e corrisponde ad un folder esistente
+  
+  /*-- ENGLISH: Confirm TOONZROOT Path 
+  	Check if the xxxroot is defined and corresponds to an existing folder
+  --*/
+  
   TFilePath stuffDir = TEnv::getStuffDir();
-  if (stuffDir == TFilePath() || !TFileStatus(stuffDir).isDirectory()) {
-    if (stuffDir == TFilePath())
-      fatalError("Undefined or empty: \"" + toQString(TEnv::getRootVarPath()) +
-                 "\"");
-    else
-      fatalError("Folder \"" + toQString(stuffDir) +
-                 "\" not found or not readable");
-  }
+  if (stuffDir == TFilePath())
+      fatalError("Undefined or empty: \"" + toQString(TEnv::getRootVarPath()) + "\"");
+  else if (!TFileStatus(stuffDir).isDirectory())
+      fatalError("Folder \"" + toQString(stuffDir) + "\" not found or not readable");
 
   Tiio::defineStd();
   initImageIo();


### PR DESCRIPTION
Original code checks the condition (stuffDir == TFilePath()) twice, so I rewrote it so that it is only checked once, for efficiency. Also I translated the comment for this section of code to English to help future coders.