### PR TITLE
Fix raster crash after unhiding column

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -381,6 +381,8 @@ void FullColorBrushTool::leftButtonUp(const TPointD &pos,
   TRasterImageP ri = (TRasterImageP)getImage(true);
   if (!ri) return;
 
+  if (!m_toonz_brush) return;
+
   TRasterP ras      = ri->getRaster();
   TPointD rasCenter = ras->getCenterD();
   TPointD point(pos + rasCenter);


### PR DESCRIPTION
This PR fixes #2311

When attempting to draw immediately after unhiding a column, a button-up event is encountered but the raster bush is not initialized properly so it crashes when trying to access certain variables.

Similar to Toonz Raster (where it does not crash), I modified to block the button-up event from processing if not properly initialized.