### PR TITLE
Fix Antialiasing on Toonz Raster Levels

### DIFF
--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1158,6 +1158,12 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
         ras = ti->getRaster();
 
       if (sl->getProperties()->antialiasSoftness() > 0) {
+        // convert colormap raster to fullcolor raster before applying antialias
+        if (ti) {
+          TRaster32P convRas(ras->getSize());
+          TRop::convert(convRas, ras, ti->getPalette(), TRect(), false, true);
+          ras = convRas;
+        }
         TRasterP appRas = ras->create(ras->getLx(), ras->getLy());
         TRop::antialias(ras, appRas, 10,
                         sl->getProperties()->antialiasSoftness());
@@ -1206,7 +1212,7 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
       // Observe that inTile is in the standard reference, ie image's minus the
       // center coordinates
 
-      if (ti) {
+      if ((TRasterCM32P)ras) {
         // In the colormapped case, we have to convert the cmap to fullcolor
         TPalette *palette = ti->getPalette();
 


### PR DESCRIPTION
This PR will fix #2270 

As [I commented](https://github.com/opentoonz/opentoonz/issues/2270#issuecomment-433767547) in the issue, I made cmapped raster to be converted to fullcolor raster just before applying antialiasing.