### PR TITLE
Frame slider and Play bar can be hidden separately

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -283,6 +283,8 @@ public:
   void pressButton(EGadget buttonId);
 
   void showHideAllParts(bool);
+  void showHidePlaybar(bool);
+  void showHideFrameSlider(bool);
 
   void enableProgressBar(bool enable);
   void setProgressBarStatus(const std::vector<UCHAR> *status);

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -429,7 +429,9 @@ enum {
   eShowDefineLoadBox   = 0x400,
   eShowUseLoadBox      = 0x800,
   eShowViewerControls  = 0x1000,
-  eShowHowMany         = 0x2000
+  eShowSound           = 0x2000,
+  eShowLocator         = 0x4000,
+  eShowHowMany         = 0x8000
 };
 
 FlipConsole::FlipConsole(QVBoxLayout *mainLayout, std::vector<int> gadgetsMask,
@@ -537,6 +539,18 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, std::vector<int> gadgetsMask,
 
 void FlipConsole::showHideAllParts(bool isShow) {
   m_playToolBarContainer->setVisible(isShow);
+  m_frameSliderFrame->setVisible(isShow);
+}
+
+//-----------------------------------------------------------------------------
+
+void FlipConsole::showHidePlaybar(bool isShow) {
+  m_playToolBarContainer->setVisible(isShow);
+}
+
+//-----------------------------------------------------------------------------
+
+void FlipConsole::showHideFrameSlider(bool isShow) {
   m_frameSliderFrame->setVisible(isShow);
 }
 
@@ -992,10 +1006,20 @@ void FlipConsole::applyCustomizeMask() {
   enableButton(eDefineSubCamera, m_customizeMask & eShowDefineSubCamera);
   enableButton(eDefineLoadBox, m_customizeMask & eShowDefineLoadBox);
   enableButton(eUseLoadBox, m_customizeMask & eShowUseLoadBox);
-  if (m_subcamSep)
-    m_subcamSep->setVisible(m_customizeMask & eShowDefineSubCamera ||
-                            m_customizeMask & eShowDefineLoadBox ||
-                            m_customizeMask & eShowUseLoadBox);
+  if (m_subcamSep) {
+    int count = m_gadgetsMask.size();
+    bool hasDefineLoadBox =
+        std::find(m_gadgetsMask.begin(), m_gadgetsMask.end(), eDefineLoadBox) ==
+        m_gadgetsMask.end();
+    bool hasUseLoadBox = std::find(m_gadgetsMask.begin(), m_gadgetsMask.end(),
+                                   eUseLoadBox) == m_gadgetsMask.end();
+    bool hasDefineSubCam = std::find(m_gadgetsMask.begin(), m_gadgetsMask.end(),
+                                     eDefineSubCamera) == m_gadgetsMask.end();
+    m_subcamSep->setVisible(
+        (hasDefineSubCam && m_customizeMask & eShowDefineSubCamera) ||
+        (hasDefineLoadBox && m_customizeMask & eShowDefineLoadBox) ||
+        (hasUseLoadBox && m_customizeMask & eShowUseLoadBox));
+  }
 
   enableButton(eWhiteBg, m_customizeMask & eShowBg);
   enableButton(eBlackBg, m_customizeMask & eShowBg);
@@ -1015,6 +1039,9 @@ void FlipConsole::applyCustomizeMask() {
   enableButton(eLoop, m_customizeMask & eShowVcr);
   enableButton(eNext, m_customizeMask & eShowVcr);
   enableButton(eLast, m_customizeMask & eShowVcr);
+
+  enableButton(eSound, m_customizeMask & eShowSound);
+  enableButton(eLocator, m_customizeMask & eShowLocator);
 
   if (m_vcrSep) m_vcrSep->setVisible(m_customizeMask & eShowVcr);
 
@@ -1094,8 +1121,6 @@ void FlipConsole::createCustomizeMenu(bool withCustomWidget) {
         hasButton(m_gadgetsMask, eBlackBg) ||
         hasButton(m_gadgetsMask, eCheckBg))
       addMenuItem(eShowBg, tr("Background Colors"), menu);
-    if (hasButton(m_gadgetsMask, eRate))
-      addMenuItem(eShowFramerate, tr("Framerate"), menu);
 
     addMenuItem(eShowVcr, tr("Playback Controls"), menu);
 
@@ -1103,10 +1128,16 @@ void FlipConsole::createCustomizeMenu(bool withCustomWidget) {
         hasButton(m_gadgetsMask, eBlue) || hasButton(m_gadgetsMask, eMatte))
       addMenuItem(eShowcolorFilter, tr("Color Channels"), menu);
 
-    if (withCustomWidget) addMenuItem(eShowCustom, tr("Set Key"), menu);
+    if (hasButton(m_gadgetsMask, eSound))
+      addMenuItem(eShowSound, tr("Sound"), menu);
 
     if (hasButton(m_gadgetsMask, eHisto))
       addMenuItem(eShowHisto, tr("Histogram"), menu);
+
+    if (hasButton(m_gadgetsMask, eLocator))
+      addMenuItem(eShowLocator, tr("Locator"), menu);
+
+    if (withCustomWidget) addMenuItem(eShowCustom, tr("Set Key"), menu);
 
     if (hasButton(m_gadgetsMask, eFilledRaster))
       addMenuItem(eFilledRaster, tr("Display Areas as Filled"), menu);
@@ -1117,6 +1148,9 @@ void FlipConsole::createCustomizeMenu(bool withCustomWidget) {
         hasButton(m_gadgetsMask, eFlipVertical) ||
         hasButton(m_gadgetsMask, eResetView))
       addMenuItem(eShowViewerControls, tr("Viewer Controls"), menu);
+
+    if (hasButton(m_gadgetsMask, eRate))
+      addMenuItem(eShowFramerate, tr("Framerate"), menu);
 
     bool ret = connect(menu, SIGNAL(triggered(QAction *)), this,
                        SLOT(onCustomizeButtonPressed(QAction *)));


### PR DESCRIPTION
This allows the user to hide the playback bar and the frame slider separately.
It also allows the sound and locator icons to be hidden from the play bar using the menu
Finally it reorders the menu of the play bar to show up in the order they are in the bar.