### PR TITLE
Fix Animate Tool Availability

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -603,7 +603,7 @@ void TTool::notifyImageChanged() {
 //-----------------------------------------------------------------------------
 
 /*! Notify change of image in \b fid: update icon and notify level change.
-*/
+ */
 void TTool::notifyImageChanged(const TFrameId &fid) {
   onImageChanged();
 
@@ -846,6 +846,17 @@ QString TTool::updateEnabled() {
   if (columnIndex < 0 && (targetType & TTool::EmptyTarget) &&
       (m_name == T_Type || m_name == T_Geometric || m_name == T_Brush))
     return (enable(false), QString());
+
+  // In case of Animate Tool
+  if (m_name == T_Edit && !filmstrip) {
+    // if an object other than column is selected, then enable the tool
+    // regardless of the current column state
+    if (!m_application->getCurrentObject()->getObjectId().isColumn())
+      return (enable(true), QString());
+    // if a column object is selected, switch the inspected column to it
+    column = xsh->getColumn(
+        m_application->getCurrentObject()->getObjectId().getIndex());
+  }
 
   // Check against unplaced columns (not in filmstrip mode)
   if (column && !filmstrip) {


### PR DESCRIPTION
This PR fixes Animate Tool being incorrectly disabled with operations as follows:
1. Load or create a level in a column 1.
1. Hide the column 1.
1. Select Animate Tool.
1. In tool options, switch the current object to "Camera1" .
1. Move the cursor to the viewer and see if the tool is available.

I modified the animate tool's availability to be defined not by the _current column_'s state, but by the _current object_.