### PR TITLE
Remove stage schematic grouping restriction

### DIFF
--- a/toonz/sources/toonzqt/stageobjectselection.cpp
+++ b/toonz/sources/toonzqt/stageobjectselection.cpp
@@ -277,7 +277,7 @@ bool StageObjectSelection::isConnected() const {
 //-------------------------------------------------------
 
 void StageObjectSelection::groupSelection() {
-  if (m_selectedObjects.size() <= 1 || !isConnected()) return;
+  if (m_selectedObjects.size() <= 1) return;
   TStageObjectCmd::group(m_selectedObjects, m_xshHandle);
   selectNone();
   m_xshHandle->notifyXsheetChanged();


### PR DESCRIPTION
This PR updates the grouping logic in the Stage Schematic.

Current logic only allows the grouping of nodes in the Stage Schematic if all the selected nodes are connected back to 1 node.  This is not consistent with the Fx Schematic grouping, which allows any nodes to be group.

Logic has been updated to remove the connection requirement, allowing any combination of nodes to be grouped in the Stage Schematic.

This change was a result of a couple of users who couldn't understand why Stage Schematic nodes couldn't be grouped sometimes.  I couldn't find a reason why the connection requirement was needed, and tests without it did not appear to have any negative impact or side effects.