### PR TITLE
Revert "Use alignas instead of DV_ALIGNED (#2437)"

### DIFF
--- a/toonz/sources/common/trop/tresample.cpp
+++ b/toonz/sources/common/trop/tresample.cpp
@@ -1349,7 +1349,7 @@ void resample_main_rgbm(TRasterPT<T> rout, const TRasterPT<T> &rin,
 
 namespace {
 
-class alignas(16) TPixelFloat {
+DV_ALIGNED(16) class TPixelFloat {
 public:
   TPixelFloat() : b(0), g(0), r(0), m(0) {}
 

--- a/toonz/sources/common/trop/tropcm.cpp
+++ b/toonz/sources/common/trop/tropcm.cpp
@@ -34,7 +34,7 @@ extern "C" {
 
 namespace {
 
-class alignas(16) TPixelFloat {
+DV_ALIGNED(16) class TPixelFloat {
 public:
   TPixelFloat() : b(0), g(0), r(0), m(0) {}
 

--- a/toonz/sources/include/tcommon.h
+++ b/toonz/sources/include/tcommon.h
@@ -149,6 +149,12 @@ const unsigned int c_maxuint = (unsigned int)(~0U);
 #define DV_IMPORT_VAR
 #endif
 
+#ifdef _MSC_VER
+#define DV_ALIGNED(val) __declspec(align(val))
+#else
+#define DV_ALIGNED(val) __attribute__((aligned(val)))
+#endif
+
 inline short swapShort(short val) { return ((val >> 8) & 0x00ff) | (val << 8); }
 inline TINT32 swapTINT32(TINT32 val) {
   TINT32 appo, aux, aux1;

--- a/toonz/sources/include/tpixel.h
+++ b/toonz/sources/include/tpixel.h
@@ -40,7 +40,7 @@ class TPixelGR16;
     A set of predefined colors are included as well.
     Note that channel ordering is platform depending. */
 
-class DVAPI alignas(4) TPixelRGBM32 {
+class DVAPI DV_ALIGNED(4) TPixelRGBM32 {
   TPixelRGBM32(TUINT32 mask) { *(TUINT32 *)this = mask; };
 
 public:
@@ -154,9 +154,9 @@ dithering
 //  Since SSE2 mostly require 16 byte aligned, changing 8 byte align to 4 byte
 //  align will not cause problems.
 #if defined(_MSC_VER) && !defined(x64)
-class DVAPI alignas(4) TPixelRGBM64 {
+class DVAPI DV_ALIGNED(4) TPixelRGBM64 {
 #else
-class DVAPI alignas(8) TPixelRGBM64 {
+class DVAPI DV_ALIGNED(8) TPixelRGBM64 {
 #endif
 public:
   static const int maxChannelValue;


### PR DESCRIPTION
The GCC/C++ parser has trouble combining the C++11 `alignas` specifier and the GNU `__attribute__` specifier in the same class declaration:

```
class __attribute__(...) alignas(...) MyClass { ... }; // does not work
class alignas(...) __attribute__(...) MyClass { ... }; // does not work
class alignas(...) MyClass { ... } __attribute__(...); // works but ugly
```

Bug raises in MinGW build where used combination of attribute and align:
for example include/tpixel.h:43
https://github.com/opentoonz/opentoonz/blob/e4aac6f4338a4f40d9526d32cc32c0b184f6c141/toonz/sources/include/tpixel.h#L43

`class DVAPI alignas(4) TPixelRGBM32 { ... }`
aka
`class __declspec(dllexport) alignas(4) TPixelRGBM32 { ... }`
aka
`class __attribute__((dllexport)) alignas(4) TPixelRGBM32 { ... }`


Bug at GCC bugtracker:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69585