### PR TITLE
Fix "Vector Guided Style" preference option

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -415,7 +415,7 @@ public:
     return getBoolValue(useOnionColorsForShiftAndTraceGhosts);
   }
   bool getAnimatedGuidedDrawing() const {
-    return getBoolValue(animatedGuidedDrawing);
+    return getIntValue(animatedGuidedDrawing) == 1;
   }
 
   // Colors  tab


### PR DESCRIPTION
This PR fixes a problem with `Preferences > Onion Skin > Vector Guided Style` . Currently OT always shows the arrow markers even if you choose the `Animated Guide` .
It was my mistake when I overhauled the preferences. Sorry for the trouble!
