### PR TITLE
fix hook problem with vector brush tool

### DIFF
--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -701,7 +701,7 @@ static void Smooth(std::vector<TThickPoint> &points, int radius) {
   if (points.size() >= 3) {
     std::vector<TThickPoint> pts;
     CatmullRomInterpolate(points[0], points[0], points[1], points[2], 10, pts);
-    std::vector<TThickPoint>::iterator it = points.begin();
+    std::vector<TThickPoint>::iterator it = points.begin() + 1;
     points.insert(it, pts.begin(), pts.end());
 
     pts.clear();


### PR DESCRIPTION
related issue: #2526 #2861 

The "hook" problem is that, when you use vector brush tool to draw quickly with high smooth value, there will be a "hook" at the start of the stroke.

![a](https://user-images.githubusercontent.com/60221547/79083453-02c53600-7d61-11ea-9ebd-2fde6b1f22a3.jpg)

The problem no longer exists on my end when I applied this fix. However, I don't have a drawing tablet to confirm that it won't happen if you are using it.

Explanation: If I didn't misunderstand [this article](http://www.mvps.org/directx/articles/catmull/), CatmullRomInterpolate(p0, p1, p2, p3, samples) function generates `samples` points between p1 and p2 and thus all points generated should be inserted between p1 and p2. However in

https://github.com/opentoonz/opentoonz/blob/f49503f713d2942e4afa418c2e1f3b56085ddd78/toonz/sources/tnztools/toonzrasterbrushtool.cpp#L702-L705

where

* p0 = points[0]
* p1 = points[0]
* p2 = points[1]
* p3 = points[2]

the code inserts generated points BEFORE p1 and I assume that's the reason that caused the hook problem.