### PR TITLE
Fix Geometric Tool - MultiArc Shape - Smooth Option

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -416,7 +416,7 @@ class GeometricToolOptionsBox final : public ToolOptionsBox {
   ToolOptionCombo *m_shapeField;
   ToolOptionCheckbox *m_pencilMode;
   ToolOptionIntSlider *m_miterField;
-  ToolOptionCheckbox *m_snapCheckbox;
+  ToolOptionCheckbox *m_snapCheckbox, *m_smoothCheckbox;
   ToolOptionCombo *m_snapSensitivityCombo;
   TTool *m_tool;
 

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -427,7 +427,6 @@ public:
     if (targetType & TTool::Vectors) {
       m_prop[0].bind(m_autogroup);
       m_prop[0].bind(m_autofill);
-      m_prop[0].bind(m_smooth);
       m_prop[0].bind(m_snap);
       m_snap.setId("Snap");
       m_prop[0].bind(m_snapSensitivity);
@@ -441,6 +440,7 @@ public:
       m_prop[0].bind(m_pencil);
       m_pencil.setId("PencilMode");
     }
+    m_prop[0].bind(m_smooth);
 
     m_capStyle.addValue(BUTT_WSTR, QString::fromStdWString(BUTT_WSTR));
     m_capStyle.addValue(ROUNDC_WSTR, QString::fromStdWString(ROUNDC_WSTR));

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -536,7 +536,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_nsPosField =
       new PegbarChannelField(m_tool, TStageObject::T_Y, "field", frameHandle,
                              objHandle, xshHandle, this);
-  m_zField = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
+  m_zField        = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
                                     frameHandle, objHandle, xshHandle, this);
   m_noScaleZField = new NoScaleField(m_tool, "field");
 
@@ -667,7 +667,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_zField->setPrecision(4);
   m_noScaleZField->setPrecision(4);
 
-  bool splined                        = isCurrentObjectSplined();
+  bool splined = isCurrentObjectSplined();
   if (splined != m_splined) m_splined = splined;
   setSplined(m_splined);
 
@@ -1300,7 +1300,7 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   // assert(ret);
   bool ret = connect(m_scaleXField, SIGNAL(valueChange(bool)),
                      SLOT(onScaleXValueChanged(bool)));
-  ret = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
+  ret      = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
                        SLOT(onScaleYValueChanged(bool)));
   if (m_setSaveboxCheckbox)
     ret = ret && connect(m_setSaveboxCheckbox, SIGNAL(toggled(bool)),
@@ -1441,6 +1441,7 @@ GeometricToolOptionsBox::GeometricToolOptionsBox(QWidget *parent, TTool *tool,
     , m_poligonSideField(0)
     , m_shapeField(0)
     , m_snapCheckbox(0)
+    , m_smoothCheckbox(0)
     , m_snapSensitivityCombo(0)
     , m_tool(tool)
     , m_pencilMode(0) {
@@ -1474,6 +1475,13 @@ GeometricToolOptionsBox::GeometricToolOptionsBox(QWidget *parent, TTool *tool,
     m_poligonSideLabel->setEnabled(false);
     m_poligonSideField->setEnabled(false);
   }
+
+  m_smoothCheckbox =
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Smooth"));
+  if (m_shapeField->getProperty()->getValue() != L"MultiArc") {
+    m_smoothCheckbox->setEnabled(false);
+  }
+
   bool ret = connect(m_shapeField, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onShapeValueChanged(int)));
 
@@ -1523,9 +1531,11 @@ void GeometricToolOptionsBox::updateStatus() {
 
 void GeometricToolOptionsBox::onShapeValueChanged(int index) {
   const TEnumProperty::Range &range = m_shapeField->getProperty()->getRange();
-  bool enabled                      = range[index] == L"Polygon";
-  m_poligonSideLabel->setEnabled(enabled);
-  m_poligonSideField->setEnabled(enabled);
+  bool polygonEnabled               = range[index] == L"Polygon";
+  m_poligonSideLabel->setEnabled(polygonEnabled);
+  m_poligonSideField->setEnabled(polygonEnabled);
+
+  m_smoothCheckbox->setEnabled(range[index] == L"MultiArc");
 }
 
 //-----------------------------------------------------------------------------
@@ -1711,11 +1721,11 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_colorMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onColorModeChanged(int)));
-  ret = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
+  ret      = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolTypeChanged(int)));
-  ret = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
                        SLOT(onOnionModeToggled(bool)));
-  ret = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
                        SLOT(onMultiFrameModeToggled(bool)));
   assert(ret);
   if (m_colorMode->getProperty()->getValue() == L"Lines") {
@@ -2314,9 +2324,9 @@ TapeToolOptionsBox::TapeToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_typeMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onToolTypeChanged(int)));
-  ret = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
+  ret      = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolModeChanged(int)));
-  ret = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
                        SLOT(onJoinStrokesModeChanged()));
   assert(ret);
 }
@@ -2403,10 +2413,11 @@ protected:
       p.setPen(Qt::black);
     p.setBrush(Qt::NoBrush);
 
-    p.drawText(rect(), Qt::AlignCenter, QString("R:%1 G:%2 B:%3")
-                                            .arg(m_color.red())
-                                            .arg(m_color.green())
-                                            .arg(m_color.blue()));
+    p.drawText(rect(), Qt::AlignCenter,
+               QString("R:%1 G:%2 B:%3")
+                   .arg(m_color.red())
+                   .arg(m_color.green())
+                   .arg(m_color.blue()));
   }
 };
 
@@ -2834,7 +2845,7 @@ void ToolOptions::onToolSwitched() {
   TTool *tool = app->getCurrentTool()->getTool();
   if (tool) {
     // c'e' un tool corrente
-    ToolOptionsBox *panel = 0;
+    ToolOptionsBox *panel                            = 0;
     std::map<TTool *, ToolOptionsBox *>::iterator it = m_panels.find(tool);
     if (it == m_panels.end()) {
       // ... senza panel associato


### PR DESCRIPTION
This PR quick-patches the issue reported by @openanim in https://github.com/opentoonz/opentoonz/pull/3360#issuecomment-653891320

- The Smooth option now appears in all level types.
- The option will be disabled unless the "MultiArc" shape mode is selected.

Actually I feel it would be better to hide the unnecessary options (instead of disabling it) in order to save space of the tool options bar.
But for now I made it consistent with `Polygon Sides` field which is also only enabled in "Polygon" shape mode. 