### PR TITLE
Fix loading macrofx preset issue

### DIFF
--- a/toonz/sources/common/tfx/tfx.cpp
+++ b/toonz/sources/common/tfx/tfx.cpp
@@ -61,6 +61,7 @@ void skipChild(TIStream &is) {
       if (is.isBeginEndTag()) is.matchTag(tagName);
       is.closeChild();
     }
+    if (is.isBeginEndTag()) is.matchTag(tagName);
   }
 }
 


### PR DESCRIPTION
This PR fixes #2424

The `skipChild()` procedure does not handle Open-Close tags (ie `<tagname />`) properly like the pointParam of a Curves Fx.  Corrected logic to account for this.