### PR TITLE
Fix "Convert to Vectors" command for TLV with MyPaint Styles

### DIFF
--- a/toonz/sources/toonz/vectorizerswatch.h
+++ b/toonz/sources/toonz/vectorizerswatch.h
@@ -3,6 +3,9 @@
 #ifndef VECTORIZER_SWATCH_H
 #define VECTORIZER_SWATCH_H
 
+// TnzCore includes
+#include "tpalette.h"
+
 // Toonz includes
 #include "tthread.h"
 #include "timage.h"
@@ -95,8 +98,11 @@ class VectorizationSwatchTask final : public TThread::Runnable {
 
   std::unique_ptr<VectorizerConfiguration> m_config;
 
+  TPaletteP m_substitutePalette;
+
 public:
-  VectorizationSwatchTask(int row, int col);
+  VectorizationSwatchTask(int row, int col,
+                          TPaletteP substitutePalette = TPaletteP());
 
   void run() override;
   void onStarted(TThread::RunnableP task) override;


### PR DESCRIPTION
This PR will fix `Convert to Vectors` command to preview / work properly when the target level has a palette containing MyPaint styles.

Toonz Raster Level may have palette including MyPaint styles, which cannot be rendered in vector levels.
In such case `TMyPaintBrushStyle` will be replaced by `TSolidColorStyle` with the same color in the converted result.