### PR TITLE
Allow note frame creation on Animation Sheet

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2988,8 +2988,12 @@ void CellArea::mouseDoubleClickEvent(QMouseEvent *event) {
   // in modalita' xsheet as animation sheet non deve essere possibile creare
   // livelli con doppio click: se la cella e' vuota non bisogna fare nulla
   if ((Preferences::instance()->isAnimationSheetEnabled() &&
-       m_viewer->getXsheet()->getCell(row, col).isEmpty()))
-    return;
+       m_viewer->getXsheet()->getCell(row, col).isEmpty())) {
+    TXshColumn *column = m_viewer->getXsheet()->getColumn(col);
+    if (!column ||
+        column->getColumnType() != TXshColumn::ColumnType::eSoundTextType)
+      return;
+  }
 
   int colCount = m_viewer->getCellSelection()->getSelectedCells().getColCount();
 


### PR DESCRIPTION
This PR fixes #2893

Added exception to allow empty cell rename on doubleclicks for Note levels when `Use Xsheet as Animation Sheet` is enabled so that new note frames can be created wherever needed in that column

Unless otherwise requested, `Enable auto-stretch frame` does not auto extend the prior note frame to meet the newly created frame like it normally would on drawn levels.