### PR TITLE
Vector Guided Drawings Menu (modified by #2992)

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -836,7 +836,7 @@ QCheckBox:disabled {
   color: #808080;
 }
 .CheckBox::indicator,
-QMenu::indicator,
+QMenu::indicator:non-exclusive,
 QCheckBox::indicator,
 .GroupBox::indicator,
 QGroupBox::indicator {
@@ -850,13 +850,13 @@ QGroupBox::indicator {
   /* fix for QMenu */
 }
 .CheckBox::indicator:hover,
-QMenu::indicator:hover,
+QMenu::indicator:non-exclusive:hover,
 .CheckBox::indicator:checked:hover,
 .CheckBox::indicator:indeterminate:hover,
 QCheckBox::indicator:hover,
 .GroupBox::indicator:hover,
-QMenu::indicator:checked:hover,
-QMenu::indicator:indeterminate:hover,
+QMenu::indicator:non-exclusive:checked:hover,
+QMenu::indicator:non-exclusive:indeterminate:hover,
 QCheckBox::indicator:checked:hover,
 QCheckBox::indicator:indeterminate:hover,
 .GroupBox::indicator:checked:hover,
@@ -868,7 +868,7 @@ QGroupBox::indicator:indeterminate:hover {
   border-color: #5385a6;
 }
 .CheckBox::indicator:checked,
-QMenu::indicator:checked,
+QMenu::indicator:non-exclusive:checked,
 QCheckBox::indicator:checked,
 .GroupBox::indicator:checked,
 QGroupBox::indicator:checked {
@@ -877,7 +877,7 @@ QGroupBox::indicator:checked {
   image: url('../Default/imgs/white/checkmark.svg');
 }
 .CheckBox::indicator:checked:disabled,
-QMenu::indicator:checked:disabled,
+QMenu::indicator:non-exclusive:checked:disabled,
 QCheckBox::indicator:checked:disabled,
 .GroupBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
@@ -886,7 +886,7 @@ QGroupBox::indicator:checked:disabled {
   image: url('../Default/imgs/white/checkmark_disabled.svg');
 }
 .CheckBox::indicator:indeterminate,
-QMenu::indicator:indeterminate,
+QMenu::indicator:non-exclusive:indeterminate,
 QCheckBox::indicator:indeterminate,
 .GroupBox::indicator:indeterminate,
 QGroupBox::indicator:indeterminate {
@@ -895,7 +895,7 @@ QGroupBox::indicator:indeterminate {
   image: url('../Default/imgs/white/checkpartially.svg');
 }
 .CheckBox::indicator:indeterminate:disabled,
-QMenu::indicator:indeterminate:disabled,
+QMenu::indicator:non-exclusive:indeterminate:disabled,
 QCheckBox::indicator:indeterminate:disabled,
 .GroupBox::indicator:indeterminate:disabled,
 QGroupBox::indicator:indeterminate:disabled {
@@ -904,7 +904,7 @@ QGroupBox::indicator:indeterminate:disabled {
   image: url('../Default/imgs/white/checkpartially_disabled.svg');
 }
 .CheckBox::indicator:disabled,
-QMenu::indicator:disabled,
+QMenu::indicator:non-exclusive:disabled,
 QCheckBox::indicator:disabled,
 .GroupBox::indicator:disabled,
 QGroupBox::indicator:disabled {
@@ -915,12 +915,14 @@ QGroupBox::indicator:disabled {
    Radio Button
 ----------------------------------------------------------------------------- */
 .RadioButton::indicator:unchecked,
+QMenu::indicator:exclusive:unchecked,
 QRadioButton::indicator:unchecked,
 #CameraSettingsRadioButton_Small::indicator:unchecked {
   image: url('../Default/imgs/white/radiobutton_unchecked.svg');
   image-position: center center;
 }
 .RadioButton::indicator:checked,
+QMenu::indicator:exclusive:checked,
 QRadioButton::indicator:checked,
 #CameraSettingsRadioButton_Small::indicator:checked {
   image: url('../Default/imgs/white/radiobutton_checked.svg');

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -836,7 +836,7 @@ QCheckBox:disabled {
   color: #808080;
 }
 .CheckBox::indicator,
-QMenu::indicator,
+QMenu::indicator:non-exclusive,
 QCheckBox::indicator,
 .GroupBox::indicator,
 QGroupBox::indicator {
@@ -850,13 +850,13 @@ QGroupBox::indicator {
   /* fix for QMenu */
 }
 .CheckBox::indicator:hover,
-QMenu::indicator:hover,
+QMenu::indicator:non-exclusive:hover,
 .CheckBox::indicator:checked:hover,
 .CheckBox::indicator:indeterminate:hover,
 QCheckBox::indicator:hover,
 .GroupBox::indicator:hover,
-QMenu::indicator:checked:hover,
-QMenu::indicator:indeterminate:hover,
+QMenu::indicator:non-exclusive:checked:hover,
+QMenu::indicator:non-exclusive:indeterminate:hover,
 QCheckBox::indicator:checked:hover,
 QCheckBox::indicator:indeterminate:hover,
 .GroupBox::indicator:checked:hover,
@@ -868,7 +868,7 @@ QGroupBox::indicator:indeterminate:hover {
   border-color: #5385a6;
 }
 .CheckBox::indicator:checked,
-QMenu::indicator:checked,
+QMenu::indicator:non-exclusive:checked,
 QCheckBox::indicator:checked,
 .GroupBox::indicator:checked,
 QGroupBox::indicator:checked {
@@ -877,7 +877,7 @@ QGroupBox::indicator:checked {
   image: url('../Default/imgs/white/checkmark.svg');
 }
 .CheckBox::indicator:checked:disabled,
-QMenu::indicator:checked:disabled,
+QMenu::indicator:non-exclusive:checked:disabled,
 QCheckBox::indicator:checked:disabled,
 .GroupBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
@@ -886,7 +886,7 @@ QGroupBox::indicator:checked:disabled {
   image: url('../Default/imgs/white/checkmark_disabled.svg');
 }
 .CheckBox::indicator:indeterminate,
-QMenu::indicator:indeterminate,
+QMenu::indicator:non-exclusive:indeterminate,
 QCheckBox::indicator:indeterminate,
 .GroupBox::indicator:indeterminate,
 QGroupBox::indicator:indeterminate {
@@ -895,7 +895,7 @@ QGroupBox::indicator:indeterminate {
   image: url('../Default/imgs/white/checkpartially.svg');
 }
 .CheckBox::indicator:indeterminate:disabled,
-QMenu::indicator:indeterminate:disabled,
+QMenu::indicator:non-exclusive:indeterminate:disabled,
 QCheckBox::indicator:indeterminate:disabled,
 .GroupBox::indicator:indeterminate:disabled,
 QGroupBox::indicator:indeterminate:disabled {
@@ -904,7 +904,7 @@ QGroupBox::indicator:indeterminate:disabled {
   image: url('../Default/imgs/white/checkpartially_disabled.svg');
 }
 .CheckBox::indicator:disabled,
-QMenu::indicator:disabled,
+QMenu::indicator:non-exclusive:disabled,
 QCheckBox::indicator:disabled,
 .GroupBox::indicator:disabled,
 QGroupBox::indicator:disabled {
@@ -915,12 +915,14 @@ QGroupBox::indicator:disabled {
    Radio Button
 ----------------------------------------------------------------------------- */
 .RadioButton::indicator:unchecked,
+QMenu::indicator:exclusive:unchecked,
 QRadioButton::indicator:unchecked,
 #CameraSettingsRadioButton_Small::indicator:unchecked {
   image: url('../Default/imgs/white/radiobutton_unchecked.svg');
   image-position: center center;
 }
 .RadioButton::indicator:checked,
+QMenu::indicator:exclusive:checked,
 QRadioButton::indicator:checked,
 #CameraSettingsRadioButton_Small::indicator:checked {
   image: url('../Default/imgs/white/radiobutton_checked.svg');

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -836,7 +836,7 @@ QCheckBox:disabled {
   color: #808080;
 }
 .CheckBox::indicator,
-QMenu::indicator,
+QMenu::indicator:non-exclusive,
 QCheckBox::indicator,
 .GroupBox::indicator,
 QGroupBox::indicator {
@@ -850,13 +850,13 @@ QGroupBox::indicator {
   /* fix for QMenu */
 }
 .CheckBox::indicator:hover,
-QMenu::indicator:hover,
+QMenu::indicator:non-exclusive:hover,
 .CheckBox::indicator:checked:hover,
 .CheckBox::indicator:indeterminate:hover,
 QCheckBox::indicator:hover,
 .GroupBox::indicator:hover,
-QMenu::indicator:checked:hover,
-QMenu::indicator:indeterminate:hover,
+QMenu::indicator:non-exclusive:checked:hover,
+QMenu::indicator:non-exclusive:indeterminate:hover,
 QCheckBox::indicator:checked:hover,
 QCheckBox::indicator:indeterminate:hover,
 .GroupBox::indicator:checked:hover,
@@ -868,7 +868,7 @@ QGroupBox::indicator:indeterminate:hover {
   border-color: #5385a6;
 }
 .CheckBox::indicator:checked,
-QMenu::indicator:checked,
+QMenu::indicator:non-exclusive:checked,
 QCheckBox::indicator:checked,
 .GroupBox::indicator:checked,
 QGroupBox::indicator:checked {
@@ -877,7 +877,7 @@ QGroupBox::indicator:checked {
   image: url('imgs/white/checkmark.svg');
 }
 .CheckBox::indicator:checked:disabled,
-QMenu::indicator:checked:disabled,
+QMenu::indicator:non-exclusive:checked:disabled,
 QCheckBox::indicator:checked:disabled,
 .GroupBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
@@ -886,7 +886,7 @@ QGroupBox::indicator:checked:disabled {
   image: url('imgs/white/checkmark_disabled.svg');
 }
 .CheckBox::indicator:indeterminate,
-QMenu::indicator:indeterminate,
+QMenu::indicator:non-exclusive:indeterminate,
 QCheckBox::indicator:indeterminate,
 .GroupBox::indicator:indeterminate,
 QGroupBox::indicator:indeterminate {
@@ -895,7 +895,7 @@ QGroupBox::indicator:indeterminate {
   image: url('imgs/white/checkpartially.svg');
 }
 .CheckBox::indicator:indeterminate:disabled,
-QMenu::indicator:indeterminate:disabled,
+QMenu::indicator:non-exclusive:indeterminate:disabled,
 QCheckBox::indicator:indeterminate:disabled,
 .GroupBox::indicator:indeterminate:disabled,
 QGroupBox::indicator:indeterminate:disabled {
@@ -904,7 +904,7 @@ QGroupBox::indicator:indeterminate:disabled {
   image: url('imgs/white/checkpartially_disabled.svg');
 }
 .CheckBox::indicator:disabled,
-QMenu::indicator:disabled,
+QMenu::indicator:non-exclusive:disabled,
 QCheckBox::indicator:disabled,
 .GroupBox::indicator:disabled,
 QGroupBox::indicator:disabled {
@@ -915,12 +915,14 @@ QGroupBox::indicator:disabled {
    Radio Button
 ----------------------------------------------------------------------------- */
 .RadioButton::indicator:unchecked,
+QMenu::indicator:exclusive:unchecked,
 QRadioButton::indicator:unchecked,
 #CameraSettingsRadioButton_Small::indicator:unchecked {
   image: url('imgs/white/radiobutton_unchecked.svg');
   image-position: center center;
 }
 .RadioButton::indicator:checked,
+QMenu::indicator:exclusive:checked,
 QRadioButton::indicator:checked,
 #CameraSettingsRadioButton_Small::indicator:checked {
   image: url('imgs/white/radiobutton_checked.svg');

--- a/stuff/config/qss/Default/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Default/less/layouts/mainwindow.less
@@ -168,7 +168,12 @@ QMenu {
     }
   }
   &::indicator {
-    &:extend(.CheckBox::indicator all);
+    &:non-exclusive {
+      &:extend(.CheckBox::indicator all);
+    }
+    &:exclusive {
+      &:extend(.RadioButton::indicator all);
+    }
     margin-left: 7;
   }
 }

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -836,7 +836,7 @@ QCheckBox:disabled {
   color: rgba(0, 0, 0, 0.466);
 }
 .CheckBox::indicator,
-QMenu::indicator,
+QMenu::indicator:non-exclusive,
 QCheckBox::indicator,
 .GroupBox::indicator,
 QGroupBox::indicator {
@@ -850,13 +850,13 @@ QGroupBox::indicator {
   /* fix for QMenu */
 }
 .CheckBox::indicator:hover,
-QMenu::indicator:hover,
+QMenu::indicator:non-exclusive:hover,
 .CheckBox::indicator:checked:hover,
 .CheckBox::indicator:indeterminate:hover,
 QCheckBox::indicator:hover,
 .GroupBox::indicator:hover,
-QMenu::indicator:checked:hover,
-QMenu::indicator:indeterminate:hover,
+QMenu::indicator:non-exclusive:checked:hover,
+QMenu::indicator:non-exclusive:indeterminate:hover,
 QCheckBox::indicator:checked:hover,
 QCheckBox::indicator:indeterminate:hover,
 .GroupBox::indicator:checked:hover,
@@ -868,7 +868,7 @@ QGroupBox::indicator:indeterminate:hover {
   border-color: #525252;
 }
 .CheckBox::indicator:checked,
-QMenu::indicator:checked,
+QMenu::indicator:non-exclusive:checked,
 QCheckBox::indicator:checked,
 .GroupBox::indicator:checked,
 QGroupBox::indicator:checked {
@@ -877,7 +877,7 @@ QGroupBox::indicator:checked {
   image: url('../Default/imgs/black/checkmark.svg');
 }
 .CheckBox::indicator:checked:disabled,
-QMenu::indicator:checked:disabled,
+QMenu::indicator:non-exclusive:checked:disabled,
 QCheckBox::indicator:checked:disabled,
 .GroupBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
@@ -886,7 +886,7 @@ QGroupBox::indicator:checked:disabled {
   image: url('../Default/imgs/black/checkmark_disabled.svg');
 }
 .CheckBox::indicator:indeterminate,
-QMenu::indicator:indeterminate,
+QMenu::indicator:non-exclusive:indeterminate,
 QCheckBox::indicator:indeterminate,
 .GroupBox::indicator:indeterminate,
 QGroupBox::indicator:indeterminate {
@@ -895,7 +895,7 @@ QGroupBox::indicator:indeterminate {
   image: url('../Default/imgs/black/checkpartially.svg');
 }
 .CheckBox::indicator:indeterminate:disabled,
-QMenu::indicator:indeterminate:disabled,
+QMenu::indicator:non-exclusive:indeterminate:disabled,
 QCheckBox::indicator:indeterminate:disabled,
 .GroupBox::indicator:indeterminate:disabled,
 QGroupBox::indicator:indeterminate:disabled {
@@ -904,7 +904,7 @@ QGroupBox::indicator:indeterminate:disabled {
   image: url('../Default/imgs/black/checkpartially_disabled.svg');
 }
 .CheckBox::indicator:disabled,
-QMenu::indicator:disabled,
+QMenu::indicator:non-exclusive:disabled,
 QCheckBox::indicator:disabled,
 .GroupBox::indicator:disabled,
 QGroupBox::indicator:disabled {
@@ -915,12 +915,14 @@ QGroupBox::indicator:disabled {
    Radio Button
 ----------------------------------------------------------------------------- */
 .RadioButton::indicator:unchecked,
+QMenu::indicator:exclusive:unchecked,
 QRadioButton::indicator:unchecked,
 #CameraSettingsRadioButton_Small::indicator:unchecked {
   image: url('../Default/imgs/black/radiobutton_unchecked.svg');
   image-position: center center;
 }
 .RadioButton::indicator:checked,
+QMenu::indicator:exclusive:checked,
 QRadioButton::indicator:checked,
 #CameraSettingsRadioButton_Small::indicator:checked {
   image: url('../Default/imgs/black/radiobutton_checked.svg');

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -134,90 +134,85 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
   if (Preferences::instance()->isOnionSkinEnabled() &&
       !parent->isPreviewEnabled())
     OnioniSkinMaskGUI::addOnionSkinCommand(this);
-  QMenu *guidedDrawingMenu = addMenu(tr("Vector Guided Drawing"));
-  int guidedDrawingStatus  = Preferences::instance()->getGuidedDrawing();
-  action                   = guidedDrawingMenu->addAction(tr("Off"));
-  action->setCheckable(true);
-  action->setChecked(guidedDrawingStatus == 0);
-  ret    = ret && parent->connect(action, SIGNAL(triggered()), this,
-                               SLOT(setGuidedDrawingOff()));
-  action = guidedDrawingMenu->addAction(tr("Closest Drawing"));
-  action->setCheckable(true);
-  action->setChecked(guidedDrawingStatus == 1);
-  ret    = ret && parent->connect(action, SIGNAL(triggered()), this,
-                               SLOT(setGuidedDrawingClosest()));
-  action = guidedDrawingMenu->addAction(tr("Farthest Drawing"));
-  action->setCheckable(true);
-  action->setChecked(guidedDrawingStatus == 2);
-  ret    = ret && parent->connect(action, SIGNAL(triggered()), this,
-                               SLOT(setGuidedDrawingFarthest()));
-  action = guidedDrawingMenu->addAction(tr("All Drawings"));
-  action->setCheckable(true);
-  action->setChecked(guidedDrawingStatus == 3);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), this,
-                            SLOT(setGuidedDrawingAll()));
-  guidedDrawingMenu->addSeparator();
-  bool enableOption = guidedDrawingStatus == 1 || guidedDrawingStatus == 2;
-  action = guidedDrawingMenu->addAction(tr("Auto Inbetween"));
-  action->setCheckable(true);
-  action->setChecked(Preferences::instance()->getGuidedAutoInbetween());
-  action->setEnabled(enableOption);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), this,
-                            SLOT(setGuidedAutoInbetween()));
-  guidedDrawingMenu->addSeparator();
-  int guidedInterpolation = Preferences::instance()->getGuidedInterpolation();
-  action = guidedDrawingMenu->addAction(tr("Linear Interpolation"));
-  action->setCheckable(true);
-  action->setChecked(guidedInterpolation == 1);
-  action->setEnabled(enableOption);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), this,
-                            SLOT(setGuidedInterpolationLinear()));
-  action = guidedDrawingMenu->addAction(tr("Ease In Interpolation"));
-  action->setCheckable(true);
-  action->setChecked(guidedInterpolation == 2);
-  action->setEnabled(enableOption);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), this,
-                            SLOT(setGuidedInterpolationEaseIn()));
-  action = guidedDrawingMenu->addAction(tr("Ease Out Interpolation"));
-  action->setCheckable(true);
-  action->setChecked(guidedInterpolation == 3);
-  action->setEnabled(enableOption);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), this,
-                            SLOT(setGuidedInterpolationEaseOut()));
-  action = guidedDrawingMenu->addAction(tr("Ease In/Out Interpolation"));
-  action->setCheckable(true);
-  action->setChecked(guidedInterpolation == 4);
-  action->setEnabled(enableOption);
-  ret = ret && parent->connect(action, SIGNAL(triggered()), this,
-                            SLOT(setGuidedInterpolationEaseInOut()));
-  guidedDrawingMenu->addSeparator();
-  action = CommandManager::instance()->getAction(MI_SelectPrevGuideStroke);
-  action->setEnabled(enableOption);
-  guidedDrawingMenu->addAction(action);
-  action = CommandManager::instance()->getAction(MI_SelectNextGuideStroke);
-  action->setEnabled(enableOption);
-  guidedDrawingMenu->addAction(action);
-  action = CommandManager::instance()->getAction(MI_SelectBothGuideStrokes);
-  action->setEnabled(enableOption);
-  guidedDrawingMenu->addAction(action);
-  action = CommandManager::instance()->getAction(MI_SelectGuideStrokeReset);
-  action->setEnabled(true);
-  guidedDrawingMenu->addAction(action);
-  guidedDrawingMenu->addSeparator();
-  action = CommandManager::instance()->getAction(MI_TweenGuideStrokes);
-  action->setEnabled(enableOption);
-  guidedDrawingMenu->addAction(action);
-  action = CommandManager::instance()->getAction(MI_TweenGuideStrokeToSelected);
-  action->setEnabled(enableOption);
-  guidedDrawingMenu->addAction(action);
-  action = CommandManager::instance()->getAction(MI_SelectGuidesAndTweenMode);
-  action->setEnabled(enableOption);
-  guidedDrawingMenu->addAction(action);
 
-  // Zero Thick
-  if (!parent->isPreviewEnabled())
-    ZeroThickToggleGui::addZeroThickCommand(this);
+  if (tool->getTargetType() & TTool::VectorImage) {
+    auto addOptionAction = [](const QString &label, const int data,
+                              const int currentData, QMenu *menu,
+                              QActionGroup *group) {
+      QAction *action = menu->addAction(label);
+      action->setData(data);
+      action->setCheckable(true);
+      action->setChecked(data == currentData);
+      group->addAction(action);
+    };
+    QMenu *guidedDrawingMenu = addMenu(tr("Vector Guided Drawing"));
+    int guidedDrawingStatus  = Preferences::instance()->getGuidedDrawing();
+    QActionGroup *guidedDrawingGroup = new QActionGroup(this);
+    addOptionAction(tr("Off"), 0, guidedDrawingStatus, guidedDrawingMenu,
+                    guidedDrawingGroup);
+    addOptionAction(tr("Closest Drawing"), 1, guidedDrawingStatus,
+                    guidedDrawingMenu, guidedDrawingGroup);
+    addOptionAction(tr("Farthest Drawing"), 2, guidedDrawingStatus,
+                    guidedDrawingMenu, guidedDrawingGroup);
+    addOptionAction(tr("All Drawings"), 3, guidedDrawingStatus,
+                    guidedDrawingMenu, guidedDrawingGroup);
+    ret =
+        ret && parent->connect(guidedDrawingGroup, SIGNAL(triggered(QAction *)),
+                               this, SLOT(setGuidedDrawingType(QAction *)));
 
+    guidedDrawingMenu->addSeparator();
+    bool enableOption = guidedDrawingStatus == 1 || guidedDrawingStatus == 2;
+    action            = guidedDrawingMenu->addAction(tr("Auto Inbetween"));
+    action->setCheckable(true);
+    action->setChecked(Preferences::instance()->getGuidedAutoInbetween());
+    action->setEnabled(enableOption);
+    ret = ret && parent->connect(action, SIGNAL(triggered()), this,
+                                 SLOT(setGuidedAutoInbetween()));
+    guidedDrawingMenu->addSeparator();
+    int guidedInterpolation = Preferences::instance()->getGuidedInterpolation();
+    QActionGroup *interpolationGroup = new QActionGroup(this);
+    addOptionAction(tr("Linear Interpolation"), 1, guidedInterpolation,
+                    guidedDrawingMenu, interpolationGroup);
+    addOptionAction(tr("Ease In Interpolation"), 2, guidedInterpolation,
+                    guidedDrawingMenu, interpolationGroup);
+    addOptionAction(tr("Ease Out Interpolation"), 3, guidedInterpolation,
+                    guidedDrawingMenu, interpolationGroup);
+    addOptionAction(tr("Ease In/Out Interpolation"), 4, guidedInterpolation,
+                    guidedDrawingMenu, interpolationGroup);
+    ret = ret &&
+          parent->connect(interpolationGroup, SIGNAL(triggered(QAction *)),
+                          this, SLOT(setGuidedInterpolationState(QAction *)));
+    interpolationGroup->setEnabled(enableOption);
+
+    guidedDrawingMenu->addSeparator();
+    action = CommandManager::instance()->getAction(MI_SelectPrevGuideStroke);
+    action->setEnabled(enableOption);
+    guidedDrawingMenu->addAction(action);
+    action = CommandManager::instance()->getAction(MI_SelectNextGuideStroke);
+    action->setEnabled(enableOption);
+    guidedDrawingMenu->addAction(action);
+    action = CommandManager::instance()->getAction(MI_SelectBothGuideStrokes);
+    action->setEnabled(enableOption);
+    guidedDrawingMenu->addAction(action);
+    action = CommandManager::instance()->getAction(MI_SelectGuideStrokeReset);
+    action->setEnabled(true);
+    guidedDrawingMenu->addAction(action);
+    guidedDrawingMenu->addSeparator();
+    action = CommandManager::instance()->getAction(MI_TweenGuideStrokes);
+    action->setEnabled(enableOption);
+    guidedDrawingMenu->addAction(action);
+    action =
+        CommandManager::instance()->getAction(MI_TweenGuideStrokeToSelected);
+    action->setEnabled(enableOption);
+    guidedDrawingMenu->addAction(action);
+    action = CommandManager::instance()->getAction(MI_SelectGuidesAndTweenMode);
+    action->setEnabled(enableOption);
+    guidedDrawingMenu->addAction(action);
+
+    // Zero Thick
+    if (!parent->isPreviewEnabled())
+      ZeroThickToggleGui::addZeroThickCommand(this);
+  }
   // Brush size outline
   CursorOutlineToggleGui::addCursorOutlineCommand(this);
 
@@ -424,23 +419,8 @@ void SceneViewerContextMenu::onSetCurrent() {
 }
 
 //-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedDrawingOff() {
-  Preferences::instance()->setValue(guidedDrawingType, 0);
-}
-
-//-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedDrawingClosest() {
-  Preferences::instance()->setValue(guidedDrawingType, 1);
-}
-
-//-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedDrawingFarthest() {
-  Preferences::instance()->setValue(guidedDrawingType, 2);
-}
-
-//-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedDrawingAll() {
-  Preferences::instance()->setValue(guidedDrawingType, 3);
+void SceneViewerContextMenu::setGuidedDrawingType(QAction *action) {
+  Preferences::instance()->setValue(guidedDrawingType, action->data().toInt());
 }
 
 //-----------------------------------------------------------------------------
@@ -450,23 +430,9 @@ void SceneViewerContextMenu::setGuidedAutoInbetween() {
 }
 
 //-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedInterpolationLinear() {
-  Preferences::instance()->setValue(guidedInterpolationType, 1);
-}
-
-//-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedInterpolationEaseIn() {
-  Preferences::instance()->setValue(guidedInterpolationType, 2);
-}
-
-//-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedInterpolationEaseOut() {
-  Preferences::instance()->setValue(guidedInterpolationType, 3);
-}
-
-//-----------------------------------------------------------------------------
-void SceneViewerContextMenu::setGuidedInterpolationEaseInOut() {
-  Preferences::instance()->setValue(guidedInterpolationType, 4);
+void SceneViewerContextMenu::setGuidedInterpolationState(QAction *action) {
+  Preferences::instance()->setValue(guidedInterpolationType,
+                                    action->data().toInt());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewercontextmenu.h
+++ b/toonz/sources/toonz/sceneviewercontextmenu.h
@@ -31,15 +31,9 @@ public slots:
 
   void enterVectorImageGroup();
   void exitVectorImageGroup();
-  void setGuidedDrawingOff();
-  void setGuidedDrawingClosest();
-  void setGuidedDrawingFarthest();
-  void setGuidedDrawingAll();
+  void setGuidedDrawingType(QAction *);
   void setGuidedAutoInbetween();
-  void setGuidedInterpolationLinear();
-  void setGuidedInterpolationEaseIn();
-  void setGuidedInterpolationEaseOut();
-  void setGuidedInterpolationEaseInOut();
+  void setGuidedInterpolationState(QAction *);
 
   void onShowHide();
   void onSetCurrent();


### PR DESCRIPTION
This PR slightly modifies the UI and behavior of the `Vector Guided Drawings` menu which was recently updated ( #2931 by @manongjohn  ). Hoping this will not interfere the original intention of the feature..

- Replaced the exclusive items under `Vector Guided Drawing` by radio buttons, putting them into `QActionGroup` .
- Made the `Vector Guided Drawing` submenu and the `Hide ZeroThickness Lines` command to be displayed only when the current tool is for vector levels. 

<img src="https://user-images.githubusercontent.com/17974955/71441853-b2d94980-2746-11ea-9dc8-6390c6a39266.png" width=400>
