### PR TITLE
Viewer context menu additions

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -712,7 +712,6 @@ class ZoomToolOptionsBox final : public ToolOptionsBox {
 public:
   ZoomToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
                      ToolHandle *toolHandle);
-  void updateStatus();
 };
 
 //=============================================================================
@@ -727,7 +726,6 @@ class RotateToolOptionsBox final : public ToolOptionsBox {
 public:
   RotateToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
                        ToolHandle *toolHandle);
-  void updateStatus();
 };
 
 //=============================================================================
@@ -742,7 +740,6 @@ class HandToolOptionsBox final : public ToolOptionsBox {
 public:
   HandToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
                      ToolHandle *toolHandle);
-  void updateStatus();
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -700,6 +700,51 @@ protected slots:
   void updateColors();
 };
 
+//=============================================================================
+//
+// ZoomToolOptionsBox
+//
+//=============================================================================
+
+class ZoomToolOptionsBox final : public ToolOptionsBox {
+  Q_OBJECT
+
+public:
+  ZoomToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
+                     ToolHandle *toolHandle);
+  void updateStatus();
+};
+
+//=============================================================================
+//
+// RotateToolOptionsBox
+//
+//=============================================================================
+
+class RotateToolOptionsBox final : public ToolOptionsBox {
+  Q_OBJECT
+
+public:
+  RotateToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
+                       ToolHandle *toolHandle);
+  void updateStatus();
+};
+
+//=============================================================================
+//
+// HandToolOptionsBox
+//
+//=============================================================================
+
+class HandToolOptionsBox final : public ToolOptionsBox {
+  Q_OBJECT
+
+public:
+  HandToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,
+                     ToolHandle *toolHandle);
+  void updateStatus();
+};
+
 //-----------------------------------------------------------------------------
 
 class DVAPI ToolOptions final : public QFrame {

--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -234,6 +234,9 @@ protected:
   virtual bool setFlipY() {
     return false;
   }  //!< Handler for 'flip viewer horizontally' commands.
+  virtual bool resetZoom() {
+    return false;
+  }  //!< Handler for 'reset zoom' commands.
   virtual bool resetRotation() {
     return false;
   }  //!< Handler for 'reset rotation' commands.

--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -234,6 +234,9 @@ protected:
   virtual bool setFlipY() {
     return false;
   }  //!< Handler for 'flip viewer horizontally' commands.
+  virtual bool resetRotation() {
+    return false;
+  }  //!< Handler for 'reset rotation' commands.
   virtual bool toggleFullScreen(
       bool quit = false)  //!  Handler for 'toggle fullscreen' commands.
   {

--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -240,6 +240,9 @@ protected:
   virtual bool resetRotation() {
     return false;
   }  //!< Handler for 'reset rotation' commands.
+  virtual bool resetPosition() {
+    return false;
+  }  //!< Handler for 'reset position' commands.
   virtual bool toggleFullScreen(
       bool quit = false)  //!  Handler for 'toggle fullscreen' commands.
   {

--- a/toonz/sources/include/toonzqt/viewcommandids.h
+++ b/toonz/sources/include/toonzqt/viewcommandids.h
@@ -13,5 +13,6 @@
 #define V_FlipX "T_FlipX"
 #define V_FlipY "T_FlipY"
 #define V_RotateReset "T_RotateReset"
+#define V_PositionReset "T_PositionReset"
 
 #endif  // VIEWCOMMANDIDS_H

--- a/toonz/sources/include/toonzqt/viewcommandids.h
+++ b/toonz/sources/include/toonzqt/viewcommandids.h
@@ -11,5 +11,6 @@
 #define V_ActualPixelSize "T_ActualPixelSize"
 #define V_FlipX "T_FlipX"
 #define V_FlipY "T_FlipY"
+#define V_RotateReset "T_RotateReset"
 
 #endif  // VIEWCOMMANDIDS_H

--- a/toonz/sources/include/toonzqt/viewcommandids.h
+++ b/toonz/sources/include/toonzqt/viewcommandids.h
@@ -3,6 +3,7 @@
 #ifndef VIEWCOMMANDIDS_H
 #define VIEWCOMMANDIDS_H
 
+#define V_ViewReset "T_ViewReset"
 #define V_ZoomIn "T_Zoomin"  // Can't change prefix due to retrocompatibility
 #define V_ZoomOut "T_Zoomout"
 #define V_ZoomReset "T_ZoomReset"

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2658,22 +2658,8 @@ ZoomToolOptionsBox::ZoomToolOptionsBox(QWidget *parent, TTool *tool,
   button->addAction(resetZoomAction);
   connect(button, SIGNAL(clicked()), resetZoomAction, SLOT(trigger()));
 
-  TPropertyGroup *props = tool->getProperties(0);
-  assert(props->getPropertyCount() > 0);
-
-  ToolOptionControlBuilder builder(this, tool, pltHandle, toolHandle);
-  if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
-
   m_layout->addStretch(1);
   m_layout->addWidget(button, 0);
-}
-
-//-----------------------------------------------------------------------------
-
-void ZoomToolOptionsBox::updateStatus() {
-  QMap<std::string, ToolOptionControl *>::iterator it;
-  for (it = m_controls.begin(); it != m_controls.end(); it++)
-    it.value()->updateStatus();
 }
 
 //=============================================================================
@@ -2695,22 +2681,8 @@ RotateToolOptionsBox::RotateToolOptionsBox(QWidget *parent, TTool *tool,
   button->addAction(resetRotationAction);
   connect(button, SIGNAL(clicked()), resetRotationAction, SLOT(trigger()));
 
-  TPropertyGroup *props = tool->getProperties(0);
-  assert(props->getPropertyCount() > 0);
-
-  ToolOptionControlBuilder builder(this, tool, pltHandle, toolHandle);
-  if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
-
   m_layout->addStretch(1);
   m_layout->addWidget(button, 0);
-}
-
-//-----------------------------------------------------------------------------
-
-void RotateToolOptionsBox::updateStatus() {
-  QMap<std::string, ToolOptionControl *>::iterator it;
-  for (it = m_controls.begin(); it != m_controls.end(); it++)
-    it.value()->updateStatus();
 }
 
 //=============================================================================
@@ -2732,22 +2704,8 @@ HandToolOptionsBox::HandToolOptionsBox(QWidget *parent, TTool *tool,
   button->addAction(resetPositionAction);
   connect(button, SIGNAL(clicked()), resetPositionAction, SLOT(trigger()));
 
-  TPropertyGroup *props = tool->getProperties(0);
-  assert(props->getPropertyCount() > 0);
-
-  ToolOptionControlBuilder builder(this, tool, pltHandle, toolHandle);
-  if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
-
   m_layout->addStretch(1);
   m_layout->addWidget(button, 0);
-}
-
-//-----------------------------------------------------------------------------
-
-void HandToolOptionsBox::updateStatus() {
-  QMap<std::string, ToolOptionControl *>::iterator it;
-  for (it = m_controls.begin(); it != m_controls.end(); it++)
-    it.value()->updateStatus();
 }
 
 //=============================================================================

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -25,6 +25,7 @@
 #include "toonzqt/gutil.h"
 #include "toonzqt/dvscrollwidget.h"
 #include "toonzqt/lutcalibrator.h"
+#include "toonzqt/viewcommandids.h"
 
 // TnzLib includes
 #include "toonz/tobjecthandle.h"
@@ -2640,6 +2641,116 @@ void ShiftTraceToolOptionBox::onAfterRadioBtnClicked() {
 }
 
 //=============================================================================
+// ZoomToolOptionBox
+//-----------------------------------------------------------------------------
+
+ZoomToolOptionsBox::ZoomToolOptionsBox(QWidget *parent, TTool *tool,
+                                       TPaletteHandle *pltHandle,
+                                       ToolHandle *toolHandle)
+    : ToolOptionsBox(parent) {
+  setFrameStyle(QFrame::StyledPanel);
+  setFixedHeight(26);
+
+  QAction *resetZoomAction = CommandManager::instance()->getAction(V_ZoomReset);
+
+  QPushButton *button = new QPushButton(tr("Reset Zoom"));
+  button->setFixedHeight(20);
+  button->addAction(resetZoomAction);
+  connect(button, SIGNAL(clicked()), resetZoomAction, SLOT(trigger()));
+
+  TPropertyGroup *props = tool->getProperties(0);
+  assert(props->getPropertyCount() > 0);
+
+  ToolOptionControlBuilder builder(this, tool, pltHandle, toolHandle);
+  if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
+
+  m_layout->addStretch(1);
+  m_layout->addWidget(button, 0);
+}
+
+//-----------------------------------------------------------------------------
+
+void ZoomToolOptionsBox::updateStatus() {
+  QMap<std::string, ToolOptionControl *>::iterator it;
+  for (it = m_controls.begin(); it != m_controls.end(); it++)
+    it.value()->updateStatus();
+}
+
+//=============================================================================
+// RotateToolOptionBox
+//-----------------------------------------------------------------------------
+
+RotateToolOptionsBox::RotateToolOptionsBox(QWidget *parent, TTool *tool,
+                                           TPaletteHandle *pltHandle,
+                                           ToolHandle *toolHandle)
+    : ToolOptionsBox(parent) {
+  setFrameStyle(QFrame::StyledPanel);
+  setFixedHeight(26);
+
+  QAction *resetRotationAction =
+      CommandManager::instance()->getAction(V_RotateReset);
+
+  QPushButton *button = new QPushButton(tr("Reset Rotation"));
+  button->setFixedHeight(20);
+  button->addAction(resetRotationAction);
+  connect(button, SIGNAL(clicked()), resetRotationAction, SLOT(trigger()));
+
+  TPropertyGroup *props = tool->getProperties(0);
+  assert(props->getPropertyCount() > 0);
+
+  ToolOptionControlBuilder builder(this, tool, pltHandle, toolHandle);
+  if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
+
+  m_layout->addStretch(1);
+  m_layout->addWidget(button, 0);
+}
+
+//-----------------------------------------------------------------------------
+
+void RotateToolOptionsBox::updateStatus() {
+  QMap<std::string, ToolOptionControl *>::iterator it;
+  for (it = m_controls.begin(); it != m_controls.end(); it++)
+    it.value()->updateStatus();
+}
+
+//=============================================================================
+// HandToolOptionBox
+//-----------------------------------------------------------------------------
+
+HandToolOptionsBox::HandToolOptionsBox(QWidget *parent, TTool *tool,
+                                       TPaletteHandle *pltHandle,
+                                       ToolHandle *toolHandle)
+    : ToolOptionsBox(parent) {
+  setFrameStyle(QFrame::StyledPanel);
+  setFixedHeight(26);
+
+  QAction *resetPositionAction =
+      CommandManager::instance()->getAction(V_PositionReset);
+
+  QPushButton *button = new QPushButton(tr("Reset Position"));
+  button->setFixedHeight(20);
+  button->addAction(resetPositionAction);
+  connect(button, SIGNAL(clicked()), resetPositionAction, SLOT(trigger()));
+
+  TPropertyGroup *props = tool->getProperties(0);
+  assert(props->getPropertyCount() > 0);
+
+  ToolOptionControlBuilder builder(this, tool, pltHandle, toolHandle);
+  if (tool && tool->getProperties(0)) tool->getProperties(0)->accept(builder);
+
+  m_layout->addStretch(1);
+  m_layout->addWidget(button, 0);
+}
+
+//-----------------------------------------------------------------------------
+
+void HandToolOptionsBox::updateStatus() {
+  QMap<std::string, ToolOptionControl *>::iterator it;
+  for (it = m_controls.begin(); it != m_controls.end(); it++)
+    it.value()->updateStatus();
+}
+
+//=============================================================================
 // ToolOptions
 //-----------------------------------------------------------------------------
 
@@ -2749,6 +2860,12 @@ void ToolOptions::onToolSwitched() {
                                               app->getPaletteController());
       else if (tool->getName() == "T_ShiftTrace")
         panel = new ShiftTraceToolOptionBox(this, tool);
+      else if (tool->getName() == T_Zoom)
+        panel = new ZoomToolOptionsBox(0, tool, currPalette, currTool);
+      else if (tool->getName() == T_Rotate)
+        panel = new RotateToolOptionsBox(0, tool, currPalette, currTool);
+      else if (tool->getName() == T_Hand)
+        panel = new HandToolOptionsBox(0, tool, currPalette, currTool);
       else
         panel = tool->createOptionsBox();  // Only this line should remain out
                                            // of that if/else monstrosity

--- a/toonz/sources/toonz/colormodelviewer.cpp
+++ b/toonz/sources/toonz/colormodelviewer.cpp
@@ -244,7 +244,7 @@ void ColorModelViewer::contextMenuEvent(QContextMenuEvent *event) {
   menu.addSeparator();
 
   QString shortcut = QString::fromStdString(
-      CommandManager::instance()->getShortcutFromId(V_ZoomReset));
+      CommandManager::instance()->getShortcutFromId(V_ViewReset));
   QAction *reset = menu.addAction(tr("Reset View") + "\t " + shortcut);
   connect(reset, SIGNAL(triggered()), m_imageViewer, SLOT(resetView()));
 

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -297,7 +297,7 @@ void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
 
   QAction *reset = menu->addAction(tr("Reset View"));
   reset->setShortcut(
-      QKeySequence(CommandManager::instance()->getKeyFromId(V_ZoomReset)));
+      QKeySequence(CommandManager::instance()->getKeyFromId(V_ViewReset)));
   connect(reset, SIGNAL(triggered()), SLOT(resetView()));
 
   QAction *fit = menu->addAction(tr("Fit To Window"));

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2096,6 +2096,7 @@ void MainWindow::defineActions() {
   createViewerAction(V_ZoomOut, tr("Zoom Out"), "-");
   createViewerAction(V_ViewReset, tr("Reset View"), "Alt+0");
   createViewerAction(V_ZoomFit, tr("Fit to Window"), "Alt+9");
+  createViewerAction(V_ZoomReset, tr("Reset Zoom"), "");
   createViewerAction(V_RotateReset, tr("Reset Rotation"), "");
   createViewerAction(V_ActualPixelSize, tr("Actual Pixel Size"), "N");
   createViewerAction(V_FlipX, tr("Flip Viewer Horizontally"), "");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2094,7 +2094,7 @@ void MainWindow::defineActions() {
 
   createViewerAction(V_ZoomIn, tr("Zoom In"), "+");
   createViewerAction(V_ZoomOut, tr("Zoom Out"), "-");
-  createViewerAction(V_ZoomReset, tr("Reset View"), "Alt+0");
+  createViewerAction(V_ViewReset, tr("Reset View"), "Alt+0");
   createViewerAction(V_ZoomFit, tr("Fit to Window"), "Alt+9");
   createViewerAction(V_RotateReset, tr("Reset Rotation"), "");
   createViewerAction(V_ActualPixelSize, tr("Actual Pixel Size"), "N");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2096,6 +2096,7 @@ void MainWindow::defineActions() {
   createViewerAction(V_ZoomOut, tr("Zoom Out"), "-");
   createViewerAction(V_ZoomReset, tr("Reset View"), "Alt+0");
   createViewerAction(V_ZoomFit, tr("Fit to Window"), "Alt+9");
+  createViewerAction(V_RotateReset, tr("Reset Rotation"), "");
   createViewerAction(V_ActualPixelSize, tr("Actual Pixel Size"), "N");
   createViewerAction(V_FlipX, tr("Flip Viewer Horizontally"), "");
   createViewerAction(V_FlipY, tr("Flip Viewer Vertically"), "");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2098,6 +2098,7 @@ void MainWindow::defineActions() {
   createViewerAction(V_ZoomFit, tr("Fit to Window"), "Alt+9");
   createViewerAction(V_ZoomReset, tr("Reset Zoom"), "");
   createViewerAction(V_RotateReset, tr("Reset Rotation"), "");
+  createViewerAction(V_PositionReset, tr("Reset Position"), "");
   createViewerAction(V_ActualPixelSize, tr("Actual Pixel Size"), "N");
   createViewerAction(V_FlipX, tr("Flip Viewer Horizontally"), "");
   createViewerAction(V_FlipY, tr("Flip Viewer Vertically"), "");

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -24,6 +24,7 @@
 #include "toonzqt/gutil.h"
 #include "toonzqt/imageutils.h"
 #include "toonzqt/lutcalibrator.h"
+#include "toonzqt/viewcommandids.h"
 
 // TnzLib includes
 #include "toonz/tscenehandle.h"
@@ -450,6 +451,56 @@ public:
     if (tool) tool->reset();
   }
 } resetShiftTraceCommand;
+
+class TViewResetCommand final : public MenuItemHandler {
+public:
+  TViewResetCommand() : MenuItemHandler(V_ViewReset) {}
+  void execute() override {
+    TApp::instance()->getActiveViewer()->resetSceneViewer();
+  }
+} viewResetCommand;
+
+class TZoomResetCommand final : public MenuItemHandler {
+public:
+  TZoomResetCommand() : MenuItemHandler(V_ZoomReset) {}
+  void execute() override { TApp::instance()->getActiveViewer()->resetZoom(); }
+} zoomResetCommand;
+
+class TZoomFitCommand final : public MenuItemHandler {
+public:
+  TZoomFitCommand() : MenuItemHandler(V_ZoomFit) {}
+  void execute() override {
+    TApp::instance()->getActiveViewer()->fitToCamera();
+  }
+} zoomFitCommand;
+
+class TActualPixelSizeCommand final : public MenuItemHandler {
+public:
+  TActualPixelSizeCommand() : MenuItemHandler(V_ActualPixelSize) {}
+  void execute() override {
+    TApp::instance()->getActiveViewer()->setActualPixelSize();
+  }
+} aActualPixelSizeCommand;
+
+class TFlipViewerXCommand final : public MenuItemHandler {
+public:
+  TFlipViewerXCommand() : MenuItemHandler(V_FlipX) {}
+  void execute() override { TApp::instance()->getActiveViewer()->flipX(); }
+} flipViewerXCommand;
+
+class TFlipViewerYCommand final : public MenuItemHandler {
+public:
+  TFlipViewerYCommand() : MenuItemHandler(V_FlipY) {}
+  void execute() override { TApp::instance()->getActiveViewer()->flipY(); }
+} flipViewerYCommand;
+
+class TRotateResetCommand final : public MenuItemHandler {
+public:
+  TRotateResetCommand() : MenuItemHandler(V_RotateReset) {}
+  void execute() override {
+    TApp::instance()->getActiveViewer()->resetRotation();
+  }
+} rotateResetCommand;
 
 //=============================================================================
 // SceneViewer

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -502,6 +502,14 @@ public:
   }
 } rotateResetCommand;
 
+class TPositionResetCommand final : public MenuItemHandler {
+public:
+  TPositionResetCommand() : MenuItemHandler(V_PositionReset) {}
+  void execute() override {
+    TApp::instance()->getActiveViewer()->resetPosition();
+  }
+} positionResetCommand;
+
 //=============================================================================
 // SceneViewer
 //-----------------------------------------------------------------------------
@@ -2208,6 +2216,14 @@ void SceneViewer::resetRotation() {
               ->getValueAsString() == "1")
     center = TPointD(0, 0);
   rotate(center, reverseRotatation);
+}
+
+//-----------------------------------------------------------------------------
+
+void SceneViewer::resetPosition() {
+  m_viewAff[m_viewMode].a13 = 0.0;
+  m_viewAff[m_viewMode].a23 = 0.0;
+  invalidateAll();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2130,8 +2130,23 @@ void SceneViewer::resetSceneViewer() {
 
 //-----------------------------------------------------------------------------
 
+void SceneViewer::resetZoom() {
+  TPointD realCenter(m_viewAff[m_viewMode].a13, m_viewAff[m_viewMode].a23);
+  TAffine aff =
+      getNormalZoomScale() * TRotation(realCenter, m_rotationAngle[m_viewMode]);
+  aff.a13               = realCenter.x;
+  aff.a23               = realCenter.y;
+  if (m_isFlippedX) aff = aff * TScale(-1, 1);
+  if (m_isFlippedY) aff = aff * TScale(1, -1);
+  setViewMatrix(aff, m_viewMode);
+  invalidateAll();
+  emit onZoomChanged();
+}
+
+//-----------------------------------------------------------------------------
+
 void SceneViewer::resetRotation() {
-  double reverseRotatation = (m_rotationAngle[m_viewMode] * -1);
+  double reverseRotatation = m_rotationAngle[m_viewMode] * -1;
   if (m_isFlippedX) reverseRotatation *= -1;
   if (m_isFlippedY) reverseRotatation *= -1;
   rotate(m_viewAff[m_viewMode].inv() * TPointD(0, 0), reverseRotatation);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2200,7 +2200,14 @@ void SceneViewer::resetRotation() {
   double reverseRotatation = m_rotationAngle[m_viewMode] * -1;
   if (m_isFlippedX) reverseRotatation *= -1;
   if (m_isFlippedY) reverseRotatation *= -1;
-  rotate(m_viewAff[m_viewMode].inv() * TPointD(0, 0), reverseRotatation);
+  TTool *tool    = TApp::instance()->getCurrentTool()->getTool();
+  TPointD center = m_viewAff[m_viewMode].inv() * TPointD(0, 0);
+  if (tool->getName() == "T_Rotate" &&
+      tool->getProperties(0)
+              ->getProperty("Rotate On Camera Center")
+              ->getValueAsString() == "1")
+    center = TPointD(0, 0);
+  rotate(center, reverseRotatation);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -396,6 +396,7 @@ protected:
 public slots:
 
   void resetSceneViewer();
+  void resetZoom();
   void resetRotation();
   void setActualPixelSize();
   void flipX();

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -178,6 +178,8 @@ class SceneViewer final : public GLWidgetForHighDpi,
   // updated in drawScene() and used in GLInvalidateRect()
   TRectD m_guidedDrawingBBox;
 
+  double m_rotationAngle[2];
+
 public:
   enum ReferenceMode {
     NORMAL_REFERENCE   = 1,
@@ -394,6 +396,7 @@ protected:
 public slots:
 
   void resetSceneViewer();
+  void resetRotation();
   void setActualPixelSize();
   void flipX();
   void flipY();

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -398,6 +398,7 @@ public slots:
   void resetSceneViewer();
   void resetZoom();
   void resetRotation();
+  void resetPosition();
   void setActualPixelSize();
   void flipX();
   void flipY();

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -95,6 +95,11 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
           parent->connect(action, SIGNAL(triggered()), SLOT(fitToCamera()));
   }
 
+  // reset zoom
+  action = commandManager->createAction(V_ZoomReset, this);
+  addAction(action);
+  ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(resetZoom()));
+
   // reset rotation
   action = commandManager->createAction(V_RotateReset, this);
   addAction(action);

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -81,22 +81,6 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
           parent->connect(action, SIGNAL(triggered()), SLOT(swapCompared()));
   }
 
-  // flip horizontally
-  action = commandManager->createAction(V_FlipX, this);
-  addAction(action);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(flipX()));
-
-  // flip vertically
-  action = commandManager->createAction(V_FlipY, this);
-  addAction(action);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(flipY()));
-
-  // reset
-  action = commandManager->createAction(V_ViewReset, this);
-  addAction(action);
-  ret = ret &&
-        parent->connect(action, SIGNAL(triggered()), SLOT(resetSceneViewer()));
-
   if (!isEditingLevel) {
     // fit camera
     action = commandManager->createAction(V_ZoomFit, this);
@@ -105,20 +89,40 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
           parent->connect(action, SIGNAL(triggered()), SLOT(fitToCamera()));
   }
 
+  QMenu *flipViewMenu = addMenu(tr("Flip View"));
+
+  // flip horizontally
+  action = commandManager->createAction(V_FlipX, this);
+  flipViewMenu->addAction(action);
+  ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(flipX()));
+
+  // flip vertically
+  action = commandManager->createAction(V_FlipY, this);
+  flipViewMenu->addAction(action);
+  ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(flipY()));
+
+  QMenu *resetViewMenu = addMenu(tr("Reset View"));
+
+  // reset
+  action = commandManager->createAction(V_ViewReset, this);
+  resetViewMenu->addAction(action);
+  ret = ret &&
+        parent->connect(action, SIGNAL(triggered()), SLOT(resetSceneViewer()));
+
   // reset zoom
   action = commandManager->createAction(V_ZoomReset, this);
-  addAction(action);
+  resetViewMenu->addAction(action);
   ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(resetZoom()));
 
   // reset rotation
   action = commandManager->createAction(V_RotateReset, this);
-  addAction(action);
+  resetViewMenu->addAction(action);
   ret = ret &&
         parent->connect(action, SIGNAL(triggered()), SLOT(resetRotation()));
 
   // reset position
   action = commandManager->createAction(V_PositionReset, this);
-  addAction(action);
+  resetViewMenu->addAction(action);
   ret = ret &&
         parent->connect(action, SIGNAL(triggered()), SLOT(resetPosition()));
 

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -81,6 +81,16 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
           parent->connect(action, SIGNAL(triggered()), SLOT(swapCompared()));
   }
 
+  // flip horizontally
+  action = commandManager->createAction(V_FlipX, this);
+  addAction(action);
+  ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(flipX()));
+
+  // flip vertically
+  action = commandManager->createAction(V_FlipY, this);
+  addAction(action);
+  ret = ret && parent->connect(action, SIGNAL(triggered()), SLOT(flipY()));
+
   // reset
   action = commandManager->createAction(V_ViewReset, this);
   addAction(action);

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -82,7 +82,7 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
   }
 
   // reset
-  action = commandManager->createAction(V_ZoomReset, this);
+  action = commandManager->createAction(V_ViewReset, this);
   addAction(action);
   ret = ret &&
         parent->connect(action, SIGNAL(triggered()), SLOT(resetSceneViewer()));

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -116,6 +116,12 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
   ret = ret &&
         parent->connect(action, SIGNAL(triggered()), SLOT(resetRotation()));
 
+  // reset position
+  action = commandManager->createAction(V_PositionReset, this);
+  addAction(action);
+  ret = ret &&
+        parent->connect(action, SIGNAL(triggered()), SLOT(resetPosition()));
+
   // actual pixel size
   action = commandManager->createAction(V_ActualPixelSize, this);
   addAction(action);

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -95,6 +95,12 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
           parent->connect(action, SIGNAL(triggered()), SLOT(fitToCamera()));
   }
 
+  // reset rotation
+  action = commandManager->createAction(V_RotateReset, this);
+  addAction(action);
+  ret = ret &&
+        parent->connect(action, SIGNAL(triggered()), SLOT(resetRotation()));
+
   // actual pixel size
   action = commandManager->createAction(V_ActualPixelSize, this);
   addAction(action);

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -810,7 +810,7 @@ void getViewerShortcuts(int &zoomIn, int &zoomOut, int &zoomReset, int &zoomFit,
   zoomOut =
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomOut));
   zoomReset =
-      cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomReset));
+      cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ViewReset));
   zoomFit =
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomFit));
   showHideFullScreen = cManager->getKeyFromShortcut(

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -803,7 +803,7 @@ namespace {
 
 void getViewerShortcuts(int &zoomIn, int &zoomOut, int &zoomReset, int &zoomFit,
                         int &showHideFullScreen, int &actualPixelSize,
-                        int &flipX, int &flipY) {
+                        int &flipX, int &flipY, int &rotateReset) {
   CommandManager *cManager = CommandManager::instance();
 
   zoomIn = cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomIn));
@@ -819,6 +819,8 @@ void getViewerShortcuts(int &zoomIn, int &zoomOut, int &zoomReset, int &zoomFit,
       cManager->getShortcutFromId(V_ActualPixelSize));
   flipX = cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_FlipX));
   flipY = cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_FlipY));
+  rotateReset =
+      cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_RotateReset));
 }
 
 }  // namespace
@@ -834,9 +836,10 @@ ShortcutZoomer::ShortcutZoomer(QWidget *zoomingWidget)
 
 bool ShortcutZoomer::exec(QKeyEvent *event) {
   int zoomInKey, zoomOutKey, zoomResetKey, zoomFitKey, showHideFullScreenKey,
-      actualPixelSize, flipX, flipY;
+      actualPixelSize, flipX, flipY, rotateReset;
   getViewerShortcuts(zoomInKey, zoomOutKey, zoomResetKey, zoomFitKey,
-                     showHideFullScreenKey, actualPixelSize, flipX, flipY);
+                     showHideFullScreenKey, actualPixelSize, flipX, flipY,
+                     rotateReset);
 
   int key = event->key();
   if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt)
@@ -860,8 +863,11 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
                                             key == zoomResetKey)
                                      : (key == flipX)
                                            ? setFlipX()
-                                           : (key == flipY) ? setFlipY()
-                                                            : false;
+                                           : (key == flipY)
+                                                 ? setFlipY()
+                                                 : (key == rotateReset)
+                                                       ? resetRotation()
+                                                       : false;
 }
 
 //*********************************************************************************************

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -804,7 +804,7 @@ namespace {
 void getViewerShortcuts(int &zoomIn, int &zoomOut, int &viewReset, int &zoomFit,
                         int &showHideFullScreen, int &actualPixelSize,
                         int &flipX, int &flipY, int &zoomReset,
-                        int &rotateReset) {
+                        int &rotateReset, int &positionReset) {
   CommandManager *cManager = CommandManager::instance();
 
   zoomIn = cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomIn));
@@ -824,6 +824,8 @@ void getViewerShortcuts(int &zoomIn, int &zoomOut, int &viewReset, int &zoomFit,
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomReset));
   rotateReset =
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_RotateReset));
+  positionReset = cManager->getKeyFromShortcut(
+      cManager->getShortcutFromId(V_PositionReset));
 }
 
 }  // namespace
@@ -839,10 +841,10 @@ ShortcutZoomer::ShortcutZoomer(QWidget *zoomingWidget)
 
 bool ShortcutZoomer::exec(QKeyEvent *event) {
   int zoomInKey, zoomOutKey, viewResetKey, zoomFitKey, showHideFullScreenKey,
-      actualPixelSize, flipX, flipY, zoomReset, rotateReset;
+      actualPixelSize, flipX, flipY, zoomReset, rotateReset, positionReset;
   getViewerShortcuts(zoomInKey, zoomOutKey, viewResetKey, zoomFitKey,
                      showHideFullScreenKey, actualPixelSize, flipX, flipY,
-                     zoomReset, rotateReset);
+                     zoomReset, rotateReset, positionReset);
 
   int key = event->key();
   if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt)
@@ -872,7 +874,10 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
                                                        ? resetZoom()
                                                        : (key == rotateReset)
                                                              ? resetRotation()
-                                                             : false;
+                                                             : (key ==
+                                                                positionReset)
+                                                                   ? resetPosition()
+                                                                   : false;
   ;
 }
 

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -801,15 +801,16 @@ double getQuantizedZoomFactor(double zf, bool forward) {
 
 namespace {
 
-void getViewerShortcuts(int &zoomIn, int &zoomOut, int &zoomReset, int &zoomFit,
+void getViewerShortcuts(int &zoomIn, int &zoomOut, int &viewReset, int &zoomFit,
                         int &showHideFullScreen, int &actualPixelSize,
-                        int &flipX, int &flipY, int &rotateReset) {
+                        int &flipX, int &flipY, int &zoomReset,
+                        int &rotateReset) {
   CommandManager *cManager = CommandManager::instance();
 
   zoomIn = cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomIn));
   zoomOut =
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomOut));
-  zoomReset =
+  viewReset =
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ViewReset));
   zoomFit =
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomFit));
@@ -819,6 +820,8 @@ void getViewerShortcuts(int &zoomIn, int &zoomOut, int &zoomReset, int &zoomFit,
       cManager->getShortcutFromId(V_ActualPixelSize));
   flipX = cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_FlipX));
   flipY = cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_FlipY));
+  zoomReset =
+      cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomReset));
   rotateReset =
       cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_RotateReset));
 }
@@ -835,11 +838,11 @@ ShortcutZoomer::ShortcutZoomer(QWidget *zoomingWidget)
 //--------------------------------------------------------------------------
 
 bool ShortcutZoomer::exec(QKeyEvent *event) {
-  int zoomInKey, zoomOutKey, zoomResetKey, zoomFitKey, showHideFullScreenKey,
-      actualPixelSize, flipX, flipY, rotateReset;
-  getViewerShortcuts(zoomInKey, zoomOutKey, zoomResetKey, zoomFitKey,
+  int zoomInKey, zoomOutKey, viewResetKey, zoomFitKey, showHideFullScreenKey,
+      actualPixelSize, flipX, flipY, zoomReset, rotateReset;
+  getViewerShortcuts(zoomInKey, zoomOutKey, viewResetKey, zoomFitKey,
                      showHideFullScreenKey, actualPixelSize, flipX, flipY,
-                     rotateReset);
+                     zoomReset, rotateReset);
 
   int key = event->key();
   if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt)
@@ -858,16 +861,19 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
                          : (key == zoomFitKey)
                                ? fit()
                                : (key == zoomInKey || key == zoomOutKey ||
-                                  key == zoomResetKey)
+                                  key == viewResetKey)
                                      ? zoom(key == zoomInKey,
-                                            key == zoomResetKey)
+                                            key == viewResetKey)
                                      : (key == flipX)
                                            ? setFlipX()
                                            : (key == flipY)
                                                  ? setFlipY()
-                                                 : (key == rotateReset)
-                                                       ? resetRotation()
-                                                       : false;
+                                                 : (key == zoomReset)
+                                                       ? resetZoom()
+                                                       : (key == rotateReset)
+                                                             ? resetRotation()
+                                                             : false;
+  ;
 }
 
 //*********************************************************************************************


### PR DESCRIPTION
This PR adds the following options to the Viewer's (canvas) context menu

1) Reset Rotation
User request to be able to reset the rotation back to normal without having to adjust zoom or flip.

2) Reset Zoom
User request to be able to reset the zoom back to normal without having to adjust rotation or flip.

NOTE: This is different from `Reset View`. Reset View reverts zoom, rotation and flip all back to normal which is not always ideal

3) Reset Position
Reset the screen back to center without having to adjust rotation, zoom, flip.

4) Flip Viewer Horizontally and Flip Viewer Vertically

Just so it's easily accessible without a keyboard

5) Enable the following visualization commands on Command Bar:
- Reset View
- Reset Zoom
- Fit to Window
- Actual Pixel Size
- Flip Viewer Horizontally
- Flip Viewer Vertically
- Reset Rotation
- Reset Position

6) Added appropriate reset button to tool option bar for Zoom, Rotate and Hand tools.
