### PR TITLE
Optional Frame Separator Line in Level Strip

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1345,6 +1345,10 @@ StyledTreeView {
 #FilmStrip QComboBox QAbstractItemView {
   background-color: #414345;
 }
+FilmstripFrames {
+  qproperty-LightLineColor: #414345;
+  qproperty-DarkLineColor: #000;
+}
 /* -----------------------------------------------------------------------------
    Cleanup Settings
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1345,6 +1345,10 @@ StyledTreeView {
 #FilmStrip QComboBox QAbstractItemView {
   background-color: #262626;
 }
+FilmstripFrames {
+  qproperty-LightLineColor: #303030;
+  qproperty-DarkLineColor: #000;
+}
 /* -----------------------------------------------------------------------------
    Cleanup Settings
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1345,6 +1345,10 @@ StyledTreeView {
 #FilmStrip QComboBox QAbstractItemView {
   background-color: #484848;
 }
+FilmstripFrames {
+  qproperty-LightLineColor: #484848;
+  qproperty-DarkLineColor: #000;
+}
 /* -----------------------------------------------------------------------------
    Cleanup Settings
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -567,3 +567,10 @@
 // Expression Field
 @function-ExpressionFieldBG-color:     lighten(@bg, 61.9608);
 @function-ExpressionFieldBorder-color: darken(@bg, 8.2353);
+
+// -----------------------------------------------------------------------------
+// Level Strip [aka Film Stip]
+// -----------------------------------------------------------------------------
+
+@levelstrip-Bg-color: @bg;
+@levelstrip-SeparatorLine-color: @levelstrip-Bg-color;

--- a/stuff/config/qss/Default/less/layouts/filmstrip.less
+++ b/stuff/config/qss/Default/less/layouts/filmstrip.less
@@ -7,7 +7,7 @@
 }
 
 #FilmStrip {
-  qproperty-BGColor: @bg;
+  qproperty-BGColor: @levelstrip-Bg-color;
   margin: 0;
   padding: 0;
   & QComboBox {
@@ -16,4 +16,9 @@
       background-color: @menu-bg-color;
     }
   }
+}
+
+FilmstripFrames {
+  qproperty-LightLineColor: @levelstrip-SeparatorLine-color;
+  qproperty-DarkLineColor: #000; // afaik unused
 }

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1345,6 +1345,10 @@ StyledTreeView {
 #FilmStrip QComboBox QAbstractItemView {
   background-color: #DBDBDB;
 }
+FilmstripFrames {
+  qproperty-LightLineColor: #DBDBDB;
+  qproperty-DarkLineColor: #000;
+}
 /* -----------------------------------------------------------------------------
    Cleanup Settings
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1345,6 +1345,10 @@ StyledTreeView {
 #FilmStrip QComboBox QAbstractItemView {
   background-color: #b3b3b3;
 }
+FilmstripFrames {
+  qproperty-LightLineColor: #808080;
+  qproperty-DarkLineColor: #000;
+}
 /* -----------------------------------------------------------------------------
    Cleanup Settings
 ----------------------------------------------------------------------------- */

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1284,15 +1284,9 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   QMenu *panelMenu           = menu->addMenu(tr("Panel Settings"));
   QAction *toggleOrientation = panelMenu->addAction(tr("Toggle Orientation"));
   panelMenu->addSeparator();
-  QAction *hideComboBox  = panelMenu->addAction(tr("Show Level Select Menu"));
-  QAction *hideNavigator = panelMenu->addAction(tr("Show Navigator"));
-  QAction *hideSeparatorLine = panelMenu->addAction(tr("Hide Separator Line"));
-  hideComboBox->setCheckable(true);
-  hideComboBox->setChecked(m_showComboBox);
-  hideNavigator->setCheckable(true);
-  hideNavigator->setChecked(m_showNavigator);
-  hideSeparatorLine->setCheckable(true);
-  hideSeparatorLine->setChecked(m_hideSeparatorLine);
+  QAction *hideComboBox  = panelMenu->addAction(tr("Show/Hide Drop Down Menu"));
+  QAction *hideNavigator = panelMenu->addAction(tr("Show/Hide Level Navigator"));
+  QAction *hideSeparatorLine = panelMenu->addAction(tr("Show/Hide Frame Separator Line"));
   connect(toggleOrientation, SIGNAL(triggered(bool)), this,
           SLOT(orientationToggled(bool)));
   connect(hideComboBox, SIGNAL(triggered(bool)), this,

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -642,7 +642,7 @@ void FilmstripFrames::paintEvent(QPaintEvent *evt) {
   int frameHeight = m_iconSize.height();
 
   // horizontal lines that separate the frames
-  if (m_showSeparatorLine) {
+  if (!m_hideSeparatorLine) {
     p.setPen(getLightLineColor());
     for (i = i0; i <= i1; i++) {
       if (m_isVertical) {
@@ -1286,13 +1286,13 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   panelMenu->addSeparator();
   QAction *hideComboBox  = panelMenu->addAction(tr("Show Level Select Menu"));
   QAction *hideNavigator = panelMenu->addAction(tr("Show Navigator"));
-  QAction *hideSeparatorLine = panelMenu->addAction(tr("Show Separator Line"));
+  QAction *hideSeparatorLine = panelMenu->addAction(tr("Hide Separator Line"));
   hideComboBox->setCheckable(true);
   hideComboBox->setChecked(m_showComboBox);
   hideNavigator->setCheckable(true);
   hideNavigator->setChecked(m_showNavigator);
   hideSeparatorLine->setCheckable(true);
-  hideSeparatorLine->setChecked(m_showSeparatorLine);
+  hideSeparatorLine->setChecked(m_hideSeparatorLine);
   connect(toggleOrientation, SIGNAL(triggered(bool)), this,
           SLOT(orientationToggled(bool)));
   connect(hideComboBox, SIGNAL(triggered(bool)), this,
@@ -1409,7 +1409,7 @@ void FilmstripFrames::setComboBox(bool showComboBox) {
 //-----------------------------------------------------------------------------
 
 void FilmstripFrames::setSeparatorLine(bool showSeparatorLine) {
-  m_showSeparatorLine = showSeparatorLine;
+  m_hideSeparatorLine = showSeparatorLine;
 }
 
 //-----------------------------------------------------------------------------
@@ -1939,8 +1939,8 @@ void Filmstrip::comboBoxToggled() {
 //-----------------------------------------------------------------------------
 
 void Filmstrip::separatorLineToggled() {
-  m_showSeparatorLine = !m_showSeparatorLine;
-  m_frames->setSeparatorLine(m_showSeparatorLine);
+  m_hideSeparatorLine = !m_hideSeparatorLine;
+  m_frames->setSeparatorLine(m_hideSeparatorLine);
 }
 
 //-----------------------------------------------------------------------------
@@ -1978,7 +1978,7 @@ void Filmstrip::save(QSettings &settings) const {
   settings.setValue("showCombo", showCombo);
 
   UINT separatorLine = 0;
-  separatorLine      = m_showSeparatorLine ? 1 : 0;
+  separatorLine      = m_hideSeparatorLine ? 1 : 0;
   settings.setValue("separatorLine", separatorLine);
 
   UINT navigator = 0;
@@ -1996,8 +1996,8 @@ void Filmstrip::load(QSettings &settings) {
   m_frames->setNavigator(m_showNavigator);
 
   UINT separatorLine  = settings.value("separatorLine", 1).toUInt();
-  m_showSeparatorLine = separatorLine == 1;
-  m_frames->setSeparatorLine(m_showSeparatorLine);
+  m_hideSeparatorLine = separatorLine == 1;
+  m_frames->setSeparatorLine(m_hideSeparatorLine);
 
   UINT showCombo = settings.value("showCombo", 1).toUInt();
   m_showComboBox = showCombo == 1;

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -642,7 +642,7 @@ void FilmstripFrames::paintEvent(QPaintEvent *evt) {
   int frameHeight = m_iconSize.height();
 
   // horizontal lines that separate the frames
-  if (!m_hideSeparatorLine) {
+  if (m_showSeparatorLine) {
     p.setPen(getLightLineColor());
     for (i = i0; i <= i1; i++) {
       if (m_isVertical) {
@@ -1284,9 +1284,15 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   QMenu *panelMenu           = menu->addMenu(tr("Panel Settings"));
   QAction *toggleOrientation = panelMenu->addAction(tr("Toggle Orientation"));
   panelMenu->addSeparator();
-  QAction *hideComboBox  = panelMenu->addAction(tr("Show/Hide Drop Down Menu"));
-  QAction *hideNavigator = panelMenu->addAction(tr("Show/Hide Level Navigator"));
-  QAction *hideSeparatorLine = panelMenu->addAction(tr("Show/Hide Frame Separator Line"));
+  QAction *hideComboBox  = panelMenu->addAction(tr("Show Level Select Menu"));
+  QAction *hideNavigator = panelMenu->addAction(tr("Show Navigator"));
+  QAction *hideSeparatorLine = panelMenu->addAction(tr("Show Separator Line"));
+  hideComboBox->setCheckable(true);
+  hideComboBox->setChecked(m_showComboBox);
+  hideNavigator->setCheckable(true);
+  hideNavigator->setChecked(m_showNavigator);
+  hideSeparatorLine->setCheckable(true);
+  hideSeparatorLine->setChecked(m_showSeparatorLine);
   connect(toggleOrientation, SIGNAL(triggered(bool)), this,
           SLOT(orientationToggled(bool)));
   connect(hideComboBox, SIGNAL(triggered(bool)), this,
@@ -1403,7 +1409,7 @@ void FilmstripFrames::setComboBox(bool showComboBox) {
 //-----------------------------------------------------------------------------
 
 void FilmstripFrames::setSeparatorLine(bool showSeparatorLine) {
-  m_hideSeparatorLine = showSeparatorLine;
+  m_showSeparatorLine = showSeparatorLine;
 }
 
 //-----------------------------------------------------------------------------
@@ -1933,8 +1939,8 @@ void Filmstrip::comboBoxToggled() {
 //-----------------------------------------------------------------------------
 
 void Filmstrip::separatorLineToggled() {
-  m_hideSeparatorLine = !m_hideSeparatorLine;
-  m_frames->setSeparatorLine(m_hideSeparatorLine);
+  m_showSeparatorLine = !m_showSeparatorLine;
+  m_frames->setSeparatorLine(m_showSeparatorLine);
 }
 
 //-----------------------------------------------------------------------------
@@ -1972,7 +1978,7 @@ void Filmstrip::save(QSettings &settings) const {
   settings.setValue("showCombo", showCombo);
 
   UINT separatorLine = 0;
-  separatorLine      = m_hideSeparatorLine ? 1 : 0;
+  separatorLine      = m_showSeparatorLine ? 1 : 0;
   settings.setValue("separatorLine", separatorLine);
 
   UINT navigator = 0;
@@ -1989,9 +1995,9 @@ void Filmstrip::load(QSettings &settings) {
   m_showNavigator = navigator == 1;
   m_frames->setNavigator(m_showNavigator);
 
-  UINT separatorLine  = settings.value("separatorLine", 1).toUInt();
-  m_hideSeparatorLine = separatorLine == 1;
-  m_frames->setSeparatorLine(m_hideSeparatorLine);
+  UINT separatorLine  = settings.value("separatorLine", 0).toUInt();
+  m_showSeparatorLine = separatorLine == 1;
+  m_frames->setSeparatorLine(m_showSeparatorLine);
 
   UINT showCombo = settings.value("showCombo", 1).toUInt();
   m_showComboBox = showCombo == 1;

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -52,7 +52,7 @@ public:
   bool m_isVertical        = true;
   bool m_showNavigator     = true;
   bool m_showComboBox      = true;
-  bool m_showSeparatorLine = false;
+  bool m_hideSeparatorLine = true;
 
   void setBGColor(const QColor &color) { m_bgColor = color; }
   QColor getBGColor() const { return m_bgColor; }
@@ -124,7 +124,7 @@ public:
   void setOrientation(bool isVertical);
   void setNavigator(bool showNavigator);
   void setComboBox(bool showComboBox);
-  void setSeparatorLine(bool showSeparatorLine);
+  void setSeparatorLine(bool hideSeparatorLine);
 
 signals:
   void orientationToggledSignal(bool);
@@ -241,7 +241,7 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
   bool m_isVertical        = true;
   bool m_showNavigator     = true;
   bool m_showComboBox      = true;
-  bool m_showSeparatorLine = false;
+  bool m_hideSeparatorLine = true;
 
 public:
 #if QT_VERSION >= 0x050500

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -52,7 +52,7 @@ public:
   bool m_isVertical        = true;
   bool m_showNavigator     = true;
   bool m_showComboBox      = true;
-  bool m_hideSeparatorLine = true;
+  bool m_showSeparatorLine = false;
 
   void setBGColor(const QColor &color) { m_bgColor = color; }
   QColor getBGColor() const { return m_bgColor; }
@@ -241,7 +241,7 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
   bool m_isVertical        = true;
   bool m_showNavigator     = true;
   bool m_showComboBox      = true;
-  bool m_hideSeparatorLine = true;
+  bool m_showSeparatorLine = false;
 
 public:
 #if QT_VERSION >= 0x050500

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -49,9 +49,10 @@ public:
 #endif
   ~FilmstripFrames();
 
-  bool m_isVertical    = true;
-  bool m_showNavigator = true;
-  bool m_showComboBox  = true;
+  bool m_isVertical        = true;
+  bool m_showNavigator     = true;
+  bool m_showComboBox      = true;
+  bool m_showSeparatorLine = false;
 
   void setBGColor(const QColor &color) { m_bgColor = color; }
   QColor getBGColor() const { return m_bgColor; }
@@ -123,12 +124,14 @@ public:
   void setOrientation(bool isVertical);
   void setNavigator(bool showNavigator);
   void setComboBox(bool showComboBox);
+  void setSeparatorLine(bool showSeparatorLine);
 
 signals:
   void orientationToggledSignal(bool);
   void comboBoxToggledSignal();
   void navigatorToggledSignal();
   void levelSelectedSignal(int);
+  void separatorLineToggledSignal();
 
 protected:
   void showEvent(QShowEvent *) override;
@@ -173,6 +176,7 @@ protected slots:
   void navigatorToggled(bool);
   void levelSelected(int);
   void onViewerAboutToBeDestroyed();
+  void separatorLineToggled(bool);
 
 private:
   // QSS Properties
@@ -234,9 +238,10 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
 
   std::vector<TXshSimpleLevel *> m_levels;
   std::map<TXshSimpleLevel *, TFrameId> m_workingFrames;
-  bool m_isVertical    = true;
-  bool m_showNavigator = true;
-  bool m_showComboBox  = true;
+  bool m_isVertical        = true;
+  bool m_showNavigator     = true;
+  bool m_showComboBox      = true;
+  bool m_showSeparatorLine = false;
 
 public:
 #if QT_VERSION >= 0x050500
@@ -276,6 +281,7 @@ public slots:
   void orientationToggled(bool);
   void comboBoxToggled();
   void navigatorToggled();
+  void separatorLineToggled();
 
 private:
   void updateWindowTitle();


### PR DESCRIPTION
This makes it so it's easier to select a blank frame in the Level Strip and draw directly to the canvas. It's something that was useful in Harlequin it seems, since you scroll in the window to add 'ghost' frames that are selectable, but don't exist unless you draw.

It's optional (right-click under Panel Settings) and is hidden by default.

![image](https://user-images.githubusercontent.com/19820721/110088665-0ef91e00-7d8d-11eb-94bb-c9160dc687ed.png)