### PR TITLE
Fix failing assert in filebrowswermodel

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -1289,9 +1289,9 @@ void DvDirModel::onFolderChanged(const TFilePath &path) { refreshFolder(path); }
 void DvDirModel::refresh(const QModelIndex &index) {
   if (!index.isValid()) return;
   DvDirModelNode *node = getNode(index);
-  if (!node) return;
+  if (!node || node->getChildCount() < 1) return;
   emit layoutAboutToBeChanged();
-  emit beginRemoveRows(index, 0, node->getChildCount());
+  emit beginRemoveRows(index, 0, node->getChildCount() - 1);
   node->refreshChildren();
   emit endRemoveRows();
   emit layoutChanged();


### PR DESCRIPTION
I'm seeing a failing assert in filebrowsermodel.cpp line 1294.

To recreate, 
Start OpenToonz
In the startup popup, enter a name.
Hit create.

I never had this before, so I'm a little puzzled.