### PR TITLE
Change Step and Interpolation Type of Selected Multiple Keyframes in Function Editor

### DIFF
--- a/toonz/sources/include/toonzqt/functionselection.h
+++ b/toonz/sources/include/toonzqt/functionselection.h
@@ -109,6 +109,28 @@ public:
   void doDelete();
   void insertCells();
 
+  // if inclusive == true, consider all segments overlapping the selection
+  void setStep(int, bool inclusive = true);
+  void setStep1() { setStep(1); }
+  void setStep2() { setStep(2); }
+  void setStep3() { setStep(3); }
+  void setStep4() { setStep(4); }
+
+  // return step if all the selected segments has the same value.
+  // return -1 if the selection does not overlap any segments
+  // return 0 if the step value is uneven in the selection
+  // if inclusive == true, consider all segments overlapping the selection
+  int getCommonStep(bool inclusive = true);
+
+  void setSegmentType(TDoubleKeyframe::Type type, bool inclusive = true);
+
+  // return TDoubleKeyframe::Type value if the selected segments has the same
+  // interpolation type. return -1 if the selection does not overlap any
+  // segments return 0 (TDoubleKeyframe::None) if the interpolation is not
+  // identical in the selection if inclusive == true, consider all segments
+  // overlapping the selection
+  int getCommonSegmentType(bool inclusive = true);
+
 signals:
   void selectionChanged();
 };

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -880,30 +880,17 @@ void FunctionSheetCellViewer::onMouseMovedInLineEdit(QMouseEvent *event) {
 
 // TODO: refactor: cfr functionpanel.cpp
 void FunctionSheetCellViewer::openContextMenu(QMouseEvent *e) {
-  struct locals {
-    static void sheet__setSegmentType(FunctionSelection *selection,
-                                      TDoubleParam *curve, int segmentIndex,
-                                      TDoubleKeyframe::Type type) {
-      selection->selectSegment(curve, segmentIndex);
-      KeyframeSetter setter(curve, segmentIndex);
-      setter.setType(type);
-    }
-  };  // locals
-
   QAction deleteKeyframeAction(tr("Delete Key"), 0);
   QAction insertKeyframeAction(tr("Set Key"), 0);
-  QAction setLinearAction(tr("Linear Interpolation"), 0);
-  QAction setSpeedInOutAction(tr("Speed In / Speed Out Interpolation"), 0);
-  QAction setEaseInOutAction(tr("Ease In / Ease Out Interpolation"), 0);
-  QAction setEaseInOut2Action(tr("Ease In / Ease Out (%) Interpolation"), 0);
-  QAction setExponentialAction(tr("Exponential Interpolation"), 0);
-  QAction setExpressionAction(tr("Expression Interpolation"), 0);
-  QAction setFileAction(tr("File Interpolation"), 0);
-  QAction setConstantAction(tr("Constant Interpolation"), 0);
-  QAction setStep1Action(tr("Step 1"), 0);
-  QAction setStep2Action(tr("Step 2"), 0);
-  QAction setStep3Action(tr("Step 3"), 0);
-  QAction setStep4Action(tr("Step 4"), 0);
+
+  QStringList interpNames;
+  interpNames << tr("Constant Interpolation") << tr("Linear Interpolation")
+              << tr("Speed In / Speed Out Interpolation")
+              << tr("Ease In / Ease Out Interpolation")
+              << tr("Ease In / Ease Out (%) Interpolation")
+              << tr("Exponential Interpolation")
+              << tr("Expression Interpolation") << tr("File Interpolation")
+              << tr("Similar Shape Interpolation");
   QAction activateCycleAction(tr("Activate Cycle"), 0);
   QAction deactivateCycleAction(tr("Deactivate Cycle"), 0);
   QAction showIbtwnAction(tr("Show Inbetween Values"), 0);
@@ -929,6 +916,15 @@ void FunctionSheetCellViewer::openContextMenu(QMouseEvent *e) {
   }
   int kIndex = curve->getPrevKeyframe(row);
 
+  // if the FunctionSelection is not current or when clicking outside of the
+  // selection, then select the clicked cell.
+  FunctionSelection *selection = m_sheet->getSelection();
+  if (!selection->getSelectedCells().contains(col, row)) {
+    selection->makeCurrent();
+    selection->selectCells(QRect(col, row, 1, 1));
+  }
+  CommandManager *cmdManager = CommandManager::instance();
+
   // build menu
   QMenu menu(0);
 
@@ -943,37 +939,35 @@ void FunctionSheetCellViewer::openContextMenu(QMouseEvent *e) {
   if (!isKeyframe)  // menu.addAction(&deleteKeyframeAction); else
     menu.addAction(&insertKeyframeAction);
 
-  if (!isEmpty && !isKeyframe && kIndex >= 0) {
+  // change interpolation commands
+  QList<QAction *> interpActions;
+  int interp = selection->getCommonSegmentType();
+  if (interp != -1) {
     menu.addSeparator();
-    QMenu *interpMenu  = menu.addMenu(tr("Change Interpolation"));
-    TDoubleKeyframe kf = curve->getKeyframe(kIndex);
-    if (kf.m_type != TDoubleKeyframe::Linear)
-      interpMenu->addAction(&setLinearAction);
-    if (kf.m_type != TDoubleKeyframe::SpeedInOut)
-      interpMenu->addAction(&setSpeedInOutAction);
-    if (kf.m_type != TDoubleKeyframe::EaseInOut)
-      interpMenu->addAction(&setEaseInOutAction);
-    if (kf.m_type != TDoubleKeyframe::EaseInOutPercentage)
-      interpMenu->addAction(&setEaseInOut2Action);
-    if (kf.m_type != TDoubleKeyframe::Exponential)
-      interpMenu->addAction(&setExponentialAction);
-    if (kf.m_type != TDoubleKeyframe::Expression)
-      interpMenu->addAction(&setExpressionAction);
-    if (kf.m_type != TDoubleKeyframe::File)
-      interpMenu->addAction(&setFileAction);
-    if (kf.m_type != TDoubleKeyframe::Constant)
-      interpMenu->addAction(&setConstantAction);
+    QMenu *interpMenu = menu.addMenu(tr("Change Interpolation"));
+    for (int i = (int)TDoubleKeyframe::Constant;
+         i <= (int)TDoubleKeyframe::SimilarShape; i++) {
+      if (interp != i) {
+        QAction *interpAction = new QAction(interpNames[i - 1], 0);
+        interpAction->setData(i);
+        interpActions.append(interpAction);
+        interpMenu->addAction(interpAction);
+      }
+    }
+  }
 
+  // change step commands
+  int step = selection->getCommonStep();
+  if (step != -1) {
     QMenu *stepMenu = menu.addMenu(tr("Change Step"));
-    if (kf.m_step != 1) stepMenu->addAction(&setStep1Action);
-    if (kf.m_step != 2) stepMenu->addAction(&setStep2Action);
-    if (kf.m_step != 3) stepMenu->addAction(&setStep3Action);
-    if (kf.m_step != 4) stepMenu->addAction(&setStep4Action);
+    if (step != 1) stepMenu->addAction(cmdManager->getAction("MI_ResetStep"));
+    if (step != 2) stepMenu->addAction(cmdManager->getAction("MI_Step2"));
+    if (step != 3) stepMenu->addAction(cmdManager->getAction("MI_Step3"));
+    if (step != 4) stepMenu->addAction(cmdManager->getAction("MI_Step4"));
   }
 
   menu.addSeparator();
 
-  CommandManager *cmdManager = CommandManager::instance();
   menu.addAction(cmdManager->getAction("MI_Cut"));
   menu.addAction(cmdManager->getAction("MI_Copy"));
   menu.addAction(cmdManager->getAction("MI_Paste"));
@@ -989,47 +983,16 @@ void FunctionSheetCellViewer::openContextMenu(QMouseEvent *e) {
       menu.addAction(&showIbtwnAction);
   }
 
-  FunctionSelection *selection = m_sheet->getSelection();
-  TSceneHandle *sceneHandle    = m_sheet->getViewer()->getSceneHandle();
+  TSceneHandle *sceneHandle = m_sheet->getViewer()->getSceneHandle();
   // execute menu
   QAction *action = menu.exec(e->globalPos());  // QCursor::pos());
   if (action == &deleteKeyframeAction) {
     KeyframeSetter::removeKeyframeAt(curve, row);
   } else if (action == &insertKeyframeAction) {
     KeyframeSetter(curve).createKeyframe(row);
-  } else if (action == &setLinearAction)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::Linear);
-  else if (action == &setSpeedInOutAction)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::SpeedInOut);
-  else if (action == &setEaseInOutAction)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::EaseInOut);
-  else if (action == &setEaseInOut2Action)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::EaseInOutPercentage);
-  else if (action == &setExponentialAction)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::Exponential);
-  else if (action == &setExpressionAction)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::Expression);
-  else if (action == &setFileAction)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::File);
-  else if (action == &setConstantAction)
-    locals::sheet__setSegmentType(selection, curve, kIndex,
-                                  TDoubleKeyframe::Constant);
-  else if (action == &setStep1Action)
-    KeyframeSetter(curve, kIndex).setStep(1);
-  else if (action == &setStep2Action)
-    KeyframeSetter(curve, kIndex).setStep(2);
-  else if (action == &setStep3Action)
-    KeyframeSetter(curve, kIndex).setStep(3);
-  else if (action == &setStep4Action)
-    KeyframeSetter(curve, kIndex).setStep(4);
-  else if (action == &activateCycleAction)
+  } else if (interpActions.contains(action)) {
+    selection->setSegmentType((TDoubleKeyframe::Type)action->data().toInt());
+  } else if (action == &activateCycleAction)
     KeyframeSetter::enableCycle(curve, true, sceneHandle);
   else if (action == &deactivateCycleAction)
     KeyframeSetter::enableCycle(curve, false, sceneHandle);


### PR DESCRIPTION
This PR will enhance the behavior of `Change Step` and `Change Interpolation` submenu commands in the context menu of Function Editor spread sheet. Now they will not only modify the clicked key frame segment, but also modify all segments overlapping the selection at the same time.

- When you right click outside of the selected cells, the selection will set to a single cell at the clicked position in advance of opening the context menu. (This behavior is just like the one in the Xsheet)
- `Change Step` commands can now trigger from the shortcut keys. Shortcut keys for the Xsheet commands `Reset Step` , `Step 2`, `Step 3` , and `Step 4` are now available in Function Editor as well.