### PR TITLE
Fix tool crashes on Palette and Zerary column

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -875,6 +875,12 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
         m_application->getCurrentObject()->getObjectId().getIndex());
   }
 
+  bool isZeraryCol =
+      column ? (column->getZeraryFxColumn() ? true : false) : false;
+  bool isPaletteCol =
+      column ? (column->getPaletteColumn() ? true : false) : false;
+  bool isMeshCol = column ? (column->getMeshColumn() ? true : false) : false;
+
   // Check against splines
   if (spline && (toolType & TTool::LevelTool)) {
     return (targetType & Splines)
@@ -930,8 +936,10 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
   if (toolType & TTool::LevelTool) {
     // Check against empty levels
     if (!xl)
-      return (targetType & EmptyTarget) ? (enable(true), QString())
-                                        : (enable(false), QString());
+      return ((targetType & EmptyTarget) && !isZeraryCol && !isPaletteCol &&
+              !isMeshCol)
+                 ? (enable(true), QString())
+                 : (enable(false), QString());
 
     // Check against simple-level-edness
     if (!sl)


### PR DESCRIPTION
This PR fixes #2910

Added logic to disable Level tools like brushes, geometry tools and type tool on blank frames if it is a Palette, ZeraryFx or Mesh column since you cannot add new levels to these columns.