### PR TITLE
Save Specified Frame Numbers of Color Model in Palette

### DIFF
--- a/toonz/sources/include/tpalette.h
+++ b/toonz/sources/include/tpalette.h
@@ -216,6 +216,8 @@ private:
 
   int m_currentStyleId;
 
+  bool m_areRefLevelFidsSpecified = false;
+
 public:
   TPalette();
   ~TPalette();
@@ -318,10 +320,11 @@ between RGBA color components.
     m_version = v;
   }  //!< Sets the palette's version number
 
-  void setRefLevelFids(const std::vector<TFrameId> fids);  //!< Associates the
-                                                           //! list of frames \e
-  //! fids to this
-  //! palette.
+  void setRefLevelFids(const std::vector<TFrameId> fids,
+                       bool specified);  //!< Associates the
+                                         //! list of frames \e
+  //! fids to this palette.
+  //! When specified == true fids were specified by user on loading.
   std::vector<TFrameId> getRefLevelFids();  //!< Returns the list of frames
                                             //! associated to this palette.
 

--- a/toonz/sources/toonz/colormodelviewer.cpp
+++ b/toonz/sources/toonz/colormodelviewer.cpp
@@ -519,7 +519,7 @@ void ColorModelViewer::loadCurrentFrame() {
 
   std::vector<TFrameId> fids;
   fids.push_back(fid);
-  currentPalette->setRefLevelFids(fids);
+  currentPalette->setRefLevelFids(fids, false);
 
   m_currentRefImgPath = xl->getPath();
 

--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -718,7 +718,7 @@ public:
     assert(page);
     m_pageName = page->getName();
     m_styles.resize(page->getStyleCount());
-    for (int i    = 0; i < page->getStyleCount(); i++)
+    for (int i = 0; i < page->getStyleCount(); i++)
       m_styles[i] = page->getStyleId(i);
   }
   void undo() const override {
@@ -840,7 +840,7 @@ int loadRefImage(TPaletteHandle *paletteHandle,
         }
       }
     }
-    levelPalette->setRefLevelFids(fids);
+    levelPalette->setRefLevelFids(fids, !frames.empty());
 
     const TLevel::Table *table = level->getTable();
 
@@ -1018,7 +1018,7 @@ void PaletteCmd::removeReferenceImage(TPaletteHandle *paletteHandle) {
   levelPalette->setRefImgPath(TFilePath());
 
   std::vector<TFrameId> fids;
-  levelPalette->setRefLevelFids(fids);
+  levelPalette->setRefLevelFids(fids, false);
 
   levelPalette->setDirtyFlag(true);
   paletteHandle->notifyPaletteChanged();
@@ -1242,7 +1242,7 @@ public:
   }
   int getHistoryType() override { return HistoryType::Palette; }
 };
-}
+}  // namespace
 
 void PaletteCmd::organizePaletteStyle(
     TPaletteHandle *paletteHandle, int styleId,
@@ -1335,7 +1335,7 @@ TPixel32 pickColor(TRasterImageP ri, const TPoint &rasterPoint) {
 
   return TPixel32::Transparent;
 }
-}
+}  // namespace
 
 void PaletteCmd::pickColorByUsingPickedPosition(TPaletteHandle *paletteHandle,
                                                 TImageP img, int frame) {


### PR DESCRIPTION
When loading the color model, you can specify frames to load by typing frame numbers in the `Frames` field in the `Load Color Model` popup.
However, currently such frame numbers are not saved in the palette.
Therefore, when you are using this feature, if you would like to continue your ink&paint work from yesterday you need to load the same color model just for specifying the frames again.

This PR will resolve such trouble.
If user specifies the frames on loading the color model, it will be saved in `fids` attribute of `refImgPath` tag in the palette file (.tpl) so that it will be reproduced on loading.