### PR TITLE
Fix Crash When Drawing on Absent Level

### DIFF
--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -243,6 +243,10 @@ Editable range is contained in \b m_editableRange.
   //!  and assigns the specified level path.
   TImageP createEmptyFrame();
 
+  void initializePalette();
+  void initializeResolutionAndDpi(const TDimension &dim = TDimension(),
+                                  double dpi            = 0);
+
   TDimension getResolution();
 
   TPointD getImageDpi(const TFrameId &fid = TFrameId::NO_FRAME,

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -14,6 +14,7 @@
 #include "toonz/stage.h"
 #include "toonz/textureutils.h"
 #include "toonz/levelset.h"
+#include "toonz/tcamera.h"
 
 // TnzBase includes
 #include "tenv.h"
@@ -1903,9 +1904,69 @@ void TXshSimpleLevel::invalidateFrame(const TFrameId &fid) {
 }
 
 //-----------------------------------------------------------------------------
+// note that the palette will always be replaced by the new one.
+void TXshSimpleLevel::initializePalette() {
+  assert(getScene());
+  int type = getType();
+  if (type == TZP_XSHLEVEL || type == PLI_XSHLEVEL) setPalette(new TPalette());
+  if (type == OVL_XSHLEVEL)
+    setPalette(FullColorPalette::instance()->getPalette(getScene()));
+  TPalette *palette = getPalette();
+  if (palette && type != OVL_XSHLEVEL) {
+    palette->setPaletteName(getName());
+    palette->setDirtyFlag(true);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshSimpleLevel::initializeResolutionAndDpi(const TDimension &dim,
+                                                 double dpi) {
+  assert(getScene());
+  if (getProperties()->getImageRes() != TDimension() &&
+      getProperties()->getDpi() != TPointD())
+    return;
+
+  double dpiY = dpi;
+  getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
+  if (dim == TDimension()) {
+    double w, h;
+    Preferences *pref = Preferences::instance();
+    if (pref->isNewLevelSizeToCameraSizeEnabled()) {
+      TDimensionD camSize = getScene()->getCurrentCamera()->getSize();
+      w                   = camSize.lx;
+      h                   = camSize.ly;
+      getProperties()->setDpiPolicy(LevelProperties::DP_CustomDpi);
+      dpi  = getScene()->getCurrentCamera()->getDpi().x;
+      dpiY = getScene()->getCurrentCamera()->getDpi().y;
+    } else {
+      w    = pref->getDefLevelWidth();
+      h    = pref->getDefLevelHeight();
+      dpi  = pref->getDefLevelDpi();
+      dpiY = dpi;
+    }
+
+    getProperties()->setImageRes(TDimension(tround(w * dpi), tround(h * dpiY)));
+  } else
+    getProperties()->setImageRes(dim);
+
+  getProperties()->setImageDpi(TPointD(dpi, dpiY));
+  getProperties()->setDpi(dpi);
+}
+
+//-----------------------------------------------------------------------------
 
 // crea un frame con tipo, dimensioni, dpi, ecc. compatibili con il livello
 TImageP TXshSimpleLevel::createEmptyFrame() {
+  // In case this is the first frame to be created in this level (i.e. the level
+  // file was missing when loading resources) initialize the level in the same
+  // manner as createNewLevel() in order to avoid crash. This can be happened if
+  // the level was not saved after creating and being placed in the xsheet.
+  if (isEmpty()) {
+    initializePalette();
+    initializeResolutionAndDpi();
+  }
+
   TImageP result;
 
   switch (m_type) {


### PR DESCRIPTION
This PR fixes #3531 .
This PR also takes care of the similar problem occurs with Raster and Toonz Raster levels.

The crash occurred due to the initialization (like setting the palette, resolution and dpi) is not completed which is normally done when loading the resources on opening the scene.
This PR will initialize the level on creating the new frame if the level is empty to avoid crash. The initialization will be done with the values set in the preferences. 