### PR TITLE
Fix Crash When Re-create the Plastic Skeleton

### DIFF
--- a/toonz/sources/tnztools/plastictool_build.cpp
+++ b/toonz/sources/tnztools/plastictool_build.cpp
@@ -805,6 +805,9 @@ void PlasticTool::removeSkeleton(int skelId) {
   clearSkeletonSelections();
 
   if (m_sd) {
+    // in order to solve the crash issue #1967, try releasing deformer data here
+    PlasticDeformerStorage::instance()->releaseSkeletonData(
+        stageObject()->getPlasticSkeletonDeformation().getPointer(), skelId);
     m_sd->detach(skelId);
     if (m_sd->empty())
       stageObject()->setPlasticSkeletonDeformation(


### PR DESCRIPTION
This fixes #1967 .

As far as I can see, the crash seems to be resolved...
I believe (hopefully) this will not cause any bad side effect!