### PR TITLE
Actions: Use Custom Qt for Windows Build

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -10,6 +10,8 @@ jobs:
       CLCACHE_CL: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl_original.exe'
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
+      QT_ROOT: ${{github.workspace}}/3rdparty/qt
+      QT_URL: https://github.com/shun-iwasawa/qt5/releases/download/v5.15.2_wintab/Qt5.15.2_wintab.zip
     steps:
     - uses: actions/checkout@v2
 
@@ -52,17 +54,20 @@ jobs:
 
     - name: Cache Qt
       id: cache-qt
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
-        path: ../Qt
+        path: ${{env.QT_ROOT}}
         key: ${{ runner.os }}-QtCache
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
-      with:
-        version: '5.15.2'
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
-        modules: 'qtscript'
+      run: |
+        # fix up paths to be forward slashes consistently
+        QT_ROOT=$(echo $QT_ROOT | sed 's/\\/\//g')
+        mkdir -p $QT_ROOT
+        curl --progress-bar -L -o $QT_ROOT/Qt.zip $QT_URL
+        7z -o$QT_ROOT x $QT_ROOT/Qt.zip -y -bd
+        rm -f $QT_ROOT/Qt.zip
+      shell: bash
 
     - name: Restore Boost cache
       uses: actions/cache@v2
@@ -165,7 +170,8 @@ jobs:
         cd build
         $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
         $env:BOOST_ROOT = '${{ env.BOOST_ROOT }}'
-        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH='D:/a/opentoonz/Qt/5.15.2/msvc2019_64' -DOpenCV_DIR='C:/vcpkg/installed/x64-windows/share/opencv' -DBOOST_ROOT="$env:BOOST_ROOT"
+        $env:QT_PATH = '${{ env.QT_ROOT }}/Qt5.15.2_wintab/5.15.2_wintab/msvc2019_64'
+        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH="$env:QT_PATH" -DOpenCV_DIR='C:/vcpkg/installed/x64-windows/share/opencv' -DBOOST_ROOT="$env:BOOST_ROOT" -DWITH_WINTAB=ON
         cmake --build . --config Release
 
     - name: Create Artifact
@@ -176,7 +182,7 @@ jobs:
         cd artifact
         cp -Recurse ../stuff portablestuff
         cp ../toonz/build/Release/* .
-        D:/a/opentoonz/Qt/5.15.2/msvc2019_64/bin/windeployqt.exe OpenToonz.exe
+        ${{ env.QT_ROOT }}/Qt5.15.2_wintab/5.15.2_wintab/msvc2019_64/bin/windeployqt.exe OpenToonz.exe
         cp C:/vcpkg/installed/x64-windows/bin/freeglut.dll .
         cp C:/vcpkg/installed/x64-windows/bin/glew32.dll .
         cp C:/vcpkg/installed/x64-windows/bin/opencv_world.dll .


### PR DESCRIPTION
This PR modifies Windows runner of GitHub Actions so that it will use "customized" Qt 5.15.2 in which WinTab API is enabled.

 @RodneyBaker 
I'm sorry to bother you again, but can you please verify #3895 after introducing this, since [the problem](https://github.com/opentoonz/opentoonz/pull/3895#issuecomment-818513497) may due to Qt's native Windows Ink API. 