### PR TITLE
Fix Updating Scene Settings Popup Checkbox

### DIFF
--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -252,6 +252,8 @@ void SceneSettingsPopup::update() {
   sprop->getMarkers(markerDistance, markerOffset);
   m_markerIntervalFld->setValue(markerDistance);
   m_startFrameFld->setValue(markerOffset + 1);
+  m_colorFilterOnRenderCB->setChecked(
+      sprop->isColumnColorFilterOnRenderEnabled());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR will fix the following problem:

When you load scene, `Enable Column Color Filter and Transparency for Rendering` checkbox in the scene settings popup does not update with the loaded scene property.