### PR TITLE
Remove unnecessary version numbers from macOS paths

### DIFF
--- a/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
@@ -368,8 +368,7 @@ static QString getExeName(bool isComposer) {
   return name + ".exe ";
 #elif defined(MACOSX)
   TVER::ToonzVersion tver;
-  return "\"./" + QString::fromStdString(tver.getAppName()) + "_" +
-         QString::fromStdString(tver.getAppVersionString()) +
+  return "\"./" + QString::fromStdString(tver.getAppName()) +
          ".app/Contents/MacOS/" + name + "\" ";
 #else
   return name;

--- a/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
+++ b/toonz/sources/toonzfarm/tfarmcontroller/tfarmcontroller.cpp
@@ -70,8 +70,7 @@ TFilePath getGlobalRoot() {
 // Leggo la globalRoot da File txt
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
-  std::string unixpath = "./" + tver.getAppName() + "_" +
-                         tver.getAppVersionString() +
+  std::string unixpath = "./" + tver.getAppName() +
                          ".app/Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
@@ -116,8 +115,7 @@ std:
 // Leggo la localRoot da File txt
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
-  std::string unixpath = "./" + tver.getAppName() + "_" +
-                         tver.getAppVersionString() +
+  std::string unixpath = "./" + tver.getAppName() +
                          ".app/Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -385,8 +385,7 @@ static QString getExeName(bool isComposer) {
   return name + ".exe ";
 #elif defined(MACOSX)
   TVER::ToonzVersion tver;
-  return "\"./" + QString::fromStdString(tver.getAppName()) + "_" +
-         QString::fromStdString(tver.getAppVersionString()) +
+  return "\"./" + QString::fromStdString(tver.getAppName()) +
          ".app/Contents/MacOS/" + name + "\" ";
 #else
   return name;

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -76,8 +76,7 @@ TFilePath getGlobalRoot() {
 // Leggo la localRoot da File txt
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
-  std::string unixpath = "./" + tver.getAppName() + "_" +
-                         tver.getAppVersionString() +
+  std::string unixpath = "./" + tver.getAppName() +
                          ".app/Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
@@ -121,8 +120,7 @@ TFilePath getLocalRoot() {
 #else
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
-  std::string unixpath = "./" + tver.getAppName() + "_" +
-                         tver.getAppVersionString() +
+  std::string unixpath = "./" + tver.getAppName() + 
                          ".app/Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems


### PR DESCRIPTION
This removes "_" + the version number from the tasks/farm app paths. Hopefully this will help with the failed task rendering that currently happens on macOS #2940. 

With this change I still haven't been able to render from the tasks window when building myself. That could just be a result of some build issues I've been having (ie. can't save) or there could be an additional issue that prevents the batch rendering.