### PR TITLE
Make control points easier to click (#1722)

### DIFF
--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -429,7 +429,8 @@ void ControlPointEditorTool::mouseMove(const TPointD &pos,
 void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
                                             const TMouseEvent &e) {
   m_pos           = pos;
-  double maxDist  = 5 * getPixelSize();
+  double pix      = getPixelSize() * 2.0f;
+  double maxDist  = 5 * pix;
   double maxDist2 = maxDist * maxDist;
   double dist2    = 0;
   int pointIndex;


### PR DESCRIPTION
Fixes #1722. When a control point is highlighted (expanded), clicking anywhere on it will select and drag it as expected.

Demo below:

![control-point-demo](https://user-images.githubusercontent.com/24422213/65006249-a464e000-d956-11e9-95a6-6897f790b11f.gif)

For this fix, I updated the calculation for `maxDist2` in `ControlPointEditorTool::leftButtonDown` to match `ControlPointEditorTool::drawControlPoint`.

NOTE: The second post on on the bug report (https://github.com/opentoonz/opentoonz/issues/1722#issuecomment-356170985) mentions a problem with selecting a vector by clicking on it's fill. Should that be logged as a separate issue?
