### PR TITLE
Premultiply on Loading PNG Images

### DIFF
--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -112,9 +112,9 @@ public:
 
   /*! \return   The \a coded path to be used for import. */
 
-  TFilePath getImportedLevelPath(const TFilePath path)
-      const;  //!< Builds the path to be used during a level import
-              //!< operation.
+  TFilePath getImportedLevelPath(
+      const TFilePath path) const;  //!< Builds the path to be used during a
+                                    //!< level import operation.
 
   /*! \details  If convertion is required, a new level file will be created
           and \p levelPath will be substituted with its new path.
@@ -267,9 +267,11 @@ private:
   TLevelSet *m_levelSet;
   TProject *m_project;
   TContentHistory *m_contentHistory;
-  bool m_isUntitled;  //!< Whether the scene is untitled.
-                      //!  \sa  The setUntitled() member function.
-  VersionNumber m_versionNumber;
+  bool m_isUntitled;              //!< Whether the scene is untitled.
+                                  //!  \sa  The setUntitled() member function.
+  VersionNumber m_versionNumber;  // last saved scene file version. Note that
+                                  // currently it is not match with OT version.
+                                  // TODO: Revise VersionNumber with OT version
 
 private:
   // noncopyable

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -30,6 +30,9 @@
 #include "toutputproperties.h"
 #include "toonz/imagestyles.h"
 #include "tproperty.h"
+#include "toonz/levelset.h"
+#include "toonz/txshsimplelevel.h"
+#include "toonz/levelproperties.h"
 
 // TnzSound includes
 #include "tnzsound.h"
@@ -226,6 +229,35 @@ void tcomposerRunOutOfContMemHandler(unsigned long size) {
   TImageCache::instance()->clear(true);
   exit(2);
 }
+
+// Check if the scene saved with the previous version AND the premultiply option
+// is set to PNG level setting
+void UnsetPremultiplyOptionsInPngLevels(ToonzScene *scene) {
+  if (scene->getVersionNumber() <
+      VersionNumber(71, 1)) {  // V1.4 = 71.0 , V1.5 = 71.1
+    QStringList modifiedPNGLevelNames;
+    std::vector<TXshLevel *> levels;
+    scene->getLevelSet()->listLevels(levels);
+    for (auto level : levels) {
+      if (!level || !level->getSimpleLevel()) continue;
+      TFilePath path = level->getPath();
+      if (path.isEmpty() || path.getType() != "png") continue;
+      if (level->getSimpleLevel()->getProperties()->doPremultiply()) {
+        level->getSimpleLevel()->getProperties()->setDoPremultiply(false);
+        modifiedPNGLevelNames.append(QString::fromStdWString(level->getName()));
+      }
+    }
+    if (!modifiedPNGLevelNames.isEmpty()) {
+      std::string msg =
+          "The Premultiply options in the following levels are disabled, since "
+          "PNG files are premultiplied on loading in the current version:" +
+          modifiedPNGLevelNames.join(", ").toStdString();
+      cout << msg << endl;
+      m_userLog->info(msg);
+    }
+  }
+}
+
 }  // namespace
 
 //==============================================================================================
@@ -406,7 +438,7 @@ static std::pair<int, int> generateMovie(ToonzScene *scene, const TFilePath &fp,
   r0 = r0 - 1;
   r1 = r1 - 1;
 
-  if (r0 < 0) r0                                 = 0;
+  if (r0 < 0) r0 = 0;
   if (r1 < 0 || r1 >= scene->getFrameCount()) r1 = scene->getFrameCount() - 1;
   string msg;
   assert(r1 >= r0);
@@ -724,7 +756,7 @@ int main(int argc, char *argv[]) {
   TVectorBrushStyle::setRootDir(libraryFolder);
   TPalette::setRootDir(libraryFolder);
   TImageStyle::setLibraryDir(libraryFolder);
-  TFilePath cacheRoot                = ToonzFolder::getCacheRootFolder();
+  TFilePath cacheRoot = ToonzFolder::getCacheRootFolder();
   if (cacheRoot.isEmpty()) cacheRoot = TEnv::getStuffDir() + "cache";
   TImageCache::instance()->setRootDir(cacheRoot);
   // #endif
@@ -818,6 +850,10 @@ int main(int argc, char *argv[]) {
       m_userLog->error(msg);
       // return false;
     }
+
+    // Check if the scene saved with the previous version AND the premultiply
+    // option is set to PNG level setting
+    UnsetPremultiplyOptionsInPngLevels(scene);
 
     msg = "scene loaded";
     cout << "scene loaded" << endl;
@@ -991,8 +1027,8 @@ int main(int argc, char *argv[]) {
     DVGui::info(QString::fromStdString(msg));
     TImageCache::instance()->clear(true);
   } catch (TException &e) {
-    msg = "Untrapped exception: " + ::to_string(e.getMessage()), cout << msg
-                                                                      << endl;
+    msg = "Untrapped exception: " + ::to_string(e.getMessage()),
+    cout << msg << endl;
     m_userLog->error(msg);
     TImageCache::instance()->clear(true);
   } catch (...) {

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -670,6 +670,16 @@ void ChildLevelResourceImporter::process(TXshSimpleLevel *sl) {
     sl->load();
   } catch (...) {
   }
+
+  // Check if the scene saved with the previous version AND the premultiply
+  // option is set to PNG level setting
+  if (m_childScene->getVersionNumber() <
+      VersionNumber(71, 1)) {  // V1.4 = 71.0 , V1.5 = 71.1
+    if (!path.isEmpty() && path.getType() == "png" &&
+        sl->getProperties()->doPremultiply())
+      sl->getProperties()->setDoPremultiply(false);
+  }
+
   sl->release();
 }
 
@@ -1991,6 +2001,31 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
         app->getCurrentScene()->setDirtyFlag(true);
         app->getCurrentXsheet()->notifyXsheetChanged();
       }
+    }
+  }
+
+  // Check if the scene saved with the previous version AND the premultiply
+  // option is set to PNG level setting
+  if (scene->getVersionNumber() <
+      VersionNumber(71, 1)) {  // V1.4 = 71.0 , V1.5 = 71.1
+    QStringList modifiedPNGLevelNames;
+    std::vector<TXshLevel *> levels;
+    scene->getLevelSet()->listLevels(levels);
+    for (auto level : levels) {
+      if (!level || !level->getSimpleLevel()) continue;
+      TFilePath path = level->getPath();
+      if (path.isEmpty() || path.getType() != "png") continue;
+      if (level->getSimpleLevel()->getProperties()->doPremultiply()) {
+        level->getSimpleLevel()->getProperties()->setDoPremultiply(false);
+        modifiedPNGLevelNames.append(QString::fromStdWString(level->getName()));
+      }
+    }
+    if (!modifiedPNGLevelNames.isEmpty()) {
+      DVGui::info(QObject::tr("The Premultiply options in the following levels "
+                              "are disabled, since PNG files are premultiplied "
+                              "on loading in the current version: %1")
+                      .arg(modifiedPNGLevelNames.join(", ")));
+      app->getCurrentScene()->setDirtyFlag(true);
     }
   }
 

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -60,8 +60,11 @@ TOfflineGL *currentOfflineGL = 0;
 // Utility functions
 //=============================================================================
 namespace {
-
-const VersionNumber l_currentVersion(71, 0);
+// tentatively update the scene file version from 71.0 to 71.1 in order to
+// manage PNG level settings
+const VersionNumber l_currentVersion(71, 1);
+// TODO: Revise VersionNumber with OT version (converting 71.0 -> 14.0 , 71.1
+// -> 15.0)
 
 //-----------------------------------------------------------------------------
 
@@ -345,12 +348,9 @@ bool ToonzScene::isUntitled() const {
 //-----------------------------------------------------------------------------
 
 void ToonzScene::load(const TFilePath &path, bool withProgressDialog) {
-  loadNoResources(path);              // This loads a version number ..
-  loadResources(withProgressDialog);  // .. this uses the version number ..
-
-  setVersionNumber(
-      VersionNumber());  // .. but scene instances in memory do not retain
-}  // a version number beyond resource loading
+  loadNoResources(path);
+  loadResources(withProgressDialog);
+}
 
 //-----------------------------------------------------------------------------
 
@@ -456,7 +456,9 @@ void ToonzScene::loadTnzFile(const TFilePath &fp) {
       while (is.matchTag(tagName)) {
         if (tagName == "generator") {
           std::string program = is.getString();
-          reading22           = program.find("2.2") != std::string::npos;
+          // TODO: This obsolete condition should be removed before releasing OT
+          // v2.2 !
+          reading22 = program.find("2.2") != std::string::npos;
         } else if (tagName == "properties")
           m_properties->loadData(is, false);
         else if (tagName == "palette")  // per compatibilita' beta1
@@ -685,6 +687,8 @@ void ToonzScene::save(const TFilePath &fp, TXsheet *subxsh) {
   } else {
     if (wasUntitled) deleteUntitledScene(oldScenePath.getParentDir());
   }
+  // update the last saved version
+  setVersionNumber(l_currentVersion);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR will fix #3718 by changing loading strategy of PNG format.
From this PR, PNG files will always be premultiplied on loading.

After investigating the issue, I found that there is two problems as follows:

1. Tools are designed to work on premultiplied-alpha image. On straight-alpha image (like PNG format) they don't work properly. (as written in #3718)
2.  OT has inconsistency in I/O of PNG file format. i.e. when loading, OT loads the straight-alpha image as-is from the file. OTOH when saving [OT un-premultiplies the raster data](https://github.com/opentoonz/opentoonz/blob/45bac5a15c26f3cdd0ff4e624a3722d2cc063715/toonz/sources/image/png/tiio_png.cpp#L931) before saving it to the file, assuming that raster data is always premultiplied. This works OK when rendering in PNG format - since the rendered image is premultiplied - but overwriting the PNG image by `Save Level` command will cause wrong result by un-premultiplying straight-alpha image.

To resolve both of the problems, I decided to make the premultiply operation to be done in the loading process which is corresponding to the un-premultiply operation in the saving process.


In order to make the change not to affect the rendering result of scenes made with the previous versions, I also added the following:

- The option `Preferences > Loading > Level Settings by FIle Format > PNG` will be **silently** removed. 
- When loading the scene created by the previous version of OT, OT will search for PNG levels and automatically unset `Level Settings > Premultiply` option. The result is notified in the Message Center.
- When loading the scene as sub-xsheet level, OT will search for PNG levels and automatically and **silently** unset `Level Settings > Premultiply` option. 
- tcomposer will also automatically modify the level settings before rendering.

------

Related to PNG format I/O, I also fixed the following problem:

- OT fails to save dpi of the PNG image.

I found that `png_write_info()` is called before `png_set_pHYs()` , which I think should be swapped in order to write dpi information properly. 

