### PR TITLE
Fix expression reference in sub xsheet

### DIFF
--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -1123,9 +1123,16 @@ void bringPegbarsInsideChildXsheet(TXsheet *xsh, TXsheet *childXsh,
   for (pegbarIt = pegbarIds.begin(); pegbarIt != pegbarIds.end(); ++pegbarIt) {
     TStageObjectId id        = *pegbarIt;
     TStageObjectParams *data = xsh->getStageObject(id)->getParams();
-    childXsh->getStageObject(id)->assignParams(data);
+    TStageObject *obj        = childXsh->getStageObject(id);
+    obj->assignParams(data);
     delete data;
-    childXsh->getStageObject(id)->setParent(xsh->getStageObjectParent(id));
+    obj->setParent(xsh->getStageObjectParent(id));
+
+    // reset grammers of all parameters or they fails to refer to other
+    // parameters via expression
+    for (int c = 0; c != TStageObject::T_ChannelCount; ++c)
+      childXsh->getStageObjectTree()->setGrammar(
+          obj->getParam((TStageObject::Channel)c));
   }
 }
 


### PR DESCRIPTION
This PR fixes #3326 .

Each parameters is needed to set "grammar" associated with the current xsheet.
If you bring some object from the parent xsheet to another sub-xsheet, you need to reset the grammar one or it still refer to the parameters in the parent xsheet.