### PR TITLE
Prevent Preview from Recomputation-checking when Switching Camstand Toggle

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2366,7 +2366,19 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
       assert(false);
 
     app->getCurrentScene()->notifySceneChanged();
-    app->getCurrentXsheet()->notifyXsheetChanged();
+    // signal XsheetChanged will invoke PreviewFxManager to all rendered frames,
+    // if necessary. it causes slowness when opening preview flipbook of large
+    // scene.
+    bool isTransparencyRendered = app->getCurrentScene()
+                                      ->getScene()
+                                      ->getProperties()
+                                      ->isColumnColorFilterOnRenderEnabled();
+    if ((isTransparencyRendered && (m_doOnRelease == ToggleTransparency ||
+                                    m_doOnRelease == ToggleAllTransparency ||
+                                    m_doOnRelease == OpenSettings)) ||
+        m_doOnRelease == TogglePreviewVisible ||
+        m_doOnRelease == ToggleAllPreviewVisible)
+      app->getCurrentXsheet()->notifyXsheetChanged();
     update();
     m_doOnRelease = 0;
   }


### PR DESCRIPTION
This PR will enhance response of clicking the camstand toggle in the Xsheet while preview flipbook is opened.

The signal `xsheetChanged()` will invoke "recomputation-checking" in `PreviewFxManager`, which traces all upstream fx nodes starting from the previewed node and check if any of fx/object paramaters has been changed or not. It can be time-consuming especially when working in large scene.

For now, clicking any part of the column header will emit `xsheetChanged()` signal, however toggling camstand view does not effect rendered result unless the `Enable Column Color Filter and Transparency for Rendering` option (in the Scene Settings) is enabled.
So, I made the `xsheetChanged()` signal to be emitted only after a manipulation which will affect the render result.

