### PR TITLE
Fix updating Style Editor when switching between level palette and studio palette by Style Picker tool

### DIFF
--- a/toonz/sources/include/toonz/tapplication.h
+++ b/toonz/sources/include/toonz/tapplication.h
@@ -49,7 +49,8 @@ public:
   // Current Palette (PaletteController) methods
   virtual TColorStyle *getCurrentLevelStyle() const = 0;
   virtual int getCurrentLevelStyleIndex() const     = 0;
-  virtual void setCurrentLevelStyleIndex(int index) = 0;
+  virtual void setCurrentLevelStyleIndex(int index,
+                                         bool forceUpdate = false) = 0;
 };
 
 #endif  // TAPPLICATION_H

--- a/toonz/sources/tnztools/stylepickertool.cpp
+++ b/toonz/sources/tnztools/stylepickertool.cpp
@@ -63,14 +63,15 @@ StylePickerTool::StylePickerTool()
 void StylePickerTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
   m_oldStyleId = m_currentStyleId =
       getApplication()->getCurrentLevelStyleIndex();
-  pick(pos, e);
+  pick(pos, e, false);
 }
 
 void StylePickerTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
   pick(pos, e);
 }
 
-void StylePickerTool::pick(const TPointD &pos, const TMouseEvent &e) {
+void StylePickerTool::pick(const TPointD &pos, const TMouseEvent &e,
+                           bool isDragging) {
   // Area = 0, Line = 1, All = 2
   int modeValue = m_colorType.getIndex();
 
@@ -132,7 +133,8 @@ void StylePickerTool::pick(const TPointD &pos, const TMouseEvent &e) {
                 ->getSelection()
                 ->selectNone();
           /*-- StyleIdの移動 --*/
-          getApplication()->setCurrentLevelStyleIndex(superPicked_StyleId);
+          getApplication()->setCurrentLevelStyleIndex(superPicked_StyleId,
+                                                      !isDragging);
           return;
         }
       }
@@ -181,7 +183,12 @@ void StylePickerTool::pick(const TPointD &pos, const TMouseEvent &e) {
     if (styleSelection) styleSelection->selectNone();
   }
 
-  getApplication()->setCurrentLevelStyleIndex(styleId);
+  // When clicking and switching between studio palette and level palette, the
+  // signal broadcastColorStyleSwitched is not emitted if the picked style is
+  // previously selected one.
+  // Therefore here I set the "forceEmit" flag to true in order to emit the
+  // signal whenever the picking with mouse press.
+  getApplication()->setCurrentLevelStyleIndex(styleId, !isDragging);
 }
 
 void StylePickerTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {

--- a/toonz/sources/tnztools/stylepickertool.h
+++ b/toonz/sources/tnztools/stylepickertool.h
@@ -36,7 +36,7 @@ public:
 
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
 
-  void pick(const TPointD &pos, const TMouseEvent &e);
+  void pick(const TPointD &pos, const TMouseEvent &e, bool isDragging = true);
 
   void mouseMove(const TPointD &pos, const TMouseEvent &e) override;
 

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -267,8 +267,9 @@ int TApp::getCurrentLevelStyleIndex() const {
 
 //-----------------------------------------------------------------------------
 
-void TApp::setCurrentLevelStyleIndex(int index) {
-  m_paletteController->getCurrentLevelPalette()->setStyleIndex(index);
+void TApp::setCurrentLevelStyleIndex(int index, bool forceUpdate) {
+  m_paletteController->getCurrentLevelPalette()->setStyleIndex(index,
+                                                               forceUpdate);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/tapp.h
+++ b/toonz/sources/toonz/tapp.h
@@ -160,7 +160,7 @@ public:
 
   int getCurrentLevelStyleIndex() const override;
 
-  void setCurrentLevelStyleIndex(int index) override;
+  void setCurrentLevelStyleIndex(int index, bool forceUpdate = false) override;
 
   void setMainWindow(QMainWindow *mainWindow) { m_mainWindow = mainWindow; }
   /*!

--- a/toonz/sources/toonzlib/tpalettehandle.cpp
+++ b/toonz/sources/toonzlib/tpalettehandle.cpp
@@ -142,8 +142,9 @@ void TPaletteHandle::setPalette(TPalette *palette, int styleIndex) {
 }
 
 //-----------------------------------------------------------------------------
-// forceEmit flag is used in PageViewer.
+// forceEmit flag is used in PageViewer and StylePicker tool.
 // See the function PageViewer::setCurrentStyleIndex() in paletteviewergui.cpp
+// Also see the function StylePickerTool::pick() in stylepickertool.cpp
 
 void TPaletteHandle::setStyleIndex(int index, bool forceEmit) {
   if (m_styleIndex != index || m_styleParamIndex != 0 || forceEmit) {


### PR DESCRIPTION
This PR is related to #2558 .
This resolves the problem that the Style Editor does not refresh when switching between level palette and studio palette by picking style with Style Picker tool.
Please note that the difference from #2557 is that the trigger of switching style is not by directly clicking the style in the palette but by picking with Style Picker tool.
