### PR TITLE
Enable Pencil Mode for Toonz Raster Eraser in Freehand and Polyline types

### DIFF
--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -119,7 +119,7 @@ QList<TRect> splitRect(const TRect &first, const TRect &second);
 //! the \b imageBounds.
 //! If this intersection is empty a TRaster32P() is returned.
 TRaster32P convertStrokeToImage(TStroke *stroke, const TRect &imageBounds,
-                                TPoint &pos);
+                                TPoint &pos, bool pencilMode = false);
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -57,7 +57,7 @@ void mapToVector(const std::map<int, VIStroke *> &theMap,
                  std::vector<int> &theVect) {
   assert(theMap.size() == theVect.size());
   std::map<int, VIStroke *>::const_iterator it = theMap.begin();
-  UINT i = 0;
+  UINT i                                       = 0;
   for (; it != theMap.end(); ++it) {
     theVect[i++] = it->first;
   }
@@ -373,7 +373,7 @@ QList<TRect> ToolUtils::splitRect(const TRect &first, const TRect &second) {
 
 TRaster32P ToolUtils::convertStrokeToImage(TStroke *stroke,
                                            const TRect &imageBounds,
-                                           TPoint &pos) {
+                                           TPoint &pos, bool pencilMode) {
   int count = stroke->getControlPointCount();
   if (count == 0) return TRaster32P();
   TPointD imgCenter = TPointD((imageBounds.x0 + imageBounds.x1) * 0.5,
@@ -407,7 +407,7 @@ TRaster32P ToolUtils::convertStrokeToImage(TStroke *stroke,
   QPainter p(&img);
   p.setPen(QPen(color, 1, Qt::SolidLine));
   p.setBrush(color);
-  p.setRenderHint(QPainter::Antialiasing, true);
+  p.setRenderHint(QPainter::Antialiasing, !pencilMode);
   QPainterPath path = strokeToPainterPath(&s);
   QRectF pathRect   = path.boundingRect();
   p.translate(-toQPoint(pos));


### PR DESCRIPTION
This PR will make the Pencil Mode of Toonz Raster Eraser tool effective in the Freehand and the Polyline types.
With the Pencil Mode being active, boundary of the erased area will not have semi-transparent pixels.