### PR TITLE
Update Tool State on Level Switch

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2188,6 +2188,7 @@ void SceneViewer::onLevelChanged() {
  * for Ink&Paint work properly
  */
 void SceneViewer::onLevelSwitched() {
+  invalidateToolStatus();
   TApp *app        = TApp::instance();
   TTool *tool      = app->getCurrentTool()->getTool();
   TXshLevel *level = app->getCurrentLevel()->getLevel();


### PR DESCRIPTION
This will fix the problem after merging #2364 as follows:

- Create a raster or toonz raster level with one frame
- Draw with the brush or geometric tool
- Use the shortcut "S" to change to the select tool
- Click & drag to select a rectangle around the drawing
- Ctrl-C to copy
- Left-click to exit the selection & then use the right or down arrow key TWO TIMES to navigate to the two frames down.
- Ctrl-V to paste
- Level is created, but the pasted selection does not appear in the viewer.