### PR TITLE
New Color Keys Global Palette

### DIFF
--- a/stuff/studiopalette/Global Palettes/color_key.tpl
+++ b/stuff/studiopalette/Global Palettes/color_key.tpl
@@ -1,0 +1,62 @@
+<palette name="1611507682_28145">
+  <version>
+    71 0 
+  </version>
+  <styles>
+    <style>
+      "|-1611507682_28145-0"color_0 3 255 255 255 0 
+    </style>
+    <style>
+      "|-1611507682_28145-1"color_1 3 0 0 0 255 
+    </style>
+    <style>
+      "|-1611507682_28145-2"color_2 3 255 255 255 255 
+    </style>
+    <style>
+      _1 "|-1611507682_28145-3"color_3 3 255 0 0 255 
+    </style>
+    <style>
+      _1 "|-1611507682_28145-4"color_4 3 0 255 0 255 
+    </style>
+    <style>
+      _1 "|-1611507682_28145-5"color_5 3 0 0 255 255 
+    </style>
+    <style>
+      "|-1611507682_28145-6"color_6 3 255 128 255 255 
+    </style>
+    <style>
+      "|-1611507682_28145-7"color_7 3 128 255 192 255 
+    </style>
+    <style>
+      "|-1611507682_28145-8"color_8 3 255 255 0 255 
+    </style>
+    <style>
+      "|-1611507682_28145-9"color_9 3 128 128 255 255 
+    </style>
+    <style>
+      "|-1611507682_28145-10"color_10 3 255 128 0 255 
+    </style>
+    <style>
+      "|-1611507682_28145-11"color_11 3 0 192 255 255 
+    </style>
+    <style>
+      "|-1611507682_28145-12"color_12 3 128 255 255 255 
+    </style>
+    <style>
+      "|-1611507682_28145-13"color_13 3 255 128 128 255 
+    </style>
+    </styles>
+  <stylepages>
+    <page>
+      <name>
+        colors 
+      </name>
+      <indices>
+        0 1 2 3 4 5 6 7 8 9 10 11 12 13 
+      </indices>
+      </page>
+    </stylepages>
+  <shortcuts>
+    9 0 1 2 3 4 5 6 7 8 
+  </shortcuts>
+  </palette>


### PR DESCRIPTION
This adds a new global palette that contains the color keys from the Retas PaintMan workflow.

![image](https://user-images.githubusercontent.com/19820721/105638132-fb42c980-5e68-11eb-9669-acf37c6735cb.png)