### PR TITLE
Fix Pinch Tool Crash

### DIFF
--- a/toonz/sources/tnztools/pinchtool.cpp
+++ b/toonz/sources/tnztools/pinchtool.cpp
@@ -376,6 +376,15 @@ void PinchTool::onLeave() {
 void PinchTool::onImageChanged() {
   m_status.stroke2change_ = 0;
   m_deformation->reset();
+  // m_active may be true if the frame switched while dragging
+  if (m_active) {
+    m_deformation->deactivate();
+    m_active = false;
+    if (m_undo) {
+      delete m_undo;
+      m_undo = 0;
+    }
+  }
 
   double w        = 0;
   TStroke *stroke = getClosestStroke(m_lastMouseEvent.m_pos, w);
@@ -529,7 +538,7 @@ bool PinchTool::keyDown(QKeyEvent *event) {
     }
   }
 #endif
-  return true;
+  return false;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This will fix #2050 
This PR also enables standard keyboard shortcuts (such as arrow keys and Home/End keys for moving the current frame) available when the pinch tool is active. 

Please note that undoing the pinch tool sometimes causes assertion failure on debug mode. It has happened in the current master branch and is not the scope of this PR.