### PR TITLE
Fix Fx intensity malfunction

### DIFF
--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -551,7 +551,12 @@ public:
   // (at least) of a particle Fx
   int m_particleDescendentCount;
 
-  QList<std::wstring> m_globalControlledFx;
+  // fxid and pointer to the correspondent blend fx for the global
+  // control. Boolean is the flag indicating that the makePF is just called
+  // from the blend fx. If the flag is true then just compute the
+  // global controlled Fx without inserting the same blend fx in order to
+  // prevent infinite loop.
+  QMap<std::wstring, QPair<TFxP, bool>> m_globalControlledFx;
 
 public:
   FxBuilder(ToonzScene *scene, TXsheet *xsh, double frame, int whichLevels,
@@ -1006,20 +1011,27 @@ PlacedFx FxBuilder::makePFfromUnaryFx(TFx *fx) {
   if (!inputFx) return PlacedFx();
 
   // global controllable fx
-  if (fx->getAttributes()->hasGlobalControl() &&
-      !m_globalControlledFx.contains(fx->getFxId())) {
-    GlobalControllableFx *gcFx = dynamic_cast<GlobalControllableFx *>(fx);
-    double val                 = gcFx->getGrobalControlValue(m_frame);
-    if (val < 1.0) {
-      m_globalControlledFx.append(fx->getFxId());
-      // insert cross disolve fx and mix with the input fx
-      TFxP blendFx = TFx::create("blendFx");
-      blendFx->connect("Source1", fx);
-      blendFx->connect("Source2", inputFx);
-      // set the global intensity value to the cross disolve fx
-      dynamic_cast<TDoubleParam *>(blendFx->getParams()->getParam("value"))
-          ->setDefaultValue(val * 100.0);
-      return makePF(blendFx.getPointer());
+  if (fx->getAttributes()->hasGlobalControl()) {
+    if (!m_globalControlledFx.contains(fx->getFxId())) {
+      GlobalControllableFx *gcFx = dynamic_cast<GlobalControllableFx *>(fx);
+      double val                 = gcFx->getGrobalControlValue(m_frame);
+      if (val < 1.0) {
+        // insert cross disolve fx and mix with the input fx
+        TFxP blendFx = TFx::create("blendFx");
+        blendFx->connect("Source1", fx);
+        blendFx->connect("Source2", inputFx);
+        // set the global intensity value to the cross disolve fx
+        dynamic_cast<TDoubleParam *>(blendFx->getParams()->getParam("value"))
+            ->setDefaultValue(val * 100.0);
+        m_globalControlledFx.insert(fx->getFxId(), {blendFx, true});
+        return makePF(blendFx.getPointer());
+      }
+    } else if (m_globalControlledFx.value(fx->getFxId()).second)
+      m_globalControlledFx[fx->getFxId()].second = false;
+    else {
+      m_globalControlledFx[fx->getFxId()].second = true;
+      return makePF(
+          m_globalControlledFx.value(fx->getFxId()).first.getPointer());
     }
   }
 
@@ -1090,22 +1102,29 @@ PlacedFx FxBuilder::makePFfromGenericFx(TFx *fx) {
   }
 
   // global controllable fx
-  if (fx->getAttributes()->hasGlobalControl() &&
-      !m_globalControlledFx.contains(fx->getFxId())) {
-    GlobalControllableFx *gcFx = dynamic_cast<GlobalControllableFx *>(fx);
-    double val                 = gcFx->getGrobalControlValue(m_frame);
-    if (val < 1.0) {
-      TFxP inputFx = fx->getInputPort(fx->getPreferredInputPort())->getFx();
-      if (!inputFx) return pf;
-      m_globalControlledFx.append(fx->getFxId());
-      // insert cross disolve fx and mix with the input fx
-      TFxP blendFx = TFx::create("blendFx");
-      blendFx->connect("Source1", fx);
-      blendFx->connect("Source2", inputFx.getPointer());
-      // set the global intensity value to the cross disolve fx
-      dynamic_cast<TDoubleParam *>(blendFx->getParams()->getParam("value"))
-          ->setDefaultValue(val * 100.0);
-      return makePF(blendFx.getPointer());
+  if (fx->getAttributes()->hasGlobalControl()) {
+    if (!m_globalControlledFx.contains(fx->getFxId())) {
+      GlobalControllableFx *gcFx = dynamic_cast<GlobalControllableFx *>(fx);
+      double val                 = gcFx->getGrobalControlValue(m_frame);
+      if (val < 1.0) {
+        TFxP inputFx = fx->getInputPort(fx->getPreferredInputPort())->getFx();
+        if (!inputFx) return pf;
+        // insert cross disolve fx and mix with the input fx
+        TFxP blendFx = TFx::create("blendFx");
+        blendFx->connect("Source1", fx);
+        blendFx->connect("Source2", inputFx.getPointer());
+        m_globalControlledFx.insert(fx->getFxId(), {blendFx, true});
+        // set the global intensity value to the cross disolve fx
+        dynamic_cast<TDoubleParam *>(blendFx->getParams()->getParam("value"))
+            ->setDefaultValue(val * 100.0);
+        return makePF(blendFx.getPointer());
+      }
+    } else if (m_globalControlledFx.value(fx->getFxId()).second)
+      m_globalControlledFx[fx->getFxId()].second = false;
+    else {
+      m_globalControlledFx[fx->getFxId()].second = true;
+      return makePF(
+          m_globalControlledFx.value(fx->getFxId()).first.getPointer());
     }
   }
 


### PR DESCRIPTION
This PR fixes #4076 
The Fx intensity is achieved by inserting a cross dissolve fx which blends the fx result and its input.
When rendering, I set some flag for handling such insertion in order to prevent infinite loop.

However it did not work properly when the fx has more than one output.
Now I modified the flag and made it to work fine. Sorry for the trouble!