### PR TITLE
Fix vector brush drawing issue using alt key

### DIFF
--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1333,8 +1333,8 @@ void ToonzVectorBrushTool::checkStrokeSnapping(bool beforeMousePress,
   TVectorImageP vi(getImage(false));
   bool checkSnap = m_snap.getValue();
   if (invertCheck) checkSnap = !checkSnap;
+  m_dragDraw = true;
   if (vi && checkSnap) {
-    m_dragDraw          = true;
     double minDistance2 = m_minDistance2;
     if (beforeMousePress)
       m_strokeIndex1 = -1;


### PR DESCRIPTION
Fixes #2131. The brush no longer gets "stuck" to drawing points using the steps described in the bug report. Video demo below:

![alt-drawing-demo](https://user-images.githubusercontent.com/24422213/77198407-c9c3e800-6b4b-11ea-98ad-35a9b30ff808.gif)

Works for me on Ubuntu 18.04.