### PR TITLE
Add search bar in fx browser

### DIFF
--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -494,8 +494,9 @@ TFx *InsertFxPopup::createFx() {
   TXsheet *xsh      = scene->getXsheet();
 
   QTreeWidgetItem *item = m_fxTree->currentItem();
-  QString text          = item->data(0, Qt::UserRole).toString();
+  if (item == NULL) return 0;
 
+  QString text = item->data(0, Qt::UserRole).toString();
   if (text.isEmpty()) return 0;
 
   TFx *fx;

--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -143,16 +143,34 @@ TFx *createMacroFxByPath(TFilePath path) {
 // FxTree
 //=============================================================================
 
+void FxTree::displayAll(QTreeWidgetItem *item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    displayAll(item->child(i));
+  }
+  item->setHidden(false);
+  item->setExpanded(false);
+}
+
+//-------------------------------------------------------------------
+
+void FxTree::hideAll(QTreeWidgetItem *item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    hideAll(item->child(i));
+  }
+  item->setHidden(true);
+  item->setExpanded(false);
+}
+
+//-------------------------------------------------------------------
+
 void FxTree::searchItems(const QString &searchWord) {
   // if search word is empty, show all items
   if (searchWord.isEmpty()) {
     int itemCount = topLevelItemCount();
     for (int i = 0; i < itemCount; ++i) {
-      QTreeWidgetItem *item = topLevelItem(i);
-      int childCount        = item->childCount();
-      for (int j = 0; j < childCount; ++j) item->child(j)->setHidden(false);
-      item->setHidden(false);
-      item->setExpanded(false);
+      displayAll(topLevelItem(i));
     }
     update();
     return;
@@ -161,11 +179,7 @@ void FxTree::searchItems(const QString &searchWord) {
   // hide all items first
   int itemCount = topLevelItemCount();
   for (int i = 0; i < itemCount; ++i) {
-    QTreeWidgetItem *item = topLevelItem(i);
-    int childCount        = item->childCount();
-    for (int j = 0; j < childCount; ++j) item->child(j)->setHidden(true);
-    item->setHidden(true);
-    item->setExpanded(false);
+    hideAll(topLevelItem(i));
   }
 
   QList<QTreeWidgetItem *> foundItems =
@@ -177,11 +191,10 @@ void FxTree::searchItems(const QString &searchWord) {
 
   // for each item found, show it and show its parent
   for (auto item : foundItems) {
-    item->setHidden(false);
-    QTreeWidgetItem *parent = item->parent();
-    if (parent) {
-      parent->setHidden(false);
-      parent->setExpanded(true);
+    while (item) {
+      item->setHidden(false);
+      item->setExpanded(true);
+      item = item->parent();
     }
   }
 

--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -287,17 +287,20 @@ InsertFxPopup::InsertFxPopup()
 
   QPushButton *insertBtn = new QPushButton(tr("Insert"), this);
   insertBtn->setFixedSize(65, 25);
+  insertBtn->setObjectName("PushButton_NoPadding");
   connect(insertBtn, SIGNAL(clicked()), this, SLOT(onInsert()));
   insertBtn->setDefault(true);
   m_buttonLayout->addWidget(insertBtn);
 
   QPushButton *addBtn = new QPushButton(tr("Add"), this);
   addBtn->setFixedSize(65, 25);
+  addBtn->setObjectName("PushButton_NoPadding");
   connect(addBtn, SIGNAL(clicked()), this, SLOT(onAdd()));
   m_buttonLayout->addWidget(addBtn);
 
   QPushButton *replaceBtn = new QPushButton(tr("Replace"), this);
   replaceBtn->setFixedHeight(25);
+  replaceBtn->setObjectName("PushButton_NoPadding");
   connect(replaceBtn, SIGNAL(clicked()), this, SLOT(onReplace()));
   m_buttonLayout->addWidget(replaceBtn);
 }

--- a/toonz/sources/toonz/insertfxpopup.h
+++ b/toonz/sources/toonz/insertfxpopup.h
@@ -3,6 +3,7 @@
 #ifndef INSERTFXPOPUP_H
 #define INSERTFXPOPUP_H
 
+#include <QTreeWidget>
 #include "toonzqt/dvdialog.h"
 #include "tfilepath.h"
 #include "tstream.h"
@@ -15,13 +16,24 @@ class TFx;
 #include <QIcon>
 
 //=============================================================================
+// FxTree
+//-----------------------------------------------------------------------------
+
+class FxTree final : public QTreeWidget {
+  Q_OBJECT
+
+public:
+  void searchItems(const QString &searchWord = QString());
+};
+
+//=============================================================================
 // InsertFxPopup
 //-----------------------------------------------------------------------------
 
 class InsertFxPopup final : public DVGui::Dialog {
   Q_OBJECT
 
-  QTreeWidget *m_fxTree;
+  FxTree *m_fxTree;
 
   TIStream *m_is;
   TFilePath m_presetFolder;
@@ -59,6 +71,7 @@ protected:
 protected slots:
   void updatePresets();
   void removePreset();
+  void onSearchTextChanged(const QString &text);
 };
 
 #endif  // INSERTFXPOPUP_H

--- a/toonz/sources/toonz/insertfxpopup.h
+++ b/toonz/sources/toonz/insertfxpopup.h
@@ -24,6 +24,10 @@ class FxTree final : public QTreeWidget {
 
 public:
   void searchItems(const QString &searchWord = QString());
+
+private:
+  void displayAll(QTreeWidgetItem *item);
+  void hideAll(QTreeWidgetItem *item);
 };
 
 //=============================================================================


### PR DESCRIPTION
This PR allows you to search in Fx browser.

video: https://youtu.be/THvFztcCJX0

I created this because I constantly forget where "palette filter" FX is.....

code wise, I copied some from toonz/shortcutpopup.cpp for the QT widgets. Was about to copy the search algorithm as well but I failed to do so so I had to write my own version. Logic is basically the same, though.

During testing, I encountered a bug where if nothing is selected and you click on "insert" or "add", opentoonz will crash. I also fixed this bug in this PR.