### PR TITLE
Modify Creating Scene from Startup Popup

### DIFF
--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -504,10 +504,11 @@ void StartupPopup::onCreateButton() {
       size);
   TApp::instance()->getCurrentScene()->getScene()->getCurrentCamera()->setRes(
       res);
-  // this one is debatable - should the scene be saved right away?
-  // IoCmd::saveScene();
+  // save the scene right away
+  IoCmd::saveScene();
   // this makes sure the scene viewers update to the right fps
   TApp::instance()->getCurrentScene()->notifySceneSwitched();
+  TApp::instance()->getCurrentScene()->notifyNameSceneChange();
 
   hide();
 }


### PR DESCRIPTION
This PR resolves #3034 .

- Made the scene to be saved on the disk right away when the `Create Scene` button is clicked. Unlike the levels, users still can edit the untitled scene without being saved just by closing the popup.
- Fix the title bar to be updated when creating the scene.