### PR TITLE
Fix copyDir for macOS

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -298,9 +298,10 @@ void TSystem::copyDir(const TFilePath &dst, const TFilePath &src) {
       TFilePath srcDir = TFilePath(fi.filePath().toStdString());
       TFilePath dstDir = dst + srcDir.getName();
       copyDir(dstDir, srcDir);
-    } else
-      QFile::copy(fi.filePath(),
-                  toQString(dst) + QString("\\") + fi.fileName());
+    } else {
+      TFilePath srcFi = dst + TFilePath(fi.fileName());
+      QFile::copy(fi.filePath(), toQString(srcFi));
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue with the TSystem::copyDir() function that affect macOS (and likely Linux).

Currently when it copies the files from a source directory, instead of creating a destination directory with the file in it. it creates a file with the format "destination\file"

Ex:  /rootdir/sourceDir/sourceFile -> /rootdir/destintationDir\sourceFile

Replaced the logic that created the new path using a direct string concatenation with "\\" as the directory separator. It now uses TFilePath concatenation and then extracting the full string allowing existing logic to determine the correct path separator to use.