### PR TITLE
Fix issue with tape tool not drawing after switching via shortcut

### DIFF
--- a/toonz/sources/tnztools/vectortapetool.cpp
+++ b/toonz/sources/tnztools/vectortapetool.cpp
@@ -23,6 +23,7 @@
 #include "tenv.h"
 // For Qt translation support
 #include <QCoreApplication>
+#include <QApplication>
 
 using namespace ToolUtils;
 
@@ -744,6 +745,11 @@ public:
   }
 
   void onActivate() override {
+    // enable drawing if we are in a scene viewer
+    QWidget *focusWidget = QApplication::focusWidget();
+    if (focusWidget && QString(focusWidget->metaObject()->className()) == "SceneViewer")
+      m_draw = true;
+
     if (!m_firstTime) return;
 
     std::wstring s = ::to_wstring(TapeMode.getValue());


### PR DESCRIPTION
Fixes #2190. The tape tool should now draw correctly when switching to it via keyboard shortcut inside the viewer. Demo below:

![issue-2190-fix-demo](https://user-images.githubusercontent.com/24422213/75802728-11bfdc80-5de2-11ea-8b40-f5fbe2a062a3.gif)

Thanks to @shun-iwasawa for the original analysis (in https://github.com/opentoonz/opentoonz/issues/2190#issuecomment-436302870).