### PR TITLE
Fix moving note cells crash

### DIFF
--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -378,7 +378,8 @@ bool LevelMoverTool::isTotallyEmptyColumn(int col) const {
   TXshColumn *column = xsh->getColumn(col);
   if (!column) return true;
   if (!column->isEmpty()) return false;
-  if (column->getFx()->getOutputConnectionCount() != 0) return false;
+  TFx *fx = column->getFx();
+  if (fx && fx->getOutputConnectionCount() != 0) return false;
   // bisogna controllare lo stage object
   return true;
 }


### PR DESCRIPTION
This fixes a crash that can happen if you attempt to select all the cells on a Note Level and attempt to drag it to an empty column (prevented) and back again to where it was