### PR TITLE
Use std::sort instead of obsoleted qSort

### DIFF
--- a/toonz/sources/common/tapptools/tcolorutils.cpp
+++ b/toonz/sources/common/tapptools/tcolorutils.cpp
@@ -1043,7 +1043,7 @@ void TColorUtils::buildColorChipPalette(QList<QPair<TPixel32, TPoint>> &palette,
 
   // std::cout << "edgePoints.count = " << edgePoints.count() << std::endl;
   // This may be unnecessary
-  qSort(edgePoints.begin(), edgePoints.end(), lowerLeftThan);
+  std::sort(edgePoints.begin(), edgePoints.end(), lowerLeftThan);
 
   QList<ColorChip> colorChips;
 
@@ -1126,13 +1126,13 @@ void TColorUtils::buildColorChipPalette(QList<QPair<TPixel32, TPoint>> &palette,
     // sort the color chips
     switch (colorChipOrder) {
     case 0:
-      qSort(colorChips.begin(), colorChips.end(), colorChipUpperLeftThan);
+      std::sort(colorChips.begin(), colorChips.end(), colorChipUpperLeftThan);
       break;
     case 1:
-      qSort(colorChips.begin(), colorChips.end(), colorChipLowerLeftThan);
+      std::sort(colorChips.begin(), colorChips.end(), colorChipLowerLeftThan);
       break;
     case 2:
-      qSort(colorChips.begin(), colorChips.end(), colorChipLeftUpperThan);
+      std::sort(colorChips.begin(), colorChips.end(), colorChipLeftUpperThan);
       break;
     }
 

--- a/toonz/sources/stdfx/iwa_bokehfx.cpp
+++ b/toonz/sources/stdfx/iwa_bokehfx.cpp
@@ -772,7 +772,7 @@ QList<int> Iwa_BokehFx::getSortedSourceIndices(double frame) {
   if (usedSourceList.empty()) return QList<int>();
 
   // Sort the layers in descending distance order
-  qSort(usedSourceList.begin(), usedSourceList.end(), isFurtherLayer);
+  std::sort(usedSourceList.begin(), usedSourceList.end(), isFurtherLayer);
 
   QList<int> indicesList;
   for (int i = 0; i < usedSourceList.size(); i++) {

--- a/toonz/sources/stdfx/iwa_particlesengine.cpp
+++ b/toonz/sources/stdfx/iwa_particlesengine.cpp
@@ -291,7 +291,7 @@ void Iwa_Particles_Engine::roll_particles(
   /*- 背景だけを描画するモードのときは、particlesOriginを更新するだけでOK -*/
   if (values.iw_rendermode_val == Iwa_TiledParticlesFx::REND_BG) {
     /*- インデックスを小さい順にならべる -*/
-    qSort(leavingPartIndex.begin(), leavingPartIndex.end());
+    std::sort(leavingPartIndex.begin(), leavingPartIndex.end());
     /*- インデックス大きい方から消していく -*/
     for (int lp = leavingPartIndex.size() - 1; lp >= 0; lp--)
       particleOrigins.removeAt(leavingPartIndex.at(lp));
@@ -448,7 +448,7 @@ void Iwa_Particles_Engine::roll_particles(
 
   /*- すでに発生したparticleOriginを消去する
           インデックスを小さい順にならべる -*/
-  qSort(leavingPartIndex.begin(), leavingPartIndex.end());
+  std::sort(leavingPartIndex.begin(), leavingPartIndex.end());
   /*- インデックス大きい方から消していく -*/
   for (int lp = leavingPartIndex.size() - 1; lp >= 0; lp--)
     particleOrigins.removeAt(leavingPartIndex.at(lp));
@@ -1447,7 +1447,7 @@ void Iwa_Particles_Engine::initParticleOrigins(
   }
 
   /*- 粒子をランダム値の大きい順に並べる -*/
-  qSort(particleOrigins.begin(), particleOrigins.end(), potentialLessThan);
+  std::sort(particleOrigins.begin(), particleOrigins.end(), potentialLessThan);
 }
 
 //--------------------------------------------------

--- a/toonz/sources/toonz/xdtsio.cpp
+++ b/toonz/sources/toonz/xdtsio.cpp
@@ -132,7 +132,7 @@ QVector<int> XdtsFieldTrackItem::getCellNumberTrack() const {
   QList<QPair<int, int>> frameCellNumbers;
   for (const XdtsTrackFrameItem &frame : m_frames)
     frameCellNumbers.append(frame.frameCellNumber());
-  qSort(frameCellNumbers.begin(), frameCellNumbers.end(), frameLessThan);
+  std::sort(frameCellNumbers.begin(), frameCellNumbers.end(), frameLessThan);
 
   QVector<int> cells;
   int currentFrame = 0;

--- a/toonz/sources/toonzlib/Naa2TlvConverter.cpp
+++ b/toonz/sources/toonzlib/Naa2TlvConverter.cpp
@@ -1109,7 +1109,7 @@ TToonzImageP Naa2TlvConverter::makeTlv(bool transparentSyntheticInks,
       locals::addPaint(neighborPaints, bottomScanLine[prev_x].getPaint());
       locals::addPaint(neighborPaints, bottomScanLine[x].getPaint());
       locals::addPaint(neighborPaints, bottomScanLine[next_x].getPaint());
-      qSort(neighborPaints.begin(), neighborPaints.end(), locals::compare);
+      std::sort(neighborPaints.begin(), neighborPaints.end(), locals::compare);
 
       if (!neighborPaints.isEmpty())
         outScanLine[x].setPaint(neighborPaints[0].first);

--- a/toonz/sources/toonzlib/convert2tlv.cpp
+++ b/toonz/sources/toonzlib/convert2tlv.cpp
@@ -561,7 +561,7 @@ TPalette *Convert2Tlv::buildPalette() {
 
   /*- インデックス順にページに格納する -*/
   if (!stylesToBeAddedToPage.isEmpty()) {
-    qSort(stylesToBeAddedToPage.begin(), stylesToBeAddedToPage.end());
+    std::sort(stylesToBeAddedToPage.begin(), stylesToBeAddedToPage.end());
     for (int s = 0; s < stylesToBeAddedToPage.size(); s++)
       page->addStyle(stylesToBeAddedToPage.at(s));
   }

--- a/toonz/sources/toonzlib/tstageobjectcmd.cpp
+++ b/toonz/sources/toonzlib/tstageobjectcmd.cpp
@@ -1490,9 +1490,15 @@ void TStageObjectCmd::deleteSelection(
     if (it2->isPegbar()) pegbarIndexes.append(it2->getIndex());
     if (it2->isCamera()) cameraIndexes.append(it2->getIndex());
   }
-  if (!columnIndexes.isEmpty()) qSort(columnIndexes);
-  if (!pegbarIndexes.isEmpty()) qSort(pegbarIndexes);
-  if (!cameraIndexes.isEmpty()) qSort(cameraIndexes);
+  if (!columnIndexes.isEmpty()) {
+    std::sort(columnIndexes.begin(), columnIndexes.end());
+  }
+  if (!pegbarIndexes.isEmpty()) {
+    std::sort(pegbarIndexes.begin(), pegbarIndexes.end());
+  }
+  if (!cameraIndexes.isEmpty()) {
+    std::sort(cameraIndexes.begin(), cameraIndexes.end());
+  }
 
   // remove all selected objects
   removeColums(columnIndexes, xshHandle, objHandle, fxHandle, doUndo);

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -880,7 +880,7 @@ bool TXshSoundColumn::isPlaying() const {
 void TXshSoundColumn::insertColumnLevel(ColumnLevel *columnLevel, int index) {
   if (index == -1) index = m_levels.size();
   m_levels.insert(index, columnLevel);
-  qSort(m_levels.begin(), m_levels.end(), lessThan);
+  std::sort(m_levels.begin(), m_levels.end(), lessThan);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/addfxcontextmenu.cpp
+++ b/toonz/sources/toonzqt/addfxcontextmenu.cpp
@@ -344,21 +344,21 @@ void AddFxContextMenu::loadFxPlugins(QMenu *insertFxGroup, QMenu *addFxGroup,
   for (auto &&ins : insVendors) {
     QList<QAction *> actions = ins.second->actions();
     ins.second->clear();
-    qSort(actions.begin(), actions.end(), comp);
+    std::sort(actions.begin(), actions.end(), comp);
     ins.second->addActions(actions);
   }
 
   for (auto &&ins : addVendors) {
     QList<QAction *> actions = ins.second->actions();
     ins.second->clear();
-    qSort(actions.begin(), actions.end(), comp);
+    std::sort(actions.begin(), actions.end(), comp);
     ins.second->addActions(actions);
   }
 
   for (auto &&ins : repVendors) {
     QList<QAction *> actions = ins.second->actions();
     ins.second->clear();
-    qSort(actions.begin(), actions.end(), comp);
+    std::sort(actions.begin(), actions.end(), comp);
     ins.second->addActions(actions);
   }
 }

--- a/toonz/sources/toonzqt/fxselection.cpp
+++ b/toonz/sources/toonzqt/fxselection.cpp
@@ -92,7 +92,7 @@ void FxSelection::select(TFxP fx) { m_selectedFxs.append(fx); }
 
 void FxSelection::select(int colIndex) {
   m_selectedColIndexes.append(colIndex);
-  qSort(m_selectedColIndexes);
+  std::sort(m_selectedColIndexes.begin(), m_selectedColIndexes.end());
 }
 
 //---------------------------------------------------------


### PR DESCRIPTION
qSort is obsoleted.
We should use std::sort.

https://doc.qt.io/qt-5/qtalgorithms-obsolete.html#qSort