### PR TITLE
Pressure Sensitivy Loss Fix

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -689,7 +689,11 @@ void SceneViewer::onPress(const TMouseEvent &event) {
 void SceneViewer::mouseReleaseEvent(QMouseEvent *event) {
   // if this is called just after tabletEvent, skip the execution
   if (m_tabletEvent) {
-    m_tabletEvent = false;
+    // mouseRelease should not clear flag if we are starting or in middle of
+    // stroke
+    // initiated by tableEvent. All other cases, it's ok to clear flag
+    if (m_tabletState == Released || m_tabletState == None)
+      m_tabletEvent = false;
     return;
   }
   // for touchscreens but not touchpads...
@@ -771,11 +775,16 @@ void SceneViewer::onRelease(const TMouseEvent &event) {
 
 quit:
   m_mouseButton = Qt::NoButton;
-  m_tabletState = None;
-  m_tabletMove  = false;
-  m_pressure    = 0;
+  // If m_tabletState is "Touched", we've been called by tabletPress event.
+  // Don't clear it out table state so the tablePress event will process
+  // correctly.
+  if (m_tabletState != Touched) m_tabletState = None;
+  m_tabletMove                                = false;
+  m_pressure                                  = 0;
   // Leave m_tabletEvent as-is in order to check whether the onRelease is called
   // from tabletEvent or not in mouseReleaseEvent.
+  if (m_tabletState == Released)  // only clear if tabletRelease event
+    m_tabletEvent = false;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a random pressure sensitivity loss I experience a lot since switching to a non-wacom tablet.  It should be noted, I do run into this issue on my older wacom tablet as we..

This was caused by the order of mouse/tablet events when drawing with a pen.  The current logic worked fine if the TabletPress event occurred before the MousePress event.  The MousePress event is designed to be ignored if the TabletPress happened first.

However, when a MousePress event occurs before the TabletPress event, usually randomly and for reasons unknown, the TabletPress event fails to overwrite the settings set up by the MousePress event and therefore fails to send pressure data to the brush tool.

I also ran into this issue when a TabletPress was somehow immediately followed by a MouseRelease event which resulted in the same issue.  For this case, I made it so the MouseRelease event is ignored if the tabletRelease event hasn't been called first.