### PR TITLE
Fix extra selection in palette

### DIFF
--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -999,6 +999,8 @@ void PageViewer::mousePressEvent(QMouseEvent *event) {
     if (ShowNewStyleButton && indexInPage == getChipCount() &&
         !m_page->getPalette()->isLocked()) {
       PaletteCmd::createStyle(getPaletteHandle(), getPage());
+      m_styleSelection->select(pageIndex);
+      m_styleSelection->select(pageIndex, indexInPage, true);
     } else {
       // the user clicked out of the color chips.wants to deselect everything
       // (leaving the selection active, for a possible paste)


### PR DESCRIPTION
When using the new style button, sometimes the old selected style would stay highlighted. This should fix that.
(Note: This bug fix was implemented in Tahoma.)

Co-Authored-By: Jeremy Bullock <turtletooth@users.noreply.github.com>
