### PR TITLE
Modify Autocreation Feature

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -518,14 +518,23 @@ transformation.
   }
 
 public:
-  static std::vector<int> m_cellsData;  //!< \deprecated  brutto brutto. fix
-                                        //! quick & dirty del baco #6213 (undo
+  struct CellOps {
+    int r0;
+    int r1;
+    enum Type { ExistingToNew = 0, BlankToExisting, BlankToNew } type;
+  };
+  static std::vector<CellOps>
+      m_cellsData;  //!< \deprecated  brutto brutto. fix
+                    //! quick & dirty del baco #6213 (undo
   //! con animation sheet) spiegazioni in
   //! tool.cpp
   static bool m_isLevelCreated;  //!< \deprecated  Shouldn't expose global
                                  //! static variables.
   static bool m_isFrameCreated;  //!< \deprecated  Shouldn't expose global
                                  //! static variables.
+  static std::vector<TFrameId> m_oldFids;
+  static std::vector<TFrameId> m_newFids;
+  static bool m_isLevelRenumbererd;
 
 protected:
   std::string m_name;  //!< The tool's name.
@@ -578,9 +587,8 @@ public:
   }
   ImagePainter::VisualSettings &visualSettings() { return m_visualSettings; }
 
-  virtual double getPixelSize()
-      const = 0;  //!< Returns the length of a pixel in current OpenGL
-                  //!< coordinates
+  virtual double getPixelSize() const = 0;  //!< Returns the length of a pixel
+                                            //!< in current OpenGL coordinates
 
   virtual void invalidateAll() = 0;    //!< Redraws the entire viewer, passing
                                        //! through Qt's event system
@@ -600,7 +608,7 @@ public:
   //! return the column index of the drawing intersecting point \b p
   //! (window coordinate, pixels, bottom-left origin)
   virtual int posToColumnIndex(const TPointD &p, double distance,
-                               bool includeInvisible = true) const = 0;
+                               bool includeInvisible = true) const    = 0;
   virtual void posToColumnIndexes(const TPointD &p, std::vector<int> &indexes,
                                   double distance,
                                   bool includeInvisible = true) const = 0;
@@ -632,9 +640,9 @@ public:
 
   virtual void rotate(const TPointD &center, double angle) = 0;
   virtual void rotate3D(double dPhi, double dTheta)        = 0;
-  virtual bool is3DView() const      = 0;
-  virtual bool getIsFlippedX() const = 0;
-  virtual bool getIsFlippedY() const = 0;
+  virtual bool is3DView() const                            = 0;
+  virtual bool getIsFlippedX() const                       = 0;
+  virtual bool getIsFlippedY() const                       = 0;
 
   virtual double projectToZ(const TPointD &delta) = 0;
 

--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -152,10 +152,13 @@ protected:
   bool m_isEditingLevel;
   bool m_createdFrame;
   bool m_createdLevel;
-  bool m_animationSheetEnabled;
-  std::vector<int> m_cellsData;  // represent original frame range when
-                                 // m_animationSheetEnabled, m_createdFrame and
-                                 // !m_isEditingLevel; see tool.cpp
+  bool m_renumberedLevel;
+  std::vector<TTool::CellOps>
+      m_cellsData;  // represent original frame range when
+                    // m_animationSheetEnabled, m_createdFrame and
+                    // !m_isEditingLevel; see tool.cpp
+  std::vector<TFrameId> m_oldFids;
+  std::vector<TFrameId> m_newFids;
   TPaletteP m_oldPalette;
   std::string m_imageId;
   static int m_idCount;
@@ -504,6 +507,14 @@ TRasterPT<PIXEL> rotate90(const TRasterPT<PIXEL> &ras, bool toRight) {
   }
   return workRas;
 }
+
+bool DVAPI doUpdateXSheet(TXshSimpleLevel *sl, std::vector<TFrameId> oldFids,
+                          std::vector<TFrameId> newFids, TXsheet *xsh,
+                          std::vector<TXshChildLevel *> &childLevels =
+                              std::vector<TXshChildLevel *>());
+
+bool DVAPI renumberForInsertFId(TXshSimpleLevel *sl, const TFrameId &fid,
+                                const TFrameId &maxFid, TXsheet *xsh);
 
 }  // namespace ToolUtils
 

--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -510,8 +510,7 @@ TRasterPT<PIXEL> rotate90(const TRasterPT<PIXEL> &ras, bool toRight) {
 
 bool DVAPI doUpdateXSheet(TXshSimpleLevel *sl, std::vector<TFrameId> oldFids,
                           std::vector<TFrameId> newFids, TXsheet *xsh,
-                          std::vector<TXshChildLevel *> &childLevels =
-                              std::vector<TXshChildLevel *>());
+                          std::vector<TXshChildLevel *> &childLevels);
 
 bool DVAPI renumberForInsertFId(TXshSimpleLevel *sl, const TFrameId &fid,
                                 const TFrameId &maxFid, TXsheet *xsh);

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -134,6 +134,7 @@ public:
               QVariant defaultValue, QVariant min = 0, QVariant max = -1);
 
   void setCallBack(const PreferencesItemId id, OnEditedFunc func);
+  void resolveCompatibility();
 
   PreferencesItem &getItem(const PreferencesItemId id);
   bool getBoolValue(const PreferencesItemId id) const;
@@ -285,8 +286,15 @@ public:
   double getDefLevelWidth() const { return getDoubleValue(DefLevelWidth); }
   double getDefLevelHeight() const { return getDoubleValue(DefLevelHeight); }
   double getDefLevelDpi() const { return getDoubleValue(DefLevelDpi); }
-  int getAutocreationType() const { return getIntValue(AutocreationType); }
+  bool isAutoCreateEnabled() const { return getBoolValue(EnableAutocreation); }
+  int getNumberingSystem() const { return getIntValue(NumberingSystem); }
   bool isAutoStretchEnabled() const { return getBoolValue(EnableAutoStretch); }
+  bool isCreationInHoldCellsEnabled() const {
+    return getBoolValue(EnableCreationInHoldCells);
+  }
+  bool isAutorenumberEnabled() const {
+    return getBoolValue(EnableAutoRenumber);
+  }
   int getVectorSnappingTarget() { return getIntValue(vectorSnappingTarget); }
   bool isSaveUnpaintedInCleanupEnable() const {
     return getBoolValue(saveUnpaintedInCleanup);
@@ -468,9 +476,8 @@ public:
 
   void setPrecompute(bool enabled);
   bool getPrecompute() { return m_precompute; }
-  bool isAutoCreateEnabled() const { return getIntValue(AutocreationType) > 0; }
   bool isAnimationSheetEnabled() const {
-    return getIntValue(AutocreationType) == 2;
+    return getIntValue(NumberingSystem) == 1;
   }
   bool isXsheetCameraColumnVisible() const {
     return getBoolValue(showXsheetCameraColumn) &&

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -80,8 +80,12 @@ enum PreferencesItemId {
   DefLevelWidth,
   DefLevelHeight,
   DefLevelDpi,
-  AutocreationType,
+  // AutocreationType,// deprecated
+  EnableAutocreation,
+  NumberingSystem,
   EnableAutoStretch,
+  EnableCreationInHoldCells,
+  EnableAutoRenumber,
   vectorSnappingTarget,
   saveUnpaintedInCleanup,
   minimizeSaveboxAfterEditing,

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -7,6 +7,7 @@
 #include "tools/toolhandle.h"
 #include "tools/cursors.h"
 #include "tools/tooloptions.h"
+#include "tools/toolutils.h"
 
 // TnzQt includes
 #include "toonzqt/icongenerator.h"
@@ -102,6 +103,27 @@ TFrameId getNewFrameId(TXshSimpleLevel *sl, int row) {
   return fid;
 }
 
+TFrameId getDesiredFId(TXshCellColumn *column, int r0, TXshSimpleLevel *sl,
+                       int row, TFrameId &maxFId) {
+  // search upper cells in the current column and return the next fids to be
+  // inserted if the maximum fid has no suffix it returns next number, otherwise
+  // returns next suffix.
+  maxFId = TFrameId(0);
+  // in case inserting a new frame on the top
+  if (row <= r0) return TFrameId(1);
+  TFrameId neighborFId;
+  for (int r = row - 1; r >= r0; r--) {
+    if (sl != column->getCell(r).getSimpleLevel()) continue;
+    TFrameId tmpFId = column->getCell(r).getFrameId();
+    if (neighborFId.isEmptyFrame()) neighborFId = tmpFId;
+    if (maxFId < tmpFId) maxFId = tmpFId;
+  }
+  if (maxFId.getLetter() && maxFId.getLetter() < 'z' && maxFId == neighborFId)
+    return TFrameId(maxFId.getNumber(), maxFId.getLetter() + 1);
+  else
+    return TFrameId(maxFId.getNumber() + 1);
+}
+
 }  // namespace
 
 //*****************************************************************************************
@@ -112,6 +134,7 @@ TTool::Application *TTool::m_application   = 0;
 std::set<TFrameId> TTool::m_selectedFrames = std::set<TFrameId>();
 bool TTool::m_isLevelCreated               = false;
 bool TTool::m_isFrameCreated               = false;
+bool TTool::m_isLevelRenumbererd           = false;
 
 // m_cellsData
 // brutto brutto. fix quick & dirty del baco #6213 (undo con animation sheet)
@@ -126,7 +149,9 @@ bool TTool::m_isFrameCreated               = false;
 // cfr. il codice di TTool::touchImage()
 // ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded()
 
-std::vector<int> TTool::m_cellsData;
+std::vector<TTool::CellOps> TTool::m_cellsData;
+std::vector<TFrameId> TTool::m_oldFids;
+std::vector<TFrameId> TTool::m_newFids;
 
 //*****************************************************************************************
 //    TTool  implementation
@@ -259,14 +284,19 @@ TImage *TTool::touchImage() {
   if (!m_application) return 0;
 
   m_cellsData.clear();
+  m_oldFids.clear();
+  m_newFids.clear();
 
-  m_isLevelCreated  = false;
-  m_isFrameCreated  = false;
-  Preferences *pref = Preferences::instance();
+  m_isLevelCreated     = false;
+  m_isFrameCreated     = false;
+  m_isLevelRenumbererd = false;
+  Preferences *pref    = Preferences::instance();
 
-  bool isAutoCreateEnabled   = pref->isAutoCreateEnabled();
-  bool animationSheetEnabled = pref->isAnimationSheetEnabled();
-  bool isAutoStretchEnabled  = pref->isAutoStretchEnabled();
+  bool isAutoCreateEnabled        = pref->isAutoCreateEnabled();
+  bool animationSheetEnabled      = pref->isAnimationSheetEnabled();
+  bool isAutoStretchEnabled       = pref->isAutoStretchEnabled();
+  bool isAutoRenumberEnabled      = pref->isAutorenumberEnabled();
+  bool isCreateInHoldCellsEnabled = pref->isCreationInHoldCellsEnabled();
 
   TFrameHandle *currentFrame    = m_application->getCurrentFrame();
   TXshLevelHandle *currentLevel = m_application->getCurrentLevel();
@@ -294,132 +324,167 @@ TImage *TTool::touchImage() {
       m_isFrameCreated = true;
     }
     return img.getPointer();
-  } else {
-    // editing xsheet
-    if (m_application->getCurrentObject()->isSpline()) return 0;
+  }
 
-    TSceneHandle *currentScene = m_application->getCurrentScene();
-    ToonzScene *scene          = currentScene->getScene();
-    int row                    = currentFrame->getFrame();
-    int col = m_application->getCurrentColumn()->getColumnIndex();
-    if (col < 0) return 0;
+  //- - - - editing xsheet case starts here - - - -
 
-    TXsheetHandle *currentXsheet = m_application->getCurrentXsheet();
-    TXsheet *xsh                 = currentXsheet->getXsheet();
-    if (!xsh) return 0;
+  if (m_application->getCurrentObject()->isSpline()) return 0;
 
-    TXshCell cell       = xsh->getCell(row, col);
-    TXshSimpleLevel *sl = cell.getSimpleLevel();
+  TSceneHandle *currentScene = m_application->getCurrentScene();
+  ToonzScene *scene          = currentScene->getScene();
+  int row                    = currentFrame->getFrame();
+  int col = m_application->getCurrentColumn()->getColumnIndex();
+  if (col < 0) return 0;
 
-    if (sl != 0) {
-      // current cell is not empty
-      if (isAutoCreateEnabled && animationSheetEnabled && row > 0 &&
-          xsh->getCell(row - 1, col) == xsh->getCell(row, col)) {
-        // animationSheet is enabled and the current cell is a "hold". We must
-        // create a new drawing.
-        // measure the hold length (starting from the current row) : r0-r1
-        int r0 = row, r1 = row;
-        if (isAutoStretchEnabled)
-          while (xsh->getCell(r1 + 1, col) == cell) r1++;
-        // find the proper frameid (possibly addisng suffix, in order to avoid a
-        // fid already used)
-        TFrameId fid = getNewFrameId(sl, row);
-        // create the new drawing
-        TImageP img      = sl->createEmptyFrame();
-        m_isFrameCreated = true;
-        // insert the drawing in the level
-        sl->setFrame(fid, img);
-        // update the cell
-        cell = TXshCell(sl, fid);
-        // update the xsheet (change the current cell and possibly all the
-        // following "hold")
-        for (int r = r0; r <= r1; r++) xsh->setCell(r, col, cell);
-        // notify
-        currentXsheet->notifyXsheetChanged();
-        currentScene->notifyCastChange();
-        currentLevel->notifyLevelChange();
-        m_cellsData.push_back(r0);
-        m_cellsData.push_back(r1);
-        m_cellsData.push_back(0);
-      }
-      // we've found the image. return it.
-      return cell.getImage(true).getPointer();
+  TXsheetHandle *currentXsheet = m_application->getCurrentXsheet();
+  TXsheet *xsh                 = currentXsheet->getXsheet();
+  if (!xsh) return 0;
+
+  TXshCell cell       = xsh->getCell(row, col);
+  TXshSimpleLevel *sl = cell.getSimpleLevel();
+
+  if (sl) {
+    // current cell is not empty
+    if (isCreateInHoldCellsEnabled && row > 0 &&
+        xsh->getCell(row - 1, col) == xsh->getCell(row, col)) {
+      // CreateInHoldCells is enabled and the current cell is a "hold".
+      // We must create a new drawing.
+      // measure the hold length (starting from the current row) : r0-r1
+      int r0 = row, r1 = row;
+      if (isAutoStretchEnabled)
+        while (xsh->getCell(r1 + 1, col) == cell) r1++;
+      // find the proper frameid (possibly addisng suffix, in order to avoid a
+      // fid already used)
+      // find the proper frameid
+      TFrameId fid;
+      TXshCellColumn *column = xsh->getColumn(col)->getCellColumn();
+      if (isAutoRenumberEnabled && column) {
+        TFrameId maxFid;
+        if (animationSheetEnabled) {
+          fid    = TFrameId(row + 1);
+          maxFid = TFrameId(row);
+        } else {
+          int r_begin, r_end;
+          column->getRange(r_begin, r_end);
+          fid = getDesiredFId(column, r_begin, sl, row, maxFid);
+        }
+        // renumber fids
+        sl->getFids(m_oldFids);
+        m_isLevelRenumbererd = ToolUtils::renumberForInsertFId(
+            sl, fid, maxFid, scene->getTopXsheet());
+        if (m_isLevelRenumbererd) sl->getFids(m_newFids);
+      } else
+        fid = (animationSheetEnabled) ? getNewFrameId(sl, row)
+                                      : sl->index2fid(sl->getFrameCount());
+      // create the new drawing
+      TImageP img      = sl->createEmptyFrame();
+      m_isFrameCreated = true;
+      // insert the drawing in the level
+      sl->setFrame(fid, img);
+      // update the cell
+      cell = TXshCell(sl, fid);
+      // update the xsheet (change the current cell and possibly all the
+      // following "hold")
+      for (int r = r0; r <= r1; r++) xsh->setCell(r, col, cell);
+      // notify
+      currentXsheet->notifyXsheetChanged();
+      currentScene->notifyCastChange();
+      currentLevel->notifyLevelChange();
+      m_cellsData.push_back({r0, r1, CellOps::ExistingToNew});
+    }
+    // if the level does not contain a frame in the current cell
+    // (i.e. drawing on the cell with red numbers)
+    else if (!sl->isFid(cell.getFrameId())) {
+      // no drawing found
+      if (sl->isSubsequence() || sl->isReadOnly() || !isAutoCreateEnabled)
+        return 0;
+      // create a new drawing
+      TImageP img = sl->createEmptyFrame();
+      sl->setFrame(cell.getFrameId(), img);
+      currentXsheet->notifyXsheetChanged();
+      currentLevel->notifyLevelChange();
+      m_isFrameCreated = true;
+      return img.getPointer();
     }
 
-    // current cell is empty.
-    if (!isAutoCreateEnabled) return 0;
+    // we've found the image. return it.
+    return cell.getImage(true).getPointer();
+  }
 
-    // get the column range
-    int r0, r1;
-    xsh->getCellRange(col, r0, r1);
+  // current cell is empty.
+  if (!isAutoCreateEnabled) return 0;
 
-    if (animationSheetEnabled && r0 <= r1) {
-      // animation sheet enabled and not empty column. We must create a new
-      // drawing in the column level and possibly add "holds"
+  // get the column range
+  int r0, r1;
+  xsh->getCellRange(col, r0, r1);
+  // in case the column is not empty
+  if (r0 <= r1) {
+    // We must create a new drawing in the column level and possibly add "holds"
 
-      // find the last not-empty cell before the current one (a) and the first
-      // after (b)
-      int a = row - 1, b = row + 1;
-      while (a >= r0 && xsh->getCell(a, col).isEmpty()) a--;
-      while (b <= r1 && xsh->getCell(b, col).isEmpty()) b++;
+    // find the last not-empty cell before the current one (a) and the first
+    // after (b)
+    int a = row - 1, b = row + 1;
+    while (a >= r0 && xsh->getCell(a, col).isEmpty()) a--;
+    while (b <= r1 && xsh->getCell(b, col).isEmpty()) b++;
 
-      // find the level we must attach to
-      if (a >= r0) {
-        // there is a not-emtpy cell before the current one
-        sl = xsh->getCell(a, col).getSimpleLevel();
-      } else if (b <= r1) {
-        sl = xsh->getCell(b, col).getSimpleLevel();
-      }
-      if (sl) {
-        // note: sl should be always !=0 (the column is not empty)
-        // if - for some reason - it is ==0 then we skip to the standard (i.e.
-        // !animationSheetEnabled) beahviour
+    // find the level we must attach to
+    if (a >= r0) {
+      // there is a not-empty cell before the current one
+      sl = xsh->getCell(a, col).getSimpleLevel();
+    } else if (b <= r1) {
+      sl = xsh->getCell(b, col).getSimpleLevel();
+    }
+    if (sl && !sl->isSubsequence() && !sl->isReadOnly()) {
+      // note: sl should be always !=0 (the column is not empty)
+      // if - for some reason - it is == 0 or it is not editable,
+      // then we skip to empty-column behaviour
 
-        // create the drawing
-        // find the proper frameid (possibly addisng suffix, in order to avoid a
-        // fid already used)
-        TFrameId fid = getNewFrameId(sl, row);
-        // create the new drawing
-        TImageP img      = sl->createEmptyFrame();
-        m_isFrameCreated = true;
-        // insert the drawing in the level
-        sl->setFrame(fid, img);
-        // update the cell
-        cell = TXshCell(sl, fid);
-        xsh->setCell(row, col, cell);
+      // create the drawing
+      // find the proper frameid
+      TFrameId fid;
+      TXshCellColumn *column = xsh->getColumn(col)->getCellColumn();
+      if (isAutoRenumberEnabled && column) {
+        TFrameId maxFid(row);
+        fid = (animationSheetEnabled)
+                  ? TFrameId(row + 1)
+                  : getDesiredFId(column, r0, sl, row, maxFid);
+        sl->getFids(m_oldFids);
+        m_isLevelRenumbererd = ToolUtils::renumberForInsertFId(
+            sl, fid, maxFid, scene->getTopXsheet());
+        if (m_isLevelRenumbererd) sl->getFids(m_newFids);
+      } else
+        fid = (animationSheetEnabled) ? getNewFrameId(sl, row)
+                                      : sl->index2fid(sl->getFrameCount());
+      // create the new drawing
+      TImageP img      = sl->createEmptyFrame();
+      m_isFrameCreated = true;
+      // insert the drawing in the level
+      sl->setFrame(fid, img);
+      // update the cell
+      cell = TXshCell(sl, fid);
+      xsh->setCell(row, col, cell);
 
-        // create holds
-        if (!isAutoStretchEnabled) {
-          m_cellsData.push_back(row);
-          m_cellsData.push_back(row);
-          m_cellsData.push_back(2);  // vuoto => nuovo
-        } else {
-          if (a >= r0) {
-            // create a hold before : [a+1, row-1]
-            TXshCell aCell = xsh->getCell(a, col);
-            for (int i = a + 1; i < row; i++) xsh->setCell(i, col, aCell);
-            m_cellsData.push_back(a + 1);
-            m_cellsData.push_back(row - 1);
-            m_cellsData.push_back(1);  // vuoto => vecchio
+      // create holds
+      if (!isAutoStretchEnabled) {
+        m_cellsData.push_back({row, row, CellOps::BlankToNew});
+      } else {
+        if (a >= r0) {
+          // create a hold before : [a+1, row-1]
+          TXshCell aCell = xsh->getCell(a, col);
+          for (int i = a + 1; i < row; i++) xsh->setCell(i, col, aCell);
+          m_cellsData.push_back({a + 1, row - 1, CellOps::BlankToExisting});
 
-            if (b <= r1 && xsh->getCell(b, col).getSimpleLevel() == sl) {
-              // create also a hold after
-              for (int i = row + 1; i < b; i++) xsh->setCell(i, col, cell);
-              m_cellsData.push_back(row);
-              m_cellsData.push_back(b - 1);
-              m_cellsData.push_back(2);  // vuoto => nuovo
-            } else {
-              m_cellsData.push_back(row);
-              m_cellsData.push_back(row);
-              m_cellsData.push_back(2);  // vuoto => nuovo
-            }
-          } else if (b <= r1) {
-            // create a hold after
+          if (b <= r1 && xsh->getCell(b, col).getSimpleLevel() == sl) {
+            // create also a hold after
             for (int i = row + 1; i < b; i++) xsh->setCell(i, col, cell);
-            m_cellsData.push_back(row);
-            m_cellsData.push_back(b - 1);
-            m_cellsData.push_back(2);  // vuoto => nuovo
+            m_cellsData.push_back({row, b - 1, CellOps::BlankToNew});
+          } else {
+            m_cellsData.push_back({row, row, CellOps::BlankToNew});
           }
+        } else if (b <= r1) {
+          // create a hold after
+          for (int i = row + 1; i < b; i++) xsh->setCell(i, col, cell);
+          m_cellsData.push_back({row, b - 1, CellOps::BlankToNew});
         }
       }
       // notify & return
@@ -428,55 +493,27 @@ TImage *TTool::touchImage() {
       currentLevel->notifyLevelChange();
       return cell.getImage(true).getPointer();
     }
-
-    if (row > 0 && xsh->getCell(row - 1, col).getSimpleLevel() != 0 &&
-        !animationSheetEnabled) {
-      sl = xsh->getCell(row - 1, col).getSimpleLevel();
-      if (sl->getType() != OVL_XSHLEVEL ||
-          sl->getPath().getFrame() != TFrameId::NO_FRAME) {
-        // la cella precedente contiene un drawing di un livello. animationSheet
-        // e' disabilitato
-        // creo un nuovo frame
-        currentLevel->setLevel(sl);
-        if (sl->isSubsequence() || sl->isReadOnly()) return 0;
-        TFrameId fid     = sl->index2fid(sl->getFrameCount());
-        TImageP img      = sl->createEmptyFrame();
-        m_isFrameCreated = true;
-        sl->setFrame(fid, img);
-        cell = TXshCell(sl, fid);
-        xsh->setCell(row, col, cell);
-        currentXsheet->notifyXsheetChanged();
-        currentScene->notifyCastChange();
-        currentLevel->notifyLevelChange();
-        return img.getPointer();
-      }
-    }
-
-    // animation sheet disabled or empty column. autoCreate is enabled: we must
-    // create a new level
-    int levelType    = pref->getDefLevelType();
-    TXshLevel *xl    = scene->createNewLevel(levelType);
-    sl               = xl->getSimpleLevel();
-    m_isLevelCreated = true;
-
-    // create the drawing
-    TFrameId fid = animationSheetEnabled ? getNewFrameId(sl, row) : TFrameId(1);
-    TImageP img  = sl->createEmptyFrame();
-    m_isFrameCreated = true;
-    sl->setFrame(fid, img);
-    cell = TXshCell(sl, fid);
-    xsh->setCell(row, col, cell);
-    if (animationSheetEnabled) {
-      m_cellsData.push_back(row);
-      m_cellsData.push_back(row);
-      m_cellsData.push_back(2);  // vuoto => nuovo
-    }
-
-    currentXsheet->notifyXsheetChanged();
-    currentScene->notifyCastChange();
-    currentLevel->notifyLevelChange();
-    return img.getPointer();
   }
+
+  // - - - - empty column case starts here - - - -
+  // autoCreate is enabled: we must create a new level
+  int levelType    = pref->getDefLevelType();
+  TXshLevel *xl    = scene->createNewLevel(levelType);
+  sl               = xl->getSimpleLevel();
+  m_isLevelCreated = true;
+
+  // create the drawing
+  TFrameId fid = animationSheetEnabled ? getNewFrameId(sl, row) : TFrameId(1);
+  TImageP img  = sl->createEmptyFrame();
+  m_isFrameCreated = true;
+  sl->setFrame(fid, img);
+  cell = TXshCell(sl, fid);
+  xsh->setCell(row, col, cell);
+  m_cellsData.push_back({row, row, CellOps::BlankToNew});  // vuoto => nuovo
+  currentXsheet->notifyXsheetChanged();
+  currentScene->notifyCastChange();
+  currentLevel->notifyLevelChange();
+  return img.getPointer();
 }
 
 //-----------------------------------------------------------------------------
@@ -813,8 +850,7 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
     levelType     = cell.isEmpty() ? NO_XSHLEVEL : cell.m_level->getType();
   }
 
-  if (Preferences::instance()->isAutoCreateEnabled() &&
-      Preferences::instance()->isAnimationSheetEnabled()) {
+  if (Preferences::instance()->isAutoCreateEnabled()) {
     // If not in Level editor, let's use our current cell from the xsheet to
     // find the nearest level before it
     if (levelType == NO_XSHLEVEL &&

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -492,7 +492,9 @@ void ToolUtils::TToolUndo::insertLevelAndFrameIfNeeded() const {
   TTool::Application *app = TTool::getApplication();
   if (m_renumberedLevel) {
     TXsheet *xsh = app->getCurrentScene()->getScene()->getTopXsheet();
-    ToolUtils::doUpdateXSheet(m_level.getPointer(), m_oldFids, m_newFids, xsh);
+    std::vector<TXshChildLevel *> childLevels;
+    ToolUtils::doUpdateXSheet(m_level.getPointer(), m_oldFids, m_newFids, xsh,
+                              childLevels);
     m_level->renumber(m_newFids);
     app->getCurrentXsheet()->notifyXsheetChanged();
   }
@@ -556,7 +558,9 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
   }
   if (m_renumberedLevel) {
     TXsheet *xsh = app->getCurrentScene()->getScene()->getTopXsheet();
-    ToolUtils::doUpdateXSheet(m_level.getPointer(), m_newFids, m_oldFids, xsh);
+    std::vector<TXshChildLevel *> childLevels;
+    ToolUtils::doUpdateXSheet(m_level.getPointer(), m_newFids, m_oldFids, xsh,
+                              childLevels);
     m_level->renumber(m_oldFids);
     app->getCurrentXsheet()->notifyXsheetChanged();
   }
@@ -1853,7 +1857,8 @@ bool ToolUtils::renumberForInsertFId(TXshSimpleLevel *sl, const TFrameId &fid,
     }
   }
 
-  doUpdateXSheet(sl, oldFrames, fids, xsh);
+  std::vector<TXshChildLevel *> childLevels;
+  doUpdateXSheet(sl, oldFrames, fids, xsh, childLevels);
   sl->renumber(fids);
 
   return true;

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -32,6 +32,7 @@
 #include "toonz/toonzscene.h"
 #include "toonz/preferences.h"
 #include "toonz/palettecontroller.h"
+#include "toonz/txshchildlevel.h"
 
 #include "toonzqt/tselectionhandle.h"
 #include "toonzqt/icongenerator.h"
@@ -459,16 +460,18 @@ ToolUtils::TToolUndo::TToolUndo(TXshSimpleLevel *level, const TFrameId &frameId,
     , m_isEditingLevel(false)
     , m_createdFrame(createdFrame)
     , m_createdLevel(createdLevel)
+    , m_renumberedLevel(TTool::m_isLevelRenumbererd)
     , m_imageId("") {
-  m_animationSheetEnabled = Preferences::instance()->isAnimationSheetEnabled();
   TTool::Application *app = TTool::getApplication();
   m_isEditingLevel        = app->getCurrentFrame()->isEditingLevel();
   if (!m_isEditingLevel) {
-    m_col = app->getCurrentColumn()->getColumnIndex();
-    m_row = app->getCurrentFrame()->getFrameIndex();
-    if (m_animationSheetEnabled) {
-      m_cellsData = TTool::m_cellsData;
-    }
+    m_col       = app->getCurrentColumn()->getColumnIndex();
+    m_row       = app->getCurrentFrame()->getFrameIndex();
+    m_cellsData = TTool::m_cellsData;
+  }
+  if (m_renumberedLevel) {
+    m_oldFids = TTool::m_oldFids;
+    m_newFids = TTool::m_newFids;
   }
   if (createdFrame) {
     m_imageId = "TToolUndo" + std::to_string(m_idCount++);
@@ -487,6 +490,12 @@ ToolUtils::TToolUndo::~TToolUndo() {
 
 void ToolUtils::TToolUndo::insertLevelAndFrameIfNeeded() const {
   TTool::Application *app = TTool::getApplication();
+  if (m_renumberedLevel) {
+    TXsheet *xsh = app->getCurrentScene()->getScene()->getTopXsheet();
+    ToolUtils::doUpdateXSheet(m_level.getPointer(), m_oldFids, m_newFids, xsh);
+    m_level->renumber(m_newFids);
+    app->getCurrentXsheet()->notifyXsheetChanged();
+  }
   if (m_createdLevel) {
     TLevelSet *levelSet = app->getCurrentScene()->getScene()->getLevelSet();
     if (levelSet) {
@@ -499,22 +508,14 @@ void ToolUtils::TToolUndo::insertLevelAndFrameIfNeeded() const {
     TImageP img  = TImageCache::instance()->get(m_imageId, false);
     m_level->setFrame(m_frameId, img);
     if (!m_isEditingLevel) {
-      if (m_animationSheetEnabled) {
-        int m = m_cellsData.size() / 3;
-        for (int i = 0; i < m; i++) {
-          int r0   = m_cellsData[i * 3];
-          int r1   = m_cellsData[i * 3 + 1];
-          int type = m_cellsData[i * 3 + 2];
-          TXshCell cell;
-          if (type == 1)
-            cell = xsh->getCell(r0 - 1, m_col);
-          else
-            cell = TXshCell(m_level.getPointer(), m_frameId);
-          for (int r = r0; r <= r1; r++) xsh->setCell(r, m_col, cell);
-        }
-      } else {
-        TXshCell cell(m_level.getPointer(), m_frameId);
-        xsh->setCell(m_row, m_col, cell);
+      for (const TTool::CellOps &cellOps : m_cellsData) {
+        TXshCell cell;
+        if (cellOps.type == TTool::CellOps::BlankToExisting)
+          cell = xsh->getCell(cellOps.r0 - 1, m_col);
+        else
+          cell = TXshCell(m_level.getPointer(), m_frameId);
+        for (int r = cellOps.r0; r <= cellOps.r1; r++)
+          xsh->setCell(r, m_col, cell);
       }
     }
     app->getCurrentLevel()->notifyLevelChange();
@@ -529,18 +530,12 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
     m_level->eraseFrame(m_frameId);
     if (!m_isEditingLevel) {
       TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
-      if (m_animationSheetEnabled) {
-        int m = m_cellsData.size() / 3;
-        for (int i = 0; i < m; i++) {
-          int r0   = m_cellsData[i * 3];
-          int r1   = m_cellsData[i * 3 + 1];
-          int type = m_cellsData[i * 3 + 2];
-          TXshCell cell;
-          if (type == 0) cell = xsh->getCell(r0 - 1, m_col);
-          for (int r = r0; r <= r1; r++) xsh->setCell(r, m_col, cell);
-        }
-      } else {
-        xsh->clearCells(m_row, m_col);
+      for (const TTool::CellOps &cellOps : m_cellsData) {
+        TXshCell cell;
+        if (cellOps.type == TTool::CellOps::ExistingToNew)
+          cell = xsh->getCell(cellOps.r0 - 1, m_col);
+        for (int r = cellOps.r0; r <= cellOps.r1; r++)
+          xsh->setCell(r, m_col, cell);
       }
     }
     if (m_createdLevel) {
@@ -558,6 +553,12 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
     app->getPaletteController()
         ->getCurrentLevelPalette()
         ->notifyPaletteChanged();
+  }
+  if (m_renumberedLevel) {
+    TXsheet *xsh = app->getCurrentScene()->getScene()->getTopXsheet();
+    ToolUtils::doUpdateXSheet(m_level.getPointer(), m_newFids, m_oldFids, xsh);
+    m_level->renumber(m_oldFids);
+    app->getCurrentXsheet()->notifyXsheetChanged();
   }
 }
 
@@ -1757,3 +1758,103 @@ TRasterPT<PIXEL> ToolUtils::rotate90(const TRasterPT<PIXEL> &ras, bool toRight)
         }
         return workRas;
 }*/
+
+//-----------------------------------------------------------------------------
+
+bool ToolUtils::doUpdateXSheet(TXshSimpleLevel *sl,
+                               std::vector<TFrameId> oldFids,
+                               std::vector<TFrameId> newFids, TXsheet *xsh,
+                               std::vector<TXshChildLevel *> &childLevels) {
+  bool ret = false;
+  for (int c = 0; c < xsh->getColumnCount(); ++c) {
+    int r0, r1;
+    int n = xsh->getCellRange(c, r0, r1);
+    if (n > 0) {
+      bool changed = false;
+      std::vector<TXshCell> cells(n);
+      xsh->getCells(r0, c, n, &cells[0]);
+      for (int i = 0; i < n; i++) {
+        TXshCell currCell = cells[i];
+        // check the sub xsheets too
+        if (!cells[i].isEmpty() &&
+            cells[i].m_level->getType() == CHILD_XSHLEVEL) {
+          TXshChildLevel *level = cells[i].m_level->getChildLevel();
+          // make sure we haven't already checked the level
+          if (level && std::find(childLevels.begin(), childLevels.end(),
+                                 level) == childLevels.end()) {
+            childLevels.push_back(level);
+            TXsheet *subXsh = level->getXsheet();
+            ret |= doUpdateXSheet(sl, oldFids, newFids, subXsh, childLevels);
+          }
+        }
+        for (int j = 0; j < oldFids.size(); j++) {
+          if (oldFids.at(j) == newFids.at(j)) continue;
+          TXshCell tempCell(sl, oldFids.at(j));
+          bool sameSl  = tempCell.getSimpleLevel() == currCell.getSimpleLevel();
+          bool sameFid = tempCell.getFrameId() == currCell.getFrameId();
+          if (sameSl && sameFid) {
+            TXshCell newCell(sl, newFids.at(j));
+            cells[i] = newCell;
+            changed  = true;
+            break;
+          }
+        }
+      }
+      if (changed) {
+        xsh->setCells(r0, c, n, &cells[0]);
+        ret = true;
+        // TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+      }
+    }
+  }
+  return ret;
+}
+
+//-----------------------------------------------------------------------------
+
+bool ToolUtils::renumberForInsertFId(TXshSimpleLevel *sl, const TFrameId &fid,
+                                     const TFrameId &maxFid, TXsheet *xsh) {
+  std::vector<TFrameId> fids;
+  std::vector<TFrameId> oldFrames;
+  sl->getFids(oldFrames);
+  sl->getFids(fids);
+  std::vector<TFrameId>::iterator it = std::find(fids.begin(), fids.end(), fid);
+  if (it == fids.end()) return false;
+
+  std::set<TFrameId> fidsSet(fids.begin(), fids.end());
+  QList<TFrameId> fIdsToBeShifted;
+  TFrameId tmpFid = fid;
+  for (auto itr = fidsSet.upper_bound(maxFid); itr != fidsSet.end(); ++itr) {
+    if (*itr > tmpFid) break;
+    fIdsToBeShifted.push_back(*itr);
+    if (fid.getLetter()) {
+      if ((*itr).getLetter() < 'z')
+        tmpFid = TFrameId((*itr).getNumber(),
+                          ((*itr).getLetter()) ? (*itr).getLetter() + 1 : 'a');
+      else
+        tmpFid = TFrameId((*itr).getNumber() + 1);
+    } else
+      tmpFid = TFrameId((*itr).getNumber() + 1, (*itr).getLetter());
+  }
+
+  if (fIdsToBeShifted.isEmpty()) return false;
+
+  for (TFrameId &tmpFid : fids) {
+    if (fIdsToBeShifted.contains(tmpFid)) {
+      if (fid.getLetter()) {
+        if (tmpFid.getLetter() < 'z')
+          tmpFid =
+              TFrameId(tmpFid.getNumber(),
+                       (tmpFid.getLetter()) ? tmpFid.getLetter() + 1 : 'a');
+        else
+          tmpFid = TFrameId(tmpFid.getNumber() + 1);
+      } else
+        tmpFid = TFrameId(tmpFid.getNumber() + 1, tmpFid.getLetter());
+    }
+  }
+
+  doUpdateXSheet(sl, oldFrames, fids, xsh);
+  sl->renumber(fids);
+
+  return true;
+}

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2017,7 +2017,12 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
   // If autocreate disabled, let's turn it on temporarily
   bool isAutoCreateEnabled = Preferences::instance()->isAutoCreateEnabled();
   if (!isAutoCreateEnabled)
-    Preferences::instance()->setValue(AutocreationType, 1, false);
+    Preferences::instance()->setValue(EnableAutocreation, true, false);
+  // Enable inserting in the hold cells temporarily too.
+  bool isCreationInHoldCellsEnabled =
+      Preferences::instance()->isCreationInHoldCellsEnabled();
+  if (!isCreationInHoldCellsEnabled)
+    Preferences::instance()->setValue(EnableCreationInHoldCells, true, false);
 
   TImage *img = toolHandle->getTool()->touchImage();
 
@@ -2026,7 +2031,10 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
 
   if (!img || !sl) {
     if (!isAutoCreateEnabled)
-      Preferences::instance()->setValue(AutocreationType, 0, false);
+      Preferences::instance()->setValue(EnableAutocreation, false, false);
+    if (!isCreationInHoldCellsEnabled)
+      Preferences::instance()->setValue(EnableCreationInHoldCells, false,
+                                        false);
     if (!multiple)
       DVGui::warning(QObject::tr(
           "Unable to create a blank drawing on the current column"));
@@ -2051,7 +2059,9 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
 
   // Reset back to what these were
   if (!isAutoCreateEnabled)
-    Preferences::instance()->setValue(AutocreationType, 0, false);
+    Preferences::instance()->setValue(EnableAutocreation, false, false);
+  if (!isCreationInHoldCellsEnabled)
+    Preferences::instance()->setValue(EnableCreationInHoldCells, false, false);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -52,7 +52,7 @@ TFrameId operator+(const TFrameId &fid, int d) {
 }
 
 //-----------------------------------------------------------------------------
-
+/*
 void doUpdateXSheet(TXshSimpleLevel *sl, std::vector<TFrameId> oldFids,
                     std::vector<TFrameId> newFids, TXsheet *xsh,
                     std::vector<TXshChildLevel *> &childLevels) {
@@ -97,7 +97,7 @@ void doUpdateXSheet(TXshSimpleLevel *sl, std::vector<TFrameId> oldFids,
     }
   }
 }
-
+*/
 //-----------------------------------------------------------------------------
 
 static void updateXSheet(TXshSimpleLevel *sl, std::vector<TFrameId> oldFids,
@@ -105,7 +105,9 @@ static void updateXSheet(TXshSimpleLevel *sl, std::vector<TFrameId> oldFids,
   std::vector<TXshChildLevel *> childLevels;
   TXsheet *xsh =
       TApp::instance()->getCurrentScene()->getScene()->getTopXsheet();
-  doUpdateXSheet(sl, oldFids, newFids, xsh, childLevels);
+  bool changed =
+      ToolUtils::doUpdateXSheet(sl, oldFids, newFids, xsh, childLevels);
+  if (changed) TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/filmstripcommand.h
+++ b/toonz/sources/toonz/filmstripcommand.h
@@ -57,7 +57,7 @@ void inbetween(TXshSimpleLevel *sl, const TFrameId &fid0, const TFrameId &fid1,
 
 void renumberDrawing(TXshSimpleLevel *sl, const TFrameId &oldFid,
                      const TFrameId &desiredNewFid);
-}
+}  // namespace FilmstripCmd
 
 TFrameId operator+(const TFrameId &fid, int d);
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -450,13 +450,6 @@ void PreferencesPopup::onDefLevelTypeChanged() {
 
 //-----------------------------------------------------------------------------
 
-void PreferencesPopup::onAutocreationTypeChanged() {
-  int autoCreationType = m_pref->getIntValue(AutocreationType);
-  m_controlIdMap.key(EnableAutoStretch)->setEnabled(autoCreationType == 2);
-}
-
-//-----------------------------------------------------------------------------
-
 void PreferencesPopup::onUseNumpadForSwitchingStylesClicked() {
   bool checked = m_pref->getBoolValue(useNumpadForSwitchingStyles);
   if (checked) {
@@ -1011,8 +1004,11 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {DefLevelWidth, tr("Width:")},
       {DefLevelHeight, tr("  Height:")},
       {DefLevelDpi, tr("DPI:")},
-      {AutocreationType, tr("Autocreation:")},
-      {EnableAutoStretch, tr("Enable auto-stretch frame")},
+      {EnableAutocreation, tr("Enable Autocreation")},
+      {NumberingSystem, tr("Numbering System:")},
+      {EnableAutoStretch, tr("Enable Auto-stretch Frame")},
+      {EnableCreationInHoldCells, tr("Enable Creation in Hold Cells")},
+      {EnableAutoRenumber, tr("Enable Autorenumber")},
       {vectorSnappingTarget, tr("Vector Snapping:")},
       {saveUnpaintedInCleanup,
        tr("Keep Original Cleaned Up Drawings As Backup")},
@@ -1154,10 +1150,8 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
        {{tr("Toonz Vector Level"), PLI_XSHLEVEL},
         {tr("Toonz Raster Level"), TZP_XSHLEVEL},
         {tr("Raster Level"), OVL_XSHLEVEL}}},
-      {AutocreationType,
-       {{tr("Disabled"), 0},
-        {tr("Enabled"), 1},
-        {tr("Use Xsheet as Animation Sheet"), 2}}},
+      {NumberingSystem,
+       {{tr("Incremental"), 0}, {tr("Use Xsheet as Animation Sheet"), 1}}},
       {vectorSnappingTarget,
        {{tr("Strokes"), 0}, {tr("Guides"), 1}, {tr("All"), 2}}},
       {dropdownShortcutsCycleOptions,
@@ -1593,8 +1587,14 @@ QWidget* PreferencesPopup::createDrawingPage() {
   insertUI(newLevelSizeToCameraSizeEnabled, lay);
   insertDualUIs(DefLevelWidth, DefLevelHeight, lay);
   insertUI(DefLevelDpi, lay);
-  insertDualUIs(AutocreationType, EnableAutoStretch, lay,
-                getComboItemList(AutocreationType));
+  QGridLayout* autoCreationLay = insertGroupBoxUI(EnableAutocreation, lay);
+  {
+    insertUI(NumberingSystem, autoCreationLay,
+             getComboItemList(NumberingSystem));
+    insertUI(EnableAutoStretch, autoCreationLay);
+    insertUI(EnableCreationInHoldCells, autoCreationLay);
+    insertUI(EnableAutoRenumber, autoCreationLay);
+  }
   insertUI(vectorSnappingTarget, lay, getComboItemList(vectorSnappingTarget));
   insertUI(saveUnpaintedInCleanup, lay);
   insertUI(minimizeSaveboxAfterEditing, lay);
@@ -1613,8 +1613,6 @@ QWidget* PreferencesPopup::createDrawingPage() {
                            &PreferencesPopup::onDefLevelTypeChanged);
   m_onEditedFuncMap.insert(newLevelSizeToCameraSizeEnabled,
                            &PreferencesPopup::onDefLevelTypeChanged);
-  m_onEditedFuncMap.insert(AutocreationType,
-                           &PreferencesPopup::onAutocreationTypeChanged);
 
   onDefLevelTypeChanged();
 
@@ -1623,9 +1621,6 @@ QWidget* PreferencesPopup::createDrawingPage() {
     getUI<MeasuredDoubleLineEdit*>(DefLevelWidth)->setDecimals(0);
     getUI<MeasuredDoubleLineEdit*>(DefLevelHeight)->setDecimals(0);
   }
-
-  if (m_pref->getIntValue(AutocreationType) != 2)
-    m_controlIdMap.key(EnableAutoStretch)->setDisabled(true);
 
   return widget;
 }

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -122,7 +122,6 @@ private:
   void beforeRoomChoiceChanged();
   // Drawing
   void onDefLevelTypeChanged();
-  void onAutocreationTypeChanged();
   void onUseNumpadForSwitchingStylesClicked();
   // Tools
   void onLevelBasedToolsDisplayChanged();

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -277,6 +277,7 @@ void parse(const QString &text, std::wstring &levelName, TFrameId &fid) {
   QRegExp spaces("\\t|\\s");
   QRegExp numbers("\\d+");
   QRegExp caracters("[^\\d+]");
+  QRegExp fidWithSuffix("([0-9]+)([a-z]?)");
   QString str = text;
 
   // remove final spaces
@@ -293,6 +294,11 @@ void parse(const QString &text, std::wstring &levelName, TFrameId &fid) {
     if (str.contains(numbers) && !str.contains(caracters)) {
       levelName = L"";
       fid       = TFrameId(str.toInt());
+    } else if (fidWithSuffix.exactMatch(str)) {
+      levelName = L"";
+      fid       = TFrameId(
+          fidWithSuffix.cap(1).toInt(),
+          fidWithSuffix.cap(2) == "" ? 0 : fidWithSuffix.cap(2).toLatin1()[0]);
     } else if (str.contains(caracters)) {
       levelName = text.toStdWString();
       fid       = TFrameId::NO_FRAME;
@@ -303,6 +309,12 @@ void parse(const QString &text, std::wstring &levelName, TFrameId &fid) {
       QString firstString = str.left(lastSpaceIndex);
       levelName           = firstString.toStdWString();
       fid                 = TFrameId(lastString.toInt());
+    } else if (fidWithSuffix.exactMatch(lastString)) {
+      QString firstString = str.left(lastSpaceIndex);
+      levelName           = firstString.toStdWString();
+      fid                 = TFrameId(
+          fidWithSuffix.cap(1).toInt(),
+          fidWithSuffix.cap(2) == "" ? 0 : fidWithSuffix.cap(2).toLatin1()[0]);
     } else if (lastString.contains(caracters)) {
       levelName = text.toStdWString();
       fid       = TFrameId::NO_FRAME;
@@ -318,46 +330,36 @@ bool isGlobalKeyFrameWithSameTypeDiffFromLinear(TStageObject *stageObject,
   TDoubleKeyframe::Type type =
       stageObject->getParam(TStageObject::T_Angle)->getKeyframeAt(frame).m_type;
   if (type == TDoubleKeyframe::Linear) return false;
-  if (type !=
-          stageObject->getParam(TStageObject::T_X)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_Y)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_Z)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_SO)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_ScaleX)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_ScaleY)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_Scale)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_Path)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_ShearX)
-              ->getKeyframeAt(frame)
-              .m_type ||
-      type !=
-          stageObject->getParam(TStageObject::T_ShearY)
-              ->getKeyframeAt(frame)
-              .m_type)
+  if (type != stageObject->getParam(TStageObject::T_X)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_Y)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_Z)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_SO)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_ScaleX)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_ScaleY)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_Scale)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_Path)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_ShearX)
+                  ->getKeyframeAt(frame)
+                  .m_type ||
+      type != stageObject->getParam(TStageObject::T_ShearY)
+                  ->getKeyframeAt(frame)
+                  .m_type)
     return false;
   return true;
 }
@@ -380,46 +382,36 @@ bool isGlobalKeyFrameWithSamePrevTypeDiffFromLinear(TStageObject *stageObject,
                                    ->getKeyframeAt(frame)
                                    .m_prevType;
   if (type == TDoubleKeyframe::Linear) return false;
-  if (type !=
-          stageObject->getParam(TStageObject::T_X)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_Y)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_Z)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_SO)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_ScaleX)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_ScaleY)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_Scale)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_Path)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_ShearX)
-              ->getKeyframeAt(frame)
-              .m_prevType ||
-      type !=
-          stageObject->getParam(TStageObject::T_ShearY)
-              ->getKeyframeAt(frame)
-              .m_prevType)
+  if (type != stageObject->getParam(TStageObject::T_X)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_Y)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_Z)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_SO)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_ScaleX)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_ScaleY)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_Scale)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_Path)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_ShearX)
+                  ->getKeyframeAt(frame)
+                  .m_prevType ||
+      type != stageObject->getParam(TStageObject::T_ShearY)
+                  ->getKeyframeAt(frame)
+                  .m_prevType)
     return false;
   return true;
 }
@@ -759,12 +751,13 @@ void RenameCellField::renameCell() {
   // Ex.  12 -> 1B    21 -> 2A   30 -> 3
   if (Preferences::instance()->isShowFrameNumberWithLettersEnabled())
     parse_with_letter(QString::fromStdWString(newName), levelName, fid);
-  else
+  else {
     parse(QString::fromStdWString(newName), levelName, fid);
-
+  }
   bool animationSheetEnabled =
       Preferences::instance()->isAnimationSheetEnabled();
-  bool levelDefined =
+
+  /*bool levelDefined =
       xsheet->getCell(m_row, m_col).getSimpleLevel() != 0 ||
       m_row > 0 && xsheet->getCell(m_row - 1, m_col).getSimpleLevel() != 0;
 
@@ -785,8 +778,7 @@ void RenameCellField::renameCell() {
       }
     }
     return;
-  }
-
+  }*/
   TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
       TApp::instance()->getCurrentSelection()->getSelection());
   if (!cellSelection) return;
@@ -1825,10 +1817,10 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
   nameRect.adjust(0, 0, -frameAdj, 0);
 
   // draw text in red if the file does not exist
-  bool isRed                                  = false;
-  TXshSimpleLevel *sl                         = cell.getSimpleLevel();
+  bool isRed          = false;
+  TXshSimpleLevel *sl = cell.getSimpleLevel();
   if (sl && !sl->isFid(cell.m_frameId)) isRed = true;
-  TXshChildLevel *cl                          = cell.getChildLevel();
+  TXshChildLevel *cl = cell.getChildLevel();
   if (cl && cell.getFrameId().getNumber() - 1 >= cl->getFrameCount())
     isRed = true;
   QColor penColor =
@@ -1928,8 +1920,9 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
   bool isSelected                   = cellSelection->isCellSelected(row, col) ||
                     columnSelection->isColumnSelected(col);
 
-  if (row > 0) prevCell = xsh->getCell(row - 1, col);  // cell in previous frame
-                                                       // nothing to draw
+  if (row > 0)
+    prevCell = xsh->getCell(row - 1, col);  // cell in previous frame
+                                            // nothing to draw
 
   bool sameLevel = prevCell.m_level.getPointer() == cell.m_level.getPointer();
 
@@ -2035,7 +2028,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
 #ifdef _WIN32
     fontName = "Arial";
 #else
-    fontName          = "Helvetica";
+    fontName = "Helvetica";
 #endif
   }
   static QFont font(fontName, -1, QFont::Normal);
@@ -2067,7 +2060,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
 #if QT_VERSION >= 0x050500
   QString elidaName = elideText(text, metric, nameRect.width(), "~");
 #else
-  QString elidaName   = elideText(text, font, nameRect.width(), "~");
+  QString elidaName = elideText(text, font, nameRect.width(), "~");
 #endif
 
   if (!sameLevel || prevCell.m_frameId != cell.m_frameId)
@@ -2088,7 +2081,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
   bool isSelected               = cellSelection->isCellSelected(row, col);
 
   if (row > 0) prevCell = xsh->getCell(row - 1, col);
-  TXshCell nextCell     = xsh->getCell(row + 1, col);
+  TXshCell nextCell = xsh->getCell(row + 1, col);
 
   bool sameLevel = prevCell.m_level.getPointer() == cell.m_level.getPointer();
 
@@ -2099,8 +2092,8 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
   bool isAfterMarkers =
       distance > 0 && ((row - offset) % distance) == 0 && row != 0;
 
-  bool isRed                         = false;
-  TXshPaletteLevel *pl               = cell.getPaletteLevel();
+  bool isRed           = false;
+  TXshPaletteLevel *pl = cell.getPaletteLevel();
   if (pl && !pl->getPalette()) isRed = true;
 
   QPoint xy = m_viewer->positionToXY(CellPosition(row, col));
@@ -2232,7 +2225,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
 #ifdef _WIN32
       fontName = "Arial";
 #else
-      fontName        = "Helvetica";
+      fontName = "Helvetica";
 #endif
     }
     static QFont font(fontName, -1, QFont::Normal);
@@ -2791,10 +2784,9 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
         setDragTool(XsheetGUI::DragTool::makeLevelMoverTool(m_viewer));
     } else {
       m_viewer->getKeyframeSelection()->selectNone();
-      if (isSoundColumn &&
-          o->rect(PredefinedRect::PREVIEW_TRACK)
-              .adjusted(0, 0, -frameAdj, 0)
-              .contains(mouseInCell))
+      if (isSoundColumn && o->rect(PredefinedRect::PREVIEW_TRACK)
+                               .adjusted(0, 0, -frameAdj, 0)
+                               .contains(mouseInCell))
         setDragTool(XsheetGUI::DragTool::makeSoundScrubTool(
             m_viewer, column->getSoundColumn()));
       else if (isSoundColumn &&
@@ -2929,10 +2921,9 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
                       : QString::fromStdWString(levelName) + QString(" ") +
                             QString::fromStdString(frameNumber));
     }
-  } else if (isSoundColumn &&
-             o->rect(PredefinedRect::PREVIEW_TRACK)
-                 .adjusted(0, 0, -frameAdj, 0)
-                 .contains(mouseInCell))
+  } else if (isSoundColumn && o->rect(PredefinedRect::PREVIEW_TRACK)
+                                  .adjusted(0, 0, -frameAdj, 0)
+                                  .contains(mouseInCell))
     m_tooltip = tr("Click and drag to play");
   else if (m_levelExtenderRect.contains(pos))
     m_tooltip = tr("Click and drag to repeat selected cells");

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -226,6 +226,8 @@ Preferences::Preferences() {
   initializeOptions();
 
   definePreferenceItems();
+  // resolve compatibility for deprecated items
+  resolveCompatibility();
 
   // initialize environment based on loaded preferences
   setUnits();
@@ -450,9 +452,15 @@ void Preferences::definePreferenceItems() {
          TCamera().getSize().ly, 0.1, std::numeric_limits<double>::max());
   define(DefLevelDpi, "DefLevelDpi", QMetaType::Double, TCamera().getDpi().x,
          0.1, std::numeric_limits<double>::max());
-  define(AutocreationType, "AutocreationType", QMetaType::Int,
-         2);  // Use Xsheet as Animation Sheet
+
+  define(EnableAutocreation, "EnableAutocreation", QMetaType::Bool, true);
+  define(NumberingSystem, "NumberingSystem", QMetaType::Int,
+         0);  // Incremental
   define(EnableAutoStretch, "EnableAutoStretch", QMetaType::Bool, true);
+  define(EnableCreationInHoldCells, "EnableCreationInHoldCells",
+         QMetaType::Bool, true);
+  define(EnableAutoRenumber, "EnableAutoRenumber", QMetaType::Bool, true);
+
   define(vectorSnappingTarget, "vectorSnappingTarget", QMetaType::Int,
          (int)SnapAll);
   define(saveUnpaintedInCleanup, "saveUnpaintedInCleanup", QMetaType::Bool,
@@ -661,6 +669,30 @@ void Preferences::define(PreferencesItemId id, QString idString,
 
 void Preferences::setCallBack(const PreferencesItemId id, OnEditedFunc func) {
   getItem(id).onEditedFunc = func;
+}
+
+//-----------------------------------------------------------------
+
+void Preferences::resolveCompatibility() {
+  // autocreation type is divided into "EnableAutocreation" and
+  // "NumberingSystem"
+  if (m_settings->contains("AutocreationType") &&
+      !m_settings->contains("EnableAutocreation")) {
+    int type = m_settings->value("AutocreationType").toInt();
+    switch (type) {
+    case 0:  // former "Disabled"
+      setValue(EnableAutocreation, false);
+      break;
+    case 1:  // former "Enabled"
+      setValue(EnableAutocreation, true);
+      setValue(NumberingSystem, 0);  // set numbering system to "Incremental"
+      break;
+    case 2:  // former "Use Xsheet as Animation Sheet"
+      setValue(EnableAutocreation, true);
+      setValue(NumberingSystem, 1);
+      break;
+    }
+  }
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
This PR modifies the autocreation feature based on comments in #2905 , also including my proposed options based on the discussion with an animator in our studio.

### New Options Introduced
![autocreation](https://user-images.githubusercontent.com/17974955/70889400-dd7c2180-2025-11ea-9541-901fa0d78faa.png)
I divided up the behaviors which were available in conventional `Use Xsheet as Animation Sheet` mode and made them optional like as follows:

- **Numbering System** : option is either `Incremental` and `Use Xsheet as Animation Sheet` . It specifies a number to be set for new drawing. ( `Incremental` will be just like the former `Autocreation:Enabled` option. )
- **Enable Auto-stretch Frame** : same as before, except that it now works regardless of other options. 
- **Enable Creation in Hold Cells** : specifies whether a new drawing will be created when start drawing in the "hold" cell - i.e. the cell with the same contents as the previous one. (This behavior was enabled only in the "former" `Use Xsheet as Animation Sheet` mode). Note that when you use the `Create Blank Drawing` command, now this option will become temporarily activated so that you can insert drawings in hold cells regardless of the current state.
- **Enable Autorenumber** : when inserting a new drawing between existing frames, with this options being ON, the following frames will be automatically renumbered so that the frame orders becomes straightforward as possible.

Whole options are grouped and nested in the `Enable Autocreation` box.
The former `Autocreation mode` is deprecated in this PR. OT will automatically reproduce the similar environment for existing users.

### Other changes

- "One level for one column" basis - Expose the same level even when drawing on the cell further down from exiting level on the column in any modes.
- When typing numbers on the cell, if the drawing exists, expose it in any modes, instead of creating the new drawing with suffix.
- Typing suffix is now available in any modes.
- Enabled to create a new drawing in a cell without images (i.e. cells with red numbers). You can now type numbers in the Xsheet before actually draw the images.

### Default values

I made the default values as follows, but are still open for discussion:

- **Enable Autocreation** : Enabled
- **Numbering System**: Incremental
- **Enable Auto-stretch Frame**, **Enable Creation in Hold Cells**, and **Enable Autorenumber** : Enabled


