### PR TITLE
Actions: use setup-python to specify Python version

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -57,15 +57,21 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
+        version: '5.15.2'
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         modules: 'qtscript'
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9.1'
 
     - name: Install clcache
       run: |
         pip install clcache
         Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe' -NewName 'cl_original.exe'
         Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe.config' -NewName 'cl_original.exe.config'
-        cp 'C:/hostedtoolcache/windows/Python/3.9.0/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe'
+        cp 'C:/hostedtoolcache/windows/Python/3.9.1/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe'
 
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
This PR specifies Python version by using `actions/setup-python` so that it will be installed if it does not exist in the cache.

This PR specifies Qt version as will.