### PR TITLE
Fix build on vs 2019

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -462,7 +462,7 @@ void TSystem::readDirectory_DirItems(QStringList &dst, const TFilePath &path) {
 #ifdef _WIN32
   // equivalent to sorting with QDir::LocaleAware
   struct strCompare {
-    bool operator()(const QString &s1, const QString &s2) {
+    bool operator()(const QString &s1, const QString &s2) const {
       return QString::localeAwareCompare(s1, s2) < 0;
     }
   };


### PR DESCRIPTION
This allows an error free build with VS 2019.

Note:
I am also using Qt 5.9.9 and Boost 1.72