### PR TITLE
Fix -Wunused-command-line-argument

### DIFF
--- a/toonz/sources/colorfx/CMakeLists.txt
+++ b/toonz/sources/colorfx/CMakeLists.txt
@@ -26,7 +26,7 @@ add_definitions(
 )
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libcolorfx.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libcolorfx.dylib")
     add_dependencies(colorfx tnzcore tnzbase)
 endif()
 

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -101,7 +101,7 @@ add_definitions(
 )
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libimage.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libimage.dylib")
     add_dependencies(image tnzcore tnzbase toonzlib)
 endif()
 

--- a/toonz/sources/sound/CMakeLists.txt
+++ b/toonz/sources/sound/CMakeLists.txt
@@ -22,7 +22,7 @@ add_definitions(
 )
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libsound.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libsound.dylib")
     add_dependencies(sound tnzcore tnzbase toonzlib)
 endif()
 

--- a/toonz/sources/stdfx/CMakeLists.txt
+++ b/toonz/sources/stdfx/CMakeLists.txt
@@ -276,7 +276,7 @@ add_definitions(
 )
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnzstdfx.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtnzstdfx.dylib")
     add_dependencies(tnzstdfx tnzcore tnzbase toonzlib)
 endif()
 

--- a/toonz/sources/tnzbase/CMakeLists.txt
+++ b/toonz/sources/tnzbase/CMakeLists.txt
@@ -163,7 +163,7 @@ qt5_wrap_cpp(SOURCES ${MOC_HEADERS})
 add_library(tnzbase SHARED ${HEADERS} ${SOURCES} ${OBJCSOURCES})
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnzbase.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtnzbase.dylib")
     add_dependencies(tnzbase tnzcore)
 endif()
 

--- a/toonz/sources/tnzcore/CMakeLists.txt
+++ b/toonz/sources/tnzcore/CMakeLists.txt
@@ -269,7 +269,7 @@ qt5_wrap_cpp(SOURCES ${MOC_HEADERS})
 add_library(tnzcore SHARED ${HEADERS} ${SOURCES})
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnzcore.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtnzcore.dylib")
 endif()
 
 add_definitions(

--- a/toonz/sources/tnzext/CMakeLists.txt
+++ b/toonz/sources/tnzext/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 add_library(tnzext SHARED ${HEADERS} ${SOURCES} ${OBJCSOURCES})
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnzext.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtnzext.dylib")
     add_dependencies(tnzext tnzcore tnzbase)
 endif()
 

--- a/toonz/sources/tnztools/CMakeLists.txt
+++ b/toonz/sources/tnztools/CMakeLists.txt
@@ -119,7 +119,7 @@ add_definitions(
 )
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtnztools.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtnztools.dylib")
     add_dependencies(tnztools tnzcore tnzbase tnzext toonzlib toonzqt)
 endif()
 

--- a/toonz/sources/toonzfarm/tfarm/CMakeLists.txt
+++ b/toonz/sources/toonzfarm/tfarm/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions(
 )
 
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtfarm.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtfarm.dylib")
 endif()
 
 message("subdir: tfarm")

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -335,7 +335,7 @@ qt5_wrap_cpp(SOURCES ${MOC_HEADERS})
 
 add_library(toonzlib SHARED ${HEADERS} ${SOURCES})
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtoonzlib.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtoonzlib.dylib")
     add_dependencies(toonzlib tnzcore tnzbase tnzext)
 endif()
 

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -219,7 +219,7 @@ qt5_wrap_cpp(SOURCES ${MOC_HEADERS} OPTIONS ${incs})
 
 add_library(toonzqt SHARED ${HEADERS} ${SOURCES} ${RESOURCES})
 if(BUILD_ENV_APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-install_name,@rpath/libtoonzqt.dylib")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-install_name,@rpath/libtoonzqt.dylib")
     add_dependencies(toonzqt tnzcore tnzbase tnzext toonzlib sound)
 endif()
 


### PR DESCRIPTION
Fix these warnings.
```
[ 34%] Building CXX object stdfx/CMakeFiles/tnzstdfx.dir/dissolvefx.cpp.o
clang: warning: -Wl,-install_name,@rpath/libtnzstdfx.dylib: 'linker' input unused [-Wunused-command-line-argument]
3 warnings generated.
[ 34%] Building CXX object image/CMakeFiles/image.dir/pli/tags.cpp.o
clang: warning: -Wl,-install_name,@rpath/libimage.dylib: 'linker' input unused [-Wunused-command-line-argument]
```
https://travis-ci.org/opentoonz/opentoonz/jobs/638233144#L4946