### PR TITLE
Fix Github Actions to work: update versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,9 @@ jobs:
     - name: Install libraries
       run: |
         brew update
-        brew install pkg-config ninja glew lz4 libjpeg libpng lzo qt boost libusb libmypaint ccache
+        brew install pkg-config glew lz4 libjpeg libpng lzo qt boost libusb libmypaint ccache
+        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/284557d4f5b29a7b9fb48bf8a54cf8a72d26c5eb/Formula/ninja.rb
+        brew install ./ninja.rb
 
     - uses: actions/cache@v1
       with:
@@ -140,8 +142,8 @@ jobs:
   Windows:
     runs-on: windows-2019
     env:
-      vcpkg_ref: d989ad416b923a9f895c4bddc446d1ef370a3af8
-      CLCACHE_CL: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.24.28314/bin/Hostx64/x64/cl_original.exe'
+      vcpkg_ref: 1d8728ae1ba66ad94b344708cf8d0ace1a6330b8
+      CLCACHE_CL: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl_original.exe'
     steps:
     - uses: actions/checkout@v2
 
@@ -185,9 +187,9 @@ jobs:
     - name: Install clcache
       run: |
         pip install clcache
-        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.24.28314/bin/Hostx64/x64/cl.exe' -NewName 'cl_original.exe'
-        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.24.28314/bin/Hostx64/x64/cl.exe.config' -NewName 'cl_original.exe.config'
-        cp 'C:/hostedtoolcache/windows/Python/3.6.8/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.24.28314/bin/Hostx64/x64/cl.exe'
+        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe' -NewName 'cl_original.exe'
+        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe.config' -NewName 'cl_original.exe.config'
+        cp 'C:/hostedtoolcache/windows/Python/3.7.9/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe'
 
     - uses: actions/cache@v1
       with:
@@ -217,7 +219,7 @@ jobs:
         cmake ../ -G 'Visual Studio 16 2019' -Ax64 -Djson-c_DIR='C:/vcpkg/installed/x64-windows-static/share/json-c/' -DJSON-C_INCLUDE_DIR='C:/vcpkg/installed/x64-windows-static/include/json-c/'
         cmake --build . --config Release
         cp C:/vcpkg/installed/x64-windows-static/lib/json-c.lib .
-        $env:Path += ';C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.24.28314/bin/Hostx64/x64'
+        $env:Path += ';C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64'
         lib /OUT:libmypaint.lib Release/libmypaint.lib json-c.lib
         cp libmypaint.lib Release/libmypaint.lib
 
@@ -257,7 +259,7 @@ jobs:
         mkdir build | Out-Null
         cd build
         $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
-        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH='C:/vcpkg/installed/x64-windows/bin' -DQt5_DIR='C:/vcpkg/installed/x64-windows/share/cmake/Qt5' -DBOOST_ROOT="$env:BOOST_ROOT_1_69_0"
+        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH='C:/vcpkg/installed/x64-windows/bin' -DQt5_DIR='C:/vcpkg/installed/x64-windows/share/cmake/Qt5' -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0"
         cmake --build . --config Release
 
     - name: Create Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,8 +95,20 @@ jobs:
 
     - name: Install libraries
       run: |
+        checkPkgAndInstall()
+        {
+          while [ $# -ne 0 ]
+          do
+            if brew ls --versions $1 ; then
+              brew upgrade $1
+            else
+              brew install $1
+            fi
+            shift
+          done
+        }
         brew update
-        brew install pkg-config glew lz4 libjpeg libpng lzo qt boost libusb libmypaint ccache
+        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo qt boost libusb libmypaint ccache
         curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/284557d4f5b29a7b9fb48bf8a54cf8a72d26c5eb/Formula/ninja.rb
         brew install ./ninja.rb
 


### PR DESCRIPTION
This PR modifies Github Actions settings to work on Windows and MacOS environments.

I confirmed it to work on my remote repository.
Windows build seems to take so long time (about 3hrs) mainly for installing and building the dependency library like Qt.