### PR TITLE
Fix Task Display issue

### DIFF
--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -324,7 +324,7 @@ void TaskSheet::update(TFarmTask *task) {
   m_commandLine->setText(task->getCommandLine());
   m_server->setText(task->m_server);
   m_submittedBy->setText(task->m_user);
-  m_submittedOn->setText(task->m_submissionDate.toString());
+  m_submittedOn->setText(task->m_callerMachineName);
   m_priority->setText(QString::number(task->m_priority));
   m_submitDate->setText(task->m_submissionDate.toString());
   m_startDate->setText(task->m_startDate.toString());


### PR DESCRIPTION
This PR fixes #2639.

Was being populated using the Submission Date rather than the local computer name that submitted the task. Corrected the field's source.