### PR TITLE
Mode Sensitive Tag for Fx Settings Layout

### DIFF
--- a/stuff/profiles/layouts/fxs/STD_iwa_TextFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_TextFx.xml
@@ -2,8 +2,12 @@
 	<page name="Text Iwa">
  	<vbox>
 		<control>targetType</control>
-		<control>columnIndex</control>
-		<control>text</control>
+		<vbox modeSensitive="targetType" mode="1">
+			<control>columnIndex</control>
+		</vbox>
+		<vbox modeSensitive="targetType" mode="2">
+			<control>text</control>
+		</vbox>
 		<control>hAlign</control>
 		<control>center</control>
 		<control>width</control>

--- a/stuff/profiles/layouts/fxs/STD_iwa_TimeCodeFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_TimeCodeFx.xml
@@ -2,13 +2,17 @@
 	<page name="TimeCode Iwa">
  	<vbox>
 		<control>displayType</control>
-		<control>frameRate</control>
+		<vbox modeSensitive="displayType" mode="0,2">
+			<control>frameRate</control>
+		</vbox>
 		<control>startFrame</control>
 		<control>position</control>
 		<control>size</control>
 		<control>textColor</control>
 		<control>showBox</control>
-		<control>boxColor</control>
+		<vbox modeSensitive="showBox" mode="1">
+			<control>boxColor</control>
+		</vbox>
   	</vbox>
   	</page>
 </fxlayout>

--- a/toonz/sources/include/toonzqt/paramfield.h
+++ b/toonz/sources/include/toonzqt/paramfield.h
@@ -426,10 +426,36 @@ protected slots:
 };
 
 //=============================================================================
+// Mode Sensitive Box
+//-----------------------------------------------------------------------------
+
+class ModeChangerParamField : public ParamField {
+  Q_OBJECT
+public:
+  ModeChangerParamField(QWidget *parent, QString paramName,
+                        const TParamP &param, bool addEmptyLabel = true)
+      : ParamField(parent, paramName, param, addEmptyLabel) {}
+signals:
+  void modeChanged(int);
+};
+
+class DVAPI ModeSensitiveBox final : public QWidget {
+  Q_OBJECT
+  QList<int> m_modes;
+
+public:
+  ModeSensitiveBox(QWidget *parent, ModeChangerParamField *modeChanger,
+                   QList<int> modes);
+  QList<int> modes() { return m_modes; }
+protected slots:
+  void onModeChanged(int mode);
+};
+
+//=============================================================================
 // EnumParamField
 //-----------------------------------------------------------------------------
 
-class EnumParamField final : public ParamField {
+class EnumParamField final : public ModeChangerParamField {
   Q_OBJECT
 
   TIntEnumParamP m_currentParam, m_actualParam;
@@ -452,7 +478,7 @@ protected slots:
 // BoolParamField
 //-----------------------------------------------------------------------------
 
-class DVAPI BoolParamField final : public ParamField {
+class DVAPI BoolParamField final : public ModeChangerParamField {
   Q_OBJECT
 
   TBoolParamP m_currentParam, m_actualParam;

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -1243,12 +1243,30 @@ void SpectrumParamField::onKeyRemoved(int keyIndex) {
 }
 
 //=============================================================================
+// Mode Sensitive Box
+//-----------------------------------------------------------------------------
+
+ModeSensitiveBox::ModeSensitiveBox(QWidget *parent,
+                                   ModeChangerParamField *modeChanger,
+                                   QList<int> modes)
+    : QWidget(parent), m_modes(modes) {
+  connect(modeChanger, SIGNAL(modeChanged(int)), this,
+          SLOT(onModeChanged(int)));
+}
+
+//-----------------------------------------------------------------------------
+
+void ModeSensitiveBox::onModeChanged(int modeValue) {
+  setVisible(m_modes.contains(modeValue));
+}
+
+//=============================================================================
 // EnumParamField
 //-----------------------------------------------------------------------------
 
 EnumParamField::EnumParamField(QWidget *parent, QString name,
                                const TIntEnumParamP &param)
-    : ParamField(parent, name, param) {
+    : ModeChangerParamField(parent, name, param) {
   QString str;
   m_paramName = str.fromStdString(param->getName());
   m_om        = new QComboBox(this);
@@ -1300,6 +1318,8 @@ void EnumParamField::onChange(const QString &str) {
   emit currentParamChanged();
   emit actualParamChanged();
 
+  emit modeChanged(m_actualParam->getValue());
+
   if (undo) TUndoManager::manager()->add(undo);
 }
 
@@ -1312,6 +1332,7 @@ void EnumParamField::setParam(const TParamP &current, const TParamP &actual,
   assert(m_currentParam);
   assert(m_actualParam);
   update(frame);
+  emit modeChanged(m_actualParam->getValue());
 }
 
 //-----------------------------------------------------------------------------
@@ -1336,7 +1357,7 @@ void EnumParamField::update(int frame) {
 
 BoolParamField::BoolParamField(QWidget *parent, QString name,
                                const TBoolParamP &param)
-    : ParamField(parent, name, param) {
+    : ModeChangerParamField(parent, name, param) {
   QString str;
   m_paramName = str.fromStdString(param->getName());
   if (!param->hasUILabel()) m_interfaceName = name;
@@ -1362,6 +1383,8 @@ void BoolParamField::onToggled(bool checked) {
   emit currentParamChanged();
   emit actualParamChanged();
 
+  emit modeChanged((checked) ? 1 : 0);
+
   TBoolParamP boolParam = m_actualParam;
   if (boolParam)
     TUndoManager::manager()->add(new BoolParamFieldUndo(
@@ -1377,6 +1400,7 @@ void BoolParamField::setParam(const TParamP &current, const TParamP &actual,
   assert(m_currentParam);
   assert(m_actualParam);
   update(frame);
+  emit modeChanged((m_actualParam->getValue()) ? 1 : 0);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR enables Fx Settings to hide the unnecessary controls according to its mode specified by another control of the same Fx.

![mode_sensitive_box](https://user-images.githubusercontent.com/17974955/87137930-9f539180-c2d8-11ea-9db1-c95d405a3623.png)

Some Fx has an ability to render several types of images according to its "mode". And some Fx parameters are only used in a specific mode.
For instance, the `Text` field in the Text Iwa Fx is used only when the `Source` combo box is set to `Input Text` mode.
In another instance, the `Box Color` field in the TimeCode Iwa Fx is needed only when the `Show Box` checkbox is checked.

In such case, this feature will hide unrelated controls and can keep the UI simpler.

### Usage

This feature can be added by adding special tag like as follows to the layout XML file in `$TOONZPROFILE/layouts/fxs` .

```
<vbox modeSensitive="mode_controller_name" mode="mode_indices">
  <control>control_to_be_mode_sensitive</control>
  <control>another_control_to_be_mode_sensitive</control>
   . . .
</vbox>
```

where;
- **mode_controller_name** : Specify the name (parameter id) of control to change the mode. It must be either a combo box (for `TIntEnumParam`) or a checkbox (for `TBoolParam`) .
- **mode_indices** : Specify the mode index in which the controls will be displayed. 
  - If the controller is a combo box, it will be the series of values of `TIntEnumParam` separated by comma "," (N.B. it can be different from the combobox' item indices). 
  - If the controller is a the checkbox, it will be either 1 (=on) or 0 (=off).

For trial, I modified the fx settings layout of Text Iwa Fx and TimeCode Iwa Fx.



