### PR TITLE
Fix Cache Fx Not Working

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2039,8 +2039,6 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
           return;
         setDragTool(XsheetGUI::DragTool::makeColumnSelectionTool(m_viewer));
       }
-      // synchronize the current column and the current fx
-      if (column) TApp::instance()->getCurrentFx()->setFx(column->getFx());
     }
     // clicking on the normal columns
     else if (!isEmpty) {
@@ -2146,14 +2144,16 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
           }
         }
       }
-      // synchronize the current column and the current fx
-      if (column) TApp::instance()->getCurrentFx()->setFx(column->getFx());
+      // update the current fx when zerary fx column is clicked
+      if (column && column->getZeraryFxColumn()) {
+        TFx *fx = column->getZeraryFxColumn()->getZeraryColumnFx();
+        TApp::instance()->getCurrentFx()->setFx(fx);
+      }
     } else {
       if (m_viewer->getColumnSelection()->isColumnSelected(m_col) &&
           event->button() == Qt::RightButton)
         return;
       setDragTool(XsheetGUI::DragTool::makeColumnSelectionTool(m_viewer));
-      TApp::instance()->getCurrentFx()->setFx(0);
     }
 
     m_viewer->dragToolClick(event);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -390,11 +390,11 @@ void XsheetViewer::positionSections() {
     if (o->isVerticalTimeline()) {
       headerFrame = headerFrame.adjusted(XsheetGUI::TOOLBAR_HEIGHT,
                                          XsheetGUI::TOOLBAR_HEIGHT);
-      bodyFrame = bodyFrame.adjusted(XsheetGUI::TOOLBAR_HEIGHT, 0);
+      bodyFrame   = bodyFrame.adjusted(XsheetGUI::TOOLBAR_HEIGHT, 0);
     } else {
       headerLayer = headerLayer.adjusted(XsheetGUI::TOOLBAR_HEIGHT,
                                          XsheetGUI::TOOLBAR_HEIGHT);
-      bodyLayer = bodyLayer.adjusted(XsheetGUI::TOOLBAR_HEIGHT, 0);
+      bodyLayer   = bodyLayer.adjusted(XsheetGUI::TOOLBAR_HEIGHT, 0);
     }
   } else {
     m_toolbar->showToolbar(false);
@@ -503,10 +503,9 @@ void XsheetViewer::setCurrentColumn(int col) {
       objectHandle->setObjectId(TStageObjectId::ColumnId(col));
       TXsheet *xsh       = getXsheet();
       TXshColumn *column = xsh->getColumn(col);
-      if (!column || column->isEmpty())
-        TApp::instance()->getCurrentFx()->setFx(0);
-      else
-        TApp::instance()->getCurrentFx()->setFx(column->getFx());
+      if (!column || !column->getZeraryFxColumn()) return;
+      TFx *fx = column->getZeraryFxColumn()->getZeraryColumnFx();
+      TApp::instance()->getCurrentFx()->setFx(fx);
     }
     return;
   }
@@ -724,9 +723,9 @@ void XsheetViewer::updateAreeSize() {
           positionToXY(CellPosition(xsh->getFrameCount() + 1, firstCol));
 
       ColumnFan *fan = xsh->getColumnFan(m_orientation);
-      areaFilled.setY(areaFilled.y() + 1 + (fan->isActive(firstCol)
-                                                ? o->cellHeight()
-                                                : o->foldedCellSize()));
+      areaFilled.setY(
+          areaFilled.y() + 1 +
+          (fan->isActive(firstCol) ? o->cellHeight() : o->foldedCellSize()));
     }
   }
   if (viewArea.width() < areaFilled.x()) viewArea.setWidth(areaFilled.x());
@@ -818,9 +817,9 @@ QPoint XsheetViewer::positionToXY(const CellPosition &pos) const {
   // area
   // since the layers are flipped
 
-  usePoint.setY(usePoint.y() - o->cellHeight() + (fan->isActive(pos.layer())
-                                                      ? o->cellHeight()
-                                                      : o->foldedCellSize()));
+  usePoint.setY(
+      usePoint.y() - o->cellHeight() +
+      (fan->isActive(pos.layer()) ? o->cellHeight() : o->foldedCellSize()));
   int columnCount = std::max(1, xsh->getColumnCount());
   int colsHeight  = o->colToLayerAxis(columnCount, fan);
 
@@ -950,8 +949,8 @@ bool XsheetViewer::areCameraCellsSelected() {
 
 void XsheetViewer::setScrubHighlight(int row, int startRow, int col) {
   if (m_scrubCol == -1) m_scrubCol = col;
-  m_scrubRow0                      = std::min(row, startRow);
-  m_scrubRow1                      = std::max(row, startRow);
+  m_scrubRow0 = std::min(row, startRow);
+  m_scrubRow1 = std::max(row, startRow);
   return;
 }
 
@@ -1156,12 +1155,12 @@ void XsheetViewer::wheelEvent(QWheelEvent *event) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-    {
-      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
-                   "Qt::MouseEventSynthesizedByApplication"
-                << std::endl;
-      break;
-    }
+  {
+    std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                 "Qt::MouseEventSynthesizedByApplication"
+              << std::endl;
+    break;
+  }
 
   }  // end switch
 }
@@ -1300,7 +1299,7 @@ void XsheetViewer::enterEvent(QEvent *) {
 
 //-----------------------------------------------------------------------------
 /*! scroll the cell area to make a cell at (row,col) visible
-*/
+ */
 void XsheetViewer::scrollTo(int row, int col) {
   QRect visibleRect = m_cellArea->visibleRegion().boundingRect();
   QPoint topLeft    = positionToXY(CellPosition(row, col));
@@ -1391,8 +1390,8 @@ void XsheetViewer::onCurrentColumnSwitched() {
 void XsheetViewer::scrollToColumn(int col) {
   int colNext = col + (m_orientation->isVerticalTimeline() ? 1 : -1);
   if (colNext < 0) colNext = -1;
-  int x0                   = columnToLayerAxis(col);
-  int x1                   = columnToLayerAxis(colNext);
+  int x0 = columnToLayerAxis(col);
+  int x1 = columnToLayerAxis(colNext);
 
   if (orientation()->isVerticalTimeline())
     scrollToHorizontalRange(x0, x1);
@@ -1492,7 +1491,7 @@ void XsheetViewer::onSelectionSwitched(TSelection *oldSelection,
 
 //-----------------------------------------------------------------------------
 /*! update display of the cell selection range in title bar
-*/
+ */
 void XsheetViewer::onSelectionChanged(TSelection *selection) {
   if ((TSelection *)getCellSelection() == selection) {
     changeWindowTitle();

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -384,12 +384,12 @@ void SchematicSceneViewer::wheelEvent(QWheelEvent *me) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-    {
-      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
-                   "Qt::MouseEventSynthesizedByApplication"
-                << std::endl;
-      break;
-    }
+  {
+    std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                 "Qt::MouseEventSynthesizedByApplication"
+              << std::endl;
+    break;
+  }
 
   }  // end switch
 
@@ -685,10 +685,9 @@ bool SchematicSceneViewer::event(QEvent *e) {
   }
   */
 
-  if (e->type() == QEvent::Gesture &&
-      CommandManager::instance()
-          ->getAction(MI_TouchGestureControl)
-          ->isChecked()) {
+  if (e->type() == QEvent::Gesture && CommandManager::instance()
+                                          ->getAction(MI_TouchGestureControl)
+                                          ->isChecked()) {
     gestureEvent(static_cast<QGestureEvent *>(e));
     return true;
   }
@@ -1139,7 +1138,7 @@ void SchematicViewer::setStageSchematicViewed(bool isStageSchematic) {
 }
 
 //------------------------------------------------------------------
-
+// called when the signals xshLevelChanged or objectSwitched is emited
 void SchematicViewer::updateScenes() {
   TStageObjectId id = m_stageScene->getCurrentObject();
   if (id.isColumn()) {
@@ -1147,12 +1146,9 @@ void SchematicViewer::updateScenes() {
     TXsheet *xsh = m_stageScene->getXsheetHandle()->getXsheet();
     if (!xsh) return;
     TXshColumn *column = xsh->getColumn(id.getIndex());
-    if (!column) {
-      m_fxScene->getFxHandle()->setFx(0, false);
-      return;
-    }
-    TFx *fx = column->getFx();
-    m_fxScene->getFxHandle()->setFx(fx, false);
+    if (!column || !column->getZeraryFxColumn()) return;
+    TFx *fx = column->getZeraryFxColumn()->getZeraryColumnFx();
+    m_fxScene->getFxHandle()->setFx(fx);
     m_fxScene->update();
   }
 }


### PR DESCRIPTION
This PR fixes #3108 .

When there is a changes in fx, the cached fxs are checked if it should be recomputed or not.
The check is actually to see if the "current Fx" is contained in upstream nodes of the cached fx.

However, there is a case that the "current fx" is not the one displayed in the Fx Settings.
For now, when clicking in the xsheet cell, the current fx will be switched to the clicked column ( inside OT, columns are also handled as Fxs, but with no parameters ). In such case, the current fx will be switched but the fx settings popup remains to show the previously-selected fx paramters because it is more useful than updating (= showing nothing).
It causes misunderstanding by OT that the edited Fx is contained in the cached Fx tree.

To resolve the issue, I made the current fx not to be changed by clicking the xsheet cell.
Exceptionally, if the cells containing zerary Fx is clicked, current fx will be switched to such fx and the Fx Settings will be updated accordingly.