### PR TITLE
Add ability to move curve points using arrow keys

### DIFF
--- a/toonz/sources/include/toonzqt/tonecurvefield.h
+++ b/toonz/sources/include/toonzqt/tonecurvefield.h
@@ -93,6 +93,11 @@ protected:
   void removeControlPoint(int index);
   void removeCurrentControlPoint();
 
+  void selectNextControlPoint();
+  void selectPreviousControlPoint();
+  void moveCurrentControlPointUp();
+  void moveCurrentControlPointDown();
+
   QPainterPath getPainterPath();
 
   void paintEvent(QPaintEvent *) override;

--- a/toonz/sources/toonzqt/tonecurvefield.cpp
+++ b/toonz/sources/toonzqt/tonecurvefield.cpp
@@ -460,6 +460,64 @@ void ChennelCurveEditor::removeCurrentControlPoint() {
 
 //-----------------------------------------------------------------------------
 
+void ChennelCurveEditor::selectNextControlPoint()
+{
+  int controlPointCount = (int)m_points.size();
+
+  if (controlPointCount == 0)
+    return;
+
+  int firstVisibleControlPoint = 3;
+  int lastVisibleControlPoint = m_points.size() - 4;
+
+  m_currentControlPointIndex++;
+  if (m_currentControlPointIndex < firstVisibleControlPoint || m_currentControlPointIndex > lastVisibleControlPoint)
+    m_currentControlPointIndex = firstVisibleControlPoint;
+
+  update();
+}
+
+//-----------------------------------------------------------------------------
+
+void ChennelCurveEditor::selectPreviousControlPoint()
+{
+  int controlPointCount = (int)m_points.size();
+
+  if (controlPointCount == 0)
+    return;
+
+  int firstVisibleControlPoint = 3;
+  int lastVisibleControlPoint = m_points.size() - 4;
+
+  m_currentControlPointIndex--;
+  if (m_currentControlPointIndex < firstVisibleControlPoint || m_currentControlPointIndex > lastVisibleControlPoint)
+    m_currentControlPointIndex = lastVisibleControlPoint;
+
+  update();
+}
+
+//-----------------------------------------------------------------------------
+
+void ChennelCurveEditor::moveCurrentControlPointUp()
+{
+  if (m_currentControlPointIndex < 0)
+    return;
+
+  moveCurrentControlPoint(QPointF(0, -10));
+}
+
+//-----------------------------------------------------------------------------
+
+void ChennelCurveEditor::moveCurrentControlPointDown()
+{
+  if (m_currentControlPointIndex < 0)
+    return;
+
+  moveCurrentControlPoint(QPointF(0, 10));
+}
+
+//-----------------------------------------------------------------------------
+
 void ChennelCurveEditor::removeControlPoint(int index) {
   // Non posso eliminare il primo punto di controllo visibile quindi lo rimetto
   // in condizione iniziale
@@ -681,6 +739,10 @@ void ChennelCurveEditor::mouseReleaseEvent(QMouseEvent *e) {
 
 void ChennelCurveEditor::keyPressEvent(QKeyEvent *e) {
   if (e->key() == Qt::Key_Delete) removeCurrentControlPoint();
+  if (e->key() == Qt::Key_Right) selectNextControlPoint();
+  if (e->key() == Qt::Key_Left) selectPreviousControlPoint();
+  if (e->key() == Qt::Key_Up) moveCurrentControlPointUp();
+  if (e->key() == Qt::Key_Down) moveCurrentControlPointDown();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This is a possible fix for #2480 and alternative to #2767. Allows selecting/moving points in the graph editor using the arrow keys:

- Right arrow key selects next point.
- Left arrow key selects previous point.
- Up arrow key moves selected point up 10 units.
- Down arrow key moves selected point down 10 units.

Demo below:

![arrow-key-move-demo](https://user-images.githubusercontent.com/24422213/65369174-3134d400-dc9e-11e9-824e-29cffa2aa593.gif)

I'm happy for the PR to be closed if it does not seem that useful.
