### PR TITLE
Fix Studio Palette Hang Up on Clicking Item in the Tree View

### DIFF
--- a/toonz/sources/include/toonzqt/studiopaletteviewer.h
+++ b/toonz/sources/include/toonzqt/studiopaletteviewer.h
@@ -64,6 +64,8 @@ class DVAPI StudioPaletteTreeViewer final : public QTreeWidget,
   // keep the checked item list in order to avoid multiple check
   QSet<QTreeWidgetItem *> m_openedItems;
 
+  QPoint m_startPos;
+
 public:
   StudioPaletteTreeViewer(QWidget *parent, TPaletteHandle *studioPaletteHandle,
                           TPaletteHandle *levelPaletteHandle,
@@ -177,7 +179,9 @@ protected:
   void createMenuAction(QMenu &menu, const char *id, QString name,
                         const char *slot);
   /*! If button left is pressed start drag and drop. */
+  void mousePressEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;
+  void mouseReleaseEvent(QMouseEvent *event) override;
   /*! If path related to current item exist and is a palette execute drag. */
   void startDragDrop();
   /*! Verify drag enter data, if it has an url and it's path is a palette or

--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -39,6 +39,7 @@
 #include <QInputDialog>
 #include <QPushButton>
 #include <QDrag>
+#include <QApplication>
 
 #include <time.h>
 
@@ -99,7 +100,8 @@ StudioPaletteTreeViewer::StudioPaletteTreeViewer(
     , m_xsheetHandle(xsheetHandle)
     , m_folderIcon(QIcon())
     , m_levelPaletteIcon(QIcon())
-    , m_studioPaletteIcon(QIcon()) {
+    , m_studioPaletteIcon(QIcon())
+    , m_startPos() {
   setIndentation(14);
   setAlternatingRowColors(true);
 
@@ -966,10 +968,27 @@ void StudioPaletteTreeViewer::createMenuAction(QMenu &menu, const char *id,
 
 //-----------------------------------------------------------------------------
 
+void StudioPaletteTreeViewer::mousePressEvent(QMouseEvent *event) {
+  QTreeWidget::mousePressEvent(event);
+  // If left button is not pressed return
+  if (event->button() == Qt::LeftButton) m_startPos = event->pos();
+}
+
+//-----------------------------------------------------------------------------
+
 void StudioPaletteTreeViewer::mouseMoveEvent(QMouseEvent *event) {
   // If left button is not pressed return; is not drag event.
   if (!(event->buttons() & Qt::LeftButton)) return;
-  startDragDrop();
+  if (!m_startPos.isNull() && (m_startPos - event->pos()).manhattanLength() >=
+                                  QApplication::startDragDistance())
+    startDragDrop();
+}
+
+//-----------------------------------------------------------------------------
+
+void StudioPaletteTreeViewer::mouseReleaseEvent(QMouseEvent *event) {
+  QTreeWidget::mouseReleaseEvent(event);
+  if (event->button() == Qt::LeftButton) m_startPos = QPoint();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following problem in the Studio Palette:

- When clicking the item in the tree view, if you move any pixels while pressing the mouse button, the studio palette hangs a while.

The problem was due to starting a drag and drop operation.
I modified it so that the drag and drop starts only when user moves the cursor a certain distance ( `QApplication::startDragDistance()` is set to 10 pixels by default )  with a button held down.