### PR TITLE
Fix timeline multi-cell dragging into empty columns

### DIFF
--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -183,10 +183,7 @@ bool CellsMover::canMoveCells(const TPoint &pos) {
     while (i < m_rowCount * m_colCount) {
       TXshColumn::ColumnType srcType = getColumnTypeFromCell(i);
       int dstIndex                   = c + i;
-      if (!m_orientation->isVerticalTimeline() &&
-          dstIndex >= xsh->getColumnCount())
-        return false;
-      TXshColumn *dstColumn = xsh->getColumn(dstIndex);
+      TXshColumn *dstColumn          = xsh->getColumn(dstIndex);
       if (srcType == TXshColumn::eZeraryFxType ||
           srcType == TXshColumn::eSoundTextType)
         return false;


### PR DESCRIPTION
This PR fixes an issue reported by a Discord user.

The issue occurred when selecting multiple cells across multiple columns in the Timeline and attempting to drag it to empty cells in adjacent columns. The selection box would turn red and not allow the cells to move into the new position.

I found the bigger the cell selection area was, the more likely the cells could not be dragged into empty cells in adjacent columns.

Removed incorrect timeline-only logic that was erroneously limiting what columns the selected cells could be dropped in.