### PR TITLE
Use "Current Column Color" for the current column in the Function Editor

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1959,7 +1959,6 @@ XsheetViewer {
   qproperty-CurrentRowBgColor: #506082;
   qproperty-OnionSkinAreaBgColor: #303133;
   qproperty-EmptyColumnHeadColor: #5a5d60;
-  qproperty-SelectedColumnTextColor: #E66464;
   qproperty-EmptyCellColor: #393b3d;
   qproperty-NotEmptyColumnColor: #414345;
   qproperty-SelectedEmptyCellColor: #64676a;
@@ -2080,7 +2079,6 @@ XsheetViewer {
 }
 FunctionTreeView {
   qproperty-TextColor: #d6d8dd;
-  qproperty-CurrentTextColor: #E66464;
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
@@ -2111,7 +2109,6 @@ SpreadsheetViewer {
   qproperty-SelectedSceneRangeEmptyColor: #6d7073;
   qproperty-TextColor: #d6d8dd;
   qproperty-ColumnHeaderBorderColor: #777b7f;
-  qproperty-SelectedColumnTextColor: #E66464;
 }
 #ExpressionField {
   background-color: #e0e1e2;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1959,7 +1959,6 @@ XsheetViewer {
   qproperty-CurrentRowBgColor: #506082;
   qproperty-OnionSkinAreaBgColor: #262626;
   qproperty-EmptyColumnHeadColor: #444444;
-  qproperty-SelectedColumnTextColor: #E66464;
   qproperty-EmptyCellColor: #303030;
   qproperty-NotEmptyColumnColor: #383838;
   qproperty-SelectedEmptyCellColor: #545454;
@@ -2080,7 +2079,6 @@ XsheetViewer {
 }
 FunctionTreeView {
   qproperty-TextColor: #e9e9e9;
-  qproperty-CurrentTextColor: #E66464;
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
@@ -2111,7 +2109,6 @@ SpreadsheetViewer {
   qproperty-SelectedSceneRangeEmptyColor: #5d5d5d;
   qproperty-TextColor: #e9e9e9;
   qproperty-ColumnHeaderBorderColor: #686868;
-  qproperty-SelectedColumnTextColor: #E66464;
 }
 #ExpressionField {
   background-color: #cecece;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1959,7 +1959,6 @@ XsheetViewer {
   qproperty-CurrentRowBgColor: #506082;
   qproperty-OnionSkinAreaBgColor: #363636;
   qproperty-EmptyColumnHeadColor: #626262;
-  qproperty-SelectedColumnTextColor: #E66464;
   qproperty-EmptyCellColor: #404040;
   qproperty-NotEmptyColumnColor: #484848;
   qproperty-SelectedEmptyCellColor: #6c6c6c;
@@ -2080,7 +2079,6 @@ XsheetViewer {
 }
 FunctionTreeView {
   qproperty-TextColor: #e6e6e6;
-  qproperty-CurrentTextColor: #E66464;
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
@@ -2111,7 +2109,6 @@ SpreadsheetViewer {
   qproperty-SelectedSceneRangeEmptyColor: #757575;
   qproperty-TextColor: #e6e6e6;
   qproperty-ColumnHeaderBorderColor: #808080;
-  qproperty-SelectedColumnTextColor: #E66464;
 }
 #ExpressionField {
   background-color: #e6e6e6;

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -352,7 +352,6 @@
 @xsheet-OnionSkinAreaBG-color:              darken(@bg, 7);
 
 @xsheet-EmptyColumnHead-color:              lighten(@bg, 10.1961);
-@xsheet-SelectedColumnText-color:           #E66464;
 
 @xsheet-EmptyCell-color:                    darken(@bg, 3.1373);
 @xsheet-NotEmptyColumn-color:               @bg;
@@ -520,7 +519,6 @@
 
 // Function Treeview
 @function-treeview-text-color: @text-color;
-@function-treeview-text-color-selected: #E66464;
 
 // Function Curve Panel
 @function-panel-bg-color: darken(@bg, 5.0980);

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -61,7 +61,6 @@ XsheetViewer {
   qproperty-OnionSkinAreaBgColor: @xsheet-OnionSkinAreaBG-color;
 
   qproperty-EmptyColumnHeadColor: @xsheet-EmptyColumnHead-color;
-  qproperty-SelectedColumnTextColor: @xsheet-SelectedColumnText-color;
 
   qproperty-EmptyCellColor: @xsheet-EmptyCell-color;
   qproperty-NotEmptyColumnColor: @xsheet-NotEmptyColumn-color;
@@ -220,7 +219,6 @@ XsheetViewer {
 
 FunctionTreeView {
   qproperty-TextColor: @function-treeview-text-color;
-  qproperty-CurrentTextColor: @function-treeview-text-color-selected;
 }
 
 /* Function Editor Spreadsheet
@@ -257,7 +255,6 @@ SpreadsheetViewer {
   qproperty-SelectedSceneRangeEmptyColor: @function-SelectedSceneRangeEmpty-color;
   qproperty-TextColor: @xsheet-text-color; // paired
   qproperty-ColumnHeaderBorderColor: @xsheet-VerticalLineHead-color; // paired
-  qproperty-SelectedColumnTextColor: @xsheet-SelectedColumnText-color; // paired
 }
 
 #FunctionSegmentViewer {

--- a/stuff/config/qss/Default/less/themes/Light.less
+++ b/stuff/config/qss/Default/less/themes/Light.less
@@ -257,7 +257,6 @@
 @xsheet-OnionSkinAreaBG-color:              darken(@bg, 0);
 
 @xsheet-EmptyColumnHead-color:              darken(@bg, 10);
-@xsheet-SelectedColumnText-color:           rgb(158, 0, 0);
 
 @xsheet-EmptyCell-color:                    darken(@bg, 1.57);
 @xsheet-NotEmptyColumn-color:               lighten(@bg, 10);
@@ -312,7 +311,6 @@
 
 // Function Treeview
 @function-treeview-text-color: @text-color;
-@function-treeview-text-color-selected: #ffe366;
 
 // Function Curve Panel
 @function-panel-bg-color: darken(@bg, 15);

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1960,7 +1960,6 @@ XsheetViewer {
   qproperty-CurrentRowBgColor: #B5C0D0;
   qproperty-OnionSkinAreaBgColor: #808080;
   qproperty-EmptyColumnHeadColor: #676767;
-  qproperty-SelectedColumnTextColor: #9e0000;
   qproperty-EmptyCellColor: #7c7c7c;
   qproperty-NotEmptyColumnColor: #9a9a9a;
   qproperty-SelectedEmptyCellColor: #b3b3b3;
@@ -2081,7 +2080,6 @@ XsheetViewer {
 }
 FunctionTreeView {
   qproperty-TextColor: #000;
-  qproperty-CurrentTextColor: #ffe366;
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
@@ -2112,7 +2110,6 @@ SpreadsheetViewer {
   qproperty-SelectedSceneRangeEmptyColor: #d2d2d2;
   qproperty-TextColor: #000;
   qproperty-ColumnHeaderBorderColor: #000000;
-  qproperty-SelectedColumnTextColor: #9e0000;
 }
 #ExpressionField {
   background-color: #ffffff;

--- a/toonz/sources/include/toonzqt/functiontreeviewer.h
+++ b/toonz/sources/include/toonzqt/functiontreeviewer.h
@@ -235,9 +235,8 @@ public:
   Channel *getClosestChannel(double frame, double value) const;
 
   void refreshActiveChannels();
-  void refreshData(
-      TXsheet *xsh);  // call this method when the stageObject/Fx structure
-                      // has been modified
+  void refreshData(TXsheet *xsh);  // call this method when the stageObject/Fx
+                                   // structure has been modified
   void resetAll();
 
   void applyShowFilters();
@@ -375,14 +374,12 @@ class FunctionTreeView final : public TreeView {
 
   FunctionTreeModel::Channel *m_draggingChannel;
   QPoint m_dragStartPosition;
+  FunctionViewer *m_viewer;
   //---
 
   // set color by using style sheet
-  QColor m_textColor;         // text color (black)
-  QColor m_currentTextColor;  // current item text color (red)
+  QColor m_textColor;  // text color (black)
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
-  Q_PROPERTY(QColor CurrentTextColor READ getCurrentTextColor WRITE
-                 setCurrentTextColor)
 
 public:
   FunctionTreeView(FunctionViewer *parent);
@@ -393,8 +390,7 @@ public:
 
   void setTextColor(const QColor &color) { m_textColor = color; }
   QColor getTextColor() const { return m_textColor; }
-  void setCurrentTextColor(const QColor &color) { m_currentTextColor = color; }
-  QColor getCurrentTextColor() const { return m_currentTextColor; }
+  FunctionViewer *getViewer() { return m_viewer; }
 
 protected:
   void onClick(TreeModel::Item *item, const QPoint &itemPos,

--- a/toonz/sources/include/toonzqt/functionviewer.h
+++ b/toonz/sources/include/toonzqt/functionviewer.h
@@ -126,6 +126,9 @@ public:
   virtual void save(QSettings &settings) const override;
   virtual void load(QSettings &settings) override;
 
+  // refer to the preferences' "Current Column Color"
+  QColor getCurrentTextColor() const;
+
 signals:
 
   void curveChanged();

--- a/toonz/sources/include/toonzqt/spreadsheetviewer.h
+++ b/toonz/sources/include/toonzqt/spreadsheetviewer.h
@@ -220,7 +220,7 @@ protected:
   void paintEvent(QPaintEvent *) override;
   virtual void drawCells(QPainter &p, int r0, int c0, int r1, int c1) {}
 };
-}
+}  // namespace Spreadsheet
 
 //-------------------------------------------------------------------
 
@@ -279,11 +279,8 @@ class DVAPI SpreadsheetViewer : public QDialog {
           WRITE setSelectedSceneRangeEmptyColor)
 
   QColor m_columnHeaderBorderColor;  // column header border lines (46,47,46)
-  QColor m_selectedColumnTextColor;  // selected column text (red)
   Q_PROPERTY(QColor ColumnHeaderBorderColor READ getColumnHeaderBorderColor
                  WRITE setColumnHeaderBorderColor)
-  Q_PROPERTY(QColor SelectedColumnTextColor READ getSelectedColumnTextColor
-                 WRITE setSelectedColumnTextColor)
 
   Spreadsheet::ScrollArea *m_columnScrollArea;
   Spreadsheet::ScrollArea *m_rowScrollArea;
@@ -379,12 +376,6 @@ public:
   }
   QColor getColumnHeaderBorderColor() const {
     return m_columnHeaderBorderColor;
-  }
-  void setSelectedColumnTextColor(const QColor &color) {
-    m_selectedColumnTextColor = color;
-  }
-  QColor getSelectedColumnTextColor() const {
-    return m_selectedColumnTextColor;
   }
 
   void scroll(QPoint delta);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -153,7 +153,7 @@ const QColor TimelineConfigButtonBgColor(255, 255, 255, 0);
 const QColor RowAreaBGColor(164, 164, 164);
 const QColor CurrentFrameBGColor(210, 210, 210);
 
-}  // namespace XsheetGUI;
+}  // namespace XsheetGUI
 
 //=============================================================================
 // XsheetScrollArea
@@ -227,12 +227,10 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   Q_PROPERTY(QColor OnionSkinAreaBgColor READ getOnionSkinAreaBgColor WRITE
                  setOnionSkinAreaBgColor)
   // Column
-  QColor m_emptyColumnHeadColor;     // empty column header (200,200,200)
-  QColor m_selectedColumnTextColor;  // selected column text (red)
+  QColor m_emptyColumnHeadColor;  // empty column header (200,200,200)
   Q_PROPERTY(QColor EmptyColumnHeadColor READ getEmptyColumnHeadColor WRITE
                  setEmptyColumnHeadColor)
-  Q_PROPERTY(QColor SelectedColumnTextColor READ getSelectedColumnTextColor
-                 WRITE setSelectedColumnTextColor)
+
   // Cell
   QColor m_emptyCellColor;          // empty cell (124,124,124)
   QColor m_notEmptyColumnColor;     // occupied column (164,164,164)
@@ -748,9 +746,8 @@ public:
     m_emptyColumnHeadColor = color;
   }
   QColor getEmptyColumnHeadColor() const { return m_emptyColumnHeadColor; }
-  void setSelectedColumnTextColor(const QColor &color) {
-    m_selectedColumnTextColor = color;
-  }
+
+  // specified by preferences
   QColor getSelectedColumnTextColor() const;
 
   // Cell

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -344,7 +344,7 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
     // channel name
     painter.setPen(getViewer()->getTextColor());
     if (channel->isCurrent())
-      painter.setPen(getViewer()->getSelectedColumnTextColor());
+      painter.setPen(m_sheet->getViewer()->getCurrentTextColor());
 
     QString text = channel->getShortName();
     int d        = 8;
@@ -357,7 +357,7 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
       int tmpwidth = (lastGroupColumn) ? width : width * 2;
       painter.setPen(getViewer()->getTextColor());
       if (group == currentGroup)
-        painter.setPen(getViewer()->getSelectedColumnTextColor());
+        painter.setPen(m_sheet->getViewer()->getCurrentTextColor());
       text = group->getShortName();
       painter.drawText(x0 + d, y0, tmpwidth - d, y1 - y0 + 1,
                        Qt::AlignLeft | Qt::AlignVCenter, text);

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -172,11 +172,11 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
   bool ret = true;
   ret      = ret && connect(m_toolbar, SIGNAL(numericalColumnToggled()), this,
                        SLOT(toggleMode()));
-  ret = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
+  ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
                        m_functionGraph, SLOT(update()));
-  ret = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
+  ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
                        m_numericalColumns, SLOT(updateAll()));
-  ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_treeView,
+  ret      = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_treeView,
                        SLOT(update()));
   ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_functionGraph,
                        SLOT(update()));
@@ -606,7 +606,7 @@ void FunctionViewer::onStageObjectChanged(bool isDragging) {
 void FunctionViewer::onFxSwitched() {
   TFx *fx              = m_fxHandle->getFx();
   TZeraryColumnFx *zfx = dynamic_cast<TZeraryColumnFx *>(fx);
-  if (zfx) fx          = zfx->getZeraryFx();
+  if (zfx) fx = zfx->getZeraryFx();
   static_cast<FunctionTreeModel *>(m_treeView->model())->setCurrentFx(fx);
   m_treeView->updateAll();
   m_functionGraph->update();
@@ -743,4 +743,16 @@ void FunctionViewer::load(QSettings &settings) {
                                  m_numericalColumns->isIbtwnValueVisible())
                           .toBool();
   m_numericalColumns->setIbtwnValueVisible(ibtwnVisible);
+}
+
+//-----------------------------------------------------------------------------
+
+QColor FunctionViewer::getCurrentTextColor() const {
+  // get colors
+  TPixel currentColumnPixel;
+  Preferences::instance()->getCurrentColumnData(currentColumnPixel);
+  QColor currentColumnColor((int)currentColumnPixel.r,
+                            (int)currentColumnPixel.g,
+                            (int)currentColumnPixel.b, 255);
+  return currentColumnColor;
 }


### PR DESCRIPTION
This PR will make the Function Editor to use `Current Column Color` value in the preference instead of the style sheet in order to gain consistency.
The current column color in the spread sheet and the current item color in the tree view have been changed.

![currentcolumncolorforfunctioneditor](https://user-images.githubusercontent.com/17974955/82538037-0e88f100-9b86-11ea-9f57-a8125fa60596.png)
