### PR TITLE
Fix bad Fx connection crash

### DIFF
--- a/toonz/sources/toonzqt/fxselection.cpp
+++ b/toonz/sources/toonzqt/fxselection.cpp
@@ -417,6 +417,7 @@ Link FxSelection::getBoundingFxs(SchematicLink *link) {
 Link FxSelection::getBoundingFxs(SchematicPort *inputPort,
                                  SchematicPort *outputPort) {
   Link boundingFxs;
+  if (!inputPort || !outputPort) return boundingFxs;
   FxSchematicNode *inputNode =
       dynamic_cast<FxSchematicNode *>(outputPort->getNode());
   FxSchematicNode *outputNode =

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -564,6 +564,12 @@ void SchematicLink::mousePressEvent(QGraphicsSceneMouseEvent *me) {
   QPointF pos              = me->scenePos();
   SchematicPort *startPort = getStartPort();
   SchematicPort *endPort   = getEndPort();
+
+  if (!startPort || !endPort) {
+    me->ignore();
+    return;
+  }
+
   if (startPort && endPort) {
     QRectF startRect = startPort->boundingRect();
     startRect.moveTopLeft(startPort->scenePos());


### PR DESCRIPTION
This PR fixes #2552 

This crash is due to accessing elements on null pointers which are somehow generated as a result of an issue identified with port swapping.  Added checks to deal with the null pointers that it was not expecting to see.

The underlying issue caused by the port swapping will still need to be looked at and fixed. These checks should be there anyway in case there are other scenarios that cause the null pointers.
