### PR TITLE
Enable context menu on workspace for tablet on Linux

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -307,6 +307,15 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       m_tabletEvent = false;
 #endif
 
+#ifdef LINUX
+    // for Linux, create context menu on right click here.
+    // could possibly merge with OSX code above
+    if(e->button() == Qt::RightButton) {
+      m_mouseButton = Qt::NoButton;
+      onContextMenu(e->pos(), e->globalPos());
+    }
+#endif
+
   } break;
   case QEvent::TabletRelease: {
 #ifdef MACOSX


### PR DESCRIPTION
Fixes #1790. For Linux: Right-clicking on the viewer using a drawing tablet now creates the context menu (like the mouse does). Works for me using a Wacom Intuos 4 tablet on Ubuntu 18.04. Video demo below:

![context-menu-demo](https://user-images.githubusercontent.com/24422213/78215455-057b8c00-7514-11ea-9b14-c1a85a3fb422.gif)

If anyone else using Linux can test this, please let me know if it works for you.
