### PR TITLE
Expand tool-switching shortcuts

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -452,6 +452,16 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_EditCenter, this, &MainWindow::toggleEditNextCenter);
   setCommandHandler(MI_EditAll, this, &MainWindow::toggleEditNextAll);
 
+  /*-- Selection tool + mode switching shortcuts --*/
+  setCommandHandler(MI_SelectionNextMode, this,
+                    &MainWindow::toggleSelectionNextMode);
+  setCommandHandler(MI_SelectionRectangular, this,
+                    &MainWindow::toggleSelectionRectangular);
+  setCommandHandler(MI_SelectionFreehand, this,
+                    &MainWindow::toggleSelectionFreehand);
+  setCommandHandler(MI_SelectionPolyline, this,
+                    &MainWindow::toggleSelectionPolyline);
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   setCommandHandler(MI_FillAreas, this, &MainWindow::toggleFillAreas);
   setCommandHandler(MI_FillLines, this, &MainWindow::toggleFillLines);
@@ -2372,6 +2382,16 @@ void MainWindow::defineActions() {
   createAction(MI_EditCenter, tr("Animate Tool - Center"), "", ToolCommandType);
   createAction(MI_EditAll, tr("Animate Tool - All"), "", ToolCommandType);
 
+  /*-- Selection tool + mode switching shortcuts --*/
+  createAction(MI_SelectionNextMode, tr("Selection Tool - Next Mode"), "",
+               ToolCommandType);
+  createAction(MI_SelectionRectangular, tr("Selection Tool - Rectangular"), "",
+               ToolCommandType);
+  createAction(MI_SelectionFreehand, tr("Selection Tool - Freehand"), "",
+               ToolCommandType);
+  createAction(MI_SelectionPolyline, tr("Selection Tool - Polyline"), "",
+               ToolCommandType);
+
   /*-- FillAreas, FillLinesにキー1つで切り替えるためのコマンド --*/
   createAction(MI_FillAreas, tr("Fill Tool - Areas"), "", ToolCommandType);
   createAction(MI_FillLines, tr("Fill Tool - Lines"), "", ToolCommandType);
@@ -2467,6 +2487,36 @@ void MainWindow::toggleEditNextAll() {
   CommandManager::instance()->getAction(T_Edit)->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_EditToolActiveAxis:All")
+      ->trigger();
+}
+
+//---------------------------------------------------------------------------------------
+/*-- Selection tool + mode switching shortcuts --*/
+void MainWindow::toggleSelectionNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Selection)
+    CommandManager::instance()->getAction("A_ToolOption_Type")->trigger();
+  else
+    CommandManager::instance()->getAction(T_Selection)->trigger();
+}
+
+void MainWindow::toggleSelectionRectangular() {
+  CommandManager::instance()->getAction(T_Selection)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Rectangular")
+      ->trigger();
+}
+
+void MainWindow::toggleSelectionFreehand() {
+  CommandManager::instance()->getAction(T_Selection)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Freehand")
+      ->trigger();
+}
+
+void MainWindow::toggleSelectionPolyline() {
+  CommandManager::instance()->getAction(T_Selection)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Polyline")
       ->trigger();
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -478,6 +478,14 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_GeometricPolygon, this,
                     &MainWindow::toggleGeometricPolygon);
 
+  /*-- Type tool + mode switching shortcuts --*/
+  setCommandHandler(MI_TypeNextMode, this, &MainWindow::toggleTypeNextMode);
+  setCommandHandler(MI_TypeOblique, this, &MainWindow::toggleTypeOblique);
+  setCommandHandler(MI_TypeRegular, this, &MainWindow::toggleTypeRegular);
+  setCommandHandler(MI_TypeBoldOblique, this,
+                    &MainWindow::toggleTypeBoldOblique);
+  setCommandHandler(MI_TypeBold, this, &MainWindow::toggleTypeBold);
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   setCommandHandler(MI_FillAreas, this, &MainWindow::toggleFillAreas);
   setCommandHandler(MI_FillLines, this, &MainWindow::toggleFillLines);
@@ -2366,6 +2374,14 @@ void MainWindow::defineActions() {
   createToolOptionsAction("A_ToolOption_TypeFont", tr("TypeTool Font"), "");
   createToolOptionsAction("A_ToolOption_TypeSize", tr("TypeTool Size"), "");
   createToolOptionsAction("A_ToolOption_TypeStyle", tr("TypeTool Style"), "");
+  createToolOptionsAction("A_ToolOption_TypeStyle:Oblique",
+                          tr("TypeTool Style - Oblique"), "");
+  createToolOptionsAction("A_ToolOption_TypeStyle:Regular",
+                          tr("TypeTool Style - Regular"), "");
+  createToolOptionsAction("A_ToolOption_TypeStyle:Bold Oblique",
+                          tr("TypeTool Style - Bold Oblique"), "");
+  createToolOptionsAction("A_ToolOption_TypeStyle:Bold",
+                          tr("TypeTool Style - Bold"), "");
 
   createToolOptionsAction("A_ToolOption_EditToolActiveAxis", tr("Active Axis"),
                           "");
@@ -2439,6 +2455,15 @@ void MainWindow::defineActions() {
                ToolCommandType);
   createAction(MI_GeometricPolygon, tr("Geometric Tool - Polygon"), "",
                ToolCommandType);
+
+  /*-- Type tool + mode switching shortcuts --*/
+  createAction(MI_TypeNextMode, tr("Type Tool - Next Mode"), "",
+               ToolCommandType);
+  createAction(MI_TypeOblique, tr("Type Tool - Oblique"), "", ToolCommandType);
+  createAction(MI_TypeRegular, tr("Type Tool - Regular"), "", ToolCommandType);
+  createAction(MI_TypeBoldOblique, tr("Type Tool - Bold Oblique"), "",
+               ToolCommandType);
+  createAction(MI_TypeBold, tr("Type Tool - Bold"), "", ToolCommandType);
 
   /*-- FillAreas, FillLinesにキー1つで切り替えるためのコマンド --*/
   createAction(MI_FillAreas, tr("Fill Tool - Areas"), "", ToolCommandType);
@@ -2625,6 +2650,42 @@ void MainWindow::toggleGeometricPolygon() {
   CommandManager::instance()->getAction(T_Geometric)->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_GeometricShape:Polygon")
+      ->trigger();
+}
+//---------------------------------------------------------------------------------------
+/*-- Type tool + mode switching shortcuts --*/
+void MainWindow::toggleTypeNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Type)
+    CommandManager::instance()->getAction("A_ToolOption_TypeStyle")->trigger();
+  else
+    CommandManager::instance()->getAction(T_Type)->trigger();
+}
+
+void MainWindow::toggleTypeOblique() {
+  CommandManager::instance()->getAction(T_Type)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_TypeStyle:Oblique")
+      ->trigger();
+}
+
+void MainWindow::toggleTypeRegular() {
+  CommandManager::instance()->getAction(T_Type)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_TypeStyle:Regular")
+      ->trigger();
+}
+
+void MainWindow::toggleTypeBoldOblique() {
+  CommandManager::instance()->getAction(T_Type)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_TypeStyle:Bold Oblique")
+      ->trigger();
+}
+
+void MainWindow::toggleTypeBold() {
+  CommandManager::instance()->getAction(T_Type)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_TypeStyle:Bold")
       ->trigger();
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -528,6 +528,18 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_PickStyleLinesAndAreas, this,
                     &MainWindow::togglePickStyleLinesAndAreas);
 
+  /*-- RGB Picker tool + type switching shortcuts --*/
+  setCommandHandler(MI_RGBPickerNextType, this,
+                    &MainWindow::toggleRGBPickerNextType);
+  setCommandHandler(MI_RGBPickerNormal, this,
+                    &MainWindow::toggleRGBPickerNormal);
+  setCommandHandler(MI_RGBPickerRectangular, this,
+                    &MainWindow::toggleRGBPickerRectangular);
+  setCommandHandler(MI_RGBPickerFreehand, this,
+                    &MainWindow::toggleRGBPickerFreehand);
+  setCommandHandler(MI_RGBPickerPolyline, this,
+                    &MainWindow::toggleRGBPickerPolyline);
+
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_OpenOnlineManual, this, &MainWindow::onOpenOnlineManual);
   setCommandHandler(MI_OpenWhatsNew, this, &MainWindow::onOpenWhatsNew);
@@ -2564,6 +2576,18 @@ void MainWindow::defineActions() {
   createAction(MI_PickStyleLinesAndAreas,
                tr("Style Picker Tool - Lines & Areas"), "", ToolCommandType);
 
+  /*-- RGB Picker tool + type switching shortcuts --*/
+  createAction(MI_RGBPickerNextType, tr("RGB Picker Tool - Next Type"), "",
+               ToolCommandType);
+  createAction(MI_RGBPickerNormal, tr("RGB Picker Tool - Normal"), "",
+               ToolCommandType);
+  createAction(MI_RGBPickerRectangular, tr("RGB Picker Tool - Rectangular"), "",
+               ToolCommandType);
+  createAction(MI_RGBPickerFreehand, tr("RGB Picker Tool - Freehand"), "",
+               ToolCommandType);
+  createAction(MI_RGBPickerPolyline, tr("RGB Picker Tool - Polyline"), "",
+               ToolCommandType);
+
   createMiscAction("A_FxSchematicToggle", tr("Toggle FX/Stage schematic"), "");
 #ifdef WITH_STOPMOTION
   createAction(MI_StopMotionCapture, tr("Capture Stop Motion Frame"), "");
@@ -2955,6 +2979,43 @@ void MainWindow::togglePickStyleLinesAndAreas() {
   CommandManager::instance()->getAction(T_StylePicker)->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_Mode:Lines & Areas")
+      ->trigger();
+}
+//-----------------------------------------------------------------------------
+/*-- RGB Picker tool + type switching shortcuts --*/
+void MainWindow::toggleRGBPickerNextType() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_RGBPicker)
+    CommandManager::instance()->getAction("A_ToolOption_Type")->trigger();
+  else
+    CommandManager::instance()->getAction(T_RGBPicker)->trigger();
+}
+
+void MainWindow::toggleRGBPickerNormal() {
+  CommandManager::instance()->getAction(T_RGBPicker)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+}
+
+void MainWindow::toggleRGBPickerRectangular() {
+  CommandManager::instance()->getAction(T_RGBPicker)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Rectangular")
+      ->trigger();
+}
+
+void MainWindow::toggleRGBPickerFreehand() {
+  CommandManager::instance()->getAction(T_RGBPicker)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Freehand")
+      ->trigger();
+}
+
+void MainWindow::toggleRGBPickerPolyline() {
+  CommandManager::instance()->getAction(T_RGBPicker)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Polyline")
       ->trigger();
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -520,9 +520,13 @@ centralWidget->setLayout(centralWidgetLayout);*/
                     &MainWindow::toggleTapeEndpointToLine);
   setCommandHandler(MI_TapeLineToLine, this, &MainWindow::toggleTapeLineToLine);
 
-  /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
+  /*-- Style Picker tool + mode switching shortcuts --*/
+  setCommandHandler(MI_PickStyleNextMode, this,
+                    &MainWindow::togglePickStyleNextMode);
   setCommandHandler(MI_PickStyleAreas, this, &MainWindow::togglePickStyleAreas);
   setCommandHandler(MI_PickStyleLines, this, &MainWindow::togglePickStyleLines);
+  setCommandHandler(MI_PickStyleLinesAndAreas, this,
+                    &MainWindow::togglePickStyleLinesAndAreas);
 
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_OpenOnlineManual, this, &MainWindow::onOpenOnlineManual);
@@ -2550,12 +2554,15 @@ void MainWindow::defineActions() {
   createAction(MI_TapeLineToLine, tr("Tape Tool - Line to Line"), "",
                ToolCommandType);
 
-  /*-- Style picker Area, Style picker Lineににキー1つで切り替えるためのコマンド
-   * --*/
+  /*-- Style Picker tool + mode switching shortcuts --*/
+  createAction(MI_PickStyleNextMode, tr("Style Picker Tool - Next Mode"), "",
+               ToolCommandType);
   createAction(MI_PickStyleAreas, tr("Style Picker Tool - Areas"), "",
                ToolCommandType);
   createAction(MI_PickStyleLines, tr("Style Picker Tool - Lines"), "",
                ToolCommandType);
+  createAction(MI_PickStyleLinesAndAreas,
+               tr("Style Picker Tool - Lines & Areas"), "", ToolCommandType);
 
   createMiscAction("A_FxSchematicToggle", tr("Toggle FX/Stage schematic"), "");
 #ifdef WITH_STOPMOTION
@@ -2926,8 +2933,14 @@ void MainWindow::toggleTapeLineToLine() {
 }
 
 //---------------------------------------------------------------------------------------
-/*-- Style picker Area, Style picker Lineににキー1つで切り替えるためのコマンド
- * --*/
+/*-- Style Picker tool + mode switching shortcuts --*/
+void MainWindow::togglePickStyleNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_StylePicker)
+    CommandManager::instance()->getAction("A_ToolOption_Mode")->trigger();
+  else
+    CommandManager::instance()->getAction(T_StylePicker)->trigger();
+}
+
 void MainWindow::togglePickStyleAreas() {
   CommandManager::instance()->getAction(T_StylePicker)->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Mode:Areas")->trigger();
@@ -2936,6 +2949,13 @@ void MainWindow::togglePickStyleAreas() {
 void MainWindow::togglePickStyleLines() {
   CommandManager::instance()->getAction(T_StylePicker)->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Mode:Lines")->trigger();
+}
+
+void MainWindow::togglePickStyleLinesAndAreas() {
+  CommandManager::instance()->getAction(T_StylePicker)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Mode:Lines & Areas")
+      ->trigger();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -462,6 +462,22 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_SelectionPolyline, this,
                     &MainWindow::toggleSelectionPolyline);
 
+  /*-- Geometric tool + mode switching shortcuts --*/
+  setCommandHandler(MI_GeometricNextMode, this,
+                    &MainWindow::toggleGeometricNextMode);
+  setCommandHandler(MI_GeometricRectangle, this,
+                    &MainWindow::toggleGeometricRectangle);
+  setCommandHandler(MI_GeometricCircle, this,
+                    &MainWindow::toggleGeometricCircle);
+  setCommandHandler(MI_GeometricEllipse, this,
+                    &MainWindow::toggleGeometricEllipse);
+  setCommandHandler(MI_GeometricLine, this, &MainWindow::toggleGeometricLine);
+  setCommandHandler(MI_GeometricPolyline, this,
+                    &MainWindow::toggleGeometricPolyline);
+  setCommandHandler(MI_GeometricArc, this, &MainWindow::toggleGeometricArc);
+  setCommandHandler(MI_GeometricPolygon, this,
+                    &MainWindow::toggleGeometricPolygon);
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   setCommandHandler(MI_FillAreas, this, &MainWindow::toggleFillAreas);
   setCommandHandler(MI_FillLines, this, &MainWindow::toggleFillLines);
@@ -2318,6 +2334,20 @@ void MainWindow::defineActions() {
   createToolOptionsAction("A_ToolOption_BrushPreset", tr("Brush Preset"), "");
   createToolOptionsAction("A_ToolOption_GeometricShape", tr("Geometric Shape"),
                           "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:Rectangle",
+                          tr("Geometric Shape Rectangle"), "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:Circle",
+                          tr("Geometric Shape Circle"), "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:Ellipse",
+                          tr("Geometric Shape Ellipse"), "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:Line",
+                          tr("Geometric Shape Line"), "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:Polyline",
+                          tr("Geometric Shape Polyline"), "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:Arc",
+                          tr("Geometric Shape Arc"), "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:Polygon",
+                          tr("Geometric Shape Polygon"), "");
   createToolOptionsAction("A_ToolOption_GeometricEdge", tr("Geometric Edge"),
                           "");
   createToolOptionsAction("A_ToolOption_Mode", tr("Mode"), "");
@@ -2390,6 +2420,24 @@ void MainWindow::defineActions() {
   createAction(MI_SelectionFreehand, tr("Selection Tool - Freehand"), "",
                ToolCommandType);
   createAction(MI_SelectionPolyline, tr("Selection Tool - Polyline"), "",
+               ToolCommandType);
+
+  /*-- Geometric tool + mode switching shortcuts --*/
+  createAction(MI_GeometricNextMode, tr("Geometric Tool - Next Mode"), "",
+               ToolCommandType);
+  createAction(MI_GeometricRectangle, tr("Geometric Tool - Rectangle"), "",
+               ToolCommandType);
+  createAction(MI_GeometricCircle, tr("Geometric Tool - Circle"), "",
+               ToolCommandType);
+  createAction(MI_GeometricEllipse, tr("Geometric Tool - Ellipse"), "",
+               ToolCommandType);
+  createAction(MI_GeometricLine, tr("Geometric Tool - Line"), "",
+               ToolCommandType);
+  createAction(MI_GeometricPolyline, tr("Geometric Tool - Polyline"), "",
+               ToolCommandType);
+  createAction(MI_GeometricArc, tr("Geometric Tool - Arc"), "",
+               ToolCommandType);
+  createAction(MI_GeometricPolygon, tr("Geometric Tool - Polygon"), "",
                ToolCommandType);
 
   /*-- FillAreas, FillLinesにキー1つで切り替えるためのコマンド --*/
@@ -2517,6 +2565,66 @@ void MainWindow::toggleSelectionPolyline() {
   CommandManager::instance()->getAction(T_Selection)->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_Type:Polyline")
+      ->trigger();
+}
+
+//---------------------------------------------------------------------------------------
+/*-- Geometric tool + mode switching shortcuts --*/
+void MainWindow::toggleGeometricNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Geometric)
+    CommandManager::instance()
+        ->getAction("A_ToolOption_GeometricShape")
+        ->trigger();
+  else
+    CommandManager::instance()->getAction(T_Geometric)->trigger();
+}
+
+void MainWindow::toggleGeometricRectangle() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:Rectangle")
+      ->trigger();
+}
+
+void MainWindow::toggleGeometricCircle() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:Circle")
+      ->trigger();
+}
+
+void MainWindow::toggleGeometricEllipse() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:Ellipse")
+      ->trigger();
+}
+
+void MainWindow::toggleGeometricLine() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:Line")
+      ->trigger();
+}
+
+void MainWindow::toggleGeometricPolyline() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:Polyline")
+      ->trigger();
+}
+
+void MainWindow::toggleGeometricArc() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:Arc")
+      ->trigger();
+}
+
+void MainWindow::toggleGeometricPolygon() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:Polygon")
       ->trigger();
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -486,9 +486,19 @@ centralWidget->setLayout(centralWidgetLayout);*/
                     &MainWindow::toggleTypeBoldOblique);
   setCommandHandler(MI_TypeBold, this, &MainWindow::toggleTypeBold);
 
-  /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
+  /*-- Fill tool + type/mode switching shortcuts --*/
+  setCommandHandler(MI_FillNextType, this, &MainWindow::toggleFillNextType);
+  setCommandHandler(MI_FillNormal, this, &MainWindow::toggleFillNormal);
+  setCommandHandler(MI_FillRectangular, this,
+                    &MainWindow::toggleFillRectangular);
+  setCommandHandler(MI_FillFreehand, this, &MainWindow::toggleFillFreehand);
+  setCommandHandler(MI_FillPolyline, this, &MainWindow::toggleFillPolyline);
+  setCommandHandler(MI_FillNextMode, this, &MainWindow::toggleFillNextMode);
   setCommandHandler(MI_FillAreas, this, &MainWindow::toggleFillAreas);
   setCommandHandler(MI_FillLines, this, &MainWindow::toggleFillLines);
+  setCommandHandler(MI_FillLinesAndAreas, this,
+                    &MainWindow::toggleFillLinesAndAreas);
+
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   setCommandHandler(MI_PickStyleAreas, this, &MainWindow::togglePickStyleAreas);
   setCommandHandler(MI_PickStyleLines, this, &MainWindow::togglePickStyleLines);
@@ -2465,9 +2475,22 @@ void MainWindow::defineActions() {
                ToolCommandType);
   createAction(MI_TypeBold, tr("Type Tool - Bold"), "", ToolCommandType);
 
-  /*-- FillAreas, FillLinesにキー1つで切り替えるためのコマンド --*/
+  /*-- Fill tool + type/mode switching shortcuts --*/
+  createAction(MI_FillNextType, tr("Fill Tool - Next Type"), "",
+               ToolCommandType);
+  createAction(MI_FillNormal, tr("Fill Tool - Normal"), "", ToolCommandType);
+  createAction(MI_FillRectangular, tr("Fill Tool - Rectangular"), "",
+               ToolCommandType);
+  createAction(MI_FillFreehand, tr("Fill Tool - Freehand"), "",
+               ToolCommandType);
+  createAction(MI_FillPolyline, tr("Fill Tool - Polyline"), "",
+               ToolCommandType);
+  createAction(MI_FillNextMode, tr("Fill Tool - Next Mode"), "",
+               ToolCommandType);
   createAction(MI_FillAreas, tr("Fill Tool - Areas"), "", ToolCommandType);
   createAction(MI_FillLines, tr("Fill Tool - Lines"), "", ToolCommandType);
+  createAction(MI_FillLinesAndAreas, tr("Fill Tool - Lines & Areas"), "",
+               ToolCommandType);
 
   /*-- Style picker Area, Style picker Lineににキー1つで切り替えるためのコマンド
    * --*/
@@ -2690,7 +2713,50 @@ void MainWindow::toggleTypeBold() {
 }
 
 //---------------------------------------------------------------------------------------
-/*-- FillAreas, FillLinesにキー1つで切り替えるためのコマンド --*/
+/*-- Fill tool + type/mode switching shortcuts --*/
+void MainWindow::toggleFillNextType() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Fill)
+    CommandManager::instance()->getAction("A_ToolOption_Type")->trigger();
+  else
+    CommandManager::instance()->getAction(T_Fill)->trigger();
+}
+
+void MainWindow::toggleFillNormal() {
+  CommandManager::instance()->getAction(T_Fill)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+}
+
+void MainWindow::toggleFillRectangular() {
+  CommandManager::instance()->getAction(T_Fill)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Rectangular")
+      ->trigger();
+}
+
+void MainWindow::toggleFillFreehand() {
+  CommandManager::instance()->getAction(T_Fill)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Freehand")
+      ->trigger();
+}
+
+void MainWindow::toggleFillPolyline() {
+  CommandManager::instance()->getAction(T_Fill)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Polyline")
+      ->trigger();
+}
+
+void MainWindow::toggleFillNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Fill)
+    CommandManager::instance()->getAction("A_ToolOption_Mode")->trigger();
+  else
+    CommandManager::instance()->getAction(T_Fill)->trigger();
+}
+
 void MainWindow::toggleFillAreas() {
   CommandManager::instance()->getAction(T_Fill)->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Mode:Areas")->trigger();
@@ -2699,6 +2765,13 @@ void MainWindow::toggleFillAreas() {
 void MainWindow::toggleFillLines() {
   CommandManager::instance()->getAction(T_Fill)->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Mode:Lines")->trigger();
+}
+
+void MainWindow::toggleFillLinesAndAreas() {
+  CommandManager::instance()->getAction(T_Fill)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Mode:Lines & Areas")
+      ->trigger();
 }
 
 //---------------------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -452,9 +452,9 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_EditCenter, this, &MainWindow::toggleEditNextCenter);
   setCommandHandler(MI_EditAll, this, &MainWindow::toggleEditNextAll);
 
-  /*-- Selection tool + mode switching shortcuts --*/
-  setCommandHandler(MI_SelectionNextMode, this,
-                    &MainWindow::toggleSelectionNextMode);
+  /*-- Selection tool + type switching shortcuts --*/
+  setCommandHandler(MI_SelectionNextType, this,
+                    &MainWindow::toggleSelectionNextType);
   setCommandHandler(MI_SelectionRectangular, this,
                     &MainWindow::toggleSelectionRectangular);
   setCommandHandler(MI_SelectionFreehand, this,
@@ -462,9 +462,9 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_SelectionPolyline, this,
                     &MainWindow::toggleSelectionPolyline);
 
-  /*-- Geometric tool + mode switching shortcuts --*/
-  setCommandHandler(MI_GeometricNextMode, this,
-                    &MainWindow::toggleGeometricNextMode);
+  /*-- Geometric tool + shape switching shortcuts --*/
+  setCommandHandler(MI_GeometricNextShape, this,
+                    &MainWindow::toggleGeometricNextShape);
   setCommandHandler(MI_GeometricRectangle, this,
                     &MainWindow::toggleGeometricRectangle);
   setCommandHandler(MI_GeometricCircle, this,
@@ -478,8 +478,8 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_GeometricPolygon, this,
                     &MainWindow::toggleGeometricPolygon);
 
-  /*-- Type tool + mode switching shortcuts --*/
-  setCommandHandler(MI_TypeNextMode, this, &MainWindow::toggleTypeNextMode);
+  /*-- Type tool + style switching shortcuts --*/
+  setCommandHandler(MI_TypeNextStyle, this, &MainWindow::toggleTypeNextStyle);
   setCommandHandler(MI_TypeOblique, this, &MainWindow::toggleTypeOblique);
   setCommandHandler(MI_TypeRegular, this, &MainWindow::toggleTypeRegular);
   setCommandHandler(MI_TypeBoldOblique, this,
@@ -2509,8 +2509,8 @@ void MainWindow::defineActions() {
   createAction(MI_EditCenter, tr("Animate Tool - Center"), "", ToolCommandType);
   createAction(MI_EditAll, tr("Animate Tool - All"), "", ToolCommandType);
 
-  /*-- Selection tool + mode switching shortcuts --*/
-  createAction(MI_SelectionNextMode, tr("Selection Tool - Next Mode"), "",
+  /*-- Selection tool + type switching shortcuts --*/
+  createAction(MI_SelectionNextType, tr("Selection Tool - Next Type"), "",
                ToolCommandType);
   createAction(MI_SelectionRectangular, tr("Selection Tool - Rectangular"), "",
                ToolCommandType);
@@ -2519,8 +2519,8 @@ void MainWindow::defineActions() {
   createAction(MI_SelectionPolyline, tr("Selection Tool - Polyline"), "",
                ToolCommandType);
 
-  /*-- Geometric tool + mode switching shortcuts --*/
-  createAction(MI_GeometricNextMode, tr("Geometric Tool - Next Mode"), "",
+  /*-- Geometric tool + shape switching shortcuts --*/
+  createAction(MI_GeometricNextShape, tr("Geometric Tool - Next Shape"), "",
                ToolCommandType);
   createAction(MI_GeometricRectangle, tr("Geometric Tool - Rectangle"), "",
                ToolCommandType);
@@ -2537,8 +2537,8 @@ void MainWindow::defineActions() {
   createAction(MI_GeometricPolygon, tr("Geometric Tool - Polygon"), "",
                ToolCommandType);
 
-  /*-- Type tool + mode switching shortcuts --*/
-  createAction(MI_TypeNextMode, tr("Type Tool - Next Mode"), "",
+  /*-- Type tool + style switching shortcuts --*/
+  createAction(MI_TypeNextStyle, tr("Type Tool - Next Style"), "",
                ToolCommandType);
   createAction(MI_TypeOblique, tr("Type Tool - Oblique"), "", ToolCommandType);
   createAction(MI_TypeRegular, tr("Type Tool - Regular"), "", ToolCommandType);
@@ -2724,8 +2724,8 @@ void MainWindow::toggleEditNextAll() {
 }
 
 //---------------------------------------------------------------------------------------
-/*-- Selection tool + mode switching shortcuts --*/
-void MainWindow::toggleSelectionNextMode() {
+/*-- Selection tool + type switching shortcuts --*/
+void MainWindow::toggleSelectionNextType() {
   if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Selection)
     CommandManager::instance()->getAction("A_ToolOption_Type")->trigger();
   else
@@ -2754,8 +2754,8 @@ void MainWindow::toggleSelectionPolyline() {
 }
 
 //---------------------------------------------------------------------------------------
-/*-- Geometric tool + mode switching shortcuts --*/
-void MainWindow::toggleGeometricNextMode() {
+/*-- Geometric tool + shape switching shortcuts --*/
+void MainWindow::toggleGeometricNextShape() {
   if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Geometric)
     CommandManager::instance()
         ->getAction("A_ToolOption_GeometricShape")
@@ -2814,7 +2814,7 @@ void MainWindow::toggleGeometricPolygon() {
 }
 //---------------------------------------------------------------------------------------
 /*-- Type tool + mode switching shortcuts --*/
-void MainWindow::toggleTypeNextMode() {
+void MainWindow::toggleTypeNextStyle() {
   if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Type)
     CommandManager::instance()->getAction("A_ToolOption_TypeStyle")->trigger();
   else

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -540,6 +540,16 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_RGBPickerPolyline, this,
                     &MainWindow::toggleRGBPickerPolyline);
 
+  /*-- Skeleton tool + mode switching shortcuts --*/
+  setCommandHandler(MI_SkeletonNextMode, this,
+                    &MainWindow::ToggleSkeletonNextMode);
+  setCommandHandler(MI_SkeletonBuildSkeleton, this,
+                    &MainWindow::ToggleSkeletonBuildSkeleton);
+  setCommandHandler(MI_SkeletonAnimate, this,
+                    &MainWindow::ToggleSkeletonAnimate);
+  setCommandHandler(MI_SkeletonInverseKinematics, this,
+                    &MainWindow::ToggleSkeletonInverseKinematics);
+
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_OpenOnlineManual, this, &MainWindow::onOpenOnlineManual);
   setCommandHandler(MI_OpenWhatsNew, this, &MainWindow::onOpenWhatsNew);
@@ -2453,6 +2463,7 @@ void MainWindow::defineActions() {
   createToolOptionsAction("A_ToolOption_EditToolActiveAxis:All",
                           tr("Active Axis - All"), "");
 
+  createToolOptionsAction("A_ToolOption_SkeletonMode", tr("Skeleton Mode"), "");
   createToolOptionsAction("A_ToolOption_SkeletonMode:Build Skeleton",
                           tr("Build Skeleton Mode"), "");
   createToolOptionsAction("A_ToolOption_SkeletonMode:Animate",
@@ -2587,6 +2598,16 @@ void MainWindow::defineActions() {
                ToolCommandType);
   createAction(MI_RGBPickerPolyline, tr("RGB Picker Tool - Polyline"), "",
                ToolCommandType);
+
+  /*-- Skeleton tool + mode switching shortcuts --*/
+  createAction(MI_SkeletonNextMode, tr("Skeleton Tool - Next Mode"), "",
+               ToolCommandType);
+  createAction(MI_SkeletonBuildSkeleton, tr("Skeleton Tool - Build Skeleton"),
+               "", ToolCommandType);
+  createAction(MI_SkeletonAnimate, tr("Skeleton Tool - Animate"), "",
+               ToolCommandType);
+  createAction(MI_SkeletonInverseKinematics,
+               tr("Skeleton Tool - Inverse Kinematics"), "", ToolCommandType);
 
   createMiscAction("A_FxSchematicToggle", tr("Toggle FX/Stage schematic"), "");
 #ifdef WITH_STOPMOTION
@@ -3016,6 +3037,37 @@ void MainWindow::toggleRGBPickerPolyline() {
   CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_Type:Polyline")
+      ->trigger();
+}
+//-----------------------------------------------------------------------------
+/*-- Skeleton tool + type switching shortcuts --*/
+void MainWindow::ToggleSkeletonNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Skeleton)
+    CommandManager::instance()
+        ->getAction("A_ToolOption_SkeletonMode")
+        ->trigger();
+  else
+    CommandManager::instance()->getAction(T_Skeleton)->trigger();
+}
+
+void MainWindow::ToggleSkeletonBuildSkeleton() {
+  CommandManager::instance()->getAction(T_Skeleton)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_SkeletonMode:Build Skeleton")
+      ->trigger();
+}
+
+void MainWindow::ToggleSkeletonAnimate() {
+  CommandManager::instance()->getAction(T_Skeleton)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_SkeletonMode:Animate")
+      ->trigger();
+}
+
+void MainWindow::ToggleSkeletonInverseKinematics() {
+  CommandManager::instance()->getAction(T_Skeleton)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_SkeletonMode:Inverse Kinematics")
       ->trigger();
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -443,6 +443,15 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler("MI_ResetRoomLayout", this, &MainWindow::resetRoomsLayout);
   setCommandHandler(MI_AutoFillToggle, this, &MainWindow::autofillToggle);
 
+  /*-- Animate tool + mode switching shortcuts --*/
+  setCommandHandler(MI_EditNextMode, this, &MainWindow::toggleEditNextMode);
+  setCommandHandler(MI_EditPosition, this, &MainWindow::toggleEditPosition);
+  setCommandHandler(MI_EditRotation, this, &MainWindow::toggleEditRotation);
+  setCommandHandler(MI_EditScale, this, &MainWindow::toggleEditNextScale);
+  setCommandHandler(MI_EditShear, this, &MainWindow::toggleEditNextShear);
+  setCommandHandler(MI_EditCenter, this, &MainWindow::toggleEditNextCenter);
+  setCommandHandler(MI_EditAll, this, &MainWindow::toggleEditNextAll);
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   setCommandHandler(MI_FillAreas, this, &MainWindow::toggleFillAreas);
   setCommandHandler(MI_FillLines, this, &MainWindow::toggleFillLines);
@@ -2351,6 +2360,18 @@ void MainWindow::defineActions() {
   createToolOptionsAction("A_ToolOption_AutopaintLines",
                           tr("Fill Tool - Autopaint Lines"), "");
 
+  /*-- Animate tool + mode switching shortcuts --*/
+  createAction(MI_EditNextMode, tr("Animate Tool - Next Mode"), "",
+               ToolCommandType);
+  createAction(MI_EditPosition, tr("Animate Tool - Position"), "",
+               ToolCommandType);
+  createAction(MI_EditRotation, tr("Animate Tool - Rotation"), "",
+               ToolCommandType);
+  createAction(MI_EditScale, tr("Animate Tool - Scale"), "", ToolCommandType);
+  createAction(MI_EditShear, tr("Animate Tool - Shear"), "", ToolCommandType);
+  createAction(MI_EditCenter, tr("Animate Tool - Center"), "", ToolCommandType);
+  createAction(MI_EditAll, tr("Animate Tool - All"), "", ToolCommandType);
+
   /*-- FillAreas, FillLinesにキー1つで切り替えるためのコマンド --*/
   createAction(MI_FillAreas, tr("Fill Tool - Areas"), "", ToolCommandType);
   createAction(MI_FillLines, tr("Fill Tool - Lines"), "", ToolCommandType);
@@ -2394,6 +2415,59 @@ void MainWindow::onInk1CheckTriggered(bool on) {
   if (!on) return;
   QAction *inkCheckAction = CommandManager::instance()->getAction(MI_ICheck);
   if (inkCheckAction) inkCheckAction->setChecked(false);
+}
+
+//-----------------------------------------------------------------------------
+/*-- Animate tool + mode switching shortcuts --*/
+void MainWindow::toggleEditNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Edit)
+    CommandManager::instance()
+        ->getAction("A_ToolOption_EditToolActiveAxis")
+        ->trigger();
+  else
+    CommandManager::instance()->getAction(T_Edit)->trigger();
+}
+
+void MainWindow::toggleEditPosition() {
+  CommandManager::instance()->getAction(T_Edit)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_EditToolActiveAxis:Position")
+      ->trigger();
+}
+
+void MainWindow::toggleEditRotation() {
+  CommandManager::instance()->getAction(T_Edit)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_EditToolActiveAxis:Rotation")
+      ->trigger();
+}
+
+void MainWindow::toggleEditNextScale() {
+  CommandManager::instance()->getAction(T_Edit)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_EditToolActiveAxis:Scale")
+      ->trigger();
+}
+
+void MainWindow::toggleEditNextShear() {
+  CommandManager::instance()->getAction(T_Edit)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_EditToolActiveAxis:Shear")
+      ->trigger();
+}
+
+void MainWindow::toggleEditNextCenter() {
+  CommandManager::instance()->getAction(T_Edit)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_EditToolActiveAxis:Center")
+      ->trigger();
+}
+
+void MainWindow::toggleEditNextAll() {
+  CommandManager::instance()->getAction(T_Edit)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_EditToolActiveAxis:All")
+      ->trigger();
 }
 
 //---------------------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -550,6 +550,17 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_SkeletonInverseKinematics, this,
                     &MainWindow::ToggleSkeletonInverseKinematics);
 
+  /*-- Plastic tool + mode switching shortcuts --*/
+  setCommandHandler(MI_PlasticNextMode, this,
+                    &MainWindow::TogglePlasticNextMode);
+  setCommandHandler(MI_PlasticEditMesh, this,
+                    &MainWindow::TogglePlasticEditMesh);
+  setCommandHandler(MI_PlasticPaintRigid, this,
+                    &MainWindow::TogglePlasticPaintRigid);
+  setCommandHandler(MI_PlasticBuildSkeleton, this,
+                    &MainWindow::TogglePlasticBuildSkeleton);
+  setCommandHandler(MI_PlasticAnimate, this, &MainWindow::TogglePlasticAnimate);
+
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_OpenOnlineManual, this, &MainWindow::onOpenOnlineManual);
   setCommandHandler(MI_OpenWhatsNew, this, &MainWindow::onOpenWhatsNew);
@@ -2464,6 +2475,10 @@ void MainWindow::defineActions() {
                           tr("Active Axis - All"), "");
 
   createToolOptionsAction("A_ToolOption_SkeletonMode", tr("Skeleton Mode"), "");
+  createToolOptionsAction("A_ToolOption_SkeletonMode:Edit Mesh",
+                          tr("Edit Mesh Mode"), "");
+  createToolOptionsAction("A_ToolOption_SkeletonMode:Paint Rigid",
+                          tr("Paint Rigid Mode"), "");
   createToolOptionsAction("A_ToolOption_SkeletonMode:Build Skeleton",
                           tr("Build Skeleton Mode"), "");
   createToolOptionsAction("A_ToolOption_SkeletonMode:Animate",
@@ -2608,6 +2623,18 @@ void MainWindow::defineActions() {
                ToolCommandType);
   createAction(MI_SkeletonInverseKinematics,
                tr("Skeleton Tool - Inverse Kinematics"), "", ToolCommandType);
+
+  /*-- Plastic tool + mode switching shortcuts --*/
+  createAction(MI_PlasticNextMode, tr("Plastic Tool - Next Mode"), "",
+               ToolCommandType);
+  createAction(MI_PlasticEditMesh, tr("Plastic Tool - Edit Mesh"), "",
+               ToolCommandType);
+  createAction(MI_PlasticPaintRigid, tr("Plastic Tool - Paint Rigid"), "",
+               ToolCommandType);
+  createAction(MI_PlasticBuildSkeleton, tr("Plastic Tool - Build Skeleton"), "",
+               ToolCommandType);
+  createAction(MI_PlasticAnimate, tr("Plastic Tool - Animate"), "",
+               ToolCommandType);
 
   createMiscAction("A_FxSchematicToggle", tr("Toggle FX/Stage schematic"), "");
 #ifdef WITH_STOPMOTION
@@ -3068,6 +3095,45 @@ void MainWindow::ToggleSkeletonInverseKinematics() {
   CommandManager::instance()->getAction(T_Skeleton)->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_SkeletonMode:Inverse Kinematics")
+      ->trigger();
+}
+
+//-----------------------------------------------------------------------------
+/*-- Plastic tool + mode switching shortcuts --*/
+void MainWindow::TogglePlasticNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Plastic)
+    CommandManager::instance()
+        ->getAction("A_ToolOption_SkeletonMode")
+        ->trigger();
+  else
+    CommandManager::instance()->getAction(T_Plastic)->trigger();
+}
+
+void MainWindow::TogglePlasticEditMesh() {
+  CommandManager::instance()->getAction(T_Plastic)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_SkeletonMode:Edit Mesh")
+      ->trigger();
+}
+
+void MainWindow::TogglePlasticPaintRigid() {
+  CommandManager::instance()->getAction(T_Plastic)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_SkeletonMode:Paint Rigid")
+      ->trigger();
+}
+
+void MainWindow::TogglePlasticBuildSkeleton() {
+  CommandManager::instance()->getAction(T_Plastic)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_SkeletonMode:Build Skeleton")
+      ->trigger();
+}
+
+void MainWindow::TogglePlasticAnimate() {
+  CommandManager::instance()->getAction(T_Plastic)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_SkeletonMode:Animate")
       ->trigger();
 }
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -499,6 +499,15 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_FillLinesAndAreas, this,
                     &MainWindow::toggleFillLinesAndAreas);
 
+  /*-- Eraser tool + type switching shortcuts --*/
+  setCommandHandler(MI_EraserNextType, this, &MainWindow::toggleEraserNextType);
+  setCommandHandler(MI_EraserNormal, this, &MainWindow::toggleEraserNormal);
+  setCommandHandler(MI_EraserRectangular, this,
+                    &MainWindow::toggleEraserRectangular);
+  setCommandHandler(MI_EraserFreehand, this, &MainWindow::toggleEraserFreehand);
+  setCommandHandler(MI_EraserPolyline, this, &MainWindow::toggleEraserPolyline);
+  setCommandHandler(MI_EraserSegment, this, &MainWindow::toggleEraserSegment);
+
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   setCommandHandler(MI_PickStyleAreas, this, &MainWindow::togglePickStyleAreas);
   setCommandHandler(MI_PickStyleLines, this, &MainWindow::togglePickStyleLines);
@@ -2381,6 +2390,8 @@ void MainWindow::defineActions() {
                           "");
   createToolOptionsAction("A_ToolOption_Type:Polyline", tr("Type - Polyline"),
                           "");
+  createToolOptionsAction("A_ToolOption_Type:Segment", tr("Type - Segment"),
+                          "");
   createToolOptionsAction("A_ToolOption_TypeFont", tr("TypeTool Font"), "");
   createToolOptionsAction("A_ToolOption_TypeSize", tr("TypeTool Size"), "");
   createToolOptionsAction("A_ToolOption_TypeStyle", tr("TypeTool Style"), "");
@@ -2490,6 +2501,20 @@ void MainWindow::defineActions() {
   createAction(MI_FillAreas, tr("Fill Tool - Areas"), "", ToolCommandType);
   createAction(MI_FillLines, tr("Fill Tool - Lines"), "", ToolCommandType);
   createAction(MI_FillLinesAndAreas, tr("Fill Tool - Lines & Areas"), "",
+               ToolCommandType);
+
+  /*-- Eraser tool + type switching shortcuts --*/
+  createAction(MI_EraserNextType, tr("Eraser Tool - Next Type"), "",
+               ToolCommandType);
+  createAction(MI_EraserNormal, tr("Eraser Tool - Normal"), "",
+               ToolCommandType);
+  createAction(MI_EraserRectangular, tr("Eraser Tool - Rectangular"), "",
+               ToolCommandType);
+  createAction(MI_EraserFreehand, tr("Eraser Tool - Freehand"), "",
+               ToolCommandType);
+  createAction(MI_EraserPolyline, tr("Eraser Tool - Polyline"), "",
+               ToolCommandType);
+  createAction(MI_EraserSegment, tr("Eraser Tool - Segment"), "",
                ToolCommandType);
 
   /*-- Style picker Area, Style picker Lineににキー1つで切り替えるためのコマンド
@@ -2772,6 +2797,50 @@ void MainWindow::toggleFillLinesAndAreas() {
   CommandManager::instance()
       ->getAction("A_ToolOption_Mode:Lines & Areas")
       ->trigger();
+}
+
+//---------------------------------------------------------------------------------------
+/*-- Eraser tool + type switching shortcuts --*/
+void MainWindow::toggleEraserNextType() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Eraser)
+    CommandManager::instance()->getAction("A_ToolOption_Type")->trigger();
+  else
+    CommandManager::instance()->getAction(T_Eraser)->trigger();
+}
+
+void MainWindow::toggleEraserNormal() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+}
+
+void MainWindow::toggleEraserRectangular() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Rectangular")
+      ->trigger();
+}
+
+void MainWindow::toggleEraserFreehand() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Freehand")
+      ->trigger();
+}
+
+void MainWindow::toggleEraserPolyline() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Polyline")
+      ->trigger();
+}
+
+void MainWindow::toggleEraserSegment() {
+  CommandManager::instance()->getAction(T_Eraser)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Segment")->trigger();
 }
 
 //---------------------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -508,6 +508,18 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_EraserPolyline, this, &MainWindow::toggleEraserPolyline);
   setCommandHandler(MI_EraserSegment, this, &MainWindow::toggleEraserSegment);
 
+  /*-- Tape tool + type/mode switching shortcuts --*/
+  setCommandHandler(MI_TapeNextType, this, &MainWindow::toggleTapeNextType);
+  setCommandHandler(MI_TapeNormal, this, &MainWindow::toggleTapeNormal);
+  setCommandHandler(MI_TapeRectangular, this,
+                    &MainWindow::toggleTapeRectangular);
+  setCommandHandler(MI_TapeNextMode, this, &MainWindow::toggleTapeNextMode);
+  setCommandHandler(MI_TapeEndpointToEndpoint, this,
+                    &MainWindow::toggleTapeEndpointToEndpoint);
+  setCommandHandler(MI_TapeEndpointToLine, this,
+                    &MainWindow::toggleTapeEndpointToLine);
+  setCommandHandler(MI_TapeLineToLine, this, &MainWindow::toggleTapeLineToLine);
+
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   setCommandHandler(MI_PickStyleAreas, this, &MainWindow::togglePickStyleAreas);
   setCommandHandler(MI_PickStyleLines, this, &MainWindow::togglePickStyleLines);
@@ -2382,6 +2394,12 @@ void MainWindow::defineActions() {
   createToolOptionsAction("A_ToolOption_Mode:Lines", tr("Mode - Lines"), "");
   createToolOptionsAction("A_ToolOption_Mode:Lines & Areas",
                           tr("Mode - Lines & Areas"), "");
+  createToolOptionsAction("A_ToolOption_Mode:Endpoint to Endpoint",
+                          tr("Mode - Endpoint to Endpoint"), "");
+  createToolOptionsAction("A_ToolOption_Mode:Endpoint to Line",
+                          tr("Mode - Endpoint to Line"), "");
+  createToolOptionsAction("A_ToolOption_Mode:Line to Line",
+                          tr("Mode - Line to Line"), "");
   createToolOptionsAction("A_ToolOption_Type", tr("Type"), "");
   createToolOptionsAction("A_ToolOption_Type:Normal", tr("Type - Normal"), "");
   createToolOptionsAction("A_ToolOption_Type:Rectangular",
@@ -2515,6 +2533,21 @@ void MainWindow::defineActions() {
   createAction(MI_EraserPolyline, tr("Eraser Tool - Polyline"), "",
                ToolCommandType);
   createAction(MI_EraserSegment, tr("Eraser Tool - Segment"), "",
+               ToolCommandType);
+
+  /*-- Tape tool + type/mode switching shortcuts --*/
+  createAction(MI_TapeNextType, tr("Tape Tool - Next Type"), "",
+               ToolCommandType);
+  createAction(MI_TapeNormal, tr("Tape Tool - Normal"), "", ToolCommandType);
+  createAction(MI_TapeRectangular, tr("Tape Tool - Rectangular"), "",
+               ToolCommandType);
+  createAction(MI_TapeNextMode, tr("Tape Tool - Next Mode"), "",
+               ToolCommandType);
+  createAction(MI_TapeEndpointToEndpoint, tr("Tape Tool - Endpoint to Enpoint"),
+               "", ToolCommandType);
+  createAction(MI_TapeEndpointToLine, tr("Tape Tool - Endpoint to Line"), "",
+               ToolCommandType);
+  createAction(MI_TapeLineToLine, tr("Tape Tool - Line to Line"), "",
                ToolCommandType);
 
   /*-- Style picker Area, Style picker Lineににキー1つで切り替えるためのコマンド
@@ -2841,6 +2874,55 @@ void MainWindow::toggleEraserSegment() {
   CommandManager::instance()->getAction(T_Eraser)->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
   CommandManager::instance()->getAction("A_ToolOption_Type:Segment")->trigger();
+}
+//---------------------------------------------------------------------------------------
+/*-- Tape tool + type/mode switching shortcuts --*/
+void MainWindow::toggleTapeNextType() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Tape)
+    CommandManager::instance()->getAction("A_ToolOption_Type")->trigger();
+  else
+    CommandManager::instance()->getAction(T_Tape)->trigger();
+}
+
+void MainWindow::toggleTapeNormal() {
+  CommandManager::instance()->getAction(T_Tape)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+}
+
+void MainWindow::toggleTapeRectangular() {
+  CommandManager::instance()->getAction(T_Tape)->trigger();
+  CommandManager::instance()->getAction("A_ToolOption_Type:Normal")->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Type:Rectangular")
+      ->trigger();
+}
+
+void MainWindow::toggleTapeNextMode() {
+  if (TApp::instance()->getCurrentTool()->getTool()->getName() == T_Tape)
+    CommandManager::instance()->getAction("A_ToolOption_Mode")->trigger();
+  else
+    CommandManager::instance()->getAction(T_Tape)->trigger();
+}
+
+void MainWindow::toggleTapeEndpointToEndpoint() {
+  CommandManager::instance()->getAction(T_Tape)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Mode:Endpoint to Endpoint")
+      ->trigger();
+}
+
+void MainWindow::toggleTapeEndpointToLine() {
+  CommandManager::instance()->getAction(T_Tape)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Mode:Endpoint to Line")
+      ->trigger();
+}
+
+void MainWindow::toggleTapeLineToLine() {
+  CommandManager::instance()->getAction(T_Tape)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_Mode:Line to Line")
+      ->trigger();
 }
 
 //---------------------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -158,6 +158,15 @@ public:
   void toggleEraserPolyline();
   void toggleEraserSegment();
 
+  /*-- Tape tool + type/mode switching shortcuts --*/
+  void toggleTapeNextType();
+  void toggleTapeNormal();
+  void toggleTapeRectangular();
+  void toggleTapeNextMode();
+  void toggleTapeEndpointToEndpoint();
+  void toggleTapeEndpointToLine();
+  void toggleTapeLineToLine();
+
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   void togglePickStyleAreas();
   void togglePickStyleLines();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -106,6 +106,16 @@ public:
 
   Room *getCurrentRoom() const;
   void refreshWriteSettings();
+
+  /*-- Animate tool + mode switching shortcuts --*/
+  void toggleEditNextMode();
+  void toggleEditPosition();
+  void toggleEditRotation();
+  void toggleEditNextScale();
+  void toggleEditNextShear();
+  void toggleEditNextCenter();
+  void toggleEditNextAll();
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   void toggleFillAreas();
   void toggleFillLines();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -186,6 +186,13 @@ public:
   void ToggleSkeletonAnimate();
   void ToggleSkeletonInverseKinematics();
 
+  /*-- Plastic tool + mode switching shortcuts --*/
+  void TogglePlasticNextMode();
+  void TogglePlasticEditMesh();
+  void TogglePlasticPaintRigid();
+  void TogglePlasticBuildSkeleton();
+  void TogglePlasticAnimate();
+
   void onNewVectorLevelButtonPressed();
   void onNewToonzRasterLevelButtonPressed();
   void onNewRasterLevelButtonPressed();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -173,6 +173,13 @@ public:
   void togglePickStyleLines();
   void togglePickStyleLinesAndAreas();
 
+  /*-- RGB Picker tool + type switching shortcuts --*/
+  void toggleRGBPickerNextType();
+  void toggleRGBPickerNormal();
+  void toggleRGBPickerRectangular();
+  void toggleRGBPickerFreehand();
+  void toggleRGBPickerPolyline();
+
   void onNewVectorLevelButtonPressed();
   void onNewToonzRasterLevelButtonPressed();
   void onNewRasterLevelButtonPressed();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -180,6 +180,12 @@ public:
   void toggleRGBPickerFreehand();
   void toggleRGBPickerPolyline();
 
+  /*-- Skeleton tool + mode switching shortcuts --*/
+  void ToggleSkeletonNextMode();
+  void ToggleSkeletonBuildSkeleton();
+  void ToggleSkeletonAnimate();
+  void ToggleSkeletonInverseKinematics();
+
   void onNewVectorLevelButtonPressed();
   void onNewToonzRasterLevelButtonPressed();
   void onNewRasterLevelButtonPressed();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -116,6 +116,12 @@ public:
   void toggleEditNextCenter();
   void toggleEditNextAll();
 
+  /*-- Selection tool + mode switching shortcuts --*/
+  void toggleSelectionNextMode();
+  void toggleSelectionRectangular();
+  void toggleSelectionFreehand();
+  void toggleSelectionPolyline();
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   void toggleFillAreas();
   void toggleFillLines();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -139,9 +139,17 @@ public:
   void toggleTypeBoldOblique();
   void toggleTypeBold();
 
-  /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
+  /*-- Fill tool + mode switching shortcuts --*/
+  void toggleFillNextType();
+  void toggleFillNormal();
+  void toggleFillRectangular();
+  void toggleFillFreehand();
+  void toggleFillPolyline();
+  void toggleFillNextMode();
   void toggleFillAreas();
   void toggleFillLines();
+  void toggleFillLinesAndAreas();
+
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   void togglePickStyleAreas();
   void togglePickStyleLines();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -150,6 +150,14 @@ public:
   void toggleFillLines();
   void toggleFillLinesAndAreas();
 
+  /*-- Eraser tool + type switching shortcuts --*/
+  void toggleEraserNextType();
+  void toggleEraserNormal();
+  void toggleEraserRectangular();
+  void toggleEraserFreehand();
+  void toggleEraserPolyline();
+  void toggleEraserSegment();
+
   /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
   void togglePickStyleAreas();
   void togglePickStyleLines();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -117,13 +117,13 @@ public:
   void toggleEditNextAll();
 
   /*-- Selection tool + mode switching shortcuts --*/
-  void toggleSelectionNextMode();
+  void toggleSelectionNextType();
   void toggleSelectionRectangular();
   void toggleSelectionFreehand();
   void toggleSelectionPolyline();
 
-  /*-- Geometric tool + mode switching shortcuts --*/
-  void toggleGeometricNextMode();
+  /*-- Geometric tool + shape switching shortcuts --*/
+  void toggleGeometricNextShape();
   void toggleGeometricRectangle();
   void toggleGeometricCircle();
   void toggleGeometricEllipse();
@@ -132,8 +132,8 @@ public:
   void toggleGeometricArc();
   void toggleGeometricPolygon();
 
-  /*-- Type tool + mode switching shortcuts --*/
-  void toggleTypeNextMode();
+  /*-- Type tool + style switching shortcuts --*/
+  void toggleTypeNextStyle();
   void toggleTypeOblique();
   void toggleTypeRegular();
   void toggleTypeBoldOblique();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -132,6 +132,13 @@ public:
   void toggleGeometricArc();
   void toggleGeometricPolygon();
 
+  /*-- Type tool + mode switching shortcuts --*/
+  void toggleTypeNextMode();
+  void toggleTypeOblique();
+  void toggleTypeRegular();
+  void toggleTypeBoldOblique();
+  void toggleTypeBold();
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   void toggleFillAreas();
   void toggleFillLines();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -122,6 +122,16 @@ public:
   void toggleSelectionFreehand();
   void toggleSelectionPolyline();
 
+  /*-- Geometric tool + mode switching shortcuts --*/
+  void toggleGeometricNextMode();
+  void toggleGeometricRectangle();
+  void toggleGeometricCircle();
+  void toggleGeometricEllipse();
+  void toggleGeometricLine();
+  void toggleGeometricPolyline();
+  void toggleGeometricArc();
+  void toggleGeometricPolygon();
+
   /*-- FillAreas,FillLinesに直接切り替えるコマンド --*/
   void toggleFillAreas();
   void toggleFillLines();

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -167,9 +167,12 @@ public:
   void toggleTapeEndpointToLine();
   void toggleTapeLineToLine();
 
-  /*-- StylepickerAreas,StylepickerLinesに直接切り替えるコマンド --*/
+  /*-- Style Picker tool + mode switching shortcuts --*/
+  void togglePickStyleNextMode();
   void togglePickStyleAreas();
   void togglePickStyleLines();
+  void togglePickStyleLinesAndAreas();
+
   void onNewVectorLevelButtonPressed();
   void onNewToonzRasterLevelButtonPressed();
   void onNewRasterLevelButtonPressed();

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -388,8 +388,10 @@
 #define MI_TapeEndpointToLine "MI_TapeEndpointToLine"
 #define MI_TapeLineToLine "MI_TapeLineToLine"
 
+#define MI_PickStyleNextMode "MI_PickStyleNextMode"
 #define MI_PickStyleAreas "MI_PickStyleAreas"
 #define MI_PickStyleLines "MI_PickStyleLines"
+#define MI_PickStyleLinesAndAreas "MI_PickStyleLinesAndAreas"
 
 #define MI_DeactivateUpperColumns "MI_DeactivateUpperColumns"
 #define MI_CompareToSnapshot "MI_CompareToSnapshot"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -343,12 +343,12 @@
 #define MI_EditCenter "MI_EditCenter"
 #define MI_EditAll "MI_EditAll"
 
-#define MI_SelectionNextMode "MI_SelectionNextMode"
+#define MI_SelectionNextType "MI_SelectionNextType"
 #define MI_SelectionRectangular "MI_SelectionRectangular"
 #define MI_SelectionFreehand "MI_SelectionFreehand"
 #define MI_SelectionPolyline "MI_SelectionPolyline"
 
-#define MI_GeometricNextMode "MI_GeometricNextMode"
+#define MI_GeometricNextShape "MI_GeometricNextShape"
 #define MI_GeometricRectangle "MI_GeometricRectangle"
 #define MI_GeometricCircle "MI_GeometricCircle"
 #define MI_GeometricEllipse "MI_GeometricEllipse"
@@ -357,7 +357,7 @@
 #define MI_GeometricArc "MI_GeometricArc"
 #define MI_GeometricPolygon "MI_GeometricPolygon"
 
-#define MI_TypeNextMode "MI_TypeNextMode"
+#define MI_TypeNextStyle "MI_TypeNextStyle"
 #define MI_TypeOblique "MI_TypeOblique"
 #define MI_TypeRegular "MI_TypeRegular"
 #define MI_TypeBoldOblique "MI_TypeBoldOblique"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -357,6 +357,12 @@
 #define MI_GeometricArc "MI_GeometricArc"
 #define MI_GeometricPolygon "MI_GeometricPolygon"
 
+#define MI_TypeNextMode "MI_TypeNextMode"
+#define MI_TypeOblique "MI_TypeOblique"
+#define MI_TypeRegular "MI_TypeRegular"
+#define MI_TypeBoldOblique "MI_TypeBoldOblique"
+#define MI_TypeBold "MI_TypeBold"
+
 #define MI_FillAreas "MI_FillAreas"
 #define MI_FillLines "MI_FillLines"
 #define MI_PickStyleAreas "MI_PickStyleAreas"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -363,8 +363,16 @@
 #define MI_TypeBoldOblique "MI_TypeBoldOblique"
 #define MI_TypeBold "MI_TypeBold"
 
+#define MI_FillNextType "MI_FillNextType"
+#define MI_FillNormal "MI_FillNormal"
+#define MI_FillRectangular "MI_FillRectangular"
+#define MI_FillFreehand "MI_FillFreehand"
+#define MI_FillPolyline "MI_FillPolyline"
+#define MI_FillNextMode "MI_FillNextMode"
 #define MI_FillAreas "MI_FillAreas"
 #define MI_FillLines "MI_FillLines"
+#define MI_FillLinesAndAreas "MI_FillLinesAndAreas"
+
 #define MI_PickStyleAreas "MI_PickStyleAreas"
 #define MI_PickStyleLines "MI_PickStyleLines"
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -343,6 +343,11 @@
 #define MI_EditCenter "MI_EditCenter"
 #define MI_EditAll "MI_EditAll"
 
+#define MI_SelectionNextMode "MI_SelectionNextMode"
+#define MI_SelectionRectangular "MI_SelectionRectangular"
+#define MI_SelectionFreehand "MI_SelectionFreehand"
+#define MI_SelectionPolyline "MI_SelectionPolyline"
+
 #define MI_FillAreas "MI_FillAreas"
 #define MI_FillLines "MI_FillLines"
 #define MI_PickStyleAreas "MI_PickStyleAreas"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -404,6 +404,12 @@
 #define MI_SkeletonAnimate "MI_SkeletonAnimate"
 #define MI_SkeletonInverseKinematics "MI_SkeletonInverseKinematics"
 
+#define MI_PlasticNextMode "MI_PlasticNextMode"
+#define MI_PlasticEditMesh "MI_PlasticEditMesh"
+#define MI_PlasticPaintRigid "MI_PlasticPaintRigid"
+#define MI_PlasticBuildSkeleton "MI_PlasticBuildSkeleton"
+#define MI_PlasticAnimate "MI_PlasticAnimate"
+
 #define MI_DeactivateUpperColumns "MI_DeactivateUpperColumns"
 #define MI_CompareToSnapshot "MI_CompareToSnapshot"
 #define MI_PreviewFx "MI_PreviewFx"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -380,6 +380,14 @@
 #define MI_EraserPolyline "MI_EraserPolyline"
 #define MI_EraserSegment "MI_EraserSegment"
 
+#define MI_TapeNextType "MI_TapeNextType"
+#define MI_TapeNormal "MI_TapeNormal"
+#define MI_TapeRectangular "MI_TapeRectangular"
+#define MI_TapeNextMode "MI_TapeNextMode"
+#define MI_TapeEndpointToEndpoint "MI_TapeEndpointToEndpoint"
+#define MI_TapeEndpointToLine "MI_TapeEndpointToLine"
+#define MI_TapeLineToLine "MI_TapeLineToLine"
+
 #define MI_PickStyleAreas "MI_PickStyleAreas"
 #define MI_PickStyleLines "MI_PickStyleLines"
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -335,6 +335,14 @@
 #define MI_Reframe4 "MI_Reframe4"
 #define MI_ReframeWithEmptyInbetweens "MI_ReframeWithEmptyInbetweens"
 
+#define MI_EditNextMode "MI_EditNextMode"
+#define MI_EditPosition "MI_EditPosition"
+#define MI_EditRotation "MI_EditRotation"
+#define MI_EditScale "MI_EditScale"
+#define MI_EditShear "MI_EditShear"
+#define MI_EditCenter "MI_EditCenter"
+#define MI_EditAll "MI_EditAll"
+
 #define MI_FillAreas "MI_FillAreas"
 #define MI_FillLines "MI_FillLines"
 #define MI_PickStyleAreas "MI_PickStyleAreas"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -393,6 +393,12 @@
 #define MI_PickStyleLines "MI_PickStyleLines"
 #define MI_PickStyleLinesAndAreas "MI_PickStyleLinesAndAreas"
 
+#define MI_RGBPickerNextType "MI_RGBPickerNextType"
+#define MI_RGBPickerNormal "MI_RGBPickerNormal"
+#define MI_RGBPickerRectangular "MI_RGBPickerRectangular"
+#define MI_RGBPickerFreehand "MI_RGBPickerFreehand"
+#define MI_RGBPickerPolyline "MI_RGBPickerPolyline"
+
 #define MI_DeactivateUpperColumns "MI_DeactivateUpperColumns"
 #define MI_CompareToSnapshot "MI_CompareToSnapshot"
 #define MI_PreviewFx "MI_PreviewFx"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -348,6 +348,15 @@
 #define MI_SelectionFreehand "MI_SelectionFreehand"
 #define MI_SelectionPolyline "MI_SelectionPolyline"
 
+#define MI_GeometricNextMode "MI_GeometricNextMode"
+#define MI_GeometricRectangle "MI_GeometricRectangle"
+#define MI_GeometricCircle "MI_GeometricCircle"
+#define MI_GeometricEllipse "MI_GeometricEllipse"
+#define MI_GeometricLine "MI_GeometricLine"
+#define MI_GeometricPolyline "MI_GeometricPolyline"
+#define MI_GeometricArc "MI_GeometricArc"
+#define MI_GeometricPolygon "MI_GeometricPolygon"
+
 #define MI_FillAreas "MI_FillAreas"
 #define MI_FillLines "MI_FillLines"
 #define MI_PickStyleAreas "MI_PickStyleAreas"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -373,6 +373,13 @@
 #define MI_FillLines "MI_FillLines"
 #define MI_FillLinesAndAreas "MI_FillLinesAndAreas"
 
+#define MI_EraserNextType "MI_EraserNextType"
+#define MI_EraserNormal "MI_EraserNormal"
+#define MI_EraserRectangular "MI_EraserRectangular"
+#define MI_EraserFreehand "MI_EraserFreehand"
+#define MI_EraserPolyline "MI_EraserPolyline"
+#define MI_EraserSegment "MI_EraserSegment"
+
 #define MI_PickStyleAreas "MI_PickStyleAreas"
 #define MI_PickStyleLines "MI_PickStyleLines"
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -399,6 +399,11 @@
 #define MI_RGBPickerFreehand "MI_RGBPickerFreehand"
 #define MI_RGBPickerPolyline "MI_RGBPickerPolyline"
 
+#define MI_SkeletonNextMode "MI_SkeletonNextMode"
+#define MI_SkeletonBuildSkeleton "MI_SkeletonBuildSkeleton"
+#define MI_SkeletonAnimate "MI_SkeletonAnimate"
+#define MI_SkeletonInverseKinematics "MI_SkeletonInverseKinematics"
+
 #define MI_DeactivateUpperColumns "MI_DeactivateUpperColumns"
 #define MI_CompareToSnapshot "MI_CompareToSnapshot"
 #define MI_PreviewFx "MI_PreviewFx"


### PR DESCRIPTION
improvement of #3202 

![a](https://user-images.githubusercontent.com/60221547/78496244-7485fa00-7739-11ea-845d-e57b0d9f7875.jpg)

99% of the code I added is boilerplate. I tried using lambda to reduce it but failed. So if anyone knows how to reduce this boilerplate, please share!

I only check Toonz Vector level for all modes/types shortcuts. I believe anyone who uses other levels and notices that some shortcuts are missing should be able to add those shortcuts themselves by reading this PR. (please also submit a PR if you do so)

Now, for all tool switching shortcuts, there will be 5 types of shortcuts:

- tool switching - shortcuts that only switch tools and nothing else (e.g. "Eraser")
- mode cycling - shortcuts that cycles modes/types of current tool (e.g. "Mode", "Type")
- mode switching - shortcuts that switches modes/types of current tool (e.g. "Type - Freehand")
- tool switching + mode cycling - shortcuts that switches tool if you're not using that tool, cycles modes/types if you are using the tool (e.g. "Eraser Tool - Next Type")
- tool switching + mode switching shortcuts that switches tool AND modes/types (e.g. "Eraser Tool - Freehand")