### PR TITLE
Actions: Fix macOS error when installing Python

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -14,6 +14,7 @@ jobs:
         {
           while [ $# -ne 0 ]
           do
+            rm -f '/usr/local/bin/2to3'
             if brew ls --versions $1 ; then
               brew upgrade $1
             else
@@ -23,9 +24,7 @@ jobs:
           done
         }
         brew update
-        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo qt boost libusb libmypaint ccache
-        rm -f '/usr/local/bin/2to3'
-        checkPkgAndInstall ninja
+        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo qt boost libusb libmypaint ccache ninja
 
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
In GitHub Actions macOS build, the following error occurs very often when installing dependencies of necessary libraries:

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.9

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.9

Possible conflicting files are:
/usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/2.7/bin/2to3
```
So, following the error message, I added a line to remove `/usr/local/bin/2to3` every time before installing library just to be sure.
This is a part of #3674 but I picked as a separate PR so that it can resolve the error occurs in #3678 .