### PR TITLE
Fix Paste Column Bug

### DIFF
--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -794,6 +794,7 @@ void ColumnCmd::copyColumns(const std::set<int> &indices) {
 
 void ColumnCmd::pasteColumns(std::set<int> &indices,
                              const StageObjectsData *data) {
+  // indices will be updated here by inserted column ids after pasting
   bool isPaste = pasteColumnsWithoutUndo(&indices, true, data);
   if (!isPaste) return;
   TUndoManager::manager()->add(new PasteColumnsUndo(indices));

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -65,21 +65,19 @@ bool TColumnSelection::isEmpty() const { return m_indices.empty(); }
 void TColumnSelection::copyColumns() { ColumnCmd::copyColumns(m_indices); }
 
 //-----------------------------------------------------------------------------
-
-void TColumnSelection::pasteColumns() { ColumnCmd::pasteColumns(m_indices); }
+// pasteColumns will insert columns before the first column in the selection
+void TColumnSelection::pasteColumns() {
+  std::set<int> indices;
+  indices.insert(*m_indices.begin());
+  ColumnCmd::pasteColumns(indices);
+}
 
 //-----------------------------------------------------------------------------
-
+// pasteColumnsAbove will insert columns after the last column in the selection
 void TColumnSelection::pasteColumnsAbove() {
   std::set<int> indices;
-  std::set<int>::iterator it;
-
-  for (it = m_indices.begin(); it != m_indices.end(); it++) {
-    int newIdx = *it + 1;
-    indices.insert(newIdx);
-  }
-
-  ColumnCmd::pasteColumns(indices, 0);
+  indices.insert(*m_indices.rbegin() + 1);
+  ColumnCmd::pasteColumns(indices);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -68,7 +68,10 @@ void TColumnSelection::copyColumns() { ColumnCmd::copyColumns(m_indices); }
 // pasteColumns will insert columns before the first column in the selection
 void TColumnSelection::pasteColumns() {
   std::set<int> indices;
-  indices.insert(*m_indices.begin());
+  if (isEmpty())  // in case that no columns are selected
+    indices.insert(0);
+  else
+    indices.insert(*m_indices.begin());
   ColumnCmd::pasteColumns(indices);
 }
 
@@ -76,7 +79,11 @@ void TColumnSelection::pasteColumns() {
 // pasteColumnsAbove will insert columns after the last column in the selection
 void TColumnSelection::pasteColumnsAbove() {
   std::set<int> indices;
-  indices.insert(*m_indices.rbegin() + 1);
+  if (isEmpty()) {  // in case that no columns are selected
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    indices.insert(xsh->getFirstFreeColumnIndex());
+  } else
+    indices.insert(*m_indices.rbegin() + 1);
   ColumnCmd::pasteColumns(indices);
 }
 


### PR DESCRIPTION
This will fix #1957 

This PR will change pasting column commands behavior as follows:

- **Paste Insert Before/Below** will insert copied columns just before the first column of the selection.
- **Paste Insert After/Above** will insert copied columns just after the last column of the selection.

I think these behaviors are intuitive and now undo/redo works fine.   