### PR TITLE
Fix guided drawing issues

### DIFF
--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -1118,7 +1118,12 @@ public:
         ImageUtils::getFillingInformationOverlappingArea(vi, *fillInformation,
                                                          stroke->getBBox());
 
-        bool strokeAdded = false;
+        vi->addStroke(stroke);
+        TUndoManager::manager()->add(new UndoPencil(
+            vi->getStroke(vi->getStrokeCount() - 1), fillInformation, sl, id,
+            m_isFrameCreated, m_isLevelCreated, m_param.m_autogroup.getValue(),
+            m_param.m_autofill.getValue()));
+
         if ((Preferences::instance()->getGuidedDrawingType() == 1 ||
              Preferences::instance()->getGuidedDrawingType() == 2) &&
             Preferences::instance()->getGuidedAutoInbetween()) {
@@ -1127,18 +1132,10 @@ public:
           ToonzVectorBrushTool *vbTool = (ToonzVectorBrushTool *)tool;
           if (vbTool) {
             vbTool->setViewer(m_viewer);
-            strokeAdded = vbTool->doGuidedAutoInbetween(
-                id, vi, stroke, false, m_param.m_autogroup.getValue(),
-                m_param.m_autofill.getValue(), true);
+            vbTool->doGuidedAutoInbetween(id, vi, stroke, false,
+                                          m_param.m_autogroup.getValue(),
+                                          m_param.m_autofill.getValue(), false);
           }
-        }
-
-        if (!strokeAdded) {
-          vi->addStroke(stroke);
-          TUndoManager::manager()->add(new UndoPencil(
-              vi->getStroke(vi->getStrokeCount() - 1), fillInformation, sl, id,
-              m_isFrameCreated, m_isLevelCreated, m_param.m_autogroup.getValue(), 
-              m_param.m_autofill.getValue()));
         }
       }
       if (m_param.m_autogroup.getValue() && stroke->isSelfLoop()) {
@@ -2095,7 +2092,7 @@ TStroke *EllipsePrimitive::makeStroke() const {
     return 0;
 
   return makeEllipticStroke(
-      getThickness(), 
+      getThickness(),
       TPointD(0.5 * (m_selectingRect.x0 + m_selectingRect.x1),
               0.5 * (m_selectingRect.y0 + m_selectingRect.y1)),
       fabs(0.5 * (m_selectingRect.x1 - m_selectingRect.x0)),

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1473,5 +1473,7 @@ void TTool::flipGuideStrokeDirection(int mode) {
   if (!stroke) return;
 
   stroke->changeDirection();
+  sl->setDirtyFlag(true);
   getViewer()->invalidateAll();
+  m_application->getCurrentLevel()->notifyLevelChange();
 }

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1295,6 +1295,8 @@ void TTool::tweenSelectedGuideStrokes() {
   TTool *tool = TTool::getTool(T_Brush, TTool::ToolTargetType::VectorImage);
   ToonzVectorBrushTool *vbTool = (ToonzVectorBrushTool *)tool;
   if (vbTool) {
+    m_isFrameCreated = false;
+    m_isLevelCreated = false;
     vbTool->setViewer(m_viewer);
     vbTool->doFrameRangeStrokes(
         bFid, bStroke, fFid, fStroke,
@@ -1394,6 +1396,8 @@ void TTool::tweenGuideStrokeToSelected() {
   TTool *tool = TTool::getTool(T_Brush, TTool::ToolTargetType::VectorImage);
   ToonzVectorBrushTool *vbTool = (ToonzVectorBrushTool *)tool;
   if (vbTool) {
+    m_isFrameCreated = false;
+    m_isLevelCreated = false;
     vbTool->setViewer(m_viewer);
     TUndoManager::manager()->beginBlock();
     if (bStroke)

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -980,7 +980,11 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
       m_snapSelf = false;
     }
 
-    bool strokeAdded = false;
+    addStrokeToImage(getApplication(), vi, stroke, m_breakAngles.getValue(),
+                     false, false, m_isFrameCreated, m_isLevelCreated);
+    TRectD bbox = stroke->getBBox().enlarge(2) + m_track.getModifiedRegion();
+
+    invalidate();  // should use bbox?
 
     if ((Preferences::instance()->getGuidedDrawingType() == 1 ||
          Preferences::instance()->getGuidedDrawingType() == 2) &&
@@ -988,21 +992,14 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
       int fidx     = getApplication()->getCurrentFrame()->getFrameIndex();
       TFrameId fId = getFrameId();
 
-      strokeAdded = doGuidedAutoInbetween(
-          fId, vi, stroke, m_breakAngles.getValue(), false, false, true);
+      doGuidedAutoInbetween(fId, vi, stroke, m_breakAngles.getValue(), false,
+                            false, false);
 
       if (getApplication()->getCurrentFrame()->isEditingScene())
         getApplication()->getCurrentFrame()->setFrame(fidx);
       else
         getApplication()->getCurrentFrame()->setFid(fId);
     }
-
-    if (!strokeAdded)
-      addStrokeToImage(getApplication(), vi, stroke, m_breakAngles.getValue(),
-                       false, false, m_isFrameCreated, m_isLevelCreated);
-    TRectD bbox = stroke->getBBox().enlarge(2) + m_track.getModifiedRegion();
-
-    invalidate();  // should use bbox?
   }
   assert(stroke);
   m_track.clear();
@@ -1141,7 +1138,7 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
   bool resultFront           = false;
   TFrameId oFid;
   int cStrokeIdx   = cvi->getStrokeCount();
-  int cStrokeCount = cStrokeIdx + 1;
+  if (!drawStroke) cStrokeIdx--;
 
   TUndoManager::manager()->beginBlock();
   if (osBack != -1) {
@@ -1166,10 +1163,13 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
         strokeIdx < fStrokeCount) {
       TStroke *fStroke = fvi->getStroke(strokeIdx);
 
-      resultBack = doFrameRangeStrokes(
+      bool frameCreated = m_isFrameCreated;
+      m_isFrameCreated  = false;
+      resultBack        = doFrameRangeStrokes(
           oFid, fStroke, cFid, cStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,
           autoGroup, autoFill, false, drawStroke, false);
+      m_isFrameCreated = frameCreated;
     }
   }
 
@@ -1197,10 +1197,13 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
         strokeIdx < fStrokeCount) {
       TStroke *fStroke = fvi->getStroke(strokeIdx);
 
-      resultFront = doFrameRangeStrokes(
+      bool frameCreated = m_isFrameCreated;
+      m_isFrameCreated  = false;
+      resultFront       = doFrameRangeStrokes(
           cFid, cStroke, oFid, fStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,
           autoGroup, autoFill, drawFirstStroke, false, false);
+      m_isFrameCreated = frameCreated;
     }
   }
   TUndoManager::manager()->endBlock();

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2209,24 +2209,24 @@ void MainWindow::defineActions() {
   CommandManager::instance()->setToggleTexts(V_ShowHideFullScreen,
                                              tr("Full Screen Mode"),
                                              tr("Exit Full Screen Mode"));
-  createMiscAction(MI_SelectNextGuideStroke,
-                   tr("Select Next Frame Guide Stroke"), "");
-  createMiscAction(MI_SelectPrevGuideStroke,
-                   tr("Select Previous Frame Guide Stroke"), "");
-  createMiscAction(MI_SelectBothGuideStrokes,
-                   tr("Select Prev && Next Frame Guide Strokes"), "");
-  createMiscAction(MI_SelectGuideStrokeReset,
-                   tr("Reset Guide Stroke Selections"), "");
-  createMiscAction(MI_TweenGuideStrokes,
-                   tr("Tween Selected Guide Strokes"), "");
-  createMiscAction(MI_TweenGuideStrokeToSelected,
-                   tr("Tween Guide Strokes to Selected"), "");
-  createMiscAction(MI_SelectGuidesAndTweenMode,
-                   tr("Select Guide Strokes && Tween Mode"), "");
-  createMiscAction(MI_FlipNextGuideStroke,
-                   tr("Flip Next Guide Stroke Direction"), "");
-  createMiscAction(MI_FlipPrevGuideStroke,
-                   tr("Flip Previous Guide Stroke Direction"), "");
+  createToolOptionsAction(MI_SelectNextGuideStroke,
+                          tr("Select Next Frame Guide Stroke"), "");
+  createToolOptionsAction(MI_SelectPrevGuideStroke,
+                          tr("Select Previous Frame Guide Stroke"), "");
+  createToolOptionsAction(MI_SelectBothGuideStrokes,
+                          tr("Select Prev && Next Frame Guide Strokes"), "");
+  createToolOptionsAction(MI_SelectGuideStrokeReset,
+                          tr("Reset Guide Stroke Selections"), "");
+  createToolOptionsAction(MI_TweenGuideStrokes,
+                          tr("Tween Selected Guide Strokes"), "");
+  createToolOptionsAction(MI_TweenGuideStrokeToSelected,
+                          tr("Tween Guide Strokes to Selected"), "");
+  createToolOptionsAction(MI_SelectGuidesAndTweenMode,
+                          tr("Select Guide Strokes && Tween Mode"), "");
+  createToolOptionsAction(MI_FlipNextGuideStroke,
+                          tr("Flip Next Guide Stroke Direction"), "");
+  createToolOptionsAction(MI_FlipPrevGuideStroke,
+                          tr("Flip Previous Guide Stroke Direction"), "");
 
   // Following actions are for adding "Visualization" menu items to the command
   // bar. They are separated from the original actions in order to avoid


### PR DESCRIPTION
This PR does the following:

1) Marks Level as "dirty" when a guide stroke direction is changed

2) Fixes #3043

The last frame creation flag was being applied to frames where inbetween strokes were being drawn so that when an Undo was performed, it deleted those frames.  Modified the logic to reset the frame creation flag before applying the inbetween strokes.

3) Fixes #3040

The Guided Drawing shortcuts were not available when active controls, like buttons, where not visible.  Moved the shortcuts for Guided Drawing commands to be created under Tool Modifiers so that they are always available even when there are no active controls for them.