### PR TITLE
Fix Raster Deformation Slowness

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -97,6 +97,7 @@ public:
   QPointF m_mousePos;  // mouse position obtained with QMouseEvent::pos() or
                        // QTabletEvent::pos()
   bool m_isTablet;
+  bool m_isHighFrequent;
 
 public:
   TMouseEvent()
@@ -104,7 +105,8 @@ public:
       , m_modifiersMask(NO_KEY)
       , m_buttons(Qt::NoButton)
       , m_button(Qt::NoButton)
-      , m_isTablet(false) {}
+      , m_isTablet(false)
+      , m_isHighFrequent(false) {}
 
   bool isShiftPressed() const { return (m_modifiersMask & SHIFT_KEY); }
   bool isAltPressed() const { return (m_modifiersMask & ALT_KEY); }
@@ -115,6 +117,7 @@ public:
   Qt::MouseButton button() const { return m_button; }
   QPointF mousePos() const { return m_mousePos; }
   bool isTablet() const { return m_isTablet; }
+  bool isHighFrequent() const { return m_isHighFrequent; }
 
   void setModifiers(bool shiftPressed, bool altPressed, bool ctrlPressed) {
     m_modifiersMask = ModifierMask((shiftPressed << SHIFT_BITSHIFT) |

--- a/toonz/sources/tnztools/rasterselectiontool.h
+++ b/toonz/sources/tnztools/rasterselectiontool.h
@@ -108,7 +108,7 @@ protected:
   //! It's true when use RasterFreeDeformer
   bool m_isFreeDeformer;
 
-  void applyTransform(FourPoints bbox) override;
+  void applyTransform(FourPoints bbox, bool onFastDragging = false) override;
   void applyTransform(TAffine aff, bool modifyCenter);
   void addTransformUndo() override;
 
@@ -143,6 +143,7 @@ class RasterFreeDeformTool final : public RasterDeformTool {
 public:
   RasterFreeDeformTool(RasterSelectionTool *tool);
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
+  void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override;
 };
 
 //=============================================================================
@@ -169,9 +170,11 @@ class RasterScaleTool final : public RasterDeformTool {
 public:
   RasterScaleTool(RasterSelectionTool *tool, ScaleType type);
   /*! Return scale value. */
-  TPointD transform(int index, TPointD newPos) override;
+  TPointD transform(int index, TPointD newPos,
+                    bool onFastDragging = false) override;
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
+  void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override;
 };
 
 }  // namespace DragSelectionTool

--- a/toonz/sources/tnztools/selectiontool.h
+++ b/toonz/sources/tnztools/selectiontool.h
@@ -48,7 +48,7 @@ public:
   /*! Helper function. */
   virtual void setPoints(const TPointD &p0, const TPointD &p1,
                          const TPointD &p2, const TPointD &p3) = 0;
-  virtual void deformImage() = 0;
+  virtual void deformImage()                                   = 0;
 };
 
 //=============================================================================
@@ -152,15 +152,18 @@ public:
 
   SelectionTool *getTool() const { return m_tool; }
 
-  virtual void transform(TAffine aff, double angle){}
-  virtual void transform(TAffine aff){}
-  virtual TPointD transform(int index, TPointD newPos) { return TPointD(); }
-  virtual void addTransformUndo(){}
+  virtual void transform(TAffine aff, double angle) {}
+  virtual void transform(TAffine aff) {}
+  virtual TPointD transform(int index, TPointD newPos,
+                            bool onFastDragging = false) {
+    return TPointD();
+  }
+  virtual void addTransformUndo() {}
 
   virtual void leftButtonDown(const TPointD &pos, const TMouseEvent &) = 0;
   virtual void leftButtonDrag(const TPointD &pos, const TMouseEvent &) = 0;
   virtual void leftButtonUp(const TPointD &pos, const TMouseEvent &)   = 0;
-  virtual void draw() = 0;
+  virtual void draw()                                                  = 0;
 };
 
 //=============================================================================
@@ -177,7 +180,7 @@ protected:
 public:
   DeformTool(SelectionTool *tool);
 
-  virtual void applyTransform(FourPoints bbox) = 0;
+  virtual void applyTransform(FourPoints bbox, bool onFastDragging = false) = 0;
   virtual void applyTransform(TAffine aff){};
 
   void addTransformUndo() override = 0;
@@ -234,6 +237,7 @@ class FreeDeform {
 public:
   FreeDeform(DeformTool *deformTool);
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e);
+  void leftButtonUp();
 };
 
 //=============================================================================
@@ -254,11 +258,7 @@ public:
 // Scale
 //-----------------------------------------------------------------------------
 
-enum class ScaleType {
-  GLOBAL = 0,
-  HORIZONTAL,
-  VERTICAL
-};
+enum class ScaleType { GLOBAL = 0, HORIZONTAL, VERTICAL };
 
 class Scale {
   TPointD m_startCenter;
@@ -270,7 +270,6 @@ class Scale {
   DeformTool *m_deformTool;
 
 public:
-
   ScaleType m_type;
   Scale(DeformTool *deformTool, ScaleType type);
 
@@ -301,12 +300,13 @@ compute scaleValue. */
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e);
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e);
+  void leftButtonUp();
 
   std::vector<FourPoints> getStartBboxs() const { return m_startBboxs; }
   TPointD getStartCenter() const { return m_startCenter; }
   bool scaleInCenter() const { return m_scaleInCenter; }
 };
-};
+};  // namespace DragSelectionTool
 
 //=============================================================================
 // Utility
@@ -315,7 +315,8 @@ compute scaleValue. */
 DragSelectionTool::DragTool *createNewMoveSelectionTool(SelectionTool *st);
 DragSelectionTool::DragTool *createNewRotationTool(SelectionTool *st);
 DragSelectionTool::DragTool *createNewFreeDeformTool(SelectionTool *st);
-DragSelectionTool::DragTool *createNewScaleTool(SelectionTool *st, DragSelectionTool::ScaleType type);
+DragSelectionTool::DragTool *createNewScaleTool(
+    SelectionTool *st, DragSelectionTool::ScaleType type);
 
 //=============================================================================
 // SelectionTool
@@ -420,7 +421,7 @@ public:
                        int index = 0);
 
   FreeDeformer *getFreeDeformer(int index = 0) const;
-  virtual void setNewFreeDeformer()       = 0;
+  virtual void setNewFreeDeformer() = 0;
   void clearDeformers();
 
   int getSelectedPoint() const { return m_selectedPoint; }

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -575,7 +575,8 @@ DragSelectionTool::VectorDeformTool::~VectorDeformTool() {
 
 //-----------------------------------------------------------------------------
 
-void DragSelectionTool::VectorDeformTool::applyTransform(FourPoints bbox) {
+void DragSelectionTool::VectorDeformTool::applyTransform(FourPoints bbox,
+                                                         bool onFastDragging) {
   SelectionTool *tool = getTool();
 
   std::unique_ptr<VFDScopedBlock> localVfdScopedBlock;
@@ -848,8 +849,8 @@ DragSelectionTool::VectorScaleTool::VectorScaleTool(VectorSelectionTool *tool,
 
 //-----------------------------------------------------------------------------
 
-TPointD DragSelectionTool::VectorScaleTool::transform(int index,
-                                                      TPointD newPos) {
+TPointD DragSelectionTool::VectorScaleTool::transform(int index, TPointD newPos,
+                                                      bool onFastDragging) {
   SelectionTool *tool = getTool();
   TPointD scaleValue  = tool->m_deformValues.m_scaleValue;
 

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -150,7 +150,7 @@ public:
   VectorDeformTool(VectorSelectionTool *tool);
   ~VectorDeformTool();
 
-  void applyTransform(FourPoints bbox) override;
+  void applyTransform(FourPoints bbox, bool onFastDragging = false) override;
   void addTransformUndo() override;
 
   /*! Trasform whole level and add undo. */
@@ -225,8 +225,8 @@ class VectorScaleTool final : public VectorDeformTool {
 public:
   VectorScaleTool(VectorSelectionTool *tool, ScaleType type);
 
-  TPointD transform(int index,
-                    TPointD newPos) override;  //!< Returns scale value.
+  TPointD transform(int index, TPointD newPos, bool onFastDragging = false)
+      override;  //!< Returns scale value.
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -93,7 +93,8 @@ void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
 //-----------------------------------------------------------------------------
 
 void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
-                    int widgetHeight, double pressure, int devPixRatio) {
+                    int widgetHeight, double pressure, int devPixRatio,
+                    bool isHighFrequent = false) {
   toonzEvent.m_pos = TPointD(
       event->posF().x() * (float)devPixRatio,
       (float)widgetHeight - 1.0f - event->posF().y() * (float)devPixRatio);
@@ -103,9 +104,10 @@ void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
                           event->modifiers() & Qt::ControlModifier);
-  toonzEvent.m_buttons  = event->buttons();
-  toonzEvent.m_button   = event->button();
-  toonzEvent.m_isTablet = true;
+  toonzEvent.m_buttons        = event->buttons();
+  toonzEvent.m_button         = event->button();
+  toonzEvent.m_isTablet       = true;
+  toonzEvent.m_isHighFrequent = isHighFrequent;
   // this delays autosave during stylus button press until after the next
   // brush stroke - this minimizes problems from interruptions to tablet input
   TApp::instance()->getCurrentTool()->setToolBusy(true);
@@ -360,9 +362,18 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 #if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
     // Use the application attribute Qt::AA_CompressTabletEvents instead of the
     // delay timer
+    // 21/4/2021 High frequent tablet event caused slowness when deforming with
+    // Raster Selection Tool. So I re-introduced the delay timer to make
+    // necessary interval for it. Deformation will be processed at interval of
+    // 20msec. (See RasterSelectionTool::leftButtonDrag())
     if (curPos != m_lastMousePos) {
       TMouseEvent mouseEvent;
-      initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+      initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio(),
+                     m_isBusyOnTabletMove);
+      if (!m_isBusyOnTabletMove) {
+        m_isBusyOnTabletMove = true;
+        QTimer::singleShot(20, this, SLOT(releaseBusyOnTabletMove()));
+      }
 #else
     // It seems that the tabletEvent is called more often than mouseMoveEvent.
     // So I fire the interval timer in order to limit the following process


### PR DESCRIPTION
This PR fixes #3902 .
I added following 2 modifications to enhance the response when deforming raster image with the selection tool:

- **Enhancement for using Windows + Tablet case** : For now the tablet event is called too frequent for relatively time consuming operation like raster deformation. So I re-introduced the "delay timer" to Windows so that the deformation will be calculated at 20msec interval (50fps) in maximum. Note that the delay is currently applied only to the raster deformation. Other operations like drawing with the brush tool still have no interval.
- **Enhancement for all cases** : Deforming with bilinear resampling is bit slower than with nearest-neighbor resampling. So I made the operation to use nearest-neighbor resampling when the mouse cursor moves in large distance (< 3pixels per frame). When the cursor moves slowly, it calculates with bilinear resampling in order to show an accurate result. 