### PR TITLE
Update macOS build steps

### DIFF
--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -1,5 +1,5 @@
 
-# Setting Up the Development Environment on MacOSX
+# Setting Up the Development Environment on macOS
 
 ## Necessary Software
 
@@ -10,10 +10,10 @@
 - Qt (5.9.2 or later)
 - boost (1.55.0 or later)
 
-## Building on MacOSX
+## Building on macOS
 ### Download boost from https://boost.org
 
-Download the .bz2 mac (unix if mac not specified) version 1_55_0 or later (last tested with 1_69_0)
+Download the .bz2 mac (unix if mac not specified) version 1_55_0 or later (last tested with 1_72_0)
 
 Save for later step.
 
@@ -46,6 +46,13 @@ $ git lfs install
 NOTE: This will install the latest version of QT which may not be compatible with older OS versions.
 
 If you cannot use the most recent version, download the online installer from https://www.qt.io/download and install the appropriate `macOS` version (min 5.9.2).  If installing via this method, be sure to install the `Qt Script (Deprecated)` libraries.
+
+### Remove incompatible symbolic directory
+Check to see if this symbolic glew directory exists. If so, remove it:
+```
+$ ls -l /usr/local/lib/cmake/glew
+$ rm /usr/local/lib/cmake/glew
+```
 
 ### Set up OpenToonz repository
 

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -32,7 +32,7 @@ Check site for any changes in installation instructions, but they will probably 
 1. Open a Terminal window
 2. Execute the following statement:
 ```
-$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
 ### Install required software using brew


### PR DESCRIPTION
This adds a step to remove an incompatible directory, updates the name to macOS and lists the last tested boost version as 1_72_0.