### PR TITLE
Show project name in title bars and startup menu

### DIFF
--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -29,6 +29,7 @@
 #include "toonz/palettecontroller.h"
 #include "toonz/toonzfolders.h"
 #include "toonz/preferences.h"
+#include "toonz/tproject.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -616,11 +617,13 @@ void ComboViewerPanel::changeWindowTitle() {
 
   // if the frame type is "scene editing"
   if (app->getCurrentFrame()->isEditingScene()) {
-    QString sceneName = QString::fromStdWString(scene->getSceneName());
+    TProject *project   = scene->getProject();
+    QString projectName = QString::fromStdString(project->getName().getName());
+    QString sceneName   = QString::fromStdWString(scene->getSceneName());
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
 
-    if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString(" *");
-    name = tr("Scene: ") + sceneName;
+    if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
+    name = tr("Scene: ") + sceneName + "   ::   Project: " + projectName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -623,7 +623,7 @@ void ComboViewerPanel::changeWindowTitle() {
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
 
     if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-    name = tr("Scene: ") + sceneName + "   ::   Project: " + projectName;
+    name = tr("Scene: ") + sceneName + tr("   ::   Project: ") + projectName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1440,8 +1440,13 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   app->getCurrentScene()->setDirtyFlag(false);
 
   History::instance()->addItem(scenePath);
-  RecentFiles::instance()->addFilePath(toQString(scenePath),
-                                       RecentFiles::Scene);
+  RecentFiles::instance()->addFilePath(
+      toQString(scenePath), RecentFiles::Scene,
+      QString::fromStdString(app->getCurrentScene()
+                                 ->getScene()
+                                 ->getProject()
+                                 ->getName()
+                                 .getName()));
 
   QApplication::restoreOverrideCursor();
 
@@ -1884,8 +1889,9 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   TApp::instance()->getCurrentScene()->setDirtyFlag(false);
   History::instance()->addItem(scenePath);
   if (updateRecentFile)
-    RecentFiles::instance()->addFilePath(toQString(scenePath),
-                                         RecentFiles::Scene);
+    RecentFiles::instance()->addFilePath(
+        toQString(scenePath), RecentFiles::Scene,
+        QString::fromStdString(scene->getProject()->getName().getName()));
   QApplication::restoreOverrideCursor();
 
   int forbiddenLevelCount = 0;

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -32,6 +32,7 @@
 #include "toonz/tscenehandle.h"
 #include "toonz/toonzscene.h"
 #include "toonz/txshleveltypes.h"
+#include "toonz/tproject.h"
 
 // TnzBase includes
 #include "tenv.h"
@@ -484,14 +485,19 @@ void MainWindow::changeWindowTitle() {
   ToonzScene *scene = app->getCurrentScene()->getScene();
   if (!scene) return;
 
-  QString name = QString::fromStdWString(scene->getSceneName());
+  TProject *project   = scene->getProject();
+  QString projectName = QString::fromStdString(project->getName().getName());
+
+  QString sceneName = QString::fromStdWString(scene->getSceneName());
+
+  if (sceneName.isEmpty()) sceneName = tr("Untitled");
+  if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
 
   /*--- レイアウトファイル名を頭に表示させる ---*/
-  if (!m_layoutName.isEmpty()) name.prepend(m_layoutName + " : ");
+  if (!m_layoutName.isEmpty()) sceneName.prepend(m_layoutName + " : ");
 
-  if (name.isEmpty()) name = tr("Untitled");
-
-  name += " : " + QString::fromStdString(TEnv::getApplicationFullName());
+  QString name = sceneName + " [" + projectName + "] : " +
+                 QString::fromStdString(TEnv::getApplicationFullName());
 
   setWindowTitle(name);
 }
@@ -2313,7 +2319,8 @@ void MainWindow::onQuit() { close(); }
 // RecentFiles
 //=============================================================================
 
-RecentFiles::RecentFiles() : m_recentScenes(), m_recentLevels() {}
+RecentFiles::RecentFiles()
+    : m_recentScenes(), m_recentSceneProjects(), m_recentLevels() {}
 
 //-----------------------------------------------------------------------------
 
@@ -2328,17 +2335,25 @@ RecentFiles::~RecentFiles() {}
 
 //-----------------------------------------------------------------------------
 
-void RecentFiles::addFilePath(QString path, FileType fileType) {
+void RecentFiles::addFilePath(QString path, FileType fileType,
+                              QString projectName) {
   QList<QString> files =
       (fileType == Scene) ? m_recentScenes : (fileType == Level)
                                                  ? m_recentLevels
                                                  : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
-    if (files.at(i) == path) files.removeAt(i);
+    if (files.at(i) == path) {
+      files.removeAt(i);
+      if (fileType == Scene) m_recentSceneProjects.removeAt(i);
+    }
   files.insert(0, path);
+  if (fileType == Scene) m_recentSceneProjects.insert(0, projectName);
   int maxSize = 10;
-  if (files.size() > maxSize) files.removeAt(maxSize);
+  if (files.size() > maxSize) {
+    files.removeAt(maxSize);
+    if (fileType == Scene) m_recentSceneProjects.removeAt(maxSize);
+  }
 
   if (fileType == Scene)
     m_recentScenes = files;
@@ -2354,9 +2369,10 @@ void RecentFiles::addFilePath(QString path, FileType fileType) {
 //-----------------------------------------------------------------------------
 
 void RecentFiles::moveFilePath(int fromIndex, int toIndex, FileType fileType) {
-  if (fileType == Scene)
+  if (fileType == Scene) {
     m_recentScenes.move(fromIndex, toIndex);
-  else if (fileType == Level)
+    m_recentSceneProjects.move(fromIndex, toIndex);
+  } else if (fileType == Level)
     m_recentLevels.move(fromIndex, toIndex);
   else
     m_recentFlipbookImages.move(fromIndex, toIndex);
@@ -2366,9 +2382,10 @@ void RecentFiles::moveFilePath(int fromIndex, int toIndex, FileType fileType) {
 //-----------------------------------------------------------------------------
 
 void RecentFiles::removeFilePath(int index, FileType fileType) {
-  if (fileType == Scene)
+  if (fileType == Scene) {
     m_recentScenes.removeAt(index);
-  else if (fileType == Level)
+    m_recentSceneProjects.removeAt(index);
+  } else if (fileType == Level)
     m_recentLevels.removeAt(index);
   saveRecentFiles();
 }
@@ -2384,10 +2401,26 @@ QString RecentFiles::getFilePath(int index, FileType fileType) const {
 
 //-----------------------------------------------------------------------------
 
+QString RecentFiles::getFileProject(int index) const {
+  if (index >= m_recentScenes.size() || index >= m_recentSceneProjects.size())
+    return "-";
+  return m_recentSceneProjects[index];
+}
+
+QString RecentFiles::getFileProject(QString fileName) const {
+  for (int index = 0; index < m_recentScenes.size(); index++)
+    if (m_recentScenes[index] == fileName) return m_recentSceneProjects[index];
+
+  return "-";
+}
+
+//-----------------------------------------------------------------------------
+
 void RecentFiles::clearRecentFilesList(FileType fileType) {
-  if (fileType == Scene)
+  if (fileType == Scene) {
     m_recentScenes.clear();
-  else if (fileType == Level)
+    m_recentSceneProjects.clear();
+  } else if (fileType == Level)
     m_recentLevels.clear();
   else
     m_recentFlipbookImages.clear();
@@ -2411,6 +2444,22 @@ void RecentFiles::loadRecentFiles() {
     QString scene = settings.value(QString("Scenes")).toString();
     if (!scene.isEmpty()) m_recentScenes.append(scene);
   }
+
+  // Load scene's projects info. This is for display purposes only. For
+  // backwards compatibility it is stored and maintained separately.
+  QList<QVariant> sceneProjects =
+      settings.value(QString("SceneProjects")).toList();
+  if (!sceneProjects.isEmpty()) {
+    for (i = 0; i < sceneProjects.size(); i++)
+      m_recentSceneProjects.append(sceneProjects.at(i).toString());
+  } else {
+    QString sceneProject = settings.value(QString("SceneProjects")).toString();
+    if (!sceneProject.isEmpty()) m_recentSceneProjects.append(sceneProject);
+  }
+  // Should be 1-to-1. If we're short, append projects list with "-".
+  while (m_recentSceneProjects.size() < m_recentScenes.size())
+    m_recentSceneProjects.append("-");
+
   QList<QVariant> levels = settings.value(QString("Levels")).toList();
   if (!levels.isEmpty()) {
     for (i = 0; i < levels.size(); i++) {
@@ -2448,6 +2497,7 @@ void RecentFiles::saveRecentFiles() {
   TFilePath fp = ToonzFolder::getMyModuleDir() + TFilePath("RecentFiles.ini");
   QSettings settings(toQString(fp), QSettings::IniFormat);
   settings.setValue(QString("Scenes"), QVariant(m_recentScenes));
+  settings.setValue(QString("SceneProjects"), QVariant(m_recentSceneProjects));
   settings.setValue(QString("Levels"), QVariant(m_recentLevels));
   settings.setValue(QString("FlipbookImages"),
                     QVariant(m_recentFlipbookImages));

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -208,6 +208,7 @@ signals:
 class RecentFiles {
   friend class StartupPopup;
   QList<QString> m_recentScenes;
+  QList<QString> m_recentSceneProjects;
   QList<QString> m_recentLevels;
   QList<QString> m_recentFlipbookImages;
 
@@ -219,10 +220,12 @@ public:
   static RecentFiles *instance();
   ~RecentFiles();
 
-  void addFilePath(QString path, FileType fileType);
+  void addFilePath(QString path, FileType fileType, QString projectName = 0);
   void moveFilePath(int fromIndex, int toIndex, FileType fileType);
   void removeFilePath(int fromIndex, FileType fileType);
   QString getFilePath(int index, FileType fileType) const;
+  QString getFileProject(QString fileName) const;
+  QString getFileProject(int index) const;
   void clearRecentFilesList(FileType fileType);
   void loadRecentFiles();
   void saveRecentFiles();

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -527,7 +527,7 @@ void SceneViewerPanel::changeWindowTitle() {
     QString sceneName   = QString::fromStdWString(scene->getSceneName());
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
     if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-    name = tr("Scene: ") + sceneName + "   ::   Project: " + projectName;
+    name = tr("Scene: ") + sceneName + tr("   ::   Project: ") + projectName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -27,6 +27,7 @@
 #include "toonz/tonionskinmaskhandle.h"
 #include "toutputproperties.h"
 #include "toonz/preferences.h"
+#include "toonz/tproject.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -521,10 +522,12 @@ void SceneViewerPanel::changeWindowTitle() {
   int frame = app->getCurrentFrame()->getFrame();
   QString name;
   if (app->getCurrentFrame()->isEditingScene()) {
-    QString sceneName = QString::fromStdWString(scene->getSceneName());
+    TProject *project   = scene->getProject();
+    QString projectName = QString::fromStdString(project->getName().getName());
+    QString sceneName   = QString::fromStdWString(scene->getSceneName());
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
     if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-    name = tr("Scene: ") + sceneName;
+    name = tr("Scene: ") + sceneName + "   ::   Project: " + projectName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1597,7 +1597,8 @@ void XsheetViewer::changeWindowTitle() {
   QString sceneName   = QString::fromStdWString(scene->getSceneName());
   if (sceneName.isEmpty()) sceneName = tr("Untitled");
   if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-  QString name = tr("Scene: ") + sceneName + "   ::   Project: " + projectName;
+  QString name =
+      tr("Scene: ") + sceneName + tr("   ::   Project: ") + projectName;
   int frameCount = scene->getFrameCount();
   name           = name + "   ::   " + tr(std::to_string(frameCount).c_str()) +
          (frameCount == 1 ? tr(" Frame") : tr(" Frames"));

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -32,6 +32,7 @@
 #include "toonz/txshnoteset.h"
 #include "toonz/childstack.h"
 #include "toonz/txshlevelhandle.h"
+#include "toonz/tproject.h"
 #include "tconvert.h"
 
 #include "tenv.h"
@@ -1591,13 +1592,15 @@ void XsheetViewer::changeWindowTitle() {
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
   if (!scene || !app->getCurrentFrame()->isEditingScene()) return;
-  QString sceneName = QString::fromStdWString(scene->getSceneName());
+  TProject *project   = scene->getProject();
+  QString projectName = QString::fromStdString(project->getName().getName());
+  QString sceneName   = QString::fromStdWString(scene->getSceneName());
   if (sceneName.isEmpty()) sceneName = tr("Untitled");
   if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-  QString name   = tr("Scene: ") + sceneName;
+  QString name = tr("Scene: ") + sceneName + "   ::   Project: " + projectName;
   int frameCount = scene->getFrameCount();
   name           = name + "   ::   " + tr(std::to_string(frameCount).c_str()) +
-         tr(" Frames");
+         (frameCount == 1 ? tr(" Frame") : tr(" Frames"));
 
   // subXsheet or not
   ChildStack *childStack = scene->getChildStack();


### PR DESCRIPTION
This PR displays the Project name next to the Scene name in the following areas

1) Title bar

![image](https://user-images.githubusercontent.com/19245851/52180218-8b396580-27b1-11e9-8cfd-055f93e5eff5.png)

2) Viewer (shown below), Combo Viewer, Xsheet

![image](https://user-images.githubusercontent.com/19245851/52180267-0f8be880-27b2-11e9-8dc2-7717d51af478.png)

3) Startup popup - recent list

![image](https://user-images.githubusercontent.com/19245851/52180211-79f05900-27b1-11e9-9dbc-97574cb0ac2a.png)

NOTE: For existing recent history, the Project name will not display since it doesn't know where it is yet.  Once the scene is opened, it will capture the project name for displaying in the future.