### PR TITLE
Initialize Slider to Linear

### DIFF
--- a/toonz/sources/toonzqt/doublefield.cpp
+++ b/toonz/sources/toonzqt/doublefield.cpp
@@ -82,7 +82,11 @@ void DoubleValueLineEdit::mouseReleaseEvent(QMouseEvent *e) {
 
 DoubleValueField::DoubleValueField(QWidget *parent,
                                    DoubleValueLineEdit *lineEdit)
-    : QWidget(parent), m_lineEdit(lineEdit), m_slider(0), m_roller(0) {
+    : QWidget(parent)
+    , m_lineEdit(lineEdit)
+    , m_slider(0)
+    , m_roller(0)
+    , m_isLinearSlider(true) {
   assert(m_lineEdit);
 
   QWidget *field = new QWidget(this);

--- a/toonz/sources/toonzqt/doublepairfield.cpp
+++ b/toonz/sources/toonzqt/doublepairfield.cpp
@@ -39,7 +39,8 @@ DoubleValuePairField::DoubleValuePairField(QWidget *parent,
     , m_rightMargin(72)
     , m_isMaxRangeLimited(isMaxRangeLimited)
     , m_leftLineEdit(leftLineEdit)
-    , m_rightLineEdit(rightLineEdit) {
+    , m_rightLineEdit(rightLineEdit)
+    , m_isLinear(true) {
   assert(m_leftLineEdit);
   assert(m_rightLineEdit);
   setObjectName("DoublePairField");


### PR DESCRIPTION
This PR add initial settings for sliders to linear.
Without this, some sliders may become nonlinear accidentally.
Sorry for the trouble!