### PR TITLE
Update Qt Version for Travis CI

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -4,7 +4,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt/5.11.1/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt/5.11.2/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make -j 2


### PR DESCRIPTION
Updated Qt version from 5.11.1 to 5.11.2 as [the homebrew formula was updated 2 days ago](https://formulae.brew.sh/formula/qt).