### PR TITLE
Change behavior of the Layer Blending Ino fxs when the background layer does not exist

### DIFF
--- a/toonz/sources/stdfx/ino_common.cpp
+++ b/toonz/sources/stdfx/ino_common.cpp
@@ -288,8 +288,12 @@ void TBlendForeBackRasterFx::doCompute(TTile& tile, double frame,
   /* ------ 画像生成 ---------------------------------------- */
   TRasterP dn_ras, up_ras;
   this->computeUpAndDown(tile, frame, rs, dn_ras, up_ras);
-  if (!dn_ras || !up_ras) {
+  if (!up_ras) {
     return;
+  }
+  // blend on the empty raster if the back port is not active
+  if (!dn_ras) {
+    dn_ras = tile.getRaster();
   }
   /* ------ 動作パラメータを得る ---------------------------- */
   const double up_opacity =
@@ -546,7 +550,11 @@ fxをreplaceすると、
   }
   /* ------ up接続かつdown切断の時 -------------------------- */
   if (up_is && !down_is) {
-    this->m_up->compute(tile, frame, rs);
+    TTile upTile;
+    this->m_up->allocateAndCompute(upTile, tile.m_pos,
+                                   tile.getRaster()->getSize(),
+                                   tile.getRaster(), frame, rs);
+    up_ras = upTile.getRaster();
     return;
   }
   /* ------ down接続時 downのみ描画して... ------------------ */


### PR DESCRIPTION
This PR modifies the behavior of all fxs in `Layer Blending Ino` category, when the background layer does not exist.

Here is an example:
![blending_ino_fix](https://user-images.githubusercontent.com/17974955/127966770-f6b987f5-ae60-414b-b86e-8645e2badbfc.png)

Before this PR, in such case OT renders the foreground layer in full opacity regardless of the blending mode or the opacity value.
With this PR, OT will blend the foreground layer over full-transparent background, with specified blending mode and the opacity value in order to make the fx more consistent through frames.   