### PR TITLE
Add Tool Shortcut Keypress Length Option

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -340,6 +340,9 @@ public:
   bool useCtrlAltToResizeBrushEnabled() const {
     return getBoolValue(useCtrlAltToResizeBrush);
   }
+  int getTempToolSwitchTimer() const {
+    return getIntValue(tempToolSwitchTimer);
+  }
 
   // Xsheet  tab
   QString getXsheetLayoutPreference() const {

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -107,6 +107,7 @@ enum PreferencesItemId {
   cursorOutlineEnabled,
   levelBasedToolsDisplay,
   useCtrlAltToResizeBrush,
+  tempToolSwitchTimer,
 
   //----------
   // Xsheet

--- a/toonz/sources/tnztools/toolhandle.cpp
+++ b/toonz/sources/tnztools/toolhandle.cpp
@@ -7,6 +7,7 @@
 #include "timage.h"
 //#include "tapp.h"
 #include "toonzqt/menubarcommand.h"
+#include "toonz/preferences.h"
 #include <QAction>
 #include <QMap>
 #include <QDebug>
@@ -72,7 +73,8 @@ void ToolHandle::storeTool() {
 void ToolHandle::restoreTool() {
   // qDebug() << m_storedToolTime.elapsed();
   if (m_storedToolName != m_toolName && m_storedToolName != "" &&
-      m_storedToolTime.elapsed() > 500) {
+      m_storedToolTime.elapsed() >
+          Preferences::instance()->getTempToolSwitchTimer()) {
     setTool(m_storedToolName);
   }
 }

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1121,6 +1121,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {cursorOutlineEnabled, tr("Show Cursor Size Outlines")},
       {levelBasedToolsDisplay, tr("Toolbar Display Behaviour:")},
       {useCtrlAltToResizeBrush, tr("Use %1 to Resize Brush").arg(CtrlAltStr())},
+      {tempToolSwitchTimer,
+       tr("Switch Tool Temporarily Keypress Length (ms):")},
 
       // Xsheet
       {xsheetLayoutPreference, tr("Column Header Layout*:")},
@@ -1753,6 +1755,7 @@ QWidget* PreferencesPopup::createToolsPage() {
   insertUI(levelBasedToolsDisplay, lay,
            getComboItemList(levelBasedToolsDisplay));
   insertUI(useCtrlAltToResizeBrush, lay);
+  insertUI(tempToolSwitchTimer, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -492,6 +492,8 @@ void Preferences::definePreferenceItems() {
          0);  // Default
   define(useCtrlAltToResizeBrush, "useCtrlAltToResizeBrush", QMetaType::Bool,
          true);
+  define(tempToolSwitchTimer, "tempToolSwitchTimer", QMetaType::Int, 500, 1,
+         std::numeric_limits<int>::max());
 
   // Xsheet
   define(xsheetLayoutPreference, "xsheetLayoutPreference", QMetaType::QString,


### PR DESCRIPTION
This is a port of a new feature submitted to Tahoma 2D by @manongjohn and closes #3706 #1100. It will allow the user to pick a specific length of time for the keypress of temporarily switching tools, eg. by holding B for Brush for a length of time, letting go will revert back to the previously selected tool.

It seemed 500ms was too long for some (me included) and 200ms was preferred. Now the user can type a custom number in Preferences > Tools.

![image](https://user-images.githubusercontent.com/19820721/107851767-3f8c0e80-6e04-11eb-95d5-9d141b80c2e9.png)

Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>