### PR TITLE
Output Settings Popup Style Fix

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1652,21 +1652,25 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
-#PreferencesPopup QListWidget {
+#PreferencesPopup QListWidget,
+#OutputSettingsPopup QListWidget {
   background-color: #2d2f30;
   alternate-background-color: #2d2f30;
   border: 1 solid #262728;
   font-size: 13px;
 }
-#PreferencesPopup QListWidget::item {
+#PreferencesPopup QListWidget::item,
+#OutputSettingsPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
-#PreferencesPopup QListWidget::item:hover {
+#PreferencesPopup QListWidget::item:hover,
+#OutputSettingsPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.1);
   color: #d6d8dd;
 }
-#PreferencesPopup QListWidget::item:selected {
+#PreferencesPopup QListWidget::item:selected,
+#OutputSettingsPopup QListWidget::item:selected {
   background-color: #5385a6;
   color: #ffffff;
 }

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1652,21 +1652,25 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
-#PreferencesPopup QListWidget {
+#PreferencesPopup QListWidget,
+#OutputSettingsPopup QListWidget {
   background-color: #262626;
   alternate-background-color: #262626;
   border: 1 solid #111111;
   font-size: 13px;
 }
-#PreferencesPopup QListWidget::item {
+#PreferencesPopup QListWidget::item,
+#OutputSettingsPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
-#PreferencesPopup QListWidget::item:hover {
+#PreferencesPopup QListWidget::item:hover,
+#OutputSettingsPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.1);
   color: #e6e6e6;
 }
-#PreferencesPopup QListWidget::item:selected {
+#PreferencesPopup QListWidget::item:selected,
+#OutputSettingsPopup QListWidget::item:selected {
   background-color: #5385a6;
   color: #ffffff;
 }

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1652,21 +1652,25 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
-#PreferencesPopup QListWidget {
+#PreferencesPopup QListWidget,
+#OutputSettingsPopup QListWidget {
   background-color: #343434;
   alternate-background-color: #343434;
   border: 1 solid #2c2c2c;
   font-size: 13px;
 }
-#PreferencesPopup QListWidget::item {
+#PreferencesPopup QListWidget::item,
+#OutputSettingsPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
-#PreferencesPopup QListWidget::item:hover {
+#PreferencesPopup QListWidget::item:hover,
+#OutputSettingsPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.1);
   color: #e6e6e6;
 }
-#PreferencesPopup QListWidget::item:selected {
+#PreferencesPopup QListWidget::item:selected,
+#OutputSettingsPopup QListWidget::item:selected {
   background-color: #5385a6;
   color: #ffffff;
 }

--- a/stuff/config/qss/Default/less/layouts/popups.less
+++ b/stuff/config/qss/Default/less/layouts/popups.less
@@ -41,7 +41,7 @@ QDialog {
    Preferences
 ----------------------------------------------------------------------------- */
 
-#PreferencesPopup {
+#PreferencesPopup, #OutputSettingsPopup {
   & QListWidget {
     background-color: @prefs-tree-bg-color;
     alternate-background-color: @prefs-tree-bg-color;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1652,21 +1652,25 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
-#PreferencesPopup QListWidget {
+#PreferencesPopup QListWidget,
+#OutputSettingsPopup QListWidget {
   background-color: #cecece;
   alternate-background-color: #cecece;
   border: 1 solid #a8a8a8;
   font-size: 13px;
 }
-#PreferencesPopup QListWidget::item {
+#PreferencesPopup QListWidget::item,
+#OutputSettingsPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
-#PreferencesPopup QListWidget::item:hover {
+#PreferencesPopup QListWidget::item:hover,
+#OutputSettingsPopup QListWidget::item:hover {
   background-color: #b5b5b5;
   color: #000;
 }
-#PreferencesPopup QListWidget::item:selected {
+#PreferencesPopup QListWidget::item:selected,
+#OutputSettingsPopup QListWidget::item:selected {
   background-color: #a0c1dd;
   color: #000;
 }

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1652,21 +1652,25 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
 /* -----------------------------------------------------------------------------
    Preferences
 ----------------------------------------------------------------------------- */
-#PreferencesPopup QListWidget {
+#PreferencesPopup QListWidget,
+#OutputSettingsPopup QListWidget {
   background-color: #767676;
   alternate-background-color: #767676;
   border: 1 solid #5a5a5a;
   font-size: 13px;
 }
-#PreferencesPopup QListWidget::item {
+#PreferencesPopup QListWidget::item,
+#OutputSettingsPopup QListWidget::item {
   border: 0;
   padding: 3;
 }
-#PreferencesPopup QListWidget::item:hover {
+#PreferencesPopup QListWidget::item:hover,
+#OutputSettingsPopup QListWidget::item:hover {
   background-color: rgba(255, 255, 255, 0.15);
   color: #000;
 }
-#PreferencesPopup QListWidget::item:selected {
+#PreferencesPopup QListWidget::item:selected,
+#OutputSettingsPopup QListWidget::item:selected {
   background-color: #8FA0B2;
   color: #000;
 }


### PR DESCRIPTION
@shun-iwasawa Possible you forgot to upload stylesheet changes for #3641? 

This fixes the menu style in the new Output Settings Popup layout.

| Before: | After: |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19820721/106751983-d6491600-6621-11eb-93bf-048ed3a17ab1.png) | ![image](https://user-images.githubusercontent.com/19820721/106752106-fa0c5c00-6621-11eb-88de-ff83c22ff8e0.png) |
