### PR TITLE
Add snap option to control point editor tool

### DIFF
--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -770,13 +770,16 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
                                                 // deselezionata l'ultima
                                                 // selezione nel movimento
 
-    TThickPoint cp =
-        m_controlPointEditorStroke.getControlPoint(m_lastPointSelected);
-    TPointD controlPoint = TPointD(cp.x, cp.y);
+    if (m_lastPointSelected >= 0) {
+      TThickPoint cp;
+      TPointD controlPoint;
+      TPointD newPos;
 
-    TPointD newPos;
-    newPos = calculateSnap(pos);
-    delta  = newPos - m_pos + (m_pos - controlPoint);
+      cp = m_controlPointEditorStroke.getControlPoint(m_lastPointSelected);
+      controlPoint = TPointD(cp.x, cp.y);
+      newPos       = calculateSnap(pos);
+      delta        = newPos - m_pos + (m_pos - controlPoint);
+    }
 
     m_pos = pos;
 

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -231,7 +231,7 @@ TPointD ControlPointEditorTool::calculateSnap(TPointD pos) {
   TVectorImageP vi(TTool::getImage(false));
   TPointD snapPoint = pos;
   if (vi && m_snap.getValue()) {
-    double minDistance     = m_snapMinDistance;
+    double minDistance = m_snapMinDistance;
 
     int i, strokeNumber = vi->getStrokeCount();
 
@@ -241,7 +241,7 @@ TPointD ControlPointEditorTool::calculateSnap(TPointD pos) {
 
     for (i = 0; i < strokeNumber; i++) {
       stroke = vi->getStroke(i);
-      if(stroke != selfStroke){
+      if (stroke != selfStroke) {
         if (stroke->getNearestW(pos, outW, distance) &&
             distance < minDistance) {
           minDistance = distance;
@@ -252,9 +252,9 @@ TPointD ControlPointEditorTool::calculateSnap(TPointD pos) {
           else
             w = outW;
           TThickPoint point = stroke->getPoint(w);
-          snapPoint          = TPointD(point.x, point.y);
-          m_foundSnap        = true;
-          m_snapPoint        = snapPoint;
+          snapPoint         = TPointD(point.x, point.y);
+          m_foundSnap       = true;
+          m_snapPoint       = snapPoint;
         }
       }
     }
@@ -263,23 +263,21 @@ TPointD ControlPointEditorTool::calculateSnap(TPointD pos) {
 }
 
 void ControlPointEditorTool::drawSnap() {
-    double thick = 6.0;
-    if (m_foundSnap) {
-      tglColor(TPixelD(0.1, 0.9, 0.1));
-      tglDrawCircle(m_snapPoint, thick);
-    }
+  double thick = 6.0;
+  if (m_foundSnap) {
+    tglColor(TPixelD(0.1, 0.9, 0.1));
+    tglDrawCircle(m_snapPoint, thick);
+  }
 }
 
-TPointD ControlPointEditorTool::getSnap(TPointD pos){
+TPointD ControlPointEditorTool::getSnap(TPointD pos) {
   if (m_foundSnap)
     return m_snapPoint;
   else
     return pos;
 }
 
-void ControlPointEditorTool::resetSnap(){
-  m_foundSnap = false;
-}
+void ControlPointEditorTool::resetSnap() { m_foundSnap = false; }
 
 //=============================================================================
 // Spline Editor Tool
@@ -772,12 +770,13 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
                                                 // deselezionata l'ultima
                                                 // selezione nel movimento
 
-    TThickPoint cp = m_controlPointEditorStroke.getControlPoint(m_lastPointSelected);
+    TThickPoint cp =
+        m_controlPointEditorStroke.getControlPoint(m_lastPointSelected);
     TPointD controlPoint = TPointD(cp.x, cp.y);
 
     TPointD newPos;
     newPos = calculateSnap(pos);
-    delta = newPos - m_pos + (m_pos - controlPoint);
+    delta  = newPos - m_pos + (m_pos - controlPoint);
 
     m_pos = pos;
 
@@ -960,8 +959,8 @@ void ControlPointEditorTool::onLeave() {
 
 bool ControlPointEditorTool::onPropertyChanged(std::string propertyName) {
   AutoSelectDrawing = (int)(m_autoSelectDrawing.getValue());
-  Snap = (int)(m_snap.getValue());
-  SnapSensitivity = (int)(m_snapSensitivity.getIndex());
+  Snap              = (int)(m_snap.getValue());
+  SnapSensitivity   = (int)(m_snapSensitivity.getIndex());
   switch (SnapSensitivity) {
   case 0:
     m_snapMinDistance = SNAPPING_LOW;

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -37,6 +37,10 @@ TEnv::IntVar SnapSensitivity("ControlPointEditorToolSnapSensitivity", 0);
 #define MEDIUM_WSTR L"Medium"
 #define HIGH_WSTR L"High"
 
+const double SNAPPING_LOW    = 5.0;
+const double SNAPPING_MEDIUM = 25.0;
+const double SNAPPING_HIGH   = 100.0;
+
 //-----------------------------------------------------------------------------
 namespace {
 
@@ -138,6 +142,7 @@ class ControlPointEditorTool final : public TTool {
       m_autoSelectDrawing;  // Consente di scegliere se swichare tra i livelli.
   TBoolProperty m_snap;
   TEnumProperty m_snapSensitivity;
+  double m_snapMinDistance;
 
   enum Action {
     NONE,
@@ -877,6 +882,17 @@ bool ControlPointEditorTool::onPropertyChanged(std::string propertyName) {
   AutoSelectDrawing = (int)(m_autoSelectDrawing.getValue());
   Snap = (int)(m_snap.getValue());
   SnapSensitivity = (int)(m_snapSensitivity.getIndex());
+  switch (SnapSensitivity) {
+  case 0:
+    m_snapMinDistance = SNAPPING_LOW;
+    break;
+  case 1:
+    m_snapMinDistance = SNAPPING_MEDIUM;
+    break;
+  case 2:
+    m_snapMinDistance = SNAPPING_HIGH;
+    break;
+  }
   return true;
 }
 
@@ -887,6 +903,17 @@ void ControlPointEditorTool::onActivate() {
   m_autoSelectDrawing.setValue(AutoSelectDrawing ? 1 : 0);
   m_snap.setValue(Snap ? 1 : 0);
   m_snapSensitivity.setIndex(SnapSensitivity);
+  switch (SnapSensitivity) {
+  case 0:
+    m_snapMinDistance = SNAPPING_LOW;
+    break;
+  case 1:
+    m_snapMinDistance = SNAPPING_MEDIUM;
+    break;
+  case 2:
+    m_snapMinDistance = SNAPPING_HIGH;
+    break;
+  }
   m_controlPointEditorStroke.setStroke((TVectorImage *)0, -1);
   m_draw = true;
 }

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -28,6 +28,8 @@
 using namespace ToolUtils;
 
 TEnv::IntVar AutoSelectDrawing("ControlPointEditorToolAutoSelectDrawing", 1);
+TEnv::IntVar Snap("ControlPointEditorToolSnap", 0);
+TEnv::IntVar SnapSensitivity("ControlPointEditorToolSnapSensitivity", 0);
 
 //-----------------------------------------------------------------------------
 
@@ -873,6 +875,8 @@ void ControlPointEditorTool::onLeave() {
 
 bool ControlPointEditorTool::onPropertyChanged(std::string propertyName) {
   AutoSelectDrawing = (int)(m_autoSelectDrawing.getValue());
+  Snap = (int)(m_snap.getValue());
+  SnapSensitivity = (int)(m_snapSensitivity.getIndex());
   return true;
 }
 
@@ -881,6 +885,8 @@ bool ControlPointEditorTool::onPropertyChanged(std::string propertyName) {
 void ControlPointEditorTool::onActivate() {
   // TODO: getApplication()->editImageOrSpline();
   m_autoSelectDrawing.setValue(AutoSelectDrawing ? 1 : 0);
+  m_snap.setValue(Snap ? 1 : 0);
+  m_snapSensitivity.setIndex(SnapSensitivity);
   m_controlPointEditorStroke.setStroke((TVectorImage *)0, -1);
   m_draw = true;
 }

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -128,6 +128,7 @@ class ControlPointEditorTool final : public TTool {
   TPropertyGroup m_prop;
   TBoolProperty
       m_autoSelectDrawing;  // Consente di scegliere se swichare tra i livelli.
+  TBoolProperty m_snap;
 
   enum Action {
     NONE,
@@ -212,6 +213,7 @@ ControlPointEditorTool::ControlPointEditorTool()
     , m_isImageChanged(false)
     , m_selectingRect(TRectD())
     , m_autoSelectDrawing("Auto Select Drawing", true)
+    , m_snap("snap", true)
     , m_action(NONE)
     , m_cursorType(NORMAL)
     , m_undo(0)
@@ -220,15 +222,18 @@ ControlPointEditorTool::ControlPointEditorTool()
     , m_moveSegmentLimitation() {
   bind(TTool::Vectors);
   m_prop.bind(m_autoSelectDrawing);
+  m_prop.bind(m_snap);
   m_selection.setControlPointEditorStroke(&m_controlPointEditorStroke);
 
   m_autoSelectDrawing.setId("AutoSelectDrawing");
+  m_snap.setId("Snap");
 }
 
 //-----------------------------------------------------------------------------
 
 void ControlPointEditorTool::updateTranslation() {
   m_autoSelectDrawing.setQStringName(tr("Auto Select Drawing"));
+  m_snap.setQStringName(tr("Snap"));
 }
 
 //---------------------------------------------------------------------------

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -30,6 +30,12 @@ using namespace ToolUtils;
 TEnv::IntVar AutoSelectDrawing("ControlPointEditorToolAutoSelectDrawing", 1);
 
 //-----------------------------------------------------------------------------
+
+#define LOW_WSTR L"Low"
+#define MEDIUM_WSTR L"Medium"
+#define HIGH_WSTR L"High"
+
+//-----------------------------------------------------------------------------
 namespace {
 
 /*! Restituisce i parametri riferiti allo stroke della curva che si vuole
@@ -129,6 +135,7 @@ class ControlPointEditorTool final : public TTool {
   TBoolProperty
       m_autoSelectDrawing;  // Consente di scegliere se swichare tra i livelli.
   TBoolProperty m_snap;
+  TEnumProperty m_snapSensitivity;
 
   enum Action {
     NONE,
@@ -213,7 +220,8 @@ ControlPointEditorTool::ControlPointEditorTool()
     , m_isImageChanged(false)
     , m_selectingRect(TRectD())
     , m_autoSelectDrawing("Auto Select Drawing", true)
-    , m_snap("snap", true)
+    , m_snap("snap", false)
+    , m_snapSensitivity("Sensitivity:")
     , m_action(NONE)
     , m_cursorType(NORMAL)
     , m_undo(0)
@@ -223,10 +231,15 @@ ControlPointEditorTool::ControlPointEditorTool()
   bind(TTool::Vectors);
   m_prop.bind(m_autoSelectDrawing);
   m_prop.bind(m_snap);
+  m_prop.bind(m_snapSensitivity);
   m_selection.setControlPointEditorStroke(&m_controlPointEditorStroke);
 
   m_autoSelectDrawing.setId("AutoSelectDrawing");
   m_snap.setId("Snap");
+  m_snapSensitivity.addValue(LOW_WSTR);
+  m_snapSensitivity.addValue(MEDIUM_WSTR);
+  m_snapSensitivity.addValue(HIGH_WSTR);
+  m_snapSensitivity.setId("SnapSensitivity");
 }
 
 //-----------------------------------------------------------------------------
@@ -234,6 +247,10 @@ ControlPointEditorTool::ControlPointEditorTool()
 void ControlPointEditorTool::updateTranslation() {
   m_autoSelectDrawing.setQStringName(tr("Auto Select Drawing"));
   m_snap.setQStringName(tr("Snap"));
+  m_snapSensitivity.setQStringName(tr(""));
+  m_snapSensitivity.setItemUIName(L"Low", tr("Low"));
+  m_snapSensitivity.setItemUIName(L"Medium", tr("Med"));
+  m_snapSensitivity.setItemUIName(L"High", tr("High"));
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds snap option for Control Point Editor, just like Geometric tool. It allows you to snap a control point onto a point of an existing line.

https://www.youtube.com/watch?v=f_0-59Wzk1A

A few known problems with this PR:

1. The functionality is very similar to that of tape tool. So this feature may not be useful for most people which means it's a dead weight to the codebase.
2. New code is mostly copied from geometric tool so there might be a code duplication issue.
3. Whether you check snap option or not, the snap sensitivity menu will be shown unlike geometric tool where the menu will be hidden if snap option is not checked.
4. In drawSnap, there is m_tool in geometric tool which provides getPixelSize function but control point editor tool doesn't have it so I'm not sure what negative effect this might bring.
5. behavior when dragging control point is different. Now, if you drag a control point at its corner, your mouse will stay at its control point's corner. With this PR, once your mouse drags, your mouse will be dragging at its center. Again, not sure what negative effect this might bring.
6. it can not snap to itself.