### PR TITLE
Fix Export Xsheet PDF

### DIFF
--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -2169,7 +2169,7 @@ void ExportXsheetPdfPopup::updatePreview() {
 void ExportXsheetPdfPopup::onExport() {
   ToonzScene* scene = TApp::instance()->getCurrentScene()->getScene();
 
-  if (m_sceneNameEdit->text().isEmpty()) {
+  if (m_fileNameFld->text().isEmpty()) {
     DVGui::MsgBoxInPopup(DVGui::WARNING, tr("Please specify the file name."));
     return;
   }
@@ -2239,7 +2239,7 @@ void ExportXsheetPdfPopup::onExport() {
 void ExportXsheetPdfPopup::onExportPNG() {
   ToonzScene* scene = TApp::instance()->getCurrentScene()->getScene();
 
-  if (m_sceneNameEdit->text().isEmpty()) {
+  if (m_fileNameFld->text().isEmpty()) {
     DVGui::MsgBoxInPopup(DVGui::WARNING, tr("Please specify the file name."));
     return;
   }


### PR DESCRIPTION
This fixes an obvious bug in the `Export Xsheet PDF` feature as follows:

- OT fails to export PDF if the current scene is untitled. (Showing an error message "Please specify the file name.")
