### PR TITLE
Fix Toonz Raster MyPaint brush center

### DIFF
--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1019,6 +1019,7 @@ void ToonzRasterBrushTool::drawEmptyCircle(TPointD pos, int thick,
 
 TPointD ToonzRasterBrushTool::getCenteredCursorPos(
     const TPointD &originalCursorPos) {
+  if (m_isMyPaintStyleSelected) return originalCursorPos;
   TXshLevelHandle *levelHandle = m_application->getCurrentLevel();
   TXshSimpleLevel *level = levelHandle ? levelHandle->getSimpleLevel() : 0;
   TDimension resolution =

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -227,7 +227,7 @@ protected:
   static void drawEmptyCircle(TPointD point, int thick, bool isLxEven,
                               bool isLyEven, bool isPencil);
 
-  static TPointD getCenteredCursorPos(const TPointD &originalCursorPos);
+  TPointD getCenteredCursorPos(const TPointD &originalCursorPos);
 };
 
 //------------------------------------------------------------


### PR DESCRIPTION
MyPaint brush cursor is no longer centered for Toonz Raster levels.

![cursor_offset](https://user-images.githubusercontent.com/19245851/64091037-4f9d5480-cd1c-11e9-87b0-8bf35639bbb9.png)

Corrected by not applying the center adjustment logic if it's a MyPaint brush.

