### PR TITLE
Update instructions (portablestuff notes)

### DIFF
--- a/doc/how_to_test_prs.md
+++ b/doc/how_to_test_prs.md
@@ -7,9 +7,9 @@ The AppVeyor build can easily be made into a portable version of Opentoonz for e
 Simply rename the included 'Opentoonz stuff' directory as 'portablestuff' and move it into the Opentoonz directory where Opentoonz.exe is located.  If the portablestuff directory is not present the AppVeyor build will utilize the stuff directory located at C:\Opentoonz stuff.  Note that required files may not be present in the default stuff directory and use of portablestuff directory is recommended.
 
 ## Pre-Testing Notes
-- This can only be tested on Windows. There is no OSX or Linux build that can be tested.
-- You need to have OpenToonz already installed.  Do not uninstall.
-- Your current personal preferences and settings will be used.
+- This can only be tested on Windows. There is currently no OSX or Linux build that can be tested.
+- You can have OpenToonz already installed.  There is no need to uninstall.
+- Your current personal preferences and settings will be used unless a portablestuff directory is utilized.
   - Personal settings can change if you change them while testing.
   - It is recommended that you backup your `C:\OpenToonz stuff` folder before testing a PR using that directory.
 - The AppVeyor build now contains an updated `OpenToonz stuff` folder and any PR changes to default configurations (i.e. stylesheets, FXs, brushes, etc) will be located in the accompanying stuff folder.

--- a/doc/how_to_test_prs.md
+++ b/doc/how_to_test_prs.md
@@ -1,14 +1,18 @@
 # Testing Pull Requests (PRs)
 
-When a PR is submitted, it is compiled automatically by AppVeyor and Travis CI. The AppVeyor build creates an artifact which contains the OpenToonz executable and supporting DLLs needed to run.  You can easily download this artifact and run it to test out the PR before it is merged.
+When a PR is submitted, it is compiled automatically by AppVeyor and Travis CI. The AppVeyor build creates an artifact which contains the OpenToonz executable, supporting DLLs needed to run and the stuff directory containing configuration files, preferences and menus.  You can easily download this artifact and run it to test out the PR before it is merged.
+
+## Testing with a portable release of Opentoonz
+The AppVeyor build can easily be made into a portable version of Opentoonz for easy storage on USB device or for easy sharing.
+Simply rename the included 'Opentoonz stuff' directory as 'portablestuff' and move it into the Opentoonz directory where Opentoonz.exe is located.  If the portablestuff directory is not present the AppVeyor build will utilize the stuff directory located at C:\Opentoonz stuff.  Note that required files may not be present in the default stuff directory and use of portablestuff directory is recommended.
 
 ## Pre-Testing Notes
 - This can only be tested on Windows. There is no OSX or Linux build that can be tested.
 - You need to have OpenToonz already installed.  Do not uninstall.
 - Your current personal preferences and settings will be used.
   - Personal settings can change if you change them while testing.
-  - It is recommended that you backup your `C:\OpenToonz #.# stuff` folder before testing a PR.
-- The AppVeyor build does not contain an updated `C:\OpenToonz #.# stuff` folder so any PR changes to default configurations (i.e. stylesheets, FXs, brushes, etc) are not automatically included.
+  - It is recommended that you backup your `C:\OpenToonz stuff` folder before testing a PR using that directory.
+- The AppVeyor build now contains an updated `OpenToonz stuff` folder and any PR changes to default configurations (i.e. stylesheets, FXs, brushes, etc) will be located in the accompanying stuff folder.
 - It is recommended when testing to use new scenes that you can throw away.
   - If you decide to test on an existing scene, back it up first!
 


### PR DESCRIPTION
Appveyor builds now include a stuff directory with relevant changes to configuration, menu and other files in the stuff folder.  Renaming 'Opentoonz stuff'  to 'portablestuff' and placing it with the Opentoonz.exe will allow the release to be portable.

This PR updates some outdated instructions and adds information on how to set up Appveyor builds as portable releases.