### PR TITLE
Fix crash on saving palette level

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2997,7 +2997,7 @@ public:
 
     if (sl && sl->getPath().getType() == "pli")
       sl->save(palettePath, TFilePath(), true);
-    else if (sl->getType() & FULLCOLOR_TYPE)
+    else if (sl && sl->getType() & FULLCOLOR_TYPE)
       FullColorPalette::instance()->savePalette(scene);
     else
       StudioPalette::instance()->save(palettePath, palette);


### PR DESCRIPTION
This PR fixes the crash when overwriting palette levels by pressing the `Overwrite Palette` button in the Palette tool bar.
So sorry that I included the bug in #3387 .