### PR TITLE
Linux Build Instructions: Fix command for launching OpenToonz

### DIFF
--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -177,8 +177,7 @@ If you need to debug the application, you should be able to use `cmake -DCMAKE_B
 You can now run the application:
 
 ```
-$ LD_LIBRARY_PATH=./lib/opentoonz:$LD_LIBRARY_PATH
-$ ./bin/OpenToonz
+$ LD_LIBRARY_PATH=./lib/opentoonz:$LD_LIBRARY_PATH ./bin/OpenToonz
 ```
 
 ### Performing a System Installation


### PR DESCRIPTION
Shell will not consider LD_LIBRARY_PATH variable if it is placed on separate line.