### PR TITLE
Fix Crash When Using Vector Brush Frame Range with Thickness 0

### DIFF
--- a/toonz/sources/tnztools/brushtool.cpp
+++ b/toonz/sources/tnztools/brushtool.cpp
@@ -1746,8 +1746,8 @@ bool BrushTool::doFrameRangeStrokes(TFrameId firstFrameId, TStroke *firstStroke,
     swapped = true;
   }
 
-  firstImage->addStroke(first);
-  lastImage->addStroke(last);
+  firstImage->addStroke(first, false);
+  lastImage->addStroke(last, false);
   assert(firstFrameId <= lastFrameId);
 
   std::vector<TFrameId> allFids;


### PR DESCRIPTION
This will fix #2118 
`TVectorImage::addStroke(TStroke *stroke, bool discardPoints = true)` discards stroke without adding when `dscardPoints` is set to true and the bounding box of `stroke` is empty, which can be happened with a point with thickness 0.