### PR TITLE
File Browser Enhancement for Windows 

### DIFF
--- a/toonz/sources/common/tsound/tsound_nt.cpp
+++ b/toonz/sources/common/tsound/tsound_nt.cpp
@@ -1915,7 +1915,7 @@ std::string getMixerLineName(DWORD lineID) {
   assert(false);
   return "";
 #else
-  return std::string(mxl.szName);
+  return QString::fromWCharArray(mxl.szName).toStdString();
 #endif
 }
 

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -32,7 +32,6 @@ using namespace std;
 #include <winnt.h>
 #endif
 
-
 namespace {
 
 inline QString toQString(const TFilePath &path) {
@@ -437,29 +436,63 @@ public:
 };
 
 //------------------------------------------------------------
-/*! return the file list which is readable and executable
+/*! return the folder path list which is readable and executable
 */
 void TSystem::readDirectory_Dir_ReadExe(TFilePathSet &dst,
                                         const TFilePath &path) {
+  QStringList dirItems;
+  readDirectory_DirItems(dirItems, path);
+
+  for (const QString &item : dirItems) {
+    TFilePath son = path + TFilePath(item.toStdWString());
+    dst.push_back(son);
+  }
+}
+
+//------------------------------------------------------------
+// return the folder item list which is readable and executable
+// (returns only names, not full path)
+void TSystem::readDirectory_DirItems(QStringList &dst, const TFilePath &path) {
   if (!TFileStatus(path).isDirectory())
     throw TSystemException(path, " is not a directory");
 
-  std::set<TFilePath, CaselessFilepathLess> fileSet;
+  QDir dir(toQString(path));
 
-  QStringList fil =
-      QDir(toQString(path))
-          .entryList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::Readable);
+#ifdef _WIN32
+  // equivalent to sorting with QDir::LocaleAware
+  struct strCompare {
+    bool operator()(const QString &s1, const QString &s2) {
+      return QString::localeAwareCompare(s1, s2) < 0;
+    }
+  };
 
-  int i;
-  for (i = 0; i < fil.size(); i++) {
-    QString fi = fil.at(i);
+  std::set<QString, strCompare> entries;
 
-    TFilePath son = path + TFilePath(fi.toStdWString());
-
-    fileSet.insert(son);
+  WIN32_FIND_DATA find_dir_data;
+  QString dir_search_path = dir.absolutePath() + "\\*";
+  auto addEntry           = [&]() {
+    // QDir::NoDotAndDotDot condition
+    if (wcscmp(find_dir_data.cFileName, L".") != 0 &&
+        wcscmp(find_dir_data.cFileName, L"..") != 0) {
+      // QDir::AllDirs condition
+      if (find_dir_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY &&
+          (find_dir_data.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) == 0) {
+        entries.insert(QString::fromWCharArray(find_dir_data.cFileName));
+      }
+    }
+  };
+  HANDLE hFind =
+      FindFirstFile((const wchar_t *)dir_search_path.utf16(), &find_dir_data);
+  if (hFind != INVALID_HANDLE_VALUE) {
+    addEntry();
+    while (FindNextFile(hFind, &find_dir_data)) addEntry();
   }
+  for (const QString &name : entries) dst.push_back(QString(name));
 
-  dst.insert(dst.end(), fileSet.begin(), fileSet.end());
+#else
+  dst = dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot | QDir::Readable,
+                      QDir::Name | QDir::LocaleAware);
+#endif
 }
 
 //------------------------------------------------------------
@@ -473,10 +506,31 @@ void TSystem::readDirectory(TFilePathSet &groupFpSet, TFilePathSet &allFpSet,
   std::set<TFilePath, CaselessFilepathLess> fileSet_group;
   std::set<TFilePath, CaselessFilepathLess> fileSet_all;
 
-  QStringList fil =
-      QDir(toQString(path))
-          .entryList(QDir::Files | QDir::NoDotAndDotDot | QDir::Readable);
-
+  QStringList fil;
+#ifdef _WIN32
+  WIN32_FIND_DATA find_dir_data;
+  QString dir_search_path = QDir(toQString(path)).absolutePath() + "\\*";
+  auto addEntry           = [&]() {
+    // QDir::NoDotAndDotDot condition
+    if (wcscmp(find_dir_data.cFileName, L".") != 0 &&
+        wcscmp(find_dir_data.cFileName, L"..") != 0) {
+      // QDir::Files condition
+      if ((find_dir_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0 &&
+          (find_dir_data.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) == 0) {
+        fil.append(QString::fromWCharArray(find_dir_data.cFileName));
+      }
+    }
+  };
+  HANDLE hFind =
+      FindFirstFile((const wchar_t *)dir_search_path.utf16(), &find_dir_data);
+  if (hFind != INVALID_HANDLE_VALUE) {
+    addEntry();
+    while (FindNextFile(hFind, &find_dir_data)) addEntry();
+  }
+#else
+  fil = QDir(toQString(path))
+            .entryList(QDir::Files | QDir::NoDotAndDotDot | QDir::Readable);
+#endif
   if (fil.size() == 0) return;
 
   for (int i = 0; i < fil.size(); i++) {
@@ -506,8 +560,40 @@ void TSystem::readDirectory(TFilePathSet &dst, const QDir &dir,
   if (!(dir.exists() && QFileInfo(dir.path()).isDir()))
     throw TSystemException(TFilePath(dir.path().toStdWString()),
                            " is not a directory");
+  QStringList entries;
+#ifdef _WIN32
+  WIN32_FIND_DATA find_dir_data;
+  QString dir_search_path = dir.absolutePath() + "\\*";
+  QDir::Filters filter    = dir.filter();
+  auto addEntry           = [&]() {
+    // QDir::NoDotAndDotDot condition
+    if (wcscmp(find_dir_data.cFileName, L".") != 0 &&
+        wcscmp(find_dir_data.cFileName, L"..") != 0) {
+      // QDir::Files condition
+      if ((filter & QDir::Files) == 0 &&
+          (find_dir_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
+        return;
+      // QDir::Dirs condition
+      if ((filter & QDir::Dirs) == 0 &&
+          (find_dir_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+        return;
+      // QDir::Hidden condition
+      if ((filter & QDir::Hidden) == 0 &&
+          (find_dir_data.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN))
+        return;
+      entries.append(QString::fromWCharArray(find_dir_data.cFileName));
+    }
+  };
+  HANDLE hFind =
+      FindFirstFile((const wchar_t *)dir_search_path.utf16(), &find_dir_data);
+  if (hFind != INVALID_HANDLE_VALUE) {
+    addEntry();
+    while (FindNextFile(hFind, &find_dir_data)) addEntry();
+  }
+#else
+  entries    = (dir.entryList(dir.filter() | QDir::NoDotAndDotDot));
+#endif
 
-  QStringList entries(dir.entryList(dir.filter() | QDir::NoDotAndDotDot));
   TFilePath dirPath(dir.path().toStdWString());
 
   std::set<TFilePath, CaselessFilepathLess> fpSet;

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -115,8 +115,11 @@ DVAPI void readDirectoryTree(TFilePathSet &fpset, const TFilePathSet &pathSet,
 DVAPI void readDirectory(TFilePathSet &groupFpSet, TFilePathSet &allFpSet,
                          const TFilePath &path);
 
-// return the file list which is readable and executable
+// return the folder path list which is readable and executable
 DVAPI void readDirectory_Dir_ReadExe(TFilePathSet &dst, const TFilePath &path);
+
+// return the folder item list which is readable and executable (only names)
+DVAPI void readDirectory_DirItems(QStringList &dst, const TFilePath &path);
 
 // creano un set nuovo
 DVAPI TFilePathSet readDirectory(const TFilePath &path, bool groupFrames = true,

--- a/toonz/sources/tnzcore/CMakeLists.txt
+++ b/toonz/sources/tnzcore/CMakeLists.txt
@@ -290,6 +290,13 @@ add_definitions(
     -DTSTREAM_EXPORTS
 )
 
+if(BUILD_TARGET_WIN)
+    add_definitions(
+        -DUNICODE
+        -D_UNICODE
+    )
+endif()
+
 message("subdir: tnzcore")
 #message("Sources:" ${SOURCES})
 

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -579,6 +579,17 @@ void FileBrowser::refreshCurrentFolderItems() {
     }
     TFilePathSet::iterator it;
     for (it = files.begin(); it != files.end(); ++it) {
+#ifdef _WIN32
+      // include folder shortcut items
+      if (it->getType() == "lnk") {
+        TFileStatus info(*it);
+        if (info.isLink() && info.isDirectory()) {
+          m_items.push_back(
+              Item(*it, true, true, QString::fromStdString((*it).getName())));
+        }
+        continue;
+      }
+#endif
       // skip the plt file (Palette file for TOONZ 4.6 and earlier)
       if (it->getType() == "plt") continue;
 
@@ -733,6 +744,17 @@ void FileBrowser::setUnregisteredFolder(const TFilePath &fp) {
     }
 
     for (it = files.begin(); it != files.end(); ++it) {
+#ifdef _WIN32
+      // include folder shortcut items
+      if (it->getType() == "lnk") {
+        TFileStatus info(*it);
+        if (info.isLink() && info.isDirectory()) {
+          m_items.push_back(
+              Item(*it, true, true, QString::fromStdString((*it).getName())));
+        }
+        continue;
+      }
+#endif
       // skip the plt file (Palette file for TOONZ 4.6 and earlier)
       if (it->getType() == "plt") continue;
 


### PR DESCRIPTION
This PR is for enhancing the response of the folder tree view in File Browser by applying the modifications as follows:

-  `DvDirModelFileFolderNode::hasChildren()` will no longer use `QDir::count()` (equivalent to `QDir::entryList().count()` ) which will create a list of all items in the directory. Instead, it will use `QDirIterator` and only check existence of the first item.

- Only in Windows environment `DvDirModelFileFolderNode::getChildrenNames` will use WIN32 API instread of `QDir::entryList()` as it seems to be time consuming in some case such as when accessing to network drives.

**NOTICE**
As a drawback, the latter change will disable to show shortcut files (.lnk) in the folder tree view. You still can access the shortcuts from the item view on the right side of the File Browser.

This PR is WIP as I would like to verify the effect of enhancement in some animation studio, which has been bothered by the slowness.