### PR TITLE
Fix macOS brew installed glew issue

### DIFF
--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -6,3 +6,11 @@ brew install clang-format
 # from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
 # so we start to use the latest version of Qt. (#1910)
 brew install qt
+# temp workaround to brew installed glew cmake info overriding glew lib detection
+# which causes compiling issues later
+if [ -L /usr/local/lib/cmake/glew ]
+then
+   echo "Symbolic link '/usr/local/lib/cmake/glew' detected. Removing to avoid glew lib detection issue!"
+   ls -l /usr/local/lib/cmake/glew
+   rm /usr/local/lib/cmake/glew
+fi


### PR DESCRIPTION
This PR fixes the current cause of macOS Travis build failures.

When installing glew libraries using brew, it is creating the symbolic link /usr/local/lib/cmake/glew which points to glew cmake information. This symbolic link is causing cmake to incorrectly detect the actual installed glew libraries and later fails to build OT because of it.

As a temporary workaround, I updated the script to detect and delete the symbolic link after installing glew through brew.
