### PR TITLE
Fix replace fx nodes

### DIFF
--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -1152,7 +1152,13 @@ void ReplaceFxUndo::initialize() {
     fx = zcfx->getZeraryFx();
   }
 
-  if (has_fx_column(fx)) {
+  TZeraryColumnFx *zcrepfx = dynamic_cast<TZeraryColumnFx *>(repFx);
+  if (zcrepfx) repFx       = zcrepfx->getZeraryFx();
+
+  bool fxHasCol    = has_fx_column(fx);
+  bool repfxHasCol = has_fx_column(repFx);
+
+  if (fxHasCol && repfxHasCol) {
     if (zcfx) {
       // Build a column with the same source cells pattern
       m_repColumn = new TXshZeraryFxColumn(*zcfx->getColumn());
@@ -1170,6 +1176,10 @@ void ReplaceFxUndo::initialize() {
       m_repColIdx = xsh->getFirstFreeColumnIndex();
       m_repFx     = static_cast<TZeraryColumnFx *>(m_repColumn->getFx());
     }
+  } else if (!fxHasCol && repfxHasCol) {
+    m_repColumn = FxCommandUndo::createZeraryFxColumn(xsh, repFx);
+    m_repColIdx = xsh->getFirstFreeColumnIndex();
+    m_repFx     = static_cast<TZeraryColumnFx *>(m_repColumn->getFx());
   }
 
   FxCommandUndo::cloneGroupStack(fx, m_repFx.getPointer());


### PR DESCRIPTION
This PR fixes #2177 

The logic for replacing fx nodes incorrectly creates a normal fx as a ZeraryColumn fx. When this happens, accessing certain fx information can cause a crash due to bad pointers.

It should be noted that when replacing a normal fx with a ZeraryColumn fx, the ZeraryColumn fx is created as a normal fx incorrectly.

Corrected the logic such that if replacing a ZeraryColumn fx with a normal fx, the normal fx is created as a normal fx.  Conversely, if replacing a normal fx with a ZeraryColumn fx, a new ZeraryColumn fx is created