### PR TITLE
Check Folder Access on Saving Level

### DIFF
--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1391,7 +1391,10 @@ void TXshSimpleLevel::save(const TFilePath &fp, const TFilePath &oldFp,
       (!oldFp.isEmpty()) ? oldFp : getScene()->decodeFilePath(m_path);
 
   TFilePath dDstPath = getScene()->decodeFilePath(fp);
-  TSystem::touchParentDir(dDstPath);
+  if (!TSystem::touchParentDir(dDstPath))
+    throw TSystemException(
+        dDstPath,
+        "The level cannot be saved: failed to access the target folder.");
 
   // backup
   if (Preferences::instance()->isLevelsBackupEnabled() &&


### PR DESCRIPTION
This modification is demanded by some Japanese animation studio.

When overwriting level, if by any chance the destination path cannot be accessed (for instance, because of unanticipated disconnection from file server), then stop the saving procedure with showing the warning popup in order to allow users to save it to another available location.
Before this change, such exception caused removing of image cache without any notification to users.