### PR TITLE
Ensure dragged curve handles stay inside graph (#2480)

### DIFF
--- a/toonz/sources/toonzqt/tonecurvefield.cpp
+++ b/toonz/sources/toonzqt/tonecurvefield.cpp
@@ -636,7 +636,7 @@ void ChennelCurveEditor::paintEvent(QPaintEvent *e) {
 void ChennelCurveEditor::mouseMoveEvent(QMouseEvent *e) {
   if (m_mouseButton == Qt::LeftButton && m_currentControlPointIndex != -1) {
     QPoint pos   = e->pos();
-    QPointF posF = QPointF(pos.x(), pos.y());
+    QPointF posF = checkPoint(QPointF(pos.x(), pos.y()));
     moveCurrentControlPoint(posF - m_points.at(m_currentControlPointIndex));
   }
 }


### PR DESCRIPTION
Fixes #2480. When the curve handles are dragged, they will now stay within the bounds of the graph.

Demo below:

![curve-handle-demo](https://user-images.githubusercontent.com/24422213/64643620-d82a9c00-d464-11e9-8cea-9af074c8fe62.gif)
