### PR TITLE
Add "Always Overwrite" button to Camera Capture

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -320,6 +320,7 @@ class PencilTestPopup : public DVGui::Dialog {
 
   bool m_captureWhiteBGCue;
   bool m_captureCue;
+  bool m_alwaysOverwrite = false;
 
   void processImage(QImage& procImage);
   bool importImage(QImage image);


### PR DESCRIPTION
This PR will add 'Always Overwrite in This Scene' to the confirmation dialog which opens when the capturing image will overwrite an existing file.

![camcap_dialog](https://user-images.githubusercontent.com/17974955/62456068-9a29c080-b7b2-11e9-97ae-8b4b12faeee3.png)

The button will avoid opening the popup while working on the current scene, so that users can re-capture drawings efficiently. The popup will open again if you switch the scene.