### PR TITLE
Fix navigation keyframe shortcuts skipping

### DIFF
--- a/toonz/sources/toonzqt/keyframenavigator.cpp
+++ b/toonz/sources/toonzqt/keyframenavigator.cpp
@@ -148,6 +148,12 @@ void KeyframeNavigator::showEvent(QShowEvent *e) {
 void KeyframeNavigator::hideEvent(QHideEvent *e) {
   if (!m_frameHandle) return;
   disconnect(m_frameHandle);
+
+  disconnect(m_frameHandle, SIGNAL(triggerNextKeyframe(QWidget *)), this,
+             SLOT(onNextKeyframe(QWidget *)));
+  disconnect(m_frameHandle, SIGNAL(triggerPrevKeyframe(QWidget *)), this,
+             SLOT(onPrevKeyframe(QWidget *)));
+  m_panel = nullptr;
 }
 
 void KeyframeNavigator::onNextKeyframe(QWidget *panel) {


### PR DESCRIPTION
This PR fixes #2871 

When switching rooms, the keyframe navigators were not being disconnected. When switching back to the room, the keyframe navigators were getting another connection so when the signal was being emitted to handle keyframe navigation, it would execute it multiple times.

For some reason `disconnect(m_framehandle)` was not enough to remove all connections. I added logic to specifically disconnect the slots responsible for moving keyframes.