### PR TITLE
Additional Style Sheet

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -953,6 +953,7 @@ QComboBox QAbstractItemView {
 .LineEdit,
 QPlainTextEdit,
 QLineEdit,
+QTextEdit,
 #TaskSheetItem,
 #tasksRemoveBox,
 #tasksAddBox {
@@ -967,6 +968,7 @@ QLineEdit,
 .LineEdit:focus,
 QPlainTextEdit:focus,
 QLineEdit:focus,
+QTextEdit:focus,
 #TaskSheetItem:focus,
 #tasksRemoveBox:focus,
 #tasksAddBox:focus {
@@ -977,6 +979,7 @@ QLineEdit:focus,
 .LineEdit:disabled,
 QPlainTextEdit:disabled,
 QLineEdit:disabled,
+QTextEdit:disabled,
 #TaskSheetItem:disabled,
 #tasksRemoveBox:disabled,
 #tasksAddBox:disabled {

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -953,6 +953,7 @@ QComboBox QAbstractItemView {
 .LineEdit,
 QPlainTextEdit,
 QLineEdit,
+QTextEdit,
 #TaskSheetItem,
 #tasksRemoveBox,
 #tasksAddBox {
@@ -967,6 +968,7 @@ QLineEdit,
 .LineEdit:focus,
 QPlainTextEdit:focus,
 QLineEdit:focus,
+QTextEdit:focus,
 #TaskSheetItem:focus,
 #tasksRemoveBox:focus,
 #tasksAddBox:focus {
@@ -977,6 +979,7 @@ QLineEdit:focus,
 .LineEdit:disabled,
 QPlainTextEdit:disabled,
 QLineEdit:disabled,
+QTextEdit:disabled,
 #TaskSheetItem:disabled,
 #tasksRemoveBox:disabled,
 #tasksAddBox:disabled {

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -953,6 +953,7 @@ QComboBox QAbstractItemView {
 .LineEdit,
 QPlainTextEdit,
 QLineEdit,
+QTextEdit,
 #TaskSheetItem,
 #tasksRemoveBox,
 #tasksAddBox {
@@ -967,6 +968,7 @@ QLineEdit,
 .LineEdit:focus,
 QPlainTextEdit:focus,
 QLineEdit:focus,
+QTextEdit:focus,
 #TaskSheetItem:focus,
 #tasksRemoveBox:focus,
 #tasksAddBox:focus {
@@ -977,6 +979,7 @@ QLineEdit:focus,
 .LineEdit:disabled,
 QPlainTextEdit:disabled,
 QLineEdit:disabled,
+QTextEdit:disabled,
 #TaskSheetItem:disabled,
 #tasksRemoveBox:disabled,
 #tasksAddBox:disabled {

--- a/stuff/config/qss/Default/less/layouts/controls.less
+++ b/stuff/config/qss/Default/less/layouts/controls.less
@@ -145,7 +145,8 @@ QComboBox {
 }
 
 QPlainTextEdit
-,QLineEdit {
+,QLineEdit
+,QTextEdit {
   &:extend(.LineEdit all);
 }
 

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -953,6 +953,7 @@ QComboBox QAbstractItemView {
 .LineEdit,
 QPlainTextEdit,
 QLineEdit,
+QTextEdit,
 #TaskSheetItem,
 #tasksRemoveBox,
 #tasksAddBox {
@@ -967,6 +968,7 @@ QLineEdit,
 .LineEdit:focus,
 QPlainTextEdit:focus,
 QLineEdit:focus,
+QTextEdit:focus,
 #TaskSheetItem:focus,
 #tasksRemoveBox:focus,
 #tasksAddBox:focus {
@@ -977,6 +979,7 @@ QLineEdit:focus,
 .LineEdit:disabled,
 QPlainTextEdit:disabled,
 QLineEdit:disabled,
+QTextEdit:disabled,
 #TaskSheetItem:disabled,
 #tasksRemoveBox:disabled,
 #tasksAddBox:disabled {

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -953,6 +953,7 @@ QComboBox QAbstractItemView {
 .LineEdit,
 QPlainTextEdit,
 QLineEdit,
+QTextEdit,
 #TaskSheetItem,
 #tasksRemoveBox,
 #tasksAddBox {
@@ -967,6 +968,7 @@ QLineEdit,
 .LineEdit:focus,
 QPlainTextEdit:focus,
 QLineEdit:focus,
+QTextEdit:focus,
 #TaskSheetItem:focus,
 #tasksRemoveBox:focus,
 #tasksAddBox:focus {
@@ -977,6 +979,7 @@ QLineEdit:focus,
 .LineEdit:disabled,
 QPlainTextEdit:disabled,
 QLineEdit:disabled,
+QTextEdit:disabled,
 #TaskSheetItem:disabled,
 #tasksRemoveBox:disabled,
 #tasksAddBox:disabled {

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -192,7 +192,10 @@ public:
   QStringList getLanguageList() const { return m_languageList; }
   QMap<int, QString> getRoomMap() const { return m_roomMaps; }
 
-  QString getCurrentStyleSheetPath() const;  // OK
+  QString getCurrentStyleSheet() const;
+  QString getAdditionalStyleSheet() const {
+    return getStringValue(additionalStyleSheet);
+  }
   bool getPixelsOnly() const { return getBoolValue(pixelsOnly); }
   QString getOldUnits() const { return getStringValue(oldUnits); }
   QString getOldCameraUnits() const { return getStringValue(oldCameraUnits); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -24,6 +24,7 @@ enum PreferencesItemId {
   //----------
   // Interface
   CurrentStyleSheetName,
+  additionalStyleSheet,
   iconTheme,
   pixelsOnly,
   oldUnits,

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -223,7 +223,7 @@ project->setUseScenePath(TProject::Extras, false);
   // Imposto la rootDir per ImageCache
 
   /*-- TOONZCACHEROOTの設定  --*/
-  TFilePath cacheDir               = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheDir = ToonzFolder::getCacheRootFolder();
   if (cacheDir.isEmpty()) cacheDir = TEnv::getStuffDir() + "cache";
   TImageCache::instance()->setRootDir(cacheDir);
 }
@@ -322,10 +322,10 @@ int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
 
 #ifdef MACOSX
-// This workaround is to avoid missing left button problem on Qt5.6.0.
-// To invalidate m_rightButtonClicked in Qt/qnsview.mm, sending
-// NSLeftButtonDown event before NSLeftMouseDragged event propagated to
-// QApplication. See more details in ../mousedragfilter/mousedragfilter.mm.
+  // This workaround is to avoid missing left button problem on Qt5.6.0.
+  // To invalidate m_rightButtonClicked in Qt/qnsview.mm, sending
+  // NSLeftButtonDown event before NSLeftMouseDragged event propagated to
+  // QApplication. See more details in ../mousedragfilter/mousedragfilter.mm.
 
 #include "mousedragfilter.h"
 
@@ -685,7 +685,7 @@ int main(int argc, char *argv[]) {
   a.processEvents();
 
   // Carico lo styleSheet
-  QString currentStyle = Preferences::instance()->getCurrentStyleSheetPath();
+  QString currentStyle = Preferences::instance()->getCurrentStyleSheet();
   a.setStyleSheet(currentStyle);
 
   w.setWindowTitle(QString::fromStdString(TEnv::getApplicationFullName()));

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1297,7 +1297,7 @@ void MainWindow::onMenuCheckboxChanged() {
     FieldGuideToggleAction = isChecked;
   else if (cm->getAction(MI_RasterizePli) == action) {
     if (!QGLPixelBuffer::hasOpenGLPbuffers()) isChecked = 0;
-    RasterizePliToggleAction                            = isChecked;
+    RasterizePliToggleAction = isChecked;
   } else if (cm->getAction(MI_SafeArea) == action)
     SafeAreaToggleAction = isChecked;
   else if (cm->getAction(MI_ViewColorcard) == action)
@@ -3422,7 +3422,7 @@ void MainWindow::clearCacheFolder() {
   // 1. $CACHE/[Current ProcessID]
   // 2. $CACHE/temp/[Current scene folder] if the current scene is untitled
 
-  TFilePath cacheRoot                = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheRoot = ToonzFolder::getCacheRootFolder();
   if (cacheRoot.isEmpty()) cacheRoot = TEnv::getStuffDir() + "cache";
 
   TFilePathSet filesToBeRemoved;
@@ -3502,12 +3502,8 @@ class ReloadStyle final : public MenuItemHandler {
 public:
   ReloadStyle() : MenuItemHandler("MI_ReloadStyle") {}
   void execute() override {
-    QString currentStyle = Preferences::instance()->getCurrentStyleSheetPath();
-    QFile file(currentStyle);
-    file.open(QFile::ReadOnly);
-    QString styleSheet = QString(file.readAll());
-    qApp->setStyleSheet(styleSheet);
-    file.close();
+    QString currentStyle = Preferences::instance()->getCurrentStyleSheet();
+    qApp->setStyleSheet(currentStyle);
   }
 } reloadStyle;
 
@@ -3536,9 +3532,9 @@ RecentFiles::~RecentFiles() {}
 void RecentFiles::addFilePath(QString path, FileType fileType,
                               QString projectName) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   int i;
   for (i = 0; i < files.size(); i++)
     if (files.at(i) == path) {
@@ -3705,9 +3701,9 @@ void RecentFiles::saveRecentFiles() {
 
 QList<QString> RecentFiles::getFilesNameList(FileType fileType) {
   QList<QString> files =
-      (fileType == Scene) ? m_recentScenes : (fileType == Level)
-                                                 ? m_recentLevels
-                                                 : m_recentFlipbookImages;
+      (fileType == Scene)
+          ? m_recentScenes
+          : (fileType == Level) ? m_recentLevels : m_recentFlipbookImages;
   QList<QString> names;
   int i;
   for (i = 0; i < files.size(); i++) {
@@ -3734,9 +3730,9 @@ void RecentFiles::refreshRecentFilesMenu(FileType fileType) {
     menu->setEnabled(false);
   else {
     CommandId clearActionId =
-        (fileType == Scene) ? MI_ClearRecentScene : (fileType == Level)
-                                                        ? MI_ClearRecentLevel
-                                                        : MI_ClearRecentImage;
+        (fileType == Scene)
+            ? MI_ClearRecentScene
+            : (fileType == Level) ? MI_ClearRecentLevel : MI_ClearRecentImage;
     menu->setActions(names);
     menu->addSeparator();
     QAction *clearAction = CommandManager::instance()->getAction(clearActionId);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -102,7 +102,7 @@ SizeField::SizeField(QSize min, QSize max, QSize value, QWidget* parent)
   bool ret = true;
   ret      = ret && connect(m_fieldX, SIGNAL(editingFinished()), this,
                        SIGNAL(editingFinished()));
-  ret = ret && connect(m_fieldY, SIGNAL(editingFinished()), this,
+  ret      = ret && connect(m_fieldY, SIGNAL(editingFinished()), this,
                        SIGNAL(editingFinished()));
   assert(ret);
 }
@@ -267,6 +267,53 @@ Preferences::LevelFormat PreferencesPopup::FormatProperties::levelFormat()
 }
 
 //**********************************************************************************
+//    PreferencesPopup::AdditionalStyleEdit  implementation
+//**********************************************************************************
+
+PreferencesPopup::AdditionalStyleEdit::AdditionalStyleEdit(
+    PreferencesPopup* parent)
+    : DVGui::Dialog(parent, true, false, "AdditionalStyleEdit") {
+  setWindowTitle(tr("Additional Style Sheet"));
+  setModal(true);
+
+  m_edit                   = new QTextEdit(this);
+  QPushButton* okButton    = new QPushButton(tr("OK"), this);
+  QPushButton* applyButton = new QPushButton(tr("Apply"), this);
+  QPushButton* closeButton = new QPushButton(tr("Close"), this);
+
+  QString placeHolderTxt(
+      "/* Type additional style sheet here to customize GUI. \n"
+      "   Example: To enlarge the Style Editor buttons */\n\n"
+      "#StyleEditor #bottomWidget QPushButton{ \n  padding : 13 21; \n }");
+  m_edit->setPlaceholderText(placeHolderTxt);
+  m_edit->setAcceptRichText(false);
+
+  m_topLayout->addWidget(m_edit);
+
+  addButtonBarWidget(okButton, applyButton, closeButton);
+
+  bool ret = true;
+  ret      = ret && connect(okButton, SIGNAL(pressed()), this, SLOT(onOK()));
+  ret = ret && connect(applyButton, SIGNAL(pressed()), this, SLOT(onApply()));
+  ret = ret && connect(closeButton, SIGNAL(pressed()), this, SLOT(close()));
+}
+
+void PreferencesPopup::AdditionalStyleEdit::showEvent(QShowEvent*) {
+  m_edit->setPlainText(Preferences::instance()->getAdditionalStyleSheet());
+}
+
+void PreferencesPopup::AdditionalStyleEdit::onOK() {
+  onApply();
+  close();
+}
+
+void PreferencesPopup::AdditionalStyleEdit::onApply() {
+  Preferences::instance()->setValue(additionalStyleSheet,
+                                    m_edit->toPlainText());
+  emit additionalSheetEdited();
+}
+
+//**********************************************************************************
 //    PreferencesPopup  implementation
 //**********************************************************************************
 
@@ -348,7 +395,7 @@ void PreferencesPopup::onPathAliasPriorityChanged() {
 
 void PreferencesPopup::onStyleSheetTypeChanged() {
   QApplication::setOverrideCursor(Qt::WaitCursor);
-  QString currentStyle = m_pref->getCurrentStyleSheetPath();
+  QString currentStyle = m_pref->getCurrentStyleSheet();
   qApp->setStyleSheet(currentStyle);
   QApplication::restoreOverrideCursor();
 }
@@ -602,6 +649,25 @@ void PreferencesPopup::onProjectRootChanged() {
 }
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onEditAdditionalStyleSheet() {
+  if (!m_additionalStyleEdit) {
+    m_additionalStyleEdit = new AdditionalStyleEdit(this);
+
+    bool ret = connect(m_additionalStyleEdit, SIGNAL(additionalSheetEdited()),
+                       this, SLOT(onAdditionalStyleSheetEdited()));
+    assert(ret);
+  }
+  m_additionalStyleEdit->show();
+}
+
+//-----------------------------------------------------------------------------
+
+void PreferencesPopup::onAdditionalStyleSheetEdited() {
+  onStyleSheetTypeChanged();
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onPixelUnitExternallySelected(bool on) {
   CheckBox* pixelsOnlyCB = getUI<CheckBox*>(pixelsOnly);
   // call slot function onPixelsOnlyChanged() accordingly
@@ -621,7 +687,7 @@ void PreferencesPopup::onInterfaceFontChanged(const QString& text) {
   for (ComboBoxItem& item : newStyleItems)
     fontStyleCombo->addItem(item.first, item.second);
   if (!oldTypeface.isEmpty()) {
-    int newIndex               = fontStyleCombo->findText(oldTypeface);
+    int newIndex = fontStyleCombo->findText(oldTypeface);
     if (newIndex < 0) newIndex = 0;
     fontStyleCombo->setCurrentIndex(newIndex);
   }
@@ -729,7 +795,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
       for (const ComboBoxItem& item : comboItems)
         combo->addItem(item.first, item.second);
       combo->setCurrentIndex(combo->findData(item.value));
-      ret = connect(combo, SIGNAL(currentIndexChanged(int)), this,
+      ret    = connect(combo, SIGNAL(currentIndexChanged(int)), this,
                     SLOT(onChange()));
       widget = combo;
     } else {  // create IntLineEdit
@@ -766,7 +832,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
     if (id == interfaceFont) {  // create QFontComboBox
       QFontComboBox* combo = new QFontComboBox(this);
       combo->setCurrentText(item.value.toString());
-      ret = connect(combo, SIGNAL(currentIndexChanged(const QString&)), this,
+      ret    = connect(combo, SIGNAL(currentIndexChanged(const QString&)), this,
                     SLOT(onInterfaceFontChanged(const QString&)));
       widget = combo;
     } else if (!comboItems.isEmpty()) {  // create QComboBox
@@ -774,7 +840,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
       for (const ComboBoxItem& item : comboItems)
         combo->addItem(item.first, item.second);
       combo->setCurrentIndex(combo->findData(item.value));
-      ret = connect(combo, SIGNAL(currentIndexChanged(int)), this,
+      ret    = connect(combo, SIGNAL(currentIndexChanged(int)), this,
                     SLOT(onChange()));
       widget = combo;
     } else {  // create FileField
@@ -797,7 +863,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
   {
     ColorField* field =
         new ColorField(this, false, colorToTPixel(item.value.value<QColor>()));
-    ret = connect(field, SIGNAL(colorChanged(const TPixel32&, bool)), this,
+    ret    = connect(field, SIGNAL(colorChanged(const TPixel32&, bool)), this,
                   SLOT(onColorFieldChanged(const TPixel32&, bool)));
     widget = field;
   } break;
@@ -1205,7 +1271,9 @@ inline T PreferencesPopup::getUI(PreferencesItemId id) {
 //**********************************************************************************
 
 PreferencesPopup::PreferencesPopup()
-    : QDialog(TApp::instance()->getMainWindow()), m_formatProperties() {
+    : QDialog(TApp::instance()->getMainWindow())
+    , m_formatProperties()
+    , m_additionalStyleEdit(nullptr) {
   setWindowTitle(tr("Preferences"));
   setObjectName("PreferencesPopup");
 
@@ -1347,9 +1415,9 @@ QWidget* PreferencesPopup::createGeneralPage() {
   bool ret = true;
   ret      = ret && connect(m_pref, SIGNAL(stopAutoSave()), this,
                        SLOT(onAutoSaveExternallyChanged()));
-  ret = ret && connect(m_pref, SIGNAL(startAutoSave()), this,
+  ret      = ret && connect(m_pref, SIGNAL(startAutoSave()), this,
                        SLOT(onAutoSaveExternallyChanged()));
-  ret = ret && connect(m_pref, SIGNAL(autoSavePeriodChanged()), this,
+  ret      = ret && connect(m_pref, SIGNAL(autoSavePeriodChanged()), this,
                        SLOT(onAutoSavePeriodExternallyChanged()));
 
   ret = ret && connect(m_projectRootDocuments, SIGNAL(stateChanged(int)),
@@ -1383,11 +1451,16 @@ QWidget* PreferencesPopup::createInterfacePage() {
   for (const QString& name : m_pref->getLanguageList())
     languageItemList.push_back(ComboBoxItem(name, name));
 
+  QPushButton* additionalStyleSheetBtn =
+      new QPushButton(tr("Edit Additional Style Sheet.."));
+
   QWidget* widget  = new QWidget(this);
   QGridLayout* lay = new QGridLayout();
   setupLayout(lay);
 
   insertUI(CurrentStyleSheetName, lay, styleSheetItemList);
+  int row = lay->rowCount();
+  lay->addWidget(additionalStyleSheetBtn, row - 1, 3);
 
   lay->addWidget(new QLabel(tr("Icon Theme*:"), this), 2, 0,
                  Qt::AlignRight | Qt::AlignVCenter);
@@ -1431,6 +1504,8 @@ QWidget* PreferencesPopup::createInterfacePage() {
   ret      = ret && connect(TApp::instance()->getCurrentScene(),
                        SIGNAL(pixelUnitSelected(bool)), this,
                        SLOT(onPixelUnitExternallySelected(bool)));
+  ret      = ret && connect(additionalStyleSheetBtn, SIGNAL(clicked()), this,
+                       SLOT(onEditAdditionalStyleSheet()));
   assert(ret);
 
   m_onEditedFuncMap.insert(CurrentStyleSheetName,

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -17,6 +17,7 @@
 // Qt includes
 #include <QComboBox>
 #include <QFontComboBox>
+#include <QTextEdit>
 
 //==============================================================
 
@@ -63,10 +64,12 @@ public:
 
 private:
   class FormatProperties;
+  class AdditionalStyleEdit;
 
 private:
   Preferences* m_pref;
   FormatProperties* m_formatProperties;
+  AdditionalStyleEdit* m_additionalStyleEdit;
 
   DVGui::CheckBox *m_projectRootDocuments, *m_projectRootDesktop,
       *m_projectRootCustom;
@@ -149,6 +152,9 @@ private slots:
   void onAutoSaveExternallyChanged();
   void onAutoSavePeriodExternallyChanged();
   void onProjectRootChanged();
+
+  void onEditAdditionalStyleSheet();
+  void onAdditionalStyleSheetEdited();
   void onPixelUnitExternallySelected(bool on);
   void onInterfaceFontChanged(const QString& text);
   void onLutPathChanged();
@@ -187,6 +193,29 @@ private:
 private slots:
 
   void updateEnabledStatus();
+};
+
+//**********************************************************************************
+//   PreferencesPopup::AdditionalStyleEdit  definition
+//**********************************************************************************
+
+class PreferencesPopup::AdditionalStyleEdit final : public DVGui::Dialog {
+  Q_OBJECT
+
+public:
+  AdditionalStyleEdit(PreferencesPopup* parent);
+
+private:
+  QTextEdit* m_edit;
+
+protected:
+  void showEvent(QShowEvent* e) override;
+
+private slots:
+  void onOK();
+  void onApply();
+signals:
+  void additionalSheetEdited();
 };
 
 #endif  // PREFERENCESPOPUP_H

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -26,6 +26,7 @@
 #include <QStringList>
 #include <QAction>
 #include <QColor>
+#include <QTextStream>
 
 // boost includes
 #include <boost/bind.hpp>
@@ -365,6 +366,7 @@ void Preferences::definePreferenceItems() {
   // Interface
   define(CurrentStyleSheetName, "CurrentStyleSheetName", QMetaType::QString,
          "Default");
+  define(additionalStyleSheet, "additionalStyleSheet", QMetaType::QString, "");
   define(iconTheme, "iconTheme", QMetaType::Bool, false);
   define(pixelsOnly, "pixelsOnly", QMetaType::Bool, false);
   define(oldUnits, "oldUnits", QMetaType::QString, "mm");
@@ -897,13 +899,40 @@ QString Preferences::getCurrentLanguage() const {
 
 //-----------------------------------------------------------------
 
-QString Preferences::getCurrentStyleSheetPath() const {
+QString Preferences::getCurrentStyleSheet() const {
   QString currentStyleSheetName = getStringValue(CurrentStyleSheetName);
   if (currentStyleSheetName.isEmpty()) return QString();
   TFilePath path(TEnv::getConfigDir() + "qss");
   QString string = currentStyleSheetName + QString("/") +
                    currentStyleSheetName + QString(".qss");
-  return QString("file:///" + path.getQString() + "/" + string);
+  QString styleSheetPath = path.getQString() + "/" + string;
+
+  QString additionalSheetStr = getStringValue(additionalStyleSheet);
+  // if there is no additional style sheet, return the path and let
+  // Qt to load and parse it
+  if (additionalSheetStr.isEmpty()) return QString("file:///" + styleSheetPath);
+
+  // if there is any additional style sheet, load the style sheet
+  // from the file and combine with it
+  QString styleSheetStr;
+  QFile f(styleSheetPath);
+  if (f.open(QFile::ReadOnly | QFile::Text)) {
+    QTextStream ts(&f);
+    styleSheetStr = ts.readAll();
+  }
+  styleSheetStr += additionalSheetStr;
+
+  // here we will convert all relative paths to absolute paths
+  // or Qt will look for images relative to the current working directory
+  // since it has no idea where the style sheet comes from.
+
+  QString currentStyleFolderPath =
+      path.getQString().replace("\\", "/") + "/" + currentStyleSheetName;
+
+  styleSheetStr.replace(QRegExp("url\\(['\"]([^'\"]+)['\"]\\)"),
+                        "url(\"" + currentStyleFolderPath + QString("/\\1\")"));
+
+  return styleSheetStr;
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
This PR will enable users to customize style sheet from the Preferences.

![additional_style_sheet](https://user-images.githubusercontent.com/17974955/93574558-826fc480-f9d3-11ea-9d16-c26e38431666.png)

The style sheet provides an easy way to customize GUI without touching the source code. 
For instance, as shown in the image above, in our studio we enlarge the buttons in the Style Editor at Ink&Paint staffs' request.
However, currently you need to re-introduce the modifications every time you install the newer version of OT in which the style sheet has been updated.


In this PR the modifications will be separately stored in the user preferences so that it will save the trouble of re-introduction.
Furthermore, it allows personalized customization for each user sharing the same Stuff folder in the studio.

