### PR TITLE
Fix Cell Selection on Click

### DIFF
--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -128,6 +128,12 @@ public:
     int col          = pos.layer();
     m_firstCol       = col;
     m_firstRow       = row;
+    // First, check switching of the selection types. This may clear the
+    // previous selection.
+    if (m_modifier & Qt::ControlModifier)
+      getViewer()->getCellKeyframeSelection()->makeCurrent();
+    else
+      getViewer()->getCellSelection()->makeCurrent();
     if (m_modifier & Qt::ShiftModifier) {
       int r0, c0, r1, c1;
       getViewer()->getCellSelection()->getSelectedCells(r0, c0, r1, c1);
@@ -170,10 +176,6 @@ public:
       else
         getViewer()->getCellSelection()->selectCell(row, col);
     }
-    if (m_modifier & Qt::ControlModifier)
-      getViewer()->getCellKeyframeSelection()->makeCurrent();
-    else
-      getViewer()->getCellSelection()->makeCurrent();
     refreshCellsArea();
     refreshRowsArea();
   }


### PR DESCRIPTION
This PR fixes the first problem of #3918 . In particular;

1. Select cells together with keyframes by Ctrl + dragging.
1. Copy them.
1. Click (without Ctrl) at a cell for selecting the paste destination. 
1. Try to paste. Paste does not work.

The cause of the problem is that the clicked cell fails to be selected at the step 3.
This was because the switching of selection types (from Cells+Keys selection to Cells only selection) is done AFTER selecting the clicked cell and it clears the selection.

I fixed the order of the procedures to switch the selection types BEFORE selecting the clicked cell.