### PR TITLE
Fix pasting raster to cell

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -639,6 +639,8 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
       app->getCurrentLevel()->setLevel(sl);
       app->getCurrentLevel()->notifyLevelChange();
       sl->save();
+      // after saving you need to obtain the image again
+      img = sl->getFrame(fid, true);
     } else {
       img = sl->createEmptyFrame();
       assert(img);
@@ -648,6 +650,8 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
       sl->setFrame(fid, img);
     }
     xsh->setCell(row, col, TXshCell(sl, fid));
+    // to let the undo to know which frame is edited
+    TTool::m_cellsData.push_back({row, row, TTool::CellOps::BlankToNew});
   } else {
     sl  = cell.getSimpleLevel();
     fid = cell.getFrameId();
@@ -1630,6 +1634,9 @@ static void pasteStrokesInCell(int row, int col,
 
 static void pasteRasterImageInCell(int row, int col,
                                    const RasterImageData *rasterImageData) {
+  // to let the undo to know which frame is edited
+  TTool::m_cellsData.clear();
+
   TXsheet *xsh         = TApp::instance()->getCurrentXsheet()->getXsheet();
   TXshCell cell        = xsh->getCell(row, col);
   bool createdFrame    = false;

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1964,7 +1964,7 @@ TImageP TXshSimpleLevel::createEmptyFrame() {
   // manner as createNewLevel() in order to avoid crash. This can be happened if
   // the level was not saved after creating and being placed in the xsheet.
   if (isEmpty()) {
-    initializePalette();
+    if (!getPalette()) initializePalette();
     initializeResolutionAndDpi();
   }
 


### PR DESCRIPTION
This fixes #3571 

- Fixed behavior of pasting raster image to selected cell so that the image is pasted as soon as the new frame is created.
- Fixed undo of pasting operation to properly remove the cell. The Undo `PasteFullColorImageInCellsUndo` inherited `TToolUndo` , which means that you need to explicitly register the created cell to `TTool::m_cellsData` in order to make the undo to remove the cell properly.