### PR TITLE
Fix Travis-OSX : Try Using the Latest Qt

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -4,7 +4,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt/5.9.2/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt/5.10.1/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make -j 2

--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -3,6 +3,6 @@ brew update
 brew install glew lz4 lzo libusb libmypaint
 brew tap tcr/tcr
 brew install clang-format
-# obtain qt5.9.2 from the previous version of the formula
-curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/9bc1bdd8d26747cffd7a18c31975f86cd0a97bc3/Formula/qt.rb
-brew install ./qt.rb
+# from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
+# so we start to use the latest version of Qt. (#1910)
+brew install qt


### PR DESCRIPTION
This is for fixing the recent Travis-OSX errors.
Since [Homebrew was updated on April 9](https://brew.sh/2018/04/09/homebrew-1.6.0/) , old formula for obtaining Qt5.9.2 seems to become invalid with error like as follows:

```
Error: Calling 'depends_on :mysql' is disabled!
Use 'depends_on "mysql"' instead.
```
In order to resolve it, this PR will try using the latest formula which will obtain Qt 5.10.1 .