### PR TITLE
Fix Crash on Switch to Vector Tab

### DIFF
--- a/toonz/sources/toonzlib/stylemanager.cpp
+++ b/toonz/sources/toonzlib/stylemanager.cpp
@@ -104,7 +104,7 @@ void CustomStyleManager::StyleLoaderTask::run() {
 
     TRaster32P ras;
 
-    QImage *image;
+    QImage *image = nullptr;
 
     if (vimg) {
       assert(level->getPalette());
@@ -169,10 +169,9 @@ void CustomStyleManager::StyleLoaderTask::run() {
 
         TRop::addBackground(rout, TPixel::White);
         ras = rout;
-
-        image = new QImage(chipSize.lx, chipSize.ly, QImage::Format_RGB32);
-        convertRaster32ToImage(ras, image);
       }
+      image = new QImage(chipSize.lx, chipSize.ly, QImage::Format_RGB32);
+      convertRaster32ToImage(ras, image);
     } else
       assert(!"unsupported type for custom styles!");
 

--- a/toonz/sources/toonzlib/stylemanager.cpp
+++ b/toonz/sources/toonzlib/stylemanager.cpp
@@ -8,10 +8,16 @@
 #include "tropcm.h"
 #include "tvectorrenderdata.h"
 #include "tsystem.h"
+#include "tvectorgl.h"
 
 // Qt includes
 #include <QDir>
 #include <QImage>
+#include <QOffscreenSurface>
+#include <QThread>
+#include <QGuiApplication>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
 
 #include "toonz/stylemanager.h"
 
@@ -50,6 +56,7 @@ class CustomStyleManager::StyleLoaderTask final : public TThread::Runnable {
   CustomStyleManager *m_manager;
   TFilePath m_fp;
   PatternData m_data;
+  std::shared_ptr<QOffscreenSurface> m_offScreenSurface;
 
 public:
   StyleLoaderTask(CustomStyleManager *manager, const TFilePath &fp);
@@ -66,6 +73,12 @@ CustomStyleManager::StyleLoaderTask::StyleLoaderTask(
     : m_manager(manager), m_fp(fp) {
   connect(this, SIGNAL(finished(TThread::RunnableP)), this,
           SLOT(onFinished(TThread::RunnableP)));
+
+  if (QThread::currentThread() == qGuiApp->thread()) {
+    m_offScreenSurface.reset(new QOffscreenSurface());
+    m_offScreenSurface->setFormat(QSurfaceFormat::defaultFormat());
+    m_offScreenSurface->create();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -90,16 +103,39 @@ void CustomStyleManager::StyleLoaderTask::run() {
     TRasterImageP rimg = img;
 
     TRaster32P ras;
+
+    QImage *image;
+
     if (vimg) {
       assert(level->getPalette());
       TPalette *vPalette = level->getPalette();
       assert(vPalette);
       vimg->setPalette(vPalette);
 
-      TOfflineGL *glContext = 0;
-      glContext             = TOfflineGL::getStock(chipSize);
+      QOpenGLContext *glContext = new QOpenGLContext();
+      if (QOpenGLContext::currentContext())
+        glContext->setShareContext(QOpenGLContext::currentContext());
+      glContext->setFormat(QSurfaceFormat::defaultFormat());
+      glContext->create();
+      glContext->makeCurrent(m_offScreenSurface.get());
+      // attaching stencil buffer here as some styles use it
+      QOpenGLFramebufferObject fb(
+          chipSize.lx, chipSize.ly,
+          QOpenGLFramebufferObject::CombinedDepthStencil);
 
-      glContext->clear(TPixel32::White);
+      fb.bind();
+      // Draw
+      glViewport(0, 0, chipSize.lx, chipSize.ly);
+      glClearColor(1.0, 1.0, 1.0, 1.0);  // clear with white color
+      glClear(GL_COLOR_BUFFER_BIT);
+
+      glMatrixMode(GL_PROJECTION);
+      glLoadIdentity();
+      gluOrtho2D(0, chipSize.lx, 0, chipSize.ly);
+
+      glMatrixMode(GL_MODELVIEW);
+      glLoadIdentity();
+
       TRectD bbox = img->getBBox();
       double scx  = 0.8 * chipSize.lx / bbox.getLx();
       double scy  = 0.8 * chipSize.ly / bbox.getLy();
@@ -112,11 +148,14 @@ void CustomStyleManager::StyleLoaderTask::run() {
           TTranslation(-0.5 * (bbox.x0 + bbox.x1), -0.5 * (bbox.y0 + bbox.y1));
       TVectorRenderData rd(aff, chipSize, vPalette, 0, true);
 
-      glContext->draw(img, rd);
+      tglDraw(rd, vimg.getPointer());
 
-      // No need to clone! The received raster already is a copy of the
-      // context's buffer
-      ras = glContext->getRaster();  //->clone();
+      image = new QImage(fb.toImage().scaled(QSize(chipSize.lx, chipSize.ly),
+                                             Qt::IgnoreAspectRatio,
+                                             Qt::SmoothTransformation));
+      fb.release();
+      glContext->deleteLater();
+
     } else if (rimg) {
       TDimension size = rimg->getRaster()->getSize();
       if (size == chipSize)
@@ -130,12 +169,12 @@ void CustomStyleManager::StyleLoaderTask::run() {
 
         TRop::addBackground(rout, TPixel::White);
         ras = rout;
+
+        image = new QImage(chipSize.lx, chipSize.ly, QImage::Format_RGB32);
+        convertRaster32ToImage(ras, image);
       }
     } else
       assert(!"unsupported type for custom styles!");
-
-    QImage *image = new QImage(chipSize.lx, chipSize.ly, QImage::Format_RGB32);
-    convertRaster32ToImage(ras, image);
 
     m_data.m_patternName = m_fp.getName();
     m_data.m_isVector    = (m_fp.getType() == "pli" || m_fp.getType() == "svg");

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -1880,7 +1880,8 @@ else return false;
   void drawChip(QPainter &p, QRect rect, int index) override {
     assert(0 <= index && index < getChipCount());
     CustomStyleManager::PatternData pattern = styleManager()->getPattern(index);
-    p.drawImage(rect, *pattern.m_image);
+    if (pattern.m_image && !pattern.m_image->isNull())
+      p.drawImage(rect, *pattern.m_image);
   }
   void onSelect(int index) override;
 };


### PR DESCRIPTION
This PR will fix #2303 , as an alternative to #2513 .
Currently `QtOfflineGL` seems to be not suitable for rendering in threads, as it may creates `QOffscreenSurface` in non-GUI thread, [which is to avoid on cross-platform applications](https://doc.qt.io/qt-5/qoffscreensurface.html#details).

So I replaced it by the code using `QOpenGLFramebufferObject` in combination with `QOffscreenSurface` created in the main(GUI) thread.  The modification is similar to the one in [PlasticDeformerFx](https://github.com/opentoonz/opentoonz/blob/25d3db05fd57aed51d666455ac8dbc44067a4cea/toonz/sources/toonzlib/plasticdeformerfx.cpp#L365-L373) .