### PR TITLE
Apply forbidden cursor for ToolCursor::CURSOR_NO

### DIFF
--- a/toonz/sources/include/tools/cursors.h
+++ b/toonz/sources/include/tools/cursors.h
@@ -11,7 +11,6 @@ enum {
   CURSOR_ARROW,
   CURSOR_HAND,
   CURSOR_HOURGLASS,
-  CURSOR_NO,
   CURSOR_DUMMY,
 #ifndef _WIN32
   CURSOR_DND,
@@ -56,6 +55,7 @@ enum {
   SplineEditorCursorAdd,
   TrackerCursor,
   ForbiddenCursor,
+  CURSOR_NO = ForbiddenCursor,
 
   NormalEraserCursor,
   RectEraserCursor,


### PR DESCRIPTION
This PR is related to #2483 

Some tools need special treatment on defining availability. For instance, Style Picker Tool is usually available only on Toonz Raster or Toonz Vector images, but if the preference option `Multi Layer Style Picker : Switch Levels by Picking` is ON it should be available on any types of current level. Conversely, Style Picker Tool can be enabled ( `m_enabled` is set to true ) even if it is actually invalid on the current level.

In such case, `TTool::getCursorId()` may return `ToolCursor::CURSOR_NO`. However, for now no cursor image is assigned to `ToolCursor::CURSOR_NO`. This PR will set the forbidden cursor to it.