### PR TITLE
Fix Batch Rendering on Mac

### DIFF
--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -491,6 +491,7 @@ int main(int argc, char *argv[]) {
   // questo definisce la registry root e inizializza TEnv
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
+  TEnv::setApplicationFileName(argv[0]);
 
   QCoreApplication::setOrganizationName("OpenToonz");
   QCoreApplication::setOrganizationDomain("");
@@ -843,4 +844,3 @@ int main(int argc, char *argv[]) {
   return 0;
 }
 //------------------------------------------------------------------------
-

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -695,6 +695,7 @@ int main(int argc, char *argv[]) {
   // questo definisce la registry root e inizializza TEnv
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
+  TEnv::setApplicationFileName(argv[0]);
 
   QCoreApplication::setOrganizationName("OpenToonz");
   QCoreApplication::setOrganizationDomain("");

--- a/toonz/sources/tconverter/tconverter.cpp
+++ b/toonz/sources/tconverter/tconverter.cpp
@@ -177,7 +177,7 @@ void convertFromVI(const TLevelReaderP &lr, const TPaletteP &plt,
   }
   maxBbox = maxBbox.enlarge(2);
   if (width)  // calcolo l'affine
-    aff   = TScale((double)width / maxBbox.getLx());
+    aff = TScale((double)width / maxBbox.getLx());
   maxBbox = aff * maxBbox;
 
   for (i = 0; i < (int)images.size(); i++) {
@@ -365,6 +365,7 @@ int main(int argc, char *argv[]) {
 
   TEnv::setRootVarName(rootVarName);
   TEnv::setSystemVarPrefix(systemVarPrefix);
+  TEnv::setApplicationFileName(argv[0]);
   TFilePath fp = TEnv::getStuffDir();
 
   string msg;


### PR DESCRIPTION
This PR will fix #2940 . Not only `tcomposer` , but also `tcleanupper` and `tconverter` are (hopefully) fixed.