### PR TITLE
Fix Palette gizmo crash

### DIFF
--- a/toonz/sources/toonz/pltgizmopopup.cpp
+++ b/toonz/sources/toonz/pltgizmopopup.cpp
@@ -361,6 +361,11 @@ void modifyColor(const T &modifier) {
   TPaletteHandle *paletteHandle =
       TApp::instance()->getPaletteController()->getCurrentLevelPalette();
   TPaletteP palette = paletteHandle->getPalette();
+  if (!palette) {
+    QMessageBox::warning(0, QObject::tr("Error"),
+                         QObject::tr("No Palette loaded."));
+    return;
+  }
   if (palette->isLocked()) {
     QMessageBox::warning(0, QObject::tr("Warning"),
                          QObject::tr("Palette is locked."));


### PR DESCRIPTION
This PR fixes #2411 

Throws a user an error message when attempting to modify a palette using the Palette Gizmo if there is no active palette loaded.