### PR TITLE
Fix filmstrip disabled tools

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -843,7 +843,7 @@ QString TTool::updateEnabled() {
     return (enable(true), QString());
 
   // Check against camera column
-  if (columnIndex < 0 && (targetType & TTool::EmptyTarget) &&
+  if (!filmstrip && columnIndex < 0 && (targetType & TTool::EmptyTarget) &&
       (m_name == T_Type || m_name == T_Geometric || m_name == T_Brush))
     return (enable(false), QString());
 

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1201,7 +1201,7 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
   if (!app) return;
 
   int col   = app->getCurrentColumn()->getColumnIndex();
-  m_enabled = col >= 0;
+  m_enabled = col >= 0 || app->getCurrentFrame()->isEditingLevel();
   // todo: gestire autoenable
   if (!m_enabled) return;
 

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -645,7 +645,7 @@ void ToonzVectorBrushTool::leftButtonDown(const TPointD &pos,
 
   int col   = app->getCurrentColumn()->getColumnIndex();
   m_isPath  = app->getCurrentObject()->isSpline();
-  m_enabled = col >= 0 || m_isPath;
+  m_enabled = col >= 0 || m_isPath || app->getCurrentFrame()->isEditingLevel();
   // todo: gestire autoenable
   if (!m_enabled) return;
   if (!m_isPath) {


### PR DESCRIPTION
This PR fixes #2783.

Modified to
- Ignore Camera Column checks while in Level Strip.
- Ensure the Vector and Toonz Raster brushes are enabled while in Level Strip if the currentl column isn'ta valid column or a spline (if vector) to begin with.
