### PR TITLE
fix a bug where level in xsheet gets replaced when cancelling saving

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1531,7 +1531,11 @@ bool IoCmd::saveLevel(const TFilePath &path) {
   if (realPath.getType() == "")
     realPath = TFilePath(realPath.getWideString() + ::to_wstring(dotts + ext));
 
-  saveLevel(realPath, sl, false);
+  bool ret = saveLevel(realPath, sl, false);
+  if(!ret){ //save level failed
+    return false;
+  }
+
   RecentFiles::instance()->addFilePath(toQString(realPath), RecentFiles::Level);
 
   TApp::instance()


### PR DESCRIPTION
This fixes #3329 

The reason why this bug exists is because saveLevel(const TFilePath&) function doesn't return `false` if user presses cancel. Gladly, the function it calls does so it's an easy fix.