### PR TITLE
Fix copy/paste keyframe causing bad data

### DIFF
--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -137,9 +137,12 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
         // interpolation between them using preference setting
         TStageObject::Keyframe prevKey = pegbar->getKeyframe(kL);
         for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-          prevKey.m_channels[i].m_type =
-              TDoubleKeyframe::Type(Preferences::instance()->getKeyframeType());
-          newKey.m_channels[i].m_prevType = prevKey.m_channels[i].m_type;
+          if (newKey.m_channels[i].m_isKeyframe &&
+              prevKey.m_channels[i].m_isKeyframe) {
+            prevKey.m_channels[i].m_type = TDoubleKeyframe::Type(
+                Preferences::instance()->getKeyframeType());
+            newKey.m_channels[i].m_prevType = prevKey.m_channels[i].m_type;
+          }
         }
         pegbar->setKeyframeWithoutUndo(kL, prevKey);
         pegbar->setKeyframeWithoutUndo(row, newKey);
@@ -149,7 +152,9 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
         if (!pegbar->getKeyframeSpan(row - 1, kP, e0, kN, e1)) kP = row - 1;
         TStageObject::Keyframe prevKey = pegbar->getKeyframe(kP);
         for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-          newKey.m_channels[i].m_prevType = prevKey.m_channels[i].m_type;
+          if (newKey.m_channels[i].m_isKeyframe &&
+              prevKey.m_channels[i].m_isKeyframe)
+            newKey.m_channels[i].m_prevType = prevKey.m_channels[i].m_type; 
         }
         pegbar->setKeyframeWithoutUndo(row, newKey);
       }
@@ -161,9 +166,12 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
         // interpolation between them using preference setting
         TStageObject::Keyframe nextKey = pegbar->getKeyframe(kF);
         for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-          newKey.m_channels[i].m_type =
-              TDoubleKeyframe::Type(Preferences::instance()->getKeyframeType());
-          nextKey.m_channels[i].m_prevType = newKey.m_channels[i].m_type;
+          if (newKey.m_channels[i].m_isKeyframe &&
+              nextKey.m_channels[i].m_isKeyframe) {
+            newKey.m_channels[i].m_type = TDoubleKeyframe::Type(
+                Preferences::instance()->getKeyframeType());
+            nextKey.m_channels[i].m_prevType = newKey.m_channels[i].m_type;
+          }
         }
         pegbar->setKeyframeWithoutUndo(row, newKey);
         pegbar->setKeyframeWithoutUndo(kF, nextKey);
@@ -173,7 +181,10 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
         if (!pegbar->getKeyframeSpan(row + 1, kP, e0, kN, e1)) kN = row + 1;
         TStageObject::Keyframe nextKey = pegbar->getKeyframe(kN);
         for (int i = 0; i < TStageObject::T_ChannelCount; i++) {
-          newKey.m_channels[i].m_type = nextKey.m_channels[i].m_prevType;
+          if (newKey.m_channels[i].m_isKeyframe &&
+              nextKey.m_channels[i].m_isKeyframe) {
+            nextKey.m_channels[i].m_prevType = newKey.m_channels[i].m_type;
+          }
         }
         pegbar->setKeyframeWithoutUndo(row, newKey);
       }


### PR DESCRIPTION
Note:  This fix from Tahoma was created by Manongjohn.  Info following in his own words about the change.

This PR fix should stop the generation of <n> or <> keyframe data when saving.

The logic that was there assumed and worked correctly for full keyframes, but not partial keyframes. When copy-pasting partial keyframes, it would set m_prevType on channels that were not keyframed. In addition to that, the newly pasted key's interpolation was being incorrectly updated which would lead to the <n>/<> when pasting before a partial keyframe.

Added logic to only update m_prevTypes if the channel was keyframed on the newly pasted key and the next/previous key also had that channel keyframed.

Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>