### PR TITLE
Update Viewer on Opening

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -782,6 +782,8 @@ void SceneViewer::showEvent(QShowEvent *) {
     m_shownOnce = true;
   }
   TApp::instance()->setActiveViewer(this);
+
+  update();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR will resolve the following problem:
Viewer does not refresh its content on opening.

To Reproduce:
1. Open floating Viewer window.
1. Open some scene.
1. Close the Viewer.
1. New Scene.
1. Open the Viewer again by shortcut key or by navigating menu with arrow keys.

Viewer remains displaying content of the previous scene. It refreshes as soon as the mouse cursor enters.

