### PR TITLE
Fix restoring raster tool crash

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -350,6 +350,8 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
   TRasterImageP ri        = (TRasterImageP)getImage(true);
   if (!ri) return;
 
+  if (!m_toonz_brush) return;
+
   TRasterP ras      = ri->getRaster();
   TPointD rasCenter = ras->getCenterD();
   TPointD point(pos + rasCenter);


### PR DESCRIPTION
This PR fixes #2361 

When returning to the Raster bush from temporary usage of Hand Tool (holding tool shortcut) while still pressing with the pen, the Raster brush is no longer initialized properly so the drag event tries to work with an uninitialized tool and crashes when you try to continue moving.

Similar to Toonz Raster (where it does not crash), I modified to block the drag event from processing if not properly initialized.