### PR TITLE
Image viewer gesture controls

### DIFF
--- a/toonz/sources/include/toonzqt/planeviewer.h
+++ b/toonz/sources/include/toonzqt/planeviewer.h
@@ -155,6 +155,8 @@ protected:
 
   TRect m_imageBounds;
 
+  double m_dpiX, m_dpiY;
+
 protected:
   virtual void contextMenuEvent(QContextMenuEvent *event) override;
   virtual void mouseMoveEvent(QMouseEvent *event) override;

--- a/toonz/sources/include/toonzqt/planeviewer.h
+++ b/toonz/sources/include/toonzqt/planeviewer.h
@@ -13,6 +13,7 @@
 
 // Qt includes
 #include <QOpenGLWidget>
+#include <QTouchDevice>
 
 #undef DVAPI
 #undef DVVAR
@@ -30,6 +31,8 @@
 class TRasterImageP;
 class TToonzImageP;
 class TVectorImageP;
+class QTouchEvent;
+class QGestureEvent;
 
 //----------------------------------------------------------------------------
 
@@ -61,6 +64,18 @@ obsolete class until the shader fx being overhauled. 2016/6/22 Shun
 */
 
 class DVAPI PlaneViewer : public GLWidgetForHighDpi {
+  Q_OBJECT
+  bool m_touchActive                     = false;
+  bool m_gestureActive                   = false;
+  QTouchDevice::DeviceType m_touchDevice = QTouchDevice::TouchScreen;
+  bool m_zooming                         = false;
+  bool m_panning                         = false;
+  double m_scaleFactor;  // used for zoom gesture
+
+  bool m_stylusUsed = false;
+
+  bool m_firstDraw;
+
 public:
   PlaneViewer(QWidget *parent);
 
@@ -99,8 +114,6 @@ public:
   TAffine &viewAff() { return m_aff; }
   const TAffine &viewAff() const { return m_aff; }
 
-  void resetView();
-
   void zoomIn();
   void zoomOut();
 
@@ -123,6 +136,11 @@ public:
   TRaster32P rasterBuffer();
   void flushRasterBuffer();
 
+public slots:
+
+  void resetView();
+  void fitView();
+
 protected:
   int m_xpos, m_ypos;  //!< Mouse position on mouse operations.
   TAffine m_aff;       //!< Affine transform from world to widget coords.
@@ -135,12 +153,22 @@ protected:
 
   double m_zoomRange[2];  //!< Viewport zoom range (default: [-1024, 1024]).
 
+  TRect m_imageBounds;
+
 protected:
+  virtual void contextMenuEvent(QContextMenuEvent *event) override;
   virtual void mouseMoveEvent(QMouseEvent *event) override;
   virtual void mousePressEvent(QMouseEvent *event) override;
+  virtual void mouseReleaseEvent(QMouseEvent *event) override;
   virtual void wheelEvent(QWheelEvent *event) override;
   virtual void keyPressEvent(QKeyEvent *event) override;
   virtual void hideEvent(QHideEvent *event) override;
+
+  virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+  virtual void tabletEvent(QTabletEvent *e) override;
+  void touchEvent(QTouchEvent *e, int type);
+  void gestureEvent(QGestureEvent *e);
+  virtual bool event(QEvent *e) override;
 
   void initializeGL() override final;
   void resizeGL(int width, int height) override final;
@@ -150,6 +178,7 @@ private:
   bool m_firstResize;
   int m_width;
   int m_height;
+  QPointF m_firstPanPoint;
 };
 
 #endif  // PLANE_VIEWER_H

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -39,6 +39,7 @@
 #include <QMouseEvent>
 #include <QWheelEvent>
 #include <QOpenGLFramebufferObject>
+#include <QGestureEvent>
 
 //===================================================================================
 
@@ -218,7 +219,8 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
     , m_isColorModel(false)
     , m_histogramPopup(0)
     , m_isRemakingPreviewFx(false)
-    , m_rectRGBPick(false) {
+    , m_rectRGBPick(false)
+    , m_firstImage(true) {
   m_visualSettings.m_sceneProperties =
       TApp::instance()->getCurrentScene()->getScene()->getProperties();
   m_visualSettings.m_drawExternalBG = true;
@@ -226,6 +228,11 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
   setFocusPolicy(Qt::StrongFocus);
 
   setMouseTracking(true);
+
+  setAttribute(Qt::WA_AcceptTouchEvents);
+  grabGesture(Qt::SwipeGesture);
+  grabGesture(Qt::PanGesture);
+  grabGesture(Qt::PinchGesture);
 
   if (m_isHistogramEnable)
     m_histogramPopup = new HistogramPopup(tr("Flipbook Histogram"));
@@ -237,8 +244,6 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
 //-----------------------------------------------------------------------------
 
 void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
-  if (!m_flipbook) return;
-
   QAction *action;
 
   if (m_isColorModel) {
@@ -248,52 +253,55 @@ void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
 
   QMenu *menu = new QMenu(this);
 
-  if (m_flipbook->getPreviewedFx()) {
-    if (!(windowState() & Qt::WindowFullScreen)) {
-      action = menu->addAction(tr("Clone Preview"));
+  if (m_flipbook) {
+    if (m_flipbook->getPreviewedFx()) {
+      if (!(windowState() & Qt::WindowFullScreen)) {
+        action = menu->addAction(tr("Clone Preview"));
+        action->setShortcut(QKeySequence(
+            CommandManager::instance()->getKeyFromId(MI_ClonePreview)));
+        connect(action, SIGNAL(triggered()), m_flipbook, SLOT(clonePreview()));
+      }
+
+      if (m_flipbook->isFreezed()) {
+        action = menu->addAction(tr("Unfreeze Preview"));
+        action->setShortcut(QKeySequence(
+            CommandManager::instance()->getKeyFromId(MI_FreezePreview)));
+        connect(action, SIGNAL(triggered()), m_flipbook,
+                SLOT(unfreezePreview()));
+      } else {
+        action = menu->addAction(tr("Freeze Preview"));
+        action->setShortcut(QKeySequence(
+            CommandManager::instance()->getKeyFromId(MI_FreezePreview)));
+        connect(action, SIGNAL(triggered()), m_flipbook, SLOT(freezePreview()));
+      }
+
+      action = menu->addAction(tr("Regenerate Preview"));
       action->setShortcut(QKeySequence(
-          CommandManager::instance()->getKeyFromId(MI_ClonePreview)));
-      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(clonePreview()));
+          CommandManager::instance()->getKeyFromId(MI_RegeneratePreview)));
+      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(regenerate()));
+
+      action = menu->addAction(tr("Regenerate Frame Preview"));
+      action->setShortcut(QKeySequence(
+          CommandManager::instance()->getKeyFromId(MI_RegenerateFramePr)));
+      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(regenerateFrame()));
+
+      menu->addSeparator();
     }
 
-    if (m_flipbook->isFreezed()) {
-      action = menu->addAction(tr("Unfreeze Preview"));
-      action->setShortcut(QKeySequence(
-          CommandManager::instance()->getKeyFromId(MI_FreezePreview)));
-      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(unfreezePreview()));
-    } else {
-      action = menu->addAction(tr("Freeze Preview"));
-      action->setShortcut(QKeySequence(
-          CommandManager::instance()->getKeyFromId(MI_FreezePreview)));
-      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(freezePreview()));
+    action = menu->addAction(tr("Load / Append Images"));
+    connect(action, SIGNAL(triggered()), m_flipbook, SLOT(loadImages()));
+
+    // history of the loaded paths of flipbook
+    action = CommandManager::instance()->getAction(MI_LoadRecentImage);
+    menu->addAction(action);
+    action->setParent(m_flipbook);
+
+    if (m_flipbook->isSavable()) {
+      action = menu->addAction(tr("Save Images"));
+      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(saveImages()));
     }
-
-    action = menu->addAction(tr("Regenerate Preview"));
-    action->setShortcut(QKeySequence(
-        CommandManager::instance()->getKeyFromId(MI_RegeneratePreview)));
-    connect(action, SIGNAL(triggered()), m_flipbook, SLOT(regenerate()));
-
-    action = menu->addAction(tr("Regenerate Frame Preview"));
-    action->setShortcut(QKeySequence(
-        CommandManager::instance()->getKeyFromId(MI_RegenerateFramePr)));
-    connect(action, SIGNAL(triggered()), m_flipbook, SLOT(regenerateFrame()));
-
     menu->addSeparator();
   }
-
-  action = menu->addAction(tr("Load / Append Images"));
-  connect(action, SIGNAL(triggered()), m_flipbook, SLOT(loadImages()));
-
-  // history of the loaded paths of flipbook
-  action = CommandManager::instance()->getAction(MI_LoadRecentImage);
-  menu->addAction(action);
-  action->setParent(m_flipbook);
-
-  if (m_flipbook->isSavable()) {
-    action = menu->addAction(tr("Save Images"));
-    connect(action, SIGNAL(triggered()), m_flipbook, SLOT(saveImages()));
-  }
-  menu->addSeparator();
 
   QAction *reset = menu->addAction(tr("Reset View"));
   reset->setShortcut(
@@ -305,42 +313,45 @@ void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
       QKeySequence(CommandManager::instance()->getKeyFromId(V_ZoomFit)));
   connect(fit, SIGNAL(triggered()), SLOT(fitView()));
 
+  if (m_flipbook) {
 #ifdef _WIN32
+    if (ImageUtils::FullScreenWidget *fsWidget =
+            dynamic_cast<ImageUtils::FullScreenWidget *>(parentWidget())) {
+      bool isFullScreen = (fsWidget->windowState() & Qt::WindowFullScreen) != 0;
 
-  if (ImageUtils::FullScreenWidget *fsWidget =
-          dynamic_cast<ImageUtils::FullScreenWidget *>(parentWidget())) {
-    bool isFullScreen = (fsWidget->windowState() & Qt::WindowFullScreen) != 0;
+      action = menu->addAction(isFullScreen ? tr("Exit Full Screen Mode")
+                                            : tr("Full Screen Mode"));
 
-    action = menu->addAction(isFullScreen ? tr("Exit Full Screen Mode")
-                                          : tr("Full Screen Mode"));
-
-    action->setShortcut(QKeySequence(
-        CommandManager::instance()->getKeyFromId(V_ShowHideFullScreen)));
-    connect(action, SIGNAL(triggered()), fsWidget, SLOT(toggleFullScreen()));
-  }
+      action->setShortcut(QKeySequence(
+          CommandManager::instance()->getKeyFromId(V_ShowHideFullScreen)));
+      connect(action, SIGNAL(triggered()), fsWidget, SLOT(toggleFullScreen()));
+    }
 
 #endif
 
-  bool addedSep = false;
+    bool addedSep = false;
 
-  if (m_isHistogramEnable &&
-      visibleRegion().contains(event->pos() * getDevPixRatio())) {
-    menu->addSeparator();
-    addedSep = true;
-    action   = menu->addAction(tr("Show Histogram"));
-    connect(action, SIGNAL(triggered()), SLOT(showHistogram()));
-  }
+    if (m_isHistogramEnable &&
+        visibleRegion().contains(event->pos() * getDevPixRatio())) {
+      menu->addSeparator();
+      addedSep = true;
+      action   = menu->addAction(tr("Show Histogram"));
+      connect(action, SIGNAL(triggered()), SLOT(showHistogram()));
+    }
 
-  if (m_visualSettings.m_doCompare) {
-    if (!addedSep) menu->addSeparator();
-    action = menu->addAction(tr("Swap Compared Images"));
-    connect(action, SIGNAL(triggered()), SLOT(swapCompared()));
+    if (m_visualSettings.m_doCompare) {
+      if (!addedSep) menu->addSeparator();
+      action = menu->addAction(tr("Swap Compared Images"));
+      connect(action, SIGNAL(triggered()), SLOT(swapCompared()));
+    }
   }
 
   menu->exec(event->globalPos());
 
-  action = CommandManager::instance()->getAction(MI_LoadRecentImage);
-  action->setParent(0);
+  if (m_flipbook) {
+    action = CommandManager::instance()->getAction(MI_LoadRecentImage);
+    action->setParent(0);
+  }
 
   delete menu;
   update();
@@ -375,6 +386,11 @@ ImageViewer::~ImageViewer() {
 */
 void ImageViewer::setImage(TImageP image) {
   m_image = image;
+
+  if (m_image && m_firstImage) {
+    m_firstImage = false;
+    fitView();
+  }
 
   if (m_isHistogramEnable && m_histogramPopup->isVisible())
     m_histogramPopup->setImage(image);
@@ -733,6 +749,12 @@ void ImageViewer::updateCursor(const TPoint &curPos) {
 */
 void ImageViewer::mouseMoveEvent(QMouseEvent *event) {
   if (!m_image) return;
+
+  if (m_gestureActive && m_touchDevice == QTouchDevice::TouchScreen &&
+      !m_stylusUsed) {
+    return;
+  }
+
   QPoint curQPos = event->pos() * getDevPixRatio();
 
   TPoint curPos = TPoint(curQPos.x(), curQPos.y());
@@ -939,6 +961,13 @@ int ImageViewer::getDragType(const TPoint &pos, const TRect &loadbox) {
 //-------------------------------------------------------------------------------
 void ImageViewer::mouseDoubleClickEvent(QMouseEvent *event) {
   if (!m_image) return;
+  // qDebug() << "[mouseDoubleClickEvent]";
+  if (m_gestureActive && !m_stylusUsed) {
+    m_gestureActive = false;
+    fitView();
+    return;
+  }
+
   if (m_visualSettings.m_defineLoadbox && m_flipbook) {
     m_flipbook->setLoadbox(TRect());
     update();
@@ -950,6 +979,13 @@ void ImageViewer::mouseDoubleClickEvent(QMouseEvent *event) {
 
 void ImageViewer::mousePressEvent(QMouseEvent *event) {
   if (!m_image) return;
+
+  // qDebug() << "[mousePressEvent]";
+  if (m_gestureActive && m_touchDevice == QTouchDevice::TouchScreen &&
+      !m_stylusUsed) {
+    return;
+  }
+
   m_pos                   = event->pos() * getDevPixRatio();
   m_pressedMousePos       = TPoint(m_pos.x(), m_pos.y());
   m_mouseButton           = event->button();
@@ -1026,6 +1062,11 @@ void ImageViewer::mouseReleaseEvent(QMouseEvent *event) {
   m_mouseButton                    = Qt::NoButton;
   m_compareSettings.m_dragCompareX = m_compareSettings.m_dragCompareY = false;
 
+  m_gestureActive = false;
+  m_zooming       = false;
+  m_panning       = false;
+  m_stylusUsed    = false;
+
   event->ignore();
 }
 
@@ -1035,10 +1076,50 @@ void ImageViewer::mouseReleaseEvent(QMouseEvent *event) {
 void ImageViewer::wheelEvent(QWheelEvent *event) {
   if (!m_image) return;
   if (event->orientation() == Qt::Horizontal) return;
-  int delta = event->delta() > 0 ? 120 : -120;
-  QPoint center(event->pos().x() * getDevPixRatio() - width() / 2,
-                -event->pos().y() * getDevPixRatio() + height() / 2);
-  zoomQt(center, exp(0.001 * delta));
+  int delta = 0;
+  switch (event->source()) {
+  case Qt::MouseEventNotSynthesized: {
+    if (event->modifiers() & Qt::AltModifier)
+      delta = event->angleDelta().x();
+    else
+      delta = event->angleDelta().y();
+    break;
+  }
+
+  case Qt::MouseEventSynthesizedBySystem: {
+    QPoint numPixels  = event->pixelDelta();
+    QPoint numDegrees = event->angleDelta() / 8;
+    if (!numPixels.isNull()) {
+      delta = event->pixelDelta().y();
+    } else if (!numDegrees.isNull()) {
+      QPoint numSteps = numDegrees / 15;
+      delta           = numSteps.y();
+    }
+    break;
+  }
+
+  default:  // Qt::MouseEventSynthesizedByQt,
+            // Qt::MouseEventSynthesizedByApplication
+    {
+      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                   "Qt::MouseEventSynthesizedByApplication"
+                << std::endl;
+      break;
+    }
+
+  }  // end switch
+
+  if (abs(delta) > 0) {
+    if ((m_gestureActive == true &&
+         m_touchDevice == QTouchDevice::TouchScreen) ||
+        m_gestureActive == false) {
+      int delta = event->delta() > 0 ? 120 : -120;
+      QPoint center(event->pos().x() * getDevPixRatio() - width() / 2,
+                    -event->pos().y() * getDevPixRatio() + height() / 2);
+      zoomQt(center, exp(0.001 * delta));
+    }
+  }
+  event->accept();
 }
 
 //-----------------------------------------------------------------------------
@@ -1166,6 +1247,180 @@ void ImageViewer::onContextAboutToBeDestroyed() {
   makeCurrent();
   m_lutCalibrator->cleanup();
   doneCurrent();
+}
+
+//------------------------------------------------------------------
+
+void ImageViewer::tabletEvent(QTabletEvent *e) {
+  // qDebug() << "[tabletEvent]";
+  if (e->type() == QTabletEvent::TabletPress) {
+    m_stylusUsed = e->pointerType() ? true : false;
+  } else if (e->type() == QTabletEvent::TabletRelease) {
+    m_stylusUsed = false;
+  }
+
+  e->accept();
+}
+
+//------------------------------------------------------------------
+
+void ImageViewer::gestureEvent(QGestureEvent *e) {
+  // qDebug() << "[gestureEvent]";
+  m_gestureActive = false;
+  if (QGesture *swipe = e->gesture(Qt::SwipeGesture)) {
+    m_gestureActive = true;
+  } else if (QGesture *pan = e->gesture(Qt::PanGesture)) {
+    m_gestureActive = true;
+  }
+  if (QGesture *pinch = e->gesture(Qt::PinchGesture)) {
+    QPinchGesture *gesture = static_cast<QPinchGesture *>(pinch);
+    QPinchGesture::ChangeFlags changeFlags = gesture->changeFlags();
+    QPoint firstCenter                     = gesture->centerPoint().toPoint();
+    if (m_touchDevice == QTouchDevice::TouchScreen)
+      firstCenter = mapFromGlobal(firstCenter);
+
+    if (gesture->state() == Qt::GestureStarted) {
+      m_gestureActive = true;
+    } else if (gesture->state() == Qt::GestureFinished) {
+      m_gestureActive = false;
+      m_zooming       = false;
+      m_scaleFactor   = 0.0;
+    } else {
+      if (changeFlags & QPinchGesture::ScaleFactorChanged) {
+        double scaleFactor = gesture->scaleFactor();
+        // the scale factor makes for too sensitive scaling
+        // divide the change in half
+        if (scaleFactor > 1) {
+          double decimalValue = scaleFactor - 1;
+          decimalValue /= 1.5;
+          scaleFactor = 1 + decimalValue;
+        } else if (scaleFactor < 1) {
+          double decimalValue = 1 - scaleFactor;
+          decimalValue /= 1.5;
+          scaleFactor = 1 - decimalValue;
+        }
+        if (!m_zooming) {
+          double delta = scaleFactor - 1;
+          m_scaleFactor += delta;
+          if (m_scaleFactor > .2 || m_scaleFactor < -.2) {
+            m_zooming = true;
+          }
+        }
+        if (m_zooming) {
+          const QPoint center(
+              firstCenter.x() * getDevPixRatio() - width() / 2,
+              -firstCenter.y() * getDevPixRatio() + height() / 2);
+          zoomQt(center, scaleFactor);
+          m_panning = false;
+        }
+        m_gestureActive = true;
+      }
+
+      if (changeFlags & QPinchGesture::CenterPointChanged) {
+        QPointF centerDelta = (gesture->centerPoint() * getDevPixRatio()) -
+                              (gesture->lastCenterPoint() * getDevPixRatio());
+        if (centerDelta.manhattanLength() > 1) {
+          // panQt(centerDelta.toPoint());
+        }
+        m_gestureActive = true;
+      }
+    }
+  }
+  e->accept();
+}
+
+void ImageViewer::touchEvent(QTouchEvent *e, int type) {
+  // qDebug() << "[touchEvent]";
+  if (type == QEvent::TouchBegin) {
+    m_touchActive   = true;
+    m_firstPanPoint = e->touchPoints().at(0).pos();
+    // obtain device type
+    m_touchDevice = e->device()->type();
+  } else if (m_touchActive) {
+    // touchpads must have 2 finger panning for tools and navigation to be
+    // functional on other devices, 1 finger panning is preferred
+    if ((e->touchPoints().count() == 2 &&
+         m_touchDevice == QTouchDevice::TouchPad) ||
+        (e->touchPoints().count() == 1 &&
+         m_touchDevice == QTouchDevice::TouchScreen)) {
+      QTouchEvent::TouchPoint panPoint = e->touchPoints().at(0);
+      if (!m_panning) {
+        QPointF deltaPoint = panPoint.pos() - m_firstPanPoint;
+        // minimize accidental and jerky zooming/rotating during 2 finger
+        // panning
+        if ((deltaPoint.manhattanLength() > 100) && !m_zooming) {
+          m_panning = true;
+        }
+      }
+      if (m_panning) {
+        QPoint curPos      = panPoint.pos().toPoint() * getDevPixRatio();
+        QPoint lastPos     = panPoint.lastPos().toPoint() * getDevPixRatio();
+        QPoint centerDelta = curPos - lastPos;
+        panQt(centerDelta);
+      }
+    }
+  }
+  if (type == QEvent::TouchEnd || type == QEvent::TouchCancel) {
+    m_touchActive = false;
+    m_panning     = false;
+  }
+  e->accept();
+}
+
+bool ImageViewer::event(QEvent *e) {
+  /*
+  switch (e->type()) {
+  case QEvent::TabletPress: {
+  QTabletEvent *te = static_cast<QTabletEvent *>(e);
+  qDebug() << "[event] TabletPress: pointerType(" << te->pointerType()
+  << ") device(" << te->device() << ")";
+  } break;
+  case QEvent::TabletRelease:
+  qDebug() << "[event] TabletRelease";
+  break;
+  case QEvent::TouchBegin:
+  qDebug() << "[event] TouchBegin";
+  break;
+  case QEvent::TouchEnd:
+  qDebug() << "[event] TouchEnd";
+  break;
+  case QEvent::TouchCancel:
+  qDebug() << "[event] TouchCancel";
+  break;
+  case QEvent::MouseButtonPress:
+  qDebug() << "[event] MouseButtonPress";
+  break;
+  case QEvent::MouseButtonDblClick:
+  qDebug() << "[event] MouseButtonDblClick";
+  break;
+  case QEvent::MouseButtonRelease:
+  qDebug() << "[event] MouseButtonRelease";
+  break;
+  case QEvent::Gesture:
+  qDebug() << "[event] Gesture";
+  break;
+  default:
+  break;
+  }
+  */
+
+  if (e->type() == QEvent::Gesture &&
+      CommandManager::instance()
+          ->getAction(MI_TouchGestureControl)
+          ->isChecked()) {
+    gestureEvent(static_cast<QGestureEvent *>(e));
+    return true;
+  }
+  if ((e->type() == QEvent::TouchBegin || e->type() == QEvent::TouchEnd ||
+       e->type() == QEvent::TouchCancel || e->type() == QEvent::TouchUpdate) &&
+      CommandManager::instance()
+          ->getAction(MI_TouchGestureControl)
+          ->isChecked()) {
+    touchEvent(static_cast<QTouchEvent *>(e), e->type());
+    m_gestureActive = true;
+    return true;
+  }
+  return GLWidgetForHighDpi::event(e);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -6,6 +6,8 @@
 #include "toonz/imagepainter.h"
 #include "toonzqt/glwidget_for_highdpi.h"
 
+#include <QTouchDevice>
+
 //-----------------------------------------------------------------------------
 
 //  Forward declarations
@@ -13,7 +15,8 @@ class FlipBook;
 class HistogramPopup;
 class QOpenGLFramebufferObject;
 class LutCalibrator;
-
+class QTouchEvent;
+class QGestureEvent;
 //-----------------------------------------------------------------------------
 
 //====================
@@ -50,6 +53,7 @@ class ImageViewer final : public GLWidgetForHighDpi {
   QPoint m_pos;
   bool m_isHistogramEnable;
   HistogramPopup *m_histogramPopup;
+  bool m_firstImage;
 
   bool m_isColorModel;
   // when fx parameter is modified with showing the fx preview,
@@ -59,6 +63,15 @@ class ImageViewer final : public GLWidgetForHighDpi {
   // used for color calibration with 3DLUT
   QOpenGLFramebufferObject *m_fbo = NULL;
   LutCalibrator *m_lutCalibrator  = NULL;
+
+  bool m_touchActive                     = false;
+  bool m_gestureActive                   = false;
+  QTouchDevice::DeviceType m_touchDevice = QTouchDevice::TouchScreen;
+  bool m_zooming                         = false;
+  bool m_panning                         = false;
+  double m_scaleFactor;  // used for zoom gesture
+
+  bool m_stylusUsed = false;
 
   int getDragType(const TPoint &pos, const TRect &loadBox);
   void updateLoadbox(const TPoint &curPos);
@@ -127,6 +140,11 @@ protected:
 
   void dragCompare(const QPoint &dp);
 
+  void tabletEvent(QTabletEvent *e);
+  void touchEvent(QTouchEvent *e, int type);
+  void gestureEvent(QGestureEvent *e);
+  bool event(QEvent *e);
+
 public slots:
 
   void updateImageViewer();
@@ -135,6 +153,9 @@ public slots:
   void showHistogram();
   void swapCompared();
   void onContextAboutToBeDestroyed();
+
+private:
+  QPointF m_firstPanPoint;
 };
 
 #endif  // IMAGEVIEWER_INCLUDE

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -45,6 +45,7 @@ set(MOC_HEADERS
     ../include/toonzqt/paletteviewer.h
     ../include/toonzqt/paletteviewergui.h
     ../include/toonzqt/paramfield.h
+    ../include/toonzqt/planeviewer.h
     ../include/toonzqt/popupbutton.h
     ../include/toonzqt/schematicgroupeditor.h
     ../include/toonzqt/schematicnode.h
@@ -91,7 +92,6 @@ set(HEADERS
     ../include/toonzqt/lutcalibrator.h
     ../include/toonzqt/multipleselection.h
     ../include/toonzqt/pickrgbutils.h
-    ../include/toonzqt/planeviewer.h
     ../include/toonzqt/rasterimagedata.h
     ../include/toonzqt/selection.h
     ../include/toonzqt/selectioncommandids.h

--- a/toonz/sources/toonzqt/planeviewer.cpp
+++ b/toonz/sources/toonzqt/planeviewer.cpp
@@ -4,6 +4,10 @@
 
 // TnzQt includes
 #include "toonzqt/imageutils.h"
+#include "toonzqt/menubarcommand.h"
+#include "toonzqt/viewcommandids.h"
+
+#include "../toonz/menubarcommandids.h"
 
 // TnzLib includes
 #include "toonz/stage.h"
@@ -23,6 +27,7 @@
 #include <QWheelEvent>
 #include <QResizeEvent>
 #include <QHideEvent>
+#include <QGestureEvent>
 
 //#define PRINT_AFF
 
@@ -37,6 +42,7 @@ struct PlaneViewerZoomer final : public ImageUtils::ShortcutZoomer {
 
 private:
   bool zoom(bool zoomin, bool resetZoom) override;
+  bool fit() override;
 };
 
 //========================================================================
@@ -44,12 +50,19 @@ private:
 bool PlaneViewerZoomer::zoom(bool zoomin, bool resetZoom) {
   PlaneViewer &planeViewer = static_cast<PlaneViewer &>(*getWidget());
 
-  resetZoom ? planeViewer.resetView()
-            : zoomin ? planeViewer.zoomIn() : planeViewer.zoomOut();
+  resetZoom ? planeViewer.resetView() : zoomin ? planeViewer.zoomIn()
+                                               : planeViewer.zoomOut();
 
   return true;
 }
 
+bool PlaneViewerZoomer::fit() {
+  PlaneViewer &planeViewer = static_cast<PlaneViewer &>(*getWidget());
+
+  planeViewer.fitView();
+
+  return true;
+}
 }  // namespace
 
 //=========================================================================================
@@ -60,9 +73,15 @@ PlaneViewer::PlaneViewer(QWidget *parent)
     , m_xpos(0)
     , m_ypos(0)
     , m_aff()  // initialized at the first resize
-    , m_chessSize(40.0) {
+    , m_chessSize(40.0)
+    , m_firstDraw(true) {
   m_zoomRange[0] = 1e-3, m_zoomRange[1] = 1024.0;
   setBgColor(TPixel32(235, 235, 235), TPixel32(235, 235, 235));
+
+  setAttribute(Qt::WA_AcceptTouchEvents);
+  grabGesture(Qt::SwipeGesture);
+  grabGesture(Qt::PanGesture);
+  grabGesture(Qt::PinchGesture);
 }
 
 //=========================================================================================
@@ -162,6 +181,11 @@ void PlaneViewer::resizeGL(int width, int height) {
 //=========================================================================================
 
 void PlaneViewer::mouseMoveEvent(QMouseEvent *event) {
+  if (m_gestureActive && m_touchDevice == QTouchDevice::TouchScreen &&
+      !m_stylusUsed) {
+    return;
+  }
+
   QPoint curPos = event->pos() * getDevPixRatio();
   if (event->buttons() & Qt::MidButton)
     moveView(curPos.x() - m_xpos, height() - curPos.y() - m_ypos);
@@ -172,18 +196,84 @@ void PlaneViewer::mouseMoveEvent(QMouseEvent *event) {
 //------------------------------------------------------
 
 void PlaneViewer::mousePressEvent(QMouseEvent *event) {
+  // qDebug() << "[mousePressEvent]";
+  if (m_gestureActive && m_touchDevice == QTouchDevice::TouchScreen &&
+      !m_stylusUsed) {
+    return;
+  }
+
   m_xpos = event->x() * getDevPixRatio();
   m_ypos = height() - event->y() * getDevPixRatio();
 }
 
 //------------------------------------------------------
 
-void PlaneViewer::wheelEvent(QWheelEvent *event) {
-  TPointD pos(event->x() * getDevPixRatio(),
-              height() - event->y() * getDevPixRatio());
-  double zoom_par = 1 + event->delta() * 0.001;
+void PlaneViewer::mouseDoubleClickEvent(QMouseEvent *event) {
+  // qDebug() << "[mouseDoubleClickEvent]";
+  if (m_gestureActive && !m_stylusUsed) {
+    m_gestureActive = false;
+    fitView();
+    return;
+  }
+}
 
-  zoomView(pos.x, pos.y, zoom_par);
+//------------------------------------------------------
+
+void PlaneViewer::mouseReleaseEvent(QMouseEvent *event) {
+  m_gestureActive = false;
+  m_zooming       = false;
+  m_panning       = false;
+  m_stylusUsed    = false;
+}
+
+//------------------------------------------------------
+
+void PlaneViewer::wheelEvent(QWheelEvent *event) {
+  int delta = 0;
+  switch (event->source()) {
+  case Qt::MouseEventNotSynthesized: {
+    if (event->modifiers() & Qt::AltModifier)
+      delta = event->angleDelta().x();
+    else
+      delta = event->angleDelta().y();
+    break;
+  }
+
+  case Qt::MouseEventSynthesizedBySystem: {
+    QPoint numPixels  = event->pixelDelta();
+    QPoint numDegrees = event->angleDelta() / 8;
+    if (!numPixels.isNull()) {
+      delta = event->pixelDelta().y();
+    } else if (!numDegrees.isNull()) {
+      QPoint numSteps = numDegrees / 15;
+      delta           = numSteps.y();
+    }
+    break;
+  }
+
+  default:  // Qt::MouseEventSynthesizedByQt,
+            // Qt::MouseEventSynthesizedByApplication
+    {
+      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                   "Qt::MouseEventSynthesizedByApplication"
+                << std::endl;
+      break;
+    }
+
+  }  // end switch
+
+  if (abs(delta) > 0) {
+    if ((m_gestureActive == true &&
+         m_touchDevice == QTouchDevice::TouchScreen) ||
+        m_gestureActive == false) {
+      TPointD pos(event->x() * getDevPixRatio(),
+                  height() - event->y() * getDevPixRatio());
+      double zoom_par = 1 + event->delta() * 0.001;
+
+      zoomView(pos.x, pos.y, zoom_par);
+    }
+  }
+  event->accept();
 }
 
 //------------------------------------------------------
@@ -201,10 +291,217 @@ void PlaneViewer::hideEvent(QHideEvent *event) {
   m_rasterBuffer = TRaster32P();
 }
 
+//------------------------------------------------------------------
+
+void PlaneViewer::contextMenuEvent(QContextMenuEvent *event) {
+  QMenu *menu = new QMenu(this);
+
+  QAction *reset = menu->addAction(tr("Reset View"));
+  reset->setShortcut(
+      QKeySequence(CommandManager::instance()->getKeyFromId(V_ZoomReset)));
+  connect(reset, SIGNAL(triggered()), SLOT(resetView()));
+
+  QAction *fit = menu->addAction(tr("Fit To Window"));
+  fit->setShortcut(
+      QKeySequence(CommandManager::instance()->getKeyFromId(V_ZoomFit)));
+  connect(fit, SIGNAL(triggered()), SLOT(fitView()));
+
+  menu->exec(event->globalPos());
+
+  delete menu;
+  update();
+}
+
+//------------------------------------------------------------------
+
+void PlaneViewer::tabletEvent(QTabletEvent *e) {
+  // qDebug() << "[tabletEvent]";
+  if (e->type() == QTabletEvent::TabletPress) {
+    m_stylusUsed = e->pointerType() ? true : false;
+  } else if (e->type() == QTabletEvent::TabletRelease) {
+    m_stylusUsed = false;
+  }
+
+  e->accept();
+}
+
+//------------------------------------------------------------------
+
+void PlaneViewer::gestureEvent(QGestureEvent *e) {
+  // qDebug() << "[gestureEvent]";
+  m_gestureActive = false;
+  if (QGesture *swipe = e->gesture(Qt::SwipeGesture)) {
+    m_gestureActive = true;
+  } else if (QGesture *pan = e->gesture(Qt::PanGesture)) {
+    m_gestureActive = true;
+  }
+  if (QGesture *pinch = e->gesture(Qt::PinchGesture)) {
+    QPinchGesture *gesture = static_cast<QPinchGesture *>(pinch);
+    QPinchGesture::ChangeFlags changeFlags = gesture->changeFlags();
+    QPoint firstCenter                     = gesture->centerPoint().toPoint();
+    if (m_touchDevice == QTouchDevice::TouchScreen)
+      firstCenter = mapFromGlobal(firstCenter);
+
+    if (gesture->state() == Qt::GestureStarted) {
+      m_gestureActive = true;
+    } else if (gesture->state() == Qt::GestureFinished) {
+      m_gestureActive = false;
+      m_zooming       = false;
+      m_scaleFactor   = 0.0;
+    } else {
+      if (changeFlags & QPinchGesture::ScaleFactorChanged) {
+        double scaleFactor = gesture->scaleFactor();
+        // the scale factor makes for too sensitive scaling
+        // divide the change in half
+        if (scaleFactor > 1) {
+          double decimalValue = scaleFactor - 1;
+          decimalValue /= 1.5;
+          scaleFactor = 1 + decimalValue;
+        } else if (scaleFactor < 1) {
+          double decimalValue = 1 - scaleFactor;
+          decimalValue /= 1.5;
+          scaleFactor = 1 - decimalValue;
+        }
+        if (!m_zooming) {
+          double delta = scaleFactor - 1;
+          m_scaleFactor += delta;
+          if (m_scaleFactor > .2 || m_scaleFactor < -.2) {
+            m_zooming = true;
+          }
+        }
+        if (m_zooming) {
+          zoomView(firstCenter.x() * getDevPixRatio(),
+                   firstCenter.y() * getDevPixRatio(), scaleFactor);
+          m_panning = false;
+        }
+        m_gestureActive = true;
+      }
+
+      if (changeFlags & QPinchGesture::CenterPointChanged) {
+        QPointF centerDelta = (gesture->centerPoint() * getDevPixRatio()) -
+                              (gesture->lastCenterPoint() * getDevPixRatio());
+        if (centerDelta.manhattanLength() > 1) {
+          // panQt(centerDelta.toPoint());
+        }
+        m_gestureActive = true;
+      }
+    }
+  }
+  e->accept();
+}
+
+void PlaneViewer::touchEvent(QTouchEvent *e, int type) {
+  // qDebug() << "[touchEvent]";
+  if (type == QEvent::TouchBegin) {
+    m_touchActive   = true;
+    m_firstPanPoint = e->touchPoints().at(0).pos();
+    // obtain device type
+    m_touchDevice = e->device()->type();
+  } else if (m_touchActive) {
+    // touchpads must have 2 finger panning for tools and navigation to be
+    // functional on other devices, 1 finger panning is preferred
+    if ((e->touchPoints().count() == 2 &&
+         m_touchDevice == QTouchDevice::TouchPad) ||
+        (e->touchPoints().count() == 1 &&
+         m_touchDevice == QTouchDevice::TouchScreen)) {
+      QTouchEvent::TouchPoint panPoint = e->touchPoints().at(0);
+      if (!m_panning) {
+        QPointF deltaPoint = panPoint.pos() - m_firstPanPoint;
+        // minimize accidental and jerky zooming/rotating during 2 finger
+        // panning
+        if ((deltaPoint.manhattanLength() > 100) && !m_zooming) {
+          m_panning = true;
+        }
+      }
+      if (m_panning) {
+        QPoint curPos      = panPoint.pos().toPoint() * getDevPixRatio();
+        QPoint lastPos     = panPoint.lastPos().toPoint() * getDevPixRatio();
+        QPoint centerDelta = curPos - lastPos;
+        moveView(centerDelta.x(), -centerDelta.y());
+      }
+    }
+  }
+  if (type == QEvent::TouchEnd || type == QEvent::TouchCancel) {
+    m_touchActive = false;
+    m_panning     = false;
+  }
+  e->accept();
+}
+
+bool PlaneViewer::event(QEvent *e) {
+  /*
+  switch (e->type()) {
+  case QEvent::TabletPress: {
+  QTabletEvent *te = static_cast<QTabletEvent *>(e);
+  qDebug() << "[event] TabletPress: pointerType(" << te->pointerType()
+  << ") device(" << te->device() << ")";
+  } break;
+  case QEvent::TabletRelease:
+  qDebug() << "[event] TabletRelease";
+  break;
+  case QEvent::TouchBegin:
+  qDebug() << "[event] TouchBegin";
+  break;
+  case QEvent::TouchEnd:
+  qDebug() << "[event] TouchEnd";
+  break;
+  case QEvent::TouchCancel:
+  qDebug() << "[event] TouchCancel";
+  break;
+  case QEvent::MouseButtonPress:
+  qDebug() << "[event] MouseButtonPress";
+  break;
+  case QEvent::MouseButtonDblClick:
+  qDebug() << "[event] MouseButtonDblClick";
+  break;
+  case QEvent::MouseButtonRelease:
+  qDebug() << "[event] MouseButtonRelease";
+  break;
+  case QEvent::Gesture:
+  qDebug() << "[event] Gesture";
+  break;
+  default:
+  break;
+  }
+  */
+
+  if (e->type() == QEvent::Gesture &&
+      CommandManager::instance()
+          ->getAction(MI_TouchGestureControl)
+          ->isChecked()) {
+    gestureEvent(static_cast<QGestureEvent *>(e));
+    return true;
+  }
+  if ((e->type() == QEvent::TouchBegin || e->type() == QEvent::TouchEnd ||
+       e->type() == QEvent::TouchCancel || e->type() == QEvent::TouchUpdate) &&
+      CommandManager::instance()
+          ->getAction(MI_TouchGestureControl)
+          ->isChecked()) {
+    touchEvent(static_cast<QTouchEvent *>(e), e->type());
+    m_gestureActive = true;
+    return true;
+  }
+  return GLWidgetForHighDpi::event(e);
+}
+
 //=========================================================================================
 
 void PlaneViewer::resetView() {
   m_aff = TTranslation(0.5 * width(), 0.5 * height());
+  update();
+}
+
+void PlaneViewer::fitView() {
+  if (m_imageBounds.isEmpty()) return;
+  m_aff = TTranslation(0.5 * width(), 0.5 * height());
+
+  double imageScale = std::min(width() / (double)m_imageBounds.getLx(),
+                               height() / (double)m_imageBounds.getLy());
+
+  m_aff     = TScale(imageScale, imageScale);
+  m_aff.a13 = 0.5 * width();
+  m_aff.a23 = 0.5 * height();
+
   update();
 }
 
@@ -306,6 +603,12 @@ void PlaneViewer::draw(TRasterP ras, double dpiX, double dpiY, TPalette *pal) {
 
   TRaster32P aux(rasterBuffer());
 
+  m_imageBounds = ras->getBounds();
+  if (m_firstDraw && !m_imageBounds.isEmpty()) {
+    m_firstDraw = false;
+    fitView();
+  }
+
   aux->lock();
   ras->lock();
 
@@ -328,8 +631,8 @@ void PlaneViewer::draw(TRasterP ras, double dpiX, double dpiY, TPalette *pal) {
 }
 
 /*NOTE:
-    glRasterPos2d could be used, along glBitmap and glPixelZoom...
-    however, i've never been able to use them effectively...
+glRasterPos2d could be used, along glBitmap and glPixelZoom...
+however, i've never been able to use them effectively...
 */
 
 //------------------------------------------------------
@@ -360,7 +663,11 @@ void PlaneViewer::draw(TVectorImageP vi) {
   TRectD bbox(vi->getBBox());
   TRect bboxI(tfloor(bbox.x0), tfloor(bbox.y0), tceil(bbox.x1) - 1,
               tceil(bbox.y1) - 1);
-
+  m_imageBounds = bboxI;
+  if (m_firstDraw) {
+    m_firstDraw = false;
+    fitView();
+  }
   TVectorRenderData rd(TAffine(), bboxI, vi->getPalette(), 0, true, true);
   tglDraw(rd, vi.getPointer());
 }


### PR DESCRIPTION
This PR adds gesture controls to the following image viewer classes used throughout the application:

- ImageViewer (Flipbook, Color Model, Cleanup, Preview)
- PlaneViewer (Export Level, Create Mesh, Convert to Vectors, Adjust Levels, Adjust Thickness, Antialias, Binarize, Brightness and Contrast, Color Fade)
- SwatchViewer (Fx Settings)

Each class of viewer was modified as follows:

1) Added gesture controls
- 1 finger pan
- 2 finger pinch zoom
- Double-tap to Fit to Window

2) Added right-click context menu and shortcut support for `Reset View` and `Fit to Window` (Plane/Swatch viewers only)

3) The first time the dialog viewer is created the 1st displayed image will be made to "Fit to Window".
