### PR TITLE
Update Qt Version for Travis-OSX build 

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -4,7 +4,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt/5.11.2/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt/5.11.2_1/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make -j 2


### PR DESCRIPTION
From `5.11.2` to `5.11.2_1` (added revision number).