### PR TITLE
Fix Fx Settings Geometry Restoration

### DIFF
--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -232,7 +232,7 @@ public:
       return false;
   };
 
-  void restoreFloatingPanelState();
+  virtual void restoreFloatingPanelState();
 
 protected:
   void paintEvent(QPaintEvent *) override;

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -73,6 +73,7 @@
 #include "toonz/palettecmd.h"
 #include "toonz/preferences.h"
 #include "tw/stringtable.h"
+#include "toonz/toonzfolders.h"
 
 // TnzBase includes
 #include "trasterfx.h"
@@ -1381,6 +1382,26 @@ FxSettingsPanel::FxSettingsPanel(QWidget *parent) : TPanel(parent) {
   m_fxSettings->setCurrentFx();
 
   setWidget(m_fxSettings);
+}
+
+// FxSettings will adjust its size according to the current fx
+// so we only restore position of the panel.
+void FxSettingsPanel::restoreFloatingPanelState() {
+  TFilePath savePath = ToonzFolder::getMyModuleDir() + TFilePath("popups.ini");
+  QSettings settings(QString::fromStdWString(savePath.getWideString()),
+                     QSettings::IniFormat);
+  settings.beginGroup("Panels");
+
+  if (!settings.childGroups().contains("FxSettings")) return;
+
+  settings.beginGroup("FxSettings");
+
+  QRect geom = settings.value("geometry", saveGeometry()).toRect();
+  // check if it can be visible in the current screen
+  if (!(geom & QApplication::desktop()->availableGeometry(this)).isEmpty())
+    move(geom.topLeft());
+
+  // FxSettings has no optional settings (SaveLoadQSettings) to load
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -280,6 +280,9 @@ class FxSettingsPanel final : public TPanel {
 
 public:
   FxSettingsPanel(QWidget *parent);
+  // FxSettings will adjust its size according to the current fx
+  // so we only restore position of the panel.
+  void restoreFloatingPanelState() override;
 };
 
 #endif


### PR DESCRIPTION
This PR will fix the problem as follows:
- Fx settings fails to resize according to the current fx parameters when opening for the first time after launch.

To reproduce:
1. Open Schematic, create some fx (say, `Blur Fx`).
1. Double click the fx node. Fx settings opens.
1. Close the Fx settings.
1. Restart OpenToonz.
1. Create some fx which is different from the previous one (say, `Bokeh Iwa Fx`).
1. Double click the fx node. 
1. Fx settings opens with improper size. 

The problem is due to the restoration process of the panel geometry. I modified it to reproduce only the position for Fx Settings panel. 
