### PR TITLE
Fix camera capture's level control

### DIFF
--- a/toonz/sources/toonz/cameracapturelevelcontrol.cpp
+++ b/toonz/sources/toonz/cameracapturelevelcontrol.cpp
@@ -346,6 +346,7 @@ void CameraCaptureLevelControl::onFieldChanged() {
     m_histogram->setThreshold(m_thresholdFld->getValue());
 
   m_histogram->update();
+  computeLut();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following problem regarding the level control in the camera capture popup:
- Inputting the fields under the histogram does not immediately update the captured image.

![camcap_leveladjust](https://user-images.githubusercontent.com/17974955/118747304-be299980-b894-11eb-85fd-da75af88babc.png)