### PR TITLE
Actions: Update MSVC Version and Install Boost

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: windows-2019
     env:
       vcpkg_ref: 1d8728ae1ba66ad94b344708cf8d0ace1a6330b8
-      CLCACHE_CL: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl_original.exe'
+      CLCACHE_CL: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl_original.exe'
+      BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
+      BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
     steps:
     - uses: actions/checkout@v2
 
@@ -62,6 +64,26 @@ jobs:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         modules: 'qtscript'
 
+    - name: Restore Boost cache
+      uses: actions/cache@v2
+      id: cache-boost
+      with:
+        path: ${{env.BOOST_ROOT}}
+        key: boost
+
+    - name: Install Boost
+      if: steps.cache-boost.outputs.cache-hit != 'true'
+      run: |
+        # fix up paths to be forward slashes consistently
+        BOOST_ROOT=$(echo $BOOST_ROOT | sed 's/\\/\//g')
+        mkdir -p $BOOST_ROOT
+        curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
+        7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
+        7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
+        cd $BOOST_ROOT && cp -r boost_*/* .
+        rm -rf boost_*/* download.tar.bz2 download.tar
+      shell: bash
+      
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
@@ -70,9 +92,9 @@ jobs:
     - name: Install clcache
       run: |
         pip install clcache
-        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe' -NewName 'cl_original.exe'
-        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe.config' -NewName 'cl_original.exe.config'
-        cp 'C:/hostedtoolcache/windows/Python/3.9.1/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/cl.exe'
+        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe' -NewName 'cl_original.exe'
+        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe.config' -NewName 'cl_original.exe.config'
+        cp 'C:/hostedtoolcache/windows/Python/3.9.1/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe'
 
     - uses: actions/cache@v1
       with:
@@ -102,7 +124,7 @@ jobs:
         cmake ../ -G 'Visual Studio 16 2019' -Ax64 -Djson-c_DIR='C:/vcpkg/installed/x64-windows-static/share/json-c/' -DJSON-C_INCLUDE_DIR='C:/vcpkg/installed/x64-windows-static/include/json-c/'
         cmake --build . --config Release
         cp C:/vcpkg/installed/x64-windows-static/lib/json-c.lib .
-        $env:Path += ';C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64'
+        $env:Path += ';C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64'
         lib /OUT:libmypaint.lib Release/libmypaint.lib json-c.lib
         cp libmypaint.lib Release/libmypaint.lib
 
@@ -142,7 +164,8 @@ jobs:
         mkdir build | Out-Null
         cd build
         $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
-        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH='D:/a/opentoonz/Qt/5.15.2/msvc2019_64' -DOpenCV_DIR='C:/vcpkg/installed/x64-windows/share/opencv' -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0"
+        $env:BOOST_ROOT = '${{ env.BOOST_ROOT }}'
+        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH='D:/a/opentoonz/Qt/5.15.2/msvc2019_64' -DOpenCV_DIR='C:/vcpkg/installed/x64-windows/share/opencv' -DBOOST_ROOT="$env:BOOST_ROOT"
         cmake --build . --config Release
 
     - name: Create Artifact


### PR DESCRIPTION
This PR will fix recent failure in Windows job of GitHub Actions due to [the changes in the virtual environment](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md).

- MSVC tool version has been updated.
- Boost 1.72.0 has been removed from the image, so I added a work to install it (Courtesy of [Mudlet](https://github.com/Mudlet/Mudlet) ).