### PR TITLE
Fix Load Folder crashing while loading tga files

### DIFF
--- a/toonz/sources/toonz/loadfoldercommand.cpp
+++ b/toonz/sources/toonz/loadfoldercommand.cpp
@@ -182,9 +182,11 @@ TFilePath multiframeResourcePath(const TFilePath &fp) {
 
 TFilePath retasComponentPath(const TFilePath &fp) {
   std::wstring name = fp.getWideName();
-  assert(name.size() > 4);
 
-  name.insert(name.size() - 4, 1, L'.');
+  // Assumes the name is Axxxx.tga and needs to be changed to A.xxxx.tga
+  if (name.size() > 4 && fp.getDots() != "..")
+    name.insert(name.size() - 4, 1, L'.');
+
   return fp.withName(name);
 }
 
@@ -364,7 +366,7 @@ struct import_Locals {
         m_scene.getImportedLevelPath(path.absoluteResourcePath())
             .getParentDir()            // E.g. +drawings/
         + path.m_rootFp.getWideName()  // Root dir name
-    );
+        );
   }
 
   static void copy(const TFilePath &srcDir, const TFilePath &dstDir,


### PR DESCRIPTION
This PR fixes #3051

The current logic in `Load Folder` appears to want to internally convert TGA files named as `Axxxx.tga` to OT recognized sequenced file naming convention `A.xxxx.tga`.  

When `Load Folder` encounters the naming convention `A_xxxx.tga` (an accepted OT sequenced file name), it still does not think it's a properly named sequenced file and wants to put a `.` in the right place to changed it.  However, when extracting the name from the full path, it returned the name as `A` since it saw it as a sequenced file name. Due to the shortened name, OT crashed when it attempted to insert the `.` which is now outside the string's bound.

Modified logic to determine if the file name is already an accepted OT sequenced file name and skip renaming to prevent the crash and allow the level to load correctly.

NOTE: TGA files named as `Axxxx.tga` will not normally load as a sequenced level through Load Level. Instead these files are loaded as individual levels.

Due to the renaming logic in `Load Folder`, `Axxxx.tga` files will fail to load completely since it converts it to `A..tga` but cannot find files with that naming convention. This issue should be handled separately once it is decided if `Axxxx.tga` files should be loaded as sequenced files or not.