### PR TITLE
Expression Reference Manager

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2372,9 +2372,13 @@ SpreadsheetViewer {
   qproperty-KeyFrameColor: #995d1d;
   qproperty-KeyFrameBorderColor: #db9041;
   qproperty-SelectedKeyFrameColor: #a2835b;
+  qproperty-IgnoredKeyFrameColor: #ac2a39;
+  qproperty-SelectedIgnoredKeyFrameColor: #b25872;
   qproperty-InBetweenColor: #666250;
   qproperty-InBetweenBorderColor: #b0aa91;
   qproperty-SelectedInBetweenColor: #717970;
+  qproperty-IgnoredInBetweenColor: #8a695e;
+  qproperty-SelectedIgnoredInBetweenColor: #93807d;
   qproperty-SelectedEmptyColor: rgba(96, 109, 118, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(96, 109, 118, 0.5);
   qproperty-TextColor: #d6d8dd;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2372,9 +2372,13 @@ SpreadsheetViewer {
   qproperty-KeyFrameColor: #995d1d;
   qproperty-KeyFrameBorderColor: #db9041;
   qproperty-SelectedKeyFrameColor: #a2835b;
+  qproperty-IgnoredKeyFrameColor: #ac2a39;
+  qproperty-SelectedIgnoredKeyFrameColor: #b25872;
   qproperty-InBetweenColor: #666250;
   qproperty-InBetweenBorderColor: #b0aa91;
   qproperty-SelectedInBetweenColor: #717970;
+  qproperty-IgnoredInBetweenColor: #8a695e;
+  qproperty-SelectedIgnoredInBetweenColor: #93807d;
   qproperty-SelectedEmptyColor: rgba(90, 100, 106, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(90, 100, 106, 0.5);
   qproperty-TextColor: #e6e6e6;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2372,9 +2372,13 @@ SpreadsheetViewer {
   qproperty-KeyFrameColor: #995d1d;
   qproperty-KeyFrameBorderColor: #db9041;
   qproperty-SelectedKeyFrameColor: #a2835b;
+  qproperty-IgnoredKeyFrameColor: #ac2a39;
+  qproperty-SelectedIgnoredKeyFrameColor: #b25872;
   qproperty-InBetweenColor: #666250;
   qproperty-InBetweenBorderColor: #b0aa91;
   qproperty-SelectedInBetweenColor: #717970;
+  qproperty-IgnoredInBetweenColor: #8a695e;
+  qproperty-SelectedIgnoredInBetweenColor: #93807d;
   qproperty-SelectedEmptyColor: rgba(103, 113, 119, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(103, 113, 119, 0.5);
   qproperty-TextColor: #e6e6e6;

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -556,9 +556,13 @@
 @function-KeyFrame-color:          darken(desaturate(spin(@keyframe-total-color, 0.0000), 0.7570), 8.4314);
 @function-KeyFrameBorder-color:    lighten(@function-KeyFrame-color, 20);
 @function-SelectedKeyFrame-color:  mix(shade(@function-KeyFrame-color, -40), @cellHighlightTintColor, 60);
+@function-IgnoredKeyFrame-color: rgb(172,42,57);
+@function-SelectedIgnoredKeyFrame-color: mix(shade(@function-IgnoredKeyFrame-color, -40), @cellHighlightTintColor, 60);
 @function-Inbetween-color:         darken(desaturate(spin(@keyframe-inbetween-color, 0.4423), 4.8071), 7.2549);
 @function-InbetweenBorder-color:   lighten(@keyframe-inbetween-color, 20);
 @function-SelectedInbetween-color: mix(shade(@function-Inbetween-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);
+@function-IgnoredInbetween-color: rgb(138,105,94);
+@function-SelectedIgnoredInbetween-color: mix(shade(@function-IgnoredInbetween-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);
 
 // Expression Field
 @function-ExpressionFieldBG-color:     lighten(@bg, 61.9608);

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -277,9 +277,13 @@ SpreadsheetViewer {
   qproperty-KeyFrameColor: @function-KeyFrame-color;
   qproperty-KeyFrameBorderColor: @function-KeyFrameBorder-color;
   qproperty-SelectedKeyFrameColor: @function-SelectedKeyFrame-color;
+  qproperty-IgnoredKeyFrameColor: @function-IgnoredKeyFrame-color;
+  qproperty-SelectedIgnoredKeyFrameColor: @function-SelectedIgnoredKeyFrame-color;
   qproperty-InBetweenColor: @function-Inbetween-color;
   qproperty-InBetweenBorderColor: @function-InbetweenBorder-color;
   qproperty-SelectedInBetweenColor: @function-SelectedInbetween-color;
+  qproperty-IgnoredInBetweenColor: @function-IgnoredInbetween-color;
+  qproperty-SelectedIgnoredInBetweenColor: @function-SelectedIgnoredInbetween-color;
   qproperty-SelectedEmptyColor: @xsheet-SelectedEmptyCell-color; // paired
   qproperty-SelectedSceneRangeEmptyColor: @function-SelectedSceneRangeEmpty-color;
   qproperty-TextColor: @xsheet-text-color; // paired

--- a/stuff/config/qss/Default/less/themes/Light.less
+++ b/stuff/config/qss/Default/less/themes/Light.less
@@ -234,7 +234,10 @@
 @function-panel-bg-color: @schematic-viewer-bg-color;
 @function-panel-OtherCurves-color: rgb(218, 218, 218);
 @function-panel-Text-color: @text-color;
+
 @function-panel-Sub-color: #fff;
 @function-panel-Selected-color: #ffe033;
+@function-IgnoredKeyFrame-color: rgb(203,87,101);
+@function-IgnoredInbetween-color: rgb(194,156,146);
 
 @function-SelectedKeyFrame-color:  mix(shade(@function-KeyFrame-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2372,9 +2372,13 @@ SpreadsheetViewer {
   qproperty-KeyFrameColor: #edaa64;
   qproperty-KeyFrameBorderColor: #bb6a16;
   qproperty-SelectedKeyFrameColor: #c9a278;
+  qproperty-IgnoredKeyFrameColor: #cb5765;
+  qproperty-SelectedIgnoredKeyFrameColor: #eb96ad;
   qproperty-InBetweenColor: #e2dbcc;
   qproperty-InBetweenBorderColor: #ac9f82;
   qproperty-SelectedInBetweenColor: #c2c4c0;
+  qproperty-IgnoredInBetweenColor: #c29c92;
+  qproperty-SelectedIgnoredInBetweenColor: #ab9898;
   qproperty-SelectedEmptyColor: rgba(146, 153, 158, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(146, 153, 158, 0.5);
   qproperty-TextColor: #000;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2372,9 +2372,13 @@ SpreadsheetViewer {
   qproperty-KeyFrameColor: #c4833e;
   qproperty-KeyFrameBorderColor: #64421f;
   qproperty-SelectedKeyFrameColor: #deae7b;
+  qproperty-IgnoredKeyFrameColor: #ac2a39;
+  qproperty-SelectedIgnoredKeyFrameColor: #ca6377;
   qproperty-InBetweenColor: #b4b09e;
   qproperty-InBetweenBorderColor: #6e6c64;
   qproperty-SelectedInBetweenColor: #c7c7bb;
+  qproperty-IgnoredInBetweenColor: #8a695e;
+  qproperty-SelectedIgnoredInBetweenColor: #a08680;
   qproperty-SelectedEmptyColor: rgba(155, 159, 162, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(155, 159, 162, 0.5);
   qproperty-TextColor: #000;

--- a/toonz/sources/include/tgrammar.h
+++ b/toonz/sources/include/tgrammar.h
@@ -31,7 +31,7 @@ class TUnit;
 namespace TSyntax {
 class Token;
 class Calculator;
-}
+}  // namespace TSyntax
 
 //==============================================
 
@@ -62,6 +62,8 @@ public:
   virtual double compute(double vars[3]) const = 0;
 
   virtual void accept(CalculatorNodeVisitor &visitor) = 0;
+
+  virtual bool hasReference() const { return false; }
 
 private:
   // Non-copyable

--- a/toonz/sources/include/toonz/expressionreferencemonitor.h
+++ b/toonz/sources/include/toonz/expressionreferencemonitor.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#ifndef EXPRESSIONREFERENCEMONITOR_H
+#define EXPRESSIONREFERENCEMONITOR_H
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZLIB_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+
+#include <QMap>
+#include <QSet>
+#include <QString>
+
+class TDoubleParam;
+
+class DVAPI ExpressionReferenceMonitorInfo {
+  // name of the parameter
+  QString m_name = "";
+  // true if the parameter is not monitored
+  bool m_ignored = false;
+  // column indices to which the parameter refers.
+  // note that the columns refered by the "cell" syntax will be
+  // registered in this container, but not in the paramRefMap.
+  QSet<int> m_colRefMap;
+  // parameters to which the parameter refers
+  QSet<TDoubleParam*> m_paramRefMap;
+
+public:
+  QString& name() { return m_name; }
+  bool& ignored() { return m_ignored; }
+  QSet<int>& colRefMap() { return m_colRefMap; }
+  QSet<TDoubleParam*>& paramRefMap() { return m_paramRefMap; }
+};
+
+class DVAPI ExpressionReferenceMonitor {
+  QMap<TDoubleParam*, ExpressionReferenceMonitorInfo> m_info;
+
+public:
+  ExpressionReferenceMonitor() {}
+  QMap<TDoubleParam*, ExpressionReferenceMonitorInfo>& info() { return m_info; }
+
+  void clearAll() { m_info.clear(); }
+
+  ExpressionReferenceMonitor* clone() {
+    ExpressionReferenceMonitor* ret = new ExpressionReferenceMonitor();
+    ret->info()                     = m_info;
+    return ret;
+  }
+};
+
+#endif

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -395,6 +395,9 @@ public:
   // Animation  tab
   int getKeyframeType() const { return getIntValue(keyframeType); }
   int getAnimationStep() const { return getIntValue(animationStep); }
+  bool isModifyExpressionOnMovingReferencesEnabled() const {
+    return getBoolValue(modifyExpressionOnMovingReferences);
+  }
 
   // Preview  tab
   void getBlankValues(int &bCount, TPixel32 &bColor) const {

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -131,6 +131,7 @@ enum PreferencesItemId {
   // Animation
   keyframeType,
   animationStep,
+  modifyExpressionOnMovingReferences,
 
   //----------
   // Preview

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -13,6 +13,7 @@
 // TnzLib includes
 #include "toonz/txshcolumn.h"
 #include "toonz/txshlevel.h"
+#include "toonz/txsheetcolumnchange.h"
 
 #include "cellposition.h"
 
@@ -50,6 +51,8 @@ class TXshSoundColumn;
 class TXshNoteSet;
 class TFrameId;
 class Orientation;
+class TXsheetColumnChangeObserver;
+class ExpressionReferenceMonitor;
 
 //=============================================================================
 
@@ -159,6 +162,8 @@ private:
   int m_cameraColumnIndex;
   TXshColumn *m_cameraColumn;
 
+  TXsheetColumnChangeObserver *m_observer;
+
   DECLARE_CLASS_CODE
 
 public:
@@ -236,15 +241,15 @@ public:
   */
   void removeCells(int row, int col, int rowCount = 1);
 
-  /*! If column identified by index \b \e col is not empty, is a \b TXshCellColumn and is not
-    locked, clear \b \e rowCount cells starting from \b \e row and it recalls TXshCellColumn::clearCells().
-    Clears cells and it shifts remaining cells. Xsheet's frame count is updated.
-    \sa removeCells(), insertCells()
-*/ void
-  clearCells(int row, int col, int rowCount = 1);
+  /*! If column identified by index \b \e col is not empty, is a \b
+    TXshCellColumn and is not locked, clear \b \e rowCount cells starting from
+    \b \e row and it recalls TXshCellColumn::clearCells(). Clears cells and it
+    shifts remaining cells. Xsheet's frame count is updated. \sa removeCells(),
+    insertCells()
+*/ void clearCells(int row, int col, int rowCount = 1);
   /*! Clears xsheet. It sets to default values all xsheet elements contained in
    * struct \b TXsheetImp.
-  */
+   */
   void clearAll();
   /*! Returns cell range of column identified by index \b \e col and set \b \e
      r0 and \b \e r1 respectively to first and last not empty cell, it then
@@ -438,7 +443,7 @@ frame duplication.
 
   /*! Exposes level \b \e xl \b \e fids in xsheet starting from cell identified
    * by \b \e row and \b \e col.
-  */
+   */
   void exposeLevel(int row, int col, TXshLevel *xl, std::vector<TFrameId> fids,
                    bool overwrite);
   /*! Updates xsheet frame count, find max frame count between all
@@ -457,7 +462,7 @@ frame duplication.
   */
   void saveData(TOStream &os) override;
   /*! Inserts an empty column in \b \e index calling \b insertColumn().
-  */
+   */
   void insertColumn(int index,
                     TXshColumn::ColumnType type = TXshColumn::eLevelType);
   /*! Insert \b \e column in column \b \e index. Insert column in the column
@@ -487,7 +492,7 @@ in TXsheetImp.
 
   /*! Returns a pointer to the \b TXshColumn identified in xsheet by index \b \e
    * index.
-  */
+   */
   TXshColumn *getColumn(int index) const;
   /*! Returns xsheet column count, i.e the number of xsheet column used, it
      calls
@@ -496,7 +501,7 @@ in TXsheetImp.
   */
   int getColumnCount() const;
   /*! Returns first not empty column index in xsheet.
-  */
+   */
   int getFirstFreeColumnIndex() const;
 
   TSoundTrack *makeSound(SoundProperties *properties);
@@ -565,6 +570,14 @@ in TXsheetImp.
 
   void setCameraColumnLocked(bool locked) { m_cameraColumn->lock(locked); }
   bool isCameraColumnLocked() { return m_cameraColumn->isLocked(); }
+
+  ExpressionReferenceMonitor *getExpRefMonitor() const;
+  void setObserver(TXsheetColumnChangeObserver *observer);
+
+  void notify(const TXsheetColumnChange &change);
+  void notifyFxAdded(const std::vector<TFx *> &fxs);
+  void notifyStageObjectAdded(const TStageObjectId id);
+  bool isReferenceManagementIgnored(TDoubleParam *);
 
 protected:
   bool checkCircularReferences(TXsheet *childCandidate);

--- a/toonz/sources/include/toonz/txsheetcolumnchange.h
+++ b/toonz/sources/include/toonz/txsheetcolumnchange.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#ifndef TXSHEETCOLUMNCHANGE_INCLUDED
+#define TXSHEETCOLUMNCHANGE_INCLUDED
+
+// TnzCore includes
+#include "tcommon.h"
+// TnzLib includes
+#include "tstageobjectid.h"
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZLIB_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+
+class TFx;
+class TDoubleParam;
+//===========================================================
+
+//*****************************************************************************************
+//    TXsheetColumnChange  declaration
+//*****************************************************************************************
+
+class DVAPI TXsheetColumnChange {
+public:
+  enum OperationType { Insert, Remove, Move } m_type;
+
+  int m_index1, m_index2;
+
+public:
+  TXsheetColumnChange(OperationType type, int index1, int index2 = -1)
+      : m_type(type), m_index1(index1), m_index2(index2) {}
+};
+
+//*****************************************************************************************
+//    TXsheetColumnChangeObserver  definition
+//*****************************************************************************************
+
+class DVAPI TXsheetColumnChangeObserver {
+public:
+  virtual void onChange(const TXsheetColumnChange &) = 0;
+  // Call when adding fxs in which expression references may be included.
+  // This can be happen when undoing removing fxs operation.
+  virtual void onFxAdded(const std::vector<TFx *> &) = 0;
+  // Call when adding stage objects in which expression references may be
+  // included. This can be happen when undoing removing objects operation.
+  virtual void onStageObjectAdded(const TStageObjectId) = 0;
+  virtual bool isIgnored(TDoubleParam *)                = 0;
+};
+
+#endif  // TPARAMCHANGE_INCLUDED

--- a/toonz/sources/include/toonz/txsheetexpr.h
+++ b/toonz/sources/include/toonz/txsheetexpr.h
@@ -4,6 +4,7 @@
 #define XSHEETEXPR_INCLUDED
 
 #include "tgrammar.h"
+#include <QSet>
 
 #undef DVAPI
 #undef DVVAR
@@ -24,5 +25,7 @@ class TExpression;
 DVAPI TSyntax::Grammar *createXsheetGrammar(TXsheet *xsh);
 DVAPI bool dependsOn(TExpression &expr, TDoubleParam *possiblyDependentParam);
 DVAPI bool dependsOn(TDoubleParam *param, TDoubleParam *possiblyDependentParam);
+DVAPI void referenceParams(TExpression &expr, QSet<int> &columnIndices,
+                           QSet<TDoubleParam *> &params);
 
 #endif  // XSHEETEXPR_INCLUDED

--- a/toonz/sources/include/toonzqt/functiontreeviewer.h
+++ b/toonz/sources/include/toonzqt/functiontreeviewer.h
@@ -34,6 +34,7 @@ class TXsheet;
 class TParamContainer;
 class TFxHandle;
 class TObjectHandle;
+class TXsheetHandle;
 
 class FunctionTreeView;
 class FunctionViewer;
@@ -70,7 +71,7 @@ class FunctionViewer;
   TnzExt library).
 */
 
-class FunctionTreeModel final : public TreeModel, public TParamObserver {
+class DVAPI FunctionTreeModel final : public TreeModel, public TParamObserver {
   Q_OBJECT
 
 public:
@@ -85,6 +86,7 @@ to
 
     virtual bool isActive() const   = 0;
     virtual bool isAnimated() const = 0;
+    virtual bool isIgnored() const  = 0;
   };
 
   //----------------------------------------------------------------------------------
@@ -104,6 +106,7 @@ to
 
     bool isActive() const override;
     bool isAnimated() const override;
+    bool isIgnored() const override;
 
     virtual QString getShortName() const { return m_name; }
     virtual QString getLongName() const { return m_name; }
@@ -153,9 +156,9 @@ color, which
   //----------------------------------------------------------------------------------
 
   //! The model item representing a channel (i.e. a real-valued function).
-  class Channel final : public ParamWrapper,
-                        public Item,
-                        public TParamObserver {
+  class DVAPI Channel final : public ParamWrapper,
+                              public Item,
+                              public TParamObserver {
     FunctionTreeModel *m_model;  //!< (\p not \p owned) Reference to the model
     ChannelGroup
         *m_group;  //!< (\p not \p owned) Reference to the enclosing group
@@ -189,6 +192,7 @@ color, which
     void setIsActive(bool active);
 
     bool isAnimated() const override;
+    bool isIgnored() const override;
 
     bool isCurrent() const;
     void setIsCurrent(bool current);
@@ -313,7 +317,7 @@ public:
 
 //=============================================================================
 
-class FxChannelGroup final : public FunctionTreeModel::ChannelGroup {
+class DVAPI FxChannelGroup final : public FunctionTreeModel::ChannelGroup {
 public:
   TFx *m_fx;
 
@@ -337,7 +341,8 @@ public:
 
 //=============================================================================
 
-class StageObjectChannelGroup final : public FunctionTreeModel::ChannelGroup {
+class DVAPI StageObjectChannelGroup final
+    : public FunctionTreeModel::ChannelGroup {
 public:
   TStageObject *m_stageObject;  //!< (not owned) Referenced stage object
   FunctionTreeModel::ChannelGroup
@@ -381,6 +386,8 @@ class FunctionTreeView final : public TreeView {
   QColor m_textColor;  // text color (black)
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
 
+  TXsheetHandle *m_xshHandle;
+
 public:
   FunctionTreeView(FunctionViewer *parent);
 
@@ -391,6 +398,9 @@ public:
   void setTextColor(const QColor &color) { m_textColor = color; }
   QColor getTextColor() const { return m_textColor; }
   FunctionViewer *getViewer() { return m_viewer; }
+
+  void setXsheetHandle(TXsheetHandle *xshHandle) { m_xshHandle = xshHandle; }
+  TXsheetHandle *getXsheetHandle() { return m_xshHandle; }
 
 protected:
   void onClick(TreeModel::Item *item, const QPoint &itemPos,

--- a/toonz/sources/include/toonzqt/functionviewer.h
+++ b/toonz/sources/include/toonzqt/functionviewer.h
@@ -121,6 +121,7 @@ public:
   bool columnsOrGraphHasFocus();
   void setSceneHandle(TSceneHandle *sceneHandle);
   TSceneHandle *getSceneHandle() const { return m_sceneHandle; }
+  TXsheetHandle *getXsheetHandle() const { return m_xshHandle; }
 
   // SaveLoadQSettings
   virtual void save(QSettings &settings) const override;

--- a/toonz/sources/include/toonzqt/fxselection.h
+++ b/toonz/sources/include/toonzqt/fxselection.h
@@ -155,6 +155,7 @@ private:
 signals:
   void doCollapse(const QList<TFxP> &);
   void doExplodeChild(const QList<TFxP> &);
+  void doDelete();
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -54,6 +54,8 @@ class QToolButton;
 class QAction;
 class QTouchEvent;
 class QGestureEvent;
+class FxSelection;
+class StageObjectSelection;
 
 //====================================================
 namespace {
@@ -564,6 +566,9 @@ signals:
   void doExplodeChild(QList<TStageObjectId>);
   void editObject();
 
+  void doDeleteFxs(const FxSelection *);
+  void doDeleteStageObjects(const StageObjectSelection *);
+
 protected slots:
 
   void onSceneChanged();
@@ -574,6 +579,9 @@ protected slots:
   void selectModeEnabled();
   void zoomModeEnabled();
   void handModeEnabled();
+
+  void deleteFxs();
+  void deleteStageObjects();
 
 private:
   SchematicSceneViewer *m_viewer;

--- a/toonz/sources/include/toonzqt/spreadsheetviewer.h
+++ b/toonz/sources/include/toonzqt/spreadsheetviewer.h
@@ -253,10 +253,14 @@ class DVAPI SpreadsheetViewer : public QDialog {
   QColor m_keyFrameColor;          // (219,139,54)
   QColor m_keyFrameBorderColor;    // (82,51,20)
   QColor m_selectedKeyFrameColor;  // (237,197,155)
+  QColor m_ignoredKeyFrameColor;
+  QColor m_selectedIgnoredKeyFrameColor;
   // key frame inbetween
   QColor m_inBetweenColor;          // (194,194,176)
   QColor m_inBetweenBorderColor;    // (72,72,65)
   QColor m_selectedInBetweenColor;  // (225,225,216)
+  QColor m_ignoredInBetweenColor;
+  QColor m_selectedIgnoredInBetweenColor;
   // empty cell
   QColor m_selectedEmptyColor;  // (190,190,190)
   // empty cell in the scene range
@@ -266,12 +270,22 @@ class DVAPI SpreadsheetViewer : public QDialog {
                  setKeyFrameBorderColor)
   Q_PROPERTY(QColor SelectedKeyFrameColor READ getSelectedKeyFrameColor WRITE
                  setSelectedKeyFrameColor)
+  Q_PROPERTY(QColor IgnoredKeyFrameColor READ getIgnoredKeyFrameColor WRITE
+                 setIgnoredKeyFrameColor)
+  Q_PROPERTY(
+      QColor SelectedIgnoredKeyFrameColor READ getSelectedIgnoredKeyFrameColor
+          WRITE setSelectedIgnoredKeyFrameColor)
   Q_PROPERTY(
       QColor InBetweenColor READ getInBetweenColor WRITE setInBetweenColor)
   Q_PROPERTY(QColor InBetweenBorderColor READ getInBetweenBorderColor WRITE
                  setInBetweenBorderColor)
   Q_PROPERTY(QColor SelectedInBetweenColor READ getSelectedInBetweenColor WRITE
                  setSelectedInBetweenColor)
+  Q_PROPERTY(QColor IgnoredInBetweenColor READ getIgnoredInBetweenColor WRITE
+                 setIgnoredInBetweenColor)
+  Q_PROPERTY(
+      QColor SelectedIgnoredInBetweenColor READ getSelectedIgnoredInBetweenColor
+          WRITE setSelectedIgnoredInBetweenColor)
   Q_PROPERTY(QColor SelectedEmptyColor READ getSelectedEmptyColor WRITE
                  setSelectedEmptyColor)
   Q_PROPERTY(
@@ -351,6 +365,18 @@ public:
     m_selectedKeyFrameColor = color;
   }
   QColor getSelectedKeyFrameColor() const { return m_selectedKeyFrameColor; }
+
+  void setIgnoredKeyFrameColor(const QColor &color) {
+    m_ignoredKeyFrameColor = color;
+  }
+  QColor getIgnoredKeyFrameColor() const { return m_ignoredKeyFrameColor; }
+  void setSelectedIgnoredKeyFrameColor(const QColor &color) {
+    m_selectedIgnoredKeyFrameColor = color;
+  }
+  QColor getSelectedIgnoredKeyFrameColor() const {
+    return m_selectedIgnoredKeyFrameColor;
+  }
+
   void setInBetweenColor(const QColor &color) { m_inBetweenColor = color; }
   QColor getInBetweenColor() const { return m_inBetweenColor; }
   void setInBetweenBorderColor(const QColor &color) {
@@ -361,6 +387,18 @@ public:
     m_selectedInBetweenColor = color;
   }
   QColor getSelectedInBetweenColor() const { return m_selectedInBetweenColor; }
+
+  void setIgnoredInBetweenColor(const QColor &color) {
+    m_ignoredInBetweenColor = color;
+  }
+  QColor getIgnoredInBetweenColor() const { return m_ignoredInBetweenColor; }
+  void setSelectedIgnoredInBetweenColor(const QColor &color) {
+    m_selectedIgnoredInBetweenColor = color;
+  }
+  QColor getSelectedIgnoredInBetweenColor() const {
+    return m_selectedIgnoredInBetweenColor;
+  }
+
   void setSelectedEmptyColor(const QColor &color) {
     m_selectedEmptyColor = color;
   }

--- a/toonz/sources/include/toonzqt/stageobjectsdata.h
+++ b/toonz/sources/include/toonzqt/stageobjectsdata.h
@@ -19,6 +19,7 @@
 
 // Qt includes
 #include <QList>
+#include <QMap>
 
 #undef DVAPI
 #undef DVVAR
@@ -128,6 +129,12 @@ public:
   std::vector<TStageObjectId> restoreObjects(
       std::set<int> &columnIndices, std::list<int> &restoredSplinIds,
       TXsheet *xsheet, int fxFlags, const TPointD &pos = TConst::nowhere) const;
+
+  std::vector<TStageObjectId> restoreObjects(
+      std::set<int> &columnIndices, std::list<int> &restoredSplinIds,
+      TXsheet *xsheet, int fxFlags,
+      QMap<TStageObjectId, TStageObjectId> &idTable,
+      QMap<TFx *, TFx *> &fxTable, const TPointD &pos = TConst::nowhere) const;
 };
 
 #endif  // STAGEOBJECT_DATA_H

--- a/toonz/sources/include/toonzqt/stageschematicscene.h
+++ b/toonz/sources/include/toonzqt/stageschematicscene.h
@@ -139,6 +139,8 @@ public:
 
   SchematicViewer *getSchematicViewer() { return m_viewer; }
 
+  StageObjectSelection *getStageSelection() const { return m_selection; }
+
 private:
   StageSchematicNode *addStageSchematicNode(TStageObject *pegbar);
   StageSchematicGroupNode *addStageGroupNode(QList<TStageObject *> objs);

--- a/toonz/sources/include/tparser.h
+++ b/toonz/sources/include/tparser.h
@@ -40,6 +40,9 @@ public:
   //! return true if the last parsed string was correct
   bool isValid() const;
 
+  //! return true if the last parsed string was correct
+  bool hasReference() const;
+
   //! return the last parsed string
   std::string getText() const;
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -120,6 +120,7 @@ set(MOC_HEADERS
     xshrowviewer.h
     xshtoolbar.h
 	xdtsimportpopup.h
+	expressionreferencemanager.h
 )
 
 if(WITH_STOPMOTION)
@@ -351,6 +352,7 @@ set(SOURCES
 	separatecolorspopup.cpp
     xdtsio.cpp
 	xdtsimportpopup.cpp
+	expressionreferencemanager.cpp
 # Tracker file
     dummyprocessor.cpp
     metnum.cpp

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -6,6 +6,7 @@
 #include "menubarcommandids.h"
 #include "columnselection.h"
 #include "tapp.h"
+#include "expressionreferencemanager.h"
 
 // TnzQt includes
 #include "toonzqt/tselectionhandle.h"
@@ -37,6 +38,7 @@
 #include "toonz/tstageobjectspline.h"
 #include "toonz/fxcommand.h"
 #include "toonz/preferences.h"
+#include "toonz/tstageobjectid.h"
 
 // TnzBase includes
 #include "tfx.h"
@@ -51,6 +53,7 @@
 // Qt includes
 #include <QApplication>
 #include <QClipboard>
+#include <QSet>
 
 #include <memory>
 
@@ -773,8 +776,9 @@ static void copyColumns_internal(const std::set<int> &indices) {
 
   TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
 
-  data->storeColumns(indices, xsh, StageObjectsData::eDoClone |
-                                       StageObjectsData::eResetFxDagPositions);
+  data->storeColumns(
+      indices, xsh,
+      StageObjectsData::eDoClone | StageObjectsData::eResetFxDagPositions);
   data->storeColumnFxs(
       indices, xsh,
       StageObjectsData::eDoClone | StageObjectsData::eResetFxDagPositions);
@@ -962,8 +966,8 @@ void ColumnCmd::resequence(int index) {
   assert(!cell.isEmpty());
   TXshChildLevel *xl = cell.m_level->getChildLevel();
   assert(xl);
-  TXsheet *childXsh              = xl->getXsheet();
-  int frameCount                 = childXsh->getFrameCount();
+  TXsheet *childXsh = xl->getXsheet();
+  int frameCount    = childXsh->getFrameCount();
   if (frameCount < 1) frameCount = 1;
 
   TUndoManager::manager()->add(new ResequenceUndo(index, frameCount));
@@ -1001,7 +1005,7 @@ public:
   void redo() const override {
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     xsh->insertColumn(m_columnIndex);
-    int frameCount                 = m_childLevel->getXsheet()->getFrameCount();
+    int frameCount = m_childLevel->getXsheet()->getFrameCount();
     if (frameCount < 1) frameCount = 1;
     for (int r = 0; r < frameCount; r++)
       xsh->setCell(r, m_columnIndex,
@@ -1197,6 +1201,160 @@ void ColumnCmd::clearCells(int index) {
 }
 
 //=============================================================================
+// checkExpressionReferences
+//=============================================================================
+// - If onlyColumns is true, it means that only columns with specified indices
+// will be removed.
+// - If onlyColumns is false, it means that the relevant pegbars will be removed
+// as well (when collapsing collumns).
+// - Note that relevant Fxs will be removed / collapsed regardless of
+// onlyColumns.
+// - When checkInvert is true, check references both side from the main xsheet
+// and the child xsheet when collapsing columns.
+
+bool ColumnCmd::checkExpressionReferences(const std::set<int> &indices,
+                                          bool onlyColumns, bool checkInvert) {
+  if (!Preferences::instance()->isModifyExpressionOnMovingReferencesEnabled())
+    return true;
+
+  TApp *app    = TApp::instance();
+  TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+
+  // check if fxs will be deleted
+  QSet<int> colIdsToBeDeleted;
+  QSet<TFx *> fxsToBeDeleted;
+  // store column fxs to be deleted
+  std::set<TFx *> leaves;
+  for (auto index : indices) {
+    if (index < 0) continue;
+    TXshColumn *column = xsh->getColumn(index);
+    if (!column) continue;
+    colIdsToBeDeleted.insert(index);
+    TFx *fx = column->getFx();
+    if (fx) {
+      leaves.insert(fx);
+      TZeraryColumnFx *zcfx = dynamic_cast<TZeraryColumnFx *>(fx);
+      if (zcfx) fxsToBeDeleted.insert(zcfx->getZeraryFx());
+    }
+  }
+
+  // store relevant fxs which will be deleted along with the columns
+  TFxSet *fxSet = xsh->getFxDag()->getInternalFxs();
+  for (int i = 0; i < fxSet->getFxCount(); i++) {
+    TFx *fx = fxSet->getFx(i);
+    if (canRemoveFx(leaves, fx)) fxsToBeDeleted.insert(fx);
+  }
+
+  // store object ids which will be duplicated in the child xsheet on collapse
+  QList<TStageObjectId> objIdsToBeDuplicated;
+  if (checkInvert && !onlyColumns) {
+    for (auto index : indices) {
+      TStageObjectId id =
+          xsh->getStageObjectParent(TStageObjectId::ColumnId(index));
+      // store pegbars/cameras connected to the columns
+      while (id.isPegbar() || id.isCamera()) {
+        if (!objIdsToBeDuplicated.contains(id)) objIdsToBeDuplicated.append(id);
+        id = xsh->getStageObjectParent(id);
+      }
+    }
+  }
+
+  return ExpressionReferenceManager::instance()->checkReferenceDeletion(
+      colIdsToBeDeleted, fxsToBeDeleted, objIdsToBeDuplicated, checkInvert);
+}
+
+//-----------------------------------------------------------------------------
+
+bool ColumnCmd::checkExpressionReferences(const std::set<int> &indices,
+                                          const std::set<TFx *> &fxs,
+                                          bool onlyColumns, bool checkInvert) {
+  if (!Preferences::instance()->isModifyExpressionOnMovingReferencesEnabled())
+    return true;
+
+  TApp *app    = TApp::instance();
+  TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+
+  // check if fxs will be deleted
+  QSet<int> colIdsToBeDeleted;
+  QSet<TFx *> fxsToBeDeleted;
+  for (auto index : indices) {
+    if (index < 0) continue;
+    TXshColumn *column = xsh->getColumn(index);
+    if (!column) continue;
+    colIdsToBeDeleted.insert(index);
+    TFx *fx = column->getFx();
+    if (fx) {
+      TZeraryColumnFx *zcfx = dynamic_cast<TZeraryColumnFx *>(fx);
+      if (zcfx) fxsToBeDeleted.insert(zcfx->getZeraryFx());
+    }
+  }
+
+  TFxSet *fxSet = xsh->getFxDag()->getInternalFxs();
+  for (auto fx : fxs) fxsToBeDeleted.insert(fx);
+
+  // store object ids which will be duplicated in the child xsheet on collapse
+  QList<TStageObjectId> objIdsToBeDuplicated;
+  if (checkInvert && !onlyColumns) {
+    for (auto index : indices) {
+      TStageObjectId id =
+          xsh->getStageObjectParent(TStageObjectId::ColumnId(index));
+      // store pegbars/cameras connected to the columns
+      while (id.isPegbar() || id.isCamera()) {
+        if (!objIdsToBeDuplicated.contains(id)) objIdsToBeDuplicated.append(id);
+        id = xsh->getStageObjectParent(id);
+      }
+    }
+  }
+
+  return ExpressionReferenceManager::instance()->checkReferenceDeletion(
+      colIdsToBeDeleted, fxsToBeDeleted, objIdsToBeDuplicated, checkInvert);
+}
+
+//-----------------------------------------------------------------------------
+
+bool ColumnCmd::checkExpressionReferences(
+    const QList<TStageObjectId> &objects) {
+  if (!Preferences::instance()->isModifyExpressionOnMovingReferencesEnabled())
+    return true;
+
+  TApp *app    = TApp::instance();
+  TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+
+  QSet<int> colIdsToBeDeleted;
+  QSet<TFx *> fxsToBeDeleted;
+  QList<TStageObjectId> objIdsToBeDuplicated;
+
+  // store column fxs to be deleted
+  std::set<TFx *> leaves;
+  for (auto objId : objects) {
+    if (objId.isColumn()) {
+      int index = objId.getIndex();
+      if (index < 0) continue;
+      TXshColumn *column = xsh->getColumn(index);
+      if (!column) continue;
+      colIdsToBeDeleted.insert(index);
+      TFx *fx = column->getFx();
+      if (fx) {
+        leaves.insert(fx);
+        TZeraryColumnFx *zcfx = dynamic_cast<TZeraryColumnFx *>(fx);
+        if (zcfx) fxsToBeDeleted.insert(zcfx->getZeraryFx());
+      }
+    } else
+      objIdsToBeDuplicated.append(objId);
+  }
+
+  // store relevant fxs which will be deleted along with the columns
+  TFxSet *fxSet = xsh->getFxDag()->getInternalFxs();
+  for (int i = 0; i < fxSet->getFxCount(); i++) {
+    TFx *fx = fxSet->getFx(i);
+    if (canRemoveFx(leaves, fx)) fxsToBeDeleted.insert(fx);
+  }
+
+  return ExpressionReferenceManager::instance()->checkReferenceDeletion(
+      colIdsToBeDeleted, fxsToBeDeleted, objIdsToBeDuplicated, true);
+}
+
+//=============================================================================
 
 namespace {
 
@@ -1256,7 +1414,8 @@ public:
       if (m_target == TARGET_SELECTED && !isSelected) continue;
 
       /*-
-       * Skip if target is "right side of current column" mode and i is left of current column
+       * Skip if target is "right side of current column" mode and i is left of
+       * current column
        * -*/
       if (m_target == TARGET_UPPER && i < cc) continue;
 
@@ -1293,7 +1452,7 @@ public:
         else
           column->setCamstandVisible(!column->isCamstandVisible());
         if (column->getSoundColumn()) sound_changed = true;
-        viewer_changed                              = true;
+        viewer_changed = true;
       }
       /*TAB
 if(cmd & (CMD_ENABLE_PREVIEW|CMD_DISABLE_PREVIEW|CMD_TOGGLE_PREVIEW))
@@ -1358,14 +1517,13 @@ ColumnsStatusCommand
 // pasting the newly created vector column.
 class ConvertToVectorUndo final : public PasteColumnsUndo {
 public:
-  ConvertToVectorUndo(std::set<int> indices) : PasteColumnsUndo(indices) {};
+  ConvertToVectorUndo(std::set<int> indices) : PasteColumnsUndo(indices){};
 
   QString getHistoryString() override {
     return QObject::tr("Convert to Vectors");
   }
 };
 
-void ColumnCmd::addConvertToVectorUndo(std::set<int> &newColumnIndices)
-{
-    TUndoManager::manager()->add(new ConvertToVectorUndo(newColumnIndices));
+void ColumnCmd::addConvertToVectorUndo(std::set<int> &newColumnIndices) {
+  TUndoManager::manager()->add(new ConvertToVectorUndo(newColumnIndices));
 }

--- a/toonz/sources/toonz/columncommand.h
+++ b/toonz/sources/toonz/columncommand.h
@@ -4,8 +4,12 @@
 #define COLUMN_COMMAND_INCLUDED
 
 #include <set>
+#include <QList>
+
+#include "toonz/tstageobjectid.h"
 
 class StageObjectsData;
+class TFx;
 
 namespace ColumnCmd {
 
@@ -35,6 +39,21 @@ void clearCells(int index);
 //! Adds an undo object for converting layer to vector.
 void addConvertToVectorUndo(std::set<int> &newColumnIndices);
 
-}  // namespace
+// "checkInvert" flag is ON when collapsing columns.
+// expression references need to be checked in both way,
+// the columns to be collapsed and other columns to be kept in the parent
+// xsheet.
+
+bool checkExpressionReferences(const std::set<int> &indices,
+                               bool onlyColumns = true,
+                               bool checkInvert = false);
+bool checkExpressionReferences(const std::set<int> &indices,
+                               const std::set<TFx *> &fxs,
+                               bool onlyColumns = true,
+                               bool checkInvert = false);
+// checkInvert is always true for collapsing in stage schematic
+bool checkExpressionReferences(const QList<TStageObjectId> &objects);
+
+}  // namespace ColumnCmd
 
 #endif

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -95,6 +95,8 @@ void TColumnSelection::pasteColumnsAbove() {
 
 //-----------------------------------------------------------------------------
 void TColumnSelection::deleteColumns() {
+  if (!ColumnCmd::checkExpressionReferences(m_indices)) return;
+
   ColumnCmd::deleteColumns(m_indices, false, false);
 }
 

--- a/toonz/sources/toonz/expressionreferencemanager.cpp
+++ b/toonz/sources/toonz/expressionreferencemanager.cpp
@@ -1,0 +1,1010 @@
+#include "expressionreferencemanager.h"
+
+#include "tapp.h"
+
+// TnzQt includes
+#include "toonzqt/dvdialog.h"
+
+// TnzLib includes
+#include "toonz/txsheethandle.h"
+#include "toonz/tscenehandle.h"
+#include "toonz/txsheetexpr.h"
+#include "toonz/doubleparamcmd.h"
+#include "toonz/preferences.h"
+#include "toonz/tstageobject.h"
+#include "toonz/tcolumnfx.h"
+#include "toonz/txshzeraryfxcolumn.h"
+#include "toonz/fxdag.h"
+#include "toonz/tcolumnfxset.h"
+#include "toonz/toonzscene.h"
+#include "toonz/txshlevelcolumn.h"
+#include "toonz/txshcell.h"
+#include "toonz/txshchildlevel.h"
+#include "toonz/tstageobjecttree.h"
+
+// TnzBase includes
+#include "tdoubleparam.h"
+#include "texpression.h"
+#include "tdoublekeyframe.h"
+#include "tfx.h"
+
+#include "tmsgcore.h"
+
+#include <QList>
+
+#include <boost/xpressive/xpressive_static.hpp>
+#include <boost/xpressive/regex_actions.hpp>
+
+namespace {
+// reference : columncommand.cpp
+bool canRemoveFx(const std::set<TFx*>& leaves, TFx* fx) {
+  bool removeFx = false;
+  for (int i = 0; i < fx->getInputPortCount(); i++) {
+    TFx* inputFx = fx->getInputPort(i)->getFx();
+    if (!inputFx) continue;
+    if (leaves.count(inputFx) > 0) {
+      removeFx = true;
+      continue;
+    }
+    if (!canRemoveFx(leaves, inputFx)) return false;
+    removeFx = true;
+  }
+  return removeFx;
+}
+
+void gatherXsheets(TXsheet* xsheet, QSet<TXsheet*>& ret) {
+  // return if it is already registered
+  if (ret.contains(xsheet)) return;
+
+  ret.insert(xsheet);
+
+  // trace xsheet and recursively find sub-xsheets in it
+  for (int c = 0; c < xsheet->getColumnCount(); c++) {
+    if (xsheet->isColumnEmpty(c)) continue;
+    TXshLevelColumn* levelColumn = xsheet->getColumn(c)->getLevelColumn();
+    if (!levelColumn) continue;
+
+    int start, end;
+    levelColumn->getRange(start, end);
+    for (int r = start; r <= end; r++) {
+      int r0, r1;
+      if (!levelColumn->getLevelRange(r, r0, r1)) continue;
+
+      TXshChildLevel* childLevel =
+          levelColumn->getCell(r).m_level->getChildLevel();
+      if (childLevel) {
+        gatherXsheets(childLevel->getXsheet(), ret);
+      }
+
+      r = r1;
+    }
+  }
+}
+
+QSet<TXsheet*> getAllXsheets() {
+  QSet<TXsheet*> ret;
+  TXsheet* topXsheet =
+      TApp::instance()->getCurrentScene()->getScene()->getTopXsheet();
+  gatherXsheets(topXsheet, ret);
+  return ret;
+}
+
+static QList<QList<std::string>> objExprPhrases = {
+    {"table", "tab"},   // Table
+    {"col"},            // Column
+    {"cam", "camera"},  // Camera
+    {"peg", "pegbar"},  // Pegbar
+    {}                  // Spline and others
+};
+
+int getObjTypeIndex(TStageObjectId id) {
+  if (id.isTable())
+    return 0;
+  else if (id.isColumn())
+    return 1;
+  else if (id.isCamera())
+    return 2;
+  else if (id.isPegbar())
+    return 3;
+  else
+    return 4;
+}
+
+int getPhraseCount(TStageObjectId id) {
+  return objExprPhrases[getObjTypeIndex(id)].count();
+}
+
+std::string getPhrase(TStageObjectId id, int index = 0) {
+  if (getPhraseCount(id) <= index) index = 0;
+
+  std::string indexStr =
+      (id.isTable()) ? "" : std::to_string(id.getIndex() + 1);
+  // including period to avoid misunderstanding "col10" as "col1"
+  return objExprPhrases[getObjTypeIndex(id)][index] + indexStr + ".";
+}
+
+std::string getPhrase(TFx* fx) {
+  QString fxIdStr = QString::fromStdWString(toLower(fx->getFxId()));
+  return "fx." + fxIdStr.toStdString() + ".";
+}
+
+}  // namespace
+
+//----------------------------------------------------------------------------
+ExpressionReferenceMonitor* ExpressionReferenceManager::currentMonitor() {
+  return TApp::instance()->getCurrentXsheet()->getXsheet()->getExpRefMonitor();
+}
+
+QMap<TDoubleParam*, ExpressionReferenceMonitorInfo>&
+ExpressionReferenceManager::info(TXsheet* xsh) {
+  if (xsh)
+    return xsh->getExpRefMonitor()->info();
+  else
+    return currentMonitor()->info();
+}
+//-----------------------------------------------------------------------------
+
+ExpressionReferenceMonitorInfo& ExpressionReferenceManager::touchInfo(
+    TDoubleParam* param, TXsheet* xsh) {
+  if (!info(xsh).contains(param)) {
+    ExpressionReferenceMonitorInfo newInfo;
+    info(xsh).insert(param, newInfo);
+    param->addObserver(this);
+  }
+  return info(xsh)[param];
+}
+
+//-----------------------------------------------------------------------------
+
+ExpressionReferenceManager::ExpressionReferenceManager()
+    : m_model(new FunctionTreeModel()), m_blockParamChange(false) {}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::init() {
+  connect(TApp::instance()->getCurrentScene(),
+          SIGNAL(preferenceChanged(const QString&)), this,
+          SLOT(onPreferenceChanged(const QString&)));
+  onPreferenceChanged("modifyExpressionOnMovingReferences");
+}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::onPreferenceChanged(const QString& prefName) {
+  if (prefName != "modifyExpressionOnMovingReferences") return;
+
+  TXsheetHandle* xshHandle  = TApp::instance()->getCurrentXsheet();
+  TSceneHandle* sceneHandle = TApp::instance()->getCurrentScene();
+  bool on =
+      Preferences::instance()->isModifyExpressionOnMovingReferencesEnabled();
+  if (on) {
+    // when the scene switched, refresh the all list
+    connect(sceneHandle, SIGNAL(sceneSwitched()), this,
+            SLOT(onSceneSwitched()));
+    connect(xshHandle, SIGNAL(xsheetSwitched()), this,
+            SLOT(onXsheetSwitched()));
+    connect(xshHandle, SIGNAL(xsheetChanged()), this, SLOT(onXsheetChanged()));
+    onSceneSwitched();
+  } else {
+    // when the scene switched, refresh the all list
+    disconnect(sceneHandle, SIGNAL(sceneSwitched()), this,
+               SLOT(onSceneSwitched()));
+    disconnect(xshHandle, SIGNAL(xsheetSwitched()), this,
+               SLOT(onXsheetSwitched()));
+    disconnect(xshHandle, SIGNAL(xsheetChanged()), this,
+               SLOT(onXsheetChanged()));
+
+    // clear all monitor info
+    QSet<TXsheet*> allXsheets = getAllXsheets();
+    for (auto xsh : allXsheets) {
+      for (auto curve : xsh->getExpRefMonitor()->info().keys())
+        curve->removeObserver(this);
+      xsh->getExpRefMonitor()->clearAll();
+      xsh->setObserver(nullptr);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+ExpressionReferenceManager* ExpressionReferenceManager::instance() {
+  static ExpressionReferenceManager _instance;
+  return &_instance;
+}
+
+//-----------------------------------------------------------------------------
+
+bool ExpressionReferenceManager::refreshParamsRef(TDoubleParam* curve,
+                                                  TXsheet* xsh) {
+  QSet<int> colRef;
+  QSet<TDoubleParam*> paramsRef;
+  for (int k = 0; k < curve->getKeyframeCount(); k++) {
+    TDoubleKeyframe keyframe = curve->getKeyframe(k);
+
+    if (keyframe.m_type != TDoubleKeyframe::Expression &&
+        keyframe.m_type != TDoubleKeyframe::SimilarShape)
+      continue;
+
+    TExpression expr;
+    expr.setGrammar(curve->getGrammar());
+    expr.setText(keyframe.m_expressionText);
+
+    QSet<int> tmpColRef;
+    QSet<TDoubleParam*> tmpParamsRef;
+    referenceParams(expr, tmpColRef, tmpParamsRef);
+    colRef += tmpColRef;
+    paramsRef += tmpParamsRef;
+  }
+  // replace the indices
+  bool hasRef = !colRef.isEmpty() || !paramsRef.isEmpty();
+  if (hasRef) {
+    touchInfo(curve, xsh).colRefMap()   = colRef;
+    touchInfo(curve, xsh).paramRefMap() = paramsRef;
+  } else {
+    info(xsh).remove(curve);
+  }
+
+  return hasRef;
+}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::checkRef(TreeModel::Item* item, TXsheet* xsh) {
+  if (FunctionTreeModel::Channel* channel =
+          dynamic_cast<FunctionTreeModel::Channel*>(item)) {
+    TDoubleParam* curve = channel->getParam();
+    bool hasRef         = refreshParamsRef(curve, xsh);
+    if (hasRef) touchInfo(curve, xsh).name() = channel->getLongName();
+  } else
+    for (int i = 0; i < item->getChildCount(); i++)
+      checkRef(item->getChild(i), xsh);
+}
+
+//-----------------------------------------------------------------------------
+
+FunctionTreeModel::Channel* ExpressionReferenceManager::findChannel(
+    TDoubleParam* param, TreeModel::Item* item) {
+  if (FunctionTreeModel::Channel* channel =
+          dynamic_cast<FunctionTreeModel::Channel*>(item)) {
+    if (channel->getParam() == param) return channel;
+  } else {
+    for (int i = 0; i < item->getChildCount(); i++) {
+      FunctionTreeModel::Channel* ret = findChannel(param, item->getChild(i));
+      if (ret) return ret;
+    }
+  }
+  return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::gatherParams(TreeModel::Item* item,
+                                              QList<TDoubleParam*>& paramSet) {
+  if (FunctionTreeModel::Channel* channel =
+          dynamic_cast<FunctionTreeModel::Channel*>(item)) {
+    paramSet.append(channel->getParam());
+  } else
+    for (int i = 0; i < item->getChildCount(); i++)
+      gatherParams(item->getChild(i), paramSet);
+}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::onSceneSwitched() {
+  QSet<TXsheet*> allXsheets = getAllXsheets();
+  for (auto xsh : allXsheets) {
+    xsh->setObserver(this);
+
+    m_model->refreshData(xsh);
+    xsh->getExpRefMonitor()->clearAll();
+
+    for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+      checkRef(m_model->getStageObjectChannel(i), xsh);
+    }
+    for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+      checkRef(m_model->getFxChannel(i), xsh);
+    }
+  }
+  onXsheetSwitched();
+}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::onXsheetSwitched() {
+  TXsheet* xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+  xsh->setObserver(this);
+  m_model->refreshData(xsh);
+}
+
+//----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::onXsheetChanged() {
+  TXsheet* xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+  m_model->refreshData(xsh);
+  // remove deleted parameters
+  QList<TDoubleParam*> paramSet;
+  for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+    gatherParams(m_model->getStageObjectChannel(i), paramSet);
+  }
+  for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+    gatherParams(m_model->getFxChannel(i), paramSet);
+  }
+
+  // remove deleted parameter from reference map
+  for (auto itr = info(xsh).begin(); itr != info(xsh).end();) {
+    if (!paramSet.contains(itr.key()))
+      itr = info(xsh).erase(itr);
+    else {
+      // check if the referenced parameters are deleted
+      if (!itr.value().ignored()) {
+        for (auto refParam : itr.value().paramRefMap()) {
+          if (!paramSet.contains(refParam)) {
+            // ignore the parameter if the reference does not exist anymore
+            itr.value().ignored() = true;
+            break;
+          }
+        }
+      }
+      ++itr;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::onChange(const TXsheetColumnChange& change) {
+  TXsheet* xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+  QMap<TStageObjectId, TStageObjectId> idTable;
+
+  auto setIds = [&](int from, int to) {
+    idTable.insert(TStageObjectId::ColumnId(from),
+                   TStageObjectId::ColumnId(to));
+  };
+
+  switch (change.m_type) {
+  case TXsheetColumnChange::Insert: {
+    for (int c = xsh->getColumnCount() - 2; c >= change.m_index1; c--) {
+      setIds(c, c + 1);
+    }
+  } break;
+  case TXsheetColumnChange::Remove: {
+    // update ignore info
+    for (auto it = info().begin(); it != info().end(); it++) {
+      if (it.value().colRefMap().contains(change.m_index1))
+        it.value().ignored() = true;
+    }
+    for (int c = change.m_index1; c < xsh->getColumnCount(); c++) {
+      setIds(c + 1, c);
+    }
+  } break;
+  case TXsheetColumnChange::Move: {
+    if (change.m_index1 < change.m_index2) {
+      setIds(change.m_index1, change.m_index2);
+      for (int c = change.m_index1 + 1; c <= change.m_index2; c++) {
+        setIds(c, c - 1);
+      }
+    } else {
+      setIds(change.m_index1, change.m_index2);
+      for (int c = change.m_index2; c < change.m_index1; c++) {
+        setIds(c, c + 1);
+      }
+    }
+  } break;
+  }
+
+  // use empty map since the fxs does not transfer
+  QMap<TFx*, TFx*> fxTable;
+  transferReference(xsh, xsh, idTable, fxTable);
+}
+
+void ExpressionReferenceManager::onFxAdded(const std::vector<TFx*>& fxs) {
+  for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+    FxChannelGroup* fcg =
+        dynamic_cast<FxChannelGroup*>(m_model->getFxChannel(i));
+    if (fcg && fxs.end() != std::find(fxs.begin(), fxs.end(), fcg->getFx()))
+      checkRef(fcg);
+  }
+}
+
+void ExpressionReferenceManager::onStageObjectAdded(
+    const TStageObjectId objId) {
+  for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+    StageObjectChannelGroup* socg = dynamic_cast<StageObjectChannelGroup*>(
+        m_model->getStageObjectChannel(i));
+    if (socg && objId == socg->getStageObject()->getId()) checkRef(socg);
+  }
+}
+
+bool ExpressionReferenceManager::isIgnored(TDoubleParam* param) {
+  return touchInfo(param).ignored();
+}
+
+//-----------------------------------------------------------------------------
+// TParamObserver implementation
+void ExpressionReferenceManager::onChange(const TParamChange& change) {
+  // do nothing if the change is due to this manager itself
+  if (m_blockParamChange) return;
+  // do nothing if keyframe does not change or while dragging
+  if (!change.m_keyframeChanged || change.m_dragging) return;
+  TDoubleParam* curve = dynamic_cast<TDoubleParam*>(change.m_param);
+  if (!curve) return;
+  bool hasRef = refreshParamsRef(curve, nullptr);
+  if (hasRef) {
+    FunctionTreeModel::Channel* channel = nullptr;
+    for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+      channel = findChannel(curve, m_model->getStageObjectChannel(i));
+      if (channel) break;
+    }
+    if (!channel) {
+      for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+        channel = findChannel(curve, m_model->getFxChannel(i));
+        if (channel) break;
+      }
+    }
+    if (channel) {
+      touchInfo(curve).name() = channel->getLongName();
+    }
+
+    if (touchInfo(curve).ignored()) {
+      DVGui::info(tr("Expression monitoring restarted: \"%1\"")
+                      .arg(touchInfo(curve).name()));
+      touchInfo(curve).ignored() = false;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::replaceExpressionTexts(
+    TDoubleParam* curve, const std::map<std::string, std::string> replaceMap,
+    TXsheet* xsh) {
+  if (touchInfo(curve, xsh).ignored() || replaceMap.empty()) {
+    for (int kIndex = 0; kIndex < curve->getKeyframeCount(); kIndex++) {
+      TDoubleKeyframe keyframe = curve->getKeyframe(kIndex);
+      if (keyframe.m_type != TDoubleKeyframe::Expression &&
+          keyframe.m_type != TDoubleKeyframe::SimilarShape)
+        continue;
+
+      // check circular reference
+      TExpression expr;
+      expr.setGrammar(curve->getGrammar());
+      expr.setText(keyframe.m_expressionText);
+      // put "?" marks on both ends of the expression text when the circular
+      // reference is detected in order to avoid crash
+      if (dependsOn(expr, curve))
+        keyframe.m_expressionText = "?" + keyframe.m_expressionText + "?";
+
+      m_blockParamChange = true;
+      KeyframeSetter setter(curve, kIndex, false);
+      if (keyframe.m_type == TDoubleKeyframe::Expression)
+        setter.setExpression(keyframe.m_expressionText);
+      else  // SimilarShape case
+        setter.setSimilarShape(keyframe.m_expressionText,
+                               keyframe.m_similarShapeOffset);
+      m_blockParamChange = false;
+    }
+
+    return;
+  }
+
+  boost::xpressive::local<std::string const*> pstr;
+  const boost::xpressive::sregex rx =
+      (boost::xpressive::a1 = replaceMap)[pstr = &boost::xpressive::a1];
+
+  for (int kIndex = 0; kIndex < curve->getKeyframeCount(); kIndex++) {
+    TDoubleKeyframe keyframe = curve->getKeyframe(kIndex);
+
+    if (keyframe.m_type != TDoubleKeyframe::Expression &&
+        keyframe.m_type != TDoubleKeyframe::SimilarShape)
+      continue;
+
+    // replace expression
+    QString expr       = QString::fromStdString(keyframe.m_expressionText);
+    QStringList list   = expr.split('"');
+    bool isStringToken = false;
+    for (QString& partialExp : list) {
+      if (isStringToken) continue;
+      isStringToken = !isStringToken;
+
+      std::string partialExpStr = partialExp.toStdString();
+      std::string replacedStr =
+          boost::xpressive::regex_replace(partialExpStr, rx, *pstr);
+      partialExp = QString::fromStdString(replacedStr);
+    }
+
+    QString newExpr = list.join('"');
+
+    m_blockParamChange = true;
+    KeyframeSetter setter(curve, kIndex, false);
+    if (keyframe.m_type == TDoubleKeyframe::Expression)
+      setter.setExpression(newExpr.toStdString());
+    else  // SimilarShape case
+      setter.setSimilarShape(newExpr.toStdString(),
+                             keyframe.m_similarShapeOffset);
+    m_blockParamChange = false;
+
+    if (newExpr != expr) {
+      DVGui::info(tr("Expression modified: \"%1\" key at frame %2, %3 -> %4")
+                      .arg(touchInfo(curve, xsh).name())
+                      .arg(keyframe.m_frame + 1)
+                      .arg(expr)
+                      .arg(newExpr));
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+bool ExpressionReferenceManager::doCheckReferenceDeletion(
+    const QSet<int>& columnIdsToBeDeleted, const QSet<TFx*>& fxsToBeDeleted,
+    const QList<TStageObjectId>& objectIdsToBeDeleted,
+    const QList<TStageObjectId>& objIdsToBeDuplicated, bool checkInvert) {
+  QList<TDoubleParam*> paramsToBeDeleted;
+  QList<TDoubleParam*> invParamsToBeDeleted;
+  // gather Fx parameters to be deleted
+  for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+    FxChannelGroup* fcg =
+        dynamic_cast<FxChannelGroup*>(m_model->getFxChannel(i));
+    if (!fcg) continue;
+    if (fxsToBeDeleted.contains(fcg->getFx()))
+      gatherParams(fcg, paramsToBeDeleted);
+    else if (checkInvert)
+      gatherParams(fcg, invParamsToBeDeleted);
+  }
+  // gather stage objects parameters to be deleted
+  for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+    StageObjectChannelGroup* socg = dynamic_cast<StageObjectChannelGroup*>(
+        m_model->getStageObjectChannel(i));
+    if (!socg) continue;
+    TStageObjectId id = socg->getStageObject()->getId();
+    if (objectIdsToBeDeleted.contains(id))
+      gatherParams(socg, paramsToBeDeleted);
+    // objects to be duplicated in the sub xsheet will not lose referenced from
+    // either xsheet
+    else if (checkInvert && !objIdsToBeDuplicated.contains(id))
+      gatherParams(socg, invParamsToBeDeleted);
+  }
+
+  // gather parameters which refers to the parameters to be deleted
+  QSet<TDoubleParam*> cautionParams;
+  QSet<TDoubleParam*> invCautionParams;
+
+  for (auto itr = info().begin(); itr != info().end(); itr++) {
+    // find params containing columnId to be deleted
+    for (auto refColId : itr.value().colRefMap()) {
+      if (columnIdsToBeDeleted.contains(refColId))
+        cautionParams.insert(itr.key());
+      else if (checkInvert)
+        invCautionParams.insert(itr.key());
+    }
+    // find params containing fx/stage params to be deleted as well
+    for (auto refParam : itr.value().paramRefMap()) {
+      if (paramsToBeDeleted.contains(refParam)) cautionParams.insert(itr.key());
+      if (checkInvert && invParamsToBeDeleted.contains(refParam))
+        invCautionParams.insert(itr.key());
+    }
+  }
+
+  // remove parameters from the list which itself will be deleted
+  for (auto it = cautionParams.begin(); it != cautionParams.end();)
+    if (paramsToBeDeleted.contains(*it))
+      it = cautionParams.erase(it);
+    else
+      ++it;
+  for (auto it = invCautionParams.begin(); it != invCautionParams.end();)
+    if (invParamsToBeDeleted.contains(*it))
+      it = invCautionParams.erase(it);
+    else
+      ++it;
+
+  // return true if there is no parameters which will lose references
+  if (cautionParams.isEmpty() && invCautionParams.isEmpty()) return true;
+
+  // open warning popup
+  QString warningTxt =
+      tr("Following parameters will lose reference in expressions:");
+  for (auto param : cautionParams) {
+    warningTxt += "\n  " + touchInfo(param).name();
+  }
+  for (auto param : invCautionParams) {
+    warningTxt += "\n  " + touchInfo(param).name() + "  " +
+                  tr("(To be in the sub xsheet)");
+  }
+  warningTxt += "\n" + tr("Do you want to continue the operation anyway ?");
+
+  int ret = DVGui::MsgBox(warningTxt, QObject::tr("Continue"),
+                          QObject::tr("Cancel"), 0);
+  if (ret == 0 || ret == 2) return false;
+
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+// check on deleting columns
+bool ExpressionReferenceManager::checkReferenceDeletion(
+    const QSet<int>& columnIdsToBeDeleted, const QSet<TFx*>& fxsToBeDeleted,
+    const QList<TStageObjectId>& objIdsToBeDuplicated, bool checkInvert) {
+  QList<TStageObjectId> objectIdsToBeDeleted;
+  for (auto colId : columnIdsToBeDeleted)
+    objectIdsToBeDeleted.append(TStageObjectId::ColumnId(colId));
+
+  return doCheckReferenceDeletion(columnIdsToBeDeleted, fxsToBeDeleted,
+                                  objectIdsToBeDeleted, objIdsToBeDuplicated,
+                                  checkInvert);
+}
+
+//-----------------------------------------------------------------------------
+// check on deleting stage objects
+bool ExpressionReferenceManager::checkReferenceDeletion(
+    const QList<TStageObjectId>& objectIdsToBeDeleted) {
+  QSet<int> columnIdsToBeDeleted;
+  QSet<TFx*> fxsToBeDeleted;
+
+  TApp* app    = TApp::instance();
+  TXsheet* xsh = app->getCurrentXsheet()->getXsheet();
+  std::set<TFx*> leaves;
+  // fx references should be checked when deleting columns
+  for (const auto& objId : objectIdsToBeDeleted) {
+    if (objId.isColumn()) {
+      int index = objId.getIndex();
+      if (index < 0) continue;
+      TXshColumn* column = xsh->getColumn(index);
+      if (!column) continue;
+      columnIdsToBeDeleted.insert(index);
+      TFx* fx = column->getFx();
+      if (fx) {
+        leaves.insert(fx);
+        TZeraryColumnFx* zcfx = dynamic_cast<TZeraryColumnFx*>(fx);
+        if (zcfx) fxsToBeDeleted.insert(zcfx->getZeraryFx());
+      }
+    }
+  }
+  // store fx to be deleted along with columns
+  TFxSet* fxSet = xsh->getFxDag()->getInternalFxs();
+  for (int i = 0; i < fxSet->getFxCount(); i++) {
+    TFx* fx = fxSet->getFx(i);
+    if (canRemoveFx(leaves, fx)) fxsToBeDeleted.insert(fx);
+  }
+  QList<TStageObjectId> dummy;
+
+  return doCheckReferenceDeletion(columnIdsToBeDeleted, fxsToBeDeleted,
+                                  objectIdsToBeDeleted, dummy);
+}
+
+//-----------------------------------------------------------------------------
+// check on exploding sub xsheet.
+// - If removeColumn is true, it means that the sub xsheet column in the parent
+// xsheet will be deleted.
+// - If columnsOnly is true, it means that all references to the objects other
+// than columns in the sub xsheet will be lost.
+// - If columnsOnly is false, it means that references to camera not connected
+// to the table node in the sub xsheet will be lost.
+// - Open warning popup if there is any expression which will lose reference
+// after the operation.
+
+bool ExpressionReferenceManager::checkExplode(TXsheet* childXsh, int index,
+                                              bool removeColumn,
+                                              bool columnsOnly) {
+  // return if the preference option is off
+  bool on =
+      Preferences::instance()->isModifyExpressionOnMovingReferencesEnabled();
+  if (!on) return true;
+
+  QSet<TDoubleParam*> mainCautionParams, subCautionParams;
+  if (removeColumn) {
+    // find params referring to the sub xsheet column to be exploded and removed
+    for (auto itr = info().begin(); itr != info().end(); itr++) {
+      if (itr.value().colRefMap().contains(index))
+        mainCautionParams.insert(itr.key());
+    }
+  }
+
+  m_model->refreshData(childXsh);
+  // find params referring to the stage params to be deleted
+  QList<TDoubleParam*> stageParamsToBeDeleted;
+  TStageObject* table = childXsh->getStageObject(TStageObjectId::TableId);
+  for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+    StageObjectChannelGroup* socg = dynamic_cast<StageObjectChannelGroup*>(
+        m_model->getStageObjectChannel(i));
+    if (!socg) continue;
+    TStageObjectId id = socg->getStageObject()->getId();
+    if ((columnsOnly && !id.isColumn()) ||
+        (!columnsOnly && !socg->getStageObject()->isAncestor(table)))
+      gatherParams(socg, stageParamsToBeDeleted);
+  }
+  for (auto itr = info(childXsh).begin(); itr != info(childXsh).end(); itr++) {
+    for (auto refParam : itr.value().paramRefMap()) {
+      if (stageParamsToBeDeleted.contains(refParam)) {
+        subCautionParams.insert(itr.key());
+        break;
+      }
+    }
+  }
+
+  // remove parameters from the list which itself will be deleted
+  for (auto it = subCautionParams.begin(); it != subCautionParams.end();)
+    if (stageParamsToBeDeleted.contains(*it))
+      it = subCautionParams.erase(it);
+    else
+      ++it;
+
+  TXsheet* currentXsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+  m_model->refreshData(currentXsh);
+
+  // return true if there is no parameters which will lose references
+  if (mainCautionParams.isEmpty() && subCautionParams.isEmpty()) return true;
+
+  // open warning popup
+  QString warningTxt =
+      tr("Following parameters will lose reference in expressions:");
+  for (auto param : mainCautionParams) {
+    warningTxt +=
+        "\n  " + touchInfo(param).name() + "  " + tr("(In the current xsheet)");
+  }
+  for (auto param : subCautionParams) {
+    warningTxt += "\n  " + touchInfo(param, childXsh).name() + "  " +
+                  tr("(To be brought from the subxsheet)");
+  }
+  warningTxt += tr("\nDo you want to explode anyway ?");
+
+  int ret = DVGui::MsgBox(warningTxt, QObject::tr("Explode"),
+                          QObject::tr("Cancel"), 0);
+  if (ret == 0 || ret == 2) return false;
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+
+void ExpressionReferenceManager::transferReference(
+    TXsheet* fromXsh, TXsheet* toXsh,
+    const QMap<TStageObjectId, TStageObjectId>& idTable,
+    const QMap<TFx*, TFx*>& fxTable) {
+  // return if the preference option is off
+  bool on =
+      Preferences::instance()->isModifyExpressionOnMovingReferencesEnabled();
+  if (!on) return;
+
+  // 1. create 3 tables for replacing; column indices, parameter pointers, and
+  // expression texts. Note that moving columns in the same xsheet does not need
+  // to replace the paramter pointers since they are swapped along with columns.
+  QMap<int, int> colIdReplaceTable;
+  QMap<TDoubleParam*, TDoubleParam*> curveReplaceTable;
+  std::map<std::string, std::string> exprReplaceTable;
+
+  bool sameXSheet = (fromXsh == toXsh);
+
+  // First, check the stage objects
+  for (auto obj_itr = idTable.constBegin(); obj_itr != idTable.constEnd();
+       obj_itr++) {
+    TStageObjectId fromId = obj_itr.key();
+    TStageObjectId toId   = obj_itr.value();
+
+    // register column indices replacement table ( register even if fromId and
+    // toId are identical )
+    if (fromId.isColumn() && toId.isColumn())
+      colIdReplaceTable.insert(fromId.getIndex(), toId.getIndex());
+    // register expression texts replacement table ( register only if the
+    // phrases will be changed )
+    if (fromId != toId) {
+      for (int ph = 0; ph < getPhraseCount(fromId); ph++)
+        exprReplaceTable[getPhrase(fromId, ph)] = getPhrase(toId, ph);
+    }
+    if (sameXSheet) {
+      // the paramter pointers are already swapped when moving columns in the
+      // same xsheet curveReplaceTable will be used just for parameter list to
+      // be modified
+      TStageObject* toObj =
+          toXsh->getStageObjectTree()->getStageObject(toId, false);
+      assert(toObj);
+      if (toObj) {
+        for (int c = 0; c < TStageObject::T_ChannelCount; c++) {
+          TDoubleParam* to_p = toObj->getParam((TStageObject::Channel)c);
+          curveReplaceTable.insert(to_p, to_p);
+        }
+      }
+    } else {  // for transferring objects over xsheets (i.e. collapse and
+              // explode)
+      // register to the parameter pointer replacement table
+      TStageObject* fromObj =
+          fromXsh->getStageObjectTree()->getStageObject(fromId, false);
+      TStageObject* toObj =
+          toXsh->getStageObjectTree()->getStageObject(toId, false);
+      assert(fromObj && toObj);
+      if (fromObj && toObj) {
+        for (int c = 0; c < TStageObject::T_ChannelCount; c++) {
+          TDoubleParam* from_p = fromObj->getParam((TStageObject::Channel)c);
+          TDoubleParam* to_p   = toObj->getParam((TStageObject::Channel)c);
+          curveReplaceTable.insert(from_p, to_p);
+        }
+      }
+    }
+  }
+
+  // Secondly, check the Fxs
+  QMap<TFx*, QList<TDoubleParam*>> fromFxParams, toFxParams;
+  for (auto fx_itr = fxTable.constBegin(); fx_itr != fxTable.constEnd();
+       fx_itr++) {
+    TFx* fromFx = fx_itr.key();
+    TFx* toFx   = fx_itr.value();
+    // skip the case that the Xsheet node is converted to the OverFx when
+    // exploding
+    if (fromFx->getFxType() == toFx->getFxType()) {
+      fromFxParams.insert(fromFx, QList<TDoubleParam*>());
+      toFxParams.insert(toFx, QList<TDoubleParam*>());
+      // register expression texts replacement table
+      if (fromFx->getFxId() != toFx->getFxId())
+        exprReplaceTable[getPhrase(fromFx)] = getPhrase(toFx);
+    }
+  }
+  if (!fromFxParams.isEmpty() && !toFxParams.isEmpty()) {
+    // gather from-fx parameter pointers
+    m_model->refreshData(fromXsh);
+    for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+      FxChannelGroup* fcg =
+          dynamic_cast<FxChannelGroup*>(m_model->getFxChannel(i));
+      if (!fcg) continue;
+      if (fromFxParams.contains(fcg->getFx()))
+        gatherParams(fcg, fromFxParams[fcg->getFx()]);
+    }
+    // gather to-fx parameter pointers
+    m_model->refreshData(toXsh);
+    for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+      FxChannelGroup* fcg =
+          dynamic_cast<FxChannelGroup*>(m_model->getFxChannel(i));
+      if (!fcg) continue;
+      if (toFxParams.contains(fcg->getFx()))
+        gatherParams(fcg, toFxParams[fcg->getFx()]);
+    }
+    // register parameters to the table
+    for (auto ffp_itr = fromFxParams.constBegin();
+         ffp_itr != fromFxParams.constEnd(); ffp_itr++) {
+      TFx* fromFx = ffp_itr.key();
+      TFx* toFx   = fxTable.value(fromFx);
+      assert(toFx && toFxParams.contains(toFx));
+      for (int i = 0; i < ffp_itr.value().size(); i++) {
+        curveReplaceTable.insert(ffp_itr.value().at(i),
+                                 toFxParams.value(toFx).at(i));
+      }
+    }
+  }
+
+  // 2. transfer reference information from fromXsh to toXsh by using tables
+  // QMap<int, int> colIdReplaceTable;
+  // QMap<TDoubleParam*, TDoubleParam*> curveReplaceTable;
+  // std::map<std::string, std::string> exprReplaceTable;
+  QSet<TDoubleParam*> insertedCurves;
+  for (auto itr = info(fromXsh).begin(); itr != info(fromXsh).end(); itr++) {
+    TDoubleParam* fromParam = itr.key();
+    bool ignored            = touchInfo(fromParam, fromXsh).ignored();
+    if (sameXSheet) {
+      // transfer as-is if the parameter is ignored
+      if (!ignored) {
+        // converting the column indices.
+        QSet<int> convertedColIdSet;
+        for (auto fromId : itr.value().colRefMap()) {
+          if (colIdReplaceTable.contains(fromId))
+            convertedColIdSet.insert(colIdReplaceTable.value(fromId));
+          // if there is a index not in the replacement table, transfer it
+          // as-is.
+          else
+            convertedColIdSet.insert(fromId);
+        }
+        // replacing the info
+        itr.value().colRefMap() = convertedColIdSet;
+      }
+      insertedCurves.insert(fromParam);
+    }
+    // if the parameter is in the replacement table
+    else if (curveReplaceTable.contains(fromParam)) {
+      // transfer as-is if the parameter is ignored
+      // converting the column indices.
+      QSet<int> convertedColIdSet;
+      for (auto fromId : itr.value().colRefMap()) {
+        if (ignored) break;
+        if (colIdReplaceTable.contains(fromId))
+          convertedColIdSet.insert(colIdReplaceTable.value(fromId));
+        // if there is a index not in the replacement table, the parameter will
+        // be ignored
+        else
+          ignored = true;
+      }
+
+      // converting the parameter pointers
+      QSet<TDoubleParam*> convertedParamSet;
+      for (auto fromRefParam : itr.value().paramRefMap()) {
+        if (curveReplaceTable.contains(fromRefParam))
+          convertedParamSet.insert(curveReplaceTable.value(fromRefParam));
+        // if there is a index not in the replacement table, the parameter will
+        // be ignored
+        else
+          ignored = true;
+      }
+
+      // register the converted list to toXsh
+      TDoubleParam* toParam = curveReplaceTable.value(fromParam);
+      if (ignored) {
+        touchInfo(toParam, toXsh).ignored() = true;
+        // if the parameter is ignored, transfer the column reference list
+        // as-is.
+        touchInfo(toParam, toXsh).colRefMap() = itr.value().colRefMap();
+      } else
+        touchInfo(toParam, toXsh).colRefMap() = convertedColIdSet;
+
+      touchInfo(toParam, toXsh).paramRefMap() = convertedParamSet;
+
+      insertedCurves.insert(toParam);
+    }
+
+    // update parameter names
+    if (curveReplaceTable.contains(fromParam)) {
+      TDoubleParam* toParam               = curveReplaceTable.value(fromParam);
+      FunctionTreeModel::Channel* channel = nullptr;
+      // here m_model should be refreshed using toXsh
+      for (int i = 0; i < m_model->getStageObjectsChannelCount(); i++) {
+        channel = findChannel(toParam, m_model->getStageObjectChannel(i));
+        if (channel) break;
+      }
+      if (!channel) {
+        for (int i = 0; i < m_model->getFxsChannelCount(); i++) {
+          channel = findChannel(toParam, m_model->getFxChannel(i));
+          if (channel) break;
+        }
+      }
+      if (channel) {
+        touchInfo(toParam, toXsh).name() = channel->getLongName();
+      }
+    }
+  }
+
+  // refresh m_model with the current xsheet
+  if (toXsh != TApp::instance()->getCurrentXsheet()->getXsheet())
+    m_model->refreshData(TApp::instance()->getCurrentXsheet()->getXsheet());
+
+  // 3. replace the expression texts
+  for (auto ic : insertedCurves) replaceExpressionTexts(ic, exprReplaceTable);
+}
+
+//----------------------------------------------------------------------------
+// open warning popup if there is any paramters which is ignored (i.e. the
+// reference is lost and user hasn't touch yet)
+bool ExpressionReferenceManager::askIfParamIsIgnoredOnSave(bool saveSubXsheet) {
+  // return if the preference option is off
+  bool on =
+      Preferences::instance()->isModifyExpressionOnMovingReferencesEnabled();
+  if (!on) return true;
+  QSet<TXsheet*> xsheetSet;
+  TXsheet* parentXsh;
+  if (saveSubXsheet)  // check only inside the current xsheet
+    parentXsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+  else  // check whole xsheets from the top
+    parentXsh = TApp::instance()->getCurrentScene()->getScene()->getTopXsheet();
+
+  gatherXsheets(parentXsh, xsheetSet);
+
+  // gather the ignored parameter names
+  QStringList ignoredParamNames;
+  for (auto xsh : xsheetSet) {
+    bool isParent = (xsh == parentXsh);
+    for (auto itr = info(xsh).begin(); itr != info(xsh).end(); itr++) {
+      if (!itr.value().ignored()) continue;
+      QString paramName = itr.value().name();
+      if (!isParent) paramName += "  " + tr("(In a sub xsheet)");
+      ignoredParamNames.append(paramName);
+    }
+  }
+
+  // return if there is not ignored parameters
+  if (ignoredParamNames.isEmpty()) return true;
+
+  // open warning popup
+  QString warningTxt =
+      tr("Following parameters may contain broken references in expressions:");
+  warningTxt += "\n  " + ignoredParamNames.join("\n  ");
+  warningTxt += "\n" + tr("Do you want to save the scene anyway ?");
+
+  int ret =
+      DVGui::MsgBox(warningTxt, QObject::tr("Save"), QObject::tr("Cancel"), 0);
+  if (ret == 0 || ret == 2) return false;
+
+  return true;
+}

--- a/toonz/sources/toonz/expressionreferencemanager.h
+++ b/toonz/sources/toonz/expressionreferencemanager.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#ifndef EXPRESSIONREFERENCEMANAGER_H
+#define EXPRESSIONREFERENCEMANAGER_H
+
+#include "tparamchange.h"
+#include "toonzqt/treemodel.h"
+#include "toonzqt/functiontreeviewer.h"
+#include "toonz/txsheetcolumnchange.h"
+#include "toonz/tstageobjectid.h"
+#include "toonz/expressionreferencemonitor.h"
+#include <QObject>
+#include <QMap>
+#include <QSet>
+#include <QList>
+
+class TDoubleParam;
+class TFx;
+
+class ExpressionReferenceManager : public QObject,
+                                   public TXsheetColumnChangeObserver,
+                                   public TParamObserver {  // singleton
+  Q_OBJECT
+
+  FunctionTreeModel* m_model;
+  // block to run onChange() due to keyframe change caused by itself
+  bool m_blockParamChange;
+
+  ExpressionReferenceMonitor* currentMonitor();
+
+  QMap<TDoubleParam*, ExpressionReferenceMonitorInfo>& info(
+      TXsheet* xsh = nullptr);
+
+  ExpressionReferenceMonitorInfo& touchInfo(TDoubleParam* param,
+                                            TXsheet* xsh = nullptr);
+
+  ExpressionReferenceManager();
+
+  void checkRef(TreeModel::Item* item, TXsheet* xsh = nullptr);
+  FunctionTreeModel::Channel* findChannel(TDoubleParam* param,
+                                          TreeModel::Item* item);
+
+  void gatherParams(TreeModel::Item* item, QList<TDoubleParam*>&);
+  bool refreshParamsRef(TDoubleParam* curve, TXsheet* xsh = nullptr);
+
+  void replaceExpressionTexts(
+      TDoubleParam* curve, const std::map<std::string, std::string> replaceMap,
+      TXsheet* xsh = nullptr);
+
+  bool doCheckReferenceDeletion(
+      const QSet<int>& columnIdsToBeDeleted, const QSet<TFx*>& fxsToBeDeleted,
+      const QList<TStageObjectId>& objectIdsToBeDeleted,
+      const QList<TStageObjectId>& objIdsToBeDuplicated,
+      bool checkInvert = false);
+
+public:
+  static ExpressionReferenceManager* instance();
+  void onChange(const TXsheetColumnChange&) override;
+  void onFxAdded(const std::vector<TFx*>&) override;
+  void onStageObjectAdded(const TStageObjectId) override;
+  bool isIgnored(TDoubleParam*) override;
+
+  void onChange(const TParamChange&) override;
+
+  void init();
+
+  bool checkReferenceDeletion(const QSet<int>& columnIdsToBeDeleted,
+                              const QSet<TFx*>& fxsToBeDeleted,
+                              const QList<TStageObjectId>& objIdsToBeDuplicated,
+                              bool checkInvert);
+  bool checkReferenceDeletion(
+      const QList<TStageObjectId>& objectIdsToBeDeleted);
+  bool checkExplode(TXsheet* childXsh, int index, bool removeColumn,
+                    bool columnsOnly);
+
+  void transferReference(TXsheet* fromXsh, TXsheet* toXsh,
+                         const QMap<TStageObjectId, TStageObjectId>& idTable,
+                         const QMap<TFx*, TFx*>& fxTable);
+
+  bool askIfParamIsIgnoredOnSave(bool saveSubXsheet);
+
+protected slots:
+  void onSceneSwitched();
+  void onXsheetSwitched();
+  void onXsheetChanged();
+  void onPreferenceChanged(const QString& prefName);
+};
+
+#endif

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -20,6 +20,7 @@
 #include "versioncontrol.h"
 #include "cachefxcommand.h"
 #include "xdtsio.h"
+#include "expressionreferencemanager.h"
 
 // TnzTools includes
 #include "tools/toolhandle.h"
@@ -1370,6 +1371,13 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
               .arg(toQString(scenePath.getParentDir())));
     return false;
   }
+
+  // notify user if the scene will be saved including any "broken" expression
+  // reference
+  if (!ExpressionReferenceManager::instance()->askIfParamIsIgnoredOnSave(
+          saveSubxsheet))
+    return false;
+
   if (!overwrite && TFileStatus(scenePath).doesExist()) {
     QString question;
     question = QObject::tr(

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -8,6 +8,7 @@
 #include "previewfxmanager.h"
 #include "cleanupsettingspopup.h"
 #include "filebrowsermodel.h"
+#include "expressionreferencemanager.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -701,6 +702,8 @@ int main(int argc, char *argv[]) {
   TFilePath fp = ToonzFolder::getModuleFile("mainwindow.ini");
   QSettings settings(toQString(fp), QSettings::IniFormat);
   w.restoreGeometry(settings.value("MainWindowGeometry").toByteArray());
+
+  ExpressionReferenceManager::instance()->init();
 
 #ifndef MACOSX
   // Workaround for the maximized window case: Qt delivers two resize events,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -574,6 +574,13 @@ void PreferencesPopup::onShowXSheetToolbarClicked() {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onModifyExpressionOnMovingReferencesChanged() {
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
+      "modifyExpressionOnMovingReferences");
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onBlankCountChanged() {
   TApp::instance()->getCurrentScene()->notifyPreferenceChanged("BlankCount");
 }
@@ -1135,6 +1142,9 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Animation
       {keyframeType, tr("Default Interpolation:")},
       {animationStep, tr("Animation Step:")},
+      {modifyExpressionOnMovingReferences,
+       tr("[Experimental Feature] ") +
+           tr("Automatically Modify Expression On Moving Referenced Objects")},
 
       // Preview
       {blanksCount, tr("Blank Frames:")},
@@ -1795,9 +1805,15 @@ QWidget* PreferencesPopup::createAnimationPage() {
 
   insertUI(keyframeType, lay, getComboItemList(keyframeType));
   insertUI(animationStep, lay);
+  insertUI(modifyExpressionOnMovingReferences, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);
+
+  m_onEditedFuncMap.insert(
+      modifyExpressionOnMovingReferences,
+      &PreferencesPopup::onModifyExpressionOnMovingReferencesChanged);
+
   return widget;
 }
 

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -133,6 +133,8 @@ private:
   // Xsheet
   void onShowKeyframesOnCellAreaChanged();
   void onShowXSheetToolbarClicked();
+  // Animation
+  void onModifyExpressionOnMovingReferencesChanged();
   // Preview
   void onBlankCountChanged();
   void onBlankColorChanged();

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -30,6 +30,7 @@
 #include "toonz/tstageobjecttree.h"
 #include "toonz/tstageobjectspline.h"
 #include "toonz/tcamera.h"
+#include "toonz/expressionreferencemonitor.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -47,6 +48,7 @@
 #include "tapp.h"
 #include "columnselection.h"
 #include "cellselection.h"
+#include "expressionreferencemanager.h"
 
 #include "subscenecommand.h"
 
@@ -625,12 +627,10 @@ std::set<int> explodeStageObjects(
     const GroupData &fxGroupData, QList<TStageObject *> &pegObjects,
     QMap<TFx *, QPair<TFx *, int>> &fxs,
     QMap<TStageObjectSpline *, TStageObjectSpline *> &splines,
-    bool onlyColumn) {
+    QMap<TStageObjectId, TStageObjectId> &ids, bool onlyColumn) {
   /*- SubXsheet, 親Xsheet両方のツリーを取得 -*/
   TStageObjectTree *innerTree = subXsh->getStageObjectTree();
   TStageObjectTree *outerTree = xsh->getStageObjectTree();
-  // inner id->outer id
-  QMap<TStageObjectId, TStageObjectId> ids;
   // innerSpline->outerSpline
   int groupId = -1;  // outerTree->getNewGroupId();
   /*- Pegbarも持ち出す場合 -*/
@@ -926,20 +926,58 @@ void explodeFxs(TXsheet *xsh, TXsheet *subXsh, const GroupData &fxGroupData,
 
 //-----------------------------------------------------------------------------
 
+template <typename ParamCont>
+void setGrammerToParams(const ParamCont *cont,
+                        const TSyntax::Grammar *grammer) {
+  for (int p = 0; p != cont->getParamCount(); ++p) {
+    TParam &param = *cont->getParam(p);
+    if (TDoubleParam *dp = dynamic_cast<TDoubleParam *>(&param))
+      dp->setGrammar(grammer);
+    else if (TParamSet *paramSet = dynamic_cast<TParamSet *>(&param))
+      setGrammerToParams(paramSet, grammer);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
 std::set<int> explode(TXsheet *xsh, TXsheet *subXsh, int index,
-                      const TStageObjectId &parentId,
-                      const GroupData &objGroupData, const TPointD &stageSubPos,
-                      const GroupData &fxGroupData, const TPointD &fxSubPos,
-                      QList<TStageObject *> &pegObjects,
-                      QMap<TStageObjectSpline *, TStageObjectSpline *> &splines,
-                      const std::vector<TFxPort *> &outPorts, bool onlyColumn,
-                      bool linkToXsheet) {
+                 const TStageObjectId &parentId, const GroupData &objGroupData,
+                 const TPointD &stageSubPos, const GroupData &fxGroupData,
+                 const TPointD &fxSubPos, QList<TStageObject *> &pegObjects,
+                 QMap<TStageObjectSpline *, TStageObjectSpline *> &splines,
+                 const std::vector<TFxPort *> &outPorts, bool onlyColumn,
+                 bool linkToXsheet) {
   // innerFx->outerFxs
   QMap<TFx *, QPair<TFx *, int>> fxs;
+  // inner id->outer id
+  QMap<TStageObjectId, TStageObjectId> objIds;
   std::set<int> indexes = explodeStageObjects(
       xsh, subXsh, index, parentId, objGroupData, stageSubPos, fxGroupData,
-      pegObjects, fxs, splines, onlyColumn);
+      pegObjects, fxs, splines, objIds, onlyColumn);
   explodeFxs(xsh, subXsh, fxGroupData, fxs, fxSubPos, outPorts, linkToXsheet);
+
+  assert(TApp::instance()->getCurrentXsheet()->getXsheet() == xsh);
+
+  // reset grammers for all parameters brought out to the parent xsheet
+  TSyntax::Grammar *grammer = xsh->getStageObjectTree()->getGrammar();
+  for (auto id : objIds.values()) {
+    TStageObject *obj = xsh->getStageObject(id);
+    for (int c = 0; c != TStageObject::T_ChannelCount; ++c)
+      obj->getParam((TStageObject::Channel)c)->setGrammar(grammer);
+    if (const PlasticSkeletonDeformationP &sd =
+            obj->getPlasticSkeletonDeformation())
+      sd->setGrammar(grammer);
+  }
+
+  QMap<TFx *, TFx *> fxMap;
+  for (auto it = fxs.constBegin(); it != fxs.constEnd(); ++it) {
+    setGrammerToParams(it.value().first->getParams(), grammer);
+    fxMap.insert(it.key(), it.value().first);
+  }
+
+  ExpressionReferenceManager::instance()->transferReference(subXsh, xsh, objIds,
+                                                            fxMap);
+
   return indexes;
 }
 
@@ -1157,9 +1195,9 @@ bool hasPegbarsToBringInsideChildXsheet(TXsheet *xsh,
 
 //-----------------------------------------------------------------------------
 
-void bringPegbarsInsideChildXsheet(TXsheet *xsh, TXsheet *childXsh,
-                                   std::set<int> indices,
-                                   std::set<int> newIndices) {
+void bringPegbarsInsideChildXsheet(
+    TXsheet *xsh, TXsheet *childXsh, std::set<int> indices,
+    std::set<int> newIndices, QMap<TStageObjectId, TStageObjectId> &idTable) {
   // columns in the child xsheet are all connected to the table for now.
   // so we need to take parental connection information from the parent xsheet.
 
@@ -1198,6 +1236,9 @@ void bringPegbarsInsideChildXsheet(TXsheet *xsh, TXsheet *childXsh,
     for (int c = 0; c != TStageObject::T_ChannelCount; ++c)
       childXsh->getStageObjectTree()->setGrammar(
           obj->getParam((TStageObject::Channel)c));
+
+    // register pegbars to the table
+    idTable.insert(id, id);
   }
 }
 
@@ -1246,10 +1287,14 @@ void collapseColumns(std::set<int> indices, bool columnsOnly) {
   TApp *app    = TApp::instance();
   TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
 
+  std::set<int> oldIndices = indices;
+
   StageObjectsData *data = new StageObjectsData();
   // store xsheet data to be collapsed
   data->storeColumns(indices, xsh, StageObjectsData::eDoClone);
   data->storeColumnFxs(indices, xsh, StageObjectsData::eDoClone);
+
+  ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXshLevel *xl     = scene->createNewLevel(CHILD_XSHLEVEL);
@@ -1262,12 +1307,18 @@ void collapseColumns(std::set<int> indices, bool columnsOnly) {
 
   std::set<int> newIndices;
   std::list<int> restoredSplineIds;
+  QMap<TStageObjectId, TStageObjectId> idTable;
+  QMap<TFx *, TFx *> fxTable;
   // restore data into sub xsheet
-  data->restoreObjects(newIndices, restoredSplineIds, childXsh, 0);
+  data->restoreObjects(newIndices, restoredSplineIds, childXsh, 0, idTable,
+                       fxTable);
 
   // bring pegbars into sub xsheet
   if (!columnsOnly)
-    bringPegbarsInsideChildXsheet(xsh, childXsh, indices, newIndices);
+    bringPegbarsInsideChildXsheet(xsh, childXsh, indices, newIndices, idTable);
+
+  ExpressionReferenceManager::instance()->transferReference(xsh, childXsh,
+                                                            idTable, fxTable);
 
   childXsh->updateFrameCount();
 
@@ -1336,8 +1387,9 @@ void collapseColumns(std::set<int> indices,
                      const QList<TStageObjectId> &objIds) {
   if (indices.empty()) return;
 
-  TApp *app    = TApp::instance();
-  TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+  TApp *app                = TApp::instance();
+  TXsheet *xsh             = app->getCurrentXsheet()->getXsheet();
+  std::set<int> oldIndices = indices;
 
   int index = *indices.begin();
 
@@ -1353,13 +1405,7 @@ void collapseColumns(std::set<int> indices,
                      StageObjectsData::eDoClone);
   data->storeColumnFxs(indices, xsh, StageObjectsData::eDoClone);
 
-  app->getCurrentXsheet()->blockSignals(true);
-  app->getCurrentObject()->blockSignals(true);
-  ColumnCmd::deleteColumns(indices, false, true);
-  app->getCurrentXsheet()->blockSignals(false);
-  app->getCurrentObject()->blockSignals(false);
-
-  xsh->insertColumn(index);
+  ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXshLevel *xl     = scene->createNewLevel(CHILD_XSHLEVEL);
@@ -1372,8 +1418,22 @@ void collapseColumns(std::set<int> indices,
 
   std::set<int> newIndices;
   std::list<int> restoredSplineIds;
-  data->restoreObjects(newIndices, restoredSplineIds, childXsh, 0);
+  QMap<TStageObjectId, TStageObjectId> idTable;
+  QMap<TFx *, TFx *> fxTable;
+  data->restoreObjects(newIndices, restoredSplineIds, childXsh, 0, idTable,
+                       fxTable);
   childXsh->updateFrameCount();
+
+  ExpressionReferenceManager::instance()->transferReference(xsh, childXsh,
+                                                            idTable, fxTable);
+
+  app->getCurrentXsheet()->blockSignals(true);
+  app->getCurrentObject()->blockSignals(true);
+  ColumnCmd::deleteColumns(indices, false, true);
+  app->getCurrentXsheet()->blockSignals(false);
+  app->getCurrentObject()->blockSignals(false);
+
+  xsh->insertColumn(index);
 
   int r, rowCount = childXsh->getFrameCount();
   for (r = 0; r < rowCount; r++)
@@ -1402,11 +1462,14 @@ void collapseColumns(std::set<int> indices, const std::set<TFx *> &fxs,
   TApp *app    = TApp::instance();
   TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
 
+  std::set<int> oldIndices = indices;
   //++++++++++++++++++++++++++++++
 
   StageObjectsData *data = new StageObjectsData();
   data->storeColumns(indices, xsh, StageObjectsData::eDoClone);
   data->storeFxs(fxs, xsh, StageObjectsData::eDoClone);
+
+  ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXshLevel *xl     = scene->createNewLevel(CHILD_XSHLEVEL);
@@ -1417,10 +1480,16 @@ void collapseColumns(std::set<int> indices, const std::set<TFx *> &fxs,
 
   std::set<int> newIndices;
   std::list<int> restoredSplineIds;
-  data->restoreObjects(newIndices, restoredSplineIds, childXsh, 0);
+  QMap<TStageObjectId, TStageObjectId> idTable;
+  QMap<TFx *, TFx *> fxTable;
+  data->restoreObjects(newIndices, restoredSplineIds, childXsh, 0, idTable,
+                       fxTable);
 
   if (!columnsOnly)
-    bringPegbarsInsideChildXsheet(xsh, childXsh, indices, newIndices);
+    bringPegbarsInsideChildXsheet(xsh, childXsh, indices, newIndices, idTable);
+
+  ExpressionReferenceManager::instance()->transferReference(xsh, childXsh,
+                                                            idTable, fxTable);
 
   childXsh->updateFrameCount();
 
@@ -2222,6 +2291,7 @@ void SubsceneCmd::collapse(std::set<int> &indices) {
     if (ret == 0) return;
     onlyColumns = (ret == 2);
   }
+  if (!ColumnCmd::checkExpressionReferences(indices, onlyColumns, true)) return;
 
   std::set<int> oldIndices = indices;
   int index                = *indices.begin();
@@ -2269,6 +2339,8 @@ void SubsceneCmd::collapse(const QList<TStageObjectId> &objects) {
 
   std::set<int> indices;
   getColumnIndexes(objects, indices);
+
+  if (!ColumnCmd::checkExpressionReferences(objects)) return;
 
   std::set<int> oldIndices = indices;
   int index                = *indices.begin();
@@ -2318,6 +2390,7 @@ void SubsceneCmd::collapse(const QList<TFxP> &fxs) {
   TXsheet *xsh     = TApp::instance()->getCurrentXsheet()->getXsheet();
   bool onlyColumns = true;
   if (hasPegbarsToBringInsideChildXsheet(xsh, indices)) {
+    // User must decide if pegbars must be collapsed too
     QString question(QObject::tr("Collapsing columns: what you want to do?"));
     QList<QString> list;
     list.append(
@@ -2328,6 +2401,10 @@ void SubsceneCmd::collapse(const QList<TFxP> &fxs) {
     if (ret == 0) return;
     onlyColumns = (ret == 2);
   }
+
+  if (!ColumnCmd::checkExpressionReferences(indices, internalFx, onlyColumns,
+                                            true))
+    return;
 
   std::set<int> oldIndices = indices;
   int index                = *indices.begin();
@@ -2382,6 +2459,15 @@ void SubsceneCmd::explode(int index) {
   TXshChildLevel *childLevel = cell.getChildLevel();
   if (!childLevel) return;
 
+  // Cannot remove the column if it contains frames of a TXshSimpleLevel.
+  int from, to;
+
+  // removeColumn is true if the column contains only one subXsheetLevel (i.e.
+  // the column will be removed) removeColumn is false if there is another level
+  // in the same column (i.e. the column will remain)
+  bool removeColumn =
+      mustRemoveColumn(from, to, childLevel, xsh, index, frameIndex);
+
   /*- Pegbarを親Sheetに持って出るか？の質問ダイアログ -*/
   QString question(QObject::tr("Exploding Sub-xsheet: what you want to do?"));
   QList<QString> list;
@@ -2389,6 +2475,11 @@ void SubsceneCmd::explode(int index) {
   list.append(QObject::tr("Bring only columns in the main xsheet."));
   int ret = DVGui::RadioButtonMsgBox(DVGui::WARNING, question, list);
   if (ret == 0) return;
+
+  if (!ExpressionReferenceManager::instance()->checkExplode(
+          childLevel->getXsheet(), index, removeColumn, ret == 2))
+    return;
+
   // Collect column stage object informations
   TStageObjectId colId    = TStageObjectId::ColumnId(index);
   TStageObjectId parentId = xsh->getStageObjectParent(colId);
@@ -2445,14 +2536,6 @@ void SubsceneCmd::explode(int index) {
 
   std::vector<TFxPort *> outPorts;
 
-  // Cannot remove the column if it contains frames of a TXshSimpleLevel.
-  int from, to;
-  /*--
-  このカラムがsubXsheetLevelしか入っていない場合は、カラムを消去できるのでremoveColumnはtrue
-          何か別のLevelが入っていた場合は、カラムを消去しないので、removeColumnはfalse
-  --*/
-  bool removeColumn =
-      mustRemoveColumn(from, to, childLevel, xsh, index, frameIndex);
   QList<TStageObject *> pegObjects;
   QMap<TStageObjectSpline *, TStageObjectSpline *> splines;
 
@@ -2514,7 +2597,7 @@ void SubsceneCmd::explode(int index) {
         objGroupNames);
     TUndoManager::manager()->add(undo);
   } else {
-    // keep outPorts empty since the exploded node will be re-cocnected to the
+    // keep outPorts empty since the exploded node will be re-connected to the
     // xsheet node
 
     // Collect information for undo

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -26,6 +26,8 @@
 
 #include "vectorguideddrawingpane.h"
 
+#include "expressionreferencemanager.h"
+
 #ifdef WITH_STOPMOTION
 #include "stopmotioncontroller.h"
 #endif
@@ -38,6 +40,7 @@
 #include "menubarcommandids.h"
 #include "tapp.h"
 #include "mainwindow.h"
+#include "columncommand.h"
 
 // TnzTools includes
 #include "tools/tooloptions.h"
@@ -55,6 +58,8 @@
 #include "toonzqt/tmessageviewer.h"
 #include "toonzqt/scriptconsole.h"
 #include "toonzqt/fxsettings.h"
+#include "toonzqt/fxselection.h"
+#include "stageobjectselection.h"
 
 // TnzLib includes
 #include "toonz/palettecontroller.h"
@@ -75,6 +80,8 @@
 #include "toonz/preferences.h"
 #include "tw/stringtable.h"
 #include "toonz/toonzfolders.h"
+#include "toonz/fxcommand.h"
+#include "toonz/tstageobjectcmd.h"
 
 // TnzBase includes
 #include "trasterfx.h"
@@ -217,6 +224,38 @@ int SchematicScenePanel::getViewType() {
 
 //-----------------------------------------------------------------------------
 
+void SchematicScenePanel::onDeleteFxs(const FxSelection *selection) {
+  std::set<int> colIndices;
+  std::set<TFx *> fxs;
+  for (auto index : selection->getColumnIndexes()) colIndices.insert(index);
+  for (auto fx : selection->getFxs()) fxs.insert(fx.getPointer());
+
+  if (!ColumnCmd::checkExpressionReferences(colIndices, fxs)) return;
+
+  TApp *app = TApp::instance();
+  TFxCommand::deleteSelection(selection->getFxs().toStdList(),
+                              selection->getLinks().toStdList(),
+                              selection->getColumnIndexes().toStdList(),
+                              app->getCurrentXsheet(), app->getCurrentFx());
+}
+
+//-----------------------------------------------------------------------------
+
+void SchematicScenePanel::onDeleteStageObjects(
+    const StageObjectSelection *selection) {
+  if (!ExpressionReferenceManager::instance()->checkReferenceDeletion(
+          selection->getObjects()))
+    return;
+
+  TApp *app = TApp::instance();
+  TStageObjectCmd::deleteSelection(
+      selection->getObjects().toVector().toStdVector(),
+      selection->getLinks().toStdList(), selection->getSplines().toStdList(),
+      app->getCurrentXsheet(), app->getCurrentObject(), app->getCurrentFx());
+}
+
+//-----------------------------------------------------------------------------
+
 void SchematicScenePanel::showEvent(QShowEvent *e) {
   if (m_schematicViewer->isStageSchematicViewed())
     setWindowTitle(QObject::tr("Stage Schematic"));
@@ -232,8 +271,13 @@ void SchematicScenePanel::showEvent(QShowEvent *e) {
           SLOT(onCollapse(QList<TStageObjectId>)));
   connect(m_schematicViewer, SIGNAL(doExplodeChild(const QList<TFxP> &)), this,
           SLOT(onExplodeChild(const QList<TFxP> &)));
+  connect(m_schematicViewer, SIGNAL(doDeleteFxs(const FxSelection *)), this,
+          SLOT(onDeleteFxs(const FxSelection *)));
   connect(m_schematicViewer, SIGNAL(doExplodeChild(QList<TStageObjectId>)),
           this, SLOT(onExplodeChild(QList<TStageObjectId>)));
+  connect(m_schematicViewer,
+          SIGNAL(doDeleteStageObjects(const StageObjectSelection *)), this,
+          SLOT(onDeleteStageObjects(const StageObjectSelection *)));
   connect(m_schematicViewer, SIGNAL(editObject()), this, SLOT(onEditObject()));
   connect(app->getCurrentLevel(), SIGNAL(xshLevelChanged()), m_schematicViewer,
           SLOT(updateScenes()));

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -29,6 +29,8 @@ class ComboViewerPanel;
 class SceneViewerPanel;
 class FxSettings;
 class VectorGuidedDrawingPane;
+class FxSelection;
+class StageObjectSelection;
 
 //=========================================================
 // PaletteViewerPanel
@@ -187,6 +189,8 @@ protected slots:
   void onExplodeChild(const QList<TFxP> &);
   void onExplodeChild(QList<TStageObjectId>);
   void onEditObject();
+  void onDeleteFxs(const FxSelection *);
+  void onDeleteStageObjects(const StageObjectSelection *);
 };
 
 //=========================================================

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1050,7 +1050,10 @@ static void removeEmptyColumns() {
     if (!column || column->isEmpty()) indices.insert(i);
   }
 
-  if (indices.size()) ColumnCmd::deleteColumns(indices, false, false);
+  if (indices.empty()) return;
+  if (!ColumnCmd::checkExpressionReferences(indices)) return;
+
+  ColumnCmd::deleteColumns(indices, false, false);
 
   app->getCurrentXsheet()->notifyXsheetChanged();
 }

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -160,6 +160,8 @@ set(HEADERS
     ../include/toonz/vectorizerparameters.h
     ../include/toutputproperties.h
     ../include/toonz/preferencesitemids.h
+    ../include/toonz/txsheetcolumnchange.h
+    ../include/toonz/expressionreferencemonitor.h
 )
 
 set(SOURCES

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -526,6 +526,8 @@ void Preferences::definePreferenceItems() {
   // Animation
   define(keyframeType, "keyframeType", QMetaType::Int, 2);  // Linear
   define(animationStep, "animationStep", QMetaType::Int, 1, 1, 500);
+  define(modifyExpressionOnMovingReferences,
+         "modifyExpressionOnMovingReferences", QMetaType::Bool, false);
 
   // Preview
   define(blanksCount, "blanksCount", QMetaType::Int, 0, 0, 1000);

--- a/toonz/sources/toonzlib/tstageobjectcmd.cpp
+++ b/toonz/sources/toonzlib/tstageobjectcmd.cpp
@@ -406,7 +406,7 @@ public:
     TXsheet *xsh      = xshHandle->getXsheet();
     TStageObject *obj = xsh->getStageObject(id);
     assert(obj);
-    m_params                    = obj->getParams();
+    m_params = obj->getParams();
     if (id.isColumn()) m_column = xsh->getColumn(id.getIndex());
   }
 
@@ -432,6 +432,7 @@ public:
       linkedObj->setParent(m_objId);
     }
     m_xshHandle->notifyXsheetChanged();
+    xsh->notifyStageObjectAdded(m_objId);
   }
 
   void redo() const override {
@@ -518,6 +519,7 @@ public:
       terminalFxs->removeFx(m_notTerminalColumns[i]);
 
     m_xshHandle->notifyXsheetChanged();
+    xsh->notifyFxAdded(m_deletedFx);
   }
 
   void redo() const override {
@@ -1192,9 +1194,8 @@ public:
     m_xshHandle->notifyXsheetChanged();
   }
   int getSize() const override {
-    return sizeof(*this) +
-           sizeof(TDoubleKeyframe) *
-               (m_xKeyframes.size() + m_yKeyframes.size());
+    return sizeof(*this) + sizeof(TDoubleKeyframe) *
+                               (m_xKeyframes.size() + m_yKeyframes.size());
   }
 };
 
@@ -1455,7 +1456,7 @@ void TStageObjectCmd::addNewSpline(TXsheetHandle *xshHandle,
 
   TStageObjectId objId = objHandle->getObjectId();
   if (objId == TStageObjectId::NoneId) {
-    int col             = colHandle->getColumnIndex();
+    int col = colHandle->getColumnIndex();
     if (col >= 0) objId = TStageObjectId::ColumnId(col);
   }
   if (objId != TStageObjectId::NoneId) {
@@ -1600,7 +1601,7 @@ void TStageObjectCmd::renameGroup(const QList<TStageObject *> objs,
   int i;
   for (i = 0; i < objs.size(); i++) {
     if (i == 0) oldName = objs[i]->getGroupName(fromEditor);
-    int position        = objs[i]->removeGroupName(fromEditor);
+    int position = objs[i]->removeGroupName(fromEditor);
     objs[i]->setGroupName(name, position);
     positions.push_back(position);
   }

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -32,8 +32,12 @@
 #include "toonz/textureutils.h"
 #include "xshhandlemanager.h"
 #include "orientation.h"
+#include "toonz/expressionreferencemonitor.h"
 
 #include "toonz/txsheet.h"
+
+// STD includes
+#include <set>
 
 using namespace std;
 
@@ -97,6 +101,8 @@ struct TXsheet::TXsheetImp {
   XshHandleManager *m_handleManager;
   ToonzScene *m_scene;
 
+  ExpressionReferenceMonitor *m_expRefMonitor;
+
 public:
   TXsheetImp();
   ~TXsheetImp();
@@ -149,7 +155,8 @@ TXsheet::TXsheetImp::TXsheetImp()
     , m_soloColumn(-1)
     , m_viewColumn(-1)
     , m_mixedSound(0)
-    , m_scene(0) {
+    , m_scene(0)
+    , m_expRefMonitor(new ExpressionReferenceMonitor()) {
   initColumnFans();
 }
 
@@ -188,7 +195,8 @@ TXsheet::TXsheet()
     , m_player(0)
     , m_imp(new TXsheet::TXsheetImp)
     , m_notes(new TXshNoteSet())
-    , m_cameraColumnIndex(0) {
+    , m_cameraColumnIndex(0)
+    , m_observer(nullptr) {
   // extern TSyntax::Grammar *createXsheetGrammar(TXsheet*);
   m_soundProperties      = new TXsheet::SoundProperties();
   m_imp->m_handleManager = new XshHandleManager(this);
@@ -1323,6 +1331,8 @@ void TXsheet::insertColumn(int col, TXshColumn *column) {
     columnFan.rollRightFoldedState(col,
                                    m_imp->m_columnSet.getColumnCount() - col);
   }
+
+  notify(TXsheetColumnChange(TXsheetColumnChange::Insert, col));
 }
 
 //-----------------------------------------------------------------------------
@@ -1346,6 +1356,8 @@ void TXsheet::removeColumn(int col) {
     columnFan.rollLeftFoldedState(col,
                                   m_imp->m_columnSet.getColumnCount() - col);
   }
+
+  notify(TXsheetColumnChange(TXsheetColumnChange::Remove, col));
 }
 
 //-----------------------------------------------------------------------------
@@ -1385,6 +1397,8 @@ void TXsheet::moveColumn(int srcIndex, int dstIndex) {
       columnFan.rollRightFoldedState(c0, c1 - c0 + 1);
     for (int c = c1 - 1; c >= c0; --c) m_imp->m_pegTree->swapColumns(c, c + 1);
   }
+
+  notify(TXsheetColumnChange(TXsheetColumnChange::Move, srcIndex, dstIndex));
 }
 
 //-----------------------------------------------------------------------------
@@ -1477,7 +1491,7 @@ TSoundTrack *TXsheet::makeSound(SoundProperties *properties) {
 void TXsheet::scrub(int frame, bool isPreview) {
   try {
     double fps =
-      getScene()->getProperties()->getOutputProperties()->getFrameRate();
+        getScene()->getProperties()->getOutputProperties()->getFrameRate();
 
     TXsheet::SoundProperties *prop = new TXsheet::SoundProperties();
     prop->m_isPreview              = isPreview;
@@ -1775,3 +1789,29 @@ void TXsheet::autoInputCellNumbers(int increment, int interval, int step,
     }
   }
 }
+
+//---------------------------------------------------------
+
+void TXsheet::setObserver(TXsheetColumnChangeObserver *observer) {
+  m_observer = observer;
+}
+
+//---------------------------------------------------------
+
+void TXsheet::notify(const TXsheetColumnChange &change) {
+  if (m_observer) m_observer->onChange(change);
+}
+void TXsheet::notifyFxAdded(const std::vector<TFx *> &fxs) {
+  if (m_observer) m_observer->onFxAdded(fxs);
+}
+void TXsheet::notifyStageObjectAdded(const TStageObjectId id) {
+  if (m_observer) m_observer->onStageObjectAdded(id);
+}
+bool TXsheet::isReferenceManagementIgnored(TDoubleParam *param) {
+  if (m_observer) return m_observer->isIgnored(param);
+  return false;
+}
+ExpressionReferenceMonitor *TXsheet::getExpRefMonitor() const {
+  return m_imp->m_expRefMonitor;
+}
+//---------------------------------------------------------

--- a/toonz/sources/toonzlib/txsheetexpr.cpp
+++ b/toonz/sources/toonzlib/txsheetexpr.cpp
@@ -10,6 +10,8 @@
 #include "texpression.h"
 #include "tparser.h"
 #include "tfx.h"
+#include "tzeraryfx.h"
+#include "tcolumnset.h"
 
 #include "tw/stringtable.h"
 #include "tunit.h"
@@ -20,6 +22,9 @@
 #include "toonz/tstageobjectid.h"
 #include "toonz/tstageobject.h"
 #include "toonz/fxdag.h"
+#include "toonz/tstageobjecttree.h"
+#include "toonz/tcolumnfxset.h"
+#include "toonz/tcolumnfx.h"
 
 // Boost includes
 #include "boost/noncopyable.hpp"
@@ -57,16 +62,49 @@ public:
 };
 
 //===================================================================
+/*
+class ColumnReferenceFinder final : public TSyntax::CalculatorNodeVisitor {
+  QSet<int> m_indices;
+
+public:
+  ColumnReferenceFinder() {}
+
+  void registerColumnIndex(int columnIndex) { m_indices.insert(columnIndex); }
+
+  QSet<int> indices() const { return m_indices; }
+};
+*/
+//===================================================================
+
+class ParamReferenceFinder final : public TSyntax::CalculatorNodeVisitor {
+  QSet<TDoubleParam *> m_refParams;
+  QSet<int> m_columnIndices;
+
+public:
+  ParamReferenceFinder() {}
+
+  void registerRefParam(TDoubleParam *param) { m_refParams.insert(param); }
+  void registerColumnIndex(int columnIndex) {
+    m_columnIndices.insert(columnIndex);
+  }
+
+  QSet<int> columnIndices() const { return m_columnIndices; }
+  QSet<TDoubleParam *> refParams() const { return m_refParams; }
+};
+
+//===================================================================
 //
 // Calculator Nodes
 //
 //-------------------------------------------------------------------
 
-class ParamCalculatorNode final : public CalculatorNode,
-                                  public TParamObserver,
-                                  public boost::noncopyable {
-  TDoubleParamP m_param;
+class ParamCalculatorNode : public CalculatorNode,
+                            public TParamObserver,
+                            public boost::noncopyable {
   std::unique_ptr<CalculatorNode> m_frame;
+
+protected:
+  TDoubleParamP m_param;
 
 public:
   ParamCalculatorNode(Calculator *calculator, const TDoubleParamP &param,
@@ -88,10 +126,18 @@ public:
   }
 
   void accept(TSyntax::CalculatorNodeVisitor &visitor) override {
+    ParamReferenceFinder *prf = dynamic_cast<ParamReferenceFinder *>(&visitor);
+    if (prf) {
+      prf->registerRefParam(m_param.getPointer());
+      return;
+    }
+
     ParamDependencyFinder *pdf =
         dynamic_cast<ParamDependencyFinder *>(&visitor);
-    pdf->check(m_param.getPointer());
-    m_param->accept(visitor);
+    if (pdf) {
+      pdf->check(m_param.getPointer());
+      if (!pdf->found()) m_param->accept(visitor);
+    }
   }
 
   void onChange(const TParamChange &paramChange) override {
@@ -111,6 +157,36 @@ public:
       std::set<TParamObserver *>::const_iterator ot, oEnd = observers.end();
       for (ot = observers.begin(); ot != oEnd; ++ot)
         (*ot)->onChange(propagatedChange);
+    }
+  }
+
+  bool hasReference() const override { return true; }
+};
+
+// ParamCalculatorNode subclass to monitor referenced columns
+class ColumnParamCalculatorNode final : public ParamCalculatorNode {
+  int m_columnIndex;
+
+public:
+  ColumnParamCalculatorNode(Calculator *calculator, const TDoubleParamP &param,
+                            std::unique_ptr<CalculatorNode> frame,
+                            int columnIndex)
+      : ParamCalculatorNode(calculator, param, std::move(frame))
+      , m_columnIndex(columnIndex) {}
+
+  void accept(TSyntax::CalculatorNodeVisitor &visitor) override {
+    ParamReferenceFinder *prf = dynamic_cast<ParamReferenceFinder *>(&visitor);
+    if (prf) {
+      prf->registerRefParam(m_param.getPointer());
+      prf->registerColumnIndex(m_columnIndex);
+      return;
+    }
+
+    ParamDependencyFinder *pdf =
+        dynamic_cast<ParamDependencyFinder *>(&visitor);
+    if (pdf) {
+      pdf->check(m_param.getPointer());
+      if (!pdf->found()) m_param->accept(visitor);
     }
   }
 };
@@ -145,7 +221,12 @@ public:
     return d;
   }
 
-  void accept(TSyntax::CalculatorNodeVisitor &) override {}
+  void accept(TSyntax::CalculatorNodeVisitor &visitor) override {
+    ParamReferenceFinder *prf = dynamic_cast<ParamReferenceFinder *>(&visitor);
+    if (prf) prf->registerColumnIndex(m_columnIndex);
+  }
+
+  bool hasReference() const override { return true; }
 };
 
 //===================================================================
@@ -191,6 +272,15 @@ public:
       return TStageObjectId::NoneId;
   }
 
+  TStageObjectId matchExistingObjectName(const Token &token) const {
+    TStageObjectId objId = matchObjectName(token);
+    if (objId != TStageObjectId::NoneId &&
+        m_xsh->getStageObjectTree()->getStageObject(objId, false))
+      return objId;
+    else
+      return TStageObjectId::NoneId;
+  }
+
   TStageObject::Channel matchChannelName(const Token &token) const {
     std::string s = toLower(token.getText());
     if (s == "y" || s == "ns")
@@ -227,7 +317,7 @@ public:
                   const Token &token) const override {
     int i = (int)previousTokens.size();
     if (i == 0)
-      return matchObjectName(token) != TStageObjectId::NoneId;
+      return matchExistingObjectName(token) != TStageObjectId::NoneId;
     else if ((i == 1 && token.getText() == ".") ||
              (i == 3 && token.getText() == "(") ||
              (i == 5 && token.getText() == ")"))
@@ -237,7 +327,7 @@ public:
         return true;
       else
         return token.getText() == "cell" &&
-               matchObjectName(previousTokens[0]).isColumn();
+               matchExistingObjectName(previousTokens[0]).isColumn();
     } else
       return false;
   }
@@ -276,12 +366,20 @@ public:
       stack.push_back(new XsheetDrawingCalculatorNode(calc, m_xsh, columnIndex,
                                                       std::move(frameNode)));
     } else {
-      TStageObject *object              = m_xsh->getStageObject(objectId);
+      // do not create object if it does not exist
+      TStageObject *object =
+          m_xsh->getStageObjectTree()->getStageObject(objectId, false);
+      if (!object) return;
       TStageObject::Channel channelName = matchChannelName(tokens[2]);
       TDoubleParam *channel             = object->getParam(channelName);
-      if (channel)
-        stack.push_back(
-            new ParamCalculatorNode(calc, channel, std::move(frameNode)));
+      if (channel) {
+        if (objectId.isColumn())
+          stack.push_back(new ColumnParamCalculatorNode(
+              calc, channel, std::move(frameNode), objectId.getIndex()));
+        else
+          stack.push_back(
+              new ParamCalculatorNode(calc, channel, std::move(frameNode)));
+      }
     }
   }
 };
@@ -295,7 +393,20 @@ public:
   FxReferencePattern(TXsheet *xsh) : m_xsh(xsh) {}
 
   TFx *getFx(const Token &token) const {
-    return m_xsh->getFxDag()->getFxById(::to_wstring(toLower(token.getText())));
+    TFx *fx =
+        m_xsh->getFxDag()->getFxById(::to_wstring(toLower(token.getText())));
+    // removed fx cannot be referenced
+    if (!fx)
+      return nullptr;
+    else if (fx->isZerary()) {
+      TZeraryFx *zFx = dynamic_cast<TZeraryFx *>(fx);
+      // For now we cannot use zFx->getColumnFx()->getColumnIndex() < 0 to check
+      // existence of the column. See a comment in tcolumnset.h for details.
+      if (!zFx || !zFx->getColumnFx()->getXshColumn()->inColumnsSet())
+        return nullptr;
+    } else if (!m_xsh->getFxDag()->getInternalFxs()->containsFx(fx))
+      return nullptr;
+    return fx;
   }
   TParam *getParam(const TFx *fx, const Token &token) const {
     int i;
@@ -605,4 +716,12 @@ bool dependsOn(TDoubleParam *param, TDoubleParam *possiblyDependentParam) {
   ParamDependencyFinder pdf(possiblyDependentParam);
   param->accept(pdf);
   return pdf.found();
+}
+
+void referenceParams(TExpression &expr, QSet<int> &columnIndices,
+                     QSet<TDoubleParam *> &params) {
+  ParamReferenceFinder prf;
+  expr.accept(prf);
+  columnIndices = prf.columnIndices();
+  params        = prf.refParams();
 }

--- a/toonz/sources/toonzqt/Resources/paramignored_off.svg
+++ b/toonz/sources/toonzqt/Resources/paramignored_off.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="paramignored_off.svg"
+   x="0px"
+   y="0px"
+   viewBox="0 0 21 17"
+   style="enable-background:new 0 0 21 17;"
+   xml:space="preserve"><metadata
+     id="metadata13"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs11"><linearGradient
+       id="linearGradient4558"
+       osb:paint="solid"><stop
+         style="stop-color:#4b4b4b;stop-opacity:1;"
+         offset="0"
+         id="stop4556" /></linearGradient></defs><style
+     type="text/css"
+     id="style2">
+	.st0{fill:none;}
+	.st1{fill:none;stroke:#6F6C50;stroke-width:2;stroke-linecap:square;stroke-miterlimit:1.5;}
+	.st2{fill:#FFF082;}
+	.st3{stroke:#000000;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:1.4142;}
+</style><sodipodi:namedview
+     bordercolor="#666666"
+     borderopacity="1"
+     gridtolerance="10"
+     guidetolerance="10"
+     id="namedview15"
+     inkscape:current-layer="svg2"
+     inkscape:cx="26.553329"
+     inkscape:cy="7.6715202"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-height="851"
+     inkscape:window-maximized="0"
+     inkscape:window-width="1440"
+     inkscape:window-x="126"
+     inkscape:window-y="54"
+     inkscape:zoom="11.313709"
+     objecttolerance="10"
+     pagecolor="#ffffff"
+     showgrid="true"><inkscape:grid
+       type="xygrid"
+       id="grid4490" /></sodipodi:namedview><rect
+     id="rect5"
+     y="0"
+     class="st0"
+     width="21"
+     height="17" /><path
+     style="opacity:1;vector-effect:none;fill:#faafb5;fill-opacity:1;stroke-width:0.02723992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 16.178576,13 c -0.08036,0.139006 -0.230014,0.225165 -0.390893,0.225165 H 5.2121385 c -0.1604971,0 -0.310371,-0.08616 -0.3903208,-0.225574 -0.080742,-0.139196 -0.081149,-0.311761 -3.808e-4,-0.450766 L 10.109304,3.3896748 c 0.08017,-0.139005 0.229796,-0.2253832 0.390893,-0.2253832 0.160716,0 0.310154,0.086374 0.390511,0.225602 l 5.287868,9.1587684 c 0.08036,0.139168 0.08036,0.312142 0,0.451338 z"
+     id="path6-3"
+     inkscape:connector-curvature="0" /><path
+     id="path4"
+     style="fill:#606060;stroke-width:0.02539061;fill-opacity:1"
+     d="m 10.50018,10.762063 c -0.426156,0 -0.7721536,0.345642 -0.7721536,0.771798 0,0.426334 0.3459976,0.772001 0.7721536,0.772001 0.426156,0 0.771799,-0.345667 0.771799,-0.772001 2.5e-5,-0.426156 -0.345617,-0.771798 -0.771799,-0.771798 z"
+     class="st0"
+     inkscape:connector-curvature="0" /><path
+     id="path6"
+     style="fill:#606060;stroke-width:0.02539061;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 16.824727,12.031745 11.636715,3.0457546 C 11.403045,2.6409267 10.96752,2.3894835 10.499799,2.3894835 c -0.467365,0 -0.9024835,0.2514686 -1.1361533,0.6562711 L 4.1752523,12.031364 c -0.2336698,0.404803 -0.2336698,0.90774 0,1.312543 C 4.4089475,13.748709 4.8444472,14 5.3118122,14 H 15.688193 c 0.467339,0 0.902864,-0.251291 1.136534,-0.656093 0.233695,-0.404803 0.233695,-0.90774 0,-1.312162 z m -1.031671,0.642027 c -0.0749,0.129569 -0.214398,0.209879 -0.364355,0.209879 H 5.5711265 c -0.1496015,0 -0.2893006,-0.08031 -0.3638221,-0.21026 -0.075258,-0.129746 -0.075639,-0.290595 -3.555e-4,-0.420163 L 10.135825,3.7158889 C 10.21055,3.5863207 10.35002,3.505807 10.50018,3.505807 c 0.149805,0 0.289098,0.080514 0.364,0.2102851 l 4.928876,8.5369829 c 0.0749,0.129721 0.0749,0.290951 0,0.420697 z"
+     class="st0"
+     inkscape:connector-curvature="0" /><path
+     id="path8"
+     style="fill:#606060;stroke-width:0.02539061;fill-opacity:1"
+     d="m 10.50018,5.5723742 c -0.426156,0 -0.7721536,0.3456423 -0.7721536,0.7720015 l 0.2965626,3.4908788 c 0,0.2626915 0.212722,0.4754135 0.475591,0.4754135 0.262488,0 0.475592,-0.212722 0.475592,-0.4754135 L 11.271979,6.3443757 C 11.272004,5.9179912 10.926362,5.5723742 10.50018,5.5723742 Z"
+     class="st0"
+     inkscape:connector-curvature="0" /></svg>

--- a/toonz/sources/toonzqt/Resources/paramignored_on.svg
+++ b/toonz/sources/toonzqt/Resources/paramignored_on.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="paramignored_on.svg"
+   x="0px"
+   y="0px"
+   viewBox="0 0 21 17"
+   style="enable-background:new 0 0 21 17;"
+   xml:space="preserve"><metadata
+     id="metadata13"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs11"><linearGradient
+       id="linearGradient4558"
+       osb:paint="solid"><stop
+         style="stop-color:#4b4b4b;stop-opacity:1;"
+         offset="0"
+         id="stop4556" /></linearGradient></defs><style
+     type="text/css"
+     id="style2">
+	.st0{fill:none;}
+	.st1{fill:none;stroke:#6F6C50;stroke-width:2;stroke-linecap:square;stroke-miterlimit:1.5;}
+	.st2{fill:#FFF082;}
+	.st3{stroke:#000000;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:1.4142;}
+</style><sodipodi:namedview
+     bordercolor="#666666"
+     borderopacity="1"
+     gridtolerance="10"
+     guidetolerance="10"
+     id="namedview15"
+     inkscape:current-layer="svg2"
+     inkscape:cx="26.553329"
+     inkscape:cy="7.6715202"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-height="851"
+     inkscape:window-maximized="0"
+     inkscape:window-width="1440"
+     inkscape:window-x="126"
+     inkscape:window-y="54"
+     inkscape:zoom="11.313709"
+     objecttolerance="10"
+     pagecolor="#ffffff"
+     showgrid="true"><inkscape:grid
+       type="xygrid"
+       id="grid4490" /></sodipodi:namedview><rect
+     id="rect5"
+     y="0"
+     class="st0"
+     width="21"
+     height="17" /><path
+     style="opacity:1;vector-effect:none;fill:#fc5b68;fill-opacity:1;stroke-width:0.02723992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="m 16.178576,13 c -0.08036,0.139006 -0.230014,0.225165 -0.390893,0.225165 H 5.2121385 c -0.1604971,0 -0.310371,-0.08616 -0.3903208,-0.225574 -0.080742,-0.139196 -0.081149,-0.311761 -3.808e-4,-0.450766 L 10.109304,3.3896748 c 0.08017,-0.139005 0.229796,-0.2253832 0.390893,-0.2253832 0.160716,0 0.310154,0.086374 0.390511,0.225602 l 5.287868,9.1587684 c 0.08036,0.139168 0.08036,0.312142 0,0.451338 z"
+     id="path6-3"
+     inkscape:connector-curvature="0" /><path
+     id="path4"
+     style="fill:#000000;stroke-width:0.02539061;fill-opacity:1"
+     d="m 10.50018,10.762063 c -0.426156,0 -0.7721536,0.345642 -0.7721536,0.771798 0,0.426334 0.3459976,0.772001 0.7721536,0.772001 0.426156,0 0.771799,-0.345667 0.771799,-0.772001 2.5e-5,-0.426156 -0.345617,-0.771798 -0.771799,-0.771798 z"
+     class="st0"
+     inkscape:connector-curvature="0" /><path
+     id="path6"
+     style="fill:#89363f;stroke-width:0.02539061;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     d="M 16.824727,12.031745 11.636715,3.0457546 C 11.403045,2.6409267 10.96752,2.3894835 10.499799,2.3894835 c -0.467365,0 -0.9024835,0.2514686 -1.1361533,0.6562711 L 4.1752523,12.031364 c -0.2336698,0.404803 -0.2336698,0.90774 0,1.312543 C 4.4089475,13.748709 4.8444472,14 5.3118122,14 H 15.688193 c 0.467339,0 0.902864,-0.251291 1.136534,-0.656093 0.233695,-0.404803 0.233695,-0.90774 0,-1.312162 z m -1.031671,0.642027 c -0.0749,0.129569 -0.214398,0.209879 -0.364355,0.209879 H 5.5711265 c -0.1496015,0 -0.2893006,-0.08031 -0.3638221,-0.21026 -0.075258,-0.129746 -0.075639,-0.290595 -3.555e-4,-0.420163 L 10.135825,3.7158889 C 10.21055,3.5863207 10.35002,3.505807 10.50018,3.505807 c 0.149805,0 0.289098,0.080514 0.364,0.2102851 l 4.928876,8.5369829 c 0.0749,0.129721 0.0749,0.290951 0,0.420697 z"
+     class="st0"
+     inkscape:connector-curvature="0" /><path
+     id="path8"
+     style="fill:#000000;stroke-width:0.02539061;fill-opacity:1"
+     d="m 10.50018,5.5723742 c -0.426156,0 -0.7721536,0.3456423 -0.7721536,0.7720015 l 0.2965626,3.4908788 c 0,0.2626915 0.212722,0.4754135 0.475591,0.4754135 0.262488,0 0.475592,-0.212722 0.475592,-0.4754135 L 11.271979,6.3443757 C 11.272004,5.9179912 10.926362,5.5723742 10.50018,5.5723742 Z"
+     class="st0"
+     inkscape:connector-curvature="0" /></svg>

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -131,29 +131,45 @@ bool FunctionTreeModel::ChannelGroup::isAnimated() const {
 
 //-----------------------------------------------------------------------------
 
+bool FunctionTreeModel::ChannelGroup::isIgnored() const {
+  // Same for the ignored ones, show warning icon if any of its children is.
+  int c, childCount = getChildCount();
+  for (c = 0; c != childCount; ++c)
+    if (static_cast<Item *>(getChild(c))->isIgnored()) return true;
+
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+
 QVariant FunctionTreeModel::ChannelGroup::data(int role) const {
   if (role == Qt::DisplayRole)
     return getLongName();
   else if (role == Qt::DecorationRole) {
     bool animated = isAnimated();
     bool active   = isActive();
+    bool ignored  = (animated) ? isIgnored() : false;
 
     if (active) {
       static QIcon folderAnimOpen(createQIcon("folder_anim_on", true));
       static QIcon folderAnimClose(createQIcon("folder_anim", true));
       static QIcon folderOpen(createQIcon("folder_on", true));
       static QIcon folderClose(createQIcon("folder", true));
+      static QIcon ignoredOn(":Resources/paramignored_on.svg");
 
-      return animated ? isOpen() ? folderAnimOpen : folderAnimClose
-                      : isOpen() ? folderOpen : folderClose;
+      return animated ? (isOpen() ? folderAnimOpen
+                                  : (ignored ? ignoredOn : folderAnimClose))
+                      : (isOpen() ? folderOpen : folderClose);
     } else {
       static QIcon folderAnimOpen(createQIcon("folder_anim_inactive_on", true));
       static QIcon folderAnimClose(createQIcon("folder_anim_inactive", true));
       static QIcon folderOpen(createQIcon("folder_inactive_on", true));
       static QIcon folderClose(createQIcon("folder_inactive", true));
+      static QIcon ignoredOff(":Resources/paramignored_off.svg");
 
-      return animated ? isOpen() ? folderAnimOpen : folderAnimClose
-                      : isOpen() ? folderOpen : folderClose;
+      return animated ? (isOpen() ? folderAnimOpen
+                                  : (ignored ? ignoredOff : folderAnimClose))
+                      : (isOpen() ? folderOpen : folderClose);
     }
   } else
     return Item::data(role);
@@ -351,22 +367,27 @@ QVariant FxChannelGroup::data(int role) const {
       isOneChildActive = true;
       break;
     }
+    bool ignored = (isAnimated) ? isIgnored() : false;
     if (isOneChildActive) {
       static QIcon folderAnimOpen(createQIcon("folder_anim_on", true));
       static QIcon folderAnimClose(createQIcon("folder_anim", true));
       static QIcon folderOpen(createQIcon("folder_on", true));
       static QIcon folderClose(createQIcon("folder", true));
+      static QIcon ignoredOn(":Resources/paramignored_on.svg");
 
-      return isAnimated ? isOpen() ? folderAnimOpen : folderAnimClose
-                        : isOpen() ? folderOpen : folderClose;
+      return isAnimated ? (isOpen() ? folderAnimOpen
+                                    : (ignored ? ignoredOn : folderAnimClose))
+                        : (isOpen() ? folderOpen : folderClose);
     } else {
       static QIcon folderAnimOpen(createQIcon("folder_anim_inactive_on", true));
       static QIcon folderAnimClose(createQIcon("folder_anim_inactive", true));
       static QIcon folderOpen(createQIcon("folder_inactive_on", true));
       static QIcon folderClose(createQIcon("folder_inactive", true));
+      static QIcon ignoredOff(":Resources/paramignored_off.svg");
 
-      return isAnimated ? isOpen() ? folderAnimOpen : folderAnimClose
-                        : isOpen() ? folderOpen : folderClose;
+      return isAnimated ? (isOpen() ? folderAnimOpen
+                                    : (ignored ? ignoredOff : folderAnimClose))
+                        : (isOpen() ? folderOpen : folderClose);
     }
   } else if (role == Qt::DisplayRole) {
     std::wstring name = m_fx->getName();
@@ -560,12 +581,27 @@ bool FunctionTreeModel::Channel::isAnimated() const {
 
 //-----------------------------------------------------------------------------
 
+bool FunctionTreeModel::Channel::isIgnored() const {
+  if (!isAnimated()) return false;
+  TDoubleParam *dp = dynamic_cast<TDoubleParam *>(m_param.getPointer());
+  if (!dp) return false;
+  FunctionTreeView *view = dynamic_cast<FunctionTreeView *>(m_model->m_view);
+  if (!view) return false;
+  return view->getXsheetHandle()->getXsheet()->isReferenceManagementIgnored(dp);
+}
+
+//-----------------------------------------------------------------------------
+
 QVariant FunctionTreeModel::Channel::data(int role) const {
   if (role == Qt::DecorationRole) {
     static QIcon paramAnimOn(":Resources/paramanim_on.svg");
     static QIcon paramAnimOff(":Resources/paramanim_off.svg");
     static QIcon paramOn(":Resources/param_on.svg");
     static QIcon paramOff(":Resources/param_off.svg");
+    static QIcon paramIgnoredOn(":Resources/paramignored_on.svg");
+    static QIcon paramIgnoredOff(":Resources/paramignored_off.svg");
+
+    if (isIgnored()) return isActive() ? paramIgnoredOn : paramIgnoredOff;
 
     return m_param->hasKeyframes() ? isActive() ? paramAnimOn : paramAnimOff
                                    : isActive() ? paramOn : paramOff;
@@ -589,6 +625,20 @@ QVariant FunctionTreeModel::Channel::data(int role) const {
 #endif
     return (isCurrent()) ? view->getViewer()->getCurrentTextColor()
                          : view->getTextColor();
+  } else if (role == Qt::ToolTipRole) {
+    if (m_param->hasKeyframes()) {
+      TDoubleParam *dp = dynamic_cast<TDoubleParam *>(m_param.getPointer());
+      FunctionTreeView *view =
+          dynamic_cast<FunctionTreeView *>(m_model->m_view);
+      if (dp && view &&
+          view->getXsheetHandle()->getXsheet()->isReferenceManagementIgnored(
+              dp))
+        return tr(
+            "Some key(s) in this parameter loses original reference in "
+            "expression.\nManually changing any keyframe will clear the "
+            "warning.");
+    }
+    return TreeModel::Item::data(role);
   } else
     return TreeModel::Item::data(role);
 }
@@ -607,7 +657,7 @@ QString FunctionTreeModel::Channel::getShortName() const {
 //-----------------------------------------------------------------------------
 
 QString FunctionTreeModel::Channel::getLongName() const {
-  QString name                = getShortName();
+  QString name = getShortName();
   if (getChannelGroup()) name = getChannelGroup()->getLongName() + " " + name;
   return name;
 }
@@ -1085,7 +1135,7 @@ void FunctionTreeModel::addChannels(TFx *fx, ChannelGroup *groupItem,
 
   std::wstring fxId = L"";
   TMacroFx *macro   = dynamic_cast<TMacroFx *>(fxItem->getFx());
-  if (macro) fxId   = fx->getFxId();
+  if (macro) fxId = fx->getFxId();
 
   const std::string &paramNamePref = fx->getFxType() + ".";
 
@@ -1231,7 +1281,7 @@ void FunctionTreeModel::resetAll() {
 
 void FunctionTreeModel::setCurrentFx(TFx *fx) {
   TZeraryColumnFx *zcfx = dynamic_cast<TZeraryColumnFx *>(fx);
-  if (zcfx) fx          = zcfx->getZeraryFx();
+  if (zcfx) fx = zcfx->getZeraryFx();
   if (fx != m_currentFx) {
     if (fx) fx->addRef();
     if (m_currentFx) m_currentFx->release();

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -172,11 +172,11 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
   bool ret = true;
   ret      = ret && connect(m_toolbar, SIGNAL(numericalColumnToggled()), this,
                        SLOT(toggleMode()));
-  ret = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
+  ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
                        m_functionGraph, SLOT(update()));
-  ret = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
+  ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
                        m_numericalColumns, SLOT(updateAll()));
-  ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_treeView,
+  ret      = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_treeView,
                        SLOT(update()));
   ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_functionGraph,
                        SLOT(update()));
@@ -386,6 +386,7 @@ void FunctionViewer::setXsheetHandle(TXsheetHandle *xshHandle) {
 
   m_xshHandle = xshHandle;
   m_segmentViewer->setXsheetHandle(xshHandle);
+  m_treeView->setXsheetHandle(xshHandle);
 
   if (m_xshHandle && isVisible()) {
     TXsheet *xsh = m_xshHandle->getXsheet();
@@ -606,7 +607,7 @@ void FunctionViewer::onStageObjectChanged(bool isDragging) {
 void FunctionViewer::onFxSwitched() {
   TFx *fx              = m_fxHandle->getFx();
   TZeraryColumnFx *zfx = dynamic_cast<TZeraryColumnFx *>(fx);
-  if (zfx) fx          = zfx->getZeraryFx();
+  if (zfx) fx = zfx->getZeraryFx();
   static_cast<FunctionTreeModel *>(m_treeView->model())->setCurrentFx(fx);
   m_treeView->updateAll();
   m_functionGraph->update();

--- a/toonz/sources/toonzqt/fxselection.cpp
+++ b/toonz/sources/toonzqt/fxselection.cpp
@@ -35,7 +35,7 @@ bool canGroup(TFx *fx) {
   TOutputFx *ofx = dynamic_cast<TOutputFx *>(fx);
   return (!xfx && !ofx);
 }
-}
+}  // namespace
 
 //=========================================================
 //
@@ -156,10 +156,11 @@ bool FxSelection::isSelected(SchematicLink *link) {
 //---------------------------------------------------------
 
 void FxSelection::deleteSelection() {
-  std::list<TFxP, std::allocator<TFxP>> fxList = m_selectedFxs.toStdList();
-  TFxCommand::deleteSelection(fxList, m_selectedLinks.toStdList(),
-                              m_selectedColIndexes.toStdList(), m_xshHandle,
-                              m_fxHandle);
+  emit doDelete();
+  // std::list<TFxP, std::allocator<TFxP>> fxList = m_selectedFxs.toStdList();
+  // TFxCommand::deleteSelection(fxList, m_selectedLinks.toStdList(),
+  //                            m_selectedColIndexes.toStdList(), m_xshHandle,
+  //                            m_fxHandle);
 }
 
 //---------------------------------------------------------
@@ -518,8 +519,8 @@ bool FxSelection::isConnected() {
     TColumnFx *cfx  = dynamic_cast<TColumnFx *>(selectedFx);
     if (!cfx && !internalFxs->containsFx(selectedFx)) return false;
     TZeraryColumnFx *zfx = dynamic_cast<TZeraryColumnFx *>(selectedFx);
-    if (zfx) selectedFx  = zfx->getZeraryFx();
-    connected            = connected && visitedFxs.contains(selectedFx);
+    if (zfx) selectedFx = zfx->getZeraryFx();
+    connected = connected && visitedFxs.contains(selectedFx);
   }
   return connected;
 }
@@ -529,14 +530,14 @@ bool FxSelection::isConnected() {
 void FxSelection::visitFx(TFx *fx, QList<TFx *> &visitedFxs) {
   if (visitedFxs.contains(fx)) return;
   TZeraryColumnFx *zfx = dynamic_cast<TZeraryColumnFx *>(fx);
-  if (zfx) fx          = zfx->getZeraryFx();
+  if (zfx) fx = zfx->getZeraryFx();
   if (!canGroup(fx)) return;
   visitedFxs.append(fx);
   int i;
   for (i = 0; i < fx->getInputPortCount(); i++) {
     TFx *inputFx              = fx->getInputPort(i)->getFx();
     TZeraryColumnFx *onputZFx = dynamic_cast<TZeraryColumnFx *>(inputFx);
-    if (onputZFx) inputFx     = onputZFx->getZeraryFx();
+    if (onputZFx) inputFx = onputZFx->getZeraryFx();
     if (!inputFx) continue;
     bool canBeGrouped = !inputFx->getAttributes()->isGrouped() ||
                         (inputFx->getAttributes()->getEditingGroupId() ==

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -13,6 +13,8 @@
 #include "toonzqt/gutil.h"
 #include "toonzqt/imageutils.h"
 #include "toonzqt/dvscrollwidget.h"
+#include "toonzqt/fxselection.h"
+#include "stageobjectselection.h"
 
 // TnzLib includes
 #include "toonz/txsheethandle.h"
@@ -384,12 +386,12 @@ void SchematicSceneViewer::wheelEvent(QWheelEvent *me) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-    {
-      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
-                   "Qt::MouseEventSynthesizedByApplication"
-                << std::endl;
-      break;
-    }
+  {
+    std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                 "Qt::MouseEventSynthesizedByApplication"
+              << std::endl;
+    break;
+  }
 
   }  // end switch
 
@@ -422,8 +424,9 @@ void SchematicSceneViewer::zoomQt(bool zoomin, bool resetView) {
 #endif
   if ((scale2 < 100000 || !zoomin) && (scale2 > 0.001 * 0.05 || zoomin)) {
     double oldZoomScale = sqrt(scale2);
-    double zoomScale    = resetView ? 1 : ImageUtils::getQuantizedZoomFactor(
-                                           oldZoomScale, zoomin);
+    double zoomScale =
+        resetView ? 1
+                  : ImageUtils::getQuantizedZoomFactor(oldZoomScale, zoomin);
     QMatrix scale =
         QMatrix().scale(zoomScale / oldZoomScale, zoomScale / oldZoomScale);
 
@@ -684,10 +687,9 @@ bool SchematicSceneViewer::event(QEvent *e) {
   }
   */
 
-  if (e->type() == QEvent::Gesture &&
-      CommandManager::instance()
-          ->getAction(MI_TouchGestureControl)
-          ->isChecked()) {
+  if (e->type() == QEvent::Gesture && CommandManager::instance()
+                                          ->getAction(MI_TouchGestureControl)
+                                          ->isChecked()) {
     gestureEvent(static_cast<QGestureEvent *>(e));
     return true;
   }
@@ -775,6 +777,11 @@ SchematicViewer::SchematicViewer(QWidget *parent)
           SIGNAL(doExplodeChild(QList<TStageObjectId>)));
   connect(m_stageScene, SIGNAL(editObject()), this, SIGNAL(editObject()));
   connect(m_fxScene, SIGNAL(editObject()), this, SIGNAL(editObject()));
+
+  connect(m_fxScene->getFxSelection(), SIGNAL(doDelete()), this,
+          SLOT(deleteFxs()));
+  connect(m_stageScene->getStageSelection(), SIGNAL(doDelete()), this,
+          SLOT(deleteStageObjects()));
 
   m_viewer->setScene(m_stageScene);
   m_fxToolbar->hide();
@@ -925,10 +932,10 @@ void SchematicViewer::createActions() {
 
     QIcon nodeSizeIcon =
         createQIcon(m_maximizedNode ? "minimizenodes" : "maximizenodes");
-    m_nodeSize =
-        new QAction(nodeSizeIcon, m_maximizedNode ? tr("&Minimize Nodes")
-                                                  : tr("&Maximize Nodes"),
-                    m_commonToolbar);
+    m_nodeSize = new QAction(
+        nodeSizeIcon,
+        m_maximizedNode ? tr("&Minimize Nodes") : tr("&Maximize Nodes"),
+        m_commonToolbar);
     connect(m_nodeSize, SIGNAL(triggered()), this, SLOT(changeNodeSize()));
 
     QIcon selectModeIcon = createQIcon("selection_schematic");
@@ -1202,3 +1209,15 @@ void SchematicViewer::zoomModeEnabled() { setCursorMode(CursorMode::Zoom); }
 //------------------------------------------------------------------
 
 void SchematicViewer::handModeEnabled() { setCursorMode(CursorMode::Hand); }
+
+//------------------------------------------------------------------
+
+void SchematicViewer::deleteFxs() {
+  emit doDeleteFxs(m_fxScene->getFxSelection());
+}
+
+//------------------------------------------------------------------
+
+void SchematicViewer::deleteStageObjects() {
+  emit doDeleteStageObjects(m_stageScene->getStageSelection());
+}

--- a/toonz/sources/toonzqt/stageobjectsdata.cpp
+++ b/toonz/sources/toonzqt/stageobjectsdata.cpp
@@ -913,16 +913,28 @@ void StageObjectsData::storeSplines(const std::list<int> &splineIds,
 }
 
 //------------------------------------------------------------------------------
-
 std::vector<TStageObjectId> StageObjectsData::restoreObjects(
     std::set<int> &columnIndices, std::list<int> &restoredSpline, TXsheet *xsh,
     int fxFlags, const TPointD &pos) const {
+  QMap<TStageObjectId, TStageObjectId> idTable;
+  QMap<TFx *, TFx *> fxTable;
+  return restoreObjects(columnIndices, restoredSpline, xsh, fxFlags, idTable,
+                        fxTable, pos);
+}
+
+// idTable : Trace stored/restored id pairings
+// fxTable : Same for fxs
+
+std::vector<TStageObjectId> StageObjectsData::restoreObjects(
+    std::set<int> &columnIndices, std::list<int> &restoredSpline, TXsheet *xsh,
+    int fxFlags, QMap<TStageObjectId, TStageObjectId> &idTable,
+    QMap<TFx *, TFx *> &fxTable, const TPointD &pos) const {
   bool doClone             = (fxFlags & eDoClone);
   bool resetFxDagPositions = (fxFlags & eResetFxDagPositions);
 
-  QMap<TStageObjectId, TStageObjectId>
-      idTable;                     // Trace stored/restored id pairings
-  std::map<TFx *, TFx *> fxTable;  // Same for fxs here
+  // QMap<TStageObjectId, TStageObjectId>
+  //    idTable;                     // Trace stored/restored id pairings
+  // std::map<TFx *, TFx *> fxTable;  // Same for fxs here
   std::vector<TStageObjectId> restoredIds;
 
   std::set<int>::iterator idxt = columnIndices.begin();
@@ -1103,7 +1115,7 @@ std::vector<TStageObjectId> StageObjectsData::restoreObjects(
   }
 
   // Update the link, like in functions above
-  if (!fxTable.empty() && doClone) updateFxLinks(fxTable);
+  if (!fxTable.empty() && doClone) updateFxLinks(fxTable.toStdMap());
 
   // Paste any associated spline (not stored im m_splines)
   std::map<TStageObjectSpline *, TStageObjectSpline *> splines;
@@ -1193,9 +1205,9 @@ std::vector<TStageObjectId> StageObjectsData::restoreObjects(
             obj->getPlasticSkeletonDeformation())
       sd->setGrammar(grammer);
   }
-  std::map<TFx *, TFx *>::const_iterator it;
-  for (it = fxTable.begin(); it != fxTable.end(); ++it) {
-    setGrammerToParams(it->second->getParams(), grammer);
+  QMap<TFx *, TFx *>::const_iterator it;
+  for (it = fxTable.constBegin(); it != fxTable.constEnd(); ++it) {
+    setGrammerToParams(it.value()->getParams(), grammer);
   }
 
   return restoredIds;

--- a/toonz/sources/toonzqt/stageobjectselection.cpp
+++ b/toonz/sources/toonzqt/stageobjectselection.cpp
@@ -108,7 +108,7 @@ public:
   }
   int getHistoryType() override { return HistoryType::Schematic; }
 };
-}
+}  // namespace
 
 //======================================================================
 //
@@ -153,9 +153,10 @@ void StageObjectSelection::enableCommands() {
 //-------------------------------------------------------
 
 void StageObjectSelection::deleteSelection() {
-  TStageObjectCmd::deleteSelection(
-      m_selectedObjects.toVector().toStdVector(), m_selectedLinks.toStdList(),
-      m_selectedSplines.toStdList(), m_xshHandle, m_objHandle, m_fxHandle);
+  emit doDelete();
+  // TStageObjectCmd::deleteSelection(
+  //    m_selectedObjects.toVector().toStdVector(), m_selectedLinks.toStdList(),
+  //    m_selectedSplines.toStdList(), m_xshHandle, m_objHandle, m_fxHandle);
 }
 
 //-------------------------------------------------------

--- a/toonz/sources/toonzqt/stageobjectselection.h
+++ b/toonz/sources/toonzqt/stageobjectselection.h
@@ -76,6 +76,7 @@ public:
   const QList<QPair<TStageObjectId, TStageObjectId>> &getLinks() const {
     return m_selectedLinks;
   }
+  const QList<int> &getSplines() const { return m_selectedSplines; }
 
   void setXsheetHandle(TXsheetHandle *xshHandle) { m_xshHandle = xshHandle; }
   void setObjectHandle(TObjectHandle *objHandle) { m_objHandle = objHandle; }
@@ -96,6 +97,7 @@ private:
 signals:
   void doCollapse(QList<TStageObjectId>);
   void doExplodeChild(QList<TStageObjectId>);
+  void doDelete();
 };
 
 #endif

--- a/toonz/sources/toonzqt/toonzqt.qrc
+++ b/toonz/sources/toonzqt/toonzqt.qrc
@@ -8,6 +8,8 @@
         <file>Resources/param_on.svg</file>
         <file>Resources/paramanim_off.svg</file>
         <file>Resources/paramanim_on.svg</file>
+        <file>Resources/paramignored_off.svg</file>
+        <file>Resources/paramignored_on.svg</file>
         <file>Resources/resizeColumnNode.svg</file>
         <file>Resources/schematic_spin_arrows.svg</file>
         <file>Resources/schematic_spline_aim_rhomb.svg</file>

--- a/toonz/sources/toonzqt/treemodel.cpp
+++ b/toonz/sources/toonzqt/treemodel.cpp
@@ -171,7 +171,7 @@ TreeModel::~TreeModel() { delete m_rootItem; }
 //------------------------------------------------------------------------------------------------------------------
 
 void TreeModel::setExpandedItem(const QModelIndex &index, bool expanded) {
-  m_view->setExpanded(index, expanded);
+  if (m_view) m_view->setExpanded(index, expanded);
 }
 
 //------------------------------------------------------------------------------------------------------------------
@@ -320,7 +320,7 @@ void TreeModel::setRootItem_NoFree(Item *rootItem) {
 //---------------------------------------------------------------------------------------------------------------
 
 void TreeModel::setRowHidden(int row, const QModelIndex &parent, bool hide) {
-  m_view->setRowHidden(row, parent, hide);
+  if (m_view) m_view->setRowHidden(row, parent, hide);
 }
 
 //====================================================================================================


### PR DESCRIPTION
This PR will add a new experimental feature to manage references used in the expressions.

<img src="https://user-images.githubusercontent.com/17974955/86323582-0b4e4e00-bc78-11ea-95a3-6f0759c94dda.png" width=600>

### How To Enable This Feature

In Preferences popup, check the `Automatically Modify Expression On Moving Referenced Objects` option in the `Animation` category.

### What This Feature Does

Expression Reference Manager monitors all the fxs / stage objects references used in the expression. It has 2 major features:

#### When the referenced object is moved, the manager automatically adjusts the expression text so that the reference won't break.
- For instance, let's say you have an expression `col1.ew` in some parameter. If you drag&move the Column1 to Column2, the manager automatically change the expression text to `col2.ew`.
- The changes will be reported in the Message Center panel.

#### When you try to do some operation, if it will remove referenced parameter, the manager opens warning popup in advance. 
- For instance, let's say you have an expression `col1.ew` in some parameter (again). When you try to delete the column1 the manager will open the warning.
- If you proceed the operation in spite of the warning, the referencing parameter will become "ignored" state, i.e. the parameter will no longer be monitored or modified with subsequent operations.
  - There is an exception that if the expression will cause circular reference after the operation. In such case the manager will add "?" to both ends of the expression text to avoid it. 
- The ignored parameter is displayed in red color and with warning sign in the function editor so that users can detect it.
- For instance, let's say you have an expression `col1.ew` in a keyframe of Column2 E/W. When you try to delete the column1 the manager will open the warning. If you proceed deleting the column1, the followings will happen:
  - Column2 will move by one to the left and become Column1.
  - Column1 E/W (former Column2 E/W) becomes "ignored" state. i.e. the expression will no longer be modified by the manager.
  - However, leaving the expression text `col1.ew` unchanged will cause circular reference. So the manager will add "?" to the both ends like `?col1.ew?` . It is not proper syntax but can avoid the circular reference.
- When users manually modify any keyframe in the ignored parameter, the parameter will be monitored again and back to normal state.
- When users try to save scene with any parameter being left in the ignored state, the manager will open the warning popup.

### Known Issues
I marked this feature "Experimental" as there are known issues as follows;
- This feature does not cover the `vertex` expression syntax for referencing the plastic skeleton (like `vertex(2,"Vertex __2").angle`) yet, since I'm not so familiar with it.
- Undoing the operation with ignored parameters will not bring back data properly.

I think I made the feature not to affect the exiting usage as long as the preference option is not checked.