### PR TITLE
Fix Crash on Launch with Command Line Arguments

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -310,6 +310,8 @@ int main(int argc, char *argv[]) {
         argumentPathValues.insert(q_itr->first,
                                   q_itr->second->getValue().getQString());
     }
+
+    argc = 1;
   }
 
 // Enables high-DPI scaling. This attribute must be set before QApplication is


### PR DESCRIPTION
This PR fixes the crash when launching the software with command line arguments such as `-TOONZPROJECTS folderpath`, etc.