### PR TITLE
function typo setWindowFlag should be setWindowFlags

### DIFF
--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -970,7 +970,7 @@ FunctionSheet::FunctionSheet(QWidget *parent, bool isFloating)
   setRowsPanel(m_rowViewer = new FunctionSheetRowViewer(this));
   setCellsPanel(m_cellViewer = new FunctionSheetCellViewer(this));
 
-  setWindowFlag(Qt::Window);
+  setWindowFlags(Qt::Window);
   setColumnCount(20);
   setWindowTitle(tr("Function Editor"));
   setFocusPolicy(Qt::ClickFocus);


### PR DESCRIPTION
Building on `Linux 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64 GNU/Linux`

failed make at 
```
[ 52%] Building CXX object toonzqt/CMakeFiles/toonzqt.dir/functionsheet.cpp.o
/home/areckx/git/opentoonz/toonz/sources/toonzqt/functionsheet.cpp: In constructor ‘FunctionSheet::FunctionSheet(QWidget*, bool)’:
/home/areckx/git/opentoonz/toonz/sources/toonzqt/functionsheet.cpp:973:27: error: ‘setWindowFlag’ was not declared in this scope
   setWindowFlag(Qt::Window);
                           ^
toonzqt/CMakeFiles/toonzqt.dir/build.make:2371: recipe for target 'toonzqt/CMakeFiles/toonzqt.dir/functionsheet.cpp.o' failed
make[2]: *** [toonzqt/CMakeFiles/toonzqt.dir/functionsheet.cpp.o] Error 1
CMakeFiles/Makefile2:765: recipe for target 'toonzqt/CMakeFiles/toonzqt.dir/all' failed
make[1]: *** [toonzqt/CMakeFiles/toonzqt.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 52%] Linking CXX executable ../bin/tconverter
[ 52%] Built target tconverter
Makefile:127: recipe for target 'all' failed
```