### PR TITLE
Camera capture : Connect to any camera on start

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1610,9 +1610,20 @@ PencilTestPopup::PencilTestPopup()
 
   int startupCamIndex = m_cameraListCombo->findText(
       QString::fromStdString(CamCapCameraName.getValue()));
+  // if previous camera is not found, then try to activate the connected default
+  // camera
+  if (startupCamIndex <= 0 && !QCameraInfo::defaultCamera().isNull()) {
+    startupCamIndex =
+        m_cameraListCombo->findText(QCameraInfo::defaultCamera().description());
+  }
   if (startupCamIndex > 0) {
     m_cameraListCombo->setCurrentIndex(startupCamIndex);
     onCameraListComboActivated(startupCamIndex);
+  }
+  // just in case, try to activate any connected camera
+  else if (m_cameraListCombo->count() >= 2) {
+    m_cameraListCombo->setCurrentIndex(1);
+    onCameraListComboActivated(1);
   }
 
   QString resStr = QString::fromStdString(CamCapCameraResolution.getValue());


### PR DESCRIPTION
This PR modifies the initial behavior of the Camera Capture feature.

Before this PR, if OT could not find the previously connected camera, it does not activate any camera even if there is an another available one.
This PR modifies such behavior. OT will try to connect any available camera if the previously connected one is not found in order to cut out the need of selecting the camera in many cases.