### PR TITLE
Fix for pump tool using Wacom tablet (#2180)

### DIFF
--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -578,6 +578,13 @@ void DragSelectionTool::VectorDeformTool::applyTransform(FourPoints bbox) {
 
   VectorFreeDeformer *freeDeformer =
       static_cast<VectorFreeDeformer *>(tool->getFreeDeformer());
+
+  const bool stayedTheSame =
+      bbox.getP00() == freeDeformer->getPoint(0) &&
+      bbox.getP10() == freeDeformer->getPoint(1) &&
+      bbox.getP11() == freeDeformer->getPoint(2) &&
+      bbox.getP01() == freeDeformer->getPoint(3);
+
   freeDeformer->setPoints(bbox.getP00(), bbox.getP10(), bbox.getP11(),
                           bbox.getP01());
   freeDeformer->setComputeRegion(!m_isDragging);
@@ -593,7 +600,7 @@ void DragSelectionTool::VectorDeformTool::applyTransform(FourPoints bbox) {
 
   if (!m_isDragging) tool->notifyImageChanged();
 
-  tool->m_deformValues.m_isSelectionModified = true;
+  if (!stayedTheSame) tool->m_deformValues.m_isSelectionModified = true;
 
   if (!m_isDragging && (tool->isLevelType() || tool->isSelectedFramesType()))
     transformWholeLevel();


### PR DESCRIPTION
Fixes #2180. The pump tool is now enabled as expected after making a vector selection
with a tablet.