### PR TITLE
Fix Transparent MOV Output

### DIFF
--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -515,7 +515,11 @@ void RenderCommand::rasterRender(bool isPreview) {
   // fixes background colors for non alpha-enabled movie types (eventually
   // transparent gif would be good)
   currBgColor.m = 255;
-  if (isMovieType(ext)) {
+  // Mov may have alpha channel under some settings (Millions of Colors+ color
+  // depth). I tried to make OT to detect the mov settings and adaptively switch
+  // the behavior, but ended in vain :-(
+  // So I just omitted every mov from applying solid background as a quick fix.
+  if (isMovieType(ext) && ext != "mov") {
     scene->getProperties()->setBgColor(currBgColor);
   }
   // for non alpha-enabled images (like jpg), background color will be inserted


### PR DESCRIPTION
This will fix #2530 

MOV may have alpha channel under some settings (Millions of Colors+ color depth). 
Currently a solid background is always inserted, which makes impossible to render transparent MOV.

I tried to make OT to detect the MOV settings and adaptively switch the behavior of the background insertion, but ended in vain :-( ... So I just omitted every MOV from applying solid background as a quick fix.

Please note that after merging this PR you will need to set the alpha channel to 255 in `Scene Settings > Camera BG Color` in order to make the background color visible, or the rendered MOV will have black background at the transparent region if it does not support alpha channel.