### PR TITLE
Add Fx Global Controls

### DIFF
--- a/stuff/profiles/layouts/fxs/STD_externalPaletteFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_externalPaletteFx.xml
@@ -1,0 +1,4 @@
+<fxlayout>
+  <page name="External Palette">
+  </page>
+</fxlayout>

--- a/toonz/sources/include/tfxattributes.h
+++ b/toonz/sources/include/tfxattributes.h
@@ -36,6 +36,9 @@ class DVAPI TFxAttributes {
   // to maintain backward compatibility in the fx
   int m_fxVersion;
 
+  bool m_hasGlobalControl;
+  double m_globalIntensity;
+
 public:
   TFxAttributes();
   ~TFxAttributes();
@@ -67,6 +70,10 @@ public:
   void setFxVersion(int version) { m_fxVersion = version; }
   int getFxVersion() const { return m_fxVersion; };
 
+  void setHasGlobalControl(bool yes) { m_hasGlobalControl = yes; }
+  bool hasGlobalControl() const { return m_hasGlobalControl; }
+  void setGlobalIntensity(double val) { m_globalIntensity = val; }
+  double getGlobalIntensity() { return m_globalIntensity; }
   // Group management
 
   int setGroupId(int value);

--- a/toonz/sources/include/toonzqt/fxsettings.h
+++ b/toonz/sources/include/toonzqt/fxsettings.h
@@ -76,8 +76,9 @@ public:
   ParamsPage(QWidget *parent = 0, ParamViewer *paramViewer = 0);
   ~ParamsPage();
 
-  void setPage(TIStream &is, const TFxP &fx) {
+  void setPage(TIStream &is, const TFxP &fx, bool isFirstPage) {
     setPageField(is, fx);
+    if (isFirstPage) addGlobalControl(fx);
     setPageSpace();
   }
 
@@ -98,6 +99,7 @@ public:
 
 protected:
   void setPageField(TIStream &is, const TFxP &fx, bool isVertical = true);
+  void addGlobalControl(const TFxP &fx);
 
 public:
   void setPageSpace();

--- a/toonz/sources/stdfx/CMakeLists.txt
+++ b/toonz/sources/stdfx/CMakeLists.txt
@@ -85,6 +85,7 @@ set(HEADERS
     iwa_rainbowfx.h
     iwa_bokeh_advancedfx.h
     iwa_bokeh_util.h
+    globalcontrollablefx.h
 )
 
 if(OpenCV_FOUND)

--- a/toonz/sources/stdfx/adjustlevelsfx.cpp
+++ b/toonz/sources/stdfx/adjustlevelsfx.cpp
@@ -6,10 +6,11 @@
 #include "tpixelutils.h"
 #include "tparamset.h"
 #include "trop.h"
+#include "globalcontrollablefx.h"
 
 //===================================================================
 
-class AdjustLevelsFx final : public TStandardRasterFx {
+class AdjustLevelsFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(AdjustLevelsFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/stdfx/bright_contfx.cpp
+++ b/toonz/sources/stdfx/bright_contfx.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 #include "tfxparam.h"
 #include "tpixelutils.h"
+#include "globalcontrollablefx.h"
 
-class Bright_ContFx final : public TStandardRasterFx {
+class Bright_ContFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(Bright_ContFx)
 
   TRasterFxPort m_input;
@@ -60,7 +61,7 @@ void my_compute_lut(double contrast, double brightness, std::vector<T> &lut) {
       if (value > 0.5)
         nvalue = 1.0 - value;
       else
-        nvalue                 = value;
+        nvalue = value;
       if (nvalue < 0.0) nvalue = 0.0;
       nvalue = 0.5 * pow(nvalue * 2.0, (double)(1.0 + contrast));
       if (value > 0.5)
@@ -71,7 +72,7 @@ void my_compute_lut(double contrast, double brightness, std::vector<T> &lut) {
       if (value > 0.5)
         nvalue = 1.0 - value;
       else
-        nvalue                 = value;
+        nvalue = value;
       if (nvalue < 0.0) nvalue = 0.0;
       power = (contrast == 1.0) ? half_maxChannelValue : 1.0 / (1.0 - contrast);
       nvalue = 0.5 * pow(2.0 * nvalue, power);
@@ -119,11 +120,11 @@ void Bright_ContFx::doCompute(TTile &tile, double frame,
 
   m_input->compute(tile, frame, ri);
 
-  double brightness           = m_bright->getValue(frame) / 127.0;
-  double contrast             = m_contrast->getValue(frame) / 127.0;
-  if (contrast > 1) contrast  = 1;
+  double brightness = m_bright->getValue(frame) / 127.0;
+  double contrast   = m_contrast->getValue(frame) / 127.0;
+  if (contrast > 1) contrast = 1;
   if (contrast < -1) contrast = -1;
-  TRaster32P raster32         = tile.getRaster();
+  TRaster32P raster32 = tile.getRaster();
   if (raster32)
     doBrightnessContrast<TPixel32, UCHAR>(raster32, contrast, brightness);
   else {

--- a/toonz/sources/stdfx/channelmixerfx.cpp
+++ b/toonz/sources/stdfx/channelmixerfx.cpp
@@ -5,10 +5,11 @@
 //#include "trop.h"
 #include <math.h>
 #include "tpixelutils.h"
+#include "globalcontrollablefx.h"
 
 //==================================================================
 
-class ChannelMixerFx final : public TStandardRasterFx {
+class ChannelMixerFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ChannelMixerFx)
 
   TRasterFxPort m_input;
@@ -109,7 +110,7 @@ void depremult(PIXEL *pix) {
   pix->g           = (CHANNEL_TYPE)(pix->g * depremult);
   pix->b           = (CHANNEL_TYPE)(pix->b * depremult);
 }
-}
+}  // namespace
 
 template <typename PIXEL, typename CHANNEL_TYPE>
 void doChannelMixer(TRasterPT<PIXEL> ras, double r_r, double r_g, double r_b,

--- a/toonz/sources/stdfx/despecklefx.cpp
+++ b/toonz/sources/stdfx/despecklefx.cpp
@@ -9,9 +9,11 @@
 // TnzStdfx includes
 #include "stdfx.h"
 
+#include "globalcontrollablefx.h"
+
 //--------------------------------------------------------------------------
 
-class DespeckleFx final : public TStandardRasterFx {
+class DespeckleFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(DespeckleFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/stdfx/externalpalettefx.cpp
+++ b/toonz/sources/stdfx/externalpalettefx.cpp
@@ -8,10 +8,11 @@
 #include "toonz/txshcell.h"
 #include "toonz/txshsimplelevel.h"
 #include "toonz/txshpalettelevel.h"
+#include "globalcontrollablefx.h"
 
 //===================================================================
 
-class ExternalPaletteFx final : public TStandardRasterFx {
+class ExternalPaletteFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ExternalPaletteFx)
 
   TRasterFxPort m_input;
@@ -85,7 +86,7 @@ TPalette *getPalette(TFx *fx, double frame) {
 
   return 0;
 }
-}
+}  // namespace
 
 //-------------------------------------------------------------------
 

--- a/toonz/sources/stdfx/globalcontrollablefx.h
+++ b/toonz/sources/stdfx/globalcontrollablefx.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#ifndef GLOBALCONTROLLABLEFX_H
+#define GLOBALCONTROLLABLEFX_H
+
+#include "tfxparam.h"
+#include "stdfx.h"
+#include "tfxattributes.h"
+
+class GlobalControllableFx : public TStandardRasterFx {
+protected:
+  TDoubleParamP m_globalIntensity;
+
+public:
+  GlobalControllableFx() : m_globalIntensity(1.0) {
+    m_globalIntensity->setValueRange(0.0, 1.0);
+
+    bindParam(this, "globalIntensity", m_globalIntensity);
+    getAttributes()->setHasGlobalControl(true);
+    m_globalIntensity->setUILabel("Fx Intensity");
+  }
+
+  double getGrobalControlValue(double frame) {
+    return m_globalIntensity->getValue(frame);
+  }
+};
+
+#endif

--- a/toonz/sources/stdfx/hsvkeyfx.cpp
+++ b/toonz/sources/stdfx/hsvkeyfx.cpp
@@ -5,8 +5,9 @@
 #include <math.h>
 #include "stdfx.h"
 #include "hsvutil.h"
+#include "globalcontrollablefx.h"
 
-class HSVKeyFx final : public TStandardRasterFx {
+class HSVKeyFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(HSVKeyFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/stdfx/hsvscalefx.cpp
+++ b/toonz/sources/stdfx/hsvscalefx.cpp
@@ -5,8 +5,9 @@
 #include <math.h>
 #include "stdfx.h"
 #include "hsvutil.h"
+#include "globalcontrollablefx.h"
 
-class HSVScaleFx final : public TStandardRasterFx {
+class HSVScaleFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(HSVScaleFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/stdfx/ino_hls_add.cpp
+++ b/toonz/sources/stdfx/ino_hls_add.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_hls_add final : public TStandardRasterFx {
+class ino_hls_add final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_hls_add)
   TRasterFxPort m_input;
   TRasterFxPort m_noise;
@@ -117,7 +118,8 @@ void fx_(TRasterP in_ras, const TRasterP noise_ras, const TRasterP refer_ras,
           ,
       in_ras->getLy(), in_ras->getLx()  // Not use in_ras->getWrap()
       ,
-      ino::channels(), ino::bits(in_ras)
+      ino::channels(),
+      ino::bits(in_ras)
 
       //,noise_ras->getRawData() // BGRA
       //,&refer_vec.at(0) // RGBA
@@ -151,7 +153,7 @@ void fx_(TRasterP in_ras, const TRasterP noise_ras, const TRasterP refer_ras,
   noise_gr8->unlock();
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_hls_add::doCompute(TTile &tile, double frame,
                             const TRenderSettings &rend_sets) {
@@ -199,7 +201,7 @@ void ino_hls_add::doCompute(TTile &tile, double frame,
                     tile.getRaster()->getLx(),
                     tile.getRaster()
                         ->getLy()) /* ここtile.getRaster()->getSize()と同じ、将来修正する
-                                      */
+                                    */
         ,
         tile.getRaster(), frame, rend_sets);
   }
@@ -237,7 +239,7 @@ void ino_hls_add::doCompute(TTile &tile, double frame,
         ,
         xoffset, yoffset, from_rgba, offset, hue_scale, lig_scale, sat_scale,
         alp_scale, anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->unlock();
     }

--- a/toonz/sources/stdfx/ino_hls_adjust.cpp
+++ b/toonz/sources/stdfx/ino_hls_adjust.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_hls_adjust final : public TStandardRasterFx {
+class ino_hls_adjust final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_hls_adjust)
   TRasterFxPort m_input;
   TRasterFxPort m_refer;
@@ -124,7 +125,8 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
 
       ,
       hue_pivot, hue_scale, hue_shift, lig_pivot, lig_scale, lig_shift,
-      sat_pivot, sat_scale, sat_shift
+      sat_pivot, sat_scale,
+      sat_shift
 
       //,true	/* add_blend_sw */
       ,
@@ -135,7 +137,7 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_hls_adjust::doCompute(TTile &tile, double frame,
                                const TRenderSettings &rend_sets) {
@@ -215,7 +217,7 @@ void ino_hls_adjust::doCompute(TTile &tile, double frame,
         hue_scale, hue_shift, lig_pivot, lig_scale, lig_shift, sat_pivot,
         sat_scale, sat_shift,
         anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->unlock();
     }

--- a/toonz/sources/stdfx/ino_hls_noise.cpp
+++ b/toonz/sources/stdfx/ino_hls_noise.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_hls_noise final : public TStandardRasterFx {
+class ino_hls_noise final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_hls_noise)
   TRasterFxPort m_input;
   TRasterFxPort m_refer;
@@ -150,7 +151,7 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_hls_noise::doCompute(TTile &tile, double frame,
                               const TRenderSettings &rend_sets) {
@@ -203,7 +204,7 @@ void ino_hls_noise::doCompute(TTile &tile, double frame,
   if ((0 <= margin_h && 0 < margin_w)    /* 横方向のみ余白あり */
       || (0 < margin_h && 0 <= margin_w) /* 縦方向のみ余白あり */
       || (0 < margin_h && 0 < margin_w)  /* 縦横両方に余白あり */
-      ) {
+  ) {
     /*camera_x = static_cast<int>(ceil((double)margin_w / 2.));
     camera_y = static_cast<int>(ceil((double)margin_h / 2.));*/
     camera_x = margin_w / 2;
@@ -263,7 +264,7 @@ void ino_hls_noise::doCompute(TTile &tile, double frame,
         hue_range, lig_range, sat_range, mat_range, random_seed, near_blur,
         term_effective, term_center, term_type, camera_x, camera_y, camera_w,
         camera_h, anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->unlock();
     }

--- a/toonz/sources/stdfx/ino_hsv_add.cpp
+++ b/toonz/sources/stdfx/ino_hsv_add.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_hsv_add final : public TStandardRasterFx {
+class ino_hsv_add final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_hsv_add)
   TRasterFxPort m_input;
   TRasterFxPort m_noise;
@@ -120,7 +121,8 @@ void fx_(TRasterP in_ras, const TRasterP noise_ras, const TRasterP refer_ras,
           ,
       in_ras->getLy(), in_ras->getLx()  // Not use in_ras->getWrap()
       ,
-      ino::channels(), ino::bits(in_ras)
+      ino::channels(),
+      ino::bits(in_ras)
 
       //,noise_ras->getRawData() // BGRA
       //,&refer_vec.at(0) // RGBA
@@ -154,7 +156,7 @@ void fx_(TRasterP in_ras, const TRasterP noise_ras, const TRasterP refer_ras,
   noise_gr8->unlock();
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_hsv_add::doCompute(TTile &tile, double frame,
                             const TRenderSettings &rend_sets) {
@@ -236,7 +238,7 @@ void ino_hsv_add::doCompute(TTile &tile, double frame,
         ,
         xoffset, yoffset, from_rgba, offset, hue_scale, sat_scale, val_scale,
         alp_scale, anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->unlock();
     }

--- a/toonz/sources/stdfx/ino_hsv_adjust.cpp
+++ b/toonz/sources/stdfx/ino_hsv_adjust.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_hsv_adjust final : public TStandardRasterFx {
+class ino_hsv_adjust final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_hsv_adjust)
   TRasterFxPort m_input;
   TRasterFxPort m_refer;
@@ -124,7 +125,8 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
 
       ,
       hue_pivot, hue_scale, hue_shift, sat_pivot, sat_scale, sat_shift,
-      val_pivot, val_scale, val_shift
+      val_pivot, val_scale,
+      val_shift
 
       //,true	/* add_blend_sw */
       ,
@@ -135,7 +137,7 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_hsv_adjust::doCompute(TTile &tile, double frame,
                                const TRenderSettings &rend_sets) {
@@ -216,7 +218,7 @@ void ino_hsv_adjust::doCompute(TTile &tile, double frame,
         hue_scale, hue_shift, sat_pivot, sat_scale, sat_shift, val_pivot,
         val_scale, val_shift,
         anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->unlock();
     }

--- a/toonz/sources/stdfx/ino_hsv_noise.cpp
+++ b/toonz/sources/stdfx/ino_hsv_noise.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_hsv_noise final : public TStandardRasterFx {
+class ino_hsv_noise final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_hsv_noise)
   TRasterFxPort m_input;
   TRasterFxPort m_refer;
@@ -152,7 +153,7 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_hsv_noise::doCompute(TTile &tile, double frame,
                               const TRenderSettings &rend_sets) {
@@ -205,7 +206,7 @@ void ino_hsv_noise::doCompute(TTile &tile, double frame,
   if ((0 <= margin_h && 0 < margin_w)    /* 横方向のみ余白あり */
       || (0 < margin_h && 0 <= margin_w) /* 縦方向のみ余白あり */
       || (0 < margin_h && 0 < margin_w)  /* 縦横両方に余白あり */
-      ) {
+  ) {
     /*camera_x = static_cast<int>(ceil((double)margin_w / 2.));
     camera_y = static_cast<int>(ceil((double)margin_h / 2.));*/
     camera_x = margin_w / 2;
@@ -265,7 +266,7 @@ void ino_hsv_noise::doCompute(TTile &tile, double frame,
         hue_range, sat_range, val_range, mat_range, random_seed, near_blur,
         term_effective, term_center, term_type, camera_x, camera_y, camera_w,
         camera_h, anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->unlock();
     }

--- a/toonz/sources/stdfx/ino_level_auto.cpp
+++ b/toonz/sources/stdfx/ino_level_auto.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_level_auto final : public TStandardRasterFx {
+class ino_level_auto final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_level_auto)
   TRasterFxPort m_input;
   TDoubleParamP m_in_min_shift;
@@ -86,7 +87,7 @@ void fx_(TRasterP in_ras, bool *act_sw, double *in_min_shift,
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_level_auto::doCompute(TTile &tile, double frame,
                                const TRenderSettings &rend_sets) {
@@ -133,7 +134,7 @@ void ino_level_auto::doCompute(TTile &tile, double frame,
   if ((0 <= margin_h && 0 < margin_w)    /* 横方向のみ余白あり */
       || (0 < margin_h && 0 <= margin_w) /* 縦方向のみ余白あり */
       || (0 < margin_h && 0 < margin_w)  /* 縦横両方に余白あり */
-      ) {
+  ) {
     /*camera_x = static_cast<int>(ceil((double)margin_w / 2.));
     camera_y = static_cast<int>(ceil((double)margin_h / 2.));*/
     camera_x = margin_w / 2;

--- a/toonz/sources/stdfx/ino_level_master.cpp
+++ b/toonz/sources/stdfx/ino_level_master.cpp
@@ -4,8 +4,9 @@
 #include "tparamset.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_level_master final : public TStandardRasterFx {
+class ino_level_master final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_level_master)
   TRasterFxPort m_input;
   TRasterFxPort m_refer;
@@ -175,7 +176,7 @@ void ino_level_master::doCompute(TTile &tile, double frame,
         true  // clamp_sw
         ,
         alp_rend_sw, anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
 
     ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
 

--- a/toonz/sources/stdfx/ino_level_rgba.cpp
+++ b/toonz/sources/stdfx/ino_level_rgba.cpp
@@ -4,8 +4,9 @@
 #include "tparamset.h"
 
 #include "ino_common.h"
+#include "globalcontrollablefx.h"
 //------------------------------------------------------------
-class ino_level_rgba final : public TStandardRasterFx {
+class ino_level_rgba final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_level_rgba)
   TRasterFxPort m_input;
   TRasterFxPort m_refer;
@@ -270,7 +271,7 @@ void ino_level_rgba::doCompute(TTile &tile, double frame,
         true  // alpha_rendering_sw
         ,
         anti_alias_sw  // --> add_blend_sw, default is true
-        );
+    );
 
     ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
 

--- a/toonz/sources/stdfx/ino_negate.cpp
+++ b/toonz/sources/stdfx/ino_negate.cpp
@@ -2,9 +2,10 @@
 #include "tfxparam.h"
 #include "stdfx.h"
 
+#include "globalcontrollablefx.h"
 #include "ino_common.h"
 //------------------------------------------------------------
-class ino_negate final : public TStandardRasterFx {
+class ino_negate final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ino_negate)
   TRasterFxPort m_input;
   TBoolParamP m_red;
@@ -68,7 +69,7 @@ void fx_(TRasterP in_ras, const bool sw_array[4]) {
   ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_negate::doCompute(TTile &tile, double frame,
                            const TRenderSettings &rend_sets) {

--- a/toonz/sources/stdfx/multitonefx.cpp
+++ b/toonz/sources/stdfx/multitonefx.cpp
@@ -3,8 +3,9 @@
 #include "stdfx.h"
 #include "tfxparam.h"
 #include "tspectrumparam.h"
+#include "globalcontrollablefx.h"
 
-class MultiToneFx final : public TStandardRasterFx {
+class MultiToneFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(MultiToneFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/stdfx/palettefilterfx.cpp
+++ b/toonz/sources/stdfx/palettefilterfx.cpp
@@ -3,10 +3,11 @@
 #include "stdfx.h"
 #include "tfxparam.h"
 #include "ttzpimagefx.h"
+#include "globalcontrollablefx.h"
 
 //===================================================================
 
-class PaletteFilterFx final : public TStandardRasterFx {
+class PaletteFilterFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(PaletteFilterFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/stdfx/rgbkeyfx.cpp
+++ b/toonz/sources/stdfx/rgbkeyfx.cpp
@@ -6,8 +6,9 @@
 #include "stdfx.h"
 
 #include "tparamset.h"
+#include "globalcontrollablefx.h"
 
-class RGBKeyFx final : public TStandardRasterFx {
+class RGBKeyFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(RGBKeyFx)
 
   TRasterFxPort m_input;
@@ -61,7 +62,7 @@ void update_param(int &param, TRaster64P ras) {
   param = param * 257;
   return;
 }
-}
+}  // namespace
 
 //-------------------------------------------------------------------
 

--- a/toonz/sources/stdfx/rgbmcutfx.cpp
+++ b/toonz/sources/stdfx/rgbmcutfx.cpp
@@ -5,8 +5,9 @@
 #include "tpixelutils.h"
 
 #include "tparamset.h"
+#include "globalcontrollablefx.h"
 
-class RGBMCutFx final : public TStandardRasterFx {
+class RGBMCutFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(RGBMCutFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/stdfx/rgbmscalefx.cpp
+++ b/toonz/sources/stdfx/rgbmscalefx.cpp
@@ -4,10 +4,11 @@
 #include "tfxparam.h"
 #include "texception.h"
 #include "stdfx.h"
+#include "globalcontrollablefx.h"
 
 //===================================================================
 
-class RGBMScaleFx final : public TStandardRasterFx {
+class RGBMScaleFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(RGBMScaleFx)
   TRasterFxPort m_input;
   TDoubleParamP m_red;

--- a/toonz/sources/stdfx/tonecurvefx.cpp
+++ b/toonz/sources/stdfx/tonecurvefx.cpp
@@ -6,6 +6,7 @@
 #include "tparamset.h"
 #include "ttonecurveparam.h"
 #include "tcurves.h"
+#include "globalcontrollablefx.h"
 
 //===================================================================
 
@@ -108,7 +109,7 @@ void fill_lut(QList<TPointD> points, std::vector<T> &lut, bool isLinear) {
 
 //===================================================================
 
-class ToneCurveFx final : public TStandardRasterFx {
+class ToneCurveFx final : public GlobalControllableFx {
   FX_PLUGIN_DECLARATION(ToneCurveFx)
 
   TRasterFxPort m_input;

--- a/toonz/sources/tnzbase/tfxattributes.cpp
+++ b/toonz/sources/tnzbase/tfxattributes.cpp
@@ -14,7 +14,8 @@ TFxAttributes::TFxAttributes()
     , m_speed()
     , m_groupSelector(-1)
     , m_passiveCacheDataIdx(-1)
-    , m_fxVersion(1) {}
+    , m_fxVersion(1)
+    , m_hasGlobalControl(false) {}
 
 //----------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -33,8 +33,11 @@
 
 #include "../stdfx/motionawarebasefx.h"
 #include "../stdfx/textawarebasefx.h"
+#include "../stdfx/globalcontrollablefx.h"
 
 #include "toonz/scenefx.h"
+
+#include <QList>
 
 /*
   TODO: Some parts of the following render-tree building procedure should be
@@ -548,6 +551,8 @@ public:
   // (at least) of a particle Fx
   int m_particleDescendentCount;
 
+  QList<std::wstring> m_globalControlledFx;
+
 public:
   FxBuilder(ToonzScene *scene, TXsheet *xsh, double frame, int whichLevels,
             bool isPreview = false, bool expandXSheet = true);
@@ -1000,6 +1005,24 @@ PlacedFx FxBuilder::makePFfromUnaryFx(TFx *fx) {
   TFx *inputFx = fx->getInputPort(0)->getFx();
   if (!inputFx) return PlacedFx();
 
+  // global controllable fx
+  if (fx->getAttributes()->hasGlobalControl() &&
+      !m_globalControlledFx.contains(fx->getFxId())) {
+    GlobalControllableFx *gcFx = dynamic_cast<GlobalControllableFx *>(fx);
+    double val                 = gcFx->getGrobalControlValue(m_frame);
+    if (val < 1.0) {
+      m_globalControlledFx.append(fx->getFxId());
+      // insert cross disolve fx and mix with the input fx
+      TFxP blendFx = TFx::create("blendFx");
+      blendFx->connect("Source1", fx);
+      blendFx->connect("Source2", inputFx);
+      // set the global intensity value to the cross disolve fx
+      dynamic_cast<TDoubleParam *>(blendFx->getParams()->getParam("value"))
+          ->setDefaultValue(val * 100.0);
+      return makePF(blendFx.getPointer());
+    }
+  }
+
   PlacedFx pf = makePF(inputFx);  // Build sub-render-tree
   if (!pf.m_fx) return PlacedFx();
 
@@ -1064,6 +1087,26 @@ PlacedFx FxBuilder::makePFfromGenericFx(TFx *fx) {
     if (inputFx) return makePF(inputFx.getPointer());
 
     return pf;
+  }
+
+  // global controllable fx
+  if (fx->getAttributes()->hasGlobalControl() &&
+      !m_globalControlledFx.contains(fx->getFxId())) {
+    GlobalControllableFx *gcFx = dynamic_cast<GlobalControllableFx *>(fx);
+    double val                 = gcFx->getGrobalControlValue(m_frame);
+    if (val < 1.0) {
+      TFxP inputFx = fx->getInputPort(fx->getPreferredInputPort())->getFx();
+      if (!inputFx) return pf;
+      m_globalControlledFx.append(fx->getFxId());
+      // insert cross disolve fx and mix with the input fx
+      TFxP blendFx = TFx::create("blendFx");
+      blendFx->connect("Source1", fx);
+      blendFx->connect("Source2", inputFx.getPointer());
+      // set the global intensity value to the cross disolve fx
+      dynamic_cast<TDoubleParam *>(blendFx->getParams()->getParam("value"))
+          ->setDefaultValue(val * 100.0);
+      return makePF(blendFx.getPointer());
+    }
   }
 
   // Multi-input fxs are always cloned - since at least one of its input ports

--- a/toonz/sources/toonzlib/txsheetexpr.cpp
+++ b/toonz/sources/toonzlib/txsheetexpr.cpp
@@ -423,6 +423,20 @@ public:
       if (paramName == paramNameToCheck ||
           toLower(paramName) == toLower(paramNameToCheck))
         return param;
+
+      // in case the parameter has ui label
+      // ( paramters of plugin fxs and intensity of GlobalControllableFx)
+      if (param->hasUILabel()) {
+        paramName = param->getUILabel();
+        int i     = paramName.find_first_of(" -");
+        while (i != std::string::npos) {
+          paramName.erase(i, 1);
+          i = paramName.find_first_of(" -");
+        }
+        if (paramName == paramNameToCheck ||
+            toLower(paramName) == toLower(paramNameToCheck))
+          return param;
+      }
     }
     return 0;
   }

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -680,8 +680,12 @@ void FunctionTreeModel::Channel::setParam(const TParamP &param) {
 /*! in order to show the expression name in the tooltip
  */
 QString FunctionTreeModel::Channel::getExprRefName() const {
-  QString tmpName = QString(QString::fromStdWString(
-      TStringTable::translate(m_paramNamePref + m_param->getName())));
+  QString tmpName;
+  if (m_param->hasUILabel())
+    tmpName = QString::fromStdString(m_param->getUILabel());
+  else
+    tmpName = QString::fromStdWString(
+        TStringTable::translate(m_paramNamePref + m_param->getName()));
   /*--- stage
    * objectパラメータの場合、TableにあわせてtmpNameを代表的なExpression名にする---*/
   StageObjectChannelGroup *stageGroup =


### PR DESCRIPTION
This PR will add a new parameter "Fx intensity" to several fxs for controlling amount of intensity.

Some fxs (listed below) now inherits `GlobalControllableFx` class which has the "Fx intensity" parameter.
When rendering, the Cross Dissolve Fx will be inserted just after the fx and the "Fx intensity" parameter will work as mixture amount between the result of the fx and its input. The Cross Dissolve Fx is created internally just for rendering computation and is invisible from users.
<img src="https://user-images.githubusercontent.com/17974955/132157729-0ee0c604-d6bb-4bc9-a84e-8f2ca9b523da.png" width=500>

The parameter will be added to the following fxs:

**Image_Adjust**
- Adjust Levels
- Brightness Contrast
- Channel Mixer
- Curves
- Despeckle
- HLS Add Ino
- HLS Adjust Ino
- HSV Add Ino
- HSV Adjust Ino
- HSV Scale Ino
- Level Auto Ino
- Level Master Ino
- Level RGBA Ino
- Multi Tone
- Negate Ino
- RGBA Cut
- RGBA Scale

**Matte**
- HSV Key
- RGB Key

**Noise**
- HLS Noise Ino
- HSV Noise Ino

**Toonz_Level**
- External Palette ( This resolves the second request in #3776 )
- Palette Filter
