### PR TITLE
Fix Crash on Loading Thumbnail with Visualize Vector As Raster

### DIFF
--- a/toonz/sources/toonzqt/icongenerator.cpp
+++ b/toonz/sources/toonzqt/icongenerator.cpp
@@ -886,10 +886,15 @@ TRaster32P XsheetIconRenderer::generateRaster(
   ras->fill(bgColor);
 
   TImageCache::instance()->setEnabled(false);
+  // temporarily disable "Visualize Vector As Raster" option to prevent crash.
+  // (see the issue #2862)
+  bool rasterizePli               = TXshSimpleLevel::m_rasterizePli;
+  TXshSimpleLevel::m_rasterizePli = false;
 
   // All checks are disabled
   scene->renderFrame(ras, m_row, m_xsheet, false);
 
+  TXshSimpleLevel::m_rasterizePli = rasterizePli;
   TImageCache::instance()->setEnabled(true);
 
   return ras;


### PR DESCRIPTION
This fixes #2862 .

Instead of investigating the cause of the problem in detail, I just temporarily disable the `Visualize Vector As Raster` option (which is held as a static variable of `TXshSimpleLevel` ) while generating the sub-xsheet thumbnail.