### PR TITLE
Remove Changing Pins on IK

### DIFF
--- a/toonz/sources/include/tgeometry.h
+++ b/toonz/sources/include/tgeometry.h
@@ -65,7 +65,7 @@ public:
 \sa rotate270
 */
 template <class T>
-inline TPointT<T> rotate90(const TPointT<T> &p)  // counterclockwise
+inline TPointT<T> rotate90(const TPointT<T> &p)  // 90 counterclockwise
 {
   return TPointT<T>(-p.y, p.x);
 }
@@ -76,7 +76,7 @@ inline TPointT<T> rotate90(const TPointT<T> &p)  // counterclockwise
 \sa rotate90
 */
 template <class T>
-inline TPointT<T> rotate270(const TPointT<T> &p)  // clockwise
+inline TPointT<T> rotate270(const TPointT<T> &p)  // 90 clockwise
 {
   return TPointT<T>(p.y, -p.x);
 }
@@ -84,7 +84,7 @@ inline TPointT<T> rotate270(const TPointT<T> &p)  // clockwise
 /*!
 \relates TPointT
 */
-template <class T>  // prodotto scalare
+template <class T>  // Scalar(dot) Product
 inline T operator*(const TPointT<T> &a, const TPointT<T> &b) {
   return a.x * b.x + a.y * b.y;
 }
@@ -542,11 +542,11 @@ template class DVAPI TDimensionT<double>;
 //=============================================================================
 
 //! Specifies the corners of a rectangle.
-/*!\arg \a x0 specifies the x-coordinate of the bottom-left corner of a
-rectangle.
-\arg \a y0 specifies the y-coordinate of the bottom-left corner of a rectangle.
-\arg \a x1 specifies the x-coordinate of the upper-right corner of a rectangle.
-\arg \a y1 specifies the y-coordinate of the upper-right corner of a rectangle.
+/*!
+x0 specifies the x-coordinate of the bottom-left corner of a rectangle.
+y0 specifies the y-coordinate of the bottom-left corner of a rectangle.
+x1 specifies the x-coordinate of the upper-right corner of a rectangle.
+y1 specifies the y-coordinate of the upper-right corner of a rectangle.
 */
 template <class T>
 class DVAPI TRectT {
@@ -561,14 +561,18 @@ if x0==y1 && y0==y1 and rect is a  TRectD then rect is empty */
   TRectT();
 
   TRectT(T _x0, T _y0, T _x1, T _y1) : x0(_x0), y0(_y0), x1(_x1), y1(_y1){};
+
   TRectT(const TRectT &rect)
       : x0(rect.x0), y0(rect.y0), x1(rect.x1), y1(rect.y1){};
+
   TRectT(const TPointT<T> &p0, const TPointT<T> &p1)  // non importa l'ordine
       : x0(std::min((T)p0.x, (T)p1.x)),
         y0(std::min((T)p0.y, (T)p1.y)),
         x1(std::max((T)p0.x, (T)p1.x)),
         y1(std::max((T)p0.y, (T)p1.y)){};
+
   TRectT(const TPointT<T> &bottomLeft, const TDimensionT<T> &d);
+
   TRectT(const TDimensionT<T> &d);
 
   void empty();
@@ -588,15 +592,15 @@ TRectI  is empty if x0>x1 || y0>y1 */
   TPointT<T> getP11() const { return TPointT<T>(x1, y1); };
 
   //! Returns the union of two source rectangles.
-  /*!The union is the smallest rectangle that contains both source rectangles.
-*/
+  //!The union is the smallest rectangle that contains both source rectangles.
   TRectT<T> operator+(const TRectT<T> &rect) const {  // unione
     if (isEmpty())
       return rect;
     else if (rect.isEmpty())
       return *this;
     else
-      return TRectT<T>(std::min((T)x0, (T)rect.x0), std::min((T)y0, (T)rect.y0),
+      return TRectT<T>(std::min((T)x0, (T)rect.x0), 
+                       std::min((T)y0, (T)rect.y0),
                        std::max((T)x1, (T)rect.x1),
                        std::max((T)y1, (T)rect.y1));
   };
@@ -607,10 +611,8 @@ TRectI  is empty if x0>x1 || y0>y1 */
     return *this = *this * rect;
   };
 
-  /*!Returns the intersection of two existing rectangles.
-
-The intersection is the largest rectangle contained in both existing rectangles.
-*/
+  //!Returns the intersection of two existing rectangles.
+  //The intersection is the largest rectangle contained in both existing rectangles.
   TRectT<T> operator*(const TRectT<T> &rect) const {  // intersezione
     if (isEmpty() || rect.isEmpty())
       return TRectT<T>();
@@ -622,7 +624,7 @@ The intersection is the largest rectangle contained in both existing rectangles.
                        std::min((T)y1, (T)rect.y1));
   };
 
-  TRectT<T> &operator+=(const TPointT<T> &p) {  // spostamento
+  TRectT<T> &operator+=(const TPointT<T> &p) {  // shift
     x0 += p.x;
     y0 += p.y;
     x1 += p.x;
@@ -691,6 +693,7 @@ template class DVAPI TRectT<double>;
 \relates TRectT
 Convert a TRectD into a TRect
 */
+
 inline TRect convert(const TRectD &r) {
   return TRect((int)(r.x0 + 0.5), (int)(r.y0 + 0.5), (int)(r.x1 + 0.5),
                (int)(r.y1 + 0.5));
@@ -707,8 +710,8 @@ inline TRectD convert(const TRect &r) { return TRectD(r.x0, r.y0, r.x1, r.y1); }
 \relates TPointT
 */
 inline TRectD boundingBox(const TPointD &p0, const TPointD &p1) {
-  return TRectD(std::min(p0.x, p1.x), std::min(p0.y, p1.y),
-                std::max(p0.x, p1.x), std::max(p0.y, p1.y));
+  return TRectD(std::min(p0.x, p1.x), std::min(p0.y, p1.y),  // bottom left
+                std::max(p0.x, p1.x), std::max(p0.y, p1.y));  // top right
 }
 /*!
 \relates TRectT
@@ -733,6 +736,7 @@ inline TRectD boundingBox(const TPointD &p0, const TPointD &p1,
 
 //-----------------------------------------------------------------------------
 
+// TRectT is a rectangle that uses thick points
 template <>
 inline TRectT<int>::TRectT() : x0(0), y0(0), x1(-1), y1(-1) {}
 template <>
@@ -754,6 +758,8 @@ inline void TRectT<int>::empty() {
   x0 = y0 = 0;
   x1 = y1 = -1;
 }
+
+// Is the adding of one here to account for the thickness?
 template <>
 inline int TRectT<int>::getLx() const {
   return x1 >= x0 ? x1 - x0 + 1 : 0;
@@ -846,21 +852,15 @@ extern DVVAR const TRectI infiniteRectI;
 //=============================================================================
 //! This is the base class for the affine transformations.
 /*!
-                This class performs basic manipulations of affine
-   transformations.
-                An affine transformation is a linear transformation followed by
-   a translation.
-                <p>
-                \f$ 	x \mapsto \bf{A} x + b	\f$
-                </p>
-                <p>
-                \f$ \bf{A} \f$ is a \f$ 2X2 \f$ matrix.
-                In a matrix notation:
-                <p> \f$ \left(\begin{array}{c} \vec{y} \\ 1 \end{array}\right) =
-                \left( \begin{array}{cc} \bf{A} & \vec{b} \\ \vec{0} & 1
-   \end{array}\right)
-                \left(\begin{array}{c}\vec{x} \\ 1 \end{array} \right) \f$ </p>
-        */
+ This class performs basic manipulations of affine transformations.
+ An affine transformation is a linear transformation followed by a translation.
+ 
+  [a11, a12, a13]
+  [a21, a22, a23]
+
+  a13 and a23 represent translation (moving sideways or up and down)
+  the other 4 handle rotation, scale and shear
+*/
 class DVAPI TAffine {
 public:
   double a11, a12, a13;
@@ -891,7 +891,7 @@ public:
           Assignment operator.
 */
   TAffine &operator=(const TAffine &a);
-  /*Sposto in tgeometry.cpp
+  /*Moved to tgeometry.cpp
 {
 a11 = a.a11; a12 = a.a12; a13 = a.a13;
 a21 = a.a21; a22 = a.a22; a23 = a.a23;
@@ -905,7 +905,7 @@ return *this;
 
 */
   TAffine operator*(const TAffine &b) const;
-  /*Sposto in tgeometry.cpp
+  /*Moved to in tgeometry.cpp
 {
 return TAffine (
 a11 * b.a11 + a12 * b.a21,
@@ -919,7 +919,7 @@ a21 * b.a13 + a22 * b.a23 + a23);
 */
 
   TAffine operator*=(const TAffine &b);
-  /*Sposto in tgeometry.cpp
+  /*Moved to tgeometry.cpp
 {
 return *this = *this * b;
 };
@@ -930,7 +930,7 @@ return *this = *this * b;
   */
 
   TAffine inv() const;
-  /*Sposto in tgeometry.cpp
+  /*Moved to tgeometry.cpp
 {
 if(a12 == 0.0 && a21 == 0.0)
 {

--- a/toonz/sources/include/toonz/ikjacobian.h
+++ b/toonz/sources/include/toonz/ikjacobian.h
@@ -18,12 +18,7 @@
 #endif
 
 //******************** IK Utility *********************
-//
-//	Di seguito le classi VectorRn e MatrixRmn
-//	TODO: Se possibile cambiare e usare le STL
-//
-//
-//****************************************************
+//*****************************************************
 
 //***********************************************************************
 // CLASS VectorRN
@@ -683,15 +678,15 @@ public:
   void Reset();
 
 private:
-  IKSkeleton *skeleton;  // skeletro associato a questa matrice Jacobiana
+  IKSkeleton *skeleton;  // skeleton associated with this Jacobian matrix
   std::vector<TPointD> target;
-  int nEffector;  // Numero di end effectors
-  int nJoint;     // Numero di Joints
-  int nRow;       // righe matrice J (= 2*numero di end effectors)
-  int nCol;       // numero di colonne di J
+  int nEffector;  // Number of end effectors
+  int nJoint;     // Number of Joints
+  int nRow;       // matrix rows J(= 2 * number of end effectors)
+  int nCol;       // number of columns of J
 
   MatrixRmn
-      Jend;  // matrice Jacobiana basata sulle posizioni degli end effectors
+      Jend;  // Jacobian matrix based on the positions of the end effectors
   MatrixRmn Jtarget;
   MatrixRmn Jnorms;  // Norms of 2-vectors in active Jacobian (solo SDLS)
 
@@ -709,10 +704,10 @@ private:
 
   VectorRn dPreTheta;  // (vale solo per SDLS)
 
-  // Parametri per pseudorinversa
+  // Parameters for pseudorinverse
   static const double PseudoInverseThresholdFactor;
 
-  // Paremetri pe il metodo Damped Least Squares
+  // Paremeters for the Damped Least Squares method
   static const double DefaultDampingLambda;
   double DampingLambda;
   double DampingLambdaSq;

--- a/toonz/sources/include/toonz/iknode.h
+++ b/toonz/sources/include/toonz/iknode.h
@@ -22,8 +22,8 @@ public:
   enum Purpose { JOINT, EFFECTOR };
 
   IKNode() : m_parent(0), m_pos() {
-    r = TPointD(0.0, 1.0);  // r sara' aggiornato quando il nodo sara; inserito
-                            // nello skeleton
+    r = TPointD(0.0, 1.0);  // r will be updated when the node is added
+                            // in the skeleton
     theta    = 0.0;
     m_parent = 0;
   }
@@ -70,7 +70,7 @@ public:
   }
 
   bool isFrozen() const { return freezed; }
-  void freeze() { freezed = true; }  // mantiene l'angolo theta costante
+  void freeze() { freezed = true; }  // keeps the theta angle constant
   void unFreeze() { freezed = false; }
 
 private:
@@ -79,20 +79,20 @@ private:
 
   TPointD m_pos;
   Purpose m_purpose;
-  int m_seqNumJoint;     // indice del Joint nella sequenza di Joint
-  int m_seqNumEffector;  // indice dell'Effector nella sequenza di Effectors
+  int m_seqNumJoint;     // Joint index in the Joint sequence
+  int m_seqNumEffector;  // index of the effector in the sequence of effectors
 
-  TPointD r;  // Posizione relativa
-  TPointD s;  // Posizione Globale
-  // TPointD w; // Rotazione Globale dell'asse
+  TPointD r;  // Relative position
+  TPointD s;  // Global position
+  // TPointD w; // Global axis rotation
 
-  double theta;      // angolo del joint (radianti)
-  double theta0;     // angolo iniziale del joint (radianti)
-  double minTheta;   // limite inferiore angolo
-  double maxTheta;   // limite superiore angolo
-  double restAngle;  // angolo esplementare
+  double theta;      // joint angle(radians)
+  double theta0;     // initial angle of the joint(radians)
+  double minTheta;   // lower angle limit
+  double maxTheta;   // high angle limit
+  double restAngle;  
 
-  bool freezed;  // Se vero l'angolo è blocccato
+  bool freezed;  
 };
 
 #endif  // IKNODE_H

--- a/toonz/sources/tnztools/skeletonsubtools.h
+++ b/toonz/sources/tnztools/skeletonsubtools.h
@@ -86,6 +86,7 @@ public:
 
 class DragPositionTool final : public DragChannelTool {
   TPointD m_firstPos;
+  bool m_firstDrag = false;
 
 public:
   DragPositionTool(SkeletonTool *tool);
@@ -161,9 +162,10 @@ class IKTool final : public DragTool {
   int m_columnIndex;
   IKEngine m_engine;
   bool m_valid;
+  bool m_rootInvolved;
   TAffine m_footPlacement, m_firstFootPlacement;
   TStageObject *m_foot, *m_firstFoot;
-  bool m_IHateIK;
+  bool m_frameOnNewPin;
   IKToolUndo *m_undo;
 
   struct Joint {

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -78,7 +78,7 @@ inline std::string removeTrailingH(std::string handle) {
 //
 //------------------------------------------------------------
 
-// return true iff column ancestorIndex is column descentIndex or its parent or
+// return true if column ancestorIndex is column descentIndex or its parent or
 // the parent of the parent, etc.
 static bool isAncestorOf(int ancestorIndex, int descendentIndex) {
   TStageObjectId ancestorId   = TStageObjectId::ColumnId(ancestorIndex);
@@ -93,7 +93,7 @@ static bool isAncestorOf(int ancestorIndex, int descendentIndex) {
 
 static void getHooks(std::vector<HookData> &hooks, TXsheet *xsh, int row,
                      int col, TPointD dpiScale) {
-  // nota. hook position is in the coordinate system of the parent object.
+  // note. hook position is in the coordinate system of the parent object.
   // a inch is Stage::inch
 
   TXshCell cell = xsh->getCell(row, col);
@@ -342,7 +342,7 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
 
   int selectedDevice = pick(e.m_pos);
 
-  // cambio drawing
+  // change drawing
   if (selectedDevice == TD_ChangeDrawing ||
       selectedDevice == TD_IncrementDrawing ||
       selectedDevice == TD_DecrementDrawing) {
@@ -356,7 +356,7 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
     return;
   }
 
-  // click su un hook: attacca la colonna corrente tramite quell'hook
+  // click on a hook: attach the current column via that hook
   if (TD_Hook <= selectedDevice && selectedDevice < TD_Hook + 50) {
     TXsheet *xsh         = app->getCurrentXsheet()->getXsheet();
     TStageObjectId objId = TStageObjectId::ColumnId(currentColumnIndex);
@@ -381,7 +381,7 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
   bool justSelected = false;
 
   if (m_device < 0) {
-    // nessun gadget cliccato. Eventualmente seleziono la colonna
+    // No gadget clicked.  Select the column
     std::vector<int> columnIndexes;
     getViewer()->posToColumnIndexes(e.m_pos, columnIndexes, getPixelSize() * 5,
                                     false);
@@ -414,12 +414,21 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
 
   // lock/unlock: modalita IK
   if (TD_LockStageObject <= m_device && m_device < TD_LockStageObject + 1000) {
+      Skeleton* skeleton = new Skeleton();
+      buildSkeleton(*skeleton, currentColumnIndex);
     int columnIndex = m_device - TD_LockStageObject;
-    int frame       = app->getCurrentFrame()->getFrame();
-    togglePinnedStatus(columnIndex, frame, e.isShiftPressed());
-    invalidate();
-    m_dragTool = 0;
-    return;
+    int frame = app->getCurrentFrame()->getFrame();
+    if (skeleton->getBoneByColumnIndex(columnIndex) == skeleton->getRootBone()) {
+        app->getCurrentColumn()->setColumnIndex(columnIndex);
+        m_device = TD_Translation;
+    }
+    else if (e.isShiftPressed()) {
+        togglePinnedStatus(columnIndex, frame, e.isShiftPressed());
+        invalidate();
+        m_dragTool = 0;
+        return;
+    }
+    else return;
   }
 
   switch (m_device) {
@@ -989,7 +998,7 @@ void SkeletonTool::drawIKBone(const TPointD &a, const TPointD &b) {
 //-------------------------------------------------------------------
 
 void SkeletonTool::computeMagicLinks() {
-  // TODO: spostare qui il calcolo dei magic link
+  // TODO: move the calculation of the magic links here
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonzlib/ikengine.cpp
+++ b/toonz/sources/toonzlib/ikengine.cpp
@@ -18,7 +18,7 @@ int IKEngine::addJoint(const TPointD &pos, int indexParent) {
   m_skeleton.setParent(index, indexParent);
   return index;
 }
-// la root deve coincidere con un punto bloccato!
+// The root must be a pinned point!
 void IKEngine::setRoot(const TPointD &pos) {
   m_skeleton.addNode(new IKNode());
   m_skeleton.setNode(0, pos, IKNode::JOINT);
@@ -64,7 +64,7 @@ void IKEngine::drag(TPointD &pos) {
   // se lo scheletro è vuoto non succede nulla
   if (m_skeleton.getNodeCount() == 0) return;
 
-  // afferro l'ultimo punto della catena
+  // Grab the last point of the chain
   int indexDrag = m_skeleton.getNodeCount() - 1;
   if (m_skeleton.getNode(indexDrag)->getParent()->IsEffector()) return;
   m_skeleton.setPurpose(indexDrag, IKNode::EFFECTOR);


### PR DESCRIPTION
IK is currently a mess simply due to the fact that we can change which bone is the pinned bone.

The calculations for this are horribly broken and lead to errors in many different scenarios.  

This removes the ability to change which bone is pinned.  This still allows temporary pins, but the root of the skeleton will always be the main pin with this change.

Clicking on the joint will no longer change the main pin.  Shift clicking sets a temporary pin.

Clicking on the root joint now allows the user to move the skeleton around.  

I would love for changing pins to work, as it allows some neat options for workflow, but it is currently broken far beyond my ability to repair.  And I would like to see IK have some reliable functionality even if we lose changing pins.

As it stands, the unpredictable nature of the current IK system is just one more thing that would frustrate users and drive them away.