### PR TITLE
Allow double-click in Load Scene dialog to open selected scene

### DIFF
--- a/toonz/sources/toonz/dvitemview.cpp
+++ b/toonz/sources/toonz/dvitemview.cpp
@@ -1301,6 +1301,7 @@ void DvItemViewerPanel::mouseReleaseEvent(QMouseEvent *) {}
 void DvItemViewerPanel::mouseDoubleClickEvent(QMouseEvent *event) {
   int index = pos2index(event->pos());
   if (index < 0 || index >= getItemCount()) return;
+  if (m_viewer) m_viewer->notifyDoubleClick(index);
   if (!getModel()->canRenameItem(index)) return;
   QRect captionRect = getCaptionRect(index);
   if (!captionRect.contains(event->pos())) return;

--- a/toonz/sources/toonz/dvitemview.h
+++ b/toonz/sources/toonz/dvitemview.h
@@ -412,6 +412,10 @@ public:
     emit clickedItem(index);
     emit selectedItems(m_panel->getSelectedIndices());
   }
+  void notifyDoubleClick(int index) {
+    emit doubleClickedItem(index);
+    emit selectedItems(m_panel->getSelectedIndices());
+  }
 
   void enableGlobalSelection(bool enabled) {
     m_panel->enableGlobalSelection(enabled);
@@ -425,6 +429,7 @@ protected:
 
 signals:
   void clickedItem(int index);
+  void doubleClickedItem(int index);
   void selectedItems(const std::set<int> &indexes);
 };
 

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -240,6 +240,8 @@ FileBrowser::FileBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu,
 
   ret = ret && connect(m_itemViewer, SIGNAL(clickedItem(int)), this,
                        SLOT(onClickedItem(int)));
+  ret = ret && connect(m_itemViewer, SIGNAL(doubleClickedItem(int)), this,
+                       SLOT(onDoubleClickedItem(int)));
   ret =
       ret && connect(m_itemViewer, SIGNAL(selectedItems(const std::set<int> &)),
                      this, SLOT(onSelectedItems(const std::set<int> &)));
@@ -2097,6 +2099,23 @@ void FileBrowser::onClickedItem(int index) {
       if (index.isValid()) m_folderTreeView->scrollTo(index);
     } else
       emit filePathClicked(fp);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void FileBrowser::onDoubleClickedItem(int index)
+{
+  // TODO: Avoid duplicate code with onClickedItem().
+  if (0 <= index && index < (int)m_items.size()) {
+    // if the folder is clicked, then move the current folder
+    TFilePath fp = m_items[index].m_path;
+    if (m_items[index].m_isFolder) {
+      setFolder(fp, true);
+      QModelIndex index = m_folderTreeView->currentIndex();
+      if (index.isValid()) m_folderTreeView->scrollTo(index);
+    } else
+      emit filePathDoubleClicked(fp);
   }
 }
 

--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -159,6 +159,7 @@ protected slots:
                      const QModelIndex &bottomRight);
   void loadResources();
   void onClickedItem(int index);
+  void onDoubleClickedItem(int index);
   void onSelectedItems(const std::set<int> &indexes);
   void folderUp();
   void newFolder();
@@ -200,6 +201,7 @@ protected slots:
 signals:
 
   void filePathClicked(const TFilePath &);
+  void filePathDoubleClicked(const TFilePath &);
   // reuse the list of TFrameId in order to skip loadInfo() when loading the
   // level with sequencial frames.
   void filePathsSelected(const std::set<TFilePath> &,

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -346,6 +346,13 @@ void FileBrowserPopup::onFilePathsSelected(
 
 //-----------------------------------------------------------------------------
 
+void FileBrowserPopup::onFilePathDoubleClicked(const TFilePath &)
+{
+  // do nothing by default
+}
+
+//-----------------------------------------------------------------------------
+
 void FileBrowserPopup::setOkText(const QString &text) {
   m_okButton->setText(text);
 }
@@ -495,6 +502,8 @@ LoadScenePopup::LoadScenePopup() : FileBrowserPopup(tr("Load Scene")) {
 
   // set the initial current path according to the current module
   setInitialFolderByCurrentRoom();
+
+  connect(m_browser, SIGNAL(filePathDoubleClicked(const TFilePath&)), this, SLOT(onFilePathDoubleClicked(const TFilePath&)));
 }
 
 bool LoadScenePopup::execute() {
@@ -533,6 +542,11 @@ void LoadScenePopup::setInitialFolderByCurrentRoom() {
 void LoadScenePopup::showEvent(QShowEvent *e) {
   m_nameField->clear();
   FileBrowserPopup::showEvent(e);
+}
+
+void LoadScenePopup::onFilePathDoubleClicked(const TFilePath& path) {
+  Q_UNUSED(path);
+  onOkPressed();
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -144,6 +144,7 @@ protected slots:
   virtual void onFilePathsSelected(
       const std::set<TFilePath> &paths,
       const std::list<std::vector<TFrameId>> &fIds);
+  virtual void onFilePathDoubleClicked(const TFilePath &);
 
   // utility function
 public:
@@ -209,6 +210,9 @@ public:
 
 protected:
   void showEvent(QShowEvent *) override;
+
+protected slots:
+  void onFilePathDoubleClicked(const TFilePath &path);
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR allows you to double-click on a scene in the "Load Scene" dialog to open it.

Video below:

![double-click-demo](https://user-images.githubusercontent.com/24422213/70336828-bcd9fc00-18ae-11ea-980e-42c704a68e0a.gif)
