### PR TITLE
Level Settings Box on the Load Level Popup

### DIFF
--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -299,7 +299,7 @@ FileBrowser::~FileBrowser() {}
 
 //-----------------------------------------------------------------------------
 /*! when the m_folderName is edited, move the current folder accordingly
-*/
+ */
 void FileBrowser::onFolderEdited() {
   TFilePath inputPath(m_folderName->text().toStdWString());
   QModelIndex index = DvDirModel::instance()->getIndexByPath(inputPath);
@@ -399,18 +399,18 @@ void FileBrowser::onFwdButtonPushed() {
 
 //-----------------------------------------------------------------------------
 /*! clear the history when the tree date is replaced
-*/
+ */
 void FileBrowser::clearHistory() {
   int size = m_indexHistoryList.size();
   // leave the last item
-  for (int i        = 1; i < size; i++) m_indexHistoryList.removeLast();
+  for (int i = 1; i < size; i++) m_indexHistoryList.removeLast();
   m_currentPosition = 0;
   refreshHistoryButtons();
 }
 
 //-----------------------------------------------------------------------------
 /*! update the current folder when changes detected from QFileSystemWatcher
-*/
+ */
 void FileBrowser::onFileSystemChanged(const QString &folderPath) {
   if (folderPath != m_folder.getQString()) return;
   // changes may create/delete of folder, so update the DvDirModel
@@ -821,7 +821,7 @@ void FileBrowser::setHistoryDay(std::string dayDateString) {
 //-----------------------------------------------------------------------------
 /*! for all items in the folder, retrieve the file names(m_name) from the
  * paths(m_path)
-*/
+ */
 void FileBrowser::refreshData() {
   std::vector<Item>::iterator it;
   for (it = m_items.begin(); it != m_items.end(); ++it) {
@@ -1157,7 +1157,7 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
   for (i = 0; i < (int)files.size(); i++) {
     TFileType::Type type = TFileType::getInfo(files[i]);
     if (areResources && !TFileType::isResource(type)) areResources = false;
-    if (!areScenes && TFileType::isScene(type)) areScenes          = true;
+    if (!areScenes && TFileType::isScene(type)) areScenes = true;
   }
 
   bool areFullcolor = true;
@@ -1178,7 +1178,7 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
     if (clickedFile != TFilePath() && clickedFile.getType() == "tnz")
       title = tr("Load As Sub-xsheet");
     else
-      title         = tr("Load");
+      title = tr("Load");
     QAction *action = new QAction(title, menu);
     ret             = ret &&
           connect(action, SIGNAL(triggered()), this, SLOT(loadResources()));
@@ -1703,7 +1703,7 @@ namespace {
 
 bool parsePathName(const QString &fullpath, QString &parentPath, QString &name,
                    QString &format) {
-  int index              = fullpath.lastIndexOf('\\');
+  int index = fullpath.lastIndexOf('\\');
   if (index == -1) index = fullpath.lastIndexOf('/');
 
   QString filename;
@@ -2069,13 +2069,16 @@ void FileBrowser::convertToPaintedTlv() {
 //-----------------------------------------------------------------------------
 
 void FileBrowser::onSelectedItems(const std::set<int> &indexes) {
-  if (indexes.empty()) return;
-
   std::set<TFilePath> filePaths;
   std::set<int>::const_iterator it;
 
   // pass the frameId list for reuse
   std::list<std::vector<TFrameId>> frameIDs;
+
+  if (indexes.empty()) {  // inform selection is released
+    emit filePathsSelected(filePaths, frameIDs);
+    return;
+  }
 
   for (it = indexes.begin(); it != indexes.end(); ++it) {
     filePaths.insert(m_items[*it].m_path);
@@ -2104,8 +2107,7 @@ void FileBrowser::onClickedItem(int index) {
 
 //-----------------------------------------------------------------------------
 
-void FileBrowser::onDoubleClickedItem(int index)
-{
+void FileBrowser::onDoubleClickedItem(int index) {
   // TODO: Avoid duplicate code with onClickedItem().
   if (0 <= index && index < (int)m_items.size()) {
     // if the folder is clicked, then move the current folder

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -44,6 +44,7 @@
 #include "toonz/tframehandle.h"
 #include "toonz/levelset.h"
 #include "toonz/palettecmd.h"
+#include "toonz/stage.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -270,7 +271,7 @@ void FileBrowserPopup::onOkPressed() {
 
 //-----------------------------------------------------------------------------
 /*! process without closing the browser
-*/
+ */
 void FileBrowserPopup::onApplyPressed() {
   TFilePath folder = m_browser->getFolder();
   std::set<TFilePath> pathSet;
@@ -325,14 +326,11 @@ void FileBrowserPopup::onFilePathClicked(const TFilePath &fp) {
 void FileBrowserPopup::onFilePathsSelected(
     const std::set<TFilePath> &paths,
     const std::list<std::vector<TFrameId>> &fIds) {
-  if (paths.empty()) return;
-
-  const TFilePath &fp = *paths.begin();
-
   m_selectedPaths  = paths;
   m_currentFIdsSet = fIds;
 
   if (paths.size() == 1) {
+    const TFilePath &fp = *paths.begin();
     QString text;
     if (!m_isDirectoryOnly)
       text = QString::fromStdWString(fp.getLevelNameW());
@@ -346,8 +344,7 @@ void FileBrowserPopup::onFilePathsSelected(
 
 //-----------------------------------------------------------------------------
 
-void FileBrowserPopup::onFilePathDoubleClicked(const TFilePath &)
-{
+void FileBrowserPopup::onFilePathDoubleClicked(const TFilePath &) {
   // do nothing by default
 }
 
@@ -503,7 +500,8 @@ LoadScenePopup::LoadScenePopup() : FileBrowserPopup(tr("Load Scene")) {
   // set the initial current path according to the current module
   setInitialFolderByCurrentRoom();
 
-  connect(m_browser, SIGNAL(filePathDoubleClicked(const TFilePath&)), this, SLOT(onFilePathDoubleClicked(const TFilePath&)));
+  connect(m_browser, SIGNAL(filePathDoubleClicked(const TFilePath &)), this,
+          SLOT(onFilePathDoubleClicked(const TFilePath &)));
 }
 
 bool LoadScenePopup::execute() {
@@ -544,7 +542,7 @@ void LoadScenePopup::showEvent(QShowEvent *e) {
   FileBrowserPopup::showEvent(e);
 }
 
-void LoadScenePopup::onFilePathDoubleClicked(const TFilePath& path) {
+void LoadScenePopup::onFilePathDoubleClicked(const TFilePath &path) {
   Q_UNUSED(path);
   onOkPressed();
 }
@@ -646,82 +644,90 @@ void SaveSubSceneAsPopup::initFolder() {
 
 //=============================================================================
 // LoadLevelPopup
+namespace {
+QPushButton *createShowButton(QWidget *parent) {
+  QPushButton *button = new QPushButton(parent);
+  button->setObjectName("LoadLevelShowButton");
+  button->setFixedSize(15, 15);
+  button->setCheckable(true);
+  button->setChecked(false);
+  button->setAutoDefault(false);
+  return button;
+}
+}  // namespace
 
 LoadLevelPopup::LoadLevelPopup()
     : FileBrowserPopup(tr("Load Level"),
                        Options(MULTISELECTION | WITH_APPLY_BUTTON), "",
-                       new QFrame(0)) {
+                       new QWidget(0)) {
   setModal(false);
   setOkText(tr("Load"));
 
-  QFrame *optionFrame = (QFrame *)m_customWidget;
+  QWidget *optionWidget = (QWidget *)m_customWidget;
 
   // choose tlv caching behavior
   QLabel *cacheBehaviorLabel = new QLabel(tr("TLV Caching Behavior"), this);
   m_loadTlvBehaviorComboBox  = new QComboBox(this);
 
   //----Load Subsequence Level
-  QPushButton *showSubsequenceButton = new QPushButton("", this);
+  QPushButton *showSubsequenceButton = createShowButton(this);
   QLabel *subsequenceLabel = new QLabel(tr("Load Subsequence Level"), this);
   m_subsequenceFrame       = new QFrame(this);
-  m_fromFrame              = new DVGui::LineEdit(this);
-  m_toFrame                = new DVGui::LineEdit(this);
+  m_fromFrame              = new DVGui::IntLineEdit(this, 1, 1);
+  m_toFrame                = new DVGui::IntLineEdit(this, 1, 1);
 
   //----Arrangement in Xsheet
-  QPushButton *showArrangementButton = new QPushButton("", this);
-  QLabel *arrangementLabel = new QLabel(tr("Arrangement in Xsheet"), this);
-  m_arrangementFrame       = new QFrame(this);
-  m_xFrom                  = new DVGui::LineEdit(this);
-  m_xTo                    = new DVGui::LineEdit(this);
-  m_stepCombo              = new QComboBox(this);
-  m_incCombo               = new QComboBox(this);
-  m_levelName              = new DVGui::LineEdit(this);
-  m_posFrom                = new DVGui::LineEdit(this);
-  m_posTo                  = new DVGui::LineEdit(this);
+  m_arrLvlPropWidget                 = new QWidget(this);
+  QPushButton *showArrangementButton = createShowButton(this);
+  QLabel *arrangementLabel =
+      new QLabel(tr("Level Settings & Arrangement in Xsheet"), this);
+  m_arrangementFrame = new QFrame(this);
+  m_xFrom            = new DVGui::IntLineEdit(this, 1, 1);
+  m_xTo              = new DVGui::IntLineEdit(this, 1, 1);
+  m_stepCombo        = new QComboBox(this);
+  m_incCombo         = new QComboBox(this);
+  m_posFrom          = new DVGui::IntLineEdit(this, 1, 1);
+  m_posTo            = new DVGui::IntLineEdit(this, 1, 1);
+
+  //----Level Properties
+  m_levelPropertiesFrame = new QFrame(this);
+  m_levelName            = new DVGui::LineEdit(this);
+  m_dpiWidget            = new QWidget(this);
+  m_dpiPolicy            = new QComboBox(this);
+  m_dpi                  = new DVGui::DoubleLineEdit(this);
+  m_subsampling          = new DVGui::IntLineEdit(this, 1, 1);
+  m_antialias            = new DVGui::IntLineEdit(this, 10, 0, 100);
+  m_premultiply          = new DVGui::CheckBox(tr("Premultiply"), this);
+  m_whiteTransp = new DVGui::CheckBox(tr("White As Transparent"), this);
 
   m_notExistLabel = new QLabel(tr("(FILE DOES NOT EXIST)"));
 
   //----
-  QStringList behaviorList;
-  behaviorList << QString(tr("On Demand")) << QString(tr("All Icons"))
-               << QString(tr("All Icons & Images"));
-  m_loadTlvBehaviorComboBox->addItems(behaviorList);
+  m_loadTlvBehaviorComboBox->addItem(tr("On Demand"),
+                                     IoCmd::LoadResourceArguments::ON_DEMAND);
+  m_loadTlvBehaviorComboBox->addItem(tr("All Icons"),
+                                     IoCmd::LoadResourceArguments::ALL_ICONS);
+  m_loadTlvBehaviorComboBox->addItem(
+      tr("All Icons & Images"),
+      IoCmd::LoadResourceArguments::ALL_ICONS_AND_IMAGES);
   // use the default value set in the preference
   m_loadTlvBehaviorComboBox->setCurrentIndex(
-      Preferences::instance()->getInitialLoadTlvCachingBehavior());
+      m_loadTlvBehaviorComboBox->findData(
+          Preferences::instance()->getInitialLoadTlvCachingBehavior()));
   cacheBehaviorLabel->setObjectName("TitleTxtLabel");
 
-  QIntValidator *validator = new QIntValidator(this);
-  validator->setBottom(1);
-
   //----Load Subsequence Level
-  subsequenceLabel->setObjectName("TitleTxtLabel");
-  showSubsequenceButton->setObjectName("LoadLevelShowButton");
-  showSubsequenceButton->setFixedSize(15, 15);
-  showSubsequenceButton->setCheckable(true);
-  showSubsequenceButton->setChecked(false);
-
-  showSubsequenceButton->setAutoDefault(false);
-
   m_subsequenceFrame->setObjectName("LoadLevelFrame");
+  subsequenceLabel->setObjectName("TitleTxtLabel");
   m_subsequenceFrame->hide();
   m_fromFrame->setMaximumWidth(50);
   m_toFrame->setMaximumWidth(50);
-  m_fromFrame->setValidator(validator);
-  m_toFrame->setValidator(validator);
 
   //----Arrangement in Xsheet
-  arrangementLabel->setObjectName("TitleTxtLabel");
-  showArrangementButton->setObjectName("LoadLevelShowButton");
-  showArrangementButton->setFixedSize(15, 15);
-  showArrangementButton->setCheckable(true);
-  showArrangementButton->setChecked(false);
-
-  showArrangementButton->setAutoDefault(false);
-
   m_arrangementFrame->setObjectName("LoadLevelFrame");
-  m_arrangementFrame->hide();
-  m_arrangementFrame->setMaximumWidth(356);
+  m_levelPropertiesFrame->setObjectName("LoadLevelFrame");
+  arrangementLabel->setObjectName("TitleTxtLabel");
+  m_arrLvlPropWidget->hide();
 
   QStringList sList;
   sList << QString("Auto") << QString("1") << QString("2") << QString("3")
@@ -730,23 +736,37 @@ LoadLevelPopup::LoadLevelPopup()
   m_stepCombo->addItems(sList);
   m_incCombo->addItems(sList);
 
-  m_xFrom->setValidator(validator);
-  m_xTo->setValidator(validator);
-  m_posFrom->setValidator(validator);
-  m_posTo->setValidator(validator);
+  //----Level Properties
+  m_dpiPolicy->addItem(QObject::tr("Image DPI"), LevelOptions::DP_ImageDpi);
+  m_dpiPolicy->addItem(QObject::tr("Custom DPI"), LevelOptions::DP_CustomDpi);
+  m_dpi->setRange(1, (std::numeric_limits<double>::max)());
+  m_dpi->setFixedWidth(54);
+
+  // initialize with the default value
+  LevelOptions options;
+  setLevelProperties(options);
 
   //"FILE DOES NOT EXIST" lavel
   m_notExistLabel->setObjectName("FileDoesNotExistLabel");
   m_notExistLabel->hide();
 
   //----layout
-  QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(5);
-  mainLayout->setSpacing(3);
+  auto createVBoxLayout = [](int margin, int spacing) {
+    QVBoxLayout *layout = new QVBoxLayout();
+    layout->setMargin(margin);
+    layout->setSpacing(spacing);
+    return layout;
+  };
+  auto createHBoxLayout = [](int margin, int spacing) {
+    QHBoxLayout *layout = new QHBoxLayout();
+    layout->setMargin(margin);
+    layout->setSpacing(spacing);
+    return layout;
+  };
+
+  QVBoxLayout *mainLayout = createVBoxLayout(5, 3);
   {
-    QHBoxLayout *cacheLay = new QHBoxLayout();
-    cacheLay->setMargin(0);
-    cacheLay->setSpacing(5);
+    QHBoxLayout *cacheLay = createHBoxLayout(0, 5);
     {
       cacheLay->addStretch(1);
       cacheLay->addWidget(cacheBehaviorLabel, 0);
@@ -755,9 +775,8 @@ LoadLevelPopup::LoadLevelPopup()
     mainLayout->addLayout(cacheLay, 0);
 
     //----Load Subsequence Level
-    QHBoxLayout *subsequenceHeadLay = new QHBoxLayout();
-    subsequenceHeadLay->setMargin(0);
-    subsequenceHeadLay->setSpacing(5);
+
+    QHBoxLayout *subsequenceHeadLay = createHBoxLayout(0, 5);
     {
       QFontMetrics metrics(font());
       subsequenceHeadLay->addSpacing(metrics.width("File name:") + 3);
@@ -769,30 +788,20 @@ LoadLevelPopup::LoadLevelPopup()
     }
     mainLayout->addLayout(subsequenceHeadLay, 0);
 
-    QHBoxLayout *tmpLay = new QHBoxLayout();
-    tmpLay->setMargin(0);
-    tmpLay->setSpacing(0);
+    QHBoxLayout *subsequenceLay = createHBoxLayout(5, 5);
     {
-      tmpLay->addStretch(1);
-
-      QHBoxLayout *subsequenceLay = new QHBoxLayout();
-      subsequenceLay->setMargin(5);
-      subsequenceLay->setSpacing(5);
-      {
-        subsequenceLay->addWidget(new QLabel(tr("From:"), this), 0);
-        subsequenceLay->addWidget(m_fromFrame, 0);
-        subsequenceLay->addWidget(new QLabel(tr(" To:"), this), 0);
-        subsequenceLay->addWidget(m_toFrame, 0);
-      }
-      m_subsequenceFrame->setLayout(subsequenceLay);
-      tmpLay->addWidget(m_subsequenceFrame, 0);
+      subsequenceLay->addWidget(new QLabel(tr("From:"), this), 0);
+      subsequenceLay->addWidget(m_fromFrame, 0);
+      subsequenceLay->addWidget(new QLabel(tr(" To:"), this), 0);
+      subsequenceLay->addWidget(m_toFrame, 0);
     }
-    mainLayout->addLayout(tmpLay, 0);
+    m_subsequenceFrame->setLayout(subsequenceLay);
+    mainLayout->addWidget(m_subsequenceFrame, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
 
     //----Arrangement in Xsheet
-    QHBoxLayout *arrangementHeadLay = new QHBoxLayout();
-    arrangementHeadLay->setMargin(0);
-    arrangementHeadLay->setSpacing(3);
+
+    QHBoxLayout *arrangementHeadLay = createHBoxLayout(0, 3);
     {
       arrangementHeadLay->addWidget(arrangementLabel, 1,
                                     Qt::AlignRight | Qt::AlignVCenter);
@@ -800,43 +809,75 @@ LoadLevelPopup::LoadLevelPopup()
     }
     mainLayout->addLayout(arrangementHeadLay);
 
-    QVBoxLayout *arrangementLay = new QVBoxLayout();
-    arrangementLay->setMargin(5);
-    arrangementLay->setSpacing(5);
+    QHBoxLayout *bottomLay = createHBoxLayout(0, 10);
     {
-      QHBoxLayout *upLay = new QHBoxLayout();
-      upLay->setMargin(0);
-      upLay->setSpacing(5);
+      QGridLayout *levelLay = new QGridLayout();
+      levelLay->setMargin(5);
+      levelLay->setSpacing(5);
       {
-        upLay->addWidget(new QLabel(tr("From:"), this), 0);
-        upLay->addWidget(m_xFrom, 1);
-        upLay->addWidget(new QLabel(tr(" To:"), this), 0);
-        upLay->addWidget(m_xTo, 1);
-        upLay->addWidget(new QLabel(tr(" Step:"), this), 0);
-        upLay->addWidget(m_stepCombo, 1);
-        upLay->addWidget(new QLabel(tr(" Inc:"), this), 0);
-        upLay->addWidget(m_incCombo, 1);
-      }
-      arrangementLay->addLayout(upLay);
+        levelLay->addWidget(new QLabel(tr("Level Name:"), this), 0, 0,
+                            Qt::AlignRight | Qt::AlignVCenter);
+        levelLay->addWidget(m_levelName, 0, 1);
+        QHBoxLayout *dpiLay = createHBoxLayout(0, 5);
+        {
+          dpiLay->addSpacing(10);
+          dpiLay->addWidget(new QLabel(tr("DPI:"), this), 0,
+                            Qt::AlignRight | Qt::AlignVCenter);
+          dpiLay->addWidget(m_dpiPolicy, 0);
+          dpiLay->addWidget(m_dpi, 1);
+        }
+        m_dpiWidget->setLayout(dpiLay);
+        levelLay->addWidget(m_dpiWidget, 0, 2, 1, 3);
 
-      QHBoxLayout *bottomLay = new QHBoxLayout();
-      bottomLay->setMargin(0);
-      bottomLay->setSpacing(5);
-      {
-        bottomLay->addWidget(new QLabel(tr("Level Name:"), this), 0);
-        bottomLay->addWidget(m_levelName, 3);
-        bottomLay->addWidget(new QLabel(tr(" Frames:"), this), 0);
-        bottomLay->addWidget(m_posFrom, 1);
-        bottomLay->addWidget(new QLabel(tr("::"), this), 0);
-        bottomLay->addWidget(m_posTo, 1);
+        levelLay->addWidget(m_premultiply, 1, 0, 1, 2);
+        levelLay->addWidget(m_whiteTransp, 2, 0, 1, 2);
+
+        // levelLay->addWidget(m_doAntialias, 1, 3, 1, 2);
+        levelLay->addWidget(new QLabel(tr("Antialias Softness:"), this), 1, 2,
+                            1, 2, Qt::AlignRight | Qt::AlignVCenter);
+        levelLay->addWidget(m_antialias, 1, 4);
+        levelLay->addWidget(new QLabel(tr("Subsampling:"), this), 2, 2, 1, 2,
+                            Qt::AlignRight | Qt::AlignVCenter);
+        levelLay->addWidget(m_subsampling, 2, 4);
       }
-      arrangementLay->addLayout(bottomLay);
+      levelLay->setColumnStretch(1, 1);
+      levelLay->setColumnStretch(4, 1);
+      m_levelPropertiesFrame->setLayout(levelLay);
+      bottomLay->addWidget(m_levelPropertiesFrame, 0);
+
+      QGridLayout *arrLay = new QGridLayout();
+      arrLay->setMargin(5);
+      arrLay->setSpacing(5);
+      {
+        arrLay->addWidget(new QLabel(tr("From:"), this), 0, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
+        arrLay->addWidget(m_xFrom, 0, 1);
+        arrLay->addWidget(new QLabel(tr(" To:"), this), 0, 2,
+                          Qt::AlignRight | Qt::AlignVCenter);
+        arrLay->addWidget(m_xTo, 0, 3);
+        arrLay->addWidget(new QLabel(tr(" Step:"), this), 1, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
+        arrLay->addWidget(m_stepCombo, 1, 1);
+        arrLay->addWidget(new QLabel(tr(" Inc:"), this), 1, 2,
+                          Qt::AlignRight | Qt::AlignVCenter);
+        arrLay->addWidget(m_incCombo, 1, 3);
+        arrLay->addWidget(new QLabel(tr(" Frames:"), this), 2, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
+        arrLay->addWidget(m_posFrom, 2, 1);
+        arrLay->addWidget(new QLabel(tr("::"), this), 2, 2, Qt::AlignCenter);
+        arrLay->addWidget(m_posTo, 2, 3);
+      }
+      arrLay->setColumnStretch(1, 1);
+      arrLay->setColumnStretch(3, 1);
+      m_arrangementFrame->setLayout(arrLay);
+      bottomLay->addWidget(m_arrangementFrame, 0);
     }
-    m_arrangementFrame->setLayout(arrangementLay);
-    mainLayout->addWidget(m_arrangementFrame, 0,
+    m_arrLvlPropWidget->setLayout(bottomLay);
+
+    mainLayout->addWidget(m_arrLvlPropWidget, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
   }
-  optionFrame->setLayout(mainLayout);
+  optionWidget->setLayout(mainLayout);
 
   //----signal-slot connections
   //----Load Subsequence Level
@@ -848,7 +889,7 @@ LoadLevelPopup::LoadLevelPopup()
           SLOT(onSubsequentFrameChanged()));
 
   //----Arrangement in Xsheet
-  connect(showArrangementButton, SIGNAL(toggled(bool)), m_arrangementFrame,
+  connect(showArrangementButton, SIGNAL(toggled(bool)), m_arrLvlPropWidget,
           SLOT(setVisible(bool)));
   connect(m_xFrom, SIGNAL(editingFinished()), SLOT(updatePosTo()));
   connect(m_xTo, SIGNAL(editingFinished()), SLOT(updatePosTo()));
@@ -860,53 +901,53 @@ LoadLevelPopup::LoadLevelPopup()
           SLOT(onNameSetEditted()));
   connect(m_browser, SIGNAL(treeFolderChanged(const TFilePath &)), this,
           SLOT(onNameSetEditted()));
-  connect(m_browser, SIGNAL(filePathDoubleClicked(const TFilePath&)), this,
-          SLOT(onFilePathDoubleClicked(const TFilePath&)));
+  connect(m_browser, SIGNAL(filePathDoubleClicked(const TFilePath &)), this,
+          SLOT(onFilePathDoubleClicked(const TFilePath &)));
+  //----Level Properties
+  connect(m_dpiPolicy, SIGNAL(activated(int)), this,
+          SLOT(onDpiPolicyActivated()));
+  connect(m_premultiply, SIGNAL(clicked(bool)), this,
+          SLOT(onDoPremultiplyClicked()));
+  connect(m_whiteTransp, SIGNAL(clicked(bool)), this,
+          SLOT(onWhiteTranspClicked()));
 }
 
 //-----------------------------------------------------------------------
 
 void LoadLevelPopup::onNameSetEditted() {
   getCurrentPathSet().clear();
-  TFilePath path =
-      m_browser->getFolder() + TFilePath(m_nameField->text().toStdString());
-  getCurrentPathSet().insert(path);
-
   getCurrentFIdsSet().clear();
 
   // if nothing input
   if (m_nameField->text() == "") {
-    m_fromFrame->setText("");
-    m_toFrame->setText("");
-    m_subsequenceFrame->setEnabled(false);
-
-    m_xFrom->setText("1");
-    m_xTo->setText("1");
-
-    m_levelName->setText("");
-
-    updatePosTo();
+    m_notExistLabel->hide();
+    updateBottomGUI();
   }
   // if the path exists
-  else if (TSystem::doesExistFileOrLevel(path)) {
-    m_notExistLabel->hide();
+  else {
+    TFilePath path =
+        m_browser->getFolder() + TFilePath(m_nameField->text().toStdString());
+    getCurrentPathSet().insert(path);
+    if (TSystem::doesExistFileOrLevel(path)) {
+      m_notExistLabel->hide();
+      updateBottomGUI();
+    } else {
+      m_notExistLabel->show();
 
-    updateBottomGUI();
-  } else {
-    m_notExistLabel->show();
+      m_fromFrame->setText("1");
+      m_toFrame->setText("1");
+      m_subsequenceFrame->setEnabled(true);
 
-    m_fromFrame->setText("1");
-    m_toFrame->setText("1");
-    m_subsequenceFrame->setEnabled(true);
+      m_xFrom->setText("1");
+      m_xTo->setText("1");
 
-    m_xFrom->setText("1");
-    m_xTo->setText("1");
+      m_levelName->setText(QString::fromStdString(path.getName()));
 
-    m_levelName->setText(QString::fromStdString(path.getName()));
-
-    m_arrangementFrame->setEnabled(true);
-
-    updatePosTo();
+      m_arrangementFrame->setEnabled(true);
+      m_levelName->setEnabled(true);
+      m_levelPropertiesFrame->setEnabled(true);
+      updatePosTo();
+    }
   }
 
   update();
@@ -1046,7 +1087,7 @@ void LoadLevelPopup::updatePosTo() {
 }
 //-----------------------------------------------------------------------
 /*! if the from / to values in the subsequent box, update m_xFrom and m_xTo
-*/
+ */
 void LoadLevelPopup::onSubsequentFrameChanged() {
   m_xFrom->setText(m_fromFrame->text());
   m_xTo->setText(m_toFrame->text());
@@ -1060,17 +1101,25 @@ void LoadLevelPopup::showEvent(QShowEvent *e) {
 
   FileBrowserPopup::showEvent(e);
 
+  bool ret         = true;
   TFrameHandle *fh = TApp::instance()->getCurrentFrame();
-  connect(fh, SIGNAL(frameSwitched()), this, SLOT(onFrameSwitched()));
-  connect(fh, SIGNAL(frameTypeChanged()), this, SLOT(onFrameSwitched()));
+  ret              = ret &&
+        connect(fh, SIGNAL(frameSwitched()), this, SLOT(onFrameSwitched()));
+  ret = ret &&
+        connect(fh, SIGNAL(frameTypeChanged()), this, SLOT(onFrameSwitched()));
 
   TSelectionHandle *sh = TApp::instance()->getCurrentSelection();
-  connect(sh, SIGNAL(selectionChanged(TSelection *)), this,
-          SLOT(onSelectionChanged(TSelection *)));
+  ret = ret && connect(sh, SIGNAL(selectionChanged(TSelection *)), this,
+                       SLOT(onSelectionChanged(TSelection *)));
+  ret = ret && connect(TApp::instance()->getCurrentScene(),
+                       SIGNAL(preferenceChanged(const QString &)), this,
+                       SLOT(onPreferenceChanged(const QString &)));
+  assert(ret);
 
   onFrameSwitched();
-
   onSelectionChanged(sh->getSelection());
+  onPreferenceChanged("");
+  onNameSetEditted();  // clear currentPathSet
 }
 
 //-----------------------------------------------------------------------
@@ -1085,6 +1134,9 @@ void LoadLevelPopup::hideEvent(QHideEvent *e) {
   TSelectionHandle *sh = TApp::instance()->getCurrentSelection();
   disconnect(sh, SIGNAL(selectionChanged(TSelection *)), this,
              SLOT(onSelectionChanged(TSelection *)));
+  disconnect(TApp::instance()->getCurrentScene(),
+             SIGNAL(preferenceChanged(const QString &)), this,
+             SLOT(onPreferenceChanged(const QString &)));
 }
 
 //-----------------------------------------------------------------------
@@ -1141,11 +1193,11 @@ bool LoadLevelPopup::execute() {
         setLoadingLevelRange(firstFrameNumber, lastFrameNumber);
     }
 
-    int frameCount = m_posTo->text().toInt() - m_posFrom->text().toInt() + 1;
-
     IoCmd::LoadResourceArguments args(fp);
 
     args.row0 = m_posFrom->text().toInt() - 1;
+
+    args.frameCount = m_posTo->text().toInt() - m_posFrom->text().toInt() + 1;
 
     if ((int)getCurrentFIdsSet().size() != 0)
       args.frameIdsSet.push_back(*getCurrentFIdsSet().begin());
@@ -1161,21 +1213,28 @@ bool LoadLevelPopup::execute() {
       args.frameIdsSet.push_back(tmp_fids);
     }
 
-    int xFrom         = m_xFrom->text().toInt();
-    if (!xFrom) xFrom = -1;
-    int xTo           = m_xTo->text().toInt();
-    if (!xTo) xTo     = -1;
+    int xFrom = m_xFrom->text().toInt();
+    if (xFrom) args.xFrom = xFrom;
+    int xTo = m_xTo->text().toInt();
+    if (xTo) args.xTo = xTo;
 
-    return 0 < IoCmd::loadResources(
-                   args,
-                   true,  // updateRecentFile
-                   0, xFrom, xTo, m_levelName->text().toStdWString(),
-                   m_stepCombo->currentIndex(), m_incCombo->currentIndex(),
-                   frameCount,
-                   !m_notExistLabel
-                        ->isVisible(),  // this flag is true if the level exists
-                   (IoCmd::CacheTlvBehavior)
-                       m_loadTlvBehaviorComboBox->currentIndex());
+    args.levelName             = m_levelName->text().toStdWString();
+    args.step                  = m_stepCombo->currentIndex();
+    args.inc                   = m_incCombo->currentIndex();
+    args.doesFileActuallyExist = !m_notExistLabel->isVisible();
+    args.cachingBehavior       = IoCmd::LoadResourceArguments::CacheTlvBehavior(
+        m_loadTlvBehaviorComboBox->currentData().toInt());
+
+    if (m_arrLvlPropWidget->isVisible() &&
+        m_levelPropertiesFrame->isEnabled()) {
+      for (IoCmd::LoadResourceArguments::ResourceData &rd :
+           args.resourceDatas) {
+        rd.m_options = LevelOptions();
+        getLevelProperties(*rd.m_options);
+      }
+    }
+
+    return 0 < IoCmd::loadResources(args, true, 0);
   } else {
     std::set<TFilePath>::const_iterator it;
     IoCmd::LoadResourceArguments args;
@@ -1192,12 +1251,19 @@ bool LoadLevelPopup::execute() {
         args.frameIdsSet.insert(args.frameIdsSet.begin(), *fIdIt);
     }
 
-    return 0 <
-           IoCmd::loadResources(args, true,
-                                0,  // setbeginEndUndoBlock
-                                -1, -1, L"", -1, -1, -1, true,
-                                (IoCmd::CacheTlvBehavior)
-                                    m_loadTlvBehaviorComboBox->currentIndex());
+    args.cachingBehavior = IoCmd::LoadResourceArguments::CacheTlvBehavior(
+        m_loadTlvBehaviorComboBox->currentData().toInt());
+
+    if (m_arrLvlPropWidget->isVisible() &&
+        m_levelPropertiesFrame->isEnabled()) {
+      for (IoCmd::LoadResourceArguments::ResourceData &rd :
+           args.resourceDatas) {
+        rd.m_options = LevelOptions();
+        getLevelProperties(*rd.m_options);
+      }
+    }
+
+    return 0 < IoCmd::loadResources(args, true, 0);
   }
 }
 
@@ -1218,7 +1284,7 @@ void LoadLevelPopup::initFolder() {
 
 //----------------------------------------------------------------------------
 
-void LoadLevelPopup::onFilePathDoubleClicked(const TFilePath& path) {
+void LoadLevelPopup::onFilePathDoubleClicked(const TFilePath &path) {
   Q_UNUSED(path);
   onOkPressed();
 }
@@ -1236,9 +1302,7 @@ void LoadLevelPopup::onFilePathsSelected(
 //----------------------------------------------------------------------------
 
 void LoadLevelPopup::updateBottomGUI() {
-  std::set<TFilePath> paths                = getCurrentPathSet();
-  std::list<std::vector<TFrameId>> fIdsSet = getCurrentFIdsSet();
-  if (paths.empty()) {
+  auto disableAll = [&]() {
     m_fromFrame->setText("");
     m_toFrame->setText("");
     m_subsequenceFrame->setEnabled(false);
@@ -1248,17 +1312,18 @@ void LoadLevelPopup::updateBottomGUI() {
     m_levelName->setText("");
     m_posTo->setText("");
     m_arrangementFrame->setEnabled(false);
-    return;
-  }
-  if (paths.size() > 1) {
-    m_fromFrame->setText("");
-    m_toFrame->setText("");
-    m_subsequenceFrame->setEnabled(false);
+    m_levelPropertiesFrame->setEnabled(false);
+  };
 
-    m_xTo->setText("");
-    m_levelName->setText("");
-    m_posTo->setText("");
-    m_arrangementFrame->setEnabled(false);
+  std::set<TFilePath> paths                = getCurrentPathSet();
+  std::list<std::vector<TFrameId>> fIdsSet = getCurrentFIdsSet();
+
+  if (paths.empty() || paths.size() > 1) {
+    disableAll();
+    if (paths.size() > 1) {
+      m_levelName->setEnabled(false);
+      m_levelPropertiesFrame->setEnabled(true);
+    }
     return;
   }
 
@@ -1269,15 +1334,7 @@ void LoadLevelPopup::updateBottomGUI() {
 
   // initialize
   if (fp.isEmpty() || ext == "") {
-    m_fromFrame->setText("");
-    m_toFrame->setText("");
-    m_subsequenceFrame->setEnabled(false);
-
-    m_xFrom->setText("");
-    m_xTo->setText("");
-    m_levelName->setText("");
-    m_posTo->setText("");
-    m_arrangementFrame->setEnabled(false);
+    disableAll();
     return;
   } else if (ext == "tpl") {
     QString str;
@@ -1290,6 +1347,7 @@ void LoadLevelPopup::updateBottomGUI() {
     m_levelName->setText(QString::fromStdString(fp.getName()));
     m_posTo->setText(m_posFrom->text());
     m_arrangementFrame->setEnabled(false);
+    m_levelPropertiesFrame->setEnabled(false);
   } else if (ext == "tnz") {
     ToonzScene scene;
     scene.setScenePath(fp);
@@ -1305,6 +1363,7 @@ void LoadLevelPopup::updateBottomGUI() {
     m_stepCombo->setCurrentIndex(0);
     m_incCombo->setCurrentIndex(0);
     m_arrangementFrame->setEnabled(false);
+    m_levelPropertiesFrame->setEnabled(false);
   } else {
     TFrameId firstFrame;
     TFrameId lastFrame;
@@ -1322,15 +1381,7 @@ void LoadLevelPopup::updateBottomGUI() {
         firstFrame = level->begin()->first;
         lastFrame  = (--level->end())->first;
       } catch (...) {
-        m_fromFrame->setText("");
-        m_toFrame->setText("");
-        m_subsequenceFrame->setEnabled(false);
-
-        m_xFrom->setText("");
-        m_xTo->setText("");
-        m_levelName->setText("");
-        m_posTo->setText("");
-        m_arrangementFrame->setEnabled(false);
+        disableAll();
         return;
       }
     }
@@ -1357,6 +1408,9 @@ void LoadLevelPopup::updateBottomGUI() {
       m_stepCombo->setCurrentIndex(1);
 
     m_arrangementFrame->setEnabled(true);
+
+    m_levelName->setEnabled(true);
+    m_levelPropertiesFrame->setEnabled(true);
   }
   updatePosTo();
 }
@@ -1396,7 +1450,7 @@ QString LoadLevelPopup::getLevelNameWithoutSceneNumber(std::string orgName) {
 //----------------------------------------------------------------------------
 /*! if the x-sheet cells are selected, load levels at the upper-left corner of
  * the selection
-*/
+ */
 void LoadLevelPopup::onSelectionChanged(TSelection *selection) {
   TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(selection);
 
@@ -1408,6 +1462,63 @@ void LoadLevelPopup::onSelectionChanged(TSelection *selection) {
   m_posFrom->setText(QString::number(r0 + 1));
 
   updatePosTo();
+}
+
+//----------------------------------------------------------------------------
+
+void LoadLevelPopup::onPreferenceChanged(const QString &propertyName) {
+  if (!propertyName.isEmpty() && propertyName != "pixelsOnly") return;
+  bool pixelsMode = Preferences::instance()->getBoolValue(pixelsOnly);
+  m_dpiWidget->setHidden(pixelsMode);
+  if (pixelsMode) {
+    m_dpiPolicy->setCurrentIndex(
+        m_dpiPolicy->findData(LevelOptions::DP_ImageDpi));
+    m_dpi->setValue(Stage::standardDpi);
+    m_dpi->setEnabled(false);
+  }
+}
+
+//----------------------------------------------------------------------------
+
+void LoadLevelPopup::setLevelProperties(LevelOptions &options) {
+  m_dpiPolicy->setCurrentIndex(m_dpiPolicy->findData(options.m_dpiPolicy));
+  m_dpi->setValue(options.m_dpi);
+  m_subsampling->setValue(options.m_subsampling);
+  m_antialias->setValue(options.m_antialias);
+  m_whiteTransp->setChecked(options.m_whiteTransp);
+  m_premultiply->setChecked(options.m_premultiply);
+  onDpiPolicyActivated();
+}
+
+//----------------------------------------------------------------------------
+
+void LoadLevelPopup::getLevelProperties(LevelOptions &options) {
+  options.m_dpiPolicy =
+      LevelOptions::DpiPolicy(m_dpiPolicy->currentData().toInt());
+  options.m_dpi         = m_dpi->getValue();
+  options.m_subsampling = m_subsampling->getValue();
+  options.m_antialias   = m_antialias->getValue();
+  options.m_whiteTransp = m_whiteTransp->isChecked();
+  options.m_premultiply = m_premultiply->isChecked();
+}
+
+//----------------------------------------------------------------------------
+
+void LoadLevelPopup::onDpiPolicyActivated() {
+  m_dpi->setEnabled(m_dpiPolicy->currentData().toInt() ==
+                    LevelOptions::DP_CustomDpi);
+}
+
+//----------------------------------------------------------------------------
+// exclusive with the whiteTransp option
+void LoadLevelPopup::onDoPremultiplyClicked() {
+  if (m_whiteTransp->isChecked()) m_whiteTransp->setChecked(false);
+}
+
+//----------------------------------------------------------------------------
+// exclusive with the doPremultiply option
+void LoadLevelPopup::onWhiteTranspClicked() {
+  if (m_premultiply->isChecked()) m_premultiply->setChecked(false);
 }
 
 //=============================================================================
@@ -1454,7 +1565,7 @@ bool SaveLevelAsPopup::execute() {
     TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(
         TApp::instance()->getCurrentLevel()->getLevel());
     if (!sl) return false;
-    std::string ext            = sl->getPath().getType();
+    std::string ext = sl->getPath().getType();
     if (fp.getType() == "") fp = fp.withType(ext);
 
     IoCmd::LoadResourceArguments args(fp);
@@ -1928,7 +2039,7 @@ void LoadColorModelPopup::showEvent(QShowEvent *e) {
 
 //=============================================================================
 /*! replace the parent folder path of the levels in the selected cells
-*/
+ */
 
 ReplaceParentDirectoryPopup::ReplaceParentDirectoryPopup()
     : FileBrowserPopup(tr("Replace Parent Directory")) {
@@ -2110,7 +2221,7 @@ void BrowserPopup::initFolder(TFilePath path) {
   }
   if (!TFileStatus(path).doesExist()) {
     ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
-    if (scene) path   = scene->decodeFilePath(path);
+    if (scene) path = scene->decodeFilePath(path);
   }
 
   if (!path.getType().empty()) path = path.getParentDir();
@@ -2170,8 +2281,8 @@ void BrowserPopupController::openPopup(QStringList filters,
 QString BrowserPopupController::getPath(bool codePath) {
   m_isExecute = false;
   if (!m_browserPopup) return QString();
-  ToonzScene *scene         = TApp::instance()->getCurrentScene()->getScene();
-  TFilePath fp              = m_browserPopup->getPath();
+  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+  TFilePath fp      = m_browserPopup->getPath();
   if (scene && codePath) fp = scene->codeFilePath(fp);
   std::cout << ::to_string(fp) << std::endl;
   return toQString(fp);

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -25,6 +25,7 @@ class FileBrowser;
 class TDoubleParam;
 class TCamera;
 class TPropertyGroup;
+class LevelOptions;
 class QShowEvent;
 class QFrame;
 class QPushButton;
@@ -111,7 +112,7 @@ protected:
     else
       return *m_selectedPaths.begin();
   }
-  std::set<TFilePath> getCurrentPathSet() { return m_selectedPaths; }
+  std::set<TFilePath> &getCurrentPathSet() { return m_selectedPaths; }
 
   std::vector<TFrameId> getCurrentFIds() {
     std::vector<TFrameId> tmp;
@@ -121,7 +122,7 @@ protected:
     else
       return *m_currentFIdsSet.begin();
   }
-  std::list<std::vector<TFrameId>> getCurrentFIdsSet() {
+  std::list<std::vector<TFrameId>> &getCurrentFIdsSet() {
     return m_currentFIdsSet;
   }
 
@@ -260,17 +261,21 @@ class LoadLevelPopup final : public FileBrowserPopup {
   Q_OBJECT
 
   QFrame *m_subsequenceFrame;
-  DVGui::LineEdit *m_fromFrame;
-  DVGui::LineEdit *m_toFrame;
+  DVGui::IntLineEdit *m_fromFrame, *m_toFrame;
 
+  QWidget *m_arrLvlPropWidget;
   QFrame *m_arrangementFrame;
-  DVGui::LineEdit *m_xFrom;
-  DVGui::LineEdit *m_xTo;
-  QComboBox *m_stepCombo;
-  QComboBox *m_incCombo;
+  DVGui::IntLineEdit *m_xFrom, *m_xTo;
+  QComboBox *m_stepCombo, *m_incCombo;
+  DVGui::IntLineEdit *m_posFrom, *m_posTo;
+
+  QFrame *m_levelPropertiesFrame;
   DVGui::LineEdit *m_levelName;
-  DVGui::LineEdit *m_posFrom;
-  DVGui::LineEdit *m_posTo;
+  QWidget *m_dpiWidget;  // hide on pixels only mode
+  QComboBox *m_dpiPolicy;
+  DVGui::DoubleLineEdit *m_dpi;
+  DVGui::IntLineEdit *m_subsampling, *m_antialias;
+  DVGui::CheckBox *m_premultiply, *m_whiteTransp;  // , *m_doAntialias;
 
   QLabel *m_notExistLabel;
   QComboBox *m_loadTlvBehaviorComboBox;
@@ -286,7 +291,7 @@ protected:
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;
 
-public slots:
+protected slots:
   void onFilePathsSelected(
       const std::set<TFilePath> &paths,
       const std::list<std::vector<TFrameId>> &fIds) override;
@@ -303,8 +308,13 @@ public slots:
   // the selection
   void onSelectionChanged(TSelection *selection);
 
-protected slots:
   void onFilePathDoubleClicked(const TFilePath &path);
+
+  void onPreferenceChanged(const QString &);
+
+  void onDpiPolicyActivated();
+  void onDoPremultiplyClicked();
+  void onWhiteTranspClicked();
 
 private:
   // update the fields acording to the current Path
@@ -312,6 +322,9 @@ private:
   // if some option in the preferences is selected, load the level with removing
   // six letters of the scene name from the level name
   QString getLevelNameWithoutSceneNumber(std::string orgName);
+
+  void setLevelProperties(LevelOptions &options);
+  void getLevelProperties(LevelOptions &options);
 };
 
 //-----------------------------------------------------------------------------
@@ -397,7 +410,7 @@ protected:
 
 //-----------------------------------------------------------------------------
 /*! replace the parent folder path of the levels in the selected cells
-*/
+ */
 
 class ReplaceParentDirectoryPopup final : public FileBrowserPopup {
   Q_OBJECT

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -126,19 +126,22 @@ public:
 
   std::vector<TXshLevel *> loadedLevels;  //!< [\p Out]     Levels loaded by
                                           //! resource loading procedures.
+
+  int xFrom, xTo;
+  std::wstring levelName;
+  int step, inc, frameCount;
+  bool doesFileActuallyExist;
+
+  enum CacheTlvBehavior {
+    ON_DEMAND = 0,  // image data will be loaded when needed
+    ALL_ICONS,      // icon data of all frames will be cached at the begininng
+    ALL_ICONS_AND_IMAGES  // both icon and image data of all frames will be
+                          // cached at the begininng
+  } cachingBehavior;
   //! Multiple
   //!               levels \a may be loaded for a single resource data.
 public:
-  LoadResourceArguments()
-      : row0(-1)
-      , col0(-1)
-      , row1(-1)
-      , col1(-1)
-      , importPolicy(static_cast<ImportPolicy>(
-            Preferences::instance()->getDefaultImportPolicy()))
-      , expose(Preferences::instance()->isAutoExposeEnabled()) {}
-
-  LoadResourceArguments(const TFilePath &fp,
+  LoadResourceArguments(const TFilePath &fp   = TFilePath(),
                         const TFilePath &cast = TFilePath())
       : castFolder(cast)
       , row0(-1)
@@ -147,8 +150,16 @@ public:
       , col1(-1)
       , importPolicy(static_cast<ImportPolicy>(
             Preferences::instance()->getDefaultImportPolicy()))
-      , expose(Preferences::instance()->isAutoExposeEnabled()) {
-    resourceDatas.push_back(fp);
+      , expose(Preferences::instance()->isAutoExposeEnabled())
+      , xFrom(-1)
+      , xTo(-1)
+      , levelName(L"")
+      , step(-1)
+      , inc(-1)
+      , frameCount(-1)
+      , doesFileActuallyExist(true)
+      , cachingBehavior(ON_DEMAND) {
+    if (!fp.isEmpty()) resourceDatas.push_back(fp);
   }
 };
 
@@ -203,25 +214,16 @@ bool saveSound(TXshSoundLevel *sc);
 /*! \note     Will fallback to loadResourceFolders() in case all
               argument paths are folders.                                 */
 
-enum CacheTlvBehavior {
-  ON_DEMAND = 0,  // image data will be loaded when needed
-  ALL_ICONS,      // icon data of all frames will be cached at the begininng
-  ALL_ICONS_AND_IMAGES  // both icon and image data of all frames will be cached
-                        // at the begininng
-};
-
 int loadResources(
     LoadResourceArguments &args,  //!< Resources to be loaded.
     bool updateRecentFiles =
         true,  //!< Whether Toonz's <I>Recent Files</I> list must be updated.
     LoadResourceArguments::ScopedBlock *sb =
-        0,  //!< Load block. May be nonzero in order to extend block data
-            //!  access and finalization.
-            //!< Loads a group of resources by path.
-            //!  \return  The actually loaded levels count.
-    int xFrom = -1, int xTo = -1, std::wstring levelName = L"", int step = -1,
-    int inc = -1, int frameCount = -1, bool doesFileActuallyExist = true,
-    CacheTlvBehavior cachingBehavior = ON_DEMAND);
+        0  //!< Load block. May be nonzero in order to extend block data
+           //!  access and finalization.
+           //!< Loads a group of resources by path.
+           //!  \return  The actually loaded levels count.
+);
 
 int loadResourceFolders(
     LoadResourceArguments &args,  //!< Resource folders to be loaded.


### PR DESCRIPTION
![levelsettings_in_loadlevelpopup](https://user-images.githubusercontent.com/17974955/71078796-6c776e00-21cd-11ea-84ce-1221b3b3e76f.png)

This PR will add ability to set level settings on loading levels by using the Load Level Popup.
It is useful when, for instance, setting appropriate dpi on loading images which have no dpi information.

- The `Level Settings` box is located next to the `Arrangement in Xsheet` options box which opens by pressing the plus (+)  button at the bottom of the popup.
- The level settings will be set to each loaded level at the same time, if the level type is allowed to set it.
- This feature will take effect only when the `Level Settings` box is visible when clicking the `Load` or the `Apply` button.
- This feature will override the settings in `Preferences > Loading > "Level Settings by File Format"`