### PR TITLE
Fix "Merge Levels" Command to Update Thumbnails

### DIFF
--- a/toonz/sources/toonz/mergecolumns.cpp
+++ b/toonz/sources/toonz/mergecolumns.cpp
@@ -144,7 +144,8 @@ bool needTobeGrouped(const TVectorImageP &vimg) {
 
 //---------------------------------------------------------------------------------------
 
-void mergeVectorColumns(const std::vector<MatchlinePair> &matchingLevels, bool groupLevels) {
+void mergeVectorColumns(const std::vector<MatchlinePair> &matchingLevels,
+                        bool groupLevels) {
   if (matchingLevels.empty()) return;
 
   int i = 0;
@@ -157,7 +158,8 @@ void mergeVectorColumns(const std::vector<MatchlinePair> &matchingLevels, bool g
       throw TRopException("Cannot merge columns of different image types!");
     // img->lock();
 
-    if (needTobeGrouped(vimg) && groupLevels) vimg->group(0, vimg->getStrokeCount());
+    if (needTobeGrouped(vimg) && groupLevels)
+      vimg->group(0, vimg->getStrokeCount());
     bool ungroup = false;
     if (needTobeGrouped(vmatch) && groupLevels) {
       ungroup = true;
@@ -199,7 +201,7 @@ public:
       , m_mColumn(mColumn)
       , m_images(images)
       , m_palette(palette->clone())
-	  , m_groupLevels(groupLevels) {}
+      , m_groupLevels(groupLevels) {}
 
   void undo() const override {
     QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -245,7 +247,10 @@ public:
   }
 
   QString getHistoryString() override {
-    return QObject::tr("Merge Raster Levels");
+    if (m_level->getType() == PLI_XSHLEVEL)
+      return QObject::tr("Merge Vector Levels");
+    else
+      return QObject::tr("Merge Raster Levels");
   }
   int getHistoryType() override { return HistoryType::FilmStrip; }
 };
@@ -262,7 +267,8 @@ void mergeColumns(const std::set<int> &columns, bool groupLevels) {
 
   TUndoManager::manager()->beginBlock();
 
-  for (; it != columns.end(); ++it) mergeColumns(dstColumn, *it, false, groupLevels);
+  for (; it != columns.end(); ++it)
+    mergeColumns(dstColumn, *it, false, groupLevels);
 
   TUndoManager::manager()->endBlock();
 
@@ -381,10 +387,6 @@ void mergeColumns(int column, int mColumn, bool isRedo, bool groupLevels) {
     return;
   }
 
-  ToonzScene *sc = TApp::instance()->getCurrentScene()->getScene();
-  TXshSimpleLevel *simpleLevel =
-      sc->getLevelSet()->getLevel(column)->getSimpleLevel();
-
   if (!isRedo)
     TUndoManager::manager()->add(
         new MergeColumnsUndo(xl, MergeColumnsSessionId, column, level, images,
@@ -403,13 +405,8 @@ void mergeColumns(int column, int mColumn, bool isRedo, bool groupLevels) {
   } else
     mergeVectorColumns(matchingLevels, groupLevels);
 
-  TXshLevel *sl =
-      TApp::instance()->getCurrentScene()->getScene()->getLevelSet()->getLevel(
-          column);
-  std::vector<TFrameId> fidsss;
-  sl->getFids(fidsss);
-  invalidateIcons(sl, fidsss);
-  sl->setDirtyFlag(true);
+  std::vector<TFrameId> fids(alreadyDoneSet.begin(), alreadyDoneSet.end());
+  invalidateIcons(level, fids);
   level->setDirtyFlag(true);
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
 }


### PR DESCRIPTION
This PR fixes the Merge Levels command to update thumbnails properly.
Related to the command, it also fixes & refactors in the following points:

- Made the dialog message ( asking "Group strokes by vector levels?" added in #2762 ) translatable.
- Made the command to be canceled if users close the dialog by pressing a "x" button.
- Simplified the function detecting that the selected column contains vector level.
- Added a proper history string for vector merging operation.