### PR TITLE
Stop Width Change on Style Editor on Maximize

### DIFF
--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -436,7 +436,8 @@ void DockLayout::redistribute() {
         QWidget *widget = m_items.at(i)->widget();
         if (widget) {
           std::string name = widget->objectName().toStdString();
-          if (widget->objectName() == "FilmStrip") {
+          if (widget->objectName() == "FilmStrip" ||
+              widget->objectName() == "StyleEditor") {
             widgets.push_back(widget);
             widget->setFixedWidth(widget->width());
           }


### PR DESCRIPTION
Similar to the change to make the Film Strip stop changing it's width on maximizing or changing OT's main window size, I've set it so the Style Editor also stops changing it's width.

I chose Style Editor because on most drawing rooms, I have to keep shrinking that pane width to increase the drawing area after resizing OT's main window.