### PR TITLE
Fix raster paste crash

### DIFF
--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1162,9 +1162,10 @@ void RasterSelection::pasteSelection() {
   TTool *tool             = app->getCurrentTool()->getTool();
   TImageP image           = tool->getImage(true);
 
-  if (!image) image = tool->touchImage();
-  m_currentImage    = image;
-  m_fid             = tool->getCurrentFid();
+  if (!(image = tool->touchImage())) return;
+
+  m_currentImage = image;
+  m_fid          = tool->getCurrentFid();
 
   QClipboard *clipboard = QApplication::clipboard();
   const RasterImageData *riData =

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1161,8 +1161,10 @@ void RasterSelection::pasteSelection() {
   TTool::Application *app = TTool::getApplication();
   TTool *tool             = app->getCurrentTool()->getTool();
   TImageP image           = tool->getImage(true);
-  m_currentImage          = image;
-  m_fid                   = tool->getCurrentFid();
+
+  if (!image) image = tool->touchImage();
+  m_currentImage    = image;
+  m_fid             = tool->getCurrentFid();
 
   QClipboard *clipboard = QApplication::clipboard();
   const RasterImageData *riData =

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1160,9 +1160,9 @@ void RasterSelection::pasteSelection(const RasterImageData *riData) {
 void RasterSelection::pasteSelection() {
   TTool::Application *app = TTool::getApplication();
   TTool *tool             = app->getCurrentTool()->getTool();
-  TImageP image           = tool->getImage(true);
+  TImageP image           = tool->touchImage();
 
-  if (!(image = tool->touchImage())) return;
+  if (!image) return;
 
   m_currentImage = image;
   m_fid          = tool->getCurrentFid();


### PR DESCRIPTION
This PR fixes #1730 

When attempting to paste a raster selection while the current focus is the scene viewer canvas, if there isn't an image in the frame already, a new blank image will be created for the frame so it will have something to paste into.

Note: When autocreation is disabled, no blank image will be created and the paste will not do anything.