### PR TITLE
Fix tconvert tool for Linux (issue #2012)

### DIFF
--- a/toonz/sources/tconverter/tconverter.cpp
+++ b/toonz/sources/tconverter/tconverter.cpp
@@ -29,6 +29,10 @@
 #include "tvectorrenderdata.h"
 #include "tofflinegl.h"
 
+#if defined(LINUX)
+#include <QGuiApplication>
+#endif
+
 using namespace std;
 using namespace TCli;
 
@@ -355,6 +359,10 @@ void convert(const TFilePath &source, const TFilePath &dest,
 //------------------------------------------------------------------------
 
 int main(int argc, char *argv[]) {
+#if defined(LINUX)
+  QGuiApplication app(argc, argv);
+#endif
+
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
   TFilePath fp = TEnv::getStuffDir();


### PR DESCRIPTION
Fix conversion of PLI-files for Linux (issue #2012)

By documentation for QOffscreenSurface:
Due to the fact that QOffscreenSurface is backed by a QWindow on some
platforms, cross-platform applications must ensure that create() is only
called on the main (GUI) thread. The QOffscreenSurface is then safe to
be used with makeCurrent() on other threads, but the initialization and
destruction must always happen on the main (GUI) thread.

Reopened PR #2013 (i've renamed branch and solved conflicts)