### PR TITLE
Show actual fonts in font dropdowns

### DIFF
--- a/toonz/sources/common/tvrender/tfont_qt.cpp
+++ b/toonz/sources/common/tvrender/tfont_qt.cpp
@@ -429,7 +429,8 @@ void TFontManager::getAllFamilies(vector<wstring> &families) const {
 
   QStringList::const_iterator it = qFamilies.begin();
   for (; it != qFamilies.end(); ++it) {
-    families.push_back(it->toStdWString());
+    if (!m_pimpl->m_qfontdb->isPrivateFamily(*it))
+      families.push_back(it->toStdWString());
   }
 }
 

--- a/toonz/sources/include/tools/toolhandle.h
+++ b/toonz/sources/include/tools/toolhandle.h
@@ -65,7 +65,10 @@ public:
   void notifyToolChanged() { emit toolChanged(); }
 
   void notifyToolCursorTypeChanged() { emit toolCursorTypeChanged(); }
+
+  void notifyToolComboBoxListChanged() { emit toolComboBoxListChanged(); }
 signals:
+  void toolComboBoxListChanged();
   void toolSwitched();
   void toolChanged();
   void toolEditingFinished();

--- a/toonz/sources/include/tools/toolhandle.h
+++ b/toonz/sources/include/tools/toolhandle.h
@@ -66,9 +66,12 @@ public:
 
   void notifyToolCursorTypeChanged() { emit toolCursorTypeChanged(); }
 
-  void notifyToolComboBoxListChanged() { emit toolComboBoxListChanged(); }
+  void notifyToolComboBoxListChanged(std::string id) {
+    emit toolComboBoxListChanged(id);
+  }
+
 signals:
-  void toolComboBoxListChanged();
+  void toolComboBoxListChanged(std::string);
   void toolSwitched();
   void toolChanged();
   void toolEditingFinished();

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -146,7 +146,7 @@ public:
   enum SingleValueWidgetType { SLIDER = 0, FIELD };
   void setSingleValueWidgetType(int type) { m_singleValueWidgetType = type; }
 
-  enum EnumWidgetType { COMBOBOX = 0, POPUPBUTTON };
+  enum EnumWidgetType { COMBOBOX = 0, POPUPBUTTON, FONTCOMBOBOX };
   void setEnumWidgetType(int type) { m_enumWidgetType = type; }
 
 private:

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -238,6 +238,8 @@ public:
 
   void setInterfaceFont(std::string font);
   QString getInterfaceFont() { return m_interfaceFont; }
+  void setInterfaceFontStyle(std::string style);
+  QString getInterfaceFontStyle() { return m_interfaceFontStyle; }
   void setInterfaceFontWeight(int weight);
   int getInterfaceFontWeight() { return m_interfaceFontWeight; }
 
@@ -584,7 +586,7 @@ private:
 
   QString m_units, m_cameraUnits, m_scanLevelType, m_currentRoomChoice,
       m_oldUnits, m_oldCameraUnits, m_ffmpegPath, m_shortcutPreset,
-      m_customProjectRoot, m_interfaceFont;
+      m_customProjectRoot, m_interfaceFont, m_interfaceFontStyle;
   QString m_fastRenderPath;
 
   double m_defLevelWidth, m_defLevelHeight, m_defLevelDpi;

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1554,12 +1554,12 @@ TypeToolOptionsBox::TypeToolOptionsBox(QWidget *parent, TTool *tool,
   ret &&connect(fontField, SIGNAL(currentIndexChanged(int)), this,
                 SLOT(onFieldChanged()));
 
-#ifndef MACOSX
+  //#ifndef MACOSX
   ToolOptionCombo *styleField =
       dynamic_cast<ToolOptionCombo *>(m_controls.value("Style:"));
   ret &&connect(styleField, SIGNAL(currentIndexChanged(int)), this,
                 SLOT(onFieldChanged()));
-#endif
+  //#endif
 
   ToolOptionCombo *sizeField =
       dynamic_cast<ToolOptionCombo *>(m_controls.value("Size:"));

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1559,6 +1559,8 @@ TypeToolOptionsBox::TypeToolOptionsBox(QWidget *parent, TTool *tool,
       dynamic_cast<ToolOptionCombo *>(m_controls.value("Style:"));
   ret &&connect(styleField, SIGNAL(currentIndexChanged(int)), this,
                 SLOT(onFieldChanged()));
+  ret &&connect(toolHandle, SIGNAL(toolComboBoxListChanged(std::string)),
+                styleField, SLOT(reloadComboBoxList(std::string)));
   //#endif
 
   ToolOptionCombo *sizeField =

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -365,6 +365,17 @@ void ToolOptionControlBuilder::visit(TEnumProperty *p) {
     break;
   }
 
+  case FONTCOMBOBOX: {
+    if (p->getQStringName() != "") {
+      QLabel *label = addLabel(p);
+      m_panel->addLabel(p->getName(), label);
+    }
+    ToolOptionFontCombo *obj = new ToolOptionFontCombo(m_tool, p, m_toolHandle);
+    control                  = obj;
+    widget                   = obj;
+    break;
+  }
+
   case COMBOBOX:
   default: {
     if (p->getQStringName() != "") {
@@ -1529,13 +1540,17 @@ TypeToolOptionsBox::TypeToolOptionsBox(QWidget *parent, TTool *tool,
   assert(props->getPropertyCount() > 0);
 
   ToolOptionControlBuilder builder(this, tool, pltHandle, toolHandle);
+  builder.setEnumWidgetType(ToolOptionControlBuilder::FONTCOMBOBOX);
   if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
+  builder.setEnumWidgetType(ToolOptionControlBuilder::COMBOBOX);
+  if (tool && tool->getProperties(1)) tool->getProperties(1)->accept(builder);
 
   m_layout->addStretch(0);
 
   bool ret = true;
-  ToolOptionCombo *fontField =
-      dynamic_cast<ToolOptionCombo *>(m_controls.value("Font:"));
+
+  ToolOptionFontCombo *fontField =
+      dynamic_cast<ToolOptionFontCombo *>(m_controls.value("Font:"));
   ret &&connect(fontField, SIGNAL(currentIndexChanged(int)), this,
                 SLOT(onFieldChanged()));
 

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -702,13 +702,15 @@ ToolOptionFontCombo::ToolOptionFontCombo(TTool *tool, TEnumProperty *property,
   // synchronize the state with the same widgets in other tool option bars
   if (toolHandle)
     connect(this, SIGNAL(activated(int)), toolHandle, SIGNAL(toolChanged()));
+
+  updateStatus();
 }
 
 //-----------------------------------------------------------------------------
 
 void ToolOptionFontCombo::updateStatus() {
   QString value = QString::fromStdWString(m_property->getValue());
-  int index     = findData(value);
+  int index     = findText(value);
   if (index >= 0 && index != currentIndex()) setCurrentIndex(index);
 }
 
@@ -721,51 +723,6 @@ void ToolOptionFontCombo::onActivated(int index) {
   std::wstring item = range[index];
   m_property->setValue(item);
   notifyTool();
-}
-
-//-----------------------------------------------------------------------------
-
-void ToolOptionFontCombo::doShowPopup() {
-  if (Preferences::instance()->getDropdownShortcutsCycleOptions()) {
-    const TEnumProperty::Range &range           = m_property->getRange();
-    int theIndex                                = currentIndex() + 1;
-    if (theIndex >= (int)range.size()) theIndex = 0;
-    doOnActivated(theIndex);
-  } else {
-    if (isVisible()) showPopup();
-  }
-}
-
-//-----------------------------------------------------------------------------
-
-void ToolOptionFontCombo::doOnActivated(int index) {
-  if (m_toolHandle && m_toolHandle->getTool() != m_tool) return;
-  // active only if the belonging combo-viewer is visible
-  if (!isInVisibleViewer(this)) return;
-  bool cycleOptions =
-      Preferences::instance()->getDropdownShortcutsCycleOptions();
-  // Just move the index if the first item is not "Normal"
-  if (m_property->indexOf(L"Normal") != 0) {
-    onActivated(index);
-    setCurrentIndex(index);
-    // for updating the cursor
-    m_toolHandle->notifyToolChanged();
-    return;
-  }
-
-  // If the first item of this combo box is "Normal", enable shortcut key toggle
-  // can "back and forth" behavior.
-  if (currentIndex() == index) {
-    // estimating that the "Normal" option is located at the index 0
-    onActivated(0);
-    setCurrentIndex(0);
-  } else {
-    onActivated(index);
-    setCurrentIndex(index);
-  }
-
-  // for updating a cursor without any effect to the tool options
-  m_toolHandle->notifyToolCursorTypeChanged();
 }
 
 //=============================================================================

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -573,10 +573,14 @@ ToolOptionCombo::ToolOptionCombo(TTool *tool, TEnumProperty *property,
   // synchronize the state with the same widgets in other tool option bars
   if (toolHandle) {
     connect(this, SIGNAL(activated(int)), toolHandle, SIGNAL(toolChanged()));
-
-    connect(toolHandle, SIGNAL(toolComboBoxListChanged()), this,
-            SLOT(loadEntries()));
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void ToolOptionCombo::reloadComboBoxList(std::string id) {
+  if (id == "" || m_property->getName() != id) return;
+  loadEntries();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -571,8 +571,12 @@ ToolOptionCombo::ToolOptionCombo(TTool *tool, TEnumProperty *property,
   setSizeAdjustPolicy(QComboBox::AdjustToContents);
   connect(this, SIGNAL(activated(int)), this, SLOT(onActivated(int)));
   // synchronize the state with the same widgets in other tool option bars
-  if (toolHandle)
+  if (toolHandle) {
     connect(this, SIGNAL(activated(int)), toolHandle, SIGNAL(toolChanged()));
+
+    connect(toolHandle, SIGNAL(toolComboBoxListChanged()), this,
+            SLOT(loadEntries()));
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -725,6 +725,21 @@ void ToolOptionFontCombo::onActivated(int index) {
   notifyTool();
 }
 
+//-----------------------------------------------------------------------------
+
+void ToolOptionFontCombo::doShowPopup() {
+  if (!isInVisibleViewer(this)) return;
+  if (Preferences::instance()->getDropdownShortcutsCycleOptions()) {
+    const TEnumProperty::Range &range           = m_property->getRange();
+    int theIndex                                = currentIndex() + 1;
+    if (theIndex >= (int)range.size()) theIndex = 0;
+    onActivated(theIndex);
+    setCurrentIndex(theIndex);
+  } else {
+    if (isVisible()) showPopup();
+  }
+}
+
 //=============================================================================
 
 ToolOptionPopupButton::ToolOptionPopupButton(TTool *tool,

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -203,13 +203,12 @@ protected:
 public:
   ToolOptionCombo(TTool *tool, TEnumProperty *property,
                   ToolHandle *toolHandle = 0);
-  void loadEntries();
   void updateStatus() override;
 
   TEnumProperty *getProperty() const { return m_property; }
 
 public slots:
-
+  void loadEntries();
   void onActivated(int);
   void doShowPopup();
   void doOnActivated(int);

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -29,6 +29,7 @@
 
 // Qt includes
 #include <QComboBox>
+#include <QFontComboBox>
 #include <QToolButton>
 #include <QTimer>
 #include <QLabel>
@@ -203,6 +204,29 @@ public:
   ToolOptionCombo(TTool *tool, TEnumProperty *property,
                   ToolHandle *toolHandle = 0);
   void loadEntries();
+  void updateStatus() override;
+
+  TEnumProperty *getProperty() const { return m_property; }
+
+public slots:
+
+  void onActivated(int);
+  void doShowPopup();
+  void doOnActivated(int);
+};
+
+//-----------------------------------------------------------------------------
+
+class ToolOptionFontCombo final : public QFontComboBox,
+                                  public ToolOptionControl {
+  Q_OBJECT
+
+protected:
+  TEnumProperty *m_property;
+
+public:
+  ToolOptionFontCombo(TTool *tool, TEnumProperty *property,
+                      ToolHandle *toolHandle = 0);
   void updateStatus() override;
 
   TEnumProperty *getProperty() const { return m_property; }

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -234,8 +234,6 @@ public:
 public slots:
 
   void onActivated(int);
-  void doShowPopup();
-  void doOnActivated(int);
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -208,6 +208,7 @@ public:
   TEnumProperty *getProperty() const { return m_property; }
 
 public slots:
+  void reloadComboBoxList(std::string);
   void loadEntries();
   void onActivated(int);
   void doShowPopup();

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -234,6 +234,7 @@ public:
 public slots:
 
   void onActivated(int);
+  void doShowPopup();
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -539,6 +539,8 @@ void TypeTool::initTypeFaces() {
        it != typefaces.end(); ++it)
     m_typeFaceMenu.addValue(*it);
   if (m_typeFaceMenu.isValue(oldTypeface)) m_typeFaceMenu.setValue(oldTypeface);
+
+  TTool::getApplication()->getCurrentTool()->notifyToolComboBoxListChanged();
 }
 
 //---------------------------------------------------------

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -295,7 +295,7 @@ class TypeTool final : public TTool {
   TEnumProperty m_typeFaceMenu;
   TBoolProperty m_vertical;
   TEnumProperty m_size;
-  TPropertyGroup m_prop;
+  TPropertyGroup m_prop[2];
 
   // valori correnti di alcune Properties,
   // duplicati per permettere controlli sulla validita' o per ottimizzazione
@@ -389,7 +389,9 @@ public:
 
   bool onPropertyChanged(std::string propertyName) override;
 
-  TPropertyGroup *getProperties(int targetType) override { return &m_prop; }
+  TPropertyGroup *getProperties(int targetType) override {
+    return &m_prop[targetType];
+  }
 
   int getColorClass() const { return 1; }
 
@@ -421,15 +423,15 @@ TypeTool::TypeTool()
     , m_size("Size:")                            // W_ToolOptions_Size
     , m_undo(0) {
   bind(TTool::CommonLevels | TTool::EmptyTarget);
-  m_prop.bind(m_fontFamilyMenu);
+  m_prop[0].bind(m_fontFamilyMenu);
   // Su mac non e' visibile il menu dello style perche' e' stato inserito nel
   // nome
   // della font.
   //#ifndef MACOSX
-  m_prop.bind(m_typeFaceMenu);
+  m_prop[1].bind(m_typeFaceMenu);
   //#endif
-  m_prop.bind(m_size);
-  m_prop.bind(m_vertical);
+  m_prop[1].bind(m_size);
+  m_prop[1].bind(m_vertical);
   m_vertical.setId("Orientation");
   m_fontFamilyMenu.setId("TypeFont");
   m_typeFaceMenu.setId("TypeStyle");

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -540,7 +540,8 @@ void TypeTool::initTypeFaces() {
     m_typeFaceMenu.addValue(*it);
   if (m_typeFaceMenu.isValue(oldTypeface)) m_typeFaceMenu.setValue(oldTypeface);
 
-  TTool::getApplication()->getCurrentTool()->notifyToolComboBoxListChanged();
+  TTool::getApplication()->getCurrentTool()->notifyToolComboBoxListChanged(
+      m_typeFaceMenu.getName());
 }
 
 //---------------------------------------------------------

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -62,6 +62,7 @@
 #include "tsimplecolorstyles.h"
 #include "toonz/imagestyles.h"
 #include "tvectorbrushstyle.h"
+#include "tfont.h"
 
 #ifdef MACOSX
 #include "tipc.h"
@@ -623,16 +624,26 @@ int main(int argc, char *argv[]) {
   }
 
   QFont *myFont;
-  std::string fontName =
-      Preferences::instance()->getInterfaceFont().toStdString();
-  std::string isBold =
-      Preferences::instance()->getInterfaceFontWeight() ? "Yes" : "No";
-  myFont = new QFont(QString::fromStdString(fontName));
+  QString fontName  = Preferences::instance()->getInterfaceFont();
+  QString fontStyle = Preferences::instance()->getInterfaceFontStyle();
+
+  TFontManager *fontMgr = TFontManager::instance();
+  std::vector<std::wstring> typefaces;
+  fontMgr->loadFontNames();
+  fontMgr->setFamily(fontName.toStdWString());
+  fontMgr->getAllTypefaces(typefaces);
+
+  bool isBold = false, isItalic = false, hasKerning = false;
+  isBold     = fontMgr->isBold(fontName, fontStyle);
+  isItalic   = fontMgr->isItalic(fontName, fontStyle);
+  hasKerning = fontMgr->hasKerning();
+
+  myFont = new QFont(fontName);
   myFont->setPixelSize(EnvSoftwareCurrentFontSize);
-  if (strcmp(isBold.c_str(), "Yes") == 0)
-    myFont->setBold(true);
-  else
-    myFont->setBold(false);
+  myFont->setBold(isBold);
+  myFont->setItalic(isItalic);
+  myFont->setKerning(hasKerning);
+
   a.setFont(*myFont);
 
   QAction *action = CommandManager::instance()->getAction("MI_OpenTMessage");

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -38,6 +38,7 @@
 // Qt includes
 #include <QHBoxLayout>
 #include <QComboBox>
+#include <QFontComboBox>
 #include <QLabel>
 #include <QStackedWidget>
 #include <QLineEdit>
@@ -1305,7 +1306,7 @@ PreferencesPopup::PreferencesPopup()
       new QLabel(tr("* Changes will take effect the next time you run Toonz"));
   note_interface->setStyleSheet("font-size: 10px; font: italic;");
 
-  m_interfaceFont       = new QComboBox(this);
+  m_interfaceFont       = new QFontComboBox(this);
   m_interfaceFontWeight = new QComboBox(this);
 
   m_colorCalibration =
@@ -1649,26 +1650,7 @@ PreferencesPopup::PreferencesPopup()
   viewerZoomCenterComboBox->addItems(zoomCenters);
   viewerZoomCenterComboBox->setCurrentIndex(m_pref->getViewerZoomCenter());
 
-  TFontManager *instance = TFontManager::instance();
-  bool validFonts;
-  try {
-    instance->loadFontNames();
-    validFonts = true;
-  } catch (TFontLibraryLoadingError &) {
-    validFonts = false;
-    //    TMessage::error(toString(e.getMessage()));
-  }
-
-  if (validFonts) {
-    std::vector<std::wstring> names;
-    instance->getAllFamilies(names);
-
-    for (std::vector<std::wstring>::iterator it = names.begin();
-         it != names.end(); ++it)
-      m_interfaceFont->addItem(QString::fromStdWString(*it));
-
-    m_interfaceFont->setCurrentText(m_pref->getInterfaceFont());
-  }
+  m_interfaceFont->setCurrentText(m_pref->getInterfaceFont());
 
   QStringList fontStyles;
   fontStyles << "Regular"

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -16,6 +16,7 @@
 
 // Qt includes
 #include <QComboBox>
+#include <QFontComboBox>
 
 //==============================================================
 
@@ -55,9 +56,10 @@ private:
       *m_defLevelType, *m_autocreationType, *m_levelFormatNames,
       *m_columnIconOm, *m_unitOm, *m_cameraUnitOm, *m_importPolicy,
       *m_vectorSnappingTargetCB, *m_dropdownShortcutsCycleOptionsCB,
-      *m_interfaceFont, *m_interfaceFontWeight, *m_guidedDrawingStyle,
-      *m_functionEditorToggle, *m_cursorBrushType, *m_cursorBrushStyle,
-      *m_xsheetLayout;
+      *m_interfaceFontWeight, *m_guidedDrawingStyle, *m_functionEditorToggle,
+      *m_cursorBrushType, *m_cursorBrushStyle, *m_xsheetLayout;
+
+  QFontComboBox *m_interfaceFont;
 
   DVGui::MeasuredDoubleLineEdit *m_defLevelWidth, *m_defLevelHeight;
 

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -56,8 +56,8 @@ private:
       *m_defLevelType, *m_autocreationType, *m_levelFormatNames,
       *m_columnIconOm, *m_unitOm, *m_cameraUnitOm, *m_importPolicy,
       *m_vectorSnappingTargetCB, *m_dropdownShortcutsCycleOptionsCB,
-      *m_interfaceFontWeight, *m_guidedDrawingStyle, *m_functionEditorToggle,
-      *m_cursorBrushType, *m_cursorBrushStyle, *m_xsheetLayout;
+      *m_guidedDrawingStyle, *m_functionEditorToggle, *m_cursorBrushType,
+      *m_cursorBrushStyle, *m_xsheetLayout, *m_interfaceFontStyle;
 
   QFontComboBox *m_interfaceFont;
 
@@ -94,6 +94,7 @@ private:
 private:
   // QWidget* create(const QString& lbl, bool def, const char* slot);
   void rebuildFormatsList();
+  void rebuilldFontStyleList();
 
 private slots:
 
@@ -202,7 +203,7 @@ private slots:
   void onShortcutCommandsWhileRenamingCellClicked(int);
   void onWatchFileSystemClicked(int);
   void onInterfaceFontChanged(int index);
-  void onInterfaceFontWeightChanged(int index);
+  void onInterfaceFontStyleChanged(int index);
   void onXsheetLayoutChanged(int index);
   void onPathAliasPriorityChanged(int index);
   void onShowCurrentTimelineChanged(int);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -231,6 +231,7 @@ Preferences::Preferences()
 #else
     , m_interfaceFont("Helvetica")
 #endif
+    , m_interfaceFontStyle("Regular")
     , m_interfaceFontWeight(0)
     , m_defLevelWidth(0.0)
     , m_defLevelHeight(0.0)
@@ -634,6 +635,10 @@ Preferences::Preferences()
   QString interfaceFont = m_settings->value("interfaceFont").toString();
   if (interfaceFont != "") m_interfaceFont = interfaceFont;
   setInterfaceFont(m_interfaceFont.toStdString());
+  QString interfaceFontStyle =
+      m_settings->value("interfaceFontStyle").toString();
+  if (interfaceFontStyle != "") m_interfaceFontStyle = interfaceFontStyle;
+  setInterfaceFontStyle(m_interfaceFontStyle.toStdString());
   getValue(*m_settings, "interfaceFontWeight", m_interfaceFontWeight);
   getValue(*m_settings, "useNumpadForSwitchingStyles",
            m_useNumpadForSwitchingStyles);
@@ -1308,6 +1313,13 @@ QString Preferences::getCurrentStyleSheetName() const {
 void Preferences::setInterfaceFont(std::string font) {
   m_interfaceFont = QString::fromStdString(font);
   m_settings->setValue("interfaceFont", m_interfaceFont);
+}
+
+//-----------------------------------------------------------------
+
+void Preferences::setInterfaceFontStyle(std::string style) {
+  m_interfaceFontStyle = QString::fromStdString(style);
+  m_settings->setValue("interfaceFontStyle", m_interfaceFontStyle);
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
This PR updates the Font dropdown lists to show actual fonts.

![image](https://user-images.githubusercontent.com/19245851/41451564-7bfa781c-703b-11e8-8790-b0e47efb1da5.png)

The following dropdowns have been converted to use the QFontComboBox class:
- Preferences (Interface tab shown above)
- Type tool

Additionally fixed a preexisting bug where the Style Combo box was not updating when a new font was selected.