### PR TITLE
Simplify the Selective Option of Paint Brush Tool Behavior 

### DIFF
--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -401,18 +401,11 @@ bool PaintBrushTool::onPropertyChanged(std::string propertyName) {
 
   // Selective
   else if (propertyName == m_onlyEmptyAreas.getName()) {
-    if (m_onlyEmptyAreas.getValue() && m_colorType.getValue() == LINES) {
-      m_colorType.setValue(AREAS);
-      PaintBrushColorType = ::to_string(m_colorType.getValue());
-    }
     PaintBrushSelective = (int)(m_onlyEmptyAreas.getValue());
   }
 
   // Areas, Lines etc.
   else if (propertyName == m_colorType.getName()) {
-    if (m_colorType.getValue() == LINES) {
-      PaintBrushSelective = (int)(m_onlyEmptyAreas.getValue());
-    }
     PaintBrushColorType = ::to_string(m_colorType.getValue());
     /*--- ColorModelのCursor更新のためにSIGNALを出す ---*/
     TTool::getApplication()->getCurrentTool()->notifyToolChanged();
@@ -428,7 +421,7 @@ void PaintBrushTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
   TImageP image(getImage(true));
   if (m_colorType.getValue() == LINES) m_colorTypeBrush = INK;
   if (m_colorType.getValue() == AREAS) m_colorTypeBrush = PAINT;
-  if (m_colorType.getValue() == ALL) m_colorTypeBrush   = INKNPAINT;
+  if (m_colorType.getValue() == ALL) m_colorTypeBrush = INKNPAINT;
 
   if (TToonzImageP ti = image) {
     TRasterCM32P ras = ti->getRaster();
@@ -534,7 +527,7 @@ void PaintBrushTool::onDeactivate() {
 //-----------------------------------------------------------------------------
 /*!
  * 描画中にツールが切り替わった場合に備え、onDeactivateでもMouseReleaseと同じ終了処理を行う
-*/
+ */
 void PaintBrushTool::finishBrush() {
   if (TToonzImageP ti = (TToonzImageP)getImage(true)) {
     if (m_rasterTrack) {

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -535,7 +535,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_nsPosField =
       new PegbarChannelField(m_tool, TStageObject::T_Y, "field", frameHandle,
                              objHandle, xshHandle, this);
-  m_zField = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
+  m_zField        = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
                                     frameHandle, objHandle, xshHandle, this);
   m_noScaleZField = new NoScaleField(m_tool, "field");
 
@@ -666,7 +666,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_zField->setPrecision(4);
   m_noScaleZField->setPrecision(4);
 
-  bool splined                        = isCurrentObjectSplined();
+  bool splined = isCurrentObjectSplined();
   if (splined != m_splined) m_splined = splined;
   setSplined(m_splined);
 
@@ -1064,7 +1064,7 @@ void ArrowToolOptionsBox::onStageObjectChange() { updateStatus(); }
 
 //-----------------------------------------------------------------------------
 /*! update the object list in combobox
-*/
+ */
 void ArrowToolOptionsBox::updateStageObjectComboItems() {
   // clear items
   m_currentStageObjectCombo->clear();
@@ -1093,7 +1093,7 @@ void ArrowToolOptionsBox::updateStageObjectComboItems() {
 
 //------------------------------------------------------------------------------
 /*! syncronize the current item in the combobox to the selected stage object
-*/
+ */
 void ArrowToolOptionsBox::syncCurrentStageObjectComboItem() {
   TStageObjectId curObjId = m_objHandle->getObjectId();
 
@@ -1116,7 +1116,7 @@ void ArrowToolOptionsBox::syncCurrentStageObjectComboItem() {
 
 //------------------------------------------------------------------------------
 /*!change the current stage object when user changes it via combobox by hand
-*/
+ */
 void ArrowToolOptionsBox::onCurrentStageObjectComboActivated(int index) {
   int code = m_currentStageObjectCombo->itemData(index).toInt();
   TStageObjectId id;
@@ -1294,7 +1294,7 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   // assert(ret);
   bool ret = connect(m_scaleXField, SIGNAL(valueChange(bool)),
                      SLOT(onScaleXValueChanged(bool)));
-  ret = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
+  ret      = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
                        SLOT(onScaleYValueChanged(bool)));
   if (m_setSaveboxCheckbox)
     ret = ret && connect(m_setSaveboxCheckbox, SIGNAL(toggled(bool)),
@@ -1622,7 +1622,7 @@ PaintbrushToolOptionsBox::PaintbrushToolOptionsBox(QWidget *parent, TTool *tool,
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Selective"));
 
   if (m_colorMode->getProperty()->getValue() == L"Lines")
-    m_selectiveMode->setEnabled(false);
+    m_selectiveMode->setVisible(false);
 
   bool ret = connect(m_colorMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onColorModeChanged(int)));
@@ -1642,7 +1642,7 @@ void PaintbrushToolOptionsBox::updateStatus() {
 void PaintbrushToolOptionsBox::onColorModeChanged(int index) {
   const TEnumProperty::Range &range = m_colorMode->getProperty()->getRange();
   bool enabled                      = range[index] != L"Lines";
-  m_selectiveMode->setEnabled(enabled);
+  m_selectiveMode->setVisible(enabled);
 }
 
 //=============================================================================
@@ -1705,11 +1705,11 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_colorMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onColorModeChanged(int)));
-  ret = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
+  ret      = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolTypeChanged(int)));
-  ret = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
                        SLOT(onOnionModeToggled(bool)));
-  ret = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
                        SLOT(onMultiFrameModeToggled(bool)));
   assert(ret);
   if (m_colorMode->getProperty()->getValue() == L"Lines") {
@@ -2308,9 +2308,9 @@ TapeToolOptionsBox::TapeToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_typeMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onToolTypeChanged(int)));
-  ret = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
+  ret      = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolModeChanged(int)));
-  ret = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
                        SLOT(onJoinStrokesModeChanged()));
   assert(ret);
 }
@@ -2358,7 +2358,7 @@ void TapeToolOptionsBox::onJoinStrokesModeChanged() {
 
 //-----------------------------------------------------------------------------
 /*! Label with background color
-*/
+ */
 class RGBLabel final : public QWidget {
   QColor m_color;
 
@@ -2397,10 +2397,11 @@ protected:
       p.setPen(Qt::black);
     p.setBrush(Qt::NoBrush);
 
-    p.drawText(rect(), Qt::AlignCenter, QString("R:%1 G:%2 B:%3")
-                                            .arg(m_color.red())
-                                            .arg(m_color.green())
-                                            .arg(m_color.blue()));
+    p.drawText(rect(), Qt::AlignCenter,
+               QString("R:%1 G:%2 B:%3")
+                   .arg(m_color.red())
+                   .arg(m_color.green())
+                   .arg(m_color.blue()));
   }
 };
 
@@ -2811,7 +2812,7 @@ void ToolOptions::onToolSwitched() {
   TTool *tool = app->getCurrentTool()->getTool();
   if (tool) {
     // c'e' un tool corrente
-    ToolOptionsBox *panel = 0;
+    ToolOptionsBox *panel                            = 0;
     std::map<TTool *, ToolOptionsBox *>::iterator it = m_panels.find(tool);
     if (it == m_panels.end()) {
       // ... senza panel associato


### PR DESCRIPTION
This PR will simplify the behavior of "Selective" option of Paint Brush tool.

This will resolve a problem with following steps:
- Select some Toonz Raster Level.
- Select Paint Brush tool.
- In tool options, set the mode to "Lines". (The selective check box will be disabled.)
- Toggle the selective option to ON via shortcut key.
- Try drawing on the level. The tool will unexpectedly paint areas as if it is in "Areas" mode.

For now the mode is automatically switched from "Lines" to "Areas", when the selective option is activated. It seems to be rather confusing since the "Mode" combo box in the tool option does not reflect such change.

In this PR I omitted such behavior for simplicity. Toggling the Selective option will only toggle the selective option. 


