### PR TITLE
Fix BG color buttons malfunction

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -203,9 +203,6 @@ public:
     eRate,
     eSound,
     eHisto,
-    eBlackBg,
-    eWhiteBg,
-    eCheckBg,
     eSaveImg,
     eCompare,
     eCustomize,
@@ -220,6 +217,10 @@ public:
     eFlipHorizontal,
     eFlipVertical,
     eResetView,
+    // following values are hard-coded in ImagePainter
+    eBlackBg = 0x40000,
+    eWhiteBg = 0x80000,
+    eCheckBg = 0x100000,
     eEnd
   };
 

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -129,9 +129,6 @@ public:
   //! Multiple
   //!               levels \a may be loaded for a single resource data.
 public:
-  /*-
-   * Resourceは常にLoadするように変更（ファイルをプロジェクトフォルダにコピー（=Import）したい場合は、ユーザが手動で行う）
-   * -*/
   LoadResourceArguments()
       : row0(-1)
       , col0(-1)


### PR DESCRIPTION
This PR fixes the following problem after introducing #2540 :

- White BG / Black BG / Checkerboard BG buttons do not work and the Flipbook always shows white background.

I reverted the enum values of `eBlackBg, eWhiteBg, and eCheckBg` as they are refered in `ImagePainter` [with hard-coded values](https://github.com/opentoonz/opentoonz/blob/de71c0db14629308577bfda834efd73a4be64035/toonz/sources/toonzlib/imagepainter.cpp#L300).

( Deleting the comment on `iocommand.h` is not related. I deleted it as it's old and incorrect. )