### PR TITLE
Fix Crash After Converting to Vector

### DIFF
--- a/toonz/sources/toonzlib/tnewoutlinevectorize.cpp
+++ b/toonz/sources/toonzlib/tnewoutlinevectorize.cpp
@@ -770,7 +770,6 @@ void outlineVectorize(TVectorImageP &vi, const TRasterImageP &ri,
 
   // Build regions
   vi->transform(conf.m_affine);
-  vi->setAutocloseTolerance(-100.0);
   vi->findRegions();
 
   if (!conf.m_leaveUnpainted)
@@ -797,7 +796,6 @@ void outlineVectorize(TVectorImageP &vi, const TToonzImageP &ti,
   TRop::borders::readBorders_simple(rasGR16, reader, TPixelGR16::Black, false);
 
   vi->transform(conf.m_affine);
-  vi->setAutocloseTolerance(-100.0);
   vi->findRegions();
 
   if (!conf.m_leaveUnpainted) buildColorsCM(vi, reader.scHash());


### PR DESCRIPTION
This PR will fix #1916 
In the previous source there were lines setting the maximum gap value to -100, which is invalid for now.
I'm not sure this line is necessary for the following line of `findRegions()` to act in a special way, at least as far as I tried it works OK without this line. 
I'll wait user's feedback and will take another measure if there will be any problem.