### PR TITLE
Modify "Save Images" Command

### DIFF
--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -163,34 +163,33 @@ inline TRectD getImageBoundsD(const TImageP &img) {
 FlipBook::FlipBook(QWidget *parent, QString viewerTitle,
                    std::vector<int> flipConsoleButtonMask, UCHAR flags,
                    bool isColorModel)  //, bool showOnlyPlayBackgroundButton)
-    : QWidget(parent),
-      m_viewerTitle(viewerTitle),
-      m_levelNames(),
-      m_levels(),
-      m_playSound(false),
-      m_snd(0),
-      m_player(0)
-      //, m_doCompare(false)
-      ,
-      m_currentFrameToSave(0),
-      m_lw(),
-      m_lr(),
-      m_loadPopup(0),
-      m_savePopup(0),
-      m_shrink(1),
-      m_isPreviewFx(false),
-      m_previewedFx(0),
-      m_previewXsh(0),
-      m_previewUpdateTimer(this),
-      m_xl(0),
-      m_title1(),
-      m_poolIndex(-1),
-      m_freezed(false),
-      m_loadbox(),
-      m_dim(),
-      m_loadboxes(),
-      m_freezeButton(0),
-      m_flags(flags) {
+    : QWidget(parent)
+    , m_viewerTitle(viewerTitle)
+    , m_levelNames()
+    , m_levels()
+    , m_playSound(false)
+    , m_snd(0)
+    , m_player(0)
+    //, m_doCompare(false)
+    , m_currentFrameToSave(0)
+    , m_lw()
+    , m_lr()
+    , m_loadPopup(0)
+    , m_savePopup(0)
+    , m_shrink(1)
+    , m_isPreviewFx(false)
+    , m_previewedFx(0)
+    , m_previewXsh(0)
+    , m_previewUpdateTimer(this)
+    , m_xl(0)
+    , m_title1()
+    , m_poolIndex(-1)
+    , m_freezed(false)
+    , m_loadbox()
+    , m_dim()
+    , m_loadboxes()
+    , m_freezeButton(0)
+    , m_flags(flags) {
   setAcceptDrops(true);
   setFocusPolicy(Qt::StrongFocus);
 
@@ -465,7 +464,7 @@ bool LoadImagesPopup::execute() { return doLoad(false); }
 
 //-----------------------------------------------------------------------------
 /*! Append images with apply button
-*/
+ */
 bool LoadImagesPopup::executeApply() { return doLoad(true); }
 
 //-----------------------------------------------------------------------------
@@ -575,7 +574,11 @@ void FlipBook::saveImages() {
                               ->getScene()
                               ->getProperties()
                               ->getOutputProperties();
-  m_savePopup->setFolder(op->getPath().getParentDir());
+  m_savePopup->setFolder(TApp::instance()
+                             ->getCurrentScene()
+                             ->getScene()
+                             ->decodeFilePath(op->getPath())
+                             .getParentDir());
   m_savePopup->setFilename(op->getPath().withFrame().withoutParentDir());
 
   m_savePopup->show();
@@ -1098,7 +1101,7 @@ void FlipBook::setLevel(const TFilePath &fp, TPalette *palette, int from,
         fromIndex = level->begin()->first.getNumber();
         toIndex   = (--level->end())->first.getNumber();
         if (m_imageViewer->isColorModel())
-          current           = m_flipConsole->getCurrentFrame();
+          current = m_flipConsole->getCurrentFrame();
         incrementalIndexing = true;
       } else {
         TLevel::Iterator it = level->begin();
@@ -1136,10 +1139,9 @@ void FlipBook::setLevel(const TFilePath &fp, TPalette *palette, int from,
       levelToPush.m_incrementalIndexing = incrementalIndexing;
 
       int formatIdx = Preferences::instance()->matchLevelFormat(fp);
-      if (formatIdx >= 0 &&
-          Preferences::instance()
-              ->levelFormat(formatIdx)
-              .m_options.m_premultiply) {
+      if (formatIdx >= 0 && Preferences::instance()
+                                ->levelFormat(formatIdx)
+                                .m_options.m_premultiply) {
         levelToPush.m_premultiply = true;
       }
 
@@ -1655,7 +1657,7 @@ else*/
 //-----------------------------------------------------------------------------
 
 /*! Set current level frame to image viewer. Add the view image in cache.
-*/
+ */
 void FlipBook::onDrawFrame(int frame, const ImagePainter::VisualSettings &vs) {
   try {
     m_imageViewer->setVisual(vs);
@@ -2141,7 +2143,7 @@ void FlipBook::minimize(bool doMinimize) {
 */
 void FlipBook::loadAndCacheAllTlvImages(Level level, int fromFrame,
                                         int toFrame) {
-  TFilePath fp                                   = level.m_fp;
+  TFilePath fp = level.m_fp;
   if (!m_lr || (fp != m_lr->getFilePath())) m_lr = TLevelReaderP(fp);
   if (!m_lr) return;
 
@@ -2218,7 +2220,7 @@ FlipBook *viewFile(const TFilePath &path, int from, int to, int step,
   if (step == -1 || shrink == -1) {
     int _step = 1, _shrink = 1;
     Preferences::instance()->getViewValues(_shrink, _step);
-    if (step == -1) step     = _step;
+    if (step == -1) step = _step;
     if (shrink == -1) shrink = _shrink;
   }
 

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -301,10 +301,6 @@ void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
     menu->addAction(action);
     action->setParent(m_flipbook);
 
-    if (m_flipbook->isSavable()) {
-      action = menu->addAction(tr("Save Images"));
-      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(saveImages()));
-    }
     menu->addSeparator();
   }
 
@@ -345,9 +341,18 @@ void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
     }
 
     if (m_visualSettings.m_doCompare) {
-      if (!addedSep) menu->addSeparator();
+      if (!addedSep) {
+        menu->addSeparator();
+        addedSep = true;
+      }
       action = menu->addAction(tr("Swap Compared Images"));
       connect(action, SIGNAL(triggered()), SLOT(swapCompared()));
+    }
+
+    if (m_flipbook->isSavable()) {
+      if (!addedSep) menu->addSeparator();
+      action = menu->addAction(tr("Save Images"));
+      connect(action, SIGNAL(triggered()), m_flipbook, SLOT(saveImages()));
     }
   }
 


### PR DESCRIPTION
This PR modifies the "Save Images" command, which is in right mouse button menu of the flipbook panel.

- Fixed an initial folder path of the browser popup to be decoded ( i.e. convert alias like "+outputs" to regular file path ) so that the browser opens properly.
- Moved the command from under the "Load / Append Images" command to the bottommost of the menu in order to avoid being clicked by mistake when users would like to load something.