### PR TITLE
Allow double-click to open scenes in File Browser and Browser Room

### DIFF
--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -2303,6 +2303,22 @@ void FileBrowser::enableGlobalSelection(bool enabled) {
 
 void FileBrowser::selectNone() { m_itemViewer->selectNone(); }
 
+//-----------------------------------------------------------------------------
+
+void FileBrowser::enableDoubleClickToOpenScenes() {
+  // perhaps this should disconnect existing signal handlers first
+  connect(this, SIGNAL(filePathDoubleClicked(const TFilePath &)),
+  this, SLOT(tryToOpenScene(const TFilePath &)));
+}
+
+//-----------------------------------------------------------------------------
+
+void FileBrowser::tryToOpenScene(const TFilePath &filePath) {
+  if (filePath.getType() == "tnz") {
+    IoCmd::loadScene(filePath);
+  }
+}
+
 //=============================================================================
 // FCData methods
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -124,6 +124,12 @@ types to be displayed in the file browser.
 
   QSplitter *getMainSplitter() const { return m_mainSplitter; }
 
+  // Enable double-click to open a scene.
+  // This is not always desirable (e.g. if a user double-clicks on a file in
+  // a "Save As" dialog, they expect the file will be saved to, not opened).
+  // So it is disabled by default.
+  void enableDoubleClickToOpenScenes();
+
 protected:
   int findIndexWithPath(TFilePath path);
   void getExpandedFolders(DvDirModelNode *node,
@@ -197,6 +203,9 @@ protected slots:
   void onVersionControlCommandDone(const QStringList &files);
 
   void onFileSystemChanged(const QString &folderPath);
+
+  // If filePath is a valid scene file, open it. Otherwise do nothing.
+  void tryToOpenScene(const TFilePath &filePath);
 
 signals:
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -1089,6 +1089,7 @@ public:
     TFilePath currentProjectFolder =
         TProjectManager::instance()->getCurrentProjectPath().getParentDir();
     browser->setFolder(currentProjectFolder, true);
+    browser->enableDoubleClickToOpenScenes();
   }
 } browserFactory;
 


### PR DESCRIPTION
For #2941. Demo below for File Browser Window:

![file-browser-demo](https://user-images.githubusercontent.com/24422213/71492984-61dd6880-28a0-11ea-8904-2cf6c33ae93a.gif)

And for the Browser Room:

![browser-room-demo](https://user-images.githubusercontent.com/24422213/71492995-7faacd80-28a0-11ea-94a5-0201f6a70f77.gif)
