### PR TITLE
Fix Shortcut Input

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1669,6 +1669,17 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
   width: 16;
   margin-right: -1;
 }
+#ShortcutViewer {
+  font-size: 17px;
+}
+#ShortcutViewer QLineEdit {
+  color: black;
+  border-color: #b8bc7f;
+  background-color: white;
+}
+#ShortcutViewer QLineEdit:focus {
+  background-color: #abceff;
+}
 /* -----------------------------------------------------------------------------
    New Project / Configure Project Window
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1669,6 +1669,17 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
   width: 16;
   margin-right: -1;
 }
+#ShortcutViewer {
+  font-size: 17px;
+}
+#ShortcutViewer QLineEdit {
+  color: black;
+  border-color: #b8bc7f;
+  background-color: white;
+}
+#ShortcutViewer QLineEdit:focus {
+  background-color: #abceff;
+}
 /* -----------------------------------------------------------------------------
    New Project / Configure Project Window
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1669,6 +1669,17 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
   width: 16;
   margin-right: -1;
 }
+#ShortcutViewer {
+  font-size: 17px;
+}
+#ShortcutViewer QLineEdit {
+  color: black;
+  border-color: #b8bc7f;
+  background-color: white;
+}
+#ShortcutViewer QLineEdit:focus {
+  background-color: #abceff;
+}
 /* -----------------------------------------------------------------------------
    New Project / Configure Project Window
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/less/layouts/popups.less
+++ b/stuff/config/qss/Default/less/layouts/popups.less
@@ -77,6 +77,18 @@ QDialog {
   }
 }
 
+#ShortcutViewer {
+  font-size: 17px;
+  & QLineEdit{
+    color:black;
+    border-color: rgb(184, 188, 127);
+    background-color: white;
+    &:focus{
+      background-color: rgb(171, 206, 255);
+    } 
+  }
+}
+
 /* -----------------------------------------------------------------------------
    New Project / Configure Project Window
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1669,6 +1669,17 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
   width: 16;
   margin-right: -1;
 }
+#ShortcutViewer {
+  font-size: 17px;
+}
+#ShortcutViewer QLineEdit {
+  color: black;
+  border-color: #b8bc7f;
+  background-color: white;
+}
+#ShortcutViewer QLineEdit:focus {
+  background-color: #abceff;
+}
 /* -----------------------------------------------------------------------------
    New Project / Configure Project Window
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1669,6 +1669,17 @@ QDialog #dialogButtonFrame QPushButton:focus:pressed {
   width: 16;
   margin-right: -1;
 }
+#ShortcutViewer {
+  font-size: 17px;
+}
+#ShortcutViewer QLineEdit {
+  color: black;
+  border-color: #b8bc7f;
+  background-color: white;
+}
+#ShortcutViewer QLineEdit:focus {
+  background-color: #abceff;
+}
 /* -----------------------------------------------------------------------------
    New Project / Configure Project Window
 ----------------------------------------------------------------------------- */

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -72,8 +72,11 @@ public:
 // ShortcutViewer
 //-----------------------------------------------------------------------------
 
-ShortcutViewer::ShortcutViewer(QWidget *parent) : QWidget(parent), m_action(0) {
+ShortcutViewer::ShortcutViewer(QWidget *parent)
+    : QKeySequenceEdit(parent), m_action(0) {
+  setObjectName("ShortcutViewer");
   setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+  connect(this, SIGNAL(editingFinished()), this, SLOT(onEditingFinished()));
 }
 
 //-----------------------------------------------------------------------------
@@ -82,66 +85,23 @@ ShortcutViewer::~ShortcutViewer() {}
 
 //-----------------------------------------------------------------------------
 
-void ShortcutViewer::paintEvent(QPaintEvent *) {
-  QPainter p(this);
-  // sfondo azzurro se il widget ha il focus (e quindi si accorge dei tasti
-  // premuti)
-  p.fillRect(1, 1, width() - 1, height() - 1,
-             QBrush(hasFocus() ? QColor(171, 206, 255) : Qt::white));
-  // bordo
-  p.setPen(QColor(184, 188, 127));
-  p.drawRect(0, 0, width() - 1, height() - 1);
-  if (m_action) {
-    // lo shortcut corrente
-    p.setPen(Qt::black);
-    p.drawText(10, 13, m_action->shortcut().toString());
-  }
-}
-
-//-----------------------------------------------------------------------------
-
 void ShortcutViewer::setAction(QAction *action) {
   m_action = action;
-  update();
+  setKeySequence(m_action->shortcut());
   setFocus();
 }
 
 //-----------------------------------------------------------------------------
 
-bool ShortcutViewer::event(QEvent *event) {
-  // quando si vuole assegnare una combinazione che gia' assegnata bisogna
-  // evitare che lo shortcut relativo agisca.
-  if (event->type() == QEvent::ShortcutOverride) {
-    event->accept();
-    return true;
-  } else
-    return QWidget::event(event);
-}
-
-//-----------------------------------------------------------------------------
-
 void ShortcutViewer::keyPressEvent(QKeyEvent *event) {
-  int key = event->key();
-  if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt) {
+  int key                         = event->key();
+  Qt::KeyboardModifiers modifiers = event->modifiers();
+  if (key == Qt::Key_Home || key == Qt::Key_End || key == Qt::Key_PageDown ||
+      key == Qt::Key_PageUp || key == Qt::Key_Escape || key == Qt::Key_Print ||
+      key == Qt::Key_Pause || key == Qt::Key_ScrollLock) {
     event->ignore();
     return;
   }
-  Qt::KeyboardModifiers modifiers = event->modifiers();
-
-  // Tasti che non possono essere utilizzati come shortcut
-  if ((modifiers | (Qt::CTRL | Qt::SHIFT | Qt::ALT)) !=
-          (Qt::CTRL | Qt::SHIFT | Qt::ALT) ||
-      key == Qt::Key_Home || key == Qt::Key_End || key == Qt::Key_PageDown ||
-      key == Qt::Key_PageUp || key == Qt::Key_Escape || key == Qt::Key_Print ||
-      key == Qt::Key_Pause || key == Qt::Key_ScrollLock) {
-    if (key != Qt::Key_Plus && key != Qt::Key_Minus &&
-        key != Qt::Key_Asterisk && key != Qt::Key_Slash) {
-      event->ignore();
-      return;
-    } else
-      modifiers = 0;
-  }
-
   // If "Use Numpad and Tab keys for Switching Styles" option is activated,
   // then prevent to assign such keys
   if (Preferences::instance()->isUseNumpadForSwitchingStylesEnabled() &&
@@ -149,28 +109,40 @@ void ShortcutViewer::keyPressEvent(QKeyEvent *event) {
     event->ignore();
     return;
   }
+  QKeySequenceEdit::keyPressEvent(event);
+}
+
+//-----------------------------------------------------------------------------
+
+void ShortcutViewer::onEditingFinished() {
+  // limit to one shortcut key input
+  QKeySequence keys = (keySequence().isEmpty())
+                          ? QKeySequence()
+                          : QKeySequence(keySequence()[0]);
 
   if (m_action) {
-    CommandManager *cm = CommandManager::instance();
-    QKeySequence keySequence(key + modifiers);
-    std::string shortcutString = keySequence.toString().toStdString();
+    CommandManager *cm         = CommandManager::instance();
+    std::string shortcutString = keys.toString().toStdString();
     QAction *oldAction =
-        cm->getActionFromShortcut(keySequence.toString().toStdString());
+        cm->getActionFromShortcut(keys.toString().toStdString());
     if (oldAction == m_action) return;
     if (oldAction) {
       QString msg = tr("%1 is already assigned to '%2'\nAssign to '%3'?")
-                        .arg(keySequence.toString())
+                        .arg(keys.toString())
                         .arg(oldAction->iconText())
                         .arg(m_action->iconText());
       int ret = DVGui::MsgBox(msg, tr("Yes"), tr("No"), 1);
       activateWindow();
-      if (ret == 2 || ret == 0) return;
+      if (ret == 2 || ret == 0) {
+        setKeySequence(m_action->shortcut());
+        setFocus();
+        return;
+      }
     }
     CommandManager::instance()->setShortcut(m_action, shortcutString);
     emit shortcutChanged();
   }
-  event->accept();
-  update();
+  setKeySequence(keys);
 }
 
 //-----------------------------------------------------------------------------
@@ -179,7 +151,7 @@ void ShortcutViewer::removeShortcut() {
   if (m_action) {
     CommandManager::instance()->setShortcut(m_action, "", false);
     emit shortcutChanged();
-    update();
+    clear();
   }
 }
 

--- a/toonz/sources/toonz/shortcutpopup.h
+++ b/toonz/sources/toonz/shortcutpopup.h
@@ -6,6 +6,7 @@
 #include <QDialog>
 #include <QTreeWidget>
 #include <QComboBox>
+#include <QKeySequenceEdit>
 #include "filebrowserpopup.h"
 #include "toonzqt/dvdialog.h"
 
@@ -22,7 +23,7 @@ class ShortcutItem;
 // Per cancellarlo bisogna chiamare removeShortcut()
 //-----------------------------------------------------------------------------
 
-class ShortcutViewer final : public QWidget {
+class ShortcutViewer final : public QKeySequenceEdit {
   Q_OBJECT
   QAction *m_action;
 
@@ -31,15 +32,13 @@ public:
   ~ShortcutViewer();
 
 protected:
-  void paintEvent(QPaintEvent *) override;
-  bool event(QEvent *event) override;
-  void keyPressEvent(QKeyEvent *event) override;
   void enterEvent(QEvent *event) override;
   void leaveEvent(QEvent *event) override;
-
+  void keyPressEvent(QKeyEvent *event) override;
 public slots:
   void setAction(QAction *action);
   void removeShortcut();
+  void onEditingFinished();
 
 signals:
   void shortcutChanged();


### PR DESCRIPTION
This PR fixes #3926 .

The input field of the Shortcut popup now inherits `QKeySequenceEdit` .

- You need to wait one second after inputting the key to finish editing.
- Qt accepts up to 4 sequential key inputs (e.g. Pressing `Ctrl+A` then `Ctrl+B` to trigger some command) . However currently OT supports only one key input. Multiple key input will be automatically truncated.