### PR TITLE
Warn on failing level save during Save All

### DIFF
--- a/toonz/sources/toonzlib/sceneresources.cpp
+++ b/toonz/sources/toonzlib/sceneresources.cpp
@@ -237,9 +237,7 @@ void SceneLevel::save() {
         try {
           m_sl->save(actualFp, oldActualPath);
         } catch (...) {
-          DVGui::warning(
-              QObject::tr("Can't save") +
-              QString::fromStdWString(L": " + actualFp.getLevelNameW()));
+          throw;
         }
         if ((actualFp.getType() == "tlv" || actualFp.getType() == "pli") &&
             actualFp != oldActualPath && m_oldRefImgPath != TFilePath()) {
@@ -497,7 +495,20 @@ void SceneResources::getResources() {
 void SceneResources::save(const TFilePath newScenePath) {
   TFilePath oldScenePath = m_scene->getScenePath();
   m_scene->setScenePath(newScenePath);
-  for (int i = 0; i < (int)m_resources.size(); i++) m_resources[i]->save();
+  bool failedSave = false;
+  QString failedList;
+  for (int i = 0; i < (int)m_resources.size(); i++) {
+    m_resources[i]->save();
+    if (m_resources[i]->isDirty())  // didn't save for some reason
+    {
+      failedList += "\n" + m_resources[i]->getResourceName();
+      failedSave = true;
+    }
+  }
+
+  if (failedSave)
+    DVGui::warning(QObject::tr("Failed to save the following resources:\n") +
+                   failedList);
   m_scene->setScenePath(oldScenePath);
 }
 

--- a/toonz/sources/toonzlib/sceneresources.cpp
+++ b/toonz/sources/toonzlib/sceneresources.cpp
@@ -234,8 +234,13 @@ void SceneLevel::save() {
         // imageBuilder path refresh.
         m_sl->setPath(fp, false);
       } else {
-        m_sl->save(actualFp, oldActualPath);
-
+        try {
+          m_sl->save(actualFp, oldActualPath);
+        } catch (...) {
+          DVGui::warning(
+              QObject::tr("Can't save") +
+              QString::fromStdWString(L": " + actualFp.getLevelNameW()));
+        }
         if ((actualFp.getType() == "tlv" || actualFp.getType() == "pli") &&
             actualFp != oldActualPath && m_oldRefImgPath != TFilePath()) {
           // Devo preoccuparmi dell'eventuale livello colormodel


### PR DESCRIPTION
When you `Save Level` and there is an error saving, OT will immediately notify the user there was a problem saving.

When using `Save All` or `Save All Levels`, there is no warning if a level failed to save.  This can result in loss of work.

This PR will add logic to display a warning for every level that fails to save during a `Save All` or `Save All Level` operation, provided the failure actually throws an exception.