### PR TITLE
Fix Placement of Freeze Button in Preview Window

### DIFF
--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -274,7 +274,7 @@ void FlipBook::addFreezeButtonToTitleBar() {
     m_freezeButton->setToolTip("Freeze");
     titleBar->add(QPoint(-64, 0), m_freezeButton);
     connect(m_freezeButton, SIGNAL(toggled(bool)), this, SLOT(freeze(bool)));
-    QPoint p(titleBar->width() - 62, 0);
+    QPoint p(titleBar->width() - 64, 0);
     m_freezeButton->move(p);
     m_freezeButton->show();
   }

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -272,9 +272,9 @@ void FlipBook::addFreezeButtonToTitleBar() {
         titleBar, ":Resources/pane_freeze_off.svg",
         ":Resources/pane_freeze_over.svg", ":Resources/pane_freeze_on.svg");
     m_freezeButton->setToolTip("Freeze");
-    titleBar->add(QPoint(-55, 0), m_freezeButton);
+    titleBar->add(QPoint(-64, 0), m_freezeButton);
     connect(m_freezeButton, SIGNAL(toggled(bool)), this, SLOT(freeze(bool)));
-    QPoint p(titleBar->width() - 62, 1);
+    QPoint p(titleBar->width() - 62, 0);
     m_freezeButton->move(p);
     m_freezeButton->show();
   }


### PR DESCRIPTION
The freeze button is overlapping the minimize button in the preview window (**CTRL+R**). I assume it happens in the flipbook window too but I haven't seen the freeze button appear there yet to test, since the source file for fixing this is for the flipbook window.

This small fix will adjust its position.

**Here is the issue:**
![preview_window_button_issue](https://user-images.githubusercontent.com/19820721/40055473-f82d301e-583f-11e8-8de8-950fe870804c.gif)

**What this PR does:**
![preview_window_button_issue_fix](https://user-images.githubusercontent.com/19820721/40055477-fae8d088-583f-11e8-8d61-2f84f00fda46.gif)
