### PR TITLE
Fix touch rotating flipped viewer

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -965,8 +965,9 @@ void SceneViewer::gestureEvent(QGestureEvent *e) {
       if (changeFlags & QPinchGesture::RotationAngleChanged) {
         qreal rotationDelta =
             gesture->rotationAngle() - gesture->lastRotationAngle();
-        TAffine aff    = getViewMatrix().inv();
-        TPointD center = aff * TPointD(0, 0);
+        if (m_isFlippedX != m_isFlippedY) rotationDelta = -rotationDelta;
+        TAffine aff                                     = getViewMatrix().inv();
+        TPointD center                                  = aff * TPointD(0, 0);
         if (!m_rotating && !m_zooming) {
           m_rotationDelta += rotationDelta;
           double absDelta = abs(m_rotationDelta);
@@ -1517,12 +1518,11 @@ void SceneViewer::dragEnterEvent(QDragEnterEvent *event) {
   const QMimeData *mimeData = event->mimeData();
 
   if (acceptResourceOrFolderDrop(mimeData->urls())) {
-	  // Force CopyAction
-	  event->setDropAction(Qt::CopyAction);
-	  event->accept();
-  }
-  else {
-	  event->ignore();
+    // Force CopyAction
+    event->setDropAction(Qt::CopyAction);
+    event->accept();
+  } else {
+    event->ignore();
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue where touch gesture rotating a flipped viewer, rotates it in the wrong direction.

Added logic to flip the direction of the touch rotation on a flipped viewer.