### PR TITLE
Fix mesh file naming

### DIFF
--- a/toonz/sources/toonz/meshifypopup.cpp
+++ b/toonz/sources/toonz/meshifypopup.cpp
@@ -248,9 +248,13 @@ TXshSimpleLevel *createMeshLevel(TXshLevel *texturesLevel) {
       codedOrigPath = TFilePath(
           "+drawings/a");  // parent directory. Store them in "+drawings".
 
+    // temporarily disable underscore in order to get proper file path when the
+    // level name includes underscore like "sub_1"
+    TFilePath::setUnderscoreFormatAllowed(false);
     codedOrigPath = codedDstPath =
         codedOrigPath.withName(pathName).withType("mesh").withFrame(
             TFrameId::EMPTY_FRAME);
+    TFilePath::setUnderscoreFormatAllowed(true);
 
     origPath = dstPath = scene->decodeFilePath(codedOrigPath);
 
@@ -260,9 +264,10 @@ TXshSimpleLevel *createMeshLevel(TXshLevel *texturesLevel) {
       while (TSystem::doesExistFileOrLevel(dstPath) ||
              scene->getLevelSet()->hasLevel(*scene, codedDstPath)) {
         pathName = nameBuilder->getNext();
-
+        TFilePath::setUnderscoreFormatAllowed(false);
         codedDstPath = origPath.withName(pathName).withType("mesh").withFrame(
             TFrameId::EMPTY_FRAME);
+        TFilePath::setUnderscoreFormatAllowed(true);
         dstPath = scene->decodeFilePath(codedDstPath);
       }
 
@@ -1312,7 +1317,7 @@ public:
 
   void execute() override {
     static MeshifyPopup *thePopup = 0;
-    if (!thePopup) thePopup       = new MeshifyPopup;
+    if (!thePopup) thePopup = new MeshifyPopup;
 
     thePopup->raise();
     thePopup->show();


### PR DESCRIPTION
This PR fixes #3946 by teporarily disable underscore for the file path in order to get proper mesh file path for the level name with underscore like "sub_1" . 