### PR TITLE
Switch Auto-Inbetween Easing logic

### DIFF
--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1021,11 +1021,11 @@ bool ToonzVectorBrushTool::doFrameRangeStrokes(TFrameId firstFrameId,
     case 1:  // LINEAR_WSTR
       break;
     case 2:  // EASEIN_WSTR
-      s = t * t;
-      break;  // s'(0) = 0
-    case 3:   // EASEOUT_WSTR
       s = t * (2 - t);
       break;  // s'(1) = 0
+    case 3:   // EASEOUT_WSTR
+      s = t * t;
+      break;  // s'(0) = 0
     case 4:   // EASEINOUT_WSTR:
       s = t * t * (3 - 2 * t);
       break;  // s'(0) = s'(1) = 0

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -2434,16 +2434,16 @@ public:
                       .arg(QString::fromStdWString(m_level->getName()));
     switch (m_interpolation) {
     case FilmstripCmd::II_Linear:
-      str += QString("Linear Interporation");
+      str += QString("Linear Interpolation");
       break;
     case FilmstripCmd::II_EaseIn:
-      str += QString("Ease In Interporation");
+      str += QString("Ease In Interpolation");
       break;
     case FilmstripCmd::II_EaseOut:
-      str += QString("Ease Out Interporation");
+      str += QString("Ease Out Interpolation");
       break;
     case FilmstripCmd::II_EaseInOut:
-      str += QString("Ease In-Out Interporation");
+      str += QString("Ease In-Out Interpolation");
       break;
     }
     return str;
@@ -2486,11 +2486,11 @@ void FilmstripCmd::inbetweenWithoutUndo(
     case II_Linear:
       break;
     case II_EaseIn:
-      s = t * t;
-      break;  // s'(0) = 0
-    case II_EaseOut:
       s = t * (2 - t);
       break;  // s'(1) = 0
+    case II_EaseOut:
+      s = t * t;
+      break;  // s'(0) = 0
     case II_EaseInOut:
       s = t * t * (3 - 2 * t);
       break;  // s'(0) = s'(1) = 0


### PR DESCRIPTION
This PR fixes #2929 by switching the internal calculations of auto-inbetweening `Ease In` and `Ease Out` options.

Also corrected `Interporation` typo that appears in History.