### PR TITLE
Fix PSD Loading

### DIFF
--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -259,6 +259,9 @@ If \b scene is in +scenes/name.tnz return name,
   // if the path is codable with $scenefolder alias, replace it and return true
   bool codeFilePathWithSceneFolder(TFilePath &path) const;
 
+  bool isLoading() { return m_isLoading; }
+  void setIsLoading(bool isLoading) { m_isLoading = isLoading; }
+
 private:
   TFilePath m_scenePath;  //!< Full path to the scene file (.tnz).
 
@@ -272,6 +275,11 @@ private:
   VersionNumber m_versionNumber;  // last saved scene file version. Note that
                                   // currently it is not match with OT version.
                                   // TODO: Revise VersionNumber with OT version
+
+  bool m_isLoading;  // Set to true while loading the scene. Currently this flag
+                     // is used when loading PSD levels, for defining whether to
+                     // convert a layerId in the path to the layer name. See
+                     // TXshSimpleLevel::load().
 
 private:
   // noncopyable

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -276,7 +276,8 @@ static void deleteAllUntitledScenes() {
 //=============================================================================
 // ToonzScene
 
-ToonzScene::ToonzScene() : m_contentHistory(0), m_isUntitled(true) {
+ToonzScene::ToonzScene()
+    : m_contentHistory(0), m_isUntitled(true), m_isLoading(false) {
   m_childStack = new ChildStack(this);
   m_properties = new TSceneProperties();
   m_levelSet   = new TLevelSet();
@@ -348,8 +349,15 @@ bool ToonzScene::isUntitled() const {
 //-----------------------------------------------------------------------------
 
 void ToonzScene::load(const TFilePath &path, bool withProgressDialog) {
-  loadNoResources(path);
-  loadResources(withProgressDialog);
+  setIsLoading(true);
+  try {
+    loadNoResources(path);
+    loadResources(withProgressDialog);
+  } catch (...) {
+    setIsLoading(false);
+    throw;
+  }
+  setIsLoading(false);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1133,8 +1133,10 @@ void TXshSimpleLevel::load() {
   } else {
     // Not a scan + cleanup level
 
-    if (m_path.getType() == "psd" &&
-        this->getScene()->getVersionNumber().first < 71)
+    // Loading PSD files via load level command needs to convert layerID in the
+    // file path to layer name here. The conversion is not needed on loading
+    // scene as the file path loaded from the scene file is already converted.
+    if (m_path.getType() == "psd" && !this->getScene()->isLoading())
       m_path = getLevelPathAndSetNameWithPsdLevelName(this);
 
     TFilePath path = getScene()->decodeFilePath(m_path);


### PR DESCRIPTION
This PR fixes #3896 

The problem was due to [the changes](https://github.com/opentoonz/opentoonz/pull/3758/files#diff-0ee8edc63b37effb1882f7e0ee2497d82c3ee78a7579664cbc7f08c26bcf4369L348-R352) in #3758 , the scene's version number started to be kept in the scene after loading.

When loading PSD files, some convertion of file path replacing layer ids to layer names is needed ONLY when loading the level. OTOH when loading PSD levels while loading the scene, the convertion is not needed as the file path is already converted.
OT had distinguished whether the `TXshSimpleLevel::load()` is called from `Load Level` command or from `Load Scene` procedure by scene's version number. So, after #3758 the necessary conversion was skipped and caused the error.

To resolve the problem I introduced `isLoading` flag to `ToonzScene` and evaluate it instead of the version number.