### PR TITLE
Fix Removing Ghost Fx Connection

### DIFF
--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -1755,7 +1755,8 @@ assert(linkedFx);*/
       TUndoManager::manager()->endBlock();
       emit sceneChanged();
       emit xsheetChanged();
-    }
+    } else
+      SchematicPort::mouseReleaseEvent(me);
   } else
     SchematicPort::mouseReleaseEvent(me);
 }


### PR DESCRIPTION
This will fix #2552 , removing the "ghost" connection on mouse release when trying to connect two ports in the same particle fx node.

Please note this fix can coexist with #2554 by @manongjohn which seems to be more of a fail-safe.