### PR TITLE
Expanded toolbar by default

### DIFF
--- a/toonz/sources/toonz/toolbar.cpp
+++ b/toonz/sources/toonz/toolbar.cpp
@@ -29,7 +29,7 @@
 #include <QVBoxLayout>
 #include <QObject>
 
-TEnv::IntVar ShowAllToolsToggle("ShowAllToolsToggle", 0);
+TEnv::IntVar ShowAllToolsToggle("ShowAllToolsToggle", 1);
 
 namespace {
 struct {


### PR DESCRIPTION
This PR is a quick patch to resolve #3804 .
Now the toolbar will be expanded on the first launch of the software.