### PR TITLE
Fix reading escaped double-quotes in quoted strings

### DIFF
--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -24,7 +24,8 @@ namespace {
 string escape(string v) {
   int i = 0;
   for (;;) {
-// Removing escaping of apostrophe from Windows and OSX as it's not needed and causes problems
+// Removing escaping of apostrophe from Windows and OSX as it's not needed and
+// causes problems
 #ifdef LINUX
     i = v.find_first_of("\\\'\"", i);
 #else
@@ -353,10 +354,11 @@ TOStream &TOStream::operator<<(string v) {
   }
   int i;
   for (i = 0; i < len; i++)
-    if ((!iswalnum(v[i]) && v[i] != '_' && v[i] != '%')
-		|| v[i] < 32   // Less than ASCII for SPACE
-		|| v[i] > 126  // Greater than ASCII for ~
-		) break;
+    if ((!iswalnum(v[i]) && v[i] != '_' && v[i] != '%') ||
+        v[i] < 32      // Less than ASCII for SPACE
+        || v[i] > 126  // Greater than ASCII for ~
+        )
+      break;
   if (i == len)
     os << v << " ";
   else {
@@ -381,10 +383,11 @@ TOStream &TOStream::operator<<(QString _v) {
   }
   int i;
   for (i = 0; i < len; i++)
-	  if ((!iswalnum(v[i]) && v[i] != '_' && v[i] != '%')
-		  || v[i] < 32   // Less than ASCII for SPACE
-		  || v[i] > 126  // Greater than ASCII for ~
-		  ) break;
+    if ((!iswalnum(v[i]) && v[i] != '_' && v[i] != '%') ||
+        v[i] < 32      // Less than ASCII for SPACE
+        || v[i] > 126  // Greater than ASCII for ~
+        )
+      break;
   if (i == len)
     os << v << " ";
   else {
@@ -1071,9 +1074,15 @@ TIStream &TIStream::operator>>(TFilePath &v) {
   is.get(c);
   if (c == '"') {
     is.get(c);
-    while (is && c != '"') {
+    bool escapedChar = false;
+    // If processing double-quote ("), if it's escaped, keep reading.
+    while (is && (c != '"' || escapedChar)) {
       // if(c=='\\')
       //   is.get(c);
+      if (c == '\\')
+        escapedChar = true;
+      else
+        escapedChar = false;
       s.append(1, c);
       is.get(c);
     }

--- a/toonz/sources/common/tstream/tstream.cpp
+++ b/toonz/sources/common/tstream/tstream.cpp
@@ -1074,15 +1074,15 @@ TIStream &TIStream::operator>>(TFilePath &v) {
   is.get(c);
   if (c == '"') {
     is.get(c);
-    bool escapedChar = false;
+    bool escapeChar = false;
     // If processing double-quote ("), if it's escaped, keep reading.
-    while (is && (c != '"' || escapedChar)) {
+    while (is && (c != '"' || escapeChar)) {
       // if(c=='\\')
       //   is.get(c);
-      if (c == '\\')
-        escapedChar = true;
+      if (c == '\\' && !escapeChar)
+        escapeChar = true;
       else
-        escapedChar = false;
+        escapeChar = false;
       s.append(1, c);
       is.get(c);
     }


### PR DESCRIPTION
This PR fixes #2827

Normally OT stops you from loading a filename with double-quotes (") in it, but there appears to be ways around that (bug or not), that can allow it to happen.  Short of fixing all possible ways this can happen, this fix will ensure that if it does get into a filename, the scene will still load properly.

The issue: 
When OT reads in strings that are encapsulated in ", it reads character by character.  The 1st " is the start of the string but it assumed the next " is the end of the string and stopped reading the rest. It wasn't accounting for an escaped "  (\\") which is normally considered part of the string.

The fix:
Added logic to track the escape character (\\). If a \ appears immediately before a ", it will consider the " as part of the string and not the string terminator.

NOTE: It is not possible to create filenames with " in it on Windows. For testing purposes, I manually modified a scene file to have a quoted filename containing  \\" in it.  In existing code, OT fails to load the scene properly as explained. With this fix, the scene loads successfully.

