### PR TITLE
Fix Vector Region Style on OSX

### DIFF
--- a/toonz/sources/common/tvrender/qtofflinegl.cpp
+++ b/toonz/sources/common/tvrender/qtofflinegl.cpp
@@ -172,6 +172,7 @@ void QtOfflineGL::createContext(TDimension rasterSize,
   m_context->makeCurrent(m_surface.get());
 
   QOpenGLFramebufferObjectFormat fbo_format;
+  fbo_format.setAttachment(QOpenGLFramebufferObject::CombinedDepthStencil);
   m_fbo = std::make_shared<QOpenGLFramebufferObject>(rasterSize.lx,
                                                      rasterSize.ly, fbo_format);
   m_fbo->bind();


### PR DESCRIPTION
This will fix #891 
The change will not affect Windows version, since `QtOfflineGL` seems to be used only in OSX & Linux for now.
I couldn't check if this fix will take care #406 as the issue cannot be reproduced on my environment.

<img width="884" alt="2018-06-26 12 44 27" src="https://user-images.githubusercontent.com/17974955/41888403-37290dbc-7940-11e8-928d-e8fc55cb4ed6.png">
