### PR TITLE
Fix Renaming PSD Cell

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -829,8 +829,8 @@ void RenameCellField::renameCell() {
       }
 
       TXshLevel *xl = cell.m_level.getPointer();
-      if (!xl || (xl->getType() == OVL_XSHLEVEL &&
-                  xl->getPath().getFrame() == TFrameId::NO_FRAME)) {
+      if (!xl || (xl->getSimpleLevel() &&
+                  xl->getSimpleLevel()->getFirstFid() == TFrameId::NO_FRAME)) {
         cells.append(TXshCell());
         continue;
       }


### PR DESCRIPTION
This PR fixes the following problem:

Xsheet cells containing PSD levels cannot be renamed by just typing a frame number like a cell containing other types of sequential raster level.