### PR TITLE
Fix eraser mode switch crash

### DIFF
--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -834,6 +834,7 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     invalidate();
     return;
   } else if (m_eraseType.getValue() == NORMAL_ERASE) {
+    if (!m_undo) leftButtonDown(pos, e);
     if (TVectorImageP vi = image) erase(vi, pos);
   } else if (m_eraseType.getValue() == FREEHAND_ERASE) {
     freehandDrag(pos);
@@ -937,9 +938,10 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 
   TTool::Application *application = TTool::getApplication();
   if (!vi || !application) return;
-  if (m_eraseType.getValue() == NORMAL_ERASE)
+  if (m_eraseType.getValue() == NORMAL_ERASE) {
+    if (!m_undo) leftButtonDown(pos, e);
     stopErase(vi);
-  else if (m_eraseType.getValue() == RECT_ERASE) {
+  } else if (m_eraseType.getValue() == RECT_ERASE) {
     if (m_selectingRect.x0 > m_selectingRect.x1)
       std::swap(m_selectingRect.x1, m_selectingRect.x0);
     if (m_selectingRect.y0 > m_selectingRect.y1)


### PR DESCRIPTION
The PR fixes #2391

While actively erasing, if the user switches from Freehand/Rectangle/Polyline to Normal using a shortcut, internally the eraser tool is not set up properly to do an Undo in Normal mode and causes a crash when it tries to reference internal variables for it.

This fix now checks to see if it's in Normal mode and not properly setup for Normal undo and immediately initiates a new Normal mode setup (left button click).