### PR TITLE
Fix Palette Glitches

### DIFF
--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -404,8 +404,11 @@ std::map<TFrameId, QString> clearFramesWithoutUndo(
                  "-" + QString::number(it->getNumber());
     TImageCache::instance()->add(id, sl->getFrame(frameId, false));
     clearedFrames[frameId] = id;
+    // empty frame must be created BEFORE erasing frame or it may initialize
+    // palette.
+    TImageP emptyFrame = sl->createEmptyFrame();
     sl->eraseFrame(frameId);
-    sl->setFrame(*it, sl->createEmptyFrame());
+    sl->setFrame(*it, emptyFrame);
   }
   invalidateIcons(sl.getPointer(), frames);
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
@@ -629,9 +632,9 @@ public:
           ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
           if (scene) {
             TCamera *camera = scene->getCurrentCamera();
-            TPointD dpi = camera->getDpi();
-            dpiX              = dpi.x;
-            dpiY              = dpi.y;
+            TPointD dpi     = camera->getDpi();
+            dpiX            = dpi.x;
+            dpiY            = dpi.y;
           } else
             return;
         }

--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -591,7 +591,7 @@ void StudioPaletteCmd::mergeIntoCurrentPalette(TPaletteHandle *paletteHandle,
   TUndoManager::manager()->add(
       new PaletteAssignUndo(current, old, current->clone(), paletteHandle));
 
-  palette->setDirtyFlag(true);
+  current->setDirtyFlag(true);
   paletteHandle->notifyPaletteChanged();
 }
 


### PR DESCRIPTION
This PR fixes #3689 

- Merging to the current palette command had wrongly set the dirty flag to the source palette, instead of the destination palette where the source palette is dropped.
- Using the Clear command to the level with one frame had wrongly initialized the palette.