### PR TITLE
Make the tool options scrollable

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -109,7 +109,7 @@ protected:
   QHBoxLayout *m_layout;
 
 public:
-  ToolOptionsBox(QWidget *parent, bool isScrollable = false);
+  ToolOptionsBox(QWidget *parent, bool isScrollable = true);
   ~ToolOptionsBox();
 
   virtual void

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -535,7 +535,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_nsPosField =
       new PegbarChannelField(m_tool, TStageObject::T_Y, "field", frameHandle,
                              objHandle, xshHandle, this);
-  m_zField        = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
+  m_zField = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
                                     frameHandle, objHandle, xshHandle, this);
   m_noScaleZField = new NoScaleField(m_tool, "field");
 
@@ -666,7 +666,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_zField->setPrecision(4);
   m_noScaleZField->setPrecision(4);
 
-  bool splined = isCurrentObjectSplined();
+  bool splined                        = isCurrentObjectSplined();
   if (splined != m_splined) m_splined = splined;
   setSplined(m_splined);
 
@@ -1299,7 +1299,7 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   // assert(ret);
   bool ret = connect(m_scaleXField, SIGNAL(valueChange(bool)),
                      SLOT(onScaleXValueChanged(bool)));
-  ret      = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
+  ret = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
                        SLOT(onScaleYValueChanged(bool)));
   if (m_setSaveboxCheckbox)
     ret = ret && connect(m_setSaveboxCheckbox, SIGNAL(toggled(bool)),
@@ -1710,11 +1710,11 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_colorMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onColorModeChanged(int)));
-  ret      = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
+  ret = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolTypeChanged(int)));
-  ret      = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
+  ret = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
                        SLOT(onOnionModeToggled(bool)));
-  ret      = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
+  ret = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
                        SLOT(onMultiFrameModeToggled(bool)));
   assert(ret);
   if (m_colorMode->getProperty()->getValue() == L"Lines") {
@@ -2313,9 +2313,9 @@ TapeToolOptionsBox::TapeToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_typeMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onToolTypeChanged(int)));
-  ret      = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
+  ret = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolModeChanged(int)));
-  ret      = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
+  ret = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
                        SLOT(onJoinStrokesModeChanged()));
   assert(ret);
 }
@@ -2402,11 +2402,10 @@ protected:
       p.setPen(Qt::black);
     p.setBrush(Qt::NoBrush);
 
-    p.drawText(rect(), Qt::AlignCenter,
-               QString("R:%1 G:%2 B:%3")
-                   .arg(m_color.red())
-                   .arg(m_color.green())
-                   .arg(m_color.blue()));
+    p.drawText(rect(), Qt::AlignCenter, QString("R:%1 G:%2 B:%3")
+                                            .arg(m_color.red())
+                                            .arg(m_color.green())
+                                            .arg(m_color.blue()));
   }
 };
 
@@ -2425,6 +2424,8 @@ RGBPickerToolOptionsBox::RGBPickerToolOptionsBox(
       CommandManager::instance()->getAction("A_ToolOption_PickScreen");
 
   QPushButton *button = new QPushButton(tr("Pick Screen"));
+  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(pickScreenAction);
   connect(button, SIGNAL(clicked()), pickScreenAction, SLOT(trigger()));
@@ -2440,7 +2441,8 @@ RGBPickerToolOptionsBox::RGBPickerToolOptionsBox(
 
   m_layout->addWidget(m_currentRGBLabel, 0);
   m_layout->addStretch(1);
-  m_layout->addWidget(button, 0);  // new in 6.4
+  m_layout->addWidget(button, 0);
+  m_layout->addSpacing(5);
 
   if (m_realTimePickMode) {
     connect(m_realTimePickMode, SIGNAL(toggled(bool)), m_currentRGBLabel,
@@ -2503,8 +2505,9 @@ StylePickerToolOptionsBox::StylePickerToolOptionsBox(
   ToolOptionCheckbox *organizePaletteCB =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Organize Palette"));
   m_layout->removeWidget(organizePaletteCB);
-  m_layout->addWidget(new ToolOptionsBarSeparator(this), 0);
+  // m_layout->addWidget(new ToolOptionsBarSeparator(this), 0);
   m_layout->addWidget(organizePaletteCB);
+  m_layout->addSpacing(5);
   organizePaletteCB->setToolTip(
       tr("With this option being activated, the picked style will be\nmoved to "
          "the end of the first page of the palette."));
@@ -2685,15 +2688,20 @@ ZoomToolOptionsBox::ZoomToolOptionsBox(QWidget *parent, TTool *tool,
   setFrameStyle(QFrame::StyledPanel);
   setFixedHeight(26);
 
-  QAction *resetZoomAction = CommandManager::instance()->getAction(VB_ZoomReset);
+  QAction *resetZoomAction =
+      CommandManager::instance()->getAction(VB_ZoomReset);
 
   QPushButton *button = new QPushButton(tr("Reset Zoom"));
+  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetZoomAction);
+
   connect(button, SIGNAL(clicked()), resetZoomAction, SLOT(trigger()));
 
   m_layout->addStretch(1);
   m_layout->addWidget(button, 0);
+  m_layout->addSpacing(5);
 }
 
 //=============================================================================
@@ -2711,12 +2719,16 @@ RotateToolOptionsBox::RotateToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_RotateReset);
 
   QPushButton *button = new QPushButton(tr("Reset Rotation"));
+  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetRotationAction);
+
   connect(button, SIGNAL(clicked()), resetRotationAction, SLOT(trigger()));
 
   m_layout->addStretch(1);
   m_layout->addWidget(button, 0);
+  m_layout->addSpacing(5);
 }
 
 //=============================================================================
@@ -2734,12 +2746,16 @@ HandToolOptionsBox::HandToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_PositionReset);
 
   QPushButton *button = new QPushButton(tr("Reset Position"));
+  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetPositionAction);
+
   connect(button, SIGNAL(clicked()), resetPositionAction, SLOT(trigger()));
 
   m_layout->addStretch(1);
   m_layout->addWidget(button, 0);
+  m_layout->addSpacing(5);
 }
 
 //=============================================================================
@@ -2817,7 +2833,7 @@ void ToolOptions::onToolSwitched() {
   TTool *tool = app->getCurrentTool()->getTool();
   if (tool) {
     // c'e' un tool corrente
-    ToolOptionsBox *panel                            = 0;
+    ToolOptionsBox *panel = 0;
     std::map<TTool *, ToolOptionsBox *>::iterator it = m_panels.find(tool);
     if (it == m_panels.end()) {
       // ... senza panel associato

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -138,7 +138,7 @@ void ToolOptionCheckbox::doClick(bool checked) {
   notifyTool();
 
   // for updating a cursor without any effect to the tool options
-  if(m_toolHandle) m_toolHandle->notifyToolCursorTypeChanged();
+  if (m_toolHandle) m_toolHandle->notifyToolCursorTypeChanged();
 }
 
 //=============================================================================
@@ -166,7 +166,7 @@ ToolOptionSlider::ToolOptionSlider(TTool *tool, TDoubleProperty *property,
   m_lineEdit->parentWidget()->setMaximumWidth(widgetWidth);
   // set the maximum width of the slider to 250 pixels
   setMaximumWidth(250 + widgetWidth);
-
+  setMinimumWidth(50 + widgetWidth);
   updateStatus();
   connect(this, SIGNAL(valueChanged(bool)), SLOT(onValueChanged(bool)));
   // synchronize the state with the same widgets in other tool option bars
@@ -273,7 +273,7 @@ ToolOptionPairSlider::ToolOptionPairSlider(TTool *tool,
   m_rightMargin = widgetWidth + 12;
   // set the maximum width of the slider to 300 pixels
   setMaximumWidth(300 + m_leftMargin + m_rightMargin);
-
+  setMinimumWidth(120 + m_leftMargin + m_rightMargin);
   setLeftText(leftName);
   setRightText(rightName);
 
@@ -387,6 +387,7 @@ ToolOptionIntPairSlider::ToolOptionIntPairSlider(TTool *tool,
   TIntPairProperty::Range range = property->getRange();
   setRange(range.first, range.second);
   setMaximumWidth(300);
+  setMinimumWidth(200);
   updateStatus();
   connect(this, SIGNAL(valuesChanged(bool)), SLOT(onValuesChanged(bool)));
 }
@@ -499,6 +500,7 @@ ToolOptionIntSlider::ToolOptionIntSlider(TTool *tool, TIntProperty *property,
   TIntProperty::Range range = property->getRange();
   setRange(range.first, range.second);
   setMaximumWidth(300);
+  setMinimumWidth(50);
   updateStatus();
   connect(this, SIGNAL(valueChanged(bool)), SLOT(onValueChanged(bool)));
   // synchronize the state with the same widgets in other tool option bars
@@ -625,7 +627,7 @@ void ToolOptionCombo::loadEntries() {
                       }");
       }
     }
-    int tmpWidth = fontMetrics().width(items[i].UIName);
+    int tmpWidth                      = fontMetrics().width(items[i].UIName);
     if (tmpWidth > maxWidth) maxWidth = tmpWidth;
   }
 
@@ -659,8 +661,8 @@ void ToolOptionCombo::onActivated(int index) {
 
 void ToolOptionCombo::doShowPopup() {
   if (Preferences::instance()->getDropdownShortcutsCycleOptions()) {
-    const TEnumProperty::Range &range = m_property->getRange();
-    int theIndex                      = currentIndex() + 1;
+    const TEnumProperty::Range &range           = m_property->getRange();
+    int theIndex                                = currentIndex() + 1;
     if (theIndex >= (int)range.size()) theIndex = 0;
     doOnActivated(theIndex);
   } else {
@@ -742,8 +744,8 @@ void ToolOptionFontCombo::onActivated(int index) {
 void ToolOptionFontCombo::doShowPopup() {
   if (!isInVisibleViewer(this)) return;
   if (Preferences::instance()->getDropdownShortcutsCycleOptions()) {
-    const TEnumProperty::Range &range = m_property->getRange();
-    int theIndex                      = currentIndex() + 1;
+    const TEnumProperty::Range &range           = m_property->getRange();
+    int theIndex                                = currentIndex() + 1;
     if (theIndex >= (int)range.size()) theIndex = 0;
     onActivated(theIndex);
     setCurrentIndex(theIndex);
@@ -1419,8 +1421,8 @@ void PegbarCenterField::onChange(TMeasuredValue *fld, bool addToUndo) {
 
   TStageObject *obj = xsh->getStageObject(objId);
 
-  double v       = fld->getValue(TMeasuredValue::MainUnit);
-  TPointD center = obj->getCenter(frame);
+  double v                           = fld->getValue(TMeasuredValue::MainUnit);
+  TPointD center                     = obj->getCenter(frame);
   if (!m_firstMouseDrag) m_oldCenter = center;
   if (m_index == 0)
     center.x = v;
@@ -1511,7 +1513,7 @@ PropertyMenuButton::PropertyMenuButton(QWidget *parent, TTool *tool,
   setIcon(icon);
   setToolTip(tooltip);
 
-  QMenu *menu = new QMenu(tooltip, this);
+  QMenu *menu                     = new QMenu(tooltip, this);
   if (!tooltip.isEmpty()) tooltip = tooltip + " ";
 
   QActionGroup *actiongroup = new QActionGroup(this);
@@ -1597,14 +1599,14 @@ bool SelectionScaleField::applyChange(bool addToUndo) {
     return false;
   using namespace DragSelectionTool;
   DragTool *scaleTool = createNewScaleTool(m_tool, ScaleType::GLOBAL);
-  double p                               = getValue();
-  if (p == 0) p = 0.00001;
-  FourPoints points = m_tool->getBBox();
-  TPointD center                       = m_tool->getCenter();
-  TPointD p0M                          = points.getPoint(7);
-  TPointD p1M                          = points.getPoint(5);
-  TPointD pM1                          = points.getPoint(6);
-  TPointD pM0                          = points.getPoint(4);
+  double p            = getValue();
+  if (p == 0) p       = 0.00001;
+  FourPoints points   = m_tool->getBBox();
+  TPointD center      = m_tool->getCenter();
+  TPointD p0M         = points.getPoint(7);
+  TPointD p1M         = points.getPoint(5);
+  TPointD pM1         = points.getPoint(6);
+  TPointD pM0         = points.getPoint(4);
   int pointIndex;
   TPointD sign(1, 1);
   TPointD scaleFactor = m_tool->m_deformValues.m_scaleValue;


### PR DESCRIPTION
Fixes #1277
Fixes #1977 (Sort of)

This makes the options bar scrollable if the screen space is too small.