### PR TITLE
(WIP) Make sure opacity slider doesn't go off screen

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -62,6 +62,7 @@
 #include <QLabel>
 #include <QComboBox>
 #include <QPushButton>
+#include <QDesktopWidget>
 
 #include <QBitmap>
 //=============================================================================
@@ -2328,6 +2329,19 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
 
         m_columnTransparencyPopup->move(event->globalPos().x() + x,
                                         event->globalPos().y() - y);
+
+        // make sure the popup doesn't go off the screen to the right
+        QDesktopWidget *desktop = qApp->desktop();
+        QRect screenRect        = desktop->screenGeometry(app->getMainWindow());
+
+        int popupLeft = event->globalPos().x() + x;
+        int popupRight = popupLeft + m_columnTransparencyPopup->width();
+
+        if (popupRight > screenRect.right()) {
+          int distance = popupRight - screenRect.right();
+          m_columnTransparencyPopup->move(m_columnTransparencyPopup->x() - distance,
+                                          m_columnTransparencyPopup->y());
+        }
 
         openTransparencyPopup();
       }

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2337,7 +2337,9 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
         int popupLeft = event->globalPos().x() + x;
         int popupRight = popupLeft + m_columnTransparencyPopup->width();
 
-        if (popupRight > screenRect.right()) {
+        // first condition checks if popup is on same monitor as main app;
+        // if popup is on different monitor, leave as is
+        if (popupLeft < screenRect.right() && popupRight > screenRect.right()) {
           int distance = popupRight - screenRect.right();
           m_columnTransparencyPopup->move(m_columnTransparencyPopup->x() - distance,
                                           m_columnTransparencyPopup->y());


### PR DESCRIPTION
Fixes #1752. This makes sure the opacity slider popup doesn't go off-screen to the right. Demo below - note that for column 5, the pop-up is moved left so that it fits on the screen.

![popup-demo](https://user-images.githubusercontent.com/24422213/75620469-453a1580-5bee-11ea-8ca6-85d220a06618.gif)

This works for me with a single-monitor setup. I still have to test a multiple-monitor setup; will aim to do so tomorrow.