### PR TITLE
Fix blank Style Editor panel

### DIFF
--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -423,8 +423,9 @@ void DockLayout::applyTransform(const QTransform &transform) {
 //------------------------------------------------------
 
 void DockLayout::redistribute() {
-  std::vector<QWidget *> widgets;
   if (!m_regions.empty()) {
+    std::vector<QWidget *> widgets;
+
     // Recompute extremal region sizes
     // NOTA: Sarebbe da fare solo se un certo flag lo richiede; altrimenti tipo
     // per resize events e' inutile...
@@ -460,14 +461,15 @@ void DockLayout::redistribute() {
     // Recompute Layout geometry
     m_regions.front()->setGeometry(contentsRect());
     m_regions.front()->redistribute();
+
+    for (QWidget *widget : widgets) {
+      widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+      widget->setMinimumSize(0, 0);
+    }
   }
 
   // Finally, apply Region geometries found
   applyGeometry();
-  for (QWidget *widget : widgets) {
-    widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-    widget->setMinimumSize(0, 0);
-  }
 }
 
 //======================================================================


### PR DESCRIPTION
This PR fixes #2850

The Film Strip and Style Editor were made to keep their current widths when the main window is resized.

For some reason, when the Level Strip and the Style Editor panels are together like they are in the Basic Room, the Style Editor's pane takes up the vertical space, obscuring the Level Strip and paints the contents of the pane in such a way that it appears the Style Editor is blank

Moving the logic to remove the fixed width restrictions to before applying the calculated geometries, somehow allows both these panes to maintain size and refresh normally.