### PR TITLE
Fixes on the Stop Motion Support

### DIFF
--- a/doc/how_to_build_win.md
+++ b/doc/how_to_build_win.md
@@ -72,7 +72,7 @@ Rename the following files:
 
 ## Building with extended stop motion support for webcams and Canon DSLR cameras.
 You will need three additional libraries.
-  - [OpenCV](https://opencv.org/)
+  - [OpenCV](https://opencv.org/) (v4.1.0 and later)
   - [libjpeg-turbo](https://www.libjpeg-turbo.org/)
   - The Canon SDK.  This requires applying for the Canon developer program and downloading the SDK.
 
@@ -80,10 +80,9 @@ Copy the following folders into the `$opentoonz/thirdparty` folder.
   - Copy the Header and library folders from the Canon SDK to `$opentoonz/thirdparty/canon`
     - Make sure that the library is the one from the EDSDK_64 folder.
   - Copy the lib and include folders from libjpeg-turbo64 into `$opentoonz/thirdparty/libjpeg-turbo64`.
-  - Copy the include folder from opencv2/build into `$opentoonz/thirdparty/opencv2`
-  - Copy the lib folder from opencv2/build/x64/vc15 into `$opentoonz/thirdparty/opencv2`
 
 Check the checkbox in CMake to build with stop motion support.
+On configuring with CMake or in the environmental variables, specify `OpenCV_DIR` to the `build` folder in the install folder of OpenCV (like `C:/opencv/build`).
 
 To run the program with stop motion support, you will need to copy the .dll files from opencv2, libjpeg-turbo and the Canon SDK into the folder where your project is built.
 

--- a/doc/how_to_build_win_ja.md
+++ b/doc/how_to_build_win_ja.md
@@ -61,6 +61,17 @@ Visual Studio 2015 と Qt 5.9 でビルドできることを確認していま�
 1. `$opentoonz/toonz/build/OpenToonz.sln` を開いて Release 構成を選択してビルドします
 2. `$opentoonz/toonz/build/Release` にファイルが生成されます
 
+## ストップモーション機能とキヤノン製デジタルカメラのサポートを有効にするには
+
+以下の３つのライブラリが追加で必要です。
+  - [OpenCV](https://opencv.org/) (v4.1.0以上)
+  - [libjpeg-turbo](https://www.libjpeg-turbo.org/)
+  - Canon EOS Digital SDK (EDSDK)：入手方法の詳細は[キヤノンマーケティングジャパン株式会社Webサイト](https://cweb.canon.jp/eos/info/api-package/)をご参照下さい。
+
+CMake上で、`WITH_STOPMOTION` オプションをONにします。CMake上、または環境変数で`OpenCV_DIR` の値をOpenCVのインストールフォルダ内の`build`フォルダの場所に設定します。（例： `C:/opencv/build`）
+
+実行時にはOpenCV、libjpeg-turboならびにCanon EDSDKの.dllファイルを`OpenToonz.exe` と同じフォルダにコピーします。
+
 ## 実行
 ### 実行可能ファイルなどの配置
 1. `$oepntoonz/toonz/build/Release` の中身を適当なフォルダにコピーします

--- a/stuff/doc/LICENSE/LICENSE_libjpeg-turbo.txt
+++ b/stuff/doc/LICENSE/LICENSE_libjpeg-turbo.txt
@@ -1,0 +1,35 @@
+libjpeg-turbo Licenses
+
+This software is based in part on the work of the Independent JPEG  Group.
+
+- - - - - - - - - - - - - - - - - -
+
+The Modified (3-clause) BSD License
+===================================
+
+Copyright (C)2009-2019 D. R. Commander.  All Rights Reserved.
+Copyright (C)2015 Viktor Szathmáry.  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of the libjpeg-turbo Project nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS",
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/stuff/doc/LICENSE/LICENSE_opencv.txt
+++ b/stuff/doc/LICENSE/LICENSE_opencv.txt
@@ -1,0 +1,36 @@
+                          License Agreement
+               For Open Source Computer Vision Library
+                       (3-clause BSD License)
+
+Copyright (C) 2000-2019, Intel Corporation, all rights reserved.
+Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+Copyright (C) 2009-2016, NVIDIA Corporation, all rights reserved.
+Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+Copyright (C) 2015-2016, OpenCV Foundation, all rights reserved.
+Copyright (C) 2015-2016, Itseez Inc., all rights reserved.
+Third party copyrights are property of their respective owners.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+  * Neither the names of the copyright holders nor the names of the contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+This software is provided by the copyright holders and contributors "as is" and
+any express or implied warranties, including, but not limited to, the implied
+warranties of merchantability and fitness for a particular purpose are disclaimed.
+In no event shall copyright holders or contributors be liable for any direct,
+indirect, incidental, special, exemplary, or consequential damages
+(including, but not limited to, procurement of substitute goods or services;
+loss of use, data, or profits; or business interruption) however caused
+and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of
+the use of this software, even if advised of the possibility of such damage.

--- a/thirdparty/opencv2/.gitignore
+++ b/thirdparty/opencv2/.gitignore
@@ -1,2 +1,0 @@
-lib/*
-include/*

--- a/thirdparty/opencv2/copy_opencv2.txt
+++ b/thirdparty/opencv2/copy_opencv2.txt
@@ -1,2 +1,0 @@
-Copy the include folder from opencv2/build into this folder
-Copy the lib folder from opencv2/build/x64/vc15 into this folder

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -272,6 +272,7 @@ if(BUILD_ENV_MSVC AND NOT WITH_STOPMOTION)
 endif()
 
 if(BUILD_ENV_MSVC AND WITH_STOPMOTION)
+    find_package(OpenCV 4.1 REQUIRED)
     include_directories(
         SYSTEM
         ${SDKROOT}/glut/3.7.6/include
@@ -279,7 +280,7 @@ if(BUILD_ENV_MSVC AND WITH_STOPMOTION)
         ${SDKROOT}/LibJPEG/jpeg-9
         ${SDKROOT}/canon/Header
         ${SDKROOT}/libjpeg-turbo64/include
-        ${SDKROOT}/opencv2/include
+        ${OpenCV_INCLUDE_DIRS}
     )
     add_definitions(
         -DGLUT_NO_LIB_PRAGMA
@@ -347,12 +348,8 @@ if(BUILD_ENV_MSVC)
     set(OPENBLAS_LIB ${SDKROOT}/openblas/libopenblas_${PLATFORM}.lib)
     set(USB_LIB)  # unused
     if (WITH_STOPMOTION)
-    set(CANON_LIB ${SDKROOT}/canon/library/EDSDK.lib)
-    set(TURBOJPEG_LIB ${SDKROOT}/libjpeg-turbo64/lib/turbojpeg.lib)
-    set(OPENCV_LIB 
-        optimized ${SDKROOT}/opencv2/lib/opencv_world412.lib
-        debug ${SDKROOT}/opencv2/lib/opencv_world412d.lib
-    )
+        set(CANON_LIB ${SDKROOT}/canon/library/EDSDK.lib)
+        set(TURBOJPEG_LIB ${SDKROOT}/libjpeg-turbo64/lib/turbojpeg.lib)
     endif()
     if(PLATFORM EQUAL 32)
         set(QT_LIB ${SDKROOT}/quicktime/QT73SDK/Libraries/QTMLClient.lib)

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -441,7 +441,7 @@ if(BUILD_ENV_MSVC AND WITH_STOPMOTION)
         Qt5::WinMain Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
         Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia
         ${GL_LIB} ${GLUT_LIB} 
-        ${CANON_LIB} ${TURBOJPEG_LIB} ${OPENCV_LIB} strmiids
+        ${CANON_LIB} ${TURBOJPEG_LIB} ${OpenCV_LIBS} strmiids
         tnzcore tnzbase toonzlib colorfx tnzext image sound toonzqt tnztools tnzstdfx tfarm
     )
 elseif(BUILD_ENV_MSVC)


### PR DESCRIPTION
This PR modifies the stop motion support (#2635) which is just merged;
- Added license files of the `libjpeg-turbo` and the `OpenCV` libraries to comply with their licenses.
- Made OpenCV version flexible. Specifying locations of headers and libraries is now left to CMake.
- Removed `thirdparty/opencv2` folder as they can now be loaded from originally-installed location.
- Modified the `How to build` instruction accordingly.
- Added the translated content to Japanese version of `How to build` instruction.

@turtletooth 
I temporarily set the minimum available version of OpenCV to v4.1.0 (which I used for testing the feature). Please let me know if you have tested and confirmed working with older versions.