### PR TITLE
Fix style picker and type tools invalid status

### DIFF
--- a/toonz/sources/tnztools/stylepickertool.cpp
+++ b/toonz/sources/tnztools/stylepickertool.cpp
@@ -51,7 +51,7 @@ StylePickerTool::StylePickerTool()
   m_colorType.addValue(LINES);
   m_colorType.addValue(ALL);
   m_colorType.setId("Mode");
-  bind(TTool::CommonLevels);
+  bind(TTool::VectorImage | TTool::ToonzImage);
 
   m_prop.bind(m_passivePick);
   m_passivePick.setId("PassivePick");
@@ -213,6 +213,17 @@ void StylePickerTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
 int StylePickerTool::getCursorId() const {
   int ret;
+
+  TImageP img;
+  if (!m_active)
+    img = touchImage();
+  else
+    img            = getImage(true);
+  TVectorImageP vi = img;
+  TToonzImageP ti  = img;
+
+  if (!vi && !ti) return ToolCursor::CURSOR_NO;
+
   /* in case the "organize palette" option is active */
   if (m_organizePalette.getValue())
     ret = ToolCursor::PickerCursorOrganize;

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -422,7 +422,7 @@ TypeTool::TypeTool()
     , m_vertical("Vertical Orientation", false)  // W_ToolOptions_Vertical
     , m_size("Size:")                            // W_ToolOptions_Size
     , m_undo(0) {
-  bind(TTool::CommonLevels | TTool::EmptyTarget);
+  bind(TTool::VectorImage | TTool::ToonzImage | TTool::EmptyTarget);
   m_prop[0].bind(m_fontFamilyMenu);
   // Su mac non e' visibile il menu dello style perche' e' stato inserito nel
   // nome
@@ -856,7 +856,11 @@ void TypeTool::updateTextBox() {
 void TypeTool::updateMouseCursor(const TPointD &pos) {
   int oldCursor = m_cursorId;
 
-  if (!m_validFonts)
+  TImageP img      = getImage(false);
+  TVectorImageP vi = img;
+  TToonzImageP ti  = img;
+
+  if (!m_validFonts || (!vi && !ti))
     m_cursorId = ToolCursor::CURSOR_NO;
   else {
     TPointD clickPoint =


### PR DESCRIPTION
This PR fixes the issue where the Style Picker and the Type tools are invalid for certain levels but does not change icon or bring up popup message that it can't be used on non vector and non-toonz raster level types.

NOTE: These changes were moved out of PR #2087