### PR TITLE
Skip long $scenefolder levels list in the warning dialog

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -190,7 +190,7 @@ public:
   //
   TFilePath process(ToonzScene *scene, ToonzScene *srcScene,
                     TFilePath srcPath) override {
-    TFilePath actualSrcPath     = srcPath;
+    TFilePath actualSrcPath = srcPath;
     if (srcScene) actualSrcPath = srcScene->decodeFilePath(srcPath);
 
     if (!isImportEnabled()) {
@@ -1350,7 +1350,7 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   TApp *app          = TApp::instance();
 
   assert(!path.isEmpty());
-  TFilePath scenePath                      = path;
+  TFilePath scenePath = path;
   if (scenePath.getType() == "") scenePath = scenePath.withType("tnz");
   if (scenePath.getType() != "tnz") {
     error(
@@ -1389,7 +1389,7 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   TFilePath newFullPath = scene->decodeFilePath(scenePath);
 
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  TXsheet *xsheet           = 0;
+  TXsheet *xsheet = 0;
   if (saveSubxsheet) xsheet = TApp::instance()->getCurrentXsheet()->getXsheet();
   if (app->getCurrentScene()->getDirtyFlag())
     scene->getContentHistory(true)->modifiedNow();
@@ -1463,8 +1463,8 @@ bool IoCmd::saveScene() {
   ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
   if (scene->isUntitled()) {
     static SaveSceneAsPopup *popup = 0;
-    if (!popup) popup              = new SaveSceneAsPopup();
-    int ret                        = popup->exec();
+    if (!popup) popup = new SaveSceneAsPopup();
+    int ret = popup->exec();
     if (ret == QDialog::Accepted) {
       TApp::instance()->getCurrentScene()->setDirtyFlag(false);
       return true;
@@ -1728,8 +1728,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   if (checkSaveOldScene)
     if (!saveSceneIfNeeded(QApplication::tr("Load Scene"))) return false;
   assert(!path.isEmpty());
-  TFilePath scenePath                      = path;
-  bool importScene                         = false;
+  TFilePath scenePath = path;
+  bool importScene    = false;
   if (scenePath.getType() == "") scenePath = scenePath.withType("tnz");
   if (scenePath.getType() != "tnz") {
     QString msg;
@@ -1823,9 +1823,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
     // import if needed
     TProjectManager *pm      = TProjectManager::instance();
     TProjectP currentProject = pm->getCurrentProject();
-    if (!scene->getProject() ||
-        scene->getProject()->getProjectPath() !=
-            currentProject->getProjectPath()) {
+    if (!scene->getProject() || scene->getProject()->getProjectPath() !=
+                                    currentProject->getProjectPath()) {
       ResourceImportDialog resourceLoader;
       // resourceLoader.setImportEnabled(true);
       ResourceImporter importer(scene, currentProject.getPointer(),
@@ -2100,10 +2099,10 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
   int &row1 = args.row1;
   int &col1 = args.col1;
 
-  int count            = 0;
-  TApp *app            = TApp::instance();
-  ToonzScene *scene    = app->getCurrentScene()->getScene();
-  TXsheet *xsh         = scene->getXsheet();
+  int count         = 0;
+  TApp *app         = TApp::instance();
+  ToonzScene *scene = app->getCurrentScene()->getScene();
+  TXsheet *xsh      = scene->getXsheet();
   if (row0 == -1) row0 = app->getCurrentFrame()->getFrameIndex();
   if (col0 == -1) col0 = app->getCurrentColumn()->getColumnIndex();
 
@@ -2488,8 +2487,8 @@ bool IoCmd::exposeLevel(TXshSimpleLevel *sl, int row, int col,
   if (!insert && !overWrite)
     insertEmptyColumn = beforeCellsInsert(
         xsh, row, col, fids.size(), TXshColumn::toColumnType(sl->getType()));
-  ExposeType type     = eNone;
-  if (insert) type    = eShiftCells;
+  ExposeType type = eNone;
+  if (insert) type = eShiftCells;
   if (overWrite) type = eOverWrite;
   ExposeLevelUndo *undo =
       new ExposeLevelUndo(sl, row, col, frameCount, insertEmptyColumn, type);
@@ -2586,24 +2585,32 @@ bool IoCmd::takeCareSceneFolderItemsOnSaveSceneAs(ToonzScene *scene,
   QList<TXshLevel *> sceneFolderLevels;
   levelSet->listLevels(levels);
   QString str;
+  int count = 0;
   for (int i = 0; i < levels.size(); i++) {
     TXshLevel *level = levels.at(i);
     if (!level->getPath().isEmpty() &&
         TFilePath("$scenefolder").isAncestorOf(level->getPath())) {
       sceneFolderLevels.append(level);
-      str.append("    " + QString::fromStdWString(level->getName()) + " (" +
-                 level->getPath().getQString() + ")\n");
+      if (count < 10) {
+        str.append("    " + QString::fromStdWString(level->getName()) + " (" +
+                   level->getPath().getQString() + ")\n");
+      }
+      count++;
     }
   }
+  // list maximum 10 levels
+  if (count > 10)
+    str.append(QObject::tr("    + %1 more level(s) \n").arg(count - 10));
 
   // in case there is no items with $scenefolder
   if (sceneFolderLevels.isEmpty()) return true;
 
   str = QObject::tr(
             "The following level(s) use path with $scenefolder alias.\n\n") +
-        str + QObject::tr(
-                  "\nThey will not be opened properly when you load the "
-                  "scene next time.\nWhat do you want to do?");
+        str +
+        QObject::tr(
+            "\nThey will not be opened properly when you load the "
+            "scene next time.\nWhat do you want to do?");
 
   int ret = DVGui::MsgBox(
       str, QObject::tr("Copy the levels to correspondent paths"),


### PR DESCRIPTION
This PR will fix the problem as follows:
When you save some scene containing levels using `$scenefolder` path to other folder using "Save Scene As" command, the warning popup appears notifying that such level will lose link.
For now the level list in the popup shows the list of all levels using `$scenefolder` path. If the number of such level is too large, the list can push out the boundary of the popup so that it runs out the screen.

This PR will make the list to be skipped if the number of the levels is more than 10 in order to prevent such problem like as follows:

![image](https://user-images.githubusercontent.com/17974955/58720141-4befee00-840c-11e9-8d2f-626d33e115a7.png)
