### PR TITLE
Mark PSD and ffmpeg loaded files as readonly in Level Strip

### DIFF
--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -2318,7 +2318,11 @@ bool TXshSimpleLevel::isFrameReadOnly(TFrameId fid) {
   // the OS level
   if (getType() == OVL_XSHLEVEL || getType() == TZI_XSHLEVEL ||
       getType() == MESH_XSHLEVEL) {
-    TFilePath fullPath = getScene()->decodeFilePath(m_path);
+    TFilePath fullPath   = getScene()->decodeFilePath(m_path);
+    std::string fileType = fullPath.getType();
+    if (fileType == "psd" || fileType == "gif" || fileType == "mp4" ||
+        fileType == "webm")
+      return true;
     TFilePath path =
         fullPath.getDots() == ".." ? fullPath.withFrame(fid) : fullPath;
     if (!TSystem::doesExistFileOrLevel(path)) return false;


### PR DESCRIPTION
Normally, read-only files (based on file permissions) are denoted in the Level Strip with a forbidden icon in the lower left corner of each frame.

This PR adds the forbidden icon for PSD/GIF/MP4/WEBM files also so users know they are read-only files.

![image](https://user-images.githubusercontent.com/19245851/69512597-97dea400-0f12-11ea-96d3-a9d5b2c54333.png)
