### PR TITLE
Fix Saving Toonz Raster Level Failure

### DIFF
--- a/toonz/sources/image/tzl/tiio_tzl.cpp
+++ b/toonz/sources/image/tzl/tiio_tzl.cpp
@@ -40,7 +40,7 @@ char *reverse(char *buffer, int size) {
   }
   return buffer;
 }
-}
+}  // namespace
 
 static int tfwrite(const char *data, const unsigned int count, FILE *f) {
   return fwrite(data, sizeof(char), count, f);
@@ -208,8 +208,8 @@ bool readHeaderAndOffsets(FILE *chan, TzlOffsetMap &frameOffsTable,
       if (version >= 12) fread(&length, sizeof(TINT32), 1, chan);
 
 #if !TNZ_LITTLE_ENDIAN
-      number                    = swapTINT32(number);
-      offs                      = swapTINT32(offs);
+      number = swapTINT32(number);
+      offs   = swapTINT32(offs);
       if (version == 12) length = swapTINT32(length);
 #endif
       //		std::cout << "#" << i << std::hex << " n 0x" << number
@@ -270,16 +270,16 @@ bool readHeaderAndOffsets(FILE *chan, TzlOffsetMap &frameOffsTable,
         level->setFrame(TFrameId(i), TImageP());
   }
 
-  res.lx                                        = lx;
-  res.ly                                        = ly;
-  if (_offsetTablePos) *_offsetTablePos         = offsetTablePos;
+  res.lx = lx;
+  res.ly = ly;
+  if (_offsetTablePos) *_offsetTablePos = offsetTablePos;
   if (_iconOffsetTablePos) *_iconOffsetTablePos = iconOffsetTablePos;
 
   if (_frameCount) *_frameCount = frameCount;
 
   return true;
 }
-}
+}  // namespace
 
 static bool adjustIconAspectRatio(TDimension &outDimension,
                                   TDimension inDimension, TDimension imageRes) {
@@ -295,7 +295,7 @@ static bool adjustIconAspectRatio(TDimension &outDimension,
       double(ly) / inDimension.ly)
     iconLx = tround((double(lx) * inDimension.ly) / ly);
   else
-    iconLy     = tround((double(ly) * inDimension.lx) / lx);
+    iconLy = tround((double(ly) * inDimension.lx) / lx);
   outDimension = TDimension(iconLx, iconLy);
   return true;
 }
@@ -1084,7 +1084,7 @@ void TLevelWriterTzl::renumberFids(
   frameOffsTableTemp        = m_frameOffsTable;
   TzlOffsetMap::iterator it = frameOffsTableTemp.begin();
   while (it != frameOffsTableTemp.end()) {
-    TFrameId fid = it->first;
+    TFrameId fid                                     = it->first;
     std::map<TFrameId, TFrameId>::const_iterator it2 = renumberTable.find(fid);
     if (it2 == renumberTable.end()) remove(fid);
     it++;
@@ -1403,12 +1403,11 @@ bool TLevelWriterTzl::optimize() {
 
 void TLevelReaderTzl::readPalette() {
   TFilePath pltfp = m_path.withNoFrame().withType("tpl");
-  TFileStatus fs(pltfp);
-  TPersist *p = 0;
+  TPersist *p     = 0;
   TIStream is(pltfp);
   TPalette *palette = 0;
 
-  if (is && fs.doesExist()) {
+  if (is) {
     std::string tagName;
     if (is.matchTag(tagName) && tagName == "palette") {
       std::string gname;

--- a/toonz/sources/include/toonzqt/icongenerator.h
+++ b/toonz/sources/include/toonzqt/icongenerator.h
@@ -140,6 +140,10 @@ public:
                                          const TDimension &iconSize,
                                          const TFrameId &fid);
 
+  // This function is called when only colors of styles are changed in toonz
+  // raster levels. In such case it doesn't need to re-compute icons but needs
+  // to let panels to update. See TApp::onLevelColorStyleChanged() for details.
+  void notifyIconGenerated() { emit iconGenerated(); }
 signals:
 
   void iconGenerated();

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -631,10 +631,23 @@ void TApp::onLevelColorStyleSwitched() {
 
 static void notifyPaletteChanged(TXshSimpleLevel *simpleLevel) {
   simpleLevel->onPaletteChanged();
+  // palette change can update icons only for ToonzVector / ToonzRaster types
+  if (simpleLevel->getType() != TZP_XSHLEVEL &&
+      simpleLevel->getType() != PLI_XSHLEVEL)
+    return;
   std::vector<TFrameId> fids;
   simpleLevel->getFids(fids);
-  for (int i = 0; i < (int)fids.size(); i++)
-    IconGenerator::instance()->invalidate(simpleLevel, fids[i]);
+  // ToonzRaster level does not need to re-generate icons along with palette
+  // changes since the icons are cached as color mapped images and the current
+  // palette is applied just before using it. So here we just emit the signal to
+  // update related panels.
+  if (simpleLevel->getType() == TZP_XSHLEVEL)
+    IconGenerator::instance()->notifyIconGenerated();
+  else {  // ToonzVecor needs to re-generate icons since it includes colors in
+          // the cache.
+    for (int i = 0; i < (int)fids.size(); i++)
+      IconGenerator::instance()->invalidate(simpleLevel, fids[i]);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -100,7 +100,10 @@ TImageP ImageLoader::build(int imFlags, void *extData) {
         (m_path.getType() == "psd"))
       lr->loadInfo();
 
-    lr->doReadPalette(true);  // Allow palette loading
+    bool isTlvIcon = data->m_icon && m_path.getType() == "tlv";
+
+    // for TLV icons, palettes will be applied in IconGenerator later
+    if (!isTlvIcon) lr->doReadPalette(true);  // Allow palette loading
 
     TImageReaderP ir = lr->getFrameReader(m_fid);
 
@@ -110,7 +113,7 @@ TImageP ImageLoader::build(int imFlags, void *extData) {
     // Load the image
     TImageP img;
 
-    if (data->m_icon && m_path.getType() == "tlv")
+    if (isTlvIcon)
       img = ir->loadIcon();  // TODO: Why just in the tlv case??
     else {
       ir->setShrink(subsampling);


### PR DESCRIPTION
This PR will fix #3383 

The probable cause of the saving failure was that the file was opened by another thread for updating the icons in the Level Strip in response to the style change.

Before the fix, OT always invalidated and re-generated all icons in the level when a style of its palette was changed (in the function [notifyPaletteChanged()](https://github.com/opentoonz/opentoonz/blob/master/toonz/sources/toonz/tapp.cpp#L637) ).
After further investigation, I came up with the fact that re-generating level strip icons is not always needed:

- For **Raster Levels**, the icons do not need to be changed. ( The images does not change with the style color change in the `Raster Drawing Palette` )
- For **Toonz Raster Levels**, the icons do not need to be re-generated, because the icons are cached as color-mapped image and the current palette is applied just before using it. (in the function [getIcon()](https://github.com/opentoonz/opentoonz/blob/0dc08facf261210e097186e980ea2ed65dc805c8/toonz/sources/toonzqt/icongenerator.cpp#L98-L99) in icongenerator.cpp ) It only needs to trigger update of relevant panels.
- For **Toonz Vector Levels**, the icons still need to be re-generated since they are cached as raster image, including colors and shapes defined by styles.

So I modified `notifyPaletteChanged()` in tapp.cpp to decide if the icons should be re-generated according to the level types.

This change will reduce unnecessary file access. It will enhance the responce and will minimize the risk of failure on saving levels.