### PR TITLE
Additional fix of Brush Tip Display issue

### DIFF
--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -136,6 +136,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
   bool m_eraserPointerOn;
   QString m_backupTool;
   TRectD m_clipRect;
+  bool m_dirty;
 
   bool m_isPicking;
 


### PR DESCRIPTION
Additional fix to PR #1953 

We still have bug in scene invalidation functionality. When we called SceneViewer::GLInvalidateAll() and after that SceneViewer::GLInvalidateRect(), then invalidation rectangle will reduced. This PR fixes it.