### PR TITLE
Update Image DPI Field of Convert Popup Upon Opening

### DIFF
--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -838,6 +838,8 @@ void ConvertPopup::setFiles(const std::vector<TFilePath> &fps) {
   m_palettePath->setPath(CreateNewPalette);
   m_removeUnusedStyles->setEnabled(false);
 
+  // update the image dpi field
+  onDpiModeSelected(m_dpiMode->currentIndex());
   // m_fileFormat->setCurrentIndex(areFullcolor?0:m_fileFormat->findText("tif"));
 }
 


### PR DESCRIPTION
This PR fixes [a bug reported in the forum](https://groups.google.com/d/msg/opentoonz_en/vIoleLcQwoY/2NQmy6JnBgAJ) regarding the Convert Popup:

> It looks like in the RC that the Image DPI is only calculated upon changing into Image DPI mode - not upon opening the convert window which I think is the expected & desired behavior. 