### PR TITLE
Fix crash with visualization commands

### DIFF
--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -101,7 +101,7 @@ void DVAPI convert(
         false /*-- ConvertPopup
                  での指定に合わせて、[レベル名].[フレーム番号].[拡張子]のうち、
                                                                                           [レベル名]と[フレーム番号]の間のドットを消す。 --*/
-    );        //!< Converts a saved level to fullcolor, and saves the result.
+);            //!< Converts a saved level to fullcolor, and saves the result.
 
 void DVAPI convertNaa2Tlv(
     const TFilePath &source,  //!< Level path to convert from.
@@ -124,7 +124,7 @@ void DVAPI convertOldLevel2Tlv(
     const TFrameId &to,       //!< Last source frame to convert.
     FrameTaskNotifier
         *frameNotifier  //!< Observer class for frame success notifications.
-    );
+);
 
 double DVAPI getQuantizedZoomFactor(double zf, bool forward);
 
@@ -140,8 +140,9 @@ void DVAPI assignFillingInformation(TVectorImage &vi,
                                     const std::vector<TFilledRegionInf> &regs);
 
 void DVAPI getStrokeStyleInformationInArea(
-    const TVectorImageP &vi, std::vector<std::pair<int, int>>
-                                 &strokesInfo,  // pair:strokeIndex, styleIndex
+    const TVectorImageP &vi,
+    std::vector<std::pair<int, int>>
+        &strokesInfo,  // pair:strokeIndex, styleIndex
     const TRectD &area);
 
 //*********************************************************************************************
@@ -221,7 +222,7 @@ public:
 protected:
   virtual bool zoom(
       bool zoomin,
-      bool resetZoom) = 0;  //!< Handler for zoom commands. Required.
+      bool resetView) = 0;  //!< Handler for zoom commands. Required.
   virtual bool fit() {
     return false;
   }  //!< Handler for 'fit to image' commands.

--- a/toonz/sources/include/toonzqt/menubarcommand.h
+++ b/toonz/sources/include/toonzqt/menubarcommand.h
@@ -60,7 +60,8 @@ enum CommandType {
   ToolModifierCommandType,
   ZoomCommandType,
   MiscCommandType,
-  MenuCommandType
+  MenuCommandType,
+  VisualizationButtonCommandType
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -106,7 +106,7 @@ public:
   SchematicSceneViewer(QWidget *parent);
   ~SchematicSceneViewer();
 
-  void zoomQt(bool zoomin, bool resetZoom);
+  void zoomQt(bool zoomin, bool resetView);
 
   QPointF getOldScenePos() { return m_oldScenePos; }
 
@@ -120,10 +120,13 @@ protected:
 
 protected slots:
 
-  void fitScene();
   void centerOnCurrent();
   void reorderScene();
+
+public slots:
+
   void normalizeScene();
+  void fitScene();
 
 private:
   Qt::MouseButton m_buttonState;

--- a/toonz/sources/include/toonzqt/viewcommandids.h
+++ b/toonz/sources/include/toonzqt/viewcommandids.h
@@ -15,4 +15,14 @@
 #define V_RotateReset "T_RotateReset"
 #define V_PositionReset "T_PositionReset"
 
+// folloing command ids are for command bar
+#define VB_ViewReset "VB_ViewReset"
+#define VB_ZoomFit "VB_ZoomFit"
+#define VB_ZoomReset "VB_ZoomReset"
+#define VB_RotateReset "VB_RotateReset"
+#define VB_PositionReset "VB_PositionReset"
+#define VB_ActualPixelSize "VB_ActualPixelSize"
+#define VB_FlipX "VB_FlipX"
+#define VB_FlipY "VB_FlipY"
+
 #endif  // VIEWCOMMANDIDS_H

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -316,7 +316,7 @@ CommandBarListTree::CommandBarListTree(QWidget* parent) : QTreeWidget(parent) {
   addFolder(ShortcutTree::tr("Right-click Menu Commands"),
             RightClickMenuCommandType);
   addFolder(ShortcutTree::tr("Tool Modifiers"), ToolModifierCommandType);
-  addFolder(ShortcutTree::tr("Visualization"), ZoomCommandType);
+  addFolder(ShortcutTree::tr("Visualization"), VisualizationButtonCommandType);
   addFolder(ShortcutTree::tr("Misc"), MiscCommandType);
   addFolder(ShortcutTree::tr("RGBA Channels"), RGBACommandType);
 

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -109,6 +109,7 @@ public:
    */
   void hideHistogram();
   void zoomQt(bool forward, bool reset);
+  void resetZoom();
 
   void setIsRemakingPreviewFx(bool on) {
     m_isRemakingPreviewFx = on;

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -527,7 +527,7 @@ Room *MainWindow::getRoom(int index) const {
 
 //-----------------------------------------------------------------------------
 /*! Roomを名前から探す
-*/
+ */
 Room *MainWindow::getRoomByName(QString &roomName) {
   for (int i = 0; i < getRoomCount(); i++) {
     Room *room = dynamic_cast<Room *>(m_stackedWidget->widget(i));
@@ -1154,7 +1154,7 @@ void MainWindow::onMenuCheckboxChanged() {
 #endif
   else if (cm->getAction(MI_RasterizePli) == action) {
     if (!QGLPixelBuffer::hasOpenGLPbuffers()) isChecked = 0;
-    RasterizePliToggleAction                            = isChecked;
+    RasterizePliToggleAction = isChecked;
   } else if (cm->getAction(MI_SafeArea) == action)
     SafeAreaToggleAction = isChecked;
   else if (cm->getAction(MI_ViewColorcard) == action)
@@ -1430,6 +1430,13 @@ QAction *MainWindow::createMenuAction(const char *id, const QString &name,
 QAction *MainWindow::createViewerAction(const char *id, const QString &name,
                                         const QString &defaultShortcut) {
   return createAction(id, name, defaultShortcut, ZoomCommandType);
+}
+
+//-----------------------------------------------------------------------------
+
+QAction *MainWindow::createVisualizationButtonAction(const char *id,
+                                                     const QString &name) {
+  return createAction(id, name, "", VisualizationButtonCommandType);
 }
 
 //-----------------------------------------------------------------------------
@@ -2114,6 +2121,21 @@ void MainWindow::defineActions() {
                                              tr("Full Screen Mode"),
                                              tr("Exit Full Screen Mode"));
 
+  // Following actions are for adding "Visualization" menu items to the command
+  // bar. They are separated from the original actions in order to avoid
+  // assigning shortcut keys. They must be triggered only from pressing buttons
+  // in the command bar. Assinging shortcut keys and registering as MenuItem
+  // will break a logic of ShortcutZoomer. So here we register separate items
+  // and bypass the command.
+  createVisualizationButtonAction(VB_ViewReset, tr("Reset View"));
+  createVisualizationButtonAction(VB_ZoomFit, tr("Fit to Window"));
+  createVisualizationButtonAction(VB_ZoomReset, tr("Reset Zoom"));
+  createVisualizationButtonAction(VB_RotateReset, tr("Reset Rotation"));
+  createVisualizationButtonAction(VB_PositionReset, tr("Reset Position"));
+  createVisualizationButtonAction(VB_ActualPixelSize, tr("Actual Pixel Size"));
+  createVisualizationButtonAction(VB_FlipX, tr("Flip Viewer Horizontally"));
+  createVisualizationButtonAction(VB_FlipY, tr("Flip Viewer Vertically"));
+
   QAction *refreshAct =
       createMiscAction(MI_RefreshTree, tr("Refresh Folder Tree"), "");
   refreshAct->setIconText(tr("Refresh"));
@@ -2345,9 +2367,9 @@ RecentFiles::~RecentFiles() {}
 void RecentFiles::addFilePath(QString path, FileType fileType,
                               QString projectName) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) {
@@ -2514,9 +2536,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2543,9 +2565,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
-                                                        ? MI_ClearRecentLevel
-                                                        : MI_ClearRecentImage;
+        (fileType == Scene)
+            ? MI_ClearRecentScene
+            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -175,6 +175,9 @@ private:
                             const QString &defaultShortcut);
   QAction *createViewerAction(const char *id, const QString &name,
                               const QString &defaultShortcut);
+  // For command bar, no shortcut keys
+  QAction *createVisualizationButtonAction(const char *id, const QString &name);
+
   QAction *createMiscAction(const char *id, const QString &name,
                             const char *defaultShortcut);
   QAction *createToolOptionsAction(const char *id, const QString &name,

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -70,7 +70,7 @@ namespace {
 
 void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
                     int widgetHeight, double pressure, int devPixRatio) {
-  toonzEvent.m_pos = TPointD(event->pos().x() * devPixRatio,
+  toonzEvent.m_pos      = TPointD(event->pos().x() * devPixRatio,
                              widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
   toonzEvent.m_pressure = 1.0;
@@ -813,9 +813,9 @@ quit:
   // Don't clear it out table state so the tablePress event will process
   // correctly.
   if (m_tabletState != Touched) m_tabletState = None;
-  m_mouseState                                = None;
-  m_tabletMove                                = false;
-  m_pressure                                  = 0;
+  m_mouseState = None;
+  m_tabletMove = false;
+  m_pressure   = 0;
   // Leave m_tabletEvent as-is in order to check whether the onRelease is called
   // from tabletEvent or not in mouseReleaseEvent.
   if (m_tabletState == Released)  // only clear if tabletRelease event
@@ -871,12 +871,12 @@ void SceneViewer::wheelEvent(QWheelEvent *event) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-    {
-      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
-                   "Qt::MouseEventSynthesizedByApplication"
-                << std::endl;
-      break;
-    }
+  {
+    std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                 "Qt::MouseEventSynthesizedByApplication"
+              << std::endl;
+    break;
+  }
 
   }  // end switch
 
@@ -968,8 +968,8 @@ void SceneViewer::gestureEvent(QGestureEvent *e) {
         qreal rotationDelta =
             gesture->rotationAngle() - gesture->lastRotationAngle();
         if (m_isFlippedX != m_isFlippedY) rotationDelta = -rotationDelta;
-        TAffine aff                                     = getViewMatrix().inv();
-        TPointD center                                  = aff * TPointD(0, 0);
+        TAffine aff    = getViewMatrix().inv();
+        TPointD center = aff * TPointD(0, 0);
         if (!m_rotating && !m_zooming) {
           m_rotationDelta += rotationDelta;
           double absDelta = abs(m_rotationDelta);
@@ -1110,10 +1110,9 @@ bool SceneViewer::event(QEvent *e) {
     break;
   }
   */
-  if (e->type() == QEvent::Gesture &&
-      CommandManager::instance()
-          ->getAction(MI_TouchGestureControl)
-          ->isChecked()) {
+  if (e->type() == QEvent::Gesture && CommandManager::instance()
+                                          ->getAction(MI_TouchGestureControl)
+                                          ->isChecked()) {
     gestureEvent(static_cast<QGestureEvent *>(e));
     return true;
   }
@@ -1183,11 +1182,11 @@ class ViewerZoomer final : public ImageUtils::ShortcutZoomer {
 public:
   ViewerZoomer(SceneViewer *parent) : ShortcutZoomer(parent) {}
 
-  bool zoom(bool zoomin, bool resetZoom) override {
+  bool zoom(bool zoomin, bool resetView) override {
     SceneViewer *sceneViewer = static_cast<SceneViewer *>(getWidget());
 
-    resetZoom ? sceneViewer->resetSceneViewer()
-              : sceneViewer->zoomQt(zoomin, resetZoom);
+    resetView ? sceneViewer->resetSceneViewer()
+              : sceneViewer->zoomQt(zoomin, resetView);
 
     return true;
   }
@@ -1209,6 +1208,21 @@ public:
 
   bool setFlipY() override {
     static_cast<SceneViewer *>(getWidget())->flipY();
+    return true;
+  }
+
+  bool resetZoom() override {
+    static_cast<SceneViewer *>(getWidget())->resetZoom();
+    return true;
+  }
+
+  bool resetRotation() override {
+    static_cast<SceneViewer *>(getWidget())->resetRotation();
+    return true;
+  }
+
+  bool resetPosition() override {
+    static_cast<SceneViewer *>(getWidget())->resetPosition();
     return true;
   }
 

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -52,8 +52,16 @@ class SchematicZoomer final : public ImageUtils::ShortcutZoomer {
 public:
   SchematicZoomer(QWidget *parent) : ShortcutZoomer(parent) {}
 
-  bool zoom(bool zoomin, bool resetZoom) override {
-    static_cast<SchematicSceneViewer *>(getWidget())->zoomQt(zoomin, resetZoom);
+  bool zoom(bool zoomin, bool resetView) override {
+    static_cast<SchematicSceneViewer *>(getWidget())->zoomQt(zoomin, resetView);
+    return true;
+  }
+  bool resetZoom() override {
+    static_cast<SchematicSceneViewer *>(getWidget())->normalizeScene();
+    return true;
+  }
+  bool fit() override {
+    static_cast<SchematicSceneViewer *>(getWidget())->fitScene();
     return true;
   }
 };
@@ -95,7 +103,7 @@ void SchematicScene::hideEvent(QHideEvent *se) {
 //------------------------------------------------------------------
 
 /*! Removes and then deletes all item in the scene.
-*/
+ */
 
 void SchematicScene::clearAllItems() {
   clearSelection();
@@ -143,7 +151,7 @@ void SchematicScene::clearAllItems() {
 
 //------------------------------------------------------------------
 /*! check if any item exists in the rect
-*/
+ */
 bool SchematicScene::isAnEmptyZone(const QRectF &rect) {
   QList<QGraphicsItem *> allItems = items();
   for (auto const level : allItems) {
@@ -207,7 +215,7 @@ SchematicSceneViewer::~SchematicSceneViewer() {}
 //------------------------------------------------------------------
 
 /*! Reimplemets the QGraphicsView::mousePressEvent()
-*/
+ */
 void SchematicSceneViewer::mousePressEvent(QMouseEvent *me) {
   m_buttonState = me->button();
   m_oldWinPos   = me->pos();
@@ -233,7 +241,7 @@ void SchematicSceneViewer::mousePressEvent(QMouseEvent *me) {
 //------------------------------------------------------------------
 
 /*! Reimplemets the QGraphicsView::mouseMoveEvent()
-*/
+ */
 void SchematicSceneViewer::mouseMoveEvent(QMouseEvent *me) {
   QPoint currWinPos    = me->pos();
   QPointF currScenePos = mapToScene(currWinPos);
@@ -257,7 +265,7 @@ void SchematicSceneViewer::mouseMoveEvent(QMouseEvent *me) {
 //------------------------------------------------------------------
 
 /*! Reimplemets the QGraphicsView::mouseReleaseEvent()
-*/
+ */
 void SchematicSceneViewer::mouseReleaseEvent(QMouseEvent *me) {
   m_buttonState = Qt::NoButton;
   QGraphicsView::mouseReleaseEvent(me);
@@ -276,7 +284,7 @@ void SchematicSceneViewer::keyPressEvent(QKeyEvent *ke) {
 //------------------------------------------------------------------
 
 /*! Reimplemets the QGraphicsView::wheelEvent()
-*/
+ */
 void SchematicSceneViewer::wheelEvent(QWheelEvent *me) {
   me->accept();
   double factor = exp(me->delta() * 0.001);
@@ -285,33 +293,38 @@ void SchematicSceneViewer::wheelEvent(QWheelEvent *me) {
 
 //------------------------------------------------------------------
 
-void SchematicSceneViewer::zoomQt(bool zoomin, bool resetZoom) {
+void SchematicSceneViewer::zoomQt(bool zoomin, bool resetView) {
+  if (resetView) {
+    resetMatrix();
+    // reseting will set view to the center of items bounding
+    centerOn(scene()->itemsBoundingRect().center());
+    return;
+  }
+
 #if QT_VERSION >= 0x050000
   double scale2 = matrix().determinant();
 #else
   double scale2 = matrix().det();
 #endif
-  if (resetZoom ||
-      ((scale2 < 100000 || !zoomin) && (scale2 > 0.001 * 0.05 || zoomin))) {
+  if ((scale2 < 100000 || !zoomin) && (scale2 > 0.001 * 0.05 || zoomin)) {
     double oldZoomScale = sqrt(scale2);
-    double zoomScale    = resetZoom ? 1 : ImageUtils::getQuantizedZoomFactor(
-                                           oldZoomScale, zoomin);
+    double zoomScale =
+        resetView ? 1
+                  : ImageUtils::getQuantizedZoomFactor(oldZoomScale, zoomin);
     QMatrix scale =
         QMatrix().scale(zoomScale / oldZoomScale, zoomScale / oldZoomScale);
 
     // See QGraphicsView::mapToScene()'s doc for details
-    QRect rect(0, 0, width(), height());
-    QRectF sceneCenterRect(
-        mapToScene(QRect(rect.center(), QSize(2, 2))).boundingRect());
+    QPointF sceneCenter(mapToScene(rect().center()));
     setMatrix(scale, true);
-    centerOn(sceneCenterRect.center());
+    centerOn(sceneCenter);
   }
 }
 
 //------------------------------------------------------------------
 
 /*! The view is scaled around the point \b winPos by \b scaleFactor;
-*/
+ */
 void SchematicSceneViewer::changeScale(const QPoint &winPos,
                                        qreal scaleFactor) {
   QPointF startScenePos = mapToScene(winPos);
@@ -350,14 +363,12 @@ void SchematicSceneViewer::reorderScene() {
 
 void SchematicSceneViewer::normalizeScene() {
   // See QGraphicsView::mapToScene()'s doc for details
-  QRect rect(0, 0, width(), height());
-  QRectF sceneCenterRect(
-      mapToScene(QRect(rect.center(), QSize(2, 2))).boundingRect());
+  QPointF sceneCenter(mapToScene(rect().center()));
   resetMatrix();
 #if defined(MACOSX)
   scale(1.32, 1.32);
 #endif
-  centerOn(sceneCenterRect.center());
+  centerOn(sceneCenter);
 }
 
 //------------------------------------------------------------------
@@ -587,10 +598,10 @@ void SchematicViewer::createActions() {
 
     QIcon nodeSizeIcon = createQIconOnOff(
         m_maximizedNode ? "minimizenodes" : "maximizenodes", false);
-    m_nodeSize =
-        new QAction(nodeSizeIcon, m_maximizedNode ? tr("&Minimize Nodes")
-                                                  : tr("&Maximize Nodes"),
-                    m_commonToolbar);
+    m_nodeSize = new QAction(
+        nodeSizeIcon,
+        m_maximizedNode ? tr("&Minimize Nodes") : tr("&Maximize Nodes"),
+        m_commonToolbar);
     connect(m_nodeSize, SIGNAL(triggered()), this, SLOT(changeNodeSize()));
 
     if (m_fullSchematic) {


### PR DESCRIPTION
This PR will fix the following problems regarding the visualization commands ( `Reset View, Reset Zoom, Fit to Window, Actual Pixel Size, Flip Viewer Horizontally, Flip Viewer Vertically, Reset Rotation and Reset Position` ).

- OT crashes when typing shortcut key assigned any of the above visualization commands, if no Viewer is displayed. (i.e. `TApp::instance()->getActiveViewer()` returns nullptr.)
- Shortcut key for Reset View command becomes not available on Schematic or Flipbook.

To resolve this, I separated the menu items for command bar from the ones for `ShortcutZoomer`.

Also I inherited the following `ShortcutZoomer` commands and made them to work in each panel;
- `resetZoom(), resetRotation() and resetPosition()` in SceneViewer
- `resetZoom()` in Flipbook(ImageViewer) and
- `resetZoom() and fit()` in Schematic. 

In order to keep consistency, `Reset View` will now totally reset the view matrix and `Reset Zoom` will only reset the zoom ratio, keeping the position unchanged.