### PR TITLE
Fix crash when loading bad fill data

### DIFF
--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -603,7 +603,10 @@ void TVectorImage::Imp::doEraseIntersection(int index,
       p1 = p1->next();
   }
 
-  if (deleteIt) delete deleteIt;
+  if (deleteIt) {
+	  m_intersectionData->m_autocloseMap.erase(index);
+	  delete deleteIt;
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -873,7 +876,7 @@ assert(v[b.m_nextBranch].m_nextBranch==i);
       if (!p2->m_edge.m_s && p2->m_edge.m_index < 0) {
         VIStroke *vs = m_intersectionData->m_autocloseMap[p2->m_edge.m_index];
         if (vs) {
-          p2->m_edge.m_s =
+			p2->m_edge.m_s =
               m_intersectionData->m_autocloseMap[p2->m_edge.m_index]->m_s;
 
           // TEdge& e = it2->m_edge;
@@ -3309,7 +3312,7 @@ struct TDeleteMapFunctor {
 };
 
 IntersectionData::~IntersectionData() {
-  std::for_each(m_autocloseMap.begin(), m_autocloseMap.end(),
+	std::for_each(m_autocloseMap.begin(), m_autocloseMap.end(),
                 TDeleteMapFunctor());
 }
 //-----------------------------------------------------------------------------

--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -457,8 +457,9 @@ static void cleanNextIntersection(const VIList<Intersection> &interList,
 //-----------------------------------------------------------------------------
 
 void TVectorImage::Imp::eraseEdgeFromStroke(IntersectedStroke *is) {
-  if (is->m_edge.m_index >=
-      0)  // elimino il puntatore all'edge nella lista della VIStroke
+  if (is->m_edge.m_index >= 0 &&
+      is->m_edge.m_index < m_strokes.size())  // elimino il puntatore all'edge
+                                              // nella lista della VIStroke
   {
     VIStroke *s;
     s = m_strokes[is->m_edge.m_index];
@@ -771,8 +772,7 @@ for (UINT ii=0; ii<branchCount; ii++)
       if (v[i].m_currInter >=
           size)  // pezza per immagine corrotte...evito crash
       {
-        intList.clear();
-        return;
+        break;
       }
 
       branchesBefore[v[i].m_currInter] = i;
@@ -787,7 +787,7 @@ for (UINT ii=0; ii<branchCount; ii++)
     currBranch->m_edge.m_styleId = b.m_style;
     // assert(b.m_style<100);
     currBranch->m_edge.m_index = b.m_strokeIndex;
-    if (b.m_strokeIndex >= 0)
+    if (b.m_strokeIndex >= 0 && b.m_strokeIndex < m_strokes.size())
       currBranch->m_edge.m_s = m_strokes[b.m_strokeIndex]->m_s;
     else
       currBranch->m_edge.m_s = 0;
@@ -840,7 +840,7 @@ assert(v[b.m_nextBranch].m_nextBranch==i);
       while (v[j].m_strokeIndex < 0 &&
              ((j > 0 && v[j].m_currInter == v[j - 1].m_currInter) || j == 0))
         j--;
-      if (v[j].m_strokeIndex >= 0)
+      if (v[j].m_strokeIndex >= 0 && v[j].m_strokeIndex < m_strokes.size())
         currInt->m_intersection =
             m_strokes[v[j].m_strokeIndex]->m_s->getPoint(v[j].m_w);
     }


### PR DESCRIPTION
This PR fixes #1586 

After some debugging through the logic that loads in vector images from file, I discovered the issue that was causing this to crash was bad stroke intersection information used for defining fill regions.  Essentially, it was trying to access stroke information for a stroke that doesn't exist.

Modified the logic to essentially ignore the bad intersection data when preparing fill information. This prevents the crash and allows whatever fill information is can get from the file to load.

The root cause of the bad intersection data still needs to be identified and corrected.  This fix will at least stop OT from crashing because of it.

This PR also fixes #2310 and another unreported crash from a Discord user I helped with the same issue.

This crash was also related to loading intersection data.  Logic removes some unwanted information but didn't remove it from a particular array leaving the pointer behind. When trying to delete the array, it failed trying to remove the previously deleted information.  Fixed it by making sure to remove the unwanted information from the array as well.
