### PR TITLE
Fix Viewer to refresh on drawing with raster brush

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -19,6 +19,7 @@
 #include "toonz/txsheethandle.h"
 #include "toonz/txshlevelhandle.h"
 #include "toonz/tobjecthandle.h"
+#include "toonz/tframehandle.h"
 #include "toonz/ttileset.h"
 #include "toonz/ttilesaver.h"
 #include "toonz/strokegenerator.h"
@@ -289,7 +290,13 @@ bool FullColorBrushTool::askWrite(const TRect &rect) {
 bool FullColorBrushTool::preLeftButtonDown() {
   touchImage();
 
-  if (m_isFrameCreated) setWorkAndBackupImages();
+  if (m_isFrameCreated) {
+    setWorkAndBackupImages();
+    // When the xsheet frame is selected, whole viewer will be updated from
+    // SceneViewer::onXsheetChanged() on adding a new frame.
+    // We need to take care of a case when the level frame is selected.
+    if (m_application->getCurrentFrame()->isEditingLevel()) invalidate();
+  }
 
   return true;
 }
@@ -306,7 +313,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   if (!viewer) return;
 
   TRasterImageP ri = (TRasterImageP)getImage(true);
-  if (!ri) ri      = (TRasterImageP)touchImage();
+  if (!ri) ri = (TRasterImageP)touchImage();
 
   if (!ri) return;
 


### PR DESCRIPTION
This PR fixes #3722 
Added the same operation as other brushes ( invalidating Viewer on creating a new frame ) to the raster brush. 