### PR TITLE
Fix Toonz Raster Tape Tool Crash

### DIFF
--- a/toonz/sources/include/toonzqt/styleindexlineedit.h
+++ b/toonz/sources/include/toonzqt/styleindexlineedit.h
@@ -25,6 +25,8 @@ class TPaletteHandle;
 namespace DVGui {
 
 class DVAPI StyleIndexLineEdit : public LineEdit {
+  Q_OBJECT
+
   TPaletteHandle *m_pltHandle;
 
 public:

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -868,15 +868,16 @@ void StyleIndexFieldAndChip::onValueChanged(const QString &changedText) {
   // Aware of both "current" and translated string
   if (!QString("current").contains(changedText) &&
       !StyleIndexLineEdit::tr("current").contains(changedText)) {
-    int index      = changedText.toInt();
-    TPalette *plt  = m_pltHandle->getPalette();
-    int indexCount = plt->getStyleCount();
-    if (index > indexCount)
-      style = QString::number(indexCount - 1);
+    int index     = changedText.toInt();
+    TPalette *plt = m_pltHandle->getPalette();
+    if (plt && index > plt->getStyleCount())
+      style = QString::number(plt->getStyleCount() - 1);
     else
       style = text();
-  }
-  m_property->setValue(style.toStdWString());
+    m_property->setValue(style.toStdWString());
+  } else
+    m_property->setValue(changedText.toStdWString());
+
   repaint();
   // synchronize the state with the same widgets in other tool option bars
   if (m_toolHandle) m_toolHandle->notifyToolChanged();

--- a/toonz/sources/toonzqt/styleindexlineedit.cpp
+++ b/toonz/sources/toonzqt/styleindexlineedit.cpp
@@ -30,6 +30,8 @@ StyleIndexLineEdit::~StyleIndexLineEdit() {}
 void StyleIndexLineEdit::paintEvent(QPaintEvent *pe) {
   QLineEdit::paintEvent(pe);
 
+  if (!m_pltHandle->getPalette()) return;
+
   TColorStyle *style;
   // Aware of both "current" and translated string
   if (QString("current").contains(text()) || tr("current").contains(text()))


### PR DESCRIPTION
This PR fixes several problems related to the style number field of Tape Tool option as follows:

- Under non-English UI and with no level being selected, OT crashes when selecting the tape tool.
- If no level is selected, OT crashes when typing number in the style number field.
- Under non-English language UI, the style number field does not update when it is set to `current` .
- You cannot type the word `current` in the style number field.

**UPDATE:**
Please note that the problematic `Style index` field appears only with the tape tool for Toonz raster levels. @turtletooth thank you for pointing that! 
