### PR TITLE
Convert Old Level Files (.tzp / .tzu) to TLV

### DIFF
--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -116,6 +116,16 @@ void DVAPI convertNaa2Tlv(
     bool removeUnusedStyles = false,
     double dpi = 0.0);  //! Remove unused styles from input palette.
 
+// convert old levels (tzp / tzu) to tlv
+void DVAPI convertOldLevel2Tlv(
+    const TFilePath &source,  //!< Level path to convert from.
+    const TFilePath &dest,    //!< Level path to convert to.
+    const TFrameId &from,     //!< First source frame to convert.
+    const TFrameId &to,       //!< Last source frame to convert.
+    FrameTaskNotifier
+        *frameNotifier  //!< Observer class for frame success notifications.
+    );
+
 double DVAPI getQuantizedZoomFactor(double zf, bool forward);
 
 void DVAPI getFillingInformationOverlappingArea(

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -1086,6 +1086,10 @@ TSystem::renameFile(newFolder, folder);
 //-----------------------------------------------------------------------------
 
 QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
+  auto isOldLevelType = [](TFilePath &path) -> bool {
+    return path.getType() == "tzp" || path.getType() == "tzu";
+  };
+
   bool ret = true;
 
   // TODO: spostare in questa classe anche la definizione delle azioni?
@@ -1180,12 +1184,17 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
   if (i == files.size()) {
     std::string type = files[0].getType();
     for (j = 0; j < files.size(); j++)
-      if (files[j].getType() == "tzp" || files[j].getType() == "tzu") break;
+      if (isOldLevelType(files[j])) break;
     if (j == files.size()) menu->addAction(cm->getAction(MI_ViewFile));
-    for (j = 0; j < files.size(); j++)
+
+    for (j = 0; j < files.size(); j++) {
       if ((files[0].getType() == "pli" && files[j].getType() != "pli") ||
           (files[0].getType() != "pli" && files[j].getType() == "pli"))
         break;
+      else if ((isOldLevelType(files[0]) && !isOldLevelType(files[j])) ||
+               (!isOldLevelType(files[0]) && isOldLevelType(files[j])))
+        break;
+    }
     if (j == files.size()) {
       menu->addAction(cm->getAction(MI_ConvertFiles));
       // iwsw commented out temporarily

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -13,6 +13,7 @@
 #include "toonz/toonzscene.h"
 #include "toonz/tproject.h"
 #include "toonz/Naa2TlvConverter.h"
+#include "toonz/toonzimageutils.h"
 
 #ifdef _WIN32
 #include "avicodecrestrictions.h"
@@ -700,6 +701,63 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
   }
 
   if (removeUnusedStyles) converter.removeUnusedStyles(usedStyleIds);
+}
+
+//=============================================================================
+
+void convertOldLevel2Tlv(const TFilePath &source, const TFilePath &dest,
+                         const TFrameId &from, const TFrameId &to,
+                         FrameTaskNotifier *frameNotifier) {
+  TFilePath destPltPath = TFilePath(dest.getParentDir().getWideString() +
+                                    L"\\" + dest.getWideName() + L".tpl");
+  if (TSystem::doesExistFileOrLevel(destPltPath))
+    TSystem::removeFileOrLevel(destPltPath);
+
+  TLevelWriterP lw(dest);
+  lw->setIconSize(Preferences::instance()->getIconSize());
+  TPaletteP palette =
+      ToonzImageUtils::loadTzPalette(source.withType("plt").withNoFrame());
+  TLevelReaderP lr(source);
+  if (!lr) {
+    DVGui::warning(QObject::tr(
+        "The source image seems not suitable for this kind of conversion"));
+    frameNotifier->notifyError();
+    return;
+  }
+  TLevelP inLevel = lr->loadInfo();
+  if (!inLevel || inLevel->getFrameCount() == 0) {
+    DVGui::warning(QObject::tr(
+        "The source image seems not suitable for this kind of conversion"));
+    frameNotifier->notifyError();
+    return;
+  }
+  // Get the frames available in level inside the [from, to] range
+  std::vector<TFrameId> frames;
+  getFrameIds(from, to, inLevel, frames);
+  if (frames.empty()) return;
+
+  TLevelP outLevel;
+  outLevel->setPalette(palette.getPointer());
+  try {
+    int f, fCount = int(frames.size());
+    for (f = 0; f != fCount; ++f) {
+      if (frameNotifier->abortTask()) break;
+      TToonzImageP img = lr->getFrameReader(frames[f])->load();
+      if (!img) continue;
+      img->setPalette(palette.getPointer());
+      lw->getFrameWriter(frames[f])->save(img);
+
+      frameNotifier->notifyFrameCompleted(100 * (f + 1) / frames.size());
+    }
+  } catch (TException &e) {
+    QString msg = QString::fromStdWString(e.getMessage());
+    DVGui::warning(msg);
+    lw = TLevelWriterP();
+    if (TSystem::doesExistFileOrLevel(dest)) TSystem::removeFileOrLevel(dest);
+    frameNotifier->notifyError();
+    return;
+  }
+  lw = TLevelWriterP();
 }
 
 //=============================================================================


### PR DESCRIPTION
This PR enables to convert old Toonz 4.x level files (.tzp and .tzu) to TLV via `Convert...` command in the context menu of File Browser. 

This feature is requested by Studio Ghibli.