### PR TITLE
Fix Missing Checkboxes in Menu Item

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1693,6 +1693,12 @@ QAction *MainWindow::createToggle(const char *id, const char *name,
   QAction *action = createAction(id, name, defaultShortcut, type, iconSVGName);
   // Remove if the icon is not set. Checkbox will be drawn by style sheet.
   if (!iconSVGName || !*iconSVGName) action->setIcon(QIcon());
+#if defined(_WIN32)
+  else {
+    bool visible = Preferences::instance()->getBoolValue(showIconsInMenu);
+    action->setIconVisibleInMenu(visible);
+  }
+#endif
   action->setCheckable(true);
   if (startStatus == true) action->trigger();
   bool ret =


### PR DESCRIPTION
This PR fixes the following problem:

- When the preferences option `Show Icons in Menu`  is disabled, toggle commands like `Preview Cleanup` , `Transparency Check` , etc. do not show checkboxes. It is hard for users to know the commands' state.