### PR TITLE
Fix Inputting Japanese Characters

### DIFF
--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -119,19 +119,13 @@ void TPanel::enterEvent(QEvent *event) {
   QWidget *w = qApp->activeWindow();
   if (w) {
     // grab the focus, unless a line-edit is focused currently
-    bool shouldSetFocus = true;
-
     QWidget *focusWidget = qApp->focusWidget();
-    if (focusWidget) {
-      QLineEdit *lineEdit = dynamic_cast<QLineEdit *>(focusWidget);
-      if (lineEdit) {
-        shouldSetFocus = false;
-      }
+    if (focusWidget && dynamic_cast<QLineEdit *>(focusWidget)) {
+      event->accept();
+      return;
     }
 
-    if (shouldSetFocus) {
-      widgetFocusOnEnter();
-    }
+    widgetFocusOnEnter();
 
     // Some panels (e.g. Viewer, StudioPalette, Palette, ColorModel) are
     // activated when mouse enters. Viewer is activatable only when being
@@ -147,7 +141,13 @@ void TPanel::enterEvent(QEvent *event) {
 //-----------------------------------------------------------------------------
 /*! clear focus when mouse leaves
  */
-void TPanel::leaveEvent(QEvent *event) { widgetClearFocusOnLeave(); }
+void TPanel::leaveEvent(QEvent *event) {
+  QWidget *focusWidget = qApp->focusWidget();
+  if (focusWidget && dynamic_cast<QLineEdit *>(focusWidget)) {
+    return;
+  }
+  widgetClearFocusOnLeave();
+}
 
 //-----------------------------------------------------------------------------
 /*! load and restore previous geometry and state of the floating panel.


### PR DESCRIPTION
This PR fixes #3509 .

When moving the cursor while renaming styles, `TPanel::leaveEvent()` and `TPanel::enterEvent()` are randomly called even if the cursor does not leave the panel for unknown reasons. This behavior temporary loses the keyboard focus and disrupts input before combining the consonant and the vowel into Japanese character.
This PR prevents losing focus on `TPanel::leaveEvent()`  if the current focused widget is any inheritance of `QLineEdit`. 