### PR TITLE
Fix svg stroke thickness

### DIFF
--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -1332,7 +1332,7 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
       cpy        = 0;
       closedFlag = 0;
       nargs      = 0;
-	  prev_m_exists = false;
+      prev_m_exists = false;
 
       while (*s) {
         s = nsvg__getNextPathItem(s, item);
@@ -1343,18 +1343,18 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
             switch (cmd) {
             case 'm':
             case 'M':
-			  
-			  // If moveto is relative it relative to previous moveto point
-			  if (cmd == 'm' && prev_m_exists) {
-			    cpx = prev_m_cpx;
-				cpy = prev_m_cpy;
-			  }
-			  
-			  nsvg__pathMoveTo(p, &cpx, &cpy, args, cmd == 'm' ? 1 : 0);
-			  
-			  prev_m_cpx = cpx;
-			  prev_m_cpy = cpy;
-			  prev_m_exists = true;
+			 
+              // If moveto is relative it relative to previous moveto point
+              if (cmd == 'm' && prev_m_exists) {
+                cpx = prev_m_cpx;
+                cpy = prev_m_cpy;
+              }
+              
+              nsvg__pathMoveTo(p, &cpx, &cpy, args, cmd == 'm' ? 1 : 0);
+              
+              prev_m_cpx = cpx;
+              prev_m_cpy = cpy;
+              prev_m_exists = true;
 
               // Moveto can be followed by multiple coordinate pairs,
               // which should be treated as linetos.

--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -1320,6 +1320,8 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
   char closedFlag;
   int i;
   char item[64];
+  float prev_m_cpx, prev_m_cpy;
+  bool prev_m_exists;
 
   for (i = 0; attr[i]; i += 2) {
     if (strcmp(attr[i], "d") == 0) {
@@ -1330,6 +1332,7 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
       cpy        = 0;
       closedFlag = 0;
       nargs      = 0;
+	  prev_m_exists = false;
 
       while (*s) {
         s = nsvg__getNextPathItem(s, item);
@@ -1340,7 +1343,19 @@ void nsvg__parsePath(struct NSVGParser *p, const char **attr) {
             switch (cmd) {
             case 'm':
             case 'M':
-              nsvg__pathMoveTo(p, &cpx, &cpy, args, cmd == 'm' ? 1 : 0);
+			  
+			  // If moveto is relative it relative to previous moveto point
+			  if (cmd == 'm' && prev_m_exists) {
+			    cpx = prev_m_cpx;
+				cpy = prev_m_cpy;
+			  }
+			  
+			  nsvg__pathMoveTo(p, &cpx, &cpy, args, cmd == 'm' ? 1 : 0);
+			  
+			  prev_m_cpx = cpx;
+			  prev_m_cpy = cpy;
+			  prev_m_exists = true;
+
               // Moveto can be followed by multiple coordinate pairs,
               // which should be treated as linetos.
               cmd   = (cmd == 'm') ? 'l' : 'L';
@@ -2072,6 +2087,15 @@ TStroke *buildStroke(NSVGpath *path, float width) {
   TStroke *s = new TStroke(points);
 
   s->setSelfLoop(path->closed);
+
+  std::vector<TThickPoint> tpoints;
+  s->getControlPoints(tpoints);
+
+  for (int j = 0; j < tpoints.size(); j++) {
+	  tpoints[j].thick = width;
+  }
+
+  s->reshape(&tpoints[0], tpoints.size());
 
   return s;
 }


### PR DESCRIPTION
Fixed svg stroke thikness, also fixed incorrect moveto parsing

Current OT version:
![2018-11-03_01-00-23](https://user-images.githubusercontent.com/10980542/47937834-e3876f80-df03-11e8-80d1-31f20d727894.png)

 Fix:
![2018-11-03_01-07-12](https://user-images.githubusercontent.com/10980542/47938111-d3bc5b00-df04-11e8-9b62-d84eb1593d45.png)

svg from [#1009](https://github.com/opentoonz/opentoonz/issues/1009)
![2018-11-03_00-14-07](https://user-images.githubusercontent.com/10980542/47938487-06b31e80-df06-11e8-91b7-9a735f301f6e.png)

test svg files: 
[test_files.zip](https://github.com/opentoonz/opentoonz/files/2543982/test_files.zip)


