### PR TITLE
Fix Icon Rendering for Hdpi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 
 # bundled thirdparty libraries
 /thirdparty/boost
+/thirdparty/libjpeg-turbo64
 /thirdparty/lzo
 /thirdparty/tiff-4.0.3
 /thirdparty/LibJPEG/jpeg-9

--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -113,6 +113,10 @@ QPixmap DVAPI recolorPixmap(
     QPixmap pixmap, QColor color = Preferences::instance()->getIconTheme()
                                        ? Qt::black
                                        : Qt::white);
+QPixmap DVAPI compositePixmap(QPixmap pixmap, qreal opacity,
+                              int canvasWidth = 20, int canvasHeight = 20,
+                              int iconWidth = 16, int iconHeight = 16,
+                              int offset = 0);
 QIcon DVAPI createQIcon(const char *iconSVGName, bool useFullOpacity = false);
 QIcon DVAPI createQIconPNG(const char *iconPNGName);
 QIcon DVAPI createQIconOnOffPNG(const char *iconPNGName, bool withOver = true);

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -437,8 +437,11 @@ QIcon createQIconOnOffPNG(const char *iconPNGName, bool withOver) {
 //-----------------------------------------------------------------------------
 
 QIcon createTemporaryIconFromName(const char *commandName) {
-  const int visibleIconSize = 20;
-  const int menubarIconSize = 16;
+  const int visibleIconSize   = 20;
+  const int menubarIconSize   = 16;
+  const qreal normalOpacity   = 0.8;
+  const qreal disabledOpacity = 0.15;
+  const qreal onOpacity       = 1;
   QString name(commandName);
   QList<QChar> iconChar;
 
@@ -494,8 +497,18 @@ QIcon createTemporaryIconFromName(const char *commandName) {
 
     icon.addPixmap(transparentPm);
     icon.addPixmap(transparentPm, QIcon::Disabled);
-    icon.addPixmap(pixmap);
-    icon.addPixmap(setOpacity(pixmap, 0.15), QIcon::Disabled);
+    icon.addPixmap(compositePixmap(pixmap, normalOpacity, pxSize, pxSize,
+                                   pixmap.width(), pixmap.height()),
+                   QIcon::Normal, QIcon::Off);
+    icon.addPixmap(compositePixmap(pixmap, onOpacity, pxSize, pxSize,
+                                   pixmap.width(), pixmap.height()),
+                   QIcon::Normal, QIcon::On);
+    icon.addPixmap(compositePixmap(pixmap, onOpacity, pxSize, pxSize,
+                                   pixmap.width(), pixmap.height()),
+                   QIcon::Active);
+    icon.addPixmap(compositePixmap(pixmap, disabledOpacity, pxSize, pxSize,
+                                   pixmap.width(), pixmap.height()),
+                   QIcon::Disabled);
   }
   return icon;
 }


### PR DESCRIPTION
Closes #3740, and as reported by @RattusaurusRex, menu icons (16x16) were difficult to repurpose for toolbars because they would resize up to fit 20x20, the theme config file did not help unfortunately, it seems no matter what SVG is going to scale up to whatever `iconSize` is in the toolbar, despite what's said in the docs.

There's also some issue with `setOpacity` function in `gutil`, it works absolutely fine for icons that don't get resized, so I've left it alone, but for icons that do it seems to make them look frayed around the edges, I don't know why. I built-in the `setOpacity` by using `QPainter` this time. We can look at that function later as it's now only used by the viewer pane buttons.

So to solve this, I reconfigured `createQIcon` and added a new function to allow compositing two pixmaps together, and loading this additionally into the generated icon. We composite all icons onto a canvas rect, this seems much more solid than doing it onto pixmaps. I also repurposed some recent code by @shun-iwasawa with the for loop on how the generated acronym icons were generated for Hdpi scaling (very nice).

I hope this is OK, this was really difficult to work out, not a fan of Qt's Hdpi support.

So in summary, two icons of different sizes will be generated into the icon, but ONLY if the icon to be generated is 16x16 in size, this action doesn't happen for any other size, which size is used depends where it's displayed, such as the menu or toolbars.

Before: 
![image](https://user-images.githubusercontent.com/19820721/109628605-da8e2380-7b3a-11eb-94c6-c782c01daffa.png)

After:
![image](https://user-images.githubusercontent.com/19820721/109628500-ba5e6480-7b3a-11eb-9e21-764e55536500.png)
