### PR TITLE
Improve multi-layer style picker

### DIFF
--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -250,9 +250,22 @@ void Picker::onImage(const Stage::Player &player) {
     if (r) styleId   = r->getStyle();
     if (styleId != 0)
       picked = true;
-    else if (vi->getNearestStroke(point, w, strokeIndex, dist2) &&
-             dist2 < m_minDist2)
-      picked = true;
+    else if (vi->getNearestStroke(point, w, strokeIndex, dist2)) {
+      // based on TTool::Viewer::doPickGuideStroke
+
+      double pixelSize = 1.0; // TODO: Get actual pixel size from viewer.
+      double maxDist   = 5 * pixelSize;
+      double maxDist2  = maxDist * maxDist;
+      double checkDist = maxDist2 * 4;
+
+      TStroke *stroke = vi->getStroke(strokeIndex);
+      TThickPoint thickPoint = stroke->getThickPoint(w);
+      double thickness = thickPoint.thick;
+      double len = thickness * pixelSize * sqrt(m_viewAff.det());
+      checkDist = std::max(checkDist, (len * len));
+      if (dist2 < checkDist)
+        picked = true;
+    }
   } else if (TRasterImageP ri = img) {
     TRaster32P ras = ri->getRaster();
     if (!ras) return;

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -253,7 +253,10 @@ void Picker::onImage(const Stage::Player &player) {
     else if (vi->getNearestStroke(point, w, strokeIndex, dist2)) {
       // based on TTool::Viewer::doPickGuideStroke
 
-      double pixelSize = 1.0; // TODO: Get actual pixel size from viewer.
+      // m_minDist2 seems to be the pixel size to the power 4, so take the
+      // square root of the square root.
+      // Use abs() just in case m_minDist2 is negative, to avoid math errors.
+      double pixelSize = sqrt(sqrt(abs(m_minDist2)));
       double maxDist   = 5 * pixelSize;
       double maxDist2  = maxDist * maxDist;
       double checkDist = maxDist2 * 4;


### PR DESCRIPTION
Fixes #2843. Allows clicking anywhere on a stroke in another layer to pick it -- not just the center.

Demo below:

![style-picker-demo](https://user-images.githubusercontent.com/24422213/76167001-3ba14680-61c8-11ea-9d5e-65bb7adfbb58.gif)

**Still to do**:

* Get the actual pixel size from the viewer, instead of hard-coding it 1.0. Here: https://github.com/opentoonz/opentoonz/blob/01ee1736d95607fcfe1815c1948a18d121fe6667/toonz/sources/toonzlib/stagevisitor.cpp#L256
* Maybe use a shared function instead of copying and pasting the code from `TTool::Viewer::doPickGuideStroke`.

