### PR TITLE
Add WinTab Support Option by using Customized Qt

### DIFF
--- a/doc/how_to_build_win.md
+++ b/doc/how_to_build_win.md
@@ -1,40 +1,37 @@
 
 # Building on Windows
 
-This software can be built using Visual Studio 2015 or above and Qt 5.9 (later Qt versions still not working correctly.)
+This software can be built using Visual Studio 2019 and Qt 5.x
 
 ## Required Software
 
-### Visual Studio Express 2015 or higher for Windows Desktop
-- https://www.visualstudio.com/vs/older-downloads/
-- Make sure the target platform is "for Windows Desktop", not "for Windows".
-- Community and Professional versions of Visual Studio for Windows Desktop also work.
+### Visual Studio Community 2019
+- https://www.visualstudio.microsoft.com
 - During the installation, make sure to select all the Visual C++ packages.
 
 ### CMake
 - https://cmake.org/download/
-- This will be used to create the `MSVC 2015` project file.
+- This will be used to create the `MSVC 2019` project file.
 
 ### Qt
 - https://www.qt.io/download-open-source/
 - Qt is a cross-platform GUI framework.
-- Install Qt 5.9 or higher (64-bit version, tested up to 5.9.9) with the [Qt Online Installer for Windows](http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe).
+- Install Qt 5.9 or higher (64-bit version, tested up to 5.15.2) with the [Qt Online Installer for Windows](http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe).
+
+#### Customized Qt v5.15.2 with WinTab support
+- Qt have started to support Windows Ink from 5.12. Unlike WinTab API used in Qt 5.9 the tablet behaviors are different and are (at least, for OT) problematic.
+- The customized Qt5.15.2 are made with cherry-picking the WinTab feature to be officially introduced from 6.0.
+- You can build OT with WinTab support by using the prebuilt package of the customized version of Qt for MSVC2019-x64 provided [here](https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab) and checking the `WITH_WINTAB` checkbox in CMake to build.
 
 ### boost
-- Boost 1.55.0 or later is required (tested up to 1.61.0).
-- http://www.boost.org/users/history/version_1_61_0.html
+- Boost 1.55.0 or later is required (tested up to 1.73.0).
+- http://www.boost.org/users/history/version_1_73_0.html
 - Download boost_1_73_0.zip from the above link. Extract all contents to the - '$opentoonz/thirdparty/boost' directory.
-- Install the following patch (Make the changes listed in the patch file), if you use Boost 1.55.0 with Visual Studio 2013.
-- https://svn.boost.org/trac/boost/attachment/ticket/9369/vc12_fix_has_member_function_callable_with.patch
 
 ### OpenCV
 - v4.1.0 and later
 - https://opencv.org/
 - On configuring with CMake or in the environmental variables, specify `OpenCV_DIR` to the `build` folder in the install folder of OpenCV (like `C:/opencv/build`).
-
-### libjpeg-turbo
-- https://www.libjpeg-turbo.org/
-- Copy the lib and include folders from libjpeg-turbo64 into `$opentoonz/thirdparty/libjpeg-turbo64`.
 
 ## Acquiring the Source Code
 - Note: You can also perform these next commands with Github for Desktop client.
@@ -58,7 +55,7 @@ This software can be built using Visual Studio 2015 or above and Qt 5.9 (later Q
 - If the build directory is in the git repository, be sure to add the directory to .gitignore
 - If the build directory is different from the one above, be sure to change to the specified directory where appropriate below.
 -Click on Configure and select the version of Visual Studio you are using.
--If Qt was installed to a directory other than the default, and the error Specify QT_PATH properly appears, navigate to the `QT_DIR` install folder and specify the path to `msvc2015_64`. Rerun Configure.
+-If Qt was installed to a directory other than the default, and the error Specify QT_PATH properly appears, navigate to the `QT_DIR` install folder and specify the path to `msvc2019_64`. Rerun Configure.
 -If red lines appear in the bottom box, you can safely ignore them.
 -Click Generate
 -Should the CMakeLists.txt file change, such as during automatic build cleanup, there is no need to rerun CMake.
@@ -149,7 +146,7 @@ OpenToonz utilizes the QuickTime SDK's `mov` and associated file formats.  Since
 
 ### Qt
 - https://www.qt.io/download-open-source/
-- Install Qt 5.9 (32-bit version) by the  by [Qt Online Installer for Windows](http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe).
+- Install Qt 5.x (32-bit version) by the  by [Qt Online Installer for Windows](http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe).
 
 ### QuickTime SDK
 1. Sign in using your Apple developer ID and download `QuickTime 7.3 SDK for Windows.zip` from the following url.
@@ -159,7 +156,7 @@ OpenToonz utilizes the QuickTime SDK's `mov` and associated file formats.  Since
 ### Using CMake to Create a Visual Studio 32-bit Project
 - Follow the same instructions as for the 64-bit version, but change the following:
   - `$opentoonz/toonz/build` to `$opentoonz/toonz/build32`
-  - `Visual Studio 14 2015 Win64` to `Visual Studio 14 2015`
+  - `Visual Studio 16 2019 x64` to `Visual Studio 16 2019 Win32`
 - Change `QT_PATH` to the path of your 32-bit version of Qt
 
 ### Building the 32-bit Version
@@ -170,10 +167,13 @@ OpenToonz utilizes the QuickTime SDK's `mov` and associated file formats.  Since
   - From `$opentoonz/toonz/build32/Release`
     - t32bitsrv.exe
     - image.dll
+    - tnzbase.dll
     - tnzcore.dll
+    - tnzext.dll
+    - toonzlib.dll
   - From the 32-bit version of Qt
-    - Qt5Core.dll
-    - Qt5Network.dll
+    - run `windeployqt` to obtain required libraries
+    - additionally, Qt5Gui.dll
   - `$opentoonz/thirdparty/glut/3.7.6/lib/glut32.dll`
 
 ## Creating Translation Files

--- a/doc/how_to_build_win_ja.md
+++ b/doc/how_to_build_win_ja.md
@@ -1,13 +1,12 @@
 # ビルド手順（Windows）
 
-Visual Studio 2015 と Qt 5.9 でビルドできることを確認しています。
+Visual Studio 2019 (2015以降) と Qt 5.15 (5.9以降) でビルドできることを確認しています。
 
 ## 必要なソフトウェアの導入
 
-### Visual Studio Express 2015 for Windows Desktop
-- https://www.visualstudio.com/ja-jp/products/visual-studio-express-vs.aspx
-- Express 版はターゲットプラットフォームごとにバージョンが分かれています。 `for Windows` ではなく `for Windows Desktop` を使用します
-- Community 版や Professional 版などでも構いません
+### Visual Studio Community 2019
+- https://www.visualstudio.microsoft.com
+- C++ によるデスクトップ開発の環境をインストールします。
 
 ### CMake
 - https://cmake.org/download/
@@ -29,12 +28,22 @@ Visual Studio 2015 と Qt 5.9 でビルドできることを確認していま�
 ### Qt
 - https://www.qt.io/download-open-source/
 - クロスプラットフォームの GUI フレームワークです
-- 上記の URL から以下のファイルをダウンロードして Qt 5.9 (64 ビット版) を適当なフォルダにインストールします
+- 上記の URL から以下のファイルをダウンロードして Qt 5.15 (64 ビット版) を適当なフォルダにインストールします
   - [Qt Online Installer for Windows](http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe)
 
+#### WinTabサポート付きカスタマイズ版 Qt5.15.2
+- Qtは5.12以降Windows Ink APIをネイティブで使用しています。5.9まで使用されていたWinTab APIとはタブレットの挙動が異なり、それによる不具合が報告されています。
+- そこで、公式には6.0から導入されるWinTab APIへの切り替え機能をcherry-pickしたカスタマイズ版の5.15.2を頒布しています。
+- MSVC2019-x64向けのビルド済みパッケージは [こちら](https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab) から入手できます。さらにCMakeで`WITH_WINTAB`オプションを有効にすることで、WinTabAPIへの切り替えが可能になります。
+
+### OpenCV
+- v4.1.0 以降
+- https://opencv.org/
+- CMake上、または環境変数で`OpenCV_DIR` の値をOpenCVのインストールフォルダ内の`build`フォルダの場所に設定します。（例： `C:/opencv/build`）
+
 ### boost
-- http://www.boost.org/users/history/version_1_61_0.html
-- 上記の URL から boost_1_61_0.zip をダウンロードして解凍し、 boost_1_61_0 を `$opentoonz/thirdparty/boost` にコピーします
+- http://www.boost.org/users/history/version_1_73_0.html
+- 上記の URL から boost_1_73_0.zip をダウンロードして解凍し、 boost_1_61_0 を `$opentoonz/thirdparty/boost` にコピーします
 
 ## ビルド
 
@@ -45,7 +54,7 @@ Visual Studio 2015 と Qt 5.9 でビルドできることを確認していま�
   - 他の場所でも構いません
   - チェックアウトしたフォルダ内に作成する場合は、buildから開始するフォルダ名にするとgitから無視されます
   - ビルド先を変更した場合は、以下の説明を適宜読み替えてください
-4. Configure をクリックして、 Visual Studio 14 2015 Win64 を選択します
+4. Configure をクリックして、 Visual Studio 16 2019 Win64 を選択します
 5. Qt のインストール先がデフォルトではない場合、 `Specify QT_PATH properly` というエラーが表示されるので、 `QT_PATH` に Qt5 をインストールしたパスを指定します
 6. Generate をクリック
   - CMakeLists.txt に変更があった場合は、ビルド時に自動的に処理が走るので、以降は CMake を直接使用する必要はありません
@@ -61,16 +70,14 @@ Visual Studio 2015 と Qt 5.9 でビルドできることを確認していま�
 1. `$opentoonz/toonz/build/OpenToonz.sln` を開いて Release 構成を選択してビルドします
 2. `$opentoonz/toonz/build/Release` にファイルが生成されます
 
-## ストップモーション機能とキヤノン製デジタルカメラのサポートを有効にするには
+## キヤノン製デジタルカメラのサポートを有効にするには
 
-以下の３つのライブラリが追加で必要です。
-  - [OpenCV](https://opencv.org/) (v4.1.0以上)
-  - [libjpeg-turbo](https://www.libjpeg-turbo.org/)
+以下のライブラリが追加で必要です。
   - Canon EOS Digital SDK (EDSDK)：入手方法の詳細は[キヤノンマーケティングジャパン株式会社Webサイト](https://cweb.canon.jp/eos/info/api-package/)をご参照下さい。
 
-CMake上で、`WITH_STOPMOTION` オプションをONにします。CMake上、または環境変数で`OpenCV_DIR` の値をOpenCVのインストールフォルダ内の`build`フォルダの場所に設定します。（例： `C:/opencv/build`）
+CMake上で、`WITH_CANON` オプションをONにします。
 
-実行時にはOpenCV、libjpeg-turboならびにCanon EDSDKの.dllファイルを`OpenToonz.exe` と同じフォルダにコピーします。
+実行時にはCanon EDSDKの.dllファイルを`OpenToonz.exe` と同じフォルダにコピーします。
 
 ## 実行
 ### 実行可能ファイルなどの配置
@@ -80,6 +87,7 @@ CMake上で、`WITH_STOPMOTION` オプションをONにします。CMake上、�
 3. 下記のファイルを `OpenToonz.exe` と同じフォルダにコピーします
   - `$opentoonz/thirdparty/glut/3.7.6/lib/glut64.dll`
   - `$opentoonz/thirdparty/glew/glew-1.9.0/bin/64bit/glew32.dll`
+  - OpenCV、libjpeg-turboの.dllファイル
 4. バイナリ版の OpenToonz のインストール先にある `srv` フォルダを `OpenToonz.exe` と同じフォルダにコピーします
   - `srv` が無くても OpenToonz は動作しますが、 mov 形式などに対応できません
   - `srv` 内のファイルの生成方法は後述します
@@ -101,7 +109,7 @@ OpenToonz は QuickTime SDK を用いて mov 形式などへ対応していま�
 
 ### Qt
 - https://www.qt.io/download-open-source/
-- 64 ビット版と同じインストーラーで Qt 5.9 (32 ビット版) を適当なフォルダにインストールします
+- 64 ビット版と同じインストーラーで Qt 5.x (32 ビット版) を適当なフォルダにインストールします
 
 ### QuickTime SDK
 1. Apple の開発者登録をして下記のURLから `QuickTime 7.3 SDK for Windows.zip` をダウンロードします
@@ -111,7 +119,7 @@ OpenToonz は QuickTime SDK を用いて mov 形式などへ対応していま�
 ### CMake で Visual Studio の 32 ビット版のプロジェクトを生成する
 - 64 ビット版と同様の手順で、次のようにフォルダ名とターゲットを読み替えます
   - `$opentoonz/toonz/build` → `$opentoonz/toonz/build32`
-  - Visual Studio 14 2015 Win64 → Visual Studio 14 2015
+  - Visual Studio 16 2019 x64 → Visual Studio 16 2019 Win32
 - `QT_PATH` には 32 ビット版の Qt のパスを指定します
 
 ### 32 ビット版のビルド
@@ -122,10 +130,13 @@ OpenToonz は QuickTime SDK を用いて mov 形式などへ対応していま�
   - `$opentoonz/toonz/build32/Release` から
     - t32bitsrv.exe
     - image.dll
+    - tnzbase.dll
     - tnzcore.dll
+    - tnzext.dll
+    - toonzlib.dll
   - Qt の 32ビット版のインストール先から
-    - Qt5Core.dll
-    - Qt5Network.dll
+    - `windeployqt.exe`を実行して必要なライブラリを入手
+    - 追加で Qt5Gui.dll
   - `$opentoonz/thirdparty/glut/3.7.6/lib/glut32.dll`
 
 ## 翻訳ファイルの生成

--- a/stuff/doc/LICENSE/notice_about_modified_qt.txt
+++ b/stuff/doc/LICENSE/notice_about_modified_qt.txt
@@ -1,0 +1,75 @@
+## Notice about modified Qt
+
+ If you are using Windows version of OpenToonz installed from the installer 
+ provided from OpenToonz website (https://opentoonz.github.io/), Qt libraries 
+ distributed with the software may be our customized version. 
+ The other OS versions (macOS, Linux) are not the case. 
+
+
+### To check whether the Qt libraries are customized.
+
+  - Launch OpenToonz.
+  - Open Preferences.
+  - Check if there is a checkbox "Use Qt's Native Windows Ink Support" in the 
+    "Touch / Tablet Settings" category.
+
+  If the option exists, Qt libraries are customized version (Qt 5.15.2 with WinTab support).
+
+----------
+
+## About Qt 5.15.2 with WinTab support
+
+  This version is made based on v5.15.2 with cherry-picking the following commit 
+  to the qtbase module, in order to make it enable to use WinTab API in Qt 5.15.2:
+
+  commit id: [4c4693cf964e9d7370c27a26e1d263a262aee568](https://github.com/shun-iwasawa/qtbase/commit/4c4693cf964e9d7370c27a26e1d263a262aee568)
+  commit title: Windows: Provide a way to switch between WinTab and Windows Ink at run-time
+
+
+### Source Code
+
+  You can find the source code tree to build this package and track the modification here:
+  https://github.com/shun-iwasawa/qt5/tree/v5.15.2_wintab
+
+
+### Build Configurations
+
+  The attached package is built by the following command lines:
+  ```
+  > configure -debug-and-release -opensource -confirm-license -prefix ../build -make libs -no-pch -openssl OPENSSL_PREFIX="path\to\OpenSSL-Win64" -opengl dynamic
+  
+  > jom -j4
+  
+  > jom module-qtscript -j4
+  
+  > jom install
+  ```
+
+
+### Dependent Libraries
+
+  The attached package is built by using the following libraries / softwares.
+
+  - OpenSSL Toolkit 1.1.1j 
+    [Binary package from Shining Light Productions](https://slproweb.com/products/Win32OpenSSL.html)
+  - Perl
+    [ActivePerl 5.28](https://www.activestate.com/products/perl/downloads/)
+  - [Python 2.7.18](https://www.python.org/downloads/release/python-2718/)
+  - [Ruby 2.7.2-1 (x64)](https://rubyinstaller.org/downloads/)
+  - ANGLE : already included in the repository.
+  - Microsoft Visual Studio Community 2019
+  - [jom](https://wiki.qt.io/Jom)
+  - ICU : Not used.
+
+
+#### Reference: 
+
+  - [Qt for Windows - Requirements](https://doc.qt.io/qt-5/windows-requirements.html)
+  - [Qt for Windows - Building from Source](https://doc.qt.io/qt-5/windows-building.html)
+
+
+----------
+March 26, 2021
+Shun Iwasawa, OpenToonz team
+
+

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -103,6 +103,7 @@ option(WITH_SYSTEM_LZO "Use the system LZO library instead of 'thirdpary'" ${_in
 option(WITH_SYSTEM_SUPERLU "Use the system SuperLU library instead of 'thirdpary'" ${_init_SYSTEM_SUPERLU})
 option(WITH_CANON "Build with Canon DSLR support - Requires Canon SDK" OFF)
 option(WITH_TRANSLATION "Generate translation projects as well" ON)
+option(WITH_WINTAB "(Windows only) Build with customized Qt with WinTab support. https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab" OFF)
 
 # avoid using again
 option_defaults_clear()
@@ -148,7 +149,7 @@ endif()
 message(STATUS "Thirdpary Library Search path:" ${THIRDPARTY_LIBS_HINTS})
 
 if(BUILD_ENV_MSVC)
-    set(QT_PATH "C:/Qt/5.9.2/msvc2015${PLATFORM2}" CACHE PATH "Qt installation directory")
+    set(QT_PATH "C:/Qt/5.15.2/msvc2019${PLATFORM2}" CACHE PATH "Qt installation directory")
     if(NOT EXISTS ${QT_PATH})
         message("Specify QT_PATH properly")
         return()

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -469,6 +469,9 @@ public:
 
   // Tablet tab
   bool isWinInkEnabled() const { return getBoolValue(winInkEnabled); }
+  bool isQtNativeWinInkEnabled() const {
+    return getBoolValue(useQtNativeWinInk);
+  }
 
   // Others (not appeared in the popup)
   // Shortcut popup settings

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -177,6 +177,8 @@ enum PreferencesItemId {
   // TounchGestureControl // Touch Gesture is a checkable command and not in
   // preferences.ini
   winInkEnabled,
+  // This option will be shown & available only when WITH_WINTAB is defined
+  useQtNativeWinInk,
 
   //----------
   // Others (not appeared in the popup)

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -448,6 +448,10 @@ if (WITH_CANON)
     add_definitions(-DWITH_CANON)
 endif()
 
+if (WITH_WINTAB AND BUILD_TARGET_WIN AND (PLATFORM EQUAL 64))
+    add_definitions(-DWITH_WINTAB)
+endif()
+
 if(BUILD_ENV_APPLE)
     include_directories(../../sources/mousedragfilter)
     if(PLATFORM EQUAL 64)

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -359,8 +359,9 @@ int main(int argc, char *argv[]) {
 
 #ifdef Q_OS_WIN
   //	Since currently OpenToonz does not work with OpenGL of software or
-  // angle,
-  //	force Qt to use desktop OpenGL
+  // angle,	force Qt to use desktop OpenGL
+  // FIXME: This options should be called before constructing the application.
+  // Thus, ANGLE seems to be enabled as of now.
   a.setAttribute(Qt::AA_UseDesktopOpenGL, true);
 #endif
 
@@ -675,6 +676,19 @@ int main(int argc, char *argv[]) {
   // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
   if (w.windowHandle())
     QWindowsWindowFunctions::setHasBorderInFullScreen(w.windowHandle(), true);
+#endif
+
+    // Qt have started to support Windows Ink from 5.12.
+    // Unlike WinTab API used in Qt 5.9 the tablet behaviors are different and
+    // are (at least, for OT) problematic. The customized Qt5.15.2 are made with
+    // cherry-picking the WinTab feature to be officially introduced from 6.0.
+    // See https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab for
+    // details. The following feature can only be used with the customized Qt,
+    // with WITH_WINTAB build option, and in Windows-x64 build.
+
+#ifdef WITH_WINTAB
+  bool useQtNativeWinInk = Preferences::instance()->isQtNativeWinInkEnabled();
+  QWindowsWindowFunctions::setWinTabEnabled(!useQtNativeWinInk);
 #endif
 
   splash.showMessage(offsetStr + "Loading style sheet ...", Qt::AlignCenter,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1196,7 +1196,11 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Touch / Tablet Settings
       // TounchGestureControl // Touch Gesture is a checkable command and not in
       // preferences.ini
-      {winInkEnabled, tr("Enable Windows Ink Support* (EXPERIMENTAL)")}};
+      {winInkEnabled, tr("Enable Windows Ink Support* (EXPERIMENTAL)")},
+      {useQtNativeWinInk,
+       tr("Use Qt's Native Windows Ink Support*\n(CAUTION: This options is for "
+          "maintenance purpose. \n Do not activate this option or the tablet "
+          "won't work properly.)")}};
 
   return uiStringTable.value(id, QString());
 }
@@ -1967,6 +1971,9 @@ QWidget* PreferencesPopup::createTouchTabletPage() {
 
   lay->addWidget(enableTouchGestures, 0, 0, 1, 2);
   if (winInkAvailable) insertUI(winInkEnabled, lay);
+#ifdef WITH_WINTAB
+  insertUI(useQtNativeWinInk, lay);
+#endif
 
   lay->setRowStretch(lay->rowCount(), 1);
   if (winInkAvailable) insertFootNote(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -625,6 +625,8 @@ void Preferences::definePreferenceItems() {
   // TounchGestureControl // Touch Gesture is a checkable command and not in
   // preferences.ini
   define(winInkEnabled, "winInkEnabled", QMetaType::Bool, false);
+  // This option will be shown & available only when WITH_WINTAB is defined
+  define(useQtNativeWinInk, "useQtNativeWinInk", QMetaType::Bool, false);
 
   // Others (not appeared in the popup)
   // Shortcut popup settings


### PR DESCRIPTION
This PR fixes #3817 and (hopefully) fixes #3814 , #3813 and #3812 .

This PR will add a new option for enabling WinTab API instead of Widows Ink API.
To achieve the fix, I built the [customized version of Qt 5.15.2](https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab) from the source introducing the WinTab feature to be officially introduced from 6.0.

When being built with the customized Qt and with checking a `WITH_WINTAB` CMake option, a new Preference option `Use Qt's Native Windows Ink Support` will be added in the "Touch / Tablet" category which is DISABLED (= use WinTab) by default.
Enabling the check box will switch back to the Windows Ink API. It is for maintenance purpose and currently not recommended for users.

This PR will modify and redistribute the LGPL libraries so I added a necessary information in the `stuff/doc/LICENSE` folder.

I put the trial version [here](https://github.com/shun-iwasawa/opentoonz/releases/tag/v1.5.0rc_wintab) . 

Please try it and check if it will fix the issues and if there are any critical problems. Thank you!
