### PR TITLE
Modify Maximum Values for Pinch and Magnet Tools Size

### DIFF
--- a/toonz/sources/tnztools/magnettool.cpp
+++ b/toonz/sources/tnztools/magnettool.cpp
@@ -142,7 +142,7 @@ public:
       : TTool("T_Magnet")
       , m_active(false)
       , m_oldStrokesArray()
-      , m_toolSize("Size:", 10, 500, 20)  // W_ToolOptions_MagnetTool
+      , m_toolSize("Size:", 10, 1000, 20)  // W_ToolOptions_MagnetTool
   {
     bind(TTool::Vectors);
 

--- a/toonz/sources/tnztools/pinchtool.cpp
+++ b/toonz/sources/tnztools/pinchtool.cpp
@@ -73,7 +73,7 @@ PinchTool::PinchTool()
     , m_draw(false)
     , m_undo(0)
     , m_showSelector(true)
-    , m_toolRange("Size:", 1.0, 1000.0, 500.0)  // W_ToolOptions_PinchTool
+    , m_toolRange("Size:", 1.0, 10000.0, 500.0)  // W_ToolOptions_PinchTool
     , m_toolCornerSize("Corner:", 1.0, 180.0,
                        160.0)          // W_ToolOptions_PinchCorner
     , m_autoOrManual("Manual", false)  // W_ToolOptions_PinchManual


### PR DESCRIPTION
Responding to #2844, this PR will expand the maximum values for Pinch and Magnet tools in order to maintain the usability of non-linear sliders compared to the linear ones.
- `Size` of the Pinch tool is expanded from 1,000 to 10,000.
- `Size` of the Magnet tool is expanded from 500 to 1,000.

I begin to think that the `Size` slider of Pinch tool can be reverted to linear, because unlike other sliders it changes one-dimentional parameter.
Anyway, I would like to get feedback from users.