### PR TITLE
Fix channel clamping behavior in Layer Blending Fxs 

### DIFF
--- a/toonz/sources/stdfx/igs_color_blend.cpp
+++ b/toonz/sources/stdfx/igs_color_blend.cpp
@@ -200,12 +200,11 @@ double overlay_ch_(const double dn, const double dn_a, const double up,
       dn, dn_a, up, up_a, up_opacity);
 }
 double soft_light_(const double dn, const double up) {
-  return (
-      (up < 0.5)
-          ? (dn + (dn - dn * dn) * (2 * up - 1))
-          : ((dn < 0.25)
-                 ? (dn + (2 * up - 1) * (((16 * dn - 12) * dn + 4) * dn - dn))
-                 : (dn + (2 * up - 1) * (sqrt(dn) - dn))));
+  return ((up < 0.5)
+              ? (dn + (dn - dn * dn) * (2 * up - 1))
+              : ((dn < 0.25) ? (dn + (2 * up - 1) *
+                                         (((16 * dn - 12) * dn + 4) * dn - dn))
+                             : (dn + (2 * up - 1) * (sqrt(dn) - dn))));
 }
 double soft_light_ch_(const double dn, const double dn_a, const double up,
                       const double up_a, const double up_opacity) {
@@ -268,12 +267,12 @@ R,G,Bそれぞれの値に、重み付けをして3で割り、
   return (0.298912 * dn_r + 0.586611 * dn_g + 0.114478 * dn_b) <
          (0.298912 * up_r + 0.586611 * up_g + 0.114478 * up_b);
 }
-}
+}  // namespace
 //--------------------------------------------------------------------
 // 01
 void igs::color::over(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                       const double up_r, double up_g, double up_b, double up_a,
-                      const double up_opacity) {
+                      const double up_opacity, const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -288,12 +287,16 @@ void igs::color::over(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
   dn_b = up_add_dn_ch_(dn_b, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 02
 void igs::color::darken(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                         const double up_r, double up_g, double up_b,
-                        double up_a, const double up_opacity) {
+                        double up_a, const double up_opacity,
+                        const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -308,12 +311,16 @@ void igs::color::darken(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
   dn_b = darken_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 03
 void igs::color::multiply(double &dn_r, double &dn_g, double &dn_b,
                           double &dn_a, const double up_r, double up_g,
-                          double up_b, double up_a, const double up_opacity) {
+                          double up_b, double up_a, const double up_opacity,
+                          const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -333,13 +340,17 @@ void igs::color::multiply(double &dn_r, double &dn_g, double &dn_b,
   dn_b = multiply_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 04
 void igs::color::color_burn(/* 焼き込みカラー */
                             double &dn_r, double &dn_g, double &dn_b,
                             double &dn_a, const double up_r, double up_g,
-                            double up_b, double up_a, const double up_opacity) {
+                            double up_b, double up_a, const double up_opacity,
+                            const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -354,14 +365,17 @@ void igs::color::color_burn(/* 焼き込みカラー */
   dn_b = color_burn_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 05
 void igs::color::linear_burn(/* 焼き込みリニア */
                              double &dn_r, double &dn_g, double &dn_b,
                              double &dn_a, const double up_r, double up_g,
-                             double up_b, double up_a,
-                             const double up_opacity) {
+                             double up_b, double up_a, const double up_opacity,
+                             const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -376,13 +390,16 @@ void igs::color::linear_burn(/* 焼き込みリニア */
   dn_b = linear_burn_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 06
 void igs::color::darker_color(double &dn_r, double &dn_g, double &dn_b,
                               double &dn_a, const double up_r, double up_g,
-                              double up_b, double up_a,
-                              const double up_opacity) {
+                              double up_b, double up_a, const double up_opacity,
+                              const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -399,12 +416,16 @@ void igs::color::darker_color(double &dn_r, double &dn_g, double &dn_b,
   dn_b = darker_color_ch_(dn_b, dn_a, up_b, up_a, up_opacity, up_lt_sw);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 07
 void igs::color::lighten(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                          const double up_r, double up_g, double up_b,
-                         double up_a, const double up_opacity) {
+                         double up_a, const double up_opacity,
+                         const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -419,12 +440,16 @@ void igs::color::lighten(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
   dn_b = lighten_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 08
 void igs::color::screen(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                         const double up_r, double up_g, double up_b,
-                        double up_a, const double up_opacity) {
+                        double up_a, const double up_opacity,
+                        const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -439,14 +464,17 @@ void igs::color::screen(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
   dn_b = screen_(dn_b, up_b * up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 09
 void igs::color::color_dodge(/* 覆い焼きカラー */
                              double &dn_r, double &dn_g, double &dn_b,
                              double &dn_a, const double up_r, double up_g,
-                             double up_b, double up_a,
-                             const double up_opacity) {
+                             double up_b, double up_a, const double up_opacity,
+                             const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -461,14 +489,17 @@ void igs::color::color_dodge(/* 覆い焼きカラー */
   dn_b = color_dodge_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 10
 void igs::color::linear_dodge(/* 覆い焼きリニア(単純加算ではない) */
                               double &dn_r, double &dn_g, double &dn_b,
                               double &dn_a, const double up_r, double up_g,
-                              double up_b, double up_a,
-                              const double up_opacity) {
+                              double up_b, double up_a, const double up_opacity,
+                              const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -483,13 +514,16 @@ void igs::color::linear_dodge(/* 覆い焼きリニア(単純加算ではない)
   dn_b = linear_dodge_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 11
 void igs::color::lighter_color(double &dn_r, double &dn_g, double &dn_b,
                                double &dn_a, const double up_r, double up_g,
                                double up_b, double up_a,
-                               const double up_opacity) {
+                               const double up_opacity, const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -506,12 +540,16 @@ void igs::color::lighter_color(double &dn_r, double &dn_g, double &dn_b,
   dn_b = lighter_color_ch_(dn_b, dn_a, up_b, up_a, up_opacity, up_lt_sw);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 12
 void igs::color::overlay(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                          const double up_r, double up_g, double up_b,
-                         double up_a, const double up_opacity) {
+                         double up_a, const double up_opacity,
+                         const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -526,12 +564,16 @@ void igs::color::overlay(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
   dn_b = overlay_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 13
 void igs::color::soft_light(double &dn_r, double &dn_g, double &dn_b,
                             double &dn_a, const double up_r, double up_g,
-                            double up_b, double up_a, const double up_opacity) {
+                            double up_b, double up_a, const double up_opacity,
+                            const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -546,12 +588,16 @@ void igs::color::soft_light(double &dn_r, double &dn_g, double &dn_b,
   dn_b = soft_light_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 14
 void igs::color::hard_light(double &dn_r, double &dn_g, double &dn_b,
                             double &dn_a, const double up_r, double up_g,
-                            double up_b, double up_a, const double up_opacity) {
+                            double up_b, double up_a, const double up_opacity,
+                            const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -566,13 +612,16 @@ void igs::color::hard_light(double &dn_r, double &dn_g, double &dn_b,
   dn_b = hard_light_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 15
 void igs::color::vivid_light(double &dn_r, double &dn_g, double &dn_b,
                              double &dn_a, const double up_r, double up_g,
-                             double up_b, double up_a,
-                             const double up_opacity) {
+                             double up_b, double up_a, const double up_opacity,
+                             const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -587,13 +636,16 @@ void igs::color::vivid_light(double &dn_r, double &dn_g, double &dn_b,
   dn_b = vivid_light_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 16
 void igs::color::linear_light(double &dn_r, double &dn_g, double &dn_b,
                               double &dn_a, const double up_r, double up_g,
-                              double up_b, double up_a,
-                              const double up_opacity) {
+                              double up_b, double up_a, const double up_opacity,
+                              const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -608,12 +660,16 @@ void igs::color::linear_light(double &dn_r, double &dn_g, double &dn_b,
   dn_b = linear_light_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 17
 void igs::color::pin_light(double &dn_r, double &dn_g, double &dn_b,
                            double &dn_a, const double up_r, double up_g,
-                           double up_b, double up_a, const double up_opacity) {
+                           double up_b, double up_a, const double up_opacity,
+                           const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -628,12 +684,16 @@ void igs::color::pin_light(double &dn_r, double &dn_g, double &dn_b,
   dn_b = pin_light_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 18
 void igs::color::hard_mix(double &dn_r, double &dn_g, double &dn_b,
                           double &dn_a, const double up_r, double up_g,
-                          double up_b, double up_a, const double up_opacity) {
+                          double up_b, double up_a, const double up_opacity,
+                          const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -648,7 +708,10 @@ void igs::color::hard_mix(double &dn_r, double &dn_g, double &dn_b,
   dn_b = hard_mix_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 //------------------------------------------------------------------------
 namespace {
@@ -656,12 +719,12 @@ double cross_dissolve_ch_(const double dn, const double up,
                           const double up_opacity) {
   return dn * (1.0 - up_opacity) + up * up_opacity;
 }
-}
+}  // namespace
 // 19
 void igs::color::cross_dissolve(double &dn_r, double &dn_g, double &dn_b,
                                 double &dn_a, const double up_r, double up_g,
                                 double up_b, double up_a,
-                                const double up_opacity) {
+                                const double up_opacity, const bool do_clamp) {
   if ((up_a <= 0) && (dn_a <= 0)) {
     return;
   } /* up/dnとも透明ならdn値を表示 */
@@ -672,13 +735,16 @@ void igs::color::cross_dissolve(double &dn_r, double &dn_g, double &dn_b,
   dn_b = cross_dissolve_ch_(dn_b, up_b, up_opacity);
   dn_a = cross_dissolve_ch_(dn_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 20
 void igs::color::subtract(double &dn_r, double &dn_g, double &dn_b,
                           double &dn_a, const double up_r, double up_g,
                           double up_b, double up_a, const double up_opacity,
-                          const bool alpha_rendering_sw) {
+                          const bool alpha_rendering_sw, const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -696,13 +762,16 @@ void igs::color::subtract(double &dn_r, double &dn_g, double &dn_b,
     dn_a -= up_a * up_opacity;
   }
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 21
 void igs::color::add(/* 覆い焼きリニア */
                      double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                      const double up_r, double up_g, double up_b, double up_a,
-                     const double up_opacity) {
+                     const double up_opacity, const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -718,12 +787,16 @@ void igs::color::add(/* 覆い焼きリニア */
   dn_b += up_b * up_opacity;
   dn_a += up_a * up_opacity;
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }
 // 22
 void igs::color::divide(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                         const double up_r, double up_g, double up_b,
-                        double up_a, const double up_opacity) {
+                        double up_a, const double up_opacity,
+                        const bool do_clamp) {
   if (up_a <= 0) {
     return;
   }                /* upが透明のときはdown値を表示 */
@@ -738,5 +811,8 @@ void igs::color::divide(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
   dn_b = divide_ch_(dn_b, dn_a, up_b, up_a, up_opacity);
   dn_a = up_add_dn_ch_(dn_a, up_a, up_a, up_opacity);
 
-  clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  if (do_clamp)
+    clamp_rgba_(dn_r, dn_g, dn_b, dn_a); /* 0と1で範囲制限 */
+  else
+    dn_a = clamp_ch_(dn_a);
 }

--- a/toonz/sources/stdfx/igs_color_blend.h
+++ b/toonz/sources/stdfx/igs_color_blend.h
@@ -9,97 +9,98 @@ namespace color {
 void over(/* アルファ合成（通常) */
           double &dn_r, double &dn_g, double &dn_b, double &dn_a,
           const double up_r, double up_g, double up_b, double up_a,
-          const double up_opacity);
+          const double up_opacity, const bool do_clamp = true);
 // 02
 void darken(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
             const double up_r, double up_g, double up_b, double up_a,
-            const double up_opacity);
+            const double up_opacity, const bool do_clamp = true);
 // 03
 void multiply(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
               const double up_r, double up_g, double up_b, double up_a,
-              const double up_opacity);
+              const double up_opacity, const bool do_clamp = true);
 // 04
 void color_burn(/* 焼き込みカラー */
                 double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                 const double up_r, double up_g, double up_b, double up_a,
-                const double up_opacity);
+                const double up_opacity, const bool do_clamp = true);
 // 05
 void linear_burn(/* 焼き込みリニア */
                  double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                  const double up_r, double up_g, double up_b, double up_a,
-                 const double up_opacity);
+                 const double up_opacity, const bool do_clamp = true);
 // 06
 void darker_color(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                   const double up_r, double up_g, double up_b, double up_a,
-                  const double up_opacity);
+                  const double up_opacity, const bool do_clamp = true);
 // 07
 void lighten(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
              const double up_r, double up_g, double up_b, double up_a,
-             const double up_opacity);
+             const double up_opacity, const bool do_clamp = true);
 // 08
 void screen(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
             const double up_r, double up_g, double up_b, double up_a,
-            const double up_opacity);
+            const double up_opacity, const bool do_clamp = true);
 // 09
 void color_dodge(/* 覆い焼きカラー */
                  double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                  const double up_r, double up_g, double up_b, double up_a,
-                 const double up_opacity);
+                 const double up_opacity, const bool do_clamp = true);
 // 10
 void linear_dodge(/* 覆い焼きリニア(単純加算ではない) */
                   double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                   const double up_r, double up_g, double up_b, double up_a,
-                  const double up_opacity);
+                  const double up_opacity, const bool do_clamp = true);
 // 11
 void lighter_color(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                    const double up_r, double up_g, double up_b, double up_a,
-                   const double up_opacity);
+                   const double up_opacity, const bool do_clamp = true);
 // 12
 void overlay(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
              const double up_r, double up_g, double up_b, double up_a,
-             const double up_opacity);
+             const double up_opacity, const bool do_clamp = true);
 // 13
 void soft_light(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                 const double up_r, double up_g, double up_b, double up_a,
-                const double up_opacity);
+                const double up_opacity, const bool do_clamp = true);
 // 14
 void hard_light(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                 const double up_r, double up_g, double up_b, double up_a,
-                const double up_opacity);
+                const double up_opacity, const bool do_clamp = true);
 // 15
 void vivid_light(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                  const double up_r, double up_g, double up_b, double up_a,
-                 const double up_opacity);
+                 const double up_opacity, const bool do_clamp = true);
 // 16
 void linear_light(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                   const double up_r, double up_g, double up_b, double up_a,
-                  const double up_opacity);
+                  const double up_opacity, const bool do_clamp = true);
 // 17
 void pin_light(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                const double up_r, double up_g, double up_b, double up_a,
-               const double up_opacity);
+               const double up_opacity, const bool do_clamp = true);
 // 18
 void hard_mix(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
               const double up_r, double up_g, double up_b, double up_a,
-              const double up_opacity);
+              const double up_opacity, const bool do_clamp = true);
 //-----------------
 // 19
 void cross_dissolve(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
                     const double up_r, double up_g, double up_b, double up_a,
-                    const double up_opacity);
+                    const double up_opacity, const bool do_clamp = true);
 // 20
 void subtract(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
               const double up_r, double up_g, double up_b, double up_a,
-              const double up_opacity, const bool alpha_rendering_sw);
+              const double up_opacity, const bool alpha_rendering_sw,
+              const bool do_clamp = true);
 // 21
 void add(/* 単純加算 */
          double &dn_r, double &dn_g, double &dn_b, double &dn_a,
          const double up_r, double up_g, double up_b, double up_a,
-         const double up_opacity);
+         const double up_opacity, const bool do_clamp = true);
 // 22
 void divide(double &dn_r, double &dn_g, double &dn_b, double &dn_a,
             const double up_r, double up_g, double up_b, double up_a,
-            const double up_opacity);
-}
-}
+            const double up_opacity, const bool do_clamp = true);
+}  // namespace color
+}  // namespace igs
 #endif /* !igs_color_blend_h */

--- a/toonz/sources/stdfx/ino_blend_add.cpp
+++ b/toonz/sources/stdfx/ino_blend_add.cpp
@@ -27,8 +27,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::add(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::add(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                    !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_add, "inoAddFx");

--- a/toonz/sources/stdfx/ino_blend_color_burn.cpp
+++ b/toonz/sources/stdfx/ino_blend_color_burn.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::color_burn(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::color_burn(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                           !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_color_burn, "inoColorBurnFx");

--- a/toonz/sources/stdfx/ino_blend_color_dodge.cpp
+++ b/toonz/sources/stdfx/ino_blend_color_dodge.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::color_dodge(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::color_dodge(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                            !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_color_dodge, "inoColorDodgeFx");

--- a/toonz/sources/stdfx/ino_blend_cross_dissolve.cpp
+++ b/toonz/sources/stdfx/ino_blend_cross_dissolve.cpp
@@ -14,9 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
     igs::color::cross_dissolve(dnr, dng, dnb, dna, upr, upg, upb, upa,
-                               up_opacity);
+                               up_opacity, !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_cross_dissolve, "inoCrossDissolveFx");

--- a/toonz/sources/stdfx/ino_blend_darken.cpp
+++ b/toonz/sources/stdfx/ino_blend_darken.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::darken(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::darken(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                       !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_darken, "inoDarkenFx");

--- a/toonz/sources/stdfx/ino_blend_darker_color.cpp
+++ b/toonz/sources/stdfx/ino_blend_darker_color.cpp
@@ -14,9 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::darker_color(dnr, dng, dnb, dna, upr, upg, upb, upa,
-                             up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::darker_color(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                             !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_darker_color, "inoDarkerColorFx");

--- a/toonz/sources/stdfx/ino_blend_divide.cpp
+++ b/toonz/sources/stdfx/ino_blend_divide.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::divide(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::divide(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                       !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_divide, "inoDivideFx");

--- a/toonz/sources/stdfx/ino_blend_hard_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_hard_light.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::hard_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::hard_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                           !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_hard_light, "inoHardLightFx");

--- a/toonz/sources/stdfx/ino_blend_hard_mix.cpp
+++ b/toonz/sources/stdfx/ino_blend_hard_mix.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::hard_mix(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::hard_mix(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                         !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_hard_mix, "inoHardMixFx");

--- a/toonz/sources/stdfx/ino_blend_lighten.cpp
+++ b/toonz/sources/stdfx/ino_blend_lighten.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::lighten(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::lighten(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                        !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_lighten, "inoLightenFx");

--- a/toonz/sources/stdfx/ino_blend_lighter_color.cpp
+++ b/toonz/sources/stdfx/ino_blend_lighter_color.cpp
@@ -14,9 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
     igs::color::lighter_color(dnr, dng, dnb, dna, upr, upg, upb, upa,
-                              up_opacity);
+                              up_opacity, !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_lighter_color, "inoLighterColorFx");

--- a/toonz/sources/stdfx/ino_blend_linear_burn.cpp
+++ b/toonz/sources/stdfx/ino_blend_linear_burn.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::linear_burn(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::linear_burn(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                            !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_linear_burn, "inoLinearBurnFx");

--- a/toonz/sources/stdfx/ino_blend_linear_dodge.cpp
+++ b/toonz/sources/stdfx/ino_blend_linear_dodge.cpp
@@ -14,9 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::linear_dodge(dnr, dng, dnb, dna, upr, upg, upb, upa,
-                             up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::linear_dodge(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                             !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_linear_dodge, "inoLinearDodgeFx");

--- a/toonz/sources/stdfx/ino_blend_linear_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_linear_light.cpp
@@ -14,9 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::linear_light(dnr, dng, dnb, dna, upr, upg, upb, upa,
-                             up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::linear_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                             !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_linear_light, "inoLinearLightFx");

--- a/toonz/sources/stdfx/ino_blend_multiply.cpp
+++ b/toonz/sources/stdfx/ino_blend_multiply.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::multiply(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::multiply(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                         !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_multiply, "inoMultiplyFx");

--- a/toonz/sources/stdfx/ino_blend_over.cpp
+++ b/toonz/sources/stdfx/ino_blend_over.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::over(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::over(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                     !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_over, "inoOverFx");

--- a/toonz/sources/stdfx/ino_blend_overlay.cpp
+++ b/toonz/sources/stdfx/ino_blend_overlay.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::overlay(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::overlay(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                        !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_overlay, "inoOverlayFx");

--- a/toonz/sources/stdfx/ino_blend_pin_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_pin_light.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::pin_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::pin_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                          !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_pin_light, "inoPinLightFx");

--- a/toonz/sources/stdfx/ino_blend_screen.cpp
+++ b/toonz/sources/stdfx/ino_blend_screen.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::screen(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::screen(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                       !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_screen, "inoScreenFx");

--- a/toonz/sources/stdfx/ino_blend_soft_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_soft_light.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::soft_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::soft_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                           !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_soft_light, "inoSoftLightFx");

--- a/toonz/sources/stdfx/ino_blend_subtract.cpp
+++ b/toonz/sources/stdfx/ino_blend_subtract.cpp
@@ -15,9 +15,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
     igs::color::subtract(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                         alpha_rendering_sw);
+                         alpha_rendering_sw, !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_subtract, "inoSubtractFx");

--- a/toonz/sources/stdfx/ino_blend_vivid_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_vivid_light.cpp
@@ -14,8 +14,10 @@ public:
   void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
-                   const bool alpha_rendering_sw = true) override {
-    igs::color::vivid_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity);
+                   const bool alpha_rendering_sw = true,
+                   const bool is_xyz             = false) override {
+    igs::color::vivid_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
+                            !is_xyz);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_vivid_light, "inoVividLightFx");

--- a/toonz/sources/stdfx/ino_common.cpp
+++ b/toonz/sources/stdfx/ino_common.cpp
@@ -496,7 +496,7 @@ void TBlendForeBackRasterFx::linearTmpl(TRasterPT<T> dn_ras_out,
       to_xyz(upXYZ, upBGR);
 
       brendKernel(dnXYZ[0], dnXYZ[1], dnXYZ[2], dna, upXYZ[0], upXYZ[1],
-                  upXYZ[2], upa, tmp_opacity, alpha_rendering_sw);
+                  upXYZ[2], upa, tmp_opacity, alpha_rendering_sw, true);
 
       to_bgr(dnBGR, dnXYZ);
 

--- a/toonz/sources/stdfx/ino_common.h
+++ b/toonz/sources/stdfx/ino_common.h
@@ -57,29 +57,31 @@ protected:
   TBoolParamP m_alpha_rendering;  // optional
 
   void dryComputeUpAndDown(TRectD& rect, double frame,
-    const TRenderSettings& rs,
-    bool upComputesWholeTile = false);
+                           const TRenderSettings& rs,
+                           bool upComputesWholeTile = false);
 
   void doComputeFx(TRasterP& dn_ras_out, const TRasterP& up_ras,
-    const TPoint& pos, const double up_opacity,
-    const double gamma);
+                   const TPoint& pos, const double up_opacity,
+                   const double gamma);
 
   template <class T, class Q>
   void nonlinearTmpl(TRasterPT<T> dn_ras_out, const TRasterPT<T>& up_ras,
-    const double up_opacity);
+                     const double up_opacity);
 
   template <class T, class Q>
   void linearTmpl(TRasterPT<T> dn_ras_out, const TRasterPT<T>& up_ras,
-    const double up_opacity, const double gamma);
+                  const double up_opacity, const double gamma);
 
+  // when compute in xyz color space, do not clamp channel values in the kernel
   virtual void brendKernel(double& dnr, double& dng, double& dnb, double& dna,
-    const double up_, double upg, double upb, double upa,
-    const double upopacity,
-    const bool alpha_rendering_sw = true) = 0;
+                           const double up_, double upg, double upb, double upa,
+                           const double upopacity,
+                           const bool alpha_rendering_sw = true,
+                           const bool is_xyz             = false) = 0;
 
   void computeUpAndDown(TTile& tile, double frame, const TRenderSettings& rs,
-    TRasterP& dn_ras, TRasterP& up_ras,
-    bool upComputesWholeTile = false);
+                        TRasterP& dn_ras, TRasterP& up_ras,
+                        bool upComputesWholeTile = false);
 
 public:
   TBlendForeBackRasterFx(bool clipping_mask, bool has_alpha_option = false);


### PR DESCRIPTION
This PR fixes #4065 .
Each Layer Blending Fx uses the same kernel function regardless off the state of "Linear Color Space" option.
In the end of the kernel function every channels are clamped between 0.0 - 1.0.
When the "Linear Color Space" is activated, RGB channel values are converted to XYZ color space which can have more than 1 channel value. Thus clamping the maximum value to 1.0 causes wrong result in bright pixels.

Modified the clamping to be done only when the kernel function is applied to RGB channel values. 