### PR TITLE
Fix Brush Artifacts on Viewer

### DIFF
--- a/toonz/sources/include/toonz/rasterstrokegenerator.h
+++ b/toonz/sources/include/toonz/rasterstrokegenerator.h
@@ -62,7 +62,7 @@ public:
   void setAboveStyleIds(QSet<int> &ids) { m_aboveStyleIds = ids; }
 
   // Inserisce un punto in "m_points"
-  bool add(const TThickPoint &p);
+  void add(const TThickPoint &p);
 
   // Disegna il tratto interamente
   void generateStroke(bool isPencil) const;

--- a/toonz/sources/tnztools/fingertool.cpp
+++ b/toonz/sources/tnztools/fingertool.cpp
@@ -432,13 +432,11 @@ void FingerTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
                     m_rasterTrackが無くて落ちることがある。 ---*/
     if (m_rasterTrack) {
       int thickness = m_toolSize.getValue();
-      bool isAdded  = m_rasterTrack->add(
+      m_rasterTrack->add(
           TThickPoint(pos + convert(ri->getRaster()->getCenter()), thickness));
-      if (isAdded) {
-        m_tileSaver->save(m_rasterTrack->getLastRect());
-        TRect modifiedBbox = m_rasterTrack->generateLastPieceOfStroke(true);
-        invalidate();
-      }
+      m_tileSaver->save(m_rasterTrack->getLastRect());
+      TRect modifiedBbox = m_rasterTrack->generateLastPieceOfStroke(true);
+      invalidate();
     }
   }
 }
@@ -512,13 +510,10 @@ void FingerTool::finishBrush() {
   if (TToonzImageP ti = (TToonzImageP)getImage(true)) {
     if (m_rasterTrack) {
       int thickness = m_toolSize.getValue();
-      bool isAdded  = m_rasterTrack->add(TThickPoint(
+      m_rasterTrack->add(TThickPoint(
           m_mousePos + convert(ti->getRaster()->getCenter()), thickness));
-      if (isAdded) {
-        m_tileSaver->save(m_rasterTrack->getLastRect());
-        TRect modifiedBbox =
-            m_rasterTrack->generateLastPieceOfStroke(true, true);
-      }
+      m_tileSaver->save(m_rasterTrack->getLastRect());
+      TRect modifiedBbox = m_rasterTrack->generateLastPieceOfStroke(true, true);
 
       TTool::Application *app   = TTool::getApplication();
       TXshLevel *level          = app->getCurrentLevel()->getLevel();

--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -463,13 +463,11 @@ void PaintBrushTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
 　---*/
     if (m_rasterTrack) {
       int thickness = m_toolSize.getValue();
-      bool isAdded  = m_rasterTrack->add(
+      m_rasterTrack->add(
           TThickPoint(pos + convert(ri->getRaster()->getCenter()), thickness));
-      if (isAdded) {
-        m_tileSaver->save(m_rasterTrack->getLastRect());
-        TRect modifiedBbox = m_rasterTrack->generateLastPieceOfStroke(true);
-        invalidate();
-      }
+      m_tileSaver->save(m_rasterTrack->getLastRect());
+      TRect modifiedBbox = m_rasterTrack->generateLastPieceOfStroke(true);
+      invalidate();
     }
   }
 }
@@ -542,12 +540,10 @@ void PaintBrushTool::finishBrush() {
   if (TToonzImageP ti = (TToonzImageP)getImage(true)) {
     if (m_rasterTrack) {
       int thickness = m_toolSize.getValue();
-      bool isAdded  = m_rasterTrack->add(TThickPoint(
+      m_rasterTrack->add(TThickPoint(
           m_mousePos + convert(ti->getRaster()->getCenter()), thickness));
-      if (isAdded) {
-        m_tileSaver->save(m_rasterTrack->getLastRect());
-        m_rasterTrack->generateLastPieceOfStroke(true, true);
-      }
+      m_tileSaver->save(m_rasterTrack->getLastRect());
+      m_rasterTrack->generateLastPieceOfStroke(true, true);
 
       TTool::Application *app   = TTool::getApplication();
       TXshLevel *level          = app->getCurrentLevel()->getLevel();

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -1005,8 +1005,8 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
           intPos = TThickPoint(pp + convert(ti->getRaster()->getCenter()),
                                m_toolSize.getValue() - 1);
 
-        bool isAdded = m_normalEraser->add(intPos);
-        if (ti && isAdded) {
+        m_normalEraser->add(intPos);
+        if (ti) {
           m_tileSaver->save(m_normalEraser->getLastRect());
           m_normalEraser->generateLastPieceOfStroke(
               m_pencil.getValue() || m_colorType.getValue() == AREAS);

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -33,13 +33,12 @@ RasterStrokeGenerator::~RasterStrokeGenerator() {}
 
 //-----------------------------------------------------------
 
-bool RasterStrokeGenerator::add(const TThickPoint &p) {
+void RasterStrokeGenerator::add(const TThickPoint &p) {
   TThickPoint pp = p;
   TThickPoint mid((m_points.back() + pp) * 0.5,
                   (p.thick + m_points.back().thick) * 0.5);
   m_points.push_back(mid);
   m_points.push_back(pp);
-  return true;
 }
 
 //-----------------------------------------------------------


### PR DESCRIPTION
This PR fixes #2066 (brush tip artifacts appears & short stroke cannot be drawn with soft brush).

This PR fixes #2070  as well.
Now the stroke will be canceled if the current frame is moved to empty frame while dragging.