### PR TITLE
Fix crash on quit OT with selecting stage schematic node

### DIFF
--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -614,8 +614,10 @@ public:
 };
 
 bool hasVisibleChildColumn(const TStageObject *obj, const TXsheet *xsh) {
-  if (!obj->getId().isColumn()) return false;  // just in case
-  if (xsh->getColumn(obj->getId().getIndex())->isCamstandVisible()) return true;
+  if (!(obj->getId().isColumn())) return false;  // just in case
+  TXshColumn *column = xsh->getColumn(obj->getId().getIndex());
+  if (!column) return false;
+  if (column->isCamstandVisible()) return true;
   for (const auto child : obj->getChildren()) {
     if (hasVisibleChildColumn(child, xsh)) return true;
   }


### PR DESCRIPTION
This PR fixes crash as follows:

To reproduce:
- Launch OT with Viewer and Schematic.
- Select either `Table` or `Camera1` node in the Stage Schematic. Animation tool is selected accordingly.
- Quit OT. It crashes instead of quitting. 