### PR TITLE
Modify sync scroll between Xsheet and Function editor panels

### DIFF
--- a/toonz/sources/include/toonzqt/spreadsheetviewer.h
+++ b/toonz/sources/include/toonzqt/spreadsheetviewer.h
@@ -70,8 +70,9 @@ private:
   void connectScrollbars();
   void disconnectScrollbars();
 
-  void handleScroll(QPoint &offset);
+  void handleScroll(QPoint &offset, int senderMaximum, int senderValue);
   void onScroll(const CellPositionRatio &offset);
+  bool exactScroll(const int senderMaximum, const int senderValue);
 
   void prepareToScrollRatio(const CellPositionRatio &offset);
 

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1568,6 +1568,7 @@ void XsheetViewer::updateColumnArea() {
 //-----------------------------------------------------------------------------
 
 void XsheetViewer::updateCellColumnAree() {
+  if (!m_isComputingSize) refreshContentSize(0, 0);
   m_columnArea->update(m_columnArea->visibleRegion());
   m_cellArea->update(m_cellArea->visibleRegion());
 }
@@ -1575,6 +1576,7 @@ void XsheetViewer::updateCellColumnAree() {
 //-----------------------------------------------------------------------------
 
 void XsheetViewer::updateCellRowAree() {
+  if (!m_isComputingSize) refreshContentSize(0, 0);
   m_rowArea->update(m_rowArea->visibleRegion());
   m_cellArea->update(m_cellArea->visibleRegion());
 }

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -61,26 +61,55 @@ void FrameScroller::onVScroll(int y) {
   QPoint offset(0, y - m_lastY);
   if (isSyncing()) return;
   m_lastY = y;
+
+  int senderMaximum     = 0;
+  QScrollBar *scrollBar = dynamic_cast<QScrollBar *>(sender());
+  if (scrollBar) senderMaximum = scrollBar->maximum();
+
   setSyncing(true);
-  handleScroll(offset);
+  handleScroll(offset, senderMaximum, y);
   setSyncing(false);
 }
 void FrameScroller::onHScroll(int x) {
   QPoint offset(x - m_lastX, 0);
   if (isSyncing()) return;
   m_lastX = x;
+
+  int senderMaximum     = 0;
+  QScrollBar *scrollBar = dynamic_cast<QScrollBar *>(sender());
+  if (scrollBar) senderMaximum = scrollBar->maximum();
+
   setSyncing(true);
-  handleScroll(offset);
+  handleScroll(offset, senderMaximum, x);
   setSyncing(false);
 }
 
 static QList<FrameScroller *> frameScrollers;
 
-void FrameScroller::handleScroll(QPoint &offset) {
+void FrameScroller::handleScroll(QPoint &offset, int senderMaximum,
+                                 int senderValue) {
   if ((m_orientation->isVerticalTimeline() && offset.x()) ||
       (!m_orientation->isVerticalTimeline() &&
        offset.y()))  // only synchronize changes by frames axis
     return;
+
+  // If the scroller has the same maximum size, assume it as the scroll bar in
+  // the neighbor panel with the same height & scale. In such case just set the
+  // same value as the sender without zoom adjusting whichi may cause error due
+  // to rounding off.
+  QList<FrameScroller *> scrollBarCue;
+  for (auto frameScroller : frameScrollers)
+    if (frameScroller != this) {
+      if (!frameScroller->isSyncing()) {
+        if (!frameScroller->exactScroll(senderMaximum, senderValue)) {
+          // If the size is different from the sender, then put it in the cue
+          // for adjusting offset and scrolling.
+          scrollBarCue.append(frameScroller);
+        }
+      }
+    }
+
+  if (scrollBarCue.isEmpty()) return;
 
   QPointF offsetF(offset);
   // In case of a zoomed viewer is sending this out, adjust the
@@ -89,16 +118,32 @@ void FrameScroller::handleScroll(QPoint &offset) {
 
   CellPositionRatio ratio = orientation()->xyToPositionRatio(offsetF);
 
-  for (int i = 0; i < frameScrollers.size(); i++)
-    if (frameScrollers[i] != this) {
-      if (!frameScrollers[i]->isSyncing()) {
-        frameScrollers[i]->onScroll(ratio);
+  for (auto frameScroller : scrollBarCue)
+    if (frameScroller != this) {
+      if (!frameScroller->isSyncing()) {
+        frameScroller->onScroll(ratio);
         break;
       }
     }
 }
 
 void adjustScrollbar(QScrollBar *scrollBar, int add);
+
+// Check if the scroll bar has the same size as the sender and just put the
+// value
+bool FrameScroller::exactScroll(const int senderMaximum,
+                                const int senderValue) {
+  QScrollBar *scrollBar = (m_orientation->isVerticalTimeline())
+                              ? m_scrollArea->verticalScrollBar()
+                              : m_scrollArea->horizontalScrollBar();
+
+  if (scrollBar->maximum() == senderMaximum) {
+    scrollBar->setValue(senderValue);
+    return true;
+  }
+
+  return false;
+}
 
 void FrameScroller::onScroll(const CellPositionRatio &ratio) {
   QPointF offset = orientation()->positionRatioToXY(ratio);


### PR DESCRIPTION
This PR modifies the synchronization between Xsheet and Function editor panels, especially when they are placed next to each other with the same height.

Before this PR scrolling the one panel may cause flaw in synchronization with the other, i.e. scroll positions of the panels sometimes unwantedly offset by several pixels. The offset seemed to be occured due to the error when scaling the scroll value to standard size and back to the scaled size again.

This PR will resolve such problem. 
If the sender and the receiver scroll bars have the same maximum size, OT will assume that they are in the neighbor panels with the same height & scale. In such case just set the same value as the sender to the receiver without zoom adjusting.