### PR TITLE
Add project outside project root to drop-downs

### DIFF
--- a/toonz/sources/include/toonz/tproject.h
+++ b/toonz/sources/include/toonz/tproject.h
@@ -146,6 +146,7 @@ public:
   TFilePath projectNameToProjectPath(const TFilePath &projectName);
   TFilePath projectFolderToProjectPath(const TFilePath &projectFolder);
   TFilePath getProjectPathByName(const TFilePath &projectName);
+  TFilePath getProjectPathByProjectFolder(const TFilePath &projectFolder);
 
   TProjectP loadSceneProject(const TFilePath &scenePath);
   void getFolderNames(std::vector<std::string> &names);

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -482,9 +482,18 @@ ProjectSettingsPopup::ProjectSettingsPopup() : ProjectPopup(false) {
 void ProjectSettingsPopup::onChooseProjectChanged(int index) {
   TFilePath projectFp = m_projectPaths[index];
 
-  TProjectManager::instance()->setCurrentProjectPath(projectFp);
+  TProjectManager *pm = TProjectManager::instance();
+  pm->setCurrentProjectPath(projectFp);
+
   TProject *projectP =
       TProjectManager::instance()->getCurrentProject().getPointer();
+
+  // In case the project file was upgraded to current version, save it now
+  if (projectP->getProjectPath() != projectFp) {
+    m_projectPaths[index] = projectP->getProjectPath();
+    projectP->save();
+  }
+
   updateFieldsFromProject(projectP);
   IoCmd::saveSceneIfNeeded("Change project");
   IoCmd::newScene();

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -368,7 +368,14 @@ void ProjectPopup::updateChooseProjectCombo() {
       }
     }
   }
-
+  // Add in project of current project if outside known Project root folders
+  TProjectP currentProject   = TProjectManager::instance()->getCurrentProject();
+  TFilePath currentProjectFP = currentProject->getProjectPath();
+  if (m_projectPaths.indexOf(currentProjectFP) == -1) {
+    m_projectPaths.push_back(currentProjectFP);
+    m_chooseProjectCombo->addItem(
+        QString::fromStdString(currentProject->getName().getName()));
+  }
   for (int i = 0; i < m_projectPaths.size(); i++) {
     if (TProjectManager::instance()->getCurrentProjectPath() ==
         m_projectPaths[i]) {

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -347,13 +347,14 @@ void ProjectPopup::updateChooseProjectCombo() {
   m_projectPaths.clear();
   m_chooseProjectCombo->clear();
 
-  TFilePath sandboxFp = TProjectManager::instance()->getSandboxProjectFolder() +
-                        "sandbox_otprj.xml";
+  TProjectManager *pm = TProjectManager::instance();
+
+  TFilePath sandboxFp = pm->getSandboxProjectFolder() + "sandbox_otprj.xml";
   m_projectPaths.push_back(sandboxFp);
   m_chooseProjectCombo->addItem("sandbox");
 
   std::vector<TFilePath> prjRoots;
-  TProjectManager::instance()->getProjectRoots(prjRoots);
+  pm->getProjectRoots(prjRoots);
   for (int i = 0; i < prjRoots.size(); i++) {
     TFilePathSet fps;
     TSystem::readDirectory_Dir_ReadExe(fps, prjRoots[i]);
@@ -361,15 +362,16 @@ void ProjectPopup::updateChooseProjectCombo() {
     TFilePathSet::iterator it;
     for (it = fps.begin(); it != fps.end(); ++it) {
       TFilePath fp(*it);
-      if (TProjectManager::instance()->isProject(fp)) {
-        m_projectPaths.push_back(
-            TProjectManager::instance()->projectFolderToProjectPath(fp));
-        m_chooseProjectCombo->addItem(QString::fromStdString(fp.getName()));
+      if (pm->isProject(fp)) {
+        m_projectPaths.push_back(pm->projectFolderToProjectPath(fp));
+        TFilePath prjFile = pm->getProjectPathByProjectFolder(fp);
+        m_chooseProjectCombo->addItem(
+            QString::fromStdString(prjFile.getName()));
       }
     }
   }
   // Add in project of current project if outside known Project root folders
-  TProjectP currentProject   = TProjectManager::instance()->getCurrentProject();
+  TProjectP currentProject   = pm->getCurrentProject();
   TFilePath currentProjectFP = currentProject->getProjectPath();
   if (m_projectPaths.indexOf(currentProjectFP) == -1) {
     m_projectPaths.push_back(currentProjectFP);
@@ -377,8 +379,7 @@ void ProjectPopup::updateChooseProjectCombo() {
         QString::fromStdString(currentProject->getName().getName()));
   }
   for (int i = 0; i < m_projectPaths.size(); i++) {
-    if (TProjectManager::instance()->getCurrentProjectPath() ==
-        m_projectPaths[i]) {
+    if (pm->getCurrentProjectPath() == m_projectPaths[i]) {
       m_chooseProjectCombo->setCurrentIndex(i);
       break;
     }

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -508,13 +508,14 @@ void StartupPopup::updateProjectCB() {
   m_projectPaths.clear();
   m_projectsCB->clear();
 
-  TFilePath sandboxFp = TProjectManager::instance()->getSandboxProjectFolder() +
-                        "sandbox_otprj.xml";
+  TProjectManager *pm = TProjectManager::instance();
+
+  TFilePath sandboxFp = pm->getSandboxProjectFolder() + "sandbox_otprj.xml";
   m_projectPaths.push_back(sandboxFp);
   m_projectsCB->addItem("sandbox");
 
   std::vector<TFilePath> prjRoots;
-  TProjectManager::instance()->getProjectRoots(prjRoots);
+  pm->getProjectRoots(prjRoots);
   for (int i = 0; i < prjRoots.size(); i++) {
     TFilePathSet fps;
     TSystem::readDirectory_Dir_ReadExe(fps, prjRoots[i]);
@@ -522,15 +523,15 @@ void StartupPopup::updateProjectCB() {
     TFilePathSet::iterator it;
     for (it = fps.begin(); it != fps.end(); ++it) {
       TFilePath fp(*it);
-      if (TProjectManager::instance()->isProject(fp)) {
-        m_projectPaths.push_back(
-            TProjectManager::instance()->projectFolderToProjectPath(fp));
-        m_projectsCB->addItem(QString::fromStdString(fp.getName()));
+      if (pm->isProject(fp)) {
+        m_projectPaths.push_back(pm->projectFolderToProjectPath(fp));
+        TFilePath prjFile = pm->getProjectPathByProjectFolder(fp);
+        m_projectsCB->addItem(QString::fromStdString(prjFile.getName()));
       }
     }
   }
   // Add in project of current project if outside known Project root folders
-  TProjectP currentProject   = TProjectManager::instance()->getCurrentProject();
+  TProjectP currentProject   = pm->getCurrentProject();
   TFilePath currentProjectFP = currentProject->getProjectPath();
   if (m_projectPaths.indexOf(currentProjectFP) == -1) {
     m_projectPaths.push_back(currentProjectFP);
@@ -539,8 +540,7 @@ void StartupPopup::updateProjectCB() {
   }
   int i;
   for (i = 0; i < m_projectPaths.size(); i++) {
-    if (TProjectManager::instance()->getCurrentProjectPath() ==
-        m_projectPaths[i]) {
+    if (pm->getCurrentProjectPath() == m_projectPaths[i]) {
       m_projectsCB->setCurrentIndex(i);
       break;
     }

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -560,7 +560,16 @@ void StartupPopup::onProjectChanged(int index) {
   if (m_updating) return;
   TFilePath projectFp = m_projectPaths[index];
 
-  TProjectManager::instance()->setCurrentProjectPath(projectFp);
+  TProjectManager *pm = TProjectManager::instance();
+  pm->setCurrentProjectPath(projectFp);
+
+  TProjectP currentProject = pm->getCurrentProject();
+
+  // In case the project file was upgraded to current version, save it now
+  if (currentProject->getProjectPath() != projectFp) {
+    m_projectPaths[index] = currentProject->getProjectPath();
+    currentProject->save();
+  }
 
   IoCmd::newScene();
   m_pathFld->setPath(TApp::instance()

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -868,15 +868,16 @@ void StartupPopup::onRecentSceneClicked(int index) {
     refreshRecentScenes();
   } else {
     IoCmd::loadScene(TFilePath(path.toStdWString()), false);
-    if (RecentFiles::instance()->getFileProject(index) == "-") {
+    QString origProjectName = RecentFiles::instance()->getFileProject(index);
+    QString projectName     = QString::fromStdString(TApp::instance()
+                                                     ->getCurrentScene()
+                                                     ->getScene()
+                                                     ->getProject()
+                                                     ->getName()
+                                                     .getName());
+    if (origProjectName == "-" || origProjectName != projectName) {
       QString fileName =
           RecentFiles::instance()->getFilePath(index, RecentFiles::Scene);
-      QString projectName = QString::fromStdString(TApp::instance()
-                                                       ->getCurrentScene()
-                                                       ->getScene()
-                                                       ->getProject()
-                                                       ->getName()
-                                                       .getName());
       RecentFiles::instance()->removeFilePath(index, RecentFiles::Scene);
       RecentFiles::instance()->addFilePath(fileName, RecentFiles::Scene,
                                            projectName);

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -527,6 +527,14 @@ void StartupPopup::updateProjectCB() {
       }
     }
   }
+  // Add in project of current project if outside known Project root folders
+  TProjectP currentProject   = TProjectManager::instance()->getCurrentProject();
+  TFilePath currentProjectFP = currentProject->getProjectPath();
+  if (m_projectPaths.indexOf(currentProjectFP) == -1) {
+    m_projectPaths.push_back(currentProjectFP);
+    m_projectsCB->addItem(
+        QString::fromStdString(currentProject->getName().getName()));
+  }
   int i;
   for (i = 0; i < m_projectPaths.size(); i++) {
     if (TProjectManager::instance()->getCurrentProjectPath() ==

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1290,7 +1290,7 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
 
 TFilePath ToonzScene::decodeFilePath(const TFilePath &path) const {
   TProject *project   = getProject();
-  bool projectIsEmpty = false;
+  bool projectIsEmpty = project->getFolderCount() ? false : true;
   TFilePath fp        = path;
 
   std::wstring head;

--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -810,6 +810,14 @@ TFilePath TProjectManager::projectPathToProjectName(
   assert(projectPath.isAbsolute());
   TFilePath projectFolder = projectPath.getParentDir();
   if (m_projectsRoots.empty()) addDefaultProjectsRoot();
+
+  std::wstring fpName = projectPath.getWideName();
+  for (int i = 0; i < prjSuffixCount; ++i) {
+    //	  std::wstring::size_type const i = fpName.find(prjSuffix[i]);
+    if (fpName.find(prjSuffix[i]) != std::wstring::npos)
+      return TFilePath(fpName.substr(0, fpName.find(prjSuffix[i])));
+  }
+
   int i;
   for (i = 0; i < (int)m_projectsRoots.size(); i++) {
     if (m_projectsRoots[i].isAncestorOf(projectFolder))
@@ -874,6 +882,15 @@ TFilePath TProjectManager::getProjectPathByName(const TFilePath &projectName) {
     if (TFileStatus(projectPath).doesExist()) return projectPath;
   }
   return TFilePath();
+}
+
+//-------------------------------------------------------------------
+
+TFilePath TProjectManager::getProjectPathByProjectFolder(
+    const TFilePath &projectFolder) {
+  assert(!projectFolder.isAbsolute());
+  TFilePath projectPath = searchProjectPath(projectFolder);
+  return projectPathToProjectName(projectPath);
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses a minor issue where if you load a project that doesn't fall under the Project Root folders you've configured the Project doesn't appear in the drop-downs as a selectable project. An example of this is if someone shares a project with you and you drop it in a Downloads folder or some other folder you don't normally use for new projects.

I added logic to check if the current scene is not under a configured project root folder and temporarily adds the project name to the Start Up and Project Settings popup drop-down. This give the ability to see the settings in the Project Settings dialog as well start in that project on startup.

Additionally I fixed an issue where the "+directoryname" (i.e. +drawing, +extra) notation is used for level paths but the folder is not configured in the Project settings file.  Assuming there are no folders defined, it will build the path relative to the project folder as normal.
