### PR TITLE
Ignore OT's paste shortcut in TypeTool box

### DIFF
--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -1515,17 +1515,11 @@ bool TypeTool::keyDown(QKeyEvent *event) {
   QString text = event->text();
   if ((event->modifiers() & Qt::ShiftModifier)) text.toUpper();
 
-  std::string keyStr =
-      QKeySequence(event->key() + event->modifiers()).toString().toStdString();
-  QAction *action = CommandManager::instance()->getActionFromShortcut(keyStr);
-  if (action) {
-    std::string actionId = CommandManager::instance()->getIdFromAction(action);
-    if (actionId == "MI_Paste") {
-      QClipboard *clipboard     = QApplication::clipboard();
-      const QMimeData *mimeData = clipboard->mimeData();
-      if (!mimeData->hasText()) return true;
-      text = mimeData->text().replace('\n', '\r');
-    }
+  if (QKeySequence(event->key() + event->modifiers()) == QKeySequence::Paste) {
+    QClipboard *clipboard     = QApplication::clipboard();
+    const QMimeData *mimeData = clipboard->mimeData();
+    if (!mimeData->hasText()) return true;
+    text = mimeData->text().replace('\n', '\r');
   }
 
   std::wstring unicodeChar = text.toStdWString();
@@ -1605,7 +1599,7 @@ bool TypeTool::keyDown(QKeyEvent *event) {
     invalidate();
     break;
 
-    /////////////////// end cursors
+  /////////////////// end cursors
 
   case Qt::Key_Escape:
     resetInputMethod();


### PR DESCRIPTION
This PR fixes #2899 

Due to change in #2773, the TypeTool edit box was checking against OT's shortcuts for the Paste command (defaulted to Ctrl+V). If the shortcut was changed to a single letter/character that one would normally type in an edit box, it would execute the Paste shortcut every time it was typed.

Modified so that it only recognizes the system Paste command to know when to execute a Paste action in the edit box.
