### PR TITLE
Improve sound quality for playback and scrubbing on Linux #2244 (modified)

### DIFF
--- a/ci-scripts/linux/travis-install.sh
+++ b/ci-scripts/linux/travis-install.sh
@@ -1,4 +1,4 @@
-sudo add-apt-repository --yes ppa:beineri/opt-qt591-trusty
+sudo add-apt-repository --yes ppa:beineri/opt-qt597-trusty
 sudo add-apt-repository --yes ppa:achadwick/mypaint-testing
 sudo apt-get update
 sudo apt-get install -y liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libsdl2-dev libglew-dev freeglut3-dev qt59script libsuperlu3-dev qt59svg qt59tools qt59multimedia wget libusb-1.0-0-dev libboost-all-dev liblzma-dev libjson-c-dev libmypaint-dev

--- a/toonz/sources/common/tsound/tsound_qt.cpp
+++ b/toonz/sources/common/tsound/tsound_qt.cpp
@@ -182,7 +182,7 @@ public:
       qint64 audioBufferSize = format.bytesForDuration(100000);
       m_audioOutput->setBufferSize(audioBufferSize);
       m_audioOutput->setNotifyInterval(50);
-      QObject::connect(m_audioOutput, &QAudioOutput::notify, [=](){ sendBuffer(); });
+      QObject::connect(m_audioOutput.data(), &QAudioOutput::notify, [=](){ sendBuffer(); });
 
       reset();
     }/* audio buffer too small, so optimization not uses


### PR DESCRIPTION
This PR is based on #2244 , with only updating Qt version used in Travis-linux CI for trial.

----------

**UPDATE:** I modified a line claimed by Travis, using `QAudioOutput*` instead of `QPointer<QAudioOutput>` for sender argument of `QObject::connect()` .