### PR TITLE
cmake: Fix SuperLU include discovery on Fedora 32

### DIFF
--- a/toonz/cmake/FindSuperLU.cmake
+++ b/toonz/cmake/FindSuperLU.cmake
@@ -4,6 +4,7 @@ if(WITH_SYSTEM_SUPERLU)
     set(_header_hints)
     set(_header_suffixes
         superlu
+        SuperLU
     )
     set(_lib_suffixes)
 else()


### PR DESCRIPTION
```
$ rpm -qa | grep SuperLU
SuperLU-devel-5.2.1-8.fc32.x86_64
SuperLU-5.2.1-8.fc32.x86_64
```

```
$ dnf provides /usr/include/SuperLU
Last metadata expiration check: 0:07:22 ago on Thu 27 Aug 2020 12:04:38 PM CDT.
SuperLU-devel-5.2.1-8.fc32.x86_64 : Header files and libraries for SuperLU development
Repo        : @System
Matched from:
Filename    : /usr/include/SuperLU
```


With this, opentoolz builds on Fedora 32