### PR TITLE
Update Travis to xcode9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ matrix:
         - os: linux
           compiler: clang
         - os: osx
-          osx_image: xcode8.3
+          osx_image: xcode9.2


### PR DESCRIPTION
Changing Travis macOS build environment to use Xcode 9.2 to see if it resolves the build error.

Note: We've been building on macOS 10.12. This setting will now build on macOS 10.13 per Travis documentation.

EDIT: The 1 Travis page is incorrect and xcode9.2 is the last build on macOS 10.12, so no OS change, this time.