### PR TITLE
Selectable Parameter Name Label

### DIFF
--- a/toonz/sources/toonzqt/functionsegmentviewer.cpp
+++ b/toonz/sources/toonzqt/functionsegmentviewer.cpp
@@ -948,6 +948,7 @@ FunctionSegmentViewer::FunctionSegmentViewer(QWidget *parent,
   validator->setBottom(1);
   m_fromFld->setValidator(validator);
   m_toFld->setValidator(validator);
+  m_paramNameLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
 
   m_stepFld->setEnabled(true);
 


### PR DESCRIPTION
This PR enables to select parameter name label in the segment viewer panel of the Function Editor in order to copy & paste it into the expression field.
This idea was suggested in [this comment](https://github.com/opentoonz/opentoonz/pull/3375#issuecomment-708597360) by @RodneyBaker . Thanks!