### PR TITLE
Remember last brush preset used

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -578,6 +578,8 @@ void FullColorBrushTool::setWorkAndBackupImages() {
 //------------------------------------------------------------------
 
 bool FullColorBrushTool::onPropertyChanged(std::string propertyName) {
+  if (m_propertyUpdating) return true;
+
   updateCurrentStyle();
 
   if (propertyName == "Preset:") {
@@ -587,7 +589,9 @@ bool FullColorBrushTool::onPropertyChanged(std::string propertyName) {
       loadLastBrush();
 
     FullcolorBrushPreset = m_preset.getValueAsString();
+    m_propertyUpdating   = true;
     getApplication()->getCurrentTool()->notifyToolChanged();
+    m_propertyUpdating = false;
     return true;
   }
 
@@ -605,7 +609,9 @@ bool FullColorBrushTool::onPropertyChanged(std::string propertyName) {
   if (m_preset.getValue() != CUSTOM_WSTR) {
     m_preset.setValue(CUSTOM_WSTR);
     FullcolorBrushPreset = m_preset.getValueAsString();
+    m_propertyUpdating   = true;
     getApplication()->getCurrentTool()->notifyToolChanged();
+    m_propertyUpdating = false;
   }
 
   return true;

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -76,6 +76,8 @@ public:
   void addPreset(QString name);
   void removePreset();
 
+  void loadLastBrush();
+
   void onCanvasSizeChanged();
   void onColorStyleChanged();
 

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -122,6 +122,8 @@ protected:
   bool m_firstTime;
   bool m_mousePressed = false;
   TMouseEvent m_mouseEvent;
+
+  bool m_propertyUpdating = false;
 };
 
 //------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -55,6 +55,7 @@ TEnv::IntVar RasterBrushPencilMode("InknpaintRasterBrushPencilMode", 0);
 TEnv::IntVar BrushPressureSensitivity("InknpaintBrushPressureSensitivity", 1);
 TEnv::DoubleVar RasterBrushHardness("RasterBrushHardness", 100);
 TEnv::DoubleVar RasterBrushModifierSize("RasterBrushModifierSize", 0);
+TEnv::StringVar RasterBrushPreset("RasterBrushPreset", "<custom>");
 
 //-------------------------------------------------------------------
 #define CUSTOM_WSTR L"<custom>"
@@ -1125,17 +1126,16 @@ void ToonzRasterBrushTool::onActivate() {
   if (!m_notifier) m_notifier = new ToonzRasterBrushToolNotifier(this);
 
   if (m_firstTime) {
-    m_rasThickness.setValue(
-        TDoublePairProperty::Value(RasterBrushMinSize, RasterBrushMaxSize));
-
-    m_drawOrder.setIndex(BrushDrawOrder);
-    m_pencil.setValue(RasterBrushPencilMode ? 1 : 0);
-    m_hardness.setValue(RasterBrushHardness);
-
-    m_pressure.setValue(BrushPressureSensitivity ? 1 : 0);
     m_firstTime = false;
-    m_smooth.setValue(BrushSmooth);
-    m_modifierSize.setValue(RasterBrushModifierSize);
+
+    std::wstring wpreset =
+        QString::fromStdString(RasterBrushPreset.getValue()).toStdWString();
+    if (wpreset != CUSTOM_WSTR) {
+      initPresets();
+      m_preset.setValue(wpreset);
+      loadPreset();
+    } else
+      loadLastBrush();
   }
   m_brushPad = ToolUtils::getBrushPad(m_rasThickness.getValue().second,
                                       m_hardness.getValue() * 0.01);
@@ -1936,11 +1936,18 @@ void ToonzRasterBrushTool::setWorkAndBackupImages() {
 //------------------------------------------------------------------
 
 bool ToonzRasterBrushTool::onPropertyChanged(std::string propertyName) {
-  // Set the following to true whenever a different piece of interface must
-  // be refreshed - done once at the end.
-  bool notifyTool = false;
+  if (propertyName == m_preset.getName()) {
+    if (m_preset.getValue() != CUSTOM_WSTR)
+      loadPreset();
+    else  // Chose <custom>, go back to last saved brush settings
+      loadLastBrush();
 
-  /*--- 変更されたPropertyに合わせて処理を分ける ---*/
+    RasterBrushPreset = m_preset.getValueAsString();
+    getApplication()->getCurrentTool()->notifyToolChanged();
+    return true;
+  }
+
+  /*--- Divide the process according to the changed Property ---*/
 
   /*--- determine which type of brush to be modified ---*/
   if (propertyName == m_rasThickness.getName()) {
@@ -1951,9 +1958,6 @@ bool ToonzRasterBrushTool::onPropertyChanged(std::string propertyName) {
     m_maxThick = m_rasThickness.getValue().second;
   } else if (propertyName == m_smooth.getName()) {
     BrushSmooth = m_smooth.getValue();
-  } else if (propertyName == m_preset.getName()) {
-    loadPreset();
-    notifyTool = true;
   } else if (propertyName == m_drawOrder.getName()) {
     BrushDrawOrder = m_drawOrder.getIndex();
   } else if (propertyName == m_pencil.getName()) {
@@ -1974,13 +1978,11 @@ bool ToonzRasterBrushTool::onPropertyChanged(std::string propertyName) {
     invalidate(rect);
   }
 
-  if (propertyName != m_preset.getName() &&
-      m_preset.getValue() != CUSTOM_WSTR) {
+  if (m_preset.getValue() != CUSTOM_WSTR) {
     m_preset.setValue(CUSTOM_WSTR);
-    notifyTool = true;
+    RasterBrushPreset = m_preset.getValueAsString();
+    getApplication()->getCurrentTool()->notifyToolChanged();
   }
-
-  if (notifyTool) getApplication()->getCurrentTool()->notifyToolChanged();
 
   return true;
 }
@@ -2069,6 +2071,21 @@ void ToonzRasterBrushTool::removePreset() {
 
   // No parameter change, and set the preset value to custom
   m_preset.setValue(CUSTOM_WSTR);
+}
+
+//------------------------------------------------------------------
+
+void ToonzRasterBrushTool::loadLastBrush() {
+  m_rasThickness.setValue(
+      TDoublePairProperty::Value(RasterBrushMinSize, RasterBrushMaxSize));
+
+  m_drawOrder.setIndex(BrushDrawOrder);
+  m_pencil.setValue(RasterBrushPencilMode ? 1 : 0);
+  m_hardness.setValue(RasterBrushHardness);
+
+  m_pressure.setValue(BrushPressureSensitivity ? 1 : 0);
+  m_smooth.setValue(BrushSmooth);
+  m_modifierSize.setValue(RasterBrushModifierSize);
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1936,14 +1936,18 @@ void ToonzRasterBrushTool::setWorkAndBackupImages() {
 //------------------------------------------------------------------
 
 bool ToonzRasterBrushTool::onPropertyChanged(std::string propertyName) {
+  if (m_propertyUpdating) return true;
+
   if (propertyName == m_preset.getName()) {
     if (m_preset.getValue() != CUSTOM_WSTR)
       loadPreset();
     else  // Chose <custom>, go back to last saved brush settings
       loadLastBrush();
 
-    RasterBrushPreset = m_preset.getValueAsString();
+    RasterBrushPreset  = m_preset.getValueAsString();
+    m_propertyUpdating = true;
     getApplication()->getCurrentTool()->notifyToolChanged();
+    m_propertyUpdating = false;
     return true;
   }
 
@@ -1980,8 +1984,10 @@ bool ToonzRasterBrushTool::onPropertyChanged(std::string propertyName) {
 
   if (m_preset.getValue() != CUSTOM_WSTR) {
     m_preset.setValue(CUSTOM_WSTR);
-    RasterBrushPreset = m_preset.getValueAsString();
+    RasterBrushPreset  = m_preset.getValueAsString();
+    m_propertyUpdating = true;
     getApplication()->getCurrentTool()->notifyToolChanged();
+    m_propertyUpdating = false;
   }
 
   return true;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -156,6 +156,8 @@ public:
   void addPreset(QString name);
   void removePreset();
 
+  void loadLastBrush();
+
   void finishRasterBrush(const TPointD &pos, double pressureVal);
   // return true if the pencil mode is active in the Brush / PaintBrush / Eraser
   // Tools.

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -223,6 +223,8 @@ protected:
   QElapsedTimer m_brushTimer;
   int m_minCursorThick, m_maxCursorThick;
 
+  bool m_propertyUpdating = false;
+
 protected:
   static void drawLine(const TPointD &point, const TPointD &centre,
                        bool horizontal, bool isDecimal);

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1438,6 +1438,8 @@ void ToonzVectorBrushTool::resetFrameRange() {
 //------------------------------------------------------------------
 
 bool ToonzVectorBrushTool::onPropertyChanged(std::string propertyName) {
+  if (m_propertyUpdating) return true;
+
   // Set the following to true whenever a different piece of interface must
   // be refreshed - done once at the end.
   bool notifyTool = false;
@@ -1449,7 +1451,9 @@ bool ToonzVectorBrushTool::onPropertyChanged(std::string propertyName) {
       loadLastBrush();
 
     V_VectorBrushPreset = m_preset.getValueAsString();
+    m_propertyUpdating  = true;
     getApplication()->getCurrentTool()->notifyToolChanged();
+    m_propertyUpdating = false;
     return true;
   }
 
@@ -1505,7 +1509,11 @@ bool ToonzVectorBrushTool::onPropertyChanged(std::string propertyName) {
     notifyTool          = true;
   }
 
-  if (notifyTool) getApplication()->getCurrentTool()->notifyToolChanged();
+  if (notifyTool) {
+    m_propertyUpdating = true;
+    getApplication()->getCurrentTool()->notifyToolChanged();
+    m_propertyUpdating = false;
+  }
 
   return true;
 }

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -197,6 +197,8 @@ protected:
 
   TPointD m_lastDragPos;        //!< Position where mouse was last dragged.
   TMouseEvent m_lastDragEvent;  //!< Previous mouse-drag event.
+
+  bool m_propertyUpdating = false;
 };
 
 #endif  // TOONZVECTORBRUSHTOOL_H

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -118,6 +118,8 @@ public:
   void addPreset(QString name);
   void removePreset();
 
+  void loadLastBrush();
+
   // return true if the pencil mode is active in the Brush / PaintBrush / Eraser
   // Tools.
   bool isPencilModeActive() override;
@@ -193,8 +195,8 @@ protected:
   ˆÚ“®‚µ‚Ä‚¢‚½‚Æ‚«‚Ì•s‹ï‡‚ğC³‚·‚éB---*/
   TFrameId m_workingFrameId;
 
-  TPointD m_lastDragPos; //!< Position where mouse was last dragged.
-  TMouseEvent m_lastDragEvent; //!< Previous mouse-drag event.
+  TPointD m_lastDragPos;        //!< Position where mouse was last dragged.
+  TMouseEvent m_lastDragEvent;  //!< Previous mouse-drag event.
 };
 
 #endif  // TOONZVECTORBRUSHTOOL_H


### PR DESCRIPTION
This PR fixes #2757 

Modified the logic to save the preset value for later use.   When loading the brush tool, if the preset is valued, it will load the settings for it instead of the `<custom>` settings stored in environment variables.

Also made it so when switching to a preset, the `<custom>` settings are not changed so if the user switches back to `<custom>`, the prior values are restored.  The settings are overridden when changing a setting on a preset, making the new settings the `<custom>` settings.

Also fixed an issue when changing from `<custom>` to a preset.  Although the preset values are loaded which switching, the `Preset:` dropdown reverts back to `<custom>`.  This typically happens only when the custom and preset values for a single control sliders differ, like Accuracy on the Vector brush options.
