### PR TITLE
Fix incorrect keyframe cell pasting and redo

### DIFF
--- a/toonz/sources/toonz/cellkeyframeselection.cpp
+++ b/toonz/sources/toonz/cellkeyframeselection.cpp
@@ -71,7 +71,9 @@ void TCellKeyframeSelection::copyCellsKeyframes() {
     QClipboard *clipboard       = QApplication::clipboard();
     TXsheet *xsh                = m_xsheetHandle->getXsheet();
     TKeyframeData *keyframeData = new TKeyframeData();
-    keyframeData->setKeyframes(m_keyframeSelection->getSelection(), xsh);
+    TKeyframeData::Position startPos(r0, c0);
+    keyframeData->setKeyframes(m_keyframeSelection->getSelection(), xsh,
+                               startPos);
     data->setKeyframeData(keyframeData);
   }
   // Set the cliboard

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1627,9 +1627,11 @@ void TCellSelection::pasteCells() {
       // (r0,c0)
       std::set<TKeyframeSelection::Position> positions;
       int newC0 = c0;
-      if (viewer && !viewer->orientation()->isVerticalTimeline())
+      if (viewer && !viewer->orientation()->isVerticalTimeline() && !cellData)
         newC0 = c0 - keyframeData->getColumnSpanCount() + 1;
-      positions.insert(TKeyframeSelection::Position(r0, newC0));
+      TKeyframeSelection::Position offset(keyframeData->getKeyframesOffset());
+      positions.insert(TKeyframeSelection::Position(r0 + offset.first,
+                                                    newC0 + offset.second));
       keyframeData->getKeyframes(positions);
       selection.select(positions);
 

--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -23,7 +23,8 @@ TKeyframeData::TKeyframeData() {}
 
 TKeyframeData::TKeyframeData(const TKeyframeData *src)
     : m_keyData(src->m_keyData)
-    , m_isPegbarsCycleEnabled(src->m_isPegbarsCycleEnabled) {}
+    , m_isPegbarsCycleEnabled(src->m_isPegbarsCycleEnabled)
+    , m_offset(src->m_offset) {}
 
 //-----------------------------------------------------------------------------
 
@@ -32,6 +33,12 @@ TKeyframeData::~TKeyframeData() {}
 //-----------------------------------------------------------------------------
 // data <- xsheet
 void TKeyframeData::setKeyframes(std::set<Position> positions, TXsheet *xsh) {
+  Position startPos(-1, -1);
+  setKeyframes(positions, xsh, startPos);
+}
+
+void TKeyframeData::setKeyframes(std::set<Position> positions, TXsheet *xsh,
+                                 Position startPos) {
   if (positions.empty()) return;
 
   TStageObjectId cameraId = xsh->getStageObjectTree()->getCurrentCameraId();
@@ -50,6 +57,9 @@ void TKeyframeData::setKeyframes(std::set<Position> positions, TXsheet *xsh) {
 
   m_columnSpanCount = c1 - c0 + 1;
   m_rowSpanCount    = r1 - r0 + 1;
+
+  if (startPos.first >= 0 && startPos.second >= 0)
+    m_offset = std::make_pair(r0 - startPos.first, c0 - startPos.second);
 
   for (it = positions.begin(); it != positions.end(); ++it) {
     int row              = it->first;
@@ -125,4 +135,8 @@ void TKeyframeData::getKeyframes(std::set<Position> &positions) const {
     positions.insert(
         TKeyframeSelection::Position(pos.first + r0, pos.second + c0));
   }
+}
+
+void TKeyframeData::setKeyframesOffset(int row, int col) {
+  m_offset = std::make_pair(row, col);
 }

--- a/toonz/sources/toonz/keyframedata.h
+++ b/toonz/sources/toonz/keyframedata.h
@@ -25,6 +25,8 @@ public:
   int m_columnSpanCount;
   int m_rowSpanCount;
 
+  Position m_offset = std::make_pair(0, 0);
+
   // Numero di colonna della pegbar associato al booleano isCycleEnabled della
   // pegbar
   std::map<int, bool> m_isPegbarsCycleEnabled;
@@ -37,6 +39,8 @@ public:
 
   // data <- xsh
   void setKeyframes(std::set<Position> positions, TXsheet *xsh);
+  void setKeyframes(std::set<Position> positions, TXsheet *xsh,
+                    Position startPos);
 
   // data -> xsh
   bool getKeyframes(std::set<Position> &positions, TXsheet *xsh) const;
@@ -52,6 +56,9 @@ public:
 
   int getColumnSpanCount() const { return m_columnSpanCount; }
   int getRowSpanCount() const { return m_rowSpanCount; }
+
+  void setKeyframesOffset(int row, int col);
+  Position getKeyframesOffset() const { return m_offset; }
 };
 
 #endif  // KEYFRAMEDATA_INCLUDED

--- a/toonz/sources/toonz/keyframeselection.cpp
+++ b/toonz/sources/toonz/keyframeselection.cpp
@@ -144,12 +144,17 @@ public:
   // data->xsh
   void setXshFromData(QMimeData *data) const {
     const TKeyframeData *keyframeData = dynamic_cast<TKeyframeData *>(data);
-    if (keyframeData)
-      pasteKeyframesWithoutUndo(keyframeData, &m_selection->getSelection());
+    if (keyframeData) {
+      TKeyframeSelection *selection =
+          new TKeyframeSelection(m_selection->getSelection());
+      pasteKeyframesWithoutUndo(keyframeData, &selection->getSelection());
+    }
   }
   void undo() const override {
     // Delete merged data
-    deleteKeyframesWithoutUndo(&m_selection->getSelection());
+    TKeyframeSelection *selection =
+        new TKeyframeSelection(m_selection->getSelection());
+    deleteKeyframesWithoutUndo(&selection->getSelection());
     if (-(m_r1 - m_r0 + 1) != 0)
       shiftKeyframesWithoutUndo(m_r0, m_r1, m_c0, m_c1, true);
     if (m_oldData) setXshFromData(m_oldData);


### PR DESCRIPTION
This PR fixes #2242 

Added logic to offset where the keyframes need to be pasted based on the cell selection area that was copied.

This PR also fixes #2189

Internally it was clearing information on undo so it couldn't complete the redo properly. Corrected the logic so it would keep the information it needed.