### PR TITLE
Fix note icon drag area in timeline

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2440,7 +2440,9 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
       int c       = notes->getNoteCol(i);
       QPoint xy   = m_viewer->positionToXY(CellPosition(r, c));
       TPointD pos = notes->getNotePos(i) + TPointD(xy.x(), xy.y());
-      QRect rect(pos.x, pos.y, NoteWidth, NoteHeight);
+      QRect rect(pos.x, pos.y,
+                 (!o->isVerticalTimeline() ? NoteWidthTimeline : NoteWidth),
+                 NoteHeight);
       if (!rect.contains(event->pos())) continue;
       setDragTool(XsheetGUI::DragTool::makeNoteMoveTool(m_viewer));
       m_viewer->setCurrentNoteIndex(i);
@@ -2757,7 +2759,9 @@ void CellArea::mouseDoubleClickEvent(QMouseEvent *event) {
     int c       = notes->getNoteCol(i);
     QPoint xy   = m_viewer->positionToXY(CellPosition(r, c));
     TPointD pos = notes->getNotePos(i) + TPointD(xy.x(), xy.y());
-    QRect rect(pos.x, pos.y, NoteWidth, NoteHeight);
+    QRect rect(pos.x, pos.y,
+               (!o->isVerticalTimeline() ? NoteWidthTimeline : NoteWidth),
+               NoteHeight);
     if (!rect.contains(event->pos())) continue;
     m_viewer->setCurrentNoteIndex(i);
     m_viewer->getNotesWidget().at(i)->openNotePopup();
@@ -2823,7 +2827,9 @@ void CellArea::contextMenuEvent(QContextMenuEvent *event) {
     int c       = notes->getNoteCol(i);
     QPoint xy   = m_viewer->positionToXY(CellPosition(r, c));
     TPointD pos = notes->getNotePos(i) + TPointD(xy.x(), xy.y());
-    QRect rect(pos.x, pos.y, NoteWidth, NoteHeight);
+    QRect rect(pos.x, pos.y,
+               (!o->isVerticalTimeline() ? NoteWidthTimeline : NoteWidth),
+               NoteHeight);
     if (!rect.contains(event->pos())) continue;
     m_viewer->setCurrentNoteIndex(i);
     createNoteMenu(menu);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2440,9 +2440,7 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
       int c       = notes->getNoteCol(i);
       QPoint xy   = m_viewer->positionToXY(CellPosition(r, c));
       TPointD pos = notes->getNotePos(i) + TPointD(xy.x(), xy.y());
-      QRect rect(pos.x, pos.y,
-                 (!o->isVerticalTimeline() ? NoteWidthTimeline : NoteWidth),
-                 NoteHeight);
+      QRect rect  = o->rect(PredefinedRect::NOTE_ICON).translated(pos.x, pos.y);
       if (!rect.contains(event->pos())) continue;
       setDragTool(XsheetGUI::DragTool::makeNoteMoveTool(m_viewer));
       m_viewer->setCurrentNoteIndex(i);
@@ -2759,9 +2757,7 @@ void CellArea::mouseDoubleClickEvent(QMouseEvent *event) {
     int c       = notes->getNoteCol(i);
     QPoint xy   = m_viewer->positionToXY(CellPosition(r, c));
     TPointD pos = notes->getNotePos(i) + TPointD(xy.x(), xy.y());
-    QRect rect(pos.x, pos.y,
-               (!o->isVerticalTimeline() ? NoteWidthTimeline : NoteWidth),
-               NoteHeight);
+    QRect rect  = o->rect(PredefinedRect::NOTE_ICON).translated(pos.x, pos.y);
     if (!rect.contains(event->pos())) continue;
     m_viewer->setCurrentNoteIndex(i);
     m_viewer->getNotesWidget().at(i)->openNotePopup();
@@ -2827,9 +2823,7 @@ void CellArea::contextMenuEvent(QContextMenuEvent *event) {
     int c       = notes->getNoteCol(i);
     QPoint xy   = m_viewer->positionToXY(CellPosition(r, c));
     TPointD pos = notes->getNotePos(i) + TPointD(xy.x(), xy.y());
-    QRect rect(pos.x, pos.y,
-               (!o->isVerticalTimeline() ? NoteWidthTimeline : NoteWidth),
-               NoteHeight);
+    QRect rect  = o->rect(PredefinedRect::NOTE_ICON).translated(pos.x, pos.y);
     if (!rect.contains(event->pos())) continue;
     m_viewer->setCurrentNoteIndex(i);
     createNoteMenu(menu);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -51,9 +51,8 @@ namespace XsheetGUI {
 extern const int ColumnWidth;
 extern const int RowHeight;
 
-const int NoteWidth         = 72;
-const int NoteWidthTimeline = 48;
-const int NoteHeight        = 18;
+const int NoteWidth  = 70;
+const int NoteHeight = 18;
 
 // TZP column
 const QColor LevelColumnColor(127, 219, 127);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -51,8 +51,9 @@ namespace XsheetGUI {
 extern const int ColumnWidth;
 extern const int RowHeight;
 
-const int NoteWidth  = 70;
-const int NoteHeight = 18;
+const int NoteWidth         = 72;
+const int NoteWidthTimeline = 48;
+const int NoteHeight        = 18;
 
 // TZP column
 const QColor LevelColumnColor(127, 219, 127);


### PR DESCRIPTION
This PR fixes the size of the note icon's drag area in the timeline.

The note icon in timeline mode is not as wide as the icon in xsheet mode, so when you try to select a cell too close to the end of the timeline's note icon, you wind up initiating a drag on the note. 

I shortened the drag area to match the actual icon size in timeline mode
