### PR TITLE
Inputting Numbers in XSheet Cell Can Use the Level in the Following Cells

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -803,6 +803,10 @@ void RenameCellField::renameCell() {
       // if there is no level at the current cell, take the level from the
       // previous frames
       // (when editing not empty column)
+      if (xsheet->isColumnEmpty(c)) {
+        cells.append(TXshCell());
+        continue;
+      }
 
       TXshCell cell;
       int tmpRow = m_row;
@@ -811,6 +815,19 @@ void RenameCellField::renameCell() {
         if (!cell.isEmpty() || tmpRow == 0) break;
         tmpRow--;
       }
+
+      // if the level is not found in the previous frames, then search in the
+      // following frames
+      if (cell.isEmpty()) {
+        tmpRow       = m_row + 1;
+        int maxFrame = xsheet->getFrameCount();
+        while (1) {
+          cell = xsheet->getCell(tmpRow, c);
+          if (!cell.isEmpty() || tmpRow >= maxFrame) break;
+          tmpRow++;
+        }
+      }
+
       TXshLevel *xl = cell.m_level.getPointer();
       if (!xl || (xl->getType() == OVL_XSHLEVEL &&
                   xl->getPath().getFrame() == TFrameId::NO_FRAME)) {


### PR DESCRIPTION
This feature was requested by some Japanese animation studio.

When inputting the xsheet by using the rename cell field which pops up by double-clicking on the xsheet cell, typing the number had no effect if there was no occupied cell in the above.
I changed its behavior to search the following cells if all the above cells are vacant. It will be useful when you would like to input a cell on top of the column.

![rename_cell](https://user-images.githubusercontent.com/17974955/43249235-251e1e24-90f5-11e8-87d2-1e210564941a.gif)
