### PR TITLE
Fix Viewer Update Problems

### DIFF
--- a/toonz/sources/include/toonz/strokegenerator.h
+++ b/toonz/sources/include/toonz/strokegenerator.h
@@ -35,6 +35,7 @@ class DVAPI StrokeGenerator {
 
   //! Rettangolo che contiene l'ultima regione modificata
   TRectD m_lastModifiedRegion;
+  TRectD m_lastPointRect;
 
   //! Ultimo punto del frammento visualizzato
   TPointD m_p0, /*! Ultimo punto del frammento visualizzato*/ m_p1;

--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -1330,7 +1330,7 @@ void BrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
       /*-- 作業中のFidを登録 --*/
       m_workingFrameId = getFrameId();
 
-      (m_isFrameCreated) ? invalidate() : invalidate(invalidateRect.enlarge(2));
+      invalidate(invalidateRect.enlarge(2));
     }
   } else {  // vector happens here
     m_track.clear();
@@ -1351,8 +1351,8 @@ void BrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
     } else
       addTrackPoint(TThickPoint(pos, thickness),
                     getPixelSize() * getPixelSize());
-
-    if (m_isFrameCreated) invalidate();
+    TRectD invalidateRect = m_track.getLastModifiedRegion();
+    invalidate(invalidateRect.enlarge(2));
   }
 
   // updating m_brushPos is needed to refresh viewer properly
@@ -1704,7 +1704,7 @@ void BrushTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       addStrokeToImage(getApplication(), vi, stroke, m_breakAngles.getValue(),
                        m_isFrameCreated, m_isLevelCreated);
       TRectD bbox = stroke->getBBox().enlarge(2) + m_track.getModifiedRegion();
-      invalidate();
+      invalidate();  // should use bbox?
     }
     assert(stroke);
     m_track.clear();

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -337,7 +337,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   invalidateRect += TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
   invalidateRect +=
       TRectD(previousBrushPos - thickOffset, previousBrushPos + thickOffset);
-  (m_isFrameCreated) ? invalidate() : invalidate(invalidateRect.enlarge(2.0));
+  invalidate(invalidateRect.enlarge(2.0));
 }
 
 //-------------------------------------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -337,7 +337,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   invalidateRect += TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
   invalidateRect +=
       TRectD(previousBrushPos - thickOffset, previousBrushPos + thickOffset);
-  invalidate(invalidateRect.enlarge(2.0));
+  (m_isFrameCreated) ? invalidate() : invalidate(invalidateRect.enlarge(2.0));
 }
 
 //-------------------------------------------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/strokegenerator.cpp
+++ b/toonz/sources/toonzlib/strokegenerator.cpp
@@ -13,7 +13,9 @@ using namespace std;
 
 void StrokeGenerator::clear() {
   m_points.clear();
-  m_modifiedRegion    = TRectD();
+  m_modifiedRegion = TRectD();
+  m_lastPointRect.empty();
+  m_lastModifiedRegion.empty();
   m_paintedPointCount = 0;
   m_p0 = m_p1 = TPointD();
 }
@@ -30,6 +32,7 @@ void StrokeGenerator::add(const TThickPoint &point, double pixelSize2) {
     m_points.push_back(point);
     TRectD rect(x - d, y - d, x + d, y + d);
     m_modifiedRegion     = rect;
+    m_lastPointRect      = rect;
     m_lastModifiedRegion = rect;
     m_p0 = m_p1 = point;
   } else {
@@ -39,7 +42,8 @@ void StrokeGenerator::add(const TThickPoint &point, double pixelSize2) {
       double d = std::max(point.thick, lastPoint.thick) + 3;
       TRectD rect(TRectD(lastPoint, point).enlarge(d));
       m_modifiedRegion += rect;
-      m_lastModifiedRegion += rect;
+      m_lastModifiedRegion = m_lastPointRect + rect;
+      m_lastPointRect      = rect;
     } else {
       m_points.back().thick = std::max(m_points.back().thick, point.thick);
     }
@@ -251,11 +255,7 @@ void StrokeGenerator::removeMiddlePoints() {
 
 //-------------------------------------------------------------------
 
-TRectD StrokeGenerator::getLastModifiedRegion() {
-  TRectD lastModifiedRegion = m_lastModifiedRegion;
-  m_lastModifiedRegion.empty();
-  return lastModifiedRegion;
-}
+TRectD StrokeGenerator::getLastModifiedRegion() { return m_lastModifiedRegion; }
 
 //-------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes the problem mentioned by @beeheemooth in the [comment](https://github.com/opentoonz/opentoonz/issues/2035#issuecomment-394282967) in #2035.
This PR also fixes #2016 .

All of the above are related to setting proper region for partial update of the Viewer.

**UPDATE**
#2035 itself will be resolved by introducing #2056, as the entire refresh of the viewer is invoked from `xsheetChanged` signal when the frame is created. 