### PR TITLE
Preserve gap indicator color when fill check is enabled

### DIFF
--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -744,7 +744,13 @@ static void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
 
   rd.m_palette = plt;
   buildAutocloseImage(vaux, vi, startPoints, endPoints);
+  // temporarily disable fill check, to preserve the gap indicator color
+  bool tCheckEnabledOriginal = rd.m_tcheckEnabled;
+  rd.m_tcheckEnabled = false;
+  // draw
   tglDraw(rd, vaux);
+  // restore original value
+  rd.m_tcheckEnabled = tCheckEnabledOriginal;
   delete vaux;
 }
 


### PR DESCRIPTION
For #514, addresses this issue about the gap check indicators:

> 2. They become black when you enable fill check - considering that you will most probably have gap and fill check enabled together, and that your lineart is likely going to be black - the black color on these lines is not helpful here.
 
This fixes that, making sure they are still magenta even when fill check is enabled. Demo below:

![gap-check-demo](https://user-images.githubusercontent.com/24422213/76455460-9f32aa80-643a-11ea-9417-066a9bd08b21.gif)
