### PR TITLE
Use Xcode 8.3 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ matrix:
         - os: linux
           compiler: clang
         - os: osx
+          osx_image: xcode8.3


### PR DESCRIPTION
This PR is to check if the recent Travis CI failures are due to the Travis CI update on July 31st, [the default macOS image was changed to Xcode 9.4](https://changelog.travis-ci.com/default-macos-image-is-now-xcode-9-4-67738).