### PR TITLE
Load Palette's Global Name on Loading Level

### DIFF
--- a/toonz/sources/image/tzl/tiio_tzl.cpp
+++ b/toonz/sources/image/tzl/tiio_tzl.cpp
@@ -1409,8 +1409,15 @@ void TLevelReaderTzl::readPalette() {
   TPalette *palette = 0;
 
   if (is && fs.doesExist()) {
-    is >> p;
-    palette = dynamic_cast<TPalette *>(p);
+    std::string tagName;
+    if (is.matchTag(tagName) && tagName == "palette") {
+      std::string gname;
+      is.getTagParam("name", gname);
+      palette = new TPalette();
+      palette->loadData(is);
+      palette->setGlobalName(::to_wstring(gname));
+      is.matchEndTag();
+    }
   }
 
   if (!palette) {

--- a/toonz/sources/toonzlib/txshpalettelevel.cpp
+++ b/toonz/sources/toonzlib/txshpalettelevel.cpp
@@ -77,12 +77,20 @@ void TXshPaletteLevel::load() {
     TFileStatus fs(path);
     TPersist *p = 0;
     TIStream is(path);
+    TPalette *palette = nullptr;
 
     if (is && fs.doesExist()) {
-      is >> p;
-      TPalette *palette = dynamic_cast<TPalette *>(p);
-      palette->setPaletteName(path.getWideName());
-      setPalette(palette);
+      std::string tagName;
+      if (is.matchTag(tagName) && tagName == "palette") {
+        std::string gname;
+        is.getTagParam("name", gname);
+        palette = new TPalette();
+        palette->loadData(is);
+        palette->setGlobalName(::to_wstring(gname));
+        is.matchEndTag();
+        palette->setPaletteName(path.getWideName());
+        setPalette(palette);
+      }
     }
     assert(m_palette);
   }


### PR DESCRIPTION
This will fix #2298 
`TIStream::operator>>(TPersist *&v)` seems to have no ability to load attribute value of the current tag.