### PR TITLE
Add Desktop and Documents location in file browser for Linux

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -49,7 +49,13 @@ TFilePath getMyDocumentsPath() {
   return TFilePath((const char *)[documentsDirectory
       cStringUsingEncoding:NSASCIIStringEncoding]);
 #else
-  return TFilePath();
+  std::string path(getenv("HOME"));
+  if(path.empty()) return TFilePath();
+  path += "/Documents";
+  QString pathAsQString = QString::fromStdString(path);
+  QDir dir(pathAsQString);
+  if(!dir.exists()) return TFilePath();
+  return TFilePath(path);
 #endif
 }
 
@@ -71,7 +77,13 @@ TFilePath getDesktopPath() {
   return TFilePath((const char *)[desktopDirectory
       cStringUsingEncoding:NSASCIIStringEncoding]);
 #else
-  return TFilePath();
+  std::string path(getenv("HOME"));
+  if(path.empty()) return TFilePath();
+  path += "/Desktop";
+  QString pathAsQString = QString::fromStdString(path);
+  QDir dir(pathAsQString);
+  if(!dir.exists()) return TFilePath();
+  return TFilePath(path);
 #endif
 }
 }


### PR DESCRIPTION
**Problem**: I am using Linux (Ubuntu). In the File Browser, the _Desktop_ and _My Documents_ items don't work. See below:

![desktop-location-demo-before](https://user-images.githubusercontent.com/24422213/63793268-77bf3900-c953-11e9-815f-c244ef805412.gif)

**Solution**: I pointed them to the default paths for _Desktop_ and _My Documents_ on Linux (if the OS is not Windows or Mac). See below:

![desktop-location-demo-after](https://user-images.githubusercontent.com/24422213/63793277-7db51a00-c953-11e9-8895-820129819794.gif)


The code applies to any OS besides Windows or Mac. It works for me on Ubuntu, but should also be tested on other Linux distributions, and any other OS used for OpenToonz.