### PR TITLE
Fix Loading Pegbars' Expression To Refer Parameters Properly 

### DIFF
--- a/toonz/sources/toonzlib/tstageobject.cpp
+++ b/toonz/sources/toonzlib/tstageobject.cpp
@@ -258,8 +258,8 @@ bool setKeyframe(const TDoubleParamP &param, const TDoubleKeyframe &kf,
 
   TDoubleKeyframe kfCopy = kf;
 
-  kfCopy.m_frame                        = frame;
-  if (easeIn >= 0.0) kfCopy.m_speedIn   = TPointD(-easeIn, kfCopy.m_speedIn.y);
+  kfCopy.m_frame = frame;
+  if (easeIn >= 0.0) kfCopy.m_speedIn = TPointD(-easeIn, kfCopy.m_speedIn.y);
   if (easeOut >= 0.0) kfCopy.m_speedOut = TPointD(easeOut, kfCopy.m_speedOut.y);
 
   param->setKeyframe(kfCopy);
@@ -773,7 +773,7 @@ void TStageObject::setCenterAndOffset(const TPointD &center,
 //-----------------------------------------------------------------------------
 
 void TStageObject::setHandle(const std::string &s) {
-  m_handle                                = s;
+  m_handle = s;
   if (!s.empty() && s[0] == 'H') m_offset = m_center = TPointD();
 
   invalidate();
@@ -971,7 +971,7 @@ void TStageObject::removeKeyframeWithoutUndo(int frame) {
 
   if (m_skeletonDeformation) m_skeletonDeformation->deleteKeyframe(frame);
 
-  time                                          = -1;
+  time = -1;
   if ((int)keyframes.size() < 2) m_cycleEnabled = false;
 
   invalidate();
@@ -1304,17 +1304,17 @@ TAffine TStageObject::computeIkRootOffset(int t) {
   TAffine placement                   = foot->getPlacement(t).inv();
   int t0                              = 0;
   const TPinnedRangeSet::Range *range = foot->getPinnedRangeSet()->getRange(t);
-  if (range) t0                       = range->first;
+  if (range) t0 = range->first;
   while (t0 > 0) {
     TStageObject *oldFoot = getPinnedDescendant(t0 - 1);
     if (oldFoot == 0) break;  // oldFoot = this;
     assert(oldFoot != foot);
     TAffine changeFootAff =
         oldFoot->getPlacement(t0).inv() * foot->getPlacement(t0);
-    placement     = changeFootAff * placement;
-    foot          = oldFoot;
-    range         = oldFoot->getPinnedRangeSet()->getRange(t0 - 1);
-    t0            = 0;
+    placement = changeFootAff * placement;
+    foot      = oldFoot;
+    range     = oldFoot->getPinnedRangeSet()->getRange(t0 - 1);
+    t0        = 0;
     if (range) t0 = range->first;
   }
   m_ikflag--;
@@ -1412,7 +1412,7 @@ TAffine TStageObject::getPlacement(double t) {
   if (m_parent)
     place = m_parent->getPlacement(t) * computeLocalPlacement(tt);
   else
-    place        = computeLocalPlacement(tt);
+    place = computeLocalPlacement(tt);
   m_absPlacement = place;
   time           = t;
   return place;
@@ -1815,7 +1815,11 @@ void TStageObject::loadData(TIStream &is) {
     for (; itKfInd != keyframeIndexSet.end(); itKfInd++)
       setkey(m_scale, *itKfInd);
   }
-  updateKeyframes();
+  // Calling updateKeyframes() here may cause failure to load expressions
+  // especially if it refers to a curve which is to be loaded AFTER this
+  // function while loading scene process. So I will skip it assuming that
+  // updateKeyframes() will be called when it is actually needed.
+  // updateKeyframes();
   if (m_spline != 0 && isUppkEnabled())
     m_spline->addParam(m_posPath.getPointer());
   invalidate();
@@ -1851,8 +1855,8 @@ TStageObjectParams *TStageObject::getParams() const {
   data->m_cycleEnabled = m_cycleEnabled;
   data->m_spline       = m_spline;
 
-  data->m_handle                               = m_handle;
-  data->m_parentHandle                         = m_parentHandle;
+  data->m_handle       = m_handle;
+  data->m_parentHandle = m_parentHandle;
   if (m_pinnedRangeSet) data->m_pinnedRangeSet = m_pinnedRangeSet->clone();
 
   return data;
@@ -1918,7 +1922,7 @@ void TStageObject::assignParams(const TStageObjectParams *src,
   m_handle       = src->m_handle;
   m_parentHandle = src->m_parentHandle;
 
-  m_cycleEnabled                          = src->m_cycleEnabled;
+  m_cycleEnabled = src->m_cycleEnabled;
   if (m_pinnedRangeSet) *m_pinnedRangeSet = *src->m_pinnedRangeSet;
   updateKeyframes();
   if (m_spline && isUppkEnabled()) m_spline->addParam(m_posPath.getPointer());


### PR DESCRIPTION
This PR will fix #3405 

I have commented-out the line calling `updateKeyframes()` in `TStageObject::loadData()` .
Calling `updateKeyframes()` before completing loading the scene may cause failure to load expressions properly especially if it refers to a curve which is to be loaded lately in the loading scene process.
So I removed it assuming that `updateKeyframes()` will be called when it is actually needed as it is managed under the lazy data model.