### PR TITLE
Fix brush using wrong initial thickness value

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -1335,7 +1335,7 @@ void BrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
 
     /*--- ストロークの最初にMaxサイズの円が描かれてしまう不具合を防止する ---*/
     if (m_pressure.getValue() && e.m_pressure == 1.0)
-      thickness     = m_rasThickness.getValue().first;
+      thickness     = m_thickness.getValue().first;
     m_currThickness = thickness;
     m_smoothStroke.beginStroke(m_smooth.getValue());
 


### PR DESCRIPTION
This PR fixes a minor issue I accidentally encountered with the Vector Brush. 

The issue is when you click to start drawing with the Vector Brush with Pressure sensitivity turned ON and you start at max pressure (or using a mouse), it uses the Min Size value of the Toonz Raster Brush setting instead of the Toonz Vector Brush Setting.  It becomes obvous if the Toonz Raster Brush min size setting is higher than the Toonz Vector min size.