### PR TITLE
Motion Blur Fx Iwa : default value change

### DIFF
--- a/stuff/profiles/layouts/fxs/STD_iwa_MotionBlurCompFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_MotionBlurCompFx.xml
@@ -1,10 +1,10 @@
 <fxlayout help_file="MotionBlurIwa.html">
 	<page name="Motion Blur Iwa">
  	<vbox>
-		<hbox>
 		<control>motionObjectType</control>
+		<vbox modeSensitive="motionObjectType" mode="1,2,4">
 		<control>motionObjectIndex</control>
-		</hbox>
+		</vbox>
 		<control>shutterStart</control>
 		<control>startValue</control>
 		<control>startCurve</control>

--- a/toonz/sources/stdfx/motionawarebasefx.h
+++ b/toonz/sources/stdfx/motionawarebasefx.h
@@ -32,7 +32,7 @@ public:
       , m_shutterEnd(0.05)
       , m_traceResolution(4)
       , m_motionObjectType(new TIntEnumParam(OBJTYPE_OWN, "Own Motion"))
-      , m_motionObjectIndex(0) {
+      , m_motionObjectIndex(1) {
     m_shutterStart->setValueRange(0.0, 1.0);
     m_shutterEnd->setValueRange(0.0, 1.0);
     m_traceResolution->setValueRange(1, 20);


### PR DESCRIPTION
This PR modifies the default value of the `Index` parameter of Motion Blur Fx Iwa.
It is changed from `0` to `1` since this value is meaningless when less than 1.

Also the `Index` field is now sensitive to the `Reference Object` value.
When the `Reference Object` is set to `Own Motion` or `Table` , the `Index` field becomes hidden.