### PR TITLE
Add FX Editor to Windows menu

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -299,6 +299,7 @@
         <command>MI_OpenTimelineView</command>
         <command>MI_OpenFunctionEditor</command>
         <command>MI_OpenSchematic</command>
+        <command>MI_FxParamEditor</command>
         <command>MI_OpenFilmStrip</command>
         <separator/>
         <command>MI_OpenFileBrowser</command>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1763,8 +1763,6 @@ void MainWindow::defineActions() {
       createMenuXsheetAction(MI_NewOutputFx, tr("&New Output"), "Alt+O");
   newOutputAction->setIcon(createQIconOnOff("output", false));
 
-  createRightClickMenuAction(MI_FxParamEditor, tr("&Edit FX..."), "Ctrl+K");
-
   createMenuXsheetAction(MI_InsertSceneFrame, tr("Insert Frame"), "");
   createMenuXsheetAction(MI_RemoveSceneFrame, tr("Remove Frame"), "");
   createMenuXsheetAction(MI_InsertGlobalKeyframe, tr("Insert Multiple Keys"),
@@ -1963,6 +1961,7 @@ void MainWindow::defineActions() {
   createMenuWindowsAction(MI_OpenColorModel, tr("&Color Model"), "");
   createMenuWindowsAction(MI_OpenStudioPalette, tr("&Studio Palette"), "");
   createMenuWindowsAction(MI_OpenSchematic, tr("&Schematic"), "");
+  createMenuWindowsAction(MI_FxParamEditor, tr("&FX Editor"), "Ctrl+K");
   createMenuWindowsAction(MI_OpenCleanupSettings, tr("&Cleanup Settings"), "");
 
   createMenuWindowsAction(MI_OpenFileBrowser2, tr("&Scene Cast"), "");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1411,6 +1411,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(windowsMenu, MI_OpenTimelineView);
   addMenuItem(windowsMenu, MI_OpenFunctionEditor);
   addMenuItem(windowsMenu, MI_OpenSchematic);
+  addMenuItem(windowsMenu, MI_FxParamEditor);
   addMenuItem(windowsMenu, MI_OpenFilmStrip);
   windowsMenu->addSeparator();
   addMenuItem(windowsMenu, MI_OpenFileBrowser);


### PR DESCRIPTION
This PR does the following

1. Relabels the `Edit FX...` command to `FX Editor` (per https://github.com/opentoonz/opentoonz/pull/2479#issuecomment-486527803)
2. Converts the `FX Editor` command from a Right-Click menu option to a Windows menu option.  It still appears as a right-click menu option when right-clicking an fx node
3. Adds the `FX Editor` below the `Schematic` command in Windows menus
