### PR TITLE
Actions: use the latest ninja

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -24,8 +24,8 @@ jobs:
         }
         brew update
         checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo qt boost libusb libmypaint ccache
-        curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/284557d4f5b29a7b9fb48bf8a54cf8a72d26c5eb/Formula/ninja.rb
-        brew install ./ninja.rb
+        rm -f '/usr/local/bin/2to3'
+        checkPkgAndInstall ninja
 
     - uses: actions/cache@v1
       with:
@@ -45,7 +45,7 @@ jobs:
         cd toonz
         mkdir build
         cd build
-        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH='/usr/local/opt/qt/lib'
+        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH='/usr/local/opt/qt/lib' -DWITH_TRANSLATION=OFF
         ninja -w dupbuild=warn
 
     - name: Create Artifact

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -11,11 +11,6 @@
 - boost (1.55.0 or later)
 
 ## Building on macOS
-### Download boost from https://boost.org
-
-Download the .bz2 mac (unix if mac not specified) version 1_55_0 or later (last tested with 1_72_0)
-
-Save for later step.
 
 ### Download and install Xcode from Apple
 
@@ -39,7 +34,7 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 
 In a Terminal window, execute the following statements:
 ```
-$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt
+$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt boost
 $ git lfs install
 ```
 
@@ -62,21 +57,18 @@ $ cd ~/Documents   #or where you want to store the repository#
 $ git clone https://github.com/opentoonz/opentoonz
 $ cd opentoonz
 $ git lfs pull
-$ cd thirdparty/boost
-$ mv ~/Downloads/boost_1_72_0.tar.bz2 .   #or whatever the boost filename you downloaded is#
-$ tar xvjf boost_1_72_0.tar.bz2
-$ cd ../lzo
+$ cd thirdparty/lzo
 $ cp -r 2.03/include/lzo driver
 $ cd ../tiff-4.0.3
 $ ./configure && make
 ```
 
-### Configure build for QT version
-
-Edit the `/Users/yourlogin/Documents/opentoonz/toonz/sources/CMakeLists.txt` file at line 160 (64-bit OS) or 172 (32-bit OS) and modify the root path for the QT lib directory
-
-If you installed QT using `brew`, you can get the version and path to use with: `$ brew info qt`.  The lib path will look something like this: `/usr/local/Cellar/qt/5.12.2/lib`
-If you downloaded the QT installer and installed to `/Users/yourlogin/Qt`, your lib path may look something like this: `~/Qt/5.12.2/clang_64/lib` or `~/Qt/5.12.2/clang_32/lib`
+If you downloaded and installed boost from https://boost.org instead of homebrew, move the package under `thirdparty/boost` as follows: 
+```
+$ cd thirdparty/boost
+$ mv ~/Downloads/boost_1_72_0.tar.bz2 .   #or whatever the boost filename you downloaded is#
+$ tar xvjf boost_1_72_0.tar.bz2
+```
 
 ### Configure environment and Build OpenToonz
 
@@ -91,16 +83,17 @@ $ cd build
 
 To build from command line, do the following:
 ```
-$ CMAKE_PREFIX_PATH=/usr/local/Cellar/qt/5.12.2 cmake ../sources   #replace QT path with your installed QT version#
+$ cmake ../sources -DQT_PATH='/usr/local/opt/qt/lib'  #replace QT path with your installed QT version#
 $ make
 ```
+- If you downloaded the QT installer and installed to `/Users/yourlogin/Qt` instead of by using homebrew, your lib path may look something like this: `~/Qt/5.12.2/clang_64/lib` or `~/Qt/5.12.2/clang_32/lib`
 
 To build using Xcode, do the following:
 ```
 $ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-$ CMAKE_PREFIX_PATH=/usr/local/Cellar/qt/5.12.2 cmake -G Xcode ../sources -B.   #replace QT path with your installed QT version#
+$ cmake -G Xcode ../sources -B. -DQT_PATH='/usr/local/opt/qt/lib' -DWITH_TRANSLATION=OFF   #replace QT path with your installed QT version#
 ```
-
+- Note that the option `-DWITH_TRANSLATION=OFF` is needed to avoid error when using XCode 12+ which does not allow to add the same source to multiple targets.
 - Open Xcode app and open project /Users/yourlogin/Documents/opentoonz/toonz/build/OpenToonz.xcodeproj
 - Change `ALL_BUILD` to `OpenToonz`
 - Start build with: Product -> Build

--- a/doc/how_to_build_macosx_ja.md
+++ b/doc/how_to_build_macosx_ja.md
@@ -5,27 +5,74 @@
 - git
 - brew
 - Xcode
-- cmake
-  - バージョン 3.2.2 で動作確認済みです。
-- Qt
-  - http://download.qt.io/official_releases/qt/5.9/5.9.2/
-    - qt-opensource-mac-x64-5.9.2.dmg
-- boost
-  - http://www.boost.org/users/history/version_1_55_0.html
+- cmake (3.2.2以降)
+- Qt (5.9.2以降)
+- boost　(1.55.0以降)
 
 ## ビルド手順
+
+### Xcode をインストール
+
+### Homebrew をインストール
+
+1. ターミナルウィンドウを起動
+2. 下記を実行します：
+```
+$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+```
 
 ### brew で必要なパッケージをインストール
 
 ```
-$ brew install glew lz4 libjpeg libpng lzo pkg-config
+$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt boost
+$ git lfs install
 ```
 
 ### リポジトリを clone
 
 ```
 $ git clone https://github.com/opentoonz/opentoonz
+$ cd opentoonz
+$ git lfs pull
+$ cd thirdparty/lzo
+$ cp -r 2.03/include/lzo driver
+$ cd ../tiff-4.0.3
+$ ./configure && make
 ```
+
+boost をhomebrewではなく https://boost.org からダウンロードした場合は以下を実行します。以下のコマンドは `~/Downsloads` に `boost_1_72_0.tar.bz2` がダウンロードされていることを想定しています。
+```
+$ cd ../boost
+$ mv ~/Downloads/boost_1_72_0.tar.bz2 .
+$ tar xjvf boost_1_72_0.tar.bz2
+```
+
+### 本体のビルド
+
+1. buildディレクトリの作成
+```
+$ cd ../../toonz
+$ mkdir build
+$ cd build
+```
+
+2. ビルド
+コマンドラインの場合は下記を実行します。
+```
+$ cmake ../sources -DQT_PATH='/usr/local/opt/qt/lib'
+$ make
+```
+- Qt をHomebrewでなく http://download.qt.io/official_releases/qt/ からダウンロードして `/Users/ユーザ名/Qt` にインストールしている場合、`QT_PATH`の値は `~/Qt/5.12.2/clang_64/lib` または `~/Qt/5.12.2/clang_32/lib` のようになります。
+
+ビルドが長いので気長に待ちます。
+
+Xcodeを用いる場合は下記を実行します。
+```
+$ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+$ cmake -G Xcode ../sources -B. -DQT_PATH='/usr/local/opt/qt/lib' -DWITH_TRANSLATION=OFF
+```
+- オプション `-DWITH_TRANSLATION=OFF` はXcode12以降で必要です。
+- Xcodeでプロジェクト `/opentoonz/toonz/build/OpenToonz.xcodeproj` を開き、ビルドします。
 
 ### stuff ディレクトリの設置 (任意)
 
@@ -33,39 +80,13 @@ $ git clone https://github.com/opentoonz/opentoonz
 
 ```
 $ sudo cp -r opentoonz/stuff /Applications/OpenToonz/OpenToonz_stuff
+$ sudo chmod -R 777 /Applications/OpenToonz
 ```
 
-### thirdparty 下の tiff をビルド
-
-```
-$ cd opentoonz/thirdparty/tiff-4.0.3
-$ ./configure && make
-```
-
-### thirdpaty 下に boost を設置
-
-以下のコマンドは `~/Downsloads` に `boost_1_55_0.tar.bz2` がダウンロードされていることを想定しています。
-
-```
-$ cd ../boost
-$ mv ~/Downloads/boost_1_55_0.tar.bz2 .
-$ tar xjvf boost_1_55_0.tar.bz2
-```
-
-### 本体のビルド
-
-```
-$ cd ../../toonz
-$ mkdir build
-$ cd build
-$ cmake ../sources
-$ make
-```
-
-ビルドが長いので気長に待ちます。
-
-### 完成
+### アプリケーションの実行
 
 ```
 $ open ./toonz/OpenToonz.app
 ```
+
+- Xcode でビルドしている場合、アプリケーションは　`.toonz/build/Debug/OpenToonz.app` にあります。


### PR DESCRIPTION
Just like Xcode, the latest version of Ninja does not allow to add the same source to multiple targets.  So I needed to install older version of ninja by rolling back Homebrew in Github Actions MacOS build.
Since #3650 was merged, now we can use the latest version of Ninja.

I also modified the MacOS build instruction.

