### PR TITLE
Fix touch controls for touchpad and stylus issue

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -100,6 +100,9 @@ void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
   toonzEvent.m_buttons  = event->buttons();
   toonzEvent.m_button   = event->button();
   toonzEvent.m_isTablet = true;
+  // this delays autosave during stylus button press until after the next 
+  // brush stroke - this minimizes problems from interruptions to tablet input
+  TApp::instance()->getCurrentTool()->setToolBusy(true);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This changes the touch controls so that they are fully usable on computers with touchpads #1579. This should not impact touch screen devices and will not change any behaviors when touch is not active.
 
- 2 finger panning is enabled so that 1 finger can navigate and use tools (1 finger panning continues for touch screen devices)
- Enables disabled mouse behaviors when touch is active so that tools can be used again
- Mouse wheel scrolling behavior is disabled (when touch controls are active) to prevent jerky, simultaneous panning/zooming during 2 finger scrolling

The mouse wheel scrolling change is necessary but currently does add one unexpected (but noncritical) behavior: 
- after switching from touch to no touch, you need to click in the viewer before zooming in/out the first time using the 2 finger scrolling behavior

This also adds a fix for some undesired behaviors when autosave interrupts stylus button input, including #618 