### PR TITLE
Force all thumbnail icons to refresh when toggling Paint Check

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -297,6 +297,16 @@ void invalidateIcons() {
   s.m_paintIndex = mask & ToonzCheck::ePaint ? tc->getColorIndex() : -1;
   IconGenerator::instance()->setSettings(s);
 
+   // Force icons to refresh
+  TXshLevel *sl = TApp::instance()->getCurrentLevel()->getLevel();
+  if (sl) {
+    std::vector<TFrameId> fids;
+    sl->getFids(fids);
+
+    for (int i = 0; i < (int)fids.size(); i++)
+      IconGenerator::instance()->invalidate(sl, fids[i]);
+  }
+
   // Do not remove icons here as they will be re-used for updating icons in the
   // level strip
 


### PR DESCRIPTION
Fixes #1122. All thumbnail icons in the film strip are now refreshed when toggling Paint Check. They are also refreshed when toggling the other checks in the view menu (Ink Check, Black Bkg Check, etc.)

Demo below before the fix:

![thumbnail-demo-before](https://user-images.githubusercontent.com/24422213/77849847-20f04980-722b-11ea-871e-54cbfe012842.gif)

After the fix:

![thumbnail-demo-after](https://user-images.githubusercontent.com/24422213/77849850-251c6700-722b-11ea-8db2-9b120775d2f3.gif)

I recommend testing with a large scene with a lot of frames to see that this doesn't cause any slowdown. It seems to go quickly for me.