### PR TITLE
Fix Note Button Text Clipping

### DIFF
--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -140,16 +140,14 @@ NotePopup::NotePopup(XsheetViewer *viewer, int noteIndex)
 
   QPushButton *addNoteButton = new QPushButton(tr("Post"));
   addNoteButton->setMinimumSize(50, 20);
-  addNoteButton->setStyleSheet("padding-left: 0;"
-                               "padding-right: 0;");
+  addNoteButton->setObjectName("PushButton_NoPadding");
   ret = ret &&
         connect(addNoteButton, SIGNAL(pressed()), this, SLOT(onNoteAdded()));
   layout->addWidget(addNoteButton, row, col, 1, 1);
   col++;
   QPushButton *discardNoteButton = new QPushButton(tr("Discard"));
   discardNoteButton->setMinimumSize(50, 20);
-  discardNoteButton->setStyleSheet("padding-left: 0;"
-                                   "padding-right: 0;");
+  discardNoteButton->setObjectName("PushButton_NoPadding");
   ret = ret && connect(discardNoteButton, SIGNAL(pressed()), this,
                        SLOT(onNoteDiscarded()));
   layout->addWidget(discardNoteButton, row, col, 1, 1);

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -140,6 +140,8 @@ NotePopup::NotePopup(XsheetViewer *viewer, int noteIndex)
 
   QPushButton *addNoteButton = new QPushButton(tr("Post"));
   addNoteButton->setMinimumSize(50, 20);
+  addNoteButton->setStyleSheet("padding-left: 0;"
+                               "padding-right: 0;");
   ret = ret &&
         connect(addNoteButton, SIGNAL(pressed()), this, SLOT(onNoteAdded()));
   layout->addWidget(addNoteButton, row, col, 1, 1);

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -146,6 +146,8 @@ NotePopup::NotePopup(XsheetViewer *viewer, int noteIndex)
   col++;
   QPushButton *discardNoteButton = new QPushButton(tr("Discard"));
   discardNoteButton->setMinimumSize(50, 20);
+  discardNoteButton->setStyleSheet("padding-left: 0;"
+                                   "padding-right: 0;");
   ret = ret && connect(discardNoteButton, SIGNAL(pressed()), this,
                        SLOT(onNoteDiscarded()));
   layout->addWidget(discardNoteButton, row, col, 1, 1);


### PR DESCRIPTION
Note buttons have a liberal amount of padding inherited from stylesheets, this will remove most of it by using the predefined `#PushButton_NoPadding` block in the stylesheet.

**Before:**
![note_before](https://user-images.githubusercontent.com/19820721/40079952-6cede3bc-5881-11e8-8edd-a299d99f7f67.PNG)
**After:**
![note_after](https://user-images.githubusercontent.com/19820721/40079956-6ea161ca-5881-11e8-838d-6c162042d8df.PNG)
