### PR TITLE
Fix Crash on Copying Column Connected to Plugin Fx

### DIFF
--- a/toonz/sources/toonzqt/pluginhost.cpp
+++ b/toonz/sources/toonzqt/pluginhost.cpp
@@ -56,7 +56,7 @@ bool PluginLoader::load_entries(const std::string &basepath) {
   if (!aw) {
     aw = new PluginLoadController(basepath, NULL);
   }
-  bool ret    = aw->wait(16 /* ms */);
+  bool ret = aw->wait(16 /* ms */);
   if (ret) aw = NULL; /* deleteLater で消えるはず */
   return ret;
 }
@@ -152,7 +152,7 @@ PluginDescription::PluginDescription(const plugin_probe_t *const probe) {
 }
 
 RasterFxPluginHost::RasterFxPluginHost(PluginInformation *pinfo)
-    : TZeraryFx(), pi_(pinfo), user_data_(nullptr) {
+    : TRasterFx(), pi_(pinfo), user_data_(nullptr) {
   pi_->add_ref();
 }
 

--- a/toonz/sources/toonzqt/pluginhost.h
+++ b/toonz/sources/toonzqt/pluginhost.h
@@ -149,7 +149,7 @@ signals:
   void start(const QString &filepath);
 };
 
-class RasterFxPluginHost final : public TZeraryFx, public TPluginInterface {
+class RasterFxPluginHost final : public TRasterFx, public TPluginInterface {
   PluginInformation *pi_;
 
   std::vector<std::shared_ptr<TFxPort>> inputs_;


### PR DESCRIPTION
This PR fixes a crash problem which can be reproduced by following steps:

-  Load some level to the column 1 and build the fx schematic like as follows;
![plugin_crash](https://user-images.githubusercontent.com/17974955/76392375-c181e500-63b4-11ea-9a32-77593224675b.png)
  In the above example, I used `DWANGO_LightBloom` plugin fx.
- Select the column 1 and try to copy it ( `Ctrl+C` ). OT crashes immediately.

The cause of the crash was that the plugin fx has been wrongly derived from `TZeraryFx` instead of `TRasterFx` .
