### PR TITLE
Fix folded columns slipping

### DIFF
--- a/toonz/sources/include/toonz/columnfan.h
+++ b/toonz/sources/include/toonz/columnfan.h
@@ -93,6 +93,9 @@ of column identified by \b col.
 
   void saveData(TOStream &os);
   void loadData(TIStream &is);
+
+  void rollLeftFoldedState(int index, int count);
+  void rollRightFoldedState(int index, int count);
 };
 
 #endif

--- a/toonz/sources/toonzlib/columnfan.cpp
+++ b/toonz/sources/toonzlib/columnfan.cpp
@@ -178,3 +178,58 @@ void ColumnFan::loadData(TIStream &is) {
     for (j = 0; j < count; j++) deactivate(index + j);
   }
 }
+
+//-----------------------------------------------------------------------------
+
+void ColumnFan::rollLeftFoldedState(int index, int count) {
+  assert(index >= 0);
+  assert(count > 1);
+  int columnCount = m_columns.size();
+  if (columnCount <= index) return;
+  if (index + count - 1 > columnCount) count = columnCount - index + 1;
+  if (count < 2) return;
+
+  int i = index, j = index + count - 1;
+  bool tmp = isActive(i);
+
+  for (int k = i; k < j; ++k) {
+    if (isActive(k) && !isActive(k + 1))
+      deactivate(k);
+    else if (!isActive(k) && isActive(k + 1))
+      activate(k);
+  }
+  if (isActive(j) && !tmp)
+    deactivate(j);
+  else if (!isActive(j) && tmp)
+    activate(j);
+
+  update();
+}
+
+//-----------------------------------------------------------------------------
+
+void ColumnFan::rollRightFoldedState(int index, int count) {
+  assert(index >= 0);
+  assert(count > 1);
+
+  int columnCount = m_columns.size();
+  if (columnCount <= index) return;
+  if (index + count - 1 > columnCount) count = columnCount - index + 1;
+  if (count < 2) return;
+
+  int i = index, j = index + count - 1;
+  bool tmp = isActive(j);
+
+  for (int k = j; k > i; --k) {
+    if (isActive(k) && !isActive(k - 1))
+      deactivate(k);
+    else if (!isActive(k) && isActive(k - 1))
+      activate(k);
+  }
+  if (isActive(i) && !tmp)
+    deactivate(i);
+  else if (!isActive(i) && tmp)
+    activate(i);
+
+  update();
+}

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -1318,6 +1318,11 @@ void TXsheet::insertColumn(int col, TXshColumn *column) {
     TFx *fx = column->getFx();
     if (fx) getFxDag()->addToXsheet(fx);
   }
+
+  for (ColumnFan &columnFan : m_imp->m_columnFans) {
+    columnFan.rollRightFoldedState(col,
+                                   m_imp->m_columnSet.getColumnCount() - col);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1336,6 +1341,11 @@ void TXsheet::removeColumn(int col) {
   }
   m_imp->m_columnSet.removeColumn(col);
   m_imp->m_pegTree->removeColumn(col);
+
+  for (ColumnFan &columnFan : m_imp->m_columnFans) {
+    columnFan.rollLeftFoldedState(col,
+                                  m_imp->m_columnSet.getColumnCount() - col);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1363,12 +1373,16 @@ void TXsheet::moveColumn(int srcIndex, int dstIndex) {
     int c1 = dstIndex;
     assert(c0 < c1);
     m_imp->m_columnSet.rollLeft(c0, c1 - c0 + 1);
+    for (ColumnFan &columnFan : m_imp->m_columnFans)
+      columnFan.rollLeftFoldedState(c0, c1 - c0 + 1);
     for (int c = c0; c < c1; ++c) m_imp->m_pegTree->swapColumns(c, c + 1);
   } else {
     int c0 = dstIndex;
     int c1 = srcIndex;
     assert(c0 < c1);
     m_imp->m_columnSet.rollRight(c0, c1 - c0 + 1);
+    for (ColumnFan &columnFan : m_imp->m_columnFans)
+      columnFan.rollRightFoldedState(c0, c1 - c0 + 1);
     for (int c = c1 - 1; c >= c0; --c) m_imp->m_pegTree->swapColumns(c, c + 1);
   }
 }


### PR DESCRIPTION
This PR will fix the folded xsheet columns "slipping" when you reorder / insert / remove columns.
Now the folded columns will keep their contents unchanged through column reordering.