### PR TITLE
Add stuff folder to AppVeyor build artifact

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,9 +53,9 @@ after_build:
     
     copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%\OpenToonz
 
-    mkdir "%CONFIGURATION%\OpenToonz\OpenToonz stuff"
+    mkdir "%CONFIGURATION%\OpenToonz stuff"
 
-    xcopy /Y /E ..\..\stuff "%CONFIGURATION%\OpenToonz\OpenToonz stuff"
+    xcopy /Y /E ..\..\stuff "%CONFIGURATION%\OpenToonz stuff"
     
 artifacts:
 - path: toonz\$(PLATFORM)\$(CONFIGURATION)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,19 +33,30 @@ build:
   verbosity: minimal
 after_build:
 - cmd: >-
-    C:\Qt\5.9\msvc2015_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz.exe
+    mkdir %CONFIGURATION%\OpenToonz
 
-    copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%
+    move %CONFIGURATION%\*.dll %CONFIGURATION%\OpenToonz
 
-    copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION%
+    move %CONFIGURATION%\*.exe %CONFIGURATION%\OpenToonz
 
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll %CONFIGURATION%
+    C:\Qt\5.9\msvc2015_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz\OpenToonz.exe
 
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll %CONFIGURATION%
+    copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%\OpenToonz
 
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll %CONFIGURATION%
+    copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION%\OpenToonz
+
+    copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll %CONFIGURATION%\OpenToonz
+
+    copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll %CONFIGURATION%\OpenToonz
+
+    copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll %CONFIGURATION%\OpenToonz
     
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%
+    copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%\OpenToonz
+
+    mkdir "%CONFIGURATION%\OpenToonz\OpenToonz stuff"
+
+    xcopy /Y /E ..\..\stuff "%CONFIGURATION%\OpenToonz\OpenToonz stuff"
+    
 artifacts:
 - path: toonz\$(PLATFORM)\$(CONFIGURATION)
   name: OpenToonz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,7 @@ after_build:
 - cmd: >-
     mkdir %CONFIGURATION%\OpenToonz
 
-    move %CONFIGURATION%\*.dll %CONFIGURATION%\OpenToonz
-
-    move %CONFIGURATION%\*.exe %CONFIGURATION%\OpenToonz
+    move %CONFIGURATION%\*.* %CONFIGURATION%\OpenToonz
 
     C:\Qt\5.9\msvc2015_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz\OpenToonz.exe
 


### PR DESCRIPTION
In order to facilitate proper testing of AppVeyor builds by the community, it is necessary to include the `stuff` folder as part of the artifact so they can test any changes to it.

Therefore, this PR modifies the AppVeyor build script to do the following:

1. Create an `OpenToonz` folder and move all OpenToonz components (.exe, .dll, etc) into it as normal.
     - Currently if you unzip the AppVeyor artifact, it spits it out into the current directory which is annoying.

2. Creates an `OpenToonz stuff` folder and copies the contents of the `stuff` folder into it

     - Testers can either temporarily replace theirs with this one or rename it `portablestuff` and move it into the `OpenToonz` directory to test as a portable.