### PR TITLE
Modifications on Studio Palette tree view

### DIFF
--- a/toonz/sources/toonzlib/studiopalette.cpp
+++ b/toonz/sources/toonzlib/studiopalette.cpp
@@ -256,9 +256,10 @@ TPalette *StudioPalette::getPalette(const TFilePath &path,
 void StudioPalette::movePalette(const TFilePath &dstPath,
                                 const TFilePath &srcPath) {
   try {
-    TSystem::renameFile(dstPath, srcPath);
+    // do not allow overwrite palette
+    TSystem::renameFile(dstPath, srcPath, false);
   } catch (...) {
-    return;
+    throw;
   }
   std::wstring id = readPaletteGlobalName(dstPath);
   table.erase(id);

--- a/toonz/sources/toonzlib/studiopalette.cpp
+++ b/toonz/sources/toonzlib/studiopalette.cpp
@@ -279,8 +279,18 @@ int StudioPalette::getChildren(std::vector<TFilePath> &fps,
     }
   }
 
-  for (TFilePathSet::iterator i = q.begin(); i != q.end(); ++i)
-    if (isFolder(*i) || isPalette(*i)) fps.push_back(*i);
+  // put the folders above the palette items
+  std::vector<TFilePath> palettes;
+  for (TFilePathSet::iterator i = q.begin(); i != q.end(); ++i) {
+    if (isFolder(*i))
+      fps.push_back(*i);
+    else if (isPalette(*i))
+      palettes.push_back(*i);
+  }
+  if (!palettes.empty()) {
+    fps.reserve(fps.size() + palettes.size());
+    std::copy(palettes.begin(), palettes.end(), std::back_inserter(fps));
+  }
   //  fps.push_back(m_root+"butta.tpl");
   return fps.size();
 }

--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -241,10 +241,13 @@ public:
 
 class MovePaletteUndo final : public TUndo {
   TFilePath m_dstPath, m_srcPath;
+  bool m_isRename;
 
 public:
   MovePaletteUndo(const TFilePath &dstPath, const TFilePath &srcPath)
-      : m_dstPath(dstPath), m_srcPath(srcPath) {}
+      : m_dstPath(dstPath), m_srcPath(srcPath) {
+    m_isRename = (m_srcPath.getParentDir() == m_dstPath.getParentDir());
+  }
 
   void undo() const override {
     StudioPalette::instance()->movePalette(m_srcPath, m_dstPath);
@@ -254,10 +257,15 @@ public:
   }
   int getSize() const override { return sizeof(*this); }
   QString getHistoryString() override {
-    return QObject::tr("Move Studio Palette Folder  : %1 : %2 > %3")
-        .arg(QString::fromStdString(m_srcPath.getName()))
-        .arg(QString::fromStdString(m_srcPath.getParentDir().getName()))
-        .arg(QString::fromStdString(m_dstPath.getParentDir().getName()));
+    if (m_isRename)
+      return QObject::tr("Rename Studio Palette : %1 > %2")
+          .arg(QString::fromStdString(m_srcPath.getName()))
+          .arg(QString::fromStdString(m_dstPath.getName()));
+    else
+      return QObject::tr("Move Studio Palette Folder  : %1 : %2 > %3")
+          .arg(QString::fromStdString(m_srcPath.getName()))
+          .arg(QString::fromStdString(m_srcPath.getParentDir().getName()))
+          .arg(QString::fromStdString(m_dstPath.getParentDir().getName()));
   }
   int getHistoryType() override { return HistoryType::Palette; }
 };

--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -10,6 +10,7 @@
 #include "tconvert.h"
 #include "ttoonzimage.h"
 #include "timagecache.h"
+#include "tmsgcore.h"
 
 #include "toonz/studiopalette.h"
 #include "toonz/toonzscene.h"
@@ -250,10 +251,29 @@ public:
   }
 
   void undo() const override {
-    StudioPalette::instance()->movePalette(m_srcPath, m_dstPath);
+    QString errorStr = (m_isRename) ? QObject::tr("Can't undo rename palette")
+                                    : QObject::tr("Can't undo move palette");
+    try {
+      StudioPalette::instance()->movePalette(m_srcPath, m_dstPath);
+    } catch (TException &e) {
+      DVGui::error(errorStr + " : " +
+                   QString(::to_string(e.getMessage()).c_str()));
+    } catch (...) {
+      DVGui::error(errorStr);
+    }
   }
+
   void redo() const override {
-    StudioPalette::instance()->movePalette(m_dstPath, m_srcPath);
+    QString errorStr = (m_isRename) ? QObject::tr("Can't redo rename palette")
+                                    : QObject::tr("Can't redo move palette");
+    try {
+      StudioPalette::instance()->movePalette(m_dstPath, m_srcPath);
+    } catch (TException &e) {
+      DVGui::error(errorStr + ":" +
+                   QString(::to_string(e.getMessage()).c_str()));
+    } catch (...) {
+      DVGui::error(errorStr);
+    }
   }
   int getSize() const override { return sizeof(*this); }
   QString getHistoryString() override {


### PR DESCRIPTION
This PR will modify dragging behavior in the tree view of Studio Palette window as follows:

- Made a confirmation dialog to be opened before drag&move palette inside the tree view in order to prevent unintended moving files by mistake. Since the studio palette is usually shared among studio staffs, I think it is reasonable to take users attention on modifying it.
- Drag an item and drop on another palette item will now cause moving the selected item to the same folder as such palette. Before this PR, dropping on another palette caused nothing (but the operation added an useless undo).
- Item order in the tree view is changed for simplicity. Now all sub-folder items are put above palette items. Before this PR, items were all mixed up and put in alphabetical order.

This modification was requested by some Japanese animation studio.