### PR TITLE
Revert "None" line pocessing option to the cleanup settings

### DIFF
--- a/toonz/sources/toonz/cleanupsettingspane.h
+++ b/toonz/sources/toonz/cleanupsettingspane.h
@@ -24,7 +24,7 @@ namespace DVGui {
 
 class DoubleField;
 class IntField;
-}
+}  // namespace DVGui
 
 /*
 "Save In"
@@ -70,6 +70,8 @@ private:
 
   CleanupParameters m_backupParams;
   bool m_attached;
+
+  QList<QWidget *> m_lpWidgets;
 
 public:
   CleanupSettingsPane(QWidget *parent = 0);


### PR DESCRIPTION
This resolves #2729 
Also fixed the cleanup settings to properly load the default settings on launching the software.