### PR TITLE
Palette Filter Fx Enhancement

### DIFF
--- a/toonz/sources/include/tropcm.h
+++ b/toonz/sources/include/tropcm.h
@@ -57,7 +57,8 @@ DVAPI void overlayCmapped(TRasterCM32P rasOut, const TRasterCM32P &rasUp,
 // keepInks=false);
 
 DVAPI void eraseColors(TRasterCM32P ras, std::vector<int> *colorIds,
-                       bool eraseInks);  // colorsId==0 ->erase ALL
+                       bool eraseInks,
+                       bool noGap = false);  // colorsId==0 ->erase ALL
 // DVAPI void  eraseColors(TRasterCM32P ras, vector<int>& colorIds, bool
 // eraseInks, bool keepColor);
 DVAPI void eraseStyleIds(TToonzImage *image, const std::vector<int> styleIds);

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -468,9 +468,10 @@ static TImageP applyCmappedFx(TToonzImageP &ti,
                                          // sicuramente devo cancellare dei
                                          // paint
         TRop::eraseColors(
-            copyRas, PaletteFilterData->m_type == eApplyToInksDeletingAllPaints
-                         ? 0
-                         : &indexes,
+            copyRas,
+            PaletteFilterData->m_type == eApplyToInksDeletingAllPaints
+                ? 0
+                : &indexes,
             false);
 
       /*-- Inkの消去 --*/
@@ -480,10 +481,11 @@ static TImageP applyCmappedFx(TToonzImageP &ti,
                                          // sicuramente devo cancellare degli
                                          // ink
         TRop::eraseColors(
-            copyRas, PaletteFilterData->m_type == eApplyToPaintsDeletingAllInks
-                         ? 0
-                         : &indexes,
-            true);
+            copyRas,
+            PaletteFilterData->m_type == eApplyToPaintsDeletingAllInks
+                ? 0
+                : &indexes,
+            true, PaletteFilterData->m_type == eApplyToInksAndPaints_NoGap);
     }
   }
 


### PR DESCRIPTION
This PR will enhance the Palette Filter Fx with `Lines & Areas (No Gap)` option.

A major purpose of the `Lines & Areas (No Gap)` option is to retrieve the portion of image assuming that it will be composited back with the inverse-filtered part of the image after applying some fxs.
For instance, consider the character which is drawn together with its shadow. This option can be used to retrieve the shadow part and composite again after making it semi-transparent by Transparency Fx.

However, currently the option still leave transparent part after deleting lines and causes unwanted gap after re-composition.
This PR enhances the option so that the transparent gap is filled with neighbor pixel's style ( i.e. making the image with No Gap, in the true sense of the word ).

Here is a simple example scene showcasing the enhancement:
In the Fx Schematic the two Palette Filter Fx, one is for deleting lines (with style#1) and the other is for keeping only lines, are composited again. 
<img src="https://user-images.githubusercontent.com/17974955/95961621-3e3fda80-0e40-11eb-8ea6-4ca7c44ec635.png" width=500>

Here are the results (click to enlarge):
<img src="https://user-images.githubusercontent.com/17974955/95962043-d8078780-0e40-11eb-95ac-8ff4937a3119.png" width=500>
Please note that the rendering result by existing one has small semi-transparent gaps (where the green background can be can be seen through) especially around the eye of the character. This PR resolves it.