### PR TITLE
Change Temporary File Name Suffix

### DIFF
--- a/toonz/sources/toonzlib/levelupdater.cpp
+++ b/toonz/sources/toonzlib/levelupdater.cpp
@@ -342,7 +342,9 @@ TFilePath LevelUpdater::getNewTemporaryFilePath(const TFilePath &fp) {
   int count = 1;
 
   for (;;) {
-    fp2 = fp.withName(fp.getWideName() + L"__" + std::to_wstring(count++));
+    // changed the temporary name as the previous naming (like
+    // "filename__1.png") had been misteken as sequential images
+    fp2 = fp.withName(fp.getWideName() + L"_ottmp" + std::to_wstring(count++));
     if (!TSystem::doesExistFileOrLevel(fp2)) break;
   }
 


### PR DESCRIPTION
This will hopefully fix #2306 .

When saving the raster images, OT firstly save them into temporary files.
The temporary names has some suffix (like `image__1.png` for temporary file on saving `image.png` ) and it seemed to be misunderstood as sequential files under the current file name rules. 

So I changed the suffix like `image_ottmp1.png` in order to avoid such misunderstanding.