### PR TITLE
Update how_to_build_bsd.md

### DIFF
--- a/doc/how_to_build_bsd.md
+++ b/doc/how_to_build_bsd.md
@@ -28,4 +28,4 @@ Notes:
 * If your BSD operating system doesn't have the up to date packages such as gsl, you may install them by compiling from source.
 
 
-Continue the instructions as stated in [the linux guide](https://github.com/jointri/opentoonz/blob/master/doc/how_to_build_linux.md) to finish the compilation.
+Continue the instructions as stated in [the linux guide](https://github.com/opentoonz/opentoonz/blob/master/doc/how_to_build_linux.md) to finish the compilation.


### PR DESCRIPTION
By mistake the link to the linux instructions were pointed to my temporary fork. I fixed it.