### PR TITLE
Fix Toonz Raster brush style update crash

### DIFF
--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2081,6 +2081,11 @@ void ToonzRasterBrushTool::updateCurrentStyle() {
     TTool::Application *app = TTool::getApplication();
     TMyPaintBrushStyle *brushStyle =
         dynamic_cast<TMyPaintBrushStyle *>(app->getCurrentLevelStyle());
+    if (!brushStyle) {
+      // brush changed to normal abnormally. Complete color style change.
+      onColorStyleChanged();
+      return;
+    }
     double radiusLog = brushStyle->getBrush().getBaseValue(
                            MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC) +
                        m_modifierSize.getValue() * log(2.0);


### PR DESCRIPTION
This PR fixes #2516.

When updating the current style, if it thinks it's a MyPaint brush but actually is not, it will complete a color style change, internally, and allow it to continue as a normal Toonz Raster brush.

