### PR TITLE
Fix margin bottom slider-v-handle

### DIFF
--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -276,14 +276,16 @@
 @slider-groove-img: 'slider-groove.svg';
 @slider-groove-img-disabled: 'slider-groove_disabled.svg';
 
+@slider-handle-margin: -2 -1;
 @slider-handle-width: 10;
 @slider-handle-img: 'slider-handle.svg';
 @slider-handle-img-disabled: 'slider-handle_disabled.svg';
+
+@slider-v-handle-margin: -1 -2;
 @slider-v-handle-img: 'slider-v-handle.svg';
 @slider-v-handle-img-disabled: 'slider-v-handle_disabled.svg';
 
 // This one is used only for #ViewerFpsSlider
-@slider-handle-margin: -2 -1;
 @slider-handle-bg-color: lighten(@bg, 35);
 @slider-handle-border-color: @slider-handle-bg-color;
 

--- a/stuff/config/qss/Default/less/layouts/controls.less
+++ b/stuff/config/qss/Default/less/layouts/controls.less
@@ -332,14 +332,14 @@ QGroupBox {
   &::handle{
     &:horizontal {
       margin: @slider-handle-margin;
-    width: @slider-handle-width;
-    image: url('@{img-url}/@{slider-handle-img}');
-    &:disabled {
-      image: url('@{img-url}/@{slider-handle-img-disabled}');
+      width: @slider-handle-width;
+      image: url('@{img-url}/@{slider-handle-img}');
+      &:disabled {
+        image: url('@{img-url}/@{slider-handle-img-disabled}');
       }
     }
     &:vertical {
-      margin: -1 -2;
+      margin: @slider-v-handle-margin;
       height: @slider-handle-width;
       image: url('@{img-url}/@{slider-v-handle-img}');
       &:disabled {

--- a/stuff/config/qss/Default/less/themes/Neutral.less
+++ b/stuff/config/qss/Default/less/themes/Neutral.less
@@ -146,8 +146,10 @@
 // Slider
 // -----------------------------------------------------------------------------
 
-// This one is used only for #ViewerFpsSlider
 @slider-handle-margin: -2 0;
+@slider-v-handle-margin: 0 -2;
+
+// This one is used only for #ViewerFpsSlider
 @slider-handle-bg-color: lighten(@bg, 15);
 @slider-handle-border-color: @accent;
 

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1229,7 +1229,7 @@ QSlider::handle:horizontal:disabled {
 }
 .Slider::handle:vertical,
 QSlider::handle:vertical {
-  margin: -1 -2;
+  margin: 0 -2;
   height: 10;
   image: url('../Default/imgs/black/slider-v-handle_light.svg');
 }

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1229,7 +1229,7 @@ QSlider::handle:horizontal:disabled {
 }
 .Slider::handle:vertical,
 QSlider::handle:vertical {
-  margin: -1 -2;
+  margin: 0 -2;
   height: 10;
   image: url('../Default/imgs/black/slider-v-handle.svg');
 }


### PR DESCRIPTION
Added @slider-v-handle-margin to pass the value as @slider-handle-margin in controls.less

![fix_slider](https://user-images.githubusercontent.com/11843239/129614137-32541b23-f07a-4d71-8358-5e24a8ff8271.jpg)

Fixed margin bottom of slider-v-handle.svg to Neutral and Light theme, respectively.


