### PR TITLE
Fix Flipbook Color Mask When Viewing TLV Files

### DIFF
--- a/toonz/sources/toonzlib/imagepainter.cpp
+++ b/toonz/sources/toonzlib/imagepainter.cpp
@@ -394,26 +394,22 @@ void Painter::doFlushRasterImages(const TRasterP &rin, int bg,
 
   bool showChannelsOnMatte =
       (chan != TRop::MChan && chan != 0 && !m_vSettings.m_greytones);
-  if ((!showChannelsOnMatte && !m_vSettings.m_useTexture && chan != 0) ||
-      (!showChannelsOnMatte && m_vSettings.m_useTexture &&
-       (chan == TRop::MChan || m_vSettings.m_greytones))) {
-    TRasterP app = _rin->create(_rin->getLx(), _rin->getLy());
-    try {
-      TRop::setChannel(_rin, app, chan, m_vSettings.m_greytones);
-      if (!m_vSettings.m_useTexture)
-        _rin = app;
-      else
-        ras = app;
-    } catch (...) {
-    }
-  }
 
   if (m_vSettings.m_useTexture) {
     TRaster32P checkBoardRas = buildCheckboard(bg, _rin->getSize());
     GLRasterPainter::drawRaster(aff, checkBoardRas->getRawData(),
                                 checkBoardRas->getWrap(), 4,
                                 checkBoardRas->getSize(), true);
-    if (showChannelsOnMatte) ras = keepChannels(_rin, m_palette, chan);
+    if (showChannelsOnMatte)
+      ras = keepChannels(_rin, m_palette, chan);
+    else if (chan == TRop::MChan || m_vSettings.m_greytones) {
+      TRasterP app = ras->create(ras->getLx(), ras->getLy());
+      try {
+        TRop::setChannel(ras, app, chan, m_vSettings.m_greytones);
+        ras = app;
+      } catch (...) {
+      }
+    }
     GLRasterPainter::drawRaster(aff, ras->getRawData(), ras->getWrap(), 4,
                                 ras->getSize(), true);
     ras->unlock();
@@ -437,9 +433,19 @@ void Painter::doFlushRasterImages(const TRasterP &rin, int bg,
       quickput(ras, keepChannels(_rin, m_palette, chan), m_palette,
                m_vSettings.m_useTexture ? TAffine() : aff * TTranslation(offs),
                m_vSettings.m_useChecks);
-    else
+    else if (chan != 0) {
+      TRasterP app = ras->create(_rin->getLx(), _rin->getLy());
+      quickput(app, _rin, m_palette, TAffine(), m_vSettings.m_useChecks);
+      try {
+        TRop::setChannel(app, app, chan, m_vSettings.m_greytones);
+      } catch (...) {
+      }
+      quickput(ras, app, m_palette, aff * TTranslation(offs),
+               m_vSettings.m_useChecks);
+    } else {
       quickput(ras, _rin, m_palette, aff * TTranslation(offs),
                m_vSettings.m_useChecks);
+    }
 
     glDisable(GL_BLEND);
 


### PR DESCRIPTION
This PR will fix the following problem:

- When viewing TLV files by using `View...` command, `Red/Green/Blue Channel in Grayscale` buttons and `Alpha Channel` button in the Flipbook console does not take effect.

Please note that the same problem occurs on viewing PLI files as well but not resolved in this PR.