### PR TITLE
Fixed crash with wheel zoom (too much) on Flipbook

### DIFF
--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -635,9 +635,10 @@ void ImageViewer::panQt(const QPoint &delta) {
 void ImageViewer::zoomQt(const QPoint &center, double factor) {
   if (factor == 1.0) return;
   TPointD delta(center.x(), center.y());
-
-  setViewAff(TTranslation(delta) * TScale(factor) * TTranslation(-delta) *
-             m_viewAff);
+  double scale2 = fabs(m_viewAff.det());
+  if ((scale2 < 100000 || factor < 1) && (scale2 > 0.001 * 0.05 || factor > 1))
+    setViewAff(TTranslation(delta) * TScale(factor) * TTranslation(-delta) *
+               m_viewAff);
   update();
 }
 


### PR DESCRIPTION
This may be a bad news for elementary particle physicists using OpenToonz. You can't explore mysteries in the deepest substructure of a single pixel anymore.

This will fix #1860 , applying the same limit as the Viewer to Flipbook (maximum of around 31623%) which is IMO sufficient for normal users to observe both raster and vector images.