### PR TITLE
Reset Undo when Saving Levels Preference Option

### DIFF
--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -65,6 +65,7 @@ enum PreferencesItemId {
   //----------
   // Saving
   rasterBackgroundColor,
+  resetUndoOnSavingLevel,
 
   //----------
   // Import / Export

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -1651,7 +1651,8 @@ bool SaveLevelAsPopup::execute() {
     DvDirModel::instance()->refreshFolder(fp.getParentDir());
 
     // reset undo memory!!
-    TUndoManager::manager()->reset();
+    if (Preferences::instance()->getBoolValue(resetUndoOnSavingLevel))
+      TUndoManager::manager()->reset();
   }
 
   if (ret)

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2788,8 +2788,8 @@ public:
     }
 
     // reset the undo before save level
-    // TODO: この仕様、Preferencesでオプション化する
-    TUndoManager::manager()->reset();
+    if (Preferences::instance()->getBoolValue(resetUndoOnSavingLevel))
+      TUndoManager::manager()->reset();
 
     if (!IoCmd::saveLevel()) error(QObject::tr("Save level Failed"));
   }
@@ -2985,8 +2985,8 @@ public:
     else if (pl)
       pl->getPalette()->setDirtyFlag(false);
 
-    /*- Undoをリセット。 TODO:この挙動、Preferencesでオプション化 -*/
-    TUndoManager::manager()->reset();
+    if (Preferences::instance()->getBoolValue(resetUndoOnSavingLevel))
+      TUndoManager::manager()->reset();
 
     TApp::instance()
         ->getPaletteController()

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -990,6 +990,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
 
       // Saving
       {rasterBackgroundColor, tr("Matte color: ")},
+      {resetUndoOnSavingLevel, tr("Clear Undo History when Saving Levels")},
 
       // Import / Export
       {ffmpegPath, tr("FFmpeg Path: ")},
@@ -1532,6 +1533,7 @@ QWidget* PreferencesPopup::createSavingPage() {
                  this);
   lay->addWidget(matteColorLabel, 0, 0, 1, 3, Qt::AlignLeft);
   insertUI(rasterBackgroundColor, lay);
+  insertUI(resetUndoOnSavingLevel, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -432,6 +432,8 @@ void Preferences::definePreferenceItems() {
   // Saving
   define(rasterBackgroundColor, "rasterBackgroundColor", QMetaType::QColor,
          QColor(Qt::white));
+  define(resetUndoOnSavingLevel, "resetUndoOnSavingLevel", QMetaType::Bool,
+         true);
 
   setCallBack(rasterBackgroundColor, &Preferences::setRasterBackgroundColor);
 


### PR DESCRIPTION
**It's devatable if it should be merged into v1.4 - as there is a known issue (see below).**

Currently, the undo history is cleared when user uses `Save Level` , `Save Level As` or `Overwrite Palette` command. 
This behavior was originally demanded by Ghibli ink&paint staffs.
Since undo can change non-working frame without realizing it, they would like to use the `Save Level` command when they finish each frame and "pack up" their work by clearing undo.

This PR will make this behavior optional. The option will be in `Preferences > Saving` category and set to ON ( = do clear undo when saving levels ) by default.

**Known Issue :** I confirmed that some level-editing operations do not set dirty flag to the level on undo.  I think it is difficult to fix all of them to set dirty flag properly before releasing v1.4 . 
I'm leaning towards keeping this PR open (unmerged) until after releasing v1.4, since there seems to be no incovinience reported with the current behavior so far.