### PR TITLE
Tahoma2D porting (Dec 9, 2020) by jeremybullock and manongjohn

### DIFF
--- a/stuff/doc/LICENSE/LICENSE_tahoma2d.txt
+++ b/stuff/doc/LICENSE/LICENSE_tahoma2d.txt
@@ -1,9 +1,9 @@
-License Agreement For Tahoma
-[https://github.com/turtletooth/tahoma]
+License Agreement For Tahoma2D
+[https://github.com/tahoma2d/tahoma2d/]
 
 - - - - - - - - - - - - - - - -
 
-Tahoma
+Tahoma2D
 
 All contributions by Jeremy Bullock:
 Copyright (c) 2016 - 2020, Jeremy Bullock

--- a/toonz/sources/include/toonz/palettecontroller.h
+++ b/toonz/sources/include/toonz/palettecontroller.h
@@ -96,6 +96,7 @@ signals:
 
   void colorAutoApplyEnabled(bool enabled);
   void colorSampleChanged(const TPixel32 &);
+  void checkPaletteLock();
 
   // used for "passive pick" feature in the tool options bar of the rgb picker
   // tool

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -727,6 +727,7 @@ protected slots:
   void onCleanupStyleChanged(bool isDragging);
   void onOldStyleClicked(const TColorStyle &);
   void updateOrientationButton();
+  void checkPaletteLock();
   // called (e.g.) by PaletteController when an other StyleEditor change the
   // toggle
   void enableColorAutoApply(bool enabled);

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -304,7 +304,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   if (!viewer) return;
 
   TRasterImageP ri = (TRasterImageP)getImage(true);
-  if (!ri) ri = (TRasterImageP)touchImage();
+  if (!ri) ri      = (TRasterImageP)touchImage();
 
   if (!ri) return;
 
@@ -580,12 +580,12 @@ void FullColorBrushTool::setWorkAndBackupImages() {
   TRasterP ras   = ri->getRaster();
   TDimension dim = ras->getSize();
 
-  if (!m_workRaster || m_workRaster->getLx() > dim.lx ||
-      m_workRaster->getLy() > dim.ly)
+  if (!m_workRaster || m_workRaster->getLx() != dim.lx ||
+      m_workRaster->getLy() != dim.ly)
     m_workRaster = TRaster32P(dim);
 
-  if (!m_backUpRas || m_backUpRas->getLx() > dim.lx ||
-      m_backUpRas->getLy() > dim.ly ||
+  if (!m_backUpRas || m_backUpRas->getLx() != dim.lx ||
+      m_backUpRas->getLy() != dim.ly ||
       m_backUpRas->getPixelSize() != ras->getPixelSize())
     m_backUpRas = ras->create(dim.lx, dim.ly);
 

--- a/toonz/sources/tnztools/shifttracetool.cpp
+++ b/toonz/sources/tnztools/shifttracetool.cpp
@@ -121,8 +121,8 @@ void ShiftTraceTool::updateBox() {
 void ShiftTraceTool::updateData() {
   m_box = TRectD();
   for (int i = 0; i < 2; i++) m_row[i] = -1;
-  m_dpiAff                             = TAffine();
-  TApplication *app                    = TTool::getApplication();
+  m_dpiAff          = TAffine();
+  TApplication *app = TTool::getApplication();
 
   OnionSkinMask osm  = app->getCurrentOnionSkin()->getOnionSkinMask();
   int previousOffset = osm.getShiftTraceGhostFrameOffset(0);
@@ -442,15 +442,16 @@ void ShiftTraceTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
 
   bool notify = false;
 
-  if (m_gadget == NoGadget || m_gadget == NoGadget_InBox) {
-    if (!e.isCtrlPressed()) {
-      if (m_gadget == NoGadget_InBox)
-        m_gadget = TranslateGadget;
-      else
-        m_gadget = RotateGadget;
-      // m_curveStatus = NoCurve;
+  if (!e.isCtrlPressed() &&
+      (m_gadget == NoGadget || m_gadget == NoGadget_InBox)) {
+    if (m_gadget == NoGadget_InBox) {
+      m_gadget = TranslateGadget;
+    } else {
+      m_gadget = RotateGadget;
     }
-    int row = getViewer()->posToRow(e.m_pos, 5 * getPixelSize(), false, true);
+
+    int row = getViewer()->posToRow(e.m_pos, getPixelSize() * getPixelSize(),
+                                    false, true);
     if (row >= 0) {
       int index         = -1;
       TApplication *app = TTool::getApplication();
@@ -475,6 +476,8 @@ void ShiftTraceTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
         notify              = true;
       }
     }
+  } else if (e.isCtrlPressed()) {
+    m_gadget = NoGadget_InBox;
   }
 
   m_oldAff = m_aff[m_ghostIndex];

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1287,6 +1287,7 @@ void TTool::tweenSelectedGuideStrokes() {
   if (vbTool) {
     m_isFrameCreated = false;
     m_isLevelCreated = false;
+    vbTool->touchImage();
     vbTool->setViewer(m_viewer);
     vbTool->doFrameRangeStrokes(
         bFid, bStroke, fFid, fStroke,
@@ -1388,6 +1389,7 @@ void TTool::tweenGuideStrokeToSelected() {
   if (vbTool) {
     m_isFrameCreated = false;
     m_isLevelCreated = false;
+    vbTool->touchImage();
     vbTool->setViewer(m_viewer);
     TUndoManager::manager()->beginBlock();
     if (bStroke)

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -536,7 +536,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_nsPosField =
       new PegbarChannelField(m_tool, TStageObject::T_Y, "field", frameHandle,
                              objHandle, xshHandle, this);
-  m_zField = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
+  m_zField        = new PegbarChannelField(m_tool, TStageObject::T_Z, "field",
                                     frameHandle, objHandle, xshHandle, this);
   m_noScaleZField = new NoScaleField(m_tool, "field");
 
@@ -629,14 +629,12 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_nsCenterLabel = new ClickableLabel(tr("Y:"), this);
 
   // Lock X Center
-  lockProp =
-      dynamic_cast<TBoolProperty *>(m_pg->getProperty("Lock Center X"));
+  lockProp = dynamic_cast<TBoolProperty *>(m_pg->getProperty("Lock Center X"));
   if (lockProp)
     m_lockEWCenterCheckbox =
         new ToolOptionCheckbox(m_tool, lockProp, toolHandle, this);
   // Lock Y Center
-  lockProp =
-      dynamic_cast<TBoolProperty *>(m_pg->getProperty("Lock Center Y"));
+  lockProp = dynamic_cast<TBoolProperty *>(m_pg->getProperty("Lock Center Y"));
   if (lockProp)
     m_lockNSCenterCheckbox =
         new ToolOptionCheckbox(m_tool, lockProp, toolHandle, this);
@@ -667,7 +665,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
   m_zField->setPrecision(4);
   m_noScaleZField->setPrecision(4);
 
-  bool splined                        = isCurrentObjectSplined();
+  bool splined = isCurrentObjectSplined();
   if (splined != m_splined) m_splined = splined;
   setSplined(m_splined);
 
@@ -1300,7 +1298,7 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   // assert(ret);
   bool ret = connect(m_scaleXField, SIGNAL(valueChange(bool)),
                      SLOT(onScaleXValueChanged(bool)));
-  ret = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
+  ret      = ret && connect(m_scaleYField, SIGNAL(valueChange(bool)),
                        SLOT(onScaleYValueChanged(bool)));
   if (m_setSaveboxCheckbox)
     ret = ret && connect(m_setSaveboxCheckbox, SIGNAL(toggled(bool)),
@@ -1721,11 +1719,11 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_colorMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onColorModeChanged(int)));
-  ret = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
+  ret      = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolTypeChanged(int)));
-  ret = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_onionMode, SIGNAL(toggled(bool)), this,
                        SLOT(onOnionModeToggled(bool)));
-  ret = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
                        SLOT(onMultiFrameModeToggled(bool)));
   assert(ret);
   if (m_colorMode->getProperty()->getValue() == L"Lines") {
@@ -2324,9 +2322,9 @@ TapeToolOptionsBox::TapeToolOptionsBox(QWidget *parent, TTool *tool,
 
   bool ret = connect(m_typeMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onToolTypeChanged(int)));
-  ret = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
+  ret      = ret && connect(m_toolMode, SIGNAL(currentIndexChanged(int)), this,
                        SLOT(onToolModeChanged(int)));
-  ret = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_joinStrokesMode, SIGNAL(toggled(bool)), this,
                        SLOT(onJoinStrokesModeChanged()));
   assert(ret);
 }
@@ -2413,10 +2411,11 @@ protected:
       p.setPen(Qt::black);
     p.setBrush(Qt::NoBrush);
 
-    p.drawText(rect(), Qt::AlignCenter, QString("R:%1 G:%2 B:%3")
-                                            .arg(m_color.red())
-                                            .arg(m_color.green())
-                                            .arg(m_color.blue()));
+    p.drawText(rect(), Qt::AlignCenter,
+               QString("R:%1 G:%2 B:%3")
+                   .arg(m_color.red())
+                   .arg(m_color.green())
+                   .arg(m_color.blue()));
   }
 };
 
@@ -2579,6 +2578,10 @@ ShiftTraceToolOptionBox::ShiftTraceToolOptionBox(QWidget *parent, TTool *tool)
 
   m_prevFrame->setFixedSize(10, 21);
   m_afterFrame->setFixedSize(10, 21);
+  int buttonWidth = fontMetrics().width(m_resetPrevGhostBtn->text()) + 10;
+  m_resetPrevGhostBtn->setFixedWidth(buttonWidth);
+  buttonWidth = fontMetrics().width(m_resetAfterGhostBtn->text()) + 10;
+  m_resetAfterGhostBtn->setFixedWidth(buttonWidth);
 
   m_layout->addWidget(m_prevFrame, 0);
   m_layout->addWidget(m_prevRadioBtn, 0);
@@ -2844,7 +2847,7 @@ void ToolOptions::onToolSwitched() {
   TTool *tool = app->getCurrentTool()->getTool();
   if (tool) {
     // c'e' un tool corrente
-    ToolOptionsBox *panel = 0;
+    ToolOptionsBox *panel                            = 0;
     std::map<TTool *, ToolOptionsBox *>::iterator it = m_panels.find(tool);
     if (it == m_panels.end()) {
       // ... senza panel associato

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1165,6 +1165,7 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
 
       bool frameCreated = m_isFrameCreated;
       m_isFrameCreated  = false;
+      touchImage();
       resultBack        = doFrameRangeStrokes(
           oFid, fStroke, cFid, cStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,
@@ -1199,6 +1200,7 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
 
       bool frameCreated = m_isFrameCreated;
       m_isFrameCreated  = false;
+      touchImage();
       resultFront       = doFrameRangeStrokes(
           cFid, cStroke, oFid, fStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1238,6 +1238,8 @@ public:
   void redo() const override {
     insertLevelAndFrameIfNeeded();
 
+    IconGenerator::instance()->invalidate(m_level.getPointer(), m_frameId);
+
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
     notifyImageChanged();
   }
@@ -2418,6 +2420,8 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
   CreateBlankDrawingUndo *undo = new CreateBlankDrawingUndo(
       sl, frame, toolHandle->getTool()->m_isLevelCreated, palette);
   TUndoManager::manager()->add(undo);
+
+  IconGenerator::instance()->invalidate(sl, frame);
 
   // Reset back to what these were
   if (!isAutoCreateEnabled)

--- a/toonz/sources/toonzlib/palettecontroller.cpp
+++ b/toonz/sources/toonzlib/palettecontroller.cpp
@@ -90,6 +90,7 @@ void PaletteController::setCurrentPalette(TPaletteHandle *paletteHandle) {
 
 void PaletteController::editLevelPalette() {
   setCurrentPalette(m_currentLevelPalette);
+  emit(checkPaletteLock());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -3283,6 +3283,8 @@ void StyleEditor::showEvent(QShowEvent *) {
                        SLOT(onStyleChanged(bool)));
   ret      = ret && connect(m_paletteHandle, SIGNAL(paletteSwitched()), this,
                        SLOT(onStyleSwitched()));
+  ret = ret && connect(m_paletteController, SIGNAL(checkPaletteLock()), this,
+                       SLOT(checkPaletteLock()));
   if (m_cleanupPaletteHandle)
     ret =
         ret && connect(m_cleanupPaletteHandle, SIGNAL(colorStyleChanged(bool)),
@@ -3492,8 +3494,8 @@ void StyleEditor::onColorChanged(const ColorModel &color, bool isDragging) {
 
     m_newColor->setStyle(*m_editedStyle);
     m_colorParameterSelector->setStyle(*m_editedStyle);
-
-    if (m_autoButton->isChecked()) {
+    // Auto Button should be disabled with locked palette
+    if (m_autoButton->isEnabled() && m_autoButton->isChecked()) {
       copyEditedStyleToPalette(isDragging);
     }
   }
@@ -3525,13 +3527,23 @@ void StyleEditor::enable(bool enabled, bool enabledOnlyFirstTab,
     // when the palette is locked
     if (palette->isLocked()) {
       m_applyButton->setEnabled(false);
-      m_autoButton->setChecked(false);
       m_autoButton->setEnabled(false);
     } else  // when the palette is unlocked
     {
       m_applyButton->setDisabled(m_autoButton->isChecked());
       m_autoButton->setEnabled(true);
     }
+  }
+}
+//-----------------------------------------------------------------------------
+
+void StyleEditor::checkPaletteLock() {
+  if (getPalette() && getPalette()->isLocked()) {
+    m_applyButton->setEnabled(false);
+    m_autoButton->setEnabled(false);
+  } else {
+    m_applyButton->setDisabled(m_autoButton->isChecked());
+    m_autoButton->setEnabled(true);
   }
 }
 


### PR DESCRIPTION
This PR will port several bug fixes done in Tahoma2D as follows:

- tahoma2d/tahoma2d#38 Fix brush tool on rasters with different sizes
  by @jeremybullock
  This fixes #3283 
- tahoma2d/tahoma2d#48 Fix variety of panels (partially)
  by @jeremybullock
  I ported only the part of Auto-apply button's behavior. Note that I slightly modified it so that the auto applying will not effect when the Apply button is disabled.
- tahoma2d/tahoma2d#52 Misc fixes (partially)
  by @jeremybullock
  I ported only the fixes related to the Shift & Trace feature. 
- tahoma2d/tahoma2d#109 Fix undo guided strokes clearing frames
  by @manongjohn
- tahoma2d/tahoma2d#111 Fix no icon for newly created blank frames
  by @manongjohn

Thank you @jeremybullock and @manongjohn for sharing your great work, it's very helpful.