### PR TITLE
Fix Black Camera Capture View on MacOS

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -602,14 +602,6 @@ MyVideoWidget::MyVideoWidget(QWidget* parent)
     , m_upsideDown(false)
     , m_countDownTime(0)
     , m_subCameraRect(QRect()) {
-  setAutoFillBackground(false);
-  setAttribute(Qt::WA_NoSystemBackground, true);
-  setAttribute(Qt::WA_PaintOnScreen, true);
-
-  QPalette palette = this->palette();
-  palette.setColor(QPalette::Background, Qt::black);
-  setPalette(palette);
-
   setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
   m_surface = new MyVideoSurface(this);


### PR DESCRIPTION
This fixes #2922 . Sorry for the trouble !