### PR TITLE
v1.3RC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.2.1.{build}
+version: 1.3.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -16,8 +16,8 @@ public:
 
 private:
   const char *applicationName     = "OpenToonz";
-  const float applicationVersion  = 1.2;
-  const float applicationRevision = 1;
+  const float applicationVersion  = 1.3;
+  const float applicationRevision = 0;
 };
 
 std::string ToonzVersion::getAppName(void) {

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿set(VERSION 1.2)
+﻿set(VERSION 1.3)
 
 set(MOC_HEADERS
     addfilmstripframespopup.h

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -33,7 +33,7 @@
 
 using namespace DVGui;
 
-QString DialogTitle = QObject::tr("OpenToonz 1.2");
+QString DialogTitle = QObject::tr("OpenToonz 1.3");
 
 //=============================================================================
 namespace {

--- a/toonz/sources/xdg-data/io.github.OpenToonz.appdata.xml
+++ b/toonz/sources/xdg-data/io.github.OpenToonz.appdata.xml
@@ -27,6 +27,6 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="1.2.1" date="2018-06-28"></release>
+    <release version="1.3.0" date="2019-01-31"></release>
   </releases>
 </component>


### PR DESCRIPTION
This PR is for preparing the release of v1.3 Release Candidate.
Note that in the RC period https://opentoonz.github.io/opentoonz-version.txt will not be updated so that the version notification popup does not appear when launching v1.2.1 .

Here is an updated schedule:
- ~~January 7~~ January 8 - Release of v1.3 RC
- January 21 - Release of v1.3  ( or v1.3 RC2 if needed )
- By the end of January -  Release of v1.3 upon RC2

Note that introducing opentoonz/opentoonz_installer_windows#11 ~~and updating Jenkins settings~~ is needed before merging this. (update: I noticed that the Jen.kins settings are already free from version number changes.)