### PR TITLE
Scene/Level Editor changes

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -202,6 +202,9 @@ public:
   void setPreviewBGColor(const TPixel32 &color, bool isDragging);
   TPixel getPreviewBgColor() const { return m_previewBGColor; }
 
+  void setLevelEditorBoxColor(const TPixel32 &color, bool isDragging);
+  TPixel getLevelEditorBoxColor() const { return m_levelEditorBoxColor; }
+
   void setChessboardColor1(const TPixel32 &color, bool isDragging);
   void setChessboardColor2(const TPixel32 &color, bool isDragging);
   void getChessboardColors(TPixel32 &col1, TPixel32 &col2) const {
@@ -475,12 +478,10 @@ public:
   }
 
   void enableXsheetCameraColumn(bool on);
-  bool isXsheetCameraColumnEnabled() const {
-    return m_showXsheetCameraColumn;
-  }
+  bool isXsheetCameraColumnEnabled() const { return m_showXsheetCameraColumn; }
 
   bool isXsheetCameraColumnVisible() const {
-	  return m_showXsheetCameraColumn && m_showKeyframesOnXsheetCellArea;
+    return m_showXsheetCameraColumn && m_showKeyframesOnXsheetCellArea;
   }
 
   // Animation  tab
@@ -658,7 +659,7 @@ private:
   bool m_keepFillOnVectorSimplify, m_useHigherDpiOnVectorSimplify;
   bool m_downArrowInLevelStripCreatesNewFrame;
   TPixel32 m_viewerBGColor, m_previewBGColor, m_chessboardColor1,
-      m_chessboardColor2;
+      m_chessboardColor2, m_levelEditorBoxColor;
   bool m_showRasterImagesDarkenBlendedInViewer,
       m_actualPixelViewOnSceneEditingMode;
   bool m_dropdownShortcutsCycleOptions;

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -623,7 +623,7 @@ void ComboViewerPanel::changeWindowTitle() {
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
 
     if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-    name = tr("Scene: ") + sceneName + tr("   ::   Project: ") + projectName;
+    name = tr("[SCENE]: ") + sceneName + tr("   ::   Project: ") + projectName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());
@@ -692,7 +692,7 @@ void ComboViewerPanel::changeWindowTitle() {
       QString imageName = QString::fromStdWString(
           fp.withFrame(app->getCurrentFrame()->getFid()).getWideString());
 
-      name = name + tr("Level: ") + imageName;
+      name = name + tr("[LEVEL]: ") + imageName;
       if (!m_sceneViewer->is3DView()) {
         TAffine aff = m_sceneViewer->getViewMatrix();
         if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -617,13 +617,12 @@ void ComboViewerPanel::changeWindowTitle() {
 
   // if the frame type is "scene editing"
   if (app->getCurrentFrame()->isEditingScene()) {
-    TProject *project   = scene->getProject();
-    QString projectName = QString::fromStdString(project->getName().getName());
-    QString sceneName   = QString::fromStdWString(scene->getSceneName());
+    TProject *project = scene->getProject();
+    QString sceneName = QString::fromStdWString(scene->getSceneName());
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
 
     if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-    name = tr("[SCENE]: ") + sceneName + tr("   ::   Project: ") + projectName;
+    name = tr("[SCENE]: ") + sceneName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -651,7 +651,7 @@ void ComboViewerPanel::changeWindowTitle() {
         QString::fromStdWString(fp.withFrame(cell.m_frameId).getWideString());
     name = name + tr("   ::   Level: ") + imageName;
 
-    if (m_sceneViewer->isPreviewEnabled() && !m_sceneViewer->is3DView()) {
+    if (!m_sceneViewer->is3DView()) {
       TAffine aff                             = m_sceneViewer->getViewMatrix();
       if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
       if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -765,6 +765,14 @@ void PreferencesPopup::setPreviewBgColor(const TPixel32 &color,
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::setLevelEditorBoxColor(const TPixel32 &color,
+                                              bool isDragging) {
+  m_pref->setLevelEditorBoxColor(color, isDragging);
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::setChessboardColor1(const TPixel32 &color,
                                            bool isDragging) {
   m_pref->setChessboardColor1(color, isDragging);
@@ -1627,6 +1635,9 @@ PreferencesPopup::PreferencesPopup()
   // Preview BG color
   m_previewBgColorFld =
       new ColorField(this, false, m_pref->getPreviewBgColor());
+  // Level Editor Box color
+  m_levelEditorBoxColorFld =
+      new ColorField(this, false, m_pref->getLevelEditorBoxColor());
   // bg chessboard colors
   TPixel32 col1, col2;
   m_pref->getChessboardColors(col1, col2);
@@ -2744,13 +2755,17 @@ PreferencesPopup::PreferencesPopup()
                           Qt::AlignRight | Qt::AlignVCenter);
       colorLay->addWidget(m_previewBgColorFld, 1, 1);
 
-      colorLay->addWidget(new QLabel(tr("ChessBoard Color 1"), this), 2, 0,
+      colorLay->addWidget(new QLabel(tr("Level Editor Box Color"), this), 2, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
-      colorLay->addWidget(m_chessboardColor1Fld, 2, 1);
+      colorLay->addWidget(m_levelEditorBoxColorFld, 2, 1);
 
-      colorLay->addWidget(new QLabel(tr("Chessboard Color 2"), this), 3, 0,
+      colorLay->addWidget(new QLabel(tr("ChessBoard Color 1"), this), 3, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
-      colorLay->addWidget(m_chessboardColor2Fld, 3, 1);
+      colorLay->addWidget(m_chessboardColor1Fld, 3, 1);
+
+      colorLay->addWidget(new QLabel(tr("Chessboard Color 2"), this), 4, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
+      colorLay->addWidget(m_chessboardColor2Fld, 4, 1);
 
       QGroupBox *tcBox   = new QGroupBox(tr("Transparency Check"), this);
       QGridLayout *tcLay = new QGridLayout();
@@ -2773,16 +2788,16 @@ PreferencesPopup::PreferencesPopup()
       tcLay->setColumnStretch(1, 0);
       tcLay->setColumnStretch(2, 1);
       for (int i = 0; i <= 2; i++) tcLay->setRowStretch(i, 0);
-      tcLay->setRowStretch(3, 1);
+      tcLay->setRowStretch(5, 1);
       tcBox->setLayout(tcLay);
 
-      colorLay->addWidget(tcBox, 4, 0, 1, 3);
+      colorLay->addWidget(tcBox, 5, 0, 1, 3);
     }
     colorLay->setColumnStretch(0, 0);
     colorLay->setColumnStretch(1, 0);
     colorLay->setColumnStretch(2, 1);
     for (int i = 0; i <= 4; i++) colorLay->setRowStretch(i, 0);
-    colorLay->setRowStretch(5, 1);
+    colorLay->setRowStretch(6, 1);
     colorBox->setLayout(colorLay);
     stackedWidget->addWidget(colorBox);
 
@@ -3142,6 +3157,10 @@ PreferencesPopup::PreferencesPopup()
   ret = ret && connect(m_previewBgColorFld,
                        SIGNAL(colorChanged(const TPixel32 &, bool)), this,
                        SLOT(setPreviewBgColor(const TPixel32 &, bool)));
+  // Level Editor Box color
+  ret = ret && connect(m_levelEditorBoxColorFld,
+                       SIGNAL(colorChanged(const TPixel32 &, bool)), this,
+                       SLOT(setLevelEditorBoxColor(const TPixel32 &, bool)));
   // bg chessboard colors
   ret = ret && connect(m_chessboardColor1Fld,
                        SIGNAL(colorChanged(const TPixel32 &, bool)), this,

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -50,7 +50,7 @@ private:
   DVGui::ColorField *m_blankColor, *m_frontOnionColor, *m_backOnionColor,
       *m_transpCheckBgColor, *m_transpCheckInkColor, *m_transpCheckPaintColor,
       *m_viewerBgColorFld, *m_previewBgColorFld, *m_chessboardColor1Fld,
-      *m_chessboardColor2Fld;
+      *m_chessboardColor2Fld, *m_levelEditorBoxColorFld;
 
   QComboBox *m_keyframeType, *m_cellsDragBehaviour, *m_defScanLevelType,
       *m_defLevelType, *m_autocreationType, *m_levelFormatNames,
@@ -179,6 +179,7 @@ private slots:
   void onMoveCurrentFrameChanged(int index);
   void setViewerBgColor(const TPixel32 &, bool);
   void setPreviewBgColor(const TPixel32 &, bool);
+  void setLevelEditorBoxColor(const TPixel32 &, bool);
   void setChessboardColor1(const TPixel32 &, bool);
   void setChessboardColor2(const TPixel32 &, bool);
   void onColumnIconChange(const QString &);

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -522,12 +522,11 @@ void SceneViewerPanel::changeWindowTitle() {
   int frame = app->getCurrentFrame()->getFrame();
   QString name;
   if (app->getCurrentFrame()->isEditingScene()) {
-    TProject *project   = scene->getProject();
-    QString projectName = QString::fromStdString(project->getName().getName());
-    QString sceneName   = QString::fromStdWString(scene->getSceneName());
+    TProject *project = scene->getProject();
+    QString sceneName = QString::fromStdWString(scene->getSceneName());
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
     if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-    name = tr("[SCENE]: ") + sceneName + tr("   ::   Project: ") + projectName;
+    name = tr("[SCENE]: ") + sceneName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -527,7 +527,7 @@ void SceneViewerPanel::changeWindowTitle() {
     QString sceneName   = QString::fromStdWString(scene->getSceneName());
     if (sceneName.isEmpty()) sceneName = tr("Untitled");
     if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-    name = tr("Scene: ") + sceneName + tr("   ::   Project: ") + projectName;
+    name = tr("[SCENE]: ") + sceneName + tr("   ::   Project: ") + projectName;
     if (frame >= 0)
       name =
           name + tr("   ::   Frame: ") + tr(std::to_string(frame + 1).c_str());
@@ -564,7 +564,7 @@ void SceneViewerPanel::changeWindowTitle() {
       TFilePath fp(level->getName());
       QString imageName = QString::fromStdWString(
           fp.withFrame(app->getCurrentFrame()->getFid()).getWideString());
-      name = name + tr("Level: ") + imageName;
+      name = name + tr("[LEVEL]: ") + imageName;
     }
   }
   if (!m_sceneViewer->is3DView()) {

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -653,7 +653,8 @@ void XsheetViewer::timerEvent(QTimerEvent *) {
 bool XsheetViewer::refreshContentSize(int dx, int dy) {
   QSize viewportSize = m_cellScrollArea->viewport()->size();
   QPoint offset      = m_cellArea->pos();
-  offset = QPoint(std::min(0, offset.x() - dx), std::min(0, offset.y() - dy));  // what?
+  offset             = QPoint(std::min(0, offset.x() - dx),
+                  std::min(0, offset.y() - dy));  // what?
 
   TXsheet *xsh    = getXsheet();
   int frameCount  = xsh ? xsh->getFrameCount() : 0;
@@ -818,8 +819,8 @@ QPoint XsheetViewer::positionToXY(const CellPosition &pos) const {
   // since the layers are flipped
 
   usePoint.setY(usePoint.y() - o->cellHeight() + (fan->isActive(pos.layer())
-                                    ? o->cellHeight()
-                                    : o->foldedCellSize()));
+                                                      ? o->cellHeight()
+                                                      : o->foldedCellSize()));
   int columnCount = std::max(1, xsh->getColumnCount());
   int colsHeight  = o->colToLayerAxis(columnCount, fan);
 
@@ -1628,13 +1629,11 @@ void XsheetViewer::changeWindowTitle() {
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
   if (!scene || !app->getCurrentFrame()->isEditingScene()) return;
-  TProject *project   = scene->getProject();
-  QString projectName = QString::fromStdString(project->getName().getName());
-  QString sceneName   = QString::fromStdWString(scene->getSceneName());
+  TProject *project = scene->getProject();
+  QString sceneName = QString::fromStdWString(scene->getSceneName());
   if (sceneName.isEmpty()) sceneName = tr("Untitled");
   if (app->getCurrentScene()->getDirtyFlag()) sceneName += QString("*");
-  QString name =
-      tr("Scene: ") + sceneName + tr("   ::   Project: ") + projectName;
+  QString name   = tr("Scene: ") + sceneName;
   int frameCount = scene->getFrameCount();
   name           = name + "   ::   " + tr(std::to_string(frameCount).c_str()) +
          (frameCount == 1 ? tr(" Frame") : tr(" Frames"));

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -298,6 +298,7 @@ Preferences::Preferences()
     , m_downArrowInLevelStripCreatesNewFrame(true)
     , m_viewerBGColor(128, 128, 128, 255)
     , m_previewBGColor(64, 64, 64, 255)
+    , m_levelEditorBoxColor(128, 128, 128, 255)
     , m_chessboardColor1(180, 180, 180)
     , m_chessboardColor2(230, 230, 230)
     , m_showRasterImagesDarkenBlendedInViewer(false)
@@ -606,6 +607,7 @@ Preferences::Preferences()
   getValue(*m_settings, "IgnoreImageDpi", m_ignoreImageDpi);
   getValue(*m_settings, "viewerBGColor", m_viewerBGColor);
   getValue(*m_settings, "previewBGColor", m_previewBGColor);
+  getValue(*m_settings, "levelEditorBoxColor", m_levelEditorBoxColor);
   getValue(*m_settings, "chessboardColor1", m_chessboardColor1);
   getValue(*m_settings, "chessboardColor2", m_chessboardColor2);
   getValue(*m_settings, "showRasterImagesDarkenBlendedInViewer",
@@ -1002,6 +1004,23 @@ void Preferences::setPreviewBGColor(const TPixel32 &color, bool isDragging) {
     m_settings->setValue("previewBGColor_G", QString::number((int)color.g));
     m_settings->setValue("previewBGColor_B", QString::number((int)color.b));
     m_settings->setValue("previewBGColor_M", QString::number((int)color.m));
+  }
+}
+
+//-----------------------------------------------------------------
+
+void Preferences::setLevelEditorBoxColor(const TPixel32 &color,
+                                         bool isDragging) {
+  m_levelEditorBoxColor = color;
+  if (!isDragging) {
+    m_settings->setValue("levelEditorBoxColor_R",
+                         QString::number((int)color.r));
+    m_settings->setValue("levelEditorBoxColor_G",
+                         QString::number((int)color.g));
+    m_settings->setValue("levelEditorBoxColor_B",
+                         QString::number((int)color.b));
+    m_settings->setValue("levelEditorBoxColor_M",
+                         QString::number((int)color.m));
   }
 }
 


### PR DESCRIPTION
This PR resolves #1061 based on discussion from #2877 ( closes #2877 )

The following changes have been made:

### Level Editor
- Added filled white box for Raster Levels to match Toonz Raster Levels.
- Added `Preferences` -> `Colors` -> `Level Editor Box Color` 
   - Default color matches `Viewer BG Color`
- Viewer title bars changed from `Level: A.1 ...` to `[LEVEL]: A.1 ...` to highlight editing mode
- Project information removed form title bar to reduce visual noise

### Scene Editor
- Viewer title bars changed from `Scene: xyz ...` to `[SCENE]: xyz ...` to highlight editing mode
- Project information removed form title bar to reduce visual noise
- Added Zoom % to ComboViewer's title bar

### Xsheet viewer
- Project information removed from title bar to reduce visual noise
