### PR TITLE
Reframe popup small enhancement

### DIFF
--- a/toonz/sources/toonz/reframepopup.cpp
+++ b/toonz/sources/toonz/reframepopup.cpp
@@ -61,10 +61,10 @@ ReframePopup::ReframePopup()
   bool ret = true;
   ret      = ret && connect(m_step, SIGNAL(editingFinished()), this,
                        SLOT(updateBlankCellCount()));
-  ret = ret && connect(m_blank, SIGNAL(editingFinished()), this,
+  ret      = ret && connect(m_blank, SIGNAL(editingFinished()), this,
                        SLOT(updateBlankCellCount()));
-  ret = ret && connect(okBtn, SIGNAL(clicked()), this, SLOT(accept()));
-  ret = ret && connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
+  ret      = ret && connect(okBtn, SIGNAL(clicked()), this, SLOT(accept()));
+  ret      = ret && connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
   assert(ret);
 }
 
@@ -81,3 +81,7 @@ void ReframePopup::getValues(int& step, int& blank) {
   step  = m_step->getValue();
   blank = m_blank->getValue();
 }
+
+//-----------------------------------------------------------------------------
+
+void ReframePopup::showEvent(QShowEvent* event) { m_step->selectAll(); }

--- a/toonz/sources/toonz/reframepopup.h
+++ b/toonz/sources/toonz/reframepopup.h
@@ -32,6 +32,9 @@ public:
   ReframePopup();
   void getValues(int& step, int& blank);
 
+protected:
+  void showEvent(QShowEvent* event) override;
+
 public slots:
   void updateBlankCellCount();
 };


### PR DESCRIPTION
This PR will enhance the reframe popup (opened with `Reframe with Empty Inbetweens` command).
Now the "steps" field will be already selected on open, so that users do not need to click and select the field for editing it.