### PR TITLE
Fix autosave pen pressure loss

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -279,6 +279,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
         initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
         m_tabletState = Touched;
         onPress(mouseEvent);
+      } else if (m_tabletState == Touched) {
+        m_tabletState = StartStroke;
       }
     } else
       m_tabletEvent = false;
@@ -1046,66 +1048,66 @@ void SceneViewer::touchEvent(QTouchEvent *e, int type) {
 
 bool SceneViewer::event(QEvent *e) {
   /*
-    switch (e->type()) {
-    //	case QEvent::Enter:
-    //	qDebug() << "[enter] ************************** Enter";
-    //	break;
-    //	case QEvent::Leave:
-    //	qDebug() << "[enter] ************************** Leave";
-    //	break;
+  switch (e->type()) {
+  //	case QEvent::Enter:
+  //	qDebug() << "[enter] ************************** Enter";
+  //	break;
+  //	case QEvent::Leave:
+  //	qDebug() << "[enter] ************************** Leave";
+  //	break;
 
-    case QEvent::TabletPress: {
-      QTabletEvent *te = static_cast<QTabletEvent *>(e);
-      qDebug() << "[enter] ************************** TabletPress mouseState("
-               << m_mouseState << ") tabletState(" << m_tabletState
-               << ") pressure(" << m_pressure << ") pointerType("
-               << te->pointerType() << ") device(" << te->device() << ")";
-    } break;
-    //	case QEvent::TabletMove:
-    //	qDebug() << "[enter] ************************** TabletMove
-    //mouseState("<<m_mouseState<<") tabletState("<<m_tabletState<<") pressure("
-    //<< m_pressure << ")";
-    //	break;
-    case QEvent::TabletRelease:
-      qDebug() << "[enter] ************************** TabletRelease mouseState("
-               << m_mouseState << ") tabletState(" << m_tabletState << ")";
-      break;
+  case QEvent::TabletPress: {
+    QTabletEvent *te = static_cast<QTabletEvent *>(e);
+    qDebug() << "[enter] ************************** TabletPress mouseState("
+             << m_mouseState << ") tabletState(" << m_tabletState
+             << ") pressure(" << m_pressure << ") pointerType("
+             << te->pointerType() << ") device(" << te->device() << ")";
+  } break;
+  //	case QEvent::TabletMove:
+  //	qDebug() << "[enter] ************************** TabletMove
+  //mouseState("<<m_mouseState<<") tabletState("<<m_tabletState<<") pressure("
+  //<< m_pressure << ")";
+  //	break;
+  case QEvent::TabletRelease:
+    qDebug() << "[enter] ************************** TabletRelease mouseState("
+             << m_mouseState << ") tabletState(" << m_tabletState << ")";
+    break;
 
-    case QEvent::TouchBegin:
-      qDebug() << "[enter] ************************** TouchBegin";
-      break;
-    case QEvent::TouchEnd:
-      qDebug() << "[enter] ************************** TouchEnd";
-      break;
-    case QEvent::TouchCancel:
-      qDebug() << "[enter] ************************** TouchCancel";
-      break;
+  case QEvent::TouchBegin:
+    qDebug() << "[enter] ************************** TouchBegin";
+    break;
+  case QEvent::TouchEnd:
+    qDebug() << "[enter] ************************** TouchEnd";
+    break;
+  case QEvent::TouchCancel:
+    qDebug() << "[enter] ************************** TouchCancel";
+    break;
 
-    case QEvent::Gesture:
-      qDebug() << "[enter] ************************** Gesture";
-      break;
+  case QEvent::Gesture:
+    qDebug() << "[enter] ************************** Gesture";
+    break;
 
-    case QEvent::MouseButtonPress:
-      qDebug()
-          << "[enter] ************************** MouseButtonPress mouseState("
-          << m_mouseState << ") tabletState(" << m_tabletState << ") pressure("
-          << m_pressure << ") tabletEvent(" << m_tabletEvent << ")";
-      break;
-    //	case QEvent::MouseMove:
-    //	qDebug() << "[enter] ************************** MouseMove mouseState("
-    //<< m_mouseState << ") tabletState("<<m_tabletState<<") pressure(" <<
-    //m_pressure << ")";
-    //	break;
-    case QEvent::MouseButtonRelease:
-      qDebug()
-          << "[enter] ************************** MouseButtonRelease mouseState("
-          << m_mouseState << ") tabletState(" << m_tabletState << ")";
-      break;
+  case QEvent::MouseButtonPress:
+    qDebug()
+        << "[enter] ************************** MouseButtonPress mouseState("
+        << m_mouseState << ") tabletState(" << m_tabletState << ") pressure("
+        << m_pressure << ") tabletEvent(" << m_tabletEvent << ")";
+    break;
+  //	case QEvent::MouseMove:
+  //	qDebug() << "[enter] ************************** MouseMove mouseState("
+  //<< m_mouseState << ") tabletState("<<m_tabletState<<") pressure(" <<
+  //m_pressure << ")";
+  //	break;
+  case QEvent::MouseButtonRelease:
+    qDebug()
+        << "[enter] ************************** MouseButtonRelease mouseState("
+        << m_mouseState << ") tabletState(" << m_tabletState << ")";
+    break;
 
-    case QEvent::MouseButtonDblClick:
-      qDebug() << "[enter] ============================== MouseButtonDblClick";
-      break;
-    }
+  case QEvent::MouseButtonDblClick:
+    qDebug() << "[enter] ============================== MouseButtonDblClick";
+    break;
+  }
   */
   if (e->type() == QEvent::Gesture &&
       CommandManager::instance()


### PR DESCRIPTION
This fixes an issue reported by a Windows user where the pen pressure sensitivity is sometimes lost after an autosave.  This can happen when quickly drawing around the time autosave happens.

It's a bit difficult to recreate this issue repeatedly as it requires precise timing and a bit of luck but I was able to do it enough times to find the issue. Basically when quickly drawing marks, if an autosave happens just prior to a `TabletRelease` event, the logic keeping track of the tablet state gets locked into a `Touched` state from a series of unexpected tablet events that follow. This state causes the viewer to ignore pressure information, and default to drawing with a mouse.  Once in this bad state, the only way past it is to open a new viewer or restart OT.

Added a quick check for this scenario and force it to move to the next tablet state so subsequent events can process correctly.  This fix was only made for non-macOS systems for now.
