### PR TITLE
Add multi arc shape in geometric tool

### DIFF
--- a/toonz/sources/common/tvectorimage/tvectorimage.cpp
+++ b/toonz/sources/common/tvectorimage/tvectorimage.cpp
@@ -1034,8 +1034,8 @@ bool TVectorImage::Imp::areWholeGroups(const std::vector<int> &indexes) const {
     if (!m_strokes[indexes[i]]->m_groupId.isGrouped()) return false;
     for (j = 0; j < m_strokes.size(); j++) {
       int ret = areDifferentGroup(indexes[i], false, j, false);
-      if (ret == -1 ||
-          (ret >= 1 && find(indexes.begin(), indexes.end(), j) == indexes.end()))
+      if (ret == -1 || (ret >= 1 && find(indexes.begin(), indexes.end(), j) ==
+                                        indexes.end()))
         return false;
     }
   }
@@ -1282,7 +1282,7 @@ void TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
         } else {
           img->m_imp->m_strokes[i]->m_groupId =
               TGroupId(groupId, img->m_imp->m_strokes[i]->m_groupId);
-	}
+        }
       }
     }
   }
@@ -2154,7 +2154,8 @@ VIStroke *TVectorImage::Imp::joinStroke(int index1, int index2, int cpIndex1,
 
   // check if the both ends are at the same postion
   bool isSamePos = isAlmostZero(tdistance2(stroke1->getControlPoint(cpIndex1),
-                                           stroke2->getControlPoint(cpIndex2)));
+                                           stroke2->getControlPoint(cpIndex2)),
+                                1e-4);
   // connecting the ends in the same shape at the same postion
   // means just making the shape self-looped
   if (isSamePos && index1 == index2) {
@@ -2908,7 +2909,7 @@ void TVectorImage::Imp::regroupGhosts(std::vector<int> &changedStrokes) {
              ((currGroupId.isGrouped(false) != 0 &&
                m_strokes[i]->m_groupId == currGroupId) ||
               (currGroupId.isGrouped(true) != 0 &&
-                  m_strokes[i]->m_groupId.isGrouped(true) != 0))) {
+               m_strokes[i]->m_groupId.isGrouped(true) != 0))) {
         if (m_strokes[i]->m_groupId != currGroupId) {
           m_strokes[i]->m_groupId = currGroupId;
           changedStrokes.push_back(i);

--- a/toonz/sources/common/tvectorimage/tvectorimage.cpp
+++ b/toonz/sources/common/tvectorimage/tvectorimage.cpp
@@ -1034,8 +1034,8 @@ bool TVectorImage::Imp::areWholeGroups(const std::vector<int> &indexes) const {
     if (!m_strokes[indexes[i]]->m_groupId.isGrouped()) return false;
     for (j = 0; j < m_strokes.size(); j++) {
       int ret = areDifferentGroup(indexes[i], false, j, false);
-      if (ret == -1 || (ret >= 1 && find(indexes.begin(), indexes.end(), j) ==
-                                        indexes.end()))
+      if (ret == -1 ||
+          (ret >= 1 && find(indexes.begin(), indexes.end(), j) == indexes.end()))
         return false;
     }
   }
@@ -1282,7 +1282,7 @@ void TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
         } else {
           img->m_imp->m_strokes[i]->m_groupId =
               TGroupId(groupId, img->m_imp->m_strokes[i]->m_groupId);
-        }
+	}
       }
     }
   }
@@ -2154,8 +2154,7 @@ VIStroke *TVectorImage::Imp::joinStroke(int index1, int index2, int cpIndex1,
 
   // check if the both ends are at the same postion
   bool isSamePos = isAlmostZero(tdistance2(stroke1->getControlPoint(cpIndex1),
-                                           stroke2->getControlPoint(cpIndex2)),
-                                1e-4);
+                                           stroke2->getControlPoint(cpIndex2)));
   // connecting the ends in the same shape at the same postion
   // means just making the shape self-looped
   if (isSamePos && index1 == index2) {
@@ -2909,7 +2908,7 @@ void TVectorImage::Imp::regroupGhosts(std::vector<int> &changedStrokes) {
              ((currGroupId.isGrouped(false) != 0 &&
                m_strokes[i]->m_groupId == currGroupId) ||
               (currGroupId.isGrouped(true) != 0 &&
-               m_strokes[i]->m_groupId.isGrouped(true) != 0))) {
+                  m_strokes[i]->m_groupId.isGrouped(true) != 0))) {
         if (m_strokes[i]->m_groupId != currGroupId) {
           m_strokes[i]->m_groupId = currGroupId;
           changedStrokes.push_back(i);

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2316,6 +2316,7 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 
   case 2:
     m_tool->addStroke(m_hasLastStroke);
+    m_stroke = 0;
 
     if (!m_isSingleArc && !m_endStroke) {
       m_hasLastStroke = true;
@@ -2355,8 +2356,7 @@ void MultiArcPrimitive::mouseMove(const TPointD &pos, const TMouseEvent &e) {
     break;
   case 2:
     m_centralPoint = TThickPoint(newPos, getThickness());
-    TThickQuadratic q(m_stroke->getControlPoint(0), m_centralPoint,
-                      m_stroke->getControlPoint(8));
+    TThickQuadratic q(m_startPoint, m_centralPoint, m_endPoint);
     TThickQuadratic q0, q1, q00, q01, q10, q11;
 
     q.split(0.5, q0, q1);
@@ -2367,7 +2367,6 @@ void MultiArcPrimitive::mouseMove(const TPointD &pos, const TMouseEvent &e) {
     assert(q01.getP2() == q10.getP0());
     assert(q10.getP2() == q11.getP0());
 
-    m_stroke->setControlPoint(0, q00.getP0());
     m_stroke->setControlPoint(1, q00.getP1());
     m_stroke->setControlPoint(2, q00.getP2());
     m_stroke->setControlPoint(3, q01.getP1());
@@ -2375,7 +2374,6 @@ void MultiArcPrimitive::mouseMove(const TPointD &pos, const TMouseEvent &e) {
     m_stroke->setControlPoint(5, q10.getP1());
     m_stroke->setControlPoint(6, q10.getP2());
     m_stroke->setControlPoint(7, q11.getP1());
-    m_stroke->setControlPoint(8, q11.getP2());
     break;
   }
   m_tool->invalidate();

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -863,7 +863,7 @@ public:
       addPrimitive(new LinePrimitive(&m_param, this, false));
       addPrimitive(new MultiLinePrimitive(&m_param, this, false));
       addPrimitive(new ArcPrimitive(&m_param, this, false));
-      addPrimitive(new MultiArcPrimitive(&m_param, this, true));
+      addPrimitive(new MultiArcPrimitive(&m_param, this, false));
       addPrimitive(new PolygonPrimitive(&m_param, this, false));
     }
   }

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -221,20 +221,17 @@ private:
   TStroke *m_strokeTemp;
   TPointD m_startPoint, m_endPoint, m_centralPoint;
   int m_clickNumber;
-  TPixel32 m_color;
 
 public:
   MultiArcPrimitiveUndoData(TStroke *stroke, TStroke *strokeTemp,
                             TPointD startPoint, TPointD endPoint,
-                            TPointD centralPoint, int clickNumber,
-                            TPixel32 color)
+                            TPointD centralPoint, int clickNumber)
       : m_stroke(0)
       , m_strokeTemp(0)
       , m_startPoint(startPoint)
       , m_endPoint(endPoint)
       , m_centralPoint(centralPoint)
-      , m_clickNumber(clickNumber)
-      , m_color(color) {
+      , m_clickNumber(clickNumber) {
     if (stroke) {
       m_stroke = new TStroke(*stroke);
     }
@@ -261,22 +258,19 @@ class MultiArcPrimitiveUndo final : public TUndo {
 public:
   MultiArcPrimitiveUndo(MultiArcPrimitive *tool, TStroke *stroke,
                         TStroke *strokeTemp, TPointD startPoint,
-                        TPointD endPoint, TPointD centralPoint, int clickNumber,
-                        TPixel32 color)
+                        TPointD endPoint, TPointD centralPoint, int clickNumber)
       : TUndo()
       , m_tool(tool)
       , m_undo(stroke, strokeTemp, startPoint, endPoint, centralPoint,
-               clickNumber, color)
+               clickNumber)
       , m_redo(0) {}
 
   ~MultiArcPrimitiveUndo() { delete m_redo; }
 
   void setRedoData(TStroke *stroke, TStroke *strokeTemp, TPointD startPoint,
-                   TPointD endPoint, TPointD centralPoint, int clickNumber,
-                   TPixel32 color) {
-    m_redo =
-        new MultiArcPrimitiveUndoData(stroke, strokeTemp, startPoint, endPoint,
-                                      centralPoint, clickNumber, color);
+                   TPointD endPoint, TPointD centralPoint, int clickNumber) {
+    m_redo = new MultiArcPrimitiveUndoData(stroke, strokeTemp, startPoint,
+                                           endPoint, centralPoint, clickNumber);
   }
 
   void undo() const override;
@@ -861,8 +855,7 @@ public:
   }
 
   void replaceData(TStroke *stroke, TStroke *strokeTemp, TPointD startPoint,
-                   TPointD endPoint, TPointD centralPoint, int clickNumber,
-                   TPixel32 color) {
+                   TPointD endPoint, TPointD centralPoint, int clickNumber) {
     delete m_stroke;
     delete m_strokeTemp;
     m_stroke       = stroke;
@@ -871,7 +864,6 @@ public:
     m_endPoint     = endPoint;
     m_centralPoint = centralPoint;
     m_clickNumber  = clickNumber;
-    m_color        = color;
   }
 
   void decreaseUndo() { --m_undoCount; }
@@ -891,7 +883,7 @@ void MultiArcPrimitiveUndoData::replace(MultiArcPrimitive *tool) const {
     strokeTemp = new TStroke(*m_strokeTemp);
   }
   tool->replaceData(stroke, strokeTemp, m_startPoint, m_endPoint,
-                    m_centralPoint, m_clickNumber, m_color);
+                    m_centralPoint, m_clickNumber);
 }
 
 //-----------------------------------------------------------------------------
@@ -2383,9 +2375,9 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
   double thick = getThickness();
   double dist  = joinDistance * joinDistance;
 
-  MultiArcPrimitiveUndo *undo = new MultiArcPrimitiveUndo(
-      this, m_stroke, m_strokeTemp, m_startPoint, m_endPoint, m_centralPoint,
-      m_clickNumber, m_color);
+  MultiArcPrimitiveUndo *undo =
+      new MultiArcPrimitiveUndo(this, m_stroke, m_strokeTemp, m_startPoint,
+                                m_endPoint, m_centralPoint, m_clickNumber);
 
   if (app->getCurrentObject()->isSpline()) {
     m_isEditing = true;
@@ -2469,7 +2461,7 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
   }
 
   undo->setRedoData(m_stroke, m_strokeTemp, m_startPoint, m_endPoint,
-                    m_centralPoint, m_clickNumber, m_color);
+                    m_centralPoint, m_clickNumber);
   TUndoManager::manager()->add(undo);
   ++m_undoCount;
 

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -400,6 +400,7 @@ public:
     m_type.setItemUIName(L"Line", tr("Line"));
     m_type.setItemUIName(L"Polyline", tr("Polyline"));
     m_type.setItemUIName(L"Arc", tr("Arc"));
+    m_type.setItemUIName(L"MultiArc", tr("MultiArc"));
     m_type.setItemUIName(L"Polygon", tr("Polygon"));
 
     m_toolSize.setQStringName(tr("Size:"));
@@ -731,32 +732,43 @@ public:
 };
 
 //=============================================================================
-// Arc Primitive Class Declaration
+// Multi Arc Primitive Class Declaration
 //-----------------------------------------------------------------------------
 
-class ArcPrimitive final : public Primitive {
+class MultiArcPrimitive : public Primitive {
   TStroke *m_stroke;
   TPointD m_startPoint, m_endPoint, m_centralPoint;
   int m_clickNumber;
   TPixel32 m_color;
 
 public:
-  ArcPrimitive(PrimitiveParam *param, GeometricTool *tool, bool reasterTool)
+  MultiArcPrimitive(PrimitiveParam *param, GeometricTool *tool,
+                    bool reasterTool)
       : Primitive(param, tool, reasterTool), m_stroke(0), m_clickNumber(0) {}
 
-  ~ArcPrimitive() {
-    if (m_stroke) delete m_stroke;
-  }
+  ~MultiArcPrimitive() { delete m_stroke; }
 
-  std::string getName() const override {
-    return "Arc";
-  }  // _ToolOptions_ShapeArc";}
+  std::string getName() const override { return "MultiArc"; }
 
   TStroke *makeStroke() const override;
   void draw() override;
   void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
   void mouseMove(const TPointD &pos, const TMouseEvent &e) override;
   void onEnter() override;
+};
+
+//=============================================================================
+// Arc Primitive Class Declaration
+//-----------------------------------------------------------------------------
+
+class ArcPrimitive final : public MultiArcPrimitive {
+public:
+  ArcPrimitive(PrimitiveParam *param, GeometricTool *tool, bool reasterTool)
+      : MultiArcPrimitive(param, tool, reasterTool) {}
+
+  std::string getName() const override {
+    return "Arc";
+  }  // _ToolOptions_ShapeArc";}
 };
 
 //=============================================================================
@@ -812,6 +824,7 @@ public:
       addPrimitive(new LinePrimitive(&m_param, this, true));
       addPrimitive(new MultiLinePrimitive(&m_param, this, true));
       addPrimitive(new ArcPrimitive(&m_param, this, true));
+      addPrimitive(new MultiArcPrimitive(&m_param, this, true));
       addPrimitive(new PolygonPrimitive(&m_param, this, true));
     } else  // targetType == 1
     {
@@ -822,6 +835,7 @@ public:
       addPrimitive(new LinePrimitive(&m_param, this, false));
       addPrimitive(new MultiLinePrimitive(&m_param, this, false));
       addPrimitive(new ArcPrimitive(&m_param, this, false));
+      addPrimitive(new MultiArcPrimitive(&m_param, this, true));
       addPrimitive(new PolygonPrimitive(&m_param, this, false));
     }
   }
@@ -2134,7 +2148,7 @@ void EllipsePrimitive::onEnter() {
 // Arc Primitive Class Implementation
 //-----------------------------------------------------------------------------
 
-void ArcPrimitive::draw() {
+void MultiArcPrimitive::draw() {
   drawSnap();
 
   switch (m_clickNumber) {
@@ -2165,11 +2179,13 @@ void ArcPrimitive::draw() {
 
 //-----------------------------------------------------------------------------
 
-TStroke *ArcPrimitive::makeStroke() const { return new TStroke(*m_stroke); }
+TStroke *MultiArcPrimitive::makeStroke() const {
+  return new TStroke(*m_stroke);
+}
 
 //-----------------------------------------------------------------------------
 
-void ArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
+void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
   TTool::Application *app = TTool::getApplication();
   if (!app) return;
 
@@ -2227,7 +2243,7 @@ void ArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
 
 //-----------------------------------------------------------------------------
 
-void ArcPrimitive::mouseMove(const TPointD &pos, const TMouseEvent &e) {
+void MultiArcPrimitive::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   TPointD newPos = calculateSnap(pos);
   newPos         = checkGuideSnapping(pos);
 
@@ -2268,7 +2284,7 @@ void ArcPrimitive::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
 //-----------------------------------------------------------------------------
 
-void ArcPrimitive::onEnter() {
+void MultiArcPrimitive::onEnter() {
   TTool::Application *app = TTool::getApplication();
   if (!app) return;
 

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -338,7 +338,7 @@ public:
       , m_edgeCount("Polygon Sides:", 3, 15, 3)
       , m_autogroup("Auto Group", false)
       , m_autofill("Auto Fill", false)
-      , m_join("Join Vector", false)
+      , m_join("JoinStrokes", false)
       , m_smooth("Smooth", false)
       , m_selective("Selective", false)
       , m_pencil("Pencil Mode", false)
@@ -396,7 +396,7 @@ public:
     m_selective.setId("Selective");
     m_autogroup.setId("AutoGroup");
     m_autofill.setId("Autofill");
-    m_join.setId("JoinVector");
+    m_join.setId("JoinVectors");
     m_smooth.setId("Smooth");
     m_type.setId("GeometricShape");
     m_edgeCount.setId("GeometricEdge");
@@ -420,7 +420,7 @@ public:
     m_edgeCount.setQStringName(tr("Polygon Sides:"));
     m_autogroup.setQStringName(tr("Auto Group"));
     m_autofill.setQStringName(tr("Auto Fill"));
-    m_join.setQStringName(tr("Join Vector"));
+    m_join.setQStringName(tr("Join Vectors"));
     m_smooth.setQStringName(tr("Smooth"));
     m_selective.setQStringName(tr("Selective"));
     m_pencil.setQStringName(tr("Pencil Mode"));

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2391,6 +2391,7 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
 
   switch (m_clickNumber) {
   case 0:
+    m_endPoint = newPos;
     if (app->getCurrentObject()->isSpline()) {
       m_isEditing = true;
       m_color     = TPixel32::Red;
@@ -2411,11 +2412,12 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
     break;
 
   case 1:
-    points[0] = TThickPoint(m_startPoint, thick);
-    points[8] = TThickPoint(m_endPoint, thick);
-    points[4] = TThickPoint(0.5 * (points[0] + points[8]), thick);
-    points[2] = TThickPoint(0.5 * (points[0] + points[4]), thick);
-    points[6] = TThickPoint(0.5 * (points[4] + points[8]), thick);
+    m_centralPoint = newPos;
+    points[0]      = TThickPoint(m_startPoint, thick);
+    points[8]      = TThickPoint(m_endPoint, thick);
+    points[4]      = TThickPoint(0.5 * (points[0] + points[8]), thick);
+    points[2]      = TThickPoint(0.5 * (points[0] + points[4]), thick);
+    points[6]      = TThickPoint(0.5 * (points[4] + points[8]), thick);
 
     points[1]    = TThickPoint(0.5 * (points[0] + points[2]), thick);
     points[3]    = TThickPoint(0.5 * (points[2] + points[4]), thick);
@@ -2426,6 +2428,7 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
     break;
 
   case 2:
+    m_startPoint = newPos;
     if (!m_isSingleArc) {
       m_clickNumber = 1;
       m_startPoint  = m_endPoint;

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -776,6 +776,11 @@ public:
   void mouseMove(const TPointD &pos, const TMouseEvent &e) override;
   bool keyDown(QKeyEvent *event) override;
   void onEnter() override;
+  void onDeactivate() override {
+    delete m_stroke;
+    m_hasLastStroke = false;
+    m_clickNumber = 0;
+  }
 };
 
 //=============================================================================

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2316,15 +2316,16 @@ void MultiArcPrimitive::draw() {
 
   switch (m_clickNumber) {
   case 1:
-    tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
-                      (m_color.b + 127) % 255, m_color.m));
+    tglColor(m_color);
     tglDrawSegment(m_startPoint, m_endPoint);
 
     if (m_stroke) {
-      tglDrawCircle(m_stroke->getControlPoint(0), joinDistance * pixelSize);
-
-      tglColor(m_color);
       drawStrokeCenterline(*m_stroke, sqrt(tglGetPixelSize2()));
+      if (m_stroke->getControlPoint(0) == m_endPoint) {
+        tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
+                          (m_color.b + 127) % 255, m_color.m));
+      }
+      tglDrawCircle(m_stroke->getControlPoint(0), joinDistance * pixelSize);
     }
 
     break;
@@ -2348,9 +2349,10 @@ void MultiArcPrimitive::draw() {
       drawStrokeCenterline(*m_strokeTemp, sqrt(tglGetPixelSize2()));
 
     if (m_stroke && m_stroke->getControlPoint(0) != m_endPoint) {
-      tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
-                        (m_color.b + 127) % 255, m_color.m));
-
+      if (m_stroke->getControlPoint(0) == m_endPoint) {
+        tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
+                          (m_color.b + 127) % 255, m_color.m));
+      }
       tglDrawCircle(m_stroke->getControlPoint(0), joinDistance * pixelSize);
     }
     break;

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2321,7 +2321,8 @@ void MultiArcPrimitive::draw() {
 
     if (m_stroke) {
       drawStrokeCenterline(*m_stroke, sqrt(tglGetPixelSize2()));
-      if (m_stroke->getControlPoint(0) == m_endPoint) {
+      TPointD firstPoint = m_stroke->getControlPoint(0);
+      if (firstPoint == m_endPoint) {
         tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
                           (m_color.b + 127) % 255, m_color.m));
       }
@@ -2348,8 +2349,9 @@ void MultiArcPrimitive::draw() {
     if (m_strokeTemp)
       drawStrokeCenterline(*m_strokeTemp, sqrt(tglGetPixelSize2()));
 
-    if (m_stroke && m_stroke->getControlPoint(0) != m_endPoint) {
-      if (m_stroke->getControlPoint(0) == m_endPoint) {
+    if (m_stroke) {
+      TPointD firstPoint = m_stroke->getControlPoint(0);
+      if (firstPoint == m_endPoint) {
         tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
                           (m_color.b + 127) % 255, m_color.m));
       }

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2324,18 +2324,17 @@ void MultiArcPrimitive::draw() {
 
   switch (m_clickNumber) {
   case 1:
-    tglColor(m_color);
+    tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
+                      (m_color.b + 127) % 255, m_color.m));
     tglDrawSegment(m_startPoint, m_endPoint);
 
-    if (!m_isSingleArc) {
-      tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
-                        (m_color.b + 127) % 255, m_color.m));
+    if (m_stroke) {
+      tglDrawCircle(m_stroke->getControlPoint(0), joinDistance * pixelSize);
 
-      if (m_stroke) {
-        drawStrokeCenterline(*m_stroke, sqrt(tglGetPixelSize2()));
-        tglDrawCircle(m_stroke->getControlPoint(0), joinDistance * pixelSize);
-      }
+      tglColor(m_color);
+      drawStrokeCenterline(*m_stroke, sqrt(tglGetPixelSize2()));
     }
+
     break;
 
   case 2:
@@ -2356,8 +2355,7 @@ void MultiArcPrimitive::draw() {
     if (m_strokeTemp)
       drawStrokeCenterline(*m_strokeTemp, sqrt(tglGetPixelSize2()));
 
-    if (!m_isSingleArc && m_stroke &&
-        m_stroke->getControlPoint(0) != m_endPoint) {
+    if (m_stroke && m_stroke->getControlPoint(0) != m_endPoint) {
       tglColor(TPixel32((m_color.r + 127) % 255, m_color.g,
                         (m_color.b + 127) % 255, m_color.m));
 
@@ -2389,22 +2387,23 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
       this, m_stroke, m_strokeTemp, m_startPoint, m_endPoint, m_centralPoint,
       m_clickNumber, m_color);
 
+  if (app->getCurrentObject()->isSpline()) {
+    m_isEditing = true;
+    m_color     = TPixel32::Red;
+  } else {
+    const TColorStyle *style = app->getCurrentLevelStyle();
+    if (style) {
+      m_isEditing = style->isStrokeStyle();
+      m_color     = style->getAverageColor();
+    } else {
+      m_isEditing = false;
+      m_color     = TPixel32::Black;
+    }
+  }
+
   switch (m_clickNumber) {
   case 0:
     m_endPoint = newPos;
-    if (app->getCurrentObject()->isSpline()) {
-      m_isEditing = true;
-      m_color     = TPixel32::Red;
-    } else {
-      const TColorStyle *style = app->getCurrentLevelStyle();
-      if (style) {
-        m_isEditing = style->isStrokeStyle();
-        m_color     = style->getAverageColor();
-      } else {
-        m_isEditing = false;
-        m_color     = TPixel32::Black;
-      }
-    }
 
     if (!m_isEditing) return;
 

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -892,7 +892,10 @@ public:
   void changeType(std::wstring name) {
     std::map<std::wstring, Primitive *>::iterator it =
         m_primitiveTable.find(name);
-    if (it != m_primitiveTable.end()) m_primitive = it->second;
+    if (it != m_primitiveTable.end()) {
+      if (m_primitive) m_primitive->onDeactivate();
+      m_primitive = it->second;
+    }
   }
 
   void leftButtonDown(const TPointD &p, const TMouseEvent &e) override {

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -779,7 +779,7 @@ public:
   void onDeactivate() override {
     delete m_stroke;
     m_hasLastStroke = false;
-    m_clickNumber = 0;
+    m_clickNumber   = 0;
   }
 };
 
@@ -1173,7 +1173,19 @@ public:
               strokeNumber - 2, strokeNumber - 1,
               vi->getStroke(strokeNumber - 2)->getControlPointCount() - 1, 0,
               m_param.m_smooth.getValue());
+          vi->notifyChangedStrokes(strokeNumber - 2);
           stroke = vi->getStroke(strokeNumber - 2);
+
+          int lastPoint  = stroke->getControlPointCount() - 1;
+          TThickPoint p0 = stroke->getControlPoint(0);
+          TThickPoint pn = stroke->getControlPoint(lastPoint);
+          if (p0 == pn) {
+            vi->joinStroke(strokeNumber - 2, strokeNumber - 2, 0, lastPoint,
+                           m_param.m_smooth.getValue());
+            vi->notifyChangedStrokes(strokeNumber - 2);
+            stroke = vi->getStroke(strokeNumber - 2);
+          }
+
           TUndoManager::manager()->popUndo(1);
         }
 

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2426,7 +2426,6 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
     m_startPoint = newPos;
     if (!m_isSingleArc) {
       m_clickNumber = 1;
-      m_startPoint  = m_endPoint;
       if (m_stroke) {
         TVectorImageP vi = new TVectorImage();
         vi->addStroke(m_stroke);
@@ -2439,6 +2438,7 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
         int count          = m_stroke->getControlPointCount();
         TPointD firstPoint = m_stroke->getControlPoint(0);
         TPointD lastPoint  = m_stroke->getControlPoint(count - 1);
+        m_startPoint       = lastPoint;
         if (firstPoint == lastPoint) {
           vi->joinStroke(0, 0, 0, m_stroke->getControlPointCount() - 1,
                          getSmooth());
@@ -2452,6 +2452,7 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
       } else {
         m_stroke     = m_strokeTemp;
         m_strokeTemp = 0;
+        m_startPoint = m_endPoint;
       }
     } else {
       m_stroke     = m_strokeTemp;

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -46,7 +46,6 @@ TEnv::IntVar GeometricEdgeCount("InknpaintGeometricEdgeCount", 3);
 TEnv::IntVar GeometricSelective("InknpaintGeometricSelective", 0);
 TEnv::IntVar GeometricGroupIt("InknpaintGeometricGroupIt", 0);
 TEnv::IntVar GeometricAutofill("InknpaintGeometricAutofill", 0);
-TEnv::IntVar GeometricJoin("InknpaintGeometricJoin", 0);
 TEnv::IntVar GeometricSmooth("InknpaintGeometricSmooth", 0);
 TEnv::IntVar GeometricPencil("InknpaintGeometricPencil", 0);
 TEnv::DoubleVar GeometricBrushHardness("InknpaintGeometricHardness", 100);
@@ -309,7 +308,6 @@ public:
   TIntProperty m_edgeCount;
   TBoolProperty m_autogroup;
   TBoolProperty m_autofill;
-  TBoolProperty m_join;
   TBoolProperty m_smooth;
   TBoolProperty m_selective;
   TBoolProperty m_pencil;
@@ -338,7 +336,6 @@ public:
       , m_edgeCount("Polygon Sides:", 3, 15, 3)
       , m_autogroup("Auto Group", false)
       , m_autofill("Auto Fill", false)
-      , m_join("JoinStrokes", false)
       , m_smooth("Smooth", false)
       , m_selective("Selective", false)
       , m_pencil("Pencil Mode", false)
@@ -360,7 +357,6 @@ public:
     if (targetType & TTool::Vectors) {
       m_prop[0].bind(m_autogroup);
       m_prop[0].bind(m_autofill);
-      m_prop[0].bind(m_join);
       m_prop[0].bind(m_smooth);
       m_prop[0].bind(m_snap);
       m_snap.setId("Snap");
@@ -396,7 +392,6 @@ public:
     m_selective.setId("Selective");
     m_autogroup.setId("AutoGroup");
     m_autofill.setId("Autofill");
-    m_join.setId("JoinVectors");
     m_smooth.setId("Smooth");
     m_type.setId("GeometricShape");
     m_edgeCount.setId("GeometricEdge");
@@ -420,7 +415,6 @@ public:
     m_edgeCount.setQStringName(tr("Polygon Sides:"));
     m_autogroup.setQStringName(tr("Auto Group"));
     m_autofill.setQStringName(tr("Auto Fill"));
-    m_join.setQStringName(tr("Join Vectors"));
     m_smooth.setQStringName(tr("Smooth"));
     m_selective.setQStringName(tr("Selective"));
     m_pencil.setQStringName(tr("Pencil Mode"));
@@ -951,7 +945,6 @@ public:
       m_param.m_hardness.setValue(GeometricBrushHardness);
       m_param.m_selective.setValue(GeometricSelective ? 1 : 0);
       m_param.m_autogroup.setValue(GeometricGroupIt ? 1 : 0);
-      m_param.m_join.setValue(GeometricJoin ? 1 : 0);
       m_param.m_smooth.setValue(GeometricSmooth ? 1 : 0);
       m_param.m_autofill.setValue(GeometricAutofill ? 1 : 0);
       std::wstring typeCode = ::to_wstring(GeometricType.getValue());
@@ -1058,10 +1051,8 @@ public:
             QString::fromStdString(getName()));
       }
       GeometricGroupIt = m_param.m_autofill.getValue();
-    } else if (propertyName == m_param.m_join.getName()) {
-      GeometricJoin = m_param.m_join.getValue();
     } else if (propertyName == m_param.m_smooth.getName()) {
-      GeometricJoin = m_param.m_smooth.getValue();
+      GeometricSmooth = m_param.m_smooth.getValue();
     } else if (propertyName == m_param.m_selective.getName())
       GeometricSelective = m_param.m_selective.getValue();
     else if (propertyName == m_param.m_pencil.getName())
@@ -1167,7 +1158,7 @@ public:
                                                          stroke->getBBox());
 
         vi->addStroke(stroke);
-        if (joinLastStroke && m_param.m_join.getValue()) {
+        if (joinLastStroke) {
           int strokeNumber = vi->getStrokeCount();
           vi->joinStroke(
               strokeNumber - 2, strokeNumber - 1,

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -771,10 +771,14 @@ public:
   void draw() override;
   void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
   void mouseMove(const TPointD &pos, const TMouseEvent &e) override;
+  void leftButtonDoubleClick(const TPointD &, const TMouseEvent &e) override {
+    onDeactivate();
+  }
   bool keyDown(QKeyEvent *event) override;
   void onEnter() override;
   void onDeactivate() override {
     delete m_stroke;
+    m_stroke        = 0;
     m_hasLastStroke = false;
     m_clickNumber   = 0;
     m_endStroke     = false;
@@ -2313,15 +2317,13 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
   case 2:
     m_tool->addStroke(m_hasLastStroke);
 
-    m_stroke        = 0;
-    m_clickNumber   = 0;
-    m_hasLastStroke = false;
-
     if (!m_isSingleArc && !m_endStroke) {
       m_hasLastStroke = true;
       m_clickNumber   = 1;
       m_startPoint    = m_endPoint;
       m_endStroke     = false;
+    } else {
+      onDeactivate();
     }
     break;
   }
@@ -2332,10 +2334,7 @@ void MultiArcPrimitive::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 
 bool MultiArcPrimitive::keyDown(QKeyEvent *event) {
   if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
-    delete m_stroke;
-    m_clickNumber   = 0;
-    m_hasLastStroke = false;
-    m_endStroke     = false;
+    onDeactivate();
     return true;
   }
   return false;

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -466,6 +466,8 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_GeometricPolyline, this,
                     &MainWindow::toggleGeometricPolyline);
   setCommandHandler(MI_GeometricArc, this, &MainWindow::toggleGeometricArc);
+  setCommandHandler(MI_GeometricMultiArc, this,
+                    &MainWindow::toggleGeometricMultiArc);
   setCommandHandler(MI_GeometricPolygon, this,
                     &MainWindow::toggleGeometricPolygon);
 
@@ -1295,7 +1297,7 @@ void MainWindow::onMenuCheckboxChanged() {
     FieldGuideToggleAction = isChecked;
   else if (cm->getAction(MI_RasterizePli) == action) {
     if (!QGLPixelBuffer::hasOpenGLPbuffers()) isChecked = 0;
-    RasterizePliToggleAction                            = isChecked;
+    RasterizePliToggleAction = isChecked;
   } else if (cm->getAction(MI_SafeArea) == action)
     SafeAreaToggleAction = isChecked;
   else if (cm->getAction(MI_ViewColorcard) == action)
@@ -2074,7 +2076,7 @@ void MainWindow::defineActions() {
   // createRightClickMenuAction(MI_OpenCurrentScene,   tr("&Current Scene"),
   // "");
 
-  //createMenuWindowsAction(MI_OpenExport, tr("&Export"), "");
+  // createMenuWindowsAction(MI_OpenExport, tr("&Export"), "");
 
   createMenuWindowsAction(MI_OpenFileBrowser, tr("&File Browser"), "");
   createMenuWindowsAction(MI_OpenFileViewer, tr("&Flipbook"), "");
@@ -2393,6 +2395,8 @@ void MainWindow::defineActions() {
                           tr("Geometric Shape Polyline"), "");
   createToolOptionsAction("A_ToolOption_GeometricShape:Arc",
                           tr("Geometric Shape Arc"), "");
+  createToolOptionsAction("A_ToolOption_GeometricShape:MultiArc",
+                          tr("Geometric Shape MultiArc"), "");
   createToolOptionsAction("A_ToolOption_GeometricShape:Polygon",
                           tr("Geometric Shape Polygon"), "");
   createToolOptionsAction("A_ToolOption_GeometricEdge", tr("Geometric Edge"),
@@ -2504,6 +2508,8 @@ void MainWindow::defineActions() {
   createAction(MI_GeometricPolyline, tr("Geometric Tool - Polyline"), "",
                ToolCommandType);
   createAction(MI_GeometricArc, tr("Geometric Tool - Arc"), "",
+               ToolCommandType);
+  createAction(MI_GeometricMultiArc, tr("Geometric Tool - MultiArc"), "",
                ToolCommandType);
   createAction(MI_GeometricPolygon, tr("Geometric Tool - Polygon"), "",
                ToolCommandType);
@@ -2774,6 +2780,13 @@ void MainWindow::toggleGeometricArc() {
   CommandManager::instance()->getAction(T_Geometric)->trigger();
   CommandManager::instance()
       ->getAction("A_ToolOption_GeometricShape:Arc")
+      ->trigger();
+}
+
+void MainWindow::toggleGeometricMultiArc() {
+  CommandManager::instance()->getAction(T_Geometric)->trigger();
+  CommandManager::instance()
+      ->getAction("A_ToolOption_GeometricShape:MultiArc")
       ->trigger();
 }
 
@@ -3151,7 +3164,7 @@ void MainWindow::clearCacheFolder() {
   // 1. $CACHE/[Current ProcessID]
   // 2. $CACHE/temp/[Current scene folder] if the current scene is untitled
 
-  TFilePath cacheRoot                = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheRoot = ToonzFolder::getCacheRootFolder();
   if (cacheRoot.isEmpty()) cacheRoot = TEnv::getStuffDir() + "cache";
 
   TFilePathSet filesToBeRemoved;
@@ -3265,9 +3278,9 @@ RecentFiles::~RecentFiles() {}
 void RecentFiles::addFilePath(QString path, FileType fileType,
                               QString projectName) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) {
@@ -3434,9 +3447,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -3463,9 +3476,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
-                                                        ? MI_ClearRecentLevel
-                                                        : MI_ClearRecentImage;
+        (fileType == Scene)
+            ? MI_ClearRecentScene
+            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -130,6 +130,7 @@ public:
   void toggleGeometricLine();
   void toggleGeometricPolyline();
   void toggleGeometricArc();
+  void toggleGeometricMultiArc();
   void toggleGeometricPolygon();
 
   /*-- Type tool + style switching shortcuts --*/

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -347,6 +347,7 @@
 #define MI_GeometricLine "MI_GeometricLine"
 #define MI_GeometricPolyline "MI_GeometricPolyline"
 #define MI_GeometricArc "MI_GeometricArc"
+#define MI_GeometricMultiArc "MI_GeometricMultiArc"
 #define MI_GeometricPolygon "MI_GeometricPolygon"
 
 #define MI_TypeNextStyle "MI_TypeNextStyle"


### PR DESCRIPTION
related feature request: #3282 

video: https://youtu.be/ekCwA1bbvP4

This pull request adds a shape in Geometric Tool called Multi Arc. The way Multi Arc works is almost the same as Arc but, as soon as you finished the first Arc, it immediately starts another with the starting point of the new Arc being the same as the ending point of the previous Arc.

With Join option, all Arc drawn by Multi Arc will be joined as if you used tape tool on them. Same with Smooth option. Luckily, Auto Group and Auto Fill work automatically with the newly added code so I did not need to tackle with that.

However, this PR still has some bugs that I haven't been able to fix:

1. If join option is enabled and smooth option is disabled, sometimes the stroke will have missing control point (see #3072 and #3074) (fixed)
2. If join option is enabled, smooth option is disabled, and you draw a closed shape. The stroke WILL have problem (try dragging the control point of the connecting control point). (fixed)
3. If join option is enabled and you draw a closed shape, the Multi Arc tool won't automatically stop like how Multi Line works. (fixed)

Also, I did not test it in anything but vector level so I expect there are bugs when you use raster levels as well.

Edit: As @beeheemooth and @openanim reported:

1. use undo commend while drawing multiarc causes either crash or joining wrong strokes. (fixed)
2. Vector guided drawing doesn't work as expected. (fixed)
3. thickness doesn't work (fixed)
4. join vector shortcut doesn't work (fixed)

Edit: removed join option so that it is consistent with polyline shape (it will always join now)
double click ends the multiArc shape so that it is consistent with polyline shape

another issue as reported by @openanim:

1. no entry of multiArc shape in shortcut list (fixed)