### PR TITLE
Fix issues with Create Blank Frames

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2027,6 +2027,15 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
     return;
   }
 
+  if (!toolHandle->getTool()->m_isFrameCreated) {
+    if (!multiple)
+      DVGui::warning(QObject::tr(
+          "Unable to replace the current drawing with a blank drawing"));
+    return;
+  }
+
+  sl->setDirtyFlag(true);
+
   TPalette *palette = sl->getPalette();
   TFrameId frame    = cell.getFrameId();
 


### PR DESCRIPTION
This PR fixes the following issues related to Create Blank Frames command as reported to me:

1. Add blank frames to the end of an existing level then Save All. Close and reopen OT and find the new frames were not saved

Added logic to flag the existing level as "dirty" so it will save the new frames.

2. Select exposed drawings and attempt to create blank frames over them.  Drawings are unaffected but if you undo the creation of blank frames, the existing drawings are also deleted.

Corrected logic to check if a new frame was actually created. If not, a warning is given to the user that a blank drawing was not created. The action of creating the blank frame over an existing one is not recorded for Undo operations so undo will not delete the original frame.
