### PR TITLE
Fix shift/ctrl + right-click empty column crash

### DIFF
--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -130,7 +130,8 @@ void TColumnSelection::explodeChild() {
 static bool canMergeColumns(int column, int mColumn, bool forMatchlines) {
   TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
 
-  if (xsh->getColumn(column)->isLocked()) return false;
+  if (!xsh || !xsh->getColumn(column) || xsh->getColumn(column)->isLocked())
+    return false;
 
   int start, end;
   xsh->getCellRange(column, start, end);


### PR DESCRIPTION
This PR fixes a crash reported by a user on Discord.

If you select an empty column after the last filled column in the Xsheet and then use `SHIFT` or `CTRL` + right-click on another empty column, OT will crash. This issue only occurs with the virtual columns that follows the last filled column in the Xsheet. 

Cause of the crash was because it was trying to access column information for a column that doesn't really exist.  Added logic to prevent the crash.

