### PR TITLE
Add option to disable use of ctrl+alt for changing brush size

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -333,6 +333,9 @@ public:
   int getLevelBasedToolsDisplay() const {
     return getIntValue(levelBasedToolsDisplay);
   }
+  bool useCtrlAltToResizeBrushEnabled() const {
+    return getBoolValue(useCtrlAltToResizeBrush);
+  }
 
   // Xsheet  tab
   QString getXsheetLayoutPreference() const {

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -104,6 +104,7 @@ enum PreferencesItemId {
   cursorBrushStyle,
   cursorOutlineEnabled,
   levelBasedToolsDisplay,
+  useCtrlAltToResizeBrush,
 
   //----------
   // Xsheet

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1788,7 +1788,9 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   TPointD halfThick(thickness * 0.5, thickness * 0.5);
   TRectD invalidateRect(m_brushPos - halfThick, m_brushPos + halfThick);
 
-  if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed()) {
+  if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed() &&
+      Preferences::instance()->useCtrlAltToResizeBrushEnabled()) {
+    // Resize the brush if CTRL+ALT is pressed and the preference is enabled.
     const TPointD &diff = pos - m_mousePos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1281,7 +1281,9 @@ void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   TPointD halfThick(m_maxThick * 0.5, m_maxThick * 0.5);
   TRectD invalidateRect(m_brushPos - halfThick, m_brushPos + halfThick);
 
-  if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed()) {
+  if (e.isCtrlPressed() && e.isAltPressed() && !e.isShiftPressed() &&
+      Preferences::instance()->useCtrlAltToResizeBrushEnabled()) {
+    // Resize the brush if CTRL+ALT is pressed and the preference is enabled.
     const TPointD &diff = pos - m_mousePos;
     double max          = diff.x / 2;
     double min          = diff.y / 2;

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1032,6 +1032,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {cursorBrushStyle, tr("Cursor Style:")},
       {cursorOutlineEnabled, tr("Show Cursor Size Outlines")},
       {levelBasedToolsDisplay, tr("Toolbar Display Behaviour:")},
+      {useCtrlAltToResizeBrush, tr("Use Ctrl+Alt to Resize Brush")},
 
       // Xsheet
       {xsheetLayoutPreference, tr("Column Header Layout*:")},
@@ -1649,6 +1650,7 @@ QWidget* PreferencesPopup::createToolsPage() {
   }
   insertUI(levelBasedToolsDisplay, lay,
            getComboItemList(levelBasedToolsDisplay));
+  insertUI(useCtrlAltToResizeBrush, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -490,6 +490,8 @@ void Preferences::definePreferenceItems() {
   define(cursorOutlineEnabled, "cursorOutlineEnabled", QMetaType::Bool, true);
   define(levelBasedToolsDisplay, "levelBasedToolsDisplay", QMetaType::Int,
          0);  // Default
+  define(useCtrlAltToResizeBrush, "useCtrlAltToResizeBrush",
+         QMetaType::Bool, true);
 
   // Xsheet
   define(xsheetLayoutPreference, "xsheetLayoutPreference", QMetaType::QString,


### PR DESCRIPTION
For #2864. This adds a checkbox to the _Tools_ section in the _Preferences_ window: "Use Ctrl+Alt to Resize Brush". This is checked (on) by default. If you un-check it, the Ctrl+Alt shortcut will not resize the brush when you move the mouse.

Video demo below. Here I am moving the mouse with Ctrl+Alt pressed, before and after un-checking the preference:

![resize-brush-demo](https://user-images.githubusercontent.com/24422213/77256955-3ec32900-6cd6-11ea-86f6-7a0cc752771f.gif)

This hopefully fixes the problem in the issue summary, but there are other shortcut issues mentioned in the comments (https://github.com/opentoonz/opentoonz/issues/2864#issuecomment-547905964), which I haven't addressed.