### PR TITLE
Revised vector selection pivot re-centering logic

### DIFF
--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -306,6 +306,11 @@ public:
 
   TPropertyGroup *getProperties(int targetType) override;
 
+  bool m_resetCenter;
+
+  void setResetCenter(bool update) { m_resetCenter = update; }
+  bool canResetCenter() { return m_resetCenter; }
+
 protected:
   void onActivate() override;
   void onDeactivate() override;


### PR DESCRIPTION
Some Discord users were reporting new issues with the vector selection pivot logic and I was seeing additional issues when in Level Edit mode.

In retrospect, the implemented changes were...well...bad, I must admit.

I restored the original logic and revised it again in a different way to prevent the re-centering of the pivot when a selection was being moved, rotated, deformed or thickness changed.

The existing and default behavior is to recenter the pivot with undo/redo operations or whenever the selection objects change like adding/removing new strokes.  The pivot will still move when the bounding box is resized unfortunately.

I do note there are issues with pivots moves with undo/redo operations, since isolated pivot move history is tracked separately.  Undo/Redo operations do not account for original pivot location so it can throw off the position history. These issues will not be fixed with this PR.