### PR TITLE
Fix Autorenumber of Raster Level

### DIFF
--- a/toonz/sources/common/timage_io/tlevel_io.cpp
+++ b/toonz/sources/common/timage_io/tlevel_io.cpp
@@ -66,7 +66,7 @@ namespace {
 bool myLess(const TFilePath &l, const TFilePath &r) {
   return l.getFrame() < r.getFrame();
 }
-}
+}  // namespace
 
 //-----------------------------------------------------------
 
@@ -184,7 +184,7 @@ TLevelWriter::TLevelWriter(const TFilePath &path, TPropertyGroup *prop)
     , m_path(path)
     , m_properties(prop)
     , m_contentHistory(0) {
-  string ext              = path.getType();
+  string ext = path.getType();
   if (!prop) m_properties = Tiio::makeWriterProperties(ext);
 }
 
@@ -282,8 +282,12 @@ void TLevelWriter::renumberFids(const std::map<TFrameId, TFrameId> &table) {
           QString::fromStdWString(m_path.getParentDir().getWideString()));
       parentDir.setFilter(QDir::Files);
 
-      QStringList nameFilters(QString::fromStdWString(m_path.getWideName()) +
-                              ".*." + QString::fromStdString(m_path.getType()));
+      QStringList nameFilters;
+      // check for both period and underscore
+      nameFilters << QString::fromStdWString(m_path.getWideName()) + ".*." +
+                         QString::fromStdString(m_path.getType())
+                  << QString::fromStdWString(m_path.getWideName()) + "_*." +
+                         QString::fromStdString(m_path.getType());
       parentDir.setNameFilters(nameFilters);
 
       TFilePathSet fpset;

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2708,7 +2708,8 @@ static void dRenumberCells(int col, int r0, int r1) {
       TXshSimpleLevel *sl = cell.getSimpleLevel();
 
       TFrameId oldFid = cell.getFrameId();
-      TFrameId newFid = TFrameId(r + 1);
+      TFrameId newFid =
+          TFrameId(r + 1, 0, oldFid.getZeroPadding(), oldFid.getStartSeqInd());
 
       toCell.m_level   = sl;
       toCell.m_frameId = newFid;
@@ -2728,7 +2729,8 @@ static void dRenumberCells(int col, int r0, int r1) {
           it->first.getSimpleLevel()->isFid(it->second.getFrameId())) {
         TFrameId &fid = it->second.m_frameId;
         fid           = TFrameId(fid.getNumber(),
-                       fid.getLetter() ? fid.getLetter() + 1 : 'a');
+                       fid.getLetter() ? fid.getLetter() + 1 : 'a',
+                       fid.getZeroPadding(), fid.getStartSeqInd());
       }
     }
   }


### PR DESCRIPTION
This PR will fix following problems regarding the `Autorenumber` command applied to the raster level cells.

**To reproduce:**
1. Load `A_002.jpg` to frame 1 of column 1.
    ![autorenumber1](https://user-images.githubusercontent.com/17974955/130576665-804455a5-6515-44f1-8bcc-53bd06d862d5.png)
2. Select the cell, right-click and use `Autorenumber` command. (The frame will be renumbered from 2 to 1)
    ![autorenumber2](https://user-images.githubusercontent.com/17974955/130576731-26495fe3-92df-4f02-a393-641b3233b2ce.png)
3. Overwrite the level A. Check the level file.

The result is like this; there are 2 separate problems.
![autorenumber3](https://user-images.githubusercontent.com/17974955/130576759-410fc7b1-5591-4cd7-ae7b-5ae04d04c937.png)
- The frame number paddings are not consistent between the original frame and the renumbered frame. The file should be saved as `A_001.jpg` (with 3 digits frame) instead of `A_0001.jpg` (with 4 digits frame).
- The original file `A_002.jpg` is not deleted. It should be removed on overwriting the level.

This PR fixes both of the above problems.