### PR TITLE
Open sub-xsheet at selected sub-xsheet frame

### DIFF
--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -970,7 +970,7 @@ public:
 
 void openSubXsheet() {
   TApp *app = TApp::instance();
-  /*- 選択セル又は選択カラムの中にChildLevelが有った場合のみ中に入る -*/
+  /*- Enter only when ChildLevel exists in selected cell or selected column -*/
   TCellSelection *cellSelection =
       dynamic_cast<TCellSelection *>(TSelection::getCurrent());
   TColumnSelection *columnSelection =
@@ -978,61 +978,79 @@ void openSubXsheet() {
 
   bool ret          = false;
   ToonzScene *scene = app->getCurrentScene()->getScene();
+  int row           = app->getCurrentFrame()->getFrame();
+  int col           = app->getCurrentColumn()->getColumnIndex();
+  bool jumpToFrame  = false;
 
-  /*- カラム選択の場合 -*/
+  /*- For column selection -*/
   if (columnSelection && !columnSelection->isEmpty()) {
     TXsheet *currentXsheet = app->getCurrentXsheet()->getXsheet();
     int sceneLength        = currentXsheet->getFrameCount();
 
     std::set<int> columnIndices = columnSelection->getIndices();
     std::set<int>::iterator it;
-    /*- 各Columnについて各セルでopenChildを試みる -*/
+    /*- Try openChild on each cell for each Column -*/
     for (it = columnIndices.begin(); it != columnIndices.end(); ++it) {
       int c = *it;
-      /*- Column内の各Cellについて、中身が見つかったらbreak -*/
+      /*- For each Cell in the Column, if contents are found break -*/
       for (int r = 0; r < sceneLength; r++) {
         ret = scene->getChildStack()->openChild(r, c);
-        if (ret) break;
+        if (ret) {
+          // If our current frame is in this column, we'll jump to the specific
+          // frame
+          if (c == col) jumpToFrame = true;
+          break;
+        }
       }
       if (ret) break;
     }
   }
 
-  /*- それ以外の場合（セル選択、又はその他）-*/
+  /*- In other cases (cell selection or other) -*/
   else {
     TRect selectedArea;
-    /*- セル選択でも無い場合、カレントフレーム/カラムを見る -*/
+    /*- If it is not cell selection, see current frame / column -*/
     if (!cellSelection || cellSelection->isEmpty()) {
-      int row = app->getCurrentFrame()->getFrame();
-      int col = app->getCurrentColumn()->getColumnIndex();
-      /*- セル選択でない場合、1×1の選択範囲 -*/
+      /*- When it is not cell selection, 1 × 1 selection range -*/
       selectedArea = TRect(col, row, col, row);
     }
-    /*- セル選択の場合 -*/
+    /*- In case of cell selection -*/
     else {
       int r0, c0, r1, c1;
       cellSelection->getSelectedCells(r0, c0, r1, c1);
       selectedArea = TRect(c0, r0, c1, r1);
     }
-    /*- Rectに含まれる各セルでopenChildを試みる -*/
+    /*- Try openChild on each cell in Rect -*/
     for (int c = selectedArea.x0; c <= selectedArea.x1; c++) {
       for (int r = selectedArea.y0; r <= selectedArea.y1; r++) {
         ret = scene->getChildStack()->openChild(r, c);
-        if (ret) break;
+        if (ret) {
+          // If our current frame is this column, we'll jump to the specific
+          // frame
+          if (c == col) jumpToFrame = true;
+          break;
+        }
       }
       if (ret) break;
     }
   }
 
-  /*- subXsheet Levelが見つかった場合 -*/
+  /*- When subXsheet Level is found -*/
   if (ret) {
+    int jumpToFrameIdx = 0;
+
+    if (jumpToFrame) {
+      TXshCell cell = app->getCurrentXsheet()->getXsheet()->getCell(row, col);
+      if (!cell.isEmpty()) jumpToFrameIdx = cell.getFrameId().getNumber() - 1;
+    }
+
     if (TSelection::getCurrent()) TSelection::getCurrent()->selectNone();
 
     TUndoManager::manager()->add(new OpenChildUndo());
     app->getCurrentXsheet()->setXsheet(scene->getXsheet());
     app->getCurrentXsheet()->notifyXsheetChanged();
     app->getCurrentColumn()->setColumnIndex(0);
-    app->getCurrentFrame()->setFrameIndex(0);
+    app->getCurrentFrame()->setFrameIndex(jumpToFrameIdx);
     changeSaveSubXsheetAsCommand();
   } else
     DVGui::error(QObject::tr("Select a sub-xsheet cell."));

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2812,6 +2812,7 @@ void CellArea::contextMenuEvent(QContextMenuEvent *event) {
   CellPosition cellPosition = m_viewer->xyToPosition(event->pos());
   int row                   = cellPosition.frame();
   int col                   = cellPosition.layer();
+  TXshCell cell             = m_viewer->getXsheet()->getCell(row, col);
 
   QMenu menu(this);
 
@@ -2887,7 +2888,7 @@ void CellArea::contextMenuEvent(QContextMenuEvent *event) {
         }
       if (areCellsEmpty) break;
     }
-    createCellMenu(menu, areCellsEmpty);
+    createCellMenu(menu, areCellsEmpty, cell);
   } else {
     if (col >= 0) {
       m_viewer->getCellSelection()->makeCurrent();
@@ -2895,9 +2896,9 @@ void CellArea::contextMenuEvent(QContextMenuEvent *event) {
       m_viewer->setCurrentColumn(col);
     }
     if (!xsh->getCell(row, col).isEmpty())
-      createCellMenu(menu, true);
+      createCellMenu(menu, true, cell);
     else
-      createCellMenu(menu, false);
+      createCellMenu(menu, false, cell);
   }
 
   if (!menu.isEmpty()) menu.exec(event->globalPos());
@@ -2971,7 +2972,7 @@ void CellArea::onControlPressed(bool pressed) {
 const bool CellArea::isControlPressed() { return isCtrlPressed; }
 
 //-----------------------------------------------------------------------------
-void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
+void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell) {
   CommandManager *cmdManager = CommandManager::instance();
 
   bool soundCellsSelected = m_viewer->areSoundCellsSelected();
@@ -3110,6 +3111,13 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected) {
       menu.addAction(cmdManager->getAction(MI_ViewFile));
 
     menu.addSeparator();
+
+    if (!cell.isEmpty() && cell.m_level && cell.m_level->getChildLevel()) {
+      menu.addAction(cmdManager->getAction(MI_OpenChild));
+
+      menu.addSeparator();
+    }
+
     if (selectionContainRasterImage(m_viewer->getCellSelection(),
                                     m_viewer->getXsheet())) {
       QMenu *editImageMenu = new QMenu(tr("Edit Image"), this);

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -7,6 +7,8 @@
 #include <QLineEdit>
 #include "orientation.h"
 
+#include "toonz/txshcell.h"
+
 // forward declaration
 class XsheetViewer;
 class QMenu;
@@ -144,7 +146,7 @@ protected:
   /*!Crea il menu' del tasto destro che si visualizza quando si clicca sulla
 cella,
 distinguendo i due casi: cella piena, cella vuota.*/
-  void createCellMenu(QMenu &menu, bool isCellSelected);
+  void createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell);
   //! Crea il menu' del tasto destro che si visualizza si clicca su un key
   //! frame.
   void createKeyMenu(QMenu &menu);


### PR DESCRIPTION
This PR enhances the behavior of the "Open Sub-xsheet" as discussed in #1975.

The following logic is used when opening a sub-xsheet"
- Opening via Column selection
  - The sub-xsheet will open at the sub-xsheet frame where the Current Frame Indicator is located.  If it is an empty cell, the sub-xsheet will open at the 1st exposed sub-xsheet frame.

- Opening via drop-down menu
  - If there is no active selection, the sub-xsheet will open at the sub-xsheet frame where the Current Frame Indicator is located.  If on an empty cell, it will remind you that you need to select a cell and not do anything.
  - If there is an active selection, the sub-xsheet will open at the 1st exposed sub-xsheet frame in the selection.

- Opening via right-click context menu
  - If there is no active selection, the sub-xsheet will open at the sub-xsheet frame exposed in the cell you right-clicked regardless if it is the Current Frame Indicator or not.  If the cell is empty, the option is not available.
  - If there is an active selection, the sub-xsheet will open at the 1st exposed sub-xsheet frame in the selection.
