### PR TITLE
Fix playback skipping first frame

### DIFF
--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -172,11 +172,11 @@ void PlaybackExecutor::run() {
   TUINT32 loadedInstant, nextSampleInstant = timeResolution;
   TUINT32 sampleTotalLoadingTime = 0;
 
-  TUINT32 lastFrameCounts[4]    = {0, 0, 0,
+  TUINT32 lastFrameCounts[4] = {0, 0, 0,
                                 0};  // Keep the last 4 'played frames' counts.
   TUINT32 lastSampleInstants[4] = {0, 0, 0,
                                    0};  // Same for the last sampling instants
-  TUINT32 lastLoadingTimes[4]   = {0, 0, 0,
+  TUINT32 lastLoadingTimes[4] = {0, 0, 0,
                                  0};  // Same for total sample loading times
 
   double targetFrameTime =
@@ -191,8 +191,8 @@ void PlaybackExecutor::run() {
     emissionInstant = timer.getTotalTime();
 
     // Draw the next frame
-    emit nextFrame(fps);  // Show the next frame, telling
-                          // currently measured fps
+    if (playedFramesCount) emit nextFrame(fps);  // Show the next frame, telling
+                                                 // currently measured fps
 
     if (FlipConsole::m_areLinked) {
       // In case there are linked consoles, update them too.
@@ -320,17 +320,15 @@ void FlipSlider::paintEvent(QPaintEvent *ev) {
 
   p.drawImage(QRect(0, 0, PBColorMarginLeft, height()), PBOverlay,
               QRect(0, 0, PBColorMarginLeft, PBOverlay.height()));
-  p.drawImage(
-      QRect(PBColorMarginLeft, 0,
-            sliderRect.width() - PBColorMarginLeft - PBColorMarginRight,
-            height()),
-      PBOverlay,
-      QRect(PBColorMarginLeft, 0, overlayInnerWidth, PBOverlay.height()));
+  p.drawImage(QRect(PBColorMarginLeft, 0,
+                    sliderRect.width() - PBColorMarginLeft - PBColorMarginRight,
+                    height()),
+              PBOverlay, QRect(PBColorMarginLeft, 0, overlayInnerWidth,
+                               PBOverlay.height()));
   p.drawImage(
       QRect(width() - PBColorMarginRight, 0, PBColorMarginRight, height()),
-      PBOverlay,
-      QRect(PBOverlay.width() - PBColorMarginRight, 0, PBColorMarginRight,
-            PBOverlay.height()));
+      PBOverlay, QRect(PBOverlay.width() - PBColorMarginRight, 0,
+                       PBColorMarginRight, PBOverlay.height()));
 
   // Draw the position marker
   currPos = sliderPositionFromValue(minimum(), maxValuePlusStep, value(),
@@ -483,7 +481,7 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, UINT gadgetsMask,
     , m_fpsLabel(0)
     , m_consoleOwner(consoleOwner)
     , m_enableBlankFrameButton(0) {
-  QString s = QSettings().value(m_customizeId).toString();
+  QString s                    = QSettings().value(m_customizeId).toString();
   if (s != "") m_customizeMask = s.toUInt();
 
   if (m_gadgetsMask == 0) return;
@@ -757,8 +755,9 @@ bool FlipConsole::drawBlanks(int from, int to) {
   if (m_blanksToDraw > 1 ||
       (m_blanksToDraw == 0 &&
        ((m_reverse && m_currentFrame - m_step < from) ||
-        (!m_reverse && m_currentFrame + m_step >
-                           to))))  // we are on the last frame of the loop
+        (!m_reverse &&
+         m_currentFrame + m_step >
+             to))))  // we are on the last frame of the loop
   {
     m_blanksToDraw = (m_blanksToDraw == 0 ? m_blanksCount : m_blanksToDraw - 1);
     m_settings.m_blankColor     = m_blankColor;
@@ -861,7 +860,7 @@ void FlipConsole::setCurrentFPS(int val) {
   if (m_fps == val) return;
 
   if (val == 0) val = 1;
-  m_fps = val;
+  m_fps             = val;
   m_fpsField->setValue(m_fps);
 
   if (m_playbackExecutor.isRunning() || m_isLinkedPlaying)
@@ -1472,7 +1471,7 @@ void FlipConsole::doButtonPressed(UINT button) {
       if (m_currentFrame <= from ||
           m_currentFrame >=
               to)  // the first frame of the playback is drawn right now
-        m_currentFrame = m_reverse ? to : from;
+        m_currentFrame               = m_reverse ? to : from;
       m_settings.m_recomputeIfNeeded = true;
       m_consoleOwner->onDrawFrame(m_currentFrame, m_settings);
     }
@@ -1547,7 +1546,7 @@ void FlipConsole::doButtonPressed(UINT button) {
     if (isChecked(eGreen) || isChecked(eGGreen))
       colorMask = colorMask | TRop::GChan;
     if (isChecked(eBlue) || isChecked(eGBlue))
-      colorMask = colorMask | TRop::BChan;
+      colorMask                      = colorMask | TRop::BChan;
     if (isChecked(eMatte)) colorMask = colorMask | TRop::MChan;
 
     if (colorMask == (TRop::RChan | TRop::GChan | TRop::BChan) ||


### PR DESCRIPTION
This PR fixes #2879

When playback started, it immediately changed to the next frame then waited. Modified logic not to change frame on initial start so it just waits for the 1st frame.

NOTE:  I only changed line 194. The rest of the changes were from beautification
