### PR TITLE
Fix Style Editor bottom menu inaccessible

### DIFF
--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -434,6 +434,8 @@ signals:
 protected:
   void paintEvent(QPaintEvent *) override;
   void mousePressEvent(QMouseEvent *) override;
+
+  QSize sizeHint() const override;
 };
 
 //=============================================================================

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -1426,7 +1426,9 @@ ColorParameterSelector::ColorParameterSelector(QWidget *parent)
     , m_index(-1)
     , m_chipSize(21, 21)
     , m_chipOrigin(0, 1)
-    , m_chipDelta(21, 0) {}
+    , m_chipDelta(21, 0) {
+  setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+}
 
 //-----------------------------------------------------------------------------
 
@@ -1490,6 +1492,14 @@ void ColorParameterSelector::mousePressEvent(QMouseEvent *event) {
     emit colorParamChanged();
     update();
   }
+}
+
+//-----------------------------------------------------------------------------
+
+QSize ColorParameterSelector::sizeHint() const {
+  return QSize(m_chipOrigin.x() + (m_colors.size() - 1) * m_chipDelta.x() +
+                   m_chipSize.width(),
+               m_chipOrigin.y() + m_chipSize.height());
 }
 
 //*****************************************************************************
@@ -2995,9 +3005,6 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
   m_toolBar->setMovable(false);
   m_toolBar->setMaximumHeight(22);
   m_toolBar->addWidget(m_colorParameterSelector);
-
-  m_colorParameterSelector->setMinimumWidth(200);
-  m_colorParameterSelector->setFixedHeight(22);
 
   QMenu *menu   = new QMenu();
   m_wheelAction = new QAction(tr("Wheel"), this);


### PR DESCRIPTION
This PR fixes #3672 removing the fixed width constraint from `ColorParameterSelector` .