### PR TITLE
Bokeh Advanced Fx Quick Fix

### DIFF
--- a/toonz/sources/stdfx/iwa_bokeh_util.cpp
+++ b/toonz/sources/stdfx/iwa_bokeh_util.cpp
@@ -1102,9 +1102,9 @@ void BokehUtils::interpolateExposureAndConvertToRGB(
 
     // convert exposure by layer hardness
     if (layerHardnessRatio != 1.0) {
-      result.x = std::pow(result.x, layerHardnessRatio);
-      result.y = std::pow(result.y, layerHardnessRatio);
-      result.z = std::pow(result.z, layerHardnessRatio);
+      result.x = std::pow(result.x / result.w, layerHardnessRatio) * result.w;
+      result.y = std::pow(result.y / result.w, layerHardnessRatio) * result.w;
+      result.z = std::pow(result.z / result.w, layerHardnessRatio) * result.w;
     }
 
     // in case the result is replaced by the upper layer pixel


### PR DESCRIPTION
This PR is a quick patch for fixing a following problem in the Bokeh Advanced Iwa Fx:

- When a layer is separated into sub-layers using a depth reference image and the individual hardness is different from the master hardness, semi-transparent of blurred contour becomes incorrect.