### PR TITLE
Render bug

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -390,8 +390,12 @@ void TSystem::renameFile(const TFilePath &dst, const TFilePath &src,
 
 // gestire gli errori con GetLastError?
 void TSystem::deleteFile(const TFilePath &fp) {
-  if (!QFile::remove(toQString(fp)))
-    throw TSystemException(fp, "can't delete file!");
+  if (TSystem::doesExistFileOrLevel(fp)) {
+    if (fp.getQString().contains("cache")) {
+      QFile::remove(toQString(fp));
+    } else if (!QFile::remove(toQString(fp)))
+      throw TSystemException(fp, "can't delete file!");
+  }
 }
 
 //------------------------------------------------------------


### PR DESCRIPTION
During render, certain cache files are deleted and sometimes the deletion fails. This keeps it from flipping out if the delete fails.

Co-Authored-By: Jeremy Bullock <4576381+jeremybullock@users.noreply.github.com>