### PR TITLE
Geometric tool rotation/move

### DIFF
--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -45,6 +45,7 @@ TEnv::DoubleVar GeometricRasterSize("InknpaintGeometricRasterSize", 1);
 TEnv::StringVar GeometricType("InknpaintGeometricType", "Rectangle");
 TEnv::IntVar GeometricEdgeCount("InknpaintGeometricEdgeCount", 3);
 TEnv::IntVar GeometricSelective("InknpaintGeometricSelective", 0);
+TEnv::IntVar GeometricRotate("InknpaintGeometricRotate", 0);
 TEnv::IntVar GeometricGroupIt("InknpaintGeometricGroupIt", 0);
 TEnv::IntVar GeometricAutofill("InknpaintGeometricAutofill", 0);
 TEnv::IntVar GeometricSmooth("InknpaintGeometricSmooth", 0);
@@ -376,6 +377,7 @@ public:
   TDoubleProperty m_hardness;
   TEnumProperty m_type;
   TIntProperty m_edgeCount;
+  TBoolProperty m_rotate;
   TBoolProperty m_autogroup;
   TBoolProperty m_autofill;
   TBoolProperty m_smooth;
@@ -404,6 +406,7 @@ public:
       , m_opacity("Opacity:", 0, 100, 100)
       , m_hardness("Hardness:", 0, 100, 100)
       , m_edgeCount("Polygon Sides:", 3, 15, 3)
+      , m_rotate("rotate", false)
       , m_autogroup("Auto Group", false)
       , m_autofill("Auto Fill", false)
       , m_smooth("Smooth", false)
@@ -424,6 +427,7 @@ public:
     m_prop[0].bind(m_type);
 
     m_prop[0].bind(m_edgeCount);
+    m_prop[0].bind(m_rotate);
     if (targetType & TTool::Vectors) {
       m_prop[0].bind(m_autogroup);
       m_prop[0].bind(m_autofill);
@@ -460,6 +464,7 @@ public:
     m_prop[1].bind(m_miterJoinLimit);
 
     m_selective.setId("Selective");
+    m_rotate.setId("Rotate");
     m_autogroup.setId("AutoGroup");
     m_autofill.setId("Autofill");
     m_smooth.setId("Smooth");
@@ -483,6 +488,7 @@ public:
     m_opacity.setQStringName(tr("Opacity:"));
     m_hardness.setQStringName(tr("Hardness:"));
     m_edgeCount.setQStringName(tr("Polygon Sides:"));
+    m_rotate.setQStringName(tr("Rotate"));
     m_autogroup.setQStringName(tr("Auto Group"));
     m_autofill.setQStringName(tr("Auto Fill"));
     m_smooth.setQStringName(tr("Smooth"));
@@ -1095,6 +1101,7 @@ public:
       m_param.m_opacity.setValue(GeometricOpacity);
       m_param.m_hardness.setValue(GeometricBrushHardness);
       m_param.m_selective.setValue(GeometricSelective ? 1 : 0);
+      m_param.m_rotate.setValue(GeometricRotate ? 1 : 0);
       m_param.m_autogroup.setValue(GeometricGroupIt ? 1 : 0);
       m_param.m_smooth.setValue(GeometricSmooth ? 1 : 0);
       m_param.m_autofill.setValue(GeometricAutofill ? 1 : 0);
@@ -1180,6 +1187,8 @@ public:
       }
     } else if (propertyName == m_param.m_edgeCount.getName())
       GeometricEdgeCount = m_param.m_edgeCount.getValue();
+    else if (propertyName == m_param.m_rotate.getName())
+      GeometricRotate = m_param.m_rotate.getValue();
     else if (propertyName == m_param.m_autogroup.getName()) {
       if (!m_param.m_autogroup.getValue()) {
         m_param.m_autofill.setValue(false);
@@ -1527,9 +1536,9 @@ void RectanglePrimitive::leftButtonDrag(const TPointD &realPos,
   if (e.isShiftPressed()) {
     double distance = tdistance(realPos, m_startPoint) * M_SQRT1_2;
     pos.x           = (realPos.x > m_startPoint.x) ? m_startPoint.x + distance
-                                         : m_startPoint.x - distance;
-    pos.y = (realPos.y > m_startPoint.y) ? m_startPoint.y + distance
-                                         : m_startPoint.y - distance;
+                                                   : m_startPoint.x - distance;
+    pos.y           = (realPos.y > m_startPoint.y) ? m_startPoint.y + distance
+                                                   : m_startPoint.y - distance;
   } else {
     pos = calculateSnap(realPos);
     pos = checkGuideSnapping(realPos);
@@ -2255,9 +2264,9 @@ void EllipsePrimitive::leftButtonDrag(const TPointD &realPos,
   if (e.isShiftPressed()) {
     double distance = tdistance(realPos, m_startPoint) * M_SQRT1_2;
     pos.x           = (realPos.x > m_startPoint.x) ? m_startPoint.x + distance
-                                         : m_startPoint.x - distance;
-    pos.y = (realPos.y > m_startPoint.y) ? m_startPoint.y + distance
-                                         : m_startPoint.y - distance;
+                                                   : m_startPoint.x - distance;
+    pos.y           = (realPos.y > m_startPoint.y) ? m_startPoint.y + distance
+                                                   : m_startPoint.y - distance;
   } else {
     pos = calculateSnap(realPos);
     pos = checkGuideSnapping(realPos);

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -983,6 +983,7 @@ protected:
   TStroke *m_rotatedStroke;
   TPointD m_originalCursorPos;
   TPointD m_currentCursorPos;
+  TPixel32 m_color;
 
   // for rotation
   double m_lastRotateAngle;
@@ -1243,6 +1244,7 @@ public:
 
   void draw() override {
     if (m_isRotatingOrMoving) {
+      tglColor(m_color);
       drawStrokeCenterline(*m_rotatedStroke, sqrt(tglGetPixelSize2()));
       return;
     }
@@ -1358,6 +1360,20 @@ public:
         m_lastRotateAngle    = 0;
         m_lastMoveStrokePos  = TPointD(0, 0);
         m_wasCtrlPressed     = false;
+
+        const TTool::Application *app = TTool::getApplication();
+        if (!app) {
+          m_color = TPixel32::Red;
+          return;
+        }
+
+        const TColorStyle *style = app->getCurrentLevelStyle();
+        if (!style) {
+          m_color = TPixel32::Red;
+          return;
+        }
+
+        m_color = style->getAverageColor();
 
         return;
       }


### PR DESCRIPTION
This implements #3832.

I put Do Not Merge in the title because it's almost 1.5 release

demo:
1. https://www.youtube.com/watch?v=_U1fv0_dCWo 
2. https://www.youtube.com/watch?v=jaWoUmNsrRU

How to use:
1. select "geometric tool"
2. check the "rotate" checkbox
3. draw anything
4. once you're done drawing, you can move your mouse around to rotate the shape.
hold shift to force the rotation angle to be multiple of 45
hold ctrl to move it
5. once you're done with all those rotation and move, press left mouse button.

concern:
This will make `class GeometricTool` itself a lot more complex. Before this PR, `class GeometricTool` is rather simple: it just passes down the key/mouse events to the current geometric shape. However, after this PR, it will depend on its own state(namely:  `m_isRotatingOrMoving`) to decide if it wants to pass them down or not.