### PR TITLE
Update Appveyor OpenCV Version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ after_build:
     
     copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%\OpenToonz
 
-    copy /Y "C:\Tools\opencv\build\x64\vc15\bin\opencv_world412.dll" %CONFIGURATION%\OpenToonz
+    copy /Y "C:\Tools\opencv\build\x64\vc15\bin\opencv_world451.dll" %CONFIGURATION%\OpenToonz
 
     mkdir "%CONFIGURATION%\OpenToonz stuff"
 


### PR DESCRIPTION
This PR will fix OpenCV version to 4.5.1 as [Chocolatey updated the package on 10 Mar 2021](https://chocolatey.org/packages/OpenCV).