### PR TITLE
Fix picking color of the snapshot image on Flipbook

### DIFF
--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -82,6 +82,8 @@ class ImageViewer final : public GLWidgetForHighDpi {
   void pickColor(QMouseEvent *event, bool putValueToStyleEditor = false);
   void rectPickColor(bool putValueToStyleEditor = false);
   void setPickedColorToStyleEditor(const TPixel32 &color);
+  // get the image (m_image or the snapshot) to be picked.
+  TImageP getPickedImage(QPointF mousePos);
 
 public:
   ImageViewer(QWidget *parent, FlipBook *flipbook, bool showHistogram);


### PR DESCRIPTION
This PR fixes the following problem with Flipbook, which appeared after introducing #2744 :
- When applying color collection with 3DLUT, OT fails to pick the color on the snapshot image. Currently it always picks the color on the current image.
