### PR TITLE
Fix Crash on Launch with Shrinked ImageViewer

### DIFF
--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -1345,6 +1345,8 @@ void ImageViewer::onContextAboutToBeDestroyed() {
   makeCurrent();
   m_lutCalibrator->cleanup();
   doneCurrent();
+  disconnect(context(), SIGNAL(aboutToBeDestroyed()), this,
+             SLOT(onContextAboutToBeDestroyed()));
 }
 
 //-----------------------------------------------------------------------------
@@ -1352,6 +1354,9 @@ void ImageViewer::onContextAboutToBeDestroyed() {
 void ImageViewer::onPreferenceChanged(const QString &prefName) {
   if (prefName == "ColorCalibration") {
     if (Preferences::instance()->isColorCalibrationEnabled()) {
+      // if the window is so shriked that the gl widget is empty,
+      // showEvent can be called before creating the context.
+      if (!context()) return;
       makeCurrent();
       if (!m_lutCalibrator)
         m_lutCalibrator = new LutCalibrator();

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1201,6 +1201,9 @@ void SceneViewer::onStopMotionLiveViewStopped() {
 void SceneViewer::onPreferenceChanged(const QString &prefName) {
   if (prefName == "ColorCalibration") {
     if (Preferences::instance()->isColorCalibrationEnabled()) {
+      // if the window is so shriked that the gl widget is empty,
+      // showEvent can be called before creating the context.
+      if (!context()) return;
       makeCurrent();
       if (!m_lutCalibrator)
         m_lutCalibrator = new LutCalibrator();
@@ -3271,6 +3274,8 @@ void SceneViewer::onContextAboutToBeDestroyed() {
   makeCurrent();
   m_lutCalibrator->cleanup();
   doneCurrent();
+  disconnect(context(), SIGNAL(aboutToBeDestroyed()), this,
+             SLOT(onContextAboutToBeDestroyed()));
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -900,6 +900,8 @@ void HexagonalColorWheel::onContextAboutToBeDestroyed() {
   makeCurrent();
   m_lutCalibrator->cleanup();
   doneCurrent();
+  disconnect(context(), SIGNAL(aboutToBeDestroyed()), this,
+             SLOT(onContextAboutToBeDestroyed()));
 }
 
 //*****************************************************************************


### PR DESCRIPTION
This PR will fix the following problem occurred in our studio:

To reproduce:
- Enable 3DLut color calibration feature
- Open Color Model window and resize it to the minimum like this:
   ![shrinked_cm](https://user-images.githubusercontent.com/17974955/112083140-d8fbcc80-8bc9-11eb-8b16-adbc4faa021d.png)
- Quit OpenToonz and restart.
- OT crashes without launching.

The problem was due to calling initialization of Lut Caliburator (which uses OpenGL related functions in it) before the OpenGL context is created.