### PR TITLE
Fix Memo Popup Background Color

### DIFF
--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -31,12 +31,12 @@ QString computeBackgroundStyleSheetString(QColor color) {
   QVariant vR(color.red());
   QVariant vG(color.green());
   QVariant vB(color.blue());
-  QVariant vA(color.alpha());
-  return QString("#noteTextEdit { border-image: 0; background: rgbm(") +
-         vR.toString() + QString(",") + vG.toString() + QString(",") +
-         vB.toString() + QString(",") + vA.toString() + QString("); }");
+  QVariant vA(color.alphaF());
+  return QString(
+             "#noteTextEdit { border-image: 0; background: rgba(%1,%2,%3,%4);}")
+      .arg(vR.toString(), vG.toString(), vB.toString(), vA.toString());
 }
-}
+}  // namespace
 
 //=============================================================================
 
@@ -667,4 +667,4 @@ void NoteArea::onFrameDisplayStyleChanged(int id) {
 
 //-----------------------------------------------------------------------------
 
-}  // namespace XsheetGUI;
+}  // namespace XsheetGUI


### PR DESCRIPTION
This PR fixes the memo popup's background color to be the same as the selected color.

This problem is probably a regression with migration of Qt.