### PR TITLE
Fix misc. source comment and doxygen typos in ./toonz/sources/toonzlib

### DIFF
--- a/toonz/sources/toonzlib/boardsettings.cpp
+++ b/toonz/sources/toonzlib/boardsettings.cpp
@@ -200,7 +200,7 @@ void BoardItem::saveData(TOStream &os) {
                    << m_rect.height();
 
   if (m_type == Image) {
-    // if the path is in library folder, then save the realtive path
+    // if the path is in library folder, then save the relative path
     TFilePath libFp = ToonzFolder::getLibraryFolder();
     if (libFp.isAncestorOf(m_imgPath))
       os.child("imgPath") << 1 << m_imgPath - libFp;

--- a/toonz/sources/toonzlib/cleanuppalette.cpp
+++ b/toonz/sources/toonzlib/cleanuppalette.cpp
@@ -94,11 +94,11 @@ TPalette *createToonzPalette(TPalette *cleanupPalette, int colorParamIndex) {
 void TargetColors::update(TPalette *palette, bool noAntialias) {
   m_colors.clear();
 
-  TargetColor tranparent(TPixel32(255, 255, 255, 0) /*TPixel32::Transparent*/,
+  TargetColor transparent(TPixel32(255, 255, 255, 0) /*TPixel32::Transparent*/,
                          0,  // BackgroundStyle,
                          0, 0, 0, 0);
 
-  m_colors.push_back(tranparent);
+  m_colors.push_back(transparent);
 
   for (int i = 0; i < palette->getPage(0)->getStyleCount(); i++) {
     int styleId     = palette->getPage(0)->getStyleId(i);

--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -1163,7 +1163,7 @@ void ReplaceFxUndo::initialize() {
       m_repColumn = new TXshZeraryFxColumn(*zcfx->getColumn());
       m_repColIdx = m_colIdx;
 
-      // Substitute the column's zerary fx with the subsitute one
+      // Substitute the column's zerary fx with the substitute one
       TZeraryColumnFx *repZcfx =
           static_cast<TZeraryColumnFx *>(m_repColumn->getFx());
       repZcfx->setZeraryFx(repFx);
@@ -2240,7 +2240,7 @@ void DeleteFxOrColumnUndo::redo() const {
             ->getParams());  // However, params stored there are NOT cloned.
   }                          // This is fine since we're deleting the column...
 
-  // Peform operation
+  // Perform operation
   FxCommandUndo::removeFxOrColumn(xsh, m_fx.getPointer(), m_colIdx);
 
   m_xshHandle->notifyXsheetChanged();  // Add the rest...

--- a/toonz/sources/toonzlib/ikjacobian.cpp
+++ b/toonz/sources/toonzlib/ikjacobian.cpp
@@ -167,7 +167,7 @@ void MatrixRmn::SetSequence(const VectorRn &d, long startRow, long startCol,
 }
 
 // The matrix A is loaded, in into "this" matrix, based at (0,0).
-//  The size of "this" matrix must be large enough to accomodate A.
+//  The size of "this" matrix must be large enough to accommodate A.
 //	The rest of "this" matrix is left unchanged.  It is not filled with
 // zeroes!
 
@@ -188,7 +188,7 @@ void MatrixRmn::LoadAsSubmatrix(const MatrixRmn &A) {
 
 // The matrix A is loaded, in transposed order into "this" matrix, based at
 // (0,0).
-//  The size of "this" matrix must be large enough to accomodate A.
+//  The size of "this" matrix must be large enough to accommodate A.
 //	The rest of "this" matrix is left unchanged.  It is not filled with
 // zeroes!
 void MatrixRmn::LoadAsSubmatrixTranspose(const MatrixRmn &A) {
@@ -412,7 +412,7 @@ void MatrixRmn::Solve(const VectorRn &b, VectorRn *xVec) const {
 // The "NoFree" version operates on the assumption that no free variable will be
 // found.
 // Algorithm uses row operations and row pivoting (only).
-// Augmented matrix is correctly accomodated.  Only the first square part
+// Augmented matrix is correctly accommodated.  Only the first square part
 // participates
 //		in the main work of row operations.
 void MatrixRmn::ConvertToRefNoFree() {
@@ -1546,7 +1546,7 @@ void Jacobian::CalcDeltaThetasSDLS() {
 
     double gamma = MaxAngleSDLS;
     if (N < M) {
-      gamma *= N / M;  // Scale back maximum permissable joint angle
+      gamma *= N / M;  // Scale back maximum permissible joint angle
     }
 
     // Calculate the dTheta from pure pseudoinverse considerations

--- a/toonz/sources/toonzlib/levelupdater.cpp
+++ b/toonz/sources/toonzlib/levelupdater.cpp
@@ -246,7 +246,7 @@ void LevelUpdater::open(const TFilePath &fp, TPropertyGroup *pg) {
       m_lwPath = fp;
     }
   } catch (...) {
-    // In this case, TLevelWriterP(..) failed, that object was never contructed,
+    // In this case, TLevelWriterP(..) failed, that object was never constructed,
     // the assignment m_lw never took place. And m_lw == 0.
 
     // Reset state and rethrow

--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -404,7 +404,7 @@ std::pair<bool, int> MovieRenderer::Imp::saveFrame(
         has64bitOutputSupport = writerA->is64bitOutputSupported();
 
       // NOTE: If the writer could not be retrieved, the updater will throw.
-      // Failure will be catched then.
+      // Failure will be caught then.
     }
 
     // Prepare the images to be flushed
@@ -876,7 +876,7 @@ TRenderer *MovieRenderer::getTRenderer() {
   // MovieRenderer instance.
   // Since a TRenderer is already smart-pointer-like, we could just return a
   // copy - however, it really
-  // shouln't be that way. Maybe one day we'll revert that and actually use a
+  // shouldn't be that way. Maybe one day we'll revert that and actually use a
   // smart pointer class.
 
   // For now, no use of this function seems to access the returned pointer

--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -921,7 +921,7 @@ int loadRefImage(TPaletteHandle *paletteHandle,
           // values
           std::set<TPixel32> colors;
           if (config.rasterPickType == PaletteCmd::PickEveryColors) {
-            // different colors will become sparate styles
+            // different colors will become separate styles
             TColorUtils::buildPrecisePalette(colors, raster,
                                              availableColorCount);
           } else {  //  config.rasterPickType ==

--- a/toonz/sources/toonzlib/sandor_fxs/CallCircle.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/CallCircle.cpp
@@ -70,7 +70,7 @@ void CCallCircle::print() {
 
 void CCallCircle::draw(UCHAR *drawB, const int lX, const int lY, const int xx,
                        const int yy, const double r) {
-  double aa = 2.0 * r / 3.0;  // Size of antialising
+  double aa = 2.0 * r / 3.0;  // Size of antialiasing
 
   for (int i = 0; i < m_nb && m_c[i].w <= r; i++) {
     double w = m_c[i].w;

--- a/toonz/sources/toonzlib/sandor_fxs/STPic.h
+++ b/toonz/sources/toonzlib/sandor_fxs/STPic.h
@@ -37,7 +37,7 @@ m_ras - stores the pointer to the original RASTER picture
 #define ISINPIC(x, y) (m_pic && x >= 0 && x < m_lX && y >= 0 && y < m_lY)
 
 typedef enum {
-  ST_NIL,    // EMTY
+  ST_NIL,    // EMPTY
   ST_RGBM,   // UC_PIXEL
   ST_RGBM64  // US_PIXEL
 } ST_TYPE;

--- a/toonz/sources/toonzlib/sandor_fxs/blend.cpp
+++ b/toonz/sources/toonzlib/sandor_fxs/blend.cpp
@@ -121,7 +121,7 @@ public:
 
 //=================================================================================
 
-// Bitmap used to store blend color selections and pure color informations.
+// Bitmap used to store blend color selections and pure color information.
 class SelectionRaster {
   SelectionArrayPtr m_selection;
 

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -111,7 +111,7 @@ bool descending(int i, int j) { return (i > j); }
 }
 
 //=============================================================================
-/*! The ZPlacement class preserve camera position informations.
+/*! The ZPlacement class preserve camera position information.
 */
 //=============================================================================
 
@@ -207,11 +207,11 @@ public:
   StageBuilder();
   virtual ~StageBuilder();
 
-  /*! Add in \b players vector informations about specify cell.
+  /*! Add in \b players vector information about specify cell.
   \n	Analyze cell in row \b row and column \b col of xsheet \b xsh. If level
                   containing this cell is a simple level, \b TXshSimpleLevel,
   create a Pleyer
-                  object with informations of the cell. Else if level is a child
+                  object with information of the cell. Else if level is a child
   level,
                   \b TXshChildLevel, recall \b addFrame().
   */
@@ -232,7 +232,7 @@ public:
   void addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh, int row,
                 int level, bool includeUnvisible, bool checkPreviewVisibility);
 
-  /*! Add in \b players vector informations about \b level cell with \b TFrameId
+  /*! Add in \b players vector information about \b level cell with \b TFrameId
   \b fid.
   \n	Compute information for all cell with active onion-skin, if onion-skin
   is not active

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -1176,7 +1176,7 @@ void OpenGlPainter::onRasterImage(TRasterImage *ri,
 
   bool premultiplied = tlvFlag;  // xD
   static std::vector<char>
-      matteChan;  // Wtf this is criminal. Altough probably this
+      matteChan;  // Wtf this is criminal. Although probably this
                   // stuff is used only in the main thread... hmmm....
   TRaster32P r = (TRaster32P)ri->getRaster();
   r->lock();

--- a/toonz/sources/toonzlib/tcenterlineadjustments.cpp
+++ b/toonz/sources/toonzlib/tcenterlineadjustments.cpp
@@ -28,7 +28,7 @@ ContourFamily *currContourFamily;
 //--------------------------------------
 
 // EXPLANATION:  The raw skeleton data obtained from StraightSkeletonizer
-// class need to be grouped in joints and sequences before proceding with
+// class need to be grouped in joints and sequences before proceeding with
 // conversion in quadratics - which works on single sequences.
 
 // NOTE: Due to maxHeight, we have to assume that a single SkeletonGraph can

--- a/toonz/sources/toonzlib/tcenterlinecolors.cpp
+++ b/toonz/sources/toonzlib/tcenterlinecolors.cpp
@@ -123,10 +123,9 @@ static void sampleColor(const TRasterCM32P &ras, int threshold, Sequence &seq,
   std::vector<double> params;
 
   // Meanwhile, ensure each point belong to ras. Otherwise, typically an error
-  // occured
-  // in the thinning process and it's better avoid sampling procedure. Only
-  // exception, when
-  // a point has x==ras->getLx() || y==ras->getLy(); that is accepted.
+  // occurred in the thinning process and it's better avoid sampling procedure. 
+  // Only exception, when a point has 
+  // x==ras->getLx() || y==ras->getLy(); that is accepted.
   {
     const T3DPointD &headPos = *currGraph->getNode(seq.m_head);
 
@@ -210,9 +209,8 @@ static void sampleColor(const TRasterCM32P &ras, int threshold, Sequence &seq,
   }
 
   // NOTE: Extremities of a sequence are considered unreliable: they typically
-  // happen
-  //       to be junction points shared between possibly different-colored
-  //       strokes.
+  // happen to be junction points shared between possibly different-colored
+  // strokes.
 
   // Find first and last extremity-free sampled points
   T3DPointD first(*currGraph->getNode(seq.m_head));
@@ -385,8 +383,7 @@ void calculateSequenceColors(const TRasterP &ras, VectorizerCoreGlobals &g) {
 
   if (cm && g.currConfig->m_maxThickness > 0.0) {
     // singleSequence is traversed back-to-front because new, possibly splitted
-    // sequences
-    // are inserted at back - and don't have to be re-sampled.
+    // sequences are inserted at back - and don't have to be re-sampled.
     for (l = singleSequences.size() - 1; l >= 0; --l) {
       Sequence rear;
       sampleColor(ras, threshold, singleSequences[l], rear, singleSequences);

--- a/toonz/sources/toonzlib/tcenterlinepolygonizer.cpp
+++ b/toonz/sources/toonzlib/tcenterlinepolygonizer.cpp
@@ -257,7 +257,7 @@ void Signaturemap::readRasterData(const TRasterPT<T> &ras, int threshold) {
 
 //--------------------------------------------------------------------------
 
-// Minority check for amiguous turning directions
+// Minority check for ambiguous turning directions
 inline bool getMinorityCheck(const Signaturemap &ras, int x, int y) {
   // Assumes (x,y) is ambiguous case: 2 immediate surrounding pixels are white
   // and 2 black

--- a/toonz/sources/toonzlib/tcenterlineskeletonizer.cpp
+++ b/toonz/sources/toonzlib/tcenterlineskeletonizer.cpp
@@ -109,7 +109,7 @@ public:
   typedef std::list<ContourNode *> IndexColumn;
 
   std::vector<IndexColumn>
-      m_columns;  //!< Countours set by 'column identifier'.
+      m_columns;  //!< Contours set by 'column identifier'.
   std::vector<int>
       m_identifiers;  //!< Column identifiers by original contour index.
 
@@ -1385,7 +1385,7 @@ inline void Event::processSplitEvent() {
   m_generator->m_next->m_prev = newLeftNode;
   newLeftNode->m_next         = m_generator->m_next;
 
-  // Assign and calculate the new nodes' informations
+  // Assign and calculate the new nodes' information
   newLeftNode->m_edge  = m_generator->m_edge;
   newRightNode->m_edge = m_coGenerator->m_edge;
 
@@ -1491,7 +1491,7 @@ inline void Event::processVertexEvent() {
   m_generator->m_next->m_prev   = newLeftNode;
   newLeftNode->m_next           = m_generator->m_next;
 
-  // Assign and calculate the new nodes' informations
+  // Assign and calculate the new nodes' information
   newLeftNode->m_edge  = m_generator->m_edge;
   newRightNode->m_edge = m_coGenerator->m_edge;
 

--- a/toonz/sources/toonzlib/tcenterlinetostrokes.cpp
+++ b/toonz/sources/toonzlib/tcenterlinetostrokes.cpp
@@ -371,7 +371,7 @@ void SequenceConverter::lengthOfTriplet(unsigned int i, Length &len) {
   T3DPointD B = middleAddedSequence[i + 1];
   T3DPointD C = middleAddedSequence[i + 2];
 
-  // We assume that this convertion is faithful, avoiding length penalty
+  // We assume that this conversion is faithful, avoiding length penalty
   len.l    = 0;
   double d = tdistance(B, C - A, A);
   if (d <= 2) {
@@ -684,7 +684,7 @@ bool SequenceConverter::penalty(unsigned int a, unsigned int b, Length &len) {
 //--------------------------------------------------------------------------
 
 //-----------------------------
-//      Convertion Mains
+//      Conversion Mains
 //-----------------------------
 
 inline TStroke *convert(const Sequence &s, double penalty) {

--- a/toonz/sources/toonzlib/tcenterlinevectP.h
+++ b/toonz/sources/toonzlib/tcenterlinevectP.h
@@ -87,7 +87,7 @@ inline bool angleLess(const TPointD &a, const TPointD &b, const TPointD &ref) {
 // Container append (needs reverse iterators)
 // NOTE: Merge could be used... but it requires operator< and we don't...
 
-//! warning: must be I == T::Reverse_iterator; explicited because on Mac it was
+//! warning: must be I == T::Reverse_iterator; explicitly because on Mac it was
 //! not compiling!
 template <class T, class I>
 void append(T &cont1, T &cont2) {
@@ -288,7 +288,7 @@ public:
   // Further node properties
   bool m_concave;             //!< Whether the node represents a concave angle.
   unsigned int m_attributes,  //!< Bitwise signatures of this node
-      m_updateTime,  //!< \a Algoritmic time in which the node was updated.
+      m_updateTime,  //!< \a Algorithmic time in which the node was updated.
       m_ancestor,  //!< Index of the original node from which this one evolved.
       m_ancestorContour;  //!< Contour index of the original node from which
                           //! this one evolved.
@@ -403,7 +403,7 @@ public:
   Sequence() : m_graphHolder(0) {}
   ~Sequence() {}
 
-  // Impose a property dependant only on the extremity we consider first
+  // Impose a property dependent only on the extremity we consider first
   // - so that the same sequence is not considered twice when head and tail
   // are exchanged
   bool isForward() const {
@@ -467,7 +467,7 @@ typedef std::vector<T3DPointD> PointList;
 //! "tcenterline*.cpp"
 // sources. Instead than passing each variable repeatedly, it is easier to
 // define a Global
-// class passed to each file, which gets immediatly pointed in an anonymous
+// class passed to each file, which gets immediately pointed in an anonymous
 // namespace.
 
 class VectorizerCoreGlobals {

--- a/toonz/sources/toonzlib/tcleanupper.cpp
+++ b/toonz/sources/toonzlib/tcleanupper.cpp
@@ -45,7 +45,7 @@ centered
 
   Post-processing include despeckling (ie removal or recoloration of little
 blots with
-  uniform color), and tones' brigthness/contrast manipulation.
+  uniform color), and tones' brightness/contrast manipulation.
 
   (*) The image is first overed on top of a white background
 
@@ -501,7 +501,7 @@ bool TCleanupper::getResampleValues(const TRasterImageP &image, TAffine &aff,
 //------------------------------------------------------------------------------------
 
 // this one incorporate the preprocessColors and the finalize function; used for
-// swatch.(tipically on very small rasters)
+// swatch.(typically on very small rasters)
 TRasterP TCleanupper::processColors(const TRasterP &rin) {
   if (m_parameters->m_lineProcessingMode == lpNone) return rin;
 

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -376,7 +376,7 @@ static std::vector<int> getAllBut(std::vector<int> &colorIds) {
 //! Image
 //! will be destroyed at the most appropriate time. You should definitely *COPY*
 //! all
-//! necessary informations before calling it - however, since the intent was
+//! necessary information before calling it - however, since the intent was
 //! that of
 //! optimizing memory usage, please avoid copying the entire image buffer...
 
@@ -1423,7 +1423,7 @@ bool TLevelColumnFx::doGetBBox(double frame, TRectD &bBox,
     bBox = img->getBBox();
   }
 
-  // Add the enlargement of the bbox due to Tzp render datas
+  // Add the enlargement of the bbox due to Tzp render data
   if (info.m_data.size()) {
     TRectD imageBBox(bBox);
     for (unsigned int i = 0; i < info.m_data.size(); ++i) {

--- a/toonz/sources/toonzlib/tdistort.cpp
+++ b/toonz/sources/toonzlib/tdistort.cpp
@@ -315,12 +315,10 @@ PIXEL filterPixel(double a, double b, double c, double d,
 
   // Deal the magnification case, assuming that intervals have at least length
   // 1. This actually stands for:
-  //  1. Their midpoint is bilinear filtered whenever their former length wass
-  //  less than 1 (see fractionary
-  //     parts computing above).
+  //  1. Their midpoint is bilinear filtered whenever their former length was
+  //     less than 1 (see fractionary parts computing above).
   //  2. This behaviour is continuous with respect to interval lengths - that
-  //  is, we pass from supersampling to
-  //     subsampling in a smooth manner.
+  //     is, we pass from supersampling to subsampling in a smooth manner.
   if (b - a < 1) {
     double v = 0.5 * (a + b);
     a        = v - 0.5;

--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -205,7 +205,7 @@ void hideOlderProjectFiles(const TFilePath &folderPath) {
    and Outputs.
         Each of this folders can be renamed using the setFolder(string name,
    TFilePath path) method.
-        Usually, the \b name parameter is choosen from inputs, drawings, scenes,
+        Usually, the \b name parameter is chosen from inputs, drawings, scenes,
    extras and outputs;
         the \b path parameter contains the folder that can have a different name
    from them.
@@ -214,7 +214,7 @@ void hideOlderProjectFiles(const TFilePath &folderPath) {
    folder is used by
         every scene created in the project to save or load data. A scene
    dependent folder is used only by the scene
-        from wich the folder depends. A scene dependent folder contains the
+        from which the folder depends. A scene dependent folder contains the
    string "$scene" in its path.
 
         \code
@@ -225,7 +225,7 @@ void hideOlderProjectFiles(const TFilePath &folderPath) {
         Drawings folder path: "...\\prodA\\episode1\\SceneA\\drawings"
         \endcode
         \n\n
-        By default, from the toonz installation, exist allways a toonz project
+        By default, from the toonz installation, exist always a toonz project
    called "sandbox".
         \see TProjectManager, TSceneProperties.
 */
@@ -258,7 +258,7 @@ void hideOlderProjectFiles(const TFilePath &folderPath) {
 
 /*! \fn void TProject::save()
         Saves the project.
-        Is equvalent to save(getProjectPath()).
+        Is equivalent to save(getProjectPath()).
         The project is saved as a xml file.\n
         Uses TProjectManager and TOStream.
         \note Exceptions can be thrown.
@@ -276,7 +276,7 @@ TProject::~TProject() { delete m_sprop; }
         \code
         e.g. setFolder(TProject::Drawings, TFilePath("C:\\temp\\drawings"))
         \endcode
-        Usually, the \b name parameter is choosen from inputs, drawings, scenes,
+        Usually, the \b name parameter is chosen from inputs, drawings, scenes,
    extras and outputs;
         the \b path contains the folder that can have a different name from
    them.
@@ -705,15 +705,15 @@ public:
         and folders.
 
         It is possible to handle more than one project root.
-        The class mantains a container this purpose. All the projects roots must
-   be setted by hand in the windows
+        The class maintains a container this purpose. All the projects roots must
+   be set by hand in the windows
         registery. By default, only one project root is created when toonz is
    installed.\n
         The project root container can be updated using addProjectsRoot(const
    TFilePath &root), addDefaultProjectsRoot()
         methods.
 
-        The class mantains also information about the current project. The class
+        The class maintains also information about the current project. The class
    provides all needed method to retrieve
         the current project path, name and folder.
         \see TProject
@@ -814,7 +814,7 @@ TFilePath TProjectManager::projectPathToProjectName(
 
 //-------------------------------------------------------------------
 /*! Returns an absolute path of the specified \b projectName.\n
-        \note The returned project path is allways computed used the first
+        \note The returned project path is always computed used the first
    project root in the container.*/
 TFilePath TProjectManager::projectNameToProjectPath(
     const TFilePath &projectName) {
@@ -840,7 +840,7 @@ TFilePath TProjectManager::projectFolderToProjectPath(
 /*! Returns the absolute path of the specified \b projectName only if the
    project already exist.\n
         Returns TFilePath() if a project with the specified \b projectName
-   doesn't exsist.\n
+   doesn't exist.\n
         \note \b projectName must be a relative path.*/
 TFilePath TProjectManager::getProjectPathByName(const TFilePath &projectName) {
   assert(!TProject::isAProjectPath(projectName));
@@ -912,9 +912,9 @@ void TProjectManager::setCurrentProjectPath(const TFilePath &fp) {
 
 //-------------------------------------------------------------------
 /*! Returns the current project path.\n
-        The project path, usually, is setted in key registry. If a current
-   project path isn't setted,
-        TProject::SandboxProjectName is setted as current project.
+        The project path, usually, is set in key registry. If a current
+   project path isn't set,
+        TProject::SandboxProjectName is set as current project.
 */
 TFilePath TProjectManager::getCurrentProjectPath() {
   TFilePath fp(currentProjectPath);
@@ -1034,13 +1034,13 @@ void TProjectManager::notifyProjectChanged() {
 }
 
 //-------------------------------------------------------------------
-/*! Adds \b listener to the listners container.*/
+/*! Adds \b listener to the listeners container.*/
 void TProjectManager::addListener(Listener *listener) {
   m_listeners.insert(listener);
 }
 
 //-------------------------------------------------------------------
-/*! Removes \b listener from the listners container.*/
+/*! Removes \b listener from the listeners container.*/
 void TProjectManager::removeListener(Listener *listener) {
   m_listeners.erase(listener);
 }

--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -513,7 +513,7 @@ void TStageObject::onChange(const class TParamChange &c) {
   // one of its parameters. This means this function gets called A LOT.
 
   // Thus, we're just SCHEDULING for a data refresh. The actual refresh happens
-  // whenever the scheduled datas are accessed.
+  // whenever the scheduled data is accessed.
 
   if (c.m_keyframeChanged)
     m_lazyData.invalidate();  // Both invalidate placement AND keyframes

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -469,7 +469,7 @@ TXshColumn::ColumnType TXshColumn::toColumnType(int levelType) {
   else if (levelType == MESH_XSHLEVEL)
     colType = TXshColumn::eMeshType;
   else
-    assert(!"Unkown level type!");
+    assert(!"Unknown level type!");
 
   return colType;
 }

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -985,7 +985,7 @@ void TXsheet::rolldownCells(int r0, int c0, int r1, int c1) {
 
 //-----------------------------------------------------------------------------
 /*! Stretch cells contained in rect r0,c0,r1,c1, from r1-r0+1 to nr.
-                If nr>r1-r0+1 add cells, overwise remove cells. */
+                If nr>r1-r0+1 add cells, otherwise remove cells. */
 void TXsheet::timeStretch(int r0, int c0, int r1, int c1, int nr) {
   int oldNr = r1 - r0 + 1;
   if (nr > oldNr) /* ingrandisce */

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -238,7 +238,7 @@ bool TXshLevelColumn::setNumbers(int row, int rowCount,
 
   // Find a level to input.
   // If the first target cell is empty, search the upper cells, and lower cells
-  // and use a level of firsty-found ocupied neighbor cell.
+  // and use a level of firsty-found occupied neighbor cell.
   TXshLevelP currentLevel;
   int tmpIndex = std::min(row - m_first, (int)m_cells.size() - 1);
   // search upper cells

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -178,7 +178,7 @@ void getIndexesRangefromFids(TXshSimpleLevel *level,
 }  // namespace
 
 //******************************************************************************************
-//    TXshSimpleLevel  impementation
+//    TXshSimpleLevel  implementation
 //******************************************************************************************
 
 bool TXshSimpleLevel::m_rasterizePli        = false;
@@ -1404,7 +1404,7 @@ void TXshSimpleLevel::save(const TFilePath &fp, const TFilePath &oldFp,
 
   if (isAreadOnlyLevel(dDstPath)) {
     if (m_editableRange.empty() &&
-        !m_temporaryHookMerged)  // file interaly locked
+        !m_temporaryHookMerged)  // file internally locked
       throw TSystemException(
           dDstPath, "The level cannot be saved: it is a read only level.");
     else if (getType() != OVL_XSHLEVEL) {


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,./thirdparty -L dum,inbetween,sinc,uint ./toonz/sources/toonzlib`