### PR TITLE
Fix Shortcut Behavior on Tool Option Combobox 

### DIFF
--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -63,7 +63,7 @@ void ToolOptionControl::notifyTool(bool addToUndo) {
 //-----------------------------------------------------------------------------
 /*! return true if the control is belonging to the visible combo viewer. very
  * dirty implementation.
-*/
+ */
 bool ToolOptionControl::isInVisibleViewer(QWidget *widget) {
   if (!widget) return false;
 
@@ -605,7 +605,7 @@ void ToolOptionCombo::loadEntries() {
                       }");
       }
     }
-    int tmpWidth                      = fontMetrics().width(items[i].UIName);
+    int tmpWidth = fontMetrics().width(items[i].UIName);
     if (tmpWidth > maxWidth) maxWidth = tmpWidth;
   }
 
@@ -639,8 +639,8 @@ void ToolOptionCombo::onActivated(int index) {
 
 void ToolOptionCombo::doShowPopup() {
   if (Preferences::instance()->getDropdownShortcutsCycleOptions()) {
-    const TEnumProperty::Range &range           = m_property->getRange();
-    int theIndex                                = currentIndex() + 1;
+    const TEnumProperty::Range &range = m_property->getRange();
+    int theIndex                      = currentIndex() + 1;
     if (theIndex >= (int)range.size()) theIndex = 0;
     doOnActivated(theIndex);
   } else {
@@ -657,7 +657,7 @@ void ToolOptionCombo::doOnActivated(int index) {
   bool cycleOptions =
       Preferences::instance()->getDropdownShortcutsCycleOptions();
   // Just move the index if the first item is not "Normal"
-  if (itemText(0) != "Normal") {
+  if (m_property->indexOf(L"Normal") != 0) {
     onActivated(index);
     setCurrentIndex(index);
     // for updating the cursor
@@ -1344,8 +1344,8 @@ void PegbarCenterField::onChange(TMeasuredValue *fld, bool addToUndo) {
 
   TStageObject *obj = xsh->getStageObject(objId);
 
-  double v                           = fld->getValue(TMeasuredValue::MainUnit);
-  TPointD center                     = obj->getCenter(frame);
+  double v       = fld->getValue(TMeasuredValue::MainUnit);
+  TPointD center = obj->getCenter(frame);
   if (!m_firstMouseDrag) m_oldCenter = center;
   if (m_index == 0)
     center.x = v;
@@ -1436,7 +1436,7 @@ PropertyMenuButton::PropertyMenuButton(QWidget *parent, TTool *tool,
   setIcon(icon);
   setToolTip(tooltip);
 
-  QMenu *menu                     = new QMenu(tooltip, this);
+  QMenu *menu = new QMenu(tooltip, this);
   if (!tooltip.isEmpty()) tooltip = tooltip + " ";
 
   QActionGroup *actiongroup = new QActionGroup(this);
@@ -1522,13 +1522,13 @@ bool SelectionScaleField::applyChange(bool addToUndo) {
     return false;
   DragSelectionTool::DragTool *scaleTool = createNewScaleTool(m_tool, 0);
   double p                               = getValue();
-  if (p == 0) p                          = 0.00001;
-  DragSelectionTool::FourPoints points   = m_tool->getBBox();
-  TPointD center                         = m_tool->getCenter();
-  TPointD p0M                            = points.getPoint(7);
-  TPointD p1M                            = points.getPoint(5);
-  TPointD pM1                            = points.getPoint(6);
-  TPointD pM0                            = points.getPoint(4);
+  if (p == 0) p = 0.00001;
+  DragSelectionTool::FourPoints points = m_tool->getBBox();
+  TPointD center                       = m_tool->getCenter();
+  TPointD p0M                          = points.getPoint(7);
+  TPointD p1M                          = points.getPoint(5);
+  TPointD pM1                          = points.getPoint(6);
+  TPointD pM0                          = points.getPoint(4);
   int pointIndex;
   TPointD sign(1, 1);
   TPointD scaleFactor = m_tool->m_deformValues.m_scaleValue;


### PR DESCRIPTION
This PR will fix the following problem:

For the property of which the first item in the combobox is "Normal" , pressing the shortcut key for another item (for instance, "Rectangular") could change back and forth between "Normal" and such item.
(That is to say, pressing "Rectangular" shortcut key when the property is already set to "Rectangular", the option will change to "Normal".)
However, after introducing #1863 this feature does not work on non-English UI.