### PR TITLE
Actions: use install-qt-action and windeployqt

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -45,15 +45,27 @@ jobs:
         vcpkg install --clean-after-build --triplet x64-windows icu
         vcpkg install --clean-after-build --triplet x64-windows-static json-c libjpeg-turbo libpng lz4 lzo openblas zlib
         vcpkg install --clean-after-build --triplet x64-windows freeglut glew
-        vcpkg install --clean-after-build --triplet x64-windows qt5-base qt5-multimedia qt5-script qt5-svg qt5-tools
         ls -Recurse C:/vcpkg/installed -Filter *.pdb | rm
+
+    - name: Cache Qt
+      id: cache-qt
+      uses: actions/cache@v1
+      with:
+        path: ../Qt
+        key: ${{ runner.os }}-QtCache
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        modules: 'qtscript'
 
     - name: Install clcache
       run: |
         pip install clcache
         Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe' -NewName 'cl_original.exe'
         Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe.config' -NewName 'cl_original.exe.config'
-        cp 'C:/hostedtoolcache/windows/Python/3.7.9/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe'
+        cp 'C:/hostedtoolcache/windows/Python/3.9.0/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe'
 
     - uses: actions/cache@v1
       with:
@@ -123,43 +135,20 @@ jobs:
         mkdir build | Out-Null
         cd build
         $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
-        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH='C:/vcpkg/installed/x64-windows/bin' -DQt5_DIR='C:/vcpkg/installed/x64-windows/share/cmake/Qt5' -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0"
+        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH='D:/a/opentoonz/Qt/5.15.2/msvc2019_64' -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0"
         cmake --build . --config Release
 
     - name: Create Artifact
+      env:
+        VCINSTALLDIR: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC'
       run: |
         mkdir artifact | Out-Null
         cd artifact
         cp -Recurse ../stuff portablestuff
         cp ../toonz/build/Release/* .
+        D:/a/opentoonz/Qt/5.15.2/msvc2019_64/bin/windeployqt.exe OpenToonz.exe
         cp C:/vcpkg/installed/x64-windows/bin/freeglut.dll .
         cp C:/vcpkg/installed/x64-windows/bin/glew32.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5Core.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5Gui.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5Multimedia.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5Network.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5OpenGL.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5PrintSupport.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5Script.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5Svg.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/Qt5Widgets.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/bz2.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/freetype.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/harfbuzz.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/icudt*.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/icuin*.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/icuuc*.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/libpng16.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/pcre2-16.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/zlib1.dll .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/audio .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/bearer .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/iconengines .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/imageformats .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/mediaservice .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/platforms .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/playlistformats .
-        cp -Recurse C:/vcpkg/installed/x64-windows/plugins/printsupport .
 
     - uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
This PR modifies the Github Actions for Windows build.
It starts using [Install Qt Action by jurplel](https://github.com/jurplel/install-qt-action) for installing Qt and let `windeployqt` to collect necessary libraries on creating the artifact.