### PR TITLE
Level Extension without Rippling the Other Timing

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2709,11 +2709,16 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
 
     if (m_levelExtenderRect.contains(pos.x, pos.y)) {
       m_viewer->getKeyframeSelection()->selectNone();
-      setDragTool(XsheetGUI::DragTool::makeLevelExtenderTool(m_viewer));
+      if (event->modifiers() & Qt::ControlModifier)
+        setDragTool(
+            XsheetGUI::DragTool::makeLevelExtenderTool(m_viewer, false));
+      else
+        setDragTool(XsheetGUI::DragTool::makeLevelExtenderTool(m_viewer, true));
     } else if (event->modifiers() & Qt::ControlModifier &&
                m_upperLevelExtenderRect.contains(pos.x, pos.y)) {
       m_viewer->getKeyframeSelection()->selectNone();
-      setDragTool(XsheetGUI::DragTool::makeLevelExtenderTool(m_viewer, true));
+      setDragTool(
+          XsheetGUI::DragTool::makeLevelExtenderTool(m_viewer, false, true));
     } else if ((!xsh->getCell(row, col).isEmpty()) &&
                o->rect(PredefinedRect::DRAG_AREA)
                    .adjusted(0, 0, -frameAdj, 0)

--- a/toonz/sources/toonz/xsheetdragtool.h
+++ b/toonz/sources/toonz/xsheetdragtool.h
@@ -48,6 +48,7 @@ public:
   static DragTool *makeSelectionTool(XsheetViewer *viewer);
   static DragTool *makeLevelMoverTool(XsheetViewer *viewer);
   static DragTool *makeLevelExtenderTool(XsheetViewer *viewer,
+                                         bool insert = true,
                                          bool invert = false);
   static DragTool *makeSoundLevelModifierTool(XsheetViewer *viewer);
   static DragTool *makeKeyframeMoverTool(XsheetViewer *viewer);


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/17974955/60579941-1a799200-9dbf-11e9-92e9-57359011b0c7.gif" height=350>

This PR enables to use the level extender tab without rippling the other timing below.
To enable, press Ctrl key and drag the tab.
Note that the extension will stop when the extended level reaches non-vacant cell. 