### PR TITLE
Change Default Folder Location to $scenefolder According to User Preference

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -368,6 +368,16 @@ void FileBrowserPopup::showEvent(QShowEvent *) {
   if (m_currentProjectPath != projectPath) {
     m_currentProjectPath = projectPath;
     initFolder();
+
+    // set initial folder of all browsers to $scenefolder when the scene folder
+    // mode is set in user preferences
+    if (Preferences::instance()->getPathAliasPriority() ==
+        Preferences::SceneFolderAlias) {
+      ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+      if (scene && !scene->isUntitled())
+        setFolder(scene->getScenePath().getParentDir());
+    }
+
     m_nameField->update();
     m_nameField->setFocus();
   }

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1040,10 +1040,14 @@ void PencilTestSaveInFolderPopup::createSceneInFolder() {
   if (!scene) return;
 
   TFilePath fp(getPath().toStdWString());
-  TOutputProperties* prop = scene->getProperties()->getOutputProperties();
-  TFilePath outFp         = prop->getPath().withParentDir(fp);
 
-  prop->setPath(outFp);
+  // for the scene folder mode, output destination must be already set to
+  // $scenefolder or its subfolder. See TSceneProperties::onInitialize()
+  if (Preferences::instance()->getPathAliasPriority() !=
+      Preferences::SceneFolderAlias) {
+    TOutputProperties* prop = scene->getProperties()->getOutputProperties();
+    prop->setPath(prop->getPath().withParentDir(fp));
+  }
 
   // save the scene
   TFilePath sceneFp =

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1540,6 +1540,14 @@ PreferencesPopup::PreferencesPopup()
   pathAliasPriority->setToolTip(
       tr("This option defines which alias to be used\nif both are possible on "
          "coding file path."));
+  pathAliasPriority->setItemData(0, QString(" "), Qt::ToolTipRole);
+  QString scenefolderTooltip =
+      tr("Choosing this option will set initial location of all file browsers "
+         "to $scenefolder.\n"
+         "Also the initial output destination for new scenes will be set to "
+         "$scenefolder as well.");
+  pathAliasPriority->setItemData(1, scenefolderTooltip, Qt::ToolTipRole);
+  pathAliasPriority->setItemData(2, QString(" "), Qt::ToolTipRole);
 
   //--- Interface ------------------------------
   QStringList styleSheetList;

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -282,6 +282,15 @@ sprop->getOutputProperties()->setRenderSettings(rso);*/
 
   // Read the output filepath
   TFilePath fp = outputSettings.getPath();
+
+  // you cannot render an untitled scene to scene folder
+  if (scene->isUntitled() && TFilePath("$scenefolder").isAncestorOf(fp)) {
+    DVGui::warning(
+        QObject::tr("The scene is not yet saved and the output destination is "
+                    "set to $scenefolder.\nSave the scene first."));
+    return false;
+  }
+
   /*-- ファイル名が指定されていない場合は、シーン名を出力ファイル名にする --*/
   if (fp.getWideName() == L"")
     fp = fp.withName(scene->getScenePath().getName());

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -9,6 +9,7 @@
 #include "toonz/tcamera.h"
 #include "toonz/tstageobjecttree.h"
 #include "toonz/txshleveltypes.h"
+#include "toonz/preferences.h"
 #include "cleanuppalette.h"
 
 // TnzBase includes
@@ -98,6 +99,15 @@ void TSceneProperties::assign(const TSceneProperties *sprop) {
 //-----------------------------------------------------------------------------
 
 void TSceneProperties::onInitialize() {
+  // set initial output folder to $scenefolder when the scene folder mode is set
+  // in user preferences
+  if (Preferences::instance()->getPathAliasPriority() ==
+          Preferences::SceneFolderAlias &&
+      !TFilePath("$scenefolder").isAncestorOf(m_outputProp->getPath())) {
+    std::string ext = m_outputProp->getPath().getDottedType();
+    m_outputProp->setPath(TFilePath("$scenefolder/") + ext);
+  }
+
   //  m_scanParameters->adaptToCurrentScanner();
 }
 

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1451,6 +1451,12 @@ TFilePath ToonzScene::getDefaultLevelPath(int levelType,
   default:
     levelPath = TFilePath(levelName + L"..png");
   }
+
+  if (!isUntitled() &&
+      Preferences::instance()->getPathAliasPriority() ==
+          Preferences::SceneFolderAlias)
+    return TFilePath("$scenefolder") + levelPath;
+
   std::string folderName = getFolderName(levelType);
   if (project->getUseScenePath(folderName))
     return TFilePath("+" + folderName) + getSavePath() + levelPath;


### PR DESCRIPTION
This modification is demanded by some Japanese animation studio.

The following changes will be applied if `Path Alias Priority` in the preferences is set to `Scene Folder Alias ($scenefolder)` :
- Initial folder of all file browser popups will be set to `$scenefolder` .
- When drawing on the empty cell with the `Autocreation` preference option is enabled, a new level will be created and saved in `$scenefolder` .
- Default output destination folder for new scenes will become `$scenefolder`, regardless of the project settings.

The above changes are made according to a basic policy that users who store their assets in the scene-folder based way should not take care of project folders.
