### PR TITLE
Fix crash on "no current level" selected in level strip

### DIFF
--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1643,7 +1643,8 @@ void Filmstrip::updateChooseLevelComboItems() {
     }
   }
 
-  m_chooseLevelCombo->addItem(tr("- No Current Level -"));
+  if (m_chooseLevelCombo->count() == 0)
+    m_chooseLevelCombo->addItem(tr("- No Current Level -"));
 
   // swap the list
   m_workingFrames.clear();
@@ -1657,7 +1658,8 @@ void Filmstrip::updateChooseLevelComboItems() {
 /*! synchronize the current index of combo to the current level
  */
 void Filmstrip::updateCurrentLevelComboItem() {
-  if (m_chooseLevelCombo->count() == 1) {
+  if (m_chooseLevelCombo->count() == 1 &&
+      m_chooseLevelCombo->itemText(0) == tr("- No Current Level -")) {
     m_chooseLevelCombo->setCurrentIndex(0);
     return;
   }
@@ -1666,6 +1668,10 @@ void Filmstrip::updateCurrentLevelComboItem() {
       TApp::instance()->getCurrentLevel()->getSimpleLevel();
   if (!currentLevel) {
     int noLevelIndex = m_chooseLevelCombo->findText(tr("- No Current Level -"));
+    if (noLevelIndex == -1) {
+      noLevelIndex = m_chooseLevelCombo->count();
+      m_chooseLevelCombo->addItem(tr("- No Current Level -"));
+    }
     m_chooseLevelCombo->setCurrentIndex(noLevelIndex);
     return;
   }
@@ -1673,11 +1679,18 @@ void Filmstrip::updateCurrentLevelComboItem() {
   for (int i = 0; i < m_levels.size(); i++) {
     if (currentLevel->getName() == m_levels[i]->getName()) {
       m_chooseLevelCombo->setCurrentIndex(i);
+      int noLevelIndex =
+          m_chooseLevelCombo->findText(tr("- No Current Level -"));
+      if (noLevelIndex != -1) m_chooseLevelCombo->removeItem(noLevelIndex);
       return;
     }
   }
 
   int noLevelIndex = m_chooseLevelCombo->findText(tr("- No Current Level -"));
+  if (noLevelIndex == -1) {
+    noLevelIndex = m_chooseLevelCombo->count();
+    m_chooseLevelCombo->addItem(tr("- No Current Level -"));
+  }
   m_chooseLevelCombo->setCurrentIndex(noLevelIndex);
 }
 


### PR DESCRIPTION
This fixes #3471 
I decided to take the solution different from tahoma2d/tahoma2d#149 .

IMO the combo box item `No Current Level` should not allow users to make the current level empty. It causes unexpected problem like this issue and AFAIK there seems to be no point in doing so.
Therefore, I made the item `No Current Level` to be displayed only for notification and remove the item from the list when users click the combo box while some level is current.