### PR TITLE
Enable sending files to Trash in Browser on Linux

### DIFF
--- a/toonz/sources/common/tsystem/tsystempd.cpp
+++ b/toonz/sources/common/tsystem/tsystempd.cpp
@@ -59,7 +59,10 @@
 #include <dlfcn.h>
 #include <utime.h>
 #include <sys/time.h>
-
+#include <QDir>
+#include <QFileInfo>
+#include <QTextStream>
+#include <QUrl>
 #endif
 
 #if defined(MACOSX)
@@ -452,7 +455,40 @@ void TSystem::moveFileToRecycleBin(const TFilePath &fp) {
     } catch (...) {
     }
   }
+#elif defined(LINUX)
+  //
+  // From https://stackoverflow.com/questions/17964439/move-files-to-trash-recycle-bin-in-qt
+  //
+  QString fileToRecycle = fp.getQString();
+  QFileInfo FileName(fileToRecycle);
 
+  QDateTime currentTime(QDateTime::currentDateTime());    // get system time
+
+  QString trashFilePath = QDir::homePath() + "/.local/share/Trash/files/";    // this folder contains deleted files
+  QString trashInfoPath = QDir::homePath() + "/.local/share/Trash/info/";     // this folder contains information about the deleted files
+
+  // check paths exist
+  if( !QDir(trashFilePath).exists() || !QDir(trashFilePath).exists(trashInfoPath) ) {
+    outputDebug("Could not find the right paths to send the file to the recycle bin.");
+    return;
+  }
+
+  // create file for the "Trash/info" folder
+  QFile infoFile(trashInfoPath + FileName.completeBaseName() + "." + FileName.completeSuffix() + ".trashinfo");     // filename+extension+.trashinfo
+
+  infoFile.open(QIODevice::ReadWrite);
+
+  QTextStream stream(&infoFile);
+
+  stream << "[Trash Info]" << endl;
+  stream << "Path=" + QString(QUrl::toPercentEncoding(FileName.absoluteFilePath(), "~_-./")) << endl;     // convert path to percentage encoded string
+  stream << "DeletionDate=" + currentTime.toString("yyyy-MM-dd") + "T" + currentTime.toString("hh:mm:ss") << endl;      // get date and time in format YYYY-MM-DDThh:mm:ss
+
+  infoFile.close();
+
+  // move the original file to the "Trash/files" folder
+  QDir file;
+  file.rename(FileName.absoluteFilePath(), trashFilePath+FileName.completeBaseName() + "." + FileName.completeSuffix());  // rename(original path, trash path)
 #else
   assert(!"Not implemented yet");
 #endif

--- a/toonz/sources/common/tsystem/tsystempd.cpp
+++ b/toonz/sources/common/tsystem/tsystempd.cpp
@@ -61,6 +61,7 @@
 #include <sys/time.h>
 #include <QDir>
 #include <QFileInfo>
+#include <QStorageInfo>
 #include <QTextStream>
 #include <QUrl>
 #endif
@@ -464,11 +465,26 @@ void TSystem::moveFileToRecycleBin(const TFilePath &fp) {
 
   QDateTime currentTime(QDateTime::currentDateTime());    // get system time
 
+  // check if the file is on the local drive
+  const QStorageInfo fileStorageInfo(fileToRecycle);
+  const QStorageInfo homeStorageInfo(QDir::homePath());
+  const bool isOnHomeDrive = fileStorageInfo == homeStorageInfo;
+
   QString trashFilePath = QDir::homePath() + "/.local/share/Trash/files/";    // this folder contains deleted files
   QString trashInfoPath = QDir::homePath() + "/.local/share/Trash/info/";     // this folder contains information about the deleted files
 
+  // different paths are used for external drives
+  if (!isOnHomeDrive) {
+    //trashFilePath = fileStorageInfo.rootPath() + "/.Trash-1000/files/";
+    //trashInfoPath = fileStorageInfo.rootPath() + "/.Trash-1000/info/";
+
+    // TODO: Implement this... The standard is /.Trash-<UID>/...
+    outputDebug("Deleting files on external drives in Linux is not implemented yet.");
+    return;
+  }
+
   // check paths exist
-  if( !QDir(trashFilePath).exists() || !QDir(trashFilePath).exists(trashInfoPath) ) {
+  if( !QDir(trashFilePath).exists() || !QDir(trashInfoPath).exists() ) {
     outputDebug("Could not find the right paths to send the file to the recycle bin.");
     return;
   }


### PR DESCRIPTION
Allows sending files to the Trash (recycle bin) from Browser windows on Linux. Demo below, shows me deleting a file and then restoring from the Trash in Ubuntu:

![linux-delete-file-demo-after](https://user-images.githubusercontent.com/24422213/79385076-1b7d5800-7fbc-11ea-8c30-0a11233b8444.gif)

This works for me on Ubuntu 18.04, but I'm not sure about other Linux distributions. Is anyone else able to test?