### PR TITLE
Fix Hidden Icons

### DIFF
--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -116,7 +116,8 @@ QPixmap DVAPI recolorPixmap(
     QPixmap pixmap, QColor color = Preferences::instance()->getIconTheme()
                                        ? Qt::black
                                        : Qt::white);
-QIcon DVAPI createQIcon(const char *iconSVGName, bool useFullOpacity = false);
+QIcon DVAPI createQIcon(const char *iconSVGName, bool useFullOpacity = false,
+                        bool isForMenuItem = false);
 QIcon DVAPI createQIconPNG(const char *iconPNGName);
 QIcon DVAPI createQIconOnOffPNG(const char *iconPNGName, bool withOver = true);
 QIcon DVAPI createTemporaryIconFromName(const char *commandName);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1480,7 +1480,7 @@ QAction *MainWindow::createAction(const char *id, const char *name,
 #endif
     // do nothing for other platforms
   } else
-    action->setIcon(createQIcon(iconSVGName));
+    action->setIcon(createQIcon(iconSVGName, false, true));
   addAction(action);
 #ifdef MACOSX
   // To prevent the wrong menu items (due to MacOS menu naming conventions),
@@ -2873,7 +2873,7 @@ void MainWindow::defineActions() {
   menuAct =
       createMiscAction(MI_RefreshTree, QT_TR_NOOP("Refresh Folder Tree"), "");
   menuAct->setIconText(tr("Refresh"));
-  menuAct->setIcon(createQIcon("refresh"));
+  menuAct->setIcon(createQIcon("refresh", false, true));
   createMiscAction("A_FxSchematicToggle",
                    QT_TR_NOOP("Toggle FX/Stage schematic"), "");
 

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -267,7 +267,8 @@ QPixmap recolorPixmap(QPixmap pixmap, QColor color) {
 
 //-----------------------------------------------------------------------------
 
-QIcon createQIcon(const char *iconSVGName, bool useFullOpacity) {
+QIcon createQIcon(const char *iconSVGName, bool useFullOpacity,
+                  bool isForMenuItem) {
   static int devPixRatio = getDevPixRatio();
 
   QIcon themeIcon = QIcon::fromTheme(iconSVGName);
@@ -321,7 +322,8 @@ QIcon createQIcon(const char *iconSVGName, bool useFullOpacity) {
 #ifdef _WIN32
   bool showIconInMenu = Preferences::instance()->getBoolValue(showIconsInMenu);
   // set transparent icon
-  if (themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio) &&
+  if (isForMenuItem &&
+      themeIconPixmap.size() == QSize(16 * devPixRatio, 16 * devPixRatio) &&
       !showIconInMenu) {
     static QPixmap emptyPm(16 * devPixRatio, 16 * devPixRatio);
     emptyPm.fill(Qt::transparent);


### PR DESCRIPTION
This PR fixes the following problem:

- When you deactivate `Show Icons In Menu` Preferences option, the "squared pixel" button in the camera settings fails to show "=" icon.
![image](https://user-images.githubusercontent.com/17974955/113480901-b9ba4480-94d1-11eb-92ca-72685c0db41a.png)
