### PR TITLE
Fix PN Clouds Ino Fx

### DIFF
--- a/toonz/sources/stdfx/igs_perlin_noise.h
+++ b/toonz/sources/stdfx/igs_perlin_noise.h
@@ -12,7 +12,7 @@ namespace perlin_noise {
 IGS_PERLIN_NOISE_EXPORT void change(
     unsigned char *image_array, const int height  // pixel
     ,
-    const int width  // pixel
+    const int width, const int wrap  // pixel
     ,
     const int channels, const int bits, const bool alpha_rendering_sw = true
 
@@ -28,8 +28,8 @@ IGS_PERLIN_NOISE_EXPORT void change(
     const int octaves_end = 9  // 0...
     ,
     const double persistence = 1. / 1.7320508  // not 0
-    );
+);
 }
-}
+}  // namespace igs
 
 #endif /* !igs_perlin_noise_h */

--- a/toonz/sources/stdfx/ino_pn_clouds.cpp
+++ b/toonz/sources/stdfx/ino_pn_clouds.cpp
@@ -67,15 +67,14 @@ void fx_(TRasterP in_ras, const double zz, const int octaves,
          const double persistance, const bool alpha_rendering_sw,
          const double a11, const double a12, const double a13, const double a21,
          const double a22, const double a23) {
-  igs::perlin_noise::change(
-      in_ras->getRawData()  // BGRA
-      ,
-      in_ras->getLy(), in_ras->getLx()  // =in_ras->getWrap()???
-      ,
-      ino::channels(), ino::bits(in_ras), alpha_rendering_sw, a11, a12, a13,
-      a21, a22, a23, zz, 0, octaves, persistance);
+  igs::perlin_noise::change(in_ras->getRawData()  // BGRA
+                            ,
+                            in_ras->getLy(), in_ras->getLx(), in_ras->getWrap(),
+                            ino::channels(), ino::bits(in_ras),
+                            alpha_rendering_sw, a11, a12, a13, a21, a22, a23,
+                            zz, 0, octaves, persistance);
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_pn_clouds::doCompute(TTile &tile, double frame,
                               const TRenderSettings &rend_sets) {


### PR DESCRIPTION
This PR fixes #4067 . 
The raster image data to be computed in the fx may not tightly-packed. According to the Fx Schematic arrangement, there can be a "gap" between a pixel data at the end of scanline and the one at the beginning of next scanline.
PN Clouds Ino Fx assumed that the raster image data is always tightly packed (i.e. raster wrap = raster width) which was not always correct.

Fixed the fx to consider the raster wrap. 
