### PR TITLE
Fix Palette Gizmo Target

### DIFF
--- a/toonz/sources/toonz/pltgizmopopup.cpp
+++ b/toonz/sources/toonz/pltgizmopopup.cpp
@@ -166,7 +166,7 @@ public:
       tmpmatte = 0;
     else if (tmpmatte > 255)
       tmpmatte = 255;
-    color.m    = tmpmatte;
+    color.m = tmpmatte;
     return color;
   }
 };
@@ -186,7 +186,7 @@ public:
       tmpmatte = 0;
     else if (tmpmatte > 255)
       tmpmatte = 255;
-    color.m    = tmpmatte;
+    color.m = tmpmatte;
     return color;
   }
 };
@@ -377,11 +377,11 @@ void modifyColor(const T &modifier) {
   TUndo *undo;
   TStyleSelection *selection = dynamic_cast<TStyleSelection *>(
       TApp::instance()->getCurrentSelection()->getSelection());
-  if (selection) {
+  if (selection && !selection->isEmpty()) {
     undo = new GizmoUndo(*selection);
     getStyleIds(styleIds, *selection);
   }
-  /*-- StyleSelectionが有効でない場合はカレントStyleを用いる --*/
+  // modify the current style if the style selection is not active or is empty
   else {
     TStyleSelection tmpSelection;
     tmpSelection.setPaletteHandle(paletteHandle);


### PR DESCRIPTION
This PR fixes the Palette Gizmo to work on the current style if the style selection is active but is empty (i.e. no style is selected).
This will resolve, for instance, the following problem:

- Open Palette Gizmo popup.
- Select the Style Picker Tool.
- Pick some style from the image. (The style selection becomes empty and the current style is moved to the picked one.)
- Try to adjust color of the picked style with the Palette Gizmo.

Before this PR, the attempt have failed due to the empty selection.