### PR TITLE
Fix Crash on Recording Audio on Windows

### DIFF
--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -173,11 +173,11 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_probe->setSource(m_audioRecorder);
   QAudioEncoderSettings audioSettings;
   audioSettings.setCodec("audio/PCM");
-#ifdef MACOSX
+  // setting the sample rate to some value (like 44100)
+  // may cause divide-by-zero crash in QAudioDeviceInfo::nearestFormat()
+  // so here we set the value to -1, as the documentation says;
+  // "A value of -1 indicates the encoder should make an optimal choice"
   audioSettings.setSampleRate(-1);
-#else
-  audioSettings.setSampleRate(44100);
-#endif
   audioSettings.setChannelCount(1);
   audioSettings.setBitRate(16);
   audioSettings.setEncodingMode(QMultimedia::ConstantBitRateEncoding);


### PR DESCRIPTION
This PR fixes #3819 , making the modification #3763 applied for macOS to all OSs.
I haven't tested on Linux but I tohught it would be better to unify the code.

I hope someone can test if this work on Linux as well.