### PR TITLE
Modify Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,56 +1,24 @@
-<!--
-Use Markdown language for styling.
-Github's Markdown Guide https://guides.github.com/features/mastering-markdown/
-Please use the SEARCH function before opening a new issue!
--->
+<!-- Please use the search function before opening a new issue -->
 
-### --Issue Summary--
-<!-- A brief overview of your issue  -->
+### Issue Summary
+<!-- Please provide a brief description of your issue -->
 
-### --Video or Image Reference--
-<!-- (Optional) A screenshot, short video, etc. to show your problem -->
+### Screenshot or Video Reference
+<!-- Please provide a screenshot or video that highlights your issue -->
 
-### --Steps to reproduce--
-<!-- Describe the steps to reproduce the problem, more steps are better. -->
+### Steps to Reproduce
+<!-- Please provide any steps that can reproduce the issue -->
 
-### --Actual Results--
-<!-- Explain what you actually got. -->
+### Expected Results
+<!-- What you expected to happen -->
 
-### --Expected Results--
-<!-- Explain how the program should behave in the context you're using it. -->
+### Actual Results
+<!-- What actually happens -->
 
-### --System Information--
-+ OpenToonz Version:
-<!-- You can find the VERSION in Menu->Help->About OpenToonz -->
-
-+ Operating System:
-<!-- (e.g., Windows10, macOS 10.12, Ubuntu 16.04, Debian Stretch) -->
-
-
-+ Other Device Info (Optional):
-
-* RAM Size  4GB, 8GB, 16GB:
-
-* Graphics Tablet:
-<!-- (Optional) (Write your MODEL, e.g., WACOM Intuos 2) -->
-
-
-
----
-<!--
-### --For Code Contributors--
-(Optional) Use this space to point to relevant code chunks that might be causing the issue.
-
-```C++
-    Paste here code snippets relevant to your report like so:
-    #include <iostream>
-
-    int main() {
-        std::cout << "Hello, World" << endl;        
-        return 0;
-    }
-
-```
--->
-
-
+### System Information
+* **OpenToonz Version**: 
+* **Operating System**: 
+* **CPU**: 
+* **Memory**: 
+* **Graphics Card**: 
+* **Graphics Tablet**: 


### PR DESCRIPTION
Because:
1. It's unnecessarily instructive.
2. It's too difficult to read with the hyphens.

Finding information such as version numbers is incredibly basic, you don't need to open RegEdit to find it. Unsure why there is instructions for including code snippets for C++ developers, it's unnecessary.

Absolutely feel free to reject this or modify it, it's only a recommendation, but the hyphens is giving me a headache, thanks.