### PR TITLE
Fix OpenGL assert failures

### DIFF
--- a/toonz/sources/stdfx/shadingcontext.cpp
+++ b/toonz/sources/stdfx/shadingcontext.cpp
@@ -121,7 +121,9 @@ ShadingContext::ShadingContext(QOffscreenSurface *surface) : m_imp(new Imp) {
   // m_imp->m_pixelBuffer->context()->create();
   // m_imp->m_fbo(new QOpenGLFramebufferObject(1, 1));
   makeCurrent();
-  glewExperimental = GL_TRUE;
+   if( GLEW_VERSION_3_2 ) {
+       glewExperimental = GL_TRUE;
+   }
   glewInit();
   doneCurrent();
 }

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -346,6 +346,12 @@ add_definitions(
 message("subdir: toonzlib")
 message("Bin: " ${CMAKE_CURRENT_BINARY_DIR})
 
+if(GLEW_FOUND)
+    include_directories(${GLEW_INCLUDE_DIRS})
+else()
+    include_directories(${SDKROOT}/glew/glew-1.9.0/include)
+endif()
+
 include_directories(
     SYSTEM
     ${SDKROOT}/libusb/libusb-1.0.9/include
@@ -357,7 +363,7 @@ include_directories(
 if(BUILD_ENV_MSVC)
     target_link_libraries(toonzlib
         Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Script Qt5::Multimedia
-        ${GLUT_LIB} ${GL_LIB} ${MYPAINT_LIB_LDFLAGS} vfw32.lib
+        ${GLUT_LIB} ${GL_LIB} ${MYPAINT_LIB_LDFLAGS} ${GLEW_LIB} vfw32.lib
         tnzcore tnzbase tnzext
     )
 elseif(BUILD_ENV_APPLE)
@@ -369,7 +375,7 @@ elseif(BUILD_ENV_APPLE)
         ${MYPAINT_LIB_LDFLAGS}
     )
 
-    target_link_libraries(toonzlib Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Script Qt5::Multimedia ${GLUT_LIB} ${GL_LIB} ${EXTRA_LIBS})
+    target_link_libraries(toonzlib Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Script Qt5::Multimedia ${GLUT_LIB} ${GL_LIB} ${GLEW_LIB} ${EXTRA_LIBS})
 elseif(BUILD_ENV_UNIXLIKE)
     _find_toonz_library(EXTRA_LIBS "tnzcore;tnzbase;tnzext")
 
@@ -377,5 +383,5 @@ elseif(BUILD_ENV_UNIXLIKE)
         set(EXTRA_LIBS ${EXTRA_LIBS} -lvfw32)
     endif()
 
-    target_link_libraries(toonzlib Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Script Qt5::Multimedia ${GLUT_LIB} ${GL_LIB} ${EXTRA_LIBS} ${MYPAINT_LIB_LDFLAGS})
+    target_link_libraries(toonzlib Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Script Qt5::Multimedia ${GLUT_LIB} ${GL_LIB} ${GLEW_LIB} ${EXTRA_LIBS} ${MYPAINT_LIB_LDFLAGS})
 endif()

--- a/toonz/sources/toonzlib/imagepainter.cpp
+++ b/toonz/sources/toonzlib/imagepainter.cpp
@@ -1,4 +1,5 @@
-
+// Glew include
+#include <GL/glew.h>
 
 #include "toonz/imagepainter.h"
 #include "toonz/glrasterpainter.h"
@@ -204,18 +205,24 @@ void Painter::flushRasterImages(const TRect &loadbox, double compareX,
   glDisable(GL_STENCIL_TEST);
 
 #ifdef GL_EXT_convolution
-  glDisable(GL_CONVOLUTION_1D_EXT);
-  glDisable(GL_CONVOLUTION_2D_EXT);
-  glDisable(GL_SEPARABLE_2D_EXT);
+  if( GLEW_EXT_convolution ) {
+    glDisable(GL_CONVOLUTION_1D_EXT);
+    glDisable(GL_CONVOLUTION_2D_EXT);
+    glDisable(GL_SEPARABLE_2D_EXT);
+  }
 #endif
 
 #ifdef GL_EXT_histogram
-  glDisable(GL_HISTOGRAM_EXT);
-  glDisable(GL_MINMAX_EXT);
+  if( GLEW_EXT_histogram ) {
+    glDisable(GL_HISTOGRAM_EXT);
+    glDisable(GL_MINMAX_EXT);
+  }
 #endif
 
 #ifdef GL_EXT_texture3D
-  glDisable(GL_TEXTURE_3D_EXT);
+  if( GL_EXT_texture3D ) {
+    glDisable(GL_TEXTURE_3D_EXT);
+  }
 #endif
 
   UCHAR m = m_vSettings.m_colorMask;

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -629,19 +629,25 @@ void RasterPainter::flushRasterImages() {
  * on systems that don't support them: see #591 */
 #if 0
 #ifdef GL_EXT_convolution
-  glDisable(GL_CONVOLUTION_1D_EXT);
-  glDisable(GL_CONVOLUTION_2D_EXT);
-  glDisable(GL_SEPARABLE_2D_EXT);
+  if( GLEW_EXT_convolution ) {
+    glDisable(GL_CONVOLUTION_1D_EXT);
+    glDisable(GL_CONVOLUTION_2D_EXT);
+    glDisable(GL_SEPARABLE_2D_EXT);
+  }
 #endif
 
 #ifdef GL_EXT_histogram
-  glDisable(GL_HISTOGRAM_EXT);
-  glDisable(GL_MINMAX_EXT);
+  if( GLEW_EXT_histogram ) {
+    glDisable(GL_HISTOGRAM_EXT);
+    glDisable(GL_MINMAX_EXT);
+  }
 #endif
 #endif
 
 #ifdef GL_EXT_texture3D
-  glDisable(GL_TEXTURE_3D_EXT);
+  if( GL_EXT_texture3D ) {
+    glDisable(GL_TEXTURE_3D_EXT);
+  }
 #endif
 
   glPushMatrix();


### PR DESCRIPTION
Based on patch by @Teiji-Matsusaka.

Fixes #434. Possibly addresses #2704, too.

The demo below shows me using the preview feature, on a level with a skeleton and effect (Body Highlight) as per the description in #2704. Before applying the patch, using the preview feature on this level would crash OpenToonz due to OpenGL assert errors.

![issue-434-fix-demo](https://user-images.githubusercontent.com/24422213/75633228-09439680-5c68-11ea-9abd-474c35ee1a7b.gif)

This is on Ubuntu 18.04. I recommend testing also on Windows and Mac before merging, in case there are any compile issues.