### PR TITLE
Made small pump tool sizes actually do something.

### DIFF
--- a/toonz/sources/tnztools/pumptool.cpp
+++ b/toonz/sources/tnztools/pumptool.cpp
@@ -546,7 +546,7 @@ void PumpTool::onLeave() {
 //*****************************************************************************
 
 double PumpTool::actionRadius(double strokeLength) {
-  double toolSize         = std::max(m_toolSize.getValue(), 1.0);
+  double toolSize         = m_toolSize.getValue();
   double toolPercent      = toolSize * 0.01;
   double interpolationVal = pow(toolPercent, 5);
   double indipendentValue = 7.0 * toolSize;

--- a/toonz/sources/tnztools/pumptool.cpp
+++ b/toonz/sources/tnztools/pumptool.cpp
@@ -546,7 +546,7 @@ void PumpTool::onLeave() {
 //*****************************************************************************
 
 double PumpTool::actionRadius(double strokeLength) {
-  double toolSize         = std::max(m_toolSize.getValue(), 5.0);
+  double toolSize         = std::max(m_toolSize.getValue(), 1.0);
   double toolPercent      = toolSize * 0.01;
   double interpolationVal = pow(toolPercent, 5);
   double indipendentValue = 7.0 * toolSize;


### PR DESCRIPTION
Right now the pump tool doesn't allow for precise tapering on small objects.  This line:

`double toolSize         = std::max(m_toolSize.getValue(), 5.0);
`
takes whichever is bigger of 5 or the pump toolsize.  So anything below 5 is treated as 5.  This makes it impossible to tweak the taper of small lines.  The tool is just so big it changes the width of the whole line.  I ran into this issue in my last animation.
