### PR TITLE
Update .gitignore to re-ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ ipch/
 *.creator
 *.files
 *.includes
+
+#macOS
+.DS_Store


### PR DESCRIPTION
This (re)adds GitHub ignoring .DS_Store files that Macs create

Sorry for the mess! It turns out since I'm inexperienced at GitHub, I accidentally undid ignoring .DS_Store files in the PR to make the Plastic Tool icon in the tool bar vector. I think I've got things sorted now, I'm using separate branches which is certainly progress!