### PR TITLE
Expanding the radius of the rotation handle.

### DIFF
--- a/toonz/sources/tnztools/selectiontool.cpp
+++ b/toonz/sources/tnztools/selectiontool.cpp
@@ -923,9 +923,9 @@ void SelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
 
   double pixelSize = getPixelSize();
   if (!bbox.isEmpty()) {
-    double maxDist  = 8 * pixelSize;
+    double maxDist  = 17 * pixelSize;
     double maxDist2 = maxDist * maxDist;
-    double p        = (12 * pixelSize) - 3 * pixelSize;
+    double p        = (15 * pixelSize);
     m_selectedPoint = NONE;
     if (tdistance2(bbox.getP00(), pos) < maxDist2 + p)
       m_selectedPoint = P00;


### PR DESCRIPTION
This just changes when the cursor transforms into the rotation tool.  Before there was not a lot of space to activate the rotate handle.  
![rotate](https://user-images.githubusercontent.com/65507211/89822188-ce4e6480-db1d-11ea-9170-e769370c11d9.gif)

By adjusting the parameters a tad now it is a lot easier to grab and turn your object.  Thanks.
