### PR TITLE
Fix Crash on Attempting to Save Read-only Studio Palette

### DIFF
--- a/toonz/sources/toonzqt/palettesscanpopup.cpp
+++ b/toonz/sources/toonzqt/palettesscanpopup.cpp
@@ -49,14 +49,14 @@ PalettesScanPopup::PalettesScanPopup()
 
 //-----------------------------------------------------------------------------
 /*! Set current folder path to \b path.
-*/
+ */
 void PalettesScanPopup::setCurrentFolder(TFilePath path) {
   m_folderPath = path;
 }
 
 //-----------------------------------------------------------------------------
 /*! Return current folder path.
-*/
+ */
 TFilePath PalettesScanPopup::getCurrentFolder() { return m_folderPath; }
 
 //-----------------------------------------------------------------------------
@@ -84,7 +84,7 @@ void PalettesScanPopup::onOkBtnClicked() {
 
 //-----------------------------------------------------------------------------
 /*! Set label text to path \b fp.
-*/
+ */
 void PalettesScanPopup::setLabel(const TFilePath &fp) {
   QString elideStr =
       elideText(toQString(fp), m_label->font(), m_label->width());
@@ -107,7 +107,7 @@ void PalettesScanPopup::timerEvent(QTimerEvent *event) {
 
 //-----------------------------------------------------------------------------
 /*! Push TFilePath \b fp to the top of directories stack. Set label text to fp.
-*/
+ */
 void PalettesScanPopup::push(const TFilePath &fp) {
   setLabel(fp);
   Directory *dir = new Directory();
@@ -132,7 +132,7 @@ void PalettesScanPopup::push(const TFilePathSet &fs) {
 
 //-----------------------------------------------------------------------------
 /*! Removes the top item from the stack. If stack is empty return immediately.
-*/
+ */
 void PalettesScanPopup::pop() {
   if (m_stack.empty()) return;
   Directory *dir = m_stack.back();
@@ -173,7 +173,7 @@ bool PalettesScanPopup::step() {
 
 //-----------------------------------------------------------------------------
 /*! Resets the content of the directories stack and set label text empty.
-*/
+ */
 void PalettesScanPopup::clearStack() {
   for (int i = 0; i < (int)m_stack.size(); i++) delete m_stack[i];
   m_stack.clear();
@@ -182,10 +182,17 @@ void PalettesScanPopup::clearStack() {
 
 //-----------------------------------------------------------------------------
 /*! Import palette, defined in path \b fp, in current \b StudioPalette folder.
-*/
+ */
 void PalettesScanPopup::onPlt(const TFilePath &fp) {
   TFilePath root(m_field->getPath().toStdString());
   assert(root.isAncestorOf(fp));
   TFilePath q = fp.getParentDir() - root;
-  StudioPalette::instance()->importPalette(m_folderPath + q, fp);
+  try {
+    StudioPalette::instance()->importPalette(m_folderPath + q, fp);
+  } catch (TSystemException &se) {
+    DVGui::warning(QString::fromStdWString(se.getMessage()));
+  } catch (...) {
+    DVGui::warning(QString::fromStdWString(fp.getWideString() + L"\n") +
+                   tr("Failed to import palette."));
+  }
 }

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -948,7 +948,16 @@ void PaletteViewer::saveStudioPalette() {
     int ret =
         DVGui::MsgBox(question, tr("Overwrite"), tr("Don't Overwrite"), 0);
     if (ret == 2 || ret == 0) return;
-    sp->setPalette(fp, getPalette(), false);
+    try {
+      sp->setPalette(fp, getPalette(), false);
+    } catch (TSystemException se) {
+      DVGui::warning(QString::fromStdWString(se.getMessage()));
+      return;
+    } catch (...) {
+      DVGui::warning(QString::fromStdWString(fp.getWideString() + L"\n") +
+                     tr("Failed to save palette."));
+      return;
+    }
 
     StudioPaletteCmd::updateAllLinkedStyles(m_paletteHandle, m_xsheetHandle);
 

--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -497,13 +497,26 @@ void StudioPaletteTreeViewer::onCurrentItemChanged(QTreeWidgetItem *current,
       return;
     }
     if (ret == 1) {
-      // If the palette is level palette (i.e. NOT stdio palette), just
-      // overwrite it
-      if (gname.empty())
-        StudioPalette::instance()->save(oldPath, m_currentPalette.getPointer());
-      else
-        StudioPalette::instance()->setPalette(
-            oldPath, m_currentPalette.getPointer(), false);
+      try {
+        // If the palette is level palette (i.e. NOT stdio palette), just
+        // overwrite it
+        if (gname.empty())
+          StudioPalette::instance()->save(oldPath,
+                                          m_currentPalette.getPointer());
+        else
+          StudioPalette::instance()->setPalette(
+              oldPath, m_currentPalette.getPointer(), false);
+      } catch (TSystemException se) {
+        DVGui::warning(QString::fromStdWString(se.getMessage()));
+        setCurrentItem(previous);
+        return;
+      } catch (...) {
+        DVGui::warning(
+            QString::fromStdWString(oldPath.getWideString() + L"\n") +
+            tr("Failed to save palette."));
+        setCurrentItem(previous);
+        return;
+      }
     }
     m_currentPalette->setDirtyFlag(false);
   }


### PR DESCRIPTION
This PR will fix the following problem:

- When saving a studio palette, if the palette file is set to read only, OpenToonz crashes.

The cause of this problem was that the exception thrown from `StudioPalette::save()` was not caught by any higher functions.
In this PR I added missing `try/catch` statements to not only the usage when saving the palette but also all other cases.