### PR TITLE
Backup scene file

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -124,6 +124,9 @@ public:
   void enableBackup(bool enabled);
   bool isBackupEnabled() const { return m_backupEnabled; }
 
+  void setBackupKeepCount(int count);
+  int getBackupKeepCount() { return m_backupKeepCount; }
+
   void enableSceneNumbering(bool enabled);
   bool isSceneNumberingEnabled() const { return m_sceneNumberingEnabled; }
 
@@ -722,6 +725,8 @@ private:
 
   bool m_enableWinInk                         = false;
   bool m_useOnionColorsForShiftAndTraceGhosts = false;
+
+  int m_backupKeepCount;
 
 private:
   Preferences();

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -121,8 +121,8 @@ public:
     return m_autosaveOtherFilesEnabled;
   }
 
-  void enableLevelsBackup(bool enabled);
-  bool isLevelsBackupEnabled() const { return m_levelsBackupEnabled; }
+  void enableBackup(bool enabled);
+  bool isBackupEnabled() const { return m_backupEnabled; }
 
   void enableSceneNumbering(bool enabled);
   bool isSceneNumberingEnabled() const { return m_sceneNumberingEnabled; }
@@ -635,9 +635,8 @@ private:
       m_expandFunctionHeader, m_showColumnNumbers, m_animatedGuidedDrawing;
   bool m_rasterOptimizedMemory, m_saveUnpaintedInCleanup,
       m_askForOverrideRender, m_automaticSVNFolderRefreshEnabled, m_SVNEnabled,
-      m_levelsBackupEnabled, m_minimizeSaveboxAfterEditing,
-      m_sceneNumberingEnabled, m_animationSheetEnabled, m_inksOnly,
-      m_startupPopupEnabled;
+      m_backupEnabled, m_minimizeSaveboxAfterEditing, m_sceneNumberingEnabled,
+      m_animationSheetEnabled, m_inksOnly, m_startupPopupEnabled;
   bool m_fillOnlySavebox, m_show0ThickLines, m_regionAntialias;
   bool m_onionSkinDuringPlayback, m_ignoreImageDpi,
       m_syncLevelRenumberWithXsheet;

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -927,8 +927,14 @@ void PreferencesPopup::onLineTestFpsCapture(int index) {
 
 //-----------------------------------------------------------------------------
 
-void PreferencesPopup::onBackupChanged(int index) {
-  m_pref->enableBackup(index == Qt::Checked);
+void PreferencesPopup::onBackupChanged(bool enabled) {
+  m_pref->enableBackup(enabled);
+}
+
+//-----------------------------------------------------------------------------
+
+void PreferencesPopup::onBackupKeepCountChanged() {
+  m_pref->setBackupKeepCount(m_backupKeepCount->getValue());
 }
 
 //-----------------------------------------------------------------------------
@@ -1298,7 +1304,10 @@ PreferencesPopup::PreferencesPopup()
 
   m_undoMemorySize =
       new DVGui::IntLineEdit(this, m_pref->getUndoMemorySize(), 0, 2000);
-  m_backup = new CheckBox(tr("Backup Scene and Animation Levels when Saving"));
+  m_backup = new QGroupBox(tr("Backup Scene and Animation Levels when Saving"));
+  m_backup->setCheckable(true);
+  m_backupKeepCount =
+      new DVGui::IntLineEdit(this, m_pref->getBackupKeepCount(), 1);
   m_chunkSizeFld =
       new DVGui::IntLineEdit(this, m_pref->getDefaultTaskChunkSize(), 1, 2000);
   CheckBox *sceneNumberingCB = new CheckBox(tr("Show Info in Rendered Frames"));
@@ -2017,7 +2026,24 @@ PreferencesPopup::PreferencesPopup()
 
       generalFrameLay->addWidget(replaceAfterSaveLevelAsCB, 0,
                                  Qt::AlignLeft | Qt::AlignVCenter);
-      generalFrameLay->addWidget(m_backup, 0, Qt::AlignLeft | Qt::AlignVCenter);
+
+      QVBoxLayout *backupLay = new QVBoxLayout();
+      backupLay->setMargin(10);
+      {
+        QHBoxLayout *backupCountLay = new QHBoxLayout();
+        backupCountLay->setMargin(0);
+        backupCountLay->setSpacing(5);
+        {
+          backupCountLay->addWidget(
+              new QLabel(tr("# of backups to keep: "), this));
+          backupCountLay->addWidget(m_backupKeepCount, 0);
+          backupCountLay->addStretch(1);
+        }
+        backupLay->addLayout(backupCountLay, 0);
+      }
+      m_backup->setLayout(backupLay);
+      generalFrameLay->addWidget(m_backup);
+
       generalFrameLay->addWidget(sceneNumberingCB, 0,
                                  Qt::AlignLeft | Qt::AlignVCenter);
       generalFrameLay->addWidget(watchFileSystemCB, 0,
@@ -2767,8 +2793,10 @@ PreferencesPopup::PreferencesPopup()
                        SLOT(onDragCellsBehaviourChanged(int)));
   ret = ret && connect(m_undoMemorySize, SIGNAL(editingFinished()),
                        SLOT(onUndoMemorySizeChanged()));
-  ret = ret && connect(m_backup, SIGNAL(stateChanged(int)),
-                       SLOT(onBackupChanged(int)));
+  ret = ret &&
+        connect(m_backup, SIGNAL(toggled(bool)), SLOT(onBackupChanged(bool)));
+  ret = ret && connect(m_backupKeepCount, SIGNAL(editingFinished()), this,
+                       SLOT(onBackupKeepCountChanged()));
   ret = ret && connect(sceneNumberingCB, SIGNAL(stateChanged(int)),
                        SLOT(onSceneNumberingChanged(int)));
   ret = ret && connect(watchFileSystemCB, SIGNAL(stateChanged(int)),

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -927,8 +927,8 @@ void PreferencesPopup::onLineTestFpsCapture(int index) {
 
 //-----------------------------------------------------------------------------
 
-void PreferencesPopup::onLevelsBackupChanged(int index) {
-  m_pref->enableLevelsBackup(index == Qt::Checked);
+void PreferencesPopup::onBackupChanged(int index) {
+  m_pref->enableBackup(index == Qt::Checked);
 }
 
 //-----------------------------------------------------------------------------
@@ -1298,7 +1298,7 @@ PreferencesPopup::PreferencesPopup()
 
   m_undoMemorySize =
       new DVGui::IntLineEdit(this, m_pref->getUndoMemorySize(), 0, 2000);
-  m_levelsBackup = new CheckBox(tr("Backup Animation Levels when Saving"));
+  m_backup = new CheckBox(tr("Backup Scene and Animation Levels when Saving"));
   m_chunkSizeFld =
       new DVGui::IntLineEdit(this, m_pref->getDefaultTaskChunkSize(), 1, 2000);
   CheckBox *sceneNumberingCB = new CheckBox(tr("Show Info in Rendered Frames"));
@@ -1631,7 +1631,7 @@ PreferencesPopup::PreferencesPopup()
   replaceAfterSaveLevelAsCB->setChecked(
       m_pref->isReplaceAfterSaveLevelAsEnabled());
 
-  m_levelsBackup->setChecked(m_pref->isLevelsBackupEnabled());
+  m_backup->setChecked(m_pref->isBackupEnabled());
   sceneNumberingCB->setChecked(m_pref->isSceneNumberingEnabled());
   watchFileSystemCB->setChecked(m_pref->isWatchFileSystemEnabled());
 
@@ -2017,8 +2017,7 @@ PreferencesPopup::PreferencesPopup()
 
       generalFrameLay->addWidget(replaceAfterSaveLevelAsCB, 0,
                                  Qt::AlignLeft | Qt::AlignVCenter);
-      generalFrameLay->addWidget(m_levelsBackup, 0,
-                                 Qt::AlignLeft | Qt::AlignVCenter);
+      generalFrameLay->addWidget(m_backup, 0, Qt::AlignLeft | Qt::AlignVCenter);
       generalFrameLay->addWidget(sceneNumberingCB, 0,
                                  Qt::AlignLeft | Qt::AlignVCenter);
       generalFrameLay->addWidget(watchFileSystemCB, 0,
@@ -2768,8 +2767,8 @@ PreferencesPopup::PreferencesPopup()
                        SLOT(onDragCellsBehaviourChanged(int)));
   ret = ret && connect(m_undoMemorySize, SIGNAL(editingFinished()),
                        SLOT(onUndoMemorySizeChanged()));
-  ret = ret && connect(m_levelsBackup, SIGNAL(stateChanged(int)),
-                       SLOT(onLevelsBackupChanged(int)));
+  ret = ret && connect(m_backup, SIGNAL(stateChanged(int)),
+                       SLOT(onBackupChanged(int)));
   ret = ret && connect(sceneNumberingCB, SIGNAL(stateChanged(int)),
                        SLOT(onSceneNumberingChanged(int)));
   ret = ret && connect(watchFileSystemCB, SIGNAL(stateChanged(int)),

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -74,7 +74,7 @@ private:
 
   QPushButton *m_addLevelFormat, *m_removeLevelFormat, *m_editLevelFormat;
 
-  DVGui::CheckBox *m_inksOnly, *m_enableVersionControl, *m_levelsBackup,
+  DVGui::CheckBox *m_inksOnly, *m_enableVersionControl, *m_backup,
       *m_onionSkinVisibility, *m_pixelsOnlyCB, *m_projectRootDocuments,
       *m_projectRootDesktop, *m_projectRootCustom, *m_projectRootStuff,
       *m_onionSkinDuringPlayback, *m_autoSaveSceneCB, *m_autoSaveOtherFilesCB,
@@ -147,7 +147,7 @@ private slots:
   void onSVNEnabledChanged(int);
   void onAutomaticSVNRefreshChanged(int);
   void onDragCellsBehaviourChanged(int);
-  void onLevelsBackupChanged(int);
+  void onBackupChanged(int);
   void onSceneNumberingChanged(int);
   void onChunkSizeChanged();
   void onDefLevelTypeChanged(int);

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -70,14 +70,14 @@ private:
   DVGui::IntLineEdit *m_minuteFld, *m_chunkSizeFld, *m_iconSizeLx,
       *m_iconSizeLy, *m_viewShrink, *m_viewStep, *m_blanksCount,
       *m_onionPaperThickness, *m_animationStepField, *m_undoMemorySize,
-      *m_xsheetStep, *m_ffmpegTimeout;
+      *m_xsheetStep, *m_ffmpegTimeout, *m_backupKeepCount;
 
   QPushButton *m_addLevelFormat, *m_removeLevelFormat, *m_editLevelFormat;
 
-  DVGui::CheckBox *m_inksOnly, *m_enableVersionControl, *m_backup,
-      *m_onionSkinVisibility, *m_pixelsOnlyCB, *m_projectRootDocuments,
-      *m_projectRootDesktop, *m_projectRootCustom, *m_projectRootStuff,
-      *m_onionSkinDuringPlayback, *m_autoSaveSceneCB, *m_autoSaveOtherFilesCB,
+  DVGui::CheckBox *m_inksOnly, *m_enableVersionControl, *m_onionSkinVisibility,
+      *m_pixelsOnlyCB, *m_projectRootDocuments, *m_projectRootDesktop,
+      *m_projectRootCustom, *m_projectRootStuff, *m_onionSkinDuringPlayback,
+      *m_autoSaveSceneCB, *m_autoSaveOtherFilesCB,
       *m_useNumpadForSwitchingStyles, *m_expandFunctionHeader,
       *m_useHigherDpiOnVectorSimplifyCB, *m_keepFillOnVectorSimplifyCB,
       *m_newLevelToCameraSizeCB, *m_ignoreImageDpiCB,
@@ -90,7 +90,8 @@ private:
   DVGui::FileField *m_ffmpegPathFileFld, *m_fastRenderPathFileField,
       *m_lutPathFileField;
 
-  QGroupBox *m_autoSaveGroup, *m_showXSheetToolbar, *m_colorCalibration;
+  QGroupBox *m_autoSaveGroup, *m_showXSheetToolbar, *m_colorCalibration,
+      *m_backup;
 
   DVGui::ColorField *m_currentColumnColor;
 
@@ -147,7 +148,7 @@ private slots:
   void onSVNEnabledChanged(int);
   void onAutomaticSVNRefreshChanged(int);
   void onDragCellsBehaviourChanged(int);
-  void onBackupChanged(int);
+  void onBackupChanged(bool enabled);
   void onSceneNumberingChanged(int);
   void onChunkSizeChanged();
   void onDefLevelTypeChanged(int);
@@ -221,6 +222,7 @@ private slots:
   void onCurrentColumnDataChanged(const TPixel32 &, bool isDragging);
   void onEnableWinInkChanged(int index);
   void onRasterBackgroundColorChanged(const TPixel32 &, bool isDragging);
+  void onBackupKeepCountChanged();
 };
 
 //**********************************************************************************

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -286,7 +286,7 @@ Preferences::Preferences()
     , m_automaticSVNFolderRefreshEnabled(true)
     , m_SVNEnabled(false)
     , m_minimizeSaveboxAfterEditing(true)
-    , m_levelsBackupEnabled(false)
+    , m_backupEnabled(true)
     , m_sceneNumberingEnabled(false)
     , m_animationSheetEnabled(false)
     , m_inksOnly(false)
@@ -390,7 +390,7 @@ Preferences::Preferences()
   getValue(*m_settings, "SVNEnabled", m_SVNEnabled);
   getValue(*m_settings, "minimizeSaveboxAfterEditing",
            m_minimizeSaveboxAfterEditing);
-  getValue(*m_settings, "levelsBackupEnabled", m_levelsBackupEnabled);
+  getValue(*m_settings, "backupEnabled", m_backupEnabled);
   getValue(*m_settings, "sceneNumberingEnabled", m_sceneNumberingEnabled);
   getValue(*m_settings, "animationSheetEnabled", m_animationSheetEnabled);
   getValue(*m_settings, "autosaveEnabled", m_autosaveEnabled);
@@ -1433,9 +1433,9 @@ void Preferences::setDownArrowLevelStripNewFrame(bool on) {
 
 //-----------------------------------------------------------------
 
-void Preferences::enableLevelsBackup(bool enabled) {
-  m_levelsBackupEnabled = enabled;
-  m_settings->setValue("levelsBackupEnabled", enabled ? "1" : "0");
+void Preferences::enableBackup(bool enabled) {
+  m_backupEnabled = enabled;
+  m_settings->setValue("backupEnabled", enabled ? "1" : "0");
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -347,7 +347,8 @@ Preferences::Preferences()
     , m_currentColumnColor(TPixel::Black)
     , m_enableWinInk(false)
     , m_useOnionColorsForShiftAndTraceGhosts(false)
-    , m_rasterBackgroundColor(TPixel::White) {
+    , m_rasterBackgroundColor(TPixel::White)
+    , m_backupKeepCount(1) {
   TCamera camera;
   m_defLevelType   = PLI_XSHLEVEL;
   m_defLevelWidth  = camera.getSize().lx;
@@ -391,6 +392,7 @@ Preferences::Preferences()
   getValue(*m_settings, "minimizeSaveboxAfterEditing",
            m_minimizeSaveboxAfterEditing);
   getValue(*m_settings, "backupEnabled", m_backupEnabled);
+  getValue(*m_settings, "backupKeepCount", m_backupKeepCount);
   getValue(*m_settings, "sceneNumberingEnabled", m_sceneNumberingEnabled);
   getValue(*m_settings, "animationSheetEnabled", m_animationSheetEnabled);
   getValue(*m_settings, "autosaveEnabled", m_autosaveEnabled);
@@ -1436,6 +1438,13 @@ void Preferences::setDownArrowLevelStripNewFrame(bool on) {
 void Preferences::enableBackup(bool enabled) {
   m_backupEnabled = enabled;
   m_settings->setValue("backupEnabled", enabled ? "1" : "0");
+}
+
+//-----------------------------------------------------------------
+
+void Preferences::setBackupKeepCount(int count) {
+  m_backupKeepCount = count;
+  m_settings->setValue("backupKeepCount", count);
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -180,12 +180,11 @@ static void saveBackup(TFilePath path) {
     std::string bakExt =
         ".bak" + (totalBackups > 0 ? std::to_string(totalBackups) : "");
     backup = path.withType(path.getType() + bakExt);
-    if (!TSystem::doesExistFileOrLevel(backup)) continue;
-    try {
-      if (TSystem::doesExistFileOrLevel(prevBackup))
-        TSystem::removeFileOrLevel_throw(prevBackup);
-      TSystem::copyFileOrLevel_throw(prevBackup, backup);
-    } catch (...) {
+    if (TSystem::doesExistFileOrLevel(backup)) {
+      try {
+        TSystem::copyFileOrLevel_throw(prevBackup, backup);
+      } catch (...) {
+      }
     }
     prevBackup = backup;
   }

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -172,7 +172,7 @@ void deleteUntitledScene(const TFilePath &fp) {
 
 static void saveBackup(TFilePath path) {
   try {
-    TFilePath backup = path.withName(path.getName() + "_backup");
+    TFilePath backup = path.withType(path.getType() + ".bak");
     if (TSystem::doesExistFileOrLevel(backup))
       TSystem::removeFileOrLevel_throw(backup);
     TSystem::copyFileOrLevel_throw(backup, path);

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1375,7 +1375,7 @@ void TXshSimpleLevel::save() {
 
 static void saveBackup(TFilePath path) {
   try {
-    TFilePath backup = path.withName(path.getName() + "_backup");
+    TFilePath backup = path.withType(path.getType() + ".bak");
     if (TSystem::doesExistFileOrLevel(backup))
       TSystem::removeFileOrLevel_throw(backup);
     TSystem::copyFileOrLevel_throw(backup, path);

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1397,8 +1397,8 @@ void TXshSimpleLevel::save(const TFilePath &fp, const TFilePath &oldFp,
         "The level cannot be saved: failed to access the target folder.");
 
   // backup
-  if (Preferences::instance()->isLevelsBackupEnabled() &&
-      dOldPath == dDstPath && TSystem::doesExistFileOrLevel(dDstPath))
+  if (Preferences::instance()->isBackupEnabled() && dOldPath == dDstPath &&
+      TSystem::doesExistFileOrLevel(dDstPath))
     saveBackup(dDstPath);
 
   if (isAreadOnlyLevel(dDstPath)) {
@@ -1638,7 +1638,7 @@ void TXshSimpleLevel::saveSimpleLevel(const TFilePath &decodedFp,
         lw = TLevelWriterP();  // TLevelWriterP's destructor saves the palette
       } else if (isPaletteModified && overwritePalette) {
         TFilePath palettePath = decodedFp.withNoFrame().withType("tpl");
-        if (Preferences::instance()->isLevelsBackupEnabled() &&
+        if (Preferences::instance()->isBackupEnabled() &&
             TSystem::doesExistFileOrLevel(palettePath))
           saveBackup(palettePath);
         TOStream os(palettePath);
@@ -2199,9 +2199,8 @@ TFilePath TXshSimpleLevel::getExistingHookFile(
   }
 
   assert(h >= 0);
-  return (h < 0) ? TFilePath()
-                 : decodedLevelPath.getParentDir() +
-                       TFilePath(hookFiles[h].toStdWString());
+  return (h < 0) ? TFilePath() : decodedLevelPath.getParentDir() +
+                                     TFilePath(hookFiles[h].toStdWString());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1374,8 +1374,26 @@ void TXshSimpleLevel::save() {
 //-----------------------------------------------------------------------------
 
 static void saveBackup(TFilePath path) {
+  int totalBackups = Preferences::instance()->getBackupKeepCount();
+  totalBackups -= 1;
+  TFilePath backup = path.withType(path.getType() + ".bak");
+  TFilePath prevBackup =
+      path.withType(path.getType() + ".bak" + std::to_string(totalBackups));
+  while (--totalBackups >= 0) {
+    std::string bakExt =
+        ".bak" + (totalBackups > 0 ? std::to_string(totalBackups) : "");
+    backup = path.withType(path.getType() + bakExt);
+    if (!TSystem::doesExistFileOrLevel(backup)) continue;
+    try {
+      if (TSystem::doesExistFileOrLevel(prevBackup))
+        TSystem::removeFileOrLevel_throw(prevBackup);
+      TSystem::copyFileOrLevel_throw(prevBackup, backup);
+    } catch (...) {
+    }
+    prevBackup = backup;
+  }
+
   try {
-    TFilePath backup = path.withType(path.getType() + ".bak");
     if (TSystem::doesExistFileOrLevel(backup))
       TSystem::removeFileOrLevel_throw(backup);
     TSystem::copyFileOrLevel_throw(backup, path);


### PR DESCRIPTION
Currently there is a level-only backup, but that preference is OFF by default.  Considering OT's instability, being OFF by default is not a good thing. In my opinion, it should be ON by default.

Additionally, the scene file is not backed up and it really should do that when saving also.  I've seen 1 too many crashes by users that resulted in level(s) and scene files being corrupted and lots of work lost.

This PR will somewhat address these issue with the following changes:

1) Modified the backup Preference in the General tab to say `Backup Scene and Animation Levels when Saving`.
2) Set the backup preference setting to ON by default.
3) A simple copy of the `.tnz` file to a  `_backup.tnz` file, similar to how levels are backed up, will be created when saving scenes.

NOTE: I have intentionally changed how backup preference is saved in the preference file, making the old setting obsolete. Therefore, once upgraded to a version that includes this, backups will be created by default until they turn it off.