### PR TITLE
Color_0 chip redesign

### DIFF
--- a/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
+++ b/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
@@ -590,7 +590,7 @@ void TSolidColorStyle::makeIcon(const TDimension &size) {
     else {
       TRaster32P fg(size);
       fg->fill(premultiply(col));
-      TRop::checkBoard(m_icon, TPixel32(200, 200, 200), TPixel32::White,
+      TRop::checkBoard(m_icon, TPixel32(180, 180, 180), TPixel32(230, 230, 230),
                        TDimensionD(6, 6), TPointD());
       TRop::over(m_icon, fg);
     }

--- a/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
+++ b/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
@@ -591,7 +591,7 @@ void TSolidColorStyle::makeIcon(const TDimension &size) {
       TRaster32P fg(size);
       fg->fill(premultiply(col));
       TRop::checkBoard(m_icon, TPixel32(130, 130, 130), TPixel32(200, 200, 200),
-                       TDimensionD(9, 9), TPointD());
+                       TDimensionD(6, 6), TPointD());
       TRop::over(m_icon, fg);
     }
   }

--- a/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
+++ b/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
@@ -590,8 +590,8 @@ void TSolidColorStyle::makeIcon(const TDimension &size) {
     else {
       TRaster32P fg(size);
       fg->fill(premultiply(col));
-      TRop::checkBoard(m_icon, TPixel32(130, 130, 130), TPixel32(200, 200, 200),
-                       TDimensionD(9, 9), TPointD());
+      TRop::checkBoard(m_icon, TPixel32(200, 200, 200), TPixel32::White,
+                       TDimensionD(6, 6), TPointD());
       TRop::over(m_icon, fg);
     }
   }

--- a/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
+++ b/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
@@ -590,8 +590,8 @@ void TSolidColorStyle::makeIcon(const TDimension &size) {
     else {
       TRaster32P fg(size);
       fg->fill(premultiply(col));
-      TRop::checkBoard(m_icon, TPixel32::Black, TPixel32::White,
-                       TDimensionD(6, 6), TPointD());
+      TRop::checkBoard(m_icon, TPixel32(130, 130, 130), TPixel32(200, 200, 200),
+                       TDimensionD(9, 9), TPointD());
       TRop::over(m_icon, fg);
     }
   }

--- a/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
+++ b/toonz/sources/common/tvrender/tsimplecolorstyles.cpp
@@ -591,7 +591,7 @@ void TSolidColorStyle::makeIcon(const TDimension &size) {
       TRaster32P fg(size);
       fg->fill(premultiply(col));
       TRop::checkBoard(m_icon, TPixel32(130, 130, 130), TPixel32(200, 200, 200),
-                       TDimensionD(6, 6), TPointD());
+                       TDimensionD(9, 9), TPointD());
       TRop::over(m_icon, fg);
     }
   }

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -51,7 +51,7 @@ StyleSample::StyleSample(QWidget *parent, int sizeX, int sizeY)
     , m_bgRas(sizeX, sizeY)
     , m_style(0)
     , m_clickEnabled(false)
-    , m_chessColor1(200, 200, 200)
+    , m_chessColor1(0, 0, 0)
     , m_chessColor2(255, 255, 255)
     , m_isEditing(false) {
   setMinimumSize(sizeX, sizeY);

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -51,13 +51,13 @@ StyleSample::StyleSample(QWidget *parent, int sizeX, int sizeY)
     , m_bgRas(sizeX, sizeY)
     , m_style(0)
     , m_clickEnabled(false)
-    , m_chessColor1(0, 0, 0)
-    , m_chessColor2(255, 255, 255)
+    , m_chessColor1(130, 130, 130)
+    , m_chessColor2(200, 200, 200)
     , m_isEditing(false) {
   setMinimumSize(sizeX, sizeY);
   setColor(TPixel32::Transparent);
   TRop::checkBoard(m_bgRas, m_chessColor1, m_chessColor2,
-                   TDimensionD(sizeX / 8, sizeX / 8), TPointD(0, 0));
+                   TDimensionD(sizeX / 10, sizeX / 10), TPointD(0, 0));
   setEnable(true);
 }
 

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -51,13 +51,13 @@ StyleSample::StyleSample(QWidget *parent, int sizeX, int sizeY)
     , m_bgRas(sizeX, sizeY)
     , m_style(0)
     , m_clickEnabled(false)
-    , m_chessColor1(130, 130, 130)
-    , m_chessColor2(200, 200, 200)
+    , m_chessColor1(200, 200, 200)
+    , m_chessColor2(255, 255, 255)
     , m_isEditing(false) {
   setMinimumSize(sizeX, sizeY);
   setColor(TPixel32::Transparent);
   TRop::checkBoard(m_bgRas, m_chessColor1, m_chessColor2,
-                   TDimensionD(sizeX / 10, sizeX / 10), TPointD(0, 0));
+                   TDimensionD(sizeX / 8, sizeX / 8), TPointD(0, 0));
   setEnable(true);
 }
 

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -715,10 +715,12 @@ void PageViewer::paintEvent(QPaintEvent *e) {
         if ((int)style->getMainColor().m !=
             (int)style->getMainColor().maxChannelValue) {
           QRect bottomRect = chipRect;
+         if (styleIndex != 0) {
           if (m_viewMode == LargeChips) {
             bottomRect.adjust(0, bottomRect.height() - 12, 0, 0);
           } else
             bottomRect.adjust(0, bottomRect.height() - 6, 0, 0);
+        }
 
           TRaster32P icon = style->getIcon(qsize2Dimension(bottomRect.size()));
           p.drawPixmap(bottomRect.left(), bottomRect.top(),

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -715,15 +715,18 @@ void PageViewer::paintEvent(QPaintEvent *e) {
         if ((int)style->getMainColor().m !=
             (int)style->getMainColor().maxChannelValue) {
           QRect bottomRect = chipRect;
-        if (m_viewMode == LargeChips) {
+          if (styleIndex != 0) {          
+          if (m_viewMode == LargeChips) {
             bottomRect.adjust(0, bottomRect.height() - 12, 0, 0);
           } else
             bottomRect.adjust(0, bottomRect.height() - 6, 0, 0);
-       
+
           TRaster32P icon = style->getIcon(qsize2Dimension(bottomRect.size()));
           p.drawPixmap(bottomRect.left(), bottomRect.top(),
                        rasterToQPixmap(icon));
         }
+      }
+     
         // Use white line for dark color. Use black line for light color.
         int val = (int)style->getMainColor().r * 30 +
                   (int)style->getMainColor().g * 59 +

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -715,13 +715,11 @@ void PageViewer::paintEvent(QPaintEvent *e) {
         if ((int)style->getMainColor().m !=
             (int)style->getMainColor().maxChannelValue) {
           QRect bottomRect = chipRect;
-         if (styleIndex != 0) {
-          if (m_viewMode == LargeChips) {
+        if (m_viewMode == LargeChips) {
             bottomRect.adjust(0, bottomRect.height() - 12, 0, 0);
           } else
             bottomRect.adjust(0, bottomRect.height() - 6, 0, 0);
-        }
-
+       
           TRaster32P icon = style->getIcon(qsize2Dimension(bottomRect.size()));
           p.drawPixmap(bottomRect.left(), bottomRect.top(),
                        rasterToQPixmap(icon));

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -720,12 +720,12 @@ void PageViewer::paintEvent(QPaintEvent *e) {
             bottomRect.adjust(0, bottomRect.height() - 12, 0, 0);
           } else
             bottomRect.adjust(0, bottomRect.height() - 6, 0, 0);
-
+          }
           TRaster32P icon = style->getIcon(qsize2Dimension(bottomRect.size()));
           p.drawPixmap(bottomRect.left(), bottomRect.top(),
                        rasterToQPixmap(icon));
         }
-      }
+      
      
         // Use white line for dark color. Use black line for light color.
         int val = (int)style->getMainColor().r * 30 +


### PR DESCRIPTION
This changes  the default color_0 chip to display a checkered pattern all the way to  the top.  This is for users who keep confusing the button for white.  Studio employee use probably knows what Color_0 stands for already. The change only affects the default chip.  All chips created afterwards with Color_0 will maintain the old style.

Co-Authored-By: turtletooth <jcbullock@gmail.com>