### PR TITLE
Fit to viewer on load scene

### DIFF
--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -431,6 +431,7 @@ public slots:
 
   void onButtonPressed(FlipConsole::EGadget button);
   void fitToCamera();
+  void fitToCameraOutline();
   void swapCompared();
   void regeneratePreviewFrame();
   void regeneratePreview();


### PR DESCRIPTION
This stops the big zoom in when you load a scene.  I've often had students not realize they were only drawing on a portion of the canvas because of the zoom in.