### PR TITLE
Fix Paste Color command not to set the "edited flag" to normal styles

### DIFF
--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -1174,7 +1174,7 @@ void TStyleSelection::pasteStylesValues(bool pasteName, bool pasteColor) {
       else {  // !pasteName
         pastedStyle->setGlobalName(dstGlobalName);
         pastedStyle->setOriginalName(dstOriginalName);
-        if (dstType == LINKEDSTYLE) pastedStyle->setIsEditedFlag(true);
+        pastedStyle->setIsEditedFlag(dstType == LINKEDSTYLE);
 
         // put back the name
         page->getStyle(indexInPage)->setName(styleName);


### PR DESCRIPTION
This PR fixes a problem reproducible as follows:

1. Copy a style in a studio palette and paste it in a level palette. (The pasted style will become "linked" style.)
2. Modify color of the linked style. (The "edited" flag is set and a diagonal line appears.)
3. Copy the edited linked style.
4. Select another normal style and Paste Color.
5. Not only color, but also the edited flag is pasted. It is unwanted behavior.