### PR TITLE
Fix Crash on Exporting XDTS When There are No Columns to be Exported

### DIFF
--- a/toonz/sources/toonz/xdtsio.h
+++ b/toonz/sources/toonz/xdtsio.h
@@ -212,6 +212,10 @@ public:
   int getDuration() { return m_duration; }
 
   void build(TXsheet *, QString);
+  bool isEmpty() {
+    return m_duration == 0 || m_fields.isEmpty() ||
+           m_timeTableHeaders.isEmpty();
+  }
 };
 
 // "$schema": "http://json-schema.org/draft-07/schema",
@@ -233,6 +237,7 @@ public:
   QStringList getLevelNames() const;
   XdtsTimeTableItem &timeTable() { return m_timeTables[0]; }
   void build(TXsheet *, QString);
+  bool isEmpty() { return m_timeTables.isEmpty(); }
 };
 
 bool loadXdtsScene(ToonzScene *scene, const TFilePath &scenePath);


### PR DESCRIPTION
This PR fixes the `Export Exchange Digital Time Sheet (XDTS)` command as follows:

- Fixed crash when there are no columns to be exported (e.g. empty scene).
- Enabled to select export destination.