### PR TITLE
Fix odd behavior of LinearGradientFx handles

### DIFF
--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -1510,8 +1510,9 @@ void LinearRangeFxGadget::leftButtonDrag(const TPointD &pos,
   if (m_targetPos != m_anotherPos && e.isShiftPressed()) {
     TPointD vecA = m_targetPos - m_anotherPos;
     TPointD vecB = m_targetPos + d - m_anotherPos;
-    double ratio = std::min(vecB.x / vecA.x, vecB.y / vecA.y);
-    d            = vecA * (ratio - 1.0);
+    d            = vecA * ((vecA.x * vecB.x + vecA.y * vecB.y) /
+                    (vecA.x * vecA.x + vecA.y * vecA.y) -
+                1.0);
   }
 
   setValue(target, m_targetPos + d);

--- a/toonz/sources/toonzlib/columnfan.cpp
+++ b/toonz/sources/toonzlib/columnfan.cpp
@@ -183,7 +183,6 @@ void ColumnFan::loadData(TIStream &is) {
 
 void ColumnFan::rollLeftFoldedState(int index, int count) {
   assert(index >= 0);
-  assert(count > 1);
   int columnCount = m_columns.size();
   if (columnCount <= index) return;
   if (index + count - 1 > columnCount) count = columnCount - index + 1;
@@ -210,7 +209,6 @@ void ColumnFan::rollLeftFoldedState(int index, int count) {
 
 void ColumnFan::rollRightFoldedState(int index, int count) {
   assert(index >= 0);
-  assert(count > 1);
 
   int columnCount = m_columns.size();
   if (columnCount <= index) return;


### PR DESCRIPTION
This PR fixes odd behavior of Fx gadgets of Linear Gradient Fx which I replaced recently.
Before the fix the handle unexpectedly jumped to far away while +shift dragging.
I fixed the problem by using proper formula. Sorry for the trouble!