### PR TITLE
Add auto delete option in cutter tool

### DIFF
--- a/toonz/sources/tnztools/cuttertool.cpp
+++ b/toonz/sources/tnztools/cuttertool.cpp
@@ -324,6 +324,7 @@ public:
     if (vi->getNearestStroke(pos, pW, strokeIndex, dist) && pW >= 0 &&
         pW <= 1) {
       double w;
+      double snapW;
 
       strokeRef = vi->getStroke(strokeIndex);
 
@@ -350,21 +351,29 @@ public:
         w = strokeRef->getParameterAtLength(len);
       }
 
+      snapW = w;
       if (m_snapAtIntersection.getValue()) {
-        w = getNearestSnapAtIntersection(strokeRef, w);
+        snapW = getNearestSnapAtIntersection(strokeRef, w);
       }
 
       std::vector<DoublePair> *sortedWRanges = new std::vector<DoublePair>;
 
       if (strokeRef->isSelfLoop()) {
-        sortedWRanges->push_back(std::make_pair(0, w));
-        sortedWRanges->push_back(std::make_pair(w, 1));
+        sortedWRanges->push_back(std::make_pair(0, snapW));
+        sortedWRanges->push_back(std::make_pair(snapW, 1));
       } else {
-        if (w == 0 || w == 1)
+        if (snapW == 0 || snapW == 1)
           sortedWRanges->push_back(std::make_pair(0, 1));
         else {
-          sortedWRanges->push_back(std::make_pair(0, w));
-          sortedWRanges->push_back(std::make_pair(w, 1));
+          if (snapW != w && m_autoDelete.getValue()) {
+            if (snapW < w)
+              sortedWRanges->push_back(std::make_pair(0, snapW));
+            else
+              sortedWRanges->push_back(std::make_pair(snapW, 1));
+          } else {
+            sortedWRanges->push_back(std::make_pair(0, snapW));
+            sortedWRanges->push_back(std::make_pair(snapW, 1));
+          }
         }
       }
 

--- a/toonz/sources/tnztools/cuttertool.cpp
+++ b/toonz/sources/tnztools/cuttertool.cpp
@@ -25,6 +25,7 @@
 using namespace ToolUtils;
 
 TEnv::IntVar SnapAtIntersection("CutterToolSnapAtIntersection", 0);
+TEnv::IntVar AutoDelete("CutterToolAutoDelete", 0);
 
 //=============================================================================
 namespace {
@@ -166,15 +167,20 @@ public:
 
   TPropertyGroup m_prop;
   TBoolProperty m_snapAtIntersection;
+  TBoolProperty m_autoDelete;
 
   CutterTool()
       : TTool("T_Cutter")
       , m_mouseDown(false)
       , m_cursorId(ToolCursor::CutterCursor)
-      , m_snapAtIntersection("Snap At Intersection", false) {
+      , m_snapAtIntersection("Snap At Intersection", false)
+      , m_autoDelete("Auto delete", false) {
     bind(TTool::VectorImage);
     m_prop.bind(m_snapAtIntersection);
+    m_prop.bind(m_autoDelete);
+
     m_snapAtIntersection.setId("Snap");
+    m_autoDelete.setId("AutoDelete");
   }
 
   ToolType getToolType() const override { return TTool::LevelWriteTool; }
@@ -428,6 +434,7 @@ public:
 
   void onActivate() override {
     m_snapAtIntersection.setValue(SnapAtIntersection ? 1 : 0);
+    m_autoDelete.setValue(AutoDelete ? 1 : 0);
   }
   void onEnter() override {
     if ((TVectorImageP)getImage(false))
@@ -444,12 +451,19 @@ public:
 
   void updateTranslation() override {
     m_snapAtIntersection.setQStringName(QObject::tr("Snap At Intersection"));
+    m_autoDelete.setQStringName(QObject::tr("Auto Delete"));
   }
 
   TPropertyGroup *getProperties(int targetType) override { return &m_prop; }
 
   bool onPropertyChanged(std::string propertyName) override {
+    if (propertyName == m_snapAtIntersection.getName()) {
+      if (!m_snapAtIntersection.getValue()) m_autoDelete.setValue(false);
+    } else if (propertyName == m_autoDelete.getName()) {
+      if (m_autoDelete.getValue()) m_snapAtIntersection.setValue(true);
+    }
     SnapAtIntersection = (int)(m_snapAtIntersection.getValue());
+    AutoDelete         = (int)(m_autoDelete.getValue());
     return true;
   }
 


### PR DESCRIPTION
video https://youtu.be/RvMJdPBsA-c

The reference picture is from: https://youtu.be/iT_oMHF8Bs0?t=336.

this PR allows cutter tool to automatically remove stroke that is closer to the mouse when cutting at intersection. 

This almost always works. However, as shown in the video, if the intersection looks like this:
![a](https://user-images.githubusercontent.com/60221547/77483789-e9dff980-6e20-11ea-8386-02cac80d17aa.png)
It may not detect it as an intersection. A workaround for this is to disable auto remove and remove them yourself.

"remove vector overflow" does it by checking edge list. However, from what I see, edge list only works in closed area and thus, I wasn't able to adapt it to the cutter tool.

I wish someone could take this and improve upon it so that it always works.