### PR TITLE
Fix Hide Icons in Windows with Scale 125 %

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -406,6 +406,15 @@ int main(int argc, char *argv[]) {
   a.setAttribute(Qt::AA_CompressTabletEvents);
 #endif
 
+#ifdef _WIN32
+  // This attribute is set to make menubar icon to be always (16 x devPixRatio).
+  // Without this attribute the menu bar icon size becomes the same as tool bar
+  // when Windows scale is in 125%. Currently hiding the menu bar icon is done
+  // by setting transparent pixmap only in menu bar icon size. So the size must
+  // be different between for menu bar and for tool bar.
+  a.setAttribute(Qt::AA_Use96Dpi);
+#endif
+
   // Set the app's locale for numeric stuff to standard C. This is important for
   // atof() and similar
   // calls that are locale-dependant.


### PR DESCRIPTION
This PR fixes the following problem:

- On Windows, when setting `the size of text, app, and other items` to 125% , deactivating `Show Icons in Menu` fails to hide icons in menu.

When 125% scaling the [logical dpi](https://doc.qt.io/qt-5/qpaintdevice.html#logicalDpiX) becomes 120 from the standard dpi of 96.
It enlarges icon size for the menu bar to the same size as ones for the command bar.
Currently hiding the menu bar icon is done by setting transparent pixmap only in menu bar icon size.
So the sizes must be different between for menu bar and for tool bar.
This fix makes the logical dpi to be always 96, so that the menubar icon size becomes always `16 x devPixRatio` .