### PR TITLE
Fix plastic deformer fx crash

### DIFF
--- a/toonz/sources/toonzlib/plasticdeformerfx.cpp
+++ b/toonz/sources/toonzlib/plasticdeformerfx.cpp
@@ -20,6 +20,7 @@
 
 // TnzBase includes
 #include "trenderer.h"
+#include "trasterfx.h"
 
 // TnzCore includes
 #include "tgl.h"
@@ -367,6 +368,15 @@ void PlasticDeformerFx::doCompute(TTile &tile, double frame,
       context->setShareContext(QOpenGLContext::currentContext());
     context->setFormat(QSurfaceFormat::defaultFormat());
     context->create();
+
+    // offscreen renderer has not been created yet. Force make one now
+    if (!info.m_offScreenSurface.get()) {
+      TRenderSettings *infoptr = (TRenderSettings *)&info;
+      infoptr->m_offScreenSurface.reset(new QOffscreenSurface());
+      infoptr->m_offScreenSurface->setFormat(QSurfaceFormat::defaultFormat());
+      infoptr->m_offScreenSurface->create();
+    }
+
     context->makeCurrent(info.m_offScreenSurface.get());
 
     TDimension d = tile.getRaster()->getSize();


### PR DESCRIPTION
This PR fixes #2440 

This patch fixes an issue where the off screen rendering surface for plastic deformed levels was not previously created causing a crash when trying to use it.

This will create it immediately if not found.