### PR TITLE
Glare Fx Iwa Revised

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1310,9 +1310,16 @@
 
   <item>"STD_iwa_GlareFx" 			"Glare Iwa" 	</item>
   <item>"STD_iwa_GlareFx.renderMode"	"Render Mode"		</item>
+  <item>"STD_iwa_GlareFx.irisMode"	"Iris Shape"		</item>
+  <item>"STD_iwa_GlareFx.irisScale"	"Iris Scale"		</item>
+  <item>"STD_iwa_GlareFx.irisGearEdgeCount"	"Edges"		</item>
+  <item>"STD_iwa_GlareFx.irisRandomSeed"	"Random Seed"		</item>
+  <item>"STD_iwa_GlareFx.irisSymmetry"	"Symmetry"		</item>
+  <item>"STD_iwa_GlareFx.irisAppearance"	"Appearance"		</item>
   <item>"STD_iwa_GlareFx.intensity"	"Intensity"		</item>
   <item>"STD_iwa_GlareFx.size"	"Filter Size"		</item>
   <item>"STD_iwa_GlareFx.rotation"	"Filter Rotation"		</item>
+  <item>"STD_iwa_GlareFx.aberration"	"Chromatic Aberration"		</item>
   <item>"STD_iwa_GlareFx.noise_factor"	"Noise Factor"		</item>
   <item>"STD_iwa_GlareFx.noise_size"	"Noise Size"		</item>
   <item>"STD_iwa_GlareFx.noise_octave"	"Noise Octave"		</item>

--- a/stuff/profiles/layouts/fxs/STD_iwa_GlareFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_GlareFx.xml
@@ -1,9 +1,24 @@
 <fxlayout help_command="iexplore" help_file="BokehIwa.html">
 	<page name="Glare Iwa">
 		<control>renderMode</control>
+		<control>irisMode</control>
+		<vbox modeSensitive="irisMode" mode="1,2,3,4">
+			<separator/>
+			<control>irisScale</control>
+			<control>irisSymmetry</control>
+			<control>irisAppearance</control>
+		</vbox>
+		<vbox modeSensitive="irisMode" mode="4">
+			<control>irisGearEdgeCount</control>
+			<control>irisRandomSeed</control>
+		</vbox>
+		<vbox modeSensitive="irisMode" mode="1,2,3,4">
+			<separator/>
+		</vbox>
 		<control>intensity</control>
 		<control>size</control>
 		<control>rotation</control>
+		<control>aberration</control>
 		<control>noise_factor</control>
 		<control>noise_size</control>
 		<control>noise_octave</control>

--- a/toonz/sources/common/tfx/tfx.cpp
+++ b/toonz/sources/common/tfx/tfx.cpp
@@ -701,6 +701,9 @@ void TFx::setNewIdentifier() { m_imp->m_id = ++m_imp->m_nextId; }
 //--------------------------------------------------
 
 void TFx::loadData(TIStream &is) {
+  // default version of fx is 1
+  setFxVersion(1);
+
   std::string tagName;
   VersionNumber tnzVersion = is.getVersion();
   // Prevent to load "params" tag under "super" tag on saving macro fx.
@@ -818,6 +821,10 @@ void TFx::loadData(TIStream &is) {
         is >> groupName;
         groupNames.append(groupName);
       }
+    } else if (tagName == "fxVersion") {
+      int version = 1;
+      is >> version;
+      setFxVersion(version);
     } else {
       throw TException("Unknown tag!");
     }
@@ -907,6 +914,7 @@ void TFx::saveData(TOStream &os) {
     for (i = 0; i < groupNameStack.size(); i++) os << groupNameStack[i];
     os.closeChild();
   }
+  if (getFxVersion() != 1) os.child("fxVersion") << getFxVersion();
 }
 
 //--------------------------------------------------
@@ -991,6 +999,14 @@ TFx *TFx::getLinkedFx() const {
   assert(m_imp->m_next->m_fx != 0);
   return m_imp->m_next->m_fx;
 }
+
+//--------------------------------------------------
+
+void TFx::setFxVersion(int v) { m_imp->m_attributes.setFxVersion(v); }
+
+//--------------------------------------------------
+
+int TFx::getFxVersion() const { return m_imp->m_attributes.getFxVersion(); }
 
 //===================================================
 //

--- a/toonz/sources/include/tfx.h
+++ b/toonz/sources/include/tfx.h
@@ -503,6 +503,9 @@ public:
   // parameter is loaded. Do nothing by default.
   virtual void onObsoleteParamLoaded(const std::string &paramName) {}
 
+  void setFxVersion(int);
+  int getFxVersion() const;
+
 public:
   // Id-related functions
 

--- a/toonz/sources/include/tfxattributes.h
+++ b/toonz/sources/include/tfxattributes.h
@@ -33,6 +33,8 @@ class DVAPI TFxAttributes {
 
   /*-- MotionBlurなどのFxのために、オブジェクトの軌跡のデータを取得する --*/
   QList<TPointD> m_motionPoints;
+  // to maintain backward compatibility in the fx
+  int m_fxVersion;
 
 public:
   TFxAttributes();
@@ -62,6 +64,8 @@ public:
     m_motionPoints = motionPoints;
   }
   QList<TPointD> getMotionPoints() { return m_motionPoints; }
+  void setFxVersion(int version) { m_fxVersion = version; }
+  int getFxVersion() const { return m_fxVersion; };
 
   // Group management
 

--- a/toonz/sources/stdfx/iwa_glarefx.h
+++ b/toonz/sources/stdfx/iwa_glarefx.h
@@ -35,12 +35,21 @@ class Iwa_GlareFx : public TStandardRasterFx {
 protected:
   TRasterFxPort m_source;
   TRasterFxPort m_iris;
-  // rendering mode (filter preview / render)
+  // rendering mode (filter preview / render / iris)
   TIntEnumParamP m_renderMode;
+  TIntEnumParamP m_irisMode;
+
+  TDoubleParamP m_irisScale;
+  TDoubleParamP m_irisGearEdgeCount;
+  TIntParamP m_irisRandomSeed;
+  TDoubleParamP m_irisSymmetry;
+  TIntEnumParamP m_irisAppearance;
+
   TDoubleParamP m_intensity;
   TDoubleParamP m_size;
 
   TDoubleParamP m_rotation;
+  TDoubleParamP m_aberration;
 
   TDoubleParamP m_noise_factor;
   TDoubleParamP m_noise_size;
@@ -48,15 +57,32 @@ protected:
   TDoubleParamP m_noise_evolution;
   TPointParamP m_noise_offset;
 
-  enum { RendeMode_FilterPreview = 0, RendeMode_Render };
+  enum { RendeMode_FilterPreview = 0, RendeMode_Render, RenderMode_Iris };
+
+  enum {
+    Iris_InputImage = 0,
+    Iris_Square,
+    Iris_Hexagon,
+    Iris_Octagon,
+    Iris_GearShape
+  };
+
+  enum {
+    Appearance_ThinLine,
+    Appearance_MediumLine,
+    Appearance_ThickLine,
+    Appearance_Fill,
+  };
 
   double getSizePixelAmount(const double val, const TAffine affine);
+
+  void drawPresetIris(TRaster32P irisRas, double irisSize, const double frame);
 
   // Resize / flip the iris image according to the size ratio.
   // Normalize the brightness of the iris image.
   // Enlarge the iris to the output size.
   void convertIris(kiss_fft_cpx *kissfft_comp_iris_before, const int &dimIris,
-                   const TRectD &irisBBox, const TTile &irisTile);
+                   const TRectD &irisBBox, const TRasterP irisRaster);
 
   void powerSpectrum2GlarePattern(const double frame, const TAffine affine,
                                   kiss_fft_cpx *spectrum, double3 *glare,

--- a/toonz/sources/tnzbase/tfxattributes.cpp
+++ b/toonz/sources/tnzbase/tfxattributes.cpp
@@ -13,7 +13,8 @@ TFxAttributes::TFxAttributes()
     , m_isOpened(false)
     , m_speed()
     , m_groupSelector(-1)
-    , m_passiveCacheDataIdx(-1) {}
+    , m_passiveCacheDataIdx(-1)
+    , m_fxVersion(1) {}
 
 //----------------------------------------------------------------------
 


### PR DESCRIPTION
This PR will revise the Glare Fx Iwa, both in modifying the internal calculation and adding new features as follows.

### Modification

I fixed the chromatic calculation: when summing the intensity of each wavelength of light, weight is modified from constant to proportional to 1/(_wavelength_^2) which is more physically-accurate.
Now the modified fx generates more "white" glare pattern:
<img src="https://user-images.githubusercontent.com/17974955/100841437-a1ea9980-34ba-11eb-803f-83ba17b1a536.png" width=300>

In order to keep backward compatibility (as we already had used this Fx for production), I added a new variable `fxVersion` to the `FxAttribute` .
The Glare fx made with the older versions is with `fxVersion=1` (default) and will compute in the previous way. 
The fx created after this version will be saved as `fxVersion=2` and compute in the modified way.

### New Features

Introduced the "Iris Preset" feature, which enables to generate typical glare patterns without an input image from the `Iris` port. 
Here are the types of glare shapes:
<img src="https://user-images.githubusercontent.com/17974955/100843291-7b7a2d80-34bd-11eb-81eb-70244303bcb9.png" width=500>
And here are the parameters:
- **Iris Scale** specifies the size of the generating iris image at a ratio of `Filter Size`
- **Symmetry** specifies how the streaks with the same length / at regular intervals.
   <img src="https://user-images.githubusercontent.com/17974955/100843980-85e8f700-34be-11eb-918a-5a31e4ae8425.png" width=400>
- **Appearance** specifies line width of the iris shape which will change the interval of the rainbow coloring. Selecting the option `Filled` will minimize the rainbow coloring in the pattern. 
   <img src="https://user-images.githubusercontent.com/17974955/100844294-060f5c80-34bf-11eb-8d73-432caf973983.png" width=500>
- **Edges** and **Random Seed** are enabled only when `Iris Shape = Multiple Streaks` is selected. `Edges` specifies the number of edges of gear-shaped iris (therefore, specifies number of streaks accordingly). `Random Seed` specifies the random seed to generate asymmetric shape when the value `Symmetry` is less than 1.0.

Also added a value `Chromatic Aberration` which specifies the order and dispersion of the rainbow colors.
<img src="https://user-images.githubusercontent.com/17974955/100844934-d90f7980-34bf-11eb-9bc6-e32bae48b347.png" width=300>
Left: `Chromatic Aberration = 1.0` (default value)
Right: `Chromatic Aberration = -1.0`

Furthermore, a new option `Iris` is added to the `Render Mode`, for checking the generated iris pattern.

#### ATTENTION

Since the new parameter `fxVersion` will be saved in the scene, the scene file containing Glare Fx Iwa cannot be opened with the older versions of OT.




