### PR TITLE
Fix Bokeh Fxs Artifacts

### DIFF
--- a/toonz/sources/stdfx/iwa_bokeh_advancedfx.cpp
+++ b/toonz/sources/stdfx/iwa_bokeh_advancedfx.cpp
@@ -232,11 +232,12 @@ void Iwa_BokehAdvancedFx::doCompute(TTile& tile, double frame,
 
   // compute the input tiles
   QMap<int, TTile*> sourceTiles;
+  TRenderSettings infoOnInput(settings);
+  infoOnInput.m_bpp = 64;
   for (auto index : sourceIndices) {
     TTile* layerTile = new TTile();
     m_layerParams[index].m_source->allocateAndCompute(
-        *layerTile, _rectOut.getP00(), dimOut, tile.getRaster(), frame,
-        settings);
+        *layerTile, _rectOut.getP00(), dimOut, 0, frame, infoOnInput);
     sourceTiles[index] = layerTile;
   }
 

--- a/toonz/sources/stdfx/iwa_bokehfx.cpp
+++ b/toonz/sources/stdfx/iwa_bokehfx.cpp
@@ -136,11 +136,12 @@ void Iwa_BokehFx::doCompute(TTile& tile, double frame,
   //----------------------------
   // Compute the input tiles first
   QMap<int, TTile*> sourceTiles;
+  TRenderSettings infoOnInput(settings);
+  infoOnInput.m_bpp = 64;
   for (auto index : sourceIndices) {
     TTile* layerTile = new TTile();
     m_layerParams[index].m_source->allocateAndCompute(
-        *layerTile, _rectOut.getP00(), dimOut, tile.getRaster(), frame,
-        settings);
+        *layerTile, _rectOut.getP00(), dimOut, 0, frame, infoOnInput);
     sourceTiles[index] = layerTile;
   }
 

--- a/toonz/sources/stdfx/iwa_bokehreffx.cpp
+++ b/toonz/sources/stdfx/iwa_bokehreffx.cpp
@@ -148,11 +148,13 @@ void Iwa_BokehRefFx::doCompute(TTile& tile, double frame,
   // rasterList.append(allocateRasterAndLock<double4>(&source_buff, dimOut));
 
   LayerValue layerValue;
+  TRenderSettings infoOnInput(settings);
+  infoOnInput.m_bpp = 64;
   // source tile is used only in this focus.
   // normalized source image data is stored in source_buff.
   layerValue.sourceTile = new TTile();
   m_source->allocateAndCompute(*layerValue.sourceTile, rectOut.getP00(), dimOut,
-                               tile.getRaster(), frame, settings);
+                               0, frame, infoOnInput);
 
   // - - - iris image - - -
   // Get the original size of Iris image


### PR DESCRIPTION
This PR fixes artifacts appear in rendered result of Bokeh fxs (Bokeh Iwa, Bokeh Ref Iwa and Bokeh Advanced Iwa). 
As shown in  the following  image,  when the `Hardness` parameter is relatively small (like 0.2),  bright dots appears at the edge of the image.  The dot is more easy-to-find at the layer at the focus distance.
The artifacts appear only when rendering in 8bits per channel.

![bokeh_artifacts](https://user-images.githubusercontent.com/17974955/130547739-129380ba-194b-4b3e-a088-27494e62c86b.png)

The problem seems to be due to calculation accuracy. In the fx computation, the layer images are un-premultiplied (i.e. RGB values are divided by Alpha value). Calculation error becomes noticeable when rendered in 8bpc, especially at semi-transparent part with small alpha channel value. Small hardness value makes the error more prominent.
In order to fix the problem, this PR will make the fx to compute layer images always in 16bpc, regardless of the preview / render settings. 