### PR TITLE
Added "Select All" function for vector images (#1042)

### DIFF
--- a/toonz/sources/include/tools/strokeselection.h
+++ b/toonz/sources/include/tools/strokeselection.h
@@ -79,6 +79,8 @@ public:
 
   void enableCommands() override;
 
+  void selectAll();
+
 private:
   TVectorImageP m_vi;          //!< Selected vector image.
   IndexesContainer m_indexes;  //!< Selected stroke indexes in m_vi.

--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -455,6 +455,27 @@ void StrokeSelection::removeEndpoints() {
   m_updateSelectionBBox = false;
 }
 
+
+//=============================================================================
+//
+// selectAll
+//
+//-----------------------------------------------------------------------------
+
+void StrokeSelection::selectAll() {
+  if (!m_vi) return;
+
+  int sCount = int(m_vi->getStrokeCount());
+
+  for (int s = 0; s < sCount; ++s) {
+     m_indexes.insert(s);
+  }
+
+  StrokeSelection *selection = dynamic_cast<StrokeSelection *>(
+      TTool::getApplication()->getCurrentSelection()->getSelection());
+  if (selection) selection->notifyView();
+}
+
 //=============================================================================
 //
 // deleteStrokes
@@ -613,6 +634,7 @@ void StrokeSelection::enableCommands() {
   enableCommand(m_groupCommand.get(), MI_ExitGroup, &TGroupCommand::exitGroup);
 
   enableCommand(this, MI_RemoveEndpoints, &StrokeSelection::removeEndpoints);
+  enableCommand(this, MI_SelectAll, &StrokeSelection::selectAll);
 }
 
 //===================================================================


### PR DESCRIPTION
Enables the "Select All" function in vector layers (as requested in #1042). Using "Select All" (Ctrl+A) will select all vector lines in the current image.