### PR TITLE
Particles Fx : Use 16bpc Control Image for Gradient

### DIFF
--- a/toonz/sources/stdfx/particles.h
+++ b/toonz/sources/stdfx/particles.h
@@ -7,6 +7,8 @@
 #include "tspectrum.h"
 #include "trandom.h"
 
+const int Ctrl_64_Offset = 1000;
+
 //------------------------------------------------------------------------------
 
 struct particles_values {

--- a/toonz/sources/stdfx/particlesengine.h
+++ b/toonz/sources/stdfx/particlesengine.h
@@ -52,6 +52,8 @@ public:
                  std::map<std::pair<int, int>, double> &partScales);
 
   bool port_is_used(int i, struct particles_values &values);
+  bool port_is_used_for_value(int i, struct particles_values &values);
+  bool port_is_used_for_gradient(int i, struct particles_values &values);
 
   /*-
      do_source_gradationがONのとき、入力画像のアルファ値に比例して発生濃度を変える。
@@ -81,7 +83,7 @@ public:
   void normalize_array(std::vector<std::vector<TPointD>> &myregions,
                        TPointD pos, int lx, int ly, int regioncounter,
                        std::vector<int> &myarray, std::vector<int> &lista,
-                       std::vector<int> &listb, std::vector<int> & final);
+                       std::vector<int> &listb, std::vector<int> &final);
 
   void fill_array(TTile *ctrl1, int &regioncount, std::vector<int> &myarray,
                   std::vector<int> &lista, std::vector<int> &listb, int thres);


### PR DESCRIPTION
This PR will enhance the Particles Fx.

Unlike other parameters, `Environment > Gravity` and `Birth Params > Speed > Speed Angle` (with `Use Gradient Angle` option) use gradient (i.e. brightness difference between neighbor pixels) of the control image.
Since the gradient is computed by 2D finite difference method, the control image should be with sufficiently large color depth in order to obtain proper gradient. However, currently the Particle Fx computes the control image in 8bpc regardless of the output settings.

This PR make the Particles Fx to compute control images only for such parameters in 16bpc to obtain better result.

Here is an example. I use the following radial gradient image for `Speed Angle` parameter:
![particles_ref](https://user-images.githubusercontent.com/17974955/115360770-e8872900-a1fa-11eb-9973-da7e76436b23.png)

The center of the gradient is at the same position as the center of the Raylit Fx.

Result before this PR:
![particles_old](https://user-images.githubusercontent.com/17974955/115361005-21bf9900-a1fb-11eb-9e0e-ca7a3682302c.gif)

Result of this PR:
![particles_new](https://user-images.githubusercontent.com/17974955/115361028-25532000-a1fb-11eb-9e97-faee7a65a33f.gif)


Note that in the result before this PR some particles move wrong direction since they fail to compute the proper gradient from the control image with small color depth.


FYI the `Tiled Particles Iwa` is already using 16bpc control image for all parameters. 💪 