### PR TITLE
Fix Undo of Move Styles

### DIFF
--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -205,7 +205,7 @@ public:
     int h     = m_dstIndexInPage;
     std::set<int>::const_iterator i;
     for (i = m_srcIndicesInPage.begin(); i != m_srcIndicesInPage.end(); ++i) {
-      if (srcPage == dstPage && (*i) <= h)
+      if (srcPage == dstPage && (*i) <= m_dstIndexInPage)
         h--;
       else
         break;


### PR DESCRIPTION
This PR will fix the following problem:
Undo of move styles (by Ctrl+drag the style selection) in the Palette sometime fails to restore the style order.

One of the minimum example to reproduce the problem is as follows:
1. Create palette with 7 styles. Select styles # 2 to # 5 and ctrl+drag them to the end.
1. Undo the operation.

![drag_styles_bug](https://user-images.githubusercontent.com/17974955/38851935-cc618d52-4252-11e8-80a1-33d809219801.png)
