### PR TITLE
Fix schematic spline option icon zooming

### DIFF
--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -144,13 +144,13 @@ signals:
 class SchematicToggle_SplineOptions final : public SchematicToggle {
   Q_OBJECT
 public:
-  SchematicToggle_SplineOptions(SchematicNode *parent, const QPixmap &pixmap,
+  SchematicToggle_SplineOptions(SchematicNode *parent, const QIcon &imageIcon,
                                 int flags)
-      : SchematicToggle(parent, QIcon(pixmap), QColor(0, 0, 0, 0), flags) {}
-  SchematicToggle_SplineOptions(SchematicNode *parent, const QPixmap &pixmap1,
-                                const QPixmap &pixmap2, int flags)
-      : SchematicToggle(parent, QIcon(pixmap1), QIcon(pixmap2),
-                        QColor(0, 0, 0, 0), flags) {}
+      : SchematicToggle(parent, imageIcon, QColor(0, 0, 0, 0), flags) {}
+  SchematicToggle_SplineOptions(SchematicNode *parent, const QIcon &imageIcon,
+                                const QIcon &imageIcon2, int flags)
+      : SchematicToggle(parent, imageIcon, imageIcon2, QColor(0, 0, 0, 0),
+                        flags) {}
 
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
              QWidget *widget = 0) override;

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -334,10 +334,9 @@ void SchematicToggle_SplineOptions::paint(
   if (m_state != 0) {
     QIcon &pix =
         (m_state == 2 && !m_imageOn2.isNull()) ? m_imageOn2 : m_imageOn;
-    QRect sourceRect =
-        scene()->views()[0]->matrix().mapRect(QRect(0, 0, 18, 17));
-    QPixmap redPm = pix.pixmap(sourceRect.size());
-    QRect newRect = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
+    QRect sourceRect = scene()->views()[0]->matrix().mapRect(rect.toRect());
+    QPixmap redPm    = pix.pixmap(sourceRect.size());
+    QRect newRect    = QRect(0, 0, sourceRect.width() * getDevPixRatio(),
                           sourceRect.height() * getDevPixRatio());
     painter->drawPixmap(rect, redPm, newRect);
   }

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1322,10 +1322,10 @@ StageSchematicNode::StageSchematicNode(StageSchematicScene *scene,
   m_splineDock->setPos(x, m_height);
 
   m_pathToggle = new SchematicToggle_SplineOptions(
-      this, QPixmap(":Resources/schematic_spline_aim_rhomb.svg"),
-      QPixmap(":Resources/schematic_spline_aim_square.svg"), 0);
+      this, QIcon(":Resources/schematic_spline_aim_rhomb.svg"),
+      QIcon(":Resources/schematic_spline_aim_square.svg"), 0);
   m_cpToggle = new SchematicToggle_SplineOptions(
-      this, QPixmap(":Resources/schematic_spline_cp.svg"), 0);
+      this, QIcon(":Resources/schematic_spline_cp.svg"), 0);
   m_pathToggle->setSize(7, 7);
   m_cpToggle->setSize(7, 7);
   m_cpToggle->setPos(m_splineDock->pos() - QPointF(7, 0));

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1330,6 +1330,8 @@ StageSchematicNode::StageSchematicNode(StageSchematicScene *scene,
   m_cpToggle->setSize(7, 7);
   m_cpToggle->setPos(m_splineDock->pos() - QPointF(7, 0));
   m_pathToggle->setPos(m_cpToggle->pos() - QPointF(7, 0));
+  m_pathToggle->setToolTip(tr("Toggle Autorotate Along Motion Path"));
+  m_cpToggle->setToolTip(tr("Toggle Link Motion Path to Control Points"));
 
   if (m_stageObject->isPathEnabled()) {
     if (m_stageObject->isAimEnabled())


### PR DESCRIPTION
This PR fixes #2422

Converted storing icons as QIcon instead of QPixmap so it scaled properly.  Also added tool tips for the 2 toggles.