### PR TITLE
Fix Crash on Saving Curve in Function Editor

### DIFF
--- a/toonz/sources/include/toonzqt/filefield.h
+++ b/toonz/sources/include/toonzqt/filefield.h
@@ -55,6 +55,7 @@ class DVAPI FileField : public QWidget {
   QString m_windowTitle;
   QString m_descriptionText;  // if the initial text is not path, set the string
                               // here and prevent browsing
+  bool m_codePath;
 
 protected:  // used in the child class for CleanupSettings
   QPushButton *m_fileBrowseButton;
@@ -68,7 +69,7 @@ public:
     BrowserPopupController() {}
     virtual ~BrowserPopupController() {}
     virtual bool isExecute() { return true; };
-    virtual QString getPath() { return QString(); };
+    virtual QString getPath(bool codePath = true) { return QString(); };
     virtual void openPopup(QStringList, bool, QString,
                            const QWidget * = NULL){};
   };
@@ -76,7 +77,8 @@ public:
   static BrowserPopupController *m_browserPopupController;
 
   FileField(QWidget *parent = 0, QString path = QString(),
-            bool readOnly = false, bool doNotBrowseInitialPath = false);
+            bool readOnly = false, bool doNotBrowseInitialPath = false,
+            bool codePath = true);
   ~FileField() {}
 
   /*! Set what the user may select in the file dialog:

--- a/toonz/sources/toonz/curveio.cpp
+++ b/toonz/sources/toonz/curveio.cpp
@@ -8,6 +8,7 @@
 #include "toonz/tproject.h"
 #include "tconvert.h"
 #include "filebrowserpopup.h"
+#include "filebrowser.h"
 #include "tundo.h"
 
 //=============================================================================
@@ -42,6 +43,7 @@ public:
              TDoubleParam *curve)
       : FileBrowserPopup(name), m_folderPath(folderPath), m_curve(curve) {
     curve->addRef();
+    m_browser->enableGlobalSelection(false);
   }
 
   ~CurvePopup() { m_curve->release(); }

--- a/toonz/sources/toonz/dvdirtreeview.h
+++ b/toonz/sources/toonz/dvdirtreeview.h
@@ -91,6 +91,7 @@ public:
   void enableCommands() override;
 
   void enableGlobalSelection(bool enabled) {
+    if (!enabled) makeNotCurrent();
     m_globalSelectionEnabled = enabled;
   }
 

--- a/toonz/sources/toonz/dvitemview.h
+++ b/toonz/sources/toonz/dvitemview.h
@@ -307,6 +307,7 @@ public:
                     bool multiselectionEnabled, QWidget *parent);
 
   void enableGlobalSelection(bool enabled) {
+    if (!enabled) m_selection->makeNotCurrent();
     m_globalSelectionEnabled = enabled;
   }
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -2143,12 +2143,13 @@ void BrowserPopupController::openPopup(QStringList filters,
     m_isExecute = false;
 }
 
-QString BrowserPopupController::getPath() {
+// codePath is set to true by default
+QString BrowserPopupController::getPath(bool codePath) {
   m_isExecute = false;
   if (!m_browserPopup) return QString();
-  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
-  TFilePath fp      = m_browserPopup->getPath();
-  if (scene) fp     = scene->codeFilePath(fp);
+  ToonzScene *scene         = TApp::instance()->getCurrentScene()->getScene();
+  TFilePath fp              = m_browserPopup->getPath();
+  if (scene && codePath) fp = scene->codeFilePath(fp);
   std::cout << ::to_string(fp) << std::endl;
   return toQString(fp);
 }

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -442,7 +442,7 @@ public:
   void openPopup(QStringList filters, bool isDirectoryOnly,
                  QString lastSelectedPath,
                  const QWidget *parentWidget = NULL) override;
-  QString getPath() override;
+  QString getPath(bool codePath = true) override;
 };
 
 #endif  // FILEBROWSERPOPUP_H

--- a/toonz/sources/toonzqt/filefield.cpp
+++ b/toonz/sources/toonzqt/filefield.cpp
@@ -19,11 +19,12 @@ FileField::BrowserPopupController *FileField::m_browserPopupController = 0;
 //-----------------------------------------------------------------------------
 
 FileField::FileField(QWidget *parent, QString path, bool readOnly,
-                     bool doNotBrowseInitialPath)
+                     bool doNotBrowseInitialPath, bool codePath)
     : QWidget(parent)
     , m_filters(QStringList())
     , m_fileMode(QFileDialog::DirectoryOnly)
-    , m_lastSelectedPath(path) {
+    , m_lastSelectedPath(path)
+    , m_codePath(codePath) {
   setMaximumHeight(WidgetHeight);
 
   m_field            = new LineEdit(path);
@@ -97,7 +98,7 @@ void FileField::browseDirectory() {
       (m_lastSelectedPath == m_descriptionText) ? "" : m_lastSelectedPath,
       this);
   if (m_browserPopupController->isExecute())
-    directory = m_browserPopupController->getPath();
+    directory = m_browserPopupController->getPath(m_codePath);
 
   if (!directory.isEmpty()) {
     setPath(directory);

--- a/toonz/sources/toonzqt/functionsegmentviewer.cpp
+++ b/toonz/sources/toonzqt/functionsegmentviewer.cpp
@@ -658,7 +658,9 @@ bool FunctionExpressionSegmentPage::getGuiValues(std::string &expressionText,
 
 FileSegmentPage::FileSegmentPage(FunctionSegmentViewer *parent)
     : FunctionSegmentPage(parent) {
-  m_fileFld = new DVGui::FileField(this);
+  // Force decoding the path since the file interporation
+  // currently accepts only absolute paths.
+  m_fileFld = new DVGui::FileField(this, QString(), false, false, false);
   m_fileFld->setFileMode(QFileDialog::ExistingFile);
   QStringList filters;
   filters.append("dat");


### PR DESCRIPTION
This will fix #1983 , the crash which seems to be due to transfer of the current selection.

I found that currently the `File` interpolation only accepts absolute paths to .dat or .txt file.
When you use a file browser popup from `...` button of the input field, it usually returns aliased path (with `+drawings`, `$scenefolder`, etc) which cannot access the file properly.
As a quick workaround, in this PR I also made the input field of the `File` interpolation not to use aliases.