### PR TITLE
Fix Raster Rectangular Fill Tool

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -109,7 +109,7 @@ Fill \b rect in raster with \b color.
 else if \b fillInks is false fill only paint delimited by ink;
 else fill ink and paint in rect.
 */
-  void rectFill(const TRect &rect, int color, bool onlyUnfilled,
+  bool rectFill(const TRect &rect, int color, bool onlyUnfilled,
                 bool fillPaints, bool fillInks);
 
   /*!

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -824,10 +824,14 @@ void fillAreaWithUndo(const TImageP &img, const TRectD &area, TStroke *stroke,
     TTileSetCM32 *tileSet = new TTileSetCM32(ras->getSize());
     tileSet->add(ras, rasterFillArea);
     AreaFiller filler(ti->getRaster());
-    if (!stroke)
-      filler.rectFill(rasterFillArea, cs, onlyUnfilled, colorType != LINES,
-                      colorType != AREAS);
-    else
+    if (!stroke) {
+      bool ret = filler.rectFill(rasterFillArea, cs, onlyUnfilled,
+                                 colorType != LINES, colorType != AREAS);
+      if (!ret) {
+        delete tileSet;
+        return;
+      }
+    } else
       filler.strokeFill(stroke, cs, onlyUnfilled, colorType != LINES,
                         colorType != AREAS);
 
@@ -835,11 +839,6 @@ void fillAreaWithUndo(const TImageP &img, const TRectD &area, TStroke *stroke,
 
     // !autopaintLines will temporary disable autopaint line feature
     if ((plt && !hasAutoInks(plt)) || !autopaintLines) plt = 0;
-
-    std::set<int> autoInks;
-    autoInks.insert(3);
-    autoInks.insert(4);
-    autoInks.insert(5);
 
     if (plt) {
       TRect rect   = rasterFillArea;
@@ -1321,6 +1320,7 @@ void AreaFillTool::leftButtonDoubleClick(const TPointD &pos,
 
   if (m_polyline.size() <= 1) {
     resetMulti();
+    m_isLeftButtonPressed = false;
     return;
   }
 
@@ -1384,6 +1384,7 @@ void AreaFillTool::leftButtonDoubleClick(const TPointD &pos,
 }
 
 void AreaFillTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
+  if (!m_isLeftButtonPressed) return;
   if (m_type == RECT) {
     m_selectingRect.x1 = pos.x;
     m_selectingRect.y1 = pos.y;


### PR DESCRIPTION
This PR fixes the following problem regarding Fill Tool with tablet:

**To reproduce**

- Open some toonz raster level.
- Select the Fill tool
- Select the `Rectangular` type and the `Areas` mode
- Using tablet, double-click(tap) any point on the image.

In our environment the rectangular fill unexpectedly executed with the region from the center of the image and the double-clicked point. The problem was due to the function `FillTool::leftButtonDoubleClick()` is called between `FillTool::leftButtonDown()` and `FillTool::leftButtonUp()` when the second tap, and in the function the clicked pos is reset to the center of the image. 
I added a line to cancel the left button click when the double click is detected so that the filling operation will be skipped.


In this PR I also modified that the rectangular fill operation will not register undo if the specified rectagle is too small or contains no line pixels (i.e. the case that the operation obviously does not change the image) . 

  

