### PR TITLE
Level Settings for Multiple Selection

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1,1 +1,1935 @@
-.button-show,#LoadLevelShowButton,#CleanupSettingsShowButton,#OutputSettingsShowButton,#FxSettingsPreviewShowButton{image:url('../Default/imgs/white/plus.svg');image-position:center center;margin:0;padding:1;min-width:10;min-height:10}.button-show:checked,#LoadLevelShowButton:checked,#CleanupSettingsShowButton:checked,#OutputSettingsShowButton:checked,#FxSettingsPreviewShowButton:checked{background-color:#2b2c2d;border-color:#262728;image:url('../Default/imgs/white/minus.svg')}.button-show:checked:pressed,#LoadLevelShowButton:checked:pressed,#CleanupSettingsShowButton:checked:pressed,#OutputSettingsShowButton:checked:pressed,#FxSettingsPreviewShowButton:checked:pressed{background-color:#2b2c2d;border-color:#262728}.button-show:checked:hover,#LoadLevelShowButton:checked:hover,#CleanupSettingsShowButton:checked:hover,#OutputSettingsShowButton:checked:hover,#FxSettingsPreviewShowButton:checked:hover{background-color:#303133}.button-tool,QToolButton,#CameraSettingsRadioButton::indicator,#ForceSquaredPixelButton,#SchematicBottomFrame QToolBar QToolButton,#EditToolLockButton::indicator,#flipCustomize{background-color:rgba(255,255,255,0);border:1 solid rgba(255,255,255,0);border-radius:2;color:#e4e5e9;margin:1;padding:0}.button-tool:hover,QToolButton:hover,#CameraSettingsRadioButton::indicator:hover,#ForceSquaredPixelButton:hover,#colorSliderAddButton:hover,#colorSliderSubButton:hover,#SchematicBottomFrame QToolBar QToolButton:hover,#EditToolLockButton::indicator:hover,#flipCustomize:hover{background-color:#6e7174;border-color:#6e7174;color:#e4e5e9}.button-tool:pressed,QToolButton:pressed,#CameraSettingsRadioButton::indicator:pressed,#ForceSquaredPixelButton:pressed,#colorSliderAddButton:pressed,#colorSliderSubButton:pressed,#SchematicBottomFrame QToolBar QToolButton:pressed,#EditToolLockButton::indicator:pressed,#flipCustomize:pressed{background-color:#2b2c2d;border-color:#262728;color:#e4e5e9}.button-tool:checked,QToolButton:checked,#CameraSettingsRadioButton::indicator:checked,#ForceSquaredPixelButton:checked,#SchematicBottomFrame QToolBar QToolButton:checked,#EditToolLockButton::indicator:checked,#flipCustomize:checked{background-color:#5385a6;border-color:#5385a6;color:#fff}.button-tool:checked:hover,QToolButton:checked:hover,#CameraSettingsRadioButton::indicator:checked:hover,#ForceSquaredPixelButton:checked:hover,#SchematicBottomFrame QToolBar QToolButton:checked:hover,#EditToolLockButton::indicator:checked:hover,#flipCustomize:checked:hover{background-color:#6c98b6;border-color:#6c98b6}.button-tool:disabled,QToolButton:disabled,#CameraSettingsRadioButton::indicator:disabled,#ForceSquaredPixelButton:disabled,#SchematicBottomFrame QToolBar QToolButton:disabled,#EditToolLockButton::indicator:disabled,#flipCustomize:disabled{color:#808080}.button-flat,PaletteViewer QToolBar QToolButton{background-color:none;border:0;border-radius:0;margin:0}.button-flat:hover,PaletteViewer QToolBar QToolButton:hover{background-color:#6e7174}.button-flat:pressed,PaletteViewer QToolBar QToolButton:pressed{background-color:#212223}.frame,.GroupBox,#LoadLevelFrame,#PsdSettingsGroupBox,#CleanupSettingsFrame,#OutputSettingsBox,#OutputSettingsCameraBox,#SolidLineFrame,#FunctionParametersPanel,QGroupBox{border:1 solid #212223;border-radius:2}.tab-container,#TabBarContainer{background-color:transparent;qproperty-BottomAboveLineColor:#323435;qproperty-BottomBelowLineColor:#212223}.tab-flat,#StyleEditorTabBar::tab,#PaletteTabBar::tab,#FxSettingsTabBar::tab{background-color:#323435;border-right:1 solid #212223;border-bottom:1 solid #212223;color:#94969a;padding:3 4 3 4}.tab-flat:hover,#StyleEditorTabBar::tab:hover,#PaletteTabBar::tab:hover,#FxSettingsTabBar::tab:hover{background-color:#414345;color:#94969a}.tab-flat:selected,#StyleEditorTabBar::tab:selected,#PaletteTabBar::tab:selected,#FxSettingsTabBar::tab:selected{background-color:#414345;color:#fff;border-bottom-color:#414345}.tab-flat:only-one,#StyleEditorTabBar::tab:only-one,#PaletteTabBar::tab:only-one,#FxSettingsTabBar::tab:only-one{margin:0}.tab-round{background-color:#323435;border-top:1 solid #212223;border-right:1 solid #212223;border-left:1 solid #212223;border-bottom:1 solid #212223;color:#94969a;margin:3 -1 0 0;padding:2 7 1 7}.tab-round:hover{background-color:#414345;color:#94969a}.tab-round:selected{background-color:#414345;border-top-right-radius:2;border-top-left-radius:2;border-bottom-color:#414345;color:#fff;margin:1 -1 -1 0;padding:2 7 2 7}.tab-round:only-one{margin:1 0 0 0;padding:3 7 3 7}.tab-round:last{margin-right:0;border-top-right-radius:2}.tab-round:first{border-top-left-radius:2}QWidget{background-color:#414345;color:#d6d8dd}QWidget:disabled{color:#808080}QFrame{border:0;margin:0;padding:0}QToolTip,#helpToolTip{background-color:#fff;border:1 solid #000;color:#000;padding:1 1}#DockSeparator,QMainWindow::separator,QSplitter::handle{background-color:#141516;height:4;width:4}#TDockPlaceholder{background-color:#F77272}TPanel{background-color:#141516}#TopBar{background:#414345;border:0;border-bottom:1 solid #212223;height:21}#TopBar #EditToolLockButton{background:#414345;spacing:0}#TopBar #EditToolLockButton::indicator{background:none;border:none;height:18;margin:1 2 0 0;padding-left:0;padding-right:0}#TopBarTabContainer{background-color:#414345;margin-bottom:1}#StackedMenuBar{border:0;margin:0;padding:0}QMenuBar{background-color:#414345;border:0}QMenuBar::item{background-color:#414345;border-left:1 solid #414345;margin:0;padding:3 5}QMenuBar::item:selected{background-color:rgba(255,255,255,0.15);color:#d6d8dd}QMenuBar::item:pressed{background-color:#5385a6;color:#fff}#TopBarTab{margin:0;padding:0}#TopBarTab::tab{background-color:#323435;border-top:1 solid #212223;border-right:1 solid #212223;color:#94969a;margin:0 0 0 0;padding:2 8 3 8}#TopBarTab::tab:hover{background-color:#414345;color:#94969a}#TopBarTab::tab:selected{background-color:#414345;color:#fff}#TopBarTab::tab:first{border-left:1 solid #212223}#TopBarTab::tab:last{border-right:1 solid #212223}QMenu{background-color:#414345;border:1 solid #212223;padding:2 0}QMenu::item{padding:3 28}QMenu::item:selected{background-color:#5385a6;color:#fff}QMenu::item:checked{color:#d6d8dd}QMenu::item:checked:selected{background-color:#5385a6;color:#fff}QMenu::item:disabled{background:none;color:#808080}QMenu::item:disabled:selected{border-color:transparent}QMenu::separator{border-top:1 solid #212223;height:0;margin:2 0}QMenu::icon{border-radius:2;margin:0 0 0 3;padding:1}QMenu::icon:checked{background-color:#5385a6}QMenu::indicator{margin-left:7}TPanelTitleBar{background-color:#323435;border-color:#212223;border-style:solid;border-width:0 0 1 0;height:20;min-height:20;qproperty-TitleColor:#8c9093;qproperty-ActiveTitleColor:#43AEE5;qproperty-BorderPixmap:url('none');qproperty-ActiveBorderPixmap:url('../Default/imgs/white/none');qproperty-FloatBorderPixmap:url('none');qproperty-FloatActiveBorderPixmap:url('../Default/imgs/white/none')}QAbstractScrollArea::corner{background-color:#2d2f30}QScrollBar{background-color:#2d2f30;border:0}QScrollBar:horizontal{height:16;margin:0}QScrollBar:vertical{margin:0;width:16}QScrollBar::handle{border:1 solid #4b4d50;border-radius:4}QScrollBar::handle:horizontal:hover,QScrollBar::handle:vertical:hover{background-color:#5f6265;border-color:#5f6265}QScrollBar::handle:horizontal:pressed,QScrollBar::handle:vertical:pressed{background-color:#72767a;border-color:#72767a}QScrollBar::handle:horizontal{background-color:#4b4d50;margin:3 16;min-width:20}QScrollBar::handle:vertical{background-color:#4b4d50;margin:16 3;min-height:20}QScrollBar::add-line{subcontrol-origin:margin;border:0}QScrollBar::add-line:horizontal{subcontrol-position:right;background-color:#2d2f30;margin:0;width:16}QScrollBar::add-line:vertical{subcontrol-position:bottom;background-color:#2d2f30;margin:0;height:16}QScrollBar::sub-line{border:0;subcontrol-origin:margin}QScrollBar::sub-line:horizontal{subcontrol-position:left;background-color:#2d2f30;margin:0;width:16}QScrollBar::sub-line:vertical{subcontrol-position:top;background-color:#2d2f30;margin:0;height:16}QScrollBar::up-arrow:vertical{image:url('../Default/imgs/white/scroll-up.svg');image-position:center center}QScrollBar::up-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::down-arrow:vertical{image:url('../Default/imgs/white/scroll-down.svg');image-position:center center}QScrollBar::down-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::left-arrow:horizontal{image:url('../Default/imgs/white/scroll-left.svg');image-position:center center}QScrollBar::left-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::right-arrow:horizontal{image:url('../Default/imgs/white/scroll-right.svg');image-position:center center}QScrollBar::right-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::sub-page:horizontal,QScrollBar::add-page:horizontal,QScrollBar::sub-page:vertical,QScrollBar::add-page:vertical{background:none}QToolBar{padding:0}QToolBar::separator:horizontal{border-left:1 solid #212223;margin:0 1;width:0}QToolBar::separator:vertical{border-top:1 solid #212223;height:0;margin:1 0}QToolBar QLabel{margin-top:1}QToolBar QToolBar{border:0}QToolButton::menu-indicator{image:none}QToolButton::menu-button{border-image:none}.DvScrollWidget QPushButton,DvScrollWidget QPushButton,#ScrollLeftButton QPushButton,#ScrollRightButton QPushButton,#ScrollUpButton QPushButton,#ScrollDownButton QPushButton{background-color:#616467;border:0 solid red;border-radius:0;padding:0;max-width:16}.DvScrollWidget QPushButton:hover,DvScrollWidget QPushButton:hover,#ScrollLeftButton QPushButton:hover,#ScrollRightButton QPushButton:hover,#ScrollUpButton QPushButton:hover,#ScrollDownButton QPushButton:hover{background-color:#6e7174}.DvScrollWidget QPushButton:pressed,DvScrollWidget QPushButton:pressed,#ScrollLeftButton QPushButton:pressed,#ScrollRightButton QPushButton:pressed,#ScrollUpButton QPushButton:pressed,#ScrollDownButton QPushButton:pressed{background-color:#2b2c2d}#ScrollLeftButton,#ScrollRightButton,#ScrollUpButton,#ScrollDownButton{margin:0;min-width:16}#ScrollLeftButton{border-right:1 solid #212223;image:url('../Default/imgs/white/scroll-left.svg')}#ScrollRightButton{border-left:1 solid #212223;margin-left:3;image:url('../Default/imgs/white/scroll-right.svg')}#ScrollUpButton{image:url('../Default/imgs/white/scroll-up.svg')}#ScrollDownButton{image:url('../Default/imgs/white/scroll-down.svg')}#keyFrameNavigator{background:none;margin:0;padding:0}#keyFrameNavigator QToolButton{min-width:18}#keyFrameNavigator #PreviousKey{image:url('../Default/imgs/white/prevkey.svg')}#keyFrameNavigator #PreviousKey:hover{image:url('../Default/imgs/white/prevkey_over.svg')}#keyFrameNavigator #PreviousKey:disabled{image:url('../Default/imgs/white/prevkey_disabled.svg')}#keyFrameNavigator #NextKey{image:url('../Default/imgs/white/nextkey.svg')}#keyFrameNavigator #NextKey:hover{image:url('../Default/imgs/white/nextkey_over.svg')}#keyFrameNavigator #NextKey:disabled{image:url('../Default/imgs/white/nextkey_disabled.svg')}.treeview,QTreeWidget,QTreeView,#FunctionEditorTree{background-color:#2d2f30;alternate-background-color:#323435;border:0;margin:0;outline:0}.treeview::item:selected,QTreeWidget::item:selected,QTreeView::item:selected,#FunctionEditorTree::item:selected{background-color:#5385a6;color:#fff}.treeview::branch:adjoins-item,QTreeWidget::branch:adjoins-item,QTreeView::branch:adjoins-item,#FunctionEditorTree::branch:adjoins-item{border-image:url('')}.treeview::branch:has-siblings,QTreeWidget::branch:has-siblings,QTreeView::branch:has-siblings,#FunctionEditorTree::branch:has-siblings{border-image:url('')}.treeview::branch:has-siblings:adjoins-item,QTreeWidget::branch:has-siblings:adjoins-item,QTreeView::branch:has-siblings:adjoins-item,#FunctionEditorTree::branch:has-siblings:adjoins-item{border-image:url('')}.treeview::branch:has-children:closed,QTreeWidget::branch:has-children:closed,QTreeView::branch:has-children:closed,#FunctionEditorTree::branch:has-children:closed{background:url('../Default/imgs/white/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:open,QTreeWidget::branch:has-children:open,QTreeView::branch:has-children:open,#FunctionEditorTree::branch:has-children:open{background:url('../Default/imgs/white/treebranch-open.svg') no-repeat;background-position:center center;image:none}.treeview::branch:has-children:has-siblings:closed,QTreeWidget::branch:has-children:has-siblings:closed,QTreeView::branch:has-children:has-siblings:closed,#FunctionEditorTree::branch:has-children:has-siblings:closed{background:url('../Default/imgs/white/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:has-siblings:open,QTreeWidget::branch:has-children:has-siblings:open,QTreeView::branch:has-children:has-siblings:open,#FunctionEditorTree::branch:has-children:has-siblings:open{background:url('../Default/imgs/white/treebranch-open.svg') no-repeat;background-position:center center;border-image:none;image:none}QListView{outline:0;background:#2d2f30;alternate-background-color:#323435}#TabBarContainer{background-color:#323435}.Button,QPushButton,.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{background-color:#616467;border:1 solid #414345;border-radius:2;color:#e4e5e9;margin:0;padding:3 15}.Button:hover,QPushButton:hover,.ComboBox:hover,#ViewerFpsSlider::sub-line:horizontal:hover,#ViewerFpsSlider::add-line:horizontal:hover,QComboBox:hover{background-color:#6e7174;border-color:#414345;color:#e4e5e9}.Button:pressed,QPushButton:pressed,#ViewerFpsSlider::sub-line:horizontal:pressed,#ViewerFpsSlider::add-line:horizontal:pressed{background-color:#2b2c2d;border-color:#262728;color:#e4e5e9}.Button:checked,QPushButton:checked{background-color:#2b2c2d;border-color:#262728;color:#e4e5e9}.Button:checked:hover,QPushButton:checked:hover{background-color:#303133}.Button:checked:hover:pressed,QPushButton:checked:hover:pressed{background:#2b2c2d}.Button:disabled,QPushButton:disabled,.ComboBox:disabled,#ViewerFpsSlider::sub-line:horizontal:disabled,#ViewerFpsSlider::add-line:horizontal:disabled,QComboBox:disabled{background-color:#4d5052;border-color:#414345;color:#808080}#PushButton_NoPadding{padding:3}.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{padding:1 0 1 4;margin:1 0}.ComboBox::drop-down,QComboBox::drop-down{image:url('../Default/imgs/white/combo_downarrow.svg');image-position:center center;width:16}.ComboBox::drop-down:disabled,QComboBox::drop-down:disabled{image:url('../Default/imgs/white/combo_downarrow_disabled.svg')}.ComboBox QAbstractItemView,QComboBox QAbstractItemView{background-color:#414345;border:1 solid #212223;selection-background-color:#5385a6;selection-color:#fff}.LineEdit,QPlainTextEdit,QLineEdit,#TaskSheetItem,#tasksRemoveBox,#tasksAddBox{background-color:#28292b;border:1 solid #262728;border-radius:2;color:#d6d8dd;selection-background-color:#5385a6;selection-color:#fff;padding:0 0 0 1}.LineEdit:focus,QPlainTextEdit:focus,QLineEdit:focus,#TaskSheetItem:focus,#tasksRemoveBox:focus,#tasksAddBox:focus{background-color:#28292b;border-color:#5385a6;color:#d6d8dd}.LineEdit:disabled,QPlainTextEdit:disabled,QLineEdit:disabled,#TaskSheetItem:disabled,#tasksRemoveBox:disabled,#tasksAddBox:disabled{background-color:#353638;border-color:#333537;color:#808080}.CheckBox,QCheckBox{color:#d6d8dd}.CheckBox:hover,QCheckBox:hover,.RadioButton:hover,QRadioButton:hover{color:#fff}.CheckBox:disabled,QCheckBox:disabled{color:#808080}.CheckBox::indicator,QMenu::indicator,QCheckBox::indicator,.GroupBox::indicator,QGroupBox::indicator{background-color:#28292b;border:1 solid #262728;border-radius:2;height:9;padding:1;width:9}.CheckBox::indicator:hover,QMenu::indicator:hover,.CheckBox::indicator:checked:hover,QCheckBox::indicator:hover,.GroupBox::indicator:hover,QMenu::indicator:checked:hover,QCheckBox::indicator:checked:hover,.GroupBox::indicator:checked:hover,QGroupBox::indicator:hover,QGroupBox::indicator:checked:hover{background-color:#28292b;border-color:#5385a6}.CheckBox::indicator:checked,QMenu::indicator:checked,QCheckBox::indicator:checked,.GroupBox::indicator:checked,QGroupBox::indicator:checked{background-color:#28292b;border-color:#262728;image:url('../Default/imgs/white/checkmark.svg')}.CheckBox::indicator:checked:disabled,QMenu::indicator:checked:disabled,QCheckBox::indicator:checked:disabled,.GroupBox::indicator:checked:disabled,QGroupBox::indicator:checked:disabled{background-color:#353638;border-color:#353638;image:url('../Default/imgs/white/checkmark_disabled.svg')}.CheckBox::indicator:disabled,QMenu::indicator:disabled,QCheckBox::indicator:disabled,.GroupBox::indicator:disabled,QGroupBox::indicator:disabled{background-color:#353638;border-color:#353638}.RadioButton::indicator:unchecked,QRadioButton::indicator:unchecked,#CameraSettingsRadioButton_Small::indicator:unchecked{image:url('../Default/imgs/white/radiobutton_unchecked.svg');image-position:center center}.RadioButton::indicator:checked,QRadioButton::indicator:checked,#CameraSettingsRadioButton_Small::indicator:checked{image:url('../Default/imgs/white/radiobutton_checked.svg');image-position:center center}.GroupBox,QGroupBox{margin:6 0 0 0;padding:5 0}.GroupBox::title,QGroupBox::title{subcontrol-origin:margin;left:15;margin:-3 0 0 0;padding:0 3}.GroupBox::title:hover,QGroupBox::title:hover{color:#fff}.GroupBox::title:disabled,QGroupBox::title:disabled{color:#808080}.GroupBox::indicator,QGroupBox::indicator{subcontrol-origin:margin;margin-top:2}.GroupBox:disabled,QGroupBox:disabled{color:#808080}.Slider::groove:horizontal,QSlider::groove:horizontal{background-color:transparent;background-image:url('../Default/imgs/white/slider-groove.svg');background-position:center center;background-repeat:repeat-x;margin:0;height:20;min-height:20}.Slider::groove:horizontal:disabled,QSlider::groove:horizontal:disabled{background-image:url('../Default/imgs/white/slider-groove_disabled.svg')}.Slider::handle:horizontal,QSlider::handle:horizontal{width:10;margin:-2 -1;image:url('../Default/imgs/white/slider-handle.svg')}.Slider::handle:horizontal:disabled,QSlider::handle:horizontal:disabled{image:url('../Default/imgs/white/slider-handle_disabled.svg')}#IntPairField,#DoublePairField{qproperty-LightLineColor:#262728;qproperty-LightLineEdgeColor:#262728;qproperty-DarkLineColor:#262728;qproperty-MiddleLineColor:#262728;qproperty-HandleLeftPixmap:url("../Default/imgs/white/slider-handle.svg");qproperty-HandleRightPixmap:url("../Default/imgs/white/slider-handle.svg");qproperty-HandleLeftGrayPixmap:url("../Default/imgs/white/slider-handle_disabled.svg");qproperty-HandleRightGrayPixmap:url("../Default/imgs/white/slider-handle_disabled.svg")}#DirTreeView{background-color:#2d2f30;alternate-background-color:#2d2f30;border:1 solid #212223;border-right:0}DvItemViewerPanel{qproperty-TextColor:#d6d8dd;qproperty-AlternateBackground:#3a3b3d;qproperty-SelectedTextColor:#fff;qproperty-FolderTextColor:#9fdaff;qproperty-SelectedItemBackground:#5385a6}#FileBrowser DvItemViewerPanel,#SceneCast DvItemViewerPanel{background-color:#414345}#FileBrowser #castFrame,#SceneCast #castFrame{border-top:1 solid #212223;border-right:1 solid #212223;border-bottom:1 solid #212223;margin:0}#FileBrowser QToolButton,#SceneCast QToolButton{padding:1}DvDirTreeView{qproperty-TextColor:#d6d8dd;qproperty-SelectedTextColor:#fff;qproperty-SelectedItemBackground:#5385a6;qproperty-FolderTextColor:#9fdaff;qproperty-SelectedFolderTextColor:#fff;alternate-background-color:#323435;background-color:#2d2f30;border:1 solid #212223}#FileDoesNotExistLabel{color:#f00}#SceneCast QToolBar{border-top:1 solid #212223}#SceneCast QToolButton{margin:3 1 2 1;padding:1}#CastBrowser{border:0;margin:0}#FilmStrip QComboBox{border-radius:0;border-width:0}#FilmStrip QComboBox QAbstractItemView{background-color:#414345}#CleanupSettings #CleanupSettingsFrame{margin-top:2;margin-bottom:4}#CleanupSettings QGroupBox{margin-bottom:3}ParamsPage{qproperty-TextColor:#d6d8dd}#CameraSettingsButton{padding:2}#CameraSettingsRadioButton:hover{background:none}#CameraSettingsRadioButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#CameraSettingsRadioButton::indicator:unchecked{image:url('../Default/imgs/white/lock_off.svg')}#CameraSettingsRadioButton::indicator:checked{background-color:#C34040;border-color:#C34040;image:url('../Default/imgs/white/lock_on.svg')}#CameraSettingsRadioButton::indicator:checked:hover{background-color:#d57a7a;border-color:#d57a7a}#CameraSettingsDPI{color:#9fdaff}#CameraSettingsRadioButton_Small{padding:0}#CameraSettingsRadioButton_Small::indicator{background-color:transparent;border:0;height:21;margin:0;width:11}#ForceSquaredPixelButton{height:16;border:1 solid rgba(255,255,255,0);image:url('../Default/imgs/white/fsp_unchecked.svg');padding:2;width:16;margin:0}#ForceSquaredPixelButton:checked{image:url('../Default/imgs/white/fsp_checked.svg')}#OutputSettingsLabel{color:#9fdaff}PencilTestPopup{min-height:730px;min-width:512px}#MatchLineButton{background-color:#66696c}#MatchLineButton:checked{background-color:#8c9093;border:2 solid #5385a6;border-radius:2}#LargeSizedText{font-size:17px}#StartupLabel{padding:3}#StartupLabel:hover{background:#5a5d5f}QStatusBar{background-color:#c0c0c0}QStatusBar::item{border:0}QStatusBar QLabel{background-color:#c0c0c0}QStatusBar #StatusBarLabel{background-color:#fff;padding:1 3}#TitleTxtLabel{color:#9fdaff}#StyleEditor QPushButton{margin:2 1;padding:0}#StyleEditor #TabBarContainer{margin-left:-4}#StyleEditor #bottomWidget{border-top:1 solid #212223;padding:3 2 8 3}#StyleEditor #bottomWidget QPushButton{padding:3 5}#StyleEditorTabBar::tab::first{border-left:1 solid #212223}#HexagonalColorWheel{qproperty-BGColor:#414345}#colorSlider::groove:horizontal{height:1;border-image:none}#colorSlider::handle:horizontal{width:8;margin:-8 -4}#colorSliderAddButton,#colorSliderSubButton{background:none;border-color:transparent;image-position:center center;min-height:16;padding:0;min-width:18}#colorSliderAddButton{image:url('../Default/imgs/white/scroll-right.svg')}#colorSliderSubButton{image:url('../Default/imgs/white/scroll-left.svg')}#PlainColorPageParts{border-bottom:1 solid #212223}#PlainColorPageParts QLineEdit{max-width:35}PaletteViewer DvScrollWidget QPushButton{border-top:0;margin-bottom:1;max-width:15;min-width:15}PaletteViewer DvScrollWidget #ScrollLeftButton{border-radius:0;margin-bottom:1;max-width:16;min-width:16}PaletteViewer DvScrollWidget #ScrollRightButton{border-radius:0;margin-left:1;margin-bottom:1;max-width:16;min-width:16}PaletteViewer QToolBar{background:none;border-bottom:1 solid #212223;padding:0;margin:0}PaletteViewer QToolBar::separator:horizontal{margin:0}PaletteViewer QToolBar QToolButton{margin:0 0 1 0;padding:1 0 2 0}#PageViewer{qproperty-TextColor:#d6d8dd}#PaletteLockButton{border-radius:0;margin:0 0 1 1}#PaletteLockButton:checked{background-color:#C34040;border-color:#C34040}#PaletteLockButton:checked:hover{background-color:#d57a7a;border-color:#d57a7a}#WordButton{padding-right:0;padding-left:0}QDialog{background-color:#414345}QDialog #dialogButtonFrame{background-color:#37393a;border-top:1 solid #212223}QDialog #dialogButtonFrame QPushButton{border-color:#37393a;outline:0}QDialog #dialogButtonFrame QPushButton:focus{background-color:#5385a6;border-color:#37393a;color:#fff}QDialog #dialogButtonFrame QPushButton:focus:hover{background-color:#6c98b6}QDialog #dialogButtonFrame QPushButton:focus:pressed{background-color:#2b2c2d;border-color:#262728;color:#e4e5e9}#SceneSettings QLabel{color:#9fdaff}#PreferencesPopup QListWidget{background-color:#2d2f30;alternate-background-color:#2d2f30;border:1 solid #212223;font-size:13px}#PreferencesPopup QListWidget::item{border:0;padding:3}#PreferencesPopup QListWidget::item:hover{color:#d6d8dd;background-color:rgba(255,255,255,0.15)}#PreferencesPopup QListWidget::item:selected{background-color:#5385a6;color:#fff}#ShortcutTree{border:1 solid #212223}#ShortcutTree::item{padding:1 0}#ShortcutTree QScrollBar:vertical{width:16;margin-right:-1}ProjectPopup QLabel{color:#9fdaff}#GearButton{qproperty-icon:url('../Default/imgs/white/gear.svg')}#SubfolderButton{qproperty-icon:url('../Default/imgs/white/subfolder.svg');padding-left:6px;padding-right:6px}#SubcameraButton{qproperty-icon:url('../Default/imgs/white/subcamera.svg');padding-left:6px;padding-right:6px}SchematicViewer{qproperty-TextColor:#d6d8dd;qproperty-VerticalLineColor:#222;qproperty-LevelColumnColor:#4C6E4C;qproperty-VectorColumnColor:#7B7B4C;qproperty-ChildColumnColor:#6A526B;qproperty-FullcolorColumnColor:#657A96;qproperty-FxColumnColor:#56553C;qproperty-PaletteColumnColor:#3A655F;qproperty-MeshColumnColor:#684D86;qproperty-ReferenceColumnColor:#616161;qproperty-TableColor:#62628c;qproperty-ActiveCameraColor:#2d7dca;qproperty-OtherCameraColor:#6c797b;qproperty-GroupColor:#3b6e9c;qproperty-PegColor:#9f6e3c;qproperty-SplineColor:#6a9d1c;qproperty-ActiveOutputColor:#2d7dca;qproperty-OtherOutputColor:#6c797b;qproperty-XsheetColor:#62628c;qproperty-NormalFxColor:#6a7e96;qproperty-MacroFxColor:#815c79;qproperty-ImageAdjustFxColor:#656287;qproperty-LayerBlendingFxColor:#4f757d;qproperty-MatteFxColor:#ae7171;qproperty-SchematicPreviewButtonBgOnColor:#c8c864;qproperty-SchematicPreviewButtonOnImage:url('../Default/imgs/white/x_prev_eye_on.svg');qproperty-SchematicPreviewButtonBgOffColor:#616161;qproperty-SchematicPreviewButtonOffImage:url('../Default/imgs/white/x_prev_eye_off.svg');qproperty-SchematicCamstandButtonBgOnColor:#eb906b;qproperty-SchematicCamstandButtonOnImage:url('../Default/imgs/white/x_table_view_on.svg');qproperty-SchematicCamstandButtonTranspImage:url('../Default/imgs/white/x_table_view_transp.svg');qproperty-SchematicCamstandButtonBgOffColor:#616161;qproperty-SchematicCamstandButtonOffImage:url('../Default/imgs/white/x_table_view_off.svg')}#SchematicBottomFrame{background-color:#414345;border:0;margin:0;padding:0}#SchematicBottomFrame QToolBar::separator:horizontal{margin:0}#SchematicBottomFrame QToolBar QToolButton{padding:0;margin:2}#SchematicSceneViewer{background-color:#353638;border-bottom:1 solid #212223}#FxSettingsTabBar::tab{border-top:1 solid #212223}#FxSettingsTabBar::tab::first,#FxSettingsTabBar::tab::only-one{border-left:1 solid #212223}FxSettings QToolBar{border-top:1 solid #212223;border-right:1 solid #212223;border-left:1 solid #212223;min-height:23;padding:3 0}FxSettings QToolBar QToolBar{border:0}#FxSettingsLabel{color:#a0e680}#FxSettingsHelpButton{background-color:#80a0dc;color:#000;padding-top:0;padding-bottom:0}#FxSettingsHelpButton:hover{background-color:#a8bee7}#ScriptConsole{font-family:'Courier New',monospace;border:0;color:#000000;padding:3}#ScriptConsole QFrame{background-color:#dcdcdc}#ScriptConsole TPanelTitleBar{background-color:#323435}#TaskSheetItemLabel{color:#d6d8dd}#Tasks QToolBar{border-bottom:1 solid #212223;margin:0;padding:0}#Tasks QToolBar QToolButton{margin:2 2 3 2}#ToolBar QToolBar{padding-left:2}#ToolOptions TPanelTitleBar{border-right:1 solid #212223;border-bottom:0}#CommandBar TPanelTitleBar{border-right:1 solid #212223;border-bottom:0}IconViewField{qproperty-ThicknessPixmap:url("../Default/imgs/white/selectiontool_thickness.svg")}#EditToolLockButton{spacing:0}#EditToolLockButton:hover{background:none}#EditToolLockButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#EditToolLockButton::indicator:unchecked{image:url('../Default/imgs/white/lock_off.svg')}#EditToolLockButton::indicator:checked{background-color:#C34040;border-color:#C34040;image:url('../Default/imgs/white/lock_on.svg')}#EditToolLockButton::indicator:checked:hover{background-color:#d57a7a;border-color:#d57a7a}PopupButton::menu-indicator{border-left:0;height:17;image:url('../Default/imgs/white/combo_downarrow.svg');width:10}PopupButton::menu-indicator:hover{image:url('../Default/imgs/white/combo_downarrow.svg')}PopupButton::menu-indicator:disabled{image:url('../Default/imgs/white/combo_downarrow_disabled.svg')}#Cap,#Join{padding:0 4 0 -8;max-width:32;min-width:32}#Cap QMenu,#Join QMenu{max-width:28;min-width:28}#Cap QMenu::item,#Join QMenu::item{max-width:28;min-width:28;padding:0}QToolBar#MediumPaddingToolBar QToolButton{padding-left:3;padding-right:3}QToolBar#WidePaddingToolBar QToolButton{padding-left:6;padding-right:6}#CommandBar{margin:0;padding:0;border:0}#CommandBar::separator:horizontal{margin-right:3;margin-left:3}#expandButton:checked{background-color:transparent;border-color:transparent;color:#d6d8dd}#expandButton:checked:hover{background-color:#6e7174;border-color:#6e7174}#expandButton:checked:pressed{background-color:#2b2c2d;border-color:#262728}#ComboViewerPanel Toolbar{border-bottom:1 solid #212223}#ComboViewerPanel Toolbar::separator:horizontal{margin:0 0 0 2}#ComboViewerPanel Toolbar QToolButton{margin:2 0 3 2}#ComboViewerToolOptions{border-bottom:1 solid #212223}#ComboViewer #ToolBarContainer,#ViewerPanel #ToolBarContainer,FlipBook #ToolBarContainer{background-color:transparent;border-top:2 solid #212223;border-bottom:1 solid #212223;padding-right:-1}#flipCustomize{margin-left:3}#flipCustomize::menu-button{background-color:transparent;width:35}#flipCustomize::menu-arrow{image:none}QToolBar#FlipConsolePlayToolBar::separator:horizontal{margin:0 3}QToolBar#FlipConsolePlayToolBar QToolButton{margin-top:2;margin-bottom:2;height:16;padding-left:1;padding-right:1}#ViewerFpsSlider{background-color:transparent;background-image:url('../Default/imgs/white/slider-groove.svg');background-position:center center;background-repeat:repeat-x;border:0;height:19;margin:0 3 0 37;max-width:300;min-width:0}#ViewerFpsSlider::sub-line:horizontal{subcontrol-origin:absolute;background-color:#616467;border:1 solid #414345;border-top-left-radius:2;border-bottom-left-radius:2;height:16;left:-33;width:14}#ViewerFpsSlider::add-line:horizontal{subcontrol-position:left;background-color:#616467;border:1 solid #414345;border-top-right-radius:2;border-bottom-right-radius:2;left:18;height:16;image-position:center center;width:13}#ViewerFpsSlider::handle::horizontal{background-color:#999c9f;border:1 solid #999c9f;border-radius:2;margin:2 0 3 0;min-width:9;width:9;max-width:9}FlipSlider{qproperty-PBHeight:15;qproperty-PBOverlay:url('../Default/imgs/white/flipslider.svg');qproperty-PBColorMarginLeft:1;qproperty-PBColorMarginTop:2;qproperty-PBColorMarginRight:1;qproperty-PBColorMarginBottom:2;qproperty-PBMarker:url('../Default/imgs/white/flipmarker.svg');qproperty-PBMarkerMarginLeft:3;qproperty-PBMarkerMarginRight:3;qproperty-notStartedColor:rgba(205,101,101,0.78);qproperty-startedColor:#1abc3f;qproperty-baseColor:#28292b;qproperty-finishedColor:#28292b}Ruler{qproperty-ParentBGColor:#414345;qproperty-ScaleColor:#d6d8dd}#RulerToolOptionValues{color:#000}#xsheetArea,#ScrollArea{background-color:#2d2f30;border:0}#xsheetScrollArea{border:0}#cornerWidget QToolButton{padding:0}#xsheetColumnAreaMenu_Preview{background-color:#E6E678}#xsheetColumnAreaMenu_Lock{background-color:#F5F5F5}#xsheetColumnAreaMenu_Camstand{background-color:#FFA480}#xsheetColumnAreaMenu_Preview,#xsheetColumnAreaMenu_Lock,#xsheetColumnAreaMenu_Camstand{color:#000}#noteTextEdit{color:#000}XsheetViewer{qproperty-TextColor:#d6d8dd;qproperty-BGColor:#353638;qproperty-LightLineColor:#262728;qproperty-MarkerLineColor:#1E96C4;qproperty-VerticalLineColor:#222;qproperty-VerticalLineHeadColor:#777b7f;qproperty-PreviewFrameTextColor:#9fdaff;qproperty-CurrentRowBgColor:#506082;qproperty-OnionSkinAreaBgColor:#303133;qproperty-EmptyColumnHeadColor:#5a5d60;qproperty-SelectedColumnTextColor:#E66464;qproperty-EmptyCellColor:#393b3d;qproperty-NotEmptyColumnColor:#414345;qproperty-SelectedEmptyCellColor:#64676a;qproperty-LevelColumnColor:#4C6E4C;qproperty-LevelColumnBorderColor:#8FB38F;qproperty-SelectedLevelColumnColor:#678667;qproperty-VectorColumnColor:#7B7B4C;qproperty-VectorColumnBorderColor:#BBBB9A;qproperty-SelectedVectorColumnColor:#949466;qproperty-ChildColumnColor:#6A526B;qproperty-ChildColumnBorderColor:#B1A3B3;qproperty-SelectedChildColumnColor:#816e82;qproperty-FullcolorColumnColor:#657A96;qproperty-FullcolorColumnBorderColor:#9EB8BB;qproperty-SelectedFullcolorColumnColor:#8895a6;qproperty-FxColumnColor:#56553C;qproperty-FxColumnBorderColor:#95958A;qproperty-SelectedFxColumnColor:#6f6e56;qproperty-ReferenceColumnColor:#616161;qproperty-ReferenceColumnBorderColor:#A2A2A2;qproperty-SelectedReferenceColumnColor:#7a7a7a;qproperty-PaletteColumnColor:#3A655F;qproperty-PaletteColumnBorderColor:#86ACA7;qproperty-SelectedPaletteColumnColor:#52807a;qproperty-MeshColumnColor:#684D86;qproperty-MeshColumnBorderColor:#BA92EF;qproperty-SelectedMeshColumnColor:#82689e;qproperty-SoundTextColumnColor:#c8c8c8;qproperty-SoundTextColumnBorderColor:#8c8c8c;qproperty-SelectedSoundTextColumnColor:#e2e2e2;qproperty-SoundColumnColor:#657456;qproperty-SoundColumnBorderColor:#A0AF7D;qproperty-SelectedSoundColumnColor:#7e8b72;qproperty-SoundColumnHlColor:#34FE5E;qproperty-SoundColumnTrackColor:#B6C29D;qproperty-ColumnHeadPastelizer:#000;qproperty-SelectedColumnHead:#506082;qproperty-LightLightBGColor:#393b3d;qproperty-LightBGColor:#eaebec;qproperty-DarkBGColor:#dbdcdd;qproperty-DarkLineColor:#8e9194;qproperty-XsheetColumnNameBgColor:rgba(0,0,0,0);qproperty-XsheetDragBarHighlightColor:rgba(255,255,255,0.5);qproperty-XsheetPreviewButtonBgOnColor:#c8c864;qproperty-XsheetPreviewButtonOnImage:url('../Default/imgs/white/x_prev_eye_on.svg');qproperty-XsheetPreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetPreviewButtonOffImage:url('../Default/imgs/white/x_prev_eye_off.svg');qproperty-XsheetCamstandButtonBgOnColor:#eb906b;qproperty-XsheetCamstandButtonOnImage:url('../Default/imgs/white/x_table_view_on.svg');qproperty-XsheetCamstandButtonTranspImage:url('../Default/imgs/white/x_table_view_transp.svg');qproperty-XsheetCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetCamstandButtonOffImage:url('../Default/imgs/white/x_table_view_off.svg');qproperty-XsheetLockButtonBgOnColor:rgba(255,255,255,0.3);qproperty-XsheetLockButtonOnImage:url('../Default/imgs/white/x_lock_on.svg');qproperty-XsheetLockButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetLockButtonOffImage:url('../Default/imgs/white/x_lock_off.svg');qproperty-XsheetConfigButtonBgColor:rgba(255,255,255,0);qproperty-XsheetConfigButtonImage:url('../Default/imgs/white/x_config.svg');qproperty-TimelinePreviewButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOnImage:url('../Default/imgs/white/timeline_toggle_on.svg');qproperty-TimelinePreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOffImage:url('../Default/imgs/white/timeline_toggle_off.svg');qproperty-TimelineCamstandButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOnImage:url('../Default/imgs/white/timeline_toggle_on.svg');qproperty-TimelineCamstandButtonTranspImage:url('../Default/imgs/white/timeline_toggle_transp.svg');qproperty-TimelineCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOffImage:url('../Default/imgs/white/timeline_toggle_off.svg');qproperty-TimelineLockButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOnImage:url('../Default/imgs/white/timeline_toggle_on.svg');qproperty-TimelineLockButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOffImage:url('../Default/imgs/white/timeline_toggle_off.svg');qproperty-TimelineConfigButtonBgColor:rgba(255,255,255,0);qproperty-TimelineConfigButtonImage:url('../Default/imgs/white/timeline_config.svg');qproperty-LayerHeaderPreviewImage:url('../Default/imgs/white/layer_header_prev_eye.svg');qproperty-LayerHeaderPreviewOverImage:url('../Default/imgs/white/layer_header_prev_eye_over.svg');qproperty-LayerHeaderCamstandImage:url('../Default/imgs/white/layer_header_table_view.svg');qproperty-LayerHeaderCamstandOverImage:url('../Default/imgs/white/layer_header_table_view_over.svg');qproperty-LayerHeaderLockImage:url('../Default/imgs/white/lock_on.svg');qproperty-LayerHeaderLockOverImage:url('../Default/imgs/white/lock_on_over.svg');qproperty-ActiveCameraColor:#2d7dca;qproperty-SelectedActiveCameraColor:#5796d3;qproperty-OtherCameraColor:#6c797b;qproperty-SelectedOtherCameraColor:#8b8e8f}#XSheetToolbar{margin:0;padding:0;border:0}#XSheetToolbar QToolButton{padding:0;margin:4 1;min-height:19;height:19}#XSheetToolbar::separator:horizontal{margin:0 4}#FunctionEditor QToolBar{border-bottom:1 solid #212223}#FunctionEditor QToolBar QToolBar{border:0}#FunctionEditor QToolBar QLabel{margin-left:5}#FunctionEditor QToolBar QToolButton{height:18}#FunctionEditorTree{border-top:1 solid #212223}FunctionTreeView{qproperty-TextColor:#d6d8dd;qproperty-CurrentTextColor:#E66464}FunctionPanel{qproperty-BGColor:#343638;qproperty-ValueLineColor:#28292b;qproperty-FrameLineColor:#28292b;qproperty-OtherCurvesColor:#7f8386;qproperty-RulerBackground:#2d2e30;qproperty-TextColor:#d6d8dd;qproperty-SubColor:#000;qproperty-SelectedColor:#FFA500}SpreadsheetViewer{qproperty-LightLightBGColor:#393b3d;qproperty-CurrentRowBgColor:#506082;qproperty-LightLineColor:#262728;qproperty-MarkerLineColor:#1E96C4;qproperty-BGColor:#414345;qproperty-VerticalLineColor:#222;qproperty-KeyFrameColor:#995d1d;qproperty-KeyFrameBorderColor:#c9b04b;qproperty-SelectedKeyFrameColor:#be772b;qproperty-InBetweenColor:#666250;qproperty-InBetweenBorderColor:#cdcec8;qproperty-SelectedInBetweenColor:#7d7a6c;qproperty-SelectedEmptyColor:#64676a;qproperty-SelectedSceneRangeEmptyColor:#6d7073;qproperty-TextColor:#d6d8dd;qproperty-ColumnHeaderBorderColor:#777b7f;qproperty-SelectedColumnTextColor:#E66464}#ExpressionField{background-color:#e0e1e2;border:1 solid #2d2e2f;margin:0}#FunctionSegmentViewerLinkButton{background-image:url('../Default/imgs/white/segment_unlinked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:hover{background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:checked{background-image:url('../Default/imgs/white/segment_linked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:disabled{background-image:url('../Default/imgs/white/segment_disabled.svg');background-repeat:no-repeat}
+/* -----------------------------------------------------------------------------
+   Component: Button Styles
+----------------------------------------------------------------------------- */
+.button-show,
+#LoadLevelShowButton,
+#CleanupSettingsShowButton,
+#OutputSettingsShowButton,
+#FxSettingsPreviewShowButton {
+  image: url('../Default/imgs/white/plus.svg');
+  image-position: center center;
+  margin: 0;
+  padding: 1;
+  min-width: 10;
+  min-height: 10;
+}
+.button-show:checked,
+#LoadLevelShowButton:checked,
+#CleanupSettingsShowButton:checked,
+#OutputSettingsShowButton:checked,
+#FxSettingsPreviewShowButton:checked {
+  background-color: #2b2c2d;
+  border-color: #262728;
+  image: url('../Default/imgs/white/minus.svg');
+}
+.button-show:checked:pressed,
+#LoadLevelShowButton:checked:pressed,
+#CleanupSettingsShowButton:checked:pressed,
+#OutputSettingsShowButton:checked:pressed,
+#FxSettingsPreviewShowButton:checked:pressed {
+  background-color: #2b2c2d;
+  border-color: #262728;
+}
+.button-show:checked:hover,
+#LoadLevelShowButton:checked:hover,
+#CleanupSettingsShowButton:checked:hover,
+#OutputSettingsShowButton:checked:hover,
+#FxSettingsPreviewShowButton:checked:hover {
+  background-color: #303133;
+}
+.button-tool,
+QToolButton,
+#CameraSettingsRadioButton::indicator,
+#ForceSquaredPixelButton,
+#SchematicBottomFrame QToolBar QToolButton,
+#EditToolLockButton::indicator,
+#flipCustomize {
+  background-color: rgba(255, 255, 255, 0);
+  border: 1 solid rgba(255, 255, 255, 0);
+  border-radius: 2;
+  color: #e4e5e9;
+  margin: 1;
+  padding: 0;
+}
+.button-tool:hover,
+QToolButton:hover,
+#CameraSettingsRadioButton::indicator:hover,
+#ForceSquaredPixelButton:hover,
+#colorSliderAddButton:hover,
+#colorSliderSubButton:hover,
+#SchematicBottomFrame QToolBar QToolButton:hover,
+#EditToolLockButton::indicator:hover,
+#flipCustomize:hover {
+  background-color: #6e7174;
+  border-color: #6e7174;
+  color: #e4e5e9;
+}
+.button-tool:pressed,
+QToolButton:pressed,
+#CameraSettingsRadioButton::indicator:pressed,
+#ForceSquaredPixelButton:pressed,
+#colorSliderAddButton:pressed,
+#colorSliderSubButton:pressed,
+#SchematicBottomFrame QToolBar QToolButton:pressed,
+#EditToolLockButton::indicator:pressed,
+#flipCustomize:pressed {
+  background-color: #2b2c2d;
+  border-color: #262728;
+  color: #e4e5e9;
+}
+.button-tool:checked,
+QToolButton:checked,
+#CameraSettingsRadioButton::indicator:checked,
+#ForceSquaredPixelButton:checked,
+#SchematicBottomFrame QToolBar QToolButton:checked,
+#EditToolLockButton::indicator:checked,
+#flipCustomize:checked {
+  background-color: #5385a6;
+  border-color: #5385a6;
+  color: #ffffff;
+}
+.button-tool:checked:hover,
+QToolButton:checked:hover,
+#CameraSettingsRadioButton::indicator:checked:hover,
+#ForceSquaredPixelButton:checked:hover,
+#SchematicBottomFrame QToolBar QToolButton:checked:hover,
+#EditToolLockButton::indicator:checked:hover,
+#flipCustomize:checked:hover {
+  background-color: #6c98b6;
+  border-color: #6c98b6;
+}
+.button-tool:disabled,
+QToolButton:disabled,
+#CameraSettingsRadioButton::indicator:disabled,
+#ForceSquaredPixelButton:disabled,
+#SchematicBottomFrame QToolBar QToolButton:disabled,
+#EditToolLockButton::indicator:disabled,
+#flipCustomize:disabled {
+  color: #808080;
+}
+.button-flat,
+PaletteViewer QToolBar QToolButton {
+  background-color: none;
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+}
+.button-flat:hover,
+PaletteViewer QToolBar QToolButton:hover {
+  background-color: #6e7174;
+}
+.button-flat:pressed,
+PaletteViewer QToolBar QToolButton:pressed {
+  background-color: #212223;
+}
+/* -----------------------------------------------------------------------------
+   Component: Frames
+----------------------------------------------------------------------------- */
+.frame,
+.GroupBox,
+#LoadLevelFrame,
+#PsdSettingsGroupBox,
+#CleanupSettingsFrame,
+#OutputSettingsBox,
+#OutputSettingsCameraBox,
+#SolidLineFrame,
+#FunctionParametersPanel,
+QGroupBox {
+  border: 1 solid #212223;
+  border-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Component: Icons
+----------------------------------------------------------------------------- */
+/* -----------------------------------------------------------------------------
+   Component: Tabs
+----------------------------------------------------------------------------- */
+.tab-container,
+#TabBarContainer {
+  background-color: transparent;
+  qproperty-BottomAboveLineColor: #323435;
+  qproperty-BottomBelowLineColor: #212223;
+}
+.tab-flat,
+#StyleEditorTabBar::tab,
+#PaletteTabBar::tab,
+#FxSettingsTabBar::tab {
+  background-color: #323435;
+  border-right: 1 solid #212223;
+  border-bottom: 1 solid #212223;
+  color: #94969a;
+  padding: 3 4 3 4;
+}
+.tab-flat:hover,
+#StyleEditorTabBar::tab:hover,
+#PaletteTabBar::tab:hover,
+#FxSettingsTabBar::tab:hover {
+  background-color: #414345;
+  color: #94969a;
+}
+.tab-flat:selected,
+#StyleEditorTabBar::tab:selected,
+#PaletteTabBar::tab:selected,
+#FxSettingsTabBar::tab:selected {
+  background-color: #414345;
+  color: #ffffff;
+  border-bottom-color: #414345;
+}
+.tab-flat:only-one,
+#StyleEditorTabBar::tab:only-one,
+#PaletteTabBar::tab:only-one,
+#FxSettingsTabBar::tab:only-one {
+  margin: 0;
+}
+.tab-round {
+  background-color: #323435;
+  border-top: 1 solid #212223;
+  border-right: 1 solid #212223;
+  border-left: 1 solid #212223;
+  border-bottom: 1 solid #212223;
+  color: #94969a;
+  margin: 3 -1 0 0;
+  padding: 2 7 1 7;
+}
+.tab-round:hover {
+  background-color: #414345;
+  color: #94969a;
+}
+.tab-round:selected {
+  background-color: #414345;
+  border-top-right-radius: 2;
+  border-top-left-radius: 2;
+  border-bottom-color: #414345;
+  color: #ffffff;
+  margin: 1 -1 -1 0;
+  padding: 2 7 2 7;
+}
+.tab-round:only-one {
+  margin: 1 0 0 0;
+  padding: 3 7 3 7;
+}
+.tab-round:last {
+  margin-right: 0;
+  border-top-right-radius: 2;
+}
+.tab-round:first {
+  border-top-left-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Main
+----------------------------------------------------------------------------- */
+QWidget {
+  background-color: #414345;
+  color: #d6d8dd;
+}
+QWidget:disabled {
+  color: #808080;
+}
+QFrame {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QToolTip,
+#helpToolTip {
+  background-color: #fff;
+  border: 1 solid #000;
+  color: #000;
+  padding: 1 1;
+}
+#DockSeparator,
+QMainWindow::separator,
+QSplitter::handle {
+  background-color: #141516;
+  height: 4;
+  width: 4;
+}
+#TDockPlaceholder {
+  background-color: #F77272;
+}
+TPanel {
+  background-color: #141516;
+}
+/* -----------------------------------------------------------------------------
+   Topbar
+----------------------------------------------------------------------------- */
+#TopBar {
+  background: #414345;
+  border: 0;
+  border-bottom: 1 solid #212223;
+  height: 21;
+}
+#TopBar #EditToolLockButton {
+  background: #414345;
+  spacing: 0;
+}
+#TopBar #EditToolLockButton::indicator {
+  background: none;
+  border: none;
+  height: 18;
+  margin: 1 2 0 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+#TopBarTabContainer {
+  background-color: #414345;
+  margin-bottom: 1;
+}
+#StackedMenuBar {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QMenuBar {
+  background-color: #414345;
+  border: 0;
+}
+QMenuBar::item {
+  background-color: #414345;
+  border-left: 1 solid #414345;
+  margin: 0;
+  padding: 3 5;
+}
+QMenuBar::item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #d6d8dd;
+}
+QMenuBar::item:pressed {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Workspaces
+----------------------------------------------------------------------------- */
+#TopBarTab {
+  margin: 0;
+  padding: 0;
+}
+#TopBarTab::tab {
+  background-color: #323435;
+  border-top: 1 solid #212223;
+  border-right: 1 solid #212223;
+  color: #94969a;
+  margin: 0 0 0 0;
+  padding: 2 8 3 8;
+}
+#TopBarTab::tab:hover {
+  background-color: #414345;
+  color: #94969a;
+}
+#TopBarTab::tab:selected {
+  background-color: #414345;
+  color: #ffffff;
+}
+#TopBarTab::tab:first {
+  border-left: 1 solid #212223;
+}
+#TopBarTab::tab:last {
+  border-right: 1 solid #212223;
+}
+/* -----------------------------------------------------------------------------
+   Menu
+----------------------------------------------------------------------------- */
+QMenu {
+  background-color: #414345;
+  border: 1 solid #212223;
+  padding: 2 0;
+}
+QMenu::item {
+  padding: 3 28;
+}
+QMenu::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+QMenu::item:checked {
+  color: #d6d8dd;
+}
+QMenu::item:checked:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+QMenu::item:disabled {
+  background: none;
+  color: #808080;
+}
+QMenu::item:disabled:selected {
+  border-color: transparent;
+}
+QMenu::separator {
+  border-top: 1 solid #212223;
+  height: 0;
+  margin: 2 0;
+}
+QMenu::icon {
+  border-radius: 2;
+  margin: 0 0 0 3;
+  padding: 1;
+}
+QMenu::icon:checked {
+  background-color: #5385a6;
+}
+QMenu::indicator {
+  margin-left: 7;
+}
+/* -----------------------------------------------------------------------------
+   Titlebars
+----------------------------------------------------------------------------- */
+TPanelTitleBar {
+  background-color: #323435;
+  border-color: #212223;
+  border-style: solid;
+  border-width: 0 0 1 0;
+  height: 20;
+  min-height: 20;
+  qproperty-TitleColor: #8c9093;
+  qproperty-ActiveTitleColor: #43AEE5;
+  qproperty-BorderPixmap: url('none');
+  qproperty-ActiveBorderPixmap: url('../Default/imgs/white/none');
+  qproperty-FloatBorderPixmap: url('none');
+  qproperty-FloatActiveBorderPixmap: url('../Default/imgs/white/none');
+}
+/* -----------------------------------------------------------------------------
+   Scrollbars
+----------------------------------------------------------------------------- */
+QAbstractScrollArea::corner {
+  background-color: #2d2f30;
+}
+QScrollBar {
+  background-color: #2d2f30;
+  border: 0;
+}
+QScrollBar:horizontal {
+  height: 16;
+  margin: 0;
+}
+QScrollBar:vertical {
+  margin: 0;
+  width: 16;
+}
+QScrollBar::handle {
+  border: 1 solid #4b4d50;
+  border-radius: 4;
+}
+QScrollBar::handle:horizontal:hover,
+QScrollBar::handle:vertical:hover {
+  background-color: #5f6265;
+  border-color: #5f6265;
+}
+QScrollBar::handle:horizontal:pressed,
+QScrollBar::handle:vertical:pressed {
+  background-color: #72767a;
+  border-color: #72767a;
+}
+QScrollBar::handle:horizontal {
+  background-color: #4b4d50;
+  margin: 3 16;
+  min-width: 20;
+}
+QScrollBar::handle:vertical {
+  background-color: #4b4d50;
+  margin: 16 3;
+  min-height: 20;
+}
+QScrollBar::add-line {
+  subcontrol-origin: margin;
+  border: 0;
+}
+QScrollBar::add-line:horizontal {
+  subcontrol-position: right;
+  background-color: #2d2f30;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::add-line:vertical {
+  subcontrol-position: bottom;
+  background-color: #2d2f30;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::sub-line {
+  border: 0;
+  subcontrol-origin: margin;
+}
+QScrollBar::sub-line:horizontal {
+  subcontrol-position: left;
+  background-color: #2d2f30;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::sub-line:vertical {
+  subcontrol-position: top;
+  background-color: #2d2f30;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::up-arrow:vertical {
+  image: url('../Default/imgs/white/scroll-up.svg');
+  image-position: center center;
+}
+QScrollBar::up-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::down-arrow:vertical {
+  image: url('../Default/imgs/white/scroll-down.svg');
+  image-position: center center;
+}
+QScrollBar::down-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::left-arrow:horizontal {
+  image: url('../Default/imgs/white/scroll-left.svg');
+  image-position: center center;
+}
+QScrollBar::left-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::right-arrow:horizontal {
+  image: url('../Default/imgs/white/scroll-right.svg');
+  image-position: center center;
+}
+QScrollBar::right-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::sub-page:horizontal,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:vertical,
+QScrollBar::add-page:vertical {
+  background: none;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bars
+----------------------------------------------------------------------------- */
+QToolBar {
+  padding: 0;
+}
+QToolBar::separator:horizontal {
+  border-left: 1 solid #212223;
+  margin: 0 1;
+  width: 0;
+}
+QToolBar::separator:vertical {
+  border-top: 1 solid #212223;
+  height: 0;
+  margin: 1 0;
+}
+QToolBar QLabel {
+  margin-top: 1;
+}
+QToolBar QToolBar {
+  border: 0;
+}
+QToolButton::menu-indicator {
+  image: none;
+}
+QToolButton::menu-button {
+  border-image: none;
+}
+/* -------------------------------------------------------------------------- */
+/* Scrollable QToolBar Buttons
+/* -------------------------------------------------------------------------- */
+.DvScrollWidget QPushButton,
+DvScrollWidget QPushButton,
+#ScrollLeftButton QPushButton,
+#ScrollRightButton QPushButton,
+#ScrollUpButton QPushButton,
+#ScrollDownButton QPushButton {
+  background-color: #616467;
+  border: 0 solid red;
+  border-radius: 0;
+  padding: 0;
+  max-width: 16;
+}
+.DvScrollWidget QPushButton:hover,
+DvScrollWidget QPushButton:hover,
+#ScrollLeftButton QPushButton:hover,
+#ScrollRightButton QPushButton:hover,
+#ScrollUpButton QPushButton:hover,
+#ScrollDownButton QPushButton:hover {
+  background-color: #6e7174;
+}
+.DvScrollWidget QPushButton:pressed,
+DvScrollWidget QPushButton:pressed,
+#ScrollLeftButton QPushButton:pressed,
+#ScrollRightButton QPushButton:pressed,
+#ScrollUpButton QPushButton:pressed,
+#ScrollDownButton QPushButton:pressed {
+  background-color: #2b2c2d;
+}
+#ScrollLeftButton,
+#ScrollRightButton,
+#ScrollUpButton,
+#ScrollDownButton {
+  margin: 0;
+  min-width: 16;
+}
+#ScrollLeftButton {
+  border-right: 1 solid #212223;
+  image: url('../Default/imgs/white/scroll-left.svg');
+}
+#ScrollRightButton {
+  border-left: 1 solid #212223;
+  margin-left: 3;
+  image: url('../Default/imgs/white/scroll-right.svg');
+}
+#ScrollUpButton {
+  image: url('../Default/imgs/white/scroll-up.svg');
+}
+#ScrollDownButton {
+  image: url('../Default/imgs/white/scroll-down.svg');
+}
+/* -------------------------------------------------------------------------- */
+#keyFrameNavigator {
+  background: none;
+  margin: 0;
+  padding: 0;
+}
+#keyFrameNavigator QToolButton {
+  min-width: 18;
+}
+#keyFrameNavigator #PreviousKey {
+  image: url('../Default/imgs/white/prevkey.svg');
+}
+#keyFrameNavigator #PreviousKey:hover {
+  image: url('../Default/imgs/white/prevkey_over.svg');
+}
+#keyFrameNavigator #PreviousKey:disabled {
+  image: url('../Default/imgs/white/prevkey_disabled.svg');
+}
+#keyFrameNavigator #NextKey {
+  image: url('../Default/imgs/white/nextkey.svg');
+}
+#keyFrameNavigator #NextKey:hover {
+  image: url('../Default/imgs/white/nextkey_over.svg');
+}
+#keyFrameNavigator #NextKey:disabled {
+  image: url('../Default/imgs/white/nextkey_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Trees
+----------------------------------------------------------------------------- */
+.treeview,
+QTreeWidget,
+QTreeView,
+#FunctionEditorTree {
+  background-color: #2d2f30;
+  alternate-background-color: #323435;
+  border: 0;
+  margin: 0;
+  outline: 0;
+}
+.treeview::item:selected,
+QTreeWidget::item:selected,
+QTreeView::item:selected,
+#FunctionEditorTree::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+.treeview::branch:adjoins-item,
+QTreeWidget::branch:adjoins-item,
+QTreeView::branch:adjoins-item,
+#FunctionEditorTree::branch:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-siblings,
+QTreeWidget::branch:has-siblings,
+QTreeView::branch:has-siblings,
+#FunctionEditorTree::branch:has-siblings {
+  border-image: url('');
+}
+.treeview::branch:has-siblings:adjoins-item,
+QTreeWidget::branch:has-siblings:adjoins-item,
+QTreeView::branch:has-siblings:adjoins-item,
+#FunctionEditorTree::branch:has-siblings:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-children:closed,
+QTreeWidget::branch:has-children:closed,
+QTreeView::branch:has-children:closed,
+#FunctionEditorTree::branch:has-children:closed {
+  background: url('../Default/imgs/white/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:open,
+QTreeWidget::branch:has-children:open,
+QTreeView::branch:has-children:open,
+#FunctionEditorTree::branch:has-children:open {
+  background: url('../Default/imgs/white/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:closed,
+QTreeWidget::branch:has-children:has-siblings:closed,
+QTreeView::branch:has-children:has-siblings:closed,
+#FunctionEditorTree::branch:has-children:has-siblings:closed {
+  background: url('../Default/imgs/white/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:open,
+QTreeWidget::branch:has-children:has-siblings:open,
+QTreeView::branch:has-children:has-siblings:open,
+#FunctionEditorTree::branch:has-children:has-siblings:open {
+  background: url('../Default/imgs/white/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+QListView {
+  outline: 0;
+  background: #2d2f30;
+  alternate-background-color: #323435;
+}
+/* -----------------------------------------------------------------------------
+   Tab Systems
+----------------------------------------------------------------------------- */
+#TabBarContainer {
+  background-color: #323435;
+}
+/* -----------------------------------------------------------------------------
+   Push Button
+----------------------------------------------------------------------------- */
+.Button,
+QPushButton,
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  background-color: #616467;
+  border: 1 solid #414345;
+  border-radius: 2;
+  color: #e4e5e9;
+  margin: 0;
+  padding: 3 15;
+}
+.Button:hover,
+QPushButton:hover,
+.ComboBox:hover,
+#ViewerFpsSlider::sub-line:horizontal:hover,
+#ViewerFpsSlider::add-line:horizontal:hover,
+QComboBox:hover {
+  background-color: #6e7174;
+  border-color: #414345;
+  color: #e4e5e9;
+}
+.Button:pressed,
+QPushButton:pressed,
+#ViewerFpsSlider::sub-line:horizontal:pressed,
+#ViewerFpsSlider::add-line:horizontal:pressed {
+  background-color: #2b2c2d;
+  border-color: #262728;
+  color: #e4e5e9;
+}
+.Button:checked,
+QPushButton:checked {
+  background-color: #2b2c2d;
+  border-color: #262728;
+  color: #e4e5e9;
+}
+.Button:checked:hover,
+QPushButton:checked:hover {
+  background-color: #303133;
+}
+.Button:checked:hover:pressed,
+QPushButton:checked:hover:pressed {
+  background: #2b2c2d;
+}
+.Button:disabled,
+QPushButton:disabled,
+.ComboBox:disabled,
+#ViewerFpsSlider::sub-line:horizontal:disabled,
+#ViewerFpsSlider::add-line:horizontal:disabled,
+QComboBox:disabled {
+  background-color: #4d5052;
+  border-color: #414345;
+  color: #808080;
+}
+#PushButton_NoPadding {
+  padding: 3;
+}
+/* -----------------------------------------------------------------------------
+   Combo Box
+----------------------------------------------------------------------------- */
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  padding: 1 0 1 4;
+  margin: 1 0;
+}
+.ComboBox::drop-down,
+QComboBox::drop-down {
+  image: url('../Default/imgs/white/combo_downarrow.svg');
+  image-position: center center;
+  width: 16;
+}
+.ComboBox::drop-down:disabled,
+QComboBox::drop-down:disabled {
+  image: url('../Default/imgs/white/combo_downarrow_disabled.svg');
+}
+.ComboBox QAbstractItemView,
+QComboBox QAbstractItemView {
+  background-color: #414345;
+  border: 1 solid #212223;
+  selection-background-color: #5385a6;
+  selection-color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Textfield
+----------------------------------------------------------------------------- */
+.LineEdit,
+QPlainTextEdit,
+QLineEdit,
+#TaskSheetItem,
+#tasksRemoveBox,
+#tasksAddBox {
+  background-color: #28292b;
+  border: 1 solid #262728;
+  border-radius: 2;
+  color: #d6d8dd;
+  selection-background-color: #5385a6;
+  selection-color: #ffffff;
+  padding: 0 0 0 1;
+}
+.LineEdit:focus,
+QPlainTextEdit:focus,
+QLineEdit:focus,
+#TaskSheetItem:focus,
+#tasksRemoveBox:focus,
+#tasksAddBox:focus {
+  background-color: #28292b;
+  border-color: #5385a6;
+  color: #d6d8dd;
+}
+.LineEdit:disabled,
+QPlainTextEdit:disabled,
+QLineEdit:disabled,
+#TaskSheetItem:disabled,
+#tasksRemoveBox:disabled,
+#tasksAddBox:disabled {
+  background-color: #353638;
+  border-color: #333537;
+  color: #808080;
+}
+/* -----------------------------------------------------------------------------
+   CheckBox
+----------------------------------------------------------------------------- */
+.CheckBox,
+QCheckBox {
+  color: #d6d8dd;
+}
+.CheckBox:hover,
+QCheckBox:hover,
+.RadioButton:hover,
+QRadioButton:hover {
+  color: #ffffff;
+}
+.CheckBox:disabled,
+QCheckBox:disabled {
+  color: #808080;
+}
+.CheckBox::indicator,
+QMenu::indicator,
+QCheckBox::indicator,
+.GroupBox::indicator,
+QGroupBox::indicator {
+  background-color: #28292b;
+  border: 1 solid #262728;
+  border-radius: 2;
+  height: 9;
+  /* fix for QGroupBox */
+  padding: 1;
+  width: 9;
+  /* fix for QMenu */
+}
+.CheckBox::indicator:hover,
+QMenu::indicator:hover,
+.CheckBox::indicator:checked:hover,
+.CheckBox::indicator:indeterminate:hover,
+QCheckBox::indicator:hover,
+.GroupBox::indicator:hover,
+QMenu::indicator:checked:hover,
+QMenu::indicator:indeterminate:hover,
+QCheckBox::indicator:checked:hover,
+QCheckBox::indicator:indeterminate:hover,
+.GroupBox::indicator:checked:hover,
+.GroupBox::indicator:indeterminate:hover,
+QGroupBox::indicator:hover,
+QGroupBox::indicator:checked:hover,
+QGroupBox::indicator:indeterminate:hover {
+  background-color: #28292b;
+  border-color: #5385a6;
+}
+.CheckBox::indicator:checked,
+QMenu::indicator:checked,
+QCheckBox::indicator:checked,
+.GroupBox::indicator:checked,
+QGroupBox::indicator:checked {
+  background-color: #28292b;
+  border-color: #262728;
+  image: url('../Default/imgs/white/checkmark.svg');
+}
+.CheckBox::indicator:checked:disabled,
+QMenu::indicator:checked:disabled,
+QCheckBox::indicator:checked:disabled,
+.GroupBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
+  background-color: #353638;
+  border-color: #353638;
+  image: url('../Default/imgs/white/checkmark_disabled.svg');
+}
+.CheckBox::indicator:indeterminate,
+QMenu::indicator:indeterminate,
+QCheckBox::indicator:indeterminate,
+.GroupBox::indicator:indeterminate,
+QGroupBox::indicator:indeterminate {
+  background-color: #28292b;
+  border-color: #262728;
+  image: url('../Default/imgs/white/checkpartially.svg');
+}
+.CheckBox::indicator:indeterminate:disabled,
+QMenu::indicator:indeterminate:disabled,
+QCheckBox::indicator:indeterminate:disabled,
+.GroupBox::indicator:indeterminate:disabled,
+QGroupBox::indicator:indeterminate:disabled {
+  background-color: #353638;
+  border-color: #353638;
+  image: url('../Default/imgs/white/checkpartially_disabled.svg');
+}
+.CheckBox::indicator:disabled,
+QMenu::indicator:disabled,
+QCheckBox::indicator:disabled,
+.GroupBox::indicator:disabled,
+QGroupBox::indicator:disabled {
+  background-color: #353638;
+  border-color: #353638;
+}
+/* -----------------------------------------------------------------------------
+   Radio Button
+----------------------------------------------------------------------------- */
+.RadioButton::indicator:unchecked,
+QRadioButton::indicator:unchecked,
+#CameraSettingsRadioButton_Small::indicator:unchecked {
+  image: url('../Default/imgs/white/radiobutton_unchecked.svg');
+  image-position: center center;
+}
+.RadioButton::indicator:checked,
+QRadioButton::indicator:checked,
+#CameraSettingsRadioButton_Small::indicator:checked {
+  image: url('../Default/imgs/white/radiobutton_checked.svg');
+  image-position: center center;
+}
+/* -----------------------------------------------------------------------------
+   GroupBox
+----------------------------------------------------------------------------- */
+.GroupBox,
+QGroupBox {
+  margin: 6 0 0 0;
+  padding: 5 0;
+}
+.GroupBox::title,
+QGroupBox::title {
+  subcontrol-origin: margin;
+  left: 15;
+  margin: -3 0 0 0;
+  padding: 0 3;
+}
+.GroupBox::title:hover,
+QGroupBox::title:hover {
+  color: #ffffff;
+}
+.GroupBox::title:disabled,
+QGroupBox::title:disabled {
+  color: #808080;
+}
+.GroupBox::indicator,
+QGroupBox::indicator {
+  subcontrol-origin: margin;
+  margin-top: 2;
+}
+.GroupBox:disabled,
+QGroupBox:disabled {
+  color: #808080;
+}
+/* -----------------------------------------------------------------------------
+   Slider
+----------------------------------------------------------------------------- */
+.Slider::groove:horizontal,
+QSlider::groove:horizontal {
+  background-color: transparent;
+  background-image: url('../Default/imgs/white/slider-groove.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  margin: 0;
+  height: 20;
+  min-height: 20;
+}
+.Slider::groove:horizontal:disabled,
+QSlider::groove:horizontal:disabled {
+  background-image: url('../Default/imgs/white/slider-groove_disabled.svg');
+}
+.Slider::handle:horizontal,
+QSlider::handle:horizontal {
+  width: 10;
+  margin: -2 -1;
+  image: url('../Default/imgs/white/slider-handle.svg');
+}
+.Slider::handle:horizontal:disabled,
+QSlider::handle:horizontal:disabled {
+  image: url('../Default/imgs/white/slider-handle_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Double Slider
+----------------------------------------------------------------------------- */
+#IntPairField,
+#DoublePairField {
+  qproperty-LightLineColor: #262728;
+  qproperty-LightLineEdgeColor: #262728;
+  qproperty-DarkLineColor: #262728;
+  qproperty-MiddleLineColor: #262728;
+  qproperty-HandleLeftPixmap: url("../Default/imgs/white/slider-handle.svg");
+  qproperty-HandleRightPixmap: url("../Default/imgs/white/slider-handle.svg");
+  qproperty-HandleLeftGrayPixmap: url("../Default/imgs/white/slider-handle_disabled.svg");
+  qproperty-HandleRightGrayPixmap: url("../Default/imgs/white/slider-handle_disabled.svg");
+}
+/* -----------------------------------------------------------------------------
+   File Browser
+----------------------------------------------------------------------------- */
+/* Left Pane
+----------------------------------------------------------------------------- */
+#DirTreeView {
+  background-color: #2d2f30;
+  alternate-background-color: #2d2f30;
+  border: 1 solid #212223;
+  border-right: 0;
+}
+/* Right Pane
+----------------------------------------------------------------------------- */
+DvItemViewerPanel {
+  qproperty-TextColor: #d6d8dd;
+  qproperty-AlternateBackground: #3a3b3d;
+  qproperty-SelectedTextColor: #ffffff;
+  qproperty-FolderTextColor: #9fdaff;
+  qproperty-SelectedItemBackground: #5385a6;
+}
+#FileBrowser DvItemViewerPanel,
+#SceneCast DvItemViewerPanel {
+  background-color: #414345;
+}
+#FileBrowser #castFrame,
+#SceneCast #castFrame {
+  border-top: 1 solid #212223;
+  border-right: 1 solid #212223;
+  border-bottom: 1 solid #212223;
+  margin: 0;
+}
+#FileBrowser QToolButton,
+#SceneCast QToolButton {
+  padding: 1;
+}
+DvDirTreeView {
+  qproperty-TextColor: #d6d8dd;
+  qproperty-SelectedTextColor: #ffffff;
+  qproperty-SelectedItemBackground: #5385a6;
+  qproperty-FolderTextColor: #9fdaff;
+  qproperty-SelectedFolderTextColor: #ffffff;
+  alternate-background-color: #323435;
+  background-color: #2d2f30;
+  border: 1 solid #212223;
+}
+#FileDoesNotExistLabel {
+  color: #ff0000;
+}
+/* -----------------------------------------------------------------------------
+   Scene Cast
+----------------------------------------------------------------------------- */
+#SceneCast QToolBar {
+  border-top: 1 solid #212223;
+}
+#SceneCast QToolButton {
+  margin: 3 1 2 1;
+  padding: 1;
+}
+#CastBrowser {
+  border: 0;
+  margin: 0;
+}
+/* -----------------------------------------------------------------------------
+   Level Strip
+----------------------------------------------------------------------------- */
+#FilmStrip QComboBox {
+  border-radius: 0;
+  border-width: 0;
+}
+#FilmStrip QComboBox QAbstractItemView {
+  background-color: #414345;
+}
+/* -----------------------------------------------------------------------------
+   Cleanup Settings
+----------------------------------------------------------------------------- */
+#CleanupSettings #CleanupSettingsFrame {
+  margin-top: 2;
+  margin-bottom: 4;
+}
+#CleanupSettings QGroupBox {
+  margin-bottom: 3;
+}
+ParamsPage {
+  qproperty-TextColor: #d6d8dd;
+}
+/* -----------------------------------------------------------------------------
+   Camera Settings
+----------------------------------------------------------------------------- */
+#CameraSettingsButton {
+  padding: 2;
+}
+#CameraSettingsRadioButton:hover {
+  background: none;
+}
+#CameraSettingsRadioButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#CameraSettingsRadioButton::indicator:unchecked {
+  image: url('../Default/imgs/white/lock_off.svg');
+}
+#CameraSettingsRadioButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+  image: url('../Default/imgs/white/lock_on.svg');
+}
+#CameraSettingsRadioButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+#CameraSettingsDPI {
+  color: #9fdaff;
+}
+#CameraSettingsRadioButton_Small {
+  padding: 0;
+}
+#CameraSettingsRadioButton_Small::indicator {
+  background-color: transparent;
+  border: 0;
+  height: 21;
+  margin: 0;
+  width: 11;
+}
+#ForceSquaredPixelButton {
+  height: 16;
+  border: 1 solid rgba(255, 255, 255, 0);
+  image: url('../Default/imgs/white/fsp_unchecked.svg');
+  padding: 2;
+  width: 16;
+  margin: 0;
+}
+#ForceSquaredPixelButton:checked {
+  image: url('../Default/imgs/white/fsp_checked.svg');
+}
+/* -----------------------------------------------------------------------------
+   Output Settings
+----------------------------------------------------------------------------- */
+#OutputSettingsLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Misc 
+----------------------------------------------------------------------------- */
+PencilTestPopup {
+  min-height: 730px;
+  /* Allow for using a 768 screen */
+  min-width: 512px;
+  /* some clipping will still occur on width, but this
+                        allows for filling half of a 1024 screen */
+}
+#MatchLineButton {
+  background-color: #66696c;
+}
+#MatchLineButton:checked {
+  background-color: #8c9093;
+  border: 2 solid #5385a6;
+  border-radius: 2;
+}
+#LargeSizedText {
+  font-size: 17px;
+}
+/* -----------------------------------------------------------------------------
+   Unknowns + Legacy
+----------------------------------------------------------------------------- */
+#StartupLabel {
+  padding: 3;
+}
+#StartupLabel:hover {
+  background: #5a5d5f;
+}
+QStatusBar {
+  background-color: #c0c0c0;
+}
+QStatusBar::item {
+  border: 0;
+}
+QStatusBar QLabel {
+  background-color: #c0c0c0;
+}
+QStatusBar #StatusBarLabel {
+  background-color: #ffffff;
+  padding: 1 3;
+}
+#TitleTxtLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Style Editor
+----------------------------------------------------------------------------- */
+#StyleEditor QPushButton {
+  margin: 2 1;
+  padding: 0;
+}
+#StyleEditor #TabBarContainer {
+  margin-left: -4;
+}
+#StyleEditor #bottomWidget {
+  border-top: 1 solid #212223;
+  padding: 3 2 8 3;
+}
+#StyleEditor #bottomWidget QPushButton {
+  padding: 3 5;
+}
+#StyleEditorTabBar::tab::first {
+  border-left: 1 solid #212223;
+}
+#HexagonalColorWheel {
+  qproperty-BGColor: #414345;
+}
+/* -------------------------------------------------------------------------- */
+/* Horizontal QSlider */
+#colorSlider::groove:horizontal {
+  height: 1;
+  border-image: none;
+}
+#colorSlider::handle:horizontal {
+  width: 8;
+  margin: -8 -4;
+}
+#colorSliderAddButton,
+#colorSliderSubButton {
+  background: none;
+  border-color: transparent;
+  image-position: center center;
+  min-height: 16;
+  padding: 0;
+  min-width: 18;
+}
+#colorSliderAddButton {
+  image: url('../Default/imgs/white/scroll-right.svg');
+}
+#colorSliderSubButton {
+  image: url('../Default/imgs/white/scroll-left.svg');
+}
+#PlainColorPageParts {
+  border-bottom: 1 solid #212223;
+}
+#PlainColorPageParts QLineEdit {
+  max-width: 35;
+}
+/* -----------------------------------------------------------------------------
+   Palette Viewer / Studio Palette
+----------------------------------------------------------------------------- */
+PaletteViewer DvScrollWidget QPushButton {
+  border-top: 0;
+  margin-bottom: 1;
+  max-width: 15;
+  min-width: 15;
+}
+PaletteViewer DvScrollWidget #ScrollLeftButton {
+  border-radius: 0;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer DvScrollWidget #ScrollRightButton {
+  border-radius: 0;
+  margin-left: 1;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer QToolBar {
+  background: none;
+  border-bottom: 1 solid #212223;
+  padding: 0;
+  margin: 0;
+}
+PaletteViewer QToolBar::separator:horizontal {
+  margin: 0;
+}
+PaletteViewer QToolBar QToolButton {
+  margin: 0 0 1 0;
+  padding: 1 0 2 0;
+}
+#PageViewer {
+  qproperty-TextColor: #d6d8dd;
+}
+#PaletteLockButton {
+  border-radius: 0;
+  margin: 0 0 1 1;
+}
+#PaletteLockButton:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+}
+#PaletteLockButton:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+/* -----------------------------------------------------------------------------
+   Quick Renamer
+----------------------------------------------------------------------------- */
+#WordButton {
+  padding-right: 0;
+  padding-left: 0;
+}
+/* -----------------------------------------------------------------------------
+   Popup Windows
+----------------------------------------------------------------------------- */
+QDialog {
+  background-color: #414345;
+}
+QDialog #dialogButtonFrame {
+  background-color: #37393a;
+  border-top: 1 solid #212223;
+}
+QDialog #dialogButtonFrame QPushButton {
+  border-color: #37393a;
+  outline: 0;
+}
+QDialog #dialogButtonFrame QPushButton:focus {
+  background-color: #5385a6;
+  border-color: #37393a;
+  color: #ffffff;
+}
+QDialog #dialogButtonFrame QPushButton:focus:hover {
+  background-color: #6c98b6;
+}
+QDialog #dialogButtonFrame QPushButton:focus:pressed {
+  background-color: #2b2c2d;
+  border-color: #262728;
+  color: #e4e5e9;
+}
+/* -----------------------------------------------------------------------------
+   Scene Settings
+----------------------------------------------------------------------------- */
+#SceneSettings QLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Preferences
+----------------------------------------------------------------------------- */
+#PreferencesPopup QListWidget {
+  background-color: #2d2f30;
+  alternate-background-color: #2d2f30;
+  border: 1 solid #212223;
+  font-size: 13px;
+}
+#PreferencesPopup QListWidget::item {
+  border: 0;
+  padding: 3;
+}
+#PreferencesPopup QListWidget::item:hover {
+  color: #d6d8dd;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+#PreferencesPopup QListWidget::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Keyboard Shortcuts
+----------------------------------------------------------------------------- */
+#ShortcutTree {
+  border: 1 solid #212223;
+}
+#ShortcutTree::item {
+  padding: 1 0;
+}
+#ShortcutTree QScrollBar:vertical {
+  width: 16;
+  margin-right: -1;
+}
+/* -----------------------------------------------------------------------------
+   New Project / Configure Project Window
+----------------------------------------------------------------------------- */
+ProjectPopup QLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   PencilTestPopup / CameraCapture Window
+----------------------------------------------------------------------------- */
+#GearButton {
+  qproperty-icon: url('../Default/imgs/white/gear.svg');
+}
+#SubfolderButton {
+  qproperty-icon: url('../Default/imgs/white/subfolder.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+#SubcameraButton {
+  qproperty-icon: url('../Default/imgs/white/subcamera.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+/* -----------------------------------------------------------------------------
+   Schematic Viewer
+----------------------------------------------------------------------------- */
+SchematicViewer {
+  qproperty-TextColor: #d6d8dd;
+  qproperty-VerticalLineColor: #222222;
+  qproperty-LevelColumnColor: #4C6E4C;
+  qproperty-VectorColumnColor: #7B7B4C;
+  qproperty-ChildColumnColor: #6A526B;
+  qproperty-FullcolorColumnColor: #657A96;
+  qproperty-FxColumnColor: #56553C;
+  qproperty-PaletteColumnColor: #3A655F;
+  qproperty-MeshColumnColor: #684D86;
+  qproperty-ReferenceColumnColor: #616161;
+  qproperty-TableColor: #62628c;
+  qproperty-ActiveCameraColor: #2d7dca;
+  qproperty-OtherCameraColor: #6c797b;
+  qproperty-GroupColor: #3b6e9c;
+  qproperty-PegColor: #9f6e3c;
+  qproperty-SplineColor: #6a9d1c;
+  qproperty-ActiveOutputColor: #2d7dca;
+  qproperty-OtherOutputColor: #6c797b;
+  qproperty-XsheetColor: #62628c;
+  qproperty-NormalFxColor: #6a7e96;
+  qproperty-MacroFxColor: #815c79;
+  qproperty-ImageAdjustFxColor: #656287;
+  qproperty-LayerBlendingFxColor: #4f757d;
+  qproperty-MatteFxColor: #ae7171;
+  qproperty-SchematicPreviewButtonBgOnColor: #c8c864;
+  qproperty-SchematicPreviewButtonOnImage: url('../Default/imgs/white/x_prev_eye_on.svg');
+  qproperty-SchematicPreviewButtonBgOffColor: #616161;
+  qproperty-SchematicPreviewButtonOffImage: url('../Default/imgs/white/x_prev_eye_off.svg');
+  qproperty-SchematicCamstandButtonBgOnColor: #eb906b;
+  qproperty-SchematicCamstandButtonOnImage: url('../Default/imgs/white/x_table_view_on.svg');
+  qproperty-SchematicCamstandButtonTranspImage: url('../Default/imgs/white/x_table_view_transp.svg');
+  qproperty-SchematicCamstandButtonBgOffColor: #616161;
+  qproperty-SchematicCamstandButtonOffImage: url('../Default/imgs/white/x_table_view_off.svg');
+}
+/* -----------------------------------------------------------------------------
+   Schematic Node Viewer
+----------------------------------------------------------------------------- */
+#SchematicBottomFrame {
+  background-color: #414345;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+#SchematicBottomFrame QToolBar::separator:horizontal {
+  margin: 0;
+}
+#SchematicBottomFrame QToolBar QToolButton {
+  padding: 0;
+  margin: 2;
+}
+#SchematicSceneViewer {
+  background-color: #353638;
+  border-bottom: 1 solid #212223;
+}
+/* -----------------------------------------------------------------------------
+   FX Settings
+----------------------------------------------------------------------------- */
+#FxSettingsTabBar::tab {
+  border-top: 1 solid #212223;
+}
+#FxSettingsTabBar::tab::first,
+#FxSettingsTabBar::tab::only-one {
+  border-left: 1 solid #212223;
+}
+FxSettings QToolBar {
+  border-top: 1 solid #212223;
+  border-right: 1 solid #212223;
+  border-left: 1 solid #212223;
+  min-height: 23;
+  padding: 3 0;
+}
+FxSettings QToolBar QToolBar {
+  border: 0;
+}
+#FxSettingsLabel {
+  color: #a0e680;
+}
+#FxSettingsHelpButton {
+  background-color: #80a0dc;
+  color: #000;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+#FxSettingsHelpButton:hover {
+  background-color: #a8bee7;
+}
+/* -----------------------------------------------------------------------------
+   Script Console
+----------------------------------------------------------------------------- */
+#ScriptConsole {
+  font-family: 'Courier New', monospace;
+  border: 0;
+  color: #000000;
+  padding: 3;
+}
+#ScriptConsole QFrame {
+  background-color: #dcdcdc;
+}
+#ScriptConsole TPanelTitleBar {
+  background-color: #323435;
+}
+/* -----------------------------------------------------------------------------
+   Task Viewer
+----------------------------------------------------------------------------- */
+#TaskSheetItemLabel {
+  color: #d6d8dd;
+}
+#Tasks QToolBar {
+  border-bottom: 1 solid #212223;
+  margin: 0;
+  padding: 0;
+}
+#Tasks QToolBar QToolButton {
+  margin: 2 2 3 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bar
+----------------------------------------------------------------------------- */
+#ToolBar QToolBar {
+  padding-left: 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Options
+----------------------------------------------------------------------------- */
+#ToolOptions TPanelTitleBar {
+  border-right: 1 solid #212223;
+  border-bottom: 0;
+}
+#CommandBar TPanelTitleBar {
+  border-right: 1 solid #212223;
+  border-bottom: 0;
+}
+IconViewField {
+  qproperty-ThicknessPixmap: url("../Default/imgs/white/selectiontool_thickness.svg");
+}
+#EditToolLockButton {
+  spacing: 0;
+}
+#EditToolLockButton:hover {
+  background: none;
+}
+#EditToolLockButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#EditToolLockButton::indicator:unchecked {
+  image: url('../Default/imgs/white/lock_off.svg');
+}
+#EditToolLockButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+  image: url('../Default/imgs/white/lock_on.svg');
+}
+#EditToolLockButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+PopupButton::menu-indicator {
+  border-left: 0;
+  height: 17;
+  image: url('../Default/imgs/white/combo_downarrow.svg');
+  width: 10;
+}
+PopupButton::menu-indicator:hover {
+  image: url('../Default/imgs/white/combo_downarrow.svg');
+}
+PopupButton::menu-indicator:disabled {
+  image: url('../Default/imgs/white/combo_downarrow_disabled.svg');
+}
+#Cap,
+#Join {
+  padding: 0 4 0 -8;
+  max-width: 32;
+  min-width: 32;
+}
+#Cap QMenu,
+#Join QMenu {
+  max-width: 28;
+  min-width: 28;
+}
+#Cap QMenu::item,
+#Join QMenu::item {
+  max-width: 28;
+  min-width: 28;
+  padding: 0;
+}
+QToolBar#MediumPaddingToolBar QToolButton {
+  padding-left: 3;
+  padding-right: 3;
+}
+QToolBar#WidePaddingToolBar QToolButton {
+  padding-left: 6;
+  padding-right: 6;
+}
+#CommandBar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#CommandBar::separator:horizontal {
+  margin-right: 3;
+  margin-left: 3;
+}
+#expandButton:checked {
+  background-color: transparent;
+  border-color: transparent;
+  color: #d6d8dd;
+}
+#expandButton:checked:hover {
+  background-color: #6e7174;
+  border-color: #6e7174;
+}
+#expandButton:checked:pressed {
+  background-color: #2b2c2d;
+  border-color: #262728;
+}
+/* -----------------------------------------------------------------------------
+   ComboViewer / Viewer / FlipBook
+----------------------------------------------------------------------------- */
+#ComboViewerPanel Toolbar {
+  border-bottom: 1 solid #212223;
+}
+#ComboViewerPanel Toolbar::separator:horizontal {
+  margin: 0 0 0 2;
+}
+#ComboViewerPanel Toolbar QToolButton {
+  margin: 2 0 3 2;
+}
+#ComboViewerToolOptions {
+  border-bottom: 1 solid #212223;
+}
+#ComboViewer #ToolBarContainer,
+#ViewerPanel #ToolBarContainer,
+FlipBook #ToolBarContainer {
+  background-color: transparent;
+  border-top: 2 solid #212223;
+  border-bottom: 1 solid #212223;
+  padding-right: -1;
+}
+#flipCustomize {
+  margin-left: 3;
+}
+#flipCustomize::menu-button {
+  background-color: transparent;
+  width: 35;
+}
+#flipCustomize::menu-arrow {
+  image: none;
+}
+QToolBar#FlipConsolePlayToolBar::separator:horizontal {
+  margin: 0 3;
+}
+QToolBar#FlipConsolePlayToolBar QToolButton {
+  margin-top: 2;
+  margin-bottom: 2;
+  height: 16;
+  padding-left: 1;
+  padding-right: 1;
+}
+#ViewerFpsSlider {
+  background-color: transparent;
+  background-image: url('../Default/imgs/white/slider-groove.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  border: 0;
+  height: 19;
+  margin: 0 3 0 37;
+  max-width: 300;
+  min-width: 0;
+}
+#ViewerFpsSlider::sub-line:horizontal {
+  subcontrol-origin: absolute;
+  background-color: #616467;
+  border: 1 solid #414345;
+  border-top-left-radius: 2;
+  border-bottom-left-radius: 2;
+  height: 16;
+  left: -33;
+  width: 14;
+}
+#ViewerFpsSlider::add-line:horizontal {
+  subcontrol-position: left;
+  background-color: #616467;
+  border: 1 solid #414345;
+  border-top-right-radius: 2;
+  border-bottom-right-radius: 2;
+  left: 18;
+  height: 16;
+  image-position: center center;
+  width: 13;
+}
+#ViewerFpsSlider::handle::horizontal {
+  background-color: #999c9f;
+  border: 1 solid #999c9f;
+  border-radius: 2;
+  margin: 2 0 3 0;
+  min-width: 9;
+  width: 9;
+  max-width: 9;
+}
+FlipSlider {
+  qproperty-PBHeight: 15;
+  qproperty-PBOverlay: url('../Default/imgs/white/flipslider.svg');
+  qproperty-PBColorMarginLeft: 1;
+  qproperty-PBColorMarginTop: 2;
+  qproperty-PBColorMarginRight: 1;
+  qproperty-PBColorMarginBottom: 2;
+  qproperty-PBMarker: url('../Default/imgs/white/flipmarker.svg');
+  qproperty-PBMarkerMarginLeft: 3;
+  qproperty-PBMarkerMarginRight: 3;
+  qproperty-notStartedColor: rgba(205, 101, 101, 0.78);
+  qproperty-startedColor: #1abc3f;
+  qproperty-baseColor: #28292b;
+  qproperty-finishedColor: #28292b;
+}
+Ruler {
+  qproperty-ParentBGColor: #414345;
+  qproperty-ScaleColor: #d6d8dd;
+}
+#RulerToolOptionValues {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   XSheet Viewer
+----------------------------------------------------------------------------- */
+/* ScrollAreas (Row, Column and Cell)
+----------------------------------------------------------------------------- */
+#xsheetArea,
+#ScrollArea {
+  background-color: #2d2f30;
+  border: 0;
+}
+#xsheetScrollArea {
+  border: 0;
+}
+#cornerWidget QToolButton {
+  padding: 0;
+}
+/* xsheetColumnHeader (Context Menus)
+----------------------------------------------------------------------------- */
+#xsheetColumnAreaMenu_Preview {
+  background-color: #E6E678;
+}
+#xsheetColumnAreaMenu_Lock {
+  background-color: #F5F5F5;
+}
+#xsheetColumnAreaMenu_Camstand {
+  background-color: #FFA480;
+}
+#xsheetColumnAreaMenu_Preview,
+#xsheetColumnAreaMenu_Lock,
+#xsheetColumnAreaMenu_Camstand {
+  color: #000;
+}
+#noteTextEdit {
+  color: #000;
+}
+/* XSheet Spreadsheet
+----------------------------------------------------------------------------- */
+XsheetViewer {
+  qproperty-TextColor: #d6d8dd;
+  qproperty-BGColor: #353638;
+  qproperty-LightLineColor: #262728;
+  qproperty-MarkerLineColor: #1E96C4;
+  qproperty-VerticalLineColor: #222222;
+  qproperty-VerticalLineHeadColor: #777b7f;
+  qproperty-PreviewFrameTextColor: #9fdaff;
+  qproperty-CurrentRowBgColor: #506082;
+  qproperty-OnionSkinAreaBgColor: #303133;
+  qproperty-EmptyColumnHeadColor: #5a5d60;
+  qproperty-SelectedColumnTextColor: #E66464;
+  qproperty-EmptyCellColor: #393b3d;
+  qproperty-NotEmptyColumnColor: #414345;
+  qproperty-SelectedEmptyCellColor: #64676a;
+  qproperty-LevelColumnColor: #4C6E4C;
+  qproperty-LevelColumnBorderColor: #8FB38F;
+  qproperty-SelectedLevelColumnColor: #678667;
+  qproperty-VectorColumnColor: #7B7B4C;
+  qproperty-VectorColumnBorderColor: #BBBB9A;
+  qproperty-SelectedVectorColumnColor: #949466;
+  qproperty-ChildColumnColor: #6A526B;
+  qproperty-ChildColumnBorderColor: #B1A3B3;
+  qproperty-SelectedChildColumnColor: #816e82;
+  qproperty-FullcolorColumnColor: #657A96;
+  qproperty-FullcolorColumnBorderColor: #9EB8BB;
+  qproperty-SelectedFullcolorColumnColor: #8895a6;
+  qproperty-FxColumnColor: #56553C;
+  qproperty-FxColumnBorderColor: #95958A;
+  qproperty-SelectedFxColumnColor: #6f6e56;
+  qproperty-ReferenceColumnColor: #616161;
+  qproperty-ReferenceColumnBorderColor: #A2A2A2;
+  qproperty-SelectedReferenceColumnColor: #7a7a7a;
+  qproperty-PaletteColumnColor: #3A655F;
+  qproperty-PaletteColumnBorderColor: #86ACA7;
+  qproperty-SelectedPaletteColumnColor: #52807a;
+  qproperty-MeshColumnColor: #684D86;
+  qproperty-MeshColumnBorderColor: #BA92EF;
+  qproperty-SelectedMeshColumnColor: #82689e;
+  qproperty-SoundTextColumnColor: #c8c8c8;
+  qproperty-SoundTextColumnBorderColor: #8c8c8c;
+  qproperty-SelectedSoundTextColumnColor: #e2e2e2;
+  qproperty-SoundColumnColor: #657456;
+  qproperty-SoundColumnBorderColor: #A0AF7D;
+  qproperty-SelectedSoundColumnColor: #7e8b72;
+  qproperty-SoundColumnHlColor: #34FE5E;
+  qproperty-SoundColumnTrackColor: #B6C29D;
+  qproperty-ColumnHeadPastelizer: #000;
+  qproperty-SelectedColumnHead: #506082;
+  qproperty-LightLightBGColor: #393b3d;
+  qproperty-LightBGColor: #eaebec;
+  qproperty-DarkBGColor: #dbdcdd;
+  qproperty-DarkLineColor: #8e9194;
+  qproperty-XsheetColumnNameBgColor: rgba(0, 0, 0, 0);
+  qproperty-XsheetDragBarHighlightColor: rgba(255, 255, 255, 0.5);
+  qproperty-XsheetPreviewButtonBgOnColor: #c8c864;
+  qproperty-XsheetPreviewButtonOnImage: url('../Default/imgs/white/x_prev_eye_on.svg');
+  qproperty-XsheetPreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetPreviewButtonOffImage: url('../Default/imgs/white/x_prev_eye_off.svg');
+  qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
+  qproperty-XsheetCamstandButtonOnImage: url('../Default/imgs/white/x_table_view_on.svg');
+  qproperty-XsheetCamstandButtonTranspImage: url('../Default/imgs/white/x_table_view_transp.svg');
+  qproperty-XsheetCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetCamstandButtonOffImage: url('../Default/imgs/white/x_table_view_off.svg');
+  qproperty-XsheetLockButtonBgOnColor: rgba(255, 255, 255, 0.3);
+  qproperty-XsheetLockButtonOnImage: url('../Default/imgs/white/x_lock_on.svg');
+  qproperty-XsheetLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetLockButtonOffImage: url('../Default/imgs/white/x_lock_off.svg');
+  qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetConfigButtonImage: url('../Default/imgs/white/x_config.svg');
+  qproperty-TimelinePreviewButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelinePreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOffImage: url('../Default/imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineCamstandButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOnImage: url('../Default/imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelineCamstandButtonTranspImage: url('../Default/imgs/white/timeline_toggle_transp.svg');
+  qproperty-TimelineCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOffImage: url('../Default/imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineLockButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOnImage: url('../Default/imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelineLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOffImage: url('../Default/imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineConfigButtonImage: url('../Default/imgs/white/timeline_config.svg');
+  qproperty-LayerHeaderPreviewImage: url('../Default/imgs/white/layer_header_prev_eye.svg');
+  qproperty-LayerHeaderPreviewOverImage: url('../Default/imgs/white/layer_header_prev_eye_over.svg');
+  qproperty-LayerHeaderCamstandImage: url('../Default/imgs/white/layer_header_table_view.svg');
+  qproperty-LayerHeaderCamstandOverImage: url('../Default/imgs/white/layer_header_table_view_over.svg');
+  qproperty-LayerHeaderLockImage: url('../Default/imgs/white/lock_on.svg');
+  qproperty-LayerHeaderLockOverImage: url('../Default/imgs/white/lock_on_over.svg');
+  qproperty-ActiveCameraColor: #2d7dca;
+  qproperty-SelectedActiveCameraColor: #5796d3;
+  qproperty-OtherCameraColor: #6c797b;
+  qproperty-SelectedOtherCameraColor: #8b8e8f;
+}
+/* XSheet Toolbar
+----------------------------------------------------------------------------- */
+#XSheetToolbar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#XSheetToolbar QToolButton {
+  padding: 0;
+  margin: 4 1;
+  min-height: 19;
+  height: 19;
+}
+#XSheetToolbar::separator:horizontal {
+  margin: 0 4;
+}
+/* -----------------------------------------------------------------------------
+   Function Editor
+----------------------------------------------------------------------------- */
+#FunctionEditor QToolBar {
+  border-bottom: 1 solid #212223;
+}
+#FunctionEditor QToolBar QToolBar {
+  border: 0;
+}
+#FunctionEditor QToolBar QLabel {
+  margin-left: 5;
+}
+#FunctionEditor QToolBar QToolButton {
+  height: 18;
+}
+#FunctionEditorTree {
+  border-top: 1 solid #212223;
+}
+FunctionTreeView {
+  qproperty-TextColor: #d6d8dd;
+  qproperty-CurrentTextColor: #E66464;
+}
+/* Function Editor Spreadsheet
+----------------------------------------------------------------------------- */
+FunctionPanel {
+  qproperty-BGColor: #343638;
+  qproperty-ValueLineColor: #28292b;
+  qproperty-FrameLineColor: #28292b;
+  qproperty-OtherCurvesColor: #7f8386;
+  qproperty-RulerBackground: #2d2e30;
+  qproperty-TextColor: #d6d8dd;
+  qproperty-SubColor: #000;
+  qproperty-SelectedColor: #FFA500;
+}
+SpreadsheetViewer {
+  qproperty-LightLightBGColor: #393b3d;
+  qproperty-CurrentRowBgColor: #506082;
+  qproperty-LightLineColor: #262728;
+  qproperty-MarkerLineColor: #1E96C4;
+  qproperty-BGColor: #414345;
+  qproperty-VerticalLineColor: #222222;
+  qproperty-KeyFrameColor: #995d1d;
+  qproperty-KeyFrameBorderColor: #c9b04b;
+  qproperty-SelectedKeyFrameColor: #be772b;
+  qproperty-InBetweenColor: #666250;
+  qproperty-InBetweenBorderColor: #cdcec8;
+  qproperty-SelectedInBetweenColor: #7d7a6c;
+  qproperty-SelectedEmptyColor: #64676a;
+  qproperty-SelectedSceneRangeEmptyColor: #6d7073;
+  qproperty-TextColor: #d6d8dd;
+  qproperty-ColumnHeaderBorderColor: #777b7f;
+  qproperty-SelectedColumnTextColor: #E66464;
+}
+#ExpressionField {
+  background-color: #e0e1e2;
+  border: 1 solid #2d2e2f;
+  margin: 0;
+}
+#FunctionSegmentViewerLinkButton {
+  background-image: url('../Default/imgs/white/segment_unlinked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:hover {
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:checked {
+  background-image: url('../Default/imgs/white/segment_linked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:disabled {
+  background-image: url('../Default/imgs/white/segment_disabled.svg');
+  background-repeat: no-repeat;
+}

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1,1 +1,1935 @@
-.button-show,#LoadLevelShowButton,#CleanupSettingsShowButton,#OutputSettingsShowButton,#FxSettingsPreviewShowButton{image:url('../Default/imgs/white/plus.svg');image-position:center center;margin:0;padding:1;min-width:10;min-height:10}.button-show:checked,#LoadLevelShowButton:checked,#CleanupSettingsShowButton:checked,#OutputSettingsShowButton:checked,#FxSettingsPreviewShowButton:checked{background-color:#191919;border-color:#141414;image:url('../Default/imgs/white/minus.svg')}.button-show:checked:pressed,#LoadLevelShowButton:checked:pressed,#CleanupSettingsShowButton:checked:pressed,#OutputSettingsShowButton:checked:pressed,#FxSettingsPreviewShowButton:checked:pressed{background-color:#191919;border-color:#141414}.button-show:checked:hover,#LoadLevelShowButton:checked:hover,#CleanupSettingsShowButton:checked:hover,#OutputSettingsShowButton:checked:hover,#FxSettingsPreviewShowButton:checked:hover{background-color:#1e1e1e}.button-tool,QToolButton,#CameraSettingsRadioButton::indicator,#ForceSquaredPixelButton,#SchematicBottomFrame QToolBar QToolButton,#EditToolLockButton::indicator,#flipCustomize{background-color:rgba(255,255,255,0);border:1 solid rgba(255,255,255,0);border-radius:2;color:#dbdbdb;margin:1;padding:0}.button-tool:hover,QToolButton:hover,#CameraSettingsRadioButton::indicator:hover,#ForceSquaredPixelButton:hover,#colorSliderAddButton:hover,#colorSliderSubButton:hover,#SchematicBottomFrame QToolBar QToolButton:hover,#EditToolLockButton::indicator:hover,#flipCustomize:hover{background-color:#5e5e5e;border-color:#5e5e5e;color:#dbdbdb}.button-tool:pressed,QToolButton:pressed,#CameraSettingsRadioButton::indicator:pressed,#ForceSquaredPixelButton:pressed,#colorSliderAddButton:pressed,#colorSliderSubButton:pressed,#SchematicBottomFrame QToolBar QToolButton:pressed,#EditToolLockButton::indicator:pressed,#flipCustomize:pressed{background-color:#191919;border-color:#141414;color:#dbdbdb}.button-tool:checked,QToolButton:checked,#CameraSettingsRadioButton::indicator:checked,#ForceSquaredPixelButton:checked,#SchematicBottomFrame QToolBar QToolButton:checked,#EditToolLockButton::indicator:checked,#flipCustomize:checked{background-color:#5385a6;border-color:#5385a6;color:#fff}.button-tool:checked:hover,QToolButton:checked:hover,#CameraSettingsRadioButton::indicator:checked:hover,#ForceSquaredPixelButton:checked:hover,#SchematicBottomFrame QToolBar QToolButton:checked:hover,#EditToolLockButton::indicator:checked:hover,#flipCustomize:checked:hover{background-color:#6c98b6;border-color:#6c98b6}.button-tool:disabled,QToolButton:disabled,#CameraSettingsRadioButton::indicator:disabled,#ForceSquaredPixelButton:disabled,#SchematicBottomFrame QToolBar QToolButton:disabled,#EditToolLockButton::indicator:disabled,#flipCustomize:disabled{color:#808080}.button-flat,PaletteViewer QToolBar QToolButton{background-color:none;border:0;border-radius:0;margin:0}.button-flat:hover,PaletteViewer QToolBar QToolButton:hover{background-color:#5e5e5e}.button-flat:pressed,PaletteViewer QToolBar QToolButton:pressed{background-color:#161616}.frame,.GroupBox,#LoadLevelFrame,#PsdSettingsGroupBox,#CleanupSettingsFrame,#OutputSettingsBox,#OutputSettingsCameraBox,#SolidLineFrame,#FunctionParametersPanel,QGroupBox{border:1 solid #161616;border-radius:2}.tab-container,#TabBarContainer{background-color:transparent;qproperty-BottomAboveLineColor:#262626;qproperty-BottomBelowLineColor:#161616}.tab-flat,#StyleEditorTabBar::tab,#PaletteTabBar::tab,#FxSettingsTabBar::tab{background-color:#262626;border-right:1 solid #161616;border-bottom:1 solid #161616;color:#8b8b8b;padding:3 4 3 4}.tab-flat:hover,#StyleEditorTabBar::tab:hover,#PaletteTabBar::tab:hover,#FxSettingsTabBar::tab:hover{background-color:#303030;color:#8b8b8b}.tab-flat:selected,#StyleEditorTabBar::tab:selected,#PaletteTabBar::tab:selected,#FxSettingsTabBar::tab:selected{background-color:#303030;color:#f4f4f4;border-bottom-color:#303030}.tab-flat:only-one,#StyleEditorTabBar::tab:only-one,#PaletteTabBar::tab:only-one,#FxSettingsTabBar::tab:only-one{margin:0}.tab-round{background-color:#262626;border-top:1 solid #161616;border-right:1 solid #161616;border-left:1 solid #161616;border-bottom:1 solid #161616;color:#8b8b8b;margin:3 -1 0 0;padding:2 7 1 7}.tab-round:hover{background-color:#303030;color:#8b8b8b}.tab-round:selected{background-color:#303030;border-top-right-radius:2;border-top-left-radius:2;border-bottom-color:#303030;color:#f4f4f4;margin:1 -1 -1 0;padding:2 7 2 7}.tab-round:only-one{margin:1 0 0 0;padding:3 7 3 7}.tab-round:last{margin-right:0;border-top-right-radius:2}.tab-round:first{border-top-left-radius:2}QWidget{background-color:#303030;color:#cecece}QWidget:disabled{color:#808080}QFrame{border:0;margin:0;padding:0}QToolTip,#helpToolTip{background-color:#fff;border:1 solid #000;color:#000;padding:1 1}#DockSeparator,QMainWindow::separator,QSplitter::handle{background-color:#0c0c0c;height:4;width:4}#TDockPlaceholder{background-color:#F77272}TPanel{background-color:#0c0c0c}#TopBar{background:#303030;border:0;border-bottom:1 solid #161616;height:21}#TopBar #EditToolLockButton{background:#303030;spacing:0}#TopBar #EditToolLockButton::indicator{background:none;border:none;height:18;margin:1 2 0 0;padding-left:0;padding-right:0}#TopBarTabContainer{background-color:#303030;margin-bottom:1}#StackedMenuBar{border:0;margin:0;padding:0}QMenuBar{background-color:#303030;border:0}QMenuBar::item{background-color:#303030;border-left:1 solid #303030;margin:0;padding:3 5}QMenuBar::item:selected{background-color:rgba(255,255,255,0.15);color:#cecece}QMenuBar::item:pressed{background-color:#5385a6;color:#fff}#TopBarTab{margin:0;padding:0}#TopBarTab::tab{background-color:#262626;border-top:1 solid #161616;border-right:1 solid #161616;color:#8b8b8b;margin:0 0 0 0;padding:2 8 3 8}#TopBarTab::tab:hover{background-color:#303030;color:#8b8b8b}#TopBarTab::tab:selected{background-color:#303030;color:#f4f4f4}#TopBarTab::tab:first{border-left:1 solid #161616}#TopBarTab::tab:last{border-right:1 solid #161616}QMenu{background-color:#303030;border:1 solid #161616;padding:2 0}QMenu::item{padding:3 28}QMenu::item:selected{background-color:#5385a6;color:#fff}QMenu::item:checked{color:#cecece}QMenu::item:checked:selected{background-color:#5385a6;color:#fff}QMenu::item:disabled{background:none;color:#808080}QMenu::item:disabled:selected{border-color:transparent}QMenu::separator{border-top:1 solid #161616;height:0;margin:2 0}QMenu::icon{border-radius:2;margin:0 0 0 3;padding:1}QMenu::icon:checked{background-color:#5385a6}QMenu::indicator{margin-left:7}TPanelTitleBar{background-color:#262626;border-color:#161616;border-style:solid;border-width:0 0 1 0;height:20;min-height:20;qproperty-TitleColor:#7d7d7d;qproperty-ActiveTitleColor:#fff;qproperty-BorderPixmap:url('none');qproperty-ActiveBorderPixmap:url('../Default/imgs/white/none');qproperty-FloatBorderPixmap:url('none');qproperty-FloatActiveBorderPixmap:url('../Default/imgs/white/none')}QAbstractScrollArea::corner{background-color:#262626}QScrollBar{background-color:#262626;border:0}QScrollBar:horizontal{height:16;margin:0}QScrollBar:vertical{margin:0;width:16}QScrollBar::handle{border:1 solid #3a3a3a;border-radius:4}QScrollBar::handle:horizontal:hover,QScrollBar::handle:vertical:hover{background-color:#4f4f4f;border-color:#4f4f4f}QScrollBar::handle:horizontal:pressed,QScrollBar::handle:vertical:pressed{background-color:#636363;border-color:#636363}QScrollBar::handle:horizontal{background-color:#3a3a3a;margin:3 16;min-width:20}QScrollBar::handle:vertical{background-color:#3a3a3a;margin:16 3;min-height:20}QScrollBar::add-line{subcontrol-origin:margin;border:0}QScrollBar::add-line:horizontal{subcontrol-position:right;background-color:#262626;margin:0;width:16}QScrollBar::add-line:vertical{subcontrol-position:bottom;background-color:#262626;margin:0;height:16}QScrollBar::sub-line{border:0;subcontrol-origin:margin}QScrollBar::sub-line:horizontal{subcontrol-position:left;background-color:#262626;margin:0;width:16}QScrollBar::sub-line:vertical{subcontrol-position:top;background-color:#262626;margin:0;height:16}QScrollBar::up-arrow:vertical{image:url('../Default/imgs/white/scroll-up.svg');image-position:center center}QScrollBar::up-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::down-arrow:vertical{image:url('../Default/imgs/white/scroll-down.svg');image-position:center center}QScrollBar::down-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::left-arrow:horizontal{image:url('../Default/imgs/white/scroll-left.svg');image-position:center center}QScrollBar::left-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::right-arrow:horizontal{image:url('../Default/imgs/white/scroll-right.svg');image-position:center center}QScrollBar::right-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::sub-page:horizontal,QScrollBar::add-page:horizontal,QScrollBar::sub-page:vertical,QScrollBar::add-page:vertical{background:none}QToolBar{padding:0}QToolBar::separator:horizontal{border-left:1 solid #161616;margin:0 1;width:0}QToolBar::separator:vertical{border-top:1 solid #161616;height:0;margin:1 0}QToolBar QLabel{margin-top:1}QToolBar QToolBar{border:0}QToolButton::menu-indicator{image:none}QToolButton::menu-button{border-image:none}.DvScrollWidget QPushButton,DvScrollWidget QPushButton,#ScrollLeftButton QPushButton,#ScrollRightButton QPushButton,#ScrollUpButton QPushButton,#ScrollDownButton QPushButton{background-color:#515151;border:0 solid red;border-radius:0;padding:0;max-width:16}.DvScrollWidget QPushButton:hover,DvScrollWidget QPushButton:hover,#ScrollLeftButton QPushButton:hover,#ScrollRightButton QPushButton:hover,#ScrollUpButton QPushButton:hover,#ScrollDownButton QPushButton:hover{background-color:#5e5e5e}.DvScrollWidget QPushButton:pressed,DvScrollWidget QPushButton:pressed,#ScrollLeftButton QPushButton:pressed,#ScrollRightButton QPushButton:pressed,#ScrollUpButton QPushButton:pressed,#ScrollDownButton QPushButton:pressed{background-color:#191919}#ScrollLeftButton,#ScrollRightButton,#ScrollUpButton,#ScrollDownButton{margin:0;min-width:16}#ScrollLeftButton{border-right:1 solid #161616;image:url('../Default/imgs/white/scroll-left.svg')}#ScrollRightButton{border-left:1 solid #161616;margin-left:3;image:url('../Default/imgs/white/scroll-right.svg')}#ScrollUpButton{image:url('../Default/imgs/white/scroll-up.svg')}#ScrollDownButton{image:url('../Default/imgs/white/scroll-down.svg')}#keyFrameNavigator{background:none;margin:0;padding:0}#keyFrameNavigator QToolButton{min-width:18}#keyFrameNavigator #PreviousKey{image:url('../Default/imgs/white/prevkey.svg')}#keyFrameNavigator #PreviousKey:hover{image:url('../Default/imgs/white/prevkey_over.svg')}#keyFrameNavigator #PreviousKey:disabled{image:url('../Default/imgs/white/prevkey_disabled.svg')}#keyFrameNavigator #NextKey{image:url('../Default/imgs/white/nextkey.svg')}#keyFrameNavigator #NextKey:hover{image:url('../Default/imgs/white/nextkey_over.svg')}#keyFrameNavigator #NextKey:disabled{image:url('../Default/imgs/white/nextkey_disabled.svg')}.treeview,QTreeWidget,QTreeView,#FunctionEditorTree{background-color:#262626;alternate-background-color:#2b2b2b;border:0;margin:0;outline:0}.treeview::item:selected,QTreeWidget::item:selected,QTreeView::item:selected,#FunctionEditorTree::item:selected{background-color:#5385a6;color:#fff}.treeview::branch:adjoins-item,QTreeWidget::branch:adjoins-item,QTreeView::branch:adjoins-item,#FunctionEditorTree::branch:adjoins-item{border-image:url('')}.treeview::branch:has-siblings,QTreeWidget::branch:has-siblings,QTreeView::branch:has-siblings,#FunctionEditorTree::branch:has-siblings{border-image:url('')}.treeview::branch:has-siblings:adjoins-item,QTreeWidget::branch:has-siblings:adjoins-item,QTreeView::branch:has-siblings:adjoins-item,#FunctionEditorTree::branch:has-siblings:adjoins-item{border-image:url('')}.treeview::branch:has-children:closed,QTreeWidget::branch:has-children:closed,QTreeView::branch:has-children:closed,#FunctionEditorTree::branch:has-children:closed{background:url('../Default/imgs/white/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:open,QTreeWidget::branch:has-children:open,QTreeView::branch:has-children:open,#FunctionEditorTree::branch:has-children:open{background:url('../Default/imgs/white/treebranch-open.svg') no-repeat;background-position:center center;image:none}.treeview::branch:has-children:has-siblings:closed,QTreeWidget::branch:has-children:has-siblings:closed,QTreeView::branch:has-children:has-siblings:closed,#FunctionEditorTree::branch:has-children:has-siblings:closed{background:url('../Default/imgs/white/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:has-siblings:open,QTreeWidget::branch:has-children:has-siblings:open,QTreeView::branch:has-children:has-siblings:open,#FunctionEditorTree::branch:has-children:has-siblings:open{background:url('../Default/imgs/white/treebranch-open.svg') no-repeat;background-position:center center;border-image:none;image:none}QListView{outline:0;background:#262626;alternate-background-color:#2b2b2b}#TabBarContainer{background-color:#262626}.Button,QPushButton,.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{background-color:#515151;border:1 solid #303030;border-radius:2;color:#dbdbdb;margin:0;padding:3 15}.Button:hover,QPushButton:hover,.ComboBox:hover,#ViewerFpsSlider::sub-line:horizontal:hover,#ViewerFpsSlider::add-line:horizontal:hover,QComboBox:hover{background-color:#5e5e5e;border-color:#303030;color:#dbdbdb}.Button:pressed,QPushButton:pressed,#ViewerFpsSlider::sub-line:horizontal:pressed,#ViewerFpsSlider::add-line:horizontal:pressed{background-color:#191919;border-color:#141414;color:#dbdbdb}.Button:checked,QPushButton:checked{background-color:#191919;border-color:#141414;color:#dbdbdb}.Button:checked:hover,QPushButton:checked:hover{background-color:#1e1e1e}.Button:checked:hover:pressed,QPushButton:checked:hover:pressed{background:#191919}.Button:disabled,QPushButton:disabled,.ComboBox:disabled,#ViewerFpsSlider::sub-line:horizontal:disabled,#ViewerFpsSlider::add-line:horizontal:disabled,QComboBox:disabled{background-color:#3d3d3d;border-color:#303030;color:#808080}#PushButton_NoPadding{padding:3}.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{padding:1 0 1 4;margin:1 0}.ComboBox::drop-down,QComboBox::drop-down{image:url('../Default/imgs/white/combo_downarrow.svg');image-position:center center;width:16}.ComboBox::drop-down:disabled,QComboBox::drop-down:disabled{image:url('../Default/imgs/white/combo_downarrow_disabled.svg')}.ComboBox QAbstractItemView,QComboBox QAbstractItemView{background-color:#303030;border:1 solid #161616;selection-background-color:#5385a6;selection-color:#fff}.LineEdit,QPlainTextEdit,QLineEdit,#TaskSheetItem,#tasksRemoveBox,#tasksAddBox{background-color:#1c1c1c;border:1 solid #3d3d3d;border-radius:2;color:#cecece;selection-background-color:#5385a6;selection-color:#fff;padding:0 0 0 1}.LineEdit:focus,QPlainTextEdit:focus,QLineEdit:focus,#TaskSheetItem:focus,#tasksRemoveBox:focus,#tasksAddBox:focus{background-color:#1c1c1c;border-color:#5385a6;color:#cecece}.LineEdit:disabled,QPlainTextEdit:disabled,QLineEdit:disabled,#TaskSheetItem:disabled,#tasksRemoveBox:disabled,#tasksAddBox:disabled{background-color:#262626;border-color:#363636;color:#808080}.CheckBox,QCheckBox{color:#cecece}.CheckBox:hover,QCheckBox:hover,.RadioButton:hover,QRadioButton:hover{color:#fff}.CheckBox:disabled,QCheckBox:disabled{color:#808080}.CheckBox::indicator,QMenu::indicator,QCheckBox::indicator,.GroupBox::indicator,QGroupBox::indicator{background-color:#1c1c1c;border:1 solid #3d3d3d;border-radius:2;height:9;padding:1;width:9}.CheckBox::indicator:hover,QMenu::indicator:hover,.CheckBox::indicator:checked:hover,QCheckBox::indicator:hover,.GroupBox::indicator:hover,QMenu::indicator:checked:hover,QCheckBox::indicator:checked:hover,.GroupBox::indicator:checked:hover,QGroupBox::indicator:hover,QGroupBox::indicator:checked:hover{background-color:#1c1c1c;border-color:#5385a6}.CheckBox::indicator:checked,QMenu::indicator:checked,QCheckBox::indicator:checked,.GroupBox::indicator:checked,QGroupBox::indicator:checked{background-color:#1c1c1c;border-color:#3d3d3d;image:url('../Default/imgs/white/checkmark.svg')}.CheckBox::indicator:checked:disabled,QMenu::indicator:checked:disabled,QCheckBox::indicator:checked:disabled,.GroupBox::indicator:checked:disabled,QGroupBox::indicator:checked:disabled{background-color:#262626;border-color:#191919;image:url('../Default/imgs/white/checkmark_disabled.svg')}.CheckBox::indicator:disabled,QMenu::indicator:disabled,QCheckBox::indicator:disabled,.GroupBox::indicator:disabled,QGroupBox::indicator:disabled{background-color:#262626;border-color:#191919}.RadioButton::indicator:unchecked,QRadioButton::indicator:unchecked,#CameraSettingsRadioButton_Small::indicator:unchecked{image:url('../Default/imgs/white/radiobutton_unchecked.svg');image-position:center center}.RadioButton::indicator:checked,QRadioButton::indicator:checked,#CameraSettingsRadioButton_Small::indicator:checked{image:url('../Default/imgs/white/radiobutton_checked.svg');image-position:center center}.GroupBox,QGroupBox{margin:6 0 0 0;padding:5 0}.GroupBox::title,QGroupBox::title{subcontrol-origin:margin;left:15;margin:-3 0 0 0;padding:0 3}.GroupBox::title:hover,QGroupBox::title:hover{color:#fff}.GroupBox::title:disabled,QGroupBox::title:disabled{color:#808080}.GroupBox::indicator,QGroupBox::indicator{subcontrol-origin:margin;margin-top:2}.GroupBox:disabled,QGroupBox:disabled{color:#808080}.Slider::groove:horizontal,QSlider::groove:horizontal{background-color:transparent;background-image:url('../Default/imgs/white/slider-groove_dark.svg');background-position:center center;background-repeat:repeat-x;margin:0;height:20;min-height:20}.Slider::groove:horizontal:disabled,QSlider::groove:horizontal:disabled{background-image:url('../Default/imgs/white/slider-groove_disabled_dark.svg')}.Slider::handle:horizontal,QSlider::handle:horizontal{width:10;margin:-2 -1;image:url('../Default/imgs/white/slider-handle.svg')}.Slider::handle:horizontal:disabled,QSlider::handle:horizontal:disabled{image:url('../Default/imgs/white/slider-handle_disabled.svg')}#IntPairField,#DoublePairField{qproperty-LightLineColor:#191919;qproperty-LightLineEdgeColor:#191919;qproperty-DarkLineColor:#191919;qproperty-MiddleLineColor:#191919;qproperty-HandleLeftPixmap:url("../Default/imgs/white/slider-handle.svg");qproperty-HandleRightPixmap:url("../Default/imgs/white/slider-handle.svg");qproperty-HandleLeftGrayPixmap:url("../Default/imgs/white/slider-handle_disabled.svg");qproperty-HandleRightGrayPixmap:url("../Default/imgs/white/slider-handle_disabled.svg")}#DirTreeView{background-color:#262626;alternate-background-color:#262626;border:1 solid #161616;border-right:0}DvItemViewerPanel{qproperty-TextColor:#cecece;qproperty-AlternateBackground:#282828;qproperty-SelectedTextColor:#fff;qproperty-FolderTextColor:#9fdaff;qproperty-SelectedItemBackground:#5385a6}#FileBrowser DvItemViewerPanel,#SceneCast DvItemViewerPanel{background-color:#303030}#FileBrowser #castFrame,#SceneCast #castFrame{border-top:1 solid #161616;border-right:1 solid #161616;border-bottom:1 solid #161616;margin:0}#FileBrowser QToolButton,#SceneCast QToolButton{padding:1}DvDirTreeView{qproperty-TextColor:#cecece;qproperty-SelectedTextColor:#fff;qproperty-SelectedItemBackground:#5385a6;qproperty-FolderTextColor:#9fdaff;qproperty-SelectedFolderTextColor:#fff;alternate-background-color:#2b2b2b;background-color:#262626;border:1 solid #161616}#FileDoesNotExistLabel{color:#f00}#SceneCast QToolBar{border-top:1 solid #161616}#SceneCast QToolButton{margin:3 1 2 1;padding:1}#CastBrowser{border:0;margin:0}#FilmStrip QComboBox{border-radius:0;border-width:0}#FilmStrip QComboBox QAbstractItemView{background-color:#303030}#CleanupSettings #CleanupSettingsFrame{margin-top:2;margin-bottom:4}#CleanupSettings QGroupBox{margin-bottom:3}ParamsPage{qproperty-TextColor:#cecece}#CameraSettingsButton{padding:2}#CameraSettingsRadioButton:hover{background:none}#CameraSettingsRadioButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#CameraSettingsRadioButton::indicator:unchecked{image:url('../Default/imgs/white/lock_off.svg')}#CameraSettingsRadioButton::indicator:checked{background-color:#C34040;border-color:#C34040;image:url('../Default/imgs/white/lock_on.svg')}#CameraSettingsRadioButton::indicator:checked:hover{background-color:#d57a7a;border-color:#d57a7a}#CameraSettingsDPI{color:#9fdaff}#CameraSettingsRadioButton_Small{padding:0}#CameraSettingsRadioButton_Small::indicator{background-color:transparent;border:0;height:21;margin:0;width:11}#ForceSquaredPixelButton{height:16;border:1 solid rgba(255,255,255,0);image:url('../Default/imgs/white/fsp_unchecked.svg');padding:2;width:16;margin:0}#ForceSquaredPixelButton:checked{image:url('../Default/imgs/white/fsp_checked.svg')}#OutputSettingsLabel{color:#9fdaff}PencilTestPopup{min-height:730px;min-width:512px}#MatchLineButton{background-color:#565656}#MatchLineButton:checked{background-color:#7d7d7d;border:2 solid #5385a6;border-radius:2}#LargeSizedText{font-size:17px}#StartupLabel{padding:3}#StartupLabel:hover{background:#4a4a4a}QStatusBar{background-color:#c0c0c0}QStatusBar::item{border:0}QStatusBar QLabel{background-color:#c0c0c0}QStatusBar #StatusBarLabel{background-color:#fff;padding:1 3}#TitleTxtLabel{color:#9fdaff}#StyleEditor QPushButton{margin:2 1;padding:0}#StyleEditor #TabBarContainer{margin-left:-4}#StyleEditor #bottomWidget{border-top:1 solid #161616;padding:3 2 8 3}#StyleEditor #bottomWidget QPushButton{padding:3 5}#StyleEditorTabBar::tab::first{border-left:1 solid #161616}#HexagonalColorWheel{qproperty-BGColor:#303030}#colorSlider::groove:horizontal{height:1;border-image:none}#colorSlider::handle:horizontal{width:8;margin:-8 -4}#colorSliderAddButton,#colorSliderSubButton{background:none;border-color:transparent;image-position:center center;min-height:16;padding:0;min-width:18}#colorSliderAddButton{image:url('../Default/imgs/white/scroll-right.svg')}#colorSliderSubButton{image:url('../Default/imgs/white/scroll-left.svg')}#PlainColorPageParts{border-bottom:1 solid #161616}#PlainColorPageParts QLineEdit{max-width:35}PaletteViewer DvScrollWidget QPushButton{border-top:0;margin-bottom:1;max-width:15;min-width:15}PaletteViewer DvScrollWidget #ScrollLeftButton{border-radius:0;margin-bottom:1;max-width:16;min-width:16}PaletteViewer DvScrollWidget #ScrollRightButton{border-radius:0;margin-left:1;margin-bottom:1;max-width:16;min-width:16}PaletteViewer QToolBar{background:none;border-bottom:1 solid #161616;padding:0;margin:0}PaletteViewer QToolBar::separator:horizontal{margin:0}PaletteViewer QToolBar QToolButton{margin:0 0 1 0;padding:1 0 2 0}#PageViewer{qproperty-TextColor:#cecece}#PaletteLockButton{border-radius:0;margin:0 0 1 1}#PaletteLockButton:checked{background-color:#C34040;border-color:#C34040}#PaletteLockButton:checked:hover{background-color:#d57a7a;border-color:#d57a7a}#WordButton{padding-right:0;padding-left:0}QDialog{background-color:#303030}QDialog #dialogButtonFrame{background-color:#282828;border-top:1 solid #161616}QDialog #dialogButtonFrame QPushButton{border-color:#282828;outline:0}QDialog #dialogButtonFrame QPushButton:focus{background-color:#5385a6;border-color:#282828;color:#f4f4f4}QDialog #dialogButtonFrame QPushButton:focus:hover{background-color:#6c98b6}QDialog #dialogButtonFrame QPushButton:focus:pressed{background-color:#191919;border-color:#141414;color:#dbdbdb}#SceneSettings QLabel{color:#9fdaff}#PreferencesPopup QListWidget{background-color:#262626;alternate-background-color:#262626;border:1 solid #161616;font-size:13px}#PreferencesPopup QListWidget::item{border:0;padding:3}#PreferencesPopup QListWidget::item:hover{color:#cecece;background-color:rgba(255,255,255,0.15)}#PreferencesPopup QListWidget::item:selected{background-color:#5385a6;color:#fff}#ShortcutTree{border:1 solid #161616}#ShortcutTree::item{padding:1 0}#ShortcutTree QScrollBar:vertical{width:16;margin-right:-1}ProjectPopup QLabel{color:#9fdaff}#GearButton{qproperty-icon:url('../Default/imgs/white/gear.svg')}#SubfolderButton{qproperty-icon:url('../Default/imgs/white/subfolder.svg');padding-left:6px;padding-right:6px}#SubcameraButton{qproperty-icon:url('../Default/imgs/white/subcamera.svg');padding-left:6px;padding-right:6px}SchematicViewer{qproperty-TextColor:#cecece;qproperty-VerticalLineColor:#090909;qproperty-LevelColumnColor:#4C6E4C;qproperty-VectorColumnColor:#7B7B4C;qproperty-ChildColumnColor:#6A526B;qproperty-FullcolorColumnColor:#657A96;qproperty-FxColumnColor:#56553C;qproperty-PaletteColumnColor:#3A655F;qproperty-MeshColumnColor:#684D86;qproperty-ReferenceColumnColor:#616161;qproperty-TableColor:#62628c;qproperty-ActiveCameraColor:#2d7dca;qproperty-OtherCameraColor:#6c797b;qproperty-GroupColor:#3b6e9c;qproperty-PegColor:#9f6e3c;qproperty-SplineColor:#6a9d1c;qproperty-ActiveOutputColor:#2d7dca;qproperty-OtherOutputColor:#6c797b;qproperty-XsheetColor:#62628c;qproperty-NormalFxColor:#6a7e96;qproperty-MacroFxColor:#815c79;qproperty-ImageAdjustFxColor:#656287;qproperty-LayerBlendingFxColor:#4f757d;qproperty-MatteFxColor:#ae7171;qproperty-SchematicPreviewButtonBgOnColor:#c8c864;qproperty-SchematicPreviewButtonOnImage:url('../Default/imgs/white/x_prev_eye_on.svg');qproperty-SchematicPreviewButtonBgOffColor:#616161;qproperty-SchematicPreviewButtonOffImage:url('../Default/imgs/white/x_prev_eye_off.svg');qproperty-SchematicCamstandButtonBgOnColor:#eb906b;qproperty-SchematicCamstandButtonOnImage:url('../Default/imgs/white/x_table_view_on.svg');qproperty-SchematicCamstandButtonTranspImage:url('../Default/imgs/white/x_table_view_transp.svg');qproperty-SchematicCamstandButtonBgOffColor:#616161;qproperty-SchematicCamstandButtonOffImage:url('../Default/imgs/white/x_table_view_off.svg')}#SchematicBottomFrame{background-color:#303030;border:0;margin:0;padding:0}#SchematicBottomFrame QToolBar::separator:horizontal{margin:0}#SchematicBottomFrame QToolBar QToolButton{padding:0;margin:2}#SchematicSceneViewer{background-color:#232323;border-bottom:1 solid #161616}#FxSettingsTabBar::tab{border-top:1 solid #161616}#FxSettingsTabBar::tab::first,#FxSettingsTabBar::tab::only-one{border-left:1 solid #161616}FxSettings QToolBar{border-top:1 solid #161616;border-right:1 solid #161616;border-left:1 solid #161616;min-height:23;padding:3 0}FxSettings QToolBar QToolBar{border:0}#FxSettingsLabel{color:#a0e680}#FxSettingsHelpButton{background-color:#80a0dc;color:#000;padding-top:0;padding-bottom:0}#FxSettingsHelpButton:hover{background-color:#a8bee7}#ScriptConsole{font-family:'Courier New',monospace;border:0;color:#000000;padding:3}#ScriptConsole QFrame{background-color:#dcdcdc}#ScriptConsole TPanelTitleBar{background-color:#262626}#TaskSheetItemLabel{color:#cecece}#Tasks QToolBar{border-bottom:1 solid #161616;margin:0;padding:0}#Tasks QToolBar QToolButton{margin:2 2 3 2}#ToolBar QToolBar{padding-left:2}#ToolOptions TPanelTitleBar{border-right:1 solid #161616;border-bottom:0}#CommandBar TPanelTitleBar{border-right:1 solid #161616;border-bottom:0}IconViewField{qproperty-ThicknessPixmap:url("../Default/imgs/white/selectiontool_thickness.svg")}#EditToolLockButton{spacing:0}#EditToolLockButton:hover{background:none}#EditToolLockButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#EditToolLockButton::indicator:unchecked{image:url('../Default/imgs/white/lock_off.svg')}#EditToolLockButton::indicator:checked{background-color:#C34040;border-color:#C34040;image:url('../Default/imgs/white/lock_on.svg')}#EditToolLockButton::indicator:checked:hover{background-color:#d57a7a;border-color:#d57a7a}PopupButton::menu-indicator{border-left:0;height:17;image:url('../Default/imgs/white/combo_downarrow.svg');width:10}PopupButton::menu-indicator:hover{image:url('../Default/imgs/white/combo_downarrow.svg')}PopupButton::menu-indicator:disabled{image:url('../Default/imgs/white/combo_downarrow_disabled.svg')}#Cap,#Join{padding:0 4 0 -8;max-width:32;min-width:32}#Cap QMenu,#Join QMenu{max-width:28;min-width:28}#Cap QMenu::item,#Join QMenu::item{max-width:28;min-width:28;padding:0}QToolBar#MediumPaddingToolBar QToolButton{padding-left:3;padding-right:3}QToolBar#WidePaddingToolBar QToolButton{padding-left:6;padding-right:6}#CommandBar{margin:0;padding:0;border:0}#CommandBar::separator:horizontal{margin-right:3;margin-left:3}#expandButton:checked{background-color:transparent;border-color:transparent;color:#cecece}#expandButton:checked:hover{background-color:#5e5e5e;border-color:#5e5e5e}#expandButton:checked:pressed{background-color:#191919;border-color:#141414}#ComboViewerPanel Toolbar{border-bottom:1 solid #161616}#ComboViewerPanel Toolbar::separator:horizontal{margin:0 0 0 2}#ComboViewerPanel Toolbar QToolButton{margin:2 0 3 2}#ComboViewerToolOptions{border-bottom:1 solid #161616}#ComboViewer #ToolBarContainer,#ViewerPanel #ToolBarContainer,FlipBook #ToolBarContainer{background-color:transparent;border-top:2 solid #161616;border-bottom:1 solid #161616;padding-right:-1}#flipCustomize{margin-left:3}#flipCustomize::menu-button{background-color:transparent;width:35}#flipCustomize::menu-arrow{image:none}QToolBar#FlipConsolePlayToolBar::separator:horizontal{margin:0 3}QToolBar#FlipConsolePlayToolBar QToolButton{margin-top:2;margin-bottom:2;height:16;padding-left:1;padding-right:1}#ViewerFpsSlider{background-color:transparent;background-image:url('../Default/imgs/white/slider-groove_dark.svg');background-position:center center;background-repeat:repeat-x;border:0;height:19;margin:0 3 0 37;max-width:300;min-width:0}#ViewerFpsSlider::sub-line:horizontal{subcontrol-origin:absolute;background-color:#515151;border:1 solid #303030;border-top-left-radius:2;border-bottom-left-radius:2;height:16;left:-33;width:14}#ViewerFpsSlider::add-line:horizontal{subcontrol-position:left;background-color:#515151;border:1 solid #303030;border-top-right-radius:2;border-bottom-right-radius:2;left:18;height:16;image-position:center center;width:13}#ViewerFpsSlider::handle::horizontal{background-color:#898989;border:1 solid #898989;border-radius:2;margin:2 0 3 0;min-width:9;width:9;max-width:9}FlipSlider{qproperty-PBHeight:15;qproperty-PBOverlay:url('../Default/imgs/white/flipslider_dark.svg');qproperty-PBColorMarginLeft:1;qproperty-PBColorMarginTop:2;qproperty-PBColorMarginRight:1;qproperty-PBColorMarginBottom:2;qproperty-PBMarker:url('../Default/imgs/white/flipmarker_dark.svg');qproperty-PBMarkerMarginLeft:3;qproperty-PBMarkerMarginRight:3;qproperty-notStartedColor:rgba(205,101,101,0.78);qproperty-startedColor:#1abc3f;qproperty-baseColor:#1c1c1c;qproperty-finishedColor:#1c1c1c}Ruler{qproperty-ParentBGColor:#303030;qproperty-ScaleColor:#cecece}#RulerToolOptionValues{color:#000}#xsheetArea,#ScrollArea{background-color:#1c1c1c;border:0}#xsheetScrollArea{border:0}#cornerWidget QToolButton{padding:0}#xsheetColumnAreaMenu_Preview{background-color:#E6E678}#xsheetColumnAreaMenu_Lock{background-color:#F5F5F5}#xsheetColumnAreaMenu_Camstand{background-color:#FFA480}#xsheetColumnAreaMenu_Preview,#xsheetColumnAreaMenu_Lock,#xsheetColumnAreaMenu_Camstand{color:#000}#noteTextEdit{color:#000}XsheetViewer{qproperty-TextColor:#cecece;qproperty-BGColor:#282828;qproperty-LightLineColor:#1f1f1f;qproperty-MarkerLineColor:#1E96C4;qproperty-VerticalLineColor:#090909;qproperty-VerticalLineHeadColor:#686868;qproperty-PreviewFrameTextColor:#9fdaff;qproperty-CurrentRowBgColor:#506082;qproperty-OnionSkinAreaBgColor:#1e1e1e;qproperty-EmptyColumnHeadColor:#444;qproperty-SelectedColumnTextColor:#E66464;qproperty-EmptyCellColor:#303030;qproperty-NotEmptyColumnColor:#383838;qproperty-SelectedEmptyCellColor:#545454;qproperty-LevelColumnColor:#4C6E4C;qproperty-LevelColumnBorderColor:#8FB38F;qproperty-SelectedLevelColumnColor:#678667;qproperty-VectorColumnColor:#7B7B4C;qproperty-VectorColumnBorderColor:#BBBB9A;qproperty-SelectedVectorColumnColor:#949466;qproperty-ChildColumnColor:#6A526B;qproperty-ChildColumnBorderColor:#B1A3B3;qproperty-SelectedChildColumnColor:#816e82;qproperty-FullcolorColumnColor:#657A96;qproperty-FullcolorColumnBorderColor:#9EB8BB;qproperty-SelectedFullcolorColumnColor:#8895a6;qproperty-FxColumnColor:#56553C;qproperty-FxColumnBorderColor:#95958A;qproperty-SelectedFxColumnColor:#6f6e56;qproperty-ReferenceColumnColor:#616161;qproperty-ReferenceColumnBorderColor:#A2A2A2;qproperty-SelectedReferenceColumnColor:#7a7a7a;qproperty-PaletteColumnColor:#3A655F;qproperty-PaletteColumnBorderColor:#86ACA7;qproperty-SelectedPaletteColumnColor:#52807a;qproperty-MeshColumnColor:#684D86;qproperty-MeshColumnBorderColor:#BA92EF;qproperty-SelectedMeshColumnColor:#82689e;qproperty-SoundTextColumnColor:#c8c8c8;qproperty-SoundTextColumnBorderColor:#8c8c8c;qproperty-SelectedSoundTextColumnColor:#e2e2e2;qproperty-SoundColumnColor:#657456;qproperty-SoundColumnBorderColor:#A0AF7D;qproperty-SelectedSoundColumnColor:#7e8b72;qproperty-SoundColumnHlColor:#34FE5E;qproperty-SoundColumnTrackColor:#B6C29D;qproperty-ColumnHeadPastelizer:#000;qproperty-SelectedColumnHead:#506082;qproperty-LightLightBGColor:#303030;qproperty-LightBGColor:#d8d8d8;qproperty-DarkBGColor:#c9c9c9;qproperty-DarkLineColor:#7e7e7e;qproperty-XsheetColumnNameBgColor:rgba(0,0,0,0);qproperty-XsheetDragBarHighlightColor:rgba(255,255,255,0.5);qproperty-XsheetPreviewButtonBgOnColor:#c8c864;qproperty-XsheetPreviewButtonOnImage:url('../Default/imgs/white/x_prev_eye_on.svg');qproperty-XsheetPreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetPreviewButtonOffImage:url('../Default/imgs/white/x_prev_eye_off.svg');qproperty-XsheetCamstandButtonBgOnColor:#eb906b;qproperty-XsheetCamstandButtonOnImage:url('../Default/imgs/white/x_table_view_on.svg');qproperty-XsheetCamstandButtonTranspImage:url('../Default/imgs/white/x_table_view_transp.svg');qproperty-XsheetCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetCamstandButtonOffImage:url('../Default/imgs/white/x_table_view_off.svg');qproperty-XsheetLockButtonBgOnColor:rgba(255,255,255,0.3);qproperty-XsheetLockButtonOnImage:url('../Default/imgs/white/x_lock_on.svg');qproperty-XsheetLockButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetLockButtonOffImage:url('../Default/imgs/white/x_lock_off.svg');qproperty-XsheetConfigButtonBgColor:rgba(255,255,255,0);qproperty-XsheetConfigButtonImage:url('../Default/imgs/white/x_config.svg');qproperty-TimelinePreviewButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOnImage:url('../Default/imgs/white/timeline_toggle_on.svg');qproperty-TimelinePreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOffImage:url('../Default/imgs/white/timeline_toggle_off.svg');qproperty-TimelineCamstandButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOnImage:url('../Default/imgs/white/timeline_toggle_on.svg');qproperty-TimelineCamstandButtonTranspImage:url('../Default/imgs/white/timeline_toggle_transp.svg');qproperty-TimelineCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOffImage:url('../Default/imgs/white/timeline_toggle_off.svg');qproperty-TimelineLockButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOnImage:url('../Default/imgs/white/timeline_toggle_on.svg');qproperty-TimelineLockButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOffImage:url('../Default/imgs/white/timeline_toggle_off.svg');qproperty-TimelineConfigButtonBgColor:rgba(255,255,255,0);qproperty-TimelineConfigButtonImage:url('../Default/imgs/white/timeline_config.svg');qproperty-LayerHeaderPreviewImage:url('../Default/imgs/white/layer_header_prev_eye.svg');qproperty-LayerHeaderPreviewOverImage:url('../Default/imgs/white/layer_header_prev_eye_over.svg');qproperty-LayerHeaderCamstandImage:url('../Default/imgs/white/layer_header_table_view.svg');qproperty-LayerHeaderCamstandOverImage:url('../Default/imgs/white/layer_header_table_view_over.svg');qproperty-LayerHeaderLockImage:url('../Default/imgs/white/lock_on.svg');qproperty-LayerHeaderLockOverImage:url('../Default/imgs/white/lock_on_over.svg');qproperty-ActiveCameraColor:#2d7dca;qproperty-SelectedActiveCameraColor:#5796d3;qproperty-OtherCameraColor:#6c797b;qproperty-SelectedOtherCameraColor:#8b8e8f}#XSheetToolbar{margin:0;padding:0;border:0}#XSheetToolbar QToolButton{padding:0;margin:4 1;min-height:19;height:19}#XSheetToolbar::separator:horizontal{margin:0 4}#FunctionEditor QToolBar{border-bottom:1 solid #161616}#FunctionEditor QToolBar QToolBar{border:0}#FunctionEditor QToolBar QLabel{margin-left:5}#FunctionEditor QToolBar QToolButton{height:18}#FunctionEditorTree{border-top:1 solid #161616}FunctionTreeView{qproperty-TextColor:#cecece;qproperty-CurrentTextColor:#E66464}FunctionPanel{qproperty-BGColor:#232323;qproperty-ValueLineColor:#161616;qproperty-FrameLineColor:#161616;qproperty-OtherCurvesColor:#707070;qproperty-RulerBackground:#1b1b1b;qproperty-TextColor:#cecece;qproperty-SubColor:#000;qproperty-SelectedColor:#FFA500}SpreadsheetViewer{qproperty-LightLightBGColor:#303030;qproperty-CurrentRowBgColor:#506082;qproperty-LightLineColor:#1f1f1f;qproperty-MarkerLineColor:#1E96C4;qproperty-BGColor:#383838;qproperty-VerticalLineColor:#090909;qproperty-KeyFrameColor:#995d1d;qproperty-KeyFrameBorderColor:#c9b04b;qproperty-SelectedKeyFrameColor:#be772b;qproperty-InBetweenColor:#666250;qproperty-InBetweenBorderColor:#cdcec8;qproperty-SelectedInBetweenColor:#7d7a6c;qproperty-SelectedEmptyColor:#545454;qproperty-SelectedSceneRangeEmptyColor:#5d5d5d;qproperty-TextColor:#cecece;qproperty-ColumnHeaderBorderColor:#686868;qproperty-SelectedColumnTextColor:#E66464}#ExpressionField{background-color:#cecece;border:1 solid #1b1b1b;margin:0}#FunctionSegmentViewerLinkButton{background-image:url('../Default/imgs/white/segment_unlinked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:hover{background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:checked{background-image:url('../Default/imgs/white/segment_linked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:disabled{background-image:url('../Default/imgs/white/segment_disabled.svg');background-repeat:no-repeat}
+/* -----------------------------------------------------------------------------
+   Component: Button Styles
+----------------------------------------------------------------------------- */
+.button-show,
+#LoadLevelShowButton,
+#CleanupSettingsShowButton,
+#OutputSettingsShowButton,
+#FxSettingsPreviewShowButton {
+  image: url('../Default/imgs/white/plus.svg');
+  image-position: center center;
+  margin: 0;
+  padding: 1;
+  min-width: 10;
+  min-height: 10;
+}
+.button-show:checked,
+#LoadLevelShowButton:checked,
+#CleanupSettingsShowButton:checked,
+#OutputSettingsShowButton:checked,
+#FxSettingsPreviewShowButton:checked {
+  background-color: #191919;
+  border-color: #141414;
+  image: url('../Default/imgs/white/minus.svg');
+}
+.button-show:checked:pressed,
+#LoadLevelShowButton:checked:pressed,
+#CleanupSettingsShowButton:checked:pressed,
+#OutputSettingsShowButton:checked:pressed,
+#FxSettingsPreviewShowButton:checked:pressed {
+  background-color: #191919;
+  border-color: #141414;
+}
+.button-show:checked:hover,
+#LoadLevelShowButton:checked:hover,
+#CleanupSettingsShowButton:checked:hover,
+#OutputSettingsShowButton:checked:hover,
+#FxSettingsPreviewShowButton:checked:hover {
+  background-color: #1e1e1e;
+}
+.button-tool,
+QToolButton,
+#CameraSettingsRadioButton::indicator,
+#ForceSquaredPixelButton,
+#SchematicBottomFrame QToolBar QToolButton,
+#EditToolLockButton::indicator,
+#flipCustomize {
+  background-color: rgba(255, 255, 255, 0);
+  border: 1 solid rgba(255, 255, 255, 0);
+  border-radius: 2;
+  color: #dbdbdb;
+  margin: 1;
+  padding: 0;
+}
+.button-tool:hover,
+QToolButton:hover,
+#CameraSettingsRadioButton::indicator:hover,
+#ForceSquaredPixelButton:hover,
+#colorSliderAddButton:hover,
+#colorSliderSubButton:hover,
+#SchematicBottomFrame QToolBar QToolButton:hover,
+#EditToolLockButton::indicator:hover,
+#flipCustomize:hover {
+  background-color: #5e5e5e;
+  border-color: #5e5e5e;
+  color: #dbdbdb;
+}
+.button-tool:pressed,
+QToolButton:pressed,
+#CameraSettingsRadioButton::indicator:pressed,
+#ForceSquaredPixelButton:pressed,
+#colorSliderAddButton:pressed,
+#colorSliderSubButton:pressed,
+#SchematicBottomFrame QToolBar QToolButton:pressed,
+#EditToolLockButton::indicator:pressed,
+#flipCustomize:pressed {
+  background-color: #191919;
+  border-color: #141414;
+  color: #dbdbdb;
+}
+.button-tool:checked,
+QToolButton:checked,
+#CameraSettingsRadioButton::indicator:checked,
+#ForceSquaredPixelButton:checked,
+#SchematicBottomFrame QToolBar QToolButton:checked,
+#EditToolLockButton::indicator:checked,
+#flipCustomize:checked {
+  background-color: #5385a6;
+  border-color: #5385a6;
+  color: #ffffff;
+}
+.button-tool:checked:hover,
+QToolButton:checked:hover,
+#CameraSettingsRadioButton::indicator:checked:hover,
+#ForceSquaredPixelButton:checked:hover,
+#SchematicBottomFrame QToolBar QToolButton:checked:hover,
+#EditToolLockButton::indicator:checked:hover,
+#flipCustomize:checked:hover {
+  background-color: #6c98b6;
+  border-color: #6c98b6;
+}
+.button-tool:disabled,
+QToolButton:disabled,
+#CameraSettingsRadioButton::indicator:disabled,
+#ForceSquaredPixelButton:disabled,
+#SchematicBottomFrame QToolBar QToolButton:disabled,
+#EditToolLockButton::indicator:disabled,
+#flipCustomize:disabled {
+  color: #808080;
+}
+.button-flat,
+PaletteViewer QToolBar QToolButton {
+  background-color: none;
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+}
+.button-flat:hover,
+PaletteViewer QToolBar QToolButton:hover {
+  background-color: #5e5e5e;
+}
+.button-flat:pressed,
+PaletteViewer QToolBar QToolButton:pressed {
+  background-color: #161616;
+}
+/* -----------------------------------------------------------------------------
+   Component: Frames
+----------------------------------------------------------------------------- */
+.frame,
+.GroupBox,
+#LoadLevelFrame,
+#PsdSettingsGroupBox,
+#CleanupSettingsFrame,
+#OutputSettingsBox,
+#OutputSettingsCameraBox,
+#SolidLineFrame,
+#FunctionParametersPanel,
+QGroupBox {
+  border: 1 solid #161616;
+  border-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Component: Icons
+----------------------------------------------------------------------------- */
+/* -----------------------------------------------------------------------------
+   Component: Tabs
+----------------------------------------------------------------------------- */
+.tab-container,
+#TabBarContainer {
+  background-color: transparent;
+  qproperty-BottomAboveLineColor: #262626;
+  qproperty-BottomBelowLineColor: #161616;
+}
+.tab-flat,
+#StyleEditorTabBar::tab,
+#PaletteTabBar::tab,
+#FxSettingsTabBar::tab {
+  background-color: #262626;
+  border-right: 1 solid #161616;
+  border-bottom: 1 solid #161616;
+  color: #8b8b8b;
+  padding: 3 4 3 4;
+}
+.tab-flat:hover,
+#StyleEditorTabBar::tab:hover,
+#PaletteTabBar::tab:hover,
+#FxSettingsTabBar::tab:hover {
+  background-color: #303030;
+  color: #8b8b8b;
+}
+.tab-flat:selected,
+#StyleEditorTabBar::tab:selected,
+#PaletteTabBar::tab:selected,
+#FxSettingsTabBar::tab:selected {
+  background-color: #303030;
+  color: #f4f4f4;
+  border-bottom-color: #303030;
+}
+.tab-flat:only-one,
+#StyleEditorTabBar::tab:only-one,
+#PaletteTabBar::tab:only-one,
+#FxSettingsTabBar::tab:only-one {
+  margin: 0;
+}
+.tab-round {
+  background-color: #262626;
+  border-top: 1 solid #161616;
+  border-right: 1 solid #161616;
+  border-left: 1 solid #161616;
+  border-bottom: 1 solid #161616;
+  color: #8b8b8b;
+  margin: 3 -1 0 0;
+  padding: 2 7 1 7;
+}
+.tab-round:hover {
+  background-color: #303030;
+  color: #8b8b8b;
+}
+.tab-round:selected {
+  background-color: #303030;
+  border-top-right-radius: 2;
+  border-top-left-radius: 2;
+  border-bottom-color: #303030;
+  color: #f4f4f4;
+  margin: 1 -1 -1 0;
+  padding: 2 7 2 7;
+}
+.tab-round:only-one {
+  margin: 1 0 0 0;
+  padding: 3 7 3 7;
+}
+.tab-round:last {
+  margin-right: 0;
+  border-top-right-radius: 2;
+}
+.tab-round:first {
+  border-top-left-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Main
+----------------------------------------------------------------------------- */
+QWidget {
+  background-color: #303030;
+  color: #cecece;
+}
+QWidget:disabled {
+  color: #808080;
+}
+QFrame {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QToolTip,
+#helpToolTip {
+  background-color: #fff;
+  border: 1 solid #000;
+  color: #000;
+  padding: 1 1;
+}
+#DockSeparator,
+QMainWindow::separator,
+QSplitter::handle {
+  background-color: #0c0c0c;
+  height: 4;
+  width: 4;
+}
+#TDockPlaceholder {
+  background-color: #F77272;
+}
+TPanel {
+  background-color: #0c0c0c;
+}
+/* -----------------------------------------------------------------------------
+   Topbar
+----------------------------------------------------------------------------- */
+#TopBar {
+  background: #303030;
+  border: 0;
+  border-bottom: 1 solid #161616;
+  height: 21;
+}
+#TopBar #EditToolLockButton {
+  background: #303030;
+  spacing: 0;
+}
+#TopBar #EditToolLockButton::indicator {
+  background: none;
+  border: none;
+  height: 18;
+  margin: 1 2 0 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+#TopBarTabContainer {
+  background-color: #303030;
+  margin-bottom: 1;
+}
+#StackedMenuBar {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QMenuBar {
+  background-color: #303030;
+  border: 0;
+}
+QMenuBar::item {
+  background-color: #303030;
+  border-left: 1 solid #303030;
+  margin: 0;
+  padding: 3 5;
+}
+QMenuBar::item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #cecece;
+}
+QMenuBar::item:pressed {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Workspaces
+----------------------------------------------------------------------------- */
+#TopBarTab {
+  margin: 0;
+  padding: 0;
+}
+#TopBarTab::tab {
+  background-color: #262626;
+  border-top: 1 solid #161616;
+  border-right: 1 solid #161616;
+  color: #8b8b8b;
+  margin: 0 0 0 0;
+  padding: 2 8 3 8;
+}
+#TopBarTab::tab:hover {
+  background-color: #303030;
+  color: #8b8b8b;
+}
+#TopBarTab::tab:selected {
+  background-color: #303030;
+  color: #f4f4f4;
+}
+#TopBarTab::tab:first {
+  border-left: 1 solid #161616;
+}
+#TopBarTab::tab:last {
+  border-right: 1 solid #161616;
+}
+/* -----------------------------------------------------------------------------
+   Menu
+----------------------------------------------------------------------------- */
+QMenu {
+  background-color: #303030;
+  border: 1 solid #161616;
+  padding: 2 0;
+}
+QMenu::item {
+  padding: 3 28;
+}
+QMenu::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+QMenu::item:checked {
+  color: #cecece;
+}
+QMenu::item:checked:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+QMenu::item:disabled {
+  background: none;
+  color: #808080;
+}
+QMenu::item:disabled:selected {
+  border-color: transparent;
+}
+QMenu::separator {
+  border-top: 1 solid #161616;
+  height: 0;
+  margin: 2 0;
+}
+QMenu::icon {
+  border-radius: 2;
+  margin: 0 0 0 3;
+  padding: 1;
+}
+QMenu::icon:checked {
+  background-color: #5385a6;
+}
+QMenu::indicator {
+  margin-left: 7;
+}
+/* -----------------------------------------------------------------------------
+   Titlebars
+----------------------------------------------------------------------------- */
+TPanelTitleBar {
+  background-color: #262626;
+  border-color: #161616;
+  border-style: solid;
+  border-width: 0 0 1 0;
+  height: 20;
+  min-height: 20;
+  qproperty-TitleColor: #7d7d7d;
+  qproperty-ActiveTitleColor: #fff;
+  qproperty-BorderPixmap: url('none');
+  qproperty-ActiveBorderPixmap: url('../Default/imgs/white/none');
+  qproperty-FloatBorderPixmap: url('none');
+  qproperty-FloatActiveBorderPixmap: url('../Default/imgs/white/none');
+}
+/* -----------------------------------------------------------------------------
+   Scrollbars
+----------------------------------------------------------------------------- */
+QAbstractScrollArea::corner {
+  background-color: #262626;
+}
+QScrollBar {
+  background-color: #262626;
+  border: 0;
+}
+QScrollBar:horizontal {
+  height: 16;
+  margin: 0;
+}
+QScrollBar:vertical {
+  margin: 0;
+  width: 16;
+}
+QScrollBar::handle {
+  border: 1 solid #3a3a3a;
+  border-radius: 4;
+}
+QScrollBar::handle:horizontal:hover,
+QScrollBar::handle:vertical:hover {
+  background-color: #4f4f4f;
+  border-color: #4f4f4f;
+}
+QScrollBar::handle:horizontal:pressed,
+QScrollBar::handle:vertical:pressed {
+  background-color: #636363;
+  border-color: #636363;
+}
+QScrollBar::handle:horizontal {
+  background-color: #3a3a3a;
+  margin: 3 16;
+  min-width: 20;
+}
+QScrollBar::handle:vertical {
+  background-color: #3a3a3a;
+  margin: 16 3;
+  min-height: 20;
+}
+QScrollBar::add-line {
+  subcontrol-origin: margin;
+  border: 0;
+}
+QScrollBar::add-line:horizontal {
+  subcontrol-position: right;
+  background-color: #262626;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::add-line:vertical {
+  subcontrol-position: bottom;
+  background-color: #262626;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::sub-line {
+  border: 0;
+  subcontrol-origin: margin;
+}
+QScrollBar::sub-line:horizontal {
+  subcontrol-position: left;
+  background-color: #262626;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::sub-line:vertical {
+  subcontrol-position: top;
+  background-color: #262626;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::up-arrow:vertical {
+  image: url('../Default/imgs/white/scroll-up.svg');
+  image-position: center center;
+}
+QScrollBar::up-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::down-arrow:vertical {
+  image: url('../Default/imgs/white/scroll-down.svg');
+  image-position: center center;
+}
+QScrollBar::down-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::left-arrow:horizontal {
+  image: url('../Default/imgs/white/scroll-left.svg');
+  image-position: center center;
+}
+QScrollBar::left-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::right-arrow:horizontal {
+  image: url('../Default/imgs/white/scroll-right.svg');
+  image-position: center center;
+}
+QScrollBar::right-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::sub-page:horizontal,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:vertical,
+QScrollBar::add-page:vertical {
+  background: none;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bars
+----------------------------------------------------------------------------- */
+QToolBar {
+  padding: 0;
+}
+QToolBar::separator:horizontal {
+  border-left: 1 solid #161616;
+  margin: 0 1;
+  width: 0;
+}
+QToolBar::separator:vertical {
+  border-top: 1 solid #161616;
+  height: 0;
+  margin: 1 0;
+}
+QToolBar QLabel {
+  margin-top: 1;
+}
+QToolBar QToolBar {
+  border: 0;
+}
+QToolButton::menu-indicator {
+  image: none;
+}
+QToolButton::menu-button {
+  border-image: none;
+}
+/* -------------------------------------------------------------------------- */
+/* Scrollable QToolBar Buttons
+/* -------------------------------------------------------------------------- */
+.DvScrollWidget QPushButton,
+DvScrollWidget QPushButton,
+#ScrollLeftButton QPushButton,
+#ScrollRightButton QPushButton,
+#ScrollUpButton QPushButton,
+#ScrollDownButton QPushButton {
+  background-color: #515151;
+  border: 0 solid red;
+  border-radius: 0;
+  padding: 0;
+  max-width: 16;
+}
+.DvScrollWidget QPushButton:hover,
+DvScrollWidget QPushButton:hover,
+#ScrollLeftButton QPushButton:hover,
+#ScrollRightButton QPushButton:hover,
+#ScrollUpButton QPushButton:hover,
+#ScrollDownButton QPushButton:hover {
+  background-color: #5e5e5e;
+}
+.DvScrollWidget QPushButton:pressed,
+DvScrollWidget QPushButton:pressed,
+#ScrollLeftButton QPushButton:pressed,
+#ScrollRightButton QPushButton:pressed,
+#ScrollUpButton QPushButton:pressed,
+#ScrollDownButton QPushButton:pressed {
+  background-color: #191919;
+}
+#ScrollLeftButton,
+#ScrollRightButton,
+#ScrollUpButton,
+#ScrollDownButton {
+  margin: 0;
+  min-width: 16;
+}
+#ScrollLeftButton {
+  border-right: 1 solid #161616;
+  image: url('../Default/imgs/white/scroll-left.svg');
+}
+#ScrollRightButton {
+  border-left: 1 solid #161616;
+  margin-left: 3;
+  image: url('../Default/imgs/white/scroll-right.svg');
+}
+#ScrollUpButton {
+  image: url('../Default/imgs/white/scroll-up.svg');
+}
+#ScrollDownButton {
+  image: url('../Default/imgs/white/scroll-down.svg');
+}
+/* -------------------------------------------------------------------------- */
+#keyFrameNavigator {
+  background: none;
+  margin: 0;
+  padding: 0;
+}
+#keyFrameNavigator QToolButton {
+  min-width: 18;
+}
+#keyFrameNavigator #PreviousKey {
+  image: url('../Default/imgs/white/prevkey.svg');
+}
+#keyFrameNavigator #PreviousKey:hover {
+  image: url('../Default/imgs/white/prevkey_over.svg');
+}
+#keyFrameNavigator #PreviousKey:disabled {
+  image: url('../Default/imgs/white/prevkey_disabled.svg');
+}
+#keyFrameNavigator #NextKey {
+  image: url('../Default/imgs/white/nextkey.svg');
+}
+#keyFrameNavigator #NextKey:hover {
+  image: url('../Default/imgs/white/nextkey_over.svg');
+}
+#keyFrameNavigator #NextKey:disabled {
+  image: url('../Default/imgs/white/nextkey_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Trees
+----------------------------------------------------------------------------- */
+.treeview,
+QTreeWidget,
+QTreeView,
+#FunctionEditorTree {
+  background-color: #262626;
+  alternate-background-color: #2b2b2b;
+  border: 0;
+  margin: 0;
+  outline: 0;
+}
+.treeview::item:selected,
+QTreeWidget::item:selected,
+QTreeView::item:selected,
+#FunctionEditorTree::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+.treeview::branch:adjoins-item,
+QTreeWidget::branch:adjoins-item,
+QTreeView::branch:adjoins-item,
+#FunctionEditorTree::branch:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-siblings,
+QTreeWidget::branch:has-siblings,
+QTreeView::branch:has-siblings,
+#FunctionEditorTree::branch:has-siblings {
+  border-image: url('');
+}
+.treeview::branch:has-siblings:adjoins-item,
+QTreeWidget::branch:has-siblings:adjoins-item,
+QTreeView::branch:has-siblings:adjoins-item,
+#FunctionEditorTree::branch:has-siblings:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-children:closed,
+QTreeWidget::branch:has-children:closed,
+QTreeView::branch:has-children:closed,
+#FunctionEditorTree::branch:has-children:closed {
+  background: url('../Default/imgs/white/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:open,
+QTreeWidget::branch:has-children:open,
+QTreeView::branch:has-children:open,
+#FunctionEditorTree::branch:has-children:open {
+  background: url('../Default/imgs/white/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:closed,
+QTreeWidget::branch:has-children:has-siblings:closed,
+QTreeView::branch:has-children:has-siblings:closed,
+#FunctionEditorTree::branch:has-children:has-siblings:closed {
+  background: url('../Default/imgs/white/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:open,
+QTreeWidget::branch:has-children:has-siblings:open,
+QTreeView::branch:has-children:has-siblings:open,
+#FunctionEditorTree::branch:has-children:has-siblings:open {
+  background: url('../Default/imgs/white/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+QListView {
+  outline: 0;
+  background: #262626;
+  alternate-background-color: #2b2b2b;
+}
+/* -----------------------------------------------------------------------------
+   Tab Systems
+----------------------------------------------------------------------------- */
+#TabBarContainer {
+  background-color: #262626;
+}
+/* -----------------------------------------------------------------------------
+   Push Button
+----------------------------------------------------------------------------- */
+.Button,
+QPushButton,
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  background-color: #515151;
+  border: 1 solid #303030;
+  border-radius: 2;
+  color: #dbdbdb;
+  margin: 0;
+  padding: 3 15;
+}
+.Button:hover,
+QPushButton:hover,
+.ComboBox:hover,
+#ViewerFpsSlider::sub-line:horizontal:hover,
+#ViewerFpsSlider::add-line:horizontal:hover,
+QComboBox:hover {
+  background-color: #5e5e5e;
+  border-color: #303030;
+  color: #dbdbdb;
+}
+.Button:pressed,
+QPushButton:pressed,
+#ViewerFpsSlider::sub-line:horizontal:pressed,
+#ViewerFpsSlider::add-line:horizontal:pressed {
+  background-color: #191919;
+  border-color: #141414;
+  color: #dbdbdb;
+}
+.Button:checked,
+QPushButton:checked {
+  background-color: #191919;
+  border-color: #141414;
+  color: #dbdbdb;
+}
+.Button:checked:hover,
+QPushButton:checked:hover {
+  background-color: #1e1e1e;
+}
+.Button:checked:hover:pressed,
+QPushButton:checked:hover:pressed {
+  background: #191919;
+}
+.Button:disabled,
+QPushButton:disabled,
+.ComboBox:disabled,
+#ViewerFpsSlider::sub-line:horizontal:disabled,
+#ViewerFpsSlider::add-line:horizontal:disabled,
+QComboBox:disabled {
+  background-color: #3d3d3d;
+  border-color: #303030;
+  color: #808080;
+}
+#PushButton_NoPadding {
+  padding: 3;
+}
+/* -----------------------------------------------------------------------------
+   Combo Box
+----------------------------------------------------------------------------- */
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  padding: 1 0 1 4;
+  margin: 1 0;
+}
+.ComboBox::drop-down,
+QComboBox::drop-down {
+  image: url('../Default/imgs/white/combo_downarrow.svg');
+  image-position: center center;
+  width: 16;
+}
+.ComboBox::drop-down:disabled,
+QComboBox::drop-down:disabled {
+  image: url('../Default/imgs/white/combo_downarrow_disabled.svg');
+}
+.ComboBox QAbstractItemView,
+QComboBox QAbstractItemView {
+  background-color: #303030;
+  border: 1 solid #161616;
+  selection-background-color: #5385a6;
+  selection-color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Textfield
+----------------------------------------------------------------------------- */
+.LineEdit,
+QPlainTextEdit,
+QLineEdit,
+#TaskSheetItem,
+#tasksRemoveBox,
+#tasksAddBox {
+  background-color: #1c1c1c;
+  border: 1 solid #3d3d3d;
+  border-radius: 2;
+  color: #cecece;
+  selection-background-color: #5385a6;
+  selection-color: #ffffff;
+  padding: 0 0 0 1;
+}
+.LineEdit:focus,
+QPlainTextEdit:focus,
+QLineEdit:focus,
+#TaskSheetItem:focus,
+#tasksRemoveBox:focus,
+#tasksAddBox:focus {
+  background-color: #1c1c1c;
+  border-color: #5385a6;
+  color: #cecece;
+}
+.LineEdit:disabled,
+QPlainTextEdit:disabled,
+QLineEdit:disabled,
+#TaskSheetItem:disabled,
+#tasksRemoveBox:disabled,
+#tasksAddBox:disabled {
+  background-color: #262626;
+  border-color: #363636;
+  color: #808080;
+}
+/* -----------------------------------------------------------------------------
+   CheckBox
+----------------------------------------------------------------------------- */
+.CheckBox,
+QCheckBox {
+  color: #cecece;
+}
+.CheckBox:hover,
+QCheckBox:hover,
+.RadioButton:hover,
+QRadioButton:hover {
+  color: #ffffff;
+}
+.CheckBox:disabled,
+QCheckBox:disabled {
+  color: #808080;
+}
+.CheckBox::indicator,
+QMenu::indicator,
+QCheckBox::indicator,
+.GroupBox::indicator,
+QGroupBox::indicator {
+  background-color: #1c1c1c;
+  border: 1 solid #3d3d3d;
+  border-radius: 2;
+  height: 9;
+  /* fix for QGroupBox */
+  padding: 1;
+  width: 9;
+  /* fix for QMenu */
+}
+.CheckBox::indicator:hover,
+QMenu::indicator:hover,
+.CheckBox::indicator:checked:hover,
+.CheckBox::indicator:indeterminate:hover,
+QCheckBox::indicator:hover,
+.GroupBox::indicator:hover,
+QMenu::indicator:checked:hover,
+QMenu::indicator:indeterminate:hover,
+QCheckBox::indicator:checked:hover,
+QCheckBox::indicator:indeterminate:hover,
+.GroupBox::indicator:checked:hover,
+.GroupBox::indicator:indeterminate:hover,
+QGroupBox::indicator:hover,
+QGroupBox::indicator:checked:hover,
+QGroupBox::indicator:indeterminate:hover {
+  background-color: #1c1c1c;
+  border-color: #5385a6;
+}
+.CheckBox::indicator:checked,
+QMenu::indicator:checked,
+QCheckBox::indicator:checked,
+.GroupBox::indicator:checked,
+QGroupBox::indicator:checked {
+  background-color: #1c1c1c;
+  border-color: #3d3d3d;
+  image: url('../Default/imgs/white/checkmark.svg');
+}
+.CheckBox::indicator:checked:disabled,
+QMenu::indicator:checked:disabled,
+QCheckBox::indicator:checked:disabled,
+.GroupBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
+  background-color: #262626;
+  border-color: #191919;
+  image: url('../Default/imgs/white/checkmark_disabled.svg');
+}
+.CheckBox::indicator:indeterminate,
+QMenu::indicator:indeterminate,
+QCheckBox::indicator:indeterminate,
+.GroupBox::indicator:indeterminate,
+QGroupBox::indicator:indeterminate {
+  background-color: #1c1c1c;
+  border-color: #3d3d3d;
+  image: url('../Default/imgs/white/checkpartially.svg');
+}
+.CheckBox::indicator:indeterminate:disabled,
+QMenu::indicator:indeterminate:disabled,
+QCheckBox::indicator:indeterminate:disabled,
+.GroupBox::indicator:indeterminate:disabled,
+QGroupBox::indicator:indeterminate:disabled {
+  background-color: #262626;
+  border-color: #191919;
+  image: url('../Default/imgs/white/checkpartially_disabled.svg');
+}
+.CheckBox::indicator:disabled,
+QMenu::indicator:disabled,
+QCheckBox::indicator:disabled,
+.GroupBox::indicator:disabled,
+QGroupBox::indicator:disabled {
+  background-color: #262626;
+  border-color: #191919;
+}
+/* -----------------------------------------------------------------------------
+   Radio Button
+----------------------------------------------------------------------------- */
+.RadioButton::indicator:unchecked,
+QRadioButton::indicator:unchecked,
+#CameraSettingsRadioButton_Small::indicator:unchecked {
+  image: url('../Default/imgs/white/radiobutton_unchecked.svg');
+  image-position: center center;
+}
+.RadioButton::indicator:checked,
+QRadioButton::indicator:checked,
+#CameraSettingsRadioButton_Small::indicator:checked {
+  image: url('../Default/imgs/white/radiobutton_checked.svg');
+  image-position: center center;
+}
+/* -----------------------------------------------------------------------------
+   GroupBox
+----------------------------------------------------------------------------- */
+.GroupBox,
+QGroupBox {
+  margin: 6 0 0 0;
+  padding: 5 0;
+}
+.GroupBox::title,
+QGroupBox::title {
+  subcontrol-origin: margin;
+  left: 15;
+  margin: -3 0 0 0;
+  padding: 0 3;
+}
+.GroupBox::title:hover,
+QGroupBox::title:hover {
+  color: #ffffff;
+}
+.GroupBox::title:disabled,
+QGroupBox::title:disabled {
+  color: #808080;
+}
+.GroupBox::indicator,
+QGroupBox::indicator {
+  subcontrol-origin: margin;
+  margin-top: 2;
+}
+.GroupBox:disabled,
+QGroupBox:disabled {
+  color: #808080;
+}
+/* -----------------------------------------------------------------------------
+   Slider
+----------------------------------------------------------------------------- */
+.Slider::groove:horizontal,
+QSlider::groove:horizontal {
+  background-color: transparent;
+  background-image: url('../Default/imgs/white/slider-groove_dark.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  margin: 0;
+  height: 20;
+  min-height: 20;
+}
+.Slider::groove:horizontal:disabled,
+QSlider::groove:horizontal:disabled {
+  background-image: url('../Default/imgs/white/slider-groove_disabled_dark.svg');
+}
+.Slider::handle:horizontal,
+QSlider::handle:horizontal {
+  width: 10;
+  margin: -2 -1;
+  image: url('../Default/imgs/white/slider-handle.svg');
+}
+.Slider::handle:horizontal:disabled,
+QSlider::handle:horizontal:disabled {
+  image: url('../Default/imgs/white/slider-handle_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Double Slider
+----------------------------------------------------------------------------- */
+#IntPairField,
+#DoublePairField {
+  qproperty-LightLineColor: #191919;
+  qproperty-LightLineEdgeColor: #191919;
+  qproperty-DarkLineColor: #191919;
+  qproperty-MiddleLineColor: #191919;
+  qproperty-HandleLeftPixmap: url("../Default/imgs/white/slider-handle.svg");
+  qproperty-HandleRightPixmap: url("../Default/imgs/white/slider-handle.svg");
+  qproperty-HandleLeftGrayPixmap: url("../Default/imgs/white/slider-handle_disabled.svg");
+  qproperty-HandleRightGrayPixmap: url("../Default/imgs/white/slider-handle_disabled.svg");
+}
+/* -----------------------------------------------------------------------------
+   File Browser
+----------------------------------------------------------------------------- */
+/* Left Pane
+----------------------------------------------------------------------------- */
+#DirTreeView {
+  background-color: #262626;
+  alternate-background-color: #262626;
+  border: 1 solid #161616;
+  border-right: 0;
+}
+/* Right Pane
+----------------------------------------------------------------------------- */
+DvItemViewerPanel {
+  qproperty-TextColor: #cecece;
+  qproperty-AlternateBackground: #282828;
+  qproperty-SelectedTextColor: #ffffff;
+  qproperty-FolderTextColor: #9fdaff;
+  qproperty-SelectedItemBackground: #5385a6;
+}
+#FileBrowser DvItemViewerPanel,
+#SceneCast DvItemViewerPanel {
+  background-color: #303030;
+}
+#FileBrowser #castFrame,
+#SceneCast #castFrame {
+  border-top: 1 solid #161616;
+  border-right: 1 solid #161616;
+  border-bottom: 1 solid #161616;
+  margin: 0;
+}
+#FileBrowser QToolButton,
+#SceneCast QToolButton {
+  padding: 1;
+}
+DvDirTreeView {
+  qproperty-TextColor: #cecece;
+  qproperty-SelectedTextColor: #ffffff;
+  qproperty-SelectedItemBackground: #5385a6;
+  qproperty-FolderTextColor: #9fdaff;
+  qproperty-SelectedFolderTextColor: #ffffff;
+  alternate-background-color: #2b2b2b;
+  background-color: #262626;
+  border: 1 solid #161616;
+}
+#FileDoesNotExistLabel {
+  color: #ff0000;
+}
+/* -----------------------------------------------------------------------------
+   Scene Cast
+----------------------------------------------------------------------------- */
+#SceneCast QToolBar {
+  border-top: 1 solid #161616;
+}
+#SceneCast QToolButton {
+  margin: 3 1 2 1;
+  padding: 1;
+}
+#CastBrowser {
+  border: 0;
+  margin: 0;
+}
+/* -----------------------------------------------------------------------------
+   Level Strip
+----------------------------------------------------------------------------- */
+#FilmStrip QComboBox {
+  border-radius: 0;
+  border-width: 0;
+}
+#FilmStrip QComboBox QAbstractItemView {
+  background-color: #303030;
+}
+/* -----------------------------------------------------------------------------
+   Cleanup Settings
+----------------------------------------------------------------------------- */
+#CleanupSettings #CleanupSettingsFrame {
+  margin-top: 2;
+  margin-bottom: 4;
+}
+#CleanupSettings QGroupBox {
+  margin-bottom: 3;
+}
+ParamsPage {
+  qproperty-TextColor: #cecece;
+}
+/* -----------------------------------------------------------------------------
+   Camera Settings
+----------------------------------------------------------------------------- */
+#CameraSettingsButton {
+  padding: 2;
+}
+#CameraSettingsRadioButton:hover {
+  background: none;
+}
+#CameraSettingsRadioButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#CameraSettingsRadioButton::indicator:unchecked {
+  image: url('../Default/imgs/white/lock_off.svg');
+}
+#CameraSettingsRadioButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+  image: url('../Default/imgs/white/lock_on.svg');
+}
+#CameraSettingsRadioButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+#CameraSettingsDPI {
+  color: #9fdaff;
+}
+#CameraSettingsRadioButton_Small {
+  padding: 0;
+}
+#CameraSettingsRadioButton_Small::indicator {
+  background-color: transparent;
+  border: 0;
+  height: 21;
+  margin: 0;
+  width: 11;
+}
+#ForceSquaredPixelButton {
+  height: 16;
+  border: 1 solid rgba(255, 255, 255, 0);
+  image: url('../Default/imgs/white/fsp_unchecked.svg');
+  padding: 2;
+  width: 16;
+  margin: 0;
+}
+#ForceSquaredPixelButton:checked {
+  image: url('../Default/imgs/white/fsp_checked.svg');
+}
+/* -----------------------------------------------------------------------------
+   Output Settings
+----------------------------------------------------------------------------- */
+#OutputSettingsLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Misc 
+----------------------------------------------------------------------------- */
+PencilTestPopup {
+  min-height: 730px;
+  /* Allow for using a 768 screen */
+  min-width: 512px;
+  /* some clipping will still occur on width, but this
+                        allows for filling half of a 1024 screen */
+}
+#MatchLineButton {
+  background-color: #565656;
+}
+#MatchLineButton:checked {
+  background-color: #7d7d7d;
+  border: 2 solid #5385a6;
+  border-radius: 2;
+}
+#LargeSizedText {
+  font-size: 17px;
+}
+/* -----------------------------------------------------------------------------
+   Unknowns + Legacy
+----------------------------------------------------------------------------- */
+#StartupLabel {
+  padding: 3;
+}
+#StartupLabel:hover {
+  background: #4a4a4a;
+}
+QStatusBar {
+  background-color: #c0c0c0;
+}
+QStatusBar::item {
+  border: 0;
+}
+QStatusBar QLabel {
+  background-color: #c0c0c0;
+}
+QStatusBar #StatusBarLabel {
+  background-color: #ffffff;
+  padding: 1 3;
+}
+#TitleTxtLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Style Editor
+----------------------------------------------------------------------------- */
+#StyleEditor QPushButton {
+  margin: 2 1;
+  padding: 0;
+}
+#StyleEditor #TabBarContainer {
+  margin-left: -4;
+}
+#StyleEditor #bottomWidget {
+  border-top: 1 solid #161616;
+  padding: 3 2 8 3;
+}
+#StyleEditor #bottomWidget QPushButton {
+  padding: 3 5;
+}
+#StyleEditorTabBar::tab::first {
+  border-left: 1 solid #161616;
+}
+#HexagonalColorWheel {
+  qproperty-BGColor: #303030;
+}
+/* -------------------------------------------------------------------------- */
+/* Horizontal QSlider */
+#colorSlider::groove:horizontal {
+  height: 1;
+  border-image: none;
+}
+#colorSlider::handle:horizontal {
+  width: 8;
+  margin: -8 -4;
+}
+#colorSliderAddButton,
+#colorSliderSubButton {
+  background: none;
+  border-color: transparent;
+  image-position: center center;
+  min-height: 16;
+  padding: 0;
+  min-width: 18;
+}
+#colorSliderAddButton {
+  image: url('../Default/imgs/white/scroll-right.svg');
+}
+#colorSliderSubButton {
+  image: url('../Default/imgs/white/scroll-left.svg');
+}
+#PlainColorPageParts {
+  border-bottom: 1 solid #161616;
+}
+#PlainColorPageParts QLineEdit {
+  max-width: 35;
+}
+/* -----------------------------------------------------------------------------
+   Palette Viewer / Studio Palette
+----------------------------------------------------------------------------- */
+PaletteViewer DvScrollWidget QPushButton {
+  border-top: 0;
+  margin-bottom: 1;
+  max-width: 15;
+  min-width: 15;
+}
+PaletteViewer DvScrollWidget #ScrollLeftButton {
+  border-radius: 0;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer DvScrollWidget #ScrollRightButton {
+  border-radius: 0;
+  margin-left: 1;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer QToolBar {
+  background: none;
+  border-bottom: 1 solid #161616;
+  padding: 0;
+  margin: 0;
+}
+PaletteViewer QToolBar::separator:horizontal {
+  margin: 0;
+}
+PaletteViewer QToolBar QToolButton {
+  margin: 0 0 1 0;
+  padding: 1 0 2 0;
+}
+#PageViewer {
+  qproperty-TextColor: #cecece;
+}
+#PaletteLockButton {
+  border-radius: 0;
+  margin: 0 0 1 1;
+}
+#PaletteLockButton:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+}
+#PaletteLockButton:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+/* -----------------------------------------------------------------------------
+   Quick Renamer
+----------------------------------------------------------------------------- */
+#WordButton {
+  padding-right: 0;
+  padding-left: 0;
+}
+/* -----------------------------------------------------------------------------
+   Popup Windows
+----------------------------------------------------------------------------- */
+QDialog {
+  background-color: #303030;
+}
+QDialog #dialogButtonFrame {
+  background-color: #282828;
+  border-top: 1 solid #161616;
+}
+QDialog #dialogButtonFrame QPushButton {
+  border-color: #282828;
+  outline: 0;
+}
+QDialog #dialogButtonFrame QPushButton:focus {
+  background-color: #5385a6;
+  border-color: #282828;
+  color: #f4f4f4;
+}
+QDialog #dialogButtonFrame QPushButton:focus:hover {
+  background-color: #6c98b6;
+}
+QDialog #dialogButtonFrame QPushButton:focus:pressed {
+  background-color: #191919;
+  border-color: #141414;
+  color: #dbdbdb;
+}
+/* -----------------------------------------------------------------------------
+   Scene Settings
+----------------------------------------------------------------------------- */
+#SceneSettings QLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Preferences
+----------------------------------------------------------------------------- */
+#PreferencesPopup QListWidget {
+  background-color: #262626;
+  alternate-background-color: #262626;
+  border: 1 solid #161616;
+  font-size: 13px;
+}
+#PreferencesPopup QListWidget::item {
+  border: 0;
+  padding: 3;
+}
+#PreferencesPopup QListWidget::item:hover {
+  color: #cecece;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+#PreferencesPopup QListWidget::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Keyboard Shortcuts
+----------------------------------------------------------------------------- */
+#ShortcutTree {
+  border: 1 solid #161616;
+}
+#ShortcutTree::item {
+  padding: 1 0;
+}
+#ShortcutTree QScrollBar:vertical {
+  width: 16;
+  margin-right: -1;
+}
+/* -----------------------------------------------------------------------------
+   New Project / Configure Project Window
+----------------------------------------------------------------------------- */
+ProjectPopup QLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   PencilTestPopup / CameraCapture Window
+----------------------------------------------------------------------------- */
+#GearButton {
+  qproperty-icon: url('../Default/imgs/white/gear.svg');
+}
+#SubfolderButton {
+  qproperty-icon: url('../Default/imgs/white/subfolder.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+#SubcameraButton {
+  qproperty-icon: url('../Default/imgs/white/subcamera.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+/* -----------------------------------------------------------------------------
+   Schematic Viewer
+----------------------------------------------------------------------------- */
+SchematicViewer {
+  qproperty-TextColor: #cecece;
+  qproperty-VerticalLineColor: #090909;
+  qproperty-LevelColumnColor: #4C6E4C;
+  qproperty-VectorColumnColor: #7B7B4C;
+  qproperty-ChildColumnColor: #6A526B;
+  qproperty-FullcolorColumnColor: #657A96;
+  qproperty-FxColumnColor: #56553C;
+  qproperty-PaletteColumnColor: #3A655F;
+  qproperty-MeshColumnColor: #684D86;
+  qproperty-ReferenceColumnColor: #616161;
+  qproperty-TableColor: #62628c;
+  qproperty-ActiveCameraColor: #2d7dca;
+  qproperty-OtherCameraColor: #6c797b;
+  qproperty-GroupColor: #3b6e9c;
+  qproperty-PegColor: #9f6e3c;
+  qproperty-SplineColor: #6a9d1c;
+  qproperty-ActiveOutputColor: #2d7dca;
+  qproperty-OtherOutputColor: #6c797b;
+  qproperty-XsheetColor: #62628c;
+  qproperty-NormalFxColor: #6a7e96;
+  qproperty-MacroFxColor: #815c79;
+  qproperty-ImageAdjustFxColor: #656287;
+  qproperty-LayerBlendingFxColor: #4f757d;
+  qproperty-MatteFxColor: #ae7171;
+  qproperty-SchematicPreviewButtonBgOnColor: #c8c864;
+  qproperty-SchematicPreviewButtonOnImage: url('../Default/imgs/white/x_prev_eye_on.svg');
+  qproperty-SchematicPreviewButtonBgOffColor: #616161;
+  qproperty-SchematicPreviewButtonOffImage: url('../Default/imgs/white/x_prev_eye_off.svg');
+  qproperty-SchematicCamstandButtonBgOnColor: #eb906b;
+  qproperty-SchematicCamstandButtonOnImage: url('../Default/imgs/white/x_table_view_on.svg');
+  qproperty-SchematicCamstandButtonTranspImage: url('../Default/imgs/white/x_table_view_transp.svg');
+  qproperty-SchematicCamstandButtonBgOffColor: #616161;
+  qproperty-SchematicCamstandButtonOffImage: url('../Default/imgs/white/x_table_view_off.svg');
+}
+/* -----------------------------------------------------------------------------
+   Schematic Node Viewer
+----------------------------------------------------------------------------- */
+#SchematicBottomFrame {
+  background-color: #303030;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+#SchematicBottomFrame QToolBar::separator:horizontal {
+  margin: 0;
+}
+#SchematicBottomFrame QToolBar QToolButton {
+  padding: 0;
+  margin: 2;
+}
+#SchematicSceneViewer {
+  background-color: #232323;
+  border-bottom: 1 solid #161616;
+}
+/* -----------------------------------------------------------------------------
+   FX Settings
+----------------------------------------------------------------------------- */
+#FxSettingsTabBar::tab {
+  border-top: 1 solid #161616;
+}
+#FxSettingsTabBar::tab::first,
+#FxSettingsTabBar::tab::only-one {
+  border-left: 1 solid #161616;
+}
+FxSettings QToolBar {
+  border-top: 1 solid #161616;
+  border-right: 1 solid #161616;
+  border-left: 1 solid #161616;
+  min-height: 23;
+  padding: 3 0;
+}
+FxSettings QToolBar QToolBar {
+  border: 0;
+}
+#FxSettingsLabel {
+  color: #a0e680;
+}
+#FxSettingsHelpButton {
+  background-color: #80a0dc;
+  color: #000;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+#FxSettingsHelpButton:hover {
+  background-color: #a8bee7;
+}
+/* -----------------------------------------------------------------------------
+   Script Console
+----------------------------------------------------------------------------- */
+#ScriptConsole {
+  font-family: 'Courier New', monospace;
+  border: 0;
+  color: #000000;
+  padding: 3;
+}
+#ScriptConsole QFrame {
+  background-color: #dcdcdc;
+}
+#ScriptConsole TPanelTitleBar {
+  background-color: #262626;
+}
+/* -----------------------------------------------------------------------------
+   Task Viewer
+----------------------------------------------------------------------------- */
+#TaskSheetItemLabel {
+  color: #cecece;
+}
+#Tasks QToolBar {
+  border-bottom: 1 solid #161616;
+  margin: 0;
+  padding: 0;
+}
+#Tasks QToolBar QToolButton {
+  margin: 2 2 3 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bar
+----------------------------------------------------------------------------- */
+#ToolBar QToolBar {
+  padding-left: 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Options
+----------------------------------------------------------------------------- */
+#ToolOptions TPanelTitleBar {
+  border-right: 1 solid #161616;
+  border-bottom: 0;
+}
+#CommandBar TPanelTitleBar {
+  border-right: 1 solid #161616;
+  border-bottom: 0;
+}
+IconViewField {
+  qproperty-ThicknessPixmap: url("../Default/imgs/white/selectiontool_thickness.svg");
+}
+#EditToolLockButton {
+  spacing: 0;
+}
+#EditToolLockButton:hover {
+  background: none;
+}
+#EditToolLockButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#EditToolLockButton::indicator:unchecked {
+  image: url('../Default/imgs/white/lock_off.svg');
+}
+#EditToolLockButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+  image: url('../Default/imgs/white/lock_on.svg');
+}
+#EditToolLockButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+PopupButton::menu-indicator {
+  border-left: 0;
+  height: 17;
+  image: url('../Default/imgs/white/combo_downarrow.svg');
+  width: 10;
+}
+PopupButton::menu-indicator:hover {
+  image: url('../Default/imgs/white/combo_downarrow.svg');
+}
+PopupButton::menu-indicator:disabled {
+  image: url('../Default/imgs/white/combo_downarrow_disabled.svg');
+}
+#Cap,
+#Join {
+  padding: 0 4 0 -8;
+  max-width: 32;
+  min-width: 32;
+}
+#Cap QMenu,
+#Join QMenu {
+  max-width: 28;
+  min-width: 28;
+}
+#Cap QMenu::item,
+#Join QMenu::item {
+  max-width: 28;
+  min-width: 28;
+  padding: 0;
+}
+QToolBar#MediumPaddingToolBar QToolButton {
+  padding-left: 3;
+  padding-right: 3;
+}
+QToolBar#WidePaddingToolBar QToolButton {
+  padding-left: 6;
+  padding-right: 6;
+}
+#CommandBar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#CommandBar::separator:horizontal {
+  margin-right: 3;
+  margin-left: 3;
+}
+#expandButton:checked {
+  background-color: transparent;
+  border-color: transparent;
+  color: #cecece;
+}
+#expandButton:checked:hover {
+  background-color: #5e5e5e;
+  border-color: #5e5e5e;
+}
+#expandButton:checked:pressed {
+  background-color: #191919;
+  border-color: #141414;
+}
+/* -----------------------------------------------------------------------------
+   ComboViewer / Viewer / FlipBook
+----------------------------------------------------------------------------- */
+#ComboViewerPanel Toolbar {
+  border-bottom: 1 solid #161616;
+}
+#ComboViewerPanel Toolbar::separator:horizontal {
+  margin: 0 0 0 2;
+}
+#ComboViewerPanel Toolbar QToolButton {
+  margin: 2 0 3 2;
+}
+#ComboViewerToolOptions {
+  border-bottom: 1 solid #161616;
+}
+#ComboViewer #ToolBarContainer,
+#ViewerPanel #ToolBarContainer,
+FlipBook #ToolBarContainer {
+  background-color: transparent;
+  border-top: 2 solid #161616;
+  border-bottom: 1 solid #161616;
+  padding-right: -1;
+}
+#flipCustomize {
+  margin-left: 3;
+}
+#flipCustomize::menu-button {
+  background-color: transparent;
+  width: 35;
+}
+#flipCustomize::menu-arrow {
+  image: none;
+}
+QToolBar#FlipConsolePlayToolBar::separator:horizontal {
+  margin: 0 3;
+}
+QToolBar#FlipConsolePlayToolBar QToolButton {
+  margin-top: 2;
+  margin-bottom: 2;
+  height: 16;
+  padding-left: 1;
+  padding-right: 1;
+}
+#ViewerFpsSlider {
+  background-color: transparent;
+  background-image: url('../Default/imgs/white/slider-groove_dark.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  border: 0;
+  height: 19;
+  margin: 0 3 0 37;
+  max-width: 300;
+  min-width: 0;
+}
+#ViewerFpsSlider::sub-line:horizontal {
+  subcontrol-origin: absolute;
+  background-color: #515151;
+  border: 1 solid #303030;
+  border-top-left-radius: 2;
+  border-bottom-left-radius: 2;
+  height: 16;
+  left: -33;
+  width: 14;
+}
+#ViewerFpsSlider::add-line:horizontal {
+  subcontrol-position: left;
+  background-color: #515151;
+  border: 1 solid #303030;
+  border-top-right-radius: 2;
+  border-bottom-right-radius: 2;
+  left: 18;
+  height: 16;
+  image-position: center center;
+  width: 13;
+}
+#ViewerFpsSlider::handle::horizontal {
+  background-color: #898989;
+  border: 1 solid #898989;
+  border-radius: 2;
+  margin: 2 0 3 0;
+  min-width: 9;
+  width: 9;
+  max-width: 9;
+}
+FlipSlider {
+  qproperty-PBHeight: 15;
+  qproperty-PBOverlay: url('../Default/imgs/white/flipslider_dark.svg');
+  qproperty-PBColorMarginLeft: 1;
+  qproperty-PBColorMarginTop: 2;
+  qproperty-PBColorMarginRight: 1;
+  qproperty-PBColorMarginBottom: 2;
+  qproperty-PBMarker: url('../Default/imgs/white/flipmarker_dark.svg');
+  qproperty-PBMarkerMarginLeft: 3;
+  qproperty-PBMarkerMarginRight: 3;
+  qproperty-notStartedColor: rgba(205, 101, 101, 0.78);
+  qproperty-startedColor: #1abc3f;
+  qproperty-baseColor: #1c1c1c;
+  qproperty-finishedColor: #1c1c1c;
+}
+Ruler {
+  qproperty-ParentBGColor: #303030;
+  qproperty-ScaleColor: #cecece;
+}
+#RulerToolOptionValues {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   XSheet Viewer
+----------------------------------------------------------------------------- */
+/* ScrollAreas (Row, Column and Cell)
+----------------------------------------------------------------------------- */
+#xsheetArea,
+#ScrollArea {
+  background-color: #1c1c1c;
+  border: 0;
+}
+#xsheetScrollArea {
+  border: 0;
+}
+#cornerWidget QToolButton {
+  padding: 0;
+}
+/* xsheetColumnHeader (Context Menus)
+----------------------------------------------------------------------------- */
+#xsheetColumnAreaMenu_Preview {
+  background-color: #E6E678;
+}
+#xsheetColumnAreaMenu_Lock {
+  background-color: #F5F5F5;
+}
+#xsheetColumnAreaMenu_Camstand {
+  background-color: #FFA480;
+}
+#xsheetColumnAreaMenu_Preview,
+#xsheetColumnAreaMenu_Lock,
+#xsheetColumnAreaMenu_Camstand {
+  color: #000;
+}
+#noteTextEdit {
+  color: #000;
+}
+/* XSheet Spreadsheet
+----------------------------------------------------------------------------- */
+XsheetViewer {
+  qproperty-TextColor: #cecece;
+  qproperty-BGColor: #282828;
+  qproperty-LightLineColor: #1f1f1f;
+  qproperty-MarkerLineColor: #1E96C4;
+  qproperty-VerticalLineColor: #090909;
+  qproperty-VerticalLineHeadColor: #686868;
+  qproperty-PreviewFrameTextColor: #9fdaff;
+  qproperty-CurrentRowBgColor: #506082;
+  qproperty-OnionSkinAreaBgColor: #1e1e1e;
+  qproperty-EmptyColumnHeadColor: #444444;
+  qproperty-SelectedColumnTextColor: #E66464;
+  qproperty-EmptyCellColor: #303030;
+  qproperty-NotEmptyColumnColor: #383838;
+  qproperty-SelectedEmptyCellColor: #545454;
+  qproperty-LevelColumnColor: #4C6E4C;
+  qproperty-LevelColumnBorderColor: #8FB38F;
+  qproperty-SelectedLevelColumnColor: #678667;
+  qproperty-VectorColumnColor: #7B7B4C;
+  qproperty-VectorColumnBorderColor: #BBBB9A;
+  qproperty-SelectedVectorColumnColor: #949466;
+  qproperty-ChildColumnColor: #6A526B;
+  qproperty-ChildColumnBorderColor: #B1A3B3;
+  qproperty-SelectedChildColumnColor: #816e82;
+  qproperty-FullcolorColumnColor: #657A96;
+  qproperty-FullcolorColumnBorderColor: #9EB8BB;
+  qproperty-SelectedFullcolorColumnColor: #8895a6;
+  qproperty-FxColumnColor: #56553C;
+  qproperty-FxColumnBorderColor: #95958A;
+  qproperty-SelectedFxColumnColor: #6f6e56;
+  qproperty-ReferenceColumnColor: #616161;
+  qproperty-ReferenceColumnBorderColor: #A2A2A2;
+  qproperty-SelectedReferenceColumnColor: #7a7a7a;
+  qproperty-PaletteColumnColor: #3A655F;
+  qproperty-PaletteColumnBorderColor: #86ACA7;
+  qproperty-SelectedPaletteColumnColor: #52807a;
+  qproperty-MeshColumnColor: #684D86;
+  qproperty-MeshColumnBorderColor: #BA92EF;
+  qproperty-SelectedMeshColumnColor: #82689e;
+  qproperty-SoundTextColumnColor: #c8c8c8;
+  qproperty-SoundTextColumnBorderColor: #8c8c8c;
+  qproperty-SelectedSoundTextColumnColor: #e2e2e2;
+  qproperty-SoundColumnColor: #657456;
+  qproperty-SoundColumnBorderColor: #A0AF7D;
+  qproperty-SelectedSoundColumnColor: #7e8b72;
+  qproperty-SoundColumnHlColor: #34FE5E;
+  qproperty-SoundColumnTrackColor: #B6C29D;
+  qproperty-ColumnHeadPastelizer: #000;
+  qproperty-SelectedColumnHead: #506082;
+  qproperty-LightLightBGColor: #303030;
+  qproperty-LightBGColor: #d8d8d8;
+  qproperty-DarkBGColor: #c9c9c9;
+  qproperty-DarkLineColor: #7e7e7e;
+  qproperty-XsheetColumnNameBgColor: rgba(0, 0, 0, 0);
+  qproperty-XsheetDragBarHighlightColor: rgba(255, 255, 255, 0.5);
+  qproperty-XsheetPreviewButtonBgOnColor: #c8c864;
+  qproperty-XsheetPreviewButtonOnImage: url('../Default/imgs/white/x_prev_eye_on.svg');
+  qproperty-XsheetPreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetPreviewButtonOffImage: url('../Default/imgs/white/x_prev_eye_off.svg');
+  qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
+  qproperty-XsheetCamstandButtonOnImage: url('../Default/imgs/white/x_table_view_on.svg');
+  qproperty-XsheetCamstandButtonTranspImage: url('../Default/imgs/white/x_table_view_transp.svg');
+  qproperty-XsheetCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetCamstandButtonOffImage: url('../Default/imgs/white/x_table_view_off.svg');
+  qproperty-XsheetLockButtonBgOnColor: rgba(255, 255, 255, 0.3);
+  qproperty-XsheetLockButtonOnImage: url('../Default/imgs/white/x_lock_on.svg');
+  qproperty-XsheetLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetLockButtonOffImage: url('../Default/imgs/white/x_lock_off.svg');
+  qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetConfigButtonImage: url('../Default/imgs/white/x_config.svg');
+  qproperty-TimelinePreviewButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelinePreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOffImage: url('../Default/imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineCamstandButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOnImage: url('../Default/imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelineCamstandButtonTranspImage: url('../Default/imgs/white/timeline_toggle_transp.svg');
+  qproperty-TimelineCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOffImage: url('../Default/imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineLockButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOnImage: url('../Default/imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelineLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOffImage: url('../Default/imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineConfigButtonImage: url('../Default/imgs/white/timeline_config.svg');
+  qproperty-LayerHeaderPreviewImage: url('../Default/imgs/white/layer_header_prev_eye.svg');
+  qproperty-LayerHeaderPreviewOverImage: url('../Default/imgs/white/layer_header_prev_eye_over.svg');
+  qproperty-LayerHeaderCamstandImage: url('../Default/imgs/white/layer_header_table_view.svg');
+  qproperty-LayerHeaderCamstandOverImage: url('../Default/imgs/white/layer_header_table_view_over.svg');
+  qproperty-LayerHeaderLockImage: url('../Default/imgs/white/lock_on.svg');
+  qproperty-LayerHeaderLockOverImage: url('../Default/imgs/white/lock_on_over.svg');
+  qproperty-ActiveCameraColor: #2d7dca;
+  qproperty-SelectedActiveCameraColor: #5796d3;
+  qproperty-OtherCameraColor: #6c797b;
+  qproperty-SelectedOtherCameraColor: #8b8e8f;
+}
+/* XSheet Toolbar
+----------------------------------------------------------------------------- */
+#XSheetToolbar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#XSheetToolbar QToolButton {
+  padding: 0;
+  margin: 4 1;
+  min-height: 19;
+  height: 19;
+}
+#XSheetToolbar::separator:horizontal {
+  margin: 0 4;
+}
+/* -----------------------------------------------------------------------------
+   Function Editor
+----------------------------------------------------------------------------- */
+#FunctionEditor QToolBar {
+  border-bottom: 1 solid #161616;
+}
+#FunctionEditor QToolBar QToolBar {
+  border: 0;
+}
+#FunctionEditor QToolBar QLabel {
+  margin-left: 5;
+}
+#FunctionEditor QToolBar QToolButton {
+  height: 18;
+}
+#FunctionEditorTree {
+  border-top: 1 solid #161616;
+}
+FunctionTreeView {
+  qproperty-TextColor: #cecece;
+  qproperty-CurrentTextColor: #E66464;
+}
+/* Function Editor Spreadsheet
+----------------------------------------------------------------------------- */
+FunctionPanel {
+  qproperty-BGColor: #232323;
+  qproperty-ValueLineColor: #161616;
+  qproperty-FrameLineColor: #161616;
+  qproperty-OtherCurvesColor: #707070;
+  qproperty-RulerBackground: #1b1b1b;
+  qproperty-TextColor: #cecece;
+  qproperty-SubColor: #000;
+  qproperty-SelectedColor: #FFA500;
+}
+SpreadsheetViewer {
+  qproperty-LightLightBGColor: #303030;
+  qproperty-CurrentRowBgColor: #506082;
+  qproperty-LightLineColor: #1f1f1f;
+  qproperty-MarkerLineColor: #1E96C4;
+  qproperty-BGColor: #383838;
+  qproperty-VerticalLineColor: #090909;
+  qproperty-KeyFrameColor: #995d1d;
+  qproperty-KeyFrameBorderColor: #c9b04b;
+  qproperty-SelectedKeyFrameColor: #be772b;
+  qproperty-InBetweenColor: #666250;
+  qproperty-InBetweenBorderColor: #cdcec8;
+  qproperty-SelectedInBetweenColor: #7d7a6c;
+  qproperty-SelectedEmptyColor: #545454;
+  qproperty-SelectedSceneRangeEmptyColor: #5d5d5d;
+  qproperty-TextColor: #cecece;
+  qproperty-ColumnHeaderBorderColor: #686868;
+  qproperty-SelectedColumnTextColor: #E66464;
+}
+#ExpressionField {
+  background-color: #cecece;
+  border: 1 solid #1b1b1b;
+  margin: 0;
+}
+#FunctionSegmentViewerLinkButton {
+  background-image: url('../Default/imgs/white/segment_unlinked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:hover {
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:checked {
+  background-image: url('../Default/imgs/white/segment_linked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:disabled {
+  background-image: url('../Default/imgs/white/segment_disabled.svg');
+  background-repeat: no-repeat;
+}

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1,1 +1,1935 @@
-.button-show,#LoadLevelShowButton,#CleanupSettingsShowButton,#OutputSettingsShowButton,#FxSettingsPreviewShowButton{image:url('imgs/white/plus.svg');image-position:center center;margin:0;padding:1;min-width:10;min-height:10}.button-show:checked,#LoadLevelShowButton:checked,#CleanupSettingsShowButton:checked,#OutputSettingsShowButton:checked,#FxSettingsPreviewShowButton:checked{background-color:#313131;border-color:#2c2c2c;image:url('imgs/white/minus.svg')}.button-show:checked:pressed,#LoadLevelShowButton:checked:pressed,#CleanupSettingsShowButton:checked:pressed,#OutputSettingsShowButton:checked:pressed,#FxSettingsPreviewShowButton:checked:pressed{background-color:#313131;border-color:#2c2c2c}.button-show:checked:hover,#LoadLevelShowButton:checked:hover,#CleanupSettingsShowButton:checked:hover,#OutputSettingsShowButton:checked:hover,#FxSettingsPreviewShowButton:checked:hover{background-color:#363636}.button-tool,QToolButton,#CameraSettingsRadioButton::indicator,#ForceSquaredPixelButton,#SchematicBottomFrame QToolBar QToolButton,#EditToolLockButton::indicator,#flipCustomize{background-color:rgba(255,255,255,0);border:1 solid rgba(255,255,255,0);border-radius:2;color:#f3f3f3;margin:1;padding:0}.button-tool:hover,QToolButton:hover,#CameraSettingsRadioButton::indicator:hover,#ForceSquaredPixelButton:hover,#colorSliderAddButton:hover,#colorSliderSubButton:hover,#SchematicBottomFrame QToolBar QToolButton:hover,#EditToolLockButton::indicator:hover,#flipCustomize:hover{background-color:#767676;border-color:#767676;color:#f3f3f3}.button-tool:pressed,QToolButton:pressed,#CameraSettingsRadioButton::indicator:pressed,#ForceSquaredPixelButton:pressed,#colorSliderAddButton:pressed,#colorSliderSubButton:pressed,#SchematicBottomFrame QToolBar QToolButton:pressed,#EditToolLockButton::indicator:pressed,#flipCustomize:pressed{background-color:#313131;border-color:#2c2c2c;color:#f3f3f3}.button-tool:checked,QToolButton:checked,#CameraSettingsRadioButton::indicator:checked,#ForceSquaredPixelButton:checked,#SchematicBottomFrame QToolBar QToolButton:checked,#EditToolLockButton::indicator:checked,#flipCustomize:checked{background-color:#5385a6;border-color:#5385a6;color:#fff}.button-tool:checked:hover,QToolButton:checked:hover,#CameraSettingsRadioButton::indicator:checked:hover,#ForceSquaredPixelButton:checked:hover,#SchematicBottomFrame QToolBar QToolButton:checked:hover,#EditToolLockButton::indicator:checked:hover,#flipCustomize:checked:hover{background-color:#6c98b6;border-color:#6c98b6}.button-tool:disabled,QToolButton:disabled,#CameraSettingsRadioButton::indicator:disabled,#ForceSquaredPixelButton:disabled,#SchematicBottomFrame QToolBar QToolButton:disabled,#EditToolLockButton::indicator:disabled,#flipCustomize:disabled{color:#808080}.button-flat,PaletteViewer QToolBar QToolButton{background-color:none;border:0;border-radius:0;margin:0}.button-flat:hover,PaletteViewer QToolBar QToolButton:hover{background-color:#767676}.button-flat:pressed,PaletteViewer QToolBar QToolButton:pressed{background-color:#272727}.frame,.GroupBox,#LoadLevelFrame,#PsdSettingsGroupBox,#CleanupSettingsFrame,#OutputSettingsBox,#OutputSettingsCameraBox,#SolidLineFrame,#FunctionParametersPanel,QGroupBox{border:1 solid #272727;border-radius:2}.tab-container,#TabBarContainer{background-color:transparent;qproperty-BottomAboveLineColor:#393939;qproperty-BottomBelowLineColor:#272727}.tab-flat,#StyleEditorTabBar::tab,#PaletteTabBar::tab,#FxSettingsTabBar::tab{background-color:#393939;border-right:1 solid #272727;border-bottom:1 solid #272727;color:#a1a1a1;padding:3 4 3 4}.tab-flat:hover,#StyleEditorTabBar::tab:hover,#PaletteTabBar::tab:hover,#FxSettingsTabBar::tab:hover{background-color:#484848;color:#a1a1a1}.tab-flat:selected,#StyleEditorTabBar::tab:selected,#PaletteTabBar::tab:selected,#FxSettingsTabBar::tab:selected{background-color:#484848;color:#fff;border-bottom-color:#484848}.tab-flat:only-one,#StyleEditorTabBar::tab:only-one,#PaletteTabBar::tab:only-one,#FxSettingsTabBar::tab:only-one{margin:0}.tab-round{background-color:#393939;border-top:1 solid #272727;border-right:1 solid #272727;border-left:1 solid #272727;border-bottom:1 solid #272727;color:#a1a1a1;margin:3 -1 0 0;padding:2 7 1 7}.tab-round:hover{background-color:#484848;color:#a1a1a1}.tab-round:selected{background-color:#484848;border-top-right-radius:2;border-top-left-radius:2;border-bottom-color:#484848;color:#fff;margin:1 -1 -1 0;padding:2 7 2 7}.tab-round:only-one{margin:1 0 0 0;padding:3 7 3 7}.tab-round:last{margin-right:0;border-top-right-radius:2}.tab-round:first{border-top-left-radius:2}QWidget{background-color:#484848;color:#e6e6e6}QWidget:disabled{color:#808080}QFrame{border:0;margin:0;padding:0}QToolTip,#helpToolTip{background-color:#fff;border:1 solid #000;color:#000;padding:1 1}#DockSeparator,QMainWindow::separator,QSplitter::handle{background-color:#1a1a1a;height:4;width:4}#TDockPlaceholder{background-color:#F77272}TPanel{background-color:#1a1a1a}#TopBar{background:#484848;border:0;border-bottom:1 solid #272727;height:21}#TopBar #EditToolLockButton{background:#484848;spacing:0}#TopBar #EditToolLockButton::indicator{background:none;border:none;height:18;margin:1 2 0 0;padding-left:0;padding-right:0}#TopBarTabContainer{background-color:#484848;margin-bottom:1}#StackedMenuBar{border:0;margin:0;padding:0}QMenuBar{background-color:#484848;border:0}QMenuBar::item{background-color:#484848;border-left:1 solid #484848;margin:0;padding:3 5}QMenuBar::item:selected{background-color:rgba(255,255,255,0.15);color:#e6e6e6}QMenuBar::item:pressed{background-color:#5385a6;color:#fff}#TopBarTab{margin:0;padding:0}#TopBarTab::tab{background-color:#393939;border-top:1 solid #272727;border-right:1 solid #272727;color:#a1a1a1;margin:0 0 0 0;padding:2 8 3 8}#TopBarTab::tab:hover{background-color:#484848;color:#a1a1a1}#TopBarTab::tab:selected{background-color:#484848;color:#fff}#TopBarTab::tab:first{border-left:1 solid #272727}#TopBarTab::tab:last{border-right:1 solid #272727}QMenu{background-color:#484848;border:1 solid #272727;padding:2 0}QMenu::item{padding:3 28}QMenu::item:selected{background-color:#5385a6;color:#fff}QMenu::item:checked{color:#e6e6e6}QMenu::item:checked:selected{background-color:#5385a6;color:#fff}QMenu::item:disabled{background:none;color:#808080}QMenu::item:disabled:selected{border-color:transparent}QMenu::separator{border-top:1 solid #272727;height:0;margin:2 0}QMenu::icon{border-radius:2;margin:0 0 0 3;padding:1}QMenu::icon:checked{background-color:#5385a6}QMenu::indicator{margin-left:7}TPanelTitleBar{background-color:#393939;border-color:#272727;border-style:solid;border-width:0 0 1 0;height:20;min-height:20;qproperty-TitleColor:#949494;qproperty-ActiveTitleColor:#fff;qproperty-BorderPixmap:url('none');qproperty-ActiveBorderPixmap:url('imgs/white/none');qproperty-FloatBorderPixmap:url('none');qproperty-FloatActiveBorderPixmap:url('imgs/white/none')}QAbstractScrollArea::corner{background-color:#343434}QScrollBar{background-color:#343434;border:0}QScrollBar:horizontal{height:16;margin:0}QScrollBar:vertical{margin:0;width:16}QScrollBar::handle{border:1 solid #525252;border-radius:4}QScrollBar::handle:horizontal:hover,QScrollBar::handle:vertical:hover{background-color:#676767;border-color:#676767}QScrollBar::handle:horizontal:pressed,QScrollBar::handle:vertical:pressed{background-color:#7b7b7b;border-color:#7b7b7b}QScrollBar::handle:horizontal{background-color:#525252;margin:3 16;min-width:20}QScrollBar::handle:vertical{background-color:#525252;margin:16 3;min-height:20}QScrollBar::add-line{subcontrol-origin:margin;border:0}QScrollBar::add-line:horizontal{subcontrol-position:right;background-color:#343434;margin:0;width:16}QScrollBar::add-line:vertical{subcontrol-position:bottom;background-color:#343434;margin:0;height:16}QScrollBar::sub-line{border:0;subcontrol-origin:margin}QScrollBar::sub-line:horizontal{subcontrol-position:left;background-color:#343434;margin:0;width:16}QScrollBar::sub-line:vertical{subcontrol-position:top;background-color:#343434;margin:0;height:16}QScrollBar::up-arrow:vertical{image:url('imgs/white/scroll-up.svg');image-position:center center}QScrollBar::up-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::down-arrow:vertical{image:url('imgs/white/scroll-down.svg');image-position:center center}QScrollBar::down-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::left-arrow:horizontal{image:url('imgs/white/scroll-left.svg');image-position:center center}QScrollBar::left-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::right-arrow:horizontal{image:url('imgs/white/scroll-right.svg');image-position:center center}QScrollBar::right-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::sub-page:horizontal,QScrollBar::add-page:horizontal,QScrollBar::sub-page:vertical,QScrollBar::add-page:vertical{background:none}QToolBar{padding:0}QToolBar::separator:horizontal{border-left:1 solid #272727;margin:0 1;width:0}QToolBar::separator:vertical{border-top:1 solid #272727;height:0;margin:1 0}QToolBar QLabel{margin-top:1}QToolBar QToolBar{border:0}QToolButton::menu-indicator{image:none}QToolButton::menu-button{border-image:none}.DvScrollWidget QPushButton,DvScrollWidget QPushButton,#ScrollLeftButton QPushButton,#ScrollRightButton QPushButton,#ScrollUpButton QPushButton,#ScrollDownButton QPushButton{background-color:#696969;border:0 solid red;border-radius:0;padding:0;max-width:16}.DvScrollWidget QPushButton:hover,DvScrollWidget QPushButton:hover,#ScrollLeftButton QPushButton:hover,#ScrollRightButton QPushButton:hover,#ScrollUpButton QPushButton:hover,#ScrollDownButton QPushButton:hover{background-color:#767676}.DvScrollWidget QPushButton:pressed,DvScrollWidget QPushButton:pressed,#ScrollLeftButton QPushButton:pressed,#ScrollRightButton QPushButton:pressed,#ScrollUpButton QPushButton:pressed,#ScrollDownButton QPushButton:pressed{background-color:#313131}#ScrollLeftButton,#ScrollRightButton,#ScrollUpButton,#ScrollDownButton{margin:0;min-width:16}#ScrollLeftButton{border-right:1 solid #272727;image:url('imgs/white/scroll-left.svg')}#ScrollRightButton{border-left:1 solid #272727;margin-left:3;image:url('imgs/white/scroll-right.svg')}#ScrollUpButton{image:url('imgs/white/scroll-up.svg')}#ScrollDownButton{image:url('imgs/white/scroll-down.svg')}#keyFrameNavigator{background:none;margin:0;padding:0}#keyFrameNavigator QToolButton{min-width:18}#keyFrameNavigator #PreviousKey{image:url('imgs/white/prevkey.svg')}#keyFrameNavigator #PreviousKey:hover{image:url('imgs/white/prevkey_over.svg')}#keyFrameNavigator #PreviousKey:disabled{image:url('imgs/white/prevkey_disabled.svg')}#keyFrameNavigator #NextKey{image:url('imgs/white/nextkey.svg')}#keyFrameNavigator #NextKey:hover{image:url('imgs/white/nextkey_over.svg')}#keyFrameNavigator #NextKey:disabled{image:url('imgs/white/nextkey_disabled.svg')}.treeview,QTreeWidget,QTreeView,#FunctionEditorTree{background-color:#343434;alternate-background-color:#393939;border:0;margin:0;outline:0}.treeview::item:selected,QTreeWidget::item:selected,QTreeView::item:selected,#FunctionEditorTree::item:selected{background-color:#5385a6;color:#fff}.treeview::branch:adjoins-item,QTreeWidget::branch:adjoins-item,QTreeView::branch:adjoins-item,#FunctionEditorTree::branch:adjoins-item{border-image:url('')}.treeview::branch:has-siblings,QTreeWidget::branch:has-siblings,QTreeView::branch:has-siblings,#FunctionEditorTree::branch:has-siblings{border-image:url('')}.treeview::branch:has-siblings:adjoins-item,QTreeWidget::branch:has-siblings:adjoins-item,QTreeView::branch:has-siblings:adjoins-item,#FunctionEditorTree::branch:has-siblings:adjoins-item{border-image:url('')}.treeview::branch:has-children:closed,QTreeWidget::branch:has-children:closed,QTreeView::branch:has-children:closed,#FunctionEditorTree::branch:has-children:closed{background:url('imgs/white/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:open,QTreeWidget::branch:has-children:open,QTreeView::branch:has-children:open,#FunctionEditorTree::branch:has-children:open{background:url('imgs/white/treebranch-open.svg') no-repeat;background-position:center center;image:none}.treeview::branch:has-children:has-siblings:closed,QTreeWidget::branch:has-children:has-siblings:closed,QTreeView::branch:has-children:has-siblings:closed,#FunctionEditorTree::branch:has-children:has-siblings:closed{background:url('imgs/white/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:has-siblings:open,QTreeWidget::branch:has-children:has-siblings:open,QTreeView::branch:has-children:has-siblings:open,#FunctionEditorTree::branch:has-children:has-siblings:open{background:url('imgs/white/treebranch-open.svg') no-repeat;background-position:center center;border-image:none;image:none}QListView{outline:0;background:#343434;alternate-background-color:#393939}#TabBarContainer{background-color:#393939}.Button,QPushButton,.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{background-color:#696969;border:1 solid #484848;border-radius:2;color:#f3f3f3;margin:0;padding:3 15}.Button:hover,QPushButton:hover,.ComboBox:hover,#ViewerFpsSlider::sub-line:horizontal:hover,#ViewerFpsSlider::add-line:horizontal:hover,QComboBox:hover{background-color:#767676;border-color:#484848;color:#f3f3f3}.Button:pressed,QPushButton:pressed,#ViewerFpsSlider::sub-line:horizontal:pressed,#ViewerFpsSlider::add-line:horizontal:pressed{background-color:#313131;border-color:#2c2c2c;color:#f3f3f3}.Button:checked,QPushButton:checked{background-color:#313131;border-color:#2c2c2c;color:#f3f3f3}.Button:checked:hover,QPushButton:checked:hover{background-color:#363636}.Button:checked:hover:pressed,QPushButton:checked:hover:pressed{background:#313131}.Button:disabled,QPushButton:disabled,.ComboBox:disabled,#ViewerFpsSlider::sub-line:horizontal:disabled,#ViewerFpsSlider::add-line:horizontal:disabled,QComboBox:disabled{background-color:#555;border-color:#484848;color:#808080}#PushButton_NoPadding{padding:3}.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{padding:1 0 1 4;margin:1 0}.ComboBox::drop-down,QComboBox::drop-down{image:url('imgs/white/combo_downarrow.svg');image-position:center center;width:16}.ComboBox::drop-down:disabled,QComboBox::drop-down:disabled{image:url('imgs/white/combo_downarrow_disabled.svg')}.ComboBox QAbstractItemView,QComboBox QAbstractItemView{background-color:#484848;border:1 solid #272727;selection-background-color:#5385a6;selection-color:#fff}.LineEdit,QPlainTextEdit,QLineEdit,#TaskSheetItem,#tasksRemoveBox,#tasksAddBox{background-color:#2f2f2f;border:1 solid #2c2c2c;border-radius:2;color:#e6e6e6;selection-background-color:#5385a6;selection-color:#fff;padding:0 0 0 1}.LineEdit:focus,QPlainTextEdit:focus,QLineEdit:focus,#TaskSheetItem:focus,#tasksRemoveBox:focus,#tasksAddBox:focus{background-color:#2f2f2f;border-color:#5385a6;color:#e6e6e6}.LineEdit:disabled,QPlainTextEdit:disabled,QLineEdit:disabled,#TaskSheetItem:disabled,#tasksRemoveBox:disabled,#tasksAddBox:disabled{background-color:#3b3b3b;border-color:#3a3a3a;color:#808080}.CheckBox,QCheckBox{color:#e6e6e6}.CheckBox:hover,QCheckBox:hover,.RadioButton:hover,QRadioButton:hover{color:#fff}.CheckBox:disabled,QCheckBox:disabled{color:#808080}.CheckBox::indicator,QMenu::indicator,QCheckBox::indicator,.GroupBox::indicator,QGroupBox::indicator{background-color:#2f2f2f;border:1 solid #2c2c2c;border-radius:2;height:9;padding:1;width:9}.CheckBox::indicator:hover,QMenu::indicator:hover,.CheckBox::indicator:checked:hover,QCheckBox::indicator:hover,.GroupBox::indicator:hover,QMenu::indicator:checked:hover,QCheckBox::indicator:checked:hover,.GroupBox::indicator:checked:hover,QGroupBox::indicator:hover,QGroupBox::indicator:checked:hover{background-color:#2f2f2f;border-color:#5385a6}.CheckBox::indicator:checked,QMenu::indicator:checked,QCheckBox::indicator:checked,.GroupBox::indicator:checked,QGroupBox::indicator:checked{background-color:#2f2f2f;border-color:#2c2c2c;image:url('imgs/white/checkmark.svg')}.CheckBox::indicator:checked:disabled,QMenu::indicator:checked:disabled,QCheckBox::indicator:checked:disabled,.GroupBox::indicator:checked:disabled,QGroupBox::indicator:checked:disabled{background-color:#3b3b3b;border-color:#3b3b3b;image:url('imgs/white/checkmark_disabled.svg')}.CheckBox::indicator:disabled,QMenu::indicator:disabled,QCheckBox::indicator:disabled,.GroupBox::indicator:disabled,QGroupBox::indicator:disabled{background-color:#3b3b3b;border-color:#3b3b3b}.RadioButton::indicator:unchecked,QRadioButton::indicator:unchecked,#CameraSettingsRadioButton_Small::indicator:unchecked{image:url('imgs/white/radiobutton_unchecked.svg');image-position:center center}.RadioButton::indicator:checked,QRadioButton::indicator:checked,#CameraSettingsRadioButton_Small::indicator:checked{image:url('imgs/white/radiobutton_checked.svg');image-position:center center}.GroupBox,QGroupBox{margin:6 0 0 0;padding:5 0}.GroupBox::title,QGroupBox::title{subcontrol-origin:margin;left:15;margin:-3 0 0 0;padding:0 3}.GroupBox::title:hover,QGroupBox::title:hover{color:#fff}.GroupBox::title:disabled,QGroupBox::title:disabled{color:#808080}.GroupBox::indicator,QGroupBox::indicator{subcontrol-origin:margin;margin-top:2}.GroupBox:disabled,QGroupBox:disabled{color:#808080}.Slider::groove:horizontal,QSlider::groove:horizontal{background-color:transparent;background-image:url('imgs/white/slider-groove.svg');background-position:center center;background-repeat:repeat-x;margin:0;height:20;min-height:20}.Slider::groove:horizontal:disabled,QSlider::groove:horizontal:disabled{background-image:url('imgs/white/slider-groove_disabled.svg')}.Slider::handle:horizontal,QSlider::handle:horizontal{width:10;margin:-2 -1;image:url('imgs/white/slider-handle.svg')}.Slider::handle:horizontal:disabled,QSlider::handle:horizontal:disabled{image:url('imgs/white/slider-handle_disabled.svg')}#IntPairField,#DoublePairField{qproperty-LightLineColor:#2c2c2c;qproperty-LightLineEdgeColor:#2c2c2c;qproperty-DarkLineColor:#2c2c2c;qproperty-MiddleLineColor:#2c2c2c;qproperty-HandleLeftPixmap:url("imgs/white/slider-handle.svg");qproperty-HandleRightPixmap:url("imgs/white/slider-handle.svg");qproperty-HandleLeftGrayPixmap:url("imgs/white/slider-handle_disabled.svg");qproperty-HandleRightGrayPixmap:url("imgs/white/slider-handle_disabled.svg")}#DirTreeView{background-color:#343434;alternate-background-color:#343434;border:1 solid #272727;border-right:0}DvItemViewerPanel{qproperty-TextColor:#e6e6e6;qproperty-AlternateBackground:#404040;qproperty-SelectedTextColor:#fff;qproperty-FolderTextColor:#9fdaff;qproperty-SelectedItemBackground:#5385a6}#FileBrowser DvItemViewerPanel,#SceneCast DvItemViewerPanel{background-color:#484848}#FileBrowser #castFrame,#SceneCast #castFrame{border-top:1 solid #272727;border-right:1 solid #272727;border-bottom:1 solid #272727;margin:0}#FileBrowser QToolButton,#SceneCast QToolButton{padding:1}DvDirTreeView{qproperty-TextColor:#e6e6e6;qproperty-SelectedTextColor:#fff;qproperty-SelectedItemBackground:#5385a6;qproperty-FolderTextColor:#9fdaff;qproperty-SelectedFolderTextColor:#fff;alternate-background-color:#393939;background-color:#343434;border:1 solid #272727}#FileDoesNotExistLabel{color:#f00}#SceneCast QToolBar{border-top:1 solid #272727}#SceneCast QToolButton{margin:3 1 2 1;padding:1}#CastBrowser{border:0;margin:0}#FilmStrip QComboBox{border-radius:0;border-width:0}#FilmStrip QComboBox QAbstractItemView{background-color:#484848}#CleanupSettings #CleanupSettingsFrame{margin-top:2;margin-bottom:4}#CleanupSettings QGroupBox{margin-bottom:3}ParamsPage{qproperty-TextColor:#e6e6e6}#CameraSettingsButton{padding:2}#CameraSettingsRadioButton:hover{background:none}#CameraSettingsRadioButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#CameraSettingsRadioButton::indicator:unchecked{image:url('imgs/white/lock_off.svg')}#CameraSettingsRadioButton::indicator:checked{background-color:#C34040;border-color:#C34040;image:url('imgs/white/lock_on.svg')}#CameraSettingsRadioButton::indicator:checked:hover{background-color:#d57a7a;border-color:#d57a7a}#CameraSettingsDPI{color:#9fdaff}#CameraSettingsRadioButton_Small{padding:0}#CameraSettingsRadioButton_Small::indicator{background-color:transparent;border:0;height:21;margin:0;width:11}#ForceSquaredPixelButton{height:16;border:1 solid rgba(255,255,255,0);image:url('imgs/white/fsp_unchecked.svg');padding:2;width:16;margin:0}#ForceSquaredPixelButton:checked{image:url('imgs/white/fsp_checked.svg')}#OutputSettingsLabel{color:#9fdaff}PencilTestPopup{min-height:730px;min-width:512px}#MatchLineButton{background-color:#6e6e6e}#MatchLineButton:checked{background-color:#949494;border:2 solid #5385a6;border-radius:2}#LargeSizedText{font-size:17px}#StartupLabel{padding:3}#StartupLabel:hover{background:#626262}QStatusBar{background-color:#c0c0c0}QStatusBar::item{border:0}QStatusBar QLabel{background-color:#c0c0c0}QStatusBar #StatusBarLabel{background-color:#fff;padding:1 3}#TitleTxtLabel{color:#9fdaff}#StyleEditor QPushButton{margin:2 1;padding:0}#StyleEditor #TabBarContainer{margin-left:-4}#StyleEditor #bottomWidget{border-top:1 solid #272727;padding:3 2 8 3}#StyleEditor #bottomWidget QPushButton{padding:3 5}#StyleEditorTabBar::tab::first{border-left:1 solid #272727}#HexagonalColorWheel{qproperty-BGColor:#484848}#colorSlider::groove:horizontal{height:1;border-image:none}#colorSlider::handle:horizontal{width:8;margin:-8 -4}#colorSliderAddButton,#colorSliderSubButton{background:none;border-color:transparent;image-position:center center;min-height:16;padding:0;min-width:18}#colorSliderAddButton{image:url('imgs/white/scroll-right.svg')}#colorSliderSubButton{image:url('imgs/white/scroll-left.svg')}#PlainColorPageParts{border-bottom:1 solid #272727}#PlainColorPageParts QLineEdit{max-width:35}PaletteViewer DvScrollWidget QPushButton{border-top:0;margin-bottom:1;max-width:15;min-width:15}PaletteViewer DvScrollWidget #ScrollLeftButton{border-radius:0;margin-bottom:1;max-width:16;min-width:16}PaletteViewer DvScrollWidget #ScrollRightButton{border-radius:0;margin-left:1;margin-bottom:1;max-width:16;min-width:16}PaletteViewer QToolBar{background:none;border-bottom:1 solid #272727;padding:0;margin:0}PaletteViewer QToolBar::separator:horizontal{margin:0}PaletteViewer QToolBar QToolButton{margin:0 0 1 0;padding:1 0 2 0}#PageViewer{qproperty-TextColor:#e6e6e6}#PaletteLockButton{border-radius:0;margin:0 0 1 1}#PaletteLockButton:checked{background-color:#C34040;border-color:#C34040}#PaletteLockButton:checked:hover{background-color:#d57a7a;border-color:#d57a7a}#WordButton{padding-right:0;padding-left:0}QDialog{background-color:#484848}QDialog #dialogButtonFrame{background-color:#3e3e3e;border-top:1 solid #272727}QDialog #dialogButtonFrame QPushButton{border-color:#3e3e3e;outline:0}QDialog #dialogButtonFrame QPushButton:focus{background-color:#5385a6;border-color:#3e3e3e;color:#fff}QDialog #dialogButtonFrame QPushButton:focus:hover{background-color:#6c98b6}QDialog #dialogButtonFrame QPushButton:focus:pressed{background-color:#313131;border-color:#2c2c2c;color:#f3f3f3}#SceneSettings QLabel{color:#9fdaff}#PreferencesPopup QListWidget{background-color:#343434;alternate-background-color:#343434;border:1 solid #272727;font-size:13px}#PreferencesPopup QListWidget::item{border:0;padding:3}#PreferencesPopup QListWidget::item:hover{color:#e6e6e6;background-color:rgba(255,255,255,0.15)}#PreferencesPopup QListWidget::item:selected{background-color:#5385a6;color:#fff}#ShortcutTree{border:1 solid #272727}#ShortcutTree::item{padding:1 0}#ShortcutTree QScrollBar:vertical{width:16;margin-right:-1}ProjectPopup QLabel{color:#9fdaff}#GearButton{qproperty-icon:url('imgs/white/gear.svg')}#SubfolderButton{qproperty-icon:url('imgs/white/subfolder.svg');padding-left:6px;padding-right:6px}#SubcameraButton{qproperty-icon:url('imgs/white/subcamera.svg');padding-left:6px;padding-right:6px}SchematicViewer{qproperty-TextColor:#e6e6e6;qproperty-VerticalLineColor:#222;qproperty-LevelColumnColor:#4C6E4C;qproperty-VectorColumnColor:#7B7B4C;qproperty-ChildColumnColor:#6A526B;qproperty-FullcolorColumnColor:#657A96;qproperty-FxColumnColor:#56553C;qproperty-PaletteColumnColor:#3A655F;qproperty-MeshColumnColor:#684D86;qproperty-ReferenceColumnColor:#616161;qproperty-TableColor:#62628c;qproperty-ActiveCameraColor:#2d7dca;qproperty-OtherCameraColor:#6c797b;qproperty-GroupColor:#3b6e9c;qproperty-PegColor:#9f6e3c;qproperty-SplineColor:#6a9d1c;qproperty-ActiveOutputColor:#2d7dca;qproperty-OtherOutputColor:#6c797b;qproperty-XsheetColor:#62628c;qproperty-NormalFxColor:#6a7e96;qproperty-MacroFxColor:#815c79;qproperty-ImageAdjustFxColor:#656287;qproperty-LayerBlendingFxColor:#4f757d;qproperty-MatteFxColor:#ae7171;qproperty-SchematicPreviewButtonBgOnColor:#c8c864;qproperty-SchematicPreviewButtonOnImage:url('imgs/white/x_prev_eye_on.svg');qproperty-SchematicPreviewButtonBgOffColor:#616161;qproperty-SchematicPreviewButtonOffImage:url('imgs/white/x_prev_eye_off.svg');qproperty-SchematicCamstandButtonBgOnColor:#eb906b;qproperty-SchematicCamstandButtonOnImage:url('imgs/white/x_table_view_on.svg');qproperty-SchematicCamstandButtonTranspImage:url('imgs/white/x_table_view_transp.svg');qproperty-SchematicCamstandButtonBgOffColor:#616161;qproperty-SchematicCamstandButtonOffImage:url('imgs/white/x_table_view_off.svg')}#SchematicBottomFrame{background-color:#484848;border:0;margin:0;padding:0}#SchematicBottomFrame QToolBar::separator:horizontal{margin:0}#SchematicBottomFrame QToolBar QToolButton{padding:0;margin:2}#SchematicSceneViewer{background-color:#3b3b3b;border-bottom:1 solid #272727}#FxSettingsTabBar::tab{border-top:1 solid #272727}#FxSettingsTabBar::tab::first,#FxSettingsTabBar::tab::only-one{border-left:1 solid #272727}FxSettings QToolBar{border-top:1 solid #272727;border-right:1 solid #272727;border-left:1 solid #272727;min-height:23;padding:3 0}FxSettings QToolBar QToolBar{border:0}#FxSettingsLabel{color:#a0e680}#FxSettingsHelpButton{background-color:#80a0dc;color:#000;padding-top:0;padding-bottom:0}#FxSettingsHelpButton:hover{background-color:#a8bee7}#ScriptConsole{font-family:'Courier New',monospace;border:0;color:#000000;padding:3}#ScriptConsole QFrame{background-color:#dcdcdc}#ScriptConsole TPanelTitleBar{background-color:#393939}#TaskSheetItemLabel{color:#e6e6e6}#Tasks QToolBar{border-bottom:1 solid #272727;margin:0;padding:0}#Tasks QToolBar QToolButton{margin:2 2 3 2}#ToolBar QToolBar{padding-left:2}#ToolOptions TPanelTitleBar{border-right:1 solid #272727;border-bottom:0}#CommandBar TPanelTitleBar{border-right:1 solid #272727;border-bottom:0}IconViewField{qproperty-ThicknessPixmap:url("imgs/white/selectiontool_thickness.svg")}#EditToolLockButton{spacing:0}#EditToolLockButton:hover{background:none}#EditToolLockButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#EditToolLockButton::indicator:unchecked{image:url('imgs/white/lock_off.svg')}#EditToolLockButton::indicator:checked{background-color:#C34040;border-color:#C34040;image:url('imgs/white/lock_on.svg')}#EditToolLockButton::indicator:checked:hover{background-color:#d57a7a;border-color:#d57a7a}PopupButton::menu-indicator{border-left:0;height:17;image:url('imgs/white/combo_downarrow.svg');width:10}PopupButton::menu-indicator:hover{image:url('imgs/white/combo_downarrow.svg')}PopupButton::menu-indicator:disabled{image:url('imgs/white/combo_downarrow_disabled.svg')}#Cap,#Join{padding:0 4 0 -8;max-width:32;min-width:32}#Cap QMenu,#Join QMenu{max-width:28;min-width:28}#Cap QMenu::item,#Join QMenu::item{max-width:28;min-width:28;padding:0}QToolBar#MediumPaddingToolBar QToolButton{padding-left:3;padding-right:3}QToolBar#WidePaddingToolBar QToolButton{padding-left:6;padding-right:6}#CommandBar{margin:0;padding:0;border:0}#CommandBar::separator:horizontal{margin-right:3;margin-left:3}#expandButton:checked{background-color:transparent;border-color:transparent;color:#e6e6e6}#expandButton:checked:hover{background-color:#767676;border-color:#767676}#expandButton:checked:pressed{background-color:#313131;border-color:#2c2c2c}#ComboViewerPanel Toolbar{border-bottom:1 solid #272727}#ComboViewerPanel Toolbar::separator:horizontal{margin:0 0 0 2}#ComboViewerPanel Toolbar QToolButton{margin:2 0 3 2}#ComboViewerToolOptions{border-bottom:1 solid #272727}#ComboViewer #ToolBarContainer,#ViewerPanel #ToolBarContainer,FlipBook #ToolBarContainer{background-color:transparent;border-top:2 solid #272727;border-bottom:1 solid #272727;padding-right:-1}#flipCustomize{margin-left:3}#flipCustomize::menu-button{background-color:transparent;width:35}#flipCustomize::menu-arrow{image:none}QToolBar#FlipConsolePlayToolBar::separator:horizontal{margin:0 3}QToolBar#FlipConsolePlayToolBar QToolButton{margin-top:2;margin-bottom:2;height:16;padding-left:1;padding-right:1}#ViewerFpsSlider{background-color:transparent;background-image:url('imgs/white/slider-groove.svg');background-position:center center;background-repeat:repeat-x;border:0;height:19;margin:0 3 0 37;max-width:300;min-width:0}#ViewerFpsSlider::sub-line:horizontal{subcontrol-origin:absolute;background-color:#696969;border:1 solid #484848;border-top-left-radius:2;border-bottom-left-radius:2;height:16;left:-33;width:14}#ViewerFpsSlider::add-line:horizontal{subcontrol-position:left;background-color:#696969;border:1 solid #484848;border-top-right-radius:2;border-bottom-right-radius:2;left:18;height:16;image-position:center center;width:13}#ViewerFpsSlider::handle::horizontal{background-color:#a1a1a1;border:1 solid #a1a1a1;border-radius:2;margin:2 0 3 0;min-width:9;width:9;max-width:9}FlipSlider{qproperty-PBHeight:15;qproperty-PBOverlay:url('imgs/white/flipslider.svg');qproperty-PBColorMarginLeft:1;qproperty-PBColorMarginTop:2;qproperty-PBColorMarginRight:1;qproperty-PBColorMarginBottom:2;qproperty-PBMarker:url('imgs/white/flipmarker.svg');qproperty-PBMarkerMarginLeft:3;qproperty-PBMarkerMarginRight:3;qproperty-notStartedColor:rgba(205,101,101,0.78);qproperty-startedColor:#1abc3f;qproperty-baseColor:#2f2f2f;qproperty-finishedColor:#2f2f2f}Ruler{qproperty-ParentBGColor:#484848;qproperty-ScaleColor:#e6e6e6}#RulerToolOptionValues{color:#000}#xsheetArea,#ScrollArea{background-color:#343434;border:0}#xsheetScrollArea{border:0}#cornerWidget QToolButton{padding:0}#xsheetColumnAreaMenu_Preview{background-color:#E6E678}#xsheetColumnAreaMenu_Lock{background-color:#F5F5F5}#xsheetColumnAreaMenu_Camstand{background-color:#FFA480}#xsheetColumnAreaMenu_Preview,#xsheetColumnAreaMenu_Lock,#xsheetColumnAreaMenu_Camstand{color:#000}#noteTextEdit{color:#000}XsheetViewer{qproperty-TextColor:#e6e6e6;qproperty-BGColor:#3b3b3b;qproperty-LightLineColor:#2c2c2c;qproperty-MarkerLineColor:#1E96C4;qproperty-VerticalLineColor:#222;qproperty-VerticalLineHeadColor:#808080;qproperty-PreviewFrameTextColor:#9fdaff;qproperty-CurrentRowBgColor:#506082;qproperty-OnionSkinAreaBgColor:#363636;qproperty-EmptyColumnHeadColor:#626262;qproperty-SelectedColumnTextColor:#E66464;qproperty-EmptyCellColor:#404040;qproperty-NotEmptyColumnColor:#484848;qproperty-SelectedEmptyCellColor:#6c6c6c;qproperty-LevelColumnColor:#4C6E4C;qproperty-LevelColumnBorderColor:#8FB38F;qproperty-SelectedLevelColumnColor:#678667;qproperty-VectorColumnColor:#7B7B4C;qproperty-VectorColumnBorderColor:#BBBB9A;qproperty-SelectedVectorColumnColor:#949466;qproperty-ChildColumnColor:#6A526B;qproperty-ChildColumnBorderColor:#B1A3B3;qproperty-SelectedChildColumnColor:#816e82;qproperty-FullcolorColumnColor:#657A96;qproperty-FullcolorColumnBorderColor:#9EB8BB;qproperty-SelectedFullcolorColumnColor:#8895a6;qproperty-FxColumnColor:#56553C;qproperty-FxColumnBorderColor:#95958A;qproperty-SelectedFxColumnColor:#6f6e56;qproperty-ReferenceColumnColor:#616161;qproperty-ReferenceColumnBorderColor:#A2A2A2;qproperty-SelectedReferenceColumnColor:#7a7a7a;qproperty-PaletteColumnColor:#3A655F;qproperty-PaletteColumnBorderColor:#86ACA7;qproperty-SelectedPaletteColumnColor:#52807a;qproperty-MeshColumnColor:#684D86;qproperty-MeshColumnBorderColor:#BA92EF;qproperty-SelectedMeshColumnColor:#82689e;qproperty-SoundTextColumnColor:#c8c8c8;qproperty-SoundTextColumnBorderColor:#8c8c8c;qproperty-SelectedSoundTextColumnColor:#e2e2e2;qproperty-SoundColumnColor:#657456;qproperty-SoundColumnBorderColor:#A0AF7D;qproperty-SelectedSoundColumnColor:#7e8b72;qproperty-SoundColumnHlColor:#34FE5E;qproperty-SoundColumnTrackColor:#B6C29D;qproperty-ColumnHeadPastelizer:#000;qproperty-SelectedColumnHead:#506082;qproperty-LightLightBGColor:#404040;qproperty-LightBGColor:#f0f0f0;qproperty-DarkBGColor:#e1e1e1;qproperty-DarkLineColor:#969696;qproperty-XsheetColumnNameBgColor:rgba(0,0,0,0);qproperty-XsheetDragBarHighlightColor:rgba(255,255,255,0.5);qproperty-XsheetPreviewButtonBgOnColor:#c8c864;qproperty-XsheetPreviewButtonOnImage:url('imgs/white/x_prev_eye_on.svg');qproperty-XsheetPreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetPreviewButtonOffImage:url('imgs/white/x_prev_eye_off.svg');qproperty-XsheetCamstandButtonBgOnColor:#eb906b;qproperty-XsheetCamstandButtonOnImage:url('imgs/white/x_table_view_on.svg');qproperty-XsheetCamstandButtonTranspImage:url('imgs/white/x_table_view_transp.svg');qproperty-XsheetCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetCamstandButtonOffImage:url('imgs/white/x_table_view_off.svg');qproperty-XsheetLockButtonBgOnColor:rgba(255,255,255,0.3);qproperty-XsheetLockButtonOnImage:url('imgs/white/x_lock_on.svg');qproperty-XsheetLockButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetLockButtonOffImage:url('imgs/white/x_lock_off.svg');qproperty-XsheetConfigButtonBgColor:rgba(255,255,255,0);qproperty-XsheetConfigButtonImage:url('imgs/white/x_config.svg');qproperty-TimelinePreviewButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOnImage:url('imgs/white/timeline_toggle_on.svg');qproperty-TimelinePreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOffImage:url('imgs/white/timeline_toggle_off.svg');qproperty-TimelineCamstandButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOnImage:url('imgs/white/timeline_toggle_on.svg');qproperty-TimelineCamstandButtonTranspImage:url('imgs/white/timeline_toggle_transp.svg');qproperty-TimelineCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOffImage:url('imgs/white/timeline_toggle_off.svg');qproperty-TimelineLockButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOnImage:url('imgs/white/timeline_toggle_on.svg');qproperty-TimelineLockButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOffImage:url('imgs/white/timeline_toggle_off.svg');qproperty-TimelineConfigButtonBgColor:rgba(255,255,255,0);qproperty-TimelineConfigButtonImage:url('imgs/white/timeline_config.svg');qproperty-LayerHeaderPreviewImage:url('imgs/white/layer_header_prev_eye.svg');qproperty-LayerHeaderPreviewOverImage:url('imgs/white/layer_header_prev_eye_over.svg');qproperty-LayerHeaderCamstandImage:url('imgs/white/layer_header_table_view.svg');qproperty-LayerHeaderCamstandOverImage:url('imgs/white/layer_header_table_view_over.svg');qproperty-LayerHeaderLockImage:url('imgs/white/lock_on.svg');qproperty-LayerHeaderLockOverImage:url('imgs/white/lock_on_over.svg');qproperty-ActiveCameraColor:#2d7dca;qproperty-SelectedActiveCameraColor:#5796d3;qproperty-OtherCameraColor:#6c797b;qproperty-SelectedOtherCameraColor:#8b8e8f}#XSheetToolbar{margin:0;padding:0;border:0}#XSheetToolbar QToolButton{padding:0;margin:4 1;min-height:19;height:19}#XSheetToolbar::separator:horizontal{margin:0 4}#FunctionEditor QToolBar{border-bottom:1 solid #272727}#FunctionEditor QToolBar QToolBar{border:0}#FunctionEditor QToolBar QLabel{margin-left:5}#FunctionEditor QToolBar QToolButton{height:18}#FunctionEditorTree{border-top:1 solid #272727}FunctionTreeView{qproperty-TextColor:#e6e6e6;qproperty-CurrentTextColor:#E66464}FunctionPanel{qproperty-BGColor:#3b3b3b;qproperty-ValueLineColor:#2f2f2f;qproperty-FrameLineColor:#2f2f2f;qproperty-OtherCurvesColor:#888;qproperty-RulerBackground:#333;qproperty-TextColor:#e6e6e6;qproperty-SubColor:#000;qproperty-SelectedColor:#FFA500}SpreadsheetViewer{qproperty-LightLightBGColor:#404040;qproperty-CurrentRowBgColor:#506082;qproperty-LightLineColor:#2c2c2c;qproperty-MarkerLineColor:#1E96C4;qproperty-BGColor:#484848;qproperty-VerticalLineColor:#222;qproperty-KeyFrameColor:#995d1d;qproperty-KeyFrameBorderColor:#c9b04b;qproperty-SelectedKeyFrameColor:#be772b;qproperty-InBetweenColor:#666250;qproperty-InBetweenBorderColor:#cdcec8;qproperty-SelectedInBetweenColor:#7d7a6c;qproperty-SelectedEmptyColor:#6c6c6c;qproperty-SelectedSceneRangeEmptyColor:#757575;qproperty-TextColor:#e6e6e6;qproperty-ColumnHeaderBorderColor:#808080;qproperty-SelectedColumnTextColor:#E66464}#ExpressionField{background-color:#e6e6e6;border:1 solid #333;margin:0}#FunctionSegmentViewerLinkButton{background-image:url('imgs/white/segment_unlinked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:hover{background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:checked{background-image:url('imgs/white/segment_linked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:disabled{background-image:url('imgs/white/segment_disabled.svg');background-repeat:no-repeat}
+/* -----------------------------------------------------------------------------
+   Component: Button Styles
+----------------------------------------------------------------------------- */
+.button-show,
+#LoadLevelShowButton,
+#CleanupSettingsShowButton,
+#OutputSettingsShowButton,
+#FxSettingsPreviewShowButton {
+  image: url('imgs/white/plus.svg');
+  image-position: center center;
+  margin: 0;
+  padding: 1;
+  min-width: 10;
+  min-height: 10;
+}
+.button-show:checked,
+#LoadLevelShowButton:checked,
+#CleanupSettingsShowButton:checked,
+#OutputSettingsShowButton:checked,
+#FxSettingsPreviewShowButton:checked {
+  background-color: #313131;
+  border-color: #2c2c2c;
+  image: url('imgs/white/minus.svg');
+}
+.button-show:checked:pressed,
+#LoadLevelShowButton:checked:pressed,
+#CleanupSettingsShowButton:checked:pressed,
+#OutputSettingsShowButton:checked:pressed,
+#FxSettingsPreviewShowButton:checked:pressed {
+  background-color: #313131;
+  border-color: #2c2c2c;
+}
+.button-show:checked:hover,
+#LoadLevelShowButton:checked:hover,
+#CleanupSettingsShowButton:checked:hover,
+#OutputSettingsShowButton:checked:hover,
+#FxSettingsPreviewShowButton:checked:hover {
+  background-color: #363636;
+}
+.button-tool,
+QToolButton,
+#CameraSettingsRadioButton::indicator,
+#ForceSquaredPixelButton,
+#SchematicBottomFrame QToolBar QToolButton,
+#EditToolLockButton::indicator,
+#flipCustomize {
+  background-color: rgba(255, 255, 255, 0);
+  border: 1 solid rgba(255, 255, 255, 0);
+  border-radius: 2;
+  color: #f3f3f3;
+  margin: 1;
+  padding: 0;
+}
+.button-tool:hover,
+QToolButton:hover,
+#CameraSettingsRadioButton::indicator:hover,
+#ForceSquaredPixelButton:hover,
+#colorSliderAddButton:hover,
+#colorSliderSubButton:hover,
+#SchematicBottomFrame QToolBar QToolButton:hover,
+#EditToolLockButton::indicator:hover,
+#flipCustomize:hover {
+  background-color: #767676;
+  border-color: #767676;
+  color: #f3f3f3;
+}
+.button-tool:pressed,
+QToolButton:pressed,
+#CameraSettingsRadioButton::indicator:pressed,
+#ForceSquaredPixelButton:pressed,
+#colorSliderAddButton:pressed,
+#colorSliderSubButton:pressed,
+#SchematicBottomFrame QToolBar QToolButton:pressed,
+#EditToolLockButton::indicator:pressed,
+#flipCustomize:pressed {
+  background-color: #313131;
+  border-color: #2c2c2c;
+  color: #f3f3f3;
+}
+.button-tool:checked,
+QToolButton:checked,
+#CameraSettingsRadioButton::indicator:checked,
+#ForceSquaredPixelButton:checked,
+#SchematicBottomFrame QToolBar QToolButton:checked,
+#EditToolLockButton::indicator:checked,
+#flipCustomize:checked {
+  background-color: #5385a6;
+  border-color: #5385a6;
+  color: #ffffff;
+}
+.button-tool:checked:hover,
+QToolButton:checked:hover,
+#CameraSettingsRadioButton::indicator:checked:hover,
+#ForceSquaredPixelButton:checked:hover,
+#SchematicBottomFrame QToolBar QToolButton:checked:hover,
+#EditToolLockButton::indicator:checked:hover,
+#flipCustomize:checked:hover {
+  background-color: #6c98b6;
+  border-color: #6c98b6;
+}
+.button-tool:disabled,
+QToolButton:disabled,
+#CameraSettingsRadioButton::indicator:disabled,
+#ForceSquaredPixelButton:disabled,
+#SchematicBottomFrame QToolBar QToolButton:disabled,
+#EditToolLockButton::indicator:disabled,
+#flipCustomize:disabled {
+  color: #808080;
+}
+.button-flat,
+PaletteViewer QToolBar QToolButton {
+  background-color: none;
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+}
+.button-flat:hover,
+PaletteViewer QToolBar QToolButton:hover {
+  background-color: #767676;
+}
+.button-flat:pressed,
+PaletteViewer QToolBar QToolButton:pressed {
+  background-color: #272727;
+}
+/* -----------------------------------------------------------------------------
+   Component: Frames
+----------------------------------------------------------------------------- */
+.frame,
+.GroupBox,
+#LoadLevelFrame,
+#PsdSettingsGroupBox,
+#CleanupSettingsFrame,
+#OutputSettingsBox,
+#OutputSettingsCameraBox,
+#SolidLineFrame,
+#FunctionParametersPanel,
+QGroupBox {
+  border: 1 solid #272727;
+  border-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Component: Icons
+----------------------------------------------------------------------------- */
+/* -----------------------------------------------------------------------------
+   Component: Tabs
+----------------------------------------------------------------------------- */
+.tab-container,
+#TabBarContainer {
+  background-color: transparent;
+  qproperty-BottomAboveLineColor: #393939;
+  qproperty-BottomBelowLineColor: #272727;
+}
+.tab-flat,
+#StyleEditorTabBar::tab,
+#PaletteTabBar::tab,
+#FxSettingsTabBar::tab {
+  background-color: #393939;
+  border-right: 1 solid #272727;
+  border-bottom: 1 solid #272727;
+  color: #a1a1a1;
+  padding: 3 4 3 4;
+}
+.tab-flat:hover,
+#StyleEditorTabBar::tab:hover,
+#PaletteTabBar::tab:hover,
+#FxSettingsTabBar::tab:hover {
+  background-color: #484848;
+  color: #a1a1a1;
+}
+.tab-flat:selected,
+#StyleEditorTabBar::tab:selected,
+#PaletteTabBar::tab:selected,
+#FxSettingsTabBar::tab:selected {
+  background-color: #484848;
+  color: #ffffff;
+  border-bottom-color: #484848;
+}
+.tab-flat:only-one,
+#StyleEditorTabBar::tab:only-one,
+#PaletteTabBar::tab:only-one,
+#FxSettingsTabBar::tab:only-one {
+  margin: 0;
+}
+.tab-round {
+  background-color: #393939;
+  border-top: 1 solid #272727;
+  border-right: 1 solid #272727;
+  border-left: 1 solid #272727;
+  border-bottom: 1 solid #272727;
+  color: #a1a1a1;
+  margin: 3 -1 0 0;
+  padding: 2 7 1 7;
+}
+.tab-round:hover {
+  background-color: #484848;
+  color: #a1a1a1;
+}
+.tab-round:selected {
+  background-color: #484848;
+  border-top-right-radius: 2;
+  border-top-left-radius: 2;
+  border-bottom-color: #484848;
+  color: #ffffff;
+  margin: 1 -1 -1 0;
+  padding: 2 7 2 7;
+}
+.tab-round:only-one {
+  margin: 1 0 0 0;
+  padding: 3 7 3 7;
+}
+.tab-round:last {
+  margin-right: 0;
+  border-top-right-radius: 2;
+}
+.tab-round:first {
+  border-top-left-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Main
+----------------------------------------------------------------------------- */
+QWidget {
+  background-color: #484848;
+  color: #e6e6e6;
+}
+QWidget:disabled {
+  color: #808080;
+}
+QFrame {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QToolTip,
+#helpToolTip {
+  background-color: #fff;
+  border: 1 solid #000;
+  color: #000;
+  padding: 1 1;
+}
+#DockSeparator,
+QMainWindow::separator,
+QSplitter::handle {
+  background-color: #1a1a1a;
+  height: 4;
+  width: 4;
+}
+#TDockPlaceholder {
+  background-color: #F77272;
+}
+TPanel {
+  background-color: #1a1a1a;
+}
+/* -----------------------------------------------------------------------------
+   Topbar
+----------------------------------------------------------------------------- */
+#TopBar {
+  background: #484848;
+  border: 0;
+  border-bottom: 1 solid #272727;
+  height: 21;
+}
+#TopBar #EditToolLockButton {
+  background: #484848;
+  spacing: 0;
+}
+#TopBar #EditToolLockButton::indicator {
+  background: none;
+  border: none;
+  height: 18;
+  margin: 1 2 0 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+#TopBarTabContainer {
+  background-color: #484848;
+  margin-bottom: 1;
+}
+#StackedMenuBar {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QMenuBar {
+  background-color: #484848;
+  border: 0;
+}
+QMenuBar::item {
+  background-color: #484848;
+  border-left: 1 solid #484848;
+  margin: 0;
+  padding: 3 5;
+}
+QMenuBar::item:selected {
+  background-color: rgba(255, 255, 255, 0.15);
+  color: #e6e6e6;
+}
+QMenuBar::item:pressed {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Workspaces
+----------------------------------------------------------------------------- */
+#TopBarTab {
+  margin: 0;
+  padding: 0;
+}
+#TopBarTab::tab {
+  background-color: #393939;
+  border-top: 1 solid #272727;
+  border-right: 1 solid #272727;
+  color: #a1a1a1;
+  margin: 0 0 0 0;
+  padding: 2 8 3 8;
+}
+#TopBarTab::tab:hover {
+  background-color: #484848;
+  color: #a1a1a1;
+}
+#TopBarTab::tab:selected {
+  background-color: #484848;
+  color: #ffffff;
+}
+#TopBarTab::tab:first {
+  border-left: 1 solid #272727;
+}
+#TopBarTab::tab:last {
+  border-right: 1 solid #272727;
+}
+/* -----------------------------------------------------------------------------
+   Menu
+----------------------------------------------------------------------------- */
+QMenu {
+  background-color: #484848;
+  border: 1 solid #272727;
+  padding: 2 0;
+}
+QMenu::item {
+  padding: 3 28;
+}
+QMenu::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+QMenu::item:checked {
+  color: #e6e6e6;
+}
+QMenu::item:checked:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+QMenu::item:disabled {
+  background: none;
+  color: #808080;
+}
+QMenu::item:disabled:selected {
+  border-color: transparent;
+}
+QMenu::separator {
+  border-top: 1 solid #272727;
+  height: 0;
+  margin: 2 0;
+}
+QMenu::icon {
+  border-radius: 2;
+  margin: 0 0 0 3;
+  padding: 1;
+}
+QMenu::icon:checked {
+  background-color: #5385a6;
+}
+QMenu::indicator {
+  margin-left: 7;
+}
+/* -----------------------------------------------------------------------------
+   Titlebars
+----------------------------------------------------------------------------- */
+TPanelTitleBar {
+  background-color: #393939;
+  border-color: #272727;
+  border-style: solid;
+  border-width: 0 0 1 0;
+  height: 20;
+  min-height: 20;
+  qproperty-TitleColor: #949494;
+  qproperty-ActiveTitleColor: #fff;
+  qproperty-BorderPixmap: url('none');
+  qproperty-ActiveBorderPixmap: url('imgs/white/none');
+  qproperty-FloatBorderPixmap: url('none');
+  qproperty-FloatActiveBorderPixmap: url('imgs/white/none');
+}
+/* -----------------------------------------------------------------------------
+   Scrollbars
+----------------------------------------------------------------------------- */
+QAbstractScrollArea::corner {
+  background-color: #343434;
+}
+QScrollBar {
+  background-color: #343434;
+  border: 0;
+}
+QScrollBar:horizontal {
+  height: 16;
+  margin: 0;
+}
+QScrollBar:vertical {
+  margin: 0;
+  width: 16;
+}
+QScrollBar::handle {
+  border: 1 solid #525252;
+  border-radius: 4;
+}
+QScrollBar::handle:horizontal:hover,
+QScrollBar::handle:vertical:hover {
+  background-color: #676767;
+  border-color: #676767;
+}
+QScrollBar::handle:horizontal:pressed,
+QScrollBar::handle:vertical:pressed {
+  background-color: #7b7b7b;
+  border-color: #7b7b7b;
+}
+QScrollBar::handle:horizontal {
+  background-color: #525252;
+  margin: 3 16;
+  min-width: 20;
+}
+QScrollBar::handle:vertical {
+  background-color: #525252;
+  margin: 16 3;
+  min-height: 20;
+}
+QScrollBar::add-line {
+  subcontrol-origin: margin;
+  border: 0;
+}
+QScrollBar::add-line:horizontal {
+  subcontrol-position: right;
+  background-color: #343434;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::add-line:vertical {
+  subcontrol-position: bottom;
+  background-color: #343434;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::sub-line {
+  border: 0;
+  subcontrol-origin: margin;
+}
+QScrollBar::sub-line:horizontal {
+  subcontrol-position: left;
+  background-color: #343434;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::sub-line:vertical {
+  subcontrol-position: top;
+  background-color: #343434;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::up-arrow:vertical {
+  image: url('imgs/white/scroll-up.svg');
+  image-position: center center;
+}
+QScrollBar::up-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::down-arrow:vertical {
+  image: url('imgs/white/scroll-down.svg');
+  image-position: center center;
+}
+QScrollBar::down-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::left-arrow:horizontal {
+  image: url('imgs/white/scroll-left.svg');
+  image-position: center center;
+}
+QScrollBar::left-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::right-arrow:horizontal {
+  image: url('imgs/white/scroll-right.svg');
+  image-position: center center;
+}
+QScrollBar::right-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::sub-page:horizontal,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:vertical,
+QScrollBar::add-page:vertical {
+  background: none;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bars
+----------------------------------------------------------------------------- */
+QToolBar {
+  padding: 0;
+}
+QToolBar::separator:horizontal {
+  border-left: 1 solid #272727;
+  margin: 0 1;
+  width: 0;
+}
+QToolBar::separator:vertical {
+  border-top: 1 solid #272727;
+  height: 0;
+  margin: 1 0;
+}
+QToolBar QLabel {
+  margin-top: 1;
+}
+QToolBar QToolBar {
+  border: 0;
+}
+QToolButton::menu-indicator {
+  image: none;
+}
+QToolButton::menu-button {
+  border-image: none;
+}
+/* -------------------------------------------------------------------------- */
+/* Scrollable QToolBar Buttons
+/* -------------------------------------------------------------------------- */
+.DvScrollWidget QPushButton,
+DvScrollWidget QPushButton,
+#ScrollLeftButton QPushButton,
+#ScrollRightButton QPushButton,
+#ScrollUpButton QPushButton,
+#ScrollDownButton QPushButton {
+  background-color: #696969;
+  border: 0 solid red;
+  border-radius: 0;
+  padding: 0;
+  max-width: 16;
+}
+.DvScrollWidget QPushButton:hover,
+DvScrollWidget QPushButton:hover,
+#ScrollLeftButton QPushButton:hover,
+#ScrollRightButton QPushButton:hover,
+#ScrollUpButton QPushButton:hover,
+#ScrollDownButton QPushButton:hover {
+  background-color: #767676;
+}
+.DvScrollWidget QPushButton:pressed,
+DvScrollWidget QPushButton:pressed,
+#ScrollLeftButton QPushButton:pressed,
+#ScrollRightButton QPushButton:pressed,
+#ScrollUpButton QPushButton:pressed,
+#ScrollDownButton QPushButton:pressed {
+  background-color: #313131;
+}
+#ScrollLeftButton,
+#ScrollRightButton,
+#ScrollUpButton,
+#ScrollDownButton {
+  margin: 0;
+  min-width: 16;
+}
+#ScrollLeftButton {
+  border-right: 1 solid #272727;
+  image: url('imgs/white/scroll-left.svg');
+}
+#ScrollRightButton {
+  border-left: 1 solid #272727;
+  margin-left: 3;
+  image: url('imgs/white/scroll-right.svg');
+}
+#ScrollUpButton {
+  image: url('imgs/white/scroll-up.svg');
+}
+#ScrollDownButton {
+  image: url('imgs/white/scroll-down.svg');
+}
+/* -------------------------------------------------------------------------- */
+#keyFrameNavigator {
+  background: none;
+  margin: 0;
+  padding: 0;
+}
+#keyFrameNavigator QToolButton {
+  min-width: 18;
+}
+#keyFrameNavigator #PreviousKey {
+  image: url('imgs/white/prevkey.svg');
+}
+#keyFrameNavigator #PreviousKey:hover {
+  image: url('imgs/white/prevkey_over.svg');
+}
+#keyFrameNavigator #PreviousKey:disabled {
+  image: url('imgs/white/prevkey_disabled.svg');
+}
+#keyFrameNavigator #NextKey {
+  image: url('imgs/white/nextkey.svg');
+}
+#keyFrameNavigator #NextKey:hover {
+  image: url('imgs/white/nextkey_over.svg');
+}
+#keyFrameNavigator #NextKey:disabled {
+  image: url('imgs/white/nextkey_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Trees
+----------------------------------------------------------------------------- */
+.treeview,
+QTreeWidget,
+QTreeView,
+#FunctionEditorTree {
+  background-color: #343434;
+  alternate-background-color: #393939;
+  border: 0;
+  margin: 0;
+  outline: 0;
+}
+.treeview::item:selected,
+QTreeWidget::item:selected,
+QTreeView::item:selected,
+#FunctionEditorTree::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+.treeview::branch:adjoins-item,
+QTreeWidget::branch:adjoins-item,
+QTreeView::branch:adjoins-item,
+#FunctionEditorTree::branch:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-siblings,
+QTreeWidget::branch:has-siblings,
+QTreeView::branch:has-siblings,
+#FunctionEditorTree::branch:has-siblings {
+  border-image: url('');
+}
+.treeview::branch:has-siblings:adjoins-item,
+QTreeWidget::branch:has-siblings:adjoins-item,
+QTreeView::branch:has-siblings:adjoins-item,
+#FunctionEditorTree::branch:has-siblings:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-children:closed,
+QTreeWidget::branch:has-children:closed,
+QTreeView::branch:has-children:closed,
+#FunctionEditorTree::branch:has-children:closed {
+  background: url('imgs/white/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:open,
+QTreeWidget::branch:has-children:open,
+QTreeView::branch:has-children:open,
+#FunctionEditorTree::branch:has-children:open {
+  background: url('imgs/white/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:closed,
+QTreeWidget::branch:has-children:has-siblings:closed,
+QTreeView::branch:has-children:has-siblings:closed,
+#FunctionEditorTree::branch:has-children:has-siblings:closed {
+  background: url('imgs/white/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:open,
+QTreeWidget::branch:has-children:has-siblings:open,
+QTreeView::branch:has-children:has-siblings:open,
+#FunctionEditorTree::branch:has-children:has-siblings:open {
+  background: url('imgs/white/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+QListView {
+  outline: 0;
+  background: #343434;
+  alternate-background-color: #393939;
+}
+/* -----------------------------------------------------------------------------
+   Tab Systems
+----------------------------------------------------------------------------- */
+#TabBarContainer {
+  background-color: #393939;
+}
+/* -----------------------------------------------------------------------------
+   Push Button
+----------------------------------------------------------------------------- */
+.Button,
+QPushButton,
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  background-color: #696969;
+  border: 1 solid #484848;
+  border-radius: 2;
+  color: #f3f3f3;
+  margin: 0;
+  padding: 3 15;
+}
+.Button:hover,
+QPushButton:hover,
+.ComboBox:hover,
+#ViewerFpsSlider::sub-line:horizontal:hover,
+#ViewerFpsSlider::add-line:horizontal:hover,
+QComboBox:hover {
+  background-color: #767676;
+  border-color: #484848;
+  color: #f3f3f3;
+}
+.Button:pressed,
+QPushButton:pressed,
+#ViewerFpsSlider::sub-line:horizontal:pressed,
+#ViewerFpsSlider::add-line:horizontal:pressed {
+  background-color: #313131;
+  border-color: #2c2c2c;
+  color: #f3f3f3;
+}
+.Button:checked,
+QPushButton:checked {
+  background-color: #313131;
+  border-color: #2c2c2c;
+  color: #f3f3f3;
+}
+.Button:checked:hover,
+QPushButton:checked:hover {
+  background-color: #363636;
+}
+.Button:checked:hover:pressed,
+QPushButton:checked:hover:pressed {
+  background: #313131;
+}
+.Button:disabled,
+QPushButton:disabled,
+.ComboBox:disabled,
+#ViewerFpsSlider::sub-line:horizontal:disabled,
+#ViewerFpsSlider::add-line:horizontal:disabled,
+QComboBox:disabled {
+  background-color: #555555;
+  border-color: #484848;
+  color: #808080;
+}
+#PushButton_NoPadding {
+  padding: 3;
+}
+/* -----------------------------------------------------------------------------
+   Combo Box
+----------------------------------------------------------------------------- */
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  padding: 1 0 1 4;
+  margin: 1 0;
+}
+.ComboBox::drop-down,
+QComboBox::drop-down {
+  image: url('imgs/white/combo_downarrow.svg');
+  image-position: center center;
+  width: 16;
+}
+.ComboBox::drop-down:disabled,
+QComboBox::drop-down:disabled {
+  image: url('imgs/white/combo_downarrow_disabled.svg');
+}
+.ComboBox QAbstractItemView,
+QComboBox QAbstractItemView {
+  background-color: #484848;
+  border: 1 solid #272727;
+  selection-background-color: #5385a6;
+  selection-color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Textfield
+----------------------------------------------------------------------------- */
+.LineEdit,
+QPlainTextEdit,
+QLineEdit,
+#TaskSheetItem,
+#tasksRemoveBox,
+#tasksAddBox {
+  background-color: #2f2f2f;
+  border: 1 solid #2c2c2c;
+  border-radius: 2;
+  color: #e6e6e6;
+  selection-background-color: #5385a6;
+  selection-color: #ffffff;
+  padding: 0 0 0 1;
+}
+.LineEdit:focus,
+QPlainTextEdit:focus,
+QLineEdit:focus,
+#TaskSheetItem:focus,
+#tasksRemoveBox:focus,
+#tasksAddBox:focus {
+  background-color: #2f2f2f;
+  border-color: #5385a6;
+  color: #e6e6e6;
+}
+.LineEdit:disabled,
+QPlainTextEdit:disabled,
+QLineEdit:disabled,
+#TaskSheetItem:disabled,
+#tasksRemoveBox:disabled,
+#tasksAddBox:disabled {
+  background-color: #3b3b3b;
+  border-color: #3a3a3a;
+  color: #808080;
+}
+/* -----------------------------------------------------------------------------
+   CheckBox
+----------------------------------------------------------------------------- */
+.CheckBox,
+QCheckBox {
+  color: #e6e6e6;
+}
+.CheckBox:hover,
+QCheckBox:hover,
+.RadioButton:hover,
+QRadioButton:hover {
+  color: #ffffff;
+}
+.CheckBox:disabled,
+QCheckBox:disabled {
+  color: #808080;
+}
+.CheckBox::indicator,
+QMenu::indicator,
+QCheckBox::indicator,
+.GroupBox::indicator,
+QGroupBox::indicator {
+  background-color: #2f2f2f;
+  border: 1 solid #2c2c2c;
+  border-radius: 2;
+  height: 9;
+  /* fix for QGroupBox */
+  padding: 1;
+  width: 9;
+  /* fix for QMenu */
+}
+.CheckBox::indicator:hover,
+QMenu::indicator:hover,
+.CheckBox::indicator:checked:hover,
+.CheckBox::indicator:indeterminate:hover,
+QCheckBox::indicator:hover,
+.GroupBox::indicator:hover,
+QMenu::indicator:checked:hover,
+QMenu::indicator:indeterminate:hover,
+QCheckBox::indicator:checked:hover,
+QCheckBox::indicator:indeterminate:hover,
+.GroupBox::indicator:checked:hover,
+.GroupBox::indicator:indeterminate:hover,
+QGroupBox::indicator:hover,
+QGroupBox::indicator:checked:hover,
+QGroupBox::indicator:indeterminate:hover {
+  background-color: #2f2f2f;
+  border-color: #5385a6;
+}
+.CheckBox::indicator:checked,
+QMenu::indicator:checked,
+QCheckBox::indicator:checked,
+.GroupBox::indicator:checked,
+QGroupBox::indicator:checked {
+  background-color: #2f2f2f;
+  border-color: #2c2c2c;
+  image: url('imgs/white/checkmark.svg');
+}
+.CheckBox::indicator:checked:disabled,
+QMenu::indicator:checked:disabled,
+QCheckBox::indicator:checked:disabled,
+.GroupBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
+  background-color: #3b3b3b;
+  border-color: #3b3b3b;
+  image: url('imgs/white/checkmark_disabled.svg');
+}
+.CheckBox::indicator:indeterminate,
+QMenu::indicator:indeterminate,
+QCheckBox::indicator:indeterminate,
+.GroupBox::indicator:indeterminate,
+QGroupBox::indicator:indeterminate {
+  background-color: #2f2f2f;
+  border-color: #2c2c2c;
+  image: url('imgs/white/checkpartially.svg');
+}
+.CheckBox::indicator:indeterminate:disabled,
+QMenu::indicator:indeterminate:disabled,
+QCheckBox::indicator:indeterminate:disabled,
+.GroupBox::indicator:indeterminate:disabled,
+QGroupBox::indicator:indeterminate:disabled {
+  background-color: #3b3b3b;
+  border-color: #3b3b3b;
+  image: url('imgs/white/checkpartially_disabled.svg');
+}
+.CheckBox::indicator:disabled,
+QMenu::indicator:disabled,
+QCheckBox::indicator:disabled,
+.GroupBox::indicator:disabled,
+QGroupBox::indicator:disabled {
+  background-color: #3b3b3b;
+  border-color: #3b3b3b;
+}
+/* -----------------------------------------------------------------------------
+   Radio Button
+----------------------------------------------------------------------------- */
+.RadioButton::indicator:unchecked,
+QRadioButton::indicator:unchecked,
+#CameraSettingsRadioButton_Small::indicator:unchecked {
+  image: url('imgs/white/radiobutton_unchecked.svg');
+  image-position: center center;
+}
+.RadioButton::indicator:checked,
+QRadioButton::indicator:checked,
+#CameraSettingsRadioButton_Small::indicator:checked {
+  image: url('imgs/white/radiobutton_checked.svg');
+  image-position: center center;
+}
+/* -----------------------------------------------------------------------------
+   GroupBox
+----------------------------------------------------------------------------- */
+.GroupBox,
+QGroupBox {
+  margin: 6 0 0 0;
+  padding: 5 0;
+}
+.GroupBox::title,
+QGroupBox::title {
+  subcontrol-origin: margin;
+  left: 15;
+  margin: -3 0 0 0;
+  padding: 0 3;
+}
+.GroupBox::title:hover,
+QGroupBox::title:hover {
+  color: #ffffff;
+}
+.GroupBox::title:disabled,
+QGroupBox::title:disabled {
+  color: #808080;
+}
+.GroupBox::indicator,
+QGroupBox::indicator {
+  subcontrol-origin: margin;
+  margin-top: 2;
+}
+.GroupBox:disabled,
+QGroupBox:disabled {
+  color: #808080;
+}
+/* -----------------------------------------------------------------------------
+   Slider
+----------------------------------------------------------------------------- */
+.Slider::groove:horizontal,
+QSlider::groove:horizontal {
+  background-color: transparent;
+  background-image: url('imgs/white/slider-groove.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  margin: 0;
+  height: 20;
+  min-height: 20;
+}
+.Slider::groove:horizontal:disabled,
+QSlider::groove:horizontal:disabled {
+  background-image: url('imgs/white/slider-groove_disabled.svg');
+}
+.Slider::handle:horizontal,
+QSlider::handle:horizontal {
+  width: 10;
+  margin: -2 -1;
+  image: url('imgs/white/slider-handle.svg');
+}
+.Slider::handle:horizontal:disabled,
+QSlider::handle:horizontal:disabled {
+  image: url('imgs/white/slider-handle_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Double Slider
+----------------------------------------------------------------------------- */
+#IntPairField,
+#DoublePairField {
+  qproperty-LightLineColor: #2c2c2c;
+  qproperty-LightLineEdgeColor: #2c2c2c;
+  qproperty-DarkLineColor: #2c2c2c;
+  qproperty-MiddleLineColor: #2c2c2c;
+  qproperty-HandleLeftPixmap: url("imgs/white/slider-handle.svg");
+  qproperty-HandleRightPixmap: url("imgs/white/slider-handle.svg");
+  qproperty-HandleLeftGrayPixmap: url("imgs/white/slider-handle_disabled.svg");
+  qproperty-HandleRightGrayPixmap: url("imgs/white/slider-handle_disabled.svg");
+}
+/* -----------------------------------------------------------------------------
+   File Browser
+----------------------------------------------------------------------------- */
+/* Left Pane
+----------------------------------------------------------------------------- */
+#DirTreeView {
+  background-color: #343434;
+  alternate-background-color: #343434;
+  border: 1 solid #272727;
+  border-right: 0;
+}
+/* Right Pane
+----------------------------------------------------------------------------- */
+DvItemViewerPanel {
+  qproperty-TextColor: #e6e6e6;
+  qproperty-AlternateBackground: #404040;
+  qproperty-SelectedTextColor: #ffffff;
+  qproperty-FolderTextColor: #9fdaff;
+  qproperty-SelectedItemBackground: #5385a6;
+}
+#FileBrowser DvItemViewerPanel,
+#SceneCast DvItemViewerPanel {
+  background-color: #484848;
+}
+#FileBrowser #castFrame,
+#SceneCast #castFrame {
+  border-top: 1 solid #272727;
+  border-right: 1 solid #272727;
+  border-bottom: 1 solid #272727;
+  margin: 0;
+}
+#FileBrowser QToolButton,
+#SceneCast QToolButton {
+  padding: 1;
+}
+DvDirTreeView {
+  qproperty-TextColor: #e6e6e6;
+  qproperty-SelectedTextColor: #ffffff;
+  qproperty-SelectedItemBackground: #5385a6;
+  qproperty-FolderTextColor: #9fdaff;
+  qproperty-SelectedFolderTextColor: #ffffff;
+  alternate-background-color: #393939;
+  background-color: #343434;
+  border: 1 solid #272727;
+}
+#FileDoesNotExistLabel {
+  color: #ff0000;
+}
+/* -----------------------------------------------------------------------------
+   Scene Cast
+----------------------------------------------------------------------------- */
+#SceneCast QToolBar {
+  border-top: 1 solid #272727;
+}
+#SceneCast QToolButton {
+  margin: 3 1 2 1;
+  padding: 1;
+}
+#CastBrowser {
+  border: 0;
+  margin: 0;
+}
+/* -----------------------------------------------------------------------------
+   Level Strip
+----------------------------------------------------------------------------- */
+#FilmStrip QComboBox {
+  border-radius: 0;
+  border-width: 0;
+}
+#FilmStrip QComboBox QAbstractItemView {
+  background-color: #484848;
+}
+/* -----------------------------------------------------------------------------
+   Cleanup Settings
+----------------------------------------------------------------------------- */
+#CleanupSettings #CleanupSettingsFrame {
+  margin-top: 2;
+  margin-bottom: 4;
+}
+#CleanupSettings QGroupBox {
+  margin-bottom: 3;
+}
+ParamsPage {
+  qproperty-TextColor: #e6e6e6;
+}
+/* -----------------------------------------------------------------------------
+   Camera Settings
+----------------------------------------------------------------------------- */
+#CameraSettingsButton {
+  padding: 2;
+}
+#CameraSettingsRadioButton:hover {
+  background: none;
+}
+#CameraSettingsRadioButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#CameraSettingsRadioButton::indicator:unchecked {
+  image: url('imgs/white/lock_off.svg');
+}
+#CameraSettingsRadioButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+  image: url('imgs/white/lock_on.svg');
+}
+#CameraSettingsRadioButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+#CameraSettingsDPI {
+  color: #9fdaff;
+}
+#CameraSettingsRadioButton_Small {
+  padding: 0;
+}
+#CameraSettingsRadioButton_Small::indicator {
+  background-color: transparent;
+  border: 0;
+  height: 21;
+  margin: 0;
+  width: 11;
+}
+#ForceSquaredPixelButton {
+  height: 16;
+  border: 1 solid rgba(255, 255, 255, 0);
+  image: url('imgs/white/fsp_unchecked.svg');
+  padding: 2;
+  width: 16;
+  margin: 0;
+}
+#ForceSquaredPixelButton:checked {
+  image: url('imgs/white/fsp_checked.svg');
+}
+/* -----------------------------------------------------------------------------
+   Output Settings
+----------------------------------------------------------------------------- */
+#OutputSettingsLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Misc 
+----------------------------------------------------------------------------- */
+PencilTestPopup {
+  min-height: 730px;
+  /* Allow for using a 768 screen */
+  min-width: 512px;
+  /* some clipping will still occur on width, but this
+                        allows for filling half of a 1024 screen */
+}
+#MatchLineButton {
+  background-color: #6e6e6e;
+}
+#MatchLineButton:checked {
+  background-color: #949494;
+  border: 2 solid #5385a6;
+  border-radius: 2;
+}
+#LargeSizedText {
+  font-size: 17px;
+}
+/* -----------------------------------------------------------------------------
+   Unknowns + Legacy
+----------------------------------------------------------------------------- */
+#StartupLabel {
+  padding: 3;
+}
+#StartupLabel:hover {
+  background: #626262;
+}
+QStatusBar {
+  background-color: #c0c0c0;
+}
+QStatusBar::item {
+  border: 0;
+}
+QStatusBar QLabel {
+  background-color: #c0c0c0;
+}
+QStatusBar #StatusBarLabel {
+  background-color: #ffffff;
+  padding: 1 3;
+}
+#TitleTxtLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Style Editor
+----------------------------------------------------------------------------- */
+#StyleEditor QPushButton {
+  margin: 2 1;
+  padding: 0;
+}
+#StyleEditor #TabBarContainer {
+  margin-left: -4;
+}
+#StyleEditor #bottomWidget {
+  border-top: 1 solid #272727;
+  padding: 3 2 8 3;
+}
+#StyleEditor #bottomWidget QPushButton {
+  padding: 3 5;
+}
+#StyleEditorTabBar::tab::first {
+  border-left: 1 solid #272727;
+}
+#HexagonalColorWheel {
+  qproperty-BGColor: #484848;
+}
+/* -------------------------------------------------------------------------- */
+/* Horizontal QSlider */
+#colorSlider::groove:horizontal {
+  height: 1;
+  border-image: none;
+}
+#colorSlider::handle:horizontal {
+  width: 8;
+  margin: -8 -4;
+}
+#colorSliderAddButton,
+#colorSliderSubButton {
+  background: none;
+  border-color: transparent;
+  image-position: center center;
+  min-height: 16;
+  padding: 0;
+  min-width: 18;
+}
+#colorSliderAddButton {
+  image: url('imgs/white/scroll-right.svg');
+}
+#colorSliderSubButton {
+  image: url('imgs/white/scroll-left.svg');
+}
+#PlainColorPageParts {
+  border-bottom: 1 solid #272727;
+}
+#PlainColorPageParts QLineEdit {
+  max-width: 35;
+}
+/* -----------------------------------------------------------------------------
+   Palette Viewer / Studio Palette
+----------------------------------------------------------------------------- */
+PaletteViewer DvScrollWidget QPushButton {
+  border-top: 0;
+  margin-bottom: 1;
+  max-width: 15;
+  min-width: 15;
+}
+PaletteViewer DvScrollWidget #ScrollLeftButton {
+  border-radius: 0;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer DvScrollWidget #ScrollRightButton {
+  border-radius: 0;
+  margin-left: 1;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer QToolBar {
+  background: none;
+  border-bottom: 1 solid #272727;
+  padding: 0;
+  margin: 0;
+}
+PaletteViewer QToolBar::separator:horizontal {
+  margin: 0;
+}
+PaletteViewer QToolBar QToolButton {
+  margin: 0 0 1 0;
+  padding: 1 0 2 0;
+}
+#PageViewer {
+  qproperty-TextColor: #e6e6e6;
+}
+#PaletteLockButton {
+  border-radius: 0;
+  margin: 0 0 1 1;
+}
+#PaletteLockButton:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+}
+#PaletteLockButton:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+/* -----------------------------------------------------------------------------
+   Quick Renamer
+----------------------------------------------------------------------------- */
+#WordButton {
+  padding-right: 0;
+  padding-left: 0;
+}
+/* -----------------------------------------------------------------------------
+   Popup Windows
+----------------------------------------------------------------------------- */
+QDialog {
+  background-color: #484848;
+}
+QDialog #dialogButtonFrame {
+  background-color: #3e3e3e;
+  border-top: 1 solid #272727;
+}
+QDialog #dialogButtonFrame QPushButton {
+  border-color: #3e3e3e;
+  outline: 0;
+}
+QDialog #dialogButtonFrame QPushButton:focus {
+  background-color: #5385a6;
+  border-color: #3e3e3e;
+  color: #ffffff;
+}
+QDialog #dialogButtonFrame QPushButton:focus:hover {
+  background-color: #6c98b6;
+}
+QDialog #dialogButtonFrame QPushButton:focus:pressed {
+  background-color: #313131;
+  border-color: #2c2c2c;
+  color: #f3f3f3;
+}
+/* -----------------------------------------------------------------------------
+   Scene Settings
+----------------------------------------------------------------------------- */
+#SceneSettings QLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   Preferences
+----------------------------------------------------------------------------- */
+#PreferencesPopup QListWidget {
+  background-color: #343434;
+  alternate-background-color: #343434;
+  border: 1 solid #272727;
+  font-size: 13px;
+}
+#PreferencesPopup QListWidget::item {
+  border: 0;
+  padding: 3;
+}
+#PreferencesPopup QListWidget::item:hover {
+  color: #e6e6e6;
+  background-color: rgba(255, 255, 255, 0.15);
+}
+#PreferencesPopup QListWidget::item:selected {
+  background-color: #5385a6;
+  color: #ffffff;
+}
+/* -----------------------------------------------------------------------------
+   Keyboard Shortcuts
+----------------------------------------------------------------------------- */
+#ShortcutTree {
+  border: 1 solid #272727;
+}
+#ShortcutTree::item {
+  padding: 1 0;
+}
+#ShortcutTree QScrollBar:vertical {
+  width: 16;
+  margin-right: -1;
+}
+/* -----------------------------------------------------------------------------
+   New Project / Configure Project Window
+----------------------------------------------------------------------------- */
+ProjectPopup QLabel {
+  color: #9fdaff;
+}
+/* -----------------------------------------------------------------------------
+   PencilTestPopup / CameraCapture Window
+----------------------------------------------------------------------------- */
+#GearButton {
+  qproperty-icon: url('imgs/white/gear.svg');
+}
+#SubfolderButton {
+  qproperty-icon: url('imgs/white/subfolder.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+#SubcameraButton {
+  qproperty-icon: url('imgs/white/subcamera.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+/* -----------------------------------------------------------------------------
+   Schematic Viewer
+----------------------------------------------------------------------------- */
+SchematicViewer {
+  qproperty-TextColor: #e6e6e6;
+  qproperty-VerticalLineColor: #222222;
+  qproperty-LevelColumnColor: #4C6E4C;
+  qproperty-VectorColumnColor: #7B7B4C;
+  qproperty-ChildColumnColor: #6A526B;
+  qproperty-FullcolorColumnColor: #657A96;
+  qproperty-FxColumnColor: #56553C;
+  qproperty-PaletteColumnColor: #3A655F;
+  qproperty-MeshColumnColor: #684D86;
+  qproperty-ReferenceColumnColor: #616161;
+  qproperty-TableColor: #62628c;
+  qproperty-ActiveCameraColor: #2d7dca;
+  qproperty-OtherCameraColor: #6c797b;
+  qproperty-GroupColor: #3b6e9c;
+  qproperty-PegColor: #9f6e3c;
+  qproperty-SplineColor: #6a9d1c;
+  qproperty-ActiveOutputColor: #2d7dca;
+  qproperty-OtherOutputColor: #6c797b;
+  qproperty-XsheetColor: #62628c;
+  qproperty-NormalFxColor: #6a7e96;
+  qproperty-MacroFxColor: #815c79;
+  qproperty-ImageAdjustFxColor: #656287;
+  qproperty-LayerBlendingFxColor: #4f757d;
+  qproperty-MatteFxColor: #ae7171;
+  qproperty-SchematicPreviewButtonBgOnColor: #c8c864;
+  qproperty-SchematicPreviewButtonOnImage: url('imgs/white/x_prev_eye_on.svg');
+  qproperty-SchematicPreviewButtonBgOffColor: #616161;
+  qproperty-SchematicPreviewButtonOffImage: url('imgs/white/x_prev_eye_off.svg');
+  qproperty-SchematicCamstandButtonBgOnColor: #eb906b;
+  qproperty-SchematicCamstandButtonOnImage: url('imgs/white/x_table_view_on.svg');
+  qproperty-SchematicCamstandButtonTranspImage: url('imgs/white/x_table_view_transp.svg');
+  qproperty-SchematicCamstandButtonBgOffColor: #616161;
+  qproperty-SchematicCamstandButtonOffImage: url('imgs/white/x_table_view_off.svg');
+}
+/* -----------------------------------------------------------------------------
+   Schematic Node Viewer
+----------------------------------------------------------------------------- */
+#SchematicBottomFrame {
+  background-color: #484848;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+#SchematicBottomFrame QToolBar::separator:horizontal {
+  margin: 0;
+}
+#SchematicBottomFrame QToolBar QToolButton {
+  padding: 0;
+  margin: 2;
+}
+#SchematicSceneViewer {
+  background-color: #3b3b3b;
+  border-bottom: 1 solid #272727;
+}
+/* -----------------------------------------------------------------------------
+   FX Settings
+----------------------------------------------------------------------------- */
+#FxSettingsTabBar::tab {
+  border-top: 1 solid #272727;
+}
+#FxSettingsTabBar::tab::first,
+#FxSettingsTabBar::tab::only-one {
+  border-left: 1 solid #272727;
+}
+FxSettings QToolBar {
+  border-top: 1 solid #272727;
+  border-right: 1 solid #272727;
+  border-left: 1 solid #272727;
+  min-height: 23;
+  padding: 3 0;
+}
+FxSettings QToolBar QToolBar {
+  border: 0;
+}
+#FxSettingsLabel {
+  color: #a0e680;
+}
+#FxSettingsHelpButton {
+  background-color: #80a0dc;
+  color: #000;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+#FxSettingsHelpButton:hover {
+  background-color: #a8bee7;
+}
+/* -----------------------------------------------------------------------------
+   Script Console
+----------------------------------------------------------------------------- */
+#ScriptConsole {
+  font-family: 'Courier New', monospace;
+  border: 0;
+  color: #000000;
+  padding: 3;
+}
+#ScriptConsole QFrame {
+  background-color: #dcdcdc;
+}
+#ScriptConsole TPanelTitleBar {
+  background-color: #393939;
+}
+/* -----------------------------------------------------------------------------
+   Task Viewer
+----------------------------------------------------------------------------- */
+#TaskSheetItemLabel {
+  color: #e6e6e6;
+}
+#Tasks QToolBar {
+  border-bottom: 1 solid #272727;
+  margin: 0;
+  padding: 0;
+}
+#Tasks QToolBar QToolButton {
+  margin: 2 2 3 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bar
+----------------------------------------------------------------------------- */
+#ToolBar QToolBar {
+  padding-left: 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Options
+----------------------------------------------------------------------------- */
+#ToolOptions TPanelTitleBar {
+  border-right: 1 solid #272727;
+  border-bottom: 0;
+}
+#CommandBar TPanelTitleBar {
+  border-right: 1 solid #272727;
+  border-bottom: 0;
+}
+IconViewField {
+  qproperty-ThicknessPixmap: url("imgs/white/selectiontool_thickness.svg");
+}
+#EditToolLockButton {
+  spacing: 0;
+}
+#EditToolLockButton:hover {
+  background: none;
+}
+#EditToolLockButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#EditToolLockButton::indicator:unchecked {
+  image: url('imgs/white/lock_off.svg');
+}
+#EditToolLockButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #C34040;
+  image: url('imgs/white/lock_on.svg');
+}
+#EditToolLockButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #d57a7a;
+}
+PopupButton::menu-indicator {
+  border-left: 0;
+  height: 17;
+  image: url('imgs/white/combo_downarrow.svg');
+  width: 10;
+}
+PopupButton::menu-indicator:hover {
+  image: url('imgs/white/combo_downarrow.svg');
+}
+PopupButton::menu-indicator:disabled {
+  image: url('imgs/white/combo_downarrow_disabled.svg');
+}
+#Cap,
+#Join {
+  padding: 0 4 0 -8;
+  max-width: 32;
+  min-width: 32;
+}
+#Cap QMenu,
+#Join QMenu {
+  max-width: 28;
+  min-width: 28;
+}
+#Cap QMenu::item,
+#Join QMenu::item {
+  max-width: 28;
+  min-width: 28;
+  padding: 0;
+}
+QToolBar#MediumPaddingToolBar QToolButton {
+  padding-left: 3;
+  padding-right: 3;
+}
+QToolBar#WidePaddingToolBar QToolButton {
+  padding-left: 6;
+  padding-right: 6;
+}
+#CommandBar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#CommandBar::separator:horizontal {
+  margin-right: 3;
+  margin-left: 3;
+}
+#expandButton:checked {
+  background-color: transparent;
+  border-color: transparent;
+  color: #e6e6e6;
+}
+#expandButton:checked:hover {
+  background-color: #767676;
+  border-color: #767676;
+}
+#expandButton:checked:pressed {
+  background-color: #313131;
+  border-color: #2c2c2c;
+}
+/* -----------------------------------------------------------------------------
+   ComboViewer / Viewer / FlipBook
+----------------------------------------------------------------------------- */
+#ComboViewerPanel Toolbar {
+  border-bottom: 1 solid #272727;
+}
+#ComboViewerPanel Toolbar::separator:horizontal {
+  margin: 0 0 0 2;
+}
+#ComboViewerPanel Toolbar QToolButton {
+  margin: 2 0 3 2;
+}
+#ComboViewerToolOptions {
+  border-bottom: 1 solid #272727;
+}
+#ComboViewer #ToolBarContainer,
+#ViewerPanel #ToolBarContainer,
+FlipBook #ToolBarContainer {
+  background-color: transparent;
+  border-top: 2 solid #272727;
+  border-bottom: 1 solid #272727;
+  padding-right: -1;
+}
+#flipCustomize {
+  margin-left: 3;
+}
+#flipCustomize::menu-button {
+  background-color: transparent;
+  width: 35;
+}
+#flipCustomize::menu-arrow {
+  image: none;
+}
+QToolBar#FlipConsolePlayToolBar::separator:horizontal {
+  margin: 0 3;
+}
+QToolBar#FlipConsolePlayToolBar QToolButton {
+  margin-top: 2;
+  margin-bottom: 2;
+  height: 16;
+  padding-left: 1;
+  padding-right: 1;
+}
+#ViewerFpsSlider {
+  background-color: transparent;
+  background-image: url('imgs/white/slider-groove.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  border: 0;
+  height: 19;
+  margin: 0 3 0 37;
+  max-width: 300;
+  min-width: 0;
+}
+#ViewerFpsSlider::sub-line:horizontal {
+  subcontrol-origin: absolute;
+  background-color: #696969;
+  border: 1 solid #484848;
+  border-top-left-radius: 2;
+  border-bottom-left-radius: 2;
+  height: 16;
+  left: -33;
+  width: 14;
+}
+#ViewerFpsSlider::add-line:horizontal {
+  subcontrol-position: left;
+  background-color: #696969;
+  border: 1 solid #484848;
+  border-top-right-radius: 2;
+  border-bottom-right-radius: 2;
+  left: 18;
+  height: 16;
+  image-position: center center;
+  width: 13;
+}
+#ViewerFpsSlider::handle::horizontal {
+  background-color: #a1a1a1;
+  border: 1 solid #a1a1a1;
+  border-radius: 2;
+  margin: 2 0 3 0;
+  min-width: 9;
+  width: 9;
+  max-width: 9;
+}
+FlipSlider {
+  qproperty-PBHeight: 15;
+  qproperty-PBOverlay: url('imgs/white/flipslider.svg');
+  qproperty-PBColorMarginLeft: 1;
+  qproperty-PBColorMarginTop: 2;
+  qproperty-PBColorMarginRight: 1;
+  qproperty-PBColorMarginBottom: 2;
+  qproperty-PBMarker: url('imgs/white/flipmarker.svg');
+  qproperty-PBMarkerMarginLeft: 3;
+  qproperty-PBMarkerMarginRight: 3;
+  qproperty-notStartedColor: rgba(205, 101, 101, 0.78);
+  qproperty-startedColor: #1abc3f;
+  qproperty-baseColor: #2f2f2f;
+  qproperty-finishedColor: #2f2f2f;
+}
+Ruler {
+  qproperty-ParentBGColor: #484848;
+  qproperty-ScaleColor: #e6e6e6;
+}
+#RulerToolOptionValues {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   XSheet Viewer
+----------------------------------------------------------------------------- */
+/* ScrollAreas (Row, Column and Cell)
+----------------------------------------------------------------------------- */
+#xsheetArea,
+#ScrollArea {
+  background-color: #343434;
+  border: 0;
+}
+#xsheetScrollArea {
+  border: 0;
+}
+#cornerWidget QToolButton {
+  padding: 0;
+}
+/* xsheetColumnHeader (Context Menus)
+----------------------------------------------------------------------------- */
+#xsheetColumnAreaMenu_Preview {
+  background-color: #E6E678;
+}
+#xsheetColumnAreaMenu_Lock {
+  background-color: #F5F5F5;
+}
+#xsheetColumnAreaMenu_Camstand {
+  background-color: #FFA480;
+}
+#xsheetColumnAreaMenu_Preview,
+#xsheetColumnAreaMenu_Lock,
+#xsheetColumnAreaMenu_Camstand {
+  color: #000;
+}
+#noteTextEdit {
+  color: #000;
+}
+/* XSheet Spreadsheet
+----------------------------------------------------------------------------- */
+XsheetViewer {
+  qproperty-TextColor: #e6e6e6;
+  qproperty-BGColor: #3b3b3b;
+  qproperty-LightLineColor: #2c2c2c;
+  qproperty-MarkerLineColor: #1E96C4;
+  qproperty-VerticalLineColor: #222222;
+  qproperty-VerticalLineHeadColor: #808080;
+  qproperty-PreviewFrameTextColor: #9fdaff;
+  qproperty-CurrentRowBgColor: #506082;
+  qproperty-OnionSkinAreaBgColor: #363636;
+  qproperty-EmptyColumnHeadColor: #626262;
+  qproperty-SelectedColumnTextColor: #E66464;
+  qproperty-EmptyCellColor: #404040;
+  qproperty-NotEmptyColumnColor: #484848;
+  qproperty-SelectedEmptyCellColor: #6c6c6c;
+  qproperty-LevelColumnColor: #4C6E4C;
+  qproperty-LevelColumnBorderColor: #8FB38F;
+  qproperty-SelectedLevelColumnColor: #678667;
+  qproperty-VectorColumnColor: #7B7B4C;
+  qproperty-VectorColumnBorderColor: #BBBB9A;
+  qproperty-SelectedVectorColumnColor: #949466;
+  qproperty-ChildColumnColor: #6A526B;
+  qproperty-ChildColumnBorderColor: #B1A3B3;
+  qproperty-SelectedChildColumnColor: #816e82;
+  qproperty-FullcolorColumnColor: #657A96;
+  qproperty-FullcolorColumnBorderColor: #9EB8BB;
+  qproperty-SelectedFullcolorColumnColor: #8895a6;
+  qproperty-FxColumnColor: #56553C;
+  qproperty-FxColumnBorderColor: #95958A;
+  qproperty-SelectedFxColumnColor: #6f6e56;
+  qproperty-ReferenceColumnColor: #616161;
+  qproperty-ReferenceColumnBorderColor: #A2A2A2;
+  qproperty-SelectedReferenceColumnColor: #7a7a7a;
+  qproperty-PaletteColumnColor: #3A655F;
+  qproperty-PaletteColumnBorderColor: #86ACA7;
+  qproperty-SelectedPaletteColumnColor: #52807a;
+  qproperty-MeshColumnColor: #684D86;
+  qproperty-MeshColumnBorderColor: #BA92EF;
+  qproperty-SelectedMeshColumnColor: #82689e;
+  qproperty-SoundTextColumnColor: #c8c8c8;
+  qproperty-SoundTextColumnBorderColor: #8c8c8c;
+  qproperty-SelectedSoundTextColumnColor: #e2e2e2;
+  qproperty-SoundColumnColor: #657456;
+  qproperty-SoundColumnBorderColor: #A0AF7D;
+  qproperty-SelectedSoundColumnColor: #7e8b72;
+  qproperty-SoundColumnHlColor: #34FE5E;
+  qproperty-SoundColumnTrackColor: #B6C29D;
+  qproperty-ColumnHeadPastelizer: #000;
+  qproperty-SelectedColumnHead: #506082;
+  qproperty-LightLightBGColor: #404040;
+  qproperty-LightBGColor: #f0f0f0;
+  qproperty-DarkBGColor: #e1e1e1;
+  qproperty-DarkLineColor: #969696;
+  qproperty-XsheetColumnNameBgColor: rgba(0, 0, 0, 0);
+  qproperty-XsheetDragBarHighlightColor: rgba(255, 255, 255, 0.5);
+  qproperty-XsheetPreviewButtonBgOnColor: #c8c864;
+  qproperty-XsheetPreviewButtonOnImage: url('imgs/white/x_prev_eye_on.svg');
+  qproperty-XsheetPreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetPreviewButtonOffImage: url('imgs/white/x_prev_eye_off.svg');
+  qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
+  qproperty-XsheetCamstandButtonOnImage: url('imgs/white/x_table_view_on.svg');
+  qproperty-XsheetCamstandButtonTranspImage: url('imgs/white/x_table_view_transp.svg');
+  qproperty-XsheetCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetCamstandButtonOffImage: url('imgs/white/x_table_view_off.svg');
+  qproperty-XsheetLockButtonBgOnColor: rgba(255, 255, 255, 0.3);
+  qproperty-XsheetLockButtonOnImage: url('imgs/white/x_lock_on.svg');
+  qproperty-XsheetLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetLockButtonOffImage: url('imgs/white/x_lock_off.svg');
+  qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetConfigButtonImage: url('imgs/white/x_config.svg');
+  qproperty-TimelinePreviewButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOnImage: url('imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelinePreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOffImage: url('imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineCamstandButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOnImage: url('imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelineCamstandButtonTranspImage: url('imgs/white/timeline_toggle_transp.svg');
+  qproperty-TimelineCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOffImage: url('imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineLockButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOnImage: url('imgs/white/timeline_toggle_on.svg');
+  qproperty-TimelineLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOffImage: url('imgs/white/timeline_toggle_off.svg');
+  qproperty-TimelineConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineConfigButtonImage: url('imgs/white/timeline_config.svg');
+  qproperty-LayerHeaderPreviewImage: url('imgs/white/layer_header_prev_eye.svg');
+  qproperty-LayerHeaderPreviewOverImage: url('imgs/white/layer_header_prev_eye_over.svg');
+  qproperty-LayerHeaderCamstandImage: url('imgs/white/layer_header_table_view.svg');
+  qproperty-LayerHeaderCamstandOverImage: url('imgs/white/layer_header_table_view_over.svg');
+  qproperty-LayerHeaderLockImage: url('imgs/white/lock_on.svg');
+  qproperty-LayerHeaderLockOverImage: url('imgs/white/lock_on_over.svg');
+  qproperty-ActiveCameraColor: #2d7dca;
+  qproperty-SelectedActiveCameraColor: #5796d3;
+  qproperty-OtherCameraColor: #6c797b;
+  qproperty-SelectedOtherCameraColor: #8b8e8f;
+}
+/* XSheet Toolbar
+----------------------------------------------------------------------------- */
+#XSheetToolbar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#XSheetToolbar QToolButton {
+  padding: 0;
+  margin: 4 1;
+  min-height: 19;
+  height: 19;
+}
+#XSheetToolbar::separator:horizontal {
+  margin: 0 4;
+}
+/* -----------------------------------------------------------------------------
+   Function Editor
+----------------------------------------------------------------------------- */
+#FunctionEditor QToolBar {
+  border-bottom: 1 solid #272727;
+}
+#FunctionEditor QToolBar QToolBar {
+  border: 0;
+}
+#FunctionEditor QToolBar QLabel {
+  margin-left: 5;
+}
+#FunctionEditor QToolBar QToolButton {
+  height: 18;
+}
+#FunctionEditorTree {
+  border-top: 1 solid #272727;
+}
+FunctionTreeView {
+  qproperty-TextColor: #e6e6e6;
+  qproperty-CurrentTextColor: #E66464;
+}
+/* Function Editor Spreadsheet
+----------------------------------------------------------------------------- */
+FunctionPanel {
+  qproperty-BGColor: #3b3b3b;
+  qproperty-ValueLineColor: #2f2f2f;
+  qproperty-FrameLineColor: #2f2f2f;
+  qproperty-OtherCurvesColor: #888888;
+  qproperty-RulerBackground: #333333;
+  qproperty-TextColor: #e6e6e6;
+  qproperty-SubColor: #000;
+  qproperty-SelectedColor: #FFA500;
+}
+SpreadsheetViewer {
+  qproperty-LightLightBGColor: #404040;
+  qproperty-CurrentRowBgColor: #506082;
+  qproperty-LightLineColor: #2c2c2c;
+  qproperty-MarkerLineColor: #1E96C4;
+  qproperty-BGColor: #484848;
+  qproperty-VerticalLineColor: #222222;
+  qproperty-KeyFrameColor: #995d1d;
+  qproperty-KeyFrameBorderColor: #c9b04b;
+  qproperty-SelectedKeyFrameColor: #be772b;
+  qproperty-InBetweenColor: #666250;
+  qproperty-InBetweenBorderColor: #cdcec8;
+  qproperty-SelectedInBetweenColor: #7d7a6c;
+  qproperty-SelectedEmptyColor: #6c6c6c;
+  qproperty-SelectedSceneRangeEmptyColor: #757575;
+  qproperty-TextColor: #e6e6e6;
+  qproperty-ColumnHeaderBorderColor: #808080;
+  qproperty-SelectedColumnTextColor: #E66464;
+}
+#ExpressionField {
+  background-color: #e6e6e6;
+  border: 1 solid #333333;
+  margin: 0;
+}
+#FunctionSegmentViewerLinkButton {
+  background-image: url('imgs/white/segment_unlinked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:hover {
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:checked {
+  background-image: url('imgs/white/segment_linked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:disabled {
+  background-image: url('imgs/white/segment_disabled.svg');
+  background-repeat: no-repeat;
+}

--- a/stuff/config/qss/Default/imgs/black/checkpartially.svg
+++ b/stuff/config/qss/Default/imgs/black/checkpartially.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xml:space="preserve"
+   style="enable-background:new 0 0 16 16;"
+   viewBox="0 0 16 16"
+   y="0px"
+   x="0px"
+   id="svg4489"
+   version="1.1"
+   sodipodi:docname="checkpartially.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="871"
+   inkscape:window-height="781"
+   id="namedview7"
+   showgrid="true"
+   inkscape:zoom="14.75"
+   inkscape:cx="8"
+   inkscape:cy="5.2881356"
+   inkscape:window-x="548"
+   inkscape:window-y="67"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg4489"><inkscape:grid
+     type="xygrid"
+     id="grid814" /></sodipodi:namedview><metadata
+   id="metadata11"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs9" />
+<style
+   id="style2"
+   type="text/css">
+	
+		.st0{fill:none;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-opacity:0.5122;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;}
+</style>
+
+
+<path
+   style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+   d="M 5,3 C 3.8954762,3.0001104 3.0001104,3.8954762 3,5 v 6 c 1.104e-4,1.104524 0.8954762,1.99989 2,2 h 6 c 1.104524,-1.1e-4 1.99989,-0.895476 2,-2 V 5 C 12.99989,3.8954762 12.104524,3.0001104 11,3 Z"
+   id="rect816"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="ccccccccc" /></svg>

--- a/stuff/config/qss/Default/imgs/black/checkpartially_disabled.svg
+++ b/stuff/config/qss/Default/imgs/black/checkpartially_disabled.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xml:space="preserve"
+   style="enable-background:new 0 0 16 16;"
+   viewBox="0 0 16 16"
+   y="0px"
+   x="0px"
+   id="svg4489"
+   version="1.1"
+   sodipodi:docname="checkpartially_disabled.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="871"
+   inkscape:window-height="781"
+   id="namedview7"
+   showgrid="true"
+   inkscape:zoom="14.75"
+   inkscape:cx="8"
+   inkscape:cy="5.2881356"
+   inkscape:window-x="548"
+   inkscape:window-y="67"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg4489"><inkscape:grid
+     type="xygrid"
+     id="grid814" /></sodipodi:namedview><metadata
+   id="metadata11"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs9" />
+<style
+   id="style2"
+   type="text/css">
+	
+		.st0{fill:none;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-opacity:0.5122;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;}
+</style>
+
+
+<path
+   style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.3137255;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+   d="M 5,3 C 3.8954762,3.0001104 3.0001104,3.8954762 3,5 v 6 c 1.104e-4,1.104524 0.8954762,1.99989 2,2 h 6 c 1.104524,-1.1e-4 1.99989,-0.895476 2,-2 V 5 C 12.99989,3.8954762 12.104524,3.0001104 11,3 Z"
+   id="rect816"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="ccccccccc" /></svg>

--- a/stuff/config/qss/Default/imgs/white/checkpartially.svg
+++ b/stuff/config/qss/Default/imgs/white/checkpartially.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xml:space="preserve"
+   style="enable-background:new 0 0 16 16;"
+   viewBox="0 0 16 16"
+   y="0px"
+   x="0px"
+   id="svg4489"
+   version="1.1"
+   sodipodi:docname="checkpartially.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="871"
+   inkscape:window-height="781"
+   id="namedview7"
+   showgrid="true"
+   inkscape:zoom="14.75"
+   inkscape:cx="8"
+   inkscape:cy="5.2881356"
+   inkscape:window-x="548"
+   inkscape:window-y="67"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg4489"><inkscape:grid
+     type="xygrid"
+     id="grid814" /></sodipodi:namedview><metadata
+   id="metadata11"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs9" />
+<style
+   id="style2"
+   type="text/css">
+	
+		.st0{fill:none;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-opacity:0.5122;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;}
+</style>
+
+
+<path
+   style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+   d="M 5,3 C 3.8954762,3.0001104 3.0001104,3.8954762 3,5 v 6 c 1.104e-4,1.104524 0.8954762,1.99989 2,2 h 6 c 1.104524,-1.1e-4 1.99989,-0.895476 2,-2 V 5 C 12.99989,3.8954762 12.104524,3.0001104 11,3 Z"
+   id="rect816"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="ccccccccc" /></svg>

--- a/stuff/config/qss/Default/imgs/white/checkpartially_disabled.svg
+++ b/stuff/config/qss/Default/imgs/white/checkpartially_disabled.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xml:space="preserve"
+   style="enable-background:new 0 0 16 16;"
+   viewBox="0 0 16 16"
+   y="0px"
+   x="0px"
+   id="svg4489"
+   version="1.1"
+   sodipodi:docname="checkpartially_disabled.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="871"
+   inkscape:window-height="781"
+   id="namedview7"
+   showgrid="true"
+   inkscape:zoom="14.75"
+   inkscape:cx="8"
+   inkscape:cy="5.2881356"
+   inkscape:window-x="548"
+   inkscape:window-y="67"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg4489"><inkscape:grid
+     type="xygrid"
+     id="grid814" /></sodipodi:namedview><metadata
+   id="metadata11"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs9" />
+<style
+   id="style2"
+   type="text/css">
+	
+		.st0{fill:none;stroke:#000000;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;stroke-opacity:0.5122;}
+	.st1{fill:none;stroke:#FFFFFF;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;}
+</style>
+
+
+<path
+   style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#9a9a9a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+   d="M 5,3 C 3.8954762,3.0001104 3.0001104,3.8954762 3,5 v 6 c 1.104e-4,1.104524 0.8954762,1.99989 2,2 h 6 c 1.104524,-1.1e-4 1.99989,-0.895476 2,-2 V 5 C 12.99989,3.8954762 12.104524,3.0001104 11,3 Z"
+   id="rect816"
+   inkscape:connector-curvature="0"
+   sodipodi:nodetypes="ccccccccc" /></svg>

--- a/stuff/config/qss/Default/less/layouts/controls.less
+++ b/stuff/config/qss/Default/less/layouts/controls.less
@@ -151,6 +151,19 @@ QPlainTextEdit
         image: url('@{img-url}/checkmark_disabled.svg');
       }
     }
+    &:indeterminate {
+      background-color: @checkbox-bg-color-checked;
+      border-color: @checkbox-border-color-checked;
+      image: url('@{img-url}/checkpartially.svg');
+      &:hover {
+        &:extend(.CheckBox::indicator:hover);
+      }
+      &:disabled {
+        background-color: @checkbox-bg-color-disabled;
+        border-color: @checkbox-border-color-disabled;
+        image: url('@{img-url}/checkpartially_disabled.svg');
+      }
+    }
     &:disabled {
       background-color: @checkbox-bg-color-disabled;
       border-color: @checkbox-border-color-disabled;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1,1 +1,1936 @@
-.button-show,#LoadLevelShowButton,#CleanupSettingsShowButton,#OutputSettingsShowButton,#FxSettingsPreviewShowButton{image:url('../Default/imgs/black/plus.svg');image-position:center center;margin:0;padding:1;min-width:10;min-height:10}.button-show:checked,#LoadLevelShowButton:checked,#CleanupSettingsShowButton:checked,#OutputSettingsShowButton:checked,#FxSettingsPreviewShowButton:checked{background-color:#5a5a5a;border-color:#454545;image:url('../Default/imgs/black/minus.svg')}.button-show:checked:pressed,#LoadLevelShowButton:checked:pressed,#CleanupSettingsShowButton:checked:pressed,#OutputSettingsShowButton:checked:pressed,#FxSettingsPreviewShowButton:checked:pressed{background-color:#e1e1e1;border-color:#525252}.button-show:checked:hover,#LoadLevelShowButton:checked:hover,#CleanupSettingsShowButton:checked:hover,#OutputSettingsShowButton:checked:hover,#FxSettingsPreviewShowButton:checked:hover{background-color:#5f5f5f}.button-tool,QToolButton,#CameraSettingsRadioButton::indicator,#ForceSquaredPixelButton,#SchematicBottomFrame QToolBar QToolButton,#EditToolLockButton::indicator,#flipCustomize{background-color:rgba(255,255,255,0);border:1 solid rgba(255,255,255,0);border-radius:2;color:#000;margin:1;padding:0}.button-tool:hover,QToolButton:hover,#CameraSettingsRadioButton::indicator:hover,#ForceSquaredPixelButton:hover,#colorSliderAddButton:hover,#colorSliderSubButton:hover,#SchematicBottomFrame QToolBar QToolButton:hover,#EditToolLockButton::indicator:hover,#flipCustomize:hover{background-color:#bbb;border-color:#525252;color:#000}.button-tool:pressed,QToolButton:pressed,#CameraSettingsRadioButton::indicator:pressed,#ForceSquaredPixelButton:pressed,#colorSliderAddButton:pressed,#colorSliderSubButton:pressed,#SchematicBottomFrame QToolBar QToolButton:pressed,#EditToolLockButton::indicator:pressed,#flipCustomize:pressed{background-color:#e1e1e1;border-color:#525252;color:#000}.button-tool:checked,QToolButton:checked,#CameraSettingsRadioButton::indicator:checked,#ForceSquaredPixelButton:checked,#SchematicBottomFrame QToolBar QToolButton:checked,#EditToolLockButton::indicator:checked,#flipCustomize:checked{background-color:#5a5a5a;border-color:#454545;color:#c0c0c0}.button-tool:checked:hover,QToolButton:checked:hover,#CameraSettingsRadioButton::indicator:checked:hover,#ForceSquaredPixelButton:checked:hover,#SchematicBottomFrame QToolBar QToolButton:checked:hover,#EditToolLockButton::indicator:checked:hover,#flipCustomize:checked:hover{background-color:#6e6e6e;border-color:#454545}.button-tool:disabled,QToolButton:disabled,#CameraSettingsRadioButton::indicator:disabled,#ForceSquaredPixelButton:disabled,#SchematicBottomFrame QToolBar QToolButton:disabled,#EditToolLockButton::indicator:disabled,#flipCustomize:disabled{color:rgba(0,0,0,0.466)}.button-flat,PaletteViewer QToolBar QToolButton{background-color:none;border:0;border-radius:0;margin:0}.button-flat:hover,PaletteViewer QToolBar QToolButton:hover{background-color:#bbb}.button-flat:pressed,PaletteViewer QToolBar QToolButton:pressed{background-color:#404040}.frame,.GroupBox,#LoadLevelFrame,#PsdSettingsGroupBox,#CleanupSettingsFrame,#OutputSettingsBox,#OutputSettingsCameraBox,#SolidLineFrame,#FunctionParametersPanel,QGroupBox{border:1 solid #404040;border-radius:2}.tab-container,#TabBarContainer{background-color:transparent;qproperty-BottomAboveLineColor:#6c6c6c;qproperty-BottomBelowLineColor:#404040}.tab-flat,#StyleEditorTabBar::tab,#PaletteTabBar::tab,#FxSettingsTabBar::tab{background-color:#5a5a5a;border-right:1 solid #404040;border-bottom:1 solid #404040;color:#c0c0c0;padding:3 4 3 4}.tab-flat:hover,#StyleEditorTabBar::tab:hover,#PaletteTabBar::tab:hover,#FxSettingsTabBar::tab:hover{background-color:#6e6e6e;color:#fff}.tab-flat:selected,#StyleEditorTabBar::tab:selected,#PaletteTabBar::tab:selected,#FxSettingsTabBar::tab:selected{background-color:#808080;color:#000;border-bottom-color:#808080}.tab-flat:only-one,#StyleEditorTabBar::tab:only-one,#PaletteTabBar::tab:only-one,#FxSettingsTabBar::tab:only-one{margin:0}.tab-round{background-color:#5a5a5a;border-top:1 solid #404040;border-right:1 solid #404040;border-left:1 solid #404040;border-bottom:1 solid #404040;color:#c0c0c0;margin:3 -1 0 0;padding:2 7 1 7}.tab-round:hover{background-color:#6e6e6e;color:#fff}.tab-round:selected{background-color:#808080;border-top-right-radius:2;border-top-left-radius:2;border-bottom-color:#808080;color:#000;margin:1 -1 -1 0;padding:2 7 2 7}.tab-round:only-one{margin:1 0 0 0;padding:3 7 3 7}.tab-round:last{margin-right:0;border-top-right-radius:2}.tab-round:first{border-top-left-radius:2}QWidget{background-color:#808080;color:#000}QWidget:disabled{color:rgba(0,0,0,0.466)}QFrame{border:0;margin:0;padding:0}QToolTip,#helpToolTip{background-color:#fff;border:1 solid #000;color:#000;padding:1 1}#DockSeparator,QMainWindow::separator,QSplitter::handle{background-color:#272727;height:4;width:4}#TDockPlaceholder{background-color:#F77272}TPanel{background-color:#272727}#TopBar{background:#808080;border:0;border-bottom:1 solid #404040;height:21}#TopBar #EditToolLockButton{background:#808080;spacing:0}#TopBar #EditToolLockButton::indicator{background:none;border:none;height:18;margin:1 2 0 0;padding-left:0;padding-right:0}#TopBarTabContainer{background-color:#808080;margin-bottom:1}#StackedMenuBar{border:0;margin:0;padding:0}QMenuBar{background-color:#808080;border:0}QMenuBar::item{background-color:#808080;border-left:1 solid #808080;margin:0;padding:3 5}QMenuBar::item:selected{background-color:#9f9f9f;color:#000}QMenuBar::item:pressed{background-color:#225baf;color:#FFFFFF}#TopBarTab{margin:0;padding:0}#TopBarTab::tab{background-color:#5a5a5a;border-top:1 solid #404040;border-right:1 solid #404040;color:#afafaf;margin:0 0 0 0;padding:2 8 3 8}#TopBarTab::tab:hover{background-color:#6e6e6e;color:#fff}#TopBarTab::tab:selected{background-color:#9a9a9a;color:#000}#TopBarTab::tab:first{border-left:1 solid #404040}#TopBarTab::tab:last{border-right:1 solid #404040}QMenu{background-color:#949494;border:1 solid #404040;padding:2 0}QMenu::item{padding:3 28}QMenu::item:selected{background-color:#225baf;color:#FFFFFF}QMenu::item:checked{color:#000}QMenu::item:checked:selected{background-color:#225baf;color:#FFFFFF}QMenu::item:disabled{background:none;color:rgba(0,0,0,0.466)}QMenu::item:disabled:selected{border-color:transparent}QMenu::separator{border-top:1 solid #6e6e6e;height:0;margin:2 0}QMenu::icon{border-radius:2;margin:0 0 0 3;padding:1}QMenu::icon:checked{background-color:#225baf}QMenu::indicator{margin-left:7}TPanelTitleBar{background-color:#5a5a5a;border-color:#404040;border-style:solid;border-width:0 0 1 0;height:20;min-height:20;qproperty-TitleColor:#c0c0c0;qproperty-ActiveTitleColor:#fff;qproperty-BorderPixmap:url('none');qproperty-ActiveBorderPixmap:url('../Default/imgs/black/none');qproperty-FloatBorderPixmap:url('none');qproperty-FloatActiveBorderPixmap:url('../Default/imgs/black/none')}QAbstractScrollArea::corner{background-color:#6e6e6e}QScrollBar{background-color:#6e6e6e;border:0}QScrollBar:horizontal{height:16;margin:0}QScrollBar:vertical{margin:0;width:16}QScrollBar::handle{border:1 solid #555;border-radius:2}QScrollBar::handle:horizontal:hover,QScrollBar::handle:vertical:hover{background-color:#b3b3b3;border-color:#404040}QScrollBar::handle:horizontal:pressed,QScrollBar::handle:vertical:pressed{background-color:#c7c7c7;border-color:#404040}QScrollBar::handle:horizontal{background-color:#9f9f9f;margin:2 16;min-width:20}QScrollBar::handle:vertical{background-color:#9f9f9f;margin:16 2;min-height:20}QScrollBar::add-line{subcontrol-origin:margin;border:0}QScrollBar::add-line:horizontal{subcontrol-position:right;background-color:#6e6e6e;margin:0;width:16}QScrollBar::add-line:vertical{subcontrol-position:bottom;background-color:#6e6e6e;margin:0;height:16}QScrollBar::sub-line{border:0;subcontrol-origin:margin}QScrollBar::sub-line:horizontal{subcontrol-position:left;background-color:#6e6e6e;margin:0;width:16}QScrollBar::sub-line:vertical{subcontrol-position:top;background-color:#6e6e6e;margin:0;height:16}QScrollBar::up-arrow:vertical{image:url('../Default/imgs/black/scroll-up.svg');image-position:center center}QScrollBar::up-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::down-arrow:vertical{image:url('../Default/imgs/black/scroll-down.svg');image-position:center center}QScrollBar::down-arrow:vertical:pressed{margin:1 0 0 0}QScrollBar::left-arrow:horizontal{image:url('../Default/imgs/black/scroll-left.svg');image-position:center center}QScrollBar::left-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::right-arrow:horizontal{image:url('../Default/imgs/black/scroll-right.svg');image-position:center center}QScrollBar::right-arrow:horizontal:pressed{margin:1 0 0 0}QScrollBar::sub-page:horizontal,QScrollBar::add-page:horizontal,QScrollBar::sub-page:vertical,QScrollBar::add-page:vertical{background:none}QToolBar{padding:0}QToolBar::separator:horizontal{border-left:1 solid #404040;margin:0 1;width:0}QToolBar::separator:vertical{border-top:1 solid #404040;height:0;margin:1 0}QToolBar QLabel{margin-top:1}QToolBar QToolBar{border:0}QToolButton::menu-indicator{image:none}QToolButton::menu-button{border-image:none}.DvScrollWidget QPushButton,DvScrollWidget QPushButton,#ScrollLeftButton QPushButton,#ScrollRightButton QPushButton,#ScrollUpButton QPushButton,#ScrollDownButton QPushButton{background-color:#a6a6a6;border:0 solid red;border-radius:0;padding:0;max-width:16}.DvScrollWidget QPushButton:hover,DvScrollWidget QPushButton:hover,#ScrollLeftButton QPushButton:hover,#ScrollRightButton QPushButton:hover,#ScrollUpButton QPushButton:hover,#ScrollDownButton QPushButton:hover{background-color:#bbb}.DvScrollWidget QPushButton:pressed,DvScrollWidget QPushButton:pressed,#ScrollLeftButton QPushButton:pressed,#ScrollRightButton QPushButton:pressed,#ScrollUpButton QPushButton:pressed,#ScrollDownButton QPushButton:pressed{background-color:#e1e1e1}#ScrollLeftButton,#ScrollRightButton,#ScrollUpButton,#ScrollDownButton{margin:0;min-width:16}#ScrollLeftButton{border-right:1 solid #404040;image:url('../Default/imgs/black/scroll-left.svg')}#ScrollRightButton{border-left:1 solid #404040;margin-left:3;image:url('../Default/imgs/black/scroll-right.svg')}#ScrollUpButton{image:url('../Default/imgs/black/scroll-up.svg')}#ScrollDownButton{image:url('../Default/imgs/black/scroll-down.svg')}#keyFrameNavigator{background:none;margin:0;padding:0}#keyFrameNavigator QToolButton{min-width:18}#keyFrameNavigator #PreviousKey{image:url('../Default/imgs/black/prevkey.svg')}#keyFrameNavigator #PreviousKey:hover{image:url('../Default/imgs/black/prevkey_over.svg')}#keyFrameNavigator #PreviousKey:disabled{image:url('../Default/imgs/black/prevkey_disabled.svg')}#keyFrameNavigator #NextKey{image:url('../Default/imgs/black/nextkey.svg')}#keyFrameNavigator #NextKey:hover{image:url('../Default/imgs/black/nextkey_over.svg')}#keyFrameNavigator #NextKey:disabled{image:url('../Default/imgs/black/nextkey_disabled.svg')}.treeview,QTreeWidget,QTreeView,#FunctionEditorTree{background-color:#949494;alternate-background-color:#8a8a8a;border:0;margin:0;outline:0}.treeview::item:selected,QTreeWidget::item:selected,QTreeView::item:selected,#FunctionEditorTree::item:selected{background-color:#225baf;color:#FFFFFF}.treeview::branch:adjoins-item,QTreeWidget::branch:adjoins-item,QTreeView::branch:adjoins-item,#FunctionEditorTree::branch:adjoins-item{border-image:url('')}.treeview::branch:has-siblings,QTreeWidget::branch:has-siblings,QTreeView::branch:has-siblings,#FunctionEditorTree::branch:has-siblings{border-image:url('')}.treeview::branch:has-siblings:adjoins-item,QTreeWidget::branch:has-siblings:adjoins-item,QTreeView::branch:has-siblings:adjoins-item,#FunctionEditorTree::branch:has-siblings:adjoins-item{border-image:url('')}.treeview::branch:has-children:closed,QTreeWidget::branch:has-children:closed,QTreeView::branch:has-children:closed,#FunctionEditorTree::branch:has-children:closed{background:url('../Default/imgs/black/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:open,QTreeWidget::branch:has-children:open,QTreeView::branch:has-children:open,#FunctionEditorTree::branch:has-children:open{background:url('../Default/imgs/black/treebranch-open.svg') no-repeat;background-position:center center;image:none}.treeview::branch:has-children:has-siblings:closed,QTreeWidget::branch:has-children:has-siblings:closed,QTreeView::branch:has-children:has-siblings:closed,#FunctionEditorTree::branch:has-children:has-siblings:closed{background:url('../Default/imgs/black/treebranch-closed.svg') no-repeat;background-position:center center;border-image:none;image:none}.treeview::branch:has-children:has-siblings:open,QTreeWidget::branch:has-children:has-siblings:open,QTreeView::branch:has-children:has-siblings:open,#FunctionEditorTree::branch:has-children:has-siblings:open{background:url('../Default/imgs/black/treebranch-open.svg') no-repeat;background-position:center center;border-image:none;image:none}QListView{outline:0;background:#949494;alternate-background-color:#8a8a8a}#TabBarContainer{background-color:#6c6c6c}.Button,QPushButton,.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{background-color:#a6a6a6;border:1 solid #525252;border-radius:2;color:#000;margin:0;padding:3 15}.Button:hover,QPushButton:hover,.ComboBox:hover,#ViewerFpsSlider::sub-line:horizontal:hover,#ViewerFpsSlider::add-line:horizontal:hover,QComboBox:hover{background-color:#bbb;border-color:#525252;color:#000}.Button:pressed,QPushButton:pressed,#ViewerFpsSlider::sub-line:horizontal:pressed,#ViewerFpsSlider::add-line:horizontal:pressed{background-color:#e1e1e1;border-color:#525252;color:#000}.Button:checked,QPushButton:checked{background-color:#5a5a5a;border-color:#454545;color:#c0c0c0}.Button:checked:hover,QPushButton:checked:hover{background-color:#5f5f5f}.Button:checked:hover:pressed,QPushButton:checked:hover:pressed{background:#5a5a5a}.Button:disabled,QPushButton:disabled,.ComboBox:disabled,#ViewerFpsSlider::sub-line:horizontal:disabled,#ViewerFpsSlider::add-line:horizontal:disabled,QComboBox:disabled{background-color:#8d8d8d;border-color:#737373;color:rgba(0,0,0,0.466)}#PushButton_NoPadding{padding:3}.ComboBox,.ComboBox:checked,QComboBox,QComboBox:checked{padding:1 0 1 4;margin:1 0}.ComboBox::drop-down,QComboBox::drop-down{image:url('../Default/imgs/black/combo_downarrow.svg');image-position:center center;width:16}.ComboBox::drop-down:disabled,QComboBox::drop-down:disabled{image:url('../Default/imgs/black/combo_downarrow_disabled.svg')}.ComboBox QAbstractItemView,QComboBox QAbstractItemView{background-color:#949494;border:1 solid #404040;selection-background-color:#225baf;selection-color:#FFFFFF}.LineEdit,QPlainTextEdit,QLineEdit,#TaskSheetItem,#tasksRemoveBox,#tasksAddBox{background-color:#e6e6e6;border:1 solid #525252;border-radius:2;color:#000;selection-background-color:#225baf;selection-color:#FFFFFF;padding:0 0 0 1}.LineEdit:focus,QPlainTextEdit:focus,QLineEdit:focus,#TaskSheetItem:focus,#tasksRemoveBox:focus,#tasksAddBox:focus{background-color:#e6e6e6;border-color:#525252;color:#000}.LineEdit:disabled,QPlainTextEdit:disabled,QLineEdit:disabled,#TaskSheetItem:disabled,#tasksRemoveBox:disabled,#tasksAddBox:disabled{background-color:#9a9a9a;border-color:#696969;color:rgba(0,0,0,0.466)}.CheckBox,QCheckBox{color:#000}.CheckBox:hover,QCheckBox:hover,.RadioButton:hover,QRadioButton:hover{color:#fff}.CheckBox:disabled,QCheckBox:disabled{color:rgba(0,0,0,0.466)}.CheckBox::indicator,QMenu::indicator,QCheckBox::indicator,.GroupBox::indicator,QGroupBox::indicator{background-color:#cdcdcd;border:1 solid #525252;border-radius:2;height:9;padding:1;width:9}.CheckBox::indicator:hover,QMenu::indicator:hover,.CheckBox::indicator:checked:hover,QCheckBox::indicator:hover,.GroupBox::indicator:hover,QMenu::indicator:checked:hover,QCheckBox::indicator:checked:hover,.GroupBox::indicator:checked:hover,QGroupBox::indicator:hover,QGroupBox::indicator:checked:hover{background-color:#e6e6e6;border-color:#525252}.CheckBox::indicator:checked,QMenu::indicator:checked,QCheckBox::indicator:checked,.GroupBox::indicator:checked,QGroupBox::indicator:checked{background-color:#cdcdcd;border-color:#525252;image:url('../Default/imgs/black/checkmark.svg')}.CheckBox::indicator:checked:disabled,QMenu::indicator:checked:disabled,QCheckBox::indicator:checked:disabled,.GroupBox::indicator:checked:disabled,QGroupBox::indicator:checked:disabled{background-color:#8d8d8d;border-color:#737373;image:url('../Default/imgs/black/checkmark_disabled.svg')}.CheckBox::indicator:disabled,QMenu::indicator:disabled,QCheckBox::indicator:disabled,.GroupBox::indicator:disabled,QGroupBox::indicator:disabled{background-color:#8d8d8d;border-color:#737373}.RadioButton::indicator:unchecked,QRadioButton::indicator:unchecked,#CameraSettingsRadioButton_Small::indicator:unchecked{image:url('../Default/imgs/black/radiobutton_unchecked.svg');image-position:center center}.RadioButton::indicator:checked,QRadioButton::indicator:checked,#CameraSettingsRadioButton_Small::indicator:checked{image:url('../Default/imgs/black/radiobutton_checked.svg');image-position:center center}.GroupBox,QGroupBox{margin:6 0 0 0;padding:5 0}.GroupBox::title,QGroupBox::title{subcontrol-origin:margin;left:15;margin:-3 0 0 0;padding:0 3}.GroupBox::title:hover,QGroupBox::title:hover{color:#fff}.GroupBox::title:disabled,QGroupBox::title:disabled{color:rgba(0,0,0,0.466)}.GroupBox::indicator,QGroupBox::indicator{subcontrol-origin:margin;margin-top:2}.GroupBox:disabled,QGroupBox:disabled{color:rgba(0,0,0,0.466)}.Slider::groove:horizontal,QSlider::groove:horizontal{background-color:transparent;background-image:url('../Default/imgs/black/slider-groove.svg');background-position:center center;background-repeat:repeat-x;margin:0;height:20;min-height:20}.Slider::groove:horizontal:disabled,QSlider::groove:horizontal:disabled{background-image:url('../Default/imgs/black/slider-groove_disabled.svg')}.Slider::handle:horizontal,QSlider::handle:horizontal{width:10;margin:-2 0;image:url('../Default/imgs/black/slider-handle.svg')}.Slider::handle:horizontal:disabled,QSlider::handle:horizontal:disabled{image:url('../Default/imgs/black/slider-handle_disabled.svg')}#IntPairField,#DoublePairField{qproperty-LightLineColor:#484848;qproperty-LightLineEdgeColor:#484848;qproperty-DarkLineColor:#484848;qproperty-MiddleLineColor:#484848;qproperty-HandleLeftPixmap:url("../Default/imgs/black/slider-handle.svg");qproperty-HandleRightPixmap:url("../Default/imgs/black/slider-handle.svg");qproperty-HandleLeftGrayPixmap:url("../Default/imgs/black/slider-handle_disabled.svg");qproperty-HandleRightGrayPixmap:url("../Default/imgs/black/slider-handle_disabled.svg")}#DirTreeView{background-color:#949494;alternate-background-color:#949494;border:1 solid #404040;border-right:0}DvItemViewerPanel{qproperty-TextColor:#000;qproperty-AlternateBackground:#8a8a8a;qproperty-SelectedTextColor:#FFFFFF;qproperty-FolderTextColor:#071b9b;qproperty-SelectedItemBackground:#225baf}#FileBrowser DvItemViewerPanel,#SceneCast DvItemViewerPanel{background-color:#949494}#FileBrowser #castFrame,#SceneCast #castFrame{border-top:1 solid #404040;border-right:1 solid #404040;border-bottom:1 solid #404040;margin:0}#FileBrowser QToolButton,#SceneCast QToolButton{padding:1}DvDirTreeView{qproperty-TextColor:#000;qproperty-SelectedTextColor:#FFFFFF;qproperty-SelectedItemBackground:#225baf;qproperty-FolderTextColor:#071b9b;qproperty-SelectedFolderTextColor:#FFFFFF;alternate-background-color:#8a8a8a;background-color:#949494;border:1 solid #404040}#FileDoesNotExistLabel{color:#f00}#SceneCast QToolBar{border-top:1 solid #404040}#SceneCast QToolButton{margin:3 1 2 1;padding:1}#CastBrowser{border:0;margin:0}#FilmStrip QComboBox{border-radius:0;border-width:0}#FilmStrip QComboBox QAbstractItemView{background-color:#949494}#CleanupSettings #CleanupSettingsFrame{margin-top:2;margin-bottom:4}#CleanupSettings QGroupBox{margin-bottom:3}ParamsPage{qproperty-TextColor:#000}#CameraSettingsButton{padding:2}#CameraSettingsRadioButton:hover{background:none}#CameraSettingsRadioButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#CameraSettingsRadioButton::indicator:unchecked{image:url('../Default/imgs/black/lock_off.svg')}#CameraSettingsRadioButton::indicator:checked{background-color:#C34040;border-color:#772626;image:url('../Default/imgs/black/lock_on.svg')}#CameraSettingsRadioButton::indicator:checked:hover{background-color:#d57a7a;border-color:#772626}#CameraSettingsDPI{color:#000}#CameraSettingsRadioButton_Small{padding:0}#CameraSettingsRadioButton_Small::indicator{background-color:transparent;border:0;height:21;margin:0;width:11}#ForceSquaredPixelButton{height:16;border:1 solid rgba(255,255,255,0);image:url('../Default/imgs/black/fsp_unchecked.svg');padding:2;width:16;margin:0}#ForceSquaredPixelButton:checked{image:url('../Default/imgs/black/fsp_checked.svg')}#OutputSettingsLabel{color:#000}PencilTestPopup{min-height:730px;min-width:512px}#MatchLineButton{background-color:#a6a6a6}#MatchLineButton:checked{background-color:#cdcdcd;border:2 solid #225baf;border-radius:2}#LargeSizedText{font-size:17px}#StartupLabel{padding:3}#StartupLabel:hover{background:#9a9a9a}QStatusBar{background-color:#c0c0c0}QStatusBar::item{border:0}QStatusBar QLabel{background-color:#c0c0c0}QStatusBar #StatusBarLabel{background-color:#fff;padding:1 3}#TitleTxtLabel{color:#000}#StyleEditor QPushButton{margin:2 1;padding:0}#StyleEditor #TabBarContainer{margin-left:-4}#StyleEditor #bottomWidget{border-top:1 solid #404040;padding:3 2 8 3}#StyleEditor #bottomWidget QPushButton{padding:3 5}#StyleEditorTabBar::tab::first{border-left:1 solid #404040}#HexagonalColorWheel{qproperty-BGColor:#808080}#colorSlider::groove:horizontal{height:1;border-image:none}#colorSlider::handle:horizontal{width:8;margin:-8 -4}#colorSliderAddButton,#colorSliderSubButton{background:none;border-color:transparent;image-position:center center;min-height:16;padding:0;min-width:18}#colorSliderAddButton{image:url('../Default/imgs/black/scroll-right.svg')}#colorSliderSubButton{image:url('../Default/imgs/black/scroll-left.svg')}#PlainColorPageParts{border-bottom:1 solid #404040}#PlainColorPageParts QLineEdit{max-width:35}PaletteViewer DvScrollWidget QPushButton{border-top:0;margin-bottom:1;max-width:15;min-width:15}PaletteViewer DvScrollWidget #ScrollLeftButton{border-radius:0;margin-bottom:1;max-width:16;min-width:16}PaletteViewer DvScrollWidget #ScrollRightButton{border-radius:0;margin-left:1;margin-bottom:1;max-width:16;min-width:16}PaletteViewer QToolBar{background:none;border-bottom:1 solid #404040;padding:0;margin:0}PaletteViewer QToolBar::separator:horizontal{margin:0}PaletteViewer QToolBar QToolButton{margin:0 0 1 0;padding:1 0 2 0}#PageViewer{qproperty-TextColor:#000}#PaletteLockButton{border-radius:0;margin:0 0 1 1}#PaletteLockButton:checked{background-color:#C34040;border-color:#772626}#PaletteLockButton:checked:hover{background-color:#d57a7a;border-color:#772626}#WordButton{padding-right:0;padding-left:0}QDialog{background-color:#808080}QDialog #dialogButtonFrame{background-color:#767676;border-top:1 solid #404040}QDialog #dialogButtonFrame QPushButton{border-color:#525252;outline:0}QDialog #dialogButtonFrame QPushButton:focus{background-color:#B5C0D0;border-color:#485971;color:#000}QDialog #dialogButtonFrame QPushButton:focus:hover{background-color:#ced5e0}QDialog #dialogButtonFrame QPushButton:focus:pressed{background-color:#e1e1e1;border-color:#525252;color:#000}#SceneSettings QLabel{color:#000}#PreferencesPopup QListWidget{background-color:#949494;alternate-background-color:#949494;border:1 solid #404040;font-size:13px}#PreferencesPopup QListWidget::item{border:0;padding:3}#PreferencesPopup QListWidget::item:hover{background-color:#9f9f9f;color:#000;background-color:#a9a9a9}#PreferencesPopup QListWidget::item:selected{background-color:#225baf;color:#FFFFFF}#ShortcutTree{border:1 solid #404040}#ShortcutTree::item{padding:1 0}#ShortcutTree QScrollBar:vertical{width:16;margin-right:-1}ProjectPopup QLabel{color:#000}#GearButton{qproperty-icon:url('../Default/imgs/black/gear.svg')}#SubfolderButton{qproperty-icon:url('../Default/imgs/black/subfolder.svg');padding-left:6px;padding-right:6px}#SubcameraButton{qproperty-icon:url('../Default/imgs/black/subcamera.svg');padding-left:6px;padding-right:6px}SchematicViewer{qproperty-TextColor:#000;qproperty-VerticalLineColor:#646464;qproperty-LevelColumnColor:#76b776;qproperty-VectorColumnColor:#c0c07a;qproperty-ChildColumnColor:#d69adb;qproperty-FullcolorColumnColor:#8bbdc1;qproperty-FxColumnColor:#82815d;qproperty-PaletteColumnColor:#2aab9a;qproperty-MeshColumnColor:#ac78d4;qproperty-ReferenceColumnColor:#ababab;qproperty-TableColor:#a4a4bf;qproperty-ActiveCameraColor:#6ba5de;qproperty-OtherCameraColor:#8f9c9e;qproperty-GroupColor:#6698c6;qproperty-PegColor:#be8a56;qproperty-SplineColor:#7bb821;qproperty-ActiveOutputColor:#6ba5de;qproperty-OtherOutputColor:#8f9c9e;qproperty-XsheetColor:#a4a4bf;qproperty-NormalFxColor:#8d9caf;qproperty-MacroFxColor:#ae8ca5;qproperty-ImageAdjustFxColor:#9c9ab4;qproperty-LayerBlendingFxColor:#709ba5;qproperty-MatteFxColor:#ba8585;qproperty-SchematicPreviewButtonBgOnColor:#c8c864;qproperty-SchematicPreviewButtonOnImage:url('../Default/imgs/black/x_prev_eye_on.svg');qproperty-SchematicPreviewButtonBgOffColor:#ababab;qproperty-SchematicPreviewButtonOffImage:url('../Default/imgs/black/x_prev_eye_off.svg');qproperty-SchematicCamstandButtonBgOnColor:#eb906b;qproperty-SchematicCamstandButtonOnImage:url('../Default/imgs/black/x_table_view_on.svg');qproperty-SchematicCamstandButtonTranspImage:url('../Default/imgs/black/x_table_view_transp.svg');qproperty-SchematicCamstandButtonBgOffColor:#ababab;qproperty-SchematicCamstandButtonOffImage:url('../Default/imgs/black/x_table_view_off.svg')}#SchematicBottomFrame{background-color:#808080;border:0;margin:0;padding:0}#SchematicBottomFrame QToolBar::separator:horizontal{margin:0}#SchematicBottomFrame QToolBar QToolButton{padding:0;margin:2}#SchematicSceneViewer{background-color:#737373;border-bottom:1 solid #404040}#FxSettingsTabBar::tab{border-top:1 solid #404040}#FxSettingsTabBar::tab::first,#FxSettingsTabBar::tab::only-one{border-left:1 solid #404040}FxSettings QToolBar{border-top:1 solid #404040;border-right:1 solid #404040;border-left:1 solid #404040;min-height:23;padding:3 0}FxSettings QToolBar QToolBar{border:0}#FxSettingsLabel{color:#000}#FxSettingsHelpButton{background-color:#80a0dc;color:#000;padding-top:0;padding-bottom:0}#FxSettingsHelpButton:hover{background-color:#a8bee7}#ScriptConsole{font-family:'Courier New',monospace;border:0;color:#000000;padding:3}#ScriptConsole QFrame{background-color:#dcdcdc}#ScriptConsole TPanelTitleBar{background-color:#5a5a5a}#TaskSheetItemLabel{color:#000}#Tasks QToolBar{border-bottom:1 solid #404040;margin:0;padding:0}#Tasks QToolBar QToolButton{margin:2 2 3 2}#ToolBar QToolBar{padding-left:2}#ToolOptions TPanelTitleBar{border-right:1 solid #404040;border-bottom:0}#CommandBar TPanelTitleBar{border-right:1 solid #404040;border-bottom:0}IconViewField{qproperty-ThicknessPixmap:url("../Default/imgs/black/selectiontool_thickness.svg")}#EditToolLockButton{spacing:0}#EditToolLockButton:hover{background:none}#EditToolLockButton::indicator{border:1 solid rgba(255,255,255,0);height:18;padding:0;width:18}#EditToolLockButton::indicator:unchecked{image:url('../Default/imgs/black/lock_off.svg')}#EditToolLockButton::indicator:checked{background-color:#C34040;border-color:#772626;image:url('../Default/imgs/black/lock_on.svg')}#EditToolLockButton::indicator:checked:hover{background-color:#d57a7a;border-color:#772626}PopupButton::menu-indicator{border-left:0;height:17;image:url('../Default/imgs/black/combo_downarrow.svg');width:10}PopupButton::menu-indicator:hover{image:url('../Default/imgs/black/combo_downarrow.svg')}PopupButton::menu-indicator:disabled{image:url('../Default/imgs/black/combo_downarrow_disabled.svg')}#Cap,#Join{padding:0 4 0 -8;max-width:32;min-width:32}#Cap QMenu,#Join QMenu{max-width:28;min-width:28}#Cap QMenu::item,#Join QMenu::item{max-width:28;min-width:28;padding:0}QToolBar#MediumPaddingToolBar QToolButton{padding-left:3;padding-right:3}QToolBar#WidePaddingToolBar QToolButton{padding-left:6;padding-right:6}#CommandBar{margin:0;padding:0;border:0}#CommandBar::separator:horizontal{margin-right:3;margin-left:3}#expandButton:checked{background-color:transparent;border-color:transparent;color:#000}#expandButton:checked:hover{background-color:#bbb;border-color:#525252}#expandButton:checked:pressed{background-color:#e1e1e1;border-color:#525252}#ComboViewerPanel Toolbar{border-bottom:1 solid #404040}#ComboViewerPanel Toolbar::separator:horizontal{margin:0 0 0 2}#ComboViewerPanel Toolbar QToolButton{margin:2 0 3 2}#ComboViewerToolOptions{border-bottom:1 solid #404040}#ComboViewer #ToolBarContainer,#ViewerPanel #ToolBarContainer,FlipBook #ToolBarContainer{background-color:transparent;border-top:2 solid #404040;border-bottom:1 solid #404040;padding-right:-1}#flipCustomize{margin-left:3}#flipCustomize::menu-button{background-color:transparent;width:35}#flipCustomize::menu-arrow{image:none}QToolBar#FlipConsolePlayToolBar::separator:horizontal{margin:0 3}QToolBar#FlipConsolePlayToolBar QToolButton{margin-top:2;margin-bottom:2;height:16;padding-left:1;padding-right:1}#ViewerFpsSlider{background-color:transparent;background-image:url('../Default/imgs/black/slider-groove.svg');background-position:center center;background-repeat:repeat-x;border:0;height:19;margin:0 3 0 37;max-width:300;min-width:0}#ViewerFpsSlider::sub-line:horizontal{subcontrol-origin:absolute;background-color:#a6a6a6;border:1 solid #525252;border-top-left-radius:2;border-bottom-left-radius:2;height:16;left:-33;width:14}#ViewerFpsSlider::add-line:horizontal{subcontrol-position:left;background-color:#a6a6a6;border:1 solid #525252;border-top-right-radius:2;border-bottom-right-radius:2;left:18;height:16;image-position:center center;width:13}#ViewerFpsSlider::handle::horizontal{background-color:#a6a6a6;border:1 solid #404040;border-radius:2;margin:2 0 3 0;min-width:9;width:9;max-width:9}FlipSlider{qproperty-PBHeight:15;qproperty-PBOverlay:url('../Default/imgs/black/flipslider.svg');qproperty-PBColorMarginLeft:1;qproperty-PBColorMarginTop:2;qproperty-PBColorMarginRight:1;qproperty-PBColorMarginBottom:2;qproperty-PBMarker:url('../Default/imgs/black/flipmarker.svg');qproperty-PBMarkerMarginLeft:3;qproperty-PBMarkerMarginRight:3;qproperty-notStartedColor:#8b2525;qproperty-startedColor:#00a808;qproperty-baseColor:#676767;qproperty-finishedColor:#676767}Ruler{qproperty-ParentBGColor:#c0c0c0;qproperty-ScaleColor:#000}#RulerToolOptionValues{color:#000}#xsheetArea,#ScrollArea{background-color:#6c6c6c;border:0}#xsheetScrollArea{border:0}#cornerWidget QToolButton{padding:0}#xsheetColumnAreaMenu_Preview{background-color:#E6E678}#xsheetColumnAreaMenu_Lock{background-color:#F5F5F5}#xsheetColumnAreaMenu_Camstand{background-color:#FFA480}#xsheetColumnAreaMenu_Preview,#xsheetColumnAreaMenu_Lock,#xsheetColumnAreaMenu_Camstand{color:#000}#noteTextEdit{color:#000}XsheetViewer{qproperty-TextColor:#000;qproperty-BGColor:#929292;qproperty-LightLineColor:#616161;qproperty-MarkerLineColor:#000;qproperty-VerticalLineColor:#646464;qproperty-VerticalLineHeadColor:#393939;qproperty-PreviewFrameTextColor:#000eb6;qproperty-CurrentRowBgColor:#B5C0D0;qproperty-OnionSkinAreaBgColor:#858585;qproperty-EmptyColumnHeadColor:#808080;qproperty-SelectedColumnTextColor:#9e0000;qproperty-EmptyCellColor:#7c7c7c;qproperty-NotEmptyColumnColor:#8a8a8a;qproperty-SelectedEmptyCellColor:#b3b3b3;qproperty-LevelColumnColor:#76b776;qproperty-LevelColumnBorderColor:#496549;qproperty-SelectedLevelColumnColor:#9bc59b;qproperty-VectorColumnColor:#c0c07a;qproperty-VectorColumnBorderColor:#71714a;qproperty-SelectedVectorColumnColor:#cdcda0;qproperty-ChildColumnColor:#d69adb;qproperty-ChildColumnBorderColor:#9c53a3;qproperty-SelectedChildColumnColor:#e3c2e6;qproperty-FullcolorColumnColor:#8bbdc1;qproperty-FullcolorColumnBorderColor:#577476;qproperty-SelectedFullcolorColumnColor:#afcdd0;qproperty-FxColumnColor:#82815d;qproperty-FxColumnBorderColor:#404039;qproperty-SelectedFxColumnColor:#97967b;qproperty-ReferenceColumnColor:#ababab;qproperty-ReferenceColumnBorderColor:#6b6b6b;qproperty-SelectedReferenceColumnColor:#c4c4c4;qproperty-PaletteColumnColor:#2aab9a;qproperty-PaletteColumnBorderColor:#173e39;qproperty-SelectedPaletteColumnColor:#40c8b6;qproperty-MeshColumnColor:#ac78d4;qproperty-MeshColumnBorderColor:#6b418c;qproperty-SelectedMeshColumnColor:#c3a2dd;qproperty-SoundTextColumnColor:#c8c8c8;qproperty-SoundTextColumnBorderColor:#8c8c8c;qproperty-SelectedSoundTextColumnColor:#e2e2e2;qproperty-SoundColumnColor:#acba82;qproperty-SoundColumnBorderColor:#656b51;qproperty-SelectedSoundColumnColor:#c0c9a6;qproperty-SoundColumnHlColor:#f5ffe6;qproperty-SoundColumnTrackColor:#5a642d;qproperty-ColumnHeadPastelizer:#fff;qproperty-SelectedColumnHead:#bed2f0;qproperty-LightLightBGColor:#808080;qproperty-LightBGColor:#f0f0f0;qproperty-DarkBGColor:#e1e1e1;qproperty-DarkLineColor:#969696;qproperty-XsheetColumnNameBgColor:rgba(0,0,0,0);qproperty-XsheetDragBarHighlightColor:rgba(255,255,255,0.5);qproperty-XsheetPreviewButtonBgOnColor:#c8c864;qproperty-XsheetPreviewButtonOnImage:url('../Default/imgs/black/x_prev_eye_on.svg');qproperty-XsheetPreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetPreviewButtonOffImage:url('../Default/imgs/black/x_prev_eye_off.svg');qproperty-XsheetCamstandButtonBgOnColor:#eb906b;qproperty-XsheetCamstandButtonOnImage:url('../Default/imgs/black/x_table_view_on.svg');qproperty-XsheetCamstandButtonTranspImage:url('../Default/imgs/black/x_table_view_transp.svg');qproperty-XsheetCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetCamstandButtonOffImage:url('../Default/imgs/black/x_table_view_off.svg');qproperty-XsheetLockButtonBgOnColor:rgba(255,255,255,0.3);qproperty-XsheetLockButtonOnImage:url('../Default/imgs/black/x_lock_on.svg');qproperty-XsheetLockButtonBgOffColor:rgba(255,255,255,0);qproperty-XsheetLockButtonOffImage:url('../Default/imgs/black/x_lock_off.svg');qproperty-XsheetConfigButtonBgColor:rgba(255,255,255,0);qproperty-XsheetConfigButtonImage:url('../Default/imgs/black/x_config.svg');qproperty-TimelinePreviewButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOnImage:url('../Default/imgs/black/timeline_toggle_on.svg');qproperty-TimelinePreviewButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelinePreviewButtonOffImage:url('../Default/imgs/black/timeline_toggle_off.svg');qproperty-TimelineCamstandButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOnImage:url('../Default/imgs/black/timeline_toggle_on.svg');qproperty-TimelineCamstandButtonTranspImage:url('../Default/imgs/black/timeline_toggle_transp.svg');qproperty-TimelineCamstandButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineCamstandButtonOffImage:url('../Default/imgs/black/timeline_toggle_off.svg');qproperty-TimelineLockButtonBgOnColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOnImage:url('../Default/imgs/black/timeline_toggle_on.svg');qproperty-TimelineLockButtonBgOffColor:rgba(255,255,255,0);qproperty-TimelineLockButtonOffImage:url('../Default/imgs/black/timeline_toggle_off.svg');qproperty-TimelineConfigButtonBgColor:rgba(255,255,255,0);qproperty-TimelineConfigButtonImage:url('../Default/imgs/black/timeline_config.svg');qproperty-LayerHeaderPreviewImage:url('../Default/imgs/black/layer_header_prev_eye.svg');qproperty-LayerHeaderPreviewOverImage:url('../Default/imgs/black/layer_header_prev_eye_over.svg');qproperty-LayerHeaderCamstandImage:url('../Default/imgs/black/layer_header_table_view.svg');qproperty-LayerHeaderCamstandOverImage:url('../Default/imgs/black/layer_header_table_view_over.svg');qproperty-LayerHeaderLockImage:url('../Default/imgs/black/lock_on.svg');qproperty-LayerHeaderLockOverImage:url('../Default/imgs/black/lock_on_over.svg');qproperty-ActiveCameraColor:#6ba5de;qproperty-SelectedActiveCameraColor:#98bee4;qproperty-OtherCameraColor:#8f9c9e;qproperty-SelectedOtherCameraColor:#aeb1b2}#XSheetToolbar{margin:0;padding:0;border:0}#XSheetToolbar QToolButton{padding:0;margin:4 1;min-height:19;height:19}#XSheetToolbar::separator:horizontal{margin:0 4}#FunctionEditor QToolBar{border-bottom:1 solid #404040}#FunctionEditor QToolBar QToolBar{border:0}#FunctionEditor QToolBar QLabel{margin-left:5}#FunctionEditor QToolBar QToolButton{height:18}#FunctionEditorTree{border-top:1 solid #404040}FunctionTreeView{qproperty-TextColor:#000;qproperty-CurrentTextColor:#a70000}FunctionPanel{qproperty-BGColor:#5a5a5a;qproperty-ValueLineColor:#4d4d4d;qproperty-FrameLineColor:#4d4d4d;qproperty-OtherCurvesColor:#c5c5c5;qproperty-RulerBackground:#676767;qproperty-TextColor:#000;qproperty-SubColor:#fff;qproperty-SelectedColor:#fcae06}SpreadsheetViewer{qproperty-LightLightBGColor:#808080;qproperty-CurrentRowBgColor:#B5C0D0;qproperty-LightLineColor:#616161;qproperty-MarkerLineColor:#000;qproperty-BGColor:#8a8a8a;qproperty-VerticalLineColor:#646464;qproperty-KeyFrameColor:#db8b36;qproperty-KeyFrameBorderColor:#7b4a16;qproperty-SelectedKeyFrameColor:#dea466;qproperty-InBetweenColor:#c2c2b0;qproperty-InBetweenBorderColor:#636356;qproperty-SelectedInBetweenColor:#d6d6cf;qproperty-SelectedEmptyColor:#b3b3b3;qproperty-SelectedSceneRangeEmptyColor:#d2d2d2;qproperty-TextColor:#000;qproperty-ColumnHeaderBorderColor:#393939;qproperty-SelectedColumnTextColor:#9e0000}#ExpressionField{background-color:#fff;border:1 solid #6b6b6b;margin:0}#FunctionSegmentViewerLinkButton{background-image:url('../Default/imgs/black/segment_unlinked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:hover{background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:checked{background-image:url('../Default/imgs/black/segment_linked.svg');background-repeat:no-repeat}#FunctionSegmentViewerLinkButton:disabled{background-image:url('../Default/imgs/black/segment_disabled.svg');background-repeat:no-repeat}
+/* -----------------------------------------------------------------------------
+   Component: Button Styles
+----------------------------------------------------------------------------- */
+.button-show,
+#LoadLevelShowButton,
+#CleanupSettingsShowButton,
+#OutputSettingsShowButton,
+#FxSettingsPreviewShowButton {
+  image: url('../Default/imgs/black/plus.svg');
+  image-position: center center;
+  margin: 0;
+  padding: 1;
+  min-width: 10;
+  min-height: 10;
+}
+.button-show:checked,
+#LoadLevelShowButton:checked,
+#CleanupSettingsShowButton:checked,
+#OutputSettingsShowButton:checked,
+#FxSettingsPreviewShowButton:checked {
+  background-color: #5a5a5a;
+  border-color: #454545;
+  image: url('../Default/imgs/black/minus.svg');
+}
+.button-show:checked:pressed,
+#LoadLevelShowButton:checked:pressed,
+#CleanupSettingsShowButton:checked:pressed,
+#OutputSettingsShowButton:checked:pressed,
+#FxSettingsPreviewShowButton:checked:pressed {
+  background-color: #e1e1e1;
+  border-color: #525252;
+}
+.button-show:checked:hover,
+#LoadLevelShowButton:checked:hover,
+#CleanupSettingsShowButton:checked:hover,
+#OutputSettingsShowButton:checked:hover,
+#FxSettingsPreviewShowButton:checked:hover {
+  background-color: #5f5f5f;
+}
+.button-tool,
+QToolButton,
+#CameraSettingsRadioButton::indicator,
+#ForceSquaredPixelButton,
+#SchematicBottomFrame QToolBar QToolButton,
+#EditToolLockButton::indicator,
+#flipCustomize {
+  background-color: rgba(255, 255, 255, 0);
+  border: 1 solid rgba(255, 255, 255, 0);
+  border-radius: 2;
+  color: #000000;
+  margin: 1;
+  padding: 0;
+}
+.button-tool:hover,
+QToolButton:hover,
+#CameraSettingsRadioButton::indicator:hover,
+#ForceSquaredPixelButton:hover,
+#colorSliderAddButton:hover,
+#colorSliderSubButton:hover,
+#SchematicBottomFrame QToolBar QToolButton:hover,
+#EditToolLockButton::indicator:hover,
+#flipCustomize:hover {
+  background-color: #bbbbbb;
+  border-color: #525252;
+  color: #000000;
+}
+.button-tool:pressed,
+QToolButton:pressed,
+#CameraSettingsRadioButton::indicator:pressed,
+#ForceSquaredPixelButton:pressed,
+#colorSliderAddButton:pressed,
+#colorSliderSubButton:pressed,
+#SchematicBottomFrame QToolBar QToolButton:pressed,
+#EditToolLockButton::indicator:pressed,
+#flipCustomize:pressed {
+  background-color: #e1e1e1;
+  border-color: #525252;
+  color: #000000;
+}
+.button-tool:checked,
+QToolButton:checked,
+#CameraSettingsRadioButton::indicator:checked,
+#ForceSquaredPixelButton:checked,
+#SchematicBottomFrame QToolBar QToolButton:checked,
+#EditToolLockButton::indicator:checked,
+#flipCustomize:checked {
+  background-color: #5a5a5a;
+  border-color: #454545;
+  color: #c0c0c0;
+}
+.button-tool:checked:hover,
+QToolButton:checked:hover,
+#CameraSettingsRadioButton::indicator:checked:hover,
+#ForceSquaredPixelButton:checked:hover,
+#SchematicBottomFrame QToolBar QToolButton:checked:hover,
+#EditToolLockButton::indicator:checked:hover,
+#flipCustomize:checked:hover {
+  background-color: #6e6e6e;
+  border-color: #454545;
+}
+.button-tool:disabled,
+QToolButton:disabled,
+#CameraSettingsRadioButton::indicator:disabled,
+#ForceSquaredPixelButton:disabled,
+#SchematicBottomFrame QToolBar QToolButton:disabled,
+#EditToolLockButton::indicator:disabled,
+#flipCustomize:disabled {
+  color: rgba(0, 0, 0, 0.466);
+}
+.button-flat,
+PaletteViewer QToolBar QToolButton {
+  background-color: none;
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+}
+.button-flat:hover,
+PaletteViewer QToolBar QToolButton:hover {
+  background-color: #bbbbbb;
+}
+.button-flat:pressed,
+PaletteViewer QToolBar QToolButton:pressed {
+  background-color: #404040;
+}
+/* -----------------------------------------------------------------------------
+   Component: Frames
+----------------------------------------------------------------------------- */
+.frame,
+.GroupBox,
+#LoadLevelFrame,
+#PsdSettingsGroupBox,
+#CleanupSettingsFrame,
+#OutputSettingsBox,
+#OutputSettingsCameraBox,
+#SolidLineFrame,
+#FunctionParametersPanel,
+QGroupBox {
+  border: 1 solid #404040;
+  border-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Component: Icons
+----------------------------------------------------------------------------- */
+/* -----------------------------------------------------------------------------
+   Component: Tabs
+----------------------------------------------------------------------------- */
+.tab-container,
+#TabBarContainer {
+  background-color: transparent;
+  qproperty-BottomAboveLineColor: #6c6c6c;
+  qproperty-BottomBelowLineColor: #404040;
+}
+.tab-flat,
+#StyleEditorTabBar::tab,
+#PaletteTabBar::tab,
+#FxSettingsTabBar::tab {
+  background-color: #5a5a5a;
+  border-right: 1 solid #404040;
+  border-bottom: 1 solid #404040;
+  color: #c0c0c0;
+  padding: 3 4 3 4;
+}
+.tab-flat:hover,
+#StyleEditorTabBar::tab:hover,
+#PaletteTabBar::tab:hover,
+#FxSettingsTabBar::tab:hover {
+  background-color: #6e6e6e;
+  color: #fff;
+}
+.tab-flat:selected,
+#StyleEditorTabBar::tab:selected,
+#PaletteTabBar::tab:selected,
+#FxSettingsTabBar::tab:selected {
+  background-color: #808080;
+  color: #000;
+  border-bottom-color: #808080;
+}
+.tab-flat:only-one,
+#StyleEditorTabBar::tab:only-one,
+#PaletteTabBar::tab:only-one,
+#FxSettingsTabBar::tab:only-one {
+  margin: 0;
+}
+.tab-round {
+  background-color: #5a5a5a;
+  border-top: 1 solid #404040;
+  border-right: 1 solid #404040;
+  border-left: 1 solid #404040;
+  border-bottom: 1 solid #404040;
+  color: #c0c0c0;
+  margin: 3 -1 0 0;
+  padding: 2 7 1 7;
+}
+.tab-round:hover {
+  background-color: #6e6e6e;
+  color: #fff;
+}
+.tab-round:selected {
+  background-color: #808080;
+  border-top-right-radius: 2;
+  border-top-left-radius: 2;
+  border-bottom-color: #808080;
+  color: #000;
+  margin: 1 -1 -1 0;
+  padding: 2 7 2 7;
+}
+.tab-round:only-one {
+  margin: 1 0 0 0;
+  padding: 3 7 3 7;
+}
+.tab-round:last {
+  margin-right: 0;
+  border-top-right-radius: 2;
+}
+.tab-round:first {
+  border-top-left-radius: 2;
+}
+/* -----------------------------------------------------------------------------
+   Main
+----------------------------------------------------------------------------- */
+QWidget {
+  background-color: #808080;
+  color: #000;
+}
+QWidget:disabled {
+  color: rgba(0, 0, 0, 0.466);
+}
+QFrame {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QToolTip,
+#helpToolTip {
+  background-color: #fff;
+  border: 1 solid #000;
+  color: #000;
+  padding: 1 1;
+}
+#DockSeparator,
+QMainWindow::separator,
+QSplitter::handle {
+  background-color: #272727;
+  height: 4;
+  width: 4;
+}
+#TDockPlaceholder {
+  background-color: #F77272;
+}
+TPanel {
+  background-color: #272727;
+}
+/* -----------------------------------------------------------------------------
+   Topbar
+----------------------------------------------------------------------------- */
+#TopBar {
+  background: #808080;
+  border: 0;
+  border-bottom: 1 solid #404040;
+  height: 21;
+}
+#TopBar #EditToolLockButton {
+  background: #808080;
+  spacing: 0;
+}
+#TopBar #EditToolLockButton::indicator {
+  background: none;
+  border: none;
+  height: 18;
+  margin: 1 2 0 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+#TopBarTabContainer {
+  background-color: #808080;
+  margin-bottom: 1;
+}
+#StackedMenuBar {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+QMenuBar {
+  background-color: #808080;
+  border: 0;
+}
+QMenuBar::item {
+  background-color: #808080;
+  border-left: 1 solid #808080;
+  margin: 0;
+  padding: 3 5;
+}
+QMenuBar::item:selected {
+  background-color: #9f9f9f;
+  color: #000;
+}
+QMenuBar::item:pressed {
+  background-color: #225baf;
+  color: #FFFFFF;
+}
+/* -----------------------------------------------------------------------------
+   Workspaces
+----------------------------------------------------------------------------- */
+#TopBarTab {
+  margin: 0;
+  padding: 0;
+}
+#TopBarTab::tab {
+  background-color: #5a5a5a;
+  border-top: 1 solid #404040;
+  border-right: 1 solid #404040;
+  color: #afafaf;
+  margin: 0 0 0 0;
+  padding: 2 8 3 8;
+}
+#TopBarTab::tab:hover {
+  background-color: #6e6e6e;
+  color: #fff;
+}
+#TopBarTab::tab:selected {
+  background-color: #9a9a9a;
+  color: #000;
+}
+#TopBarTab::tab:first {
+  border-left: 1 solid #404040;
+}
+#TopBarTab::tab:last {
+  border-right: 1 solid #404040;
+}
+/* -----------------------------------------------------------------------------
+   Menu
+----------------------------------------------------------------------------- */
+QMenu {
+  background-color: #949494;
+  border: 1 solid #404040;
+  padding: 2 0;
+}
+QMenu::item {
+  padding: 3 28;
+}
+QMenu::item:selected {
+  background-color: #225baf;
+  color: #FFFFFF;
+}
+QMenu::item:checked {
+  color: #000;
+}
+QMenu::item:checked:selected {
+  background-color: #225baf;
+  color: #FFFFFF;
+}
+QMenu::item:disabled {
+  background: none;
+  color: rgba(0, 0, 0, 0.466);
+}
+QMenu::item:disabled:selected {
+  border-color: transparent;
+}
+QMenu::separator {
+  border-top: 1 solid #6e6e6e;
+  height: 0;
+  margin: 2 0;
+}
+QMenu::icon {
+  border-radius: 2;
+  margin: 0 0 0 3;
+  padding: 1;
+}
+QMenu::icon:checked {
+  background-color: #225baf;
+}
+QMenu::indicator {
+  margin-left: 7;
+}
+/* -----------------------------------------------------------------------------
+   Titlebars
+----------------------------------------------------------------------------- */
+TPanelTitleBar {
+  background-color: #5a5a5a;
+  border-color: #404040;
+  border-style: solid;
+  border-width: 0 0 1 0;
+  height: 20;
+  min-height: 20;
+  qproperty-TitleColor: #c0c0c0;
+  qproperty-ActiveTitleColor: #fff;
+  qproperty-BorderPixmap: url('none');
+  qproperty-ActiveBorderPixmap: url('../Default/imgs/black/none');
+  qproperty-FloatBorderPixmap: url('none');
+  qproperty-FloatActiveBorderPixmap: url('../Default/imgs/black/none');
+}
+/* -----------------------------------------------------------------------------
+   Scrollbars
+----------------------------------------------------------------------------- */
+QAbstractScrollArea::corner {
+  background-color: #6e6e6e;
+}
+QScrollBar {
+  background-color: #6e6e6e;
+  border: 0;
+}
+QScrollBar:horizontal {
+  height: 16;
+  margin: 0;
+}
+QScrollBar:vertical {
+  margin: 0;
+  width: 16;
+}
+QScrollBar::handle {
+  border: 1 solid #555555;
+  border-radius: 2;
+}
+QScrollBar::handle:horizontal:hover,
+QScrollBar::handle:vertical:hover {
+  background-color: #b3b3b3;
+  border-color: #404040;
+}
+QScrollBar::handle:horizontal:pressed,
+QScrollBar::handle:vertical:pressed {
+  background-color: #c7c7c7;
+  border-color: #404040;
+}
+QScrollBar::handle:horizontal {
+  background-color: #9f9f9f;
+  margin: 2 16;
+  min-width: 20;
+}
+QScrollBar::handle:vertical {
+  background-color: #9f9f9f;
+  margin: 16 2;
+  min-height: 20;
+}
+QScrollBar::add-line {
+  subcontrol-origin: margin;
+  border: 0;
+}
+QScrollBar::add-line:horizontal {
+  subcontrol-position: right;
+  background-color: #6e6e6e;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::add-line:vertical {
+  subcontrol-position: bottom;
+  background-color: #6e6e6e;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::sub-line {
+  border: 0;
+  subcontrol-origin: margin;
+}
+QScrollBar::sub-line:horizontal {
+  subcontrol-position: left;
+  background-color: #6e6e6e;
+  margin: 0;
+  width: 16;
+}
+QScrollBar::sub-line:vertical {
+  subcontrol-position: top;
+  background-color: #6e6e6e;
+  margin: 0;
+  height: 16;
+}
+QScrollBar::up-arrow:vertical {
+  image: url('../Default/imgs/black/scroll-up.svg');
+  image-position: center center;
+}
+QScrollBar::up-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::down-arrow:vertical {
+  image: url('../Default/imgs/black/scroll-down.svg');
+  image-position: center center;
+}
+QScrollBar::down-arrow:vertical:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::left-arrow:horizontal {
+  image: url('../Default/imgs/black/scroll-left.svg');
+  image-position: center center;
+}
+QScrollBar::left-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::right-arrow:horizontal {
+  image: url('../Default/imgs/black/scroll-right.svg');
+  image-position: center center;
+}
+QScrollBar::right-arrow:horizontal:pressed {
+  margin: 1 0 0 0;
+}
+QScrollBar::sub-page:horizontal,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:vertical,
+QScrollBar::add-page:vertical {
+  background: none;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bars
+----------------------------------------------------------------------------- */
+QToolBar {
+  padding: 0;
+}
+QToolBar::separator:horizontal {
+  border-left: 1 solid #404040;
+  margin: 0 1;
+  width: 0;
+}
+QToolBar::separator:vertical {
+  border-top: 1 solid #404040;
+  height: 0;
+  margin: 1 0;
+}
+QToolBar QLabel {
+  margin-top: 1;
+}
+QToolBar QToolBar {
+  border: 0;
+}
+QToolButton::menu-indicator {
+  image: none;
+}
+QToolButton::menu-button {
+  border-image: none;
+}
+/* -------------------------------------------------------------------------- */
+/* Scrollable QToolBar Buttons
+/* -------------------------------------------------------------------------- */
+.DvScrollWidget QPushButton,
+DvScrollWidget QPushButton,
+#ScrollLeftButton QPushButton,
+#ScrollRightButton QPushButton,
+#ScrollUpButton QPushButton,
+#ScrollDownButton QPushButton {
+  background-color: #a6a6a6;
+  border: 0 solid red;
+  border-radius: 0;
+  padding: 0;
+  max-width: 16;
+}
+.DvScrollWidget QPushButton:hover,
+DvScrollWidget QPushButton:hover,
+#ScrollLeftButton QPushButton:hover,
+#ScrollRightButton QPushButton:hover,
+#ScrollUpButton QPushButton:hover,
+#ScrollDownButton QPushButton:hover {
+  background-color: #bbbbbb;
+}
+.DvScrollWidget QPushButton:pressed,
+DvScrollWidget QPushButton:pressed,
+#ScrollLeftButton QPushButton:pressed,
+#ScrollRightButton QPushButton:pressed,
+#ScrollUpButton QPushButton:pressed,
+#ScrollDownButton QPushButton:pressed {
+  background-color: #e1e1e1;
+}
+#ScrollLeftButton,
+#ScrollRightButton,
+#ScrollUpButton,
+#ScrollDownButton {
+  margin: 0;
+  min-width: 16;
+}
+#ScrollLeftButton {
+  border-right: 1 solid #404040;
+  image: url('../Default/imgs/black/scroll-left.svg');
+}
+#ScrollRightButton {
+  border-left: 1 solid #404040;
+  margin-left: 3;
+  image: url('../Default/imgs/black/scroll-right.svg');
+}
+#ScrollUpButton {
+  image: url('../Default/imgs/black/scroll-up.svg');
+}
+#ScrollDownButton {
+  image: url('../Default/imgs/black/scroll-down.svg');
+}
+/* -------------------------------------------------------------------------- */
+#keyFrameNavigator {
+  background: none;
+  margin: 0;
+  padding: 0;
+}
+#keyFrameNavigator QToolButton {
+  min-width: 18;
+}
+#keyFrameNavigator #PreviousKey {
+  image: url('../Default/imgs/black/prevkey.svg');
+}
+#keyFrameNavigator #PreviousKey:hover {
+  image: url('../Default/imgs/black/prevkey_over.svg');
+}
+#keyFrameNavigator #PreviousKey:disabled {
+  image: url('../Default/imgs/black/prevkey_disabled.svg');
+}
+#keyFrameNavigator #NextKey {
+  image: url('../Default/imgs/black/nextkey.svg');
+}
+#keyFrameNavigator #NextKey:hover {
+  image: url('../Default/imgs/black/nextkey_over.svg');
+}
+#keyFrameNavigator #NextKey:disabled {
+  image: url('../Default/imgs/black/nextkey_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Trees
+----------------------------------------------------------------------------- */
+.treeview,
+QTreeWidget,
+QTreeView,
+#FunctionEditorTree {
+  background-color: #949494;
+  alternate-background-color: #8a8a8a;
+  border: 0;
+  margin: 0;
+  outline: 0;
+}
+.treeview::item:selected,
+QTreeWidget::item:selected,
+QTreeView::item:selected,
+#FunctionEditorTree::item:selected {
+  background-color: #225baf;
+  color: #FFFFFF;
+}
+.treeview::branch:adjoins-item,
+QTreeWidget::branch:adjoins-item,
+QTreeView::branch:adjoins-item,
+#FunctionEditorTree::branch:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-siblings,
+QTreeWidget::branch:has-siblings,
+QTreeView::branch:has-siblings,
+#FunctionEditorTree::branch:has-siblings {
+  border-image: url('');
+}
+.treeview::branch:has-siblings:adjoins-item,
+QTreeWidget::branch:has-siblings:adjoins-item,
+QTreeView::branch:has-siblings:adjoins-item,
+#FunctionEditorTree::branch:has-siblings:adjoins-item {
+  border-image: url('');
+}
+.treeview::branch:has-children:closed,
+QTreeWidget::branch:has-children:closed,
+QTreeView::branch:has-children:closed,
+#FunctionEditorTree::branch:has-children:closed {
+  background: url('../Default/imgs/black/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:open,
+QTreeWidget::branch:has-children:open,
+QTreeView::branch:has-children:open,
+#FunctionEditorTree::branch:has-children:open {
+  background: url('../Default/imgs/black/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:closed,
+QTreeWidget::branch:has-children:has-siblings:closed,
+QTreeView::branch:has-children:has-siblings:closed,
+#FunctionEditorTree::branch:has-children:has-siblings:closed {
+  background: url('../Default/imgs/black/treebranch-closed.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+.treeview::branch:has-children:has-siblings:open,
+QTreeWidget::branch:has-children:has-siblings:open,
+QTreeView::branch:has-children:has-siblings:open,
+#FunctionEditorTree::branch:has-children:has-siblings:open {
+  background: url('../Default/imgs/black/treebranch-open.svg') no-repeat;
+  background-position: center center;
+  border-image: none;
+  image: none;
+}
+QListView {
+  outline: 0;
+  background: #949494;
+  alternate-background-color: #8a8a8a;
+}
+/* -----------------------------------------------------------------------------
+   Tab Systems
+----------------------------------------------------------------------------- */
+#TabBarContainer {
+  background-color: #6c6c6c;
+}
+/* -----------------------------------------------------------------------------
+   Push Button
+----------------------------------------------------------------------------- */
+.Button,
+QPushButton,
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  background-color: #a6a6a6;
+  border: 1 solid #525252;
+  border-radius: 2;
+  color: #000000;
+  margin: 0;
+  padding: 3 15;
+}
+.Button:hover,
+QPushButton:hover,
+.ComboBox:hover,
+#ViewerFpsSlider::sub-line:horizontal:hover,
+#ViewerFpsSlider::add-line:horizontal:hover,
+QComboBox:hover {
+  background-color: #bbbbbb;
+  border-color: #525252;
+  color: #000000;
+}
+.Button:pressed,
+QPushButton:pressed,
+#ViewerFpsSlider::sub-line:horizontal:pressed,
+#ViewerFpsSlider::add-line:horizontal:pressed {
+  background-color: #e1e1e1;
+  border-color: #525252;
+  color: #000000;
+}
+.Button:checked,
+QPushButton:checked {
+  background-color: #5a5a5a;
+  border-color: #454545;
+  color: #c0c0c0;
+}
+.Button:checked:hover,
+QPushButton:checked:hover {
+  background-color: #5f5f5f;
+}
+.Button:checked:hover:pressed,
+QPushButton:checked:hover:pressed {
+  background: #5a5a5a;
+}
+.Button:disabled,
+QPushButton:disabled,
+.ComboBox:disabled,
+#ViewerFpsSlider::sub-line:horizontal:disabled,
+#ViewerFpsSlider::add-line:horizontal:disabled,
+QComboBox:disabled {
+  background-color: #8d8d8d;
+  border-color: #737373;
+  color: rgba(0, 0, 0, 0.466);
+}
+#PushButton_NoPadding {
+  padding: 3;
+}
+/* -----------------------------------------------------------------------------
+   Combo Box
+----------------------------------------------------------------------------- */
+.ComboBox,
+.ComboBox:checked,
+QComboBox,
+QComboBox:checked {
+  padding: 1 0 1 4;
+  margin: 1 0;
+}
+.ComboBox::drop-down,
+QComboBox::drop-down {
+  image: url('../Default/imgs/black/combo_downarrow.svg');
+  image-position: center center;
+  width: 16;
+}
+.ComboBox::drop-down:disabled,
+QComboBox::drop-down:disabled {
+  image: url('../Default/imgs/black/combo_downarrow_disabled.svg');
+}
+.ComboBox QAbstractItemView,
+QComboBox QAbstractItemView {
+  background-color: #949494;
+  border: 1 solid #404040;
+  selection-background-color: #225baf;
+  selection-color: #FFFFFF;
+}
+/* -----------------------------------------------------------------------------
+   Textfield
+----------------------------------------------------------------------------- */
+.LineEdit,
+QPlainTextEdit,
+QLineEdit,
+#TaskSheetItem,
+#tasksRemoveBox,
+#tasksAddBox {
+  background-color: #e6e6e6;
+  border: 1 solid #525252;
+  border-radius: 2;
+  color: #000;
+  selection-background-color: #225baf;
+  selection-color: #FFFFFF;
+  padding: 0 0 0 1;
+}
+.LineEdit:focus,
+QPlainTextEdit:focus,
+QLineEdit:focus,
+#TaskSheetItem:focus,
+#tasksRemoveBox:focus,
+#tasksAddBox:focus {
+  background-color: #e6e6e6;
+  border-color: #525252;
+  color: #000;
+}
+.LineEdit:disabled,
+QPlainTextEdit:disabled,
+QLineEdit:disabled,
+#TaskSheetItem:disabled,
+#tasksRemoveBox:disabled,
+#tasksAddBox:disabled {
+  background-color: #9a9a9a;
+  border-color: #696969;
+  color: rgba(0, 0, 0, 0.466);
+}
+/* -----------------------------------------------------------------------------
+   CheckBox
+----------------------------------------------------------------------------- */
+.CheckBox,
+QCheckBox {
+  color: #000;
+}
+.CheckBox:hover,
+QCheckBox:hover,
+.RadioButton:hover,
+QRadioButton:hover {
+  color: #fff;
+}
+.CheckBox:disabled,
+QCheckBox:disabled {
+  color: rgba(0, 0, 0, 0.466);
+}
+.CheckBox::indicator,
+QMenu::indicator,
+QCheckBox::indicator,
+.GroupBox::indicator,
+QGroupBox::indicator {
+  background-color: #cdcdcd;
+  border: 1 solid #525252;
+  border-radius: 2;
+  height: 9;
+  /* fix for QGroupBox */
+  padding: 1;
+  width: 9;
+  /* fix for QMenu */
+}
+.CheckBox::indicator:hover,
+QMenu::indicator:hover,
+.CheckBox::indicator:checked:hover,
+.CheckBox::indicator:indeterminate:hover,
+QCheckBox::indicator:hover,
+.GroupBox::indicator:hover,
+QMenu::indicator:checked:hover,
+QMenu::indicator:indeterminate:hover,
+QCheckBox::indicator:checked:hover,
+QCheckBox::indicator:indeterminate:hover,
+.GroupBox::indicator:checked:hover,
+.GroupBox::indicator:indeterminate:hover,
+QGroupBox::indicator:hover,
+QGroupBox::indicator:checked:hover,
+QGroupBox::indicator:indeterminate:hover {
+  background-color: #e6e6e6;
+  border-color: #525252;
+}
+.CheckBox::indicator:checked,
+QMenu::indicator:checked,
+QCheckBox::indicator:checked,
+.GroupBox::indicator:checked,
+QGroupBox::indicator:checked {
+  background-color: #cdcdcd;
+  border-color: #525252;
+  image: url('../Default/imgs/black/checkmark.svg');
+}
+.CheckBox::indicator:checked:disabled,
+QMenu::indicator:checked:disabled,
+QCheckBox::indicator:checked:disabled,
+.GroupBox::indicator:checked:disabled,
+QGroupBox::indicator:checked:disabled {
+  background-color: #8d8d8d;
+  border-color: #737373;
+  image: url('../Default/imgs/black/checkmark_disabled.svg');
+}
+.CheckBox::indicator:indeterminate,
+QMenu::indicator:indeterminate,
+QCheckBox::indicator:indeterminate,
+.GroupBox::indicator:indeterminate,
+QGroupBox::indicator:indeterminate {
+  background-color: #cdcdcd;
+  border-color: #525252;
+  image: url('../Default/imgs/black/checkpartially.svg');
+}
+.CheckBox::indicator:indeterminate:disabled,
+QMenu::indicator:indeterminate:disabled,
+QCheckBox::indicator:indeterminate:disabled,
+.GroupBox::indicator:indeterminate:disabled,
+QGroupBox::indicator:indeterminate:disabled {
+  background-color: #8d8d8d;
+  border-color: #737373;
+  image: url('../Default/imgs/black/checkpartially_disabled.svg');
+}
+.CheckBox::indicator:disabled,
+QMenu::indicator:disabled,
+QCheckBox::indicator:disabled,
+.GroupBox::indicator:disabled,
+QGroupBox::indicator:disabled {
+  background-color: #8d8d8d;
+  border-color: #737373;
+}
+/* -----------------------------------------------------------------------------
+   Radio Button
+----------------------------------------------------------------------------- */
+.RadioButton::indicator:unchecked,
+QRadioButton::indicator:unchecked,
+#CameraSettingsRadioButton_Small::indicator:unchecked {
+  image: url('../Default/imgs/black/radiobutton_unchecked.svg');
+  image-position: center center;
+}
+.RadioButton::indicator:checked,
+QRadioButton::indicator:checked,
+#CameraSettingsRadioButton_Small::indicator:checked {
+  image: url('../Default/imgs/black/radiobutton_checked.svg');
+  image-position: center center;
+}
+/* -----------------------------------------------------------------------------
+   GroupBox
+----------------------------------------------------------------------------- */
+.GroupBox,
+QGroupBox {
+  margin: 6 0 0 0;
+  padding: 5 0;
+}
+.GroupBox::title,
+QGroupBox::title {
+  subcontrol-origin: margin;
+  left: 15;
+  margin: -3 0 0 0;
+  padding: 0 3;
+}
+.GroupBox::title:hover,
+QGroupBox::title:hover {
+  color: #fff;
+}
+.GroupBox::title:disabled,
+QGroupBox::title:disabled {
+  color: rgba(0, 0, 0, 0.466);
+}
+.GroupBox::indicator,
+QGroupBox::indicator {
+  subcontrol-origin: margin;
+  margin-top: 2;
+}
+.GroupBox:disabled,
+QGroupBox:disabled {
+  color: rgba(0, 0, 0, 0.466);
+}
+/* -----------------------------------------------------------------------------
+   Slider
+----------------------------------------------------------------------------- */
+.Slider::groove:horizontal,
+QSlider::groove:horizontal {
+  background-color: transparent;
+  background-image: url('../Default/imgs/black/slider-groove.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  margin: 0;
+  height: 20;
+  min-height: 20;
+}
+.Slider::groove:horizontal:disabled,
+QSlider::groove:horizontal:disabled {
+  background-image: url('../Default/imgs/black/slider-groove_disabled.svg');
+}
+.Slider::handle:horizontal,
+QSlider::handle:horizontal {
+  width: 10;
+  margin: -2 0;
+  image: url('../Default/imgs/black/slider-handle.svg');
+}
+.Slider::handle:horizontal:disabled,
+QSlider::handle:horizontal:disabled {
+  image: url('../Default/imgs/black/slider-handle_disabled.svg');
+}
+/* -----------------------------------------------------------------------------
+   Double Slider
+----------------------------------------------------------------------------- */
+#IntPairField,
+#DoublePairField {
+  qproperty-LightLineColor: #484848;
+  qproperty-LightLineEdgeColor: #484848;
+  qproperty-DarkLineColor: #484848;
+  qproperty-MiddleLineColor: #484848;
+  qproperty-HandleLeftPixmap: url("../Default/imgs/black/slider-handle.svg");
+  qproperty-HandleRightPixmap: url("../Default/imgs/black/slider-handle.svg");
+  qproperty-HandleLeftGrayPixmap: url("../Default/imgs/black/slider-handle_disabled.svg");
+  qproperty-HandleRightGrayPixmap: url("../Default/imgs/black/slider-handle_disabled.svg");
+}
+/* -----------------------------------------------------------------------------
+   File Browser
+----------------------------------------------------------------------------- */
+/* Left Pane
+----------------------------------------------------------------------------- */
+#DirTreeView {
+  background-color: #949494;
+  alternate-background-color: #949494;
+  border: 1 solid #404040;
+  border-right: 0;
+}
+/* Right Pane
+----------------------------------------------------------------------------- */
+DvItemViewerPanel {
+  qproperty-TextColor: #000;
+  qproperty-AlternateBackground: #8a8a8a;
+  qproperty-SelectedTextColor: #FFFFFF;
+  qproperty-FolderTextColor: #071b9b;
+  qproperty-SelectedItemBackground: #225baf;
+}
+#FileBrowser DvItemViewerPanel,
+#SceneCast DvItemViewerPanel {
+  background-color: #949494;
+}
+#FileBrowser #castFrame,
+#SceneCast #castFrame {
+  border-top: 1 solid #404040;
+  border-right: 1 solid #404040;
+  border-bottom: 1 solid #404040;
+  margin: 0;
+}
+#FileBrowser QToolButton,
+#SceneCast QToolButton {
+  padding: 1;
+}
+DvDirTreeView {
+  qproperty-TextColor: #000;
+  qproperty-SelectedTextColor: #FFFFFF;
+  qproperty-SelectedItemBackground: #225baf;
+  qproperty-FolderTextColor: #071b9b;
+  qproperty-SelectedFolderTextColor: #FFFFFF;
+  alternate-background-color: #8a8a8a;
+  background-color: #949494;
+  border: 1 solid #404040;
+}
+#FileDoesNotExistLabel {
+  color: #ff0000;
+}
+/* -----------------------------------------------------------------------------
+   Scene Cast
+----------------------------------------------------------------------------- */
+#SceneCast QToolBar {
+  border-top: 1 solid #404040;
+}
+#SceneCast QToolButton {
+  margin: 3 1 2 1;
+  padding: 1;
+}
+#CastBrowser {
+  border: 0;
+  margin: 0;
+}
+/* -----------------------------------------------------------------------------
+   Level Strip
+----------------------------------------------------------------------------- */
+#FilmStrip QComboBox {
+  border-radius: 0;
+  border-width: 0;
+}
+#FilmStrip QComboBox QAbstractItemView {
+  background-color: #949494;
+}
+/* -----------------------------------------------------------------------------
+   Cleanup Settings
+----------------------------------------------------------------------------- */
+#CleanupSettings #CleanupSettingsFrame {
+  margin-top: 2;
+  margin-bottom: 4;
+}
+#CleanupSettings QGroupBox {
+  margin-bottom: 3;
+}
+ParamsPage {
+  qproperty-TextColor: #000;
+}
+/* -----------------------------------------------------------------------------
+   Camera Settings
+----------------------------------------------------------------------------- */
+#CameraSettingsButton {
+  padding: 2;
+}
+#CameraSettingsRadioButton:hover {
+  background: none;
+}
+#CameraSettingsRadioButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#CameraSettingsRadioButton::indicator:unchecked {
+  image: url('../Default/imgs/black/lock_off.svg');
+}
+#CameraSettingsRadioButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #772626;
+  image: url('../Default/imgs/black/lock_on.svg');
+}
+#CameraSettingsRadioButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #772626;
+}
+#CameraSettingsDPI {
+  color: #000000;
+}
+#CameraSettingsRadioButton_Small {
+  padding: 0;
+}
+#CameraSettingsRadioButton_Small::indicator {
+  background-color: transparent;
+  border: 0;
+  height: 21;
+  margin: 0;
+  width: 11;
+}
+#ForceSquaredPixelButton {
+  height: 16;
+  border: 1 solid rgba(255, 255, 255, 0);
+  image: url('../Default/imgs/black/fsp_unchecked.svg');
+  padding: 2;
+  width: 16;
+  margin: 0;
+}
+#ForceSquaredPixelButton:checked {
+  image: url('../Default/imgs/black/fsp_checked.svg');
+}
+/* -----------------------------------------------------------------------------
+   Output Settings
+----------------------------------------------------------------------------- */
+#OutputSettingsLabel {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   Misc 
+----------------------------------------------------------------------------- */
+PencilTestPopup {
+  min-height: 730px;
+  /* Allow for using a 768 screen */
+  min-width: 512px;
+  /* some clipping will still occur on width, but this
+                        allows for filling half of a 1024 screen */
+}
+#MatchLineButton {
+  background-color: #a6a6a6;
+}
+#MatchLineButton:checked {
+  background-color: #cdcdcd;
+  border: 2 solid #225baf;
+  border-radius: 2;
+}
+#LargeSizedText {
+  font-size: 17px;
+}
+/* -----------------------------------------------------------------------------
+   Unknowns + Legacy
+----------------------------------------------------------------------------- */
+#StartupLabel {
+  padding: 3;
+}
+#StartupLabel:hover {
+  background: #9a9a9a;
+}
+QStatusBar {
+  background-color: #c0c0c0;
+}
+QStatusBar::item {
+  border: 0;
+}
+QStatusBar QLabel {
+  background-color: #c0c0c0;
+}
+QStatusBar #StatusBarLabel {
+  background-color: #ffffff;
+  padding: 1 3;
+}
+#TitleTxtLabel {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   Style Editor
+----------------------------------------------------------------------------- */
+#StyleEditor QPushButton {
+  margin: 2 1;
+  padding: 0;
+}
+#StyleEditor #TabBarContainer {
+  margin-left: -4;
+}
+#StyleEditor #bottomWidget {
+  border-top: 1 solid #404040;
+  padding: 3 2 8 3;
+}
+#StyleEditor #bottomWidget QPushButton {
+  padding: 3 5;
+}
+#StyleEditorTabBar::tab::first {
+  border-left: 1 solid #404040;
+}
+#HexagonalColorWheel {
+  qproperty-BGColor: #808080;
+}
+/* -------------------------------------------------------------------------- */
+/* Horizontal QSlider */
+#colorSlider::groove:horizontal {
+  height: 1;
+  border-image: none;
+}
+#colorSlider::handle:horizontal {
+  width: 8;
+  margin: -8 -4;
+}
+#colorSliderAddButton,
+#colorSliderSubButton {
+  background: none;
+  border-color: transparent;
+  image-position: center center;
+  min-height: 16;
+  padding: 0;
+  min-width: 18;
+}
+#colorSliderAddButton {
+  image: url('../Default/imgs/black/scroll-right.svg');
+}
+#colorSliderSubButton {
+  image: url('../Default/imgs/black/scroll-left.svg');
+}
+#PlainColorPageParts {
+  border-bottom: 1 solid #404040;
+}
+#PlainColorPageParts QLineEdit {
+  max-width: 35;
+}
+/* -----------------------------------------------------------------------------
+   Palette Viewer / Studio Palette
+----------------------------------------------------------------------------- */
+PaletteViewer DvScrollWidget QPushButton {
+  border-top: 0;
+  margin-bottom: 1;
+  max-width: 15;
+  min-width: 15;
+}
+PaletteViewer DvScrollWidget #ScrollLeftButton {
+  border-radius: 0;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer DvScrollWidget #ScrollRightButton {
+  border-radius: 0;
+  margin-left: 1;
+  margin-bottom: 1;
+  max-width: 16;
+  min-width: 16;
+}
+PaletteViewer QToolBar {
+  background: none;
+  border-bottom: 1 solid #404040;
+  padding: 0;
+  margin: 0;
+}
+PaletteViewer QToolBar::separator:horizontal {
+  margin: 0;
+}
+PaletteViewer QToolBar QToolButton {
+  margin: 0 0 1 0;
+  padding: 1 0 2 0;
+}
+#PageViewer {
+  qproperty-TextColor: #000;
+}
+#PaletteLockButton {
+  border-radius: 0;
+  margin: 0 0 1 1;
+}
+#PaletteLockButton:checked {
+  background-color: #C34040;
+  border-color: #772626;
+}
+#PaletteLockButton:checked:hover {
+  background-color: #d57a7a;
+  border-color: #772626;
+}
+/* -----------------------------------------------------------------------------
+   Quick Renamer
+----------------------------------------------------------------------------- */
+#WordButton {
+  padding-right: 0;
+  padding-left: 0;
+}
+/* -----------------------------------------------------------------------------
+   Popup Windows
+----------------------------------------------------------------------------- */
+QDialog {
+  background-color: #808080;
+}
+QDialog #dialogButtonFrame {
+  background-color: #767676;
+  border-top: 1 solid #404040;
+}
+QDialog #dialogButtonFrame QPushButton {
+  border-color: #525252;
+  outline: 0;
+}
+QDialog #dialogButtonFrame QPushButton:focus {
+  background-color: #B5C0D0;
+  border-color: #485971;
+  color: #000000;
+}
+QDialog #dialogButtonFrame QPushButton:focus:hover {
+  background-color: #ced5e0;
+}
+QDialog #dialogButtonFrame QPushButton:focus:pressed {
+  background-color: #e1e1e1;
+  border-color: #525252;
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   Scene Settings
+----------------------------------------------------------------------------- */
+#SceneSettings QLabel {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   Preferences
+----------------------------------------------------------------------------- */
+#PreferencesPopup QListWidget {
+  background-color: #949494;
+  alternate-background-color: #949494;
+  border: 1 solid #404040;
+  font-size: 13px;
+}
+#PreferencesPopup QListWidget::item {
+  border: 0;
+  padding: 3;
+}
+#PreferencesPopup QListWidget::item:hover {
+  background-color: #9f9f9f;
+  color: #000;
+  background-color: #a9a9a9;
+}
+#PreferencesPopup QListWidget::item:selected {
+  background-color: #225baf;
+  color: #FFFFFF;
+}
+/* -----------------------------------------------------------------------------
+   Keyboard Shortcuts
+----------------------------------------------------------------------------- */
+#ShortcutTree {
+  border: 1 solid #404040;
+}
+#ShortcutTree::item {
+  padding: 1 0;
+}
+#ShortcutTree QScrollBar:vertical {
+  width: 16;
+  margin-right: -1;
+}
+/* -----------------------------------------------------------------------------
+   New Project / Configure Project Window
+----------------------------------------------------------------------------- */
+ProjectPopup QLabel {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   PencilTestPopup / CameraCapture Window
+----------------------------------------------------------------------------- */
+#GearButton {
+  qproperty-icon: url('../Default/imgs/black/gear.svg');
+}
+#SubfolderButton {
+  qproperty-icon: url('../Default/imgs/black/subfolder.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+#SubcameraButton {
+  qproperty-icon: url('../Default/imgs/black/subcamera.svg');
+  padding-left: 6px;
+  padding-right: 6px;
+}
+/* -----------------------------------------------------------------------------
+   Schematic Viewer
+----------------------------------------------------------------------------- */
+SchematicViewer {
+  qproperty-TextColor: #000;
+  qproperty-VerticalLineColor: #646464;
+  qproperty-LevelColumnColor: #76b776;
+  qproperty-VectorColumnColor: #c0c07a;
+  qproperty-ChildColumnColor: #d69adb;
+  qproperty-FullcolorColumnColor: #8bbdc1;
+  qproperty-FxColumnColor: #82815d;
+  qproperty-PaletteColumnColor: #2aab9a;
+  qproperty-MeshColumnColor: #ac78d4;
+  qproperty-ReferenceColumnColor: #ababab;
+  qproperty-TableColor: #a4a4bf;
+  qproperty-ActiveCameraColor: #6ba5de;
+  qproperty-OtherCameraColor: #8f9c9e;
+  qproperty-GroupColor: #6698c6;
+  qproperty-PegColor: #be8a56;
+  qproperty-SplineColor: #7bb821;
+  qproperty-ActiveOutputColor: #6ba5de;
+  qproperty-OtherOutputColor: #8f9c9e;
+  qproperty-XsheetColor: #a4a4bf;
+  qproperty-NormalFxColor: #8d9caf;
+  qproperty-MacroFxColor: #ae8ca5;
+  qproperty-ImageAdjustFxColor: #9c9ab4;
+  qproperty-LayerBlendingFxColor: #709ba5;
+  qproperty-MatteFxColor: #ba8585;
+  qproperty-SchematicPreviewButtonBgOnColor: #c8c864;
+  qproperty-SchematicPreviewButtonOnImage: url('../Default/imgs/black/x_prev_eye_on.svg');
+  qproperty-SchematicPreviewButtonBgOffColor: #ababab;
+  qproperty-SchematicPreviewButtonOffImage: url('../Default/imgs/black/x_prev_eye_off.svg');
+  qproperty-SchematicCamstandButtonBgOnColor: #eb906b;
+  qproperty-SchematicCamstandButtonOnImage: url('../Default/imgs/black/x_table_view_on.svg');
+  qproperty-SchematicCamstandButtonTranspImage: url('../Default/imgs/black/x_table_view_transp.svg');
+  qproperty-SchematicCamstandButtonBgOffColor: #ababab;
+  qproperty-SchematicCamstandButtonOffImage: url('../Default/imgs/black/x_table_view_off.svg');
+}
+/* -----------------------------------------------------------------------------
+   Schematic Node Viewer
+----------------------------------------------------------------------------- */
+#SchematicBottomFrame {
+  background-color: #808080;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+#SchematicBottomFrame QToolBar::separator:horizontal {
+  margin: 0;
+}
+#SchematicBottomFrame QToolBar QToolButton {
+  padding: 0;
+  margin: 2;
+}
+#SchematicSceneViewer {
+  background-color: #737373;
+  border-bottom: 1 solid #404040;
+}
+/* -----------------------------------------------------------------------------
+   FX Settings
+----------------------------------------------------------------------------- */
+#FxSettingsTabBar::tab {
+  border-top: 1 solid #404040;
+}
+#FxSettingsTabBar::tab::first,
+#FxSettingsTabBar::tab::only-one {
+  border-left: 1 solid #404040;
+}
+FxSettings QToolBar {
+  border-top: 1 solid #404040;
+  border-right: 1 solid #404040;
+  border-left: 1 solid #404040;
+  min-height: 23;
+  padding: 3 0;
+}
+FxSettings QToolBar QToolBar {
+  border: 0;
+}
+#FxSettingsLabel {
+  color: #000000;
+}
+#FxSettingsHelpButton {
+  background-color: #80a0dc;
+  color: #000;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+#FxSettingsHelpButton:hover {
+  background-color: #a8bee7;
+}
+/* -----------------------------------------------------------------------------
+   Script Console
+----------------------------------------------------------------------------- */
+#ScriptConsole {
+  font-family: 'Courier New', monospace;
+  border: 0;
+  color: #000000;
+  padding: 3;
+}
+#ScriptConsole QFrame {
+  background-color: #dcdcdc;
+}
+#ScriptConsole TPanelTitleBar {
+  background-color: #5a5a5a;
+}
+/* -----------------------------------------------------------------------------
+   Task Viewer
+----------------------------------------------------------------------------- */
+#TaskSheetItemLabel {
+  color: #000;
+}
+#Tasks QToolBar {
+  border-bottom: 1 solid #404040;
+  margin: 0;
+  padding: 0;
+}
+#Tasks QToolBar QToolButton {
+  margin: 2 2 3 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Bar
+----------------------------------------------------------------------------- */
+#ToolBar QToolBar {
+  padding-left: 2;
+}
+/* -----------------------------------------------------------------------------
+   Tool Options
+----------------------------------------------------------------------------- */
+#ToolOptions TPanelTitleBar {
+  border-right: 1 solid #404040;
+  border-bottom: 0;
+}
+#CommandBar TPanelTitleBar {
+  border-right: 1 solid #404040;
+  border-bottom: 0;
+}
+IconViewField {
+  qproperty-ThicknessPixmap: url("../Default/imgs/black/selectiontool_thickness.svg");
+}
+#EditToolLockButton {
+  spacing: 0;
+}
+#EditToolLockButton:hover {
+  background: none;
+}
+#EditToolLockButton::indicator {
+  border: 1 solid rgba(255, 255, 255, 0);
+  height: 18;
+  padding: 0;
+  width: 18;
+}
+#EditToolLockButton::indicator:unchecked {
+  image: url('../Default/imgs/black/lock_off.svg');
+}
+#EditToolLockButton::indicator:checked {
+  background-color: #C34040;
+  border-color: #772626;
+  image: url('../Default/imgs/black/lock_on.svg');
+}
+#EditToolLockButton::indicator:checked:hover {
+  background-color: #d57a7a;
+  border-color: #772626;
+}
+PopupButton::menu-indicator {
+  border-left: 0;
+  height: 17;
+  image: url('../Default/imgs/black/combo_downarrow.svg');
+  width: 10;
+}
+PopupButton::menu-indicator:hover {
+  image: url('../Default/imgs/black/combo_downarrow.svg');
+}
+PopupButton::menu-indicator:disabled {
+  image: url('../Default/imgs/black/combo_downarrow_disabled.svg');
+}
+#Cap,
+#Join {
+  padding: 0 4 0 -8;
+  max-width: 32;
+  min-width: 32;
+}
+#Cap QMenu,
+#Join QMenu {
+  max-width: 28;
+  min-width: 28;
+}
+#Cap QMenu::item,
+#Join QMenu::item {
+  max-width: 28;
+  min-width: 28;
+  padding: 0;
+}
+QToolBar#MediumPaddingToolBar QToolButton {
+  padding-left: 3;
+  padding-right: 3;
+}
+QToolBar#WidePaddingToolBar QToolButton {
+  padding-left: 6;
+  padding-right: 6;
+}
+#CommandBar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#CommandBar::separator:horizontal {
+  margin-right: 3;
+  margin-left: 3;
+}
+#expandButton:checked {
+  background-color: transparent;
+  border-color: transparent;
+  color: #000;
+}
+#expandButton:checked:hover {
+  background-color: #bbbbbb;
+  border-color: #525252;
+}
+#expandButton:checked:pressed {
+  background-color: #e1e1e1;
+  border-color: #525252;
+}
+/* -----------------------------------------------------------------------------
+   ComboViewer / Viewer / FlipBook
+----------------------------------------------------------------------------- */
+#ComboViewerPanel Toolbar {
+  border-bottom: 1 solid #404040;
+}
+#ComboViewerPanel Toolbar::separator:horizontal {
+  margin: 0 0 0 2;
+}
+#ComboViewerPanel Toolbar QToolButton {
+  margin: 2 0 3 2;
+}
+#ComboViewerToolOptions {
+  border-bottom: 1 solid #404040;
+}
+#ComboViewer #ToolBarContainer,
+#ViewerPanel #ToolBarContainer,
+FlipBook #ToolBarContainer {
+  background-color: transparent;
+  border-top: 2 solid #404040;
+  border-bottom: 1 solid #404040;
+  padding-right: -1;
+}
+#flipCustomize {
+  margin-left: 3;
+}
+#flipCustomize::menu-button {
+  background-color: transparent;
+  width: 35;
+}
+#flipCustomize::menu-arrow {
+  image: none;
+}
+QToolBar#FlipConsolePlayToolBar::separator:horizontal {
+  margin: 0 3;
+}
+QToolBar#FlipConsolePlayToolBar QToolButton {
+  margin-top: 2;
+  margin-bottom: 2;
+  height: 16;
+  padding-left: 1;
+  padding-right: 1;
+}
+#ViewerFpsSlider {
+  background-color: transparent;
+  background-image: url('../Default/imgs/black/slider-groove.svg');
+  background-position: center center;
+  background-repeat: repeat-x;
+  border: 0;
+  height: 19;
+  margin: 0 3 0 37;
+  max-width: 300;
+  min-width: 0;
+}
+#ViewerFpsSlider::sub-line:horizontal {
+  subcontrol-origin: absolute;
+  background-color: #a6a6a6;
+  border: 1 solid #525252;
+  border-top-left-radius: 2;
+  border-bottom-left-radius: 2;
+  height: 16;
+  left: -33;
+  width: 14;
+}
+#ViewerFpsSlider::add-line:horizontal {
+  subcontrol-position: left;
+  background-color: #a6a6a6;
+  border: 1 solid #525252;
+  border-top-right-radius: 2;
+  border-bottom-right-radius: 2;
+  left: 18;
+  height: 16;
+  image-position: center center;
+  width: 13;
+}
+#ViewerFpsSlider::handle::horizontal {
+  background-color: #a6a6a6;
+  border: 1 solid #404040;
+  border-radius: 2;
+  margin: 2 0 3 0;
+  min-width: 9;
+  width: 9;
+  max-width: 9;
+}
+FlipSlider {
+  qproperty-PBHeight: 15;
+  qproperty-PBOverlay: url('../Default/imgs/black/flipslider.svg');
+  qproperty-PBColorMarginLeft: 1;
+  qproperty-PBColorMarginTop: 2;
+  qproperty-PBColorMarginRight: 1;
+  qproperty-PBColorMarginBottom: 2;
+  qproperty-PBMarker: url('../Default/imgs/black/flipmarker.svg');
+  qproperty-PBMarkerMarginLeft: 3;
+  qproperty-PBMarkerMarginRight: 3;
+  qproperty-notStartedColor: #8b2525;
+  qproperty-startedColor: #00a808;
+  qproperty-baseColor: #676767;
+  qproperty-finishedColor: #676767;
+}
+Ruler {
+  qproperty-ParentBGColor: #c0c0c0;
+  qproperty-ScaleColor: #000;
+}
+#RulerToolOptionValues {
+  color: #000000;
+}
+/* -----------------------------------------------------------------------------
+   XSheet Viewer
+----------------------------------------------------------------------------- */
+/* ScrollAreas (Row, Column and Cell)
+----------------------------------------------------------------------------- */
+#xsheetArea,
+#ScrollArea {
+  background-color: #6c6c6c;
+  border: 0;
+}
+#xsheetScrollArea {
+  border: 0;
+}
+#cornerWidget QToolButton {
+  padding: 0;
+}
+/* xsheetColumnHeader (Context Menus)
+----------------------------------------------------------------------------- */
+#xsheetColumnAreaMenu_Preview {
+  background-color: #E6E678;
+}
+#xsheetColumnAreaMenu_Lock {
+  background-color: #F5F5F5;
+}
+#xsheetColumnAreaMenu_Camstand {
+  background-color: #FFA480;
+}
+#xsheetColumnAreaMenu_Preview,
+#xsheetColumnAreaMenu_Lock,
+#xsheetColumnAreaMenu_Camstand {
+  color: #000;
+}
+#noteTextEdit {
+  color: #000;
+}
+/* XSheet Spreadsheet
+----------------------------------------------------------------------------- */
+XsheetViewer {
+  qproperty-TextColor: #000;
+  qproperty-BGColor: #929292;
+  qproperty-LightLineColor: #616161;
+  qproperty-MarkerLineColor: #000;
+  qproperty-VerticalLineColor: #646464;
+  qproperty-VerticalLineHeadColor: #393939;
+  qproperty-PreviewFrameTextColor: #000eb6;
+  qproperty-CurrentRowBgColor: #B5C0D0;
+  qproperty-OnionSkinAreaBgColor: #858585;
+  qproperty-EmptyColumnHeadColor: #808080;
+  qproperty-SelectedColumnTextColor: #9e0000;
+  qproperty-EmptyCellColor: #7c7c7c;
+  qproperty-NotEmptyColumnColor: #8a8a8a;
+  qproperty-SelectedEmptyCellColor: #b3b3b3;
+  qproperty-LevelColumnColor: #76b776;
+  qproperty-LevelColumnBorderColor: #496549;
+  qproperty-SelectedLevelColumnColor: #9bc59b;
+  qproperty-VectorColumnColor: #c0c07a;
+  qproperty-VectorColumnBorderColor: #71714a;
+  qproperty-SelectedVectorColumnColor: #cdcda0;
+  qproperty-ChildColumnColor: #d69adb;
+  qproperty-ChildColumnBorderColor: #9c53a3;
+  qproperty-SelectedChildColumnColor: #e3c2e6;
+  qproperty-FullcolorColumnColor: #8bbdc1;
+  qproperty-FullcolorColumnBorderColor: #577476;
+  qproperty-SelectedFullcolorColumnColor: #afcdd0;
+  qproperty-FxColumnColor: #82815d;
+  qproperty-FxColumnBorderColor: #404039;
+  qproperty-SelectedFxColumnColor: #97967b;
+  qproperty-ReferenceColumnColor: #ababab;
+  qproperty-ReferenceColumnBorderColor: #6b6b6b;
+  qproperty-SelectedReferenceColumnColor: #c4c4c4;
+  qproperty-PaletteColumnColor: #2aab9a;
+  qproperty-PaletteColumnBorderColor: #173e39;
+  qproperty-SelectedPaletteColumnColor: #40c8b6;
+  qproperty-MeshColumnColor: #ac78d4;
+  qproperty-MeshColumnBorderColor: #6b418c;
+  qproperty-SelectedMeshColumnColor: #c3a2dd;
+  qproperty-SoundTextColumnColor: #c8c8c8;
+  qproperty-SoundTextColumnBorderColor: #8c8c8c;
+  qproperty-SelectedSoundTextColumnColor: #e2e2e2;
+  qproperty-SoundColumnColor: #acba82;
+  qproperty-SoundColumnBorderColor: #656b51;
+  qproperty-SelectedSoundColumnColor: #c0c9a6;
+  qproperty-SoundColumnHlColor: #f5ffe6;
+  qproperty-SoundColumnTrackColor: #5a642d;
+  qproperty-ColumnHeadPastelizer: #ffffff;
+  qproperty-SelectedColumnHead: #bed2f0;
+  qproperty-LightLightBGColor: #808080;
+  qproperty-LightBGColor: #f0f0f0;
+  qproperty-DarkBGColor: #e1e1e1;
+  qproperty-DarkLineColor: #969696;
+  qproperty-XsheetColumnNameBgColor: rgba(0, 0, 0, 0);
+  qproperty-XsheetDragBarHighlightColor: rgba(255, 255, 255, 0.5);
+  qproperty-XsheetPreviewButtonBgOnColor: #c8c864;
+  qproperty-XsheetPreviewButtonOnImage: url('../Default/imgs/black/x_prev_eye_on.svg');
+  qproperty-XsheetPreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetPreviewButtonOffImage: url('../Default/imgs/black/x_prev_eye_off.svg');
+  qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
+  qproperty-XsheetCamstandButtonOnImage: url('../Default/imgs/black/x_table_view_on.svg');
+  qproperty-XsheetCamstandButtonTranspImage: url('../Default/imgs/black/x_table_view_transp.svg');
+  qproperty-XsheetCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetCamstandButtonOffImage: url('../Default/imgs/black/x_table_view_off.svg');
+  qproperty-XsheetLockButtonBgOnColor: rgba(255, 255, 255, 0.3);
+  qproperty-XsheetLockButtonOnImage: url('../Default/imgs/black/x_lock_on.svg');
+  qproperty-XsheetLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetLockButtonOffImage: url('../Default/imgs/black/x_lock_off.svg');
+  qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-XsheetConfigButtonImage: url('../Default/imgs/black/x_config.svg');
+  qproperty-TimelinePreviewButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/black/timeline_toggle_on.svg');
+  qproperty-TimelinePreviewButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelinePreviewButtonOffImage: url('../Default/imgs/black/timeline_toggle_off.svg');
+  qproperty-TimelineCamstandButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOnImage: url('../Default/imgs/black/timeline_toggle_on.svg');
+  qproperty-TimelineCamstandButtonTranspImage: url('../Default/imgs/black/timeline_toggle_transp.svg');
+  qproperty-TimelineCamstandButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineCamstandButtonOffImage: url('../Default/imgs/black/timeline_toggle_off.svg');
+  qproperty-TimelineLockButtonBgOnColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOnImage: url('../Default/imgs/black/timeline_toggle_on.svg');
+  qproperty-TimelineLockButtonBgOffColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineLockButtonOffImage: url('../Default/imgs/black/timeline_toggle_off.svg');
+  qproperty-TimelineConfigButtonBgColor: rgba(255, 255, 255, 0);
+  qproperty-TimelineConfigButtonImage: url('../Default/imgs/black/timeline_config.svg');
+  qproperty-LayerHeaderPreviewImage: url('../Default/imgs/black/layer_header_prev_eye.svg');
+  qproperty-LayerHeaderPreviewOverImage: url('../Default/imgs/black/layer_header_prev_eye_over.svg');
+  qproperty-LayerHeaderCamstandImage: url('../Default/imgs/black/layer_header_table_view.svg');
+  qproperty-LayerHeaderCamstandOverImage: url('../Default/imgs/black/layer_header_table_view_over.svg');
+  qproperty-LayerHeaderLockImage: url('../Default/imgs/black/lock_on.svg');
+  qproperty-LayerHeaderLockOverImage: url('../Default/imgs/black/lock_on_over.svg');
+  qproperty-ActiveCameraColor: #6ba5de;
+  qproperty-SelectedActiveCameraColor: #98bee4;
+  qproperty-OtherCameraColor: #8f9c9e;
+  qproperty-SelectedOtherCameraColor: #aeb1b2;
+}
+/* XSheet Toolbar
+----------------------------------------------------------------------------- */
+#XSheetToolbar {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+#XSheetToolbar QToolButton {
+  padding: 0;
+  margin: 4 1;
+  min-height: 19;
+  height: 19;
+}
+#XSheetToolbar::separator:horizontal {
+  margin: 0 4;
+}
+/* -----------------------------------------------------------------------------
+   Function Editor
+----------------------------------------------------------------------------- */
+#FunctionEditor QToolBar {
+  border-bottom: 1 solid #404040;
+}
+#FunctionEditor QToolBar QToolBar {
+  border: 0;
+}
+#FunctionEditor QToolBar QLabel {
+  margin-left: 5;
+}
+#FunctionEditor QToolBar QToolButton {
+  height: 18;
+}
+#FunctionEditorTree {
+  border-top: 1 solid #404040;
+}
+FunctionTreeView {
+  qproperty-TextColor: #000;
+  qproperty-CurrentTextColor: #a70000;
+}
+/* Function Editor Spreadsheet
+----------------------------------------------------------------------------- */
+FunctionPanel {
+  qproperty-BGColor: #5a5a5a;
+  qproperty-ValueLineColor: #4d4d4d;
+  qproperty-FrameLineColor: #4d4d4d;
+  qproperty-OtherCurvesColor: #c5c5c5;
+  qproperty-RulerBackground: #676767;
+  qproperty-TextColor: #000;
+  qproperty-SubColor: #ffffff;
+  qproperty-SelectedColor: #fcae06;
+}
+SpreadsheetViewer {
+  qproperty-LightLightBGColor: #808080;
+  qproperty-CurrentRowBgColor: #B5C0D0;
+  qproperty-LightLineColor: #616161;
+  qproperty-MarkerLineColor: #000;
+  qproperty-BGColor: #8a8a8a;
+  qproperty-VerticalLineColor: #646464;
+  qproperty-KeyFrameColor: #db8b36;
+  qproperty-KeyFrameBorderColor: #7b4a16;
+  qproperty-SelectedKeyFrameColor: #dea466;
+  qproperty-InBetweenColor: #c2c2b0;
+  qproperty-InBetweenBorderColor: #636356;
+  qproperty-SelectedInBetweenColor: #d6d6cf;
+  qproperty-SelectedEmptyColor: #b3b3b3;
+  qproperty-SelectedSceneRangeEmptyColor: #d2d2d2;
+  qproperty-TextColor: #000;
+  qproperty-ColumnHeaderBorderColor: #393939;
+  qproperty-SelectedColumnTextColor: #9e0000;
+}
+#ExpressionField {
+  background-color: #ffffff;
+  border: 1 solid #6b6b6b;
+  margin: 0;
+}
+#FunctionSegmentViewerLinkButton {
+  background-image: url('../Default/imgs/black/segment_unlinked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:hover {
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:checked {
+  background-image: url('../Default/imgs/black/segment_linked.svg');
+  background-repeat: no-repeat;
+}
+#FunctionSegmentViewerLinkButton:disabled {
+  background-image: url('../Default/imgs/black/segment_disabled.svg');
+  background-repeat: no-repeat;
+}

--- a/toonz/sources/toonz/levelsettingspopup.h
+++ b/toonz/sources/toonz/levelsettingspopup.h
@@ -10,6 +10,8 @@
 #include "toonz/txshchildlevel.h"
 #include "toonz/txshsoundlevel.h"
 
+#include <QSet>
+
 // forward declaration
 class QLabel;
 class QComboBox;
@@ -25,7 +27,36 @@ class IntLineEdit;
 class DoubleLineEdit;
 class MeasuredDoubleLineEdit;
 class CheckBox;
-}
+}  // namespace DVGui
+
+enum SelectedLevelType {
+  None        = 0x0,
+  ToonzRaster = 0x1,
+  Raster      = 0x2,
+  Mesh        = 0x4,
+  ToonzVector = 0x8,
+  Palette     = 0x10,
+  SubXsheet   = 0x20,
+  Sound       = 0x40,
+  Others      = 0x80,
+
+  MultiSelection  = 0x100,
+  HideOnPixelMode = 0x200,
+  NoSelection     = 0x400,
+
+  SimpleLevel = ToonzRaster | Raster | Mesh | ToonzVector,
+  HasDPILevel = ToonzRaster | Raster | Mesh,
+  AllTypes    = SimpleLevel | Palette | SubXsheet | Sound
+};
+
+struct LevelSettingsValues {
+  QString name, path, scanPath, typeStr, imageDpi, imageRes;
+  int dpiType = -1, softness = -1, subsampling = -1;
+  TPointD dpi               = TPointD(0, 0);
+  Qt::CheckState doPremulti = Qt::Unchecked, whiteTransp = Qt::Unchecked,
+                 doAntialias = Qt::Unchecked, isDirty = Qt::Unchecked;
+  double width = 0.0, height = 0.0;
+};
 
 //=============================================================================
 // LevelSettingsPopup
@@ -34,38 +65,33 @@ class CheckBox;
 class LevelSettingsPopup final : public DVGui::Dialog {
   Q_OBJECT
 
-  TXshSimpleLevelP m_sl;
-  TXshPaletteLevelP m_pl;
-  TXshChildLevelP m_cl;
-  TXshSoundLevelP m_sdl;
+  QSet<TXshLevelP> m_selectedLevels;
+  QMap<QWidget *, unsigned int> m_activateFlags;
 
   DVGui::LineEdit *m_nameFld;
   DVGui::FileField *m_pathFld;
-  QLabel *m_scanPathLabel;
   DVGui::FileField *m_scanPathFld;
   QLabel *m_typeLabel;
   QComboBox *m_dpiTypeOm;
-  QLabel *m_dpiLabel;
   DVGui::DoubleLineEdit *m_dpiFld;
   DVGui::CheckBox *m_squarePixCB;
-  QLabel *m_widthLabel;
   DVGui::MeasuredDoubleLineEdit *m_widthFld;
-  QLabel *m_heightLabel;
   DVGui::MeasuredDoubleLineEdit *m_heightFld;
   QPushButton *m_useCameraDpiBtn;
   QLabel *m_cameraDpiLabel;
   QLabel *m_imageDpiLabel;
   QLabel *m_imageResLabel;
-  QLabel *m_cameraDpiTitle;
-  QLabel *m_imageDpiTitle;
-  QLabel *m_imageResTitle;
   DVGui::CheckBox *m_doPremultiply;
   DVGui::CheckBox *m_whiteTransp;
   DVGui::CheckBox *m_doAntialias;
+  QLabel *m_softnessLabel;
   DVGui::IntLineEdit *m_antialiasSoftness;
 
   QLabel *m_subsamplingLabel;
   DVGui::IntLineEdit *m_subsamplingFld;
+
+  SelectedLevelType getType(TXshLevelP);
+  LevelSettingsValues getValues(TXshLevelP);
 
 public:
   LevelSettingsPopup();
@@ -74,7 +100,7 @@ protected:
   void showEvent(QShowEvent *e) override;
   void hideEvent(QHideEvent *e) override;
 
-public slots:
+protected slots:
 
   void onCastSelectionChanged();
   void onSelectionSwitched(TSelection *oldSelection, TSelection *newSelection);
@@ -89,13 +115,12 @@ public slots:
   void onSquarePixelChanged(int);
   void useCameraDpi();
   void onSubsamplingChanged();
-  void onDoPremultiplyChanged(int);
-  void onDoAntialiasChanged(int);
+  void onDoPremultiplyClicked();
+  void onDoAntialiasClicked();
   void onAntialiasSoftnessChanged();
-  void onWhiteTranspChanged(int);
-
-protected slots:
+  void onWhiteTranspClicked();
   void onSceneChanged();
+  void onPreferenceChanged(const QString &);
 };
 
 #endif  // LEVELSETTINGSPOPUP_H

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -417,6 +417,7 @@ void PreferencesPopup::onPixelsOnlyChanged() {
     defLevelHeight->setDecimals(4);
     defLevelWidth->setDecimals(4);
   }
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged("pixelsOnly");
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves the Level Settings popup.
- Enabled with multiple selection and editing them together. When you select different types of levels, only the common properties become editable.
- Enabled undo for level settings changes.
- Fixed a bug that the change in the file path of palette level did not take effect.

![levelsettings](https://user-images.githubusercontent.com/17974955/70584005-d78bd800-1c02-11ea-8e2c-4797ca19fc2c.png)
