### PR TITLE
Fix empty column property issues

### DIFF
--- a/toonz/sources/include/toonz/txshcolumn.h
+++ b/toonz/sources/include/toonz/txshcolumn.h
@@ -265,6 +265,8 @@ Set column color tag to \b colorTag.
   TPixel32 getFilterColor();
   static QPair<QString, TPixel32> getFilterInfo(FilterColor key);
   static void initColorFilters();
+
+  void resetColumnProperties();
 };
 
 #ifdef _WIN32

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -119,6 +119,7 @@ void deleteCellsWithoutUndo(int &r0, int &c0, int &r1, int &c1) {
       xsh->clearCells(r0, c, r1 - r0 + 1);
       TXshColumn *column = xsh->getColumn(c);
       if (column && column->isEmpty()) {
+        column->resetColumnProperties();
         TFx *fx = column->getFx();
         if (fx) {
           int i;
@@ -144,6 +145,7 @@ void cutCellsWithoutUndo(int &r0, int &c0, int &r1, int &c1) {
     xsh->removeCells(r0, c, r1 - r0 + 1);
     TXshColumn *column = xsh->getColumn(c);
     if (column && column->isEmpty()) {
+      column->resetColumnProperties();
       TFx *fx = column->getFx();
       if (!fx) continue;
       int i;

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -476,8 +476,8 @@ TXshColumn::ColumnType TXshColumn::toColumnType(int levelType) {
 
 //-----------------------------------------------------------------------------
 bool TXshColumn::isRendered() const {
-//  if (!getXsheet() || !getFx()) return false;
-//  if (!isPreviewVisible()) return false;
+  //  if (!getXsheet() || !getFx()) return false;
+  //  if (!isPreviewVisible()) return false;
   if (!getXsheet() || !isPreviewVisible()) return false;
   if (getColumnType() == eSoundType) return true;
   if (!getFx()) return false;
@@ -650,4 +650,13 @@ QPair<QString, TPixel32> TXshColumn::getFilterInfo(
   if (!filterColors.contains(key))
     return QPair<QString, TPixel32>(QObject::tr("None"), TPixel::Black);
   return filterColors.value(key);
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshColumn::resetColumnProperties() {
+  setStatusWord(0);
+  setOpacity(255);
+  setColorTag(0);
+  setFilterColorId(FilterNone);
 }

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -91,6 +91,8 @@ TXshColumn *TXshLevelColumn::clone() const {
   column->setOpacity(getOpacity());
   column->m_cells = m_cells;
   column->m_first = m_first;
+  column->setColorTag(getColorTag());
+  column->setFilterColorId(getFilterColorId());
 
   // column->updateIcon();
   return column;

--- a/toonz/sources/toonzlib/txshmeshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshmeshcolumn.cpp
@@ -59,8 +59,11 @@ TXshColumn *TXshMeshColumn::clone() const {
   TXshMeshColumn *column = new TXshMeshColumn();
 
   column->setStatusWord(getStatusWord());
+  column->setOpacity(getOpacity());
   column->m_cells = m_cells;
   column->m_first = m_first;
+  column->setColorTag(getColorTag());
+  column->setFilterColorId(getFilterColorId());
 
   return column;
 }


### PR DESCRIPTION
This PR addresses some issues with Column properties (preview, visibility, opacity, color filter, etc) not being set/reset correctly when deleting or moving all cells in a column to an empty column.

1) This fixes #2202 

When a column becomes empty as a result of deleting or cutting all the cells within it, all column properties are reset to baseline.

NOTE: Undo of cell delete/cut will not restore the prior column properties.

2) Fixes issue with color filter disappearing when moving to a new empty column

When moving all cells to a new empty column, opacity and other button statuses and properties are kept, but the color filter is removed.  It will now copy the color filter to the empty column as well.  Impacts all Level column types and Mesh columns.
