### PR TITLE
Fix source comment typos

### DIFF
--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -391,13 +391,13 @@ public:
           cells will be inserted by shifting the other down.
   */
   void stepCells(int r0, int c0, int r1, int c1, int type);
-  /*! For each sequenze of frame with same number, contained in rect delimited
+  /*! For each sequence of frame with same number, contained in rect delimited
      by first row \b \e r0, last row \b \e r1 and
           first column \b \e c0, a frame with same number is inserted.
 */
   void increaseStepCells(int r0, int c0, int &r1, int c1);
   /*!
-For each sequenze of frame with same number, contained in rect delimited by
+For each sequence of frame with same number, contained in rect delimited by
 first row \b \e r0, last row \b \e r1 and
           first column \b \e c0, a frame with same number is removed.
 */
@@ -405,7 +405,7 @@ first row \b \e r0, last row \b \e r1 and
   /*!
 The cells, contained in rect delimited by first row \b \e r0, last row \b \e r1
 and
-          first column \b \e c0, are resetted in order to have no sequential
+          first column \b \e c0, are reset in order to have no sequential
 frame duplication.
 */
   void resetStepCells(int r0, int c0, int r1, int c1);

--- a/toonz/sources/include/tstopwatch.h
+++ b/toonz/sources/include/tstopwatch.h
@@ -86,7 +86,7 @@ public:
 
   /*!Returns the number of milliseconds that have elapsed in all the
 start()-stop() intervals since
-the stopWatch was resetted up to the getTotalTime() call. The method can be
+the stopWatch was reset up to the getTotalTime() call. The method can be
 called during a start()-stop() interval */
   TUINT32 getTotalTime();
 

--- a/toonz/sources/toonzlib/tcenterlinetostrokes.cpp
+++ b/toonz/sources/toonzlib/tcenterlinetostrokes.cpp
@@ -425,7 +425,7 @@ bool SequenceConverter::parametrize(unsigned int a, unsigned int b) {
 //==========================================================================
 
 //------------------------
-//    CP construcion
+//    CP construction
 //------------------------
 
 // NOTE: Check my thesis for variable meanings (int_ stands for 'integral').

--- a/toonz/sources/toonzlib/tcleanupper.cpp
+++ b/toonz/sources/toonzlib/tcleanupper.cpp
@@ -194,7 +194,7 @@ public:
 
 //=========================================================================
 
-//! Birghtness/Contrast color transform data
+//! Brightness/Contrast color transform data
 
 #define MAX_N_PENCILS 8
 
@@ -207,7 +207,7 @@ TPixelRGBM32 Paper = TPixel32::White;
 
 //=========================================================================
 
-//! Birghtness/Contrast color transform structure
+//! Brightness/Contrast color transform structure
 class TransfFunction {
   USHORT TransfFun[(MAX_N_PENCILS + 1) << 8];
 

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -824,7 +824,7 @@ void Region::removeItem(DockWidget *item) {
 
 //! Undocks \b item and updates geometry.
 
-//!\b NOTE: Window flags are resetted to floating appearance (thus hiding the
+//!\b NOTE: Window flags are reset to floating appearance (thus hiding the
 //! widget). Since the geometry
 //! reference changes a geometry() update may be needed - so item's show() is
 //! not forced here. You should


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,./thirdparty -L ang,dum,inbetween,sinc,uint ./toonz/sources/toonzlib`