### PR TITLE
Fix CurveFx Crash

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1630,6 +1630,9 @@ FxSettings QToolBar QToolBar {
 #FxSettingsHelpButton:hover {
   background-color: #a8bee7;
 }
+ChannelBar {
+  qproperty-TextColor: #d6d8dd;
+}
 /* -----------------------------------------------------------------------------
    Script Console
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1630,6 +1630,9 @@ FxSettings QToolBar QToolBar {
 #FxSettingsHelpButton:hover {
   background-color: #a8bee7;
 }
+ChannelBar {
+  qproperty-TextColor: #e9e9e9;
+}
 /* -----------------------------------------------------------------------------
    Script Console
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1630,6 +1630,9 @@ FxSettings QToolBar QToolBar {
 #FxSettingsHelpButton:hover {
   background-color: #a8bee7;
 }
+ChannelBar {
+  qproperty-TextColor: #e6e6e6;
+}
 /* -----------------------------------------------------------------------------
    Script Console
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/less/layouts/schematic.less
+++ b/stuff/config/qss/Default/less/layouts/schematic.less
@@ -115,3 +115,7 @@ FxSettings {
 #FxSettingsPreviewShowButton {
   &:extend(.button-show all);
 }
+
+ChannelBar {
+  qproperty-TextColor: @text-color;
+}

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1631,6 +1631,9 @@ FxSettings QToolBar QToolBar {
 #FxSettingsHelpButton:hover {
   background-color: #a8bee7;
 }
+ChannelBar {
+  qproperty-TextColor: #000;
+}
 /* -----------------------------------------------------------------------------
    Script Console
 ----------------------------------------------------------------------------- */

--- a/toonz/sources/include/toonzqt/histogram.h
+++ b/toonz/sources/include/toonzqt/histogram.h
@@ -80,6 +80,10 @@ class DVAPI ChannelBar final : public QWidget {
 
   bool m_isHorizontal;
   bool m_drawNumbers;
+  
+  QColor m_textColor;
+  
+  Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
 
 public:
   ChannelBar(QWidget *parent = 0, QColor m_color = QColor(),
@@ -93,6 +97,8 @@ public:
 
   void draw(QPainter *painter, QPoint translation = QPoint(0, 0));
 
+  void setTextColor(const QColor &color) { m_textColor = color; }
+  QColor getTextColor() const { return m_textColor; }
 protected:
   void paintEvent(QPaintEvent *event) override;
 };

--- a/toonz/sources/toonzqt/histogram.cpp
+++ b/toonz/sources/toonzqt/histogram.cpp
@@ -314,7 +314,7 @@ void ChannelBar::draw(QPainter *p, QPoint translation) {
 
   p->setBrush(QBrush(linearGrad));
 
-  p->setPen(Qt::black);
+  p->setPen(getTextColor());
   p->drawRect(x0, y0, w - 1, h - 1);
 
   if (m_drawNumbers) {

--- a/toonz/sources/toonzqt/tonecurvefield.cpp
+++ b/toonz/sources/toonzqt/tonecurvefield.cpp
@@ -363,6 +363,13 @@ void ChennelCurveEditor::moveCentralControlPoint(int index,
     setPoint(index + 2,
              getNewSecondHandlePoint(p, nextP, m_points.at(index + 2)));
     if (nextDistance < 0) d = QPointF(nextP.x() - p.x(), d.y());
+    if (nextDistance < 16) {
+      double nextYDistance = nextP.y() - (p.y() + d.y());
+      if (nextYDistance > -16 && nextYDistance < 16) {
+        double offset = nextYDistance > 0 ? -16 : +16;
+        d = QPointF(d.x(), nextP.y() - p.y() + offset);
+      }
+    }
   }
   // Caso particolare: Punto di controllo corrente == ultimo visibile,
   //                   Punto di controllo precedente
@@ -375,12 +382,21 @@ void ChennelCurveEditor::moveCentralControlPoint(int index,
     setPoint(index - 1,
              getNewSecondHandlePoint(precP, p, m_points.at(index - 1)));
     if (precDistance < 0) d = QPointF(precP.x() - p.x(), d.y());
+    if (precDistance < 16) {
+      double precYDistance = (p.y() + d.y()) - precP.y();
+      if (precYDistance > -16 && precYDistance < 16) {
+        double offset = precYDistance > 0 ? 16 : -16;
+        d = QPointF(d.x(), precP.y() - p.y() + offset);
+      }
+    }
   }
   // Altrimenti calcolo il nuovo delta
   else if (nextDistance < 16)
     d = QPointF(nextP.x() - p.x() - 16, d.y());
   else if (precDistance < 16)
     d = QPointF(precP.x() - p.x() + 16, d.y());
+
+  if (d.isNull()) return;
 
   // Punto di controllo speciale: il primo visualizzato.
   if (index == 3) {
@@ -674,17 +690,8 @@ void ChennelCurveEditor::paintEvent(QPaintEvent *e) {
       else if (isCentralControlPoint(i) && i < n - 4)
         painter.drawLine(p, nextP);
     }
-    QPainterPath circle;
     QRectF pointRect(p.x() - rad, p.y() - rad, 2 * rad, 2 * rad);
-    if (r.contains(pointRect))
-#if QT_VERSION >= 0x050000
-      painter.setClipRect(pointRect.adjusted(-1, -1, 1, 1));
-#else
-      painter.setClipRect(pointRect.adjusted(-1, -1, 1, 1), Qt::UniteClip);
-#endif
-    circle.addEllipse(pointRect);
-    painter.fillPath(circle, brush);
-    painter.drawPath(circle);
+    painter.drawEllipse(pointRect);
     p = nextP;
   }
 }


### PR DESCRIPTION
This PR fixes #3069 

Now I modified the curve panel so that the first and the last control points will not be at the same position. If they are at the same horizontal positions (i.e. forming step-like curve to get a binarized image), the points cannot be closer than 16pixels vertically. 

Related to the Curve Fx UI I also modified the following in this PR:
- Fixed a problem that the curve handles are sometimes not visible.
- Made text color of the channel bar to be style-sheet-aware.