### PR TITLE
Disable keyboard shortcuts while dragging vector line

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -513,6 +513,9 @@ transformation.
   // Tools.
   virtual bool isPencilModeActive() { return false; }
 
+  // return true if the tool is busy with a mouse drag operation
+  virtual bool isDragging() const { return false; };
+
   void setSelectedFrames(const std::set<TFrameId> &selectedFrames);
   static const std::set<TFrameId> &getSelectedFrames() {
     return m_selectedFrames;

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -1990,6 +1990,12 @@ void VectorSelectionTool::onImageChanged() {
 
 //-----------------------------------------------------------------------------
 
+bool VectorSelectionTool::isDragging() const {
+  return m_enabled && m_leftButtonMousePressed;
+}
+
+//-----------------------------------------------------------------------------
+
 void VectorSelectionTool::doOnDeactivate() {
   m_strokeSelection.selectNone();
   m_levelSelection.selectNone();

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -338,6 +338,8 @@ protected:
     return m_cursorId;
   }
 
+  bool isDragging() const override;
+
 private:
   class AttachedLevelSelection final : public LevelSelection {
     StrokeSelection &m_strokeSelection;  //!< Selection of strokes to be seen at

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1191,6 +1191,12 @@ bool SceneViewer::event(QEvent *e) {
       e->accept();
     }
 
+    // Disable keyboard shortcuts while the tool is busy with a mouse drag
+    // operation.
+    if ( tool->isDragging() ) {
+      e->accept();
+    }
+
     return true;
   }
   if (e->type() == QEvent::KeyRelease) {


### PR DESCRIPTION
Possible fix for #2148. This is an alternative to #2912.

This disables all keyboard shortcuts while dragging a vector line. 

Video demo below; this shows shortcuts disabled while dragging, but enabled again when not dragging:

![disable-shortcuts-demo](https://user-images.githubusercontent.com/24422213/70101155-f6391e80-1698-11ea-9df8-1fb9615e7c79.gif)

This could be extended for other tools such as the Brush, too.