### PR TITLE
Actions: Update Windows Runner

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -6,7 +6,7 @@ jobs:
   Windows:
     runs-on: windows-2019
     env:
-      vcpkg_ref: 1d8728ae1ba66ad94b344708cf8d0ace1a6330b8
+      vcpkg_ref: 111220b3cf3311744369425d5c323a0f17941076
       CLCACHE_CL: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30037/bin/Hostx64/x64/cl_original.exe'
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download


### PR DESCRIPTION
This PR updates Windows runner of Github Actions to resolve recent errors.

The error seems to be occurred due to incompatibility with the latest CMake (which is pre-installed in Windows runner) and the previous version of vcpkg (which is specified manually in our actions).
This PR moves the vcpkg version catching up with the latest one.

I've tested the [artifact ](https://github.com/shun-iwasawa/opentoonz/actions/runs/1069456404) and fortunately it seemed to launch with no problem.  