### PR TITLE
Update Travis QT Version to 5.12.3

### DIFF
--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -4,7 +4,7 @@ pushd thirdparty/tiff-4.0.3
 popd
 cd toonz && mkdir build && cd build
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt/5.12.2/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt/5.12.3/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make -j 2

--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -3,8 +3,10 @@ pushd thirdparty/tiff-4.0.3
 ./configure && make
 popd
 cd toonz && mkdir build && cd build
+QTVERSION=`ls /usr/local/Cellar/qt`
+echo "QT Version detected: $QTVERSION"
 cmake ../sources \
-      -DQT_PATH=/usr/local/Cellar/qt/5.12.3/lib/ \
+      -DQT_PATH=/usr/local/Cellar/qt/$QTVERSION/lib/ \
       -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
       -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
 make -j 2


### PR DESCRIPTION
Homebrew updated QT version to 5.12.3.

Added logic to automatically detect the version of QT installed by homebrew so we shouldn't have to keep updating the script every time homebrew decides to update QT version.