### PR TITLE
Enable to Paste Style's Color Into Color Field

### DIFF
--- a/toonz/sources/include/toonzqt/colorfield.h
+++ b/toonz/sources/include/toonzqt/colorfield.h
@@ -181,12 +181,15 @@ protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *event) override;
   void hideEvent(QHideEvent *) override;
+  void contextMenuEvent(QContextMenuEvent *event) override;
 
 protected slots:
   void onRedChannelChanged(int value, bool isDragging);
   void onGreenChannelChanged(int value, bool isDragging);
   void onBlueChannelChanged(int value, bool isDragging);
   void onAlphaChannelChanged(int value, bool isDragging);
+  void onPasteColor();
+  void onCopyColor();
 
 signals:
   void editingChanged(const TPixel32 &, bool isEditing);


### PR DESCRIPTION
This PR will enable to paste style's color into a color field.
The color field is a widget for specifying color parameter which is used in Fx settings, Preferences etc.

![paste_style_color_into_color_field](https://user-images.githubusercontent.com/17974955/123028381-4104bd80-d41a-11eb-86b0-15c9665b1c5d.png)

**To paste style color into the color field:**

1. Copy styles in the Palette.
2. Right click on the color field and select one from the copied styles. 

Note that if there are more than 10 styles in the clipboard, only the first 10 styles will be listed in the menu. 

This PR also enables to copy color from some color field and paste it to another one. 