### PR TITLE
Fix file loss issues

### DIFF
--- a/toonz/sources/toonz/colormodelviewer.cpp
+++ b/toonz/sources/toonz/colormodelviewer.cpp
@@ -123,7 +123,10 @@ void ColorModelViewer::dragEnterEvent(QDragEnterEvent *event) {
     std::string type = fp.getType();
     if (type == "scr" || type == "tpl") return;
   }
-  event->acceptProposedAction();
+  // Force CopyAction
+  event->setDropAction(Qt::CopyAction);
+  // For files, don't accept original proposed action in case it's a move
+  event->accept();
 }
 
 //-----------------------------------------------------------------------------
@@ -138,7 +141,10 @@ void ColorModelViewer::dropEvent(QDropEvent *event) {
       loadImage(fp);
       setLevel(fp);
     }
-    event->acceptProposedAction();
+	// Force CopyAction
+	event->setDropAction(Qt::CopyAction);
+	// For files, don't accept original proposed action in case it's a move
+	event->accept();
   }
 }
 

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -127,7 +127,12 @@ void ConvertPopup::Converter::run() {
 
     m_saveToNopaintOnlyFlag = false;
 
-    if (TSystem::doesExistFileOrLevel(dstFilePath)) {
+    if (dstFilePath == sourceLevelPath) {
+      DVGui::info(tr("Level %1 converting to same file format; skipped.")
+                      .arg(levelName));
+      m_skippedCount++;
+      continue;
+    } else if (TSystem::doesExistFileOrLevel(dstFilePath)) {
       if (m_parent->m_skip->isChecked()) {
         DVGui::info(tr("Level %1 already exists; skipped.").arg(levelName));
         m_skippedCount++;

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -431,6 +431,10 @@ void DvDirTreeView::dropEvent(QDropEvent *e) {
     TFilePath srcFp(url.toLocalFile().toStdWString());
     TFilePath dstFp = folderNode->getPath();
 
+    // Dropping file in the same directory that already exists should just be
+    // ignored
+    if (srcFp.getParentDir() == dstFp) continue;
+
     TFilePath path = dstFp + TFilePath(srcFp.getLevelNameW());
     NameBuilder *nameBuilder =
         NameBuilder::getBuilder(::to_wstring(path.getName()));

--- a/toonz/sources/toonz/dvitemview.cpp
+++ b/toonz/sources/toonz/dvitemview.cpp
@@ -40,6 +40,7 @@
 #include <QFileDialog>
 #include <QTextStream>
 #include <qdrawutil.h>
+#include <QMimeData>
 
 #include <stdint.h>  // for uint64_t
 
@@ -1515,15 +1516,29 @@ void DvItemViewer::resetVerticalScrollBar() {
 //-----------------------------------------------------------------------------
 
 void DvItemViewer::dragEnterEvent(QDragEnterEvent *event) {
-  if (m_model && m_model->acceptDrop(event->mimeData()))
-    event->acceptProposedAction();
+  const QMimeData *mimeData = event->mimeData();
+  if (m_model && m_model->acceptDrop(mimeData)) {
+    if (acceptResourceOrFolderDrop(mimeData->urls())) {
+      // Force CopyAction
+      event->setDropAction(Qt::CopyAction);
+      event->accept();
+    } else
+      event->acceptProposedAction();
+  }
 }
 
 //-----------------------------------------------------------------------------
 
 void DvItemViewer::dropEvent(QDropEvent *event) {
-  if (m_model && m_model->drop(event->mimeData()))
-    event->acceptProposedAction();
+  const QMimeData *mimeData = event->mimeData();
+  if (m_model && m_model->drop(mimeData)) {
+    if (acceptResourceOrFolderDrop(mimeData->urls())) {
+      // Force CopyAction
+      event->setDropAction(Qt::CopyAction);
+      event->accept();
+    } else
+      event->acceptProposedAction();
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1578,6 +1578,14 @@ void SceneViewer::dropEvent(QDropEvent *e) {
     }
 
     IoCmd::loadResources(args);
+
+	if (acceptResourceOrFolderDrop(mimeData->urls())) {
+		// Force Copy Action
+		e->setDropAction(Qt::CopyAction);
+		// For files, don't accept original proposed action in case it's a move
+		e->accept();
+		return;
+	}
   }
   e->acceptProposedAction();
 }

--- a/toonz/sources/toonzlib/levelupdater.cpp
+++ b/toonz/sources/toonzlib/levelupdater.cpp
@@ -246,7 +246,8 @@ void LevelUpdater::open(const TFilePath &fp, TPropertyGroup *pg) {
       m_lwPath = fp;
     }
   } catch (...) {
-    // In this case, TLevelWriterP(..) failed, that object was never constructed,
+    // In this case, TLevelWriterP(..) failed, that object was never
+    // constructed,
     // the assignment m_lw never took place. And m_lw == 0.
 
     // Reset state and rethrow
@@ -441,6 +442,10 @@ void LevelUpdater::close() {
         //       in destructors is bad. I'm not sure this is actually guaranteed
         //       in Toonz, however :(
         m_lr = TLevelReaderP(), m_lw = TLevelWriterP();
+
+        // A temp file didn't get created. What happened?  Force failure!
+        if (!TFileStatus(tempPath).doesExist())
+          throw TSystemException(tempPath, "cant find!");
 
         // Rename the level
         TSystem::removeFileOrLevel_throw(finalPath);

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -703,7 +703,10 @@ void PaletteViewer::dragEnterEvent(QDragEnterEvent *event) {
     if (!path.getType().empty() && path.getType() != "tpl") return;
   }
 
-  event->acceptProposedAction();
+  // Force CopyAction
+  event->setDropAction(Qt::CopyAction);
+  // For files, don't accept original proposed action in case it's a move
+  event->accept();
 }
 
 //-----------------------------------------------------------------------------
@@ -754,7 +757,10 @@ void PaletteViewer::dropEvent(QDropEvent *event) {
         }
       }
     }
-    event->acceptProposedAction();
+    // Force CopyAction
+    event->setDropAction(Qt::CopyAction);
+    // For files, don't accept original proposed action in case it's a move
+    event->accept();
     return;
   }
 

--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -1014,7 +1014,7 @@ void StudioPaletteTreeViewer::dragEnterEvent(QDragEnterEvent *event) {
     for (i = 0; i < count; i++) {
       QUrl url = urls[i];
       TFilePath path(url.toLocalFile().toStdWString());
-      if (!path.isEmpty() &&
+      if (!path.isEmpty() && isInStudioPalette(path) &&
           (path.getType() == "tpl" || path.getType() == "pli" ||
            path.getType() == "tlv" || path.getType() == "tnz")) {
         isPalette = true;
@@ -1120,6 +1120,7 @@ void StudioPaletteTreeViewer::dropEvent(QDropEvent *event) {
   int ret = DVGui::MsgBox(question, tr("Move"), tr("Cancel"));
   if (ret == 0 || ret == 2) return;
 
+  bool paletteMoved = false;
   TUndoManager::manager()->beginBlock();
   for (int i = 0; i < palettePaths.size(); i++) {
     TFilePath path = palettePaths[i];
@@ -1129,6 +1130,7 @@ void StudioPaletteTreeViewer::dropEvent(QDropEvent *event) {
           TFilePath(path.getWideName() + ::to_wstring(path.getDottedType()));
       try {
         StudioPaletteCmd::movePalette(newPalettePath, path);
+        paletteMoved = true;
       } catch (TException &e) {
         error("Can't rename palette: " +
               QString(::to_string(e.getMessage()).c_str()));
@@ -1138,8 +1140,10 @@ void StudioPaletteTreeViewer::dropEvent(QDropEvent *event) {
     }
   }
   TUndoManager::manager()->endBlock();
-  event->setDropAction(Qt::MoveAction);
-  event->accept();
+  if (paletteMoved) {
+    event->setDropAction(Qt::MoveAction);
+    event->accept();
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR does the following to prevent accidental file loss:

1) Some levels use an interim temp file to hold changes while saving. This temp file eventually replaces the original file.  If for some reason the temp file is not created, the logic still deletes the original file and then finally fails to save because the missing temp file can't be renamed.

Added a check to verify the temp file exists before deleting the original. If not found, an exception is thrown and the save fails.

This may address  #2581

NOTE: At present time, failed level saves only notify the user if they did a "Save Level". "Save All" hides the failure notification. This should be addressed separately.

2) On Windows systems, Shift+Drag/Drop of a file does a Move file which basically copies to new destination and then removes the old. When dragging a file from outside OT (explorer) and dropping into OT, OT accepts the drop, but then Windows deletes the original file. If the user does not modify the level and save, the file is lost when quitting

Added logic to convert Move-Drops to Copy-Drops in various places in OT.  The following were impacted:

   - Color Models
   - Tree Item viewers (details of a Tree item), like the right pane in File Browser and Scene Cast
   - Flip Books
   - Scene Viewers (ComboViewer and regular Viewer)
   - Xsheet/Timelines
   - Palette Viewers

This fixes #2363

3) If you attempted a move-drop of a non-studio palette into the Studio Palette viewer, the drop does nothing, but the original file is deleted.

The Studio Palette only allows you to drag/drop Global or Project Palettes already in the Studio Viewer. Any other palette files, like level palettes, do nothing. I added logic to block the ability to drop non-studio palettes into the Studio Palette Viewer.

4) Attempting to convert a file in the File Browser back to the same type (png -> png), results in the file being lost

Added logic to skip converting a file if the source and destination files names are exactly the same.

5) If you drag a file from the right pane of the File Browser back to the same directory in the File Browser tree (left pane), a copy of the original file is created as a numbered file and the original file is deleted. (A.png -> A_1.png)

Added logic to ignore moving file if the source's parent directory is the same as the destination directory.
