### PR TITLE
Block reserved file names

### DIFF
--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -117,6 +117,8 @@ QString DVAPI toQString(const TFilePath &path);
 bool DVAPI isSpaceString(const QString &str);
 bool DVAPI isValidFileName(const QString &fileName);
 bool DVAPI isValidFileName_message(const QString &fileName);
+bool DVAPI isReservedFileName(const QString &fileName);
+bool DVAPI isReservedFileName_message(const QString &fileName);
 
 QString DVAPI elideText(const QString &columnName, const QFont &font,
                         int width);

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1451,7 +1451,8 @@ bool CloneLevelUndo::chooseLevelName(TFilePath &fp) const {
   if (levelNamePopup->exec() == QDialog::Accepted) {
     const QString &levelName = levelNamePopup->getName();
 
-    if (isValidFileName_message(levelName)) {
+    if (isValidFileName_message(levelName) &&
+        !isReservedFileName_message(levelName)) {
       fp = fp.withName(levelName.toStdWString());
       return true;
     }

--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -658,6 +658,9 @@ bool ExportLevelPopup::execute() {
       return false;
     }
 
+    if (isReservedFileName_message(QString::fromStdString(fp.getName())))
+      return false;
+
     return IoCmd::exportLevel(fp.withType(ext).withFrame(), 0, opts);
   }
 }

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -1646,6 +1646,7 @@ void RenameAsToonzPopup::onOk() {
            "characters:(new line)  \\ / : * ? \"  |"));
     return;
   }
+  if (isReservedFileName_message(m_name->text())) return;
   accept();
 }
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -224,6 +224,7 @@ void FileBrowserPopup::onOkPressed() {
                       "following characters:\n \\ / : * ? \" < > |"));
       return;
     }
+    if (isReservedFileName_message(QFileInfo(str).baseName())) return;
 
     m_selectedPaths.clear();
     if (!m_isDirectoryOnly)

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -452,6 +452,9 @@ bool LevelCreatePopup::apply() {
     return false;
   }
 
+  if (isReservedFileName_message(QString::fromStdWString(levelName)))
+    return false;
+
   if (from > to) {
     error(tr("Invalid frame range"));
     return false;

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -933,6 +933,16 @@ void OutputSettingsPopup::onNameChanged() {
 
     return;
   }
+  if (isReservedFileName_message(name)) {
+    TOutputProperties *prop = getProperties();
+    TFilePath fp = prop->getPath();
+    QString name = QString::fromStdString(fp.getName());
+    if (name.isEmpty())
+      name = QString::fromStdString(scene->getScenePath().getName());
+    m_fileNameFld->setText(name);
+
+    return;
+  }
 
   std::wstring wname = name.toStdWString();
   {

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -584,6 +584,10 @@ void ProjectCreatePopup::createProject() {
     return;
   }
 
+  if (isReservedFileName_message(fi.baseName())) {
+    return;
+  }
+
   TProjectManager *pm   = TProjectManager::instance();
   TFilePath projectName = TFilePath(m_nameFld->text().toStdWString());
   if (projectName == TFilePath()) {

--- a/toonz/sources/toonzlib/namebuilder.cpp
+++ b/toonz/sources/toonzlib/namebuilder.cpp
@@ -33,6 +33,16 @@ std::wstring NameCreator::getNext() {
   }
   std::wstring s;
   for (i = n - 1; i >= 0; i--) s.append(1, (wchar_t)(L'A' + m_s[i]));
+
+#ifdef _WIN32
+  std::vector<std::wstring> invalidNames{L"AUX", L"COM", L"CON",
+                                         L"LPT", L"NUL", L"PRN"};
+  // If we're an invalid combination, let's check the next one
+  if (std::find(invalidNames.begin(), invalidNames.end(), s) !=
+      invalidNames.end())
+    return getNext();
+#endif
+
   return s;
 }
 

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -314,6 +314,33 @@ bool isValidFileName_message(const QString &fileName) {
 
 //-----------------------------------------------------------------------------
 
+bool isReservedFileName(const QString &fileName) {
+#ifdef _WIN32
+  std::vector<QString> invalidNames{
+      "AUX",  "CON",  "NUL",  "PRN",  "COM1", "COM2", "COM3", "COM4",
+      "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3",
+      "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
+
+  if (std::find(invalidNames.begin(), invalidNames.end(), fileName) !=
+      invalidNames.end())
+    return true;
+#endif
+
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+
+bool isReservedFileName_message(const QString &fileName) {
+  return isReservedFileName(fileName)
+             ? (DVGui::error(QObject::tr(
+                    "That is a reserved file name and cannot be used.")),
+                true)
+             : false;
+}
+
+//-----------------------------------------------------------------------------
+
 QString elideText(const QString &srcText, const QFont &font, int width) {
   QFontMetrics metrix(font);
   int srcWidth = metrix.width(srcText);


### PR DESCRIPTION
This PR fixes #2908

Added logic for the Windows version to 
1. Skip generation of level names AUX, COM, CON, LPT, NUL, PRN
2. Prevent saving names that are reserved file names AUX, COM1-9, CON, LPT1-9, NUL, PRN 
