### PR TITLE
Fix redundant preview invocation

### DIFF
--- a/toonz/sources/include/tundo.h
+++ b/toonz/sources/include/tundo.h
@@ -28,7 +28,10 @@
 
 class DVAPI TUndo {
 public:
+  // To be called in the last of the block when undo
   bool m_isLastInBlock;
+  // To be called in the last of the block when redo
+  bool m_isLastInRedoBlock;
 
 public:
   TUndo() {}


### PR DESCRIPTION
This PR fixes redundant preview invocation when deleting multiple fx nodes in the Fx Schematic as shown in a GIF below.

![preview_problem](https://user-images.githubusercontent.com/17974955/104670825-e6a35a80-571f-11eb-81cf-a5f8aceb4d7a.gif)

This behavior was very cumbersome especially when working on the time consuming fxs to render as it multiplies the rendering time.
This problem was due to the signal `xsheetChanged()` emitted for each deleting of node. Deleting multiple nodes caused multiple preview update requests. I fixed this to emit the signal once at the end of the operation.