### PR TITLE
Fix Color Model Problem on High DPI Monitor

### DIFF
--- a/toonz/sources/toonz/colormodelviewer.cpp
+++ b/toonz/sources/toonz/colormodelviewer.cpp
@@ -260,14 +260,14 @@ void ColorModelViewer::contextMenuEvent(QContextMenuEvent *event) {
 /*! If left button is pressed recall \b pick() in event pos.
 */
 void ColorModelViewer::mousePressEvent(QMouseEvent *event) {
-  if (event->button() == Qt::LeftButton) pick(event->pos());
+  if (event->button() == Qt::LeftButton) pick(event->pos() * getDevPixRatio());
 }
 
 //-----------------------------------------------------------------------------
 /*! If left button is moved recall \b pick() in event pos.
 */
 void ColorModelViewer::mouseMoveEvent(QMouseEvent *event) {
-  if (event->buttons() & Qt::LeftButton) pick(event->pos());
+  if (event->buttons() & Qt::LeftButton) pick(event->pos() * getDevPixRatio());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR will fix the following problem:

OT fails to properly pickup the style at the clicked position in the color model window if it runs on the high dpi monitor (like Retina display) environment.