### PR TITLE
Fix Playback Slowness with Opening Style Editor

### DIFF
--- a/toonz/sources/toonzlib/tpalettehandle.cpp
+++ b/toonz/sources/toonzlib/tpalettehandle.cpp
@@ -144,12 +144,11 @@ void TPaletteHandle::setPalette(TPalette *palette, int styleIndex) {
 //-----------------------------------------------------------------------------
 
 void TPaletteHandle::setStyleIndex(int index) {
-  //	if(m_styleIndex != index)
-  //	{
-  m_styleIndex      = index;
-  m_styleParamIndex = 0;
-  emit broadcastColorStyleSwitched();
-  //	}
+  if (m_styleIndex != index || m_styleParamIndex != 0) {
+    m_styleIndex      = index;
+    m_styleParamIndex = 0;
+    emit broadcastColorStyleSwitched();
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -3254,9 +3254,9 @@ void StyleEditor::showEvent(QShowEvent *) {
 //-----------------------------------------------------------------------------
 
 void StyleEditor::hideEvent(QHideEvent *) {
-  disconnect(m_paletteHandle);
-  if (m_cleanupPaletteHandle) disconnect(m_cleanupPaletteHandle);
-  disconnect(m_paletteController);
+  disconnect(m_paletteHandle, 0, this, 0);
+  if (m_cleanupPaletteHandle) disconnect(m_cleanupPaletteHandle, 0, this, 0);
+  disconnect(m_paletteController, 0, this, 0);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This will fix problems as follows:

- Viewer playback becomes unexpectedly slow once you open Style Editor.
- Closing the Style Editor does NOT remedy the slowness.

The first problem was due to repeated emit of `TPaletteHandle::broadcastColorStyleSwitched()` during playback, which seems to be unnecessary.
The second one was due to the wrong syntax of `QObject::disconnect()` called on hiding the Style Editor.