### PR TITLE
Add shortcuts for MyPaint Brush toolbar options

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -145,6 +145,7 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_preset.setId("BrushPreset");
   m_modifierEraser.setId("RasterEraser");
   m_modifierLockAlpha.setId("LockAlpha");
+  m_pressure.setId("PressureSensitivity");
 
   m_brushTimer.start();
 }

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -144,6 +144,7 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
 
   m_preset.setId("BrushPreset");
   m_modifierEraser.setId("RasterEraser");
+  m_modifierLockAlpha.setId("LockAlpha");
 
   m_brushTimer.start();
 }

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -143,6 +143,7 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_prop.bind(m_preset);
 
   m_preset.setId("BrushPreset");
+  m_modifierEraser.setId("RasterEraser");
 
   m_brushTimer.start();
 }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -124,7 +124,8 @@ ToolOptionsBox::ToolOptionsBox(QWidget *parent, bool isScrollable)
 ToolOptionsBox::~ToolOptionsBox() {
   std::for_each(m_controls.begin(), m_controls.end(),
                 std::default_delete<ToolOptionControl>());
-  std::for_each(m_labels.begin(), m_labels.end(), std::default_delete<QLabel>());
+  std::for_each(m_labels.begin(), m_labels.end(),
+                std::default_delete<QLabel>());
 }
 
 //-----------------------------------------------------------------------------
@@ -216,6 +217,17 @@ void ToolOptionControlBuilder::visit(TDoubleProperty *p) {
     a = cm->getAction("A_DecreaseMaxBrushThickness");
     control->addAction(a);
     QObject::connect(a, SIGNAL(triggered()), control, SLOT(decrease()));
+  }
+  if (p->getName() == "ModifierSize") {
+    QAction *a;
+    a = cm->getAction("A_IncreaseMaxBrushThickness");
+    control->addAction(a);
+    QObject::connect(a, SIGNAL(triggered()), control,
+                     SLOT(increaseFractional()));
+    a = cm->getAction("A_DecreaseMaxBrushThickness");
+    control->addAction(a);
+    QObject::connect(a, SIGNAL(triggered()), control,
+                     SLOT(decreaseFractional()));
   }
   if (p->getName() == "Hardness:") {
     QAction *a;

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -192,7 +192,7 @@ void ToolOptionSlider::onValueChanged(bool isDragging) {
 
 //-----------------------------------------------------------------------------
 
-void ToolOptionSlider::increase() {
+void ToolOptionSlider::increase(double step) {
   if (m_toolHandle && m_toolHandle->getTool() != m_tool) return;
   // active only if the belonging combo-viewer is visible
   if (!isInVisibleViewer(this)) return;
@@ -201,7 +201,7 @@ void ToolOptionSlider::increase() {
   double minValue, maxValue;
   getRange(minValue, maxValue);
 
-  value += 1;
+  value += step;
   if (value > maxValue) value = maxValue;
 
   setValue(value);
@@ -213,7 +213,11 @@ void ToolOptionSlider::increase() {
 
 //-----------------------------------------------------------------------------
 
-void ToolOptionSlider::decrease() {
+void ToolOptionSlider::increaseFractional() { increase(0.06); }
+
+//-----------------------------------------------------------------------------
+
+void ToolOptionSlider::decrease(double step) {
   if (m_toolHandle && m_toolHandle->getTool() != m_tool) return;
   // active only if the belonging combo-viewer is visible
   if (!isInVisibleViewer(this)) return;
@@ -222,7 +226,7 @@ void ToolOptionSlider::decrease() {
   double minValue, maxValue;
   getRange(minValue, maxValue);
 
-  value -= 1;
+  value -= step;
   if (value < minValue) value = minValue;
 
   setValue(value);
@@ -231,6 +235,10 @@ void ToolOptionSlider::decrease() {
   // update the interface
   repaint();
 }
+
+//-----------------------------------------------------------------------------
+
+void ToolOptionSlider::decreaseFractional() { decrease(0.06); }
 
 //=============================================================================
 

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -119,8 +119,10 @@ public:
 protected slots:
 
   void onValueChanged(bool isDragging);
-  void increase();
-  void decrease();
+  void increase(double step = 1.0);
+  void decrease(double step = 1.0);
+  void increaseFractional();
+  void decreaseFractional();
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2154,6 +2154,8 @@ void MainWindow::defineActions() {
                           tr("Show Only Active Skeleton"), "");
   createToolOptionsAction("A_ToolOption_RasterEraser",
                           tr("Brush Tool - Eraser (Raster option)"), "");
+  createToolOptionsAction("A_ToolOption_LockAlpha",
+                          tr("Brush Tool - Lock Alpha"), "");
 
   // Option Menu
   createToolOptionsAction("A_ToolOption_BrushPreset", tr("Brush Preset"), "");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2152,6 +2152,8 @@ void MainWindow::defineActions() {
   createToolOptionsAction("A_ToolOption_JoinVectors", tr("Join Vectors"), "");
   createToolOptionsAction("A_ToolOption_ShowOnlyActiveSkeleton",
                           tr("Show Only Active Skeleton"), "");
+  createToolOptionsAction("A_ToolOption_RasterEraser",
+                          tr("Brush Tool - Eraser (Raster option)"), "");
 
   // Option Menu
   createToolOptionsAction("A_ToolOption_BrushPreset", tr("Brush Preset"), "");


### PR DESCRIPTION
User request for shortcuts for the following MyPaint brush toolbar options:

1. `Eraser` - No default shortcut assigned.
2. `Lock Alpha` - No default shortcut assigned.
3. `Pressure` - Uses default shortcut Shift+P
4. `Size` - Uses default shortcuts U/I.  Increments value by 0.06
