### PR TITLE
Fix Pressure Lost

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -653,6 +653,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
       m_compareSettings.m_compareY     = ImagePainter::DefaultCompareValue;
       update();
       m_tabletEvent = false;
+      m_tabletState = None;
       return;
     } else if (abs((height() - m_pos.y()) -
                    height() * m_compareSettings.m_compareY) < 20) {
@@ -661,6 +662,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
       m_compareSettings.m_compareX     = ImagePainter::DefaultCompareValue;
       update();
       m_tabletEvent = false;
+      m_tabletState = None;
       return;
     } else
       m_compareSettings.m_dragCompareX = m_compareSettings.m_dragCompareY =
@@ -672,6 +674,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   if (!tool || !tool->isEnabled()) {
     m_tabletEvent = false;
+    m_tabletState = None;
     return;
   }
   tool->setViewer(this);
@@ -679,6 +682,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
     tool = TApp::instance()->getCurrentTool()->getTool();
     if (!tool || !tool->isEnabled()) {
       m_tabletEvent = false;
+      m_tabletState = None;
       return;
     }
     tool->setViewer(this);


### PR DESCRIPTION
This will fix the following problem, related with the fix #2369 .

When you are using tablet, the pressure is unexpectedly lost after you do one of the following operations:
- Try to draw on the hidden column and close the warning popup.
- Drag the vertical or horizontal marker which is for comparing the previewed frame with the snapshot.

Actually, this modification seems to avoid the crash reported in #2311 as well.