### PR TITLE
Prevent Camera Z from Being Zero

### DIFF
--- a/toonz/sources/common/tunit/tunit.cpp
+++ b/toonz/sources/common/tunit/tunit.cpp
@@ -594,7 +594,12 @@ public:
     return (1 + v * 0.001) * getCameraSize();
   }
   double convertFrom(double v) const override {
-    return (v / getCameraSize() - 1) * 1000.0;
+    // prevent camera z from being 0 which causes crash
+    double val = (v / getCameraSize() - 1) * 1000.0;
+    if (val >= -1000.0)
+      return std::max(-999.9, val);
+    else
+      return std::min(-1000.1, val);
   }
 };
 


### PR DESCRIPTION
This PR fixes #2372 , as an alternative plan for #2405 .
This solution adds some manipulation to the return value of camera z and makes it not to be zero.
For instance, if you are in the scene with camera having 16 inch width, camera z will not fall below 0.0016 fld even if you type 0 to the camera z field.