### PR TITLE
Enable To Reload PSD Levels

### DIFF
--- a/toonz/sources/toonz/levelcommand.cpp
+++ b/toonz/sources/toonz/levelcommand.cpp
@@ -358,14 +358,14 @@ void revertTo(bool isCleanedUp) {
         /*-- Revert可能なLevelタイプの条件 --*/
         if ((isCleanedUp && type == TZP_XSHLEVEL) ||
             (!isCleanedUp && (type == TZP_XSHLEVEL || type == PLI_XSHLEVEL ||
-                              (type == OVL_XSHLEVEL && ext != "psd")))) {
+                              type == OVL_XSHLEVEL))) {
           levels.insert(level);
           selectionContainLevel = true;
         }
       }
     if (levels.empty() || !selectionContainLevel) {
       DVGui::error(
-          QObject::tr("The Revert to Last Saved command is not supported for "
+          QObject::tr("The Reload command is not supported for "
                       "the current selection."));
       return;
     }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -137,8 +137,7 @@ bool selectionContainLevelImage(TCellSelection *selection, TXsheet *xsheet) {
 
       std::string ext = level->getPath().getType();
       int type        = level->getType();
-      if (type == TZP_XSHLEVEL || type == PLI_XSHLEVEL ||
-          (type == OVL_XSHLEVEL && ext != "psd"))
+      if (type == TZP_XSHLEVEL || type == PLI_XSHLEVEL || type == OVL_XSHLEVEL)
         return true;
     }
 


### PR DESCRIPTION
This PR enables Reload command on PSD levels.
I tried simply abolishing the restriction of the command and couldn't find any problem so far. 