### PR TITLE
Fix Color Model fails to display if it is minimized on loading the image

### DIFF
--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -1208,6 +1208,8 @@ TAffine ImageViewer::getImgToWidgetAffine(const TRectD &geom) const {
 void ImageViewer::adaptView(const TRect &imgRect, const TRect &viewRect) {
   QRect viewerRect(rect());
 
+  if (viewerRect.isEmpty()) return;
+
   double imageScale = std::min(viewerRect.width() / (double)viewRect.getLx(),
                                viewerRect.height() / (double)viewRect.getLy());
 


### PR DESCRIPTION
This PR fixes the problem as follows:

When switching the current level, the corresponding color model is automatically loaded if it is set.
On loading the color model image, if the color model panel is too shrinked to be visible, it fails to display the image until calling "Reset View" command.

I added a line to skip doing "fit to the window" if the panel size is empty.