### PR TITLE
Fix Viewer Updating

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -928,7 +928,11 @@ void SceneViewer::drawEnableScissor() {
 //-----------------------------------------------------------------------------
 
 void SceneViewer::drawDisableScissor() {
-  if (!m_clipRect.isEmpty() && !m_draw3DMode) glDisable(GL_SCISSOR_TEST);
+  if (!m_clipRect.isEmpty() && !m_draw3DMode) {
+    glDisable(GL_SCISSOR_TEST);
+    // clear the clipping rect
+    m_clipRect.empty();
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This will fix #1897 and #1918 .
UPDATE : This will fix #1901 as well.

Added clearing of the `m_clipRect` at the end of updating of the viewer, so that the partial update will be active only once.
By clearing `m_clipRect` , subsequent updates of the viewer will be done in the entire window.