### PR TITLE
Multi Channel Selection in Function Sheet Column Header

### DIFF
--- a/toonz/sources/include/toonzqt/functionsheet.h
+++ b/toonz/sources/include/toonzqt/functionsheet.h
@@ -48,6 +48,8 @@ class FunctionSheetColumnHeadViewer final : public Spreadsheet::ColumnPanel {
   QPoint m_dragStartPosition;
   FunctionTreeModel::Channel *m_draggingChannel;
 
+  int m_clickedColumn = -1;
+
 public:
   FunctionSheetColumnHeadViewer(FunctionSheet *parent);
 


### PR DESCRIPTION
This PR enhances the channel selection behavior of the column header area in Function Editor spread sheet.
You can now expand / shrink the channel selection by shift+clicking or by left dragging in the column header area.
This will enable users to easily copy&paste all keyframes in multiple channels to others.
