### PR TITLE
Selection pivot fix

### DIFF
--- a/toonz/sources/tnztools/selectiontool.cpp
+++ b/toonz/sources/tnztools/selectiontool.cpp
@@ -972,6 +972,12 @@ void SelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
     }
     maxDist  = 5 * pixelSize;
     maxDist2 = maxDist * maxDist;
+    if (!isLevelType() && !isSelectedFramesType() &&
+        tdistance2(getCenter(), pos) < maxDist2) {
+      m_what     = MOVE_CENTER;
+      m_cursorId = ToolCursor::PointingHandCursor;
+      return;
+    }
     if (tdistance2(bbox.getP00(), pos) < maxDist2 ||
         tdistance2(bbox.getP11(), pos) < maxDist2 ||
         tdistance2(bbox.getP01(), pos) < maxDist2 ||
@@ -1019,12 +1025,6 @@ void SelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
         m_cursorId = ToolCursor::DistortCursor;
         m_what     = DEFORM;
       }
-      return;
-    }
-    if (!isLevelType() && !isSelectedFramesType() &&
-        tdistance2(getCenter(), pos) < maxDist2) {
-      m_what     = MOVE_CENTER;
-      m_cursorId = ToolCursor::PointingHandCursor;
       return;
     }
     TPointD hpos = bbox.getP10() - TPointD(14 * pixelSize, 15 * pixelSize);

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -1423,6 +1423,7 @@ void VectorSelectionTool::clearSelectedStrokes() {
   m_strokeSelection.selectNone();
   m_levelSelection.styles().clear();
   m_deformValues.reset();
+  m_centers.clear();
 }
 
 //-----------------------------------------------------------------------------
@@ -1710,8 +1711,8 @@ void VectorSelectionTool::draw() {
 
   glPushMatrix();
 
-  if (m_strokeSelection.isEmpty())       // o_o  WTF!?
-    m_bboxs.clear(), m_centers.clear();  //
+  if (m_strokeSelection.isEmpty())  // o_o  WTF!?
+    m_bboxs.clear();                //
 
   // common draw
   if (getBBoxsCount() > 0) drawCommandHandle(vi.getPointer());
@@ -1762,7 +1763,6 @@ bool VectorSelectionTool::isSelectionEmpty() {
 
 void VectorSelectionTool::computeBBox() {
   m_bboxs.clear();
-  m_centers.clear();
 
   TVectorImageP vi = getImage(false);
   if (!vi) return;
@@ -1822,7 +1822,8 @@ void VectorSelectionTool::computeBBox() {
     FourPoints bbox;
     bbox = newBbox;
     m_bboxs.push_back(bbox);
-    m_centers.push_back(0.5 * (bbox.getP11() + bbox.getP00()));
+    if (getCenter() == TPointD())
+      m_centers.push_back(0.5 * (bbox.getP11() + bbox.getP00()));
   }
 
   ++m_selectionCount;


### PR DESCRIPTION
This PR does the following:

1) Fixes #2836 by prioritizing the pivot point selection above the selection handles and box.

2) For Vector Selections, this stops the pivot from automatically resetting back to center of selection area every time the selection box is redrawn after moving/deforming selection. Toonz Raster and Raster already do not reset pivot after moving/deforming selection.