### PR TITLE
Fix missing orientation dtor crash

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -268,6 +268,8 @@ public:
   virtual int cellHeight() const     = 0;
   virtual int foldedCellSize() const = 0;
 
+  virtual ~Orientation() {}
+
 protected:
   void addRect(PredefinedRect which, const QRect &rect);
   void addLine(PredefinedLine which, const QLine &line);


### PR DESCRIPTION
This PR fixes crash when exiting OT on MacOS, which seems to be related to the following warning at the dtor of `Orientations`:
```
Delete called on 'Orientation' that is abstract but has non-virtual destructor
```

So I added the virtual dtor to `Orientation` and the crash seems to be fixed.