### PR TITLE
Fix Viewer Window Disappearing on Undock

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1239,6 +1239,8 @@ void SceneViewer::initializeGL() {
     resizeGL(width(), height());
     update();
   }
+  // re-computing the display list for the table
+  m_tableDLId = -1;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -430,7 +430,7 @@ static void convertFromVI(const TLevelReaderP &lr, const TPaletteP &plt,
   maxBbox = maxBbox.enlarge(2);
   TAffine aff;
   if (width)  // calcolo l'affine
-    aff   = TScale((double)width / maxBbox.getLx());
+    aff = TScale((double)width / maxBbox.getLx());
   maxBbox = aff * maxBbox;
 
   for (i = 0; i < (int)images.size(); i++) {
@@ -467,9 +467,8 @@ static void convertFromFullRaster(
     const TRop::ResampleFilterType &resType, FrameTaskNotifier *frameNotifier,
     const TPixel &bgColor, bool removeDotBeforeFrameNumber = false) {
   std::vector<TFrameId> frames = _frames;
-  if (frames.empty() &&
-      lr->loadInfo()->getFrameCount() ==
-          1)  // e' una immagine singola, non un livello
+  if (frames.empty() && lr->loadInfo()->getFrameCount() ==
+                            1)  // e' una immagine singola, non un livello
     frames.push_back(TFrameId());
 
   for (int i = 0; i < (int)frames.size(); i++) {
@@ -850,9 +849,8 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
   if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt)
     return false;
 
-  key =
-      key |
-      event->modifiers() & (~0xf0000000);  // Ignore if the key is a numpad key
+  key = key | event->modifiers() &
+                  (~0xf0000000);  // Ignore if the key is a numpad key
 
   return (key == showHideFullScreenKey)
              ? toggleFullScreen()
@@ -891,12 +889,6 @@ FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
   layout->setSpacing(0);
 
   setLayout(layout);
-
-#ifdef _WIN32
-  // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
-  winId();
-  QWindowsWindowFunctions::setHasBorderInFullScreen(windowHandle(), true);
-#endif
 }
 
 //---------------------------------------------------------------------------------
@@ -916,9 +908,15 @@ bool FullScreenWidget::toggleFullScreen(bool quit) {
     setWindowFlags(windowFlags() & ~(Qt::Window | Qt::WindowStaysOnTopHint));
     showNormal();
     m_widget->setFocus();
+
     return true;
   } else if (!quit) {
     setWindowFlags(windowFlags() | Qt::Window | Qt::WindowStaysOnTopHint);
+#ifdef _WIN32
+    // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
+    winId();
+    QWindowsWindowFunctions::setHasBorderInFullScreen(windowHandle(), true);
+#endif
     showFullScreen();
 
     return true;
@@ -927,4 +925,4 @@ bool FullScreenWidget::toggleFullScreen(bool quit) {
   return false;
 }
 
-}  // imageutils
+}  // namespace ImageUtils


### PR DESCRIPTION
This PR fixes the problem reported in [the comment](https://github.com/opentoonz/opentoonz/issues/3597#issuecomment-783788804) , that the VIewer window disappears when undocking.

It was the problem with `FullScreenWidget` class which enables the panel to be displayed in full screen. (Thus, the same problem occured in Flipbook.)
It seems that, in recent Qt, calling `QWidget::winId()` at improper timing causes the problem related to OpenGL context handling.