### PR TITLE
Extend Previous Cell to Selection command

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2842,7 +2842,9 @@ void TCellSelection::extendPrevCell() {
 
   for (c = c0; c <= c1; c++) {
     TXshColumn *column = xsh->getColumn(c);
-    if (!column || column->getSoundColumn()) continue;
+    if (!column || column->isEmpty() || column->isLocked() ||
+        column->getSoundColumn())
+      continue;
 
     for (r = r1; r >= r0; r--) {
       int fillCount = 0;

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1211,17 +1211,17 @@ public:
 
 //-----------------------------------------------------------------------------
 
-class ExtendCellsUndo final : public TUndo {
+class FillEmptyCellUndo final : public TUndo {
   TCellSelection *m_selection;
   TXshCell m_cell;
 
 public:
-  ExtendCellsUndo(int r0, int r1, int c, TXshCell &cell) : m_cell(cell) {
+  FillEmptyCellUndo(int r0, int r1, int c, TXshCell &cell) : m_cell(cell) {
     m_selection = new TCellSelection();
     m_selection->selectCells(r0, c, r1, c);
   }
 
-  ~ExtendCellsUndo() { delete m_selection; }
+  ~FillEmptyCellUndo() { delete m_selection; }
 
   void undo() const override {
     int r0, c0, r1, c1;
@@ -1244,7 +1244,7 @@ public:
   int getSize() const override { return sizeof(*this); }
 
   QString getHistoryString() override {
-    return QObject::tr("Extend Previous Cells To Selection");
+    return QObject::tr("Fill In Empty Cells");
   }
 
   int getHistoryType() override { return HistoryType::Xsheet; }
@@ -1322,7 +1322,7 @@ void TCellSelection::enableCommands() {
 
   enableCommand(this, MI_PasteInto, &TCellSelection::overWritePasteCells);
 
-  enableCommand(this, MI_ExtendPrevCell, &TCellSelection::extendPrevCell);
+  enableCommand(this, MI_FillEmptyCell, &TCellSelection::fillEmptyCell);
   enableCommand(this, MI_Reframe1, &TCellSelection::reframe1Cells);
   enableCommand(this, MI_Reframe2, &TCellSelection::reframe2Cells);
   enableCommand(this, MI_Reframe3, &TCellSelection::reframe3Cells);
@@ -1376,7 +1376,7 @@ bool TCellSelection::isEnabledCommand(
                                         MI_PasteNumbers,
                                         MI_ConvertToToonzRaster,
                                         MI_ConvertVectorToVector,
-                                        MI_ExtendPrevCell};
+                                        MI_FillEmptyCell};
   return commands.contains(commandId);
 }
 
@@ -2830,7 +2830,7 @@ void TCellSelection::convertVectortoVector() {
       (TImage::Type)app->getCurrentImageType());
 }
 
-void TCellSelection::extendPrevCell() {
+void TCellSelection::fillEmptyCell() {
   if (isEmpty()) return;
 
   // set up basics
@@ -2877,7 +2877,7 @@ void TCellSelection::extendPrevCell() {
         TUndoManager::manager()->beginBlock();
       }
 
-      ExtendCellsUndo *undo = new ExtendCellsUndo(startR, endR, c, cell);
+      FillEmptyCellUndo *undo = new FillEmptyCellUndo(startR, endR, c, cell);
       TUndoManager::manager()->add(undo);
       undo->redo();
 

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1210,6 +1210,47 @@ public:
 };
 
 //-----------------------------------------------------------------------------
+
+class ExtendCellsUndo final : public TUndo {
+  TCellSelection *m_selection;
+  TXshCell m_cell;
+
+public:
+  ExtendCellsUndo(int r0, int r1, int c, TXshCell &cell) : m_cell(cell) {
+    m_selection = new TCellSelection();
+    m_selection->selectCells(r0, c, r1, c);
+  }
+
+  ~ExtendCellsUndo() { delete m_selection; }
+
+  void undo() const override {
+    int r0, c0, r1, c1;
+    m_selection->getSelectedCells(r0, c0, r1, c1);
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (int c = c0; c <= c1; c++) {
+      xsh->clearCells(r0, c, r1 - r0 + 1);
+    }
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  void redo() const override {
+    int r0, c0, r1, c1;
+    m_selection->getSelectedCells(r0, c0, r1, c1);
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (int i = r0; i <= r1; i++) xsh->setCell(i, c0, m_cell);
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override {
+    return QObject::tr("Extend Previous Cells To Selection");
+  }
+
+  int getHistoryType() override { return HistoryType::Xsheet; }
+  //-----------------------------------------------------------------------------
+};
+
 }  // namespace
 //-----------------------------------------------------------------------------
 
@@ -1281,6 +1322,7 @@ void TCellSelection::enableCommands() {
 
   enableCommand(this, MI_PasteInto, &TCellSelection::overWritePasteCells);
 
+  enableCommand(this, MI_ExtendPrevCell, &TCellSelection::extendPrevCell);
   enableCommand(this, MI_Reframe1, &TCellSelection::reframe1Cells);
   enableCommand(this, MI_Reframe2, &TCellSelection::reframe2Cells);
   enableCommand(this, MI_Reframe3, &TCellSelection::reframe3Cells);
@@ -1333,7 +1375,8 @@ bool TCellSelection::isEnabledCommand(
                                         MI_Redo,
                                         MI_PasteNumbers,
                                         MI_ConvertToToonzRaster,
-                                        MI_ConvertVectorToVector};
+                                        MI_ConvertVectorToVector,
+                                        MI_ExtendPrevCell};
   return commands.contains(commandId);
 }
 
@@ -2785,4 +2828,63 @@ void TCellSelection::convertVectortoVector() {
 
   app->getCurrentTool()->onImageChanged(
       (TImage::Type)app->getCurrentImageType());
+}
+
+void TCellSelection::extendPrevCell() {
+  if (isEmpty()) return;
+
+  // set up basics
+  bool initUndo = false;
+  TXsheet *xsh  = TApp::instance()->getCurrentXsheet()->getXsheet();
+  int r, r0, c0, c, r1, c1;
+
+  getSelectedCells(r0, c0, r1, c1);
+
+  for (c = c0; c <= c1; c++) {
+    TXshColumn *column = xsh->getColumn(c);
+    if (!column || column->getSoundColumn()) continue;
+
+    for (r = r1; r >= r0; r--) {
+      int fillCount = 0;
+      TXshCell cell = xsh->getCell(r, c);
+
+      if (cell.isEmpty()) fillCount++;
+
+      int prevR = r - 1;
+      while (prevR >= 0) {
+        cell = xsh->getCell(prevR, c);
+        if (!cell.isEmpty()) break;
+
+        prevR--;
+        fillCount++;
+      }
+
+      // We've gone past the beginning of timeline without finding a cell.
+      // Do nothing, and end current column processing immediately.
+      if (prevR < 0) break;
+
+      // Adjacent cell is filled.  Move to next one.
+      if (!fillCount) continue;
+
+      // Ok, time fill
+      int startR = prevR + 1;
+      int endR   = startR + fillCount - 1;
+
+      if (!initUndo) {
+        initUndo = true;
+        TUndoManager::manager()->beginBlock();
+      }
+
+      ExtendCellsUndo *undo = new ExtendCellsUndo(startR, endR, c, cell);
+      TUndoManager::manager()->add(undo);
+      undo->redo();
+
+      // Let's skip cells we just filled
+      r = prevR;
+    }
+  }
+
+  if (initUndo) TUndoManager::manager()->endBlock();
+
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
 }

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -116,7 +116,7 @@ public:
 
   static bool isEnabledCommand(std::string commandId);
 
-  void extendPrevCell();
+  void fillEmptyCell();
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -115,6 +115,8 @@ public:
   void renameMultiCells(QList<TXshCell> &cells);
 
   static bool isEnabledCommand(std::string commandId);
+
+  void extendPrevCell();
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1424,7 +1424,7 @@ QAction *MainWindow::createAction(const char *id, const QString &name,
   if (strcmp(id, MI_ShortcutPopup) == 0) {
     action->setMenuRole(QAction::NoRole);
   }
-  if (strcmp(id,MI_ExitGroup) == 0) {
+  if (strcmp(id, MI_ExitGroup) == 0) {
     action->setMenuRole(QAction::NoRole);
   }
 #endif
@@ -1896,6 +1896,8 @@ void MainWindow::defineActions() {
                         tr("Reframe with Empty Inbetweens..."), "");
   createMenuCellsAction(MI_AutoInputCellNumber, tr("Auto Input Cell Number..."),
                         "");
+  createMenuCellsAction(MI_ExtendPrevCell,
+                        tr("&Extend Previous Cell To Selection"), "");
 
   createRightClickMenuAction(MI_SetKeyframes, tr("&Set Key"), "Z");
   createRightClickMenuAction(MI_PasteNumbers, tr("&Paste Numbers"), "");
@@ -2405,9 +2407,9 @@ RecentFiles::~RecentFiles() {}
 
 void RecentFiles::addFilePath(QString path, FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) files.removeAt(i);
@@ -2532,9 +2534,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2561,9 +2563,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene)
-            ? MI_ClearRecentScene
-            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
+        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
+                                                        ? MI_ClearRecentLevel
+                                                        : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1896,8 +1896,7 @@ void MainWindow::defineActions() {
                         tr("Reframe with Empty Inbetweens..."), "");
   createMenuCellsAction(MI_AutoInputCellNumber, tr("Auto Input Cell Number..."),
                         "");
-  createMenuCellsAction(MI_ExtendPrevCell,
-                        tr("&Extend Previous Cell To Selection"), "");
+  createMenuCellsAction(MI_FillEmptyCell, tr("&Fill In Empty Cells"), "");
 
   createRightClickMenuAction(MI_SetKeyframes, tr("&Set Key"), "Z");
   createRightClickMenuAction(MI_PasteNumbers, tr("&Paste Numbers"), "");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1275,6 +1275,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(cellsMenu, MI_Rollup);
   addMenuItem(cellsMenu, MI_Rolldown);
   addMenuItem(cellsMenu, MI_TimeStretch);
+  addMenuItem(cellsMenu, MI_ExtendPrevCell);
   cellsMenu->addSeparator();
   addMenuItem(cellsMenu, MI_DrawingSubForward);
   addMenuItem(cellsMenu, MI_DrawingSubBackward);

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1275,7 +1275,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(cellsMenu, MI_Rollup);
   addMenuItem(cellsMenu, MI_Rolldown);
   addMenuItem(cellsMenu, MI_TimeStretch);
-  addMenuItem(cellsMenu, MI_ExtendPrevCell);
+  addMenuItem(cellsMenu, MI_FillEmptyCell);
   cellsMenu->addSeparator();
   addMenuItem(cellsMenu, MI_DrawingSubForward);
   addMenuItem(cellsMenu, MI_DrawingSubBackward);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -146,6 +146,7 @@
 
 #define MI_PasteNew "MI_PasteNew"
 #define MI_Autorenumber "MI_Autorenumber"
+#define MI_ExtendPrevCell "MI_ExtendPrevCell"
 
 #define MI_MergeFrames "MI_MergeFrames"
 #define MI_Reverse "MI_Reverse"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -146,7 +146,7 @@
 
 #define MI_PasteNew "MI_PasteNew"
 #define MI_Autorenumber "MI_Autorenumber"
-#define MI_ExtendPrevCell "MI_ExtendPrevCell"
+#define MI_FillEmptyCell "MI_FillEmptyCell"
 
 #define MI_MergeFrames "MI_MergeFrames"
 #define MI_Reverse "MI_Reverse"

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3033,6 +3033,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
             cmdManager->getAction(MI_AutoInputCellNumber));
       }
       menu.addMenu(editCellNumbersMenu);
+      menu.addAction(cmdManager->getAction(MI_ExtendPrevCell));
 
       menu.addSeparator();
       menu.addAction(cmdManager->getAction(MI_Autorenumber));
@@ -3130,6 +3131,8 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
         (TApp::instance()->getCurrentLevel()->getLevel() &&
          TApp::instance()->getCurrentLevel()->getLevel()->getChildLevel()))
       menu.addAction(cmdManager->getAction(MI_LipSyncPopup));
+  } else {
+    menu.addAction(cmdManager->getAction(MI_ExtendPrevCell));
   }
   menu.addSeparator();
   if (!soundCellsSelected)

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3033,7 +3033,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
             cmdManager->getAction(MI_AutoInputCellNumber));
       }
       menu.addMenu(editCellNumbersMenu);
-      menu.addAction(cmdManager->getAction(MI_ExtendPrevCell));
+      menu.addAction(cmdManager->getAction(MI_FillEmptyCell));
 
       menu.addSeparator();
       menu.addAction(cmdManager->getAction(MI_Autorenumber));
@@ -3132,7 +3132,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
          TApp::instance()->getCurrentLevel()->getLevel()->getChildLevel()))
       menu.addAction(cmdManager->getAction(MI_LipSyncPopup));
   } else {
-    menu.addAction(cmdManager->getAction(MI_ExtendPrevCell));
+    menu.addAction(cmdManager->getAction(MI_FillEmptyCell));
   }
   menu.addSeparator();
   if (!soundCellsSelected)


### PR DESCRIPTION
This PR introduces a new action/command that allows you to select 1 or more cells in the xsheet (in either xsheet or timeline mode) and extend the hold on the last filled cell before it, up until either the next filled cell or the end of the selection. 

![extend_prev_cell](https://user-images.githubusercontent.com/19245851/40034701-15e98c48-57cc-11e8-9b30-328fced91309.gif)

This does not work on are Sound Levels or any level that is currently locked.

Feel free to suggest a better label for this command. :)
