### PR TITLE
Enable Ink #1 Check for vector levels in the viewer

### DIFF
--- a/toonz/sources/common/tvrender/tglregions.cpp
+++ b/toonz/sources/common/tvrender/tglregions.cpp
@@ -452,6 +452,13 @@ void tglDraw(const TVectorRenderData &rd, const TStroke *s, bool pushAttribs) {
       redColor->addRef();
       redColor->setMainColor(TPixel::Red);
       style = redColor;
+    } else if (rd.m_ink1CheckEnabled && s->getStyle() == 1) {
+      // Ink #1 Check.
+      // Could possibly merge with above.
+      static TSolidColorStyle *redColor = new TSolidColorStyle();
+      redColor->addRef();
+      redColor->setMainColor(TPixel::Red);
+      style = redColor;
     } else if (rd.m_tcheckEnabled) {
       static TSolidColorStyle *color = new TSolidColorStyle();
       color->addRef();

--- a/toonz/sources/include/tvectorrenderdata.h
+++ b/toonz/sources/include/tvectorrenderdata.h
@@ -73,6 +73,7 @@ public:
       m_drawRegions,        //!< Inks only mode.
       m_tcheckEnabled,      //!< Transparency check mode.
       m_inkCheckEnabled,    //!< Ink check mode.
+      m_ink1CheckEnabled,   //!< Ink #1 check mode.
       m_paintCheckEnabled,  //!< Paint check mode.
       m_blackBgEnabled,     //!< Black background mode.
       m_isIcon,             //!< Whether image rendering is for an icon.
@@ -108,6 +109,7 @@ public:
       , m_drawRegions(true)      // Paint regions painted
       , m_tcheckEnabled(false)   // No checks
       , m_inkCheckEnabled(false)
+      , m_ink1CheckEnabled(false)
       , m_paintCheckEnabled(false)
       , m_blackBgEnabled(false)
       , m_isIcon(false)    // Not an icon by default
@@ -140,6 +142,7 @@ public:
       , m_drawRegions(true)      // Paint regions painted
       , m_tcheckEnabled(false)   // No checks
       , m_inkCheckEnabled(false)
+      , m_ink1CheckEnabled(false)
       , m_paintCheckEnabled(false)
       , m_blackBgEnabled(false)
       , m_isIcon(false)             // Not an icon by default
@@ -169,6 +172,7 @@ public:
       , m_drawRegions(other.m_drawRegions)
       , m_tcheckEnabled(other.m_tcheckEnabled)
       , m_inkCheckEnabled(other.m_inkCheckEnabled)
+      , m_ink1CheckEnabled(other.m_ink1CheckEnabled)
       , m_paintCheckEnabled(other.m_paintCheckEnabled)
       , m_blackBgEnabled(other.m_blackBgEnabled)
       , m_isIcon(other.m_isIcon)
@@ -200,6 +204,7 @@ public:
       , m_drawRegions(true)
       , m_tcheckEnabled(false)
       , m_inkCheckEnabled(false)
+      , m_ink1CheckEnabled(false)
       , m_paintCheckEnabled(false)
       , m_blackBgEnabled(false)
       , m_isIcon(false)

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -869,6 +869,7 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
 
   rd.m_drawRegions           = !inksOnly;
   rd.m_inkCheckEnabled       = tc & ToonzCheck::eInk;
+  rd.m_ink1CheckEnabled      = tc & ToonzCheck::eInk1;
   rd.m_paintCheckEnabled     = tc & ToonzCheck::ePaint;
   rd.m_blackBgEnabled        = tc & ToonzCheck::eBlackBg;
   rd.m_colorCheckIndex       = ToonzCheck::instance()->getColorIndex();


### PR DESCRIPTION
When I enabled "View --> Ink#1 Check" on a vector level, it would not highlight the ink for Style number 1 in the viewer. (It would do so in the thumbnail, though, if the thumbnail was refreshed by e.g. drawing another line.) 

This PR makes the Ink#1 Check work in the viewer for vector levels. Demo below:

![ink1-check-demo](https://user-images.githubusercontent.com/24422213/77838337-9c241200-71cf-11ea-9947-a222f3ff9a8c.gif)
