### PR TITLE
Update default OS X UI font

### DIFF
--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -226,6 +226,8 @@ Preferences::Preferences()
     , m_scanLevelType("tif")
 #ifdef _WIN32
     , m_interfaceFont("Segoe UI")
+#elif Q_OS_MACOS
+    , m_interfaceFont("Helvetica Neue")
 #else
     , m_interfaceFont("Helvetica")
 #endif

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -226,7 +226,7 @@ Preferences::Preferences()
     , m_scanLevelType("tif")
 #ifdef _WIN32
     , m_interfaceFont("Segoe UI")
-#elif Q_OS_MACOS
+#elif defined Q_OS_MACOS
     , m_interfaceFont("Helvetica Neue")
 #else
     , m_interfaceFont("Helvetica")


### PR DESCRIPTION
This changes the default UI font for OS X from Helvetica to Helvetica Neue. Helvetica has several alignment and clipping issues which are not a problem in Helvetica Neue.