### PR TITLE
Fix errors building with Qt 5.13

### DIFF
--- a/toonz/sources/include/tfxattributes.h
+++ b/toonz/sources/include/tfxattributes.h
@@ -5,6 +5,7 @@
 
 #include "tgeometry.h"
 #include <QStack>
+#include <QList>
 
 #undef DVAPI
 #undef DVVAR


### PR DESCRIPTION
This PR fixes Travis macOS build errors due to building with Qt 5.13.