### PR TITLE
GUI modifications

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -189,11 +189,13 @@ QTabBar::tab:only-one {
 /* -----------------------------------------------------------------------------
    Main
 ----------------------------------------------------------------------------- */
-QWidget {
+QWidget,
+QTextEdit[readOnly="true"] {
   background-color: #414345;
   color: #d6d8dd;
 }
-QWidget:disabled {
+QWidget:disabled,
+QTextEdit[readOnly="true"]:disabled {
   color: rgba(214, 216, 221, 0.4);
 }
 QFrame {
@@ -986,6 +988,15 @@ QTextEdit:disabled,
   background-color: #353638;
   border-color: #333537;
   color: rgba(214, 216, 221, 0.4);
+}
+QTextEdit[readOnly="true"] {
+  border: 0;
+}
+QTextEdit[readOnly="true"]:focus,
+QTextEdit[readOnly="true"]:disabled {
+  background-color: #414345;
+  color: #d6d8dd;
+  border: 0;
 }
 /* -----------------------------------------------------------------------------
    CheckBox
@@ -2157,7 +2168,9 @@ Ruler {
 /* ScrollAreas (Row, Column and Cell)
 ----------------------------------------------------------------------------- */
 #xsheetArea,
-#ScrollArea {
+#ScrollColumnArea,
+#ScrollRowArea,
+#ScrollCellArea {
   background-color: #414345;
   border: 0;
 }
@@ -2329,6 +2342,16 @@ FunctionTreeView {
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
+#ScrollRowArea,
+#ScrollCellArea {
+  border-top: 1 solid rgba(0, 0, 0, 0.3);
+}
+#ScrollCellArea {
+  border-left: 1 solid rgba(0, 0, 0, 0.3);
+}
+#ScrollColumnArea {
+  padding-left: 2;
+}
 FunctionPanel {
   qproperty-BGColor: #3a3b3d;
   qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -189,11 +189,13 @@ QTabBar::tab:only-one {
 /* -----------------------------------------------------------------------------
    Main
 ----------------------------------------------------------------------------- */
-QWidget {
+QWidget,
+QTextEdit[readOnly="true"] {
   background-color: #303030;
   color: #e6e6e6;
 }
-QWidget:disabled {
+QWidget:disabled,
+QTextEdit[readOnly="true"]:disabled {
   color: rgba(230, 230, 230, 0.4);
 }
 QFrame {
@@ -986,6 +988,15 @@ QTextEdit:disabled,
   background-color: #262626;
   border-color: #434343;
   color: rgba(230, 230, 230, 0.4);
+}
+QTextEdit[readOnly="true"] {
+  border: 0;
+}
+QTextEdit[readOnly="true"]:focus,
+QTextEdit[readOnly="true"]:disabled {
+  background-color: #303030;
+  color: #e6e6e6;
+  border: 0;
 }
 /* -----------------------------------------------------------------------------
    CheckBox
@@ -2157,7 +2168,9 @@ Ruler {
 /* ScrollAreas (Row, Column and Cell)
 ----------------------------------------------------------------------------- */
 #xsheetArea,
-#ScrollArea {
+#ScrollColumnArea,
+#ScrollRowArea,
+#ScrollCellArea {
   background-color: #303030;
   border: 0;
 }
@@ -2329,6 +2342,16 @@ FunctionTreeView {
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
+#ScrollRowArea,
+#ScrollCellArea {
+  border-top: 1 solid rgba(0, 0, 0, 0.4);
+}
+#ScrollCellArea {
+  border-left: 1 solid rgba(0, 0, 0, 0.4);
+}
+#ScrollColumnArea {
+  padding-left: 2;
+}
 FunctionPanel {
   qproperty-BGColor: #303030;
   qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);
@@ -2344,7 +2367,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: rgba(83, 133, 166, 0.7);
   qproperty-LightLineColor: rgba(0, 0, 0, 0.3);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
-  qproperty-BGColor: #303030;
+  qproperty-BGColor: #262626;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.4);
   qproperty-KeyFrameColor: #995d1d;
   qproperty-KeyFrameBorderColor: #db9041;
@@ -2355,7 +2378,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: rgba(90, 100, 106, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(90, 100, 106, 0.5);
   qproperty-TextColor: #e6e6e6;
-  qproperty-ColumnHeaderBorderColor: #0f0f0f;
+  qproperty-ColumnHeaderBorderColor: #4a4a4a;
 }
 #ExpressionField {
   background-color: #cecece;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -189,11 +189,13 @@ QTabBar::tab:only-one {
 /* -----------------------------------------------------------------------------
    Main
 ----------------------------------------------------------------------------- */
-QWidget {
+QWidget,
+QTextEdit[readOnly="true"] {
   background-color: #484848;
   color: #e6e6e6;
 }
-QWidget:disabled {
+QWidget:disabled,
+QTextEdit[readOnly="true"]:disabled {
   color: rgba(230, 230, 230, 0.4);
 }
 QFrame {
@@ -986,6 +988,15 @@ QTextEdit:disabled,
   background-color: #3b3b3b;
   border-color: #3a3a3a;
   color: rgba(230, 230, 230, 0.4);
+}
+QTextEdit[readOnly="true"] {
+  border: 0;
+}
+QTextEdit[readOnly="true"]:focus,
+QTextEdit[readOnly="true"]:disabled {
+  background-color: #484848;
+  color: #e6e6e6;
+  border: 0;
 }
 /* -----------------------------------------------------------------------------
    CheckBox
@@ -2157,7 +2168,9 @@ Ruler {
 /* ScrollAreas (Row, Column and Cell)
 ----------------------------------------------------------------------------- */
 #xsheetArea,
-#ScrollArea {
+#ScrollColumnArea,
+#ScrollRowArea,
+#ScrollCellArea {
   background-color: #484848;
   border: 0;
 }
@@ -2329,6 +2342,16 @@ FunctionTreeView {
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
+#ScrollRowArea,
+#ScrollCellArea {
+  border-top: 1 solid rgba(0, 0, 0, 0.3);
+}
+#ScrollCellArea {
+  border-left: 1 solid rgba(0, 0, 0, 0.3);
+}
+#ScrollColumnArea {
+  padding-left: 2;
+}
 FunctionPanel {
   qproperty-BGColor: #404040;
   qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -550,6 +550,7 @@
 @function-LightLightBG-color:            @xsheet-OnionSkinAreaBG-color;
 @function-SelectedSceneRangeEmpty-color: @xsheet-SelectedEmptyCell-color;
 @function-ColumnHeaderBorder-color:      darken(@bg, 13);
+@function-ColumnHeaderBG-color: @xsheet-NotEmptyColumn-color;
 
 // Keyframe Colors
 @function-KeyFrame-color:          darken(desaturate(spin(@keyframe-total-color, 0.0000), 0.7570), 8.4314);

--- a/stuff/config/qss/Default/less/layouts/controls.less
+++ b/stuff/config/qss/Default/less/layouts/controls.less
@@ -144,10 +144,22 @@ QComboBox {
   }
 }
 
-QPlainTextEdit
-,QLineEdit
-,QTextEdit {
+QPlainTextEdit,
+QLineEdit,
+QTextEdit {
   &:extend(.LineEdit all);
+}
+
+// reset all styles for read-only QtextEdit
+QTextEdit[readOnly="true"]{
+  &:extend(QWidget all);
+  border: 0;
+  &:focus,
+  &:disabled {
+    background-color: @bg;
+    color: @text-color;
+    border: 0;
+  }
 }
 
 /* -----------------------------------------------------------------------------

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -6,7 +6,9 @@
 ----------------------------------------------------------------------------- */
 
 #xsheetArea,
-#ScrollArea {
+#ScrollColumnArea,
+#ScrollRowArea,
+#ScrollCellArea {
   background-color: @xsheet-empty-bg-color;
   border: 0;
 }
@@ -240,6 +242,20 @@ FunctionTreeView {
 // If a qproperty shares the same likeness with XSheet then pair the variables.
 // XSheet should be considered as parent.
 
+
+#ScrollRowArea,
+#ScrollCellArea {  
+  border-top:1 solid @xsheet-VerticalLine-color;
+}
+
+#ScrollCellArea {
+  border-left:1 solid @xsheet-VerticalLine-color;
+}
+
+#ScrollColumnArea {
+  padding-left:2;
+}
+
 FunctionPanel {
   qproperty-BGColor: @function-panel-bg-color;
   qproperty-ValueLineColor: @function-panel-ValueLine-color;
@@ -256,7 +272,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: @xsheet-CurrentRowBG-color; // paired
   qproperty-LightLineColor: @xsheet-LightLine-color; // paired
   qproperty-MarkerLineColor: @xsheet-MarkerLine-color; // paired
-  qproperty-BGColor: @xsheet-NotEmptyColumn-color; // paired
+  qproperty-BGColor: @function-ColumnHeaderBG-color;
   qproperty-VerticalLineColor: @xsheet-VerticalLine-color; // paired
   qproperty-KeyFrameColor: @function-KeyFrame-color;
   qproperty-KeyFrameBorderColor: @function-KeyFrameBorder-color;

--- a/stuff/config/qss/Default/less/themes/Dark.less
+++ b/stuff/config/qss/Default/less/themes/Dark.less
@@ -108,3 +108,7 @@
 
 // Function Curve Panel
 @function-panel-OtherCurves-color: lighten(@function-panel-bg-color, 30);
+
+// Function Spreadsheet Viewer
+@function-ColumnHeaderBorder-color: lighten(@bg, 10);
+@function-ColumnHeaderBG-color: darken(@bg, 4);

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -189,11 +189,13 @@ QTabBar::tab:only-one {
 /* -----------------------------------------------------------------------------
    Main
 ----------------------------------------------------------------------------- */
-QWidget {
+QWidget,
+QTextEdit[readOnly="true"] {
   background-color: #DBDBDB;
   color: #000;
 }
-QWidget:disabled {
+QWidget:disabled,
+QTextEdit[readOnly="true"]:disabled {
   color: rgba(0, 0, 0, 0.4);
 }
 QFrame {
@@ -986,6 +988,15 @@ QTextEdit:disabled,
   background-color: #efefef;
   border-color: #c2c2c2;
   color: rgba(0, 0, 0, 0.4);
+}
+QTextEdit[readOnly="true"] {
+  border: 0;
+}
+QTextEdit[readOnly="true"]:focus,
+QTextEdit[readOnly="true"]:disabled {
+  background-color: #DBDBDB;
+  color: #000;
+  border: 0;
 }
 /* -----------------------------------------------------------------------------
    CheckBox
@@ -2157,7 +2168,9 @@ Ruler {
 /* ScrollAreas (Row, Column and Cell)
 ----------------------------------------------------------------------------- */
 #xsheetArea,
-#ScrollArea {
+#ScrollColumnArea,
+#ScrollRowArea,
+#ScrollCellArea {
   background-color: #DBDBDB;
   border: 0;
 }
@@ -2329,6 +2342,16 @@ FunctionTreeView {
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
+#ScrollRowArea,
+#ScrollCellArea {
+  border-top: 1 solid rgba(0, 0, 0, 0.15);
+}
+#ScrollCellArea {
+  border-left: 1 solid rgba(0, 0, 0, 0.15);
+}
+#ScrollColumnArea {
+  padding-left: 2;
+}
 FunctionPanel {
   qproperty-BGColor: #808080;
   qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -189,11 +189,13 @@ QTabBar::tab:only-one {
 /* -----------------------------------------------------------------------------
    Main
 ----------------------------------------------------------------------------- */
-QWidget {
+QWidget,
+QTextEdit[readOnly="true"] {
   background-color: #808080;
   color: #000;
 }
-QWidget:disabled {
+QWidget:disabled,
+QTextEdit[readOnly="true"]:disabled {
   color: rgba(0, 0, 0, 0.4);
 }
 QFrame {
@@ -986,6 +988,15 @@ QTextEdit:disabled,
   background-color: #9a9a9a;
   border-color: #6d6d6d;
   color: rgba(0, 0, 0, 0.4);
+}
+QTextEdit[readOnly="true"] {
+  border: 0;
+}
+QTextEdit[readOnly="true"]:focus,
+QTextEdit[readOnly="true"]:disabled {
+  background-color: #808080;
+  color: #000;
+  border: 0;
 }
 /* -----------------------------------------------------------------------------
    CheckBox
@@ -2157,7 +2168,9 @@ Ruler {
 /* ScrollAreas (Row, Column and Cell)
 ----------------------------------------------------------------------------- */
 #xsheetArea,
-#ScrollArea {
+#ScrollColumnArea,
+#ScrollRowArea,
+#ScrollCellArea {
   background-color: #808080;
   border: 0;
 }
@@ -2329,6 +2342,16 @@ FunctionTreeView {
 }
 /* Function Editor Spreadsheet
 ----------------------------------------------------------------------------- */
+#ScrollRowArea,
+#ScrollCellArea {
+  border-top: 1 solid rgba(0, 0, 0, 0.3);
+}
+#ScrollCellArea {
+  border-left: 1 solid rgba(0, 0, 0, 0.3);
+}
+#ScrollColumnArea {
+  padding-left: 2;
+}
 FunctionPanel {
   qproperty-BGColor: #5a5a5a;
   qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -289,7 +289,7 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
   /*--- Fill header with background color ---*/
   for (int c = c0; c <= c1; c++) {
     FunctionTreeModel::Channel *channel = m_sheet->getChannel(c);
-    if (!channel) continue;
+    if (!channel) break;
     int x0 = getViewer()->columnToX(c);
     int x1 = getViewer()->columnToX(c + 1) - 1;
     // Column Width
@@ -300,7 +300,15 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
 
   for (int c = c0; c <= c1; ++c) {
     FunctionTreeModel::Channel *channel = m_sheet->getChannel(c);
-    if (!channel) continue;
+    if (!channel) {
+      if (c != c0) {
+        // draw "the end" border
+        int x0 = getViewer()->columnToX(c);
+        painter.setPen(getViewer()->getColumnHeaderBorderColor());
+        painter.drawLine(x0, y0, x0, y3);
+      }
+      break;
+    }
     int i = c - c0 + 1;
     /*---- Channel Column of the current Column and the preceding and following
      * Columns ---*/

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -351,7 +351,7 @@ void RowPanel::drawCurrentRowGadget(QPainter &p, int r0, int r1) {
   int currentRow = getViewer()->getCurrentRow();
   int y          = getViewer()->rowToY(currentRow);
   if (currentRow < r0 || r1 < currentRow) return;
-  p.fillRect(1, y + 1, width() - 2, 19, getViewer()->getCurrentRowBgColor());
+  p.fillRect(1, y + 1, width() - 1, 19, getViewer()->getCurrentRowBgColor());
 }
 
 //-----------------------------------------------------------------------------
@@ -474,21 +474,21 @@ SpreadsheetViewer::SpreadsheetViewer(QWidget *parent)
 
   // column header
   m_columnScrollArea = new Spreadsheet::ScrollArea;
-  m_columnScrollArea->setObjectName("ScrollArea");
+  m_columnScrollArea->setObjectName("ScrollColumnArea");
   m_columnScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_columnScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_columnScrollArea->setFocusPolicy(Qt::NoFocus);
 
   // row area
   m_rowScrollArea = new Spreadsheet::ScrollArea;
-  m_rowScrollArea->setObjectName("ScrollArea");
+  m_rowScrollArea->setObjectName("ScrollRowArea");
   m_rowScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_rowScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_rowScrollArea->setFocusPolicy(Qt::NoFocus);
 
   // cell area
   m_cellScrollArea = new Spreadsheet::ScrollArea;
-  m_cellScrollArea->setObjectName("ScrollArea");
+  m_cellScrollArea->setObjectName("ScrollCellArea");
   m_cellScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
   m_cellScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
   // m_cellScrollArea->horizontalScrollBar()->setObjectName("XsheetScrollBar");
@@ -687,13 +687,13 @@ int SpreadsheetViewer::rowToY(int row) const {
 /*!Shift is a consequence of style sheet border.*/
 CellPosition SpreadsheetViewer::xyToPosition(const QPoint &point) const {
   int row = (point.y() + 1) / m_rowHeight;
-  int col = (point.x() + 1) / m_columnWidth;
+  int col = (point.x()) / m_columnWidth;
   return CellPosition(row, col);
 }
 
 /*!Shift is a consequence of style sheet border.*/
 QPoint SpreadsheetViewer::positionToXY(const CellPosition &pos) const {
-  int x = (pos.layer() * m_columnWidth) - 1;
+  int x = (pos.layer() * m_columnWidth);
   int y = (pos.frame() * m_rowHeight) - 1;
   return QPoint(x, y);
 }
@@ -707,8 +707,8 @@ CellRange SpreadsheetViewer::xyRectToRange(const QRect &rect) const {
 bool SpreadsheetViewer::refreshContentSize(int scrollDx, int scrollDy) {
   QSize viewportSize = m_cellScrollArea->viewport()->size();
   QPoint offset      = m_cellScrollArea->widget()->pos();
-  offset =
-      QPoint(std::min(0, offset.x() - scrollDx), std::min(0, offset.y() - scrollDy));
+  offset             = QPoint(std::min(0, offset.x() - scrollDx),
+                  std::min(0, offset.y() - scrollDy));
 
   QSize contentSize(columnToX(m_columnCount + 1), rowToY(m_rowCount + 1));
 
@@ -733,10 +733,11 @@ bool SpreadsheetViewer::refreshContentSize(int scrollDx, int scrollDy) {
 }
 
 void SpreadsheetViewer::showEvent(QShowEvent *) {
-  int viewportHeight      = m_cellScrollArea->height();
-  int contentHeight       = rowToY(m_rowCount * 0 + 50);
-  QScrollBar *vSc         = m_cellScrollArea->verticalScrollBar();
-  int actualContentHeight = std::max(contentHeight, vSc->value() + viewportHeight);
+  int viewportHeight = m_cellScrollArea->height();
+  int contentHeight  = rowToY(m_rowCount * 0 + 50);
+  QScrollBar *vSc    = m_cellScrollArea->verticalScrollBar();
+  int actualContentHeight =
+      std::max(contentHeight, vSc->value() + viewportHeight);
   m_rowScrollArea->widget()->setFixedHeight(actualContentHeight);
   m_cellScrollArea->widget()->setFixedHeight(actualContentHeight);
   if (m_frameHandle)
@@ -805,13 +806,13 @@ void SpreadsheetViewer::wheelEvent(QWheelEvent *event) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-    {
-      std::cout << "not supported wheelEvent.source(): "
-                   "Qt::MouseEventSynthesizedByQt, "
-                   "Qt::MouseEventSynthesizedByApplication"
-                << std::endl;
-      break;
-    }
+  {
+    std::cout << "not supported wheelEvent.source(): "
+                 "Qt::MouseEventSynthesizedByQt, "
+                 "Qt::MouseEventSynthesizedByApplication"
+              << std::endl;
+    break;
+  }
 
   }  // end switch
 }


### PR DESCRIPTION
This PR slightly modifies GUI as follows:

1. Function Editor - spread sheet view
    - Changed the column head colors in "Dark" theme so that the ruled lines become more visible.
    - Added 1px vertical line at the end of the column heads.
    - Slightly adjusted positions & added borders so that the panes perfectly align with each other and with Xsheet.

    ![gui_mod1](https://user-images.githubusercontent.com/17974955/94384561-d5890a80-017d-11eb-9e23-fb06d6730cca.png)

1. PSD settings popup (opens when loading .psd files)
    - Removed decorations from read-only QTextEdit in order to clarify it is just a non-editable, multi-lined label.

    ![gui_mod2](https://user-images.githubusercontent.com/17974955/94384874-a1fab000-017e-11eb-9fe5-eb439230395d.png)
