### PR TITLE
Fix Viewer Controls Assert Crash (Debug)

### DIFF
--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -1718,6 +1718,13 @@ void FlipConsole::doButtonPressed(UINT button) {
   case eFilledRaster:
     return;
 
+  case eFlipHorizontal:
+  case eFlipVertical:
+  case eZoomIn:
+  case eZoomOut:
+  case eResetView:
+    return;
+
   default:
     assert(false);
     break;


### PR DESCRIPTION
Using viewer controls causes a crash in debug.