### PR TITLE
Fix Z=0 Camera Preview crash

### DIFF
--- a/toonz/sources/common/tgeometry/tgeometry.cpp
+++ b/toonz/sources/common/tgeometry/tgeometry.cpp
@@ -58,14 +58,18 @@ TAffine TAffine::inv() const {
   if (a12 == 0.0 && a21 == 0.0) {
     assert(a11 != 0.0);
     assert(a22 != 0.0);
-    double inv_a11 = 1.0 / a11;
-    double inv_a22 = 1.0 / a22;
+    double inv_a11 =
+        (a11 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a11);
+    double inv_a22 =
+        (a22 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a22);
     return TAffine(inv_a11, 0, -a13 * inv_a11, 0, inv_a22, -a23 * inv_a22);
   } else if (a11 == 0.0 && a22 == 0.0) {
     assert(a12 != 0.0);
     assert(a21 != 0.0);
-    double inv_a21 = 1.0 / a21;
-    double inv_a12 = 1.0 / a12;
+    double inv_a21 =
+        (a21 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a21);
+    double inv_a12 =
+        (a12 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a12);
     return TAffine(0, inv_a21, -a23 * inv_a21, inv_a12, 0, -a13 * inv_a12);
   } else {
     double d = 1. / det();

--- a/toonz/sources/common/tgeometry/tgeometry.cpp
+++ b/toonz/sources/common/tgeometry/tgeometry.cpp
@@ -56,20 +56,22 @@ TAffine TAffine::operator*=(const TAffine &b) { return *this = *this * b; }
 //--------------------------------------------------------------------------------------------------
 TAffine TAffine::inv() const {
   if (a12 == 0.0 && a21 == 0.0) {
-    assert(a11 != 0.0);
-    assert(a22 != 0.0);
     double inv_a11 =
-        (a11 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a11);
+        (a11 == 0.0 ? std::numeric_limits<double>::max() / (1 << 16)
+                    : 1.0 / a11);
     double inv_a22 =
-        (a22 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a22);
+        (a22 == 0.0 ? std::numeric_limits<double>::max() / (1 << 16)
+                    : 1.0 / a22);
     return TAffine(inv_a11, 0, -a13 * inv_a11, 0, inv_a22, -a23 * inv_a22);
   } else if (a11 == 0.0 && a22 == 0.0) {
     assert(a12 != 0.0);
     assert(a21 != 0.0);
     double inv_a21 =
-        (a21 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a21);
+        (a21 == 0.0 ? std::numeric_limits<double>::max() / (1 << 16)
+                    : 1.0 / a21);
     double inv_a12 =
-        (a12 == 0.0 ? std::numeric_limits<double>::max() / 2 : 1.0 / a12);
+        (a12 == 0.0 ? std::numeric_limits<double>::max() / (1 << 16)
+                    : 1.0 / a12);
     return TAffine(0, inv_a21, -a23 * inv_a21, inv_a12, 0, -a13 * inv_a12);
   } else {
     double d = 1. / det();

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -656,6 +656,8 @@ void TRasterFx::dryCompute(TRectD &rect, double frame,
     newInfo.m_affine.a23 = fracInfoTranslation.y - intInfoTranslation.y;
 
     TRectD newRect(newTilePos, rect.getSize());
+    // Image size is a 0 point.  Do nothing
+    if (!(newRect.x0 + newRect.x1) && !(newRect.y0 + newRect.y1)) return;
 
     dryCompute(newRect, frame, newInfo);
     return;
@@ -834,6 +836,10 @@ void TRasterFx::compute(TTile &tile, double frame,
   if (tile.m_pos != newTilePos) {
     /*-- RenderSettingsのaffine行列に位置ずれを足しこむ --*/
     TRenderSettings newInfo(info);
+    // Image size is a 0 point.  Do nothing
+    if (!(newInfo.m_cameraBox.x0 + newInfo.m_cameraBox.x1) &&
+        !(newInfo.m_cameraBox.y0 + newInfo.m_cameraBox.y1))
+      return;
     newInfo.m_affine.a13 = fracInfoTranslation.x - intInfoTranslation.x;
     newInfo.m_affine.a23 = fracInfoTranslation.y - intInfoTranslation.y;
     /*-- タイルの位置は整数値にする --*/

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -656,8 +656,6 @@ void TRasterFx::dryCompute(TRectD &rect, double frame,
     newInfo.m_affine.a23 = fracInfoTranslation.y - intInfoTranslation.y;
 
     TRectD newRect(newTilePos, rect.getSize());
-    // Image size is a 0 point.  Do nothing
-    if (!(newRect.x0 + newRect.x1) && !(newRect.y0 + newRect.y1)) return;
 
     dryCompute(newRect, frame, newInfo);
     return;
@@ -836,10 +834,6 @@ void TRasterFx::compute(TTile &tile, double frame,
   if (tile.m_pos != newTilePos) {
     /*-- RenderSettingsのaffine行列に位置ずれを足しこむ --*/
     TRenderSettings newInfo(info);
-    // Image size is a 0 point.  Do nothing
-    if (!(newInfo.m_cameraBox.x0 + newInfo.m_cameraBox.x1) &&
-        !(newInfo.m_cameraBox.y0 + newInfo.m_cameraBox.y1))
-      return;
     newInfo.m_affine.a13 = fracInfoTranslation.x - intInfoTranslation.x;
     newInfo.m_affine.a23 = fracInfoTranslation.y - intInfoTranslation.y;
     /*-- タイルの位置は整数値にする --*/

--- a/toonz/sources/toonzlib/imagepainter.cpp
+++ b/toonz/sources/toonzlib/imagepainter.cpp
@@ -425,7 +425,10 @@ void Painter::doFlushRasterImages(const TRasterP &rin, int bg,
       int lx = (m_imageSize.lx == 0 ? _rin->getLx() : m_imageSize.lx);
       int ly = (m_imageSize.ly == 0 ? _rin->getLy() : m_imageSize.ly);
 
-      TRect rect      = convert(aff * TRectD(0, 0, lx - 1, ly - 1));
+      TRect rect = convert(aff * TRectD(0, 0, lx - 1, ly - 1));
+      // Image size is a 0 point.  Do nothing
+      if (rect.x0 == rect.x1 && rect.y0 == rect.y1) return;
+
       TRaster32P raux = ras->extract(rect);
       raux->fill(bg == 0x40000 ? TPixel::Black : TPixel::White);
     }


### PR DESCRIPTION
This PR fixes #2372 

NOTE: This issue not only impacts previewing, but it also causes a crash while rendering output.

Fixed it by adding simple logic in places it would crash to check if the area being rendered is a single point.  If so, it will stop trying to render the frame.

If a better solution presents itself please use that.
