### PR TITLE
Add next/prev keyframe shortcuts

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -230,6 +230,8 @@
         <separator/>
         <command>MI_PrevDrawing</command>
         <command>MI_NextDrawing</command>
+        <command>MI_PrevKeyframe</command>
+        <command>MI_NextKeyframe</command>
         <separator/>
         <command>MI_Link</command>
     </menu>

--- a/toonz/sources/include/toonz/tframehandle.h
+++ b/toonz/sources/include/toonz/tframehandle.h
@@ -103,6 +103,13 @@ public:
   int getStartFrame() { return m_frame0; }
   int getEndFrame() { return m_frame1; }
 
+  void emitTriggerNextKeyframe(QWidget *panel) {
+    emit triggerNextKeyframe(panel);
+  }
+  void emitTriggerPrevKeyframe(QWidget *panel) {
+    emit triggerPrevKeyframe(panel);
+  }
+
 public slots:
 
   void nextFrame(TFrameId = 0);
@@ -117,6 +124,9 @@ signals:
   void scrubStopped();
   void frameTypeChanged();
   void isPlayingStatusChanged();
+
+  void triggerNextKeyframe(QWidget *panel);
+  void triggerPrevKeyframe(QWidget *panel);
 
 protected:
   void timerEvent(QTimerEvent *event) override;

--- a/toonz/sources/include/toonzqt/functiontoolbar.h
+++ b/toonz/sources/include/toonzqt/functiontoolbar.h
@@ -95,6 +95,9 @@ public slots:
   void setCurve(TDoubleParam *curve);
   void setFrame(double frame);
 
+  void onNextKeyframe(QWidget *panel);
+  void onPrevKeyframe(QWidget *panel);
+
 private slots:
 
   void onValueFieldChanged();

--- a/toonz/sources/include/toonzqt/keyframenavigator.h
+++ b/toonz/sources/include/toonzqt/keyframenavigator.h
@@ -43,6 +43,8 @@ class DVAPI KeyframeNavigator : public QToolBar {
 
   TFrameHandle *m_frameHandle;
 
+  QWidget *m_panel;
+
 public:
   KeyframeNavigator(QWidget *parent = 0, TFrameHandle *frameHandle = 0);
 
@@ -62,6 +64,9 @@ public slots:
     update();
   }
   void update();
+
+  void onNextKeyframe(QWidget *panel);
+  void onPrevKeyframe(QWidget *panel);
 
 protected slots:
   void toggleKeyAct() {

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1160,7 +1160,7 @@ void MainWindow::onMenuCheckboxChanged() {
 #endif
   else if (cm->getAction(MI_RasterizePli) == action) {
     if (!QGLPixelBuffer::hasOpenGLPbuffers()) isChecked = 0;
-    RasterizePliToggleAction = isChecked;
+    RasterizePliToggleAction                            = isChecked;
   } else if (cm->getAction(MI_SafeArea) == action)
     SafeAreaToggleAction = isChecked;
   else if (cm->getAction(MI_ViewColorcard) == action)
@@ -1898,6 +1898,9 @@ void MainWindow::defineActions() {
   createAction(MI_NextStep, tr("Next Step"), "", PlaybackCommandType);
   createAction(MI_PrevStep, tr("Prev Step"), "", PlaybackCommandType);
 
+  createAction(MI_NextKeyframe, tr("Next Key"), "", MenuXsheetCommandType);
+  createAction(MI_PrevKeyframe, tr("Prev Key"), "", MenuXsheetCommandType);
+
   createRGBAAction(MI_RedChannel, tr("Red Channel"), "");
   createRGBAAction(MI_GreenChannel, tr("Green Channel"), "");
   createRGBAAction(MI_BlueChannel, tr("Blue Channel"), "");
@@ -2374,9 +2377,9 @@ RecentFiles::~RecentFiles() {}
 void RecentFiles::addFilePath(QString path, FileType fileType,
                               QString projectName) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) {
@@ -2543,9 +2546,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene)
-          ? m_recentScenes
-          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
+      (fileType == Scene) ? m_recentScenes : (fileType == Level)
+                                                 ? m_recentLevels
+                                                 : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -2572,9 +2575,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene)
-            ? MI_ClearRecentScene
-            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
+        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
+                                                        ? MI_ClearRecentLevel
+                                                        : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1898,8 +1898,8 @@ void MainWindow::defineActions() {
   createAction(MI_NextStep, tr("Next Step"), "", PlaybackCommandType);
   createAction(MI_PrevStep, tr("Prev Step"), "", PlaybackCommandType);
 
-  createAction(MI_NextKeyframe, tr("Next Key"), "", MenuXsheetCommandType);
-  createAction(MI_PrevKeyframe, tr("Prev Key"), "", MenuXsheetCommandType);
+  createAction(MI_NextKeyframe, tr("Next Key"), "Ctrl+.", MenuXsheetCommandType);
+  createAction(MI_PrevKeyframe, tr("Prev Key"), "Ctrl+,", MenuXsheetCommandType);
 
   createRGBAAction(MI_RedChannel, tr("Red Channel"), "");
   createRGBAAction(MI_GreenChannel, tr("Green Channel"), "");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1332,8 +1332,10 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(playMenu, MI_PrevStep);
   addMenuItem(playMenu, MI_NextStep);
   playMenu->addSeparator();
-  addMenuItem(playMenu, MI_NextDrawing);
   addMenuItem(playMenu, MI_PrevDrawing);
+  addMenuItem(playMenu, MI_NextDrawing);
+  addMenuItem(playMenu, MI_PrevKeyframe);
+  addMenuItem(playMenu, MI_NextKeyframe);
   playMenu->addSeparator();
   addMenuItem(playMenu, MI_Link);
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -210,6 +210,8 @@
 #define MI_PrevDrawing "MI_PrevDrawing"
 #define MI_NextStep "MI_NextStep"
 #define MI_PrevStep "MI_PrevStep"
+#define MI_NextKeyframe "MI_NextKeyframe"
+#define MI_PrevKeyframe "MI_PrevKeyframe"
 
 #define MI_RedChannel "MI_RedChannel"
 #define MI_GreenChannel "MI_GreenChannel"

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -141,7 +141,8 @@ public:
                                  "FunctionEditor", "FxSettings",
                                  "ComboViewer",    "SceneViewer"};
 
-    QWidget *panel = QApplication::focusWidget();
+    QWidget *panel    = QApplication::focusWidget();
+    if (!panel) panel = TApp::instance()->getActiveViewer();
     while (panel) {
       QString pane = panel->objectName();
       if (panel->windowType() == Qt::WindowType::SubWindow ||
@@ -169,7 +170,8 @@ public:
                                  "FunctionEditor", "FxSettings",
                                  "ComboViewer",    "SceneViewer"};
 
-    QWidget *panel = QApplication::focusWidget();
+    QWidget *panel    = QApplication::focusWidget();
+    if (!panel) panel = TApp::instance()->getActiveViewer();
     while (panel) {
       QString pane = panel->objectName();
       if (panel->windowType() == Qt::WindowType::SubWindow ||

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -3,6 +3,7 @@
 // Tnz6 includes
 #include "menubarcommandids.h"
 #include "tapp.h"
+#include "sceneviewer.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -15,6 +16,8 @@
 #include "toonz/tframehandle.h"
 #include "toonz/tcolumnhandle.h"
 #include "toonz/preferences.h"
+
+#include <QApplication>
 
 //**********************************************************************************
 //    Commands  definition
@@ -127,6 +130,62 @@ public:
   }
 };
 
+//-----------------------------------------------------------------------------
+
+class NextKeyframeCommand final : public MenuItemHandler {
+public:
+  NextKeyframeCommand() : MenuItemHandler(MI_NextKeyframe) {}
+
+  void execute() override {
+    QString navControlList[6] = {"LevelPalette",   "StudioPalette",
+                                 "FunctionEditor", "FxSettings",
+                                 "ComboViewer",    "SceneViewer"};
+
+    QWidget *panel = QApplication::focusWidget();
+    while (panel) {
+      QString pane = panel->objectName();
+      if (panel->windowType() == Qt::WindowType::SubWindow ||
+          panel->windowType() == Qt::WindowType::Tool) {
+        if (std::find(navControlList, navControlList + 6, pane) !=
+            (navControlList + 6)) {
+          TApp::instance()->getCurrentFrame()->emitTriggerNextKeyframe(panel);
+          break;
+        } else
+          panel = TApp::instance()->getActiveViewer()->parentWidget();
+      } else
+        panel = panel->parentWidget();
+    }
+  }
+};
+
+//-----------------------------------------------------------------------------
+
+class PrevKeyframeCommand final : public MenuItemHandler {
+public:
+  PrevKeyframeCommand() : MenuItemHandler(MI_PrevKeyframe) {}
+
+  void execute() override {
+    QString navControlList[6] = {"LevelPalette",   "StudioPalette",
+                                 "FunctionEditor", "FxSettings",
+                                 "ComboViewer",    "SceneViewer"};
+
+    QWidget *panel = QApplication::focusWidget();
+    while (panel) {
+      QString pane = panel->objectName();
+      if (panel->windowType() == Qt::WindowType::SubWindow ||
+          panel->windowType() == Qt::WindowType::Tool) {
+        if (std::find(navControlList, navControlList + 6, pane) !=
+            (navControlList + 6)) {
+          TApp::instance()->getCurrentFrame()->emitTriggerPrevKeyframe(panel);
+          break;
+        } else
+          panel = TApp::instance()->getActiveViewer()->parentWidget();
+      } else
+        panel = panel->parentWidget();
+    }
+  }
+};
+
 //**********************************************************************************
 //    Commands  instantiation
 //**********************************************************************************
@@ -154,3 +213,6 @@ NextDrawingCommand nextDrawingCommand;
 PrevDrawingCommand prevDrawingCommand;
 NextStepCommand nextStepCommand;
 PrevStepCommand prevStepCommand;
+
+NextKeyframeCommand nextKeyframeCommand;
+PrevKeyframeCommand prevKeyframeCommand;

--- a/toonz/sources/toonzqt/functiontoolbar.cpp
+++ b/toonz/sources/toonzqt/functiontoolbar.cpp
@@ -150,6 +150,16 @@ void FunctionToolbar::setFrame(double frame) {
     m_valueFld->setValue(0);
 }
 
+void FunctionToolbar::onNextKeyframe(QWidget *panel) {
+  m_keyframeNavigator->onNextKeyframe(panel);
+}
+
+//-------------------------------------------------------------------
+
+void FunctionToolbar::onPrevKeyframe(QWidget *panel) {
+  m_keyframeNavigator->onPrevKeyframe(panel);
+}
+
 //-------------------------------------------------------------------
 
 void FunctionToolbar::onValueFieldChanged() {

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -172,11 +172,11 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
   bool ret = true;
   ret      = ret && connect(m_toolbar, SIGNAL(numericalColumnToggled()), this,
                        SLOT(toggleMode()));
-  ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
+  ret = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
                        m_functionGraph, SLOT(update()));
-  ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
+  ret = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
                        m_numericalColumns, SLOT(updateAll()));
-  ret      = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_treeView,
+  ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_treeView,
                        SLOT(update()));
   ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_functionGraph,
                        SLOT(update()));
@@ -241,10 +241,18 @@ void FunctionViewer::showEvent(QShowEvent *) {
           ret;
   }
 
-  if (m_frameHandle)
+  if (m_frameHandle) {
     ret = connect(m_frameHandle, SIGNAL(frameSwitched()), this,
                   SLOT(propagateExternalSetFrame())) &&
           ret;
+
+    ret = connect(m_frameHandle, SIGNAL(triggerNextKeyframe(QWidget *)),
+                  m_toolbar, SLOT(onNextKeyframe(QWidget *))) &&
+          ret;
+    ret = connect(m_frameHandle, SIGNAL(triggerPrevKeyframe(QWidget *)),
+                  m_toolbar, SLOT(onPrevKeyframe(QWidget *))) &&
+          ret;
+  }
 
   if (m_objectHandle) {
     ret = connect(m_objectHandle, SIGNAL(objectSwitched()), this,
@@ -303,7 +311,10 @@ void FunctionViewer::showEvent(QShowEvent *) {
 
 void FunctionViewer::hideEvent(QHideEvent *) {
   if (m_xshHandle) m_xshHandle->disconnect(this);
-  if (m_frameHandle) m_frameHandle->disconnect(this);
+  if (m_frameHandle) {
+    m_frameHandle->disconnect(this);
+    m_frameHandle->disconnect(m_toolbar);
+  }
   if (m_objectHandle) m_objectHandle->disconnect(this);
   if (m_fxHandle) m_fxHandle->disconnect(this);
   if (m_sceneHandle) m_sceneHandle->disconnect(this);
@@ -595,7 +606,7 @@ void FunctionViewer::onStageObjectChanged(bool isDragging) {
 void FunctionViewer::onFxSwitched() {
   TFx *fx              = m_fxHandle->getFx();
   TZeraryColumnFx *zfx = dynamic_cast<TZeraryColumnFx *>(fx);
-  if (zfx) fx = zfx->getZeraryFx();
+  if (zfx) fx          = zfx->getZeraryFx();
   static_cast<FunctionTreeModel *>(m_treeView->model())->setCurrentFx(fx);
   m_treeView->updateAll();
   m_functionGraph->update();

--- a/toonz/sources/toonzqt/keyframenavigator.cpp
+++ b/toonz/sources/toonzqt/keyframenavigator.cpp
@@ -8,6 +8,7 @@
 #include "toonz/txshcolumn.h"
 #include "toonz/tstageobjectkeyframe.h"
 #include "toonz/stageobjectutil.h"
+#include "toonz/tapplication.h"
 
 #include "tpixelutils.h"
 #include "tfx.h"
@@ -35,7 +36,7 @@ using namespace std;
 //-----------------------------------------------------------------------------
 
 KeyframeNavigator::KeyframeNavigator(QWidget *parent, TFrameHandle *frameHandle)
-    : QToolBar(parent), m_frameHandle(frameHandle) {
+    : QToolBar(parent), m_frameHandle(frameHandle), m_panel(0) {
   setLayoutDirection(Qt::LeftToRight);
 
   setIconSize(QSize(18, 18));
@@ -124,6 +125,22 @@ void KeyframeNavigator::showEvent(QShowEvent *e) {
   update();
   if (!m_frameHandle) return;
   connect(m_frameHandle, SIGNAL(frameSwitched()), this, SLOT(update()));
+
+  connect(m_frameHandle, SIGNAL(triggerNextKeyframe(QWidget *)), this,
+          SLOT(onNextKeyframe(QWidget *)));
+  connect(m_frameHandle, SIGNAL(triggerPrevKeyframe(QWidget *)), this,
+          SLOT(onPrevKeyframe(QWidget *)));
+  if (!m_panel || m_panel == nullptr) {
+    QWidget *panel = this->parentWidget();
+    while (panel) {
+      if (panel->windowType() == Qt::WindowType::SubWindow ||
+          panel->windowType() == Qt::WindowType::Tool) {
+        m_panel = panel;
+        break;
+      }
+      panel = panel->parentWidget();
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -131,6 +148,16 @@ void KeyframeNavigator::showEvent(QShowEvent *e) {
 void KeyframeNavigator::hideEvent(QHideEvent *e) {
   if (!m_frameHandle) return;
   disconnect(m_frameHandle);
+}
+
+void KeyframeNavigator::onNextKeyframe(QWidget *panel) {
+  if (!m_panel || m_panel != panel) return;
+  toggleNextKeyAct();
+}
+
+void KeyframeNavigator::onPrevKeyframe(QWidget *panel) {
+  if (!m_panel || m_panel != panel) return;
+  togglePrevKeyAct();
 }
 
 //=============================================================================


### PR DESCRIPTION
Requested on Google forum, this PR adds shortcuts for keyframe navigation controls, Next Key and Prev Key.

The behavior of the shortcut keys changes based on the panel/window you are focused on, coinciding with how the keyframe navigation controls works on that panel:

When focused on...

- Scene/Combo Viewers - Moves between keyframes on the current level in Xsheet/Timeline
- Function Editor - Moves between keyframes in the Function Editor
- Level/Studio Palettes - Moves between color keyframes in either Xsheet/Timeline or Level Strip.
- Fx Settings - Moves between Fx keyframes

All other panels without a keyframe navigation control will use the Scene/Combo Viewer logic.
