### PR TITLE
Make Menu Icons Optional

### DIFF
--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -40,6 +40,7 @@ enum PreferencesItemId {
   interfaceFontStyle,
   colorCalibrationEnabled,
   colorCalibrationLutPaths,
+  showIconsInMenu,
 
   //----------
   // Visualization

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1459,6 +1459,12 @@ QAction *MainWindow::createAction(const char *id, const char *name,
                                   const QString &defaultShortcut,
                                   CommandType type, const char *iconSVGName) {
   QAction *action = new DVAction(tr(name), this);
+
+#if !defined(_WIN32)
+  bool visible = Preferences::instance()->getBoolValue(showIconsInMenu);
+  action->setIconVisibleInMenu(visible);
+#endif
+
   // In Qt5.15.2 - Windows, QMenu stylesheet has alignment issue when one item
   // has icon and another has not one. (See
   // https://bugreports.qt.io/browse/QTBUG-90242 for details.) To avoid the

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1059,6 +1059,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {colorCalibrationLutPaths,
        tr("3DLUT File for [%1]:")
            .arg(LutManager::instance()->getMonitorName())},
+      {showIconsInMenu, tr("Show Icons In Menu*")},
 
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
@@ -1512,6 +1513,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   insertUI(interfaceFontStyle, lay, buildFontStyleList());
   QGridLayout* colorCalibLay = insertGroupBoxUI(colorCalibrationEnabled, lay);
   { insertUI(colorCalibrationLutPaths, colorCalibLay); }
+  insertUI(showIconsInMenu, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -436,6 +436,15 @@ void Preferences::definePreferenceItems() {
   define(colorCalibrationLutPaths, "colorCalibrationLutPaths",
          QMetaType::QVariantMap, QVariantMap());
 
+  // hide menu icons by default in macOS since the icon color may not match with
+  // the system color theme
+#ifdef Q_OS_MACOS
+  bool defIconsVisible = false;
+#else
+  bool defIconsVisible = true;
+#endif
+  define(showIconsInMenu, "showIconsInMenu", QMetaType::Bool, defIconsVisible);
+
   setCallBack(pixelsOnly, &Preferences::setPixelsOnly);
   setCallBack(linearUnits, &Preferences::setUnits);
   setCallBack(cameraUnits, &Preferences::setCameraUnits);

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -318,31 +318,47 @@ QIcon createQIcon(const char *iconSVGName, bool useFullOpacity) {
 
   QIcon icon;
 
-  // Base icon
-  icon.addPixmap(compositePixmap(themeIconPixmap, baseOpacity), QIcon::Normal,
-                 QIcon::Off);
-  icon.addPixmap(compositePixmap(themeIconPixmap, disabledOpacity),
-                 QIcon::Disabled, QIcon::Off);
+#ifdef _WIN32
+  bool showIconInMenu = Preferences::instance()->getBoolValue(showIconsInMenu);
+  // set transparent icon
+  if (themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio) &&
+      !showIconInMenu) {
+    static QPixmap emptyPm(16 * devPixRatio, 16 * devPixRatio);
+    emptyPm.fill(Qt::transparent);
 
-  // Over icon
-  icon.addPixmap(!overPixmap.isNull()
-                     ? compositePixmap(overPixmap, activeOpacity)
-                     : compositePixmap(themeIconPixmap, activeOpacity),
-                 QIcon::Active);
-
-  // On icon
-  if (!onPixmap.isNull()) {
-    icon.addPixmap(compositePixmap(onPixmap, activeOpacity), QIcon::Normal,
-                   QIcon::On);
-    icon.addPixmap(compositePixmap(onPixmap, disabledOpacity), QIcon::Disabled,
-                   QIcon::On);
-  } else {
-    icon.addPixmap(compositePixmap(themeIconPixmap, activeOpacity),
-                   QIcon::Normal, QIcon::On);
+    icon.addPixmap(emptyPm, QIcon::Normal, QIcon::Off);
+    icon.addPixmap(emptyPm, QIcon::Normal, QIcon::On);
+    icon.addPixmap(emptyPm, QIcon::Disabled, QIcon::Off);
+    icon.addPixmap(emptyPm, QIcon::Disabled, QIcon::On);
+    icon.addPixmap(emptyPm, QIcon::Active);
+  } else
+#endif
+  {
+    // Base icon
+    icon.addPixmap(compositePixmap(themeIconPixmap, baseOpacity), QIcon::Normal,
+                   QIcon::Off);
     icon.addPixmap(compositePixmap(themeIconPixmap, disabledOpacity),
-                   QIcon::Disabled, QIcon::On);
-  }
+                   QIcon::Disabled, QIcon::Off);
 
+    // Over icon
+    icon.addPixmap(!overPixmap.isNull()
+                       ? compositePixmap(overPixmap, activeOpacity)
+                       : compositePixmap(themeIconPixmap, activeOpacity),
+                   QIcon::Active);
+
+    // On icon
+    if (!onPixmap.isNull()) {
+      icon.addPixmap(compositePixmap(onPixmap, activeOpacity), QIcon::Normal,
+                     QIcon::On);
+      icon.addPixmap(compositePixmap(onPixmap, disabledOpacity),
+                     QIcon::Disabled, QIcon::On);
+    } else {
+      icon.addPixmap(compositePixmap(themeIconPixmap, activeOpacity),
+                     QIcon::Normal, QIcon::On);
+      icon.addPixmap(compositePixmap(themeIconPixmap, disabledOpacity),
+                     QIcon::Disabled, QIcon::On);
+    }
+  }
   //----------
 
   // For icons intended for menus that are 16x16 in dimensions, to repurpose


### PR DESCRIPTION
This PR adds a new Preferences option, `Show Icons In Menu` which enables users to choose whether to display icons in menus.

In order to hide menu bar icons, 16pixel-sized icons will be replaced by transparent pixmap for Windows and `setIconVisibleInMenu(false)` will be called for other platforms.

To quick-patch #3837 the default value of this option is OFF (= hide icons) for macOS.
(I tried to get information from OT whether the macOS is in dark mode, but in vain.)