### PR TITLE
Improve Browser up button

### DIFF
--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -2196,7 +2196,14 @@ void FileBrowser::refresh() {
 
 void FileBrowser::folderUp() {
   QModelIndex index = m_folderTreeView->currentIndex();
-  if (!index.isValid() || !index.parent().isValid()) return;
+  if (!index.isValid() || !index.parent().isValid()) {
+    // cannot go up tree view, so try going to parent directory
+    TFilePath parentFp = m_folder.getParentDir();
+    if (parentFp != TFilePath("") && parentFp != m_folder) {
+      setFolder(parentFp, true);
+    }
+    return;
+  }
   m_folderTreeView->setCurrentIndex(index.parent());
   m_folderTreeView->scrollTo(index.parent());
 }


### PR DESCRIPTION
When using the Load Scene dialog (or other dialogs), the "Up" button sometimes would not go to the parent directory. It seems to only go up if the parent folder exists in the tree-view on the left.

This PR makes it always go to the parent directory if possible.

Demo before the fix below. Note how it gets "stuck" at the "sandbox" folder and does not go up any further:

![browser-up-button-before](https://user-images.githubusercontent.com/24422213/77940042-8f5d0680-7314-11ea-8b8e-310ac7a08360.gif)

Demo after:

![browser-up-demo](https://user-images.githubusercontent.com/24422213/77940063-971cab00-7314-11ea-9974-2a2383eb7bcf.gif)

