### PR TITLE
Fix font creation crash

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -690,14 +690,17 @@ int main(int argc, char *argv[]) {
 
   TFontManager *fontMgr = TFontManager::instance();
   std::vector<std::wstring> typefaces;
-  fontMgr->loadFontNames();
-  fontMgr->setFamily(fontName.toStdWString());
-  fontMgr->getAllTypefaces(typefaces);
-
   bool isBold = false, isItalic = false, hasKerning = false;
-  isBold     = fontMgr->isBold(fontName, fontStyle);
-  isItalic   = fontMgr->isItalic(fontName, fontStyle);
-  hasKerning = fontMgr->hasKerning();
+  try {
+    fontMgr->loadFontNames();
+    fontMgr->setFamily(fontName.toStdWString());
+    fontMgr->getAllTypefaces(typefaces);
+    isBold     = fontMgr->isBold(fontName, fontStyle);
+    isItalic   = fontMgr->isItalic(fontName, fontStyle);
+    hasKerning = fontMgr->hasKerning();
+  } catch (TFontCreationError &) {
+    // Do nothing. A default font should load
+  }
 
   myFont = new QFont(fontName);
   myFont->setPixelSize(EnvSoftwareCurrentFontSize);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -359,18 +359,19 @@ void PreferencesPopup::onDropdownShortcutsCycleOptionsChanged(int index) {
 void PreferencesPopup::rebuilldFontStyleList() {
   TFontManager *instance = TFontManager::instance();
   std::vector<std::wstring> typefaces;
+  std::vector<std::wstring>::iterator it;
   QString font  = m_interfaceFont->currentText();
-  QString style = m_interfaceFontStyle->currentText();
+  QString style = m_pref->getInterfaceFontStyle();
   try {
     instance->loadFontNames();
     instance->setFamily(font.toStdWString());
     instance->getAllTypefaces(typefaces);
   } catch (TFontCreationError &) {
-    // Do nothing.  The style list will be cleared
+    it = typefaces.begin();
+    typefaces.insert(it, style.toStdWString());
   }
   m_interfaceFontStyle->clear();
-  for (std::vector<std::wstring>::iterator it = typefaces.begin();
-       it != typefaces.end(); ++it)
+  for (it = typefaces.begin(); it != typefaces.end(); ++it)
     m_interfaceFontStyle->addItem(QString::fromStdWString(*it));
 }
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -359,10 +359,15 @@ void PreferencesPopup::onDropdownShortcutsCycleOptionsChanged(int index) {
 void PreferencesPopup::rebuilldFontStyleList() {
   TFontManager *instance = TFontManager::instance();
   std::vector<std::wstring> typefaces;
-  QString font = m_interfaceFont->currentText();
-  instance->loadFontNames();
-  instance->setFamily(font.toStdWString());
-  instance->getAllTypefaces(typefaces);
+  QString font  = m_interfaceFont->currentText();
+  QString style = m_interfaceFontStyle->currentText();
+  try {
+    instance->loadFontNames();
+    instance->setFamily(font.toStdWString());
+    instance->getAllTypefaces(typefaces);
+  } catch (TFontCreationError &) {
+    // Do nothing.  The style list will be cleared
+  }
   m_interfaceFontStyle->clear();
   for (std::vector<std::wstring>::iterator it = typefaces.begin();
        it != typefaces.end(); ++it)


### PR DESCRIPTION
This PR fixes #2226 

When starting up OT, it crashes if the preferred font is not a valid font for the system.  This fix should cause OT to start with whatever system default font is available.
