### PR TITLE
Enhance Studio Palette Searching

### DIFF
--- a/toonz/sources/include/toonz/studiopalette.h
+++ b/toonz/sources/include/toonz/studiopalette.h
@@ -107,6 +107,9 @@ public:
 
   void save(const TFilePath &path, TPalette *palette);
 
+  void removeEntry(const std::wstring paletteId);
+  void addEntry(const std::wstring paletteId, const TFilePath &path);
+
 private:
   StudioPalette();
   TFilePath m_root;

--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -1793,7 +1793,7 @@ void TStyleSelection::getBackOriginalStyle() {
     } else
       spPalette = palIt->second.getPointer();
 
-    // j is StudioPaletteID
+    // j is StyleID
     int j = std::stoi(gname.substr(k + 1));
 
     if (spPalette && 0 <= j && j < spPalette->getStyleCount()) {


### PR DESCRIPTION
This PR enhances studio palette searching procedure when using `Toggle Link to Studio Palette` and `Get Color from Studio Palette` commands.

These commands had tried to find the linked studio palette by checking all files in the `Global Palettes` and `Project Palettes` tree. It takes time especially if there are a lot of files under the `Project Palettes` folder tree. (In our studio, we put not only the studio palettes but also color model files for all scenes under the same folder tree as they are related to the color designing workflow.)

This PR will make an index file listing the "global palette IDs" and the "paths to relevant palettes" (`palette_paths.ini`) under the both root folders of `Global Palettes` and `Project Palettes` so that OT can find the palette efficiently.
An index of some studio palette will be automatically updated when searching it for the first time after its creation / relocation.