### PR TITLE
Enable shortcuts for Eraser Tool in Raster Levels (#2724)

### DIFF
--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -396,6 +396,10 @@ FullColorEraserTool::FullColorEraserTool(std::string name)
   m_eraseType.addValue(RECTERASE);
   m_eraseType.addValue(FREEHANDERASE);
   m_eraseType.addValue(POLYLINEERASE);
+
+  m_eraseType.setId("Type");
+  m_invertOption.setId("Invert");
+  m_multi.setId("FrameRange");
 }
 
 //---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2724. Shortcuts for Type, Invert and Frame Range will now work for the Erasor Tool in Raster Levels.