### PR TITLE
Enable Inputting Frame with Suffix in Camera Capture

### DIFF
--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -2739,7 +2739,7 @@ void StopMotionController::onFileTypeActivated() {
 //-----------------------------------------------------------------------------
 
 void StopMotionController::onFrameNumberChanged() {
-  m_stopMotion->setFrameNumber(m_frameNumberEdit->getValue());
+  m_stopMotion->setFrameNumber(m_frameNumberEdit->getValue().getNumber());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/autoinputcellnumberpopup.cpp
+++ b/toonz/sources/toonz/autoinputcellnumberpopup.cpp
@@ -201,9 +201,9 @@ AutoInputCellNumberPopup::AutoInputCellNumberPopup()
              "AutoInputCellNumberPopup") {
   setWindowTitle(tr("Auto Input Cell Number"));
 
-  m_from      = new FrameNumberLineEdit(this);
+  m_from      = new FrameNumberLineEdit(this, TFrameId(1), false);
   m_increment = new DVGui::IntLineEdit(this, 0, 0);
-  m_to        = new FrameNumberLineEdit(this);
+  m_to        = new FrameNumberLineEdit(this, TFrameId(1), false);
   m_interval  = new DVGui::IntLineEdit(this, 0, 0);
   m_step      = new DVGui::IntLineEdit(this, 1, 1);
   m_repeat    = new DVGui::IntLineEdit(this, 1, 1);
@@ -306,8 +306,8 @@ void AutoInputCellNumberPopup::doExecute(bool overwrite) {
   }
   AutoInputCellNumberUndo *undo = new AutoInputCellNumberUndo(
       m_increment->getValue(), m_interval->getValue(), m_step->getValue(),
-      m_repeat->getValue(), m_from->getValue(), m_to->getValue(), r0, r1,
-      overwrite, columnIndices, levels);
+      m_repeat->getValue(), m_from->getValue().getNumber(),
+      m_to->getValue().getNumber(), r0, r1, overwrite, columnIndices, levels);
   // if no cells will be arranged, then return
   if (undo->rowsCount() == 0) {
     DVGui::MsgBox(DVGui::WARNING,

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -7,6 +7,7 @@
 #include "toonzqt/lineedit.h"
 #include "toonz/namebuilder.h"
 #include "opencv2/opencv.hpp"
+#include "tfilepath.h"
 
 #include <QAbstractVideoSurface>
 #include <QRunnable>
@@ -120,20 +121,20 @@ signals:
 class FrameNumberLineEdit : public DVGui::LineEdit {
   Q_OBJECT
   /* having two validators and switch them according to the preferences*/
-  QIntValidator* m_intValidator;
-  QRegExpValidator* m_regexpValidator;
+  QRegExpValidator *m_regexpValidator, *m_regexpValidator_alt;
 
   void updateValidator();
   QString m_textOnFocusIn;
 
 public:
-  FrameNumberLineEdit(QWidget* parent = 0, int value = 1);
+  FrameNumberLineEdit(QWidget* parent = 0, TFrameId fId = TFrameId(1),
+                      bool acceptLetter = true);
   ~FrameNumberLineEdit() {}
 
   /*! Set text in field to \b value. */
-  void setValue(int value);
+  void setValue(TFrameId fId);
   /*! Return an integer with text field value. */
-  int getValue();
+  TFrameId getValue();
 
 protected:
   /*! If focus is lost and current text value is out of range emit signal


### PR DESCRIPTION
This PR enables to input frame number with suffix (such as `0001a`) in Camera Capture popup, which is already available in most of other part of the software. 
Please note that the Stop Motion feature (i.e. camera capture without opening the popup) is not yet modified. 

![cameracapture_framesuffix](https://user-images.githubusercontent.com/17974955/128489817-a9c29f83-129b-4df9-ac90-a5e90ba19660.png)

