### PR TITLE
Default and setting Interpolations

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1959,15 +1959,17 @@ void MainWindow::defineActions() {
                MenuViewCommandType);
   createToggle(MI_ACheck, tr("&Gap Check"), "", ACheckToggleAction ? 1 : 0,
                MenuViewCommandType);
-  QAction* shiftTraceAction = createToggle(MI_ShiftTrace, tr("Shift and Trace"), "", false,
-               MenuViewCommandType);
+  QAction *shiftTraceAction = createToggle(MI_ShiftTrace, tr("Shift and Trace"),
+                                           "", false, MenuViewCommandType);
   shiftTraceAction->setIcon(QIcon(":Resources/shift_and_trace.svg"));
-  shiftTraceAction = createToggle(MI_EditShift, tr("Edit Shift"), "", false, MenuViewCommandType);
+  shiftTraceAction = createToggle(MI_EditShift, tr("Edit Shift"), "", false,
+                                  MenuViewCommandType);
   shiftTraceAction->setIcon(QIcon(":Resources/shift_and_trace_edit.svg"));
   createToggle(MI_NoShift, tr("No Shift"), "", false, MenuViewCommandType);
   CommandManager::instance()->enable(MI_EditShift, false);
   CommandManager::instance()->enable(MI_NoShift, false);
-  shiftTraceAction = createAction(MI_ResetShift, tr("Reset Shift"), "", MenuViewCommandType);
+  shiftTraceAction =
+      createAction(MI_ResetShift, tr("Reset Shift"), "", MenuViewCommandType);
   shiftTraceAction->setIcon(QIcon(":Resources/shift_and_trace_reset.svg"));
 
   if (QGLPixelBuffer::hasOpenGLPbuffers())
@@ -2126,6 +2128,23 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_SetConstantSpeed, tr("Set Constant Speed"), "");
   createRightClickMenuAction(MI_ResetInterpolation, tr("Reset Interpolation"),
                              "");
+
+  createRightClickMenuAction(MI_UseLinearInterpolation,
+                             tr("Linear Interpolation"), "");
+  createRightClickMenuAction(MI_UseSpeedInOutInterpolation,
+                             tr("Speed In / Speed Out Interpolation"), "");
+  createRightClickMenuAction(MI_UseEaseInOutInterpolation,
+                             tr("Ease In / Ease Out Interpolation"), "");
+  createRightClickMenuAction(MI_UseEaseInOutPctInterpolation,
+                             tr("Ease In / Ease Out (%) Interpolation"), "");
+  createRightClickMenuAction(MI_UseExponentialInterpolation,
+                             tr("Exponential Interpolation"), "");
+  createRightClickMenuAction(MI_UseExpressionInterpolation,
+                             tr("Expression Interpolation"), "");
+  createRightClickMenuAction(MI_UseFileInterpolation, tr("File Interpolation"),
+                             "");
+  createRightClickMenuAction(MI_UseConstantInterpolation,
+                             tr("Constant Interpolation"), "");
 
   createRightClickMenuAction(MI_FoldColumns, tr("Fold Column"), "");
 
@@ -2427,9 +2446,9 @@ RecentFiles::~RecentFiles() {}
 
 void RecentFiles::addFilePath(QString path, FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) files.removeAt(i);
@@ -2554,9 +2573,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2583,9 +2602,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene)
-            ? MI_ClearRecentScene
-            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
+        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
+                                                        ? MI_ClearRecentLevel
+                                                        : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -277,6 +277,15 @@
 #define MI_SetConstantSpeed "MI_SetConstantSpeed"
 #define MI_ResetInterpolation "MI_ResetInterpolation"
 
+#define MI_UseLinearInterpolation "MI_UseLinearInterpolation"
+#define MI_UseSpeedInOutInterpolation "MI_UseSpeedInOutInterpolation"
+#define MI_UseEaseInOutInterpolation "MI_UseEaseInOutInterpolation"
+#define MI_UseEaseInOutPctInterpolation "MI_UseEaseInOutPctInterpolation"
+#define MI_UseExponentialInterpolation "MI_UseExponentialInterpolation"
+#define MI_UseExpressionInterpolation "MI_UseExpressionInterpolation"
+#define MI_UseFileInterpolation "MI_UseFileInterpolation"
+#define MI_UseConstantInterpolation "MI_UseConstantInterpolation"
+
 #define MI_ActivateThisColumnOnly "MI_ActivateThisColumnOnly"
 #define MI_ActivateSelectedColumns "MI_ActivateSelectedColumns"
 #define MI_ActivateAllColumns "MI_ActivateAllColumns"

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -712,7 +712,7 @@ void PreferencesPopup::onStartupPopupChanged(int index) {
 //-----------------------------------------------------------------------------
 
 void PreferencesPopup::onKeyframeTypeChanged(int index) {
-  m_pref->setKeyframeType(index + 2);
+  m_pref->setKeyframeType(index + 1);
 }
 //-----------------------------------------------------------------------------
 
@@ -1889,11 +1889,12 @@ PreferencesPopup::PreferencesPopup()
 
   //--- Animation ------------------------------
   QStringList list;
-  list << tr("Linear") << tr("Speed In / Speed Out") << tr("Ease In / Ease Out")
-       << tr("Ease In / Ease Out %");
+  list << tr("Constant") << tr("Linear") << tr("Speed In / Speed Out")
+       << tr("Ease In / Ease Out") << tr("Ease In / Ease Out %")
+       << tr("Exponential") << tr("Expression ") << tr("File");
   m_keyframeType->addItems(list);
   int keyframeType = m_pref->getKeyframeType();
-  m_keyframeType->setCurrentIndex(keyframeType - 2);
+  m_keyframeType->setCurrentIndex(keyframeType - 1);
   m_animationStepField->setValue(m_pref->getAnimationStep());
 
   //--- Preview ------------------------------

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3380,6 +3380,7 @@ void CellArea::createKeyLineMenu(QMenu &menu, int row, int col) {
     menu.addAction(cmdManager->getAction(MI_SetAcceleration));
     menu.addAction(cmdManager->getAction(MI_SetDeceleration));
     menu.addAction(cmdManager->getAction(MI_SetConstantSpeed));
+    menu.addSeparator();
   } else {
     // Se le due chiavi non sono linear aggiungo il comando ResetInterpolation
     bool isR0FullK = pegbar->isFullKeyframe(r0);
@@ -3389,9 +3390,32 @@ void CellArea::createKeyLineMenu(QMenu &menu, int row, int col) {
     TDoubleKeyframe::Type r1Type =
         pegbar->getParam(TStageObject::T_X)->getKeyframeAt(r1).m_prevType;
     if (isGlobalKeyFrameWithSameTypeDiffFromLinear(pegbar, r0) &&
-        isGlobalKeyFrameWithSamePrevTypeDiffFromLinear(pegbar, r1))
+        isGlobalKeyFrameWithSamePrevTypeDiffFromLinear(pegbar, r1)) {
       menu.addAction(cmdManager->getAction(MI_ResetInterpolation));
+      menu.addSeparator();
+    }
   }
+
+  TDoubleKeyframe::Type rType =
+      pegbar->getParam(TStageObject::T_X)->getKeyframeAt(r0).m_type;
+
+  if (rType != TDoubleKeyframe::Linear)
+    menu.addAction(cmdManager->getAction(MI_UseLinearInterpolation));
+  if (rType != TDoubleKeyframe::SpeedInOut)
+    menu.addAction(cmdManager->getAction(MI_UseSpeedInOutInterpolation));
+  if (rType != TDoubleKeyframe::EaseInOut)
+    menu.addAction(cmdManager->getAction(MI_UseEaseInOutInterpolation));
+  if (rType != TDoubleKeyframe::EaseInOutPercentage)
+    menu.addAction(cmdManager->getAction(MI_UseEaseInOutPctInterpolation));
+  if (rType != TDoubleKeyframe::Exponential)
+    menu.addAction(cmdManager->getAction(MI_UseExponentialInterpolation));
+  if (rType != TDoubleKeyframe::Expression)
+    menu.addAction(cmdManager->getAction(MI_UseExpressionInterpolation));
+  if (rType != TDoubleKeyframe::File)
+    menu.addAction(cmdManager->getAction(MI_UseFileInterpolation));
+  if (rType != TDoubleKeyframe::Constant)
+    menu.addAction(cmdManager->getAction(MI_UseConstantInterpolation));
+
 #ifdef LINETEST
   menu.addSeparator();
   int paramStep             = getParamStep(pegbar, r0);

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1687,6 +1687,338 @@ public:
 
 } ResetArrowCommand;
 
+//-----------------------------------------------------------------------------
+
+class UseLinearInterpolation final : public MenuItemHandler {
+public:
+  UseLinearInterpolation() : MenuItemHandler(MI_UseLinearInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::Linear;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::Linear;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseLinearInterpolation;
+
+//-----------------------------------------------------------------------------
+
+class UseSpeedInOutInterpolation final : public MenuItemHandler {
+public:
+  UseSpeedInOutInterpolation()
+      : MenuItemHandler(MI_UseSpeedInOutInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::SpeedInOut;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::SpeedInOut;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseSpeedInOutInterpolation;
+
+//-----------------------------------------------------------------------------
+
+class UseEaseInOutInterpolation final : public MenuItemHandler {
+public:
+  UseEaseInOutInterpolation() : MenuItemHandler(MI_UseEaseInOutInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::EaseInOut;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::EaseInOut;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseEaseInOutInterpolation;
+
+//-----------------------------------------------------------------------------
+
+class UseEaseInOutPctInterpolation final : public MenuItemHandler {
+public:
+  UseEaseInOutPctInterpolation()
+      : MenuItemHandler(MI_UseEaseInOutPctInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::EaseInOutPercentage;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::EaseInOutPercentage;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseEaseInOutPctInterpolation;
+
+//-----------------------------------------------------------------------------
+
+class UseExponentialInterpolation final : public MenuItemHandler {
+public:
+  UseExponentialInterpolation()
+      : MenuItemHandler(MI_UseExponentialInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::Exponential;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::Exponential;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseExponentialInterpolation;
+
+//-----------------------------------------------------------------------------
+
+class UseExpressionInterpolation final : public MenuItemHandler {
+public:
+  UseExpressionInterpolation()
+      : MenuItemHandler(MI_UseExpressionInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::Expression;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::Expression;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseExpressionInterpolation;
+
+//-----------------------------------------------------------------------------
+
+class UseFileInterpolation final : public MenuItemHandler {
+public:
+  UseFileInterpolation() : MenuItemHandler(MI_UseFileInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::File;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::File;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseFileInterpolation;
+
+//-----------------------------------------------------------------------------
+
+class UseConstantInterpolation final : public MenuItemHandler {
+public:
+  UseConstantInterpolation() : MenuItemHandler(MI_UseConstantInterpolation) {}
+
+  void execute() override {
+    TApp *app    = TApp::instance();
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    int row      = app->getCurrentFrame()->getFrame();
+
+    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
+    TStageObject *pegbar    = xsh->getStageObject(objectId);
+    if (!pegbar) return;
+
+    int r0, r1;
+    double ease0, ease1;
+
+    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
+
+    KeyFrameHandleCommandUndo *undo =
+        new KeyFrameHandleCommandUndo(objectId, r0, r1);
+
+    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
+    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
+
+    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
+      k0.m_channels[i].m_type     = TDoubleKeyframe::Constant;
+      k1.m_channels[i].m_prevType = TDoubleKeyframe::Constant;
+    }
+    pegbar->setKeyframeWithoutUndo(r0, k0);
+    pegbar->setKeyframeWithoutUndo(r1, k1);
+
+    TUndoManager::manager()->add(undo);
+
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
+  }
+
+} UseConstantInterpolation;
+
 //===========================================================
 //    To Be Reworked
 //===========================================================

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1688,10 +1688,13 @@ public:
 } ResetArrowCommand;
 
 //-----------------------------------------------------------------------------
+// Unify commands for all types of interpolation
+class SetInterpolation final : public MenuItemHandler {
+  TDoubleKeyframe::Type m_type;
 
-class UseLinearInterpolation final : public MenuItemHandler {
 public:
-  UseLinearInterpolation() : MenuItemHandler(MI_UseLinearInterpolation) {}
+  SetInterpolation(CommandId cmdId, TDoubleKeyframe::Type type)
+      : MenuItemHandler(cmdId), m_type(type) {}
 
   void execute() override {
     TApp *app    = TApp::instance();
@@ -1714,8 +1717,8 @@ public:
     TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
 
     for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::Linear;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::Linear;
+      k0.m_channels[i].m_type     = m_type;
+      k1.m_channels[i].m_prevType = m_type;
     }
     pegbar->setKeyframeWithoutUndo(r0, k0);
     pegbar->setKeyframeWithoutUndo(r1, k1);
@@ -1726,298 +1729,20 @@ public:
     TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
   }
 
-} UseLinearInterpolation;
-
-//-----------------------------------------------------------------------------
-
-class UseSpeedInOutInterpolation final : public MenuItemHandler {
-public:
-  UseSpeedInOutInterpolation()
-      : MenuItemHandler(MI_UseSpeedInOutInterpolation) {}
-
-  void execute() override {
-    TApp *app    = TApp::instance();
-    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-    int row      = app->getCurrentFrame()->getFrame();
-
-    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
-    TStageObject *pegbar    = xsh->getStageObject(objectId);
-    if (!pegbar) return;
-
-    int r0, r1;
-    double ease0, ease1;
-
-    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
-
-    KeyFrameHandleCommandUndo *undo =
-        new KeyFrameHandleCommandUndo(objectId, r0, r1);
-
-    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
-    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
-
-    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::SpeedInOut;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::SpeedInOut;
-    }
-    pegbar->setKeyframeWithoutUndo(r0, k0);
-    pegbar->setKeyframeWithoutUndo(r1, k1);
-
-    TUndoManager::manager()->add(undo);
-
-    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
-  }
-
-} UseSpeedInOutInterpolation;
-
-//-----------------------------------------------------------------------------
-
-class UseEaseInOutInterpolation final : public MenuItemHandler {
-public:
-  UseEaseInOutInterpolation() : MenuItemHandler(MI_UseEaseInOutInterpolation) {}
-
-  void execute() override {
-    TApp *app    = TApp::instance();
-    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-    int row      = app->getCurrentFrame()->getFrame();
-
-    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
-    TStageObject *pegbar    = xsh->getStageObject(objectId);
-    if (!pegbar) return;
-
-    int r0, r1;
-    double ease0, ease1;
-
-    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
-
-    KeyFrameHandleCommandUndo *undo =
-        new KeyFrameHandleCommandUndo(objectId, r0, r1);
-
-    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
-    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
-
-    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::EaseInOut;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::EaseInOut;
-    }
-    pegbar->setKeyframeWithoutUndo(r0, k0);
-    pegbar->setKeyframeWithoutUndo(r1, k1);
-
-    TUndoManager::manager()->add(undo);
-
-    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
-  }
-
-} UseEaseInOutInterpolation;
-
-//-----------------------------------------------------------------------------
-
-class UseEaseInOutPctInterpolation final : public MenuItemHandler {
-public:
-  UseEaseInOutPctInterpolation()
-      : MenuItemHandler(MI_UseEaseInOutPctInterpolation) {}
-
-  void execute() override {
-    TApp *app    = TApp::instance();
-    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-    int row      = app->getCurrentFrame()->getFrame();
-
-    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
-    TStageObject *pegbar    = xsh->getStageObject(objectId);
-    if (!pegbar) return;
-
-    int r0, r1;
-    double ease0, ease1;
-
-    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
-
-    KeyFrameHandleCommandUndo *undo =
-        new KeyFrameHandleCommandUndo(objectId, r0, r1);
-
-    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
-    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
-
-    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::EaseInOutPercentage;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::EaseInOutPercentage;
-    }
-    pegbar->setKeyframeWithoutUndo(r0, k0);
-    pegbar->setKeyframeWithoutUndo(r1, k1);
-
-    TUndoManager::manager()->add(undo);
-
-    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
-  }
-
-} UseEaseInOutPctInterpolation;
-
-//-----------------------------------------------------------------------------
-
-class UseExponentialInterpolation final : public MenuItemHandler {
-public:
-  UseExponentialInterpolation()
-      : MenuItemHandler(MI_UseExponentialInterpolation) {}
-
-  void execute() override {
-    TApp *app    = TApp::instance();
-    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-    int row      = app->getCurrentFrame()->getFrame();
-
-    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
-    TStageObject *pegbar    = xsh->getStageObject(objectId);
-    if (!pegbar) return;
-
-    int r0, r1;
-    double ease0, ease1;
-
-    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
-
-    KeyFrameHandleCommandUndo *undo =
-        new KeyFrameHandleCommandUndo(objectId, r0, r1);
-
-    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
-    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
-
-    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::Exponential;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::Exponential;
-    }
-    pegbar->setKeyframeWithoutUndo(r0, k0);
-    pegbar->setKeyframeWithoutUndo(r1, k1);
-
-    TUndoManager::manager()->add(undo);
-
-    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
-  }
-
-} UseExponentialInterpolation;
-
-//-----------------------------------------------------------------------------
-
-class UseExpressionInterpolation final : public MenuItemHandler {
-public:
-  UseExpressionInterpolation()
-      : MenuItemHandler(MI_UseExpressionInterpolation) {}
-
-  void execute() override {
-    TApp *app    = TApp::instance();
-    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-    int row      = app->getCurrentFrame()->getFrame();
-
-    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
-    TStageObject *pegbar    = xsh->getStageObject(objectId);
-    if (!pegbar) return;
-
-    int r0, r1;
-    double ease0, ease1;
-
-    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
-
-    KeyFrameHandleCommandUndo *undo =
-        new KeyFrameHandleCommandUndo(objectId, r0, r1);
-
-    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
-    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
-
-    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::Expression;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::Expression;
-    }
-    pegbar->setKeyframeWithoutUndo(r0, k0);
-    pegbar->setKeyframeWithoutUndo(r1, k1);
-
-    TUndoManager::manager()->add(undo);
-
-    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
-  }
-
-} UseExpressionInterpolation;
-
-//-----------------------------------------------------------------------------
-
-class UseFileInterpolation final : public MenuItemHandler {
-public:
-  UseFileInterpolation() : MenuItemHandler(MI_UseFileInterpolation) {}
-
-  void execute() override {
-    TApp *app    = TApp::instance();
-    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-    int row      = app->getCurrentFrame()->getFrame();
-
-    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
-    TStageObject *pegbar    = xsh->getStageObject(objectId);
-    if (!pegbar) return;
-
-    int r0, r1;
-    double ease0, ease1;
-
-    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
-
-    KeyFrameHandleCommandUndo *undo =
-        new KeyFrameHandleCommandUndo(objectId, r0, r1);
-
-    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
-    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
-
-    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::File;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::File;
-    }
-    pegbar->setKeyframeWithoutUndo(r0, k0);
-    pegbar->setKeyframeWithoutUndo(r1, k1);
-
-    TUndoManager::manager()->add(undo);
-
-    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
-  }
-
-} UseFileInterpolation;
-
-//-----------------------------------------------------------------------------
-
-class UseConstantInterpolation final : public MenuItemHandler {
-public:
-  UseConstantInterpolation() : MenuItemHandler(MI_UseConstantInterpolation) {}
-
-  void execute() override {
-    TApp *app    = TApp::instance();
-    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-    int row      = app->getCurrentFrame()->getFrame();
-
-    TStageObjectId objectId = app->getCurrentObject()->getObjectId();
-    TStageObject *pegbar    = xsh->getStageObject(objectId);
-    if (!pegbar) return;
-
-    int r0, r1;
-    double ease0, ease1;
-
-    pegbar->getKeyframeSpan(row, r0, ease0, r1, ease1);
-
-    KeyFrameHandleCommandUndo *undo =
-        new KeyFrameHandleCommandUndo(objectId, r0, r1);
-
-    TStageObject::Keyframe k0 = pegbar->getKeyframe(r0);
-    TStageObject::Keyframe k1 = pegbar->getKeyframe(r1);
-
-    for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-      k0.m_channels[i].m_type     = TDoubleKeyframe::Constant;
-      k1.m_channels[i].m_prevType = TDoubleKeyframe::Constant;
-    }
-    pegbar->setKeyframeWithoutUndo(r0, k0);
-    pegbar->setKeyframeWithoutUndo(r1, k1);
-
-    TUndoManager::manager()->add(undo);
-
-    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
-    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
-  }
-
-} UseConstantInterpolation;
+} UseLinearInterpolation(MI_UseLinearInterpolation, TDoubleKeyframe::Linear),
+    UseSpeedInOutInterpolation(MI_UseSpeedInOutInterpolation,
+                               TDoubleKeyframe::SpeedInOut),
+    UseEaseInOutInterpolation(MI_UseEaseInOutInterpolation,
+                              TDoubleKeyframe::EaseInOut),
+    UseEaseInOutPctInterpolation(MI_UseEaseInOutPctInterpolation,
+                                 TDoubleKeyframe::EaseInOutPercentage),
+    UseExponentialInterpolation(MI_UseExponentialInterpolation,
+                                TDoubleKeyframe::Exponential),
+    UseExpressionInterpolation(MI_UseExpressionInterpolation,
+                               TDoubleKeyframe::Expression),
+    UseFileInterpolation(MI_UseFileInterpolation, TDoubleKeyframe::File),
+    UseConstantInterpolation(MI_UseConstantInterpolation,
+                             TDoubleKeyframe::Constant);
 
 //===========================================================
 //    To Be Reworked


### PR DESCRIPTION
This PR does the following with interpolations:

1) Adds more Default Interpolation options in Preferences

Requested by a few users, I added Constant, Exponential, Expression and File to the list of Default 
 Interpolations to choose from

![image](https://user-images.githubusercontent.com/19245851/47425251-c4e0e600-d757-11e8-8e01-9b335391f5e4.png)

2) Add ability to change Interpolation between 2 keyframes from xsheet/timeline

Added options to the context menu brought up when right-clicking the white line between 2 keyframes allowing you to change the type of interpolation being used. The current interpolation will not be shown.

![image](https://user-images.githubusercontent.com/19245851/47425596-cced5580-d758-11e8-8862-10df560e51d2.png)

In either case, use of Expression and File will still require going into the Function Editor to provide more information.