### PR TITLE
Fix timeline key-scrolling

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1244,9 +1244,12 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
       if (orientation()->isVerticalTimeline())
         locals.scrollVertTo((frameCount + 1) * orientation()->cellHeight(),
                             visibleRect);
-      else
-        locals.scrollHorizTo((frameCount + 1) * orientation()->cellWidth(),
-                             visibleRect);
+      else {
+        int x = (((frameCount + 1) * orientation()->cellWidth()) *
+                 getFrameZoomFactor()) /
+                100;
+        locals.scrollHorizTo(x, visibleRect);
+      }
       break;
     }
     break;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1367,8 +1367,11 @@ void XsheetViewer::scrollToColumn(int col) {
 
   if (orientation()->isVerticalTimeline())
     scrollToHorizontalRange(x0, x1);
-  else
+  else {
+    if (colNext == col) x1 += m_orientation->cellHeight();
+
     scrollToVerticalRange(x0, x1);
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following scrolling issues when using keys to navigate the timeline.

1) When you use Down-arrow to reach the bottom of the timeline, the current frame is selected but the bottom level is not scrolled into view requiring the user to use the scroll bar to see it.

Added logic to account for the height of the bottom level when scrolling to the last column.

2) Using END key to get to last frame was jumping to a frame way past the last exposed frame.

Added logic to factor in timeline zoom factor to correctly calculate the last exposed frame.
