### PR TITLE
Fix lipsync popup layout

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -2012,7 +2012,7 @@ void ReplaceParentDirectoryPopup::initFolder() {
 // ImportMagpieFilePopup
 
 ImportMagpieFilePopup::ImportMagpieFilePopup()
-    : FileBrowserPopup(tr("Import Magpie File")) {
+    : FileBrowserPopup(tr("Import Toonz Lip Sync File")) {
   setOkText(tr("Load"));
   addFilterType("tls");
 }

--- a/toonz/sources/toonz/magpiefileimportpopup.cpp
+++ b/toonz/sources/toonz/magpiefileimportpopup.cpp
@@ -57,7 +57,7 @@ MagpieFileImportPopup::MagpieFileImportPopup()
 
   beginVLayout();
 
-  setLabelWidth(45);
+  setLabelWidth(60);
 
   addSeparator(tr("Frame Range"));
 
@@ -70,9 +70,9 @@ MagpieFileImportPopup::MagpieFileImportPopup()
   m_fromField = new DVGui::IntLineEdit(fromToWidget, 1, 1, 1);
   fromToLayout->addWidget(m_fromField, 0, Qt::AlignLeft);
   m_toField       = new DVGui::IntLineEdit(fromToWidget, 1, 1, 1);
-  QLabel *toLabel = new QLabel(tr("To:"));
+  QLabel *toLabel = new QLabel(tr("To: "));
   toLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-  toLabel->setFixedSize(20, m_toField->height());
+  toLabel->setFixedSize(20, DVGui::WidgetHeight);
   fromToLayout->addWidget(toLabel, 0, Qt::AlignRight);
   fromToLayout->addWidget(m_toField, 0, Qt::AlignLeft);
   fromToWidget->setLayout(fromToLayout);
@@ -90,13 +90,15 @@ MagpieFileImportPopup::MagpieFileImportPopup()
 
   QLabel *frameLabel = new QLabel(" Frame", this);
   frameLabel->setFixedHeight(DVGui::WidgetHeight);
+  frameLabel->setAlignment(Qt::AlignVCenter);
   addWidget(tr("Phoneme"), frameLabel);
   int i;
   for (i = 0; i < 9; i++) {
     DVGui::IntLineEdit *field = new DVGui::IntLineEdit(this, 1, 1);
-    QLabel *label             = new QLabel("", this);
+    field->setFixedSize(54, DVGui::WidgetHeight);
+    QLabel *label = new QLabel("", this);
     label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    label->setFixedSize(getLabelWidth(), field->height());
+    label->setFixedSize(getLabelWidth(), DVGui::WidgetHeight);
     m_actFields.append(QPair<QLabel *, DVGui::IntLineEdit *>(label, field));
     addWidgets(label, field);
   }
@@ -171,7 +173,7 @@ void MagpieFileImportPopup::showEvent(QShowEvent *) {
     QString act = actsIdentifier.at(i);
     field->setProperty("act", QVariant(act));
     field->show();
-    label->setText(act);
+    label->setText(act + ":");
     label->show();
   }
   QString oldLevelPath = m_levelField->getPath();

--- a/toonz/sources/toonz/magpiefileimportpopup.cpp
+++ b/toonz/sources/toonz/magpiefileimportpopup.cpp
@@ -53,7 +53,7 @@ MagpieFileImportPopup::MagpieFileImportPopup()
     , m_toField(0)
     , m_flipbook(0)
     , m_levelPath() {
-  setWindowTitle(tr("Import Magpie File"));
+  setWindowTitle(tr("Import Toonz Lip Sync File"));
 
   beginVLayout();
 
@@ -127,7 +127,7 @@ MagpieFileImportPopup::MagpieFileImportPopup()
          FlipConsole::eMatte | FlipConsole::eDefineSubCamera |
          FlipConsole::eDefineLoadBox | FlipConsole::eUseLoadBox |
          FlipConsole::eFilledRaster | FlipConsole::eLocator));
-  m_flipbook = new FlipBook(this, tr("Import Magpie File"), buttonMask);
+  m_flipbook = new FlipBook(this, tr("Import Toonz Lip Sync File"), buttonMask);
   m_flipbook->setFixedHeight(250);
   frameLayout->addWidget(m_flipbook);
   frame->setLayout(frameLayout);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1558,7 +1558,8 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_SavePaletteAs, tr("&Save Palette As..."), "");
   createRightClickMenuAction(MI_OverwritePalette, tr("&Save Palette"), "");
   createMenuFileAction(MI_LoadColorModel, tr("&Load Color Model..."), "");
-  createMenuFileAction(MI_ImportMagpieFile, tr("&Import Magpie File..."), "");
+  createMenuFileAction(MI_ImportMagpieFile,
+                       tr("&Import Toonz Lip Sync File..."), "");
   createMenuFileAction(MI_NewProject, tr("&New Project..."), "");
   createMenuFileAction(MI_ProjectSettings, tr("&Project Settings..."), "");
   createMenuFileAction(MI_SaveDefaultSettings, tr("&Save Default Settings"),
@@ -2355,7 +2356,7 @@ void MainWindow::clearCacheFolder() {
   // 1. $CACHE/[Current ProcessID]
   // 2. $CACHE/temp/[Current scene folder] if the current scene is untitled
 
-  TFilePath cacheRoot = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheRoot                = ToonzFolder::getCacheRootFolder();
   if (cacheRoot.isEmpty()) cacheRoot = TEnv::getStuffDir() + "cache";
 
   TFilePathSet filesToBeRemoved;


### PR DESCRIPTION
This PR does the following:

1) Fixes the Import Magpie File popup layout

Fields and labels had inconsistent heights causing things not to align properly. Made sure all label and field heights were consistent.

2) Relabeled "Import Magpie File" to "Import Toonz Lip Sync File"

MAGpie is no longer available, as far as I can tell. (If it is still available, please provide link).  I changed the label in order to support other caption software that might be able to export to OT's specifically formatted lip sync file (.TLS).

Here is a manually generated .TLS file I used to test (remove the .txt extension)

[test.tls.txt](https://github.com/opentoonz/opentoonz/files/3726739/test.tls.txt)

![image](https://user-images.githubusercontent.com/19245851/66264300-9c1ef880-e7d0-11e9-8ca9-884a80905384.png)
