### PR TITLE
Fix Current Frame on Load Level

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2433,10 +2433,6 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
         // increment the number of loaded resources
         ++loadedCount;
 
-        // move the current column to right
-        col0++;
-        app->getCurrentColumn()->setColumnIndex(col0);
-
         // load the image data of all frames to cache at the beginning
         if (cachingBehavior != ON_DEMAND) {
           TXshSimpleLevel *simpleLevel = xl->getSimpleLevel();
@@ -2449,10 +2445,7 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
     }
   }
 
-  if (loadedCount) {
-    app->getCurrentFrame()->setFrameIndex(row0);
-    app->getCurrentColumn()->setColumnIndex(col0 - 1);
-  }
+  if (loadedCount) app->getCurrentFrame()->setFrameIndex(row0);
 
   sb->data().m_loadedCount += loadedCount;
   sb->data().m_hasSoundLevel = sb->data().m_hasSoundLevel || isSoundLevel;

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2449,6 +2449,11 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
     }
   }
 
+  if (loadedCount) {
+    app->getCurrentFrame()->setFrameIndex(row0);
+    app->getCurrentColumn()->setColumnIndex(col0 - 1);
+  }
+
   sb->data().m_loadedCount += loadedCount;
   sb->data().m_hasSoundLevel = sb->data().m_hasSoundLevel || isSoundLevel;
 


### PR DESCRIPTION
This PR fixes #2135

When loading a level file into the xsheet/timeline, the current frame will switch to the first frame of the newly loaded level.  This is true whether the file was drag/dropped or loaded through menu items.

Note: When dragging/dropping multiple levels at once, the current frame will be set to the first frame of the **last** level loaded into the xsheet/timeline.