### PR TITLE
Change Qt Version Used in Travis CI to 5.11.0

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -4,7 +4,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt/5.10.1/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt/5.11.0/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make -j 2


### PR DESCRIPTION
This will fix the recent Travis failure due to [Homebrew updated Qt version ](https://github.com/Homebrew/homebrew-core/commit/95a2edcf3f615aef43f22a68d0ad39e2e3777c0f).