### PR TITLE
Logarithmic option for Spiral fx

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -405,6 +405,7 @@
   <item>"STD_solarizeFx.peak_edge"	"Peak Edge"	</item>
 
   <item>"STD_spiralFx"		"Spiral"		</item>
+  <item>"STD_spiralFx.type"		"Type"	</item>
   <item>"STD_spiralFx.freq"		"Frequency"	</item>
   <item>"STD_spiralFx.phase"	"Phase"		</item>
   <item>"STD_spiralFx.colors"	"Colors"		</item>

--- a/stuff/profiles/layouts/fxs/STD_spiralFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_spiralFx.xml
@@ -1,5 +1,6 @@
 <fxlayout>
   <page name="Spiral">
+    <control>type</control>
     <control>colors</control>
     <control>freq</control>
     <control>phase</control>


### PR DESCRIPTION
**Please do not merge before releasing v1.4 as this is feature-PR.**

This resolves #3055 .
Added a `Type` parameter to the Spiral Fx, having `Archimedean` and `Logarithmic` options.
The default value is `Archimedian` , which renders the same result as before.

I don't know why I implemented this so fast. 