### PR TITLE
Change eraser tool cursor icon

### DIFF
--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -709,21 +709,22 @@ void EraserTool::draw() {
 
 int EraserTool::getCursorId() const {
   int ret = ToolCursor::PenCursor;
+  /*
+    if (m_eraseType.getValue() == FREEHANDERASE)
+      ret = ret | ToolCursor::Ex_FreeHand;
+    else if (m_eraseType.getValue() == POLYLINEERASE)
+      ret = ret | ToolCursor::Ex_PolyLine;
+    else if (m_eraseType.getValue() == RECTERASE)
+      ret = ret | ToolCursor::Ex_Rectangle;
 
-  if (m_eraseType.getValue() == FREEHANDERASE)
-    ret = ret | ToolCursor::Ex_FreeHand;
-  else if (m_eraseType.getValue() == POLYLINEERASE)
-    ret = ret | ToolCursor::Ex_PolyLine;
-  else if (m_eraseType.getValue() == RECTERASE)
-    ret = ret | ToolCursor::Ex_Rectangle;
+    if (m_colorType.getValue() == LINES)
+      ret = ret | ToolCursor::Ex_Line;
+    else if (m_colorType.getValue() == AREAS)
+      ret = ret | ToolCursor::Ex_Area;
 
-  if (m_colorType.getValue() == LINES)
-    ret = ret | ToolCursor::Ex_Line;
-  else if (m_colorType.getValue() == AREAS)
-    ret = ret | ToolCursor::Ex_Area;
-
-  if (ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg)
-    ret = ret | ToolCursor::Ex_Negate;
+    if (ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg)
+      ret = ret | ToolCursor::Ex_Negate;
+  */
   return ret;
 }
 

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -708,19 +708,14 @@ void EraserTool::draw() {
 //----------------------------------------------------------------------
 
 int EraserTool::getCursorId() const {
-  int ret;
-  if (m_eraseType.getValue() == NORMALERASE)
-    ret = ToolCursor::NormalEraserCursor;
-  else {
-    ret = ToolCursor::RectEraserCursor;
+  int ret = ToolCursor::PenCursor;
 
-    if (m_eraseType.getValue() == FREEHANDERASE)
-      ret = ret | ToolCursor::Ex_FreeHand;
-    else if (m_eraseType.getValue() == POLYLINEERASE)
-      ret = ret | ToolCursor::Ex_PolyLine;
-    else if (m_eraseType.getValue() == RECTERASE)
-      ret = ret | ToolCursor::Ex_Rectangle;
-  }
+  if (m_eraseType.getValue() == FREEHANDERASE)
+    ret = ret | ToolCursor::Ex_FreeHand;
+  else if (m_eraseType.getValue() == POLYLINEERASE)
+    ret = ret | ToolCursor::Ex_PolyLine;
+  else if (m_eraseType.getValue() == RECTERASE)
+    ret = ret | ToolCursor::Ex_Rectangle;
 
   if (m_colorType.getValue() == LINES)
     ret = ret | ToolCursor::Ex_Line;
@@ -1654,11 +1649,10 @@ void EraserTool::storeUndoAndRefresh() {
     TUndoManager::manager()->add(new RasterBluredEraserUndo(
         m_tileSet, m_points,
         TTool::getApplication()->getCurrentLevelStyleIndex(),
-        m_currentStyle.getValue(),
-        TTool::getApplication()
-            ->getCurrentLevel()
-            ->getLevel()
-            ->getSimpleLevel(),
+        m_currentStyle.getValue(), TTool::getApplication()
+                                       ->getCurrentLevel()
+                                       ->getLevel()
+                                       ->getSimpleLevel(),
         m_workingFrameId.isEmptyFrame() ? getCurrentFid() : m_workingFrameId,
         m_toolSize.getValue(), m_hardness.getValue() * 0.01,
         m_colorType.getValue()));

--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -279,7 +279,7 @@ public:
 
   TPropertyGroup *getProperties(int targetType) override { return &m_prop; }
 
-  int getCursorId() const override { return ToolCursor::EraserCursor; }
+  int getCursorId() const override { return ToolCursor::PenCursor; }
   void onImageChanged() override;
 
   /*-- ドラッグ中にツールが切り替わった場合、Eraseの終了処理を行う --*/


### PR DESCRIPTION
This PR addresses a request to remove or replace the eraser cursor icon of the eraser tool.

The "eraser" icon is a little intrusive when you are trying to erase something that happens to be where the icon actually is.  I also find it a bit distracting.

I have the replaced the Toonz Vector and Toonz Raster cursor icons from an "eraser" to the "plus" sign, that the regular Raster eraser uses.  Please note, the eraser type text and the line/area text that is part of the Toonz Raster cursor icon has also been removed.