### PR TITLE
Fix restoring eraser tool crash

### DIFF
--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -526,6 +526,8 @@ void FullColorEraserTool::leftButtonDown(const TPointD &pos,
 
 void FullColorEraserTool::leftButtonDrag(const TPointD &pos,
                                          const TMouseEvent &e) {
+  if (!m_mousePressed) return;
+
   m_brushPos = m_mousePos = pos;
   m_mouseEvent            = e;
   double pixelSize2       = getPixelSize() * getPixelSize();


### PR DESCRIPTION
This is similar to PR #2362 but with the eraser tool.

When returning to the Raster Eraser from temporary usage of Hand Tool (holding tool shortcut) while still pressing with the pen, the Raster eraser is no longer initialized properly so the drag event tries to work with an uninitialized tool and crashes when you try to continue moving.

Similar to Toonz Raster Eraser (where it does not crash), I modified to block the drag event from processing if not properly initialized.