### PR TITLE
Fix locator button crash

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1822,7 +1822,7 @@ void SceneViewer::zoomQt(bool forward, bool reset) {
       TAffine &viewAff          = m_viewAff[i];
       if (m_isFlippedX) viewAff = viewAff * TScale(-1, 1);
       if (m_isFlippedX) viewAff = viewAff * TScale(1, -1);
-      double scale2             = abs(viewAff.det());
+      double scale2             = std::abs(viewAff.det());
       if (m_isFlippedX) viewAff = viewAff * TScale(-1, 1);
       if (m_isFlippedX) viewAff = viewAff * TScale(1, -1);
       if (reset || ((scale2 < 100000 || !forward) &&


### PR DESCRIPTION
This will fix #2592 . 
The fix is related to #925 . Other incorrect callings of `int abs(int n)` ( declared in `stdlib.h` ) should be replaced by `std::abs` as well.