### PR TITLE
Improve deactivate behaviour for brush (#2694)

### DIFF
--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -625,6 +625,12 @@ void ToonzVectorBrushTool::onDeactivate() {
   /*---
   * ドラッグ中にツールが切り替わった場合に備え、onDeactivateにもMouseReleaseと同じ処理を行う
   * ---*/
+
+  // End current stroke.
+  if (m_active && m_enabled) {
+      leftButtonUp(m_lastDragPos, m_lastDragEvent);
+  }
+
   if (m_tileSaver && !m_isPath) {
     m_enabled = false;
   }
@@ -718,6 +724,10 @@ void ToonzVectorBrushTool::leftButtonDrag(const TPointD &pos,
     m_brushPos = m_mousePos = pos;
     return;
   }
+
+  m_lastDragPos = pos;
+  m_lastDragEvent = e;
+
   double thickness = (m_pressure.getValue() || m_isPath)
                          ? computeThickness(e.m_pressure, m_thickness, m_isPath)
                          : m_thickness.getValue().second * 0.5;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -192,6 +192,9 @@ protected:
   作業中のFrameIdをクリック時に保存し、マウスリリース時（Undoの登録時）に別のフレームに
   移動していたときの不具合を修正する。---*/
   TFrameId m_workingFrameId;
+
+  TPointD m_lastDragPos; //!< Position where mouse was last dragged.
+  TMouseEvent m_lastDragEvent; //!< Previous mouse-drag event.
 };
 
 #endif  // TOONZVECTORBRUSHTOOL_H


### PR DESCRIPTION
Fixes #2694.

When switching from the Toonz Vector Brush tool to the Erasor tool mid-
stroke (i.e. while the mouse is still down), the brush tool now ends the
stroke correctly before the erasor becomes active.

Demo below:
![line-fix-demo](https://user-images.githubusercontent.com/24422213/62436213-157b7a00-b793-11e9-9524-9787d1974596.gif)




