### PR TITLE
Cut Level Strip Selection Behavior Fix

### DIFF
--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -238,10 +238,15 @@ void TFilmstripSelection::copyFrames() {
 void TFilmstripSelection::cutFrames() {
   TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
   if (sl) {
+    int firstSelectedIndex = sl->fid2index(*m_selectedFrames.begin());
+    assert(firstSelectedIndex >= 0);
     FilmstripCmd::cut(sl, m_selectedFrames);
     selectNone();
-    TApp::instance()->getCurrentFrame()->setFid(sl->getFirstFid());
-    select(sl->getFirstFid());
+    TFrameId fId = (firstSelectedIndex == 0)
+                       ? sl->getFirstFid()
+                       : sl->getFrameId(firstSelectedIndex - 1);
+    TApp::instance()->getCurrentFrame()->setFid(fId);
+    select(fId);
   }
 }
 


### PR DESCRIPTION
This fixes #3612 .
Now the current frame will be jump to a previous frame of the cut frames, instead of the first frame of the level.