### PR TITLE
Fix OpenGL Line Smoothing

### DIFF
--- a/toonz/sources/common/tgl/tgl.cpp
+++ b/toonz/sources/common/tgl/tgl.cpp
@@ -66,7 +66,7 @@ double tglGetPixelSize2() {
   glMatrixMode(GL_MODELVIEW);
   glGetDoublev(GL_MODELVIEW_MATRIX, mat);
 
-  double det                      = fabs(mat[0] * mat[5] - mat[1] * mat[4]);
+  double det = fabs(mat[0] * mat[5] - mat[1] * mat[4]);
   if (det < TConsts::epsilon) det = TConsts::epsilon;
   return 1.0 / det;
 }
@@ -245,6 +245,7 @@ void tglEnableBlending(GLenum src, GLenum dst) {
 
 void tglEnableLineSmooth(bool enable, double lineSize) {
   if (enable) {
+    tglEnableBlending();
     glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
     glEnable(GL_LINE_SMOOTH);
     glLineWidth(lineSize);
@@ -431,7 +432,7 @@ void tglDraw(const TRectD &rect, const std::vector<TRaster32P> &textures,
   unsigned int level = 1;
   while (pixelSize2 * level * level <= 1.0) level <<= 1;
 
-  unsigned int texturesCount       = (int)textures.size();
+  unsigned int texturesCount = (int)textures.size();
   if (level > texturesCount) level = texturesCount;
 
   level = texturesCount - level;
@@ -467,8 +468,8 @@ void tglDraw(const TRectD &rect, const TRaster32P &tex, bool blending) {
     texture = TRaster32P(texWidth, texHeight);
     texture->fill(TPixel32(0, 0, 0, 0));
     texture->copy(tex);
-    lwTex                  = (texLx) / (double)(texWidth);
-    lhTex                  = (texLy) / (double)(texHeight);
+    lwTex = (texLx) / (double)(texWidth);
+    lhTex = (texLy) / (double)(texHeight);
     if (lwTex > 1.0) lwTex = 1.0;
     if (lhTex > 1.0) lhTex = 1.0;
   } else
@@ -587,10 +588,10 @@ void tglBuildMipmaps(std::vector<TRaster32P> &rasters,
     ly >>= 1;
     if (lx < 1) lx = 1;
     if (ly < 1) ly = 1;
-    rasters[i]     = TRaster32P(lx, ly);
-    sx             = (double)lx / (double)ras2Lx;
-    sy             = (double)ly / (double)ras2Ly;
-    rasters[i]     = TRaster32P(lx, ly);
+    rasters[i] = TRaster32P(lx, ly);
+    sx         = (double)lx / (double)ras2Lx;
+    sy         = (double)ly / (double)ras2Ly;
+    rasters[i] = TRaster32P(lx, ly);
 #ifndef SCALE_BY_GLU
     TRop::resample(rasters[i], ras2, TScale(sx, sy), resampleFilter);
 #else

--- a/toonz/sources/tnzext/meshutils.cpp
+++ b/toonz/sources/tnzext/meshutils.cpp
@@ -326,7 +326,7 @@ void tglDraw(const TMeshImage &meshImage, const DrawableTextureData &texData,
                GL_HINT_BIT);  // Preserve original status bits
 
   glEnable(GL_BLEND);
-
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glEnable(GL_LINE_SMOOTH);
   glLineWidth(1.0f);
 

--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -1973,9 +1973,8 @@ void PlasticTool::drawOnionSkinSkeletons_animate(double pixelSize) {
     PlasticSkeleton skel;
     m_sd->storeDeformedSkeleton(m_sd->skeletonId(sdFrame), sdFrame, skel);
 
-    UCHAR alpha =
-        255 -
-        255.0 * OnionSkinMask::getOnionSkinFade(abs(osRows[r] - currentRow));
+    UCHAR alpha = 255 - 255.0 * OnionSkinMask::getOnionSkinFade(
+                                    abs(osRows[r] - currentRow));
     drawSkeleton(skel, pixelSize, alpha);
   }
 }
@@ -2114,6 +2113,7 @@ void PlasticTool::draw() {
   glPushAttrib(GL_LINE_BIT | GL_COLOR_BUFFER_BIT | GL_ENABLE_BIT);
 
   glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glEnable(GL_LINE_SMOOTH);
 
   switch (m_mode.getIndex()) {

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -1403,6 +1403,7 @@ void onMeshImage(TMeshImage *mi, const Stage::Player &player,
 
   // Prepare OpenGL
   glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glEnable(GL_LINE_SMOOTH);
 
   // Push mesh coordinates
@@ -1579,6 +1580,7 @@ void onPlasticDeformedImage(TStageObject *playerObj,
 
   // Set up OpenGL stuff
   glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glEnable(GL_LINE_SMOOTH);
 
   // Push mesh coordinates


### PR DESCRIPTION
This PR will fix OpenGL line smoothing to work by making sure to apply proper alpha blending function.

The change can be seen, for example, how the mesh level is displayed in the viewer:
![image](https://user-images.githubusercontent.com/17974955/111732286-75675b80-88b8-11eb-90fd-e06c11d78f5b.png)
