### PR TITLE
Allow Selection Tool copy when level is not editable

### DIFF
--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -143,6 +143,8 @@ Can be different from getSelectionBound() after a free deform transformation. */
   void pasteSelection();
 
   bool isTransformed();
+
+  bool isEditable();
 };
 
 #endif  // RASTER_SELECTION_H

--- a/toonz/sources/include/tools/strokeselection.h
+++ b/toonz/sources/include/tools/strokeselection.h
@@ -66,6 +66,8 @@ public:
 
   void setSceneHandle(TSceneHandle *tsh) { m_sceneHandle = tsh; }
 
+  bool isEditable();
+
 public:
   // Commands
 

--- a/toonz/sources/tnztools/imagegrouping.cpp
+++ b/toonz/sources/tnztools/imagegrouping.cpp
@@ -12,6 +12,7 @@
 // TnzQt includes
 #include "toonzqt/tselectionhandle.h"
 #include "toonzqt/selectioncommandids.h"
+#include "toonzqt/dvdialog.h"
 
 // TnzLib includes
 #include "toonz/tscenehandle.h"
@@ -478,6 +479,13 @@ void TGroupCommand::group() {
   TVectorImage *vimg = (TVectorImage *)tool->getImage(true);
 
   if (!vimg) return;
+
+  if (!m_sel->isEditable()) {
+    DVGui::error(
+        QObject::tr("The selection cannot be grouped. It is not editable."));
+    return;
+  }
+
   QMutexLocker lock(vimg->getMutex());
   groupWithoutUndo(vimg, m_sel);
   TXshSimpleLevel *level =
@@ -494,6 +502,13 @@ void TGroupCommand::enterGroup() {
   TVectorImage *vimg = (TVectorImage *)tool->getImage(true);
 
   if (!vimg) return;
+
+  if (!m_sel->isEditable()) {
+    DVGui::error(
+        QObject::tr("The selection cannot be entered. It is not editable."));
+    return;
+  }
+
   int index = -1;
 
   for (int i = 0; i < (int)vimg->getStrokeCount(); i++)
@@ -532,6 +547,13 @@ void TGroupCommand::ungroup() {
   if (!tool) return;
   TVectorImage *vimg = (TVectorImage *)tool->getImage(true);
   if (!vimg) return;
+
+  if (!m_sel->isEditable()) {
+    DVGui::error(
+        QObject::tr("The selection cannot be ungrouped. It is not editable."));
+    return;
+  }
+
   QMutexLocker lock(vimg->getMutex());
   ungroupWithoutUndo(vimg, m_sel);
   TXshSimpleLevel *level =
@@ -686,6 +708,12 @@ void TGroupCommand::moveGroup(UCHAR moveType) {
 
   TVectorImage *vimg = (TVectorImage *)tool->getImage(true);
   if (!vimg) return;
+
+  if (!m_sel->isEditable()) {
+    DVGui::error(
+        QObject::tr("The selection cannot be moved. It is not editable."));
+    return;
+  }
 
   std::vector<std::pair<TStroke *, int>> selectedGroups =
       getSelectedGroups(vimg, m_sel);

--- a/toonz/sources/tnztools/rasterselectiontool.h
+++ b/toonz/sources/tnztools/rasterselectiontool.h
@@ -242,6 +242,8 @@ public:
   bool onPropertyChanged(std::string propertyName) override;
   bool getNoAntialiasingValue() { return m_noAntialiasing.getValue(); }
 
+  bool isSelectionEditable() { return m_rasterSelection.isEditable(); }
+
 protected:
   void updateTranslation() override;
 };

--- a/toonz/sources/tnztools/selectiontool.cpp
+++ b/toonz/sources/tnztools/selectiontool.cpp
@@ -935,6 +935,8 @@ void SelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
   } else if (m_leftButtonMousePressed)
     return;
 
+  if (!isSelectionEditable()) return;
+
   FourPoints bbox = getBBox();
 
   double pixelSize = getPixelSize();
@@ -1224,6 +1226,8 @@ void SelectionTool::drawCommandHandle(const TImage *image) {
   tglColor(frameColor);
 
   if (m_dragTool) m_dragTool->draw();
+
+  if (!isSelectionEditable()) return;
 
   double pixelSize = getPixelSize();
   if (!isLevelType() && !isSelectedFramesType()) {

--- a/toonz/sources/tnztools/selectiontool.h
+++ b/toonz/sources/tnztools/selectiontool.h
@@ -457,6 +457,8 @@ public:
 
   // returns true if the pressed key is recognized and processed.
   bool isEventAcceptable(QEvent *e) override;
+
+  virtual bool isSelectionEditable() { return true; }
 };
 
 #endif  // SELECTIONTOOL_INCLUDED

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -770,6 +770,7 @@ bool TTool::isColumnLocked(int columnIndex) const {
   if (columnIndex < 0) return false;
   TXsheet *xsh       = getXsheet();
   TXshColumn *column = xsh->getColumn(columnIndex);
+  if (!column) return false;
   return column->isLocked();
 }
 
@@ -884,7 +885,7 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
 
   // Check against unplaced columns (not in filmstrip mode)
   if (column && !filmstrip) {
-    if (column->isLocked())
+    if (column->isLocked() && m_name != T_Selection)
       return (enable(false), QObject::tr("The current column is locked."));
 
     else if (!column->isCamstandVisible())
@@ -971,7 +972,8 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
       if (parentId.isColumn() && obj->getParentHandle()[0] != 'H') {
         TXshSimpleLevel *parentSl =
             xsh->getCell(rowIndex, parentId.getIndex()).getSimpleLevel();
-        if (parentSl && parentSl->getType() == MESH_XSHLEVEL)
+        if (parentSl && parentSl->getType() == MESH_XSHLEVEL &&
+            m_name != T_Selection)
           return (
               enable(false),
               QObject::tr(
@@ -980,7 +982,7 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
     }
 
     // Check TTool::ImageType tools
-    if (toolType == TTool::LevelWriteTool) {
+    if (toolType == TTool::LevelWriteTool && m_name != T_Selection) {
       // Check level against read-only status
       if (sl->isFrameReadOnly(getCurrentFid()))
         return (enable(false),
@@ -993,7 +995,8 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
           sl->getPath().getType() == "gif" ||
           sl->getPath().getType() == "mp4" ||
           sl->getPath().getType() == "webm" ||
-          sl->is16BitChannelLevel() ||  // Inherited by previous implementation.
+          sl->is16BitChannelLevel() ||  // Inherited by previous
+                                        // implementation.
                                         // Could be fixed?
           sl->getProperties()->getBpp() ==
               1)  // Black & White images. Again, could be fixed?

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -681,7 +681,7 @@ void ToolOptionCombo::doOnActivated(int index) {
     onActivated(index);
     setCurrentIndex(index);
     // for updating the cursor
-	if (m_toolHandle) m_toolHandle->notifyToolChanged();
+    if (m_toolHandle) m_toolHandle->notifyToolChanged();
     return;
   }
 
@@ -1649,7 +1649,8 @@ void SelectionScaleField::onChange(TMeasuredValue *fld, bool addToUndo) {
 //-----------------------------------------------------------------------------
 
 void SelectionScaleField::updateStatus() {
-  if (!m_tool || (m_tool->isSelectionEmpty() && !m_tool->isLevelType())) {
+  if (!m_tool || !m_tool->isSelectionEditable() ||
+      (m_tool->isSelectionEmpty() && !m_tool->isLevelType())) {
     setValue(0);
     setDisabled(true);
     return;
@@ -1702,7 +1703,8 @@ void SelectionRotationField::onChange(TMeasuredValue *fld, bool addToUndo) {
 //-----------------------------------------------------------------------------
 
 void SelectionRotationField::updateStatus() {
-  if (!m_tool || (m_tool->isSelectionEmpty() && !m_tool->isLevelType())) {
+  if (!m_tool || !m_tool->isSelectionEditable() ||
+      (m_tool->isSelectionEmpty() && !m_tool->isLevelType())) {
     setValue(0);
     setDisabled(true);
     return;
@@ -1763,7 +1765,8 @@ void SelectionMoveField::onChange(TMeasuredValue *fld, bool addToUndo) {
 //-----------------------------------------------------------------------------
 
 void SelectionMoveField::updateStatus() {
-  if (!m_tool || (m_tool->isSelectionEmpty() && !m_tool->isLevelType())) {
+  if (!m_tool || !m_tool->isSelectionEditable() ||
+      (m_tool->isSelectionEmpty() && !m_tool->isLevelType())) {
     setValue(0);
     setDisabled(true);
     return;
@@ -1824,7 +1827,8 @@ void ThickChangeField::onChange(TMeasuredValue *fld, bool addToUndo) {
 //-----------------------------------------------------------------------------
 
 void ThickChangeField::updateStatus() {
-  if (!m_tool || m_tool->m_deformValues.m_isSelectionModified ||
+  if (!m_tool || !m_tool->isSelectionEditable() ||
+      m_tool->m_deformValues.m_isSelectionModified ||
       (m_tool->isSelectionEmpty() && !m_tool->isLevelType())) {
     setValue(0);
     setDisabled(true);

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -1556,6 +1556,8 @@ void VectorSelectionTool::leftButtonDoubleClick(const TPointD &pos,
 void VectorSelectionTool::leftButtonDrag(const TPointD &pos,
                                          const TMouseEvent &e) {
   if (m_dragTool) {
+    if (!m_strokeSelection.isEditable()) return;
+
     m_dragTool->leftButtonDrag(pos, e);
     return;
   }
@@ -1621,6 +1623,12 @@ void VectorSelectionTool::leftButtonUp(const TPointD &pos,
   m_shiftPressed           = false;
 
   if (m_dragTool) {
+    if (!m_strokeSelection.isEditable()) {
+      delete m_dragTool;
+      m_dragTool = 0;
+      return;
+    }
+
     m_dragTool->leftButtonUp(pos, e);
     delete m_dragTool;
     m_dragTool = 0;
@@ -1827,7 +1835,7 @@ void VectorSelectionTool::computeBBox() {
             getFourPointsFromVectorImage(vi, selectedStyles(), maxThickness);
 
         m_bboxs.push_back(p);
-		m_centers.push_back(0.5 * (p.getP00() + p.getP11()));
+        m_centers.push_back(0.5 * (p.getP00() + p.getP11()));
         m_deformValues.m_maxSelectionThickness = maxThickness;
       }
     }
@@ -1998,6 +2006,8 @@ TPropertyGroup *VectorSelectionTool::getProperties(int idx) {
 //-----------------------------------------------------------------------------
 
 bool VectorSelectionTool::onPropertyChanged(std::string propertyName) {
+  if (!m_strokeSelection.isEditable()) return false;
+
   if (SelectionTool::onPropertyChanged(propertyName)) return true;
 
   if (propertyName == m_constantThickness.getName())
@@ -2179,6 +2189,8 @@ void VectorSelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
 
   SelectionTool::updateAction(pos, e);
   if (m_what != Outside || m_cursorId != ToolCursor::StrokeSelectCursor) return;
+
+  if (!m_strokeSelection.isEditable()) return;
 
   FourPoints bbox = getBBox();
   UINT index      = 0;

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -311,6 +311,8 @@ public:
   void setResetCenter(bool update) { m_resetCenter = update; }
   bool canResetCenter() { return m_resetCenter; }
 
+  bool isSelectionEditable() { return m_strokeSelection.isEditable(); }
+
 protected:
   void onActivate() override;
   void onDeactivate() override;


### PR DESCRIPTION
This PR resolves #2901 .

The Selection Tool is currently unavailable whenever the column is locked or the level is read-only. This change will make the Selection Tool available under these conditions.

The change include the following:

- Enables the Selection Tool for Vector, Toonz Raster and Raster levels under the following conditions:
   - The level is marked as read-only because of file permissions or is a PSD/GIF/MP4/WEBM file
   - The column in the xsheet/timeline is locked
   - The column is not editable because it is a mesh-deformed column
- Copying a selection is the only thing allowed.  Moving, deforming, cutting and pasting selections into are blocked.
- The Selection Tool toolbar options will become unavailable.
- The selection box will lose the deformation handles and center pivot.

![image](https://user-images.githubusercontent.com/19245851/69504892-7ec6fa80-0ef4-11ea-9d75-c43fbc8ffc5a.png)

