### PR TITLE
Fix Overwriting Raster Drawing Palette

### DIFF
--- a/toonz/sources/include/toonz/fullcolorpalette.h
+++ b/toonz/sources/include/toonz/fullcolorpalette.h
@@ -36,6 +36,7 @@ public:
   TPalette *getPalette(ToonzScene *scene);
   void savePalette(ToonzScene *scene);
   bool isFullColorPalette(TPalette *palette) { return m_palette == palette; }
+  const TFilePath getPath() const { return m_fullcolorPalettePath; }
 };
 
 #endif  // FULLCOLOR_PALETTE

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1532,7 +1532,7 @@ bool IoCmd::saveLevel(const TFilePath &path) {
     realPath = TFilePath(realPath.getWideString() + ::to_wstring(dotts + ext));
 
   bool ret = saveLevel(realPath, sl, false);
-  if(!ret){ //save level failed
+  if (!ret) {  // save level failed
     return false;
   }
 
@@ -2948,6 +2948,8 @@ public:
       }
       if (sl->getPath().getType() == "pli")
         palettePath = sl->getPath();
+      else if (sl->getType() & FULLCOLOR_TYPE)
+        palettePath = FullColorPalette::instance()->getPath();
       else
         palettePath = sl->getPath().withType("tpl");
     }
@@ -2987,6 +2989,8 @@ public:
 
     if (sl && sl->getPath().getType() == "pli")
       sl->save(palettePath, TFilePath(), true);
+    else if (sl->getType() & FULLCOLOR_TYPE)
+      FullColorPalette::instance()->savePalette(scene);
     else
       StudioPalette::instance()->save(palettePath, palette);
     /*- Dirtyフラグの変更 -*/


### PR DESCRIPTION
This PR fixes the following problem:
- When pressing "Save Palette" button in the palette viewer's tool bar, the raster level palette (`+palettes/Raster_Drawing_Palette.tpl`) is not overwritten properly. OT suggests to save palette to the wrong location, in the same folder as the level files (like `+drawings/A..tpl` for `+drawings/A..tif`) instead. 