### PR TITLE
Fix Hdpi Icons

### DIFF
--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -108,15 +108,14 @@ int DVAPI getDevPixRatio();
 
 //-----------------------------------------------------------------------------
 
-QPixmap DVAPI setOpacity(QPixmap pixmap, const qreal &opacity = 0.8);
+QPixmap DVAPI compositePixmap(QPixmap pixmap, const qreal &opacity = 0.8,
+                              const QSize &size = QSize(),
+                              const int leftAdj = 0, const int topAdj = 0,
+                              QColor bgColor = Qt::transparent);
 QPixmap DVAPI recolorPixmap(
     QPixmap pixmap, QColor color = Preferences::instance()->getIconTheme()
                                        ? Qt::black
                                        : Qt::white);
-QPixmap DVAPI compositePixmap(QPixmap pixmap, qreal opacity,
-                              int canvasWidth = 20, int canvasHeight = 20,
-                              int iconWidth = 16, int iconHeight = 16,
-                              int offset = 0);
 QIcon DVAPI createQIcon(const char *iconSVGName, bool useFullOpacity = false);
 QIcon DVAPI createQIconPNG(const char *iconPNGName);
 QIcon DVAPI createQIconOnOffPNG(const char *iconPNGName, bool withOver = true);

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -225,34 +225,23 @@ void TPanelTitleBarButton::setPressed(bool pressed) {
 //-----------------------------------------------------------------------------
 
 void TPanelTitleBarButton::paintEvent(QPaintEvent *event) {
+  // Set unique pressed colors if filename contains the following words:
+  QColor bgColor = getPressedColor();
+  if (m_standardPixmapName.contains("freeze", Qt::CaseInsensitive))
+    bgColor = getFreezeColor();
+  if (m_standardPixmapName.contains("preview", Qt::CaseInsensitive))
+    bgColor = getPreviewColor();
+
+  QPixmap panePixmap    = recolorPixmap(svgToPixmap(m_standardPixmapName));
+  QPixmap panePixmapOff = compositePixmap(panePixmap, 0.8);
+  QPixmap panePixmapOver =
+      compositePixmap(panePixmap, 1, QSize(), 0, 0, getOverColor());
+  QPixmap panePixmapOn = compositePixmap(panePixmap, 1, QSize(), 0, 0, bgColor);
+
   QPainter painter(this);
-
-  // Create color states for the button
-  QPixmap normalPixmap(m_standardPixmap.size());
-  QPixmap onPixmap(m_standardPixmap.size());
-  QPixmap overPixmap(m_standardPixmap.size());
-  normalPixmap.fill(Qt::transparent);
-  onPixmap.fill(QColor(getPressedColor()));
-  overPixmap.fill(QColor(getOverColor()));
-
-  // Set unique 'pressed' colors if filename contains...
-  if (m_standardPixmapName.contains("freeze", Qt::CaseInsensitive)) {
-    onPixmap.fill(QColor(getFreezeColor()));
-  }
-  if (m_standardPixmapName.contains("preview", Qt::CaseInsensitive)) {
-    onPixmap.fill(QColor(getPreviewColor()));
-  }
-
-  // Compose the state colors
   painter.drawPixmap(
-      0, 0, m_pressed ? onPixmap : m_rollover ? overPixmap : normalPixmap);
-
-  // Icon
-  QPixmap panePixmap    = recolorPixmap(m_standardPixmap);
-  QPixmap paneOffPixmap = setOpacity(panePixmap, 0.8);
-  painter.drawPixmap(
-      0, 0, m_pressed ? panePixmap : m_rollover ? panePixmap : paneOffPixmap);
-
+      0, 0,
+      m_pressed ? panePixmapOn : m_rollover ? panePixmapOver : panePixmapOff);
   painter.end();
 }
 

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -477,7 +477,7 @@ NoteArea::NoteArea(XsheetViewer *parent, Qt::WFlags flags)
   m_flipOrientationButton->setObjectName("flipOrientationButton");
   m_flipOrientationButton->setFocusPolicy(Qt::FocusPolicy::NoFocus);
   m_flipOrientationButton->setFixedSize(QSize(70, 23));
-  m_flipOrientationButton->setIconSize(QSize(40, 20));
+  m_flipOrientationButton->setIconSize(QSize(20, 20));
   m_flipOrientationButton->setIcon(createQIcon("toggle_xsheet_orientation"));
   m_flipOrientationButton->setToolTip(tr("Toggle Xsheet/Timeline"));
 
@@ -618,6 +618,7 @@ void NoteArea::onXsheetOrientationChanged(const Orientation *newOrientation) {
   //  m_flipOrientationButton->setText(newOrientation->caption());
 
   m_flipOrientationButton->setIcon(createQIcon("toggle_xsheet_orientation"));
+  m_flipOrientationButton->setIconSize(QSize(20, 20));
 
   removeLayout();
   createLayout();


### PR DESCRIPTION
Hopefully closes #3759, it would be great if you could test this @Efenstor. 🙏 

Linux Appimage artifacts: https://github.com/opentoonz/opentoonz/actions/runs/681563655

I combined `compositePixmap()` and `setOpacity()` into one function, this broke the viewer pane icons, so I had to rewrite how they're drawn, but at least now they use Hdpi pixmaps, they weren't doing that before.

![paneIconsHdpi](https://user-images.githubusercontent.com/19820721/112240815-f4ee8500-8c40-11eb-92b8-9f64be556ddf.png)

To test this, you can just look at the console bar at 200% scale.

![consoleIconsHdpi](https://user-images.githubusercontent.com/19820721/112240934-32531280-8c41-11eb-92cf-205cc79d2c2a.png)

I confirmed that it works on Linux (Ubuntu 20.04 LTS), Windows 10 20H2 on my system.