### PR TITLE
Fix semi-transparent gap appears with Bokeh Ref Iwa fx

### DIFF
--- a/toonz/sources/stdfx/iwa_bokehreffx.cpp
+++ b/toonz/sources/stdfx/iwa_bokehreffx.cpp
@@ -43,7 +43,7 @@ void releaseAllRastersAndPlans(QList<TRasterGR8P>& rasterList,
   releaseAllRasters(rasterList);
   for (int p = 0; p < planList.size(); p++) kiss_fft_free(planList.at(p));
 }
-};
+};  // namespace
 
 //------------------------------------
 BokehRefThread::BokehRefThread(int channel, kiss_fft_cpx* fftcpx_channel_before,
@@ -608,7 +608,9 @@ void Iwa_BokehRefFx::retrieveLayer(const float4* source_buff,
   TRasterGR8P generation_buff_ras = allocateRasterAndLock<unsigned char>(
       &generation_buff, TDimensionI(lx, ly));
 
-  for (int gen = 0; gen < margin; gen++) {
+  // extend (margin * 2) pixels in order to enough cover when two adjacent
+  // layers are both blurred in the maximum radius
+  for (int gen = 0; gen < margin * 2; gen++) {
     // apply single median filter
     doSingleMedian(source_buff, segment_layer_buff, indexMap_mainSub, index, lx,
                    ly, generation_buff, gen + 1);


### PR DESCRIPTION
This PR will fix the problem with Bokeh Ref Iwa fx with `Fill Gap` and `Use Median Filter` being activated.
To reproduce:
- Create Bokeh Ref Iwa fx,  connect any iris image to the "Iris" port, connect any non-transparent image to the "Source" port, and connect a Linear Gradient Fx to the "Depth" port, respectively.
- Make the Linear Gradient fx to be gradient from black to white, with large size.
- In the Bokeh Ref Iwa fx, set `On-Focus Distance` to 0. Toggle `Fill Gap` and `Use Median Filter` to ON.
- Preview the scene.

It causes unwanted semi-transparent gap in the result, at the border of "depth regions" separated by the depth reference images, especially where the bokeh radius is large. The gap becomes ovbious if you set the flipbook background to white.

The cause of this problem was shortage of median filter size. It should be doubled in order to enough cover when two adjacent layers are both blurred in the maximum radius.