### PR TITLE
Fix macOS portable detection

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -223,6 +223,22 @@ public:
         TFilePath(m_workingDirectory + "\\portablestuff\\");
     TFileStatus portableStatus(portableCheck);
     m_isPortable = portableStatus.doesExist();
+
+#ifdef MACOSX
+    // macOS 10.12 (Sierra) translocates applications before running them
+    // depending on how it was installed. This separates the app from the
+    // portablestuff folder and we don't know where it is so we stop treating it
+    // as a portable. Placing portablestuff inside OpenToonz.app will keep
+    // everything together when it translocates.
+    if (!m_isPortable) {
+      portableCheck = TFilePath(m_workingDirectory + "\\" +
+                                getApplicationName() + ".app\\portablestuff\\");
+      portableStatus = TFileStatus(portableCheck);
+      m_isPortable   = portableStatus.doesExist();
+      if (m_isPortable)
+        m_workingDirectory.append("\\" + getApplicationName() + ".app");
+    }
+#endif
   }
   std::string getWorkingDirectory() { return m_workingDirectory; }
 

--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -41,6 +41,7 @@ const std::map<std::string, std::string> systemPathMap{
 class EnvGlobals {  // singleton
 
   ToonzVersion m_version;
+  std::string m_applicationFileName;  // May differ from application name
   std::string m_applicationVersion;
   std::string m_applicationFullName;
   std::string m_moduleName;
@@ -76,7 +77,7 @@ public:
     QString settingsPath;
 
 #ifdef MACOSX
-    settingsPath = QString::fromStdString(getApplicationName()) +
+    settingsPath = QString::fromStdString(getApplicationFileName()) +
                    QString(".app") +
                    QString("/Contents/Resources/SystemVar.ini");
 #else /* Generic Unix */
@@ -181,6 +182,10 @@ public:
     updateEnvFile();
   }
 
+  void setApplicationFileName(std::string appFileName) {
+    m_applicationFileName = appFileName;
+  }
+  std::string getApplicationFileName() { return m_applicationFileName; }
   std::string getApplicationName() { return m_version.getAppName(); }
   std::string getApplicationVersion() { return m_applicationVersion; }
   std::string getApplicationVersionWithoutRevision() {
@@ -231,12 +236,13 @@ public:
     // as a portable. Placing portablestuff inside OpenToonz.app will keep
     // everything together when it translocates.
     if (!m_isPortable) {
-      portableCheck = TFilePath(m_workingDirectory + "\\" +
-                                getApplicationName() + ".app\\portablestuff\\");
+      portableCheck =
+          TFilePath(m_workingDirectory + "\\" + getApplicationFileName() +
+                    ".app\\portablestuff\\");
       portableStatus = TFileStatus(portableCheck);
       m_isPortable   = portableStatus.doesExist();
       if (m_isPortable)
-        m_workingDirectory.append("\\" + getApplicationName() + ".app");
+        m_workingDirectory.append("\\" + getApplicationFileName() + ".app");
     }
 #endif
   }
@@ -491,6 +497,15 @@ void Variable::assignValue(std::string value) {
 }
 
 //===================================================================
+
+void TEnv::setApplicationFileName(std::string appFileName) {
+  TFilePath fp(appFileName);
+  EnvGlobals::instance()->setApplicationFileName(fp.getName());
+}
+
+std::string TEnv::getApplicationFileName() {
+  return EnvGlobals::instance()->getApplicationFileName();
+}
 
 std::string TEnv::getApplicationName() {
   return EnvGlobals::instance()->getApplicationName();

--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -500,6 +500,13 @@ void Variable::assignValue(std::string value) {
 
 void TEnv::setApplicationFileName(std::string appFileName) {
   TFilePath fp(appFileName);
+#ifdef MACOSX
+  if (fp.getWideName().find(L".app"))
+    for (int i = 0; i < 3; i++) fp = fp.getParentDir();
+#elif LINUX
+  if (fp.getWideName().find(L".appimage"))
+    for (int i = 0; i < 2; i++) fp = fp.getParentDir();
+#endif
   EnvGlobals::instance()->setApplicationFileName(fp.getName());
 }
 

--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -184,6 +184,7 @@ public:
 
   void setApplicationFileName(std::string appFileName) {
     m_applicationFileName = appFileName;
+    setWorkingDirectory();
   }
   std::string getApplicationFileName() { return m_applicationFileName; }
   std::string getApplicationName() { return m_version.getAppName(); }
@@ -242,7 +243,8 @@ public:
       portableStatus = TFileStatus(portableCheck);
       m_isPortable   = portableStatus.doesExist();
       if (m_isPortable)
-        m_workingDirectory.append("\\" + getApplicationFileName() + ".app");
+        m_workingDirectory =
+            portableCheck.getParentDir().getQString().toStdString();
     }
 #endif
   }

--- a/toonz/sources/include/tenv.h
+++ b/toonz/sources/include/tenv.h
@@ -93,6 +93,12 @@ public:
 DVAPI std::string getApplicationName();
 DVAPI std::string getApplicationVersion();
 
+// This are for the case where the file name of application changes and doesn't
+// match actual application name and we want to keep both. We will need that for
+// some stuff
+DVAPI void setApplicationFileName(std::string appFileName);
+DVAPI std::string getApplicationFileName();
+
 DVAPI bool getIsPortable();
 
 // es.: TEnv::setModuleFullName("Toonz 5.0.1 Harlequin");

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -237,8 +237,6 @@ project->setUseScenePath(TProject::Extras, false);
 //-----------------------------------------------------------------------------
 
 int main(int argc, char *argv[]) {
-  TEnv::setApplicationFileName(argv[0]);
-
 #ifdef Q_OS_WIN
   //  Enable standard input/output on Windows Platform for debug
   BOOL consoleAttached = ::AttachConsole(ATTACH_PARENT_PROCESS);
@@ -410,6 +408,8 @@ int main(int argc, char *argv[]) {
     assert(ret);
   }
 #endif
+
+  TEnv::setApplicationFileName(argv[0]);
 
   // splash screen
   QPixmap splashPixmap = QIcon(":Resources/splash.svg").pixmap(QSize(610, 344));

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -237,6 +237,8 @@ project->setUseScenePath(TProject::Extras, false);
 //-----------------------------------------------------------------------------
 
 int main(int argc, char *argv[]) {
+  TEnv::setApplicationFileName(argv[0]);
+
 #ifdef Q_OS_WIN
   //  Enable standard input/output on Windows Platform for debug
   BOOL consoleAttached = ::AttachConsole(ATTACH_PARENT_PROCESS);


### PR DESCRIPTION
This PR addresses the following:

1) Can't detect portablestuff folder
Normally if you rename OpenToonz stuff folder to `portablestuff` and put it in the same directory as the OpenToonz.exe (win)/OpenToonz.app (macOS), OT can be placed on thumb drivers or moved to other locations without having to do an actual installation.

macOS 10.12 (Sierra) put in a change that makes applications added to the system from other sources (I'm guessing not from Apple store) to "translocate" before running. When this happens, the application is temporarily moved/copied to a new directory just before running.  Since it is not running in the same directory as the portablestuff directory it stops working as a portable and will look for the traditional stuff folder.

For macOS versions, this PR adds an additional check for a portablestuff folder inside the OpenToonz.app directory. If found in the same directory as OpenToonz.app or inside it, it will be treated as a portable.

2) Renaming the OpenToonz app causes OT not to work

This is a general problem with renaming the application in macOS.  Code currently expects the name of the app to be "OpenToonz" and builds path based on it. If the user renames it for whatever reason (say they want to keep different versions), OT cannot find the contents of "OpenToonz.app".

When app starts, it captures the name of the actual program from argv[0] and stores it for later use.