### PR TITLE
Fix New Level Undo

### DIFF
--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -276,8 +276,8 @@ LevelCreatePopup::LevelCreatePopup()
   bool ret = true;
   ret      = ret && connect(m_levelTypeOm, SIGNAL(currentIndexChanged(int)),
                        SLOT(onLevelTypeChanged(int)));
-  ret = ret && connect(okBtn, SIGNAL(clicked()), this, SLOT(onOkBtn()));
-  ret = ret && connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
+  ret      = ret && connect(okBtn, SIGNAL(clicked()), this, SLOT(onOkBtn()));
+  ret      = ret && connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
   ret =
       ret && connect(applyBtn, SIGNAL(clicked()), this, SLOT(onApplyButton()));
 
@@ -509,18 +509,6 @@ bool LevelCreatePopup::apply() {
     }
   }
 
-  TXshLevel *level =
-      scene->createNewLevel(lType, levelName, TDimension(), 0, fp);
-  TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(level);
-  assert(sl);
-  sl->setPath(fp, true);
-  if (lType == TZP_XSHLEVEL || lType == OVL_XSHLEVEL) {
-    sl->getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
-    sl->getProperties()->setDpi(dpi);
-    sl->getProperties()->setImageDpi(TPointD(dpi, dpi));
-    sl->getProperties()->setImageRes(TDimension(xres, yres));
-  }
-
   /*-- これからLevelを配置しようとしているセルが空いているかどうかのチェック
    * --*/
   bool areColumnsShifted = false;
@@ -552,6 +540,18 @@ bool LevelCreatePopup::apply() {
   CreateLevelUndo *undo =
       new CreateLevelUndo(row, col, numFrames, step, areColumnsShifted);
   TUndoManager::manager()->add(undo);
+
+  TXshLevel *level =
+      scene->createNewLevel(lType, levelName, TDimension(), 0, fp);
+  TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(level);
+  assert(sl);
+  sl->setPath(fp, true);
+  if (lType == TZP_XSHLEVEL || lType == OVL_XSHLEVEL) {
+    sl->getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
+    sl->getProperties()->setDpi(dpi);
+    sl->getProperties()->setImageDpi(TPointD(dpi, dpi));
+    sl->getProperties()->setImageRes(TDimension(xres, yres));
+  }
 
   for (i = from; i <= to; i += inc) {
     TFrameId fid(i);


### PR DESCRIPTION
This PR fixes undo of `New Level` command to remove the created level from Scene Cast properly.
In `CreateLevelUndo` constructor, it registers level amount in Scene Cast before the operation for reversion.
Thus, the creation of the undo must be in advance of creation of the level.