### PR TITLE
Fix PSD files removed on save command

### DIFF
--- a/toonz/sources/toonz/levelcommand.cpp
+++ b/toonz/sources/toonz/levelcommand.cpp
@@ -334,7 +334,7 @@ void revertTo(bool isCleanedUp) {
       delete undo;
     else {
       TUndoManager::manager()->add(undo);
-      sl->setDirtyFlag(true);
+      if (isCleanedUp) sl->setDirtyFlag(true);
     }
     app->getCurrentLevel()->notifyLevelChange();
   }
@@ -390,7 +390,7 @@ void revertTo(bool isCleanedUp) {
         delete undo;
       else {
         TUndoManager::manager()->add(undo);
-        sl->setDirtyFlag(true);
+        if (isCleanedUp) sl->setDirtyFlag(true);
       }
     }
     TUndoManager::manager()->endBlock();

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -119,6 +119,7 @@ bool isAreadOnlyLevel(const TFilePath &path) {
   if (path.getDots() == "." ||
       (path.getDots() == ".." &&
        (path.getType() == "tlv" || path.getType() == "tpl"))) {
+    if (path.getType() == "psd") return true;
     if (!TSystem::doesExistFileOrLevel(path)) return false;
     TFileStatus fs(path);
     return !fs.isWritable();


### PR DESCRIPTION
This will fix #2556 

I did two modifications as follows:
- Made the file's dirty flag not to be set on `Reload` command.
- Just in case, added a logic that all PSD files are to be classified as "read only".