### PR TITLE
Display Cycled Values in Function Editor Spread Sheet 

### DIFF
--- a/toonz/sources/include/toonz/doubleparamcmd.h
+++ b/toonz/sources/include/toonz/doubleparamcmd.h
@@ -18,6 +18,7 @@
 #endif
 
 class KeyframesUndo;
+class TSceneHandle;
 
 class DVAPI KeyframeSetter {
   TDoubleParamP m_param;
@@ -101,7 +102,8 @@ public:
   }
   static void removeKeyframeAt(TDoubleParam *curve, double frame);
 
-  static void enableCycle(TDoubleParam *curve, bool enabled);
+  static void enableCycle(TDoubleParam *curve, bool enabled,
+                          TSceneHandle *sceneHandle = nullptr);
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/functionsheet.h
+++ b/toonz/sources/include/toonzqt/functionsheet.h
@@ -124,6 +124,11 @@ public:
   int getColumnIndexByCurve(TDoubleParam *param) const;
   bool anyWidgetHasFocus();
 
+  // Obtains a pointer to the stage object containing the
+  // parameter of specified column. Returns nullptr for
+  // fx parameter columns.
+  TStageObject *getStageObject(int column);
+
 protected:
   void showEvent(QShowEvent *e) override;
   void hideEvent(QHideEvent *e) override;

--- a/toonz/sources/include/toonzqt/functiontreeviewer.h
+++ b/toonz/sources/include/toonzqt/functiontreeviewer.h
@@ -336,6 +336,31 @@ public:
   void refresh() override;
 };
 
+//=============================================================================
+
+class StageObjectChannelGroup final : public FunctionTreeModel::ChannelGroup {
+public:
+  TStageObject *m_stageObject;  //!< (not owned) Referenced stage object
+  FunctionTreeModel::ChannelGroup
+      *m_plasticGroup;  //!< (not owned) Eventual plastic channels group
+
+public:
+  StageObjectChannelGroup(TStageObject *pegbar);
+  ~StageObjectChannelGroup();
+
+  QString getShortName() const override;
+  QString getLongName() const override;
+
+  QString getIdName() const override;
+
+  void *getInternalPointer() const override {
+    return static_cast<void *>(m_stageObject);
+  }
+
+  TStageObject *getStageObject() const { return m_stageObject; }
+  QVariant data(int role) const override;
+};
+
 //*****************************************************************************************
 //    FunctionTreeView  declaration
 //*****************************************************************************************

--- a/toonz/sources/include/toonzqt/functionviewer.h
+++ b/toonz/sources/include/toonzqt/functionviewer.h
@@ -120,6 +120,8 @@ public:
   void clearFocusColumnsAndGraph();
   bool columnsOrGraphHasFocus();
   void setSceneHandle(TSceneHandle *sceneHandle);
+  TSceneHandle *getSceneHandle() const { return m_sceneHandle; }
+
   // SaveLoadQSettings
   virtual void save(QSettings &settings) const override;
   virtual void load(QSettings &settings) override;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2531,6 +2531,8 @@ public:
   void undo() const override {
     m_pegbar->enableCycle(!m_pegbar->isCycleEnabled());
     m_area->update();
+    TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    TApp::instance()->getCurrentObject()->notifyObjectIdChanged(false);
   }
   void redo() const override { undo(); }
   int getSize() const override { return sizeof *this; }
@@ -2694,8 +2696,9 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
       } else if (isKeyframeFrame && row == k1 + 1 &&
                  o->rect(PredefinedRect::LOOP_ICON)
                      .contains(mouseInCell)) {  // cycle toggle
-        pegbar->enableCycle(!pegbar->isCycleEnabled());
-        TUndoManager::manager()->add(new CycleUndo(pegbar, this));
+        CycleUndo *undo = new CycleUndo(pegbar, this);
+        undo->redo();
+        TUndoManager::manager()->add(undo);
         accept = true;
       }
       if (accept) {

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -64,31 +64,6 @@ public:
 
 //=============================================================================
 
-class StageObjectChannelGroup final : public FunctionTreeModel::ChannelGroup {
-public:
-  TStageObject *m_stageObject;  //!< (not owned) Referenced stage object
-  FunctionTreeModel::ChannelGroup
-      *m_plasticGroup;  //!< (not owned) Eventual plastic channels group
-
-public:
-  StageObjectChannelGroup(TStageObject *pegbar);
-  ~StageObjectChannelGroup();
-
-  QString getShortName() const override;
-  QString getLongName() const override;
-
-  QString getIdName() const override;
-
-  void *getInternalPointer() const override {
-    return static_cast<void *>(m_stageObject);
-  }
-
-  TStageObject *getStageObject() const { return m_stageObject; }
-  QVariant data(int role) const override;
-};
-
-//=============================================================================
-
 class SkVDChannelGroup final : public FunctionTreeModel::ChannelGroup {
 public:
   StageObjectChannelGroup *m_stageObjectGroup;  //!< Parent stage object group

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -582,7 +582,10 @@ void FunctionViewer::onStageObjectChanged(bool isDragging) {
   static_cast<FunctionTreeModel *>(m_treeView->model())
       ->setCurrentStageObject(obj);
 
-  if (!isDragging) m_treeView->updateAll();
+  if (!isDragging) {
+    m_treeView->updateAll();
+    m_numericalColumns->updateAll();
+  }
 
   m_functionGraph->update();
 }


### PR DESCRIPTION
This PR will modify Function Editor's spread sheet, making it to display values outside of the keyframe range if the parameter is cycled.

<img src="https://user-images.githubusercontent.com/17974955/60425972-a3ad8f00-9c2e-11e9-9cf5-ad5a644bdc9d.png" height=400>

- Please note that currently OT has two cycle options: one can be set by clicking the "cycle arrow" button in the xsheet ( = cycle option of the stage object ) , and the other can be set via the context menu of function curves ( = cycle option of the parameter ).
- The stage object's cycle option literally cycles values with no offset. Applied to all transformation parameters of the cycled object. Cycle range will be set to contain all key frames of all channels of the object.
- The parameter's cycle option includes value offset so that the curve connects smoothly. Applied to each parameter. 
- The stage object's cycle option has a priority to the parameter's one, if the both options are activated.

So, In this PR I modified the following:

- Displayed the cycled values from the last key frame to the end frame of the scene. You can distinguish the type of cycle option by color of zigzag line (white for stage object's cycle and light orange for parameter's cycle, in the Default style).
- Enabled to set the parameter's cycle option from the context menu of spread sheet.

Currently, the stage object's cycle option is rather "ignored" in Function Editor. The followings are not included in this PR but I'm thinking of modifying in the future, if they will be accepted by users:
If the stage object's cycle option is activated,
- Display the cycled value in the value field of the Function Editor toolbar.
- Display the cycled shape in the Function Editor graph viewer.
- Return the cycled value when the parameter is referred by an expression.