### PR TITLE
Apply Color Calibration 3DLUT On-the-fly

### DIFF
--- a/toonz/sources/include/toonzqt/lutcalibrator.h
+++ b/toonz/sources/include/toonzqt/lutcalibrator.h
@@ -9,6 +9,7 @@
 #include <QOpenGLBuffer>
 #include <QMatrix4x4>
 #include <QOpenGLFunctions>
+#include <QSet>
 
 #undef DVAPI
 #undef DVVAR
@@ -53,7 +54,8 @@ class DVAPI LutCalibrator : public QOpenGLFunctions {
 
 public:
   // static LutCalibrator* instance();
-  LutCalibrator() {}
+  LutCalibrator();
+  ~LutCalibrator();
 
   // to be computed once through the software
   void initialize();
@@ -61,22 +63,23 @@ public:
   bool isValid() { return m_isValid; }
   bool isInitialized() { return m_isInitialized; }
 
-  ~LutCalibrator() {}
-
   void onEndDraw(QOpenGLFramebufferObject*);
 
   void cleanup();
+  void update(bool textureChanged);
 };
 
 class DVAPI LutManager  // singleton
 {
-  bool m_isValid = false;
+  bool m_isValid;
+  QString m_currentLutPath;
+  QSet<LutCalibrator*> m_calibrators;
 
   LutManager();
 
   struct Lut {
     int meshSize;
-    float* data = NULL;
+    float* data = nullptr;
   } m_lut;
 
 public:
@@ -95,6 +98,11 @@ public:
   void convert(TPixel32&);
 
   QString& getMonitorName() const;
+
+  void registerCalibrator(LutCalibrator* calibrator);
+  void removeCalibrator(LutCalibrator* calibrator);
+
+  void update();
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -168,6 +168,8 @@ public:
   void setBGColor(const QColor &color) { m_bgColor = color; }
   QColor getBGColor() const { return m_bgColor; }
 
+  void updateColorCalibration();
+
 protected:
   void initializeGL() override;
   void resizeGL(int width, int height) override;
@@ -477,6 +479,8 @@ public:
   QByteArray getSplitterState();
   void setSplitterState(QByteArray state);
 
+  void updateColorCalibration();
+
 protected:
   void resizeEvent(QResizeEvent *) override;
 
@@ -682,6 +686,8 @@ public:
   // SaveLoadQSettings
   virtual void save(QSettings &settings) const override;
   virtual void load(QSettings &settings) override;
+
+  void updateColorCalibration();
 
 protected:
   /*! Return false if style is linked and style must be set to null.*/

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -774,6 +774,23 @@ void ImageViewer::updateCursor(const TPoint &curPos) {
 }
 
 //---------------------------------------------------------------------------------------------
+
+void ImageViewer::showEvent(QShowEvent *) {
+  TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
+  bool ret = connect(sceneHandle, SIGNAL(preferenceChanged(const QString &)),
+                     this, SLOT(onPreferenceChanged(const QString &)));
+  onPreferenceChanged("ColorCalibration");
+  assert(ret);
+}
+
+//---------------------------------------------------------------------------------------------
+
+void ImageViewer::hideEvent(QHideEvent *) {
+  TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
+  if (sceneHandle) sceneHandle->disconnect(this);
+}
+
+//---------------------------------------------------------------------------------------------
 /*! If middle button is pressed pan the image. Update current mouse position.
  */
 void ImageViewer::mouseMoveEvent(QMouseEvent *event) {
@@ -1326,6 +1343,27 @@ void ImageViewer::onContextAboutToBeDestroyed() {
   makeCurrent();
   m_lutCalibrator->cleanup();
   doneCurrent();
+}
+
+//-----------------------------------------------------------------------------
+
+void ImageViewer::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "ColorCalibration") {
+    if (Preferences::instance()->isColorCalibrationEnabled()) {
+      makeCurrent();
+      if (!m_lutCalibrator)
+        m_lutCalibrator = new LutCalibrator();
+      else
+        m_lutCalibrator->cleanup();
+      m_lutCalibrator->initialize();
+      connect(context(), SIGNAL(aboutToBeDestroyed()), this,
+              SLOT(onContextAboutToBeDestroyed()));
+      if (m_lutCalibrator->isValid() && !m_fbo)
+        m_fbo = new QOpenGLFramebufferObject(width(), height());
+      doneCurrent();
+    }
+    update();
+  }
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -132,6 +132,8 @@ protected:
   void resizeGL(int width, int height) override;
   void paintGL() override;
 
+  void showEvent(QShowEvent *) override;
+  void hideEvent(QHideEvent *) override;
   void mouseMoveEvent(QMouseEvent *event) override;
   void mousePressEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
@@ -157,6 +159,7 @@ public slots:
   void showHistogram();
   void swapCompared();
   void onContextAboutToBeDestroyed();
+  void onPreferenceChanged(const QString &prefName);
 
 private:
   QPointF m_firstPanPoint;

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -495,6 +495,14 @@ void PreferencesPopup::beforeRoomChoiceChanged() {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onColorCalibrationChanged() {
+  LutManager::instance()->update();
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
+      "ColorCalibration");
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onDefLevelTypeChanged() {
   bool isRaster = m_pref->getIntValue(DefLevelType) != PLI_XSHLEVEL &&
                   !m_pref->getBoolValue(newLevelSizeToCameraSizeEnabled);
@@ -704,6 +712,7 @@ void PreferencesPopup::onLutPathChanged() {
   FileField* lutPathFileField = getUI<FileField*>(colorCalibrationLutPaths);
   m_pref->setColorCalibrationLutPath(LutManager::instance()->getMonitorName(),
                                      lutPathFileField->getPath());
+  onColorCalibrationChanged();
 }
 
 //-----------------------------------------------------------------------------
@@ -1031,10 +1040,9 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {CurrentLanguageName, tr("Language*:")},
       {interfaceFont, tr("Font*:")},
       {interfaceFontStyle, tr("Style*:")},
-      {colorCalibrationEnabled,
-       tr("Color Calibration using 3D Look-up Table*")},
+      {colorCalibrationEnabled, tr("Color Calibration using 3D Look-up Table")},
       {colorCalibrationLutPaths,
-       tr("3DLUT File for [%1]*:")
+       tr("3DLUT File for [%1]:")
            .arg(LutManager::instance()->getMonitorName())},
 
       // Visualization
@@ -1516,6 +1524,8 @@ QWidget* PreferencesPopup::createInterfacePage() {
   m_onEditedFuncMap.insert(cameraUnits, &PreferencesPopup::onUnitChanged);
   m_preEditedFuncMap.insert(CurrentRoomChoice,
                             &PreferencesPopup::beforeRoomChoiceChanged);
+  m_onEditedFuncMap.insert(colorCalibrationEnabled,
+                           &PreferencesPopup::onColorCalibrationChanged);
 
   return widget;
 }

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -124,6 +124,7 @@ private:
   void onPixelsOnlyChanged();
   void onUnitChanged();
   void beforeRoomChoiceChanged();
+  void onColorCalibrationChanged();
   // Drawing
   void onDefLevelTypeChanged();
   void onUseNumpadForSwitchingStylesClicked();

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1014,52 +1014,62 @@ void SceneViewer::showEvent(QShowEvent *) {
   TApp *app = TApp::instance();
 
   TSceneHandle *sceneHandle = app->getCurrentScene();
-  connect(sceneHandle, SIGNAL(sceneSwitched()), this, SLOT(resetSceneViewer()));
-  connect(sceneHandle, SIGNAL(sceneChanged()), this, SLOT(onSceneChanged()));
+  bool ret = connect(sceneHandle, SIGNAL(sceneSwitched()), this,
+                     SLOT(resetSceneViewer()));
+  ret      = ret && connect(sceneHandle, SIGNAL(sceneChanged()), this,
+                       SLOT(onSceneChanged()));
+  ret = ret && connect(sceneHandle, SIGNAL(preferenceChanged(const QString &)),
+                       this, SLOT(onPreferenceChanged(const QString &)));
 
   TFrameHandle *frameHandle = app->getCurrentFrame();
-  connect(frameHandle, SIGNAL(frameSwitched()), this, SLOT(onFrameSwitched()));
+  ret = ret && connect(frameHandle, SIGNAL(frameSwitched()), this,
+                       SLOT(onFrameSwitched()));
 
   TPaletteHandle *paletteHandle =
       app->getPaletteController()->getCurrentLevelPalette();
-  connect(paletteHandle, SIGNAL(colorStyleChanged(bool)), this, SLOT(update()));
+  ret = ret && connect(paletteHandle, SIGNAL(colorStyleChanged(bool)), this,
+                       SLOT(update()));
 
-  connect(app->getCurrentObject(), SIGNAL(objectSwitched()), this,
-          SLOT(onObjectSwitched()));
-  connect(app->getCurrentObject(), SIGNAL(objectChanged(bool)), this,
-          SLOT(update()));
+  ret = ret && connect(app->getCurrentObject(), SIGNAL(objectSwitched()), this,
+                       SLOT(onObjectSwitched()));
+  ret = ret && connect(app->getCurrentObject(), SIGNAL(objectChanged(bool)),
+                       this, SLOT(update()));
 
-  connect(app->getCurrentOnionSkin(), SIGNAL(onionSkinMaskChanged()), this,
-          SLOT(onOnionSkinMaskChanged()));
+  ret =
+      ret && connect(app->getCurrentOnionSkin(), SIGNAL(onionSkinMaskChanged()),
+                     this, SLOT(onOnionSkinMaskChanged()));
 
-  connect(app->getCurrentLevel(), SIGNAL(xshLevelChanged()), this,
-          SLOT(update()));
-  connect(app->getCurrentLevel(), SIGNAL(xshCanvasSizeChanged()), this,
-          SLOT(update()));
+  ret = ret && connect(app->getCurrentLevel(), SIGNAL(xshLevelChanged()), this,
+                       SLOT(update()));
+  ret = ret && connect(app->getCurrentLevel(), SIGNAL(xshCanvasSizeChanged()),
+                       this, SLOT(update()));
   // when level is switched, update m_dpiScale in order to show white background
   // for Ink&Paint work properly
-  connect(app->getCurrentLevel(), SIGNAL(xshLevelSwitched(TXshLevel *)), this,
-          SLOT(onLevelSwitched()));
+  ret = ret &&
+        connect(app->getCurrentLevel(), SIGNAL(xshLevelSwitched(TXshLevel *)),
+                this, SLOT(onLevelSwitched()));
 
-  connect(app->getCurrentXsheet(), SIGNAL(xsheetChanged()), this,
-          SLOT(onXsheetChanged()));
-  connect(app->getCurrentXsheet(), SIGNAL(xsheetSwitched()), this,
-          SLOT(update()));
+  ret = ret && connect(app->getCurrentXsheet(), SIGNAL(xsheetChanged()), this,
+                       SLOT(onXsheetChanged()));
+  ret = ret && connect(app->getCurrentXsheet(), SIGNAL(xsheetSwitched()), this,
+                       SLOT(update()));
 
   // update tooltip when tool options are changed
-  connect(app->getCurrentTool(), SIGNAL(toolChanged()), this,
-          SLOT(onToolChanged()));
-  connect(app->getCurrentTool(), SIGNAL(toolCursorTypeChanged()), this,
-          SLOT(onToolChanged()));
+  ret = ret && connect(app->getCurrentTool(), SIGNAL(toolChanged()), this,
+                       SLOT(onToolChanged()));
+  ret = ret && connect(app->getCurrentTool(), SIGNAL(toolCursorTypeChanged()),
+                       this, SLOT(onToolChanged()));
 
-  connect(app, SIGNAL(tabletLeft()), this, SLOT(resetTabletStatus()));
+  ret = ret &&
+        connect(app, SIGNAL(tabletLeft()), this, SLOT(resetTabletStatus()));
 
   if (m_stopMotion) {
-    connect(m_stopMotion, SIGNAL(newLiveViewImageReady()), this,
-            SLOT(onNewStopMotionImageReady()));
-    connect(m_stopMotion, SIGNAL(liveViewStopped()), this,
-            SLOT(onStopMotionLiveViewStopped()));
+    ret = ret && connect(m_stopMotion, SIGNAL(newLiveViewImageReady()), this,
+                         SLOT(onNewStopMotionImageReady()));
+    ret = ret && connect(m_stopMotion, SIGNAL(liveViewStopped()), this,
+                         SLOT(onStopMotionLiveViewStopped()));
   }
+  assert(ret);
 
   if (m_hRuler && m_vRuler) {
     if (!viewRulerToggle.getStatus()) {
@@ -1076,6 +1086,7 @@ void SceneViewer::showEvent(QShowEvent *) {
   }
   TApp::instance()->setActiveViewer(this);
 
+  onPreferenceChanged("ColorCalibration");
   update();
 }
 
@@ -1178,6 +1189,27 @@ void SceneViewer::onNewStopMotionImageReady() {
 //-----------------------------------------------------------------------------
 
 void SceneViewer::onStopMotionLiveViewStopped() { onSceneChanged(); }
+
+//-----------------------------------------------------------------------------
+
+void SceneViewer::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "ColorCalibration") {
+    if (Preferences::instance()->isColorCalibrationEnabled()) {
+      makeCurrent();
+      if (!m_lutCalibrator)
+        m_lutCalibrator = new LutCalibrator();
+      else
+        m_lutCalibrator->cleanup();
+      m_lutCalibrator->initialize();
+      connect(context(), SIGNAL(aboutToBeDestroyed()), this,
+              SLOT(onContextAboutToBeDestroyed()));
+      if (m_lutCalibrator->isValid() && !m_fbo)
+        m_fbo = new QOpenGLFramebufferObject(width(), height());
+      doneCurrent();
+    }
+    update();
+  }
+}
 
 //-----------------------------------------------------------------------------
 void SceneViewer::initializeGL() {

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -446,6 +446,7 @@ public slots:
   void onContextAboutToBeDestroyed();
   void onNewStopMotionImageReady();
   void onStopMotionLiveViewStopped();
+  void onPreferenceChanged(const QString &prefName);
 
 signals:
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -568,6 +568,28 @@ void PaletteViewerPanel::onSceneSwitched() {
   m_paletteViewer->updateView();
 }
 
+//-----------------------------------------------------------------------------
+
+void PaletteViewerPanel::showEvent(QShowEvent *) {
+  TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
+  bool ret = connect(sceneHandle, SIGNAL(preferenceChanged(const QString &)),
+                     this, SLOT(onPreferenceChanged(const QString &)));
+  assert(ret);
+}
+
+//-----------------------------------------------------------------------------
+
+void PaletteViewerPanel::hideEvent(QHideEvent *) {
+  TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
+  if (sceneHandle) sceneHandle->disconnect(this);
+}
+
+//-----------------------------------------------------------------------------
+
+void PaletteViewerPanel::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "ColorCalibration") update();
+}
+
 //=============================================================================
 
 class PaletteViewerFactory final : public TPanelFactory {
@@ -833,6 +855,23 @@ StyleEditorPanel::StyleEditorPanel(QWidget *parent) : TPanel(parent) {
   resize(340, 630);
 }
 
+//-----------------------------------------------------------------------------
+void StyleEditorPanel::showEvent(QShowEvent *) {
+  TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
+  bool ret = connect(sceneHandle, SIGNAL(preferenceChanged(const QString &)),
+                     this, SLOT(onPreferenceChanged(const QString &)));
+  onPreferenceChanged("ColorCalibration");
+  assert(ret);
+}
+//-----------------------------------------------------------------------------
+void StyleEditorPanel::hideEvent(QHideEvent *) {
+  TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
+  if (sceneHandle) sceneHandle->disconnect(this);
+}
+//-----------------------------------------------------------------------------
+void StyleEditorPanel::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "ColorCalibration") m_styleEditor->updateColorCalibration();
+}
 //-----------------------------------------------------------------------------
 
 class StyleEditorFactory final : public TPanelFactory {

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -57,12 +57,15 @@ public:
 protected:
   void initializeTitleBar();
   bool isActivatableOnEnter() override { return true; }
+  void showEvent(QShowEvent *) override;
+  void hideEvent(QHideEvent *) override;
 
 protected slots:
   void onColorStyleSwitched();
   void onPaletteSwitched();
   void onFreezeButtonToggled(bool isFrozen);
   void onSceneSwitched();
+  void onPreferenceChanged(const QString &prefName);
 };
 
 //=========================================================
@@ -98,6 +101,12 @@ class StyleEditorPanel final : public TPanel {
 
 public:
   StyleEditorPanel(QWidget *parent);
+
+protected:
+  void showEvent(QShowEvent *) override;
+  void hideEvent(QHideEvent *) override;
+protected slots:
+  void onPreferenceChanged(const QString &prefName);
 };
 
 //=========================================================

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -1004,8 +1004,8 @@ void Preferences::setColorCalibrationLutPath(QString monitorName,
 
 QString Preferences::getColorCalibrationLutPath(QString &monitorName) const {
   PreferencesItem item = m_items.value(colorCalibrationLutPaths);
-  QMap<QString, QString> lutPathMap =
-      item.value.value<QMap<QString, QString>>();
+  QMap<QString, QVariant> lutPathMap =
+      item.value.value<QMap<QString, QVariant>>();
 
-  return lutPathMap.value(monitorName);
+  return lutPathMap.value(monitorName).toString();
 }

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -166,6 +166,18 @@ QStringList getMonitorNames() {
 
 //-----------------------------------------------------------------------------
 
+LutCalibrator::LutCalibrator() {
+  LutManager::instance()->registerCalibrator(this);
+}
+
+//-----------------------------------------------------------------------------
+
+LutCalibrator::~LutCalibrator() {
+  LutManager::instance()->removeCalibrator(this);
+}
+
+//-----------------------------------------------------------------------------
+
 void LutCalibrator::initialize() {
   initializeOpenGLFunctions();
   m_isInitialized = true;
@@ -185,8 +197,6 @@ void LutCalibrator::initialize() {
   assignLutTexture();
 
   m_isValid = true;
-
-  return;
 }
 
 //-----------------------------------------------------------------------------
@@ -369,6 +379,7 @@ void LutCalibrator::onEndDraw(QOpenGLFramebufferObject* fbo) {
 
 void LutCalibrator::assignLutTexture() {
   assert(glGetError() == GL_NO_ERROR);
+  if (m_lutTex) delete m_lutTex;
   int meshSize = LutManager::instance()->meshSize();
   m_lutTex     = new QOpenGLTexture(QOpenGLTexture::Target3D);
   m_lutTex->setSize(meshSize, meshSize, meshSize);
@@ -385,6 +396,13 @@ void LutCalibrator::assignLutTexture() {
   assert(glGetError() == GL_NO_ERROR);
 }
 
+//-----------------------------------------------------------------------------
+
+void LutCalibrator::update(bool textureChanged) {
+  m_isValid = LutManager::instance()->isValid();
+  if (textureChanged) assignLutTexture();
+}
+
 //=============================================================================
 
 LutManager* LutManager::instance() {
@@ -394,7 +412,7 @@ LutManager* LutManager::instance() {
 
 //-----------------------------------------------------------------------------
 
-LutManager::LutManager() {
+LutManager::LutManager() : m_isValid(false), m_currentLutPath() {
   // check whether preference enables color calibration
   if (!Preferences::instance()->isColorCalibrationEnabled()) return;
 
@@ -410,8 +428,8 @@ LutManager::LutManager() {
   // check existence of the 3dlut file
   // load 3dlut data
   if (!loadLutFile(lutPath)) return;
-
-  m_isValid = true;
+  m_currentLutPath = lutPath;
+  m_isValid        = true;
 }
 
 //-----------------------------------------------------------------------------
@@ -501,6 +519,7 @@ bool LutManager::loadLutFile(const QString& fp) {
     return execWarning(QObject::tr("Failed to Load 3DLUT File."));
   }
 
+  if (m_lut.data) delete[] m_lut.data;
   m_lut.data = new float[m_lut.meshSize * m_lut.meshSize * m_lut.meshSize * 3];
 
   for (int k = 0; k < m_lut.meshSize; ++k)  // r
@@ -611,4 +630,42 @@ void LutManager::convert(TPixel32& col) {
   convert(r, g, b);
   col = TPixel32((int)(r * 255.0 + 0.5), (int)(g * 255.0 + 0.5),
                  (int)(b * 255.0 + 0.5), col.m);
+}
+
+//-----------------------------------------------------------------------------
+
+void LutManager::registerCalibrator(LutCalibrator* calibrator) {
+  assert(!m_calibrators.contains(calibrator));
+  m_calibrators.insert(calibrator);
+}
+
+//-----------------------------------------------------------------------------
+
+void LutManager::removeCalibrator(LutCalibrator* calibrator) {
+  assert(m_calibrators.contains(calibrator));
+  m_calibrators.remove(calibrator);
+}
+
+//-----------------------------------------------------------------------------
+
+void LutManager::update() {
+  m_isValid           = false;
+  bool textureChanged = false;
+  if (Preferences::instance()->isColorCalibrationEnabled()) {
+    // obtain current monitor name
+    QString monitorName = getMonitorName();
+    // obtain 3dlut path associated to the monitor name
+    QString lutPath =
+        Preferences::instance()->getColorCalibrationLutPath(monitorName);
+    if (m_currentLutPath == lutPath)
+      m_isValid = true;
+    else if (loadLutFile(lutPath)) {
+      m_isValid        = true;
+      m_currentLutPath = lutPath;
+      textureChanged   = true;
+    }
+  }
+
+  // update textures for all calibrators
+  for (auto calibrator : m_calibrators) calibrator->update(textureChanged);
 }


### PR DESCRIPTION
This PR enables to apply and switch 3D Look-up Table files without rebooting OT.
The following preference options will now effect as soon as they are changed:
- Interface category > `Color Calibration using 3D Look-up Table`
- Interface category > `3DLUT File for [Monitor Name]:`