### PR TITLE
Exclude regular headers from MOC_HEADER

### DIFF
--- a/toonz/sources/tnztools/CMakeLists.txt
+++ b/toonz/sources/tnztools/CMakeLists.txt
@@ -1,43 +1,44 @@
 set(MOC_HEADERS
-    fullcolorbrushtool.h
     controlpointselection.h
-    ../include/tools/imagegrouping.h
     edittoolgadgets.h
     filltool.h
+    fullcolorbrushtool.h
+    plastictool.h
     skeletonsubtools.h
     tooloptionscontrols.h
-    plastictool.h
+    toonzrasterbrushtool.h
+    viewtools.h
+    ../include/tools/imagegrouping.h
+    ../include/tools/screenpicker.h
     ../include/tools/toolhandle.h
     ../include/tools/tooloptions.h
-    ../include/tools/screenpicker.h
-    rgbpickertool.h
-    rulertool.h
-    stylepickertool.h
-	viewtools.h
-    toonzrasterbrushtool.h
 )
 
-set(HEADERS ${MOC_HEADERS}
+set(HEADERS
+    ${MOC_HEADERS}
     autofill.h
     bluredbrush.h
+    hookselection.h
+    mypainttoonzbrush.h
+    rasterselectiontool.h
+    rgbpickertool.h
+    rulertool.h
+    selectiontool.h
+    setsaveboxtool.h
+    shifttracetool.h
+    stylepickertool.h
+    toonzvectorbrushtool.h
+    vectorselectiontool.h
+    ../include/tools/RGBpicker.h
     ../include/tools/cursormanager.h
     ../include/tools/cursors.h
     ../include/tools/levelselection.h
     ../include/tools/rasterselection.h
-    hookselection.h
-    selectiontool.h
-    setsaveboxtool.h
-    rasterselectiontool.h
-    vectorselectiontool.h
     ../include/tools/strokeselection.h
     ../include/tools/stylepicker.h
     ../include/tools/tool.h
     ../include/tools/toolcommandids.h
     ../include/tools/toolutils.h
-    ../include/tools/RGBpicker.h
-    mypainttoonzbrush.h
-    shifttracetool.h
-	toonzvectorbrushtool.h
 )
 
 set(SOURCES

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -6,126 +6,104 @@ set(MOC_HEADERS
     adjustthicknesspopup.h
     antialiaspopup.h
     audiorecordingpopup.h
+    autoinputcellnumberpopup.h
     batches.h
     batchserversviewer.h
     binarizepopup.h
+    boardsettingspopup.h
     brightnessandcontrastpopup.h
     cachefxcommand.h
+    cameracapturelevelcontrol.h
     camerasettingspopup.h
     canvassizepopup.h
-    castselection.h
     castviewer.h
-    celldata.h
-    cellkeyframedata.h
-    cellkeyframeselection.h
-    cellselection.h
-	../include/cellposition.h
     cleanuppaletteviewer.h
     cleanuppopup.h
     cleanuppreview.h
     cleanupsettingsmodel.h
+    cleanupsettingspane.h
     cleanupsettingspopup.h
     cleanupswatch.h
+    colormodelbehaviorpopup.h
     colormodelviewer.h
-    columncommand.h
-    columnselection.h
+    comboviewerpane.h
     commandbar.h
     commandbarpopup.h
     convertpopup.h
-    curveio.h
-    drawingdata.h
     duplicatepopup.h
     dvdirtreeview.h
     dvitemview.h
     dvwidgets.h
-    exportlevelcommand.h
     exportlevelpopup.h
-    exportscenepopup.h
     exportpanel.h
+    exportscenepopup.h
     filebrowser.h
     filebrowsermodel.h
     filebrowserpopup.h
-    filedata.h
     fileinfopopup.h
-    fileselection.h
     filmstrip.h
-    filmstripcommand.h
-    filmstripselection.h
     flipbook.h
-    floatingpanelcommand.h
     formatsettingspopups.h
     frameheadgadget.h
     fxparameditorpopup.h
     histogrampopup.h
-    history.h
+    historypane.h
     imageviewer.h
     insertfxpopup.h
-    iocommand.h
-    keyframedata.h
-    keyframeselection.h
-    keyframemover.h
     layerfooterpanel.h
     layerheaderpanel.h
     levelcreatepopup.h
     levelsettingspopup.h
     linesfadepopup.h
-    linetestcapturepane.h
-    linetestpane.h
-    linetestviewer.h
     lipsyncpopup.h
     loadfolderpopup.h
+    locatorpopup.h
     magpiefileimportpopup.h
     mainwindow.h
     matchline.h
     menubar.h
     menubarpopup.h
-    menubarcommandids.h
     meshifypopup.h
     messagepanel.h
-    moviegenerator.h
-	../include/orientation.h
     onionskinmaskgui.h
     outputsettingspopup.h
     overwritepopup.h
     pane.h
+    penciltestpopup.h
     pltgizmopopup.h
     preferencespopup.h
     previewer.h
     previewfxmanager.h
     projectpopup.h
     psdsettingspopup.h
+    reframepopup.h
     renumberpopup.h
     reslist.h
     ruler.h
-	../include/saveloadqsettings.h
     savepresetpopup.h
-    scanlist.h
     scanpopup.h
     scenesettingspopup.h
     sceneviewer.h
     sceneviewercontextmenu.h
-    sceneviewerevents.h
     scriptconsolepanel.h
-    selectionutils.h
+    separatecolorspopup.h
+    separatecolorsswatch.h
     shortcutpopup.h
     soundtrackexport.h
     startuppopup.h
-    subcameramanager.h
-    subscenecommand.h
+    styleshortcutswitchablepanel.h
     svncleanupdialog.h
     svncommitdialog.h
     svndeletedialog.h
     svnlockdialog.h
     svnlockframerangedialog.h
+    svnpurgedialog.h
     svnrevertdialog.h
     svnupdateandlockdialog.h
     svnupdatedialog.h
-    svnpurgedialog.h
     tapp.h
-    kis_tablet_support_win8.h
     tasksviewer.h
     testpanel.h
-    tfarmstuff.h
     timestretchpopup.h
     toolbar.h
     tpanels.h
@@ -133,43 +111,67 @@ set(MOC_HEADERS
     vectorizerpopup.h
     vectorizerswatch.h
     versioncontrol.h
-    versioncontrolgui.h
     versioncontroltimeline.h
-    versioncontrolxmlreader.h
     versioncontrolwidget.h
-    viewerdraw.h
     viewerpane.h
-    viewerpopup.h
-    xshcellmover.h
     xshcellviewer.h
     xshcolumnviewer.h
-    xsheetdragtool.h
     xsheetviewer.h
     xshnoteviewer.h
     xshrowviewer.h
     xshtoolbar.h
-    comboviewerpane.h
-    historypane.h
-    cleanupsettingspane.h
-    penciltestpopup.h
-    locatorpopup.h
-    styleshortcutswitchablepanel.h
-	cameracapturelevelcontrol.h
-	reframepopup.h
-	autoinputcellnumberpopup.h
-	colormodelbehaviorpopup.h
-	boardsettingspopup.h
-	separatecolorsswatch.h
-	separatecolorspopup.h
-# Tracker file
-    dummyprocessor.h
-    metnum.h
-    ObjectTracker.h
-    predict3d.h
-    processor.h
 )
 
-set(HEADERS ${MOC_HEADERS})
+set(HEADERS
+    ${MOC_HEADERS}
+    celldata.h
+    cellkeyframedata.h
+    cellkeyframeselection.h
+    cellselection.h
+    columncommand.h
+    columnselection.h
+    curveio.h
+    drawingdata.h
+    exportlevelcommand.h
+    filedata.h
+    fileselection.h
+    filmstripcommand.h
+    filmstripselection.h
+    floatingpanelcommand.h
+    history.h
+    iocommand.h
+    keyframedata.h
+    keyframemover.h
+    keyframeselection.h
+    kis_tablet_support_win8.h
+    linetestcapturepane.h
+    linetestpane.h
+    linetestviewer.h
+    menubarcommandids.h
+    moviegenerator.h
+    scanlist.h
+    sceneviewerevents.h
+    selectionutils.h
+    subcameramanager.h
+    subscenecommand.h
+    tfarmstuff.h
+    versioncontrolgui.h
+    versioncontrolxmlreader.h
+    viewerdraw.h
+    viewerpopup.h
+    xshcellmover.h
+    xsheetdragtool.h
+    castselection.h
+    ../include/cellposition.h
+    ../include/orientation.h
+    ../include/saveloadqsettings.h
+# Tracker file
+    ObjectTracker.h
+    dummyprocessor.h
+    metnum.h
+    processor.h
+    predict3d.h
+)
 
 set(SOURCES
     floatingpanelcommand.cpp

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -1,14 +1,77 @@
-# moc の数が多いので全部食わせる
 set(MOC_HEADERS
+    ../include/toonz/fullcolorpalette.h
+    ../include/toonz/movierenderer.h
+    ../include/toonz/multimediarenderer.h
+    ../include/toonz/palettecontroller.h
+    ../include/toonz/preferences.h
+    ../include/toonz/scriptbinding.h
+    ../include/toonz/scriptbinding_centerline_vectorizer.h
+    ../include/toonz/scriptbinding_files.h
+    ../include/toonz/scriptbinding_image.h
+    ../include/toonz/scriptbinding_image_builder.h
+    ../include/toonz/scriptbinding_level.h
+    ../include/toonz/scriptbinding_outline_vectorizer.h
+    ../include/toonz/scriptbinding_rasterizer.h
+    ../include/toonz/scriptbinding_renderer.h
+    ../include/toonz/scriptbinding_scene.h
+    ../include/toonz/scriptbinding_toonz_raster_converter.h
+    ../include/toonz/scriptengine.h
+    ../include/toonz/stylemanager.h
+    ../include/toonz/tcenterlinevectorizer.h
+    ../include/toonz/tcolumnhandle.h
+    ../include/toonz/tframehandle.h
+    ../include/toonz/tfxhandle.h
+    ../include/toonz/tobjecthandle.h
+    ../include/toonz/tonionskinmaskhandle.h
+    ../include/toonz/tpalettehandle.h
+    ../include/toonz/tscenehandle.h
+    ../include/toonz/txsheethandle.h
+    ../include/toonz/txshlevel.h
+    ../include/toonz/txshlevelhandle.h
+    ../include/toonz/txshsimplelevel.h
+    ../include/toonz/txshsoundcolumn.h
+)
+
+set(HEADERS
+    ${MOC_HEADERS}
     autoadjust.h
-    ../include/toonz/autoclose.h
-    ../include/convert2tlv.h
     autopos.h
+    cleanupcommon.h
+    cleanuppalette.h
+    imagebuilders.h
+    skeletonlut.h
+    tcenterlinevectP.h
+    texturemanager.h
+    xshhandlemanager.h
+    sandor_fxs/BlurMatrix.h
+    sandor_fxs/CIL.h
+    sandor_fxs/CallCircle.h
+    sandor_fxs/CallParam.h
+    sandor_fxs/EraseContour.h
+    sandor_fxs/InputParam.h
+    sandor_fxs/Params.h
+    sandor_fxs/Pattern.h
+    sandor_fxs/PatternMapParam.h
+    sandor_fxs/PatternPosition.h
+    sandor_fxs/SDef.h
+    sandor_fxs/SDirection.h
+    sandor_fxs/SError.h
+    sandor_fxs/STColSelPic.h
+    sandor_fxs/STPic.h
+    sandor_fxs/YOMBInputParam.h
+    sandor_fxs/YOMBParam.h
+    sandor_fxs/blend.h
+    sandor_fxs/calligraph.h
+    sandor_fxs/patternmap.h
+    sandor_fxs/toonz4_6staff.h
+    ../include/convert2tlv.h
+    ../include/orientation.h
+    ../include/toonz/Naa2TlvConverter.h
+    ../include/toonz/autoclose.h
+    ../include/toonz/boardsettings.h
     ../include/toonz/captureparameters.h
     ../include/toonz/childstack.h
     ../include/toonz/cleanupcolorstyles.h
-    cleanupcommon.h
-    cleanuppalette.h
     ../include/toonz/cleanupparameters.h
     ../include/toonz/columnfan.h
     ../include/toonz/controlpointobserver.h
@@ -16,7 +79,6 @@ set(MOC_HEADERS
     ../include/toonz/doubleparamcmd.h
     ../include/toonz/dpiscale.h
     ../include/toonz/fill.h
-    ../include/toonz/fullcolorpalette.h
     ../include/toonz/fxcommand.h
     ../include/toonz/fxdag.h
     ../include/toonz/glrasterpainter.h
@@ -33,39 +95,21 @@ set(MOC_HEADERS
     ../include/toonz/levelset.h
     ../include/toonz/levelupdater.h
     ../include/toonz/logger.h
-    ../include/toonz/movierenderer.h
-    ../include/toonz/multimediarenderer.h
     ../include/toonz/mypaint.h
-    ../include/toonz/mypainthelpers.hpp
     ../include/toonz/mypaintbrushstyle.h
+    ../include/toonz/mypainthelpers.hpp
     ../include/toonz/namebuilder.h
-    ../include/toonz/Naa2TlvConverter.h
     ../include/toonz/observer.h
     ../include/toonz/onionskinmask.h
     ../include/toonz/palettecmd.h
-    ../include/toonz/palettecontroller.h
     ../include/toonz/plasticdeformerfx.h
-    ../include/toonz/preferences.h
     ../include/toonz/rasterbrush.h
     ../include/toonz/rasterstrokegenerator.h
     ../include/toonz/scenefx.h
     ../include/toonz/sceneproperties.h
     ../include/toonz/sceneresources.h
     ../include/toonz/screensavermaker.h
-    ../include/toonz/scriptbinding.h
-    ../include/toonz/scriptbinding_centerline_vectorizer.h
-    ../include/toonz/scriptbinding_files.h
-    ../include/toonz/scriptbinding_image.h
-    ../include/toonz/scriptbinding_image_builder.h
-    ../include/toonz/scriptbinding_level.h
-    ../include/toonz/scriptbinding_outline_vectorizer.h
-    ../include/toonz/scriptbinding_rasterizer.h
-    ../include/toonz/scriptbinding_renderer.h
-    ../include/toonz/scriptbinding_scene.h
-    ../include/toonz/scriptbinding_toonz_raster_converter.h
-    ../include/toonz/scriptengine.h
     ../include/toonz/skeleton.h
-    skeletonlut.h
     ../include/toonz/stage.h
     ../include/toonz/stage2.h
     ../include/toonz/stageobjectutil.h
@@ -73,30 +117,22 @@ set(MOC_HEADERS
     ../include/toonz/stagevisitor.h
     ../include/toonz/studiopalette.h
     ../include/toonz/studiopalettecmd.h
-    ../include/toonz/stylemanager.h
     ../include/toonz/tapplication.h
     ../include/toonz/targetcolors.h
+    ../include/toonz/tbinarizer.h
     ../include/toonz/tcamera.h
-    ../include/toonz/tcenterlinevectorizer.h
-    tcenterlinevectP.h
     ../include/toonz/tcleanupper.h
     ../include/toonz/tcolumnfx.h
     ../include/toonz/tcolumnfxset.h
-    ../include/toonz/tcolumnhandle.h
     ../include/toonz/tdistort.h
-    ../include/toonz/tframehandle.h
-    ../include/toonz/tfxhandle.h
+    ../include/toonz/textureutils.h
     ../include/toonz/tlog.h
-    ../include/toonz/tobjecthandle.h
-    ../include/toonz/tonionskinmaskhandle.h
     ../include/toonz/toonzfolders.h
     ../include/toonz/toonzimageutils.h
     ../include/toonz/toonzscene.h
     ../include/toonz/tpinnedrangeset.h
-    ../include/toonz/tpalettehandle.h
     ../include/toonz/tproject.h
     ../include/toonz/trasterimageutils.h
-    ../include/toonz/tscenehandle.h
     ../include/toonz/tstageobject.h
     ../include/toonz/tstageobjectcmd.h
     ../include/toonz/tstageobjectid.h
@@ -111,55 +147,20 @@ set(MOC_HEADERS
     ../include/toonz/txshcolumn.h
     ../include/toonz/txsheet.h
     ../include/toonz/txsheetexpr.h
-    ../include/toonz/txsheethandle.h
-    ../include/toonz/txshlevel.h
     ../include/toonz/txshlevelcolumn.h
-    ../include/toonz/txshlevelhandle.h
     ../include/toonz/txshleveltypes.h
+    ../include/toonz/txshmeshcolumn.h
     ../include/toonz/txshnoteset.h
     ../include/toonz/txshpalettecolumn.h
     ../include/toonz/txshpalettelevel.h
-    ../include/toonz/txshsimplelevel.h
-    ../include/toonz/txshsoundcolumn.h
     ../include/toonz/txshsoundlevel.h
     ../include/toonz/txshsoundtextcolumn.h
     ../include/toonz/txshsoundtextlevel.h
+    ../include/toonz/txshzeraryfxcolumn.h
     ../include/toonz/txshzeraryfxlevel.h
     ../include/toonz/vectorizerparameters.h
-    ../include/toonz/txshzeraryfxcolumn.h
-    ../include/toonz/tbinarizer.h
-    ../include/toonz/txshmeshcolumn.h
-    ../include/toonz/textureutils.h
     ../include/toutputproperties.h
-    xshhandlemanager.h
-    sandor_fxs/blend.h
-    sandor_fxs/BlurMatrix.h
-    sandor_fxs/CallCircle.h
-    sandor_fxs/calligraph.h
-    sandor_fxs/CallParam.h
-    sandor_fxs/CIL.h
-    sandor_fxs/EraseContour.h
-    sandor_fxs/InputParam.h
-    sandor_fxs/Params.h
-    sandor_fxs/Pattern.h
-    sandor_fxs/patternmap.h
-    sandor_fxs/PatternMapParam.h
-    sandor_fxs/PatternPosition.h
-    sandor_fxs/SDef.h
-    sandor_fxs/SDirection.h
-    sandor_fxs/SError.h
-    sandor_fxs/STColSelPic.h
-    sandor_fxs/STPic.h
-    sandor_fxs/toonz4_6staff.h
-    sandor_fxs/YOMBInputParam.h
-    sandor_fxs/YOMBParam.h
-    texturemanager.h
-    imagebuilders.h
-	../include/orientation.h
-    ../include/toonz/boardsettings.h
 )
-
-set(HEADERS ${MOC_HEADERS})
 
 set(SOURCES
     autoadjust.cpp

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -1,19 +1,23 @@
 set(MOC_HEADERS
+    palettesscanpopup.h
+    pluginhost.h
+    stageobjectselection.h
+    tdockwindows.h
     ../include/toonzqt/addfxcontextmenu.h
+    ../include/toonzqt/camerasettingswidget.h
     ../include/toonzqt/checkbox.h
+    ../include/toonzqt/cleanupcamerasettingswidget.h
     ../include/toonzqt/colorfield.h
-    docklayout.h
+    ../include/toonzqt/combohistogram.h
     ../include/toonzqt/doublefield.h
     ../include/toonzqt/doublepairfield.h
     ../include/toonzqt/dvdialog.h
-    ../include/toonzqt/dvmimedata.h
     ../include/toonzqt/dvscrollwidget.h
     ../include/toonzqt/dvtextedit.h
     ../include/toonzqt/expressionfield.h
     ../include/toonzqt/filefield.h
     ../include/toonzqt/flipconsole.h
     ../include/toonzqt/framenavigator.h
-    ../include/toonzqt/freelayout.h
     ../include/toonzqt/functionkeyframenavigator.h
     ../include/toonzqt/functionpanel.h
     ../include/toonzqt/functionsegmentviewer.h
@@ -22,13 +26,11 @@ set(MOC_HEADERS
     ../include/toonzqt/functiontoolbar.h
     ../include/toonzqt/functiontreeviewer.h
     ../include/toonzqt/functionviewer.h
-    fxdata.h
     ../include/toonzqt/fxhistogramrender.h
     ../include/toonzqt/fxschematicnode.h
     ../include/toonzqt/fxschematicscene.h
     ../include/toonzqt/fxselection.h
     ../include/toonzqt/fxsettings.h
-	../include/toonzqt/fxtypes.h
     ../include/toonzqt/gutil.h
     ../include/toonzqt/histogram.h
     ../include/toonzqt/icongenerator.h
@@ -38,68 +40,66 @@ set(MOC_HEADERS
     ../include/toonzqt/intpairfield.h
     ../include/toonzqt/keyframenavigator.h
     ../include/toonzqt/lineedit.h
+    ../include/toonzqt/marksbar.h
     ../include/toonzqt/menubarcommand.h
-    ../include/toonzqt/multipleselection.h
-    palettedata.h
-    palettesscanpopup.h
     ../include/toonzqt/paletteviewer.h
     ../include/toonzqt/paletteviewergui.h
     ../include/toonzqt/paramfield.h
-    ../include/toonzqt/planeviewer.h
     ../include/toonzqt/popupbutton.h
-    ../include/toonzqt/rasterimagedata.h
-    ../include/toonzqt/schematicnode.h
     ../include/toonzqt/schematicgroupeditor.h
+    ../include/toonzqt/schematicnode.h
     ../include/toonzqt/schematicviewer.h
+    ../include/toonzqt/screenboard.h
     ../include/toonzqt/scriptconsole.h
-    ../include/toonzqt/selectioncommandids.h
-    ../include/toonzqt/selection.h
-    stageobjectselection.h
-    ../include/toonzqt/stageobjectsdata.h
     ../include/toonzqt/spectrumfield.h
     ../include/toonzqt/spreadsheetviewer.h
     ../include/toonzqt/stageschematicnode.h
     ../include/toonzqt/stageschematicscene.h
-    ../include/toonzqt/strokesdata.h
     ../include/toonzqt/studiopaletteviewer.h
-    styledata.h
     ../include/toonzqt/styleeditor.h
     ../include/toonzqt/styleindexlineedit.h
-    ../include/toonzqt/styleselection.h
+    ../include/toonzqt/stylenameeditor.h
     ../include/toonzqt/swatchviewer.h
     ../include/toonzqt/tabbar.h
-    tdockwindows.h
+    ../include/toonzqt/tmessageviewer.h
     ../include/toonzqt/tonecurvefield.h
     ../include/toonzqt/treemodel.h
     ../include/toonzqt/tselectionhandle.h
     ../include/toonzqt/updatechecker.h
     ../include/toonzqt/validatedchoicedialog.h
-    ../include/toonzqt/viewcommandids.h
-    ../include/toonzqt/trepetitionguard.h
-    ../include/toonzqt/camerasettingswidget.h
-    ../include/toonzqt/cleanupcamerasettingswidget.h
-    ../include/toonzqt/pickrgbutils.h
-    ../include/toonzqt/screenboard.h
-    ../include/toonzqt/marksbar.h
-    ../include/toonzqt/tmessageviewer.h
-    ../include/toonzqt/stylenameeditor.h
-    ../include/historytypes.h
-    ../include/toonzqt/flipconsoleowner.h
-    ../include/toonzqt/combohistogram.h
-    ../include/toonzqt/fxiconmanager.h
-    ../include/toonzqt/glwidget_for_highdpi.h
-    ../include/toonzqt/lutcalibrator.h
-    pluginhost.h
 )
 
 set(HEADERS
     ${MOC_HEADERS}
+    docklayout.h
     functionpaneltools.h
+    fxdata.h
+    palettedata.h
+    plugin_fxnode_interface.h
+    plugin_port_interface.h
+    plugin_tile_interface.h
+    styledata.h
     toonz_hostif.h
     toonz_plugin.h
-    plugin_tile_interface.h
-    plugin_port_interface.h
-    plugin_fxnode_interface.h
+    ../include/historytypes.h
+    ../include/toonzqt/dvmimedata.h
+    ../include/toonzqt/flipconsoleowner.h
+    ../include/toonzqt/freelayout.h
+    ../include/toonzqt/fxiconmanager.h
+    ../include/toonzqt/fxtypes.h
+    ../include/toonzqt/glwidget_for_highdpi.h
+    ../include/toonzqt/lutcalibrator.h
+    ../include/toonzqt/multipleselection.h
+    ../include/toonzqt/pickrgbutils.h
+    ../include/toonzqt/planeviewer.h
+    ../include/toonzqt/rasterimagedata.h
+    ../include/toonzqt/selection.h
+    ../include/toonzqt/selectioncommandids.h
+    ../include/toonzqt/stageobjectsdata.h
+    ../include/toonzqt/strokesdata.h
+    ../include/toonzqt/styleselection.h
+    ../include/toonzqt/trepetitionguard.h
+    ../include/toonzqt/viewcommandids.h
 )
 
 set(SOURCES


### PR DESCRIPTION
This PR eliminates warnings like the following.
```
/home/travis/build/opentoonz/opentoonz/toonz/sources/toonzlib/autoadjust.h:0: Note: No relevant classes found. No output generated.
```
https://travis-ci.org/opentoonz/opentoonz/jobs/473089104#L2934
https://travis-ci.org/opentoonz/opentoonz/jobs/473089104#L2938