### PR TITLE
Fix toonz raster deactivate crash

### DIFF
--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1133,6 +1133,7 @@ void ToonzRasterBrushTool::onDeactivate() {
   if (m_tileSaver) {
     bool isValid = m_enabled && m_active;
     m_enabled    = false;
+    m_active     = false;
     if (isValid) {
       finishRasterBrush(m_mousePos,
                         1); /*-- 最後のストロークの筆圧は1とする --*/
@@ -1474,6 +1475,7 @@ void ToonzRasterBrushTool::leftButtonUp(const TPointD &pos,
                                         const TMouseEvent &e) {
   bool isValid = m_enabled && m_active;
   m_enabled    = false;
+  m_active     = false;
   if (!isValid) {
     return;
   }
@@ -1488,6 +1490,8 @@ void ToonzRasterBrushTool::leftButtonUp(const TPointD &pos,
 void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
                                              double pressureVal) {
   TToonzImageP ti = TImageP(getImage(true));
+
+  if (!ti) return;
 
   TPointD rasCenter         = ti->getRaster()->getCenterD();
   TTool::Application *app   = TTool::getApplication();

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -544,6 +544,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     if (m_tabletEvent &&
         (m_tabletState == OnStroke || m_tabletState == StartStroke) &&
         m_tabletMove) {
+      if (m_toolSwitched) tool->leftButtonDown(pos, event);
       tool->leftButtonDrag(pos, event);
       m_tabletState = OnStroke;
     }
@@ -551,14 +552,18 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     else if (m_mouseButton == Qt::LeftButton) {
       // sometimes the mousePressedEvent is postponed to a wrong  mouse move
       // event!
-      if (m_buttonClicked && !m_toolSwitched) tool->leftButtonDrag(pos, event);
+      //      if (m_buttonClicked && !m_toolSwitched) tool->leftButtonDrag(pos,
+      //      event);
+      if (m_toolSwitched) tool->leftButtonDown(pos, event);
+      tool->leftButtonDrag(pos, event);
       m_mouseState = OnStroke;
     } else if (m_pressure == 0.0) {
       tool->mouseMove(pos, event);
     }
     if (!cursorSet) setToolCursor(this, tool->getCursorId());
-    m_pos        = curPos;
-    m_tabletMove = false;
+    m_pos          = curPos;
+    m_tabletMove   = false;
+    m_toolSwitched = false;
   } else if (m_mouseButton == Qt::MidButton) {
     if ((event.buttons() & Qt::MidButton) == 0) m_mouseButton = Qt::NoButton;
     // scrub with shift and middle click


### PR DESCRIPTION
This PR fixes #2484 

The issue occurs only when drawing with a tablet in columns with multiple levels.  The 1st time you select a new empty cell and draw, it's fine. However, if you attempt to select another empty cell right away, it will crash because of an internal tool switch (vector -> toonz raster in this case) that occurs but does not properly end the toonz raster brush stroke. It crashes because it tries to access an image that doesn't exist on the empty cell.

Added logic to do nothing in the deactivation if there is no image, as well as enhanced the logic to properly handle to tool switch.

The logic I added uses the existing `m_toolSwitched` variable that tracks tool switching on the main viewer.  When it detects a tool switch in a drag event, it will call `leftButtonDown()` on the tool to properly initiate the tool and then clear m_toolSwitched.  This will allow the `leftButtonUp()` function to be called properly when drawing stops.

There are 2 additional effects of this change when there are multiple levels in 1 column:
1) Currently when drawing with a mouse, when you click an empty cell, it will generate the frame but you cannot continue drawing. You would need to stop the click-hold and start again to draw.

Now when you draw with a mouse on an empty cell, you can continue drawing right away, similar to how it works with the pen.

2) Currently the new cell and initial drawing (with pen) are not properly recorded and cannot be undone/redone.

Now that the tool is being properly ended, changes are properly recorded for undo/redo operations.
