### PR TITLE
Remove Old Stuff Folder Check from OSX tfarm Executables

### DIFF
--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -510,23 +510,6 @@ int main(int argc, char *argv[]) {
   }
   if (i == argc) TMsgCore::instance()->connectTo("");
 
-// TThread::init();  //For the ImageManager construction
-// controllo se la xxxroot e' definita e corrisponde ad un file esistente
-#ifdef MACOSX
-
-  // StuffDir
-
-  QFileInfo infoStuff(QString("Toonz 7.1 stuff"));
-  TFilePath stuffDirPath(infoStuff.absoluteFilePath().toStdString());
-  TEnv::setStuffDir(stuffDirPath);
-
-/*
-    TFilePath  stuffDir("/Applications/Toonz 7.1/Toonz 7.1 stuff");
-
-  TEnv::setStuffDir(stuffDir);
-*/
-#endif
-
   TFilePath fproot = TEnv::getStuffDir();
   if (fproot == TFilePath())
     fatalError(string("Undefined: \"") + ::to_string(TEnv::getRootVarPath()) +

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -622,15 +622,6 @@ int main(int argc, char *argv[]) {
   }
   if (i == argc) TMsgCore::instance()->connectTo("");
 
-// TODO: non va qui. Bisognerebbe semmai modificare l'implementazione
-// delle TEnv:: precedenti. Discutiamone
-#ifdef MACOSX
-  // StuffDir
-  QFileInfo infoStuff(QString("Toonz 7.1 stuff"));
-  TFilePath stuffDirPath(infoStuff.absoluteFilePath().toStdString());
-  TEnv::setStuffDir(stuffDirPath);
-#endif
-
   // controllo se la xxxroot e' definita e corrisponde ad un file esistente
   TFilePath fp = TEnv::getStuffDir();
   if (fp == TFilePath())


### PR DESCRIPTION
I found a problem while testing #1993 (former #1141) with #1609 by @damies13 , which will enable batch rendering and batch cleanup in OSX.

For now in `tcomposer` and `tcleanup` there are unnecessary operations handling old stuff folder path and it causes crash.
Confirmed that just removing the lines works fine.