### PR TITLE
fix stop motion menu error

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -312,6 +312,7 @@
         <command>MI_OpenTMessage</command>
         <command>MI_OpenHistoryPanel</command>
         <command>MI_AudioRecording</command>
+        <command>MI_OpenStopMotionPanel</command>
         <command>MI_StartupPopup</command>
         <separator/>
         <command>MI_MaximizePanel</command>


### PR DESCRIPTION
Fixes the stop motion menu item not showing up after the first use.