### PR TITLE
Fix Viewer Refreshing with Raster Brush Being Selected

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -721,6 +721,10 @@ void FullColorBrushTool::updateCurrentStyle() {
     }
   }
 
+  // if this function is called from onEnter(), the clipping rect will not be
+  // set in order to update whole viewer.
+  if (prevMinCursorThick == 0 && prevMaxCursorThick == 0) return;
+
   if (m_minCursorThick != prevMinCursorThick ||
       m_maxCursorThick != prevMaxCursorThick) {
     TRectD rect(


### PR DESCRIPTION
This will fix the [glitch reported by @RodneyBaker](https://github.com/opentoonz/opentoonz/issues/1941#issuecomment-390521280) in #1941 .