### PR TITLE
Fix warning -Z-reserved-lib-stdc++

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -203,7 +203,10 @@ elseif(BUILD_ENV_UNIXLIKE)
 
     find_package(Qt5Widgets)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++ -std=c++11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    if (NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++")
+    endif()
 endif()
 
 add_definitions(


### PR DESCRIPTION
Fix these.
https://travis-ci.org/opentoonz/opentoonz/jobs/496829451#L2828
> clang-5.0: warning: -Z-reserved-lib-stdc++: 'linker' input unused [-Wunused-command-line-argument]

I don't know whether g++ or other compilers require -lstd.
At least Clang doesn't require -lstd.