### PR TITLE
Allow to Hide Console in Viewer

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -75,7 +75,7 @@ namespace {
 
 void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
                     int widgetHeight, double pressure, int devPixRatio) {
-  toonzEvent.m_pos      = TPointD(event->pos().x() * devPixRatio,
+  toonzEvent.m_pos = TPointD(event->pos().x() * devPixRatio,
                              widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
   toonzEvent.m_pressure = 1.0;
@@ -310,7 +310,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 #ifdef LINUX
     // for Linux, create context menu on right click here.
     // could possibly merge with OSX code above
-    if(e->button() == Qt::RightButton) {
+    if (e->button() == Qt::RightButton) {
       m_mouseButton = Qt::NoButton;
       onContextMenu(e->pos(), e->globalPos());
     }
@@ -931,12 +931,12 @@ void SceneViewer::wheelEvent(QWheelEvent *event) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-  {
-    std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
-                 "Qt::MouseEventSynthesizedByApplication"
-              << std::endl;
-    break;
-  }
+    {
+      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                   "Qt::MouseEventSynthesizedByApplication"
+                << std::endl;
+      break;
+    }
 
   }  // end switch
 
@@ -1032,8 +1032,8 @@ void SceneViewer::gestureEvent(QGestureEvent *e) {
         qreal rotationDelta =
             gesture->rotationAngle() - gesture->lastRotationAngle();
         if (m_isFlippedX != m_isFlippedY) rotationDelta = -rotationDelta;
-        TAffine aff    = getViewMatrix().inv();
-        TPointD center = aff * TPointD(0, 0);
+        TAffine aff                                     = getViewMatrix().inv();
+        TPointD center                                  = aff * TPointD(0, 0);
         if (!m_rotating && !m_zooming) {
           m_rotationDelta += rotationDelta;
           double absDelta = abs(m_rotationDelta);
@@ -1174,9 +1174,10 @@ bool SceneViewer::event(QEvent *e) {
     break;
   }
   */
-  if (e->type() == QEvent::Gesture && CommandManager::instance()
-                                          ->getAction(MI_TouchGestureControl)
-                                          ->isChecked()) {
+  if (e->type() == QEvent::Gesture &&
+      CommandManager::instance()
+          ->getAction(MI_TouchGestureControl)
+          ->isChecked()) {
     gestureEvent(static_cast<QGestureEvent *>(e));
     return true;
   }
@@ -1216,7 +1217,7 @@ bool SceneViewer::event(QEvent *e) {
 
     // Disable keyboard shortcuts while the tool is busy with a mouse drag
     // operation.
-    if ( tool->isDragging() ) {
+    if (tool->isDragging()) {
       e->accept();
     }
 
@@ -1597,6 +1598,13 @@ void SceneViewer::onContextMenu(const QPoint &pos, const QPoint &globalPos) {
     cvp->addShowHideContextMenu(menu);
   }
 
+  SceneViewerPanel *svp = qobject_cast<SceneViewerPanel *>(
+      parentWidget()->parentWidget()->parentWidget());
+  if (svp) {
+    menu->addSeparator();
+    svp->addShowHideContextMenu(menu);
+  }
+
   menu->exec(globalPos);
   delete menu;
   menuVisible = false;
@@ -1644,13 +1652,13 @@ void SceneViewer::dropEvent(QDropEvent *e) {
 
     IoCmd::loadResources(args);
 
-	if (acceptResourceOrFolderDrop(mimeData->urls())) {
-		// Force Copy Action
-		e->setDropAction(Qt::CopyAction);
-		// For files, don't accept original proposed action in case it's a move
-		e->accept();
-		return;
-	}
+    if (acceptResourceOrFolderDrop(mimeData->urls())) {
+      // Force Copy Action
+      e->setDropAction(Qt::CopyAction);
+      // For files, don't accept original proposed action in case it's a move
+      e->accept();
+      return;
+    }
   }
   e->acceptProposedAction();
 }
@@ -1664,8 +1672,8 @@ void SceneViewer::onToolSwitched() {
 
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   if (tool) {
-	  tool->updateMatrix();
-	  if (tool->getViewer()) tool->getViewer()->setGuidedStrokePickerMode(0);
+    tool->updateMatrix();
+    if (tool->getViewer()) tool->getViewer()->setGuidedStrokePickerMode(0);
   }
 
   onLevelChanged();

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -861,33 +861,6 @@ OpenFloatingPanel openStyleEditorCommand(MI_OpenStyleControl, "StyleEditor",
                                          QObject::tr("Style Editor"));
 //-----------------------------------------------------------------------------
 
-//=============================================================================
-// SceneViewer
-//-----------------------------------------------------------------------------
-
-class SceneViewerFactory final : public TPanelFactory {
-public:
-  SceneViewerFactory() : TPanelFactory("SceneViewer") {}
-
-  TPanel *createPanel(QWidget *parent) override {
-    SceneViewerPanel *panel = new SceneViewerPanel(parent);
-    panel->setObjectName(getPanelType());
-    panel->setWindowTitle(QObject::tr("Viewer"));
-    panel->setMinimumSize(220, 280);
-    return panel;
-  }
-
-  void initialize(TPanel *panel) override { assert(0); }
-
-} sceneViewerFactory;
-
-//=============================================================================
-OpenFloatingPanel openSceneViewerCommand(MI_OpenLevelView, "SceneViewer",
-                                         QObject::tr("Viewer"));
-//-----------------------------------------------------------------------------
-
-//-----------------------------------------------------------------------------
-
 class ToolbarFactory final : public TPanelFactory {
 public:
   ToolbarFactory() : TPanelFactory("ToolBar") {}
@@ -1330,6 +1303,53 @@ public:
 //=============================================================================
 OpenFloatingPanel openComboViewerCommand(MI_OpenComboViewer, "ComboViewer",
                                          QObject::tr("Combo Viewer"));
+//-----------------------------------------------------------------------------
+
+//=============================================================================
+// SceneViewer
+//-----------------------------------------------------------------------------
+
+SceneViewerPanelContainer::SceneViewerPanelContainer(QWidget* parent)
+    : StyleShortcutSwitchablePanel(parent) {
+    m_sceneViewer = new SceneViewerPanel(parent);
+    setFocusProxy(m_sceneViewer);
+    setWidget(m_sceneViewer);
+
+    m_sceneViewer->initializeTitleBar(getTitleBar());
+}
+// reimplementation of TPanel::widgetInThisPanelIsFocused
+bool SceneViewerPanelContainer::widgetInThisPanelIsFocused() {
+    return m_sceneViewer->hasFocus();
+}
+// reimplementation of TPanel::widgetFocusOnEnter
+void SceneViewerPanelContainer::widgetFocusOnEnter() {
+    m_sceneViewer->onEnterPanel();
+}
+void SceneViewerPanelContainer::widgetClearFocusOnLeave() {
+    m_sceneViewer->onLeavePanel();
+}
+
+
+//-----------------------------------------------------------------------------
+
+class SceneViewerFactory final : public TPanelFactory {
+public:
+    SceneViewerFactory() : TPanelFactory("SceneViewer") {}
+
+    TPanel* createPanel(QWidget* parent) override {
+        SceneViewerPanelContainer* panel = new SceneViewerPanelContainer(parent);
+        panel->setObjectName(getPanelType());
+        panel->setWindowTitle(QObject::tr("Viewer"));
+        panel->setMinimumSize(220, 280);
+        //panel->resize(700, 600);
+        return panel;
+    }
+    void initialize(TPanel* panel) override { assert(0); }
+} sceneViewerFactory;
+
+//=============================================================================
+OpenFloatingPanel openSceneViewerCommand(MI_OpenLevelView, "SceneViewer",
+    QObject::tr("Viewer"));
 //-----------------------------------------------------------------------------
 
 //=============================================================================

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -26,6 +26,7 @@ class FunctionViewer;
 class FlipBook;
 class ToolOptions;
 class ComboViewerPanel;
+class SceneViewerPanel;
 class FxSettings;
 class VectorGuidedDrawingPane;
 
@@ -269,6 +270,25 @@ protected:
   // reimplementation of TPanel::widgetFocusOnEnter
   void widgetFocusOnEnter() override;
   void widgetClearFocusOnLeave() override;
+};
+
+//=========================================================
+// SceneViewerPanel
+//---------------------------------------------------------
+
+class SceneViewerPanelContainer final : public StyleShortcutSwitchablePanel {
+    Q_OBJECT
+        SceneViewerPanel *m_sceneViewer;
+
+public:
+    SceneViewerPanelContainer(QWidget* parent);
+    // reimplementation of TPanel::widgetInThisPanelIsFocused
+    bool widgetInThisPanelIsFocused() override;
+
+protected:
+    // reimplementation of TPanel::widgetFocusOnEnter
+    void widgetFocusOnEnter() override;
+    void widgetClearFocusOnLeave() override;
 };
 
 //=========================================================


### PR DESCRIPTION
This allows the Console (playback controls and playback slider) to be hidden in the viewer.  If you know the shortcuts, this can save screen space.

![NoConsole](https://user-images.githubusercontent.com/4576381/79182623-781a2080-7dcc-11ea-966f-05bb663bab73.png)

This adds the show/hide menu options that are available in the combo viewer.

![menu](https://user-images.githubusercontent.com/4576381/79182629-7c463e00-7dcc-11ea-82c4-b2ca89e5583b.png)
