### PR TITLE
Fix vector replacement crash

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2632,7 +2632,7 @@ bool TCellSelection::areOnlyVectorCellsSelected() {
   }
 
   TXshSimpleLevel *sourceSl = firstCell.getSimpleLevel();
-  if (sourceSl->getType() != PLI_XSHLEVEL) {
+  if (!sourceSl || sourceSl->getType() != PLI_XSHLEVEL) {
     DVGui::error(QObject::tr("This command only works on vector cells."));
     return false;
   }


### PR DESCRIPTION
This PR fixes #2466 

Corrects logic to pop up a message if actions are not performed on a valid level.