### PR TITLE
reverse snap option when holding control key

### DIFF
--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -217,7 +217,7 @@ public:
   // returns true if the pressed key is recognized and processed.
   bool isEventAcceptable(QEvent *e) override;
 
-  TPointD calculateSnap(TPointD pos);
+  TPointD calculateSnap(TPointD pos, bool ctrlPressed);
   void drawSnap();
   TPointD getSnap(TPointD pos);
   void resetSnap();
@@ -226,11 +226,11 @@ public:
 
 //-----------------------------------------------------------------------------
 
-TPointD ControlPointEditorTool::calculateSnap(TPointD pos) {
+TPointD ControlPointEditorTool::calculateSnap(TPointD pos, bool ctrlPressed) {
   m_foundSnap = false;
   TVectorImageP vi(TTool::getImage(false));
   TPointD snapPoint = pos;
-  if (vi && m_snap.getValue()) {
+  if (vi && (m_snap.getValue() != ctrlPressed)) {
     double minDistance = m_snapMinDistance;
 
     int i, strokeNumber = vi->getStrokeCount();
@@ -777,7 +777,7 @@ void ControlPointEditorTool::leftButtonDrag(const TPointD &pos,
 
       cp = m_controlPointEditorStroke.getControlPoint(m_lastPointSelected);
       controlPoint = TPointD(cp.x, cp.y);
-      newPos       = calculateSnap(pos);
+      newPos       = calculateSnap(pos, e.isCtrlPressed());
       delta        = newPos - m_pos + (m_pos - controlPoint);
     }
 


### PR DESCRIPTION
This pull request allows you to temporarily reverse snap option by holding control key in both geometric tool and control point editor tool. This is especially useful when drawing a line or any shapes that don't allow you to release left mouse button using geometric tool as you don't get a chance to reverse the snap option mid drawing.

Brush tool already has this functionality by holding alt key so I didn't touch it.

video demonstrations:
https://youtu.be/AY0vCMq0WvY
https://youtu.be/mWYV5zO5kAU

There is one problem, though... inconsistency. In brush tool, you can hold alt key to temporarily reverse snap. However, in this pull request, I used control key to do it because alt key have another usage in both geometric tool and control point editor tool... Any suggestion?