### PR TITLE
fix a bug where moving a control point while holding alt has unintended result

### DIFF
--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -652,6 +652,7 @@ void ControlPointEditorTool::leftButtonDown(const TPointD &pos,
     m_selection.makeCurrent();
   } else if (pointType == ControlPointEditorStroke::CONTROL_POINT) {
     if (e.isAltPressed()) {
+      m_action = NONE;
       m_selection.selectNone();
       m_selection.select(pointIndex);
       initUndo();


### PR DESCRIPTION
this fixes #3332

To reproduce this bug:
1. select control point editor tool
2. select a stroke
3. move a control point
4. move another control point while holding alt

The bug happens because `m_action` isn't initialized when you press a control point while holding alt. So, if you drag a control point, `m_action` is initialized as `CP_MOVEMENT`. Then, when you hold alt and drag a control point again, it would then misbehave.