### PR TITLE
Fix lip sync extend to end

### DIFF
--- a/toonz/sources/include/toonzqt/icongenerator.h
+++ b/toonz/sources/include/toonzqt/icongenerator.h
@@ -105,6 +105,8 @@ public:
   // icons from toonz levels
   QPixmap getIcon(TXshLevel *sl, const TFrameId &fid, bool filmStrip = true,
                   bool onDemand = false);
+  QPixmap getSizedIcon(TXshLevel *sl, const TFrameId &fid, std::string newId,
+                       TDimension dim = TDimension(0, 0));
   void invalidate(TXshLevel *sl, const TFrameId &fid,
                   bool onlyFilmStrip = false);
   void remove(TXshLevel *sl, const TFrameId &fid, bool onlyFilmStrip = false);

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -432,7 +432,8 @@ void LipSyncPopup::onApplyButton() {
 
   if (m_restToEnd->isChecked()) {
     int r0, r1, step;
-    XsheetGUI::getPlayRange(r0, r1, step);
+    TApp::instance()->getCurrentXsheet()->getXsheet()->getCellRange(m_col, r0,
+                                                                    r1);
     if (lastFrame < r1 + 1) lastFrame = r1 + 1;
   }
   std::vector<TFrameId> previousFrameIds;
@@ -469,7 +470,7 @@ void LipSyncPopup::imageNavClicked(int id) {
   else if (frameIndex == 0 && direction == -1)
     newIndex = m_levelFrameIds.size() - 1;
   else
-    newIndex = frameIndex + direction;
+    newIndex                    = frameIndex + direction;
   m_activeFrameIds[frameNumber] = m_levelFrameIds.at(newIndex);
   TXshCell newCell =
       TApp::instance()->getCurrentScene()->getScene()->getXsheet()->getCell(
@@ -486,7 +487,8 @@ void LipSyncPopup::paintEvent(QPaintEvent *) {
     while (i < 10) {
       QPixmap pm;
       if (m_sl)
-        pm = IconGenerator::instance()->getIcon(m_sl, m_activeFrameIds[i]);
+        pm = IconGenerator::instance()->getSizedIcon(
+            m_sl, m_activeFrameIds[i], "_lips", TDimension(160, 90));
 
       if (m_cl) {
         TFrameId currentFrameId = m_activeFrameIds[i];


### PR DESCRIPTION
Fixes #3218

Fixed the icon size in the lip sync popup window 
and fixed extend rest drawing to end.