### PR TITLE
Replace the palette's freeze button icon

### DIFF
--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -46,7 +46,6 @@ TPanel::TPanel(QWidget *parent, Qt::WindowFlags flags,
     , m_panelType("")
     , m_isMaximizable(true)
     , m_isMaximized(false)
-    , m_isActive(true)
     , m_panelTitleBar(0)
     , m_multipleInstancesAllowed(true) {
   // setFeatures(QDockWidget::DockWidgetMovable |
@@ -78,15 +77,6 @@ TPanel::~TPanel() {
     if (SaveLoadQSettings *persistent =
             dynamic_cast<SaveLoadQSettings *>(widget()))
       persistent->save(settings);
-  }
-}
-
-//-----------------------------------------------------------------------------
-
-void TPanel::setActive(bool value) {
-  m_isActive = value;
-  if (m_panelTitleBar) {
-    m_panelTitleBar->setIsActive(m_isActive);
   }
 }
 
@@ -401,16 +391,9 @@ void TPanelTitleBarButtonSet::select(TPanelTitleBarButton *button) {
 
 TPanelTitleBar::TPanelTitleBar(QWidget *parent,
                                TDockWidget::Orientation orientation)
-    : QFrame(parent), m_isActive(true), m_closeButtonHighlighted(false) {
+    : QFrame(parent), m_closeButtonHighlighted(false) {
   setMouseTracking(true);
   setFocusPolicy(Qt::NoFocus);
-}
-
-//-----------------------------------------------------------------------------
-
-void TPanelTitleBar::setIsActive(bool value) {
-  if (m_isActive == value) return;
-  m_isActive = value;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -111,7 +111,6 @@ signals:
 class TPanelTitleBar final : public QFrame {
   Q_OBJECT
 
-  bool m_isActive;
   bool m_closeButtonHighlighted;
   std::vector<std::pair<QPoint, QWidget *>> m_buttons;
 
@@ -124,9 +123,6 @@ public:
 
   QSize sizeHint() const override { return minimumSizeHint(); }
   QSize minimumSizeHint() const override;
-
-  void setIsActive(bool value);
-  bool isActive() { return m_isActive; }
 
   // pos = widget position. n.b. if pos.x()<0 then origin is topright corner
   void add(const QPoint &pos, QWidget *widget);
@@ -192,7 +188,6 @@ class TPanel : public TDockWidget {
   std::string m_panelType;
   bool m_isMaximizable;
   bool m_isMaximized;
-  bool m_isActive;
   bool m_multipleInstancesAllowed;
 
   TPanelTitleBar *m_panelTitleBar;
@@ -215,9 +210,6 @@ public:
 
   QList<TPanel *> getHiddenDockWidget() const { return m_hiddenDockWidgets; }
   QByteArray getSavedOldState() const { return m_currentRoomOldState; }
-
-  bool isActive() { return m_isActive; }
-  void setActive(bool value);
 
   // void setTitleBarWidget(TPanelTitleBar *newTitleBar);
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -423,7 +423,7 @@ public:
 //-----------------------------------------------------------------------------
 
 PaletteViewerPanel::PaletteViewerPanel(QWidget *parent)
-    : StyleShortcutSwitchablePanel(parent) {
+    : StyleShortcutSwitchablePanel(parent), m_isFrozen(false) {
   m_paletteHandle = new TPaletteHandle();
   connect(m_paletteHandle, SIGNAL(colorStyleSwitched()),
           SLOT(onColorStyleSwitched()));
@@ -465,19 +465,20 @@ int PaletteViewerPanel::getViewType() { return m_paletteViewer->getViewMode(); }
 void PaletteViewerPanel::reset() {
   m_paletteViewer->setPaletteHandle(
       TApp::instance()->getPaletteController()->getCurrentLevelPalette());
-  m_isCurrentButton->setPressed(true);
-  setActive(true);
+  m_freezeButton->setPressed(false);
+  setFrozen(false);
 }
 
 //-----------------------------------------------------------------------------
 
 void PaletteViewerPanel::initializeTitleBar() {
-  m_isCurrentButton = new TPanelTitleBarButton(
-      getTitleBar(), svgToPixmap(getIconThemePath("actions/18/switch.svg")));
-  getTitleBar()->add(QPoint(-54, 0), m_isCurrentButton);
-  m_isCurrentButton->setPressed(true);
-  connect(m_isCurrentButton, SIGNAL(toggled(bool)),
-          SLOT(onCurrentButtonToggled(bool)));
+  m_freezeButton = new TPanelTitleBarButton(
+      getTitleBar(), getIconThemePath("actions/20/pane_freeze.svg"));
+  m_freezeButton->setToolTip("Freeze");
+  getTitleBar()->add(QPoint(-54, 0), m_freezeButton);
+  m_freezeButton->setPressed(m_isFrozen);
+  connect(m_freezeButton, SIGNAL(toggled(bool)),
+          SLOT(onFreezeButtonToggled(bool)));
 }
 
 //-----------------------------------------------------------------------------
@@ -494,23 +495,23 @@ void PaletteViewerPanel::onPaletteSwitched() {
 
 //-----------------------------------------------------------------------------
 
-void PaletteViewerPanel::onCurrentButtonToggled(bool isCurrent) {
-  if (isActive() == isCurrent) return;
+void PaletteViewerPanel::onFreezeButtonToggled(bool frozen) {
+  if (isFrozen() == frozen) return;
 
   TApp *app          = TApp::instance();
   TPaletteHandle *ph = app->getPaletteController()->getCurrentLevelPalette();
   // Se sono sulla palette del livello corrente e le palette e' vuota non
   // consento di bloccare il pannello.
-  if (isActive() && !ph->getPalette()) {
-    m_isCurrentButton->setPressed(true);
+  if (!isFrozen() && !ph->getPalette()) {
+    m_freezeButton->setPressed(false);
     return;
   }
 
-  setActive(isCurrent);
-  m_paletteViewer->enableSaveAction(isCurrent);
+  setFrozen(frozen);
+  m_paletteViewer->enableSaveAction(!frozen);
 
   // Cambio il livello corrente
-  if (isCurrent) {
+  if (!frozen) {
     std::set<TXshSimpleLevel *> levels;
     TXsheet *xsheet = app->getCurrentXsheet()->getXsheet();
     int row, column;
@@ -553,14 +554,14 @@ void PaletteViewerPanel::onCurrentButtonToggled(bool isCurrent) {
 void PaletteViewerPanel::onSceneSwitched() {
   // Se e' il paletteHandle del livello corrente l'aggiornamento viene fatto
   // grazie all'aggiornamento del livello.
-  if (isActive()) return;
+  if (!isFrozen()) return;
 
   // Setto a zero la palette del "paletteHandle bloccato".
   m_paletteHandle->setPalette(0);
   // Sblocco il viewer nel caso in cui il e' bloccato.
-  if (!isActive()) {
-    setActive(true);
-    m_isCurrentButton->setPressed(true);
+  if (isFrozen()) {
+    setFrozen(false);
+    m_freezeButton->setPressed(false);
     m_paletteViewer->setPaletteHandle(
         TApp::instance()->getPaletteController()->getCurrentLevelPalette());
   }

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -40,8 +40,8 @@ class PaletteViewerPanel final : public StyleShortcutSwitchablePanel {
   TPaletteHandle *m_paletteHandle;
   PaletteViewer *m_paletteViewer;
 
-  TPanelTitleBarButton *m_isCurrentButton;
-  bool m_isCurrent;
+  TPanelTitleBarButton *m_freezeButton;
+  bool m_isFrozen;
 
 public:
   PaletteViewerPanel(QWidget *parent);
@@ -51,6 +51,9 @@ public:
 
   void reset() override;
 
+  bool isFrozen() { return m_isFrozen; }
+  void setFrozen(bool frozen) { m_isFrozen = frozen; }
+
 protected:
   void initializeTitleBar();
   bool isActivatableOnEnter() override { return true; }
@@ -58,7 +61,7 @@ protected:
 protected slots:
   void onColorStyleSwitched();
   void onPaletteSwitched();
-  void onCurrentButtonToggled(bool isCurrent);
+  void onFreezeButtonToggled(bool isFrozen);
   void onSceneSwitched();
 };
 
@@ -277,18 +280,18 @@ protected:
 //---------------------------------------------------------
 
 class SceneViewerPanelContainer final : public StyleShortcutSwitchablePanel {
-    Q_OBJECT
-        SceneViewerPanel *m_sceneViewer;
+  Q_OBJECT
+  SceneViewerPanel *m_sceneViewer;
 
 public:
-    SceneViewerPanelContainer(QWidget* parent);
-    // reimplementation of TPanel::widgetInThisPanelIsFocused
-    bool widgetInThisPanelIsFocused() override;
+  SceneViewerPanelContainer(QWidget *parent);
+  // reimplementation of TPanel::widgetInThisPanelIsFocused
+  bool widgetInThisPanelIsFocused() override;
 
 protected:
-    // reimplementation of TPanel::widgetFocusOnEnter
-    void widgetFocusOnEnter() override;
-    void widgetClearFocusOnLeave() override;
+  // reimplementation of TPanel::widgetFocusOnEnter
+  void widgetFocusOnEnter() override;
+  void widgetClearFocusOnLeave() override;
 };
 
 //=========================================================


### PR DESCRIPTION
This PR will replace the "freeze" button icon by the "pause VCR button" icon - the same icon as the ones in the Viewer and the Flipbook in order to gain consistency.

![palette_freeze_button](https://user-images.githubusercontent.com/17974955/93312876-b23b9280-f842-11ea-85cb-52061b7c2351.png)

Please note that now the state of the button has opposite meaning: The button had been with the "I/O power" icon which means that the panel synchronizes with the current palette when it is activated. Now the panel won't synchronize when the freeze button is activated.

@konero sorry for the change but I would be happy if you accepted my proposal.