### PR TITLE
Replace RGBM and fix typos

### DIFF
--- a/stuff/profiles/layouts/fxs/STD_rgbmCutFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_rgbmCutFx.xml
@@ -1,5 +1,5 @@
 <fxlayout>
-  <page name="RGBM Cut">
+  <page name="RGBA Cut">
      <control>r_range</control>
      <control>g_range</control>
      <control>b_range</control>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1725,7 +1725,7 @@ void MainWindow::defineActions() {
   createMenuEditAction(MI_Ungroup, tr("&Ungroup"), "Ctrl+Shift+G");
   createMenuEditAction(MI_BringToFront, tr("&Bring to Front"), "Ctrl+]");
   createMenuEditAction(MI_BringForward, tr("&Bring Forward"), "]");
-  createMenuEditAction(MI_SendBack, tr("&Send Back"), "Ctrl+[");
+  createMenuEditAction(MI_SendBack, tr("&Send to Back"), "Ctrl+[");
   createMenuEditAction(MI_SendBackward, tr("&Send Backward"), "[");
   createMenuEditAction(MI_EnterGroup, tr("&Enter Group"), "");
   createMenuEditAction(MI_ExitGroup, tr("&Exit Group"), "");

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1138,7 +1138,7 @@ void TXshSimpleLevel::load() {
       if (info && info->m_samplePerPixel >= 5) {
         QString msg = QString(
                           "Failed to open %1.\nSamples per pixel is more than "
-                          "4. It may containt more than one alpha channel.")
+                          "4. It may contain more than one alpha channel.")
                           .arg(QString::fromStdWString(m_path.getWideString()));
         QMessageBox::warning(0, "Image format not supported", msg);
         return;

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -216,7 +216,7 @@ void premultiply(const TFilePath &levelPath) {
     /*
 if (!isMovie && lr->getImageInfo()->m_samplePerPixel!=4)
 {
-QMessageBox::information(0, QString("ERROR"), QString("Only rgbm images can be
+QMessageBox::information(0, QString("ERROR"), QString("Only rgba images can be
 premultiplied!"));
 return;
 }


### PR DESCRIPTION
This fixes: 
- visible occurrences of RGBM (#2548) which should have been replaced with RGBA
- error message typo
- makes "Send Back" command consistent with  "Send to Front"

If anyone finds other typos, I'd be happy to include the corrections here.