### PR TITLE
Fix Color Tab on Style Editor

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1503,9 +1503,6 @@ QStatusBar #StatusBarLabel {
 /* -----------------------------------------------------------------------------
    Style Editor
 ----------------------------------------------------------------------------- */
-#StyleEditor #TabBarContainer {
-  margin-left: -5px;
-}
 #StyleEditor #bottomWidget {
   border-top: 1 solid #262728;
   padding: 3 2 8 3;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1503,9 +1503,6 @@ QStatusBar #StatusBarLabel {
 /* -----------------------------------------------------------------------------
    Style Editor
 ----------------------------------------------------------------------------- */
-#StyleEditor #TabBarContainer {
-  margin-left: -5px;
-}
 #StyleEditor #bottomWidget {
   border-top: 1 solid #111111;
   padding: 3 2 8 3;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1503,9 +1503,6 @@ QStatusBar #StatusBarLabel {
 /* -----------------------------------------------------------------------------
    Style Editor
 ----------------------------------------------------------------------------- */
-#StyleEditor #TabBarContainer {
-  margin-left: -5px;
-}
 #StyleEditor #bottomWidget {
   border-top: 1 solid #2c2c2c;
   padding: 3 2 8 3;

--- a/stuff/config/qss/Default/less/layouts/palette.less
+++ b/stuff/config/qss/Default/less/layouts/palette.less
@@ -3,9 +3,6 @@
 ----------------------------------------------------------------------------- */
 
 #StyleEditor {
-  & #TabBarContainer {
-    margin-left: -5px;
-  }
   & #bottomWidget {
     border-top: 1 solid @accent;
     padding: 3 2 8 3;

--- a/stuff/config/qss/Default/less/themes/Light.less
+++ b/stuff/config/qss/Default/less/themes/Light.less
@@ -5,6 +5,8 @@
 // -----------------------------------------------------------------------------
 // This inherits from NEUTRAL theme, when updating NEUTRAL make sure to check
 // changes against LIGHT.
+//
+// NOTE: Compile Neutral.less before this.
 // -----------------------------------------------------------------------------
 
 // Override

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1503,9 +1503,6 @@ QStatusBar #StatusBarLabel {
 /* -----------------------------------------------------------------------------
    Style Editor
 ----------------------------------------------------------------------------- */
-#StyleEditor #TabBarContainer {
-  margin-left: -5px;
-}
 #StyleEditor #bottomWidget {
   border-top: 1 solid #a8a8a8;
   padding: 3 2 8 3;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1503,9 +1503,6 @@ QStatusBar #StatusBarLabel {
 /* -----------------------------------------------------------------------------
    Style Editor
 ----------------------------------------------------------------------------- */
-#StyleEditor #TabBarContainer {
-  margin-left: -5px;
-}
 #StyleEditor #bottomWidget {
   border-top: 1 solid #5a5a5a;
   padding: 3 2 8 3;


### PR DESCRIPTION
Removes the negative margin set for tab area.

It was previously a dirty fix, but since I modified it in the source awhile back this line is no longer needed in the style sheets, and actually causes the tab to go off screen a bit. Removing it makes the color tab align properly again.

![cap1](https://user-images.githubusercontent.com/19820721/105629288-f9addd00-5e39-11eb-8b7a-a94bcd6e7d1b.PNG)
