### PR TITLE
Fix File Path Issues

### DIFF
--- a/toonz/sources/include/tfilepath.h
+++ b/toonz/sources/include/tfilepath.h
@@ -76,8 +76,10 @@ public:
   const TFrameId &operator--();
 
   TFrameId &operator=(const TFrameId &f) {
-    m_frame  = f.m_frame;
-    m_letter = f.m_letter;
+    m_frame       = f.m_frame;
+    m_letter      = f.m_letter;
+    m_zeroPadding = f.m_zeroPadding;
+    m_startSeqInd = f.m_startSeqInd;
     return *this;
   }
 


### PR DESCRIPTION
This will fix #2281 , and will fix #2306 as well.

Made the zero padding and the letter before frame numbers to be passed with equal ( `=` ) operator. 