### PR TITLE
Skip Unnecessary Icon Invalidation

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -297,9 +297,9 @@ void invalidateIcons() {
   s.m_paintIndex = mask & ToonzCheck::ePaint ? tc->getColorIndex() : -1;
   IconGenerator::instance()->setSettings(s);
 
-  // Force icons to refresh
+  // Force icons to refresh for Toonz Vector levels
   TXshLevel *sl = TApp::instance()->getCurrentLevel()->getLevel();
-  if (sl) {
+  if (sl && sl->getType() == PLI_XSHLEVEL) {
     std::vector<TFrameId> fids;
     sl->getFids(fids);
 
@@ -2026,7 +2026,7 @@ double SceneViewer::projectToZ(const TPointD &delta) {
   GLint viewport[4];
   double modelview[16], projection[16];
   glGetIntegerv(GL_VIEWPORT, viewport);
-  for (int i      = 0; i < 16; i++)
+  for (int i = 0; i < 16; i++)
     projection[i] = (double)m_projectionMatrix.constData()[i];
   glGetDoublev(GL_MODELVIEW_MATRIX, modelview);
 
@@ -2188,8 +2188,9 @@ void SceneViewer::zoomQt(bool forward, bool reset) {
     if (reset || ((m_zoomScale3D < 500 || !forward) &&
                   (m_zoomScale3D > 0.01 || forward))) {
       double oldZoomScale = m_zoomScale3D;
-      m_zoomScale3D       = reset ? 1 : ImageUtils::getQuantizedZoomFactor(
-                                      m_zoomScale3D, forward);
+      m_zoomScale3D =
+          reset ? 1
+                : ImageUtils::getQuantizedZoomFactor(m_zoomScale3D, forward);
 
       m_pan3D = -(m_zoomScale3D / oldZoomScale) * -m_pan3D;
     }
@@ -2210,17 +2211,18 @@ void SceneViewer::zoomQt(bool forward, bool reset) {
     int i;
 
     for (i = 0; i < 2; i++) {
-      TAffine &viewAff          = m_viewAff[i];
+      TAffine &viewAff = m_viewAff[i];
       if (m_isFlippedX) viewAff = viewAff * TScale(-1, 1);
       if (m_isFlippedX) viewAff = viewAff * TScale(1, -1);
-      double scale2             = std::abs(viewAff.det());
+      double scale2 = std::abs(viewAff.det());
       if (m_isFlippedX) viewAff = viewAff * TScale(-1, 1);
       if (m_isFlippedX) viewAff = viewAff * TScale(1, -1);
       if (reset || ((scale2 < 100000 || !forward) &&
                     (scale2 > 0.001 * 0.05 || forward))) {
         double oldZoomScale = sqrt(scale2) * dpiFactor;
-        double zoomScale    = reset ? 1 : ImageUtils::getQuantizedZoomFactor(
-                                           oldZoomScale, forward);
+        double zoomScale =
+            reset ? 1
+                  : ImageUtils::getQuantizedZoomFactor(oldZoomScale, forward);
 
         // threshold value -0.001 is intended to absorb the error of calculation
         if ((oldZoomScale - zoomScaleFittingWithScreen) *
@@ -2523,9 +2525,9 @@ void SceneViewer::fitToCamera() {
   TPointD P11       = cameraAff * cameraRect.getP11();
   TPointD p0        = TPointD(std::min({P00.x, P01.x, P10.x, P11.x}),
                        std::min({P00.y, P01.y, P10.y, P11.y}));
-  TPointD p1 = TPointD(std::max({P00.x, P01.x, P10.x, P11.x}),
+  TPointD p1        = TPointD(std::max({P00.x, P01.x, P10.x, P11.x}),
                        std::max({P00.y, P01.y, P10.y, P11.y}));
-  cameraRect = TRectD(p0.x, p0.y, p1.x, p1.y);
+  cameraRect        = TRectD(p0.x, p0.y, p1.x, p1.y);
 
   // Pan
   if (!is3DView()) {
@@ -2568,9 +2570,9 @@ void SceneViewer::fitToCameraOutline() {
   TPointD P11       = cameraAff * cameraRect.getP11();
   TPointD p0        = TPointD(std::min({P00.x, P01.x, P10.x, P11.x}),
                        std::min({P00.y, P01.y, P10.y, P11.y}));
-  TPointD p1 = TPointD(std::max({P00.x, P01.x, P10.x, P11.x}),
+  TPointD p1        = TPointD(std::max({P00.x, P01.x, P10.x, P11.x}),
                        std::max({P00.y, P01.y, P10.y, P11.y}));
-  cameraRect = TRectD(p0.x, p0.y, p1.x, p1.y);
+  cameraRect        = TRectD(p0.x, p0.y, p1.x, p1.y);
 
   // Pan
   if (!is3DView()) {
@@ -2620,8 +2622,8 @@ void SceneViewer::resetZoom() {
   TPointD realCenter(m_viewAff[m_viewMode].a13, m_viewAff[m_viewMode].a23);
   TAffine aff =
       getNormalZoomScale() * TRotation(realCenter, m_rotationAngle[m_viewMode]);
-  aff.a13               = realCenter.x;
-  aff.a23               = realCenter.y;
+  aff.a13 = realCenter.x;
+  aff.a23 = realCenter.y;
   if (m_isFlippedX) aff = aff * TScale(-1, 1);
   if (m_isFlippedY) aff = aff * TScale(1, -1);
   setViewMatrix(aff, m_viewMode);
@@ -2678,16 +2680,17 @@ void SceneViewer::setActualPixelSize() {
   } else
     dpi = sl->getDpi(fid);
 
-  const double inch             = Stage::inch;
-  TAffine tempAff               = getNormalZoomScale();
-  if (m_isFlippedX) tempAff     = tempAff * TScale(-1, 1);
-  if (m_isFlippedY) tempAff     = tempAff * TScale(1, -1);
-  TPointD tempScale             = dpi;
+  const double inch = Stage::inch;
+  TAffine tempAff   = getNormalZoomScale();
+  if (m_isFlippedX) tempAff = tempAff * TScale(-1, 1);
+  if (m_isFlippedY) tempAff = tempAff * TScale(1, -1);
+  TPointD tempScale = dpi;
   if (m_isFlippedX) tempScale.x = -tempScale.x;
   if (m_isFlippedY) tempScale.y = -tempScale.y;
   for (int i = 0; i < m_viewAff.size(); ++i)
-    setViewMatrix(dpi == TPointD(0, 0) ? tempAff : TScale(tempScale.x / inch,
-                                                          tempScale.y / inch),
+    setViewMatrix(dpi == TPointD(0, 0)
+                      ? tempAff
+                      : TScale(tempScale.x / inch, tempScale.y / inch),
                   i);
 
   m_pos         = QPoint(0, 0);
@@ -2970,7 +2973,7 @@ void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
 
   TStageObject *pegbar =
       objId != TStageObjectId::NoneId ? xsh->getStageObject(objId) : 0;
-  const TStroke *stroke                     = 0;
+  const TStroke *stroke = 0;
   if (pegbar && pegbar->getSpline()) stroke = pegbar->getSpline()->getStroke();
   if (!stroke) return;
 

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -593,6 +593,10 @@ void TApp::onPaletteChanged() { m_currentScene->setDirtyFlag(true); }
 //-----------------------------------------------------------------------------
 
 void TApp::onLevelColorStyleSwitched() {
+  TXshLevel *sl = m_currentLevel->getLevel();
+  if (!sl || (sl->getType() != TZP_XSHLEVEL && sl->getType() != PLI_XSHLEVEL))
+    return;
+
   TPaletteHandle *ph = m_paletteController->getCurrentLevelPalette();
   assert(ph);
 
@@ -610,14 +614,12 @@ void TApp::onLevelColorStyleSwitched() {
 
       IconGenerator::instance()->setSettings(s);
 
-      TXshLevel *sl = m_currentLevel->getLevel();
-      if (!sl) return;
-
-      std::vector<TFrameId> fids;
-      sl->getFids(fids);
-
-      for (int i = 0; i < (int)fids.size(); i++)
-        IconGenerator::instance()->invalidate(sl, fids[i]);
+      if (sl->getType() == PLI_XSHLEVEL) {
+        std::vector<TFrameId> fids;
+        sl->getFids(fids);
+        for (int i = 0; i < (int)fids.size(); i++)
+          IconGenerator::instance()->invalidate(sl, fids[i]);
+      }
 
       m_currentLevel->notifyLevelViewChange();
     }

--- a/toonz/sources/toonzlib/tpalettehandle.cpp
+++ b/toonz/sources/toonzlib/tpalettehandle.cpp
@@ -149,6 +149,8 @@ void TPaletteHandle::setPalette(TPalette *palette, int styleIndex) {
     m_styleParamIndex = 0;
 
     emit paletteSwitched();
+    // to let ToonzCheck to update the current index
+    emit broadcastColorStyleSwitched();
   }
 }
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1600,6 +1600,7 @@ void TXshSimpleLevel::saveSimpleLevel(const TFilePath &decodedFp,
 
     if (TSystem::doesExistFileOrLevel(decodedFp)) {
       TLevelReaderP lr(decodedFp);
+      lr->doReadPalette(false);
       const TImageInfo *imageInfo = m_frames.empty()
                                         ? lr->getImageInfo()
                                         : lr->getImageInfo(*(m_frames.begin()));


### PR DESCRIPTION
This PR fixes the following problem:

**To reproduce:**
- Open or create Toonz Raster level with relatively large amount of frames (say, 100 frames).
- Edit the level.
- Toggle some checking option like `Paint Check` or `Ink Check`.
- Immediately try to save the level.

Saving sometimes fails with the warning saying `Can't open file. Access may be denied or someone else may be saving the same file.`

After introducing  #3192 OT regenerates all icons when toggling the check. Regeneration is done by sub threads. The threads grab the level files through their tasks and prevent the main thread to access and save the same level properly.

For Toonz Raster Levels, icons are cached as color-mapped raster. Therefore, they don't need to be regenerated for reflecting the palette changes (like toggling Paint Check which only alters the some style color to red.) And Raster level icons does not need to be updated as the checks have no effect to them. 
So I skip unncessary icon invalidation at line 302 in sceneviewer.cpp, the same modificaiton applied in  `TApp::onLevelColorStyleSwitched()` as well.