### PR TITLE
Fix Translation for Toonz Vector Brush Tool

### DIFF
--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -81,7 +81,7 @@ public:
 //************************************************************************
 
 class ToonzVectorBrushTool final : public TTool {
-  Q_DECLARE_TR_FUNCTIONS(BrushTool)
+  Q_DECLARE_TR_FUNCTIONS(ToonzVectorBrushTool)
 
 public:
   ToonzVectorBrushTool(std::string name, int targetType);


### PR DESCRIPTION
This fixes #3062 .
When I separate the brush tool into two types, I missed to update the class name in the `Q_DECLARE_TR_FUNCTIONS` macro. Sorry for the trouble!