### PR TITLE
Remove selection requirement to toggle Camera Column

### DIFF
--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -49,11 +49,6 @@ void TColumnSelection::enableCommands() {
   enableCommand(this, MI_Resequence, &TColumnSelection::resequence);
   enableCommand(this, MI_CloneChild, &TColumnSelection::cloneChild);
   enableCommand(this, MI_FoldColumns, &TColumnSelection::hideColumns);
-
-  if (Preferences::instance()->isShowKeyframesOnXsheetCellAreaEnabled())
-    enableCommand(this, MI_ToggleXsheetCameraColumn,
-                  &TColumnSelection::toggleCameraColumn);
-
   enableCommand(this, MI_Reframe1, &TColumnSelection::reframe1Cells);
   enableCommand(this, MI_Reframe2, &TColumnSelection::reframe2Cells);
   enableCommand(this, MI_Reframe3, &TColumnSelection::reframe3Cells);
@@ -269,12 +264,4 @@ void TColumnSelection::hideColumns() {
   // colonne)
   //  TApp::instance()->->notify(TColumnHeadChange());
   app->getCurrentScene()->setDirtyFlag(true);
-}
-
-//-----------------------------------------------------------------------------
-
-void TColumnSelection::toggleCameraColumn() {
-  Preferences *pref = Preferences::instance();
-  pref->enableXsheetCameraColumn(!pref->isXsheetCameraColumnVisible());
-  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
 }

--- a/toonz/sources/toonz/columnselection.h
+++ b/toonz/sources/toonz/columnselection.h
@@ -45,7 +45,6 @@ public:
   void cloneChild();
 
   void hideColumns();
-  void toggleCameraColumn();
 
   void reframeCells(int count);
   void reframe1Cells() { reframeCells(1); }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1758,7 +1758,7 @@ void MainWindow::defineActions() {
                          "Alt+L");
   createRightClickMenuAction(MI_ToggleXSheetToolbar,
                              tr("Toggle XSheet Toolbar"), "");
-  createMenuXsheetAction(MI_ToggleXsheetCameraColumn,
+  createRightClickMenuAction(MI_ToggleXsheetCameraColumn,
                          tr("Show/Hide Xsheet Camera Column"), "");
   createMenuCellsAction(MI_Reverse, tr("&Reverse"), "");
   createMenuCellsAction(MI_Swing, tr("&Swing"), "");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1758,8 +1758,8 @@ void MainWindow::defineActions() {
                          "Alt+L");
   createRightClickMenuAction(MI_ToggleXSheetToolbar,
                              tr("Toggle XSheet Toolbar"), "");
-  createRightClickMenuAction(MI_ToggleXsheetCameraColumn,
-                             tr("Show/Hide Xsheet Camera Column"), "");
+  createMenuXsheetAction(MI_ToggleXsheetCameraColumn,
+                         tr("Show/Hide Xsheet Camera Column"), "");
   createMenuCellsAction(MI_Reverse, tr("&Reverse"), "");
   createMenuCellsAction(MI_Swing, tr("&Swing"), "");
   createMenuCellsAction(MI_Random, tr("&Random"), "");

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2131,3 +2131,25 @@ void PrintXsheetCommand::execute() {
 
   TSystem::showDocument(fp);
 }
+
+//-----------------------------------------------------------------------------
+
+class ToggleXsheetCameraColumnCommand final : public MenuItemHandler {
+public:
+  ToggleXsheetCameraColumnCommand()
+      : MenuItemHandler(MI_ToggleXsheetCameraColumn) {}
+
+  void execute() override {
+    Preferences *pref = Preferences::instance();
+    if (!pref->isShowKeyframesOnXsheetCellAreaEnabled()) {
+      DVGui::warning(
+          QObject::tr("Please enable \"Show Keyframes on Cell Area\" to show "
+                      "or hide the camera column."));
+      return;
+    }
+
+    pref->enableXsheetCameraColumn(!pref->isXsheetCameraColumnVisible());
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+} ToggleXsheetCameraColumnCommand;


### PR DESCRIPTION
This PR resolves #2785

Moved the logic for toggling the Camera Column from cell selection to xsheet command.
