### PR TITLE
use std::unique_ptr instead of std::auto_ptr

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1697,7 +1697,7 @@ void PencilTestPopup::onPreviousName() {
 //-----------------------------------------------------------------------------
 
 void PencilTestPopup::setToNextNewLevel() {
-  const std::auto_ptr<NameBuilder> nameBuilder(NameBuilder::getBuilder(L""));
+  const std::unique_ptr<NameBuilder> nameBuilder(NameBuilder::getBuilder(L""));
 
   TLevelSet* levelSet =
       TApp::instance()->getCurrentScene()->getScene()->getLevelSet();


### PR DESCRIPTION
clang says

```
opentoonz/toonz/sources/toonz/penciltestpopup.cpp:1700:14:
warning: 'template<class> class std::auto_ptr' is deprecated [-Wdeprecated-declarations]  
    const std::auto_ptr<NameBuilder> nameBuilder(NameBuilder::getBuilder(L""));
```

I replaced std::auto_ptr to std::unique_ptr.