### PR TITLE
Fix of Brush Tip Display

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -522,7 +522,7 @@ void SceneViewer::setVisual(const ImagePainter::VisualSettings &settings) {
   m_visualSettings = settings;
   m_visualSettings.m_sceneProperties =
       TApp::instance()->getCurrentScene()->getScene()->getProperties();
-  if (repaint) update();
+  if (repaint) GLInvalidateAll();
 }
 
 //-----------------------------------------------------------------------------
@@ -602,7 +602,7 @@ void SceneViewer::freeze(bool on) {
     setCursor(Qt::ForbiddenCursor);
     m_freezedStatus = UPDATE_FREEZED;
   }
-  update();
+  GLInvalidateAll();
 }
 
 //-------------------------------------------------------------------------------
@@ -633,7 +633,7 @@ void SceneViewer::enablePreview(int previewMode) {
 
   m_previewMode = previewMode;
 
-  update();
+  GLInvalidateAll();
 
   // for updating the title bar
   emit previewToggled();
@@ -1715,7 +1715,12 @@ void SceneViewer::GLInvalidateAll() {
 //-----------------------------------------------------------------------------
 
 void SceneViewer::GLInvalidateRect(const TRectD &rect) {
-  m_clipRect = rect;
+  // there is a case that this function is called more than once before
+  // paintGL() is called
+  if (!m_clipRect.isEmpty())
+    m_clipRect += rect;
+  else
+    m_clipRect = rect;
   update();
   if (m_vRuler) m_vRuler->update();
   if (m_hRuler) m_hRuler->update();
@@ -2154,7 +2159,7 @@ void SceneViewer::onXsheetChanged() {
   TTool *tool    = TApp::instance()->getCurrentTool()->getTool();
   if (tool && tool->isEnabled()) tool->updateMatrix();
   onLevelChanged();
-  update();
+  GLInvalidateAll();
 }
 
 //-----------------------------------------------------------------------------
@@ -2163,14 +2168,14 @@ void SceneViewer::onObjectSwitched() {
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   if (tool && tool->isEnabled()) tool->updateMatrix();
   onLevelChanged();
-  update();
+  GLInvalidateAll();
 }
 
 //-----------------------------------------------------------------------------
 
 void SceneViewer::onSceneChanged() {
   onLevelChanged();
-  update();
+  GLInvalidateAll();
 }
 
 //-----------------------------------------------------------------------------
@@ -2185,7 +2190,7 @@ void SceneViewer::onFrameSwitched() {
     tool->onEnter();
   }
 
-  update();
+  GLInvalidateAll();
 }
 
 //-----------------------------------------------------------------------------
@@ -2194,7 +2199,7 @@ void SceneViewer::onFrameSwitched() {
 void SceneViewer::onToolChanged() {
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   if (tool) setToolCursor(this, tool->getCursorId());
-  update();
+  GLInvalidateAll();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1046,7 +1046,7 @@ bool SceneViewer::event(QEvent *e) {
   if (e->type() == QEvent::MouseButtonPress)
     clock.start();
   else if (e->type() == QEvent::MouseMove) {
-    if (clock.elapsed() < 10) {
+    if (clock.isValid() && clock.elapsed() < 10) {
       e->accept();
       return true;
     }


### PR DESCRIPTION
This PR fixes some problems regarding displaying and refreshing of the brush tip (= a red circle displayed when using Brush tool).

- Fixed #1950 . ( Hopefully it will work. Please note that I tested only on Windows yet and will remove `WIP` after checking on OSX. )
- Fixed #1899. A problem that the brush tip stuck at the center of the viewer and does not move along the cursor when the first use of the brush tool after launch. It will fix the similar problem in all other tools as well.
- Enhanced the brush tip response when moving the cursor without any mouse buttons being pressed.  ( I introduced partial GL update for `BrushTool::mouseMove()` as well. )