### PR TITLE
Bloom Fx Iwa Revised

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1350,8 +1350,12 @@
   
   <item>"STD_iwa_BloomFx" 			"Bloom Iwa" 	</item>
   <item>"STD_iwa_BloomFx.gamma"	"Gamma"		</item>
+  <item>"STD_iwa_BloomFx.auto_gain"	"Auto Gain"		</item>
+  <item>"STD_iwa_BloomFx.gain_adjust"	"Gain Adjustment"		</item>
   <item>"STD_iwa_BloomFx.gain"	"Gain"		</item>
+  <item>"STD_iwa_BloomFx.decay"	"Decay"		</item>
   <item>"STD_iwa_BloomFx.size"	"Size"		</item>
+  <item>"STD_iwa_BloomFx.alpha_mode"	"Alpha Mode"		</item>
   <item>"STD_iwa_BloomFx.alpha_rendering"	"Alpha Rendering"		</item>
 
  <!------------------------------ Tiled Particles Iwa ------------------------------------------->

--- a/stuff/profiles/layouts/fxs/STD_iwa_BloomFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_BloomFx.xml
@@ -1,8 +1,16 @@
 <fxlayout>
 	<page name="Bloom Iwa">
 		<control>gamma</control>
+		<control>auto_gain</control>
+		<control>gain_adjust</control>
 		<control>gain</control>
+		<control decimals="0">decay</control>
 		<control>size</control>
-		<control>alpha_rendering</control>
+		<control>alpha_mode</control>
+		<visibleToggle> 
+			<controller>auto_gain</controller>
+			<on>gain_adjust</on>
+			<off>gain</off>
+		</visibleToggle>
 	</page>
 </fxlayout>

--- a/toonz/sources/include/toonzqt/paramfield.h
+++ b/toonz/sources/include/toonzqt/paramfield.h
@@ -370,6 +370,7 @@ public:
   void updateField(double value) override;
 
   QSize getPreferedSize() override { return QSize(260, 28); }
+  void setPrecision(int precision) override;
 
 protected slots:
   void onChange(bool);

--- a/toonz/sources/stdfx/iwa_bloomfx.h
+++ b/toonz/sources/stdfx/iwa_bloomfx.h
@@ -19,22 +19,32 @@ value
 
 class Iwa_BloomFx : public TStandardRasterFx {
   FX_PLUGIN_DECLARATION(Iwa_BloomFx)
+
+  enum AlphaMode { NoAlpha = 0, Light, LightAndSource };
+
 protected:
   TRasterFxPort m_source;
   TDoubleParamP m_gamma;
+  TBoolParamP m_auto_gain;
+  TDoubleParamP m_gain_adjust;
   TDoubleParamP m_gain;
+  TDoubleParamP m_decay;
   TDoubleParamP m_size;
-  TBoolParamP m_alpha_rendering;
+
+  TIntEnumParamP m_alpha_mode;    // no alpha / light / light and source
+  TBoolParamP m_alpha_rendering;  // obsolete
 
   double getSizePixelAmount(const double val, const TAffine affine);
   template <typename RASTER, typename PIXEL>
-  void setSourceTileToMat(const RASTER ras, cv::Mat &ingMat,
+  void setSourceTileToMat(const RASTER ras, cv::Mat &imgMat,
                           const double gamma);
 
   template <typename RASTER, typename PIXEL>
-  void setMatToOutput(const RASTER ras, const RASTER srcRas, cv::Mat &ingMat,
+  void setMatToOutput(const RASTER ras, const RASTER srcRas, cv::Mat &imgMat,
                       const double gamma, const double gain,
-                      const bool withAlpha, const int margin);
+                      const AlphaMode alphaMode, const int margin);
+
+  double computeAutoGain(cv::Mat &imgMat);
 
 public:
   Iwa_BloomFx();
@@ -44,6 +54,7 @@ public:
                  const TRenderSettings &info) override;
   bool canHandle(const TRenderSettings &info, double frame) override;
   void getParamUIs(TParamUIConcept *&concepts, int &length) override;
+  void onObsoleteParamLoaded(const std::string &paramName) override;
 };
 
 #endif

--- a/toonz/sources/toonzqt/doublefield.cpp
+++ b/toonz/sources/toonzqt/doublefield.cpp
@@ -324,7 +324,7 @@ DoubleLineEdit::DoubleLineEdit(QWidget *parent, double value)
     : DoubleValueLineEdit(parent) {
   m_validator =
       new QDoubleValidator(-(std::numeric_limits<double>::max)(),
-                           (std::numeric_limits<double>::max)(), 8, this);
+                           (std::numeric_limits<double>::max)(), 5, this);
   setValidator(m_validator);
 
   setValue(value);

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -151,7 +151,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
     if (tagName == "control") {
       /*--- 設定ファイルからインタフェースの桁数を決める (PairSliderのみ実装。)
        * ---*/
-      int decimals            = 0;
+      int decimals            = -1;
       std::string decimalsStr = is.getTagAttribute("decimals");
       if (decimalsStr != "") {
         decimals = QString::fromStdString(decimalsStr).toInt();
@@ -168,7 +168,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
             QString::fromStdWString(TStringTable::translate(paramName));
         ParamField *field = ParamField::create(this, str, param);
         if (field) {
-          if (decimals) field->setPrecision(decimals);
+          if (decimals >= 0) field->setPrecision(decimals);
           m_fields.push_back(field);
           /*-- hboxタグに挟まれているとき --*/
           if (isVertical == false) {
@@ -919,7 +919,7 @@ void ParamsPageSet::createPage(TIStream &is, const TFxP &fx, int index) {
   std::string tagName;
   if (!is.matchTag(tagName) || tagName != "page")
     throw TException("expected <page>");
-  std::string pageName         = is.getTagAttribute("name");
+  std::string pageName = is.getTagAttribute("name");
   if (pageName == "") pageName = "page";
 
   ParamsPage *paramsPage = new ParamsPage(this, m_parent);
@@ -1197,7 +1197,7 @@ FxSettings::FxSettings(QWidget *parent, const TPixel32 &checkCol1,
   bool ret = true;
   ret      = ret && connect(m_paramViewer, SIGNAL(currentFxParamChanged()),
                        SLOT(updateViewer()));
-  ret = ret &&
+  ret      = ret &&
         connect(m_viewer, SIGNAL(pointPositionChanged(int, const TPointD &)),
                 SLOT(onPointChanged(int, const TPointD &)));
   ret = ret && connect(m_paramViewer, SIGNAL(preferredSizeChanged(QSize)), this,
@@ -1345,10 +1345,10 @@ void FxSettings::setFx(const TFxP &currentFx, const TFxP &actualFx) {
     TFxUtil::setKeyframe(currentFxWithoutCamera, m_frameHandle->getFrameIndex(),
                          actualFx, m_frameHandle->getFrameIndex());
 
-  ToonzScene *scene        = 0;
+  ToonzScene *scene = 0;
   if (m_sceneHandle) scene = m_sceneHandle->getScene();
 
-  int frameIndex                = 0;
+  int frameIndex = 0;
   if (m_frameHandle) frameIndex = m_frameHandle->getFrameIndex();
 
   m_paramViewer->setFx(currentFxWithoutCamera, actualFx, frameIndex, scene);
@@ -1408,7 +1408,7 @@ void FxSettings::setCurrentFx() {
   if (TZeraryColumnFx *zfx = dynamic_cast<TZeraryColumnFx *>(fx.getPointer()))
     fx = zfx->getZeraryFx();
   else
-    hasEmptyInput   = hasEmptyInputPort(fx);
+    hasEmptyInput = hasEmptyInputPort(fx);
   int frame         = m_frameHandle->getFrame();
   ToonzScene *scene = m_sceneHandle->getScene();
   actualFx          = fx;

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -846,6 +846,16 @@ void MeasuredDoubleParamField::onChange(bool dragging) {
 
 void MeasuredDoubleParamField::onKeyToggled() { onKeyToggle(); }
 
+//-----------------------------------------------------------------------------
+
+void MeasuredDoubleParamField::setPrecision(int precision) {
+  double min, max;
+  m_measuredDoubleField->getRange(min, max);
+  m_measuredDoubleField->setDecimals(precision);
+  // update slider
+  m_measuredDoubleField->setRange(min, max);
+}
+
 //=============================================================================
 // MeasuredRangeParamField
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
**PLEASE NOTE:** This PR is work in progress. This PR should be merged after releasing the next version v1.5. 

This PR will revise BloomFx Iwa.

- Added `Alpha Mode` parameter, replacing the `Alpha Rendering` check box.


  https://user-images.githubusercontent.com/17974955/113669288-80125500-96ee-11eb-9aad-df6deed6d00f.mp4


  Please note that the conventional `Alpha Rendering` option becomes "obsolete". i.e. `Alpha Rendering` parameter will be automatically converted to correspondent option in the new parameter on loading and will not be saved.

- Added `Decay` parameter to control how light spreads.

  ![bloomfx_decay](https://user-images.githubusercontent.com/17974955/114111354-d234bf80-9914-11eb-85ad-062ceeb6bfb0.gif)

- Added `Auto Gain` checkbox to automatically adjust gain so that the brightest pixel does not saturate.

  ![bloomfx_auto_gain](https://user-images.githubusercontent.com/17974955/114111334-c517d080-9914-11eb-964c-88835927036a.png)

- Added `Gain Adjustment` which enables to adjust blightness of the light after normalizing it with `Auto Gain` .