### PR TITLE
Update Travis QT version for OSX builds

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -4,7 +4,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt/5.12.0/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt/5.12.1/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make -j 2


### PR DESCRIPTION
Homebrew updated QT version to 5.12.1.

Updating Travis scripts for OSX builds to fix build errors.