### PR TITLE
Tahoma2D porting (Dec 16, 2020) by jeremybullock and manongjohn

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -72,8 +72,8 @@
         <menu title="Arrange">
             <command>MI_BringToFront</command>
             <command>MI_BringForward</command>
-            <command>MI_SendBack</command>
             <command>MI_SendBackward</command>
+            <command>MI_SendBack</command>
         </menu>
     </menu>
     <menu title="Scan &amp;&amp; Cleanup">

--- a/toonz/sources/common/trop/quickput.cpp
+++ b/toonz/sources/common/trop/quickput.cpp
@@ -3233,12 +3233,17 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
   std::vector<TPixel32> paints(palette->getStyleCount());
   std::vector<TPixel32> inks(palette->getStyleCount());
 
-  if (s.m_transparencyCheck)
+  if (s.m_transparencyCheck && !s.m_isOnionSkin) {
     for (int i = 0; i < palette->getStyleCount(); i++) {
-      paints[i] = s.m_transpCheckPaint;
-      inks[i]   = s.m_blackBgCheck ? s.m_transpCheckBg : s.m_transpCheckInk;
+      if (i == s.m_gapCheckIndex) {
+        paints[i] = inks[i] = applyColorScaleCMapped(
+            palette->getStyle(i)->getAverageColor(), s.m_globalColorScale);
+      } else {
+        paints[i] = s.m_transpCheckPaint;
+        inks[i]   = s.m_blackBgCheck ? s.m_transpCheckBg : s.m_transpCheckInk;
+      }
     }
-  else if (s.m_globalColorScale == TPixel::Black)
+  } else if (s.m_globalColorScale == TPixel::Black)
     for (int i  = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] =
           ::premultiply(palette->getStyle(i)->getAverageColor());

--- a/toonz/sources/common/trop/quickput.cpp
+++ b/toonz/sources/common/trop/quickput.cpp
@@ -773,7 +773,7 @@ void doQuickPutNoFilter(const TRaster32P &dn, const TRaster64P &up,
       assert((0 <= xI) && (xI <= up->getLx() - 1) && (0 <= yI) &&
              (yI <= up->getLy() - 1));
 
-      TPixel64 *upPix           = upBasePix + (yI * upWrap + xI);
+      TPixel64 *upPix = upBasePix + (yI * upWrap + xI);
       if (firstColumn) upPix->m = 65535;
       if (upPix->m == 0)
         continue;
@@ -2050,7 +2050,7 @@ void doQuickResampleColorFilter(const TRaster32P &dn, const TRaster32P &up,
     } else if (deltaXL > 0) {
       if (lxPred < xL0) continue;
 
-      kMaxX              = (lxPred - xL0) / deltaXL;          //  floor
+      kMaxX = (lxPred - xL0) / deltaXL;                       //  floor
       if (xL0 < 0) kMinX = ((-xL0) + deltaXL - 1) / deltaXL;  //  ceil
     } else                                                    //  (deltaXL < 0)
     {
@@ -2064,7 +2064,7 @@ void doQuickResampleColorFilter(const TRaster32P &dn, const TRaster32P &up,
     } else if (deltaYL > 0) {
       if (lyPred < yL0) continue;
 
-      kMaxY              = (lyPred - yL0) / deltaYL;          //  floor
+      kMaxY = (lyPred - yL0) / deltaYL;                       //  floor
       if (yL0 < 0) kMinY = ((-yL0) + deltaYL - 1) / deltaYL;  //  ceil
     } else                                                    //  (deltaYL < 0)
     {
@@ -2167,7 +2167,7 @@ void doQuickResampleColorFilter(const TRaster32P &dn, const TRaster64P &up,
     } else if (deltaXL > 0) {
       if (lxPred < xL0) continue;
 
-      kMaxX              = (lxPred - xL0) / deltaXL;          //  floor
+      kMaxX = (lxPred - xL0) / deltaXL;                       //  floor
       if (xL0 < 0) kMinX = ((-xL0) + deltaXL - 1) / deltaXL;  //  ceil
     } else                                                    //  (deltaXL < 0)
     {
@@ -2181,7 +2181,7 @@ void doQuickResampleColorFilter(const TRaster32P &dn, const TRaster64P &up,
     } else if (deltaYL > 0) {
       if (lyPred < yL0) continue;
 
-      kMaxY              = (lyPred - yL0) / deltaYL;          //  floor
+      kMaxY = (lyPred - yL0) / deltaYL;                       //  floor
       if (yL0 < 0) kMinY = ((-yL0) + deltaYL - 1) / deltaYL;  //  ceil
     } else                                                    //  (deltaYL < 0)
     {
@@ -2993,11 +2993,11 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
   // vector<TPixel32> inks(palette->getStyleCount());
 
   if (globalColorScale != TPixel::Black)
-    for (int i  = 0; i < palette->getStyleCount(); i++)
+    for (int i = 0; i < palette->getStyleCount(); i++)
       colors[i] = applyColorScaleCMapped(
           palette->getStyle(i)->getAverageColor(), globalColorScale);
   else
-    for (int i  = 0; i < palette->getStyleCount(); i++)
+    for (int i = 0; i < palette->getStyleCount(); i++)
       colors[i] = ::premultiply(palette->getStyle(i)->getAverageColor());
 
   dn->lock();
@@ -3244,11 +3244,11 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
       }
     }
   } else if (s.m_globalColorScale == TPixel::Black)
-    for (int i  = 0; i < palette->getStyleCount(); i++)
+    for (int i = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] =
           ::premultiply(palette->getStyle(i)->getAverageColor());
   else
-    for (int i  = 0; i < palette->getStyleCount(); i++)
+    for (int i = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] = applyColorScaleCMapped(
           palette->getStyle(i)->getAverageColor(), s.m_globalColorScale);
 
@@ -3268,7 +3268,7 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
     } else if (deltaXL > 0) {
       if (lxPred < xL0) continue;
 
-      kMaxX              = (lxPred - xL0) / deltaXL;          //  floor
+      kMaxX = (lxPred - xL0) / deltaXL;                       //  floor
       if (xL0 < 0) kMinX = ((-xL0) + deltaXL - 1) / deltaXL;  //  ceil
     } else {
       if (xL0 < 0) continue;
@@ -3282,7 +3282,7 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
     } else if (deltaYL > 0) {
       if (lyPred < yL0) continue;
 
-      kMaxY              = (lyPred - yL0) / deltaYL;
+      kMaxY = (lyPred - yL0) / deltaYL;
       if (yL0 < 0) kMinY = ((-yL0) + deltaYL - 1) / deltaYL;
     } else {
       if (yL0 < 0) continue;
@@ -3558,11 +3558,11 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
   std::vector<TPixel32> paints(count, TPixel32::Red);
   std::vector<TPixel32> inks(count, TPixel32::Red);
   if (globalColorScale != TPixel::Black)
-    for (int i  = 0; i < palette->getStyleCount(); i++)
+    for (int i = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] = applyColorScaleCMapped(
           palette->getStyle(i)->getAverageColor(), globalColorScale);
   else
-    for (int i  = 0; i < palette->getStyleCount(); i++)
+    for (int i = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] =
           ::premultiply(palette->getStyle(i)->getAverageColor());
 
@@ -3660,7 +3660,7 @@ void doQuickResampleColorFilter(const TRaster32P &dn, const TRasterCM32P &up,
   std::vector<TPixel32> paints(plt->getStyleCount());
   std::vector<TPixel32> inks(plt->getStyleCount());
 
-  for (int i  = 0; i < plt->getStyleCount(); i++)
+  for (int i = 0; i < plt->getStyleCount(); i++)
     paints[i] = inks[i] = ::premultiply(plt->getStyle(i)->getAverageColor());
 
   assert(std::max(up->getLx(), up->getLy()) <
@@ -3714,7 +3714,7 @@ void doQuickResampleColorFilter(const TRaster32P &dn, const TRasterCM32P &up,
     } else if (deltaXL > 0) {
       if (lxPred < xL0) continue;
 
-      kMaxX              = (lxPred - xL0) / deltaXL;          //  floor
+      kMaxX = (lxPred - xL0) / deltaXL;                       //  floor
       if (xL0 < 0) kMinX = ((-xL0) + deltaXL - 1) / deltaXL;  //  ceil
     } else                                                    //  (deltaXL < 0)
     {
@@ -3728,7 +3728,7 @@ void doQuickResampleColorFilter(const TRaster32P &dn, const TRasterCM32P &up,
     } else if (deltaYL > 0) {
       if (lyPred < yL0) continue;
 
-      kMaxY              = (lyPred - yL0) / deltaYL;          //  floor
+      kMaxY = (lyPred - yL0) / deltaYL;                       //  floor
       if (yL0 < 0) kMinY = ((-yL0) + deltaYL - 1) / deltaYL;  //  ceil
     } else                                                    //  (deltaYL < 0)
     {
@@ -4180,7 +4180,7 @@ void doQuickResampleFilter_optimized(const TRaster32P &dn, const TRaster32P &up,
 #endif
 
 // namespace
-};
+};  // namespace
 
 #ifndef TNZCORE_LIGHT
 //=============================================================================

--- a/toonz/sources/image/tif/tiio_tif.cpp
+++ b/toonz/sources/image/tif/tiio_tif.cpp
@@ -734,8 +734,8 @@ void Tiio::TifWriterProperties::updateTranslation() {
   m_bitsPerPixel.setItemUIName(L"48(RGB)", tr("48(RGB)"));
   m_bitsPerPixel.setItemUIName(L" 1(BW)", tr(" 1(BW)"));
   m_bitsPerPixel.setItemUIName(L" 8(GREYTONES)", tr(" 8(GREYTONES)"));
-  m_bitsPerPixel.setItemUIName(L"32(RGBM)", tr("32(RGBM)"));
-  m_bitsPerPixel.setItemUIName(L"64(RGBM)", tr("64(RGBM)"));
+  m_bitsPerPixel.setItemUIName(L"32(RGBM)", tr("32(RGBA)"));
+  m_bitsPerPixel.setItemUIName(L"64(RGBM)", tr("64(RGBA)"));
   m_orientation.setQStringName(tr("Orientation"));
   m_orientation.setItemUIName(TNZ_INFO_ORIENT_TOPLEFT, tr("Top Left"));
   m_orientation.setItemUIName(TNZ_INFO_ORIENT_TOPRIGHT, tr("Top Right"));

--- a/toonz/sources/image/tif/tiio_tif.cpp
+++ b/toonz/sources/image/tif/tiio_tif.cpp
@@ -257,7 +257,7 @@ break;*/
 
   if (bps == 10 || bps == 12 ||
       bps == 14)  // immagini con bps = 10 , 12 , 14 , 24 , 32
-    bps                           = 8;
+    bps = 8;
   if (bps == 24 || bps == 32) bps = 16;
 
   m_info.m_bitsPerSample = bps;
@@ -928,9 +928,9 @@ void TifWriter::open(FILE *file, const TImageInfo &info) {
       assert(false);
   }
   TIFFSetField(m_tiff, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
-  TIFFSetField(m_tiff, TIFFTAG_PHOTOMETRIC, (m_bpp == 8 || m_bpp == 1)
-                                                ? PHOTOMETRIC_MINISBLACK
-                                                : PHOTOMETRIC_RGB);
+  TIFFSetField(
+      m_tiff, TIFFTAG_PHOTOMETRIC,
+      (m_bpp == 8 || m_bpp == 1) ? PHOTOMETRIC_MINISBLACK : PHOTOMETRIC_RGB);
   TIFFSetField(m_tiff, TIFFTAG_XRESOLUTION, m_info.m_dpix);
   TIFFSetField(m_tiff, TIFFTAG_YRESOLUTION, m_info.m_dpiy);
   TIFFSetField(m_tiff, TIFFTAG_RESOLUTIONUNIT, RESUNIT_INCH);
@@ -1055,7 +1055,7 @@ extern "C" {
 static void MyWarningHandler(const char *module, const char *fmt, va_list ap) {
   std::string outMsg;
   char msg[2048];
-  msg[0]                     = 0;
+  msg[0] = 0;
   if (module != NULL) outMsg = std::string(module);
   outMsg += "Warning, ";
 
@@ -1069,7 +1069,7 @@ static void MyWarningHandler(const char *module, const char *fmt, va_list ap) {
 static void MyErrorHandler(const char *module, const char *fmt, va_list ap) {
   std::string outMsg;
   char msg[2048];
-  msg[0]                     = 0;
+  msg[0] = 0;
   if (module != NULL) outMsg = std::string(module);
   // outMsg += "Warning, ";
 

--- a/toonz/sources/include/toonz/plasticdeformerfx.h
+++ b/toonz/sources/include/toonz/plasticdeformerfx.h
@@ -28,6 +28,8 @@ class TXsheet;
 class PlasticDeformerFx final : public TRasterFx {
   FX_DECLARATION(PlasticDeformerFx)
 
+  bool m_was64bit = false;
+
 public:
   TXsheet *m_xsh;          //!< The Fx's enclosing Xsheet
   int m_col;               //!< The input column index

--- a/toonz/sources/include/trop.h
+++ b/toonz/sources/include/trop.h
@@ -178,13 +178,16 @@ public:
 
   int m_inkIndex, m_paintIndex;
 
-  bool m_inksOnly, m_transparencyCheck, m_blackBgCheck;
+  bool m_inksOnly, m_transparencyCheck, m_blackBgCheck, m_isOnionSkin;
+  int m_gapCheckIndex = -1;
 
   CmappedQuickputSettings()
       : m_globalColorScale(TPixel32::Black)
       , m_inksOnly(false)
       , m_transparencyCheck(false)
       , m_blackBgCheck(false)
+      , m_isOnionSkin(false)
+      , m_gapCheckIndex(-1)
       , m_inkIndex(-1)
       , m_paintIndex(-1) {}
 };

--- a/toonz/sources/include/trop.h
+++ b/toonz/sources/include/trop.h
@@ -387,7 +387,7 @@ DVAPI void swapRBChannels(const TRaster32P &r);
 
 //! Convert TRasterP in an old toonz raster!
 /*! Use the same buffer, not creates a new raster (the palette is new instead!)
-  */
+ */
 DVAPI _RASTER *convertRaster50to46(const TRasterP &inRas,
                                    const TPaletteP &inPalette);
 
@@ -408,4 +408,4 @@ DVAPI void lockRaster(_RASTER *raster);
 //! inactivity periods.
 DVAPI void unlockRaster(_RASTER *raster);
 
-}  // TRop namespace
+}  // namespace TRop

--- a/toonz/sources/stdfx/rgbmcutfx.cpp
+++ b/toonz/sources/stdfx/rgbmcutfx.cpp
@@ -127,7 +127,7 @@ void RGBMCutFx::doCompute(TTile &tile, double frame,
       doRGBMCut<TPixel64, USHORT>(raster64, hi_m, hi_r, hi_g, hi_b, lo_m, lo_r,
                                   lo_g, lo_b);
     else
-      throw TException("RGBMCutFx: unsupported Pixel Type");
+      throw TException("RGBACutFx: unsupported Pixel Type");
   }
 }
 

--- a/toonz/sources/stdfx/rgbmcutfx.cpp
+++ b/toonz/sources/stdfx/rgbmcutfx.cpp
@@ -58,7 +58,7 @@ void update_param(double &param, TRaster64P ras) {
   param = param * 257;
   return;
 }
-}
+}  // namespace
 
 //-------------------------------------------------------------------
 

--- a/toonz/sources/stdfx/rgbmfadefx.cpp
+++ b/toonz/sources/stdfx/rgbmfadefx.cpp
@@ -88,7 +88,7 @@ void RGBMFadeFx::doCompute(TTile &tile, double frame,
     if (raster64)
       doRGBMFade<TPixel64>(raster64, toPixel64(col), intensity);
     else
-      throw TException("RGBMFadeFx: unsupported Pixel Type");
+      throw TException("RGBAFadeFx: unsupported Pixel Type");
   }
 }
 

--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -205,7 +205,7 @@ public:
   }
 
   //------------------------------------------------------------
-  /*--  AutoCloseが実行されたらtrue,実行されなければfalseを返す --*/
+  /*--  AutoClose Returns true if executed, false otherwise --*/
   bool applyAutoclose(const TToonzImageP &ti, const TRectD &selRect = TRectD(),
                       TStroke *stroke = 0) {
     if (!ti) return false;

--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -219,7 +219,7 @@ public:
         TTool::getApplication()
             ->getCurrentLevelStyleIndex();  // TApp::instance()->getCurrentPalette()->getStyleIndex();
     if (isInt(inkString)) inkIndex = std::stoi(inkString);
-    params.m_inkIndex              = inkIndex;
+    params.m_inkIndex = inkIndex;
 
     TPoint delta;
     TRasterCM32P ras, raux = ti->getRaster();

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -328,7 +328,7 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
   m_otherColumnBBoxAff = TAffine();
   m_labelPos           = TPointD(0, 0);
   m_label              = "";
-
+  // This undo block ends in leftButtonUp
   TUndoManager::manager()->beginBlock();
   if (!doesApply()) return;
 

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -116,7 +116,7 @@ static void getHooks(std::vector<HookData> &hooks, TXsheet *xsh, int row,
         getDpiAffine(cell.m_level->getSimpleLevel(), cell.m_frameId, true);
 
   // center (inches)
-  TPointD center           = xsh->getCenter(columnId, row);  // getHooks
+  TPointD center = xsh->getCenter(columnId, row);  // getHooks
   if (handleIsHook) center = TPointD(0, 0);
 
   // add the hook #0 (i.e. the regular center)
@@ -350,7 +350,7 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
     if (selectedDevice == TD_IncrementDrawing)
       d = 1;
     else if (selectedDevice == TD_DecrementDrawing)
-      d        = -1;
+      d = -1;
     m_dragTool = new ChangeDrawingTool(this, d);
     m_dragTool->leftButtonDown(ppos, e);
     return;
@@ -414,21 +414,21 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
 
   // lock/unlock: modalita IK
   if (TD_LockStageObject <= m_device && m_device < TD_LockStageObject + 1000) {
-      Skeleton* skeleton = new Skeleton();
-      buildSkeleton(*skeleton, currentColumnIndex);
+    Skeleton *skeleton = new Skeleton();
+    buildSkeleton(*skeleton, currentColumnIndex);
     int columnIndex = m_device - TD_LockStageObject;
-    int frame = app->getCurrentFrame()->getFrame();
-    if (skeleton->getBoneByColumnIndex(columnIndex) == skeleton->getRootBone()) {
-        app->getCurrentColumn()->setColumnIndex(columnIndex);
-        m_device = TD_Translation;
-    }
-    else if (e.isShiftPressed()) {
-        togglePinnedStatus(columnIndex, frame, e.isShiftPressed());
-        invalidate();
-        m_dragTool = 0;
-        return;
-    }
-    else return;
+    int frame       = app->getCurrentFrame()->getFrame();
+    if (skeleton->getBoneByColumnIndex(columnIndex) ==
+        skeleton->getRootBone()) {
+      app->getCurrentColumn()->setColumnIndex(columnIndex);
+      m_device = TD_Translation;
+    } else if (e.isShiftPressed()) {
+      togglePinnedStatus(columnIndex, frame, e.isShiftPressed());
+      invalidate();
+      m_dragTool = 0;
+      return;
+    } else
+      return;
   }
 
   switch (m_device) {
@@ -572,8 +572,8 @@ public:
 
   void notify() const {
     m_tool->invalidate();
-    TXsheet *xsh         = getXsheet();
-    int index            = m_columnIndex;
+    TXsheet *xsh = getXsheet();
+    int index    = m_columnIndex;
     if (index < 0) index = m_oldColumnIndex;
     if (index >= 0) {
       TStageObjectId id = TStageObjectId::ColumnId(index);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1516,6 +1516,8 @@ void ToonzRasterBrushTool::leftButtonUp(const TPointD &pos,
   TPointD centeredPos = getCenteredCursorPos(pos);
   double pressure = m_pressure.getValue() && e.isTablet() ? e.m_pressure : 0.5;
   finishRasterBrush(centeredPos, pressure);
+  int tc = ToonzCheck::instance()->getChecks();
+  if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();
 }
 
 //---------------------------------------------------------------------------------------------------------------

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2403,6 +2403,11 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
   }
 
   if (!toolHandle->getTool()->m_isFrameCreated) {
+    if (!isAutoCreateEnabled)
+      Preferences::instance()->setValue(EnableAutocreation, false, false);
+    if (!isCreationInHoldCellsEnabled)
+      Preferences::instance()->setValue(EnableCreationInHoldCells, false,
+                                        false);
     if (!multiple)
       DVGui::warning(QObject::tr(
           "Unable to replace the current drawing with a blank drawing"));
@@ -2544,6 +2549,11 @@ void TCellSelection::duplicateFrame(int row, int col, bool multiple) {
 
   bool frameCreated = toolHandle->getTool()->m_isFrameCreated;
   if (!frameCreated) {
+    if (!isAutoCreateEnabled)
+      Preferences::instance()->setValue(EnableAutocreation, false, false);
+    if (!isCreationInHoldCellsEnabled)
+      Preferences::instance()->setValue(EnableCreationInHoldCells, false,
+                                        false);
     if (!multiple)
       DVGui::warning(
           QObject::tr("Unable to replace the current or next drawing with a "

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2865,7 +2865,7 @@ static void createNewDrawing(TXsheet *xsh, int row, int col,
   const Type *Var = dynamic_cast<const Type *>(Data)
 
 void TCellSelection::dPasteCells() {
-  if (isEmpty())  // Se la selezione delle celle e' vuota ritorno.
+  if (isEmpty()) 
     return;
   int r0, c0, r1, c1;
   getSelectedCells(r0, c0, r1, c1);
@@ -2874,7 +2874,10 @@ void TCellSelection::dPasteCells() {
   QClipboard *clipboard     = QApplication::clipboard();
   const QMimeData *mimeData = clipboard->mimeData();
   if (DYNAMIC_CAST(TCellData, cellData, mimeData)) {
-    if (!cellData->canChange(xsh, c0)) return;
+      if (!cellData->canChange(xsh, c0)) {
+          TUndoManager::manager()->endBlock();
+          return;
+      }
     for (int c = 0; c < cellData->getColCount(); c++) {
       for (int r = 0; r < cellData->getRowCount(); r++) {
         TXshCell src = cellData->getCell(r, c);

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2007,11 +2007,11 @@ void TCellSelection::pasteDuplicateCells() {
           DVGui::warning(
               QObject::tr("Cannot duplicate frames in read only levels"));
           return;
-        }
-        else if (level->getSimpleLevel() && it->getFrameId() == TFrameId::NO_FRAME) {
-            DVGui::warning(
-                QObject::tr("Can only duplicate frames in image sequence levels."));
-            return;
+        } else if (level->getSimpleLevel() &&
+                   it->getFrameId() == TFrameId::NO_FRAME) {
+          DVGui::warning(QObject::tr(
+              "Can only duplicate frames in image sequence levels."));
+          return;
         }
       }
       it++;
@@ -2173,9 +2173,8 @@ void TCellSelection::pasteDuplicateCells() {
       return;
     }
     TKeyframeSelection selection;
-    if (isEmpty() &&
-        TApp::instance()->getCurrentObject()->getObjectId() ==
-            TStageObjectId::CameraId(xsh->getCameraColumnIndex()))
+    if (isEmpty() && TApp::instance()->getCurrentObject()->getObjectId() ==
+                         TStageObjectId::CameraId(xsh->getCameraColumnIndex()))
     // Se la selezione e' vuota e l'objectId e' quello della camera sono nella
     // colonna di camera quindi devo selezionare la row corrente e -1.
     {
@@ -2865,8 +2864,7 @@ static void createNewDrawing(TXsheet *xsh, int row, int col,
   const Type *Var = dynamic_cast<const Type *>(Data)
 
 void TCellSelection::dPasteCells() {
-  if (isEmpty()) 
-    return;
+  if (isEmpty()) return;
   int r0, c0, r1, c1;
   getSelectedCells(r0, c0, r1, c1);
   TUndoManager::manager()->beginBlock();
@@ -2874,10 +2872,10 @@ void TCellSelection::dPasteCells() {
   QClipboard *clipboard     = QApplication::clipboard();
   const QMimeData *mimeData = clipboard->mimeData();
   if (DYNAMIC_CAST(TCellData, cellData, mimeData)) {
-      if (!cellData->canChange(xsh, c0)) {
-          TUndoManager::manager()->endBlock();
-          return;
-      }
+    if (!cellData->canChange(xsh, c0)) {
+      TUndoManager::manager()->endBlock();
+      return;
+    }
     for (int c = 0; c < cellData->getColCount(); c++) {
       for (int r = 0; r < cellData->getRowCount(); r++) {
         TXshCell src = cellData->getCell(r, c);

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -44,7 +44,12 @@ public:
       : QTreeWidgetItem(parent, UserType), m_action(action) {
     setFlags(Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
              Qt::ItemNeverHasChildren);
-    setText(0, m_action->text().remove("&"));
+    QString tempText = m_action->text();
+    if (tempText.indexOf("&") == 0) {
+        tempText = tempText.remove(0, 1);
+    }
+    tempText = tempText.replace("&&", "&");
+    setText(0, tempText);
     setToolTip(0, QObject::tr("[Drag] to move position"));
   }
   QAction* getAction() const { return m_action; }

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -45,9 +45,9 @@ public:
     setFlags(Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsEnabled |
              Qt::ItemNeverHasChildren);
     QString tempText = m_action->text();
-    if (tempText.indexOf("&") == 0) {
-        tempText = tempText.remove(0, 1);
-    }
+    // removing accelerator key indicator
+    tempText = tempText.replace(QRegExp("&([^& ])"), "\\1");
+    // removing doubled &s
     tempText = tempText.replace("&&", "&");
     setText(0, tempText);
     setToolTip(0, QObject::tr("[Drag] to move position"));

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -486,7 +486,11 @@ void FilmstripFrames::hideEvent(QHideEvent *) {
   // active viewer change
   disconnect(app, SIGNAL(activeViewerChanged()), this, SLOT(getViewer()));
 
-  if (m_viewer) {
+  // if the level strip is floating during shutting down Tahoma2D
+  // it can cause a crash disconnecting from the viewer which was already
+  // destroyed.  Checking the fps is a janky way to ensure the viewer is 
+  // stil relevant.
+  if (m_viewer && m_viewer->getFPS() > -100) { 
     disconnect(m_viewer, SIGNAL(onZoomChanged()), this, SLOT(update()));
     disconnect(m_viewer, SIGNAL(refreshNavi()), this, SLOT(update()));
     m_viewer = nullptr;

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -172,6 +172,7 @@ protected slots:
   void comboBoxToggled(bool);
   void navigatorToggled(bool);
   void levelSelected(int);
+  void onViewerAboutToBeDestroyed();
 
 private:
   // QSS Properties

--- a/toonz/sources/toonz/frameheadgadget.cpp
+++ b/toonz/sources/toonz/frameheadgadget.cpp
@@ -394,7 +394,7 @@ void FilmstripFrameHeadGadget::drawOnionSkinSelection(QPainter &p,
     int minMos = 0;
     int maxMos = 0;
     for (i = 0; i < mosCount; i++) {
-      int mos                  = osMask.getMos(i);
+      int mos = osMask.getMos(i);
       if (minMos > mos) minMos = mos;
       if (maxMos < mos) maxMos = mos;
     }
@@ -600,7 +600,10 @@ void FilmstripFrameHeadGadget::drawShiftTraceMarker(QPainter &p) {
 //-----------------------------------------------------------------------------
 
 bool FilmstripFrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
-  if (e->type() != QEvent::MouseButtonPress && e->type() != QEvent::MouseButtonDblClick && e->type() != QEvent::MouseMove) return false;
+  if (e->type() != QEvent::MouseButtonPress &&
+      e->type() != QEvent::MouseButtonDblClick &&
+      e->type() != QEvent::MouseMove)
+    return false;
   // shift & trace case
   if (CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked())
     return shiftTraceEventFilter(obj, e);
@@ -654,11 +657,11 @@ bool FilmstripFrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
 
     //----- 以下、クリック位置に応じてアクションを変えていく
     //クリックされたフレームを取得
-    QMouseEvent *mouseEvent               = dynamic_cast<QMouseEvent *>(e);
-    int frame                             = y2index(mouseEvent->pos().y());
+    QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>(e);
+    int frame               = y2index(mouseEvent->pos().y());
     if (!m_filmstrip->m_isVertical) frame = x2index(mouseEvent->pos().x());
-    m_buttonPressCellIndex                = frame;
-    int currentFrame                      = getCurrentFrame();
+    m_buttonPressCellIndex = frame;
+    int currentFrame       = getCurrentFrame();
 
     //各フレーム左上からの位置
     QPoint clickedPos = mouseEvent->pos() + QPoint(0, -index2y(frame));
@@ -702,7 +705,7 @@ bool FilmstripFrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
   else if (e->type() == QEvent::MouseButtonDblClick) {
     QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>(e);
     if (mouseEvent->buttons() & Qt::LeftButton) {
-      int frame                             = y2index(mouseEvent->pos().y());
+      int frame = y2index(mouseEvent->pos().y());
       if (!m_filmstrip->m_isVertical) frame = x2index(mouseEvent->pos().x());
       //各フレーム左上からの位置
       QPoint clickedPos = mouseEvent->pos() + QPoint(0, -index2y(frame));
@@ -729,8 +732,8 @@ bool FilmstripFrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
   }
   //----
   else if (e->type() == QEvent::MouseMove) {
-    QMouseEvent *mouseEvent               = dynamic_cast<QMouseEvent *>(e);
-    int frame                             = y2index(mouseEvent->pos().y());
+    QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>(e);
+    int frame               = y2index(mouseEvent->pos().y());
     if (!m_filmstrip->m_isVertical) frame = x2index(mouseEvent->pos().x());
     //各フレーム左上からの位置
     QPoint clickedPos = mouseEvent->pos() + QPoint(0, -index2y(frame));
@@ -863,13 +866,13 @@ bool FilmstripFrameHeadGadget::shiftTraceEventFilter(QObject *obj, QEvent *e) {
     viewer->update();
   }
 
-  QMouseEvent *mouseEvent               = dynamic_cast<QMouseEvent *>(e);
-  int frame                             = y2index(mouseEvent->pos().y());
+  QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>(e);
+  int frame               = y2index(mouseEvent->pos().y());
   if (!m_filmstrip->m_isVertical) frame = x2index(mouseEvent->pos().x());
   // position from top-left of the frame
   QPoint mousePos = mouseEvent->pos() + QPoint(0, -index2y(frame));
   if (!m_filmstrip->m_isVertical)
-    mousePos       = mouseEvent->pos() + QPoint(-index2x(frame), 0);
+    mousePos = mouseEvent->pos() + QPoint(-index2x(frame), 0);
   int currentFrame = getCurrentFrame();
 
   if (m_filmstrip->m_isVertical) {

--- a/toonz/sources/toonz/frameheadgadget.cpp
+++ b/toonz/sources/toonz/frameheadgadget.cpp
@@ -600,6 +600,7 @@ void FilmstripFrameHeadGadget::drawShiftTraceMarker(QPainter &p) {
 //-----------------------------------------------------------------------------
 
 bool FilmstripFrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
+  if (e->type() != QEvent::MouseButtonPress && e->type() != QEvent::MouseButtonDblClick && e->type() != QEvent::MouseMove) return false;
   // shift & trace case
   if (CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked())
     return shiftTraceEventFilter(obj, e);

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1155,8 +1155,8 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   {
     addMenuItem(arrangeMenu, MI_BringToFront);
     addMenuItem(arrangeMenu, MI_BringForward);
-    addMenuItem(arrangeMenu, MI_SendBack);
     addMenuItem(arrangeMenu, MI_SendBackward);
+    addMenuItem(arrangeMenu, MI_SendBack);
   }
 
   // Menu' SCAN CLEANUP

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -831,6 +831,9 @@ void SceneViewer::setVisual(const ImagePainter::VisualSettings &settings) {
 //-----------------------------------------------------------------------------
 
 SceneViewer::~SceneViewer() {
+  // notify FilmStripFrames and safely disconnect with this
+  emit aboutToBeDestroyed();
+
   if (m_fbo) delete m_fbo;
 
   // release all the registered context (once when exit the software)

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -460,6 +460,8 @@ signals:
   void refreshNavi();
   // for updating the titlebar
   void previewToggled();
+  // to notify FilmStripFrames and safely disconnect with this
+  void aboutToBeDestroyed();
 };
 
 // Functions

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -57,7 +57,10 @@ public:
   }
   void updateText() {
     QString text = m_action->text();
-    text.remove("&");
+    if (text.indexOf("&") == 0) {
+        text = text.remove(0, 1);
+    }
+    text = text.replace("&&", "&");
     setText(0, text);
     QString shortcut = m_action->shortcut().toString();
     setText(1, shortcut);

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -57,9 +57,9 @@ public:
   }
   void updateText() {
     QString text = m_action->text();
-    if (text.indexOf("&") == 0) {
-        text = text.remove(0, 1);
-    }
+    // removing accelerator key indicator
+    text = text.replace(QRegExp("&([^& ])"), "\\1");
+    // removing doubled &s
     text = text.replace("&&", "&");
     setText(0, text);
     QString shortcut = m_action->shortcut().toString();

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -941,12 +941,13 @@ void setGrammerToParams(const ParamCont *cont,
 //-----------------------------------------------------------------------------
 
 std::set<int> explode(TXsheet *xsh, TXsheet *subXsh, int index,
-                 const TStageObjectId &parentId, const GroupData &objGroupData,
-                 const TPointD &stageSubPos, const GroupData &fxGroupData,
-                 const TPointD &fxSubPos, QList<TStageObject *> &pegObjects,
-                 QMap<TStageObjectSpline *, TStageObjectSpline *> &splines,
-                 const std::vector<TFxPort *> &outPorts, bool onlyColumn,
-                 bool linkToXsheet) {
+                      const TStageObjectId &parentId,
+                      const GroupData &objGroupData, const TPointD &stageSubPos,
+                      const GroupData &fxGroupData, const TPointD &fxSubPos,
+                      QList<TStageObject *> &pegObjects,
+                      QMap<TStageObjectSpline *, TStageObjectSpline *> &splines,
+                      const std::vector<TFxPort *> &outPorts, bool onlyColumn,
+                      bool linkToXsheet) {
   // innerFx->outerFxs
   QMap<TFx *, QPair<TFx *, int>> fxs;
   // inner id->outer id
@@ -2282,10 +2283,11 @@ void SubsceneCmd::collapse(std::set<int> &indices) {
     QString question(QObject::tr("Collapsing columns: what you want to do?"));
 
     QList<QString> list;
+    list.append(QObject::tr(
+        "Maintain parenting relationships in the sub-xsheet as well."));
     list.append(
-        QObject::tr("Include relevant pegbars in the sub-xsheet as well."));
-    list.append(
-        QObject::tr("Include only selected columns in the sub-xsheet."));
+        QObject::tr("Include the selected columns in the sub-xsheet without "
+                    "parenting info."));
 
     int ret = DVGui::RadioButtonMsgBox(DVGui::WARNING, question, list);
     if (ret == 0) return;
@@ -2393,10 +2395,11 @@ void SubsceneCmd::collapse(const QList<TFxP> &fxs) {
     // User must decide if pegbars must be collapsed too
     QString question(QObject::tr("Collapsing columns: what you want to do?"));
     QList<QString> list;
+    list.append(QObject::tr(
+        "Maintain parenting relationships in the sub-xsheet as well."));
     list.append(
-        QObject::tr("Include relevant pegbars in the sub-xsheet as well."));
-    list.append(
-        QObject::tr("Include only selected columns in the sub-xsheet."));
+        QObject::tr("Include the selected columns in the sub-xsheet without "
+                    "parenting info."));
     int ret = DVGui::RadioButtonMsgBox(DVGui::WARNING, question, list);
     if (ret == 0) return;
     onlyColumns = (ret == 2);
@@ -2471,8 +2474,10 @@ void SubsceneCmd::explode(int index) {
   /*- Pegbarを親Sheetに持って出るか？の質問ダイアログ -*/
   QString question(QObject::tr("Exploding Sub-xsheet: what you want to do?"));
   QList<QString> list;
-  list.append(QObject::tr("Bring relevant pegbars in the main xsheet."));
-  list.append(QObject::tr("Bring only columns in the main xsheet."));
+  list.append(
+      QObject::tr("Maintain parenting relationships in the main xsheet."));
+  list.append(
+      QObject::tr("Bring columns in the main xsheet without parenting."));
   int ret = DVGui::RadioButtonMsgBox(DVGui::WARNING, question, list);
   if (ret == 0) return;
 

--- a/toonz/sources/toonzlib/plasticdeformerfx.cpp
+++ b/toonz/sources/toonzlib/plasticdeformerfx.cpp
@@ -176,8 +176,11 @@ void PlasticDeformerFx::buildRenderSettings(double frame,
   // So, the best choice is to let the *input fx* decide the appropriate
   // reference, by invoking
   // its handledAffine() method.
-
-  info.m_bpp    = 32;  // We need to fix the input to 32-bpp
+  m_was64bit = false;
+  if (info.m_bpp == 64) {
+      m_was64bit = true;
+      info.m_bpp = 32;  // We need to fix the input to 32-bpp
+  }
   info.m_affine = m_port->handledAffine(info, frame);
 }
 
@@ -402,13 +405,33 @@ void PlasticDeformerFx::doCompute(TTile &tile, double frame,
     QImage img = fb.toImage().scaled(QSize(d.lx, d.ly), Qt::IgnoreAspectRatio,
                                      Qt::SmoothTransformation);
     int wrap      = tile.getRaster()->getLx() * sizeof(TPixel32);
-    uchar *srcPix = img.bits();
-    uchar *dstPix = tile.getRaster()->getRawData() + wrap * (d.ly - 1);
-    for (int y = 0; y < d.ly; y++) {
-      memcpy(dstPix, srcPix, wrap);
-      dstPix -= wrap;
-      srcPix += wrap;
+    if (!m_was64bit) {
+      uchar *srcPix = img.bits();
+      uchar *dstPix = tile.getRaster()->getRawData() + wrap * (d.ly - 1);
+      for (int y = 0; y < d.ly; y++) {
+        memcpy(dstPix, srcPix, wrap);
+        dstPix -= wrap;
+        srcPix += wrap;
+      }
     }
+    else if (m_was64bit) {
+        TRaster64P newRaster(tile.getRaster()->getSize());
+        TRaster32P tempRaster(tile.getRaster()->getSize());
+        uchar *srcPix = img.bits();
+        uchar *dstPix = tempRaster.getPointer()->getRawData() + wrap * (d.ly - 1);
+        for (int y = 0; y < d.ly; y++) {
+          memcpy(dstPix, srcPix, wrap);
+          dstPix -= wrap;
+          srcPix += wrap;
+        }
+        TRop::convert(newRaster, tempRaster);
+        int size = tile.getRaster()->getLx() * tile.getRaster()->getLy() * sizeof(TPixel64);
+        srcPix = newRaster.getPointer()->getRawData();
+        dstPix = tile.getRaster()->getRawData();
+        memcpy(dstPix, srcPix, size);
+        texInfo.m_bpp = 64;
+    }
+    
     fb.release();
 
     // context->getRaster(tile.getRaster());

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -261,13 +261,12 @@ void Picker::onImage(const Stage::Player &player) {
       double maxDist2  = maxDist * maxDist;
       double checkDist = maxDist2 * 4;
 
-      TStroke *stroke = vi->getStroke(strokeIndex);
+      TStroke *stroke        = vi->getStroke(strokeIndex);
       TThickPoint thickPoint = stroke->getThickPoint(w);
-      double thickness = thickPoint.thick;
-      double len = thickness * pixelSize * sqrt(m_viewAff.det());
-      checkDist = std::max(checkDist, (len * len));
-      if (dist2 < checkDist)
-        picked = true;
+      double thickness       = thickPoint.thick;
+      double len             = thickness * pixelSize * sqrt(m_viewAff.det());
+      checkDist              = std::max(checkDist, (len * len));
+      if (dist2 < checkDist) picked = true;
     }
   } else if (TRasterImageP ri = img) {
     TRaster32P ras = ri->getRaster();
@@ -574,11 +573,12 @@ void RasterPainter::flushRasterImages() {
       m_nodes[i].m_palette->setFrame(m_nodes[i].m_frame);
 
       TPaletteP plt;
+      int styleIndex = -1;
       if ((tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) &&
           m_nodes[i].m_isCurrentColumn) {
-        srcCm          = srcCm->clone();
-        plt            = m_nodes[i].m_palette->clone();
-        int styleIndex = plt->addStyle(TPixel::Magenta);
+        srcCm      = srcCm->clone();
+        plt        = m_nodes[i].m_palette->clone();
+        styleIndex = plt->addStyle(TPixel::Magenta);
         if (tc & ToonzCheck::eAutoclose)
           TAutocloser(srcCm, AutocloseDistance, AutocloseAngle, styleIndex,
                       AutocloseOpacity)
@@ -613,6 +613,9 @@ void RasterPainter::flushRasterImages() {
         Preferences::instance()->getTranspCheckData(
             settings.m_transpCheckBg, settings.m_transpCheckInk,
             settings.m_transpCheckPaint);
+
+        settings.m_isOnionSkin = m_nodes[i].m_onionMode != Node::eOnionSkinNone;
+        settings.m_gapCheckIndex = styleIndex;
 
         TRop::quickPut(viewedRaster, srcCm, plt, aff, settings);
       }
@@ -661,7 +664,7 @@ void RasterPainter::flushRasterImages() {
 #endif
 
 #ifdef GL_EXT_texture3D
-  if( GL_EXT_texture3D ) {
+  if (GL_EXT_texture3D) {
     glDisable(GL_TEXTURE_3D_EXT);
   }
 #endif
@@ -768,7 +771,7 @@ static void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
   buildAutocloseImage(vaux, vi, startPoints, endPoints);
   // temporarily disable fill check, to preserve the gap indicator color
   bool tCheckEnabledOriginal = rd.m_tcheckEnabled;
-  rd.m_tcheckEnabled = false;
+  rd.m_tcheckEnabled         = false;
   // draw
   tglDraw(rd, vaux);
   // restore original value
@@ -1075,11 +1078,11 @@ void RasterPainter::onToonzImage(TToonzImage *ti, const Stage::Player &player) {
   int alpha                 = 255;
   Node::OnionMode onionMode = Node::eOnionSkinNone;
   if (player.m_onionSkinDistance != c_noOnionSkin) {
-    // GetOnionSkinFade va bene per il vettoriale mentre il raster funziona al
-    // contrario
-    // 1 opaco -> 0 completamente trasparente
-    // inverto quindi il risultato della funzione stando attento al caso 0
-    // (in cui era scolpito il valore 0.9)
+    // GetOnionSkinFade is good for the vector while the raster works at the
+    //    Opposite 1 opaque -> 0 completely transparent
+    //    I therefore reverse the result of the function by being attentive to
+    //    case 0
+    //    (where the value 0.9 was carved)
     double onionSkiFade = player.m_onionSkinDistance == 0
                               ? 0.9
                               : (1.0 - OnionSkinMask::getOnionSkinFade(

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -247,7 +247,7 @@ void Picker::onImage(const Stage::Player &player) {
     double dist2     = 0;
     TRegion *r       = vi->getRegion(point);
     int styleId      = 0;
-    if (r) styleId   = r->getStyle();
+    if (r) styleId = r->getStyle();
     if (styleId != 0)
       picked = true;
     else if (vi->getNearestStroke(point, w, strokeIndex, dist2)) {
@@ -277,7 +277,7 @@ void Picker::onImage(const Stage::Player &player) {
     TPoint p(tround(pp.x), tround(pp.y));
     if (!ras->getBounds().contains(p)) return;
 
-    TPixel32 *pix               = ras->pixels(p.y);
+    TPixel32 *pix = ras->pixels(p.y);
     if (pix[p.x].m != 0) picked = true;
 
     TAffine aff2 = (aff * player.m_dpiAff).inv();
@@ -292,7 +292,7 @@ void Picker::onImage(const Stage::Player &player) {
                  ras->getBounds();
     for (int y = rect.y0; !picked && y <= rect.y1; y++) {
       pix = ras->pixels(y);
-      for (int x                  = rect.x0; !picked && x <= rect.x1; x++)
+      for (int x = rect.x0; !picked && x <= rect.x1; x++)
         if (pix[x].m != 0) picked = true;
     }
 
@@ -890,7 +890,7 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
 
   TVectorRenderData rd(m_viewAff * player.m_placement, TRect(), vPalette, cf,
                        true  // alpha enabled
-                       );
+  );
 
   rd.m_drawRegions           = !inksOnly;
   rd.m_inkCheckEnabled       = tc & ToonzCheck::eInk;
@@ -996,7 +996,7 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
 //-----------------------------------------------------
 
 /*! Create a \b Node and put it in \b m_nodes.
-*/
+ */
 void RasterPainter::onRasterImage(TRasterImage *ri,
                                   const Stage::Player &player) {
   TRasterP r = ri->getRaster();
@@ -1036,7 +1036,7 @@ void RasterPainter::onRasterImage(TRasterImage *ri,
                                                   : Node::eOnionSkinNone);
     }
   } else if (player.m_opacity < 255)
-    alpha             = player.m_opacity;
+    alpha = player.m_opacity;
   TXshSimpleLevel *sl = player.m_sl;
   bool doPremultiply  = false;
   bool whiteTransp    = false;
@@ -1062,7 +1062,7 @@ void RasterPainter::onRasterImage(TRasterImage *ri,
 
 //-----------------------------------------------------------------------------
 /*! Create a \b Node and put it in \b m_nodes.
-*/
+ */
 void RasterPainter::onToonzImage(TToonzImage *ti, const Stage::Player &player) {
   TRasterCM32P r = ti->getRaster();
   if (!ti->getPalette()) return;
@@ -1375,9 +1375,9 @@ void onMeshImage(TMeshImage *mi, const Stage::Player &player,
                  const TAffine &viewAff) {
   assert(mi);
 
-  static const double soMinColor[4] = {0.0, 0.0, 0.0,
+  static const double soMinColor[4]  = {0.0, 0.0, 0.0,
                                        0.6};  // Translucent black
-  static const double soMaxColor[4] = {1.0, 1.0, 1.0,
+  static const double soMaxColor[4]  = {1.0, 1.0, 1.0,
                                        0.6};  // Translucent white
   static const double rigMinColor[4] = {0.0, 1.0, 0.0,
                                         0.6};  // Translucent green

--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -506,7 +506,10 @@ void adaptLevelToPalette(TXshLevelHandle *currentLevelHandle,
   QApplication::restoreOverrideCursor();
 
   currentLevelHandle->getSimpleLevel()->setPalette(plt);
+
+  std::wstring oldGlobalName = paletteHandle->getPalette()->getGlobalName();
   paletteHandle->setPalette(plt);
+  paletteHandle->getPalette()->setGlobalName(oldGlobalName);
   plt->setDirtyFlag(true);
   paletteHandle->notifyPaletteChanged();
   currentLevelHandle->notifyLevelChange();

--- a/toonz/sources/toonzlib/stylemanager.cpp
+++ b/toonz/sources/toonzlib/stylemanager.cpp
@@ -113,9 +113,9 @@ void CustomStyleManager::StyleLoaderTask::run() {
       vimg->setPalette(vPalette);
 
 #ifdef LINUX
-	  TOfflineGL *glContext = 0;
-	  glContext = TOfflineGL::getStock(chipSize);
-	  glContext->clear(TPixel32::White);
+      TOfflineGL *glContext = 0;
+      glContext             = TOfflineGL::getStock(chipSize);
+      glContext->clear(TPixel32::White);
 #else
       QOpenGLContext *glContext = new QOpenGLContext();
       if (QOpenGLContext::currentContext())
@@ -155,10 +155,10 @@ void CustomStyleManager::StyleLoaderTask::run() {
       TVectorRenderData rd(aff, chipSize, vPalette, 0, true);
 
 #ifdef LINUX
-	  glContext->draw(img, rd);
-	  // No need to clone! The received raster already is a copy of the	
-	  // context's buffer	
-	  ras = glContext->getRaster();  //->clone();
+      glContext->draw(img, rd);
+      // No need to clone! The received raster already is a copy of the
+      // context's buffer
+      ras = glContext->getRaster();  //->clone();
 #else
       tglDraw(rd, vimg.getPointer());
 
@@ -190,8 +190,8 @@ void CustomStyleManager::StyleLoaderTask::run() {
       assert(!"unsupported type for custom styles!");
 
 #ifdef LINUX
-	image = new QImage(chipSize.lx, chipSize.ly, QImage::Format_RGB32);
-	convertRaster32ToImage(ras, image);
+    image = new QImage(chipSize.lx, chipSize.ly, QImage::Format_RGB32);
+    convertRaster32ToImage(ras, image);
 #endif
 
     m_data.m_patternName = m_fp.getName();

--- a/toonz/sources/toonzqt/functionpaneltools.cpp
+++ b/toonz/sources/toonzqt/functionpaneltools.cpp
@@ -106,6 +106,7 @@ MovePointDragTool::MovePointDragTool(FunctionPanel *panel, TDoubleParam *curve)
     , m_speed1Index(-1)
     , m_groupEnabled(false)
     , m_selection(0) {
+    // This undo block is closed in the destructor
   TUndoManager::manager()->beginBlock();
 
   if (curve) {

--- a/toonz/sources/toonzqt/functionpaneltools.cpp
+++ b/toonz/sources/toonzqt/functionpaneltools.cpp
@@ -106,7 +106,7 @@ MovePointDragTool::MovePointDragTool(FunctionPanel *panel, TDoubleParam *curve)
     , m_speed1Index(-1)
     , m_groupEnabled(false)
     , m_selection(0) {
-    // This undo block is closed in the destructor
+  // This undo block is closed in the destructor
   TUndoManager::manager()->beginBlock();
 
   if (curve) {

--- a/toonz/sources/toonzqt/fxselection.cpp
+++ b/toonz/sources/toonzqt/fxselection.cpp
@@ -261,8 +261,8 @@ bool FxSelection::insertPasteSelection() {
 
     // auto ends the undo block in the destructor.
     if (!auto_.m_destruct) {
-        auto_.m_destruct = true;
-        TUndoManager::manager()->beginBlock();
+      auto_.m_destruct = true;
+      TUndoManager::manager()->beginBlock();
     }
 
     TFxCommand::insertPasteFxs(selectedLinks[i], fxs.toStdList(),
@@ -384,7 +384,7 @@ void FxSelection::ungroupSelection() {
   TUndoManager::manager()->beginBlock();
   QSet<int>::iterator it;
   for (it = idSet.begin(); it != idSet.end(); it++) {
-      TFxCommand::ungroupFxs(*it, m_xshHandle);
+    TFxCommand::ungroupFxs(*it, m_xshHandle);
   }
   TUndoManager::manager()->endBlock();
   selectNone();

--- a/toonz/sources/toonzqt/fxselection.cpp
+++ b/toonz/sources/toonzqt/fxselection.cpp
@@ -259,8 +259,11 @@ bool FxSelection::insertPasteSelection() {
     fxsData->getFxs(fxs, zeraryFxColumnSize, columns);
     if (fxs.empty() && columns.empty()) return true;
 
-    if (!auto_.m_destruct)
-      auto_.m_destruct = true, TUndoManager::manager()->beginBlock();
+    // auto ends the undo block in the destructor.
+    if (!auto_.m_destruct) {
+        auto_.m_destruct = true;
+        TUndoManager::manager()->beginBlock();
+    }
 
     TFxCommand::insertPasteFxs(selectedLinks[i], fxs.toStdList(),
                                zeraryFxColumnSize.toStdMap(),
@@ -301,6 +304,7 @@ bool FxSelection::addPasteSelection() {
     fxsData->getFxs(fxs, zeraryFxColumnSize, columns);
     if (fxs.empty() && columns.empty()) return true;
 
+    // auto ends the undo block in its destructor
     if (!auto_.m_destruct)
       auto_.m_destruct = true, TUndoManager::manager()->beginBlock();
 
@@ -344,6 +348,7 @@ bool FxSelection::replacePasteSelection() {
     fxsData->getFxs(fxs, zeraryFxColumnSize, columns);
     if (fxs.empty() && columns.empty()) return true;
 
+    // auto ends the undo block in its destructor
     if (!auto_.m_destruct)
       auto_.m_destruct = true, TUndoManager::manager()->beginBlock();
 
@@ -378,8 +383,9 @@ void FxSelection::ungroupSelection() {
 
   TUndoManager::manager()->beginBlock();
   QSet<int>::iterator it;
-  for (it = idSet.begin(); it != idSet.end(); it++)
-    TFxCommand::ungroupFxs(*it, m_xshHandle);
+  for (it = idSet.begin(); it != idSet.end(); it++) {
+      TFxCommand::ungroupFxs(*it, m_xshHandle);
+  }
   TUndoManager::manager()->endBlock();
   selectNone();
   m_xshHandle->notifyXsheetChanged();


### PR DESCRIPTION
This PR will port several bug fixes done in Tahoma2D as follows:

- tahoma2d/tahoma2d#260 Clarify some undo endblock info
  by @jeremybullock
- tahoma2d/tahoma2d#265 More fixes (partially)
  by @jeremybullock
  I ported only changes of messages in the Collapse / Explode sub-xsheet popup.
  This fixes #3357 
- tahoma2d/tahoma2d#285 Fix Adjust Current Level to Studio Palette links
  by @manongjohn
- tahoma2d/tahoma2d#304 Show the & in the customize shortcuts and toolbars
  by @jeremybullock
  Note that I slightly modified it to properly remove "&" used as an accelerator key indicator and not at the beginning of the command name. (e.g. `Inks &Only` command)
- tahoma2d/tahoma2d#305 Fix a couple instances of RGBM
  by @jeremybullock
- tahoma2d/tahoma2d#314 Fix Plastic Rendering on 16 bit
  by @jeremybullock
  This fixes #2563 
- tahoma2d/tahoma2d#327 Fix colors on various checks
  by @jeremybullock
  This fixes #2504 
- tahoma2d/tahoma2d#357 Fix linux crash on vector style editor tab
  by @manongjohn
  This fixes #3214
- tahoma2d/tahoma2d#397 Fix autocreation preferences turning on accidentally
  by @manongjohn
- tahoma2d/tahoma2d#400 Bring in OpenToonz updates as of 10/20 (partially)
  by @jeremybullock
  I ported only the change of the conditions in `FilmstripFrameHeadGadget::eventFilter()` . Note that I took different way to resolve the problem that the floating Level Strip causes crash on quitting OT. Please refer to the subsequent commit.

Thank you @jeremybullock and @manongjohn !