### PR TITLE
Allow undo/redo converting level to vectors

### DIFF
--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -467,7 +467,7 @@ void cloneSubXsheets(TXsheet *xsh) {
 //  PasteColumnsUndo
 //-----------------------------------------------------------------------------
 
-class PasteColumnsUndo final : public TUndo {
+class PasteColumnsUndo : public TUndo {
   std::set<int> m_indices;
   StageObjectsData *m_data;
   QMap<TFxPort *, TFx *> m_columnLinks;
@@ -1349,3 +1349,23 @@ ColumnsStatusCommand
     c16(MI_LockSelectedColumns, CMD_LOCK, TARGET_SELECTED),
     c17(MI_UnlockSelectedColumns, CMD_UNLOCK, TARGET_SELECTED);
 }  // namespace
+
+//=============================================================================
+// ConvertToVectorUndo
+//-----------------------------------------------------------------------------
+
+// Same in functionality to PasteColumnsUndo; think of it perhaps like
+// pasting the newly created vector column.
+class ConvertToVectorUndo final : public PasteColumnsUndo {
+public:
+  ConvertToVectorUndo(std::set<int> indices) : PasteColumnsUndo(indices) {};
+
+  QString getHistoryString() override {
+    return QObject::tr("Convert to Vectors");
+  }
+};
+
+void ColumnCmd::addConvertToVectorUndo(std::set<int> &newColumnIndices)
+{
+    TUndoManager::manager()->add(new ConvertToVectorUndo(newColumnIndices));
+}

--- a/toonz/sources/toonz/columncommand.h
+++ b/toonz/sources/toonz/columncommand.h
@@ -32,6 +32,9 @@ bool canResequence(int index);
 void cloneChild(int index);
 void clearCells(int index);
 
+//! Adds an undo object for converting layer to vector.
+void addConvertToVectorUndo(std::set<int> &newColumnIndices);
+
 }  // namespace
 
 #endif

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -46,6 +46,7 @@
 #include "tcolorstyles.h"
 #include "tstroke.h"
 #include "tpersistset.h"
+#include "columncommand.h"
 
 // Qt includes
 #include <QFrame>
@@ -950,6 +951,7 @@ bool VectorizerPopup::apply() {
                        SLOT(onFinished()), Qt::QueuedConnection);
   assert(ret);
 
+  std::set<int> newColumnIndices;
   int newIndexColumn = c1 + 1;
   for (auto const level : levels) {
     TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(level);
@@ -1017,15 +1019,21 @@ bool VectorizerPopup::apply() {
           }
         }
       }
+      newColumnIndices.insert(newIndexColumn);
       newIndexColumn += 1;
     } else if (vl) {
       std::vector<TFrameId> gomi;
+      newColumnIndices.insert(scene->getXsheet()->getFirstFreeColumnIndex());
       scene->getXsheet()->exposeLevel(
           0, scene->getXsheet()->getFirstFreeColumnIndex(), vl, gomi);
     }
 
     if (m_vectorizer->isCanceled()) break;
   }
+
+  // Add undo object
+  if (!m_vectorizer->isCanceled())
+    ColumnCmd::addConvertToVectorUndo(newColumnIndices);
 
   m_progressDialog->close();
   delete m_vectorizer;


### PR DESCRIPTION
Adds ability to Undo and Redo the _Level --> Convert --> Convert to Vectors..._ command. Video demo below:

![undo-convert-demo](https://user-images.githubusercontent.com/24422213/79237640-83e80e80-7ec2-11ea-9d3f-b0129d07354f.gif)

Haven't tested using a column with linked Fx's but assume they will be OK.