### PR TITLE
Making generation of translation projects optional in cmake

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 2.8.11)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 
@@ -102,6 +102,7 @@ endif()
 option(WITH_SYSTEM_LZO "Use the system LZO library instead of 'thirdpary'" ${_init_SYSTEM_LZO})
 option(WITH_SYSTEM_SUPERLU "Use the system SuperLU library instead of 'thirdpary'" ${_init_SYSTEM_SUPERLU})
 option(WITH_STOPMOTION "Build with Stop Motion features - Requires Canon SDK" OFF)
+option(WITH_TRANSLATION "Generate translation projects as well" ON)
 
 # avoid using again
 option_defaults_clear()
@@ -567,26 +568,28 @@ if(BUILD_ENV_MSVC AND MSVC_VERSION EQUAL 1800)
     add_compile_options("/wd4819")
 endif()
 
-# generate Qt translations and messages
-set(LANGUAGES japanese italian french spanish chinese german russian korean czech)
+if(WITH_TRANSLATION)
+    # generate Qt translations and messages
+    set(LANGUAGES japanese italian french spanish chinese german russian korean czech)
 
-function(add_translation module)
-    set(translation)
-    foreach(lang ${LANGUAGES})
-        set(name "${CMAKE_SOURCE_DIR}/translations/${lang}/${module}.ts")
-        list(APPEND translation ${name})
-        set_source_files_properties(${name} PROPERTIES
-            OUTPUT_LOCATION "${CMAKE_BINARY_DIR}/loc/${lang}"
+    function(add_translation module)
+        set(translation)
+        foreach(lang ${LANGUAGES})
+            set(name "${CMAKE_SOURCE_DIR}/translations/${lang}/${module}.ts")
+            list(APPEND translation ${name})
+            set_source_files_properties(${name} PROPERTIES
+                OUTPUT_LOCATION "${CMAKE_BINARY_DIR}/loc/${lang}"
+            )
+        endforeach()
+
+        qt5_create_translation(message ${translation} ${ARGN})
+
+        add_custom_target("translation_${module}" DEPENDS ${message})
+        set_target_properties("translation_${module}" PROPERTIES
+            EXCLUDE_FROM_DEFAULT_BUILD TRUE
         )
-    endforeach()
-
-    qt5_create_translation(message ${translation} ${ARGN})
-
-    add_custom_target("translation_${module}" DEPENDS ${message})
-    set_target_properties("translation_${module}" PROPERTIES
-        EXCLUDE_FROM_DEFAULT_BUILD TRUE
-    )
-endfunction()
+    endfunction()
+endif()
 
 set(CMAKE_C_FLAGS "${C_WARNINGS} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CXX_WARNINGS} ${CMAKE_CXX_FLAGS}")

--- a/toonz/sources/colorfx/CMakeLists.txt
+++ b/toonz/sources/colorfx/CMakeLists.txt
@@ -16,7 +16,9 @@ set(SOURCES
     zigzagstyles.cpp
 )
 
-add_translation(colorfx ${HEADERS} ${SOURCES})
+if(WITH_TRANSLATION)
+    add_translation(colorfx ${HEADERS} ${SOURCES})
+endif()
 
 add_library(colorfx SHARED ${HEADERS} ${SOURCES})
 add_definitions(

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -90,7 +90,9 @@ elseif(BUILD_TARGET_UNIX)
     )
 endif()
 
-add_translation(image ${HEADERS} ${SOURCES})
+if(WITH_TRANSLATION)
+    add_translation(image ${HEADERS} ${SOURCES})
+endif()
 
 add_library(image SHARED ${HEADERS} ${SOURCES})
 add_definitions(

--- a/toonz/sources/tnzcore/CMakeLists.txt
+++ b/toonz/sources/tnzcore/CMakeLists.txt
@@ -258,7 +258,9 @@ elseif(BUILD_TARGET_UNIX)
     )
 endif()
 
-add_translation(tnzcore ${HEADERS} ${SOURCES})
+if(WITH_TRANSLATION)
+    add_translation(tnzcore ${HEADERS} ${SOURCES})
+endif()
 
 qt5_wrap_cpp(SOURCES ${MOC_HEADERS})
 

--- a/toonz/sources/tnztools/CMakeLists.txt
+++ b/toonz/sources/tnztools/CMakeLists.txt
@@ -109,7 +109,9 @@ set(RESOURCES tnztools.qrc)
 
 qt5_add_resources(SOURCES ${RESOURCES})
 
-add_translation(tnztools ${HEADERS} ${SOURCES})
+if(WITH_TRANSLATION)
+    add_translation(tnztools ${HEADERS} ${SOURCES})
+endif()
 
 qt5_wrap_cpp(SOURCES ${MOC_HEADERS})
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -376,7 +376,9 @@ set(SOURCES
 )
 endif()
 
-add_translation(toonz ${HEADERS} ${SOURCES})
+if(WITH_TRANSLATION)
+    add_translation(toonz ${HEADERS} ${SOURCES})
+endif()
 
 set(OBJCSOURCES filebrowsermodel.cpp)
 

--- a/toonz/sources/toonzlib/CMakeLists.txt
+++ b/toonz/sources/toonzlib/CMakeLists.txt
@@ -329,7 +329,9 @@ if(BUILD_TARGET_WIN)
     )
 endif()
 
-add_translation(toonzlib ${HEADERS} ${SOURCES})
+if(WITH_TRANSLATION)
+    add_translation(toonzlib ${HEADERS} ${SOURCES})
+endif()
 
 qt5_wrap_cpp(SOURCES ${MOC_HEADERS})
 

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -202,7 +202,9 @@ set(SOURCES
 
 set(RESOURCES toonzqt.qrc)
 
-add_translation(toonzqt ${HEADERS} ${SOURCES})
+if(WITH_TRANSLATION)
+    add_translation(toonzqt ${HEADERS} ${SOURCES})
+endif()
 
 get_target_property(QW_LOC Qt5::Widgets INTERFACE_INCLUDE_DIRECTORIES)
 


### PR DESCRIPTION
This PR enables to run `cmake` without generating translation projects.
This is needed when building with recent Xcode. Otherwise `cmake` fails because the same source are added to multiple targets which is not allowed by the Xcode "new build system".

With this PR, adding an command line option `-DWITH_TRANSLATION=OFF` enables to avoid the error.