### PR TITLE
Handle TFontCreationError exceptions

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -691,7 +691,11 @@ int main(int argc, char *argv[]) {
   TFontManager *fontMgr = TFontManager::instance();
   std::vector<std::wstring> typefaces;
   fontMgr->loadFontNames();
-  fontMgr->setFamily(fontName.toStdWString());
+  try {
+    fontMgr->setFamily(fontName.toStdWString());
+  } catch(TFontCreationError&) {
+    std::cerr << "Font family not found: " << fontName.toStdString() << std::endl;
+  }
   fontMgr->getAllTypefaces(typefaces);
 
   bool isBold = false, isItalic = false, hasKerning = false;

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -361,7 +361,11 @@ void PreferencesPopup::rebuilldFontStyleList() {
   std::vector<std::wstring> typefaces;
   QString font = m_interfaceFont->currentText();
   instance->loadFontNames();
-  instance->setFamily(font.toStdWString());
+  try {
+    instance->setFamily(font.toStdWString());
+  } catch(TFontCreationError&) {
+    std::cerr << "Font family not found: " << font.toStdString() << std::endl;
+  }
   instance->getAllTypefaces(typefaces);
   m_interfaceFontStyle->clear();
   for (std::vector<std::wstring>::iterator it = typefaces.begin();


### PR DESCRIPTION
Fix crashing OpenToonz at startup, when font not found.

Fix #2226, and possible #2253 