### PR TITLE
Force CopyAction when drag&drop files to scene viewer.

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1517,7 +1517,9 @@ void SceneViewer::dragEnterEvent(QDragEnterEvent *event) {
   const QMimeData *mimeData = event->mimeData();
 
   if (acceptResourceOrFolderDrop(mimeData->urls()))
-    event->acceptProposedAction();
+    event->setDropAction(Qt::CopyAction);
+    event->accept();
+    // event->acceptProposedAction();
   else
     event->ignore();
 }

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1516,12 +1516,14 @@ void SceneViewer::dragEnterEvent(QDragEnterEvent *event) {
 
   const QMimeData *mimeData = event->mimeData();
 
-  if (acceptResourceOrFolderDrop(mimeData->urls()))
-    event->setDropAction(Qt::CopyAction);
-    event->accept();
-    // event->acceptProposedAction();
-  else
-    event->ignore();
+  if (acceptResourceOrFolderDrop(mimeData->urls())) {
+	  // Force CopyAction
+	  event->setDropAction(Qt::CopyAction);
+	  event->accept();
+  }
+  else {
+	  event->ignore();
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR is related to #2363 

When Drag & Drop files to scene viewer with Shift(move), Ctrl(copy), Alt(link) key, always force copy action.

This behavior just like Adobe Applications.(ex. Adobe After Effects)