### PR TITLE
Fix improperly disabled tools on secondary level frame

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -794,34 +794,41 @@ QString TTool::updateEnabled() {
   TXshSimpleLevel *sl = xl ? xl->getSimpleLevel() : 0;
   int levelType       = sl ? sl->getType() : NO_XSHLEVEL;
 
-  // If not in Level editor, let's use our current cell from the xsheet to
-  // find the nearest level before it
-  if (levelType == NO_XSHLEVEL &&
-      !m_application->getCurrentFrame()->isEditingLevel()) {
-    int r0, r1;
-    xsh->getCellRange(columnIndex, r0, r1);
-    TXshCell cell = xsh->getCell(std::min(r1, rowIndex), columnIndex);
-    xl            = cell.isEmpty() ? 0 : (TXshLevel *)(&cell.m_level);
-    sl            = cell.isEmpty() ? 0 : cell.getSimpleLevel();
-    levelType     = cell.isEmpty() ? NO_XSHLEVEL : cell.m_level->getType();
-  }
+  if (Preferences::instance()->isAutoCreateEnabled() &&
+      Preferences::instance()->isAnimationSheetEnabled()) {
+    // If not in Level editor, let's use our current cell from the xsheet to
+    // find the nearest level before it
+    if (levelType == NO_XSHLEVEL &&
+        !m_application->getCurrentFrame()->isEditingLevel()) {
+      int r0, r1;
+      xsh->getCellRange(columnIndex, r0, r1);
+      for (int r = std::min(r1, rowIndex); r > r0; r--) {
+        TXshCell cell = xsh->getCell(r, columnIndex);
+        if (cell.isEmpty()) continue;
+        xl        = (TXshLevel *)(&cell.m_level);
+        sl        = cell.getSimpleLevel();
+        levelType = cell.m_level->getType();
+        break;
+      }
+    }
 
-  // If the current tool does not match the current type, check for
-  // a version of the same tool that does
-  {
-    TTool *tool = this;
+    // If the current tool does not match the current type, check for
+    // a version of the same tool that does
+    {
+      TTool *tool = this;
 
-    if ((levelType == PLI_XSHLEVEL) && !(targetType & VectorImage))
-      tool = TTool::getTool(m_name, VectorImage);
-    else if ((levelType == TZP_XSHLEVEL) && !(targetType & ToonzImage))
-      tool = TTool::getTool(m_name, ToonzImage);
-    else if ((levelType == OVL_XSHLEVEL) && !(targetType & RasterImage))
-      tool = TTool::getTool(m_name, RasterImage);
-    else if ((levelType == MESH_XSHLEVEL) && !(targetType & MeshImage))
-      tool = TTool::getTool(m_name, MeshImage);
+      if ((levelType == PLI_XSHLEVEL) && !(targetType & VectorImage))
+        tool = TTool::getTool(m_name, VectorImage);
+      else if ((levelType == TZP_XSHLEVEL) && !(targetType & ToonzImage))
+        tool = TTool::getTool(m_name, ToonzImage);
+      else if ((levelType == OVL_XSHLEVEL) && !(targetType & RasterImage))
+        tool = TTool::getTool(m_name, RasterImage);
+      else if ((levelType == MESH_XSHLEVEL) && !(targetType & MeshImage))
+        tool = TTool::getTool(m_name, MeshImage);
 
-    if (tool && tool != this && tool->getTargetType() != TTool::NoTarget)
-      return tool->updateEnabled();
+      if (tool && tool != this && tool->getTargetType() != TTool::NoTarget)
+        return tool->updateEnabled();
+    }
   }
 
   TStageObject *obj =

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -794,6 +794,36 @@ QString TTool::updateEnabled() {
   TXshSimpleLevel *sl = xl ? xl->getSimpleLevel() : 0;
   int levelType       = sl ? sl->getType() : NO_XSHLEVEL;
 
+  // If not in Level editor, let's use our current cell from the xsheet to
+  // find the nearest level before it
+  if (levelType == NO_XSHLEVEL &&
+      !m_application->getCurrentFrame()->isEditingLevel()) {
+    int r0, r1;
+    xsh->getCellRange(columnIndex, r0, r1);
+    TXshCell cell = xsh->getCell(std::min(r1, rowIndex), columnIndex);
+    xl            = cell.isEmpty() ? 0 : (TXshLevel *)(&cell.m_level);
+    sl            = cell.isEmpty() ? 0 : cell.getSimpleLevel();
+    levelType     = cell.isEmpty() ? NO_XSHLEVEL : cell.m_level->getType();
+  }
+
+  // If the current tool does not match the current type, check for
+  // a version of the same tool that does
+  {
+    TTool *tool = this;
+
+    if ((levelType == PLI_XSHLEVEL) && !(targetType & VectorImage))
+      tool = TTool::getTool(m_name, VectorImage);
+    else if ((levelType == TZP_XSHLEVEL) && !(targetType & ToonzImage))
+      tool = TTool::getTool(m_name, ToonzImage);
+    else if ((levelType == OVL_XSHLEVEL) && !(targetType & RasterImage))
+      tool = TTool::getTool(m_name, RasterImage);
+    else if ((levelType == MESH_XSHLEVEL) && !(targetType & MeshImage))
+      tool = TTool::getTool(m_name, MeshImage);
+
+    if (tool && tool != this && tool->getTargetType() != TTool::NoTarget)
+      return tool->updateEnabled();
+  }
+
   TStageObject *obj =
       xsh->getStageObject(TStageObjectId::ColumnId(columnIndex));
   bool spline = m_application->getCurrentObject()->isSpline();


### PR DESCRIPTION
This PR fixes #2138 

Some tools like the Brush tool have multiple versions:  Vector, Toonz Raster and Raster tool. OT typically switches internally according to whatever level type you are on.  Then problem is when it is checking status on empty cells.  By default the version of the tool used is based on the 1st level in the column, say a Vector column.  OT will use the Vector Brush settings to test against the level and will fail because it's not allowed to work on a Raster/Toonz Raster level.

Added logic that if it appears the tool will fail against the current level type, it will check to see if there is a tool version for the level type being checked.  If found, it will use that version to check.

Also added logic that if you are on an empty cell, it will find the closest level before it to check against.

NOTE: These changes were moved out of PR #2087