### PR TITLE
Fix Wheel Event to Be Disabled while Touch Gesture 

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -796,6 +796,9 @@ void SceneViewer::resetTabletStatus() {
 
 void SceneViewer::wheelEvent(QWheelEvent *event) {
   if (m_freezedStatus != NO_FREEZED) return;
+  // Trackpad invokes wheel event by two finger scrolling and may conflict with
+  // OT's touch gestures. So reject wheel event if gesture is active.
+  if (m_gestureActive) return;
 
   int delta = 0;
   switch (event->source()) {


### PR DESCRIPTION
This will fix the problem mentioned by @artisteacher in the comment of #1905 as follows:

>Another issue with zooming (probably OS X specific), is that with trackpads, a two finger scrolling gesture is read as middle mouse wheel input. This triggers zooming in/out. By itself that's not a big deal but the standard (and expected) trackpad scrolling/panning behavior in OS X uses two fingers. Currently, changing panning to the standard two finger gesture results in a jerky, simultaneous zooming and panning behavior. With touch controls enabled, mouse wheel scrolling should really be disabled - at least for OS X.

I made the `wheelEvent()` not to zoom while touch gesture.