### PR TITLE
Compass Gadget for Radial and Spin Blur Fxs

### DIFF
--- a/stuff/library/shaders/radialblurGPU.xml
+++ b/stuff/library/shaders/radialblurGPU.xml
@@ -85,3 +85,13 @@
     center
   </Parameter>
 </Concept>
+
+<Concept>
+  compass_ui
+  <Name>
+  Center
+  </Name>
+  <Parameter>
+    center
+  </Parameter>
+</Concept>

--- a/stuff/library/shaders/spinblurGPU.xml
+++ b/stuff/library/shaders/spinblurGPU.xml
@@ -85,3 +85,13 @@
     center
   </Parameter>
 </Concept>
+
+<Concept>
+  compass_spin_ui
+  <Name>
+  Center
+  </Name>
+  <Parameter>
+    center
+  </Parameter>
+</Concept>

--- a/toonz/sources/include/stdfx/shaderinterface.h
+++ b/toonz/sources/include/stdfx/shaderinterface.h
@@ -86,6 +86,8 @@ public:  // Enums
     SIZE_UI,
     QUAD_UI,
     RECT_UI,
+    COMPASS_UI,
+    COMPASS_SPIN_UI,
 
     CONCEPTSCOUNT,
     UI_CONCEPTS = RADIUS_UI

--- a/toonz/sources/include/tparamuiconcept.h
+++ b/toonz/sources/include/tparamuiconcept.h
@@ -65,7 +65,8 @@ public:
                    // [TDoubleParamP] }
     LINEAR_RANGE,  // A band-like range between two points.
                    // { [2 TPointParamP] }
-    RAYLIT,
+    COMPASS,       // a line widget pointing toward some point. [TPointParamP]
+    COMPASS_SPIN,  // ... with guides in rotational direction.
 
     RAINBOW_WIDTH,
 

--- a/toonz/sources/stdfx/ino_radial_blur.cpp
+++ b/toonz/sources/stdfx/ino_radial_blur.cpp
@@ -90,7 +90,7 @@ public:
         //,this->m_radius->getValue(frame) * scale
         ,
         0 /* debug:2012-02-01:ゼロ以上だとmarginが小さすぎになり画像が切れてしまう
-             */
+           */
 
         ,
         (this->m_anti_alias->getValue() ? 4 : 1));
@@ -143,7 +143,7 @@ public:
 
   // add 20140130
   void getParamUIs(TParamUIConcept *&concepts, int &length) override {
-    concepts = new TParamUIConcept[length = 2];
+    concepts = new TParamUIConcept[length = 3];
 
     concepts[0].m_type  = TParamUIConcept::POINT;
     concepts[0].m_label = "Center";
@@ -153,6 +153,9 @@ public:
     concepts[1].m_label = "Radius";
     concepts[1].m_params.push_back(m_radius);
     concepts[1].m_params.push_back(m_center);
+
+    concepts[2].m_type = TParamUIConcept::COMPASS;
+    concepts[2].m_params.push_back(m_center);
   }
   // add 20140130
 };
@@ -210,7 +213,7 @@ void fx_(const TRasterP in_ras  // with margin
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), out_ras, margin);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_radial_blur::doCompute(TTile &tile, double frame,
                                 const TRenderSettings &ri) {
@@ -282,7 +285,8 @@ void ino_radial_blur::doCompute(TTile &tile, double frame,
     std::ostringstream os;
     os << "params"
        << "  cx " << center.x << "  cy " << center.y << "  blur " << blur
-       << "  radius " << radius << "  twist " << twist
+       << "  radius " << radius << "  twist "
+       << twist
        // << "  twist_radius " << twist_radius
        << "  reference " << refer_mode << "  alpha_rendering " << alpha_rend_sw
        << "  anti_alias " << anti_alias_sw << "  render_center "

--- a/toonz/sources/stdfx/ino_spin_blur.cpp
+++ b/toonz/sources/stdfx/ino_spin_blur.cpp
@@ -127,7 +127,7 @@ public:
 
   // add 20140130
   void getParamUIs(TParamUIConcept *&concepts, int &length) override {
-    concepts = new TParamUIConcept[length = 2];
+    concepts = new TParamUIConcept[length = 3];
 
     concepts[0].m_type  = TParamUIConcept::POINT;
     concepts[0].m_label = "Center";
@@ -137,6 +137,9 @@ public:
     concepts[1].m_label = "Radius";
     concepts[1].m_params.push_back(m_radius);
     concepts[1].m_params.push_back(m_center);
+
+    concepts[2].m_type = TParamUIConcept::COMPASS_SPIN;
+    concepts[2].m_params.push_back(m_center);
   }
   // add 20140130
 };
@@ -196,7 +199,7 @@ void fx_(const TRasterP in_ras  // with margin
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), out_ras, margin);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_spin_blur::doCompute(TTile &tile, double frame,
                               const TRenderSettings &ri) {

--- a/toonz/sources/stdfx/radialblurfx.cpp
+++ b/toonz/sources/stdfx/radialblurfx.cpp
@@ -81,7 +81,7 @@ public:
   }
 
   void getParamUIs(TParamUIConcept *&concepts, int &length) override {
-    concepts = new TParamUIConcept[length = 2];
+    concepts = new TParamUIConcept[length = 3];
 
     concepts[0].m_type  = TParamUIConcept::POINT;
     concepts[0].m_label = "Center";
@@ -91,6 +91,9 @@ public:
     concepts[1].m_label = "Radius";
     concepts[1].m_params.push_back(m_radius);
     concepts[1].m_params.push_back(m_point);
+
+    concepts[2].m_type = TParamUIConcept::COMPASS;
+    concepts[2].m_params.push_back(m_point);
   }
 };
 

--- a/toonz/sources/stdfx/raylitfx.cpp
+++ b/toonz/sources/stdfx/raylitfx.cpp
@@ -72,7 +72,7 @@ public:
     concepts[1].m_params.push_back(m_radius);
     concepts[1].m_params.push_back(m_p);
 
-    concepts[2].m_type = TParamUIConcept::RAYLIT;
+    concepts[2].m_type = TParamUIConcept::COMPASS;
     concepts[2].m_params.push_back(m_p);
   }
 };

--- a/toonz/sources/stdfx/rotationalblurfx.cpp
+++ b/toonz/sources/stdfx/rotationalblurfx.cpp
@@ -52,7 +52,7 @@ public:
     if (dist > radius)
       blurangle = intensity * ((dist - radius));
     else
-      blurangle                     = 0;
+      blurangle = 0;
     if (blurangle > M_PI) blurangle = M_PI;
     return tround(4 * blurangle * dist);
   }
@@ -88,7 +88,7 @@ public:
   }
 
   void getParamUIs(TParamUIConcept *&concepts, int &length) override {
-    concepts = new TParamUIConcept[length = 2];
+    concepts = new TParamUIConcept[length = 3];
 
     concepts[0].m_type  = TParamUIConcept::POINT;
     concepts[0].m_label = "Center";
@@ -98,6 +98,9 @@ public:
     concepts[1].m_label = "Radius";
     concepts[1].m_params.push_back(m_radius);
     concepts[1].m_params.push_back(m_point);
+
+    concepts[2].m_type = TParamUIConcept::COMPASS_SPIN;
+    concepts[2].m_params.push_back(m_point);
   }
 };
 
@@ -141,9 +144,9 @@ void doSpinBlur(const TRasterPT<PIXEL> rout, const TRasterPT<PIXEL> rin,
       if (dist > radius)
         blurangle = intensity * ((dist - radius));
       else
-        blurangle                     = 0;
+        blurangle = 0;
       if (blurangle > M_PI) blurangle = M_PI;
-      range                           = (int)(4 * blurangle * dist);
+      range = (int)(4 * blurangle * dist);
       if (range >= 1) {
         angle = atan2((double)vy, (double)vx) - blurangle;
         ddist = 0.5 / dist;

--- a/toonz/sources/stdfx/shaderfx.cpp
+++ b/toonz/sources/stdfx/shaderfx.cpp
@@ -131,7 +131,8 @@ static const TParamUIConcept::Type
         TParamUIConcept::ANGLE,   TParamUIConcept::POINT,
         TParamUIConcept::POINT_2, TParamUIConcept::VECTOR,
         TParamUIConcept::POLAR,   TParamUIConcept::SIZE,
-        TParamUIConcept::QUAD,    TParamUIConcept::RECT};
+        TParamUIConcept::QUAD,    TParamUIConcept::RECT,
+        TParamUIConcept::COMPASS, TParamUIConcept::COMPASS_SPIN};
 
 // Functions
 
@@ -400,7 +401,7 @@ void ShaderFx::initialize() {
         TParamUIConcept &uiConcept = m_this->m_uiConcepts.back();
         uiConcept.m_type           = ::l_conceptTypes[siParam.m_concept.m_type -
                                             ShaderInterface::UI_CONCEPTS];
-        uiConcept.m_label = siParam.m_concept.m_label.toStdString();
+        uiConcept.m_label          = siParam.m_concept.m_label.toStdString();
         uiConcept.m_params.push_back(param);
       }
     }

--- a/toonz/sources/stdfx/shaderinterface.cpp
+++ b/toonz/sources/stdfx/shaderinterface.cpp
@@ -47,9 +47,10 @@ const static QString l_typeNames[ShaderInterface::TYPESCOUNT] = {
     "int", "ivec2", "ivec3", "ivec4", "rgba", "rgb"};
 
 const static QString l_conceptNames[ShaderInterface::CONCEPTSCOUNT] = {
-    "none",      "percent",  "length",   "angle",    "point",
-    "radius_ui", "width_ui", "angle_ui", "point_ui", "xy_ui",
-    "vector_ui", "polar_ui", "size_ui",  "quad_ui",  "rect_ui"};
+    "none",       "percent",        "length",   "angle",    "point",
+    "radius_ui",  "width_ui",       "angle_ui", "point_ui", "xy_ui",
+    "vector_ui",  "polar_ui",       "size_ui",  "quad_ui",  "rect_ui",
+    "compass_ui", "compass_spin_ui"};
 
 const static QString l_hwtNames[ShaderInterface::HWTCOUNT] = {"none", "any",
                                                               "isotropic"};


### PR DESCRIPTION
This PR will add a new "Compass" gadget to `Radial Blur` , `Radial Blur Ino` , `GPU Radial Blur` , `Spin Blur` , `Spin Blur Ino` and `GPU Spin Blur` . The gadget is located at the center of the table and shows the direction to the center point of the fx.
It had been originally developed for the `Raylit` Fx but we found that it would be also useful for some other fxs in which the center point can be distant from the camera frame.

![radial_spin_fx_gadgets](https://user-images.githubusercontent.com/17974955/122719652-7342dd80-d2a9-11eb-8ec9-7dae8c9d9e73.png)

N.B. Currently the guide lines does not show proper direction of the blur if you set some value to the `Twist` parameter of `Radial Blur Ino` .