### PR TITLE
Fix OSX menu roles

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1421,21 +1421,15 @@ QAction *MainWindow::createAction(const char *id, const QString &name,
 // To prevent the wrong menu items (due to MacOS menu naming conventions), from
 // taking Preferences, Quit, or About roles (sometimes happens unexpectedly in
 // translations) - all menu items should have "NoRole"
-  if (MenuFileCommandType || MenuEditCommandType || MenuScanCleanupCommandType
-      || MenuLevelCommandType || MenuXsheetCommandType || MenuCellsCommandType || 
-      MenuViewCommandType || MenuWindowsCommandType) {
-    action->setMenuRole(QAction::NoRole);
-  }
   //  except for Preferences, Quit, and About
-  if (strcmp(id, MI_Preferences) == 0) {
+  if (strcmp(id, MI_Preferences) == 0)
     action->setMenuRole(QAction::PreferencesRole);
-  }
-  if (strcmp(id, MI_Quit) == 0) {
+  else if (strcmp(id, MI_Quit) == 0)
     action->setMenuRole(QAction::QuitRole);
-  }
-  if (strcmp(id, MI_About) == 0) {
+  else if (strcmp(id, MI_About) == 0)
     action->setMenuRole(QAction::AboutRole);
-  }
+  else
+    action->setMenuRole(QAction::NoRole);
 #endif
   CommandManager::instance()->define(id, type, defaultShortcut.toStdString(),
                                      action);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1418,14 +1418,23 @@ QAction *MainWindow::createAction(const char *id, const QString &name,
   QAction *action = new DVAction(name, this);
   addAction(action);
 #ifdef MACOSX
+// To prevent the wrong menu items (due to MacOS menu naming conventions), from
+// taking Preferences, Quit, or About roles (sometimes happens unexpectedly in
+// translations) - all menu items should have "NoRole"
+  if (MenuFileCommandType || MenuEditCommandType || MenuScanCleanupCommandType
+      || MenuLevelCommandType || MenuXsheetCommandType || MenuCellsCommandType || 
+      MenuViewCommandType || MenuWindowsCommandType) {
+    action->setMenuRole(QAction::NoRole);
+  }
+  //  except for Preferences, Quit, and About
   if (strcmp(id, MI_Preferences) == 0) {
     action->setMenuRole(QAction::PreferencesRole);
   }
-  if (strcmp(id, MI_ShortcutPopup) == 0) {
-    action->setMenuRole(QAction::NoRole);
+  if (strcmp(id, MI_Quit) == 0) {
+    action->setMenuRole(QAction::QuitRole);
   }
-  if (strcmp(id,MI_ExitGroup) == 0) {
-    action->setMenuRole(QAction::NoRole);
+  if (strcmp(id, MI_About) == 0) {
+    action->setMenuRole(QAction::AboutRole);
   }
 #endif
   CommandManager::instance()->define(id, type, defaultShortcut.toStdString(),


### PR DESCRIPTION
This fixes #534 and any other potential translation issues for menu items with OS X. 

Any menu items with certain keywords can override the About, Preferences, or Quit item due to naming conventions/behaviors in OS X.   Instead of adding "NoRole" to each problem menu item as it is found, this adds "NoRole" to all menu items. The menu items all stay in position as a result. Then the About, Preferences, and Quit menu items are assigned their correct role & will be placed per Mac conventions. This should prevent any hard to predict translation issues or potential problems with new menu items.