### PR TITLE
Set System Paths with Command Line Qualifiers

### DIFF
--- a/toonz/sources/include/tcli.h
+++ b/toonz/sources/include/tcli.h
@@ -45,11 +45,11 @@ inline bool fromStr(double &value, std::string s) {
     return false;
 }
 inline bool fromStr(std::string &value, std::string s) {
-  value = s;
+  value = QString::fromLocal8Bit(s.c_str()).toStdString();
   return true;
 }
 inline bool fromStr(TFilePath &value, std::string s) {
-  value = TFilePath(s);
+  value = TFilePath(QString::fromLocal8Bit(s.c_str()));
   return true;
 }
 

--- a/toonz/sources/include/tenv.h
+++ b/toonz/sources/include/tenv.h
@@ -142,6 +142,12 @@ DVAPI void setDllRelativeDir(const TFilePath &dllRelativeDir);
 
 DVAPI void saveAllEnvVariables();
 
+// register command line argument paths.
+// returns true on success
+DVAPI bool setArgPathValue(std::string key, std::string value);
+
+DVAPI const std::map<std::string, std::string> &getSystemPathMap();
+
 /*
 
   enum SystemFileId {

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -77,6 +77,7 @@
 #include <QFileInfo>
 #include <QSettings>
 #include <QLibraryInfo>
+#include <QHash>
 
 using namespace DVGui;
 #if defined LINETEST
@@ -97,9 +98,10 @@ const char *dllRelativePath     = "./toonz6.app/Contents/Frameworks";
 
 TEnv::IntVar EnvSoftwareCurrentFontSize("SoftwareCurrentFontSize", 12);
 
-const char *applicationFullName = "OpenToonz 1.2.1";  // next will be 1.3 (not 1.3.0)
-const char *rootVarName         = "TOONZROOT";
-const char *systemVarPrefix     = "TOONZ";
+const char *applicationFullName =
+    "OpenToonz 1.2.1";  // next will be 1.3 (not 1.3.0)
+const char *rootVarName     = "TOONZROOT";
+const char *systemVarPrefix = "TOONZ";
 
 #ifdef MACOSX
 #include "tthread.h"
@@ -150,7 +152,7 @@ DV_IMPORT_API void initColorFx();
     la stuffDir, controlla se la directory di outputs esiste (e provvede a
     crearla in caso contrario) verifica inoltre che stuffDir esista.
 */
-static void initToonzEnv() {
+static void initToonzEnv(QHash<QString, QString> &argPathValues) {
   StudioPalette::enable(true);
 
   TEnv::setApplication(applicationName, applicationVersion,
@@ -158,6 +160,15 @@ static void initToonzEnv() {
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
   TEnv::setDllRelativeDir(TFilePath(dllRelativePath));
+
+  QHash<QString, QString>::const_iterator i = argPathValues.constBegin();
+  while (i != argPathValues.constEnd()) {
+    if (!TEnv::setArgPathValue(i.key().toStdString(), i.value().toStdString()))
+      DVGui::error(
+          QObject::tr("The qualifier %1 is not a valid key name. Skipping.")
+              .arg(i.key()));
+    ++i;
+  }
 
   QCoreApplication::setOrganizationName("OpenToonz");
   QCoreApplication::setOrganizationDomain("");
@@ -244,17 +255,60 @@ int main(int argc, char *argv[]) {
   }
 #endif
 
-  /*-- "-layout [レイアウト設定ファイル名]"
-   * で、必要なモジュールのPageだけのレイアウトで起動することを可能にする --*/
-  QString argumentLayoutFileName = "";
+  // parsing arguments and qualifiers
   TFilePath loadScenePath;
+  QString argumentLayoutFileName = "";
+  QHash<QString, QString> argumentPathValues;
   if (argc > 1) {
-    for (int a = 1; a < argc; a++) {
-      if (QString(argv[a]) == "-layout") {
-        argumentLayoutFileName = QString(argv[a + 1]);
-        a++;
-      } else
-        loadScenePath = TFilePath(argv[a]);
+    TCli::Usage usage(argv[0]);
+    TCli::UsageLine usageLine;
+    TCli::FilePathArgument loadSceneArg("scenePath", "Source scene file");
+    TCli::StringQualifier layoutFileQual(
+        "-layout filename",
+        "Custom layout file to be used, it should be saved in "
+        "$TOONZPROFILES\\layouts\\personal\\[CurrentLayoutName].[UserName]\\. "
+        "layouts.txt is used by default.");
+    usageLine = usageLine + layoutFileQual;
+
+    // system path qualifiers
+    std::map<QString, std::unique_ptr<TCli::QualifierT<TFilePath>>>
+        systemPathQualMap;
+    QString qualKey  = QString("%1ROOT").arg(systemVarPrefix);
+    QString qualName = QString("-%1 folderpath").arg(qualKey);
+    QString qualHelp =
+        QString(
+            "%1 path. It will automatically set other system paths to %1 "
+            "unless individually specified with other qualifiers.")
+            .arg(qualKey);
+    systemPathQualMap[qualKey].reset(new TCli::QualifierT<TFilePath>(
+        qualName.toStdString(), qualHelp.toStdString()));
+    usageLine = usageLine + *systemPathQualMap[qualKey];
+
+    const std::map<std::string, std::string> &spm = TEnv::getSystemPathMap();
+    for (auto itr = spm.begin(); itr != spm.end(); ++itr) {
+      qualKey = QString("%1%2")
+                    .arg(systemVarPrefix)
+                    .arg(QString::fromStdString((*itr).first));
+      qualName = QString("-%1 folderpath").arg(qualKey);
+      qualHelp = QString("%1 path.").arg(qualKey);
+      systemPathQualMap[qualKey].reset(new TCli::QualifierT<TFilePath>(
+          qualName.toStdString(), qualHelp.toStdString()));
+      usageLine = usageLine + *systemPathQualMap[qualKey];
+    }
+    usage.add(usageLine);
+    usage.add(usageLine + loadSceneArg);
+
+    if (!usage.parse(argc, argv)) exit(1);
+
+    loadScenePath = loadSceneArg.getValue();
+    if (layoutFileQual.isSelected())
+      argumentLayoutFileName =
+          QString::fromStdString(layoutFileQual.getValue());
+    for (auto q_itr = systemPathQualMap.begin();
+         q_itr != systemPathQualMap.end(); ++q_itr) {
+      if (q_itr->second->isSelected())
+        argumentPathValues.insert(q_itr->first,
+                                  q_itr->second->getValue().getQString());
     }
   }
 
@@ -409,7 +463,7 @@ int main(int argc, char *argv[]) {
       &toonzRunOutOfContMemHandler);
 
   // Toonz environment
-  initToonzEnv();
+  initToonzEnv(argumentPathValues);
 
   // Initialize thread components
   TThread::init();

--- a/toonz/sources/toonzlib/toonzfolders.cpp
+++ b/toonz/sources/toonzlib/toonzfolders.cpp
@@ -50,7 +50,9 @@ TFilePathSet ToonzFolder::getProjectsFolders() {
         fps.push_back(TFilePath(tempPath));
       }
     }
-    if (tempFps.size() == 0) fps.push_back(TEnv::getStuffDir() + "Projects");
+    if (tempFps.size() == 0)
+      fps.push_back(TEnv::getStuffDir() +
+                    TEnv::getSystemPathMap().at("PROJECTS"));
   }
   if (documents) {
     fps.push_back(getMyDocumentsPath() + "OpenToonz");
@@ -85,31 +87,36 @@ TFilePath ToonzFolder::getFirstProjectsFolder() {
 
 TFilePath ToonzFolder::getLibraryFolder() {
   TFilePath fp = getSystemVarPathValue(getSystemVarPrefix() + "LIBRARY");
-  if (fp == TFilePath()) fp = getStuffDir() + "library";
+  if (fp == TFilePath())
+    fp = getStuffDir() + TEnv::getSystemPathMap().at("LIBRARY");
   return fp;
 }
 
 TFilePath ToonzFolder::getStudioPaletteFolder() {
   TFilePath fp = getSystemVarPathValue(getSystemVarPrefix() + "STUDIOPALETTE");
-  if (fp == TFilePath()) fp = getStuffDir() + "studiopalette";
+  if (fp == TFilePath())
+    fp = getStuffDir() + TEnv::getSystemPathMap().at("STUDIOPALETTE");
   return fp;
 }
 
 TFilePath ToonzFolder::getFxPresetFolder() {
   TFilePath fp = getSystemVarPathValue(getSystemVarPrefix() + "FXPRESETS");
-  if (fp == TFilePath()) fp = getStuffDir() + "fxs";
+  if (fp == TFilePath())
+    fp = getStuffDir() + TEnv::getSystemPathMap().at("FXPRESETS");
   return fp;
 }
 
 TFilePath ToonzFolder::getCacheRootFolder() {
   TFilePath fp = getSystemVarPathValue(getSystemVarPrefix() + "CACHEROOT");
-  if (fp == TFilePath()) fp = getStuffDir() + "cache";
+  if (fp == TFilePath())
+    fp = getStuffDir() + TEnv::getSystemPathMap().at("CACHEROOT");
   return fp;
 }
 
 TFilePath ToonzFolder::getProfileFolder() {
   TFilePath fp = getSystemVarPathValue(getSystemVarPrefix() + "PROFILES");
-  if (fp == TFilePath()) fp = getStuffDir() + "profiles";
+  if (fp == TFilePath())
+    fp = getStuffDir() + TEnv::getSystemPathMap().at("PROFILES");
   return fp;
 }
 


### PR DESCRIPTION
This PR is requested by some Japanese animation studio.

For now, working configuration (such as UI, preference settings, current projects, etc.) is separated for each user. And one user is usually associated with one current configuration.

In Japanese animation production, there is a case that a machine for pencil testing is shared by multiple users, as it is connected to a camera stand, which is quite a large instrument.
Using OT for pencil testing just like other de facto softwares needs some special configuration, and such configuration is different from the one for other "normal" workflow like ink&painting or compositing. Therefore, there was a need to have multiple working configuration for single user. One is for pencil testing, and another one is for the other workflow.
To achieve such demand, they had been prepared two stuff folders, and separated registry values between the pencil test machine and other machines in order to use the different configurations. However, registry values are not easy to maintain as it needs administrative right to modify. 

This PR enables OT to input command line qualifies, which will specify the system paths (like `TOONZROOT`, `TOONZPROFILES`, etc.) overriding the registry values.

Here are the usage (you can see this by typing `OpenToonz_1.2.exe -help` in command line as well) :
```
usage: 
       OpenToonz_1.2.exe -help
       OpenToonz_1.2.exe -release
       OpenToonz_1.2.exe -version
       OpenToonz_1.2.exe [ -layout filename ] [ -TOONZROOT folderpath ] [ -TOONZCACHEROOT folderpath ] [ -TOONZCONFIG folderpath ] [ -TOONZFXPRESETS folderpath ] [ -TOONZLIBRARY folderpath ] [ -TOONZPROFILES folderpath ] [ -TOONZPROJECTS folderpath ] [ -TOONZSTUDIOPALETTE folderpath ]
       OpenToonz_1.2.exe [ -layout filename ] [ -TOONZROOT folderpath ] [ -TOONZCACHEROOT folderpath ] [ -TOONZCONFIG folderpath ] [ -TOONZFXPRESETS folderpath ] [ -TOONZLIBRARY folderpath ] [ -TOONZPROFILES folderpath ] [ -TOONZPROJECTS folderpath ] [ -TOONZSTUDIOPALETTE folderpath ] scenePath


  -help
       Print this help page
  -release
       Print the current Toonz version
  -version
       Print the current Toonz version
  -layout filename
       Custom layout file to be used, it should be saved in $TOONZPROFILES\layouts\personal\[CurrentLayoutName].[UserName]\. layouts.txt is used by default.
  -TOONZROOT folderpath
       TOONZROOT path. It will automatically set other system paths to TOONZROOT unless individually specified with other qualifiers.
  -TOONZCACHEROOT folderpath
       TOONZCACHEROOT path.
  -TOONZCONFIG folderpath
       TOONZCONFIG path.
  -TOONZFXPRESETS folderpath
       TOONZFXPRESETS path.
  -TOONZLIBRARY folderpath
       TOONZLIBRARY path.
  -TOONZPROFILES folderpath
       TOONZPROFILES path.
  -TOONZPROJECTS folderpath
       TOONZPROJECTS path.
  -TOONZSTUDIOPALETTE folderpath
       TOONZSTUDIOPALETTE path.
  scenePath
       Source scene file
```
Please note that these command line qualifiers also override the portable mode.

Also please note, for now I don't include such qualifiers to `tcomposer` and `tcleanupper` since it will work without changing configuration in most cases. However there are exceptions - if you alter `TOONZPROFILES` and would like to render in ffmpeg-based format, you need to make sure to set the same ffmpeg paths in both preferences. And if you alter `TOONZROOT` and would like to render plugin fxs, you need to make sure to have the same plugin in both `TOONZROOT\plugins` folders.
