### PR TITLE
Fix schematic group node display issue

### DIFF
--- a/toonz/sources/include/toonzqt/fxschematicscene.h
+++ b/toonz/sources/include/toonzqt/fxschematicscene.h
@@ -228,6 +228,8 @@ protected slots:
 
   void onIconifyNodesToggled(bool iconified);
 
+  void onNodeChangedSize();
+
 private:
   void setEnableCache(bool toggle);
 

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -451,6 +451,7 @@ protected:
 signals:
   void sceneChanged();
   void xsheetChanged();
+  void nodeChangedSize();
 };
 
 #endif  // SCHEMATICNODE_H

--- a/toonz/sources/include/toonzqt/stageschematicscene.h
+++ b/toonz/sources/include/toonzqt/stageschematicscene.h
@@ -215,6 +215,7 @@ protected slots:
   void onSelectionChanged();
   void onCollapse(QList<TStageObjectId>);
   void onEditGroup();
+  void onNodeChangedSize();
 
   void onSwitchPortModeToggled(bool withLetter);
 };

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -3113,6 +3113,7 @@ void FxSchematicColumnNode::onChangedSize(bool expand) {
   m_height = (m_isNormalIconView) ? 32 : 50;
   updateLinksGeometry();
   update();
+  emit nodeChangedSize();
 }
 
 //-----------------------------------------------------

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -163,7 +163,7 @@ QList<TFxP> getRoots(const QList<TFxP> &fxs, TFxSet *terminals) {
 }
 
 bool resizingNodes = false;
-
+bool updatingScene = false;
 }  // namespace
 
 //==================================================================
@@ -355,6 +355,8 @@ void FxSchematicScene::setApplication(TApplication *app) {
 //------------------------------------------------------------------
 
 void FxSchematicScene::updateScene() {
+  if (updatingScene) return;
+  updatingScene = true;
   if (!views().empty()) m_disconnectionLinks.clearAll();
   m_connectionLinks.clearAll();
   m_selectionOldPos.clear();
@@ -462,6 +464,7 @@ void FxSchematicScene::updateScene() {
   updateEditedMacros(editedMacro);
   updateLink();
   m_nodesToPlace.clear();
+  updatingScene = false;
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -162,6 +162,8 @@ QList<TFxP> getRoots(const QList<TFxP> &fxs, TFxSet *terminals) {
   return roots;
 }
 
+bool resizingNodes = false;
+
 }  // namespace
 
 //==================================================================
@@ -528,6 +530,9 @@ FxSchematicNode *FxSchematicScene::addFxSchematicNode(TFx *fx) {
 
   connect(node, SIGNAL(fxNodeDoubleClicked()), this,
           SLOT(onFxNodeDoubleClicked()));
+
+  connect(node, SIGNAL(nodeChangedSize()), this, SLOT(onNodeChangedSize()));
+
   if (fx->getAttributes()->getDagNodePos() == TConst::nowhere) {
     node->resize(m_gridDimension == 0);
     placeNode(node);
@@ -1964,6 +1969,8 @@ void FxSchematicScene::closeInnerMacroEditor(int groupId) {
 //------------------------------------------------------------------
 
 void FxSchematicScene::resizeNodes(bool maximizedNode) {
+  resizingNodes = true;
+
   // resize nodes
   m_gridDimension = maximizedNode ? eLarge : eSmall;
   m_xshHandle->getXsheet()->getFxDag()->setDagGridDimension(m_gridDimension);
@@ -1990,6 +1997,8 @@ void FxSchematicScene::resizeNodes(bool maximizedNode) {
     it3.value()->resizeNodes(maximizedNode);
   }
   updateScene();
+
+  resizingNodes = false;
 }
 
 //------------------------------------------------------------------
@@ -1999,4 +2008,11 @@ void FxSchematicScene::updatePositionOnResize(TFx *fx, bool maximizedNode) {
   double oldPosY = oldPos.y - 25000;
   double newPosY = maximizedNode ? oldPosY * 2 : oldPosY * 0.5;
   fx->getAttributes()->setDagNodePos(TPointD(oldPos.x, newPosY + 25000));
+}
+
+//------------------------------------------------------------------
+
+void FxSchematicScene::onNodeChangedSize() {
+  if (resizingNodes) return;
+  updateScene();
 }

--- a/toonz/sources/toonzqt/schematicgroupeditor.cpp
+++ b/toonz/sources/toonzqt/schematicgroupeditor.cpp
@@ -275,7 +275,9 @@ void FxSchematicGroupEditor::onNameChanged() {
 
 QRectF FxSchematicGroupEditor::boundingSceneRect() const {
   QRectF rect = m_groupedNode[0]->boundingRect();
-  rect.moveTopLeft(m_groupedNode[0]->scenePos() - rect.topLeft());
+  QPointF shiftPos(m_groupedNode[0]->scenePos().x() - rect.left(),
+                   m_groupedNode[0]->scenePos().y() + rect.top() + 10);
+  rect.moveTopLeft(shiftPos);
   int i;
   for (i = 0; i < m_groupedNode.size(); i++) {
     FxSchematicNode *node = dynamic_cast<FxSchematicNode *>(m_groupedNode[i]);
@@ -283,7 +285,9 @@ QRectF FxSchematicGroupEditor::boundingSceneRect() const {
     TFx *fx = node->getFx();
     assert(fx);
     QRectF app = node->boundingRect();
-    app.moveTopLeft(node->scenePos() - app.topLeft());
+    QPointF shiftAppPos(node->scenePos().x() - app.left(),
+                        node->scenePos().y() + app.top() + 10);
+    app.moveTopLeft(shiftAppPos);
     bool isASubgroupedNode =
         fx->getAttributes()->getEditingGroupId() != m_groupId;
     if (isASubgroupedNode) {
@@ -370,7 +374,9 @@ void FxSchematicMacroEditor::onNameChanged() {
 
 QRectF FxSchematicMacroEditor::boundingSceneRect() const {
   QRectF rect = m_groupedNode[0]->boundingRect();
-  rect.moveTopLeft(m_groupedNode[0]->scenePos() - rect.topLeft());
+  QPointF shiftPos(m_groupedNode[0]->scenePos().x() - rect.left(),
+                   m_groupedNode[0]->scenePos().y() + rect.top() + 10);
+  rect.moveTopLeft(shiftPos);
   int i;
   for (i = 0; i < m_groupedNode.size(); i++) {
     FxSchematicNode *node = dynamic_cast<FxSchematicNode *>(m_groupedNode[i]);
@@ -378,7 +384,9 @@ QRectF FxSchematicMacroEditor::boundingSceneRect() const {
     TFx *fx = node->getFx();
     assert(fx);
     QRectF app = node->boundingRect();
-    app.moveTopLeft(node->scenePos() - app.topLeft());
+    QPointF shiftAppPos(node->scenePos().x() - app.left(),
+                        node->scenePos().y() + app.top() + 10);
+    app.moveTopLeft(shiftAppPos);
 #if QT_VERSION >= 0x050000
     rect = rect.united(app);
 #else
@@ -440,7 +448,9 @@ StageSchematicGroupEditor::~StageSchematicGroupEditor() {}
 
 QRectF StageSchematicGroupEditor::boundingSceneRect() const {
   QRectF rect = m_groupedNode[0]->boundingRect();
-  rect.moveTopLeft(m_groupedNode[0]->scenePos() - rect.topLeft());
+  QPointF shiftPos(m_groupedNode[0]->scenePos().x() - rect.left(),
+                   m_groupedNode[0]->scenePos().y() + rect.top() + 10);
+  rect.moveTopLeft(shiftPos);
   int i;
   for (i = 0; i < m_groupedNode.size(); i++) {
     StageSchematicNode *node =
@@ -449,7 +459,9 @@ QRectF StageSchematicGroupEditor::boundingSceneRect() const {
     TStageObject *obj = node->getStageObject();
     assert(obj);
     QRectF app = node->boundingRect();
-    app.moveTopLeft(node->scenePos() - app.topLeft());
+    QPointF shiftAppPos(node->scenePos().x() - app.left(),
+                        node->scenePos().y() + app.top() + 10);
+    app.moveTopLeft(shiftAppPos);
     bool isASubgroupedNode = obj->getEditingGroupId() != m_groupId;
     if (isASubgroupedNode) app.adjust(-30, -30, 30, 30);
 #if QT_VERSION >= 0x050000

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1892,6 +1892,7 @@ void StageSchematicColumnNode::onChangedSize(bool expand) {
   updatePortsPosition();
   updateLinksGeometry();
   update();
+  emit nodeChangedSize();
 }
 
 //--------------------------------------------------------

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -106,6 +106,7 @@ void keepSubgroup(QMap<int, QList<SchematicNode *>> &editedGroup) {
   }
 }
 
+bool resizingNodes = false;
 }  // namespace
 
 //==================================================================
@@ -367,6 +368,7 @@ StageSchematicNode *StageSchematicScene::addStageSchematicNode(
   connect(node, SIGNAL(currentColumnChanged(int)), this,
           SLOT(onCurrentColumnChanged(int)));
   connect(node, SIGNAL(editObject()), this, SIGNAL(editObject()));
+  connect(node, SIGNAL(nodeChangedSize()), this, SLOT(onNodeChangedSize()));
 
   // specify the node position
   if (pegbar->getDagNodePos() == TConst::nowhere) {
@@ -539,6 +541,7 @@ void StageSchematicScene::updateNestedGroupEditors(StageSchematicNode *node,
 //------------------------------------------------------------------
 
 void StageSchematicScene::resizeNodes(bool maximizedNode) {
+  resizingNodes             = true;
   m_gridDimension           = maximizedNode ? eLarge : eSmall;
   TStageObjectTree *pegTree = m_xshHandle->getXsheet()->getStageObjectTree();
   pegTree->setDagGridDimension(m_gridDimension);
@@ -578,6 +581,7 @@ void StageSchematicScene::resizeNodes(bool maximizedNode) {
   for (it2 = m_groupEditorTable.begin(); it2 != m_groupEditorTable.end(); it2++)
     it2.value()->resizeNodes(maximizedNode);
   updateScene();
+  resizingNodes = false;
 }
 
 //------------------------------------------------------------------
@@ -1248,4 +1252,11 @@ void StageSchematicScene::onEditGroup() {
 
 TStageObjectId StageSchematicScene::getCurrentObject() {
   return m_objHandle->getObjectId();
+}
+
+//------------------------------------------------------------------
+
+void StageSchematicScene::onNodeChangedSize() {
+  if (resizingNodes) return;
+  updateScene();
 }

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -107,6 +107,7 @@ void keepSubgroup(QMap<int, QList<SchematicNode *>> &editedGroup) {
 }
 
 bool resizingNodes = false;
+bool updatingScene = false;
 }  // namespace
 
 //==================================================================
@@ -195,6 +196,8 @@ void StageSchematicScene::onSelectionSwitched(TSelection *oldSel,
 //------------------------------------------------------------------
 
 void StageSchematicScene::updateScene() {
+  if (updatingScene) return;
+  updatingScene = true;
   clearAllItems();
 
   QPointF firstPos = sceneRect().center();
@@ -352,6 +355,7 @@ void StageSchematicScene::updateScene() {
     }
   }
   m_nodesToPlace.clear();
+  updatingScene = false;
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #951 

Corrected logic that was shifting the nodes in the wrong direction whenever the nodes were maximized.

Additionally added logic to automatically resize the group editor box appropriately when toggling individual node's thumbnails.
