### PR TITLE
Use correct default units when re-showing Create Level popup

### DIFF
--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -345,11 +345,15 @@ void LevelCreatePopup::showEvent(QShowEvent *) {
     m_dpiLabel->hide();
     m_widthFld->setDecimals(0);
     m_heightFld->setDecimals(0);
+    m_widthFld->setMeasure("camera.lx");
+    m_heightFld->setMeasure("camera.ly");
   } else {
     m_dpiFld->show();
     m_dpiLabel->show();
     m_widthFld->setDecimals(4);
     m_heightFld->setDecimals(4);
+    m_widthFld->setMeasure("level.lx");
+    m_heightFld->setMeasure("level.ly");
   }
 }
 


### PR DESCRIPTION
Fixes part of #3254. The _New Level_ pop-up should now use correct measurement units for width and height, even if they are changed in the Preferences. Demo below:

![change-unit-demo](https://user-images.githubusercontent.com/24422213/80569473-1d7bf800-8a4d-11ea-9d80-886f23594576.gif)

This should fix the problem from the issue description. The first comment (https://github.com/opentoonz/opentoonz/issues/3254#issuecomment-619154377) mentions about the Drawing tab still showing old units. I haven't looked at that.