### PR TITLE
Allow loading levels/images with numeric names

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -606,8 +606,7 @@ std::string TFilePath::getLevelName() const {
 }
 
 //-----------------------------------------------------------------------------
-// es. TFilePath("/pippo/pluto.0001.tif").getLevelName() == "pluto..tif"
-// es. TFilePath("/pippo/0001.tif").getLevelName() == "0001.tif"
+// es. TFilePath("/pippo/pluto.0001.gif").getLevelName() == "pluto..gif"
 
 std::wstring TFilePath::getLevelNameW() const {
   int i            = getLastSlash(m_path);  // cerco l'ultimo slash
@@ -623,7 +622,8 @@ std::wstring TFilePath::getLevelNameW() const {
   if (j == i || j - i == 1)  // prova.tif o prova..tif
     return str;
 
-  if (!checkForSeqNum(type) || !isNumbers(str, i, j) || i == -1) return str;
+  if (!checkForSeqNum(type) || !isNumbers(str, i, j) ||
+      i == (int)std::wstring::npos) return str;
   // prova.0001.tif
   return str.erase(i + 1, j - i - 1);
 }

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -606,7 +606,8 @@ std::string TFilePath::getLevelName() const {
 }
 
 //-----------------------------------------------------------------------------
-// es. TFilePath("/pippo/pluto.0001.gif").getLevelName() == "pluto..gif"
+// es. TFilePath("/pippo/pluto.0001.tif").getLevelName() == "pluto..tif"
+// es. TFilePath("/pippo/0001.tif").getLevelName() == "0001.tif"
 
 std::wstring TFilePath::getLevelNameW() const {
   int i            = getLastSlash(m_path);  // cerco l'ultimo slash
@@ -622,7 +623,7 @@ std::wstring TFilePath::getLevelNameW() const {
   if (j == i || j - i == 1)  // prova.tif o prova..tif
     return str;
 
-  if (!checkForSeqNum(type) || !isNumbers(str, i, j)) return str;
+  if (!checkForSeqNum(type) || !isNumbers(str, i, j) || i == -1) return str;
   // prova.0001.tif
   return str.erase(i + 1, j - i - 1);
 }


### PR DESCRIPTION
Fixes #2945. Video demo below - here I select images with name "1a.png" and "1234.png", and the filename is loaded correctly in the Load Level dialog:

![numeric-filename-demo](https://user-images.githubusercontent.com/24422213/78120274-1f5e9580-7466-11ea-9354-0598ffcdf206.gif)

I tested a sequence, too ("series.0001", "series.0002") - also works fine, still.