### PR TITLE
Fix text color style inside some windows

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -195,6 +195,7 @@ QFrame {
   border: 0;
   margin: 0;
   padding: 0;
+  alternate-background-color: #d6d8dd;
 }
 QToolTip,
 #helpToolTip {

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -195,6 +195,7 @@ QFrame {
   border: 0;
   margin: 0;
   padding: 0;
+  alternate-background-color: #e6e6e6;
 }
 QToolTip,
 #helpToolTip {

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -195,6 +195,7 @@ QFrame {
   border: 0;
   margin: 0;
   padding: 0;
+  alternate-background-color: #e6e6e6;
 }
 QToolTip,
 #helpToolTip {

--- a/stuff/config/qss/Default/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Default/less/layouts/mainwindow.less
@@ -14,6 +14,7 @@ QFrame {
   border: 0;
   margin: 0;
   padding: 0;
+  alternate-background-color: @text-color;
 }
 
 QToolTip,

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -195,6 +195,7 @@ QFrame {
   border: 0;
   margin: 0;
   padding: 0;
+  alternate-background-color: #000;
 }
 QToolTip,
 #helpToolTip {

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -195,6 +195,7 @@ QFrame {
   border: 0;
   margin: 0;
   padding: 0;
+  alternate-background-color: #000;
 }
 QToolTip,
 #helpToolTip {


### PR DESCRIPTION
The change fix the text color inside the windows:

Canvas Size | Export Level | Convert to Vectors
---               | ---                | ---          
(Current Size, New Size and Anchor) | (Vectors Export Box and Vectors Thickness) | (Full color non-AA images)


 ## Preview - Linux
<p align="center">  <img src="https://user-images.githubusercontent.com/11843239/127062742-da6d6f91-3573-490d-9204-b7b491844b36.jpg" alt="fix style Linux" ></p>

## Preview - Windows 
![fix_style Windows 10](https://user-images.githubusercontent.com/11843239/127085556-69cd11ee-572d-4eb9-ac29-ddb5f4c4bc3c.jpg)


I found this problem when using window dark decoration with dark themes and light decoration with light themes. I tested it on Linux and Windows.
