### PR TITLE
Use QDir::home() instead of getenv("HOME") in file browser

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -51,13 +51,10 @@ TFilePath getMyDocumentsPath() {
   return TFilePath((const char *)[documentsDirectory
       cStringUsingEncoding:NSASCIIStringEncoding]);
 #else
-  std::string path(getenv("HOME"));
-  if(path.empty()) return TFilePath();
-  path += "/Documents";
-  QString pathAsQString = QString::fromStdString(path);
-  QDir dir(pathAsQString);
+  QDir dir = QDir::home();
+  dir.cd("Documents");
   if(!dir.exists()) return TFilePath();
-  return TFilePath(path);
+  return TFilePath(dir.absolutePath().toStdString());
 #endif
 }
 
@@ -79,13 +76,10 @@ TFilePath getDesktopPath() {
   return TFilePath((const char *)[desktopDirectory
       cStringUsingEncoding:NSASCIIStringEncoding]);
 #else
-  std::string path(getenv("HOME"));
-  if(path.empty()) return TFilePath();
-  path += "/Desktop";
-  QString pathAsQString = QString::fromStdString(path);
-  QDir dir(pathAsQString);
+  QDir dir = QDir::home();
+  dir.cd("Desktop");
   if(!dir.exists()) return TFilePath();
-  return TFilePath(path);
+  return TFilePath(dir.absolutePath().toStdString());
 #endif
 }
 }

--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -52,8 +52,7 @@ TFilePath getMyDocumentsPath() {
       cStringUsingEncoding:NSASCIIStringEncoding]);
 #else
   QDir dir = QDir::home();
-  dir.cd("Documents");
-  if(!dir.exists()) return TFilePath();
+  if (!dir.cd("Documents")) return TFilePath();
   return TFilePath(dir.absolutePath().toStdString());
 #endif
 }
@@ -77,8 +76,7 @@ TFilePath getDesktopPath() {
       cStringUsingEncoding:NSASCIIStringEncoding]);
 #else
   QDir dir = QDir::home();
-  dir.cd("Desktop");
-  if(!dir.exists()) return TFilePath();
+  if (!dir.cd("Desktop")) return TFilePath();
   return TFilePath(dir.absolutePath().toStdString());
 #endif
 }


### PR DESCRIPTION
Use `QDir::home()` instead of `getenv("HOME")` when getting the "My Documents" and "Desktop" folders in the File Browser. This is more robust and makes the code easier to read.

This is following up from PR #2735.