### PR TITLE
Fix sound not playing after dragging the sound level

### DIFF
--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -772,7 +772,7 @@ void TXsheet::increaseStepCells(int r0, int c0, int &r1, int c1) {
   // controllo se devo cambiare la selezione
   bool allIncreaseIsEqual = true;
   for (c = 0; c < ends.size() - 1 && allIncreaseIsEqual; c++)
-    allIncreaseIsEqual       = allIncreaseIsEqual && ends[c] == ends[c + 1];
+    allIncreaseIsEqual = allIncreaseIsEqual && ends[c] == ends[c + 1];
   if (allIncreaseIsEqual) r1 = ends[0];
 }
 
@@ -806,7 +806,7 @@ void TXsheet::decreaseStepCells(int r0, int c0, int &r1, int c1) {
   // controllo se devo cambiare la selezione
   bool allDecreaseIsEqual = true;
   for (c = 0; c < ends.size() - 1 && allDecreaseIsEqual; c++)
-    allDecreaseIsEqual       = allDecreaseIsEqual && ends[c] == ends[c + 1];
+    allDecreaseIsEqual = allDecreaseIsEqual && ends[c] == ends[c + 1];
   if (allDecreaseIsEqual) r1 = ends[0];
 }
 
@@ -940,7 +940,7 @@ void TXsheet::resetStepCells(int r0, int c0, int r1, int c1) {
 //-----------------------------------------------------------------------------
 /*! Roll first cells of rect r0,c0,r1,c1. Move cells contained in first row to
  * last row.
-*/
+ */
 void TXsheet::rollupCells(int r0, int c0, int r1, int c1) {
   int nc   = c1 - c0 + 1;
   int size = 1 * nc;
@@ -963,7 +963,7 @@ void TXsheet::rollupCells(int r0, int c0, int r1, int c1) {
 //-----------------------------------------------------------------------------
 /*! Roll last cells of rect r0,c0,r1,c1. Move cells contained in last row to
  * first row.
-*/
+ */
 void TXsheet::rolldownCells(int r0, int c0, int r1, int c1) {
   int nc   = c1 - c0 + 1;
   int size = 1 * nc;
@@ -1417,8 +1417,9 @@ void searchAudioColumn(TXsheet *xsh, std::vector<TXshSoundColumn *> &sounds,
     TXshColumn *column = xsh->getColumn(i);
     if (column) {
       TXshSoundColumn *soundCol = column->getSoundColumn();
-      if (soundCol && ((isPreview && soundCol->isCamstandVisible()) ||
-                       (!isPreview && soundCol->isPreviewVisible()))) {
+      if (soundCol && !soundCol->isEmpty() &&
+          ((isPreview && soundCol->isCamstandVisible()) ||
+           (!isPreview && soundCol->isPreviewVisible()))) {
         sounds.push_back(soundCol);
         continue;
       }


### PR DESCRIPTION
This PR will fix the problem as follows:
Sound fails to play once you move the sound level in the xsheet.

To reproduce:

1. Load a sound level to column 1.
1. Click the play button on the viewer console and make sure the sound plays with no problem.
1. Select whole sound level cells by clicking the side bar of the xsheet cell.
1. Drag the sound level cells to column 2. (*)
1. Click the play button on the viewer console. The sound will not play.

(*) Please note you need to drag the _cells_ , not the sound columns in order to reproduce the problem.

Dragging the sound cells can create the empty `TXshSoundColumn` . The function `searchAudioColumn()` should ignore it or OT fails to mix the sound properly.