### PR TITLE
Fix Travis macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ matrix:
         - os: linux
           compiler: clang
         - os: osx
-          osx_image: xcode8.3
+          osx_image: xcode10.1

--- a/ci-scripts/osx/travis-build.sh
+++ b/ci-scripts/osx/travis-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 pushd thirdparty/tiff-4.0.3
-./configure && make
+./configure --disable-lzma && make
 popd
 cd toonz && mkdir build && cd build
 QTVERSION=`ls /usr/local/Cellar/qt`


### PR DESCRIPTION
This is an attempt to fix the failing macOS Travis builds.

1) Fix LZMA compile/linking errors
Prior successful macOS Travis builds did not detect LZMA libraries when building libtiff.a so it built without it. For some reason it is now detecting it and causing the builds to fail later when linking libimage to libtiff built with LZMA support.

For now, disabling LZMA support in libtiff for macOS builds only.

2) Fix Xcode 8.3.3 outdated warnings

Homebrew now recommends a minimum macOS 10.13. We were building on 10.12. Building on 10.12 using Xcode 9.2 even after fixing the LZMA issue was either throwing other linkage errors or compiling homebrew components so slowly that Travis killed the build for taking so long.

Upgraded to Xcode 10.1 which is the last Xcode version Travis has for macOS 10.13. This seemed to fix the problems with taking too long to build.