### PR TITLE
Update macOS Info.plist to include missing strings

### DIFF
--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -4,28 +4,26 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenToonz</string>
 	<key>CFBundleExecutable</key>
 	<string>OpenToonz</string>
-	<key>CFBundleGetInfoString</key>
-	<string></string>
 	<key>CFBundleIconFile</key>
 	<string>OpenToonz.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>io.github.opentoonz.OpenToonz</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleLongVersionString</key>
-	<string></string>
 	<key>CFBundleName</key>
-	<string></string>
+	<string>OpenToonz</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string></string>
+	<string>1.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string></string>
+	<string>1.3</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>
@@ -33,6 +31,6 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string></string>
+	<string>This Open Source Program is developed from Toonz, a software originally created by Digital Video, S.p.A., Rome Italy</string>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #288.
Untested; might have unwanted effects.