### PR TITLE
Allow for multilingual FX Help tooltips by jpturcotte (modified)

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath_io.cpp
+++ b/toonz/sources/common/tsystem/tfilepath_io.cpp
@@ -31,8 +31,12 @@ FILE *fopen(const TFilePath &fp, string mode) {
   return pFile;
 }
 
-Tifstream::Tifstream(const TFilePath &fp)
-    : ifstream(m_file = fopen(fp, "rb")) {}
+Tifstream::Tifstream(const TFilePath &fp) : ifstream(m_file = fopen(fp, "rb")) {
+  // manually set the fail bit here, since constructor ifstream::ifstream(FILE*)
+  // does not so even if the argument is null pointer.
+  // the state will be refered in "TIStream::operator bool()" ( in tstream.cpp )
+  if (!m_file) setstate(failbit);
+}
 
 Tifstream::~Tifstream() {
   if (m_file) {
@@ -47,7 +51,12 @@ void Tifstream::close() {
 }
 
 Tofstream::Tofstream(const TFilePath &fp, bool append_existing)
-    : ofstream(m_file = fopen(fp, append_existing ? "ab" : "wb")) {}
+    : ofstream(m_file = fopen(fp, append_existing ? "ab" : "wb")) {
+  // manually set the fail bit here, since constructor ofstream::ofstream(FILE*)
+  // does not so even if the argument is null pointer.
+  // the state will be refered in "TOStream::operator bool()" ( in tstream.cpp )
+  if (!m_file) setstate(failbit);
+}
 
 Tofstream::~Tofstream() {
   if (m_file) {

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -824,12 +824,8 @@ void ParamsPageSet::createControls(const TFxP &fx, int index) {
   TFilePath fp = ToonzFolder::getProfileFolder() + "layouts" + "fxs" +
                  (fx->getFxType() + ".xml");
 
-  // Verify XML file exists
-  if (!TFileStatus(fp).doesExist()) {
-	  return;
-  }
-  
   TIStream is(fp);
+  if (!is) return;
 
   if (fx->getParams()->getParamCount()) {
     try {
@@ -915,12 +911,11 @@ void ParamsPageSet::openHelpFile() {
   std::string helpDocLang = currentLanguage.toStdString();
 
   // Assume associated language subdir exists
-  TFilePath helpFp =
-      TEnv::getStuffDir() + TFilePath("doc") + TFilePath(helpDocLang) + TFilePath(m_helpFilePath);
-  
+  TFilePath helpFp = TEnv::getStuffDir() + "doc" + helpDocLang + m_helpFilePath;
+
   // Verify subdir exists; if not, default to standard doc dir
   if (!TFileStatus(helpFp).doesExist()) {
-	  helpFp = TEnv::getStuffDir() + TFilePath("doc") + TFilePath(m_helpFilePath);
+    helpFp = TEnv::getStuffDir() + "doc" + m_helpFilePath;
   }
 
   // commandString +=


### PR DESCRIPTION
This PR is based on #1861 by @jpturcotte .

It seems that `TIStream::operator bool()` is overloaded for checking whether the file is successfully opened.
However, it doesn't work on Windows because `explicit basic_ifstream::basic_ifstream(_Filet *_File)` does not set `ios_base::failbit` in constructor even if `_File` is null.
This PR will fix such problem by setting `failbit` manually in the constructor of `Tifstream` in case it fails to open the file.

I also modified `Tofstream` in the same manner.

Regarding the multilingual Fx help files, I confirmed it works fine. (Thank you @jpturcotte for that!)
I think the default help files (to be put in `OpenToonz 1.2 stuff/doc/`) can be replaced by English ones as soon as they are ready, in order to coordinate with the default UI language.