### PR TITLE
Fix tabletEvent not to call onMove when the cursor position does not move

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -313,7 +313,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       break;
     }
 #endif
-    QPoint curPos = e->pos() * getDevPixRatio();
+    QPointF curPos = e->posF() * getDevPixRatio();
     // It seems that the tabletEvent is called more often than mouseMoveEvent.
     // So I fire the interval timer in order to limit the following process
     // to be called in 50fps in maximum.


### PR DESCRIPTION
This will fix the following problem:
When using tablet, `TTool::leftButtonDrag()` is called continuously even if the cursor does not move.

There was a condition expression to prevent calling `onMove` if the cursor does not move from the previous position, but it didn't work properly since it compared `QPoint` (integer) and `QPointF` (decimal fraction).

I found this bug while reviewing #1904 and I think this PR will also relieve the slowness mentioned in #1904 .