### PR TITLE
fix language definitions

### DIFF
--- a/toonz/sources/translations/chinese/colorfx.ts
+++ b/toonz/sources/translations/chinese/colorfx.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>ArtisticSolidColor</name>
     <message>

--- a/toonz/sources/translations/chinese/image.ts
+++ b/toonz/sources/translations/chinese/image.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>AviWriterProperties</name>
     <message>

--- a/toonz/sources/translations/chinese/tnzcore.ts
+++ b/toonz/sources/translations/chinese/tnzcore.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>BmpWriterProperties</name>
     <message>

--- a/toonz/sources/translations/chinese/tnztools.ts
+++ b/toonz/sources/translations/chinese/tnztools.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>ArrowToolOptionsBox</name>
     <message>

--- a/toonz/sources/translations/chinese/toonz.ts
+++ b/toonz/sources/translations/chinese/toonz.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>AddFilmstripFramesPopup</name>
     <message>

--- a/toonz/sources/translations/chinese/toonzlib.ts
+++ b/toonz/sources/translations/chinese/toonzlib.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>CenterlineVectorizer</name>
     <message>

--- a/toonz/sources/translations/chinese/toonzqt.ts
+++ b/toonz/sources/translations/chinese/toonzqt.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="zh_CN">
+<TS version="2.1" language="zh_CN" sourcelanguage="en">
 <context>
     <name>AddFxContextMenu</name>
     <message>

--- a/toonz/sources/translations/czech/colorfx.ts
+++ b/toonz/sources/translations/czech/colorfx.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs_CZ">
+<TS version="2.1" language="cs_CZ" sourcelanguage="en">
 <context>
     <name>ArtisticSolidColor</name>
     <message>

--- a/toonz/sources/translations/czech/image.ts
+++ b/toonz/sources/translations/czech/image.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs_CZ">
+<TS version="2.1" language="cs_CZ" sourcelanguage="en">
 <context>
     <name>AviWriterProperties</name>
     <message>

--- a/toonz/sources/translations/czech/tnzcore.ts
+++ b/toonz/sources/translations/czech/tnzcore.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs_CZ">
+<TS version="2.1" language="cs_CZ" sourcelanguage="en">
 <context>
     <name>BmpWriterProperties</name>
     <message>

--- a/toonz/sources/translations/czech/tnztools.ts
+++ b/toonz/sources/translations/czech/tnztools.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs_CZ">
+<TS version="2.1" language="cs_CZ" sourcelanguage="en">
 <context>
     <name>ArrowToolOptionsBox</name>
     <message>

--- a/toonz/sources/translations/czech/toonz.ts
+++ b/toonz/sources/translations/czech/toonz.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs_CZ">
+<TS version="2.1" language="cs_CZ" sourcelanguage="en">
 <context>
     <name>AddFilmstripFramesPopup</name>
     <message>

--- a/toonz/sources/translations/czech/toonzlib.ts
+++ b/toonz/sources/translations/czech/toonzlib.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs_CZ">
+<TS version="2.1" language="cs_CZ" sourcelanguage="en">
 <context>
     <name>Preferences</name>
     <message>

--- a/toonz/sources/translations/czech/toonzqt.ts
+++ b/toonz/sources/translations/czech/toonzqt.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="cs_CZ">
+<TS version="2.1" language="cs_CZ" sourcelanguage="en">
 <context>
     <name>AddFxContextMenu</name>
     <message>

--- a/toonz/sources/translations/italian/colorfx.ts
+++ b/toonz/sources/translations/italian/colorfx.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>ArtisticSolidColor</name>
     <message>

--- a/toonz/sources/translations/italian/image.ts
+++ b/toonz/sources/translations/italian/image.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>AviWriterProperties</name>
     <message>

--- a/toonz/sources/translations/italian/tnzcore.ts
+++ b/toonz/sources/translations/italian/tnzcore.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>BmpWriterProperties</name>
     <message>

--- a/toonz/sources/translations/italian/tnztools.ts
+++ b/toonz/sources/translations/italian/tnztools.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>ArrowToolOptionsBox</name>
     <message>

--- a/toonz/sources/translations/italian/toonz.ts
+++ b/toonz/sources/translations/italian/toonz.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>AddFilmstripFramesPopup</name>
     <message>

--- a/toonz/sources/translations/italian/toonzlib.ts
+++ b/toonz/sources/translations/italian/toonzlib.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>CenterlineVectorizer</name>
     <message>

--- a/toonz/sources/translations/italian/toonzqt.ts
+++ b/toonz/sources/translations/italian/toonzqt.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="it" sourcelanguage="en">
 <context>
     <name>AddFxContextMenu</name>
     <message>

--- a/toonz/sources/translations/japanese/colorfx.ts
+++ b/toonz/sources/translations/japanese/colorfx.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
 <context>
     <name>ArtisticSolidColor</name>
     <message>

--- a/toonz/sources/translations/japanese/image.ts
+++ b/toonz/sources/translations/japanese/image.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
 <context>
     <name>AviWriterProperties</name>
     <message>

--- a/toonz/sources/translations/japanese/tnzcore.ts
+++ b/toonz/sources/translations/japanese/tnzcore.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
 <context>
     <name>BmpWriterProperties</name>
     <message>

--- a/toonz/sources/translations/japanese/tnztools.ts
+++ b/toonz/sources/translations/japanese/tnztools.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
 <context>
     <name>ArrowToolOptionsBox</name>
     <message>

--- a/toonz/sources/translations/japanese/toonz.ts
+++ b/toonz/sources/translations/japanese/toonz.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
 <context>
     <name>AddFilmstripFramesPopup</name>
     <message>

--- a/toonz/sources/translations/japanese/toonzlib.ts
+++ b/toonz/sources/translations/japanese/toonzlib.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
 <context>
     <name>Preferences</name>
     <message>

--- a/toonz/sources/translations/japanese/toonzqt.ts
+++ b/toonz/sources/translations/japanese/toonzqt.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ja_JP">
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
 <context>
     <name>AddFxContextMenu</name>
     <message>


### PR DESCRIPTION
Weblate can't correctly define some languages.
![Снимок экрана от 2020-09-23 22-17-32](https://user-images.githubusercontent.com/34054456/94025171-cce5ac80-fdea-11ea-9d35-6114279338cb.png)
Instead of names in English, there should be Russians (in my case, it depending on the your chosen Weblate interface language).
https://weblate-ru.readthedocs.io/ru/weblate-2.7/admin/projects.html?#component-configuration