### PR TITLE
Add TNZ files to the Extension Whitelist of Checking Seqence

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -73,7 +73,8 @@ bool isNumbers(std::wstring str, int fromSeg, int toSeg) {
 }
 
 bool checkForSeqNum(QString type) {
-  if (type == "myb" || type == "tlv" || type == "pli" || type == "tpl")
+  if (type == "myb" || type == "tlv" || type == "pli" || type == "tpl" ||
+      type == "tnz")
     return false;
   return true;
 }


### PR DESCRIPTION
This quick patch will fix the following problem:

For now OT cannot load the scene with the name like `scene_44.tnz` .