### PR TITLE
[Do Not Merge] include intersect when drawing counterclockwise

### DIFF
--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -358,7 +358,6 @@ private:
 private:
   TEnumProperty m_selectionTarget;  //!< Selected target content (strokes, whole
                                     //! image, styles...).
-  TBoolProperty m_includeIntersection;
   TBoolProperty m_constantThickness;
 
   StrokeSelection m_strokeSelection;        //!< Standard selection of a set of
@@ -385,7 +384,7 @@ private:
   void doOnActivate() override;
   void doOnDeactivate() override;
 
-  void selectRegionVectorImage(bool includeIntersect);
+  void selectRegionVectorImage();
 
   void updateTranslation() override;
 


### PR DESCRIPTION
based on this comment: https://github.com/opentoonz/opentoonz/pull/3369#issuecomment-657152672

video: https://youtu.be/YNpGgJa3Khs

I followed the answer on this link: https://stackoverflow.com/questions/1165647/how-to-determine-if-a-list-of-polygon-points-are-in-clockwise-order to implement the algorithm for detecting if a stroke is clockwise or counterclockwise.

this PR removes "include intersection" option in selection tool. Now, instead of checking an option to include intersection, you draw counterclockwise if you want to include intersection. If you don't want to include them, draw clockwise.

I chose not to add a preference option because 1.4 doesn't have this feature so I don't need to keep it backward compatible. (also because I'm lazy :p )