### PR TITLE
Truncate File List in the Popup

### DIFF
--- a/toonz/sources/include/toonz/sceneresources.h
+++ b/toonz/sources/include/toonz/sceneresources.h
@@ -17,6 +17,7 @@
 #endif
 
 #include <QString>
+#include <QSet>
 
 //=============================================================================
 // forward declarations
@@ -112,8 +113,8 @@ If scene is untitled update save path.
 */
   void updatePath(TFilePath &fp);
 
-  virtual bool isDirty()            = 0;
-  virtual QString getResourceName() = 0;
+  virtual bool isDirty()                = 0;
+  virtual QStringList getResourceName() = 0;
 };
 
 //=============================================================================
@@ -157,7 +158,7 @@ Set simple level path to old path.
   }
 
   bool isDirty() override;
-  QString getResourceName() override;
+  QStringList getResourceName() override;
 };
 
 //=============================================================================
@@ -203,7 +204,7 @@ Set simple level path to old path.
   }
 
   bool isDirty() override;
-  QString getResourceName() override;
+  QStringList getResourceName() override;
 };
 
 //=============================================================================
@@ -247,7 +248,7 @@ Set sound track path to old path.
   }
 
   bool isDirty() override { return false; }
-  QString getResourceName() override { return QString(); }
+  QStringList getResourceName() override { return QStringList(); }
 };
 
 //=============================================================================
@@ -316,7 +317,7 @@ If doesn't make \b commit() destroyer calls \b rollbackPaths().
   void accept(ResourceProcessor *processor, bool autoCommit = true);
 
   // return the name list of dirty resources
-  void getDirtyResources(std::vector<QString> &dirtyResources);
+  void getDirtyResources(QStringList &dirtyResources);
 
 private:
   // not implemented

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1202,21 +1202,29 @@ bool IoCmd::saveSceneIfNeeded(QString msg) {
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   if (scene) {
-    std::vector<QString> dirtyResources;
+    QStringList dirtyResources;
     {
       SceneResources resources(scene, 0);
       resources.getDirtyResources(dirtyResources);
     }
 
     if (!dirtyResources.empty()) {
+      // show up to 5 items
+      int extraCount = dirtyResources.count() - 5;
+      if (extraCount > 0) {
+        dirtyResources = dirtyResources.mid(0, 5);
+        dirtyResources.append(
+            QObject::tr("and %1 more item(s).").arg(extraCount));
+      }
+
       QString question;
 
       question = msg + ":" +
                  QObject::tr(" The following file(s) have been modified.\n\n");
-      for (int i = 0; i < dirtyResources.size(); i++) {
-        question += "   " + dirtyResources[i] + "\n";
-      }
-      question += QObject::tr("\nWhat would you like to do? ");
+
+      question += "  " + dirtyResources.join("\n  ");
+
+      question += "\n" + QObject::tr("\nWhat would you like to do? ");
 
       int ret =
           DVGui::MsgBox(question, QObject::tr("Save Changes"),


### PR DESCRIPTION
This PR resolves #3146 
- The file list will be truncated up to 5 items. Items more than 5 will be skipped like `and # more item(s).` 
- `Raster Drawing Palette.tpl` will be united to one item in the list.

![truncated_list_in_popup](https://user-images.githubusercontent.com/17974955/76482947-12e3b000-6459-11ea-84b4-bfc041626c83.png)
