### PR TITLE
Actions: Update Ubuntu Version

### DIFF
--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Ubuntu:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         compiler: [gcc, clang]


### PR DESCRIPTION
This PR updates Ubuntu version used in Linux workflow of GitHub Actions, being hopeful that the newer version of Qt will be used in it. (see the comment [here](https://github.com/opentoonz/opentoonz/pull/3714#issuecomment-784557282))