### PR TITLE
Fix undo/redo issue when pasting to new frame (#1807)

### DIFF
--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -22,6 +22,7 @@
 #include "toonz/tobjecthandle.h"
 #include "toonz/txshlevelhandle.h"
 #include "toonz/tscenehandle.h"
+#include "toonz/txsheethandle.h"
 
 #include "toonz/tcenterlinevectorizer.h"
 #include "toonz/stage.h"
@@ -196,22 +197,18 @@ public:
 // PasteStrokesUndo
 //-----------------------------------------------------------------------------
 
-class PasteStrokesUndo final : public TUndo {
-  TXshSimpleLevelP m_level;
-  TFrameId m_frameId;
+class PasteStrokesUndo final : public ToolUtils::TToolUndo {
   std::set<int> m_indexes;
-  TPaletteP m_oldPalette;
   QMimeData *m_oldData;
   TSceneHandle *m_sceneHandle;
 
 public:
   PasteStrokesUndo(TXshSimpleLevel *level, const TFrameId &frameId,
                    std::set<int> &indexes, TPaletteP oldPalette,
-                   TSceneHandle *sceneHandle)
-      : m_level(level)
-      , m_frameId(frameId)
+                   TSceneHandle *sceneHandle, bool createdFrame,
+                   bool createdLevel)
+      : TToolUndo(level, frameId, createdFrame, createdLevel, oldPalette)
       , m_indexes(indexes)
-      , m_oldPalette(oldPalette)
       , m_sceneHandle(sceneHandle) {
     QClipboard *clipboard = QApplication::clipboard();
     m_oldData             = cloneData(clipboard->mimeData());
@@ -230,9 +227,16 @@ public:
 
     std::set<int> indexes = m_indexes;
     deleteStrokesWithoutUndo(image, indexes);
+
+    removeLevelAndFrameIfNeeded();
+
+    TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
+    notifyImageChanged();
   }
 
   void redo() const override {
+    insertLevelAndFrameIfNeeded();
+
     TVectorImageP image   = m_level->getFrame(m_frameId, true);
     std::set<int> indexes = m_indexes;
 
@@ -245,6 +249,9 @@ public:
     TTool::getApplication()->getCurrentTool()->getTool()->notifyImageChanged();
 
     clipboard->setMimeData(data, QClipboard::Clipboard);
+
+    TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
+    notifyImageChanged();
   }
 
   int getSize() const override { return sizeof(*this); }
@@ -545,7 +552,8 @@ void StrokeSelection::paste() {
     TXshSimpleLevel *level =
         TTool::getApplication()->getCurrentLevel()->getSimpleLevel();
     TUndoManager::manager()->add(new PasteStrokesUndo(
-        level, tool->getCurrentFid(), m_indexes, oldPalette, m_sceneHandle));
+        level, tool->getCurrentFid(), m_indexes, oldPalette, m_sceneHandle,
+        tool->m_isFrameCreated, tool->m_isLevelCreated));
     m_updateSelectionBBox = isPaste;
   }
   tool->notifyImageChanged();


### PR DESCRIPTION
Fixes #1807. If a new frame is created by pasting a vector selection, the undo operation also removes the new frame; the redo operation will add it again. This fixes the issue described in the bug report.

Demo below:

![paste-fix-demo](https://user-images.githubusercontent.com/24422213/63888586-5b92c900-ca33-11e9-8bd5-54a6501fdcca.gif)

**Note for code reviewers**: I changed the parent of _PasteStrokesUndo_ from _TUndo_ to _TToolUndo_ in order to use the _insertLevelAndFrameIfNeeded_ and _removeLevelAndFrameIfNeeded_ methods.

