### PR TITLE
Fix Background Color of Export Level Popup Fails to be Alpha-enabled in Non-English UI

### DIFF
--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -360,7 +360,7 @@ ExportLevelPopup::ExportLevelPopup()
   bool ret = true;
   ret      = connect(tabBar, SIGNAL(currentChanged(int)), stackedWidget,
                 SLOT(setCurrentIndex(int)));
-  ret = connect(m_format, SIGNAL(currentIndexChanged(const QString &)),
+  ret      = connect(m_format, SIGNAL(currentIndexChanged(const QString &)),
                 SLOT(onformatChanged(const QString &))) &&
         ret;
   ret = connect(m_retas, SIGNAL(stateChanged(int)), SLOT(onRetas(int))) && ret;
@@ -501,8 +501,8 @@ void ExportLevelPopup::checkAlpha() {
   for (int i = 0; i < props->getPropertyCount(); ++i) {
     TProperty *p = props->getProperty(i);
 
-    const QString &name = p->getQStringName();
-    const QString &val  = QString::fromStdString(p->getValueAsString());
+    const std::string &name = p->getName();
+    const QString &val      = QString::fromStdString(p->getValueAsString());
 
     if (name == "Bits Per Pixel") {
       withAlpha = (val.contains("32") || val.contains("64"));


### PR DESCRIPTION
This PR fixes the problem as follows:

- In non-English UI, the background color field in the Export Level popup does not become alpha-enabled even if the exported format allows to have transparent background.

When checking whether the format has alpha channel, the property name should be obtained by using `TProperty::getName()` instead of `TProperty::getQStringName()` , since the latter function returns translated string for UI.