### PR TITLE
Fix Updating Animated Guided Drawing

### DIFF
--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -252,6 +252,8 @@ private:
   // darken blended view mode for viewing the non-cleanuped and stacked drawings
   bool m_doRasterDarkenBlendedView;
 
+  std::vector<TStroke *> m_guidedStrokes;
+
 public:
   RasterPainter(const TDimension &dim, const TAffine &viewAff,
                 const TRect &rect, const ImagePainter::VisualSettings &vs,
@@ -279,6 +281,8 @@ public:
   bool isSingleColumnEnabled() const { return m_singleColumnEnabled; }
 
   void setRasterDarkenBlendedView(bool on) { m_doRasterDarkenBlendedView = on; }
+
+  std::vector<TStroke *> &getGuidedStrokes() { return m_guidedStrokes; }
 };
 
 //=============================================================================

--- a/toonz/sources/include/tvectorgl.h
+++ b/toonz/sources/include/tvectorgl.h
@@ -49,7 +49,8 @@ class TVectorRenderData;
   \par stroke is element to draw
   \par rd: \sa TVectorRenderData
  */
-void DVAPI tglDraw(const TVectorRenderData &rd, const TVectorImage *vim);
+void DVAPI tglDraw(const TVectorRenderData &rd, const TVectorImage *vim,
+                   TStroke **guidedStroke = (TStroke **)nullptr);
 void DVAPI tglDrawMask(const TVectorRenderData &rd, const TVectorImage *vim);
 void DVAPI tglDraw(const TVectorRenderData &rd, const TStroke *stroke,
                    bool pushAttribs = true);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -807,7 +807,7 @@ void PreferencesPopup::onOnionSkinDuringPlaybackChanged(int index) {
 //-----------------------------------------------------------------------------
 
 void PreferencesPopup::onGuidedDrawingStyleChanged(int index) {
-  m_pref->setAnimatedGuidedDrawing(index);
+  m_pref->setAnimatedGuidedDrawing(index == 1);
 }
 
 //-----------------------------------------------------------------------------
@@ -1902,7 +1902,8 @@ PreferencesPopup::PreferencesPopup()
   QStringList guidedDrawingStyles;
   guidedDrawingStyles << tr("Arrow Markers") << tr("Animated Guide");
   m_guidedDrawingStyle->addItems(guidedDrawingStyles);
-  m_guidedDrawingStyle->setCurrentIndex(m_pref->getAnimatedGuidedDrawing());
+  m_guidedDrawingStyle->setCurrentIndex(m_pref->getAnimatedGuidedDrawing() ? 1
+                                                                           : 0);
 
   //--- Version Control ------------------------------
   m_enableVersionControl->setChecked(m_pref->isSVNEnabled());

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -173,6 +173,10 @@ class SceneViewer final : public GLWidgetForHighDpi,
   // So discarding the resources in old context in initializeGL.
   TGlContext m_currentContext;
 
+  // used for updating viewer where the animated guide appears
+  // updated in drawScene() and used in GLInvalidateRect()
+  TRectD m_guidedDrawingBBox;
+
 public:
   enum ReferenceMode {
     NORMAL_REFERENCE   = 1,

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -1588,7 +1588,7 @@ void Preferences::setGuidedDrawing(int status) {
 
 void Preferences::setAnimatedGuidedDrawing(bool status) {
   m_animatedGuidedDrawing = status;
-  m_settings->setValue("animatedGuidedDrawing", status);
+  m_settings->setValue("animatedGuidedDrawing", status ? "1" : "0");
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -916,10 +916,11 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
     vi->selectFill(vi->getBBox(), 0, 1, true, true, false);
   }
 
+  TStroke *guidedStroke = 0;
   if (m_maskLevel > 0)
     tglDrawMask(rd, vi);
   else
-    tglDraw(rd, vi);
+    tglDraw(rd, vi, &guidedStroke);
 
   if (tc & ToonzCheck::eAutoclose) drawAutocloses(vi, rd);
 
@@ -928,6 +929,8 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
 
   delete cf;
   delete guidedCf;
+
+  if (guidedStroke) m_guidedStrokes.push_back(guidedStroke);
 }
 
 //-----------------------------------------------------


### PR DESCRIPTION
This will fix #2251

If the animated guided drawing appears on the viewer, the bounding box of such guide strokes will be added to the clipping area of the viewer.
I think this will (hopefully) not cause an appreciable slowness when not using this mode...