### PR TITLE
Timeline height and keyframe area adjustments

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -120,7 +120,11 @@ enum class PredefinedRect {
   LAYER_FOOTER_PANEL,
   PREVIEW_FRAME_AREA,
   SHIFTTRACE_DOT,
-  SHIFTTRACE_DOT_AREA
+  SHIFTTRACE_DOT_AREA,
+  PANEL_EYE,
+  PANEL_PREVIEW_LAYER,
+  PANEL_LOCK,
+  PANEL_LAYER_NAME
 };
 enum class PredefinedLine {
   LOCKED,              //! dotted vertical line when cell is locked

--- a/toonz/sources/toonz/layerheaderpanel.cpp
+++ b/toonz/sources/toonz/layerheaderpanel.cpp
@@ -77,9 +77,9 @@ void LayerHeaderPanel::paintEvent(QPaintEvent *event) {
                      ? m_viewer->getLayerHeaderLockOverImage()
                      : m_viewer->getLayerHeaderLockImage());
 
-  drawIcon(p, PredefinedRect::EYE, boost::none, preview);
-  drawIcon(p, PredefinedRect::PREVIEW_LAYER, boost::none, camstand);
-  drawIcon(p, PredefinedRect::LOCK, boost::none, lock);
+  drawIcon(p, PredefinedRect::PANEL_EYE, boost::none, preview);
+  drawIcon(p, PredefinedRect::PANEL_PREVIEW_LAYER, boost::none, camstand);
+  drawIcon(p, PredefinedRect::PANEL_LOCK, boost::none, lock);
 
   QRect numberRect = o->rect(PredefinedRect::LAYER_NUMBER);
 
@@ -91,7 +91,7 @@ void LayerHeaderPanel::paintEvent(QPaintEvent *event) {
   }
 
   QRect nameRect =
-      o->rect(PredefinedRect::LAYER_NAME).adjusted(leftadj, 0, -1, 0);
+      o->rect(PredefinedRect::PANEL_LAYER_NAME).adjusted(leftadj, 0, -1, 0);
   p.drawText(nameRect, Qt::AlignLeft | Qt::AlignVCenter | Qt::TextSingleLine,
              QObject::tr("Layer name"));
 

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2282,17 +2282,11 @@ void CellArea::drawKeyframe(QPainter &p, const QRect toBeUpdated) {
                              handleRow1)) {
             QPoint topLeft =
                 m_viewer->positionToXY(CellPosition(handleRow0, col));
-            if (!o->isVerticalTimeline() &&
-                m_viewer->getFrameZoomFactor() <= 50)
-              topLeft.setY(topLeft.y() - 1);
             m_viewer->drawPredefinedPath(p, PredefinedPath::BEGIN_EASE_TRIANGLE,
                                          topLeft + QPoint(-frameAdj / 2, 0),
                                          keyFrameColor, outline);
 
             topLeft = m_viewer->positionToXY(CellPosition(handleRow1, col));
-            if (!o->isVerticalTimeline() &&
-                m_viewer->getFrameZoomFactor() <= 50)
-              topLeft.setY(topLeft.y() - 1);
             m_viewer->drawPredefinedPath(p, PredefinedPath::END_EASE_TRIANGLE,
                                          topLeft + QPoint(-frameAdj / 2, 0),
                                          keyFrameColor, outline);
@@ -2392,13 +2386,6 @@ void CellArea::drawKeyframeLine(QPainter &p, int col,
       keyRect.center() + m_viewer->positionToXY(CellPosition(rows.from(), col));
   QPoint end =
       keyRect.center() + m_viewer->positionToXY(CellPosition(rows.to(), col));
-
-  if (!m_viewer->orientation()->isVerticalTimeline() &&
-      m_viewer->getFrameZoomFactor() <= 50) {
-    begin.setY(begin.y() - 1);
-    end.setY(end.y() - 1);
-  }
-
   p.setPen(Qt::white);
   p.drawLine(QLine(begin, end));
 }

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -109,6 +109,8 @@ class CellArea final : public QWidget {
   // Restistusce true
   bool getEaseHandles(int r0, int r1, double e0, double e1, int &rh0, int &rh1);
 
+  bool isKeyFrameArea(int col, int row, QPoint mouseInCell);
+
   DragTool *getDragTool() const;
   void setDragTool(DragTool *dragTool);
 

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -866,8 +866,6 @@ void ColumnArea::DrawHeader::drawColumnName() const {
         leftadj = 24;
     }
 
-    if (!o->isVerticalTimeline() && column->getFilterColorId()) rightadj -= 15;
-
     p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
                          : nameBacklit ? Qt::black : m_viewer->getTextColor());
   } else

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -788,8 +788,9 @@ void ColumnArea::DrawHeader::drawConfig() const {
   p.fillRect(configRect, bgColor);
   if (o->flag(PredefinedFlag::CONFIG_AREA_BORDER)) p.drawRect(configRect);
 
-  if (column->getSoundColumn() || column->getPaletteColumn() ||
-      column->getSoundTextColumn())
+  TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(column);
+
+  if (zColumn || column->getPaletteColumn() || column->getSoundTextColumn())
     return;
 
   p.drawImage(configImgRect, icon);
@@ -865,12 +866,7 @@ void ColumnArea::DrawHeader::drawColumnName() const {
         leftadj = 24;
     }
 
-    if (!o->isVerticalTimeline()) {
-      if (column->getSoundColumn())
-        rightadj -= 97;
-      else if (column->getFilterColorId())
-        rightadj -= 15;
-    }
+    if (!o->isVerticalTimeline() && column->getFilterColorId()) rightadj -= 15;
 
     p.setPen((isCurrent) ? m_viewer->getSelectedColumnTextColor()
                          : nameBacklit ? Qt::black : m_viewer->getTextColor());
@@ -897,7 +893,10 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
         xsh->getColumn(col) ? xsh->getColumn(col)->getSoundColumn() : 0;
 
     drawSoundIcon(sc->isPlaying());
-    drawVolumeControl(sc->getVolume());
+    // Volume control now in config button. If no config button
+    // draw control
+    if (!o->flag(PredefinedFlag::CONFIG_AREA_VISIBLE))
+      drawVolumeControl(sc->getVolume());
     return;
   }
 
@@ -1110,7 +1109,8 @@ ColumnArea::ColumnArea(XsheetViewer *parent, Qt::WFlags flags)
     , m_col(-1)
     , m_columnTransparencyPopup(0)
     , m_transparencyPopupTimer(0)
-    , m_isPanning(false) {
+    , m_isPanning(false)
+    , m_soundColumnPopup(0) {
   TXsheetHandle *xsheetHandle = TApp::instance()->getCurrentXsheet();
 #ifndef LINETEST
   TObjectHandle *objectHandle = TApp::instance()->getCurrentObject();
@@ -1357,7 +1357,7 @@ void ColumnArea::drawSoundColumnHead(QPainter &p, int col) {  // AREA
   drawHeader.levelColors(columnColor, dragColor);
   drawHeader.drawBaseFill(columnColor, dragColor);
   drawHeader.drawEye();
-  drawHeader.drawPreviewToggle(255);
+  drawHeader.drawPreviewToggle(sc ? (troundp(255.0 * sc->getVolume())) : 0);
   drawHeader.drawLock();
   drawHeader.drawConfig();
   drawHeader.drawColumnName();
@@ -1582,7 +1582,7 @@ using namespace DVGui;
 
 ColumnTransparencyPopup::ColumnTransparencyPopup(QWidget *parent)
     : QWidget(parent, Qt::Popup) {
-  setFixedWidth(8 + 30 + 8 + 100 + 8 + 8 + 8 + 7);
+  setFixedWidth(8 + 78 + 8 + 100 + 8 + 8 + 8 + 7);
 
   m_slider = new QSlider(Qt::Horizontal, this);
   m_slider->setMinimum(1);
@@ -1608,6 +1608,7 @@ m_value->setFont(font);*/
   }
 
   QLabel *filterLabel = new QLabel(tr("Filter:"), this);
+  QLabel *sliderLabel = new QLabel(tr("Opacity:"), this);
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setMargin(3);
@@ -1617,6 +1618,7 @@ m_value->setFont(font);*/
     // hlayout->setContentsMargins(0, 3, 0, 3);
     hlayout->setMargin(0);
     hlayout->setSpacing(3);
+    hlayout->addWidget(sliderLabel, 0);
     hlayout->addWidget(m_slider);
     hlayout->addWidget(m_value);
     hlayout->addWidget(new QLabel("%"));
@@ -1720,6 +1722,106 @@ void ColumnTransparencyPopup::mouseReleaseEvent(QMouseEvent *e) {
 
 //------------------------------------------------------------------------------
 
+SoundColumnPopup::SoundColumnPopup(QWidget *parent)
+    : QWidget(parent, Qt::Popup) {
+  setFixedWidth(8 + 78 + 8 + 100 + 8 + 8 + 8 + 7);
+
+  m_slider = new QSlider(Qt::Horizontal, this);
+  m_slider->setMinimum(0);
+  m_slider->setMaximum(100);
+  m_slider->setFixedHeight(14);
+  m_slider->setFixedWidth(100);
+
+  m_value = new DVGui::IntLineEdit(this, 1, 1, 100);
+
+  QLabel *sliderLabel = new QLabel(tr("Volume:"), this);
+
+  QVBoxLayout *mainLayout = new QVBoxLayout();
+  mainLayout->setMargin(3);
+  mainLayout->setSpacing(3);
+  {
+    QHBoxLayout *hlayout = new QHBoxLayout;
+    // hlayout->setContentsMargins(0, 3, 0, 3);
+    hlayout->setMargin(0);
+    hlayout->setSpacing(3);
+    hlayout->addWidget(sliderLabel, 0);
+    hlayout->addWidget(m_slider);
+    hlayout->addWidget(m_value);
+    hlayout->addWidget(new QLabel("%"));
+    mainLayout->addLayout(hlayout, 0);
+  }
+  setLayout(mainLayout);
+
+  bool ret = connect(m_slider, SIGNAL(sliderReleased()), this,
+                     SLOT(onSliderReleased()));
+  ret = ret && connect(m_slider, SIGNAL(sliderMoved(int)), this,
+                       SLOT(onSliderChange(int)));
+  ret = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
+                       SLOT(onSliderValueChanged(int)));
+  ret = ret && connect(m_value, SIGNAL(textChanged(const QString &)), this,
+                       SLOT(onValueChanged(const QString &)));
+  assert(ret);
+}
+
+//----------------------------------------------------------------
+
+void SoundColumnPopup::onSliderValueChanged(int val) {
+  if (m_slider->isSliderDown()) return;
+  m_value->setText(QString::number(val));
+  onSliderReleased();
+}
+
+void SoundColumnPopup::onSliderReleased() {
+  int val = m_slider->value();
+  m_column->getSoundColumn()->setVolume(((double)val / 100.0));
+  TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  ((ColumnArea *)parent())->update();
+}
+
+//-----------------------------------------------------------------------
+
+void SoundColumnPopup::onSliderChange(int val) {
+  disconnect(m_value, SIGNAL(textChanged(const QString &)), 0, 0);
+  m_value->setText(QString::number(val));
+  connect(m_value, SIGNAL(textChanged(const QString &)), this,
+          SLOT(onValueChanged(const QString &)));
+}
+
+//----------------------------------------------------------------
+
+void SoundColumnPopup::onValueChanged(const QString &str) {
+  int val = str.toInt();
+  m_slider->setValue(val);
+  m_column->getSoundColumn()->setVolume(((double)val / 100.0));
+
+  TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  ((ColumnArea *)parent())->update();
+}
+
+//----------------------------------------------------------------
+
+void SoundColumnPopup::setColumn(TXshColumn *column) {
+  m_column = column;
+  assert(m_column);
+  double volume = m_column->getSoundColumn()->getVolume();
+  int val       = (int)troundp(100.0 * volume);
+  m_slider->setValue(val);
+  disconnect(m_value, SIGNAL(textChanged(const QString &)), 0, 0);
+  m_value->setText(QString::number(val));
+  connect(m_value, SIGNAL(textChanged(const QString &)), this,
+          SLOT(onValueChanged(const QString &)));
+}
+
+void SoundColumnPopup::mouseReleaseEvent(QMouseEvent *e) {
+  // hide();
+}
+
+//----------------------------------------------------------------
+
 void ColumnArea::openTransparencyPopup() {
   if (m_transparencyPopupTimer) m_transparencyPopupTimer->stop();
   if (m_col < 0) return;
@@ -1735,6 +1837,23 @@ void ColumnArea::openTransparencyPopup() {
 
   m_columnTransparencyPopup->setColumn(column);
   m_columnTransparencyPopup->show();
+}
+
+void ColumnArea::openSoundColumnPopup() {
+  if (m_col < 0) return;
+  TXshColumn *column = m_viewer->getXsheet()->getColumn(m_col);
+  if (!column || column->isEmpty()) return;
+
+  if (!column->isCamstandVisible()) {
+    column->setCamstandVisible(true);
+    TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
+    TApp::instance()->getCurrentScene()->notifySceneChanged();
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    update();
+  }
+
+  m_soundColumnPopup->setColumn(column);
+  m_soundColumnPopup->show();
 }
 
 //----------------------------------------------------------------
@@ -1854,7 +1973,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
         TXshZeraryFxColumn *zColumn =
             dynamic_cast<TXshZeraryFxColumn *>(column);
 
-        if (zColumn || column->getSoundColumn() || column->getPaletteColumn() ||
+        if (zColumn || column->getPaletteColumn() ||
             column->getSoundTextColumn()) {
           // do nothing
         } else
@@ -1882,7 +2001,8 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
               QTimer::singleShot(interval, this, SLOT(update()));
           }
           update();
-        } else if (o->rect(PredefinedRect::VOLUME_AREA).contains(mouseInCell))
+        } else if (!o->flag(PredefinedFlag::CONFIG_AREA_VISIBLE) &&
+                   o->rect(PredefinedRect::VOLUME_AREA).contains(mouseInCell))
           setDragTool(XsheetGUI::DragTool::makeVolumeDragTool(m_viewer));
         else
           setDragTool(XsheetGUI::DragTool::makeColumnSelectionTool(m_viewer));
@@ -1997,7 +2117,8 @@ void ColumnArea::mouseMoveEvent(QMouseEvent *event) {
       // sound column
       if (o->rect(PredefinedRect::SOUND_ICON).contains(mouseInCell))
         m_tooltip = tr("Click to play the soundtrack back");
-      else if (o->rect(PredefinedRect::VOLUME_AREA).contains(mouseInCell))
+      else if (!o->flag(PredefinedFlag::CONFIG_AREA_VISIBLE) &&
+               o->rect(PredefinedRect::VOLUME_AREA).contains(mouseInCell))
         m_tooltip = tr("Set the volume of the soundtrack");
     } else
       m_tooltip = tr("Click to select column, double-click to edit");
@@ -2015,7 +2136,8 @@ void ColumnArea::mouseMoveEvent(QMouseEvent *event) {
       // sound column
       if (o->rect(PredefinedRect::SOUND_ICON).contains(mouseInCell))
         m_tooltip = tr("Click to play the soundtrack back");
-      else if (o->rect(PredefinedRect::VOLUME_AREA).contains(mouseInCell))
+      else if (!o->flag(PredefinedFlag::CONFIG_AREA_VISIBLE) &&
+               o->rect(PredefinedRect::VOLUME_AREA).contains(mouseInCell))
         m_tooltip = tr("Set the volume of the soundtrack");
     } else if (Preferences::instance()->getColumnIconLoadingPolicy() ==
                Preferences::LoadOnDemand)
@@ -2055,9 +2177,6 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
     else if (m_doOnRelease == ToggleLock)
       column->lock(!column->isLocked());
     else if (m_doOnRelease == OpenSettings) {
-      if (!m_columnTransparencyPopup)
-        m_columnTransparencyPopup = new ColumnTransparencyPopup(this);
-
       // Align popup to be below to CONFIG button
       QRect configRect =
           m_viewer->orientation()->rect(PredefinedRect::CONFIG_AREA);
@@ -2071,10 +2190,24 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
       int y =
           mouseInCell.y() -
           configRect.bottom();  // distance from bottum edge of CONFIG button
-      m_columnTransparencyPopup->move(event->globalPos().x() + x,
-                                      event->globalPos().y() - y);
 
-      openTransparencyPopup();
+      if (column->getSoundColumn()) {
+        if (!m_soundColumnPopup)
+          m_soundColumnPopup = new SoundColumnPopup(this);
+
+        m_soundColumnPopup->move(event->globalPos().x() + x,
+                                 event->globalPos().y() - y);
+
+        openSoundColumnPopup();
+      } else {
+        if (!m_columnTransparencyPopup)
+          m_columnTransparencyPopup = new ColumnTransparencyPopup(this);
+
+        m_columnTransparencyPopup->move(event->globalPos().x() + x,
+                                        event->globalPos().y() - y);
+
+        openTransparencyPopup();
+      }
     } else if (m_doOnRelease == ToggleAllPreviewVisible) {
       for (col = 0; col < totcols; col++) {
         TXshColumn *column = xsh->getColumn(col);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -901,9 +901,7 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
     return;
   }
 
-  if (!o->isVerticalTimeline() ||
-      !o->flag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE))
-    return;
+  if (!o->flag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE)) return;
 
   QRect thumbnailImageRect =
       o->rect(PredefinedRect::THUMBNAIL).translated(orig);

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -178,6 +178,28 @@ protected slots:
   void onFilterColorChanged(int id);
 };
 
+class SoundColumnPopup final : public QWidget {
+  Q_OBJECT
+
+  QSlider *m_slider;
+  QLineEdit *m_value;
+  TXshColumn *m_column;
+
+public:
+  SoundColumnPopup(QWidget *parent);
+  void setColumn(TXshColumn *column);
+
+protected:
+  // void mouseMoveEvent ( QMouseEvent * e );
+  void mouseReleaseEvent(QMouseEvent *e) override;
+
+protected slots:
+  void onSliderReleased();
+  void onSliderChange(int val);
+  void onSliderValueChanged(int);
+  void onValueChanged(const QString &);
+};
+
 //! The class in charge of the region showing layer headers
 class ColumnArea final : public QWidget {
   Q_OBJECT
@@ -193,6 +215,7 @@ class ColumnArea final : public QWidget {
   };
 
   ColumnTransparencyPopup *m_columnTransparencyPopup;
+  SoundColumnPopup *m_soundColumnPopup;
   QTimer *m_transparencyPopupTimer;
   int m_doOnRelease;
   XsheetViewer *m_viewer;
@@ -302,6 +325,7 @@ protected:
 protected slots:
   void onSubSampling(QAction *);
   void openTransparencyPopup();
+  void openSoundColumnPopup();
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -92,10 +92,11 @@ class LeftToRightOrientation : public Orientation {
   const int ICON_HEIGHT        = 20;
   const int ICON_OFFSET        = ICON_WIDTH;
   const int ICONS_WIDTH        = ICON_OFFSET * 4;  // 88
+  const int THUMBNAIL_WIDTH    = 43;
   const int LAYER_NUMBER_WIDTH = 20;
   const int LAYER_NAME_WIDTH   = 150;
   const int LAYER_HEADER_WIDTH =
-      ICONS_WIDTH + LAYER_NUMBER_WIDTH + LAYER_NAME_WIDTH;
+      ICONS_WIDTH + THUMBNAIL_WIDTH + LAYER_NUMBER_WIDTH + LAYER_NAME_WIDTH;
   const int FOLDED_LAYER_HEADER_HEIGHT = 8;
   const int FOLDED_LAYER_HEADER_WIDTH  = LAYER_HEADER_WIDTH;
   const int TRACKLEN                   = 60;
@@ -943,7 +944,8 @@ LeftToRightOrientation::LeftToRightOrientation() {
           panelEye.translated(ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
   addRect(PredefinedRect::PANEL_LOCK,
           panelEye.translated(2 * ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
-  QRect panelName(ICONS_WIDTH + 1, 0, LAYER_NAME_WIDTH + LAYER_NUMBER_WIDTH - 4,
+  QRect panelName(ICONS_WIDTH + THUMBNAIL_WIDTH + 1, 0,
+                  LAYER_NAME_WIDTH + LAYER_NUMBER_WIDTH - 4,
                   LAYER_HEADER_PANEL_HEIGHT);
   addRect(PredefinedRect::PANEL_LAYER_NAME, panelName);
 
@@ -995,7 +997,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(
       PredefinedRect::FOLDED_LAYER_HEADER,
       QRect(1, 0, FOLDED_LAYER_HEADER_WIDTH - 2, FOLDED_LAYER_HEADER_HEIGHT));
-  QRect columnName(ICONS_WIDTH + 1, 0,
+  QRect columnName(ICONS_WIDTH + THUMBNAIL_WIDTH + 1, 0,
                    LAYER_NAME_WIDTH + LAYER_NUMBER_WIDTH - 4, CELL_HEIGHT);
   addRect(PredefinedRect::RENAME_COLUMN, columnName);
   QRect eyeArea(1, 0, ICON_WIDTH, CELL_HEIGHT);
@@ -1015,13 +1017,17 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(PredefinedRect::CONFIG,
           eye.translated(3 * ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
   addRect(PredefinedRect::DRAG_LAYER,
-          QRect(ICONS_WIDTH + 1, 0, LAYER_HEADER_WIDTH - ICONS_WIDTH - 3,
+          QRect(ICONS_WIDTH + THUMBNAIL_WIDTH + 1, 0,
+                LAYER_HEADER_WIDTH - ICONS_WIDTH - THUMBNAIL_WIDTH - 3,
                 CELL_DRAG_HEIGHT));
   addRect(PredefinedRect::LAYER_NAME, columnName);
   addRect(PredefinedRect::LAYER_NUMBER,
-          QRect(ICONS_WIDTH + 1, 0, LAYER_NUMBER_WIDTH, CELL_HEIGHT));
-  addRect(PredefinedRect::THUMBNAIL_AREA, QRect(0, 0, -1, -1));  // hide
-  addRect(PredefinedRect::THUMBNAIL, QRect(0, 0, -1, -1));       // hide
+          QRect(ICONS_WIDTH + THUMBNAIL_WIDTH + 1, 0, LAYER_NUMBER_WIDTH,
+                CELL_HEIGHT));
+  QRect thumbnailArea = QRect(ICONS_WIDTH + 1, 0, THUMBNAIL_WIDTH, CELL_HEIGHT);
+  addRect(PredefinedRect::THUMBNAIL_AREA, thumbnailArea);
+  QRect thumbnail = thumbnailArea.adjusted(1, 1, 0, 0);
+  addRect(PredefinedRect::THUMBNAIL, thumbnail);
   addRect(PredefinedRect::FILTER_COLOR,
           QRect(LAYER_HEADER_WIDTH - 17, CELL_DRAG_HEIGHT + 2, 12, 12));
   addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));         // hide
@@ -1078,8 +1084,8 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addFlag(PredefinedFlag::PEGBAR_NAME_VISIBLE, false);
   addFlag(PredefinedFlag::PARENT_HANDLE_NAME_BORDER, false);
   addFlag(PredefinedFlag::PARENT_HANDLE_NAME_VISIBILE, false);
-  addFlag(PredefinedFlag::THUMBNAIL_AREA_BORDER, false);
-  addFlag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE, false);
+  addFlag(PredefinedFlag::THUMBNAIL_AREA_BORDER, true);
+  addFlag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE, true);
   addFlag(PredefinedFlag::VOLUME_AREA_VERTICAL, false);
 
   //

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -1033,7 +1033,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
   QRect thumbnail = thumbnailArea.adjusted(1, 1, 0, 0);
   addRect(PredefinedRect::THUMBNAIL, thumbnail);
   addRect(PredefinedRect::FILTER_COLOR,
-          QRect(LAYER_HEADER_WIDTH - 17, CELL_DRAG_HEIGHT + 2, 12, 12));
+          QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
   addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));         // hide
   addRect(PredefinedRect::PARENT_HANDLE_NAME, QRect(0, 0, -1, -1));  // hide
 

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -80,8 +80,8 @@ public:
 
 class LeftToRightOrientation : public Orientation {
   const int CELL_WIDTH           = 50;
-  const int CELL_HEIGHT          = 20;
-  const int CELL_DRAG_HEIGHT     = 5;
+  const int CELL_HEIGHT          = 24;
+  const int CELL_DRAG_HEIGHT     = 7;
   const int EXTENDER_WIDTH       = 8;
   const int EXTENDER_HEIGHT      = 12;
   const int SOUND_PREVIEW_HEIGHT = 6;
@@ -100,6 +100,8 @@ class LeftToRightOrientation : public Orientation {
   const int FOLDED_LAYER_HEADER_WIDTH  = LAYER_HEADER_WIDTH;
   const int TRACKLEN                   = 60;
   const int SHIFTTRACE_DOT_OFFSET      = 5;
+  const int LAYER_HEADER_PANEL_HEIGHT  = 20;
+  const int LAYER_FOOTER_PANEL_HEIGHT  = 16;
 
 public:
   LeftToRightOrientation();
@@ -315,7 +317,13 @@ TopToBottomOrientation::TopToBottomOrientation() {
       QRect(QPoint(0, 0), QSize(FRAME_HEADER_WIDTH, use_header_height - 1)));
   addRect(PredefinedRect::NOTE_ICON,
           QRect(QPoint(0, 0), QSize(CELL_WIDTH - 2, CELL_HEIGHT - 2)));
-  addRect(PredefinedRect::LAYER_HEADER_PANEL, QRect(0, 0, -1, -1));  // hide
+
+  // Layer header panel
+  addRect(PredefinedRect::LAYER_HEADER_PANEL, QRect(0, 0, -1, -1));   // hide
+  addRect(PredefinedRect::PANEL_EYE, QRect(0, 0, -1, -1));            // hide
+  addRect(PredefinedRect::PANEL_PREVIEW_LAYER, QRect(0, 0, -1, -1));  // hide
+  addRect(PredefinedRect::PANEL_LOCK, QRect(0, 0, -1, -1));           // hide
+  addRect(PredefinedRect::PANEL_LAYER_NAME, QRect(0, 0, -1, -1));     // hide
 
   // Row viewer
   addRect(PredefinedRect::FRAME_LABEL,
@@ -888,15 +896,16 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(PredefinedRect::DRAG_HANDLE_CORNER,
           QRect(0, 0, CELL_WIDTH, CELL_DRAG_HEIGHT));
   QRect keyRect((CELL_WIDTH - KEY_ICON_WIDTH) / 2,
-                CELL_HEIGHT - KEY_ICON_HEIGHT, KEY_ICON_WIDTH, KEY_ICON_HEIGHT);
+                CELL_HEIGHT - KEY_ICON_HEIGHT - 2, KEY_ICON_WIDTH,
+                KEY_ICON_HEIGHT);
   addRect(PredefinedRect::KEY_ICON, keyRect);
   QRect nameRect = cellRect.adjusted(4, 4, -6, 0);
   addRect(PredefinedRect::CELL_NAME, nameRect);
   addRect(PredefinedRect::CELL_NAME_WITH_KEYFRAME, nameRect);
   addRect(PredefinedRect::END_EXTENDER,
-          QRect(0, -EXTENDER_HEIGHT - 10, EXTENDER_WIDTH, EXTENDER_HEIGHT));
+          QRect(0, -EXTENDER_HEIGHT - 14, EXTENDER_WIDTH, EXTENDER_HEIGHT));
   addRect(PredefinedRect::BEGIN_EXTENDER,
-          QRect(-EXTENDER_WIDTH, -EXTENDER_HEIGHT - 10, EXTENDER_WIDTH,
+          QRect(-EXTENDER_WIDTH, -EXTENDER_HEIGHT - 14, EXTENDER_WIDTH,
                 EXTENDER_HEIGHT));
   addRect(PredefinedRect::KEYFRAME_AREA, keyRect);
   addRect(PredefinedRect::DRAG_AREA, QRect(0, 0, CELL_WIDTH, CELL_DRAG_HEIGHT));
@@ -913,7 +922,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
                 CELL_HEIGHT - CELL_DRAG_HEIGHT));
   addRect(PredefinedRect::LOOP_ICON, QRect(0, keyRect.top(), 10, 11));
   QRect frameMarker((CELL_WIDTH - FRAME_MARKER_SIZE) / 2 - 1,
-                    CELL_HEIGHT - FRAME_MARKER_SIZE - 6, FRAME_MARKER_SIZE,
+                    CELL_HEIGHT - FRAME_MARKER_SIZE - 7, FRAME_MARKER_SIZE,
                     FRAME_MARKER_SIZE);
   addRect(PredefinedRect::FRAME_MARKER_AREA, frameMarker);
 
@@ -923,9 +932,20 @@ LeftToRightOrientation::LeftToRightOrientation() {
       QRect(QPoint(0, 0), QSize(LAYER_HEADER_WIDTH - 1, FRAME_HEADER_HEIGHT)));
   addRect(PredefinedRect::NOTE_ICON,
           QRect(QPoint(0, 0), QSize(CELL_WIDTH - 2, CELL_HEIGHT - 2)));
+
+  // Layer header panel
   addRect(PredefinedRect::LAYER_HEADER_PANEL,
           QRect(0, FRAME_HEADER_HEIGHT - CELL_HEIGHT, LAYER_HEADER_WIDTH,
-                CELL_HEIGHT));
+                LAYER_HEADER_PANEL_HEIGHT));
+  QRect panelEye(1, 0, ICON_WIDTH, ICON_HEIGHT);
+  addRect(PredefinedRect::PANEL_EYE, panelEye.adjusted(1, 1, -1, -1));
+  addRect(PredefinedRect::PANEL_PREVIEW_LAYER,
+          panelEye.translated(ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
+  addRect(PredefinedRect::PANEL_LOCK,
+          panelEye.translated(2 * ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
+  QRect panelName(ICONS_WIDTH + 1, 0, LAYER_NAME_WIDTH + LAYER_NUMBER_WIDTH - 4,
+                  LAYER_HEADER_PANEL_HEIGHT);
+  addRect(PredefinedRect::PANEL_LAYER_NAME, panelName);
 
   // Row viewer
   addRect(PredefinedRect::FRAME_LABEL,
@@ -978,16 +998,20 @@ LeftToRightOrientation::LeftToRightOrientation() {
   QRect columnName(ICONS_WIDTH + 1, 0,
                    LAYER_NAME_WIDTH + LAYER_NUMBER_WIDTH - 4, CELL_HEIGHT);
   addRect(PredefinedRect::RENAME_COLUMN, columnName);
-  QRect eye(1, 0, ICON_WIDTH, ICON_HEIGHT);
-  addRect(PredefinedRect::EYE_AREA, eye);
+  QRect eyeArea(1, 0, ICON_WIDTH, CELL_HEIGHT);
+  QRect eye(1,
+            eyeArea.top() + ((eyeArea.height() / 2) - ((ICON_HEIGHT - 1) / 2)),
+            ICON_WIDTH, ICON_HEIGHT);
+  addRect(PredefinedRect::EYE_AREA, eyeArea);
   addRect(PredefinedRect::EYE, eye.adjusted(1, 1, -1, -1));
-  addRect(PredefinedRect::PREVIEW_LAYER_AREA, eye.translated(ICON_OFFSET, 0));
+  addRect(PredefinedRect::PREVIEW_LAYER_AREA,
+          eyeArea.translated(ICON_OFFSET, 0));
   addRect(PredefinedRect::PREVIEW_LAYER,
           eye.translated(ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
-  addRect(PredefinedRect::LOCK_AREA, eye.translated(2 * ICON_OFFSET, 0));
+  addRect(PredefinedRect::LOCK_AREA, eyeArea.translated(2 * ICON_OFFSET, 0));
   addRect(PredefinedRect::LOCK,
           eye.translated(2 * ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
-  addRect(PredefinedRect::CONFIG_AREA, eye.translated(3 * ICON_OFFSET, 0));
+  addRect(PredefinedRect::CONFIG_AREA, eyeArea.translated(3 * ICON_OFFSET, 0));
   addRect(PredefinedRect::CONFIG,
           eye.translated(3 * ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
   addRect(PredefinedRect::DRAG_LAYER,
@@ -999,7 +1023,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(PredefinedRect::THUMBNAIL_AREA, QRect(0, 0, -1, -1));  // hide
   addRect(PredefinedRect::THUMBNAIL, QRect(0, 0, -1, -1));       // hide
   addRect(PredefinedRect::FILTER_COLOR,
-          QRect(LAYER_HEADER_WIDTH - 17, 6, 12, 12));
+          QRect(LAYER_HEADER_WIDTH - 17, CELL_DRAG_HEIGHT + 2, 12, 12));
   addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));         // hide
   addRect(PredefinedRect::PARENT_HANDLE_NAME, QRect(0, 0, -1, -1));  // hide
 
@@ -1007,28 +1031,31 @@ LeftToRightOrientation::LeftToRightOrientation() {
           QRect(columnName.topRight(), QSize(27, columnName.height()))
               .adjusted(-28, 0, -28, 0));
 
-  QRect volumeArea(QRect(columnName.topRight(), QSize(TRACKLEN + 8, 14))
-                       .adjusted(-97, 4, -97, 4));
+  QRect volumeArea(
+      QRect(columnName.topRight(), QSize(TRACKLEN + 8, 14))
+          .adjusted(-97, CELL_DRAG_HEIGHT + 1, -97, CELL_DRAG_HEIGHT + 1));
   addRect(PredefinedRect::VOLUME_AREA, volumeArea);
   QPoint soundTopLeft(volumeArea.left() + 4, volumeArea.bottom() - 6);
   addRect(PredefinedRect::VOLUME_TRACK,
           QRect(soundTopLeft, QSize(TRACKLEN, 3)));
 
   // Layer footer panel
-  QRect layerFooterPanel(QRect(0, 0, LAYER_HEADER_WIDTH + 2, 16));
+  QRect layerFooterPanel(
+      QRect(0, 0, LAYER_HEADER_WIDTH + 2, LAYER_FOOTER_PANEL_HEIGHT));
   addRect(PredefinedRect::LAYER_FOOTER_PANEL, layerFooterPanel);
 
   QRect zoomSlider, zoomIn, zoomOut;
 
-  zoomSlider = QRect(layerFooterPanel.width() - 100, 0, 81, 16);
+  zoomSlider =
+      QRect(layerFooterPanel.width() - 100, 0, 81, LAYER_FOOTER_PANEL_HEIGHT);
   addRect(PredefinedRect::ZOOM_SLIDER_AREA, zoomSlider);
   addRect(PredefinedRect::ZOOM_SLIDER, zoomSlider.adjusted(1, 0, 0, 0));
 
-  zoomIn = QRect(zoomSlider.right() + 1, 0, 16, 16);
+  zoomIn = QRect(zoomSlider.right() + 1, 0, 16, LAYER_FOOTER_PANEL_HEIGHT);
   addRect(PredefinedRect::ZOOM_IN_AREA, zoomIn);
   addRect(PredefinedRect::ZOOM_IN, zoomIn.adjusted(1, 1, 0, 0));
 
-  zoomOut = QRect(zoomSlider.left() - 16, 0, 16, 16);
+  zoomOut = QRect(zoomSlider.left() - 16, 0, 16, LAYER_FOOTER_PANEL_HEIGHT);
   addRect(PredefinedRect::ZOOM_OUT_AREA, zoomOut);
   addRect(PredefinedRect::ZOOM_OUT, zoomOut.adjusted(1, 1, 0, 0));
 

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -451,9 +451,11 @@ TopToBottomOrientation::TopToBottomOrientation() {
             QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
 
     addRect(PredefinedRect::SOUND_ICON,
-            QRect(thumbnailArea.topLeft(), QSize(27, 20))
-                .adjusted((thumbnailArea.width() / 2) - (27 / 2), 3,
-                          (thumbnailArea.width() / 2) - (27 / 2), 3));
+            QRect(thumbnailArea.topLeft(), QSize(40, 30))
+                .adjusted((thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2),
+                          (thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2)));
 
     volumeArea =
         QRect(QPoint(thumbnailArea.left() + 3, thumbnailArea.bottom() - 16),
@@ -554,9 +556,11 @@ TopToBottomOrientation::TopToBottomOrientation() {
             QRect(thumbnail.right() - 14, thumbnail.top() + 3, 12, 12));
 
     addRect(PredefinedRect::SOUND_ICON,
-            QRect(thumbnailArea.topLeft(), QSize(27, 20))
-                .adjusted((thumbnailArea.width() / 2) - (27 / 2), 3,
-                          (thumbnailArea.width() / 2) - (27 / 2), 3));
+            QRect(thumbnailArea.topLeft(), QSize(40, 30))
+                .adjusted((thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2),
+                          (thumbnailArea.width() / 2) - (40 / 2),
+                          (thumbnailArea.height() / 2) - (30 / 2)));
 
     volumeArea =
         QRect(QPoint(thumbnailArea.left() + 3, thumbnailArea.bottom() - 16),
@@ -1034,12 +1038,13 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(PredefinedRect::PARENT_HANDLE_NAME, QRect(0, 0, -1, -1));  // hide
 
   addRect(PredefinedRect::SOUND_ICON,
-          QRect(columnName.topRight(), QSize(27, columnName.height()))
-              .adjusted(-28, 0, -28, 0));
+          QRect(thumbnailArea.topLeft(), QSize(27, thumbnailArea.height()))
+              .adjusted((thumbnailArea.width() / 2) - (27 / 2), 0,
+                        (thumbnailArea.width() / 2) - (27 / 2), 0));
 
   QRect volumeArea(
       QRect(columnName.topRight(), QSize(TRACKLEN + 8, 14))
-          .adjusted(-97, CELL_DRAG_HEIGHT + 1, -97, CELL_DRAG_HEIGHT + 1));
+          .adjusted(-77, CELL_DRAG_HEIGHT + 1, -77, CELL_DRAG_HEIGHT + 1));
   addRect(PredefinedRect::VOLUME_AREA, volumeArea);
   QPoint soundTopLeft(volumeArea.left() + 4, volumeArea.bottom() - 6);
   addRect(PredefinedRect::VOLUME_TRACK,


### PR DESCRIPTION
This PR addresses #2261 and #2262 by the following:

- Increased the height of the timeline layers

![image](https://user-images.githubusercontent.com/19245851/44949671-2d6cb000-ae04-11e8-836e-a53c86b46597.png)

With the increased height, I also increased the height of the dragbar so the height matches the width of the xsheet dragbar.  Hopefully this will make it a bit easier to target with a pen.

**NOTE**: This does not mean this is the end of cell/column dragging conversation! It's merely to help for now in case it takes a while to find an agreeable dragging method.

Additionally, the increased height actually makes the timeline a bit easier on the eyes to look at.

- Narrowed the activation area for key frame selection

I narrowed the active selection area around where the keyframe icons and white lines are. Coupled with the increased height, this should allow for slightly better click/right-click access to target the cell rather than the keyframe icons/lines with a pen.

- Update: Added thumbnail into timeline

With the increased height, it made for a better area to display a thumbnail

![image](https://user-images.githubusercontent.com/19245851/45587239-331cc800-b8d1-11e8-8629-27fa1c3f5a86.png)

With the addition on thumbnail
1) Sound icon moved to thumbnail area
2) Filter color icon moved to thumbnail area

Additionally, made a Config button dropdown just for the Sound volume control, removing it from the thumbnail/name areas.  This change was made for all layouts except the "Classic" view since there is no config button. It should be noted that volume setting < 100 will change the Camera Stand Visibility icon similar to changing Opacity on other columns.

![image](https://user-images.githubusercontent.com/19245851/47066827-5af39a00-d1b5-11e8-9c17-2541c22787eb.png)
