### PR TITLE
Added BSD compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Older versions and unstable nightly build are also available at <https://github.
 - [Windows](./doc/how_to_build_win.md)
 - [OS X](./doc/how_to_build_macosx.md)
 - [Linux](./doc/how_to_build_linux.md)
+- [BSD](./doc/how_to_build_bsd.md)
 
 For instructions on how to build stylesheets, please [see here](./doc/how_to_stylesheet.md).
 

--- a/doc/how_to_build_bsd.md
+++ b/doc/how_to_build_bsd.md
@@ -1,0 +1,31 @@
+# Setting up the development environment for BSD operatings systems such as NetBSD, FreeBSD, Dragonfly BSD, or OpenBSD
+
+## Required software
+
+Building OpenToonz from source requires the following dependencies:
+- Git
+- GCC or Clang
+- CMake (3.4.1 or newer).
+- Qt5 (5.9 or newer)
+- Boost (1.55 or newer)
+- LibPNG
+- SuperLU
+- Lzo2
+- FreeType
+- LibMyPaint (1.3 or newer)
+- Jpeg-Turbo (1.4 or newer)
+- OpenCV 3.2 or newer
+
+## OpenBSD example
+```
+# pkg_add git cmake pkgconf boost qt5 lz4 usb lzo2 png jpeg glew freeglut freetype json-c mypaint opencv
+```
+For programs such as SuperLU or Jpeg-Turbo, you might need to compile from source.
+
+Notes:
+* It's possible we also need `libgsl2` (Called gsl in BSD systems or maybe `libopenblas-dev` (called just blas in BSD.))
+* We may also need `libegl1-mesa-dev libgles2-mesa-dev libglib2.0-dev liblzma-dev` Install the BSD equivilency to those GNU/Linux packages. They might not be available as precompiled packages, so compiling from source might be required.
+* If your BSD operating system doesn't have the up to date packages such as gsl, you may install them by compiling from source.
+
+
+Continue the instructions as stated in [the linux guide](https://github.com/jointri/opentoonz/blob/master/doc/how_to_build_linux.md) to finish the compilation.


### PR DESCRIPTION
Added BSD compiling instructions because it should be made. Let me know how the instructions can be improved. I decided that it was only necessary to point out the initial dependencies and then have the user continue with the Linux guide. Let me know if there are any problems.