### PR TITLE
Enhancement of the Shift and Trace Feature

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -118,7 +118,9 @@ enum class PredefinedRect {
   ZOOM_OUT_AREA,
   ZOOM_OUT,
   LAYER_FOOTER_PANEL,
-  PREVIEW_FRAME_AREA
+  PREVIEW_FRAME_AREA,
+  SHIFTTRACE_DOT,
+  SHIFTTRACE_DOT_AREA
 };
 enum class PredefinedLine {
   LOCKED,              //! dotted vertical line when cell is locked

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -669,6 +669,26 @@ protected slots:
   void updateRealTimePickLabel(const int, const int, const int);
 };
 
+//=============================================================================
+//
+// ShiftTraceToolOptionBox
+// shown only when "Edit Shift" mode is active
+//
+//=============================================================================
+
+class ShiftTraceToolOptionBox final : public ToolOptionsBox {
+  Q_OBJECT
+  QPushButton *m_resetPrevGhostBtn;
+  QPushButton *m_resetAfterGhostBtn;
+  void resetGhost(int index);
+
+public:
+  ShiftTraceToolOptionBox(QWidget *parent = 0);
+protected slots:
+  void onResetPrevGhostBtnPressed();
+  void onResetAfterGhostBtnPressed();
+};
+
 //-----------------------------------------------------------------------------
 
 class DVAPI ToolOptions final : public QFrame {

--- a/toonz/sources/include/toonz/onionskinmask.h
+++ b/toonz/sources/include/toonz/onionskinmask.h
@@ -7,6 +7,8 @@
 #include "tcommon.h"
 #include "tgeometry.h"
 
+#include <QList>
+
 #undef DVAPI
 #undef DVVAR
 #ifdef TOONZLIB_EXPORTS
@@ -114,6 +116,23 @@ since underlying onion-skinned drawings must be visible.
   }
   void setShiftTraceGhostCenter(int index, const TPointD &center);
 
+  const int getShiftTraceGhostFrameOffset(int index) {
+    return m_ghostFrame[index];
+  }
+  void setShiftTraceGhostFrameOffset(int index, int offset) {
+    m_ghostFrame[index] = offset;
+  }
+
+  const int getGhostFlipKey() {
+    return (m_ghostFlipKeys.isEmpty()) ? 0 : m_ghostFlipKeys.last();
+  }
+  void appendGhostFlipKey(int key) {
+    m_ghostFlipKeys.removeAll(key);
+    m_ghostFlipKeys.append(key);
+  }
+  void removeGhostFlipKey(int key) { m_ghostFlipKeys.removeAll(key); }
+  void clearGhostFlipKey() { m_ghostFlipKeys.clear(); }
+
 private:
   std::vector<int> m_fos, m_mos;  //!< Fixed and Mobile Onion Skin indices
   bool m_enabled;                 //!< Whether onion skin is enabled
@@ -122,6 +141,9 @@ private:
   ShiftTraceStatus m_shiftTraceStatus;
   TAffine m_ghostAff[2];
   TPointD m_ghostCenter[2];
+  int m_ghostFrame[2];         // relative frame position of the ghosts
+  QList<int> m_ghostFlipKeys;  // If F1, F2 or F3 key is pressed, then only
+                               // display the corresponding ghost
 };
 
 //***************************************************************************

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -36,6 +36,7 @@
 #include "toonz/preferences.h"
 #include "toonz/tstageobjecttree.h"
 #include "toonz/mypaintbrushstyle.h"
+#include "toonz/tonionskinmaskhandle.h"
 
 // TnzCore includes
 #include "tproperty.h"
@@ -2480,6 +2481,45 @@ void StylePickerToolOptionsBox::updateRealTimePickLabel(const int ink,
 }
 
 //=============================================================================
+// ShiftTraceToolOptionBox
+//-----------------------------------------------------------------------------
+
+ShiftTraceToolOptionBox::ShiftTraceToolOptionBox(QWidget *parent)
+    : ToolOptionsBox(parent) {
+  setFrameStyle(QFrame::StyledPanel);
+  setFixedHeight(26);
+
+  m_resetPrevGhostBtn =
+      new QPushButton(tr("Reset Shift of Previous Drawing"), this);
+  m_resetAfterGhostBtn =
+      new QPushButton(tr("Reset Shift of Forward Drawing"), this);
+
+  m_layout->addWidget(m_resetPrevGhostBtn, 0);
+  m_layout->addWidget(m_resetAfterGhostBtn, 0);
+  m_layout->addStretch(1);
+
+  connect(m_resetPrevGhostBtn, SIGNAL(clicked()), this,
+          SLOT(onResetPrevGhostBtnPressed()));
+  connect(m_resetAfterGhostBtn, SIGNAL(clicked()), this,
+          SLOT(onResetAfterGhostBtnPressed()));
+}
+
+void ShiftTraceToolOptionBox::resetGhost(int index) {
+  TTool::Application *app = TTool::getApplication();
+  OnionSkinMask osm       = app->getCurrentOnionSkin()->getOnionSkinMask();
+  osm.setShiftTraceGhostCenter(index, TPointD());
+  osm.setShiftTraceGhostAff(index, TAffine());
+  app->getCurrentOnionSkin()->setOnionSkinMask(osm);
+  app->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
+  TTool *tool = app->getCurrentTool()->getTool();
+  if (tool) tool->reset();
+}
+
+void ShiftTraceToolOptionBox::onResetPrevGhostBtnPressed() { resetGhost(0); }
+
+void ShiftTraceToolOptionBox::onResetAfterGhostBtnPressed() { resetGhost(1); }
+
+//=============================================================================
 // ToolOptions
 //-----------------------------------------------------------------------------
 
@@ -2587,6 +2627,8 @@ void ToolOptions::onToolSwitched() {
       } else if (tool->getName() == T_StylePicker)
         panel = new StylePickerToolOptionsBox(0, tool, currPalette, currTool,
                                               app->getPaletteController());
+      else if (tool->getName() == "T_ShiftTrace")
+        panel = new ShiftTraceToolOptionBox(this);
       else
         panel = tool->createOptionsBox();  // Only this line should remain out
                                            // of that if/else monstrosity

--- a/toonz/sources/toonz/frameheadgadget.h
+++ b/toonz/sources/toonz/frameheadgadget.h
@@ -46,6 +46,8 @@ public:
   virtual void drawOnionSkinSelection(QPainter &p, const QColor &lightColor,
                                       const QColor &darkColor);
 
+  virtual void drawShiftTraceMarker(QPainter &p) {}
+
   virtual int getY() const = 0;
 
   virtual int index2y(int index) const = 0;
@@ -70,6 +72,7 @@ public:
 class FilmstripFrameHeadGadget final : public FrameHeadGadget {
   FilmstripFrames *m_filmstrip;
   int m_dy;
+  int m_highlightedghostFrame;
 
 public:
   FilmstripFrameHeadGadget(FilmstripFrames *filmstrip);
@@ -81,10 +84,13 @@ public:
   void drawOnionSkinSelection(QPainter &p, const QColor &lightColor,
                               const QColor &darkColor) override;
 
+  void drawShiftTraceMarker(QPainter &p) override;
+
   void setCurrentFrame(int index) const override;
   int getCurrentFrame() const override;
 
   bool eventFilter(QObject *obj, QEvent *event) override;
+  bool shiftTraceEventFilter(QObject *obj, QEvent *event);
 };
 
 #endif

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1960,6 +1960,8 @@ void MainWindow::defineActions() {
                MenuViewCommandType);
   createToggle(MI_EditShift, tr("Edit Shift"), "", false, MenuViewCommandType);
   createToggle(MI_NoShift, tr("No Shift"), "", false, MenuViewCommandType);
+  CommandManager::instance()->enable(MI_EditShift, false);
+  CommandManager::instance()->enable(MI_NoShift, false);
   createAction(MI_ResetShift, tr("Reset Shift"), "", MenuViewCommandType);
 
   if (QGLPixelBuffer::hasOpenGLPbuffers())

--- a/toonz/sources/toonz/onionskinmaskgui.cpp
+++ b/toonz/sources/toonz/onionskinmaskgui.cpp
@@ -3,6 +3,11 @@
 #include "onionskinmaskgui.h"
 #include "tapp.h"
 #include "toonz/tonionskinmaskhandle.h"
+#include "toonz/tframehandle.h"
+#include "toonz/txshlevelhandle.h"
+#include "toonz/txsheethandle.h"
+#include "toonz/tcolumnhandle.h"
+#include "toonz/txshsimplelevel.h"
 
 #include "toonz/onionskinmask.h"
 
@@ -103,5 +108,68 @@ void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
         menu->addAction(QString(QObject::tr("Activate Onion Skin")));
     menu->connect(activateOnionSkin, SIGNAL(triggered()), &switcher,
                   SLOT(activate()));
+  }
+}
+
+//------------------------------------------------------------------------------
+
+void OnioniSkinMaskGUI::resetShiftTraceFrameOffset() {
+  auto setGhostOffset = [](int firstOffset, int secondOffset) {
+    OnionSkinMask osm =
+        TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
+    osm.setShiftTraceGhostFrameOffset(0, firstOffset);
+    osm.setShiftTraceGhostFrameOffset(1, secondOffset);
+    TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
+  };
+
+  TApp *app = TApp::instance();
+  if (app->getCurrentFrame()->isEditingLevel()) {
+    TXshSimpleLevel *level = app->getCurrentLevel()->getSimpleLevel();
+    if (!level) {
+      setGhostOffset(0, 0);
+      return;
+    }
+    TFrameId fid     = app->getCurrentFrame()->getFid();
+    int firstOffset  = (fid > level->getFirstFid()) ? -1 : 0;
+    int secondOffset = (fid < level->getLastFid()) ? 1 : 0;
+
+    setGhostOffset(firstOffset, secondOffset);
+  } else {  // when scene frame is selected
+    TXsheet *xsh       = app->getCurrentXsheet()->getXsheet();
+    int col            = app->getCurrentColumn()->getColumnIndex();
+    TXshColumn *column = xsh->getColumn(col);
+    if (!column || column->isEmpty()) {
+      setGhostOffset(0, 0);
+      return;
+    }
+    int r0, r1;
+    column->getRange(r0, r1);
+    int row         = app->getCurrentFrame()->getFrame();
+    TXshCell cell   = xsh->getCell(row, col);
+    int firstOffset = -1;
+    while (1) {
+      int r = row + firstOffset;
+      if (r < r0) {
+        firstOffset = 0;
+        break;
+      }
+      if (!xsh->getCell(r, col).isEmpty() && xsh->getCell(r, col) != cell) {
+        break;
+      }
+      firstOffset--;
+    }
+    int secondOffset = 1;
+    while (1) {
+      int r = row + secondOffset;
+      if (r > r1) {
+        secondOffset = 0;
+        break;
+      }
+      if (!xsh->getCell(r, col).isEmpty() && xsh->getCell(r, col) != cell) {
+        break;
+      }
+      secondOffset++;
+    }
+    setGhostOffset(firstOffset, secondOffset);
   }
 }

--- a/toonz/sources/toonz/onionskinmaskgui.h
+++ b/toonz/sources/toonz/onionskinmaskgui.h
@@ -15,6 +15,8 @@ namespace OnioniSkinMaskGUI {
 // Da fare per la filmstrip!!
 void addOnionSkinCommand(QMenu *, bool isFilmStrip = false);
 
+void resetShiftTraceFrameOffset();
+
 //=============================================================================
 // OnionSkinSwitcher
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1211,6 +1211,18 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
         event->ignore();
         return true;
       }
+      // pressing F1, F2 or F3 key will flip between corresponding ghost
+      if (CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked() &&
+          (Qt::Key_F1 <= key && key <= Qt::Key_F3)) {
+        OnionSkinMask osm =
+            TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
+        if (osm.getGhostFlipKey() != key) {
+          osm.appendGhostFlipKey(key);
+          TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
+          TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
+        }
+        return true;
+      }
     }
 
     if (!tool->isEnabled()) return false;
@@ -1307,6 +1319,15 @@ void SceneViewer::keyReleaseEvent(QKeyEvent *event) {
 
     tool->mouseMove(pos, toonzEvent);
     setToolCursor(this, tool->getCursorId());
+  }
+
+  if (CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked() &&
+      (Qt::Key_F1 <= key && key <= Qt::Key_F3)) {
+    OnionSkinMask osm =
+        TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
+    osm.removeGhostFlipKey(key);
+    TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
+    TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
   }
 
   if (tool->getName() == T_Type)

--- a/toonz/sources/toonz/shifttracetool.cpp
+++ b/toonz/sources/toonz/shifttracetool.cpp
@@ -14,10 +14,16 @@
 #include "toonz/txsheethandle.h"
 #include "toonz/tframehandle.h"
 #include "toonz/tcolumnhandle.h"
+#include "toonz/txshlevelhandle.h"
+#include "toonz/txshsimplelevel.h"
 #include "toonz/dpiscale.h"
+#include "toonz/stage.h"
 #include "tapp.h"
 #include "tpixel.h"
 #include "toonzqt/menubarcommand.h"
+
+#include "toonz/preferences.h"
+#include "toonzqt/gutil.h"
 
 #include "tgl.h"
 #include <math.h>
@@ -54,12 +60,14 @@ public:
 
   enum GadgetId {
     NoGadget,
+    NoGadget_InBox,
     CurveP0Gadget,
     CurveP1Gadget,
     CurvePmGadget,
     MoveCenterGadget,
     RotateGadget,
-    TranslateGadget
+    TranslateGadget,
+    ScaleGadget
   };
   inline bool isCurveGadget(GadgetId id) const {
     return CurveP0Gadget <= id && id <= CurvePmGadget;
@@ -80,6 +88,8 @@ private:
   TAffine m_aff[2];
   TPointD m_center[2];
 
+  TAffine m_oldAff;
+
 public:
   ShiftTraceTool();
 
@@ -92,8 +102,10 @@ public:
   void updateGhost();
 
   void reset() override {
+    int ghostIndex = m_ghostIndex;
     onActivate();
     invalidate();
+    m_ghostIndex = ghostIndex;
   }
 
   void mouseMove(const TPointD &, const TMouseEvent &e) override;
@@ -152,71 +164,95 @@ void ShiftTraceTool::clearData() {
 }
 
 void ShiftTraceTool::updateBox() {
-  if (0 <= m_ghostIndex && m_ghostIndex < 2 && m_row[m_ghostIndex] >= 0) {
-    int col      = TApp::instance()->getCurrentColumn()->getColumnIndex();
+  if (m_ghostIndex < 0 || 2 <= m_ghostIndex || m_row[m_ghostIndex] < 0) return;
+
+  TImageP img;
+
+  TApp *app = TApp::instance();
+  if (app->getCurrentFrame()->isEditingScene()) {
+    int col      = app->getCurrentColumn()->getColumnIndex();
     int row      = m_row[m_ghostIndex];
-    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
 
     TXshCell cell       = xsh->getCell(row, col);
     TXshSimpleLevel *sl = cell.getSimpleLevel();
     if (sl) {
-      m_dpiAff    = getDpiAffine(sl, cell.m_frameId);
-      TImageP img = cell.getImage(false);
-      if (img) {
-        if (TRasterImageP ri = img) {
-          TRasterP ras = ri->getRaster();
-          m_box        = (convert(ras->getBounds()) - ras->getCenterD()) *
-                  ri->getSubsampling();
-        } else if (TToonzImageP ti = img) {
-          TRasterP ras = ti->getRaster();
-          m_box        = (convert(ras->getBounds()) - ras->getCenterD()) *
-                  ti->getSubsampling();
-        } else if (TVectorImageP vi = img) {
-          m_box = vi->getBBox();
-        }
-      }
+      m_dpiAff = getDpiAffine(sl, cell.m_frameId);
+      img      = cell.getImage(false);
+    }
+  }
+  // on editing level
+  else {
+    TXshLevel *level = app->getCurrentLevel()->getLevel();
+    if (!level) return;
+    TXshSimpleLevel *sl = level->getSimpleLevel();
+    if (!sl) return;
+
+    const TFrameId &ghostFid = sl->index2fid(m_row[m_ghostIndex]);
+    m_dpiAff                 = getDpiAffine(sl, ghostFid);
+    img                      = sl->getFrame(ghostFid, false);
+  }
+
+  if (img) {
+    if (TRasterImageP ri = img) {
+      TRasterP ras = ri->getRaster();
+      m_box        = (convert(ras->getBounds()) - ras->getCenterD()) *
+              ri->getSubsampling();
+    } else if (TToonzImageP ti = img) {
+      TRasterP ras = ti->getRaster();
+      m_box        = (convert(ras->getBounds()) - ras->getCenterD()) *
+              ti->getSubsampling();
+    } else if (TVectorImageP vi = img) {
+      m_box = vi->getBBox();
     }
   }
 }
 
 void ShiftTraceTool::updateData() {
-  TXsheet *xsh  = TApp::instance()->getCurrentXsheet()->getXsheet();
-  int row       = TApp::instance()->getCurrentFrame()->getFrame();
-  int col       = TApp::instance()->getCurrentColumn()->getColumnIndex();
-  TXshCell cell = xsh->getCell(row, col);
-  m_box         = TRectD();
+  m_box = TRectD();
   for (int i = 0; i < 2; i++) m_row[i] = -1;
   m_dpiAff                             = TAffine();
+  TApp *app                            = TApp::instance();
 
+  OnionSkinMask osm =
+      TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
+  int previousOffset = osm.getShiftTraceGhostFrameOffset(0);
+  int forwardOffset  = osm.getShiftTraceGhostFrameOffset(1);
   // we must find the prev (m_row[0]) and next (m_row[1]) reference images
   // (either might not exist)
   // see also stage.cpp, StageBuilder::addCellWithOnionSkin
-
-  if (cell.isEmpty()) {
-    // current cell is empty. search for the prev ref img
-    int r = row - 1;
-    while (r >= 0 && xsh->getCell(r, col).getSimpleLevel() == 0) r--;
-    if (r >= 0) m_row[0] = r;
-    // else prev drawing doesn't exist : nothing to do
-  } else {
-    // current cell is not empty
-    // search for prev ref img
-    TXshSimpleLevel *sl = cell.getSimpleLevel();
-    int r               = row - 1;
-    if (r >= 0) {
-      TXshCell otherCell = xsh->getCell(r, col);
-      if (otherCell.getSimpleLevel() == sl) {
-        // find the span start
-        while (r - 1 >= 0 && xsh->getCell(r - 1, col) == otherCell) r--;
-        m_row[0] = r;
-      }
+  if (app->getCurrentFrame()->isEditingScene()) {
+    TXsheet *xsh  = app->getCurrentXsheet()->getXsheet();
+    int row       = app->getCurrentFrame()->getFrame();
+    int col       = app->getCurrentColumn()->getColumnIndex();
+    TXshCell cell = xsh->getCell(row, col);
+    int r;
+    r = row + previousOffset;
+    if (r >= 0 && xsh->getCell(r, col) != cell &&
+        (cell.getSimpleLevel() == 0 ||
+         xsh->getCell(r, col).getSimpleLevel() == cell.getSimpleLevel())) {
+      m_row[0] = r;
     }
 
-    // search for next ref img
-    r = row + 1;
-    while (xsh->getCell(r, col) == cell) r++;
-    // first cell after the current span has the same level
-    if (xsh->getCell(r, col).getSimpleLevel() == sl) m_row[1] = r;
+    r = row + forwardOffset;
+    if (r >= 0 && xsh->getCell(r, col) != cell &&
+        (cell.getSimpleLevel() == 0 ||
+         xsh->getCell(r, col).getSimpleLevel() == cell.getSimpleLevel())) {
+      m_row[1] = r;
+    }
+  }
+  // on editing level
+  else {
+    TXshLevel *level = app->getCurrentLevel()->getLevel();
+    if (level) {
+      TXshSimpleLevel *sl = level->getSimpleLevel();
+      if (sl) {
+        TFrameId fid = app->getCurrentFrame()->getFid();
+        int row      = sl->guessIndex(fid);
+        m_row[0]     = row + previousOffset;
+        m_row[1]     = row + forwardOffset;
+      }
+    }
   }
   updateBox();
 }
@@ -269,35 +305,42 @@ void ShiftTraceTool::drawDot(const TPointD &center, double r,
   tglDrawCircle(center, r);
 }
 
-void ShiftTraceTool::drawControlRect() {
+void ShiftTraceTool::drawControlRect() {  // TODO
   if (m_ghostIndex < 0 || m_ghostIndex > 1) return;
   int row = m_row[m_ghostIndex];
   if (row < 0) return;
-  int col       = TApp::instance()->getCurrentColumn()->getColumnIndex();
-  TXsheet *xsh  = TApp::instance()->getCurrentXsheet()->getXsheet();
-  TXshCell cell = xsh->getCell(row, col);
-  if (cell.isEmpty()) return;
-  TImageP img = cell.getImage(false);
-  if (!img) return;
-  TRectD box;
-  if (TRasterImageP ri = img) {
-    TRasterP ras = ri->getRaster();
-    box =
-        (convert(ras->getBounds()) - ras->getCenterD()) * ri->getSubsampling();
-  } else if (TToonzImageP ti = img) {
-    TRasterP ras = ti->getRaster();
-    box =
-        (convert(ras->getBounds()) - ras->getCenterD()) * ti->getSubsampling();
-  } else if (TVectorImageP vi = img) {
-    box = vi->getBBox();
-  } else {
-    return;
-  }
+
+  TRectD box = m_box;
+  if (box.isEmpty()) return;
   glPushMatrix();
   tglMultMatrix(getGhostAff());
+
   TPixel32 color;
-  color = m_highlightedGadget == TranslateGadget ? TPixel32(200, 100, 100)
-                                                 : TPixel32(120, 120, 120);
+
+  // draw onion-colored rectangle to indicate which ghost is grabbed
+  {
+    TPixel32 frontOniColor, backOniColor;
+    bool inksOnly;
+    Preferences::instance()->getOnionData(frontOniColor, backOniColor,
+                                          inksOnly);
+    color       = (m_ghostIndex == 0) ? backOniColor : frontOniColor;
+    double unit = sqrt(tglGetPixelSize2());
+    unit *= getDevPixRatio();
+    TRectD coloredBox = box.enlarge(3.0 * unit);
+    tglColor(color);
+    glBegin(GL_LINE_STRIP);
+    glVertex2d(coloredBox.x0, coloredBox.y0);
+    glVertex2d(coloredBox.x1, coloredBox.y0);
+    glVertex2d(coloredBox.x1, coloredBox.y1);
+    glVertex2d(coloredBox.x0, coloredBox.y1);
+    glVertex2d(coloredBox.x0, coloredBox.y0);
+    glEnd();
+  }
+
+  color = m_highlightedGadget == TranslateGadget
+              ? TPixel32(200, 100, 100)
+              : m_highlightedGadget == RotateGadget ? TPixel32(100, 200, 100)
+                                                    : TPixel32(120, 120, 120);
   tglColor(color);
   glBegin(GL_LINE_STRIP);
   glVertex2d(box.x0, box.y0);
@@ -306,16 +349,16 @@ void ShiftTraceTool::drawControlRect() {
   glVertex2d(box.x0, box.y1);
   glVertex2d(box.x0, box.y0);
   glEnd();
-  color =
-      m_highlightedGadget == 2000 ? TPixel32(200, 100, 100) : TPixel32::White;
+  color = m_highlightedGadget == ScaleGadget ? TPixel32(200, 100, 100)
+                                             : TPixel32::White;
   double r = 4 * sqrt(tglGetPixelSize2());
   drawDot(box.getP00(), r, color);
   drawDot(box.getP01(), r, color);
   drawDot(box.getP10(), r, color);
   drawDot(box.getP11(), r, color);
   if (m_curveStatus == NoCurve) {
-    color =
-        m_highlightedGadget == 2001 ? TPixel32(200, 100, 100) : TPixel32::White;
+    color = m_highlightedGadget == MoveCenterGadget ? TPixel32(200, 100, 100)
+                                                    : TPixel32::White;
     TPointD c = m_center[m_ghostIndex];
     drawDot(c, r, color);
   }
@@ -327,18 +370,20 @@ void ShiftTraceTool::drawCurve() {
   double r = 4 * sqrt(tglGetPixelSize2());
   double u = getPixelSize();
   if (m_curveStatus == TwoPointsCurve) {
-    TPixel32 color =
-        m_highlightedGadget == 1000 ? TPixel32(200, 100, 100) : TPixel32::White;
+    TPixel32 color = m_highlightedGadget == CurveP0Gadget
+                         ? TPixel32(200, 100, 100)
+                         : TPixel32::White;
     drawDot(m_p0, r, color);
     glColor3d(0.2, 0.2, 0.2);
     tglDrawSegment(m_p0, m_p1);
     drawDot(m_p1, r, TPixel32::Red);
   } else if (m_curveStatus == ThreePointsCurve) {
-    TPixel32 color =
-        m_highlightedGadget == 1000 ? TPixel32(200, 100, 100) : TPixel32::White;
+    TPixel32 color = m_highlightedGadget == CurveP0Gadget
+                         ? TPixel32(200, 100, 100)
+                         : TPixel32::White;
     drawDot(m_p0, r, color);
-    color =
-        m_highlightedGadget == 1001 ? TPixel32(200, 100, 100) : TPixel32::White;
+    color = m_highlightedGadget == CurveP1Gadget ? TPixel32(200, 100, 100)
+                                                 : TPixel32::White;
     drawDot(m_p1, r, color);
 
     glColor3d(0.2, 0.2, 0.2);
@@ -364,8 +409,8 @@ void ShiftTraceTool::drawCurve() {
     } else {
       tglDrawSegment(m_p0, m_p1);
     }
-    color =
-        m_highlightedGadget == 1002 ? TPixel32(200, 100, 100) : TPixel32::White;
+    color = m_highlightedGadget == CurvePmGadget ? TPixel32(200, 100, 100)
+                                                 : TPixel32::White;
     drawDot(m_p2, r, color);
   }
 }
@@ -375,17 +420,19 @@ ShiftTraceTool::GadgetId ShiftTraceTool::getGadget(const TPointD &p) {
   gadgets.push_back(std::make_pair(m_p0, CurveP0Gadget));
   gadgets.push_back(std::make_pair(m_p1, CurveP1Gadget));
   gadgets.push_back(std::make_pair(m_p2, CurvePmGadget));
-  TAffine aff = getGhostAff();
+  TAffine aff      = getGhostAff();
+  double pixelSize = getPixelSize();
+  double d         = 15 * pixelSize;  // offset for rotation handle
   if (0 <= m_ghostIndex && m_ghostIndex < 2) {
-    gadgets.push_back(std::make_pair(aff * m_box.getP00(), RotateGadget));
-    gadgets.push_back(std::make_pair(aff * m_box.getP01(), RotateGadget));
-    gadgets.push_back(std::make_pair(aff * m_box.getP10(), RotateGadget));
-    gadgets.push_back(std::make_pair(aff * m_box.getP11(), RotateGadget));
+    gadgets.push_back(std::make_pair(aff * m_box.getP00(), ScaleGadget));
+    gadgets.push_back(std::make_pair(aff * m_box.getP01(), ScaleGadget));
+    gadgets.push_back(std::make_pair(aff * m_box.getP10(), ScaleGadget));
+    gadgets.push_back(std::make_pair(aff * m_box.getP11(), ScaleGadget));
     gadgets.push_back(
         std::make_pair(aff * m_center[m_ghostIndex], MoveCenterGadget));
   }
   int k           = -1;
-  double minDist2 = pow(10 * getPixelSize(), 2);
+  double minDist2 = pow(10 * pixelSize, 2);
   for (int i = 0; i < (int)gadgets.size(); i++) {
     double d2 = norm2(gadgets[i].first - p);
     if (d2 < minDist2) {
@@ -397,8 +444,7 @@ ShiftTraceTool::GadgetId ShiftTraceTool::getGadget(const TPointD &p) {
 
   // rect-point
   if (0 <= m_ghostIndex && m_ghostIndex < 2) {
-    TPointD q = aff.inv() * p;
-
+    TPointD q  = aff.inv() * p;
     double big = 1.0e6;
     double d = big, x = 0, y = 0;
     if (m_box.x0 < q.x && q.x < m_box.x1) {
@@ -414,8 +460,8 @@ ShiftTraceTool::GadgetId ShiftTraceTool::getGadget(const TPointD &p) {
       }
     }
     if (m_box.y0 < q.y && q.y < m_box.y1) {
-      double d0 = fabs(m_box.x0 - q.y);
-      double d1 = fabs(m_box.x1 - q.y);
+      double d0 = fabs(m_box.x0 - q.x);
+      double d1 = fabs(m_box.x1 - q.x);
       if (d0 < d) {
         d = d0;
         y = q.y;
@@ -431,9 +477,16 @@ ShiftTraceTool::GadgetId ShiftTraceTool::getGadget(const TPointD &p) {
       TPointD pp = aff * TPointD(x, y);
       double d   = norm(p - pp);
       if (d < 10 * getPixelSize()) {
-        return TranslateGadget;
+        if (m_box.contains(q))
+          return TranslateGadget;
+        else
+          return RotateGadget;
       }
     }
+    if (m_box.contains(q))
+      return NoGadget_InBox;
+    else
+      return NoGadget;
   }
   return NoGadget;
 }
@@ -450,31 +503,46 @@ void ShiftTraceTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
   m_gadget = m_highlightedGadget;
   m_oldPos = m_startPos = pos;
 
-  if (m_gadget == NoGadget) {
+  if (m_gadget == NoGadget || m_gadget == NoGadget_InBox) {
+    if (!e.isCtrlPressed()) {
+      if (m_gadget == NoGadget_InBox)
+        m_gadget = TranslateGadget;
+      else
+        m_gadget = RotateGadget;
+      // m_curveStatus = NoCurve;
+    }
     int row = getViewer()->posToRow(e.m_pos, 5 * getPixelSize(), false);
     if (row >= 0) {
-      int currentRow = getFrame();
-      int index      = -1;
-      if (m_row[0] >= 0 && row <= currentRow)
-        index = 0;
-      else if (m_row[1] >= 0 && row > currentRow)
-        index = 1;
+      int index = -1;
+      TApp *app = TApp::instance();
+      if (app->getCurrentFrame()->isEditingScene()) {
+        int currentRow = getFrame();
+        if (m_row[0] >= 0 && row <= currentRow)
+          index = 0;
+        else if (m_row[1] >= 0 && row > currentRow)
+          index = 1;
+      } else {
+        if (m_row[0] == row)
+          index = 0;
+        else if (m_row[1] == row)
+          index = 1;
+      }
+
       if (index >= 0) {
         m_ghostIndex = index;
         updateBox();
+        m_gadget            = TranslateGadget;
+        m_highlightedGadget = TranslateGadget;
       }
     }
-
-    if (!e.isCtrlPressed()) {
-      m_gadget = TranslateGadget;
-      // m_curveStatus = NoCurve;
-    }
   }
+
+  m_oldAff = m_aff[m_ghostIndex];
   invalidate();
 }
 
-void ShiftTraceTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
-  if (m_gadget == NoGadget) {
+void ShiftTraceTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
+  if (m_gadget == NoGadget || m_gadget == NoGadget_InBox) {
     if (norm(pos - m_oldPos) > 10 * getPixelSize()) {
       m_curveStatus = TwoPointsCurve;
       m_p0          = m_oldPos;
@@ -512,6 +580,17 @@ void ShiftTraceTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
     TPointD delta       = pos - m_oldPos;
     m_oldPos            = pos;
     m_aff[m_ghostIndex] = TTranslation(delta) * m_aff[m_ghostIndex];
+  } else if (m_gadget == ScaleGadget) {
+    TAffine aff = getGhostAff();
+    TPointD c   = aff * m_center[m_ghostIndex];
+    TPointD a   = m_oldPos - c;
+    TPointD b   = pos - c;
+    if (e.isShiftPressed())
+      m_aff[m_ghostIndex] = m_oldAff * TScale(b.x / a.x, b.y / a.y);
+    else {
+      double scale        = std::max(b.x / a.x, b.y / a.y);
+      m_aff[m_ghostIndex] = m_oldAff * TScale(scale, scale);
+    }
   }
 
   updateGhost();
@@ -541,11 +620,13 @@ void ShiftTraceTool::draw() {
 }
 
 int ShiftTraceTool::getCursorId() const {
-  if (m_highlightedGadget == RotateGadget)
+  if (m_highlightedGadget == RotateGadget || m_highlightedGadget == NoGadget)
     return ToolCursor::RotateCursor;
+  else if (m_highlightedGadget == ScaleGadget)
+    return ToolCursor::ScaleCursor;
   else if (isCurveGadget(m_highlightedGadget))
     return ToolCursor::PinchCursor;
-  else
+  else  // Curve Points, TranslateGadget, NoGadget_InBox
     return ToolCursor::MoveCursor;
 }
 

--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -26,8 +26,9 @@ class RowArea final : public QWidget {
   enum ShowOnionToSetFlag {
     None = 0,
     Fos,
-    Mos
-  } m_showOnionToSet;  // TODO:明日はこれをFos,Mosどちらをハイライトしているのか判定させる！！！！
+    Mos,
+    ShiftTraceGhost
+  } m_showOnionToSet;
 
   enum Direction { up = 0, down };
 
@@ -51,6 +52,7 @@ class RowArea final : public QWidget {
   void drawPinnedCenterKeys(QPainter &p, int r0, int r1);
   void drawCurrentTimeIndicator(QPainter &p);
   void drawCurrentTimeLine(QPainter &p);
+  void drawShiftTraceMarker(QPainter &p);
 
   DragTool *getDragTool() const;
   void setDragTool(DragTool *dragTool);

--- a/toonz/sources/toonzlib/onionskinmask.cpp
+++ b/toonz/sources/toonzlib/onionskinmask.cpp
@@ -64,6 +64,8 @@ void OnionSkinMask::clear() {
   m_ghostAff[1]    = TAffine();
   m_ghostCenter[0] = TPointD();
   m_ghostCenter[1] = TPointD();
+  m_ghostFrame[0]  = 0;
+  m_ghostFrame[1]  = 0;
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -10,15 +10,16 @@
 using std::pair;
 
 namespace {
-const int KEY_ICON_WIDTH     = 11;
-const int KEY_ICON_HEIGHT    = 13;
-const int EASE_TRIANGLE_SIZE = 4;
-const int PLAY_MARKER_SIZE   = 10;
-const int ONION_SIZE         = 19;
-const int ONION_DOT_SIZE     = 8;
-const int PINNED_SIZE        = 10;
-const int FRAME_MARKER_SIZE  = 4;
-const int FOLDED_CELL_SIZE   = 9;
+const int KEY_ICON_WIDTH      = 11;
+const int KEY_ICON_HEIGHT     = 13;
+const int EASE_TRIANGLE_SIZE  = 4;
+const int PLAY_MARKER_SIZE    = 10;
+const int ONION_SIZE          = 19;
+const int ONION_DOT_SIZE      = 8;
+const int PINNED_SIZE         = 10;
+const int FRAME_MARKER_SIZE   = 4;
+const int FOLDED_CELL_SIZE    = 9;
+const int SHIFTTRACE_DOT_SIZE = 12;
 }
 
 class TopToBottomOrientation : public Orientation {
@@ -34,9 +35,10 @@ class TopToBottomOrientation : public Orientation {
   const int FRAME_HEADER_WIDTH         = CELL_WIDTH;
   const int PLAY_RANGE_X = FRAME_HEADER_WIDTH / 2 - PLAY_MARKER_SIZE;
   const int ONION_X = 0, ONION_Y = 0;
-  const int ICON_WIDTH  = 18;
-  const int ICON_HEIGHT = 18;
-  const int TRACKLEN    = 60;
+  const int ICON_WIDTH            = 18;
+  const int ICON_HEIGHT           = 18;
+  const int TRACKLEN              = 60;
+  const int SHIFTTRACE_DOT_OFFSET = 3;
 
 public:
   TopToBottomOrientation();
@@ -97,6 +99,7 @@ class LeftToRightOrientation : public Orientation {
   const int FOLDED_LAYER_HEADER_HEIGHT = 8;
   const int FOLDED_LAYER_HEADER_WIDTH  = LAYER_HEADER_WIDTH;
   const int TRACKLEN                   = 60;
+  const int SHIFTTRACE_DOT_OFFSET      = 5;
 
 public:
   LeftToRightOrientation();
@@ -346,6 +349,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
   addRect(
       PredefinedRect::PREVIEW_FRAME_AREA,
       QRect(PLAY_RANGE_X, 0, (FRAME_HEADER_WIDTH - PLAY_RANGE_X), CELL_HEIGHT));
+
+  addRect(PredefinedRect::SHIFTTRACE_DOT,
+          QRect(SHIFTTRACE_DOT_OFFSET, (CELL_HEIGHT - SHIFTTRACE_DOT_SIZE) / 2,
+                SHIFTTRACE_DOT_SIZE, SHIFTTRACE_DOT_SIZE));
+  addRect(PredefinedRect::SHIFTTRACE_DOT_AREA,
+          QRect(SHIFTTRACE_DOT_OFFSET, 0, SHIFTTRACE_DOT_SIZE, CELL_HEIGHT));
 
   // Column viewer
   addRect(PredefinedRect::LAYER_HEADER,
@@ -952,6 +961,13 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(
       PredefinedRect::PREVIEW_FRAME_AREA,
       QRect(0, PLAY_RANGE_Y, CELL_WIDTH, (FRAME_HEADER_HEIGHT - PLAY_RANGE_Y)));
+
+  addRect(PredefinedRect::SHIFTTRACE_DOT,
+          QRect((CELL_WIDTH - SHIFTTRACE_DOT_SIZE) / 2, SHIFTTRACE_DOT_OFFSET,
+                SHIFTTRACE_DOT_SIZE, SHIFTTRACE_DOT_SIZE)
+              .adjusted(-1, 0, -1, 0));
+  addRect(PredefinedRect::SHIFTTRACE_DOT_AREA,
+          QRect(0, SHIFTTRACE_DOT_OFFSET, CELL_WIDTH, SHIFTTRACE_DOT_SIZE));
 
   // Column viewer
   addRect(PredefinedRect::LAYER_HEADER,


### PR DESCRIPTION
This PR will enhance the Shift & Trace feature, based on demands from some Japanese animation studio.

- The frames to be shown for "ghosts" can now be specified by user. A special gadget appears at the onion skin handle both in the xsheet and in the level strip. (Previously, only neighbor frames were shown.)
- Enabled this feature when the level strip frame is selected as well. (Previously, this feature was available only when the xsheet frame is selected.)
- On the Edit Shift mode, the control boxes are now colored (with the onion skin colors) in order to make it easier to know which "ghost" drawing is grasped. 
- On the Edit Shift mode, users now can modify scale of the "ghost". Holding shift+drag can modify vertical and horizontal scales independently.
- Transparency of the "ghost" now can be modified with "Preferences > Onion Skin > Paper Thickness"
- Holding F1, F2 or F3 key on the Viewer will display only the corresponding "ghost" or the current drawing. This feature can "flip" your drawing for checking the movement.

![shiftandtrace](https://user-images.githubusercontent.com/17974955/43633891-99aea3fc-9745-11e8-9c54-1c0bf21ce8ed.gif)
