### PR TITLE
Fix crash in Type tool on linux (#2011, #3604)

### DIFF
--- a/toonz/sources/common/tvrender/tfont_qt.cpp
+++ b/toonz/sources/common/tvrender/tfont_qt.cpp
@@ -167,6 +167,19 @@ TPoint TFont::drawChar(QImage &outImage, TPoint &unused, wchar_t charcode,
     return TPoint(0, 0);
   }
 
+  // Workaround for unix when the user using the space character:
+  // alphaMapForGlyph with a space character returns an invalid
+  // QImage for some reason.
+  // Bug 3604: https://github.com/opentoonz/opentoonz/issues/3604
+#ifdef Q_OS_UNIX
+  if (chars[0] == L' ') {
+      outImage = QImage(raw.averageCharWidth(), raw.ascent() + raw.descent(),
+                        QImage::Format_Grayscale8);
+      outImage.fill(255);
+      return getDistance(charcode, nextCharCode);
+  }
+#endif
+
   QImage image = raw.alphaMapForGlyph(indices[0], QRawFont::PixelAntialiasing);
   if (image.format() != QImage::Format_Indexed8 &&
       image.format() != QImage::Format_Alpha8)


### PR DESCRIPTION
Looks like for some reasons, the method alphaMapForGlyph (from QRawFront) returns an invalid QImage, even if the QRawFront is valid, only on Linux/Unix.

I also tested with the Qt version 5.15.2 and I had the same issue.

I did a workaround (not really pretty, but it works), really inspired from https://forum.qt.io/topic/61457/qimage-from-alphamapforglyph/9

Tested on my PC (Linux mint 20.1 Cinnamon, Linux 5.4.0-65, 16Go, NVidia GTX 1070)
![image](https://user-images.githubusercontent.com/2419385/108602781-3bcc2f00-73a4-11eb-9ffb-9c4ccaf76ec3.png)
