### PR TITLE
Curves Fx Enhancement

### DIFF
--- a/toonz/sources/include/toonzqt/fxsettings.h
+++ b/toonz/sources/include/toonzqt/fxsettings.h
@@ -91,7 +91,7 @@ public:
   }
 
   /*- 現在のページの最適なサイズを返す -*/
-  QSize getPreferedSize();
+  QSize getPreferredSize();
 
   void setTextColor(const QColor &color) { m_textColor = color; }
   QColor getTextColor() const { return m_textColor; }
@@ -118,6 +118,11 @@ public:
   TOONZ_DECLARE_NEW_COMPONENT(newComboBox);
 
 #undef TOONZ_DECLARE_NEW_COMPONENT
+
+  // make ParamsPageSet to re-compute preferred size.
+  // currently emitted only from ToneCurveParamField
+signals:
+  void preferredPageSizeChanged();
 };
 
 //=============================================================================
@@ -138,7 +143,7 @@ class DVAPI ParamsPageSet final : public QWidget {
   //! Allows to map page and index, useful to display a macro.
   QMap<ParamsPage *, int> m_pageFxIndexTable;
 
-  QSize m_preferedSize;
+  QSize m_preferredSize;
   /*-- ヘルプのファイルパス（もしあれば）---*/
   std::string m_helpFilePath;
   /*-- pdfファイルのページ指定など、引数が必要な場合の追加引数 --*/
@@ -170,7 +175,7 @@ public:
   ParamsPage *createParamsPage();
   void addParamsPage(ParamsPage *page, const char *name);
 
-  QSize getPreferedSize() { return m_preferedSize; }
+  QSize getPreferredSize() { return m_preferredSize; }
 
 protected:
   void createPage(TIStream &is, const TFxP &fx, int index);
@@ -179,6 +184,7 @@ protected slots:
   void setPage(int);
   void openHelpFile();
   void openHelpUrl();
+  void recomputePreferredSize();
 };
 
 //=============================================================================
@@ -212,6 +218,10 @@ public:
 
   void setPointValue(int index, const TPointD &p);
 
+  void notifyPreferredSizeChanged(QSize size) {
+    emit preferredSizeChanged(size);
+  }
+
 protected:
   ParamsPageSet *getCurrentPageSet() const;
 
@@ -220,7 +230,7 @@ signals:
   void actualFxParamChanged();
   void paramKeyChanged();
 
-  void preferedSizeChanged(QSize);
+  void preferredSizeChanged(QSize);
   void showSwatchButtonToggled(bool);
 };
 
@@ -302,7 +312,7 @@ protected slots:
   void setBlackBg();
   void setCheckboardBg();
 
-  void onPreferedSizeChanged(QSize);
+  void onPreferredSizeChanged(QSize);
   void onShowSwatchButtonToggled(bool);
 };
 

--- a/toonz/sources/include/toonzqt/histogram.h
+++ b/toonz/sources/include/toonzqt/histogram.h
@@ -62,7 +62,8 @@ public:
   void setLogScale(bool onOff) { m_logScale = onOff; }
   bool logScale() const { return m_logScale; }
 
-  void draw(QPainter *painter, QPoint translation = QPoint(0, 0));
+  void draw(QPainter *painter, QPoint translation = QPoint(0, 0),
+            int size = -1);
 
 protected:
   void paintEvent(QPaintEvent *pe) override;
@@ -75,15 +76,22 @@ protected:
 class DVAPI ChannelBar final : public QWidget {
   Q_OBJECT
 
+public:
+  enum Range { Range_0_255, Range_0_1 };
+
+private:
   QColor m_color;
   int m_colorBarLength;
 
   bool m_isHorizontal;
   bool m_drawNumbers;
-  
+
   QColor m_textColor;
-  
+  Range m_range;
+
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
+
+  int m_size;
 
 public:
   ChannelBar(QWidget *parent = 0, QColor m_color = QColor(),
@@ -95,10 +103,14 @@ public:
   void setDrawNumbers(bool onOff);
   bool drawNumbers() const { return m_drawNumbers; }
 
-  void draw(QPainter *painter, QPoint translation = QPoint(0, 0));
+  void draw(QPainter *painter, QPoint translation = QPoint(0, 0),
+            int size = -1);
 
   void setTextColor(const QColor &color) { m_textColor = color; }
   QColor getTextColor() const { return m_textColor; }
+
+  void setLabelRange(Range range) { m_range = range; }
+
 protected:
   void paintEvent(QPaintEvent *event) override;
 };
@@ -135,7 +147,8 @@ public:
   void setValues(const int values[]);
   const QVector<int> &values() const { return m_histogramGraph->values(); }
 
-  void draw(QPainter *painter, QPoint translation = QPoint(0, 0));
+  void draw(QPainter *painter, QPoint translation = QPoint(0, 0),
+            int width = -1);
 };
 
 //=============================================================================

--- a/toonz/sources/include/toonzqt/paramfield.h
+++ b/toonz/sources/include/toonzqt/paramfield.h
@@ -590,7 +590,7 @@ public:
 
   void setParams();
 
-  QSize getPreferedSize() override { return QSize(400, 380); }
+  QSize getPreferedSize() override;
 
 protected slots:
   void onChannelChanged(int);

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -1715,6 +1715,10 @@ ToneCurveParamField::ToneCurveParamField(QWidget *parent, QString name,
   connect(m_keyToggle, SIGNAL(keyToggled()), SLOT(onKeyToggled()));
   connect(m_toneCurveField, SIGNAL(currentChannelIndexChanged(int)),
           SLOT(onChannelChanged(int)));
+  // on enlarged, make the ParamPageSet to recompute the preferred size
+  if (paramsPage)
+    connect(m_toneCurveField, SIGNAL(sizeChanged()), paramsPage,
+            SIGNAL(preferredPageSizeChanged()));
 
   int i;
   for (i = 0; i < m_toneCurveField->getChannelCount(); i++) {
@@ -1760,6 +1764,15 @@ void ToneCurveParamField::setParams() {
   updateKeyToggle();
 
   emit currentParamChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+QSize ToneCurveParamField::getPreferedSize() {
+  if (m_toneCurveField->isEnlarged())
+    return QSize(676, 640);
+  else
+    return QSize(420, 384);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR will improve the Curves Fx . 

<img src="https://user-images.githubusercontent.com/17974955/76984415-270c3d80-6982-11ea-98c3-b44e9cac2347.png" width=500>

- Enabled to stretch handles to any lengths. It can be expanded even to outside of the graph area.
- Handle positions are now displayed and controlled in decimal number.
- Added input fields for displaying and editing the selected point.
- Enabled to enlarge the graph (x2 scaled) for detailed operation.
- Added an option to change the value range from `0-255` to `0.0-1.0` .
- Narrowed the minimum interval between control points from 16 to 4 in order to gain consistency with the one of Adobe Photoshop's tone curve feature.
- Keyboard controls are now changed as follows:
  - **Arrow keys** : move the selected point to each direction by 1 unit.
  - **Shift+Arrow keys** : move the selected point to each direction by 10 units
  - **Ctrl + Right or Left arrow key** : switch the selected point.
- Changed the interpolation method between key frames. Instead of just interpolating position of each point separately, left and right handles are now interpolated in angles and lengths from connected control points.

**NOTICE**
- the `Range` and the `Enlarge` states are not saved in the scene, as it is just for UI settings.
- This PR will replace the existing Curve Fx. The fx created in the previous versions can be loaded in this version and vice versa. Please note that the curve shape may become different especially in animation (i.e. between the key frames), since the interpolation method has been changed.