### PR TITLE
Fix Type Tool Cursor Jumping

### DIFF
--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -700,7 +700,7 @@ void TypeTool::updateStrokeChar() {
 
 void TypeTool::updateCharPositions(int updateFrom) {
   if (updateFrom < 0) updateFrom = 0;
-  UINT size                      = m_string.size();
+  UINT size = m_string.size();
   TPointD currentOffset;
   TFontManager *instance = TFontManager::instance();
   m_fontYOffset          = (double)(instance->getLineSpacing()) * m_scale.a11;
@@ -1150,7 +1150,7 @@ void TypeTool::setCursorIndexFromPoint(TPointD point) {
             m_cursorIndex = j;
           else
             m_cursorIndex = j + 1;
-          m_preeditRange  = std::make_pair(m_cursorIndex, m_cursorIndex);
+          m_preeditRange = std::make_pair(m_cursorIndex, m_cursorIndex);
           return;
         }
       } else {
@@ -1162,7 +1162,7 @@ void TypeTool::setCursorIndexFromPoint(TPointD point) {
               m_cursorIndex = j;
             else
               m_cursorIndex = j + 1;
-            m_preeditRange  = std::make_pair(m_cursorIndex, m_cursorIndex);
+            m_preeditRange = std::make_pair(m_cursorIndex, m_cursorIndex);
             return;
           }
         } else {
@@ -1174,7 +1174,7 @@ void TypeTool::setCursorIndexFromPoint(TPointD point) {
               m_cursorIndex = j;
             else
               m_cursorIndex = j + 1;
-            m_preeditRange  = std::make_pair(m_cursorIndex, m_cursorIndex);
+            m_preeditRange = std::make_pair(m_cursorIndex, m_cursorIndex);
             return;
           }
         }
@@ -1206,7 +1206,7 @@ void TypeTool::leftButtonDown(const TPointD &pos, const TMouseEvent &) {
   if (!m_active)
     img = touchImage();
   else
-    img            = getImage(true);
+    img = getImage(true);
   TVectorImageP vi = img;
   TToonzImageP ti  = img;
 
@@ -1304,7 +1304,7 @@ void TypeTool::replaceText(std::wstring text, int from, int to) {
         adv = instance->drawChar(characterImage, character,
                                  m_string[index].m_key);
       else
-        adv        = instance->drawChar(characterImage, character);
+        adv = instance->drawChar(characterImage, character);
       TPointD advD = m_scale * TPointD(adv.x, adv.y);
 
       characterImage->transform(m_scale);
@@ -1530,14 +1530,14 @@ bool TypeTool::keyDown(QKeyEvent *event) {
 
   std::wstring unicodeChar = text.toStdWString();
 
+  // return if only ALT, SHIFT or CTRL key is pressed
+  if (event->modifiers() != Qt::NoModifier && (unicodeChar.empty()))
+    return true;
+
   // per sicurezza
   m_preeditRange = std::make_pair(0, 0);
 
   if (!m_validFonts || !m_active) return true;
-
-  // Se ho premuto solo i tasti ALT, SHIFT e CTRL (da soli) esco
-  if (event->modifiers() != Qt::NoModifier && (unicodeChar.empty()))
-    return true;
 
   switch (event->key()) {
   case Qt::Key_Insert:
@@ -1605,7 +1605,7 @@ bool TypeTool::keyDown(QKeyEvent *event) {
     invalidate();
     break;
 
-  /////////////////// end cursors
+    /////////////////// end cursors
 
   case Qt::Key_Escape:
     resetInputMethod();


### PR DESCRIPTION
This PR fixes a following problem of Type Tool when inputting text with non-Latin alphabets such as Japanese.

- While typing the text, pressing the Shift key unexpectedly moves the cursor to the beginning.

In the type tool [QInputMethodEvent](https://www3.sra.co.jp/qt/relation/doc/qtgui/qinputmethodevent.html) is used only when typing non-latin alphabets. `TypeTool::m_preeditRange` specifies the location where the text to be inserted.
Pressing the Shift key reset the location (at [line 1534](https://github.com/opentoonz/opentoonz/compare/master...shun-iwasawa:g/fix_type_tool_cursor_jumping?expand=1#diff-b408ae6d02f0b8239a28e3ecbec5b9a3L1534)) before going out of the function, which was the cause of the problem.