### PR TITLE
Fix Crash on Switching Rooms

### DIFF
--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -152,7 +152,8 @@ class DVAPI HexagonalColorWheel final : public GLWidgetForHighDpi {
   QOpenGLFramebufferObject *m_fbo = NULL;
   LutCalibrator *m_lutCalibrator  = NULL;
 
-  bool m_firstInitialized = true;
+  bool m_firstInitialized      = true;
+  bool m_cuedCalibrationUpdate = false;
 
 private:
   void drawCurrentColorMark();
@@ -169,6 +170,7 @@ public:
   QColor getBGColor() const { return m_bgColor; }
 
   void updateColorCalibration();
+  void cueCalibrationUpdate() { m_cuedCalibrationUpdate = true; }
 
 protected:
   void initializeGL() override;
@@ -180,6 +182,7 @@ protected:
   void mouseMoveEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
 
+  void showEvent(QShowEvent *) override;
 signals:
   void colorChanged(const ColorModel &color, bool isDragging);
 

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -596,6 +596,15 @@ void HexagonalColorWheel::updateColorCalibration() {
 
 //-----------------------------------------------------------------------------
 
+void HexagonalColorWheel::showEvent(QShowEvent *) {
+  if (m_cuedCalibrationUpdate) {
+    updateColorCalibration();
+    m_cuedCalibrationUpdate = false;
+  }
+}
+
+//-----------------------------------------------------------------------------
+
 void HexagonalColorWheel::initializeGL() {
   initializeOpenGLFunctions();
 
@@ -1716,7 +1725,10 @@ void PlainColorPage::setSplitterState(QByteArray state) {
 //-----------------------------------------------------------------------------
 
 void PlainColorPage::updateColorCalibration() {
-  m_hexagonalColorWheel->updateColorCalibration();
+  if (m_hexagonalColorWheel->isVisible())
+    m_hexagonalColorWheel->updateColorCalibration();
+  else
+    m_hexagonalColorWheel->cueCalibrationUpdate();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes crash on switching rooms, with conditions as follows:

**To reproduce:**
- Display the Style Editor in floating window.
- Enable 3DLUT color calibration.
- Select an empty cell or a cell containing 16bpc raster level so that the hexagonal color wheel is hidden in the Style Editor.
- Switch the rooms. OT crashes.

The crash occurs when calling `initializeOpenGLFunctions()` in the function `LutCalibrator::initialize()` .
When the color wheel is hidden, this function crashes due to absence of OpenGL context.

I added a line to postpone the update of calibrator until the color wheel is shown.