### PR TITLE
Fix for changing size of the magnet tool using hotkeys (#1436)

### DIFF
--- a/toonz/sources/tnztools/magnettool.cpp
+++ b/toonz/sources/tnztools/magnettool.cpp
@@ -160,16 +160,7 @@ public:
     else
       m_cursorId = ToolCursor::CURSOR_NO;
 
-    double x = m_toolSize.getValue();
-
-    double minRange = 1;
-    double maxRange = 100;
-
-    double minSize = 10;
-    double maxSize = 100;
-
-    m_pointSize =
-        (x - minRange) / (maxRange - minRange) * (maxSize - minSize) + minSize;
+    updatePointSize();
   }
 
   void onLeave() override { m_pointSize = -1; }
@@ -448,6 +439,31 @@ lefrightButtonDown(p);
 
   int getCursorId() const override { return m_cursorId; }
 
+  bool onPropertyChanged(std::string propertyName) override
+  {
+    if(propertyName == m_toolSize.getName()) {
+      updatePointSize();
+      invalidate();
+    }
+
+    return true;
+  }
+
+private:
+  /// Update point size based on property.
+  void updatePointSize()
+  {
+    double x = m_toolSize.getValue();
+
+    double minRange = 1;
+    double maxRange = 100;
+
+    double minSize = 10;
+    double maxSize = 100;
+
+    m_pointSize =
+        (x - minRange) / (maxRange - minRange) * (maxSize - minSize) + minSize;
+  }
 } magnetTool;
 
 // TTool *getMagnetTool() {return &magnetTool;}


### PR DESCRIPTION
Fixes #1436. The viewer now correctly shows the updated tool size after using the hotkeys ("I" and "U" by default).