### PR TITLE
Search in the Special Folder Trees on Moving Folders in the File Browser

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -1061,16 +1061,19 @@ void DvDirModelRootNode::refreshChildren() {
     child = new DvDirModelSpecialFileFolderNode(this, L"My Documents",
                                                 getMyDocumentsPath());
     child->setPixmap(svgToPixmap(":Resources/my_documents.svg"));
+    m_specialNodes.push_back(child);
     addChild(child);
 
     child =
         new DvDirModelSpecialFileFolderNode(this, L"Desktop", getDesktopPath());
     child->setPixmap(svgToPixmap(":Resources/desktop.svg"));
+    m_specialNodes.push_back(child);
     addChild(child);
 
     child = new DvDirModelSpecialFileFolderNode(
         this, L"Library", ToonzFolder::getLibraryFolder());
     child->setPixmap(svgToPixmap(":Resources/library.svg"));
+    m_specialNodes.push_back(child);
     addChild(child);
 
     addChild(new DvDirModelHistoryNode(this));
@@ -1188,6 +1191,12 @@ DvDirModelNode *DvDirModelRootNode::getNodeByPath(const TFilePath &path) {
   if (priority == Preferences::ProjectFolderAliases &&
       !m_sceneFolderNode->getPath().isEmpty()) {
     node = m_sceneFolderNode->getNodeByPath(path);
+    if (node) return node;
+  }
+
+  // check for the special folders (My Documents / Desktop / Library)
+  for (DvDirModelSpecialFileFolderNode *specialNode : m_specialNodes) {
+    DvDirModelNode *node = specialNode->getNodeByPath(path);
     if (node) return node;
   }
 

--- a/toonz/sources/toonz/filebrowsermodel.h
+++ b/toonz/sources/toonz/filebrowsermodel.h
@@ -311,6 +311,7 @@ class DvDirModelRootNode final : public DvDirModelNode {
   DvDirModelNetworkNode *m_networkNode;
   DvDirModelProjectNode *m_sandboxProjectNode;
   DvDirModelSceneFolderNode *m_sceneFolderNode;
+  std::vector<DvDirModelSpecialFileFolderNode *> m_specialNodes;
 
   void add(std::wstring name, const TFilePath &path);
 


### PR DESCRIPTION
This PR will modify a behavior of the folder tree view on the left side in the file browser.
When accessing some folder which is not located under the project folders, if such folder is located under `My Document` , `Desktop` , or `Library` folder, the current node in the tree view will move to under the corresponding tree.
Before this change, accessing such folders always move the current node under the `My Computer` tree.

![specialfolder](https://user-images.githubusercontent.com/17974955/46333083-e3245c00-c659-11e8-84ce-f8c6f13aa64c.png)
