### PR TITLE
Add shortcut to eraser modes

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2452,6 +2452,7 @@ void MainWindow::toggleEraserNormal() {
 
 void MainWindow::toggleEraserRectangular() {
   CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_Type:Rectangular")
       ->trigger();
@@ -2459,6 +2460,7 @@ void MainWindow::toggleEraserRectangular() {
 
 void MainWindow::toggleEraserFreehand() {
   CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_Type:Freehand")
       ->trigger();
@@ -2466,6 +2468,7 @@ void MainWindow::toggleEraserFreehand() {
 
 void MainWindow::toggleEraserPolyline() {
   CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_Type:Polyline")
       ->trigger();
@@ -2473,6 +2476,7 @@ void MainWindow::toggleEraserPolyline() {
 
 void MainWindow::toggleEraserSegment() {
   CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Type:Segment")->trigger();
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -450,6 +450,14 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_PickStyleAreas, this, &MainWindow::togglePickStyleAreas);
   setCommandHandler(MI_PickStyleLines, this, &MainWindow::togglePickStyleLines);
 
+  /*-- Eraser Tool modes --*/
+  setCommandHandler(MI_EraserNormal, this, &MainWindow::toggleEraserNormal);
+  setCommandHandler(MI_EraserRectangular, this,
+                    &MainWindow::toggleEraserRectangular);
+  setCommandHandler(MI_EraserFreehand, this, &MainWindow::toggleEraserFreehand);
+  setCommandHandler(MI_EraserPolyline, this, &MainWindow::toggleEraserPolyline);
+  setCommandHandler(MI_EraserSegment, this, &MainWindow::toggleEraserSegment);
+
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_OpenOnlineManual, this, &MainWindow::onOpenOnlineManual);
   setCommandHandler(MI_OpenWhatsNew, this, &MainWindow::onOpenWhatsNew);
@@ -2314,6 +2322,8 @@ void MainWindow::defineActions() {
                           "");
   createToolOptionsAction("A_ToolOption_Type:Polyline", tr("Type - Polyline"),
                           "");
+  createToolOptionsAction("A_ToolOption_Type:Segment", tr("Type - Segment"),
+                          "");
   createToolOptionsAction("A_ToolOption_TypeFont", tr("TypeTool Font"), "");
   createToolOptionsAction("A_ToolOption_TypeSize", tr("TypeTool Size"), "");
   createToolOptionsAction("A_ToolOption_TypeStyle", tr("TypeTool Style"), "");
@@ -2360,6 +2370,18 @@ void MainWindow::defineActions() {
   createAction(MI_PickStyleAreas, tr("Style Picker Tool - Areas"), "",
                ToolCommandType);
   createAction(MI_PickStyleLines, tr("Style Picker Tool - Lines"), "",
+               ToolCommandType);
+
+  /*-- Eraser Tool modes --*/
+  createAction(MI_EraserNormal, tr("Eraser Tool - Normal"), "",
+               ToolCommandType);
+  createAction(MI_EraserRectangular, tr("Eraser Tool - Rectangular"), "",
+               ToolCommandType);
+  createAction(MI_EraserFreehand, tr("Eraser Tool - Freehand"), "",
+               ToolCommandType);
+  createAction(MI_EraserPolyline, tr("Eraser Tool - Polyline"), "",
+               ToolCommandType);
+  createAction(MI_EraserSegment, tr("Eraser Tool - Segment"), "",
                ToolCommandType);
 
   createMiscAction("A_FxSchematicToggle", tr("Toggle FX/Stage schematic"), "");
@@ -2419,6 +2441,39 @@ void MainWindow::togglePickStyleAreas() {
 void MainWindow::togglePickStyleLines() {
   CommandManager::instance()->getAction(T_StylePicker)->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Mode:Lines")->trigger();
+}
+
+//---------------------------------------------------------------------------------------
+/*-- eraser tool modes --*/
+void MainWindow::toggleEraserNormal() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+}
+
+void MainWindow::toggleEraserRectangular() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Rectangular")
+      ->trigger();
+}
+
+void MainWindow::toggleEraserFreehand() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Freehand")
+      ->trigger();
+}
+
+void MainWindow::toggleEraserPolyline() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Polyline")
+      ->trigger();
+}
+
+void MainWindow::toggleEraserSegment() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Segment")->trigger();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -112,6 +112,12 @@ public:
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   void togglePickStyleAreas();
   void togglePickStyleLines();
+  /*-- eraser tool modes --*/
+  void toggleEraserNormal();
+  void toggleEraserRectangular();
+  void toggleEraserFreehand();
+  void toggleEraserPolyline();
+  void toggleEraserSegment();
   void onNewVectorLevelButtonPressed();
   void onNewToonzRasterLevelButtonPressed();
   void onNewRasterLevelButtonPressed();

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -340,6 +340,12 @@
 #define MI_PickStyleAreas "MI_PickStyleAreas"
 #define MI_PickStyleLines "MI_PickStyleLines"
 
+#define MI_EraserNormal "MI_EraserNormal"
+#define MI_EraserRectangular "MI_EraserRectangular"
+#define MI_EraserFreehand "MI_EraserFreehand"
+#define MI_EraserPolyline "MI_EraserPolyline"
+#define MI_EraserSegment "MI_EraserSegment"
+
 #define MI_DeactivateUpperColumns "MI_DeactivateUpperColumns"
 #define MI_CompareToSnapshot "MI_CompareToSnapshot"
 #define MI_PreviewFx "MI_PreviewFx"


### PR DESCRIPTION
this PR allows you to assign shortcuts to eraser modes.

![a](https://user-images.githubusercontent.com/60221547/78136147-aa15a500-7412-11ea-90fd-3afa58facf68.png)

In the code, I had to make it switch to normal then to the respective mode. Without doing so, it will switch back to normal mode if it's already in that mode. e.g. user press freehand shortcut -> switch to eraser freehand mode -> user presses it again -> switch to eraser normal mode.

Tried to find the root cause but to no avail. Well, this workaround works.