### PR TITLE
Keeping Separate Colors Parameters

### DIFF
--- a/toonz/sources/toonz/separatecolorspopup.h
+++ b/toonz/sources/toonz/separatecolorspopup.h
@@ -31,7 +31,7 @@ class ProgressDialog;
 class CheckBox;
 class DoubleField;
 class IntField;
-}
+}  // namespace DVGui
 
 namespace ImageUtils {
 class FrameTaskNotifier;
@@ -144,6 +144,9 @@ class SeparateColorsPopup : public DVGui::Dialog {
 
   ProgressDialog* m_progressDialog;
   std::vector<TFilePath> m_srcFilePaths;
+
+  QString m_lastAcceptedSaveInPath;
+
   bool m_isConverting;
 
   void doSeparate(const TFilePath& source, int from, int to, int framerate,
@@ -180,6 +183,14 @@ public slots:
   void onChange(bool isDragging);
   void onToggle() { onChange(false); }
   void onColorChange(const TPixel32&, bool isDragging) { onChange(isDragging); }
+
+  void onSaveSettings();
+  void onLoadSettings();
+
+  void doSaveSettings(const TFilePath&);
+  void doLoadSettings(const TFilePath&, bool loadAll);
+
+  void onSaveInPathChanged();
 };
 
 #endif


### PR DESCRIPTION
**Please do not merge before releasing v1.4 as this is feature-PR.**

This will improve `Separate Colors` feature as follows so that users can save processing parameters and reproduce the same result afterwards.

- After executing the processing, parameters will be saved in a settings file ( `.sep` file ) with the same name and the location as the level. ( i.e. after processing the level `C:\foo\bar\A..tif` , the settings will be saved at `C:\foo\bar\A.sep` )
- When opening the `Separate Colors` popup, if the settings file for the target level exists, it will be loaded.
- The setting file can also be imported from / exported to any location by using newly-added `Save Settings` and `Load Settings` buttons.

This PR also improves the `Save In` field. When user manually typing non-existent path, a new folder will be created after confirmation.
