### PR TITLE
Fix symlink crashes (alternative to #1842)

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -411,7 +411,7 @@ void Ffmpeg::getFramesFromMovie(int frame) {
 
 QString Ffmpeg::cleanPathSymbols() {
   return m_path.getQString().remove(QRegExp(
-      QString::fromUtf8("[-`~!@#$%^&*()_E=|:;<>«»,.?/{}\'\"\\[\\]\\\\]")));
+      QString::fromUtf8("[-`~!@#$%^&*()_Â—+=|:;<>Â«Â»,.?/{}\'\"\\[\\]\\\\]")));
 }
 
 int Ffmpeg::getGifFrameCount() {

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -189,6 +189,9 @@ QString Ffmpeg::runFfprobe(QStringList args) {
   results += ffmpeg.readAllStandardOutput();
   int exitCode = ffmpeg.exitCode();
   ffmpeg.close();
+  // If the url cannot be opened or recognized as a multimedia file, ffprobe
+  // returns a positive exit code.
+  if (exitCode > 0) throw TImageException(m_path, "error reading info.");
   std::string strResults = results.toStdString();
   return results;
 }
@@ -408,7 +411,7 @@ void Ffmpeg::getFramesFromMovie(int frame) {
 
 QString Ffmpeg::cleanPathSymbols() {
   return m_path.getQString().remove(QRegExp(
-      QString::fromUtf8("[-`~!@#$%^&*()_ó+=|:;<>´ª,.?/{}\'\"\\[\\]\\\\]")));
+      QString::fromUtf8("[-`~!@#$%^&*()_ÅE=|:;<>´ª,.?/{}\'\"\\[\\]\\\\]")));
 }
 
 int Ffmpeg::getGifFrameCount() {

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -689,7 +689,8 @@ void FileBrowser::setFolder(const TFilePath &fp, bool expandNode,
 
   refreshCurrentFolderItems();
 
-  m_folderTreeView->setCurrentNode(fp, expandNode);
+  if (!TFileStatus(fp).isLink())
+    m_folderTreeView->setCurrentNode(fp, expandNode);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes #1227 and #984 , with keeping the symbolic link available.
This is alternative to #1842.

Please note that OT can handle symbolic links (which can be created with `ln -s` command), but seems to have no capability to resolve macOS aliases (created by `File > Make Alias` command, or by pressing `Command-L`) due to the Qt bug ([QTBUG-23927](https://bugreports.qt.io/browse/QTBUG-23927)).
Actually I wasn't aware of the difference of them before investigating this.