### PR TITLE
Fix Crash on Loading XDTS and Other Improvements

### DIFF
--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -2258,13 +2258,15 @@ void BrowserPopupController::openPopup(QStringList filters,
   m_browserPopup->initFolder(TFilePath(lastSelectedPath.toStdWString()));
   m_browserPopup->setFileMode(isDirectoryOnly);
 
+  Qt::WindowFlags flags = m_browserPopup->windowFlags();
+  bool parentSet        = false;
   if (parentWidget) {
     for (QWidget *pwidget : QApplication::topLevelWidgets()) {
       if (pwidget->isWindow() && pwidget->isVisible() &&
           pwidget->isAncestorOf(parentWidget)) {
-        Qt::WindowFlags flags = m_browserPopup->windowFlags();
         m_browserPopup->setParent(pwidget);
         m_browserPopup->setWindowFlags(flags);
+        parentSet = true;
         break;
       }
     }
@@ -2277,6 +2279,13 @@ void BrowserPopupController::openPopup(QStringList filters,
     m_isExecute = true;
   else
     m_isExecute = false;
+
+  // set back the parent to the main window in order to prevent to be
+  // deleted along with the parent widget
+  if (parentSet) {
+    m_browserPopup->setParent(TApp::instance()->getMainWindow());
+    m_browserPopup->setWindowFlags(flags);
+  }
 }
 
 // codePath is set to true by default

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1917,6 +1917,7 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
       scene->getProperties()->getFieldGuideAspectRatio());
   IconGenerator::instance()->invalidateSceneIcon();
   DvDirModel::instance()->refreshFolder(scenePath.getParentDir());
+  // set dirty for xdts files since converted tnz is not yet saved
   TApp::instance()->getCurrentScene()->setDirtyFlag(isXdts);
   History::instance()->addItem(scenePath);
   if (updateRecentFile)

--- a/toonz/sources/toonz/xdtsio.cpp
+++ b/toonz/sources/toonz/xdtsio.cpp
@@ -10,6 +10,9 @@
 #include "toonz/txsheethandle.h"
 #include "toonz/tscenehandle.h"
 #include "toonz/preferences.h"
+#include "toonz/sceneproperties.h"
+#include "toonz/tstageobject.h"
+#include "toutputproperties.h"
 
 #include "toonzqt/menubarcommand.h"
 #include "toonzqt/gutil.h"
@@ -135,11 +138,18 @@ QVector<int> XdtsFieldTrackItem::getCellNumberTrack() const {
   qSort(frameCellNumbers.begin(), frameCellNumbers.end(), frameLessThan);
 
   QVector<int> cells;
-  int currentFrame = 0;
+  int currentFrame  = 0;
+  int initialNumber = 0;
   for (QPair<int, int> &frameCellNumber : frameCellNumbers) {
     while (currentFrame < frameCellNumber.first) {
-      cells.append((cells.isEmpty()) ? 0 : cells.last());
+      cells.append((cells.isEmpty()) ? initialNumber : cells.last());
       currentFrame++;
+    }
+    // CSP may export negative frame data (although it is not allowed in XDTS
+    // format specification) so handle such case.
+    if (frameCellNumber.first < 0) {
+      initialNumber = frameCellNumber.second;
+      continue;
     }
     // ignore sheet symbols for now
     int cellNumber = frameCellNumber.second;
@@ -417,6 +427,8 @@ bool XdtsIo::loadXdtsScene(ToonzScene *scene, const TFilePath &scenePath) {
   scene->setProject(sceneProject.getPointer());
   std::string sceneFileName = scenePath.getName() + ".tnz";
   scene->setScenePath(scenePath.getParentDir() + sceneFileName);
+  // set the current scene here in order to use $scenefolder node properly
+  // in the file browser which opens from XDTSImportPopup
   TApp::instance()->getCurrentScene()->setScene(scene);
 
   XDTSImportPopup popup(levelNames, scene, scenePath);
@@ -468,8 +480,23 @@ bool XdtsIo::loadXdtsScene(ToonzScene *scene, const TFilePath &scenePath) {
       for (; row < duration; row++)
         xsh->setCell(row, column, TXshCell(level, TFrameId(lastFid)));
     }
+
+    TStageObject *pegbar =
+        xsh->getStageObject(TStageObjectId::ColumnId(column));
+    if (pegbar) pegbar->setName(levelName.toStdString());
   }
   xsh->updateFrameCount();
+
+  // if the duration is shorter than frame count, then set it both in
+  // preview range and output range.
+  if (duration < xsh->getFrameCount()) {
+    scene->getProperties()->getPreviewProperties()->setRange(0, duration - 1,
+                                                             1);
+    scene->getProperties()->getOutputProperties()->setRange(0, duration - 1, 1);
+  }
+
+  // emit signal here for updating the frame slider range of flip console
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
 
   return true;
 }


### PR DESCRIPTION
This PR fixes several problems & improves regarding XDTS input as follows:

- Fixed crash on clicking `...` button in the file field of XDTS popup when loading XDTS file for the second time.
- Fixed OT to load XDTS properly when it contains data in negative frame. Actually containing data in negative frame is not officially allowed in XDTS specification, but Clip Studio Paint may export such data.
- Fixed the frame range of flip console to be properly updated on loading.
- Swap positions of `Load` and `Cancel` buttons to be consistent with the file browser popup.
- Made XDTS popup to suggest the level locations not only in the same folder as the .xdts file, but also sub-folders with the same name as levels (like `$scenefolder/A/A..png` ). Because CSP exports level images into sub-folders.
- Made the column names to be the same as containing level names.
- If the `duration` value in XDTS is smaller than the maximum frame number where the data actually input, such duration is now set to both in preview range and output range.

