### PR TITLE
Fix tool option on Command bar crash

### DIFF
--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -138,7 +138,7 @@ void ToolOptionCheckbox::doClick(bool checked) {
   notifyTool();
 
   // for updating a cursor without any effect to the tool options
-  m_toolHandle->notifyToolCursorTypeChanged();
+  if(m_toolHandle) m_toolHandle->notifyToolCursorTypeChanged();
 }
 
 //=============================================================================
@@ -681,7 +681,7 @@ void ToolOptionCombo::doOnActivated(int index) {
     onActivated(index);
     setCurrentIndex(index);
     // for updating the cursor
-    m_toolHandle->notifyToolChanged();
+	if (m_toolHandle) m_toolHandle->notifyToolChanged();
     return;
   }
 
@@ -697,7 +697,7 @@ void ToolOptionCombo::doOnActivated(int index) {
   }
 
   // for updating a cursor without any effect to the tool options
-  m_toolHandle->notifyToolCursorTypeChanged();
+  if (m_toolHandle) m_toolHandle->notifyToolCursorTypeChanged();
 }
 
 //=============================================================================


### PR DESCRIPTION
This PR fixes #2881 

To prevent crash, added test for a valid Tool Handle before using it similar to other options that also accessed the tool handle before using it.

I updated other tool options that had unchecked tool handle usage just in case.