### PR TITLE
Fix Plastic Mesh Visibility

### DIFF
--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -997,9 +997,13 @@ void PlasticTool::onDeactivate() {
   assert(ret);
 
   Viewer *viewer = getViewer();
-  if (viewer)
+  if (viewer) {
     viewer->visualSettings().m_plasticVisualSettings = PlasticVisualSettings();
-
+    // Only the mesh visibility is not reset in order to enable to keep the mesh
+    // hidden while using other tools
+    viewer->visualSettings().m_plasticVisualSettings.m_drawMeshesWireframe =
+        m_pvs.m_drawMeshesWireframe;
+  }
   m_sd = PlasticSkeletonDeformationP();
 }
 


### PR DESCRIPTION
This will fix #2141 , and will fix #2317 .

The mesh visibility will now be kept hidden even when the current tool is changed.
Please note that I made the modification only for the mesh visibility. The following properties will still be reset (=hidden) when you deactivate the plastic tool:
- The visibility of rigidity map. 
- The visibility of stacking order (SO) map.