### PR TITLE
Fix travis-install

### DIFF
--- a/ci-scripts/osx/travis-install.sh
+++ b/ci-scripts/osx/travis-install.sh
@@ -6,6 +6,8 @@ brew install clang-format
 # from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
 # so we start to use the latest version of Qt. (#1910)
 brew install qt
+# delete older qt versions and make sure to have only the latest
+brew cleanup qt
 # temp workaround to brew installed glew cmake info overriding glew lib detection
 # which causes compiling issues later
 if [ -L /usr/local/lib/cmake/glew ]


### PR DESCRIPTION
This PR is an attempt to fix recent failures in Travis CI - MacOS build.

According to the command log it seems that the older version of Qt (5.13.2) remains together with the latest version (5.15.0) for unknown reasons and it causes failure to set `QT_PATH` properly.