### PR TITLE
Fix deleted Camera1 returning due to Camera Column refresh

### DIFF
--- a/toonz/sources/toonzlib/tstageobjectcmd.cpp
+++ b/toonz/sources/toonzlib/tstageobjectcmd.cpp
@@ -793,7 +793,8 @@ void removeStageObjectNode(const TStageObjectId &id, TXsheetHandle *xshHandle,
     return;
 
   if (id.isCamera() && xsh->getCameraColumnIndex() == id.getIndex())
-    xsh->setCameraColumnIndex(0);
+    xsh->setCameraColumnIndex(
+        xsh->getStageObjectTree()->getCurrentCameraId().getIndex());
 
   // stacco tutti i figli e li attacco al padre
   QList<TStageObjectId> linkedObjects;


### PR DESCRIPTION
This PR fixes #2784

When deleting a camera, if it was the current camera showing in the xsheet, it forced it to Camera1 (index 0), which would make it come back later when checking camera states. Changed it to switch to the index of the active camera.

This does not handle the existing issue I mentioned regarding delete Camera1, closing and reopening OT and finding it has been recreated.  That will likely be in a separate PR.