### PR TITLE
Allow viewer arrow keys to shift cell selection

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -15,6 +15,7 @@
 #include "ruler.h"
 #include "comboviewerpane.h"
 #include "locatorpopup.h"
+#include "cellselection.h"
 
 // TnzQt includes
 #include "toonzqt/tselectionhandle.h"
@@ -1331,6 +1332,7 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
     if (changeFrameSkippingHolds(event)) return;
 
     TFrameHandle *fh = TApp::instance()->getCurrentFrame();
+    int origFrame    = fh->getFrame();
 
     if (key == Qt::Key_Up || key == Qt::Key_Left)
       fh->prevFrame();
@@ -1356,6 +1358,21 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
       fh->firstFrame();
     else if (key == Qt::Key_End)
       fh->lastFrame();
+
+    // Use arrow keys to shift the cell selection.
+    if (Preferences::instance()->isUseArrowKeyToShiftCellSelectionEnabled() &&
+        fh->getFrameType() != TFrameHandle::LevelFrame) {
+      TCellSelection *cellSel =
+          dynamic_cast<TCellSelection *>(TSelection::getCurrent());
+      if (cellSel && !cellSel->isEmpty()) {
+        int r0, c0, r1, c1;
+        cellSel->getSelectedCells(r0, c0, r1, c1);
+        int shiftFrame = fh->getFrame() - origFrame;
+
+        cellSel->selectCells(r0 + shiftFrame, c0, r1 + shiftFrame, c1);
+        TApp::instance()->getCurrentSelection()->notifySelectionChanged();
+      }
+    }
   }
   update();
   // TODO: devo accettare l'evento?


### PR DESCRIPTION
The PR extends the `Use Arrow Keys to Shift Cell Selection` preference to the arrow key bindings of the Viewer.

Assuming you have `Use Arrow Keys to Shift Cell Selection` enabled...currently,  when you select a cell in the xsheet and move about with the arrow keys, the cell selection moves with the current frame.  However, if you are in the viewer and use the arrow keys to move left or right, the xsheet's current frame moves, but the cell selection remains where it is. 

Updated the viewer logic to shift the cell selection with the frame selection when this preference is enabled.

Scenario in which this is useful:
Say you have Frames 1-10 filled. You click on Frame 2 to select it in the xsheet and draw.  Now you decided you want to add a new frame between Frame 4 and 5. You use arrow keys to get to Frame 5 and hit Insert key.  In the current version, Frames 2 - 10 shift because the cell selection didn't move.  With this PR, the selected cell moves from Frame 2 to Frame 5 with the arrow keys. Now when you hit Insert, it will shift Frames 5-10 down exposing an empty frame where you want it.
