### PR TITLE
Fix Camera Settings response

### DIFF
--- a/toonz/sources/include/toonzqt/camerasettingswidget.h
+++ b/toonz/sources/include/toonzqt/camerasettingswidget.h
@@ -40,7 +40,7 @@ class DoubleLineEdit;
 class IntLineEdit;
 class MeasuredDoubleLineEdit;
 class CheckBox;
-}
+}  // namespace DVGui
 
 //---------------------------------------------------------------
 
@@ -124,8 +124,8 @@ public:
   // camera => widget fields (i.e. initialize widget)
   void setFields(const TCamera *camera);
 
-  // widget fields => camera
-  void getFields(TCamera *camera);
+  // widget fields => camera return true if the value is actually changed
+  bool getFields(TCamera *camera);
 
   QSize sizeHint() const override { return minimumSize(); }
 

--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -165,15 +165,15 @@ void CameraSettingsPopup::hideEvent(QHideEvent *e) {
   bool ret = true;
   ret      = ret && disconnect(sceneHandle, SIGNAL(sceneChanged()), this,
                           SLOT(updateFields()));
-  ret = ret && disconnect(sceneHandle, SIGNAL(sceneSwitched()), this,
+  ret      = ret && disconnect(sceneHandle, SIGNAL(sceneSwitched()), this,
                           SLOT(updateFields()));
-  ret = ret && disconnect(objectHandle, SIGNAL(objectChanged(bool)), this,
+  ret      = ret && disconnect(objectHandle, SIGNAL(objectChanged(bool)), this,
                           SLOT(updateFields(bool)));
-  ret = ret && disconnect(objectHandle, SIGNAL(objectSwitched()), this,
+  ret      = ret && disconnect(objectHandle, SIGNAL(objectSwitched()), this,
                           SLOT(updateFields()));
-  ret = ret && disconnect(xsheetHandle, SIGNAL(xsheetSwitched()), this,
+  ret      = ret && disconnect(xsheetHandle, SIGNAL(xsheetSwitched()), this,
                           SLOT(updateFields()));
-  ret = ret && disconnect(xsheetHandle, SIGNAL(xsheetChanged()), this,
+  ret      = ret && disconnect(xsheetHandle, SIGNAL(xsheetChanged()), this,
                           SLOT(updateFields()));
   ret = ret && disconnect(levelHandle, SIGNAL(xshLevelSwitched(TXshLevel *)),
                           this, SLOT(onLevelSwitched(TXshLevel *)));
@@ -219,11 +219,12 @@ void CameraSettingsPopup::updateWindowTitle() {
 void CameraSettingsPopup::onChanged() {
   TCamera *camera = getCamera();
   if (!camera) return;
-  m_cameraSettingsWidget->getFields(camera);
-  TApp::instance()->getCurrentScene()->notifySceneChanged();
-  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  if (m_cameraSettingsWidget->getFields(camera)) {
+    TApp::instance()->getCurrentScene()->notifySceneChanged();
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
 
-  emit changed();
+    emit changed();
+  }
 }
 
 void CameraSettingsPopup::onNameChanged() {

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -581,9 +581,14 @@ void CameraSettingsWidget::setFields(const TCamera *camera) {
   updatePresetListOm();
 }
 
-void CameraSettingsWidget::getFields(TCamera *camera) {
+bool CameraSettingsWidget::getFields(TCamera *camera) {
+  TDimensionD old_sz = camera->getSize();
+  TDimension old_res = camera->getRes();
+
+  if (old_sz == getSize() && old_res == getRes()) return false;
   camera->setSize(getSize());
   camera->setRes(getRes());
+  return true;
 }
 
 TDimensionD CameraSettingsWidget::getSize() const {
@@ -944,8 +949,8 @@ double CameraSettingsWidget::aspectRatioStringToValue(const QString &s) {
   }
   int i = s.indexOf("/");
   if (i <= 0 || i + 1 >= s.length()) return s.toDouble();
-  int num           = s.left(i).toInt();
-  int den           = s.mid(i + 1).toInt();
+  int num = s.left(i).toInt();
+  int den = s.mid(i + 1).toInt();
   if (den <= 0) den = 1;
   return (double)num / (double)den;
 }


### PR DESCRIPTION
This PR modifies response of the camera settings (used in Camera Settings popup and Output Settings).
Since the field is using `editingFinished()` signal, it emits the signal even when it just lose focus with the value unchanged. This fix will check if the values are actually changed or not and prevent unnecessary emitting of signals like `sceneChanged()` and `xsheetChanged()` which will cause updates in other panels.