### PR TITLE
Set CFBundleIdentifier in Info.plist

### DIFF
--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string>OpenToonz.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string></string>
+	<string>io.github.opentoonz.OpenToonz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>


### PR DESCRIPTION
CFBundleIdentifier must be a unique identifier according to Apple's docummention.
Failure to have this set breaks the ability for other tools to identify OpenToonz.

I set it to `io.github.opentoonz.OpenToonz` since the OpenToonz website is https://opentoonz.github.io

This fixes issue #2053 
