### PR TITLE
Fix OpenGL widgets in floating panels disapper on room switch

### DIFF
--- a/toonz/sources/include/toonzqt/lutcalibrator.h
+++ b/toonz/sources/include/toonzqt/lutcalibrator.h
@@ -29,7 +29,8 @@ class QOpenGLContext;
 class QColor;
 
 class DVAPI LutCalibrator : public QOpenGLFunctions {
-  bool m_isValid = false;
+  bool m_isValid       = false;
+  bool m_isInitialized = false;
 
   struct LutTextureShader {
     QOpenGLShader* vert           = nullptr;
@@ -58,6 +59,7 @@ public:
   void initialize();
 
   bool isValid() { return m_isValid; }
+  bool isInitialized() { return m_isInitialized; }
 
   ~LutCalibrator() {}
 

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -152,6 +152,8 @@ class DVAPI HexagonalColorWheel final : public GLWidgetForHighDpi {
   QOpenGLFramebufferObject *m_fbo = NULL;
   LutCalibrator *m_lutCalibrator  = NULL;
 
+  bool m_contextReplaced = false;
+
 private:
   void drawCurrentColorMark();
   void clickLeftWheel(const QPoint &pos);

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -152,7 +152,7 @@ class DVAPI HexagonalColorWheel final : public GLWidgetForHighDpi {
   QOpenGLFramebufferObject *m_fbo = NULL;
   LutCalibrator *m_lutCalibrator  = NULL;
 
-  bool m_contextReplaced = false;
+  bool m_firstInitialized = true;
 
 private:
   void drawCurrentColorMark();

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -442,7 +442,9 @@ void ImageViewer::initializeGL() {
   // glClearColor(1.0,1.0,1.0,1);
   glClear(GL_COLOR_BUFFER_BIT);
 
-  if (m_contextReplaced) {
+  if (m_firstInitialized)
+    m_firstInitialized = false;
+  else {
     resizeGL(width(), height());
     update();
   }
@@ -1248,7 +1250,6 @@ void ImageViewer::keyPressEvent(QKeyEvent *event) {
 //-----------------------------------------------------------------------------
 
 void ImageViewer::onContextAboutToBeDestroyed() {
-  m_contextReplaced = true;
   if (!m_lutCalibrator) return;
   makeCurrent();
   m_lutCalibrator->cleanup();

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -383,7 +383,7 @@ ImageViewer::~ImageViewer() {
 //-----------------------------------------------------------------------------
 /*! Set current image to \b image and update. If Histogram is visible set its
  * image.
-*/
+ */
 void ImageViewer::setImage(TImageP image) {
   m_image = image;
 
@@ -433,7 +433,7 @@ void ImageViewer::initializeGL() {
   initializeOpenGLFunctions();
 
   // to be computed once through the software
-  if (m_lutCalibrator) {
+  if (m_lutCalibrator && !m_lutCalibrator->isInitialized()) {
     m_lutCalibrator->initialize();
     connect(context(), SIGNAL(aboutToBeDestroyed()), this,
             SLOT(onContextAboutToBeDestroyed()));
@@ -441,6 +441,11 @@ void ImageViewer::initializeGL() {
 
   // glClearColor(1.0,1.0,1.0,1);
   glClear(GL_COLOR_BUFFER_BIT);
+
+  if (m_contextReplaced) {
+    resizeGL(width(), height());
+    update();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -573,7 +578,7 @@ void ImageViewer::paintGL() {
   } else if (m_draggingZoomSelection || m_rectRGBPick) {
     fromPos = TPoint(m_pressedMousePos.x - width() * 0.5,
                      height() * 0.5 - m_pressedMousePos.y);
-    toPos = TPoint(m_pos.x() - width() * 0.5, height() * 0.5 - m_pos.y());
+    toPos   = TPoint(m_pos.x() - width() * 0.5, height() * 0.5 - m_pos.y());
   }
   if (fromPos != TPoint() || toPos != TPoint()) {
     if (m_rectRGBPick) {
@@ -612,7 +617,7 @@ void ImageViewer::paintGL() {
 
 //------------------------------------------------------------------------------
 /*! Add to current trasformation matrix a \b delta traslation.
-*/
+ */
 void ImageViewer::panQt(const QPoint &delta) {
   if (delta == QPoint()) return;
 
@@ -746,7 +751,7 @@ void ImageViewer::updateCursor(const TPoint &curPos) {
 
 //---------------------------------------------------------------------------------------------
 /*! If middle button is pressed pan the image. Update current mouse position.
-*/
+ */
 void ImageViewer::mouseMoveEvent(QMouseEvent *event) {
   if (!m_image) return;
 
@@ -841,7 +846,7 @@ void ImageViewer::mouseMoveEvent(QMouseEvent *event) {
 
 //---------------------------------------------------------------------------------------------
 /*! notify the color picked by rgb picker to palette controller
-*/
+ */
 void ImageViewer::setPickedColorToStyleEditor(const TPixel32 &color) {
   // do not modify the style #0
   TPaletteHandle *ph =
@@ -853,7 +858,7 @@ void ImageViewer::setPickedColorToStyleEditor(const TPixel32 &color) {
 
 //---------------------------------------------------------------------------------------------
 /*! rgb picking
-*/
+ */
 void ImageViewer::pickColor(QMouseEvent *event, bool putValueToStyleEditor) {
   if (!m_isHistogramEnable) return;
   if (!m_histogramPopup->isVisible()) return;
@@ -897,7 +902,7 @@ void ImageViewer::pickColor(QMouseEvent *event, bool putValueToStyleEditor) {
 //---------------------------------------------------------------------------------------------
 /*! rectangular rgb picking. The picked color will be an average of pixels in
  * specified rectangle
-*/
+ */
 void ImageViewer::rectPickColor(bool putValueToStyleEditor) {
   if (!m_isHistogramEnable) return;
   if (!m_histogramPopup->isVisible()) return;
@@ -1031,7 +1036,7 @@ void ImageViewer::mousePressEvent(QMouseEvent *event) {
 
 //-----------------------------------------------------------------------------
 /*! Reset current mouse position and current mouse button event.
-*/
+ */
 void ImageViewer::mouseReleaseEvent(QMouseEvent *event) {
   if (!m_image) return;
   if (m_draggingZoomSelection && !m_visualSettings.m_defineLoadbox) {
@@ -1072,7 +1077,7 @@ void ImageViewer::mouseReleaseEvent(QMouseEvent *event) {
 
 //-----------------------------------------------------------------------------
 /*! Apply zoom.
-*/
+ */
 void ImageViewer::wheelEvent(QWheelEvent *event) {
   if (!m_image) return;
   if (event->orientation() == Qt::Horizontal) return;
@@ -1100,12 +1105,12 @@ void ImageViewer::wheelEvent(QWheelEvent *event) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-    {
-      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
-                   "Qt::MouseEventSynthesizedByApplication"
-                << std::endl;
-      break;
-    }
+  {
+    std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                 "Qt::MouseEventSynthesizedByApplication"
+              << std::endl;
+    break;
+  }
 
   }  // end switch
 
@@ -1243,6 +1248,7 @@ void ImageViewer::keyPressEvent(QKeyEvent *event) {
 //-----------------------------------------------------------------------------
 
 void ImageViewer::onContextAboutToBeDestroyed() {
+  m_contextReplaced = true;
   if (!m_lutCalibrator) return;
   makeCurrent();
   m_lutCalibrator->cleanup();
@@ -1404,10 +1410,9 @@ bool ImageViewer::event(QEvent *e) {
   }
   */
 
-  if (e->type() == QEvent::Gesture &&
-      CommandManager::instance()
-          ->getAction(MI_TouchGestureControl)
-          ->isChecked()) {
+  if (e->type() == QEvent::Gesture && CommandManager::instance()
+                                          ->getAction(MI_TouchGestureControl)
+                                          ->isChecked()) {
     gestureEvent(static_cast<QGestureEvent *>(e));
     return true;
   }
@@ -1425,7 +1430,7 @@ bool ImageViewer::event(QEvent *e) {
 
 //-----------------------------------------------------------------------------
 /*! load image from history
-*/
+ */
 class LoadRecentFlipbookImagesCommandHandler final : public MenuItemHandler {
 public:
   LoadRecentFlipbookImagesCommandHandler()
@@ -1453,7 +1458,7 @@ public:
 
 //-----------------------------------------------------------------------------
 /*! clear the history
-*/
+ */
 class ClearRecentFlipbookImagesCommandHandler final : public MenuItemHandler {
 public:
   ClearRecentFlipbookImagesCommandHandler()

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -71,7 +71,8 @@ class ImageViewer final : public GLWidgetForHighDpi {
   bool m_panning                         = false;
   double m_scaleFactor;  // used for zoom gesture
 
-  bool m_stylusUsed = false;
+  bool m_stylusUsed      = false;
+  bool m_contextReplaced = false;
 
   int getDragType(const TPoint &pos, const TRect &loadBox);
   void updateLoadbox(const TPoint &curPos);

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -71,8 +71,8 @@ class ImageViewer final : public GLWidgetForHighDpi {
   bool m_panning                         = false;
   double m_scaleFactor;  // used for zoom gesture
 
-  bool m_stylusUsed      = false;
-  bool m_contextReplaced = false;
+  bool m_stylusUsed       = false;
+  bool m_firstInitialized = true;
 
   int getDragType(const TPoint &pos, const TRect &loadBox);
   void updateLoadbox(const TPoint &curPos);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -527,7 +527,7 @@ Room *MainWindow::getRoom(int index) const {
 
 //-----------------------------------------------------------------------------
 /*! Roomを名前から探す
-*/
+ */
 Room *MainWindow::getRoomByName(QString &roomName) {
   for (int i = 0; i < getRoomCount(); i++) {
     Room *room = dynamic_cast<Room *>(m_stackedWidget->widget(i));
@@ -1056,7 +1056,6 @@ void MainWindow::onCurrentRoomChanged(int newRoomIndex) {
     TPanel *pane = paneList.at(i);
     if (pane->isFloating() && !pane->isHidden()) {
       QRect oldGeometry = pane->geometry();
-
       // Just setting the new parent is not enough for the new layout manager.
       // Must be removed from the old and added to the new.
       oldRoom->removeDockWidget(pane);
@@ -1154,7 +1153,7 @@ void MainWindow::onMenuCheckboxChanged() {
 #endif
   else if (cm->getAction(MI_RasterizePli) == action) {
     if (!QGLPixelBuffer::hasOpenGLPbuffers()) isChecked = 0;
-    RasterizePliToggleAction                            = isChecked;
+    RasterizePliToggleAction = isChecked;
   } else if (cm->getAction(MI_SafeArea) == action)
     SafeAreaToggleAction = isChecked;
   else if (cm->getAction(MI_ViewColorcard) == action)
@@ -2345,9 +2344,9 @@ RecentFiles::~RecentFiles() {}
 void RecentFiles::addFilePath(QString path, FileType fileType,
                               QString projectName) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) {
@@ -2514,9 +2513,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2543,9 +2542,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
-                                                        ? MI_ClearRecentLevel
-                                                        : MI_ClearRecentImage;
+        (fileType == Scene)
+            ? MI_ClearRecentScene
+            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -919,7 +919,9 @@ void SceneViewer::initializeGL() {
   // glClearColor(1.0,1.0,1.0,1);
   glClear(GL_COLOR_BUFFER_BIT);
 
-  if (m_contextReplaced) {
+  if (m_firstInitialized)
+    m_firstInitialized = false;
+  else {
     resizeGL(width(), height());
     update();
   }
@@ -2753,7 +2755,6 @@ void SceneViewer::releaseFBO() {
 //-----------------------------------------------------------------------------
 
 void SceneViewer::onContextAboutToBeDestroyed() {
-  m_contextReplaced = true;
   if (!m_lutCalibrator) return;
   makeCurrent();
   m_lutCalibrator->cleanup();

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -910,7 +910,7 @@ void SceneViewer::initializeGL() {
   registerContext();
 
   // to be computed once through the software
-  if (m_lutCalibrator) {
+  if (m_lutCalibrator && !m_lutCalibrator->isInitialized()) {
     m_lutCalibrator->initialize();
     connect(context(), SIGNAL(aboutToBeDestroyed()), this,
             SLOT(onContextAboutToBeDestroyed()));
@@ -918,6 +918,11 @@ void SceneViewer::initializeGL() {
 
   // glClearColor(1.0,1.0,1.0,1);
   glClear(GL_COLOR_BUFFER_BIT);
+
+  if (m_contextReplaced) {
+    resizeGL(width(), height());
+    update();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1696,7 +1701,7 @@ double SceneViewer::projectToZ(const TPointD &delta) {
   GLint viewport[4];
   double modelview[16], projection[16];
   glGetIntegerv(GL_VIEWPORT, viewport);
-  for (int i      = 0; i < 16; i++)
+  for (int i = 0; i < 16; i++)
     projection[i] = (double)m_projectionMatrix.constData()[i];
   glGetDoublev(GL_MODELVIEW_MATRIX, modelview);
 
@@ -1858,8 +1863,9 @@ void SceneViewer::zoomQt(bool forward, bool reset) {
     if (reset || ((m_zoomScale3D < 500 || !forward) &&
                   (m_zoomScale3D > 0.01 || forward))) {
       double oldZoomScale = m_zoomScale3D;
-      m_zoomScale3D       = reset ? 1 : ImageUtils::getQuantizedZoomFactor(
-                                      m_zoomScale3D, forward);
+      m_zoomScale3D =
+          reset ? 1
+                : ImageUtils::getQuantizedZoomFactor(m_zoomScale3D, forward);
 
       m_pan3D = -(m_zoomScale3D / oldZoomScale) * -m_pan3D;
     }
@@ -1880,17 +1886,18 @@ void SceneViewer::zoomQt(bool forward, bool reset) {
     int i;
 
     for (i = 0; i < 2; i++) {
-      TAffine &viewAff          = m_viewAff[i];
+      TAffine &viewAff = m_viewAff[i];
       if (m_isFlippedX) viewAff = viewAff * TScale(-1, 1);
       if (m_isFlippedX) viewAff = viewAff * TScale(1, -1);
-      double scale2             = std::abs(viewAff.det());
+      double scale2 = std::abs(viewAff.det());
       if (m_isFlippedX) viewAff = viewAff * TScale(-1, 1);
       if (m_isFlippedX) viewAff = viewAff * TScale(1, -1);
       if (reset || ((scale2 < 100000 || !forward) &&
                     (scale2 > 0.001 * 0.05 || forward))) {
         double oldZoomScale = sqrt(scale2) * dpiFactor;
-        double zoomScale    = reset ? 1 : ImageUtils::getQuantizedZoomFactor(
-                                           oldZoomScale, forward);
+        double zoomScale =
+            reset ? 1
+                  : ImageUtils::getQuantizedZoomFactor(oldZoomScale, forward);
 
         // threshold value -0.001 is intended to absorb the error of calculation
         if ((oldZoomScale - zoomScaleFittingWithScreen) *
@@ -2162,9 +2169,9 @@ void SceneViewer::fitToCamera() {
   TPointD P11       = cameraAff * cameraRect.getP11();
   TPointD p0        = TPointD(std::min({P00.x, P01.x, P10.x, P11.x}),
                        std::min({P00.y, P01.y, P10.y, P11.y}));
-  TPointD p1 = TPointD(std::max({P00.x, P01.x, P10.x, P11.x}),
+  TPointD p1        = TPointD(std::max({P00.x, P01.x, P10.x, P11.x}),
                        std::max({P00.y, P01.y, P10.y, P11.y}));
-  cameraRect = TRectD(p0.x, p0.y, p1.x, p1.y);
+  cameraRect        = TRectD(p0.x, p0.y, p1.x, p1.y);
 
   // Pan
   if (!is3DView()) {
@@ -2213,8 +2220,8 @@ void SceneViewer::resetZoom() {
   TPointD realCenter(m_viewAff[m_viewMode].a13, m_viewAff[m_viewMode].a23);
   TAffine aff =
       getNormalZoomScale() * TRotation(realCenter, m_rotationAngle[m_viewMode]);
-  aff.a13               = realCenter.x;
-  aff.a23               = realCenter.y;
+  aff.a13 = realCenter.x;
+  aff.a23 = realCenter.y;
   if (m_isFlippedX) aff = aff * TScale(-1, 1);
   if (m_isFlippedY) aff = aff * TScale(1, -1);
   setViewMatrix(aff, m_viewMode);
@@ -2271,16 +2278,17 @@ void SceneViewer::setActualPixelSize() {
   } else
     dpi = sl->getDpi(fid);
 
-  const double inch             = Stage::inch;
-  TAffine tempAff               = getNormalZoomScale();
-  if (m_isFlippedX) tempAff     = tempAff * TScale(-1, 1);
-  if (m_isFlippedY) tempAff     = tempAff * TScale(1, -1);
-  TPointD tempScale             = dpi;
+  const double inch = Stage::inch;
+  TAffine tempAff   = getNormalZoomScale();
+  if (m_isFlippedX) tempAff = tempAff * TScale(-1, 1);
+  if (m_isFlippedY) tempAff = tempAff * TScale(1, -1);
+  TPointD tempScale = dpi;
   if (m_isFlippedX) tempScale.x = -tempScale.x;
   if (m_isFlippedY) tempScale.y = -tempScale.y;
   for (int i = 0; i < tArrayCount(m_viewAff); i++)
-    setViewMatrix(dpi == TPointD(0, 0) ? tempAff : TScale(tempScale.x / inch,
-                                                          tempScale.y / inch),
+    setViewMatrix(dpi == TPointD(0, 0)
+                      ? tempAff
+                      : TScale(tempScale.x / inch, tempScale.y / inch),
                   i);
 
   m_pos         = QPoint(0, 0);
@@ -2563,7 +2571,7 @@ void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
 
   TStageObject *pegbar =
       objId != TStageObjectId::NoneId ? xsh->getStageObject(objId) : 0;
-  const TStroke *stroke                     = 0;
+  const TStroke *stroke = 0;
   if (pegbar && pegbar->getSpline()) stroke = pegbar->getSpline()->getStroke();
   if (!stroke) return;
 
@@ -2745,6 +2753,7 @@ void SceneViewer::releaseFBO() {
 //-----------------------------------------------------------------------------
 
 void SceneViewer::onContextAboutToBeDestroyed() {
+  m_contextReplaced = true;
   if (!m_lutCalibrator) return;
   makeCurrent();
   m_lutCalibrator->cleanup();

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -180,7 +180,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
 
   double m_rotationAngle[2];
 
-  bool m_contextReplaced = false;
+  bool m_firstInitialized = true;
 
 public:
   enum ReferenceMode {

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -98,11 +98,11 @@ class SceneViewer final : public GLWidgetForHighDpi,
   bool m_isMouseEntered, m_forceGlFlush;
   bool m_isFlippedX = false, m_isFlippedY = false;
   /*!  FreezedStatus:
-*  \li NO_FREEZED freezed is not active;
-*  \li NORMAL_FREEZED freezed is active: show grab image;
-*  \li UPDATE_FREEZED freezed is active: draw last unfreezed image and grab
-* view;
-*/
+   *  \li NO_FREEZED freezed is not active;
+   *  \li NORMAL_FREEZED freezed is active: show grab image;
+   *  \li UPDATE_FREEZED freezed is active: draw last unfreezed image and grab
+   * view;
+   */
   enum FreezedStatus {
     NO_FREEZED     = 0,
     NORMAL_FREEZED = 1,
@@ -179,6 +179,8 @@ class SceneViewer final : public GLWidgetForHighDpi,
   TRectD m_guidedDrawingBBox;
 
   double m_rotationAngle[2];
+
+  bool m_contextReplaced = false;
 
 public:
   enum ReferenceMode {

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -20,7 +20,7 @@ inline bool execWarning(const QString& s) {
   DVGui::MsgBox(DVGui::WARNING, s);
   return false;
 }
-};
+};  // namespace
 
 #ifdef WIN32
 
@@ -161,13 +161,14 @@ QStringList getMonitorNames() {
 
   return nameList;
 }
-};
+};  // namespace
 #endif
 
 //-----------------------------------------------------------------------------
 
 void LutCalibrator::initialize() {
   initializeOpenGLFunctions();
+  m_isInitialized = true;
 
   if (!LutManager::instance()->isValid()) return;
 
@@ -560,7 +561,7 @@ void LutManager::convert(float& r, float& g, float& b) {
       for (int bb = 0; bb < 2; bb++) {
         float* val = &m_lut.data[locals::getCoord(
             index[0][rr], index[1][gg], index[2][bb], m_lut.meshSize)];
-        for (int chan                    = 0; chan < 3; chan++, val++)
+        for (int chan = 0; chan < 3; chan++, val++)
           vertex_color[rr][gg][bb][chan] = *val;
       }
   float result[3];

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -214,6 +214,8 @@ void LutCalibrator::cleanup() {
     delete m_lutTex;
     m_lutTex = NULL;
   }
+  m_isInitialized = false;
+  m_isValid       = false;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -192,6 +192,7 @@ void LutCalibrator::initialize() {
 //-----------------------------------------------------------------------------
 
 void LutCalibrator::cleanup() {
+  m_isInitialized = false;
   if (!isValid()) return;
   // release shader
   if (m_shader.program) {
@@ -214,8 +215,7 @@ void LutCalibrator::cleanup() {
     delete m_lutTex;
     m_lutTex = NULL;
   }
-  m_isInitialized = false;
-  m_isValid       = false;
+  m_isValid = false;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -577,7 +577,7 @@ void HexagonalColorWheel::initializeGL() {
   initializeOpenGLFunctions();
 
   // to be computed once through the software
-  if (m_lutCalibrator) {
+  if (m_lutCalibrator && !m_lutCalibrator->isInitialized()) {
     m_lutCalibrator->initialize();
     connect(context(), SIGNAL(aboutToBeDestroyed()), this,
             SLOT(onContextAboutToBeDestroyed()));
@@ -585,6 +585,13 @@ void HexagonalColorWheel::initializeGL() {
 
   QColor const color = getBGColor();
   glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+
+  // Without the following lines, the wheel in a floating style editor
+  // dissapears on switching the room due to context switching.
+  if (m_contextReplaced) {
+    resizeGL(width(), height());
+    update();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -813,7 +820,7 @@ void HexagonalColorWheel::mouseReleaseEvent(QMouseEvent *event) {
 
 //-----------------------------------------------------------------------------
 /*! compute hue and saturation position. saturation value must be clamped
-*/
+ */
 void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
   QLineF p(m_wp[0] + m_wheelPosition, QPointF(pos));
   QLineF horizontal(0, 0, 1, 0);
@@ -824,7 +831,7 @@ void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
   // d is a length from center to edge of the wheel when saturation = 100
   float d = m_triHeight / cosf(phi / 180.0f * 3.1415f);
 
-  int h          = (int)theta;
+  int h = (int)theta;
   if (h > 359) h = 359;
   // clamping
   int s = (int)(std::min(p.length() / d, 1.0) * 100.0f);
@@ -855,6 +862,7 @@ void HexagonalColorWheel::clickRightTriangle(const QPoint &pos) {
 //-----------------------------------------------------------------------------
 
 void HexagonalColorWheel::onContextAboutToBeDestroyed() {
+  m_contextReplaced = true;
   if (!m_lutCalibrator) return;
   makeCurrent();
   m_lutCalibrator->cleanup();
@@ -2326,7 +2334,7 @@ void SpecialStyleChooserPage::loadItems() {
         tagId == 2002 ||  // ??
         tagId == 3000 ||  // vector brush
         tagId == 4001     // mypaint brush
-        )
+    )
       continue;
 
     TColorStyle *style = TColorStyle::create(tagId);
@@ -3128,7 +3136,7 @@ QFrame *StyleEditor::createBottomWidget() {
   bool ret = true;
   ret      = ret && connect(m_applyButton, SIGNAL(clicked()), this,
                        SLOT(applyButtonClicked()));
-  ret = ret && connect(m_autoButton, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_autoButton, SIGNAL(toggled(bool)), this,
                        SLOT(autoCheckChanged(bool)));
   ret = ret && connect(m_oldColor, SIGNAL(clicked(const TColorStyle &)), this,
                        SLOT(onOldStyleClicked(const TColorStyle &)));
@@ -3191,9 +3199,9 @@ QFrame *StyleEditor::createVectorPage() {
   bool ret = true;
   ret      = ret && connect(specialButton, SIGNAL(toggled(bool)), this,
                        SLOT(onSpecialButtonToggled(bool)));
-  ret = ret && connect(customButton, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(customButton, SIGNAL(toggled(bool)), this,
                        SLOT(onCustomButtonToggled(bool)));
-  ret = ret && connect(vectorBrushButton, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(vectorBrushButton, SIGNAL(toggled(bool)), this,
                        SLOT(onVectorBrushButtonToggled(bool)));
   assert(ret);
   return vectorOutsideFrame;
@@ -3230,9 +3238,9 @@ void StyleEditor::showEvent(QShowEvent *) {
   bool ret = true;
   ret      = ret && connect(m_paletteHandle, SIGNAL(colorStyleSwitched()),
                        SLOT(onStyleSwitched()));
-  ret = ret && connect(m_paletteHandle, SIGNAL(colorStyleChanged(bool)),
+  ret      = ret && connect(m_paletteHandle, SIGNAL(colorStyleChanged(bool)),
                        SLOT(onStyleChanged(bool)));
-  ret = ret && connect(m_paletteHandle, SIGNAL(paletteSwitched()), this,
+  ret      = ret && connect(m_paletteHandle, SIGNAL(paletteSwitched()), this,
                        SLOT(onStyleSwitched()));
   if (m_cleanupPaletteHandle)
     ret =
@@ -3381,10 +3389,9 @@ void StyleEditor::copyEditedStyleToPalette(bool isDragging) {
     m_editedStyle->setIsEditedFlag(true);
   }
 
-  palette->setStyle(
-      styleIndex,
-      m_editedStyle->clone());  // Must be done *before* setting the eventual
-                                // palette keyframe
+  palette->setStyle(styleIndex,
+                    m_editedStyle->clone());  // Must be done *before* setting
+                                              // the eventual palette keyframe
   if (!isDragging) {
     if (!(*m_oldStyle == *m_editedStyle)) {
       // do not register undo if the edited color is special one (e.g. changing

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -588,7 +588,9 @@ void HexagonalColorWheel::initializeGL() {
 
   // Without the following lines, the wheel in a floating style editor
   // dissapears on switching the room due to context switching.
-  if (m_contextReplaced) {
+  if (m_firstInitialized)
+    m_firstInitialized = false;
+  else {
     resizeGL(width(), height());
     update();
   }
@@ -862,7 +864,6 @@ void HexagonalColorWheel::clickRightTriangle(const QPoint &pos) {
 //-----------------------------------------------------------------------------
 
 void HexagonalColorWheel::onContextAboutToBeDestroyed() {
-  m_contextReplaced = true;
   if (!m_lutCalibrator) return;
   makeCurrent();
   m_lutCalibrator->cleanup();


### PR DESCRIPTION
This PR will fix the following problem:

- The hexagonal color wheel in the floating style editor disappears on switching the rooms.
- Contents in the floating flipbook / color model disappear / wrongly offset on switching the rooms.
- Contents in the floating viewer / combo viewer are sometimes wrongly deformed on switching the rooms.

All the above floating panels come back to normal once you resize them.

I added lines to call `resizeGL()` on switching context, which seems to be needed to display properly.
