### PR TITLE
Fix Placing Macro Fx Node

### DIFF
--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -727,7 +727,14 @@ void FxSchematicScene::placeNode(FxSchematicNode *node) {
       maxY = std::max(fx->getAttributes()->getDagNodePos().y, maxY);
     }
     if (QPointF(minX, minY) == QPointF(TConst::nowhere.x, TConst::nowhere.y)) {
-      pos = sceneRect().center();
+      TFx *inputFx = node->getFx()->getInputPort(0)->getFx();
+      if (inputFx &&
+          inputFx->getAttributes()->getDagNodePos() != TConst::nowhere) {
+        TPointD dagPos =
+            inputFx->getAttributes()->getDagNodePos() + TPointD(150, 0);
+        pos = QPointF(dagPos.x, dagPos.y);
+      } else
+        pos = sceneRect().center();
       nodeRect.moveTopLeft(pos);
       while (!isAnEmptyZone(nodeRect)) nodeRect.translate(0, -step);
       pos = nodeRect.topLeft();


### PR DESCRIPTION
This PR will fix the following problem in Fx Schematic:

When creating & placing a Macro Fx node by using `Add Fx` command in the context menu of a fx node, the Macro Fx node is placed not next to the selected node (just like when adding a normal fx), but near the XSheet node.