### PR TITLE
Allow double-click in Load Level dialog to open selected level(s)

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -860,6 +860,8 @@ LoadLevelPopup::LoadLevelPopup()
           SLOT(onNameSetEditted()));
   connect(m_browser, SIGNAL(treeFolderChanged(const TFilePath &)), this,
           SLOT(onNameSetEditted()));
+  connect(m_browser, SIGNAL(filePathDoubleClicked(const TFilePath&)), this,
+          SLOT(onFilePathDoubleClicked(const TFilePath&)));
 }
 
 //-----------------------------------------------------------------------
@@ -1213,6 +1215,14 @@ void LoadLevelPopup::initFolder() {
   setFolder(fp);
   onFilePathsSelected(getCurrentPathSet(), getCurrentFIdsSet());
 }
+
+//----------------------------------------------------------------------------
+
+void LoadLevelPopup::onFilePathDoubleClicked(const TFilePath& path) {
+  Q_UNUSED(path);
+  onOkPressed();
+}
+
 //----------------------------------------------------------------------------
 
 void LoadLevelPopup::onFilePathsSelected(

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -303,6 +303,9 @@ public slots:
   // the selection
   void onSelectionChanged(TSelection *selection);
 
+protected slots:
+  void onFilePathDoubleClicked(const TFilePath &path);
+
 private:
   // update the fields acording to the current Path
   void updateBottomGUI(void);


### PR DESCRIPTION
This is for #2941. Demo below:

![double-click-demo](https://user-images.githubusercontent.com/24422213/71044367-5c906780-2196-11ea-983a-73bf7cdbb2d3.gif)


