### PR TITLE
fix undo data when pasting in group

### DIFF
--- a/toonz/sources/common/tvectorimage/tvectorimage.cpp
+++ b/toonz/sources/common/tvectorimage/tvectorimage.cpp
@@ -1034,8 +1034,8 @@ bool TVectorImage::Imp::areWholeGroups(const std::vector<int> &indexes) const {
     if (!m_strokes[indexes[i]]->m_groupId.isGrouped()) return false;
     for (j = 0; j < m_strokes.size(); j++) {
       int ret = areDifferentGroup(indexes[i], false, j, false);
-      if (ret == -1 ||
-          (ret >= 1 && find(indexes.begin(), indexes.end(), j) == indexes.end()))
+      if (ret == -1 || (ret >= 1 && find(indexes.begin(), indexes.end(), j) ==
+                                        indexes.end()))
         return false;
     }
   }
@@ -1219,8 +1219,8 @@ VIStroke::VIStroke(const VIStroke &s, bool sameId)
 
 //-----------------------------------------------------------------------------
 
-void TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
-                              bool sameStrokeId) {
+int TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
+                             bool sameStrokeId) {
   QMutexLocker sl(m_imp->m_mutex);
 
 #ifdef _DEBUG
@@ -1243,16 +1243,16 @@ void TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
   // mettere comunque un test qui
   if (srcPlt) mergePalette(tarPlt, styleTable, srcPlt, usedStyles);
 
-  mergeImage(img, affine, styleTable, sameStrokeId);
+  return mergeImage(img, affine, styleTable, sameStrokeId);
 }
 
 //-----------------------------------------------------------------------------
 
-void TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
-                              const std::map<int, int> &styleTable,
-                              bool sameStrokeId) {
+int TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
+                             const std::map<int, int> &styleTable,
+                             bool sameStrokeId) {
   int imageSize = img->getStrokeCount();
-  if (imageSize == 0) return;
+  if (imageSize == 0) return 0;
   QMutexLocker sl(m_imp->m_mutex);
 
   m_imp->m_computedAlmostOnce |= img->m_imp->m_computedAlmostOnce;
@@ -1282,7 +1282,7 @@ void TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
         } else {
           img->m_imp->m_strokes[i]->m_groupId =
               TGroupId(groupId, img->m_imp->m_strokes[i]->m_groupId);
-	}
+        }
       }
     }
   }
@@ -1351,6 +1351,8 @@ void TVectorImage::mergeImage(const TVectorImageP &img, const TAffine &affine,
 #ifdef _DEBUG
   checkIntersections();
 #endif
+
+  return insertAt;
 }
 
 //-----------------------------------------------------------------------------
@@ -2908,7 +2910,7 @@ void TVectorImage::Imp::regroupGhosts(std::vector<int> &changedStrokes) {
              ((currGroupId.isGrouped(false) != 0 &&
                m_strokes[i]->m_groupId == currGroupId) ||
               (currGroupId.isGrouped(true) != 0 &&
-                  m_strokes[i]->m_groupId.isGrouped(true) != 0))) {
+               m_strokes[i]->m_groupId.isGrouped(true) != 0))) {
         if (m_strokes[i]->m_groupId != currGroupId) {
           m_strokes[i]->m_groupId = currGroupId;
           changedStrokes.push_back(i);

--- a/toonz/sources/include/tvectorimage.h
+++ b/toonz/sources/include/tvectorimage.h
@@ -82,7 +82,7 @@ public:
   void validateRegions(bool state = false);
   //! Get valid regions flags
   /*! Call validateRegions() after region/stroke changes
-*/
+   */
   bool areValidRegions();
 
   //! Return a clone of image
@@ -306,7 +306,7 @@ get the stroke nearest at point
 
   /*! if enabled, region edges are joined together when possible. for flash
    * render, should be disabled!
-*/
+   */
   void enableMinimizeEdges(bool enabled);
   /*! Creates a new Image using the selected strokes. If removeFlag==true then
      removes selected strokes
@@ -316,12 +316,12 @@ get the stroke nearest at point
   TVectorImageP splitSelected(bool removeFlag);
 
   //! Merge the image with the \b img.
-  void mergeImage(const TVectorImageP &img, const TAffine &affine,
-                  bool sameStrokeId = true);
+  int mergeImage(const TVectorImageP &img, const TAffine &affine,
+                 bool sameStrokeId = true);
 
-  void mergeImage(const TVectorImageP &img, const TAffine &affine,
-                  const std::map<int, int> &styleTable,
-                  bool sameStrokeId = true);
+  int mergeImage(const TVectorImageP &img, const TAffine &affine,
+                 const std::map<int, int> &styleTable,
+                 bool sameStrokeId = true);
   //! Merge the image with the vector of image \b images.
   void mergeImage(const std::vector<const TVectorImage *> &images);
 

--- a/toonz/sources/toonzqt/strokesdata.cpp
+++ b/toonz/sources/toonzqt/strokesdata.cpp
@@ -111,10 +111,15 @@ void StrokesData::getImage(TVectorImageP image, std::set<int> &indices,
     TAffine offset    = findOffset(srcImg, image);
     UINT oldImageSize = image->getStrokeCount();
 
-    image->mergeImage(srcImg, offset, false);
+    int insertAt      = image->mergeImage(srcImg, offset, false);
     UINT newImageSize = image->getStrokeCount();
     indices.clear();
-    for (UINT sI = oldImageSize; sI < newImageSize; sI++) indices.insert(sI);
+
+    if (insertAt == 0)
+      for (UINT sI = oldImageSize; sI < newImageSize; sI++) indices.insert(sI);
+    else
+      for (UINT sI = oldImageSize; sI < newImageSize; sI++)
+        indices.insert(sI - oldImageSize + insertAt);
   } else {
     std::vector<int> indicesToInsert(indices.begin(), indices.end());
     if (indicesToInsert.empty()) return;


### PR DESCRIPTION
There is a bug where undo data is wrong when you paste strokes in a group.

The bug: https://youtu.be/4I9z5I5gKXA

To reproduce the bug:
1. draw some strokes
2. group the first stroke you drew
3. cut/copy any other strokes except the first and the last stroke
4. double click on the stroke you just grouped so that other strokes are gray
5. paste the stroke

At this point, you'll see that the selected stroke is not the one you just pasted but the last stroke you drew. Try to undo and redo and you should see it removes the wrong stroke when you undo and restore the wrong stroke when you redo.

This PR fixes this.

Note that this PR touches toonz/sources/common/tvectorimage/tvectorimage.cpp which I consider to be really core part of the codebase. And thus, I'm not entirely sure if my change can be accepted.