### PR TITLE
Fix Main Window Full Screen Mode

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -82,6 +82,10 @@
 #include <QLibraryInfo>
 #include <QHash>
 
+#ifdef _WIN32
+#include <QtPlatformHeaders/QWindowsWindowFunctions>
+#endif
+
 using namespace DVGui;
 #if defined LINETEST
 const char *applicationName    = "Toonz LineTest";
@@ -229,7 +233,7 @@ project->setUseScenePath(TProject::Extras, false);
   // Imposto la rootDir per ImageCache
 
   /*-- TOONZCACHEROOTの設定  --*/
-  TFilePath cacheDir = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheDir               = ToonzFolder::getCacheRootFolder();
   if (cacheDir.isEmpty()) cacheDir = TEnv::getStuffDir() + "cache";
   TImageCache::instance()->setRootDir(cacheDir);
 }
@@ -315,10 +319,10 @@ int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
 
 #ifdef MACOSX
-  // This workaround is to avoid missing left button problem on Qt5.6.0.
-  // To invalidate m_rightButtonClicked in Qt/qnsview.mm, sending
-  // NSLeftButtonDown event before NSLeftMouseDragged event propagated to
-  // QApplication. See more details in ../mousedragfilter/mousedragfilter.mm.
+// This workaround is to avoid missing left button problem on Qt5.6.0.
+// To invalidate m_rightButtonClicked in Qt/qnsview.mm, sending
+// NSLeftButtonDown event before NSLeftMouseDragged event propagated to
+// QApplication. See more details in ../mousedragfilter/mousedragfilter.mm.
 
 #include "mousedragfilter.h"
 
@@ -658,6 +662,11 @@ int main(int argc, char *argv[]) {
   // a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
   if (Preferences::instance()->isLatestVersionCheckEnabled())
     w.checkForUpdates();
+
+#ifdef _WIN32
+  // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
+  QWindowsWindowFunctions::setHasBorderInFullScreen(w.windowHandle(), true);
+#endif
 
   w.show();
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -620,6 +620,11 @@ int main(int argc, char *argv[]) {
   /*-- Layoutファイル名をMainWindowのctorに渡す --*/
   MainWindow w(argumentLayoutFileName);
 
+#ifdef _WIN32
+  // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
+  QWindowsWindowFunctions::setHasBorderInFullScreen(w.windowHandle(), true);
+#endif
+
   splash.showMessage(offsetStr + "Loading style sheet ...", Qt::AlignCenter,
                      Qt::white);
   a.processEvents();
@@ -662,11 +667,6 @@ int main(int argc, char *argv[]) {
   // a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
   if (Preferences::instance()->isLatestVersionCheckEnabled())
     w.checkForUpdates();
-
-#ifdef _WIN32
-  // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
-  QWindowsWindowFunctions::setHasBorderInFullScreen(w.windowHandle(), true);
-#endif
 
   w.show();
 


### PR DESCRIPTION
This PR fixes #2796 and fixes #2215

There is a known Qt limitation concerning Full Screen mode on Windows system.

The suggested workaround was only applied to the Image viewer to allow it to go to full screen. I applied the same workaround to the main window to fix the full screen issue.
