### PR TITLE
Fix crash on clicking shortcut tree

### DIFF
--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -87,8 +87,14 @@ ShortcutViewer::~ShortcutViewer() {}
 
 void ShortcutViewer::setAction(QAction *action) {
   m_action = action;
-  setKeySequence(m_action->shortcut());
-  setFocus();
+  if (m_action) {
+    setEnabled(true);
+    setKeySequence(m_action->shortcut());
+    setFocus();
+  } else {
+    setEnabled(false);
+    setKeySequence(QKeySequence());
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -212,6 +218,8 @@ ShortcutTree::ShortcutTree(QWidget *parent) : QTreeWidget(parent) {
   connect(
       this, SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)),
       this, SLOT(onCurrentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
+  connect(this, SIGNAL(clicked(const QModelIndex &)), this,
+          SLOT(onItemClicked(const QModelIndex &)));
 }
 
 //-----------------------------------------------------------------------------
@@ -327,6 +335,12 @@ void ShortcutTree::onCurrentItemChanged(QTreeWidgetItem *current,
 void ShortcutTree::onShortcutChanged() {
   int i;
   for (i = 0; i < (int)m_items.size(); i++) m_items[i]->updateText();
+}
+
+//-----------------------------------------------------------------------------
+
+void ShortcutTree::onItemClicked(const QModelIndex &index) {
+  isExpanded(index) ? collapse(index) : expand(index);
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/shortcutpopup.h
+++ b/toonz/sources/toonz/shortcutpopup.h
@@ -76,6 +76,8 @@ public slots:
                             QTreeWidgetItem *previous);
   void onShortcutChanged();
 
+  void onItemClicked(const QModelIndex &);
+
 signals:
   void actionSelected(QAction *);
   void searched(bool haveResult);


### PR DESCRIPTION
This PR fixes the following problem in the Shortcut popup:

- When clicking the category name in the shortcut tree, OT crashes.

This PR also enables to expand the category by single-clicking of the category name.