### PR TITLE
Allow sequenced files starting with 0

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -687,12 +687,12 @@ TFrameId TFilePath::getFrame() const {
   }
   char letter                  = '\0';
   if (iswalpha(str[k])) letter = str[k++] + ('a' - L'a');
-
-  if (number == 0 || k < i)  // || letter!='\0')
-    throw TMalformedFrameException(
-        *this,
-        str + L": " + QObject::tr("Malformed frame name").toStdWString());
-
+  /*
+    if (number == 0 || k < i)  // || letter!='\0')
+      throw TMalformedFrameException(
+          *this,
+          str + L": " + QObject::tr("Malformed frame name").toStdWString());
+  */
   int padding = 0;
 
   if (str[j + 1] == '0') padding = digits;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1861,7 +1861,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
     else {
       std::string frameNumber("");
       // set number
-      frameNumber = std::to_string(fid.getNumber());
+      if (fid.getNumber() >= 0) frameNumber = std::to_string(fid.getNumber());
       // add letter
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       fnum = QString::fromStdString(frameNumber);
@@ -2876,7 +2876,7 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
                     m_viewer->getFrameNumberWithLetters(fid.getNumber());
     } else {
       std::string frameNumber("");
-      frameNumber = std::to_string(fid.getNumber());
+      if (fid.getNumber() >= 0) frameNumber = std::to_string(fid.getNumber());
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       m_tooltip =
           QString((frameNumber.empty())

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -792,6 +792,7 @@ void RenameCellField::renameCell() {
   if (!cellSelection) return;
 
   QList<TXshCell> cells;
+  bool hasFrameZero = false;
 
   if (levelName == L"") {
     int r0, c0, r1, c1;
@@ -837,7 +838,9 @@ void RenameCellField::renameCell() {
       if (fid == TFrameId::NO_FRAME)
         fid = (m_row - tmpRow <= 1) ? cell.m_frameId : TFrameId(0);
       cells.append(TXshCell(xl, fid));
-      changed = true;
+      changed      = true;
+      hasFrameZero = (fid.getNumber() == 0 && xl->getSimpleLevel() &&
+                      xl->getSimpleLevel()->isFid(fid));
     }
     if (!changed) return;
   } else {
@@ -857,9 +860,11 @@ void RenameCellField::renameCell() {
     }
     if (!xl) return;
     cells.append(TXshCell(xl, fid));
+    hasFrameZero = (fid.getNumber() == 0 && xl->getSimpleLevel() &&
+                    xl->getSimpleLevel()->isFid(fid));
   }
 
-  if (fid.getNumber() == 0) {
+  if (fid.getNumber() == 0 && !hasFrameZero) {
     TCellSelection::Range range = cellSelection->getSelectedCells();
     cellSelection->deleteCells();
     // revert cell selection
@@ -1856,7 +1861,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
     else {
       std::string frameNumber("");
       // set number
-      if (fid.getNumber() > 0) frameNumber = std::to_string(fid.getNumber());
+      frameNumber = std::to_string(fid.getNumber());
       // add letter
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       fnum = QString::fromStdString(frameNumber);
@@ -2871,7 +2876,7 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
                     m_viewer->getFrameNumberWithLetters(fid.getNumber());
     } else {
       std::string frameNumber("");
-      if (fid.getNumber() > 0) frameNumber = std::to_string(fid.getNumber());
+      frameNumber = std::to_string(fid.getNumber());
       if (fid.getLetter() != 0) frameNumber.append(1, fid.getLetter());
       m_tooltip =
           QString((frameNumber.empty())


### PR DESCRIPTION
This PR allows sequenced files starting with frame 0 to load.

Apparently some fix to sequenced file detection and handling actually fixed the issue that would cause OT to crash whenever it tried to process a sequenced file starting with 0.

After discovering this I disabled the malformed exception that was thrown when a file started with frame 0. This allows level frame 0 to load successfully.

![image](https://user-images.githubusercontent.com/19245851/57132718-777cab80-6d6e-11e9-847b-492b3ca206b9.png)

Also, I modified the logic of renaming a level cell to 0. Normally when Autocreation mode is not `Use Xsheet as Animation Sheet` and you double click a filled cell then enter 0, the cell is deleted.  I enhanced the logic to delete the cell only if the level does not have a frame 0, otherwise it will replace the cell with level frame 0.
