### PR TITLE
[DO NOT MERGE THIS] Test altering bundle identifier

### DIFF
--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -11,7 +11,7 @@
 	<key>CFBundleIconFile</key>
 	<string>OpenToonz.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>io.github.opentoonz.OpenToonz</string>
+	<string>io.github.opentoonz.OpenToonz_test</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>


### PR DESCRIPTION
**PLEASE DO NOT MERGE THIS**
This PR is just for testing if the OSX installer's behavior changes with modified `CFBundleIdentifier` .