### PR TITLE
Suppress context menu on rulers

### DIFF
--- a/toonz/sources/toonz/ruler.cpp
+++ b/toonz/sources/toonz/ruler.cpp
@@ -137,8 +137,8 @@ void Ruler::drawVertical(QPainter &p) {
   for (i = 0; i < count; i++) {
     QColor color = (m_moving && count - 1 == i ? QColor(getHandleDragColor())
                                                : QColor(getHandleColor()));
-    double v = guides[i] / (double)getDevPixRatio();
-    int y    = (int)(origin - zoom * v);
+    double v     = guides[i] / (double)getDevPixRatio();
+    int y        = (int)(origin - zoom * v);
     p.fillRect(QRect(x0, y - 1, x1 - x0, 2), QBrush(color));
   }
 
@@ -192,8 +192,8 @@ void Ruler::drawHorizontal(QPainter &p) {
   for (i = 0; i < count; i++) {
     QColor color = (m_moving && count - 1 == i ? QColor(getHandleDragColor())
                                                : QColor(getHandleColor()));
-    double v = guides[i] / (double)getDevPixRatio();
-    int x    = (int)(origin + zoom * v);
+    double v     = guides[i] / (double)getDevPixRatio();
+    int x        = (int)(origin + zoom * v);
     p.fillRect(QRect(x - 1, y0, 2, y1 - y0), QBrush(color));
   }
 
@@ -334,6 +334,13 @@ void Ruler::mouseReleaseEvent(QMouseEvent *e) {
   m_moving = m_hiding = false;
   update();
   m_viewer->update();
+}
+
+//-----------------------------------------------------------------------------
+
+void Ruler::contextMenuEvent(QContextMenuEvent *event) {
+  // do nothing. just accept event to prevent context menu to open
+  event->accept();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/ruler.h
+++ b/toonz/sources/toonz/ruler.h
@@ -80,6 +80,7 @@ public:
   void mousePressEvent(QMouseEvent *e) override;
   void mouseMoveEvent(QMouseEvent *e) override;
   void mouseReleaseEvent(QMouseEvent *e) override;
+  void contextMenuEvent(QContextMenuEvent *event) override;
 };
 
 #endif


### PR DESCRIPTION
This PR fixes #3331 taking different way from tahoma2d/tahoma2d#412 . 
Instead of removing the GUI menu, this PR prevents the menu to open on the rulers by overriding `contextMenuEvent()` .