### PR TITLE
(WIP) Fix crash when using keyboard shortcuts while moving a line

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -517,6 +517,8 @@ transformation.
     return m_selectedFrames;
   }
 
+  virtual void beforeCut() {}
+
 public:
   static std::vector<int> m_cellsData;  //!< \deprecated  brutto brutto. fix
                                         //! quick & dirty del baco #6213 (undo

--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -515,6 +515,8 @@ void StrokeSelection::deleteStrokes() {
     undo = new ToolUtils::UndoPath(
         tool->getXsheet()->getStageObject(tool->getObjectId())->getSpline());
 
+  tool->beforeCut();
+
   StrokesData *data = new StrokesData();
   data->setImage(m_vi, m_indexes);
   std::set<int> oldIndexes = m_indexes;
@@ -628,6 +630,8 @@ void StrokeSelection::cut() {
   if (isSpline)
     undo = new ToolUtils::UndoPath(
         tool->getXsheet()->getStageObject(tool->getObjectId())->getSpline());
+
+  tool->beforeCut();
 
   StrokesData *data = new StrokesData();
   data->setImage(m_vi, m_indexes);

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -34,6 +34,9 @@ using namespace DragSelectionTool;
 //    Global variables
 //********************************************************************************
 
+static TPointD lastDragPos; // previous mouse-drag position
+static TMouseEvent lastDragEvent; // previous mouse-drag event
+
 namespace {
 
 VectorSelectionTool l_vectorSelectionTool(TTool::Vectors);
@@ -1555,6 +1558,9 @@ void VectorSelectionTool::leftButtonDoubleClick(const TPointD &pos,
 
 void VectorSelectionTool::leftButtonDrag(const TPointD &pos,
                                          const TMouseEvent &e) {
+  lastDragPos = pos;
+  lastDragEvent = e;
+
   if (m_dragTool) {
     if (!m_strokeSelection.isEditable()) return;
 
@@ -1979,6 +1985,8 @@ void VectorSelectionTool::onImageChanged() {
 //-----------------------------------------------------------------------------
 
 void VectorSelectionTool::doOnDeactivate() {
+  beforeCut();
+
   m_strokeSelection.selectNone();
   m_levelSelection.selectNone();
   m_deformValues.reset();
@@ -1988,6 +1996,22 @@ void VectorSelectionTool::doOnDeactivate() {
   TTool::getApplication()->getCurrentSelection()->setSelection(0);
 
   invalidate();
+}
+
+//-----------------------------------------------------------------------------
+
+void VectorSelectionTool::beforeCut()
+{
+  if(m_enabled && m_leftButtonMousePressed) {
+    leftButtonUp(lastDragPos, lastDragEvent);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void VectorSelectionTool::onLeave()
+{
+  beforeCut();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -313,6 +313,9 @@ public:
 
   bool isSelectionEditable() { return m_strokeSelection.isEditable(); }
 
+  void beforeCut() override;
+  void onLeave() override;
+
 protected:
   void onActivate() override;
   void onDeactivate() override;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1171,6 +1171,19 @@ bool SceneViewer::event(QEvent *e) {
       e->accept();
     }
 
+    // Ensure the current tool finishes any mouse drag operation
+    // before performing an undo or redo.
+    QKeyEvent *ke = (QKeyEvent *)e;
+    std::string keyStr =
+        QKeySequence(ke->key() + ke->modifiers()).toString().toStdString();
+    QAction *action = CommandManager::instance()->getActionFromShortcut(keyStr);
+    if (action) {
+      std::string actionId = CommandManager::instance()->getIdFromAction(action);
+      if (actionId == "MI_Undo" || actionId == "MI_Redo") {
+        tool->beforeCut();
+      }
+    }
+
     return true;
   }
   if (e->type() == QEvent::KeyRelease) {


### PR DESCRIPTION
Fixes #2148.

Somehow I messed up the original PR (#2686), so I created this one instead. This avoids crashing when pressing Ctrl+X (cut), Delete, Ctrl+Z (undo) or opening a dialog (e.g. with Ctrl+N) while moving a vector line.

Video below:

![moving-line-demo](https://user-images.githubusercontent.com/24422213/70015351-f0cccd00-15e1-11ea-9852-a7259df9539a.gif)