### PR TITLE
Streamline Fx Settings

### DIFF
--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -1345,7 +1345,7 @@ void FxSettings::setCurrentFx() {
   actualFx->getAttributes()->enable(true);
   if (hasEmptyInput)
     currentFx = actualFx;
-  else {
+  else if (m_viewer->isEnabled()) {
     if (!m_isCameraModeView)
       currentFx = buildSceneFx(scene, frame, actualFx, false);
     else {
@@ -1353,7 +1353,8 @@ void FxSettings::setCurrentFx() {
           scene->getProperties()->getPreviewProperties()->getRenderSettings();
       currentFx = buildPartialSceneFx(scene, (double)frame, actualFx, 1, false);
     }
-  }
+  } else
+    currentFx = TFxP();
 
   if (currentFx) currentFx = currentFx->clone(true);
 


### PR DESCRIPTION
This PR will enhance refresh response of the Fx Settings on clicking a fx node in the Fx Schematic.

When switching the current fx, the function `buildSceneFx()` is called.
It can be time-consuming especially when working in large scene, since the function traces all upstream nodes. (In an extreme case, in a scene containing about 300 fx nodes it takes several seconds after clicking nodes to refresh the contents.)

After investigation, I found that calling `buildSceneFx()` seems to be needed to render the swatch preview ( = a small preview area in the bottom of the Fx Settings ).
So, I modified it to call `buildSceneFx()` only when the swatch preview is enabled.