### PR TITLE
Fix Undocking Window

### DIFF
--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -201,9 +201,9 @@ QSize DockLayout::maximumSize() const {
 
 QSize DockLayout::sizeHint() const {
   QSize s(0, 0);
-  int n        = m_items.size();
+  int n = m_items.size();
   if (n > 0) s = QSize(100, 70);  // start with a nice default size
-  int i        = 0;
+  int i = 0;
   while (i < n) {
     QLayoutItem *o = m_items[i];
     s              = s.expandedTo(o->sizeHint());
@@ -431,7 +431,8 @@ bool Region::checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
       return false;
     }
     if ((m_item->objectName() == "FilmStrip" && m_item->getCanFixWidth()) ||
-        m_item->objectName() == "StyleEditor") {
+        m_item->objectName() == "StyleEditor" ||
+        m_item->objectName() == "ToolBar") {
       widgets.push_back(m_item);
       return true;
     } else
@@ -1508,7 +1509,7 @@ bool DockLayout::restoreState(const State &state) {
   }
 
   // Else, deallocate old regions and substitute with new ones
-  for (j    = 0; j < m_regions.size(); ++j) delete m_regions[j];
+  for (j = 0; j < m_regions.size(); ++j) delete m_regions[j];
   m_regions = newHierarchy;
 
   // Now re-initialize dock widgets' infos.


### PR DESCRIPTION
This PR fixes an issue reported in [the comment](https://github.com/opentoonz/opentoonz/issues/3835#issuecomment-809782822) in #3835 by @konero .

Added Tool Bar to the items to be with fixed width when another item is undocked from the main window.

Hope this fix will resolve the issue #3835 itself as well.
