### PR TITLE
Fix processing touchEvents after tablet events

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -966,6 +966,8 @@ void SceneViewer::gestureEvent(QGestureEvent *e) {
 
 void SceneViewer::touchEvent(QTouchEvent *e, int type) {
   if (type == QEvent::TouchBegin) {
+    if (m_tabletEvent) return;
+
     m_touchActive   = true;
     m_firstPanPoint = e->touchPoints().at(0).pos();
     m_undoPoint     = m_firstPanPoint;


### PR DESCRIPTION
This PR fixes #2220 

Sometimes when quickly switching to and using a tool with a pen, the tool winds up moving the canvas rather than what the tool should be doing, like drawing or selecting. This is because sometimes a TouchEvent immediately follows a TabletPress event and takes over operation acting like the Hand tool.

Similar to mousePress events, if a begin TouchEvent event is encountered while a Tablet event is active, the TouchEvent will be ignored.
