### PR TITLE
add include intersection option in selection tool

### DIFF
--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -358,6 +358,7 @@ private:
 private:
   TEnumProperty m_selectionTarget;  //!< Selected target content (strokes, whole
                                     //! image, styles...).
+  TBoolProperty m_includeIntersection;
   TBoolProperty m_constantThickness;
 
   StrokeSelection m_strokeSelection;        //!< Standard selection of a set of
@@ -384,7 +385,7 @@ private:
   void doOnActivate() override;
   void doOnDeactivate() override;
 
-  void selectRegionVectorImage();
+  void selectRegionVectorImage(bool includeIntersect);
 
   void updateTranslation() override;
 


### PR DESCRIPTION
related feature request: #3365 

video: https://youtu.be/YLiPx2pxNRw

this PR adds a "include intersection" option in selection tool. When this option is unchecked, Polyline and Freehand will only select strokes that is completely inside the region drawn. With it checked, it would also select any stroke that touches the drawn line.

I used an option(or a checkbox) instead of adding a "intersect" type so that polyline mode would also benefit from this.