### PR TITLE
Fix Import Files with Underscore

### DIFF
--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1096,11 +1096,11 @@ TFilePath ToonzScene::getImportedLevelPath(const TFilePath path) const {
   if (ltype.m_ltype == UNKNOWN_XSHLEVEL) return path;
 
   const std::wstring &levelName = path.getWideName();
-  const std::string &ext = path.getType(), &dots = path.getDots();
+  const std::string &dots       = path.getDots();
 
   TFilePath importedLevelPath =
       getDefaultLevelPath(ltype.m_ltype, levelName).getParentDir() +
-      (levelName + ::to_wstring(dots + ext));
+      path.getLevelNameW();
 
   if (dots == "..")
     importedLevelPath = importedLevelPath.withFrame(TFrameId::EMPTY_FRAME);


### PR DESCRIPTION
This will fix #2281 .

For now `TFilePath::getDots()` returns `".."` on any sequential image paths even if they are using underscores.
So it should not be used in part of file path conversion or it may unexpectedly alter the path from w/ underscore to w/ period. 