### PR TITLE
Add Raster Lock Alpha tool setting 

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -458,6 +458,7 @@ class PaintbrushToolOptionsBox final : public ToolOptionsBox {
 
   ToolOptionCombo *m_colorMode;
   ToolOptionCheckbox *m_selectiveMode;
+  ToolOptionCheckbox *m_lockAlphaMode;
 
 public:
   PaintbrushToolOptionsBox(QWidget *parent, TTool *tool,

--- a/toonz/sources/include/toonz/rasterstrokegenerator.h
+++ b/toonz/sources/include/toonz/rasterstrokegenerator.h
@@ -37,6 +37,7 @@ class DVAPI RasterStrokeGenerator {
   bool m_doAnArc;
   bool m_isPaletteOrder;  // Used in the Draw Order option of Brush Tool,
                           // use style order to define line stacking order
+  bool m_modifierLockAlpha;
   QSet<int> m_aboveStyleIds;
 
   // Ricalcola i punti in un nuovo sistema di riferimento
@@ -50,13 +51,14 @@ class DVAPI RasterStrokeGenerator {
 public:
   RasterStrokeGenerator(const TRasterCM32P &raster, Tasks task,
                         ColorType colorType, int styleId, const TThickPoint &p,
-                        bool selective, int selectedStyle, bool keepAntialias,
-                        bool isPaletteOrder = false);
+                        bool selective, int selectedStyle, bool lockAlpha,
+                        bool keepAntialias, bool isPaletteOrder = false);
   ~RasterStrokeGenerator();
   void setRaster(const TRasterCM32P &ras) { m_raster = ras; }
   void setStyle(int styleId) { m_styleId = styleId; }
   int getStyleId() const { return m_styleId; }
   bool isSelective() { return m_selective; }
+  bool isAlphaLocked() { return m_modifierLockAlpha; }
 
   bool isPaletteOrder() { return m_isPaletteOrder; }
   void setAboveStyleIds(QSet<int> &ids) { m_aboveStyleIds = ids; }

--- a/toonz/sources/tnztools/bluredbrush.cpp
+++ b/toonz/sources/tnztools/bluredbrush.cpp
@@ -27,7 +27,8 @@ QImage rasterToQImage(const TRasterP &ras, bool premultiplied = false) {
 //----------------------------------------------------------------------------------
 // drawOrderMode : 0=OverAll, 1=UnderAll, 2=PaletteOrder
 void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
-                   int drawOrderMode, const QSet<int> &aboveStyleIds) {
+                   int drawOrderMode, bool lockAlpha,
+                   const QSet<int> &aboveStyleIds) {
   if (!out.getPointer() || !in.getPointer()) return;
   assert(out->getSize() == in->getSize());
   int x, y;
@@ -43,6 +44,12 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         TPixel32 *inPix = &in->pixels(y)[x];
         if (inPix->m == 0) continue;
         TPixelCM32 *outPix = &out->pixels(y)[x];
+        if (lockAlpha && !outPix->isPureInk() && outPix->getPaint() == 0 &&
+            outPix->getTone() == 255) {
+          *outPix = TPixelCM32(outPix->getInk(), outPix->getPaint(),
+                               outPix->getTone());
+          continue;
+        }
         bool sameStyleId   = styleId == outPix->getInk();
         // line with the same style : multiply tones
         // line with different style : pick darker tone
@@ -66,6 +73,12 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         TPixel32 *inPix = &in->pixels(y)[x];
         if (inPix->m == 0) continue;
         TPixelCM32 *outPix = &out->pixels(y)[x];
+        if (lockAlpha && !outPix->isPureInk() && outPix->getPaint() == 0 &&
+            outPix->getTone() == 255) {
+          *outPix = TPixelCM32(outPix->getInk(), outPix->getPaint(),
+                               outPix->getTone());
+          continue;
+        }
         bool sameStyleId   = styleId == outPix->getInk();
         // line with the same style : multiply tones
         // line with different style : pick darker tone
@@ -83,6 +96,12 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
         TPixel32 *inPix = &in->pixels(y)[x];
         if (inPix->m == 0) continue;
         TPixelCM32 *outPix = &out->pixels(y)[x];
+        if (lockAlpha && !outPix->isPureInk() && outPix->getPaint() == 0 &&
+            outPix->getTone() == 255) {
+          *outPix = TPixelCM32(outPix->getInk(), outPix->getPaint(),
+                               outPix->getTone());
+          continue;
+        }
         bool sameStyleId   = styleId == outPix->getInk();
         // line with the same style : multiply tones
         // line with different style : pick darker tone
@@ -365,7 +384,7 @@ void BluredBrush::eraseDrawing(const TRasterP ras, const TRasterP rasBackup,
 void BluredBrush::updateDrawing(const TRasterCM32P rasCM,
                                 const TRasterCM32P rasBackupCM,
                                 const TRect &bbox, int styleId,
-                                int drawOrderMode) const {
+                                int drawOrderMode, bool lockAlpha) const {
   if (!rasCM) return;
 
   TRect rasRect    = rasCM->getBounds();
@@ -374,7 +393,7 @@ void BluredBrush::updateDrawing(const TRasterCM32P rasCM,
 
   rasCM->copy(rasBackupCM->extract(targetRect), targetRect.getP00());
   putOnRasterCM(rasCM->extract(targetRect), m_ras->extract(targetRect), styleId,
-                drawOrderMode, m_aboveStyleIds);
+                drawOrderMode, lockAlpha, m_aboveStyleIds);
 }
 
 //----------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/bluredbrush.h
+++ b/toonz/sources/tnztools/bluredbrush.h
@@ -40,7 +40,8 @@ public:
   TRect getBoundFromPoints(const std::vector<TThickPoint> &points) const;
   // colormapped
   void updateDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
-                     const TRect &bbox, int styleId, int drawOrderMode) const;
+                     const TRect &bbox, int styleId, int drawOrderMode,
+                     bool lockAlpha) const;
   void eraseDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
                     const TRect &bbox, bool selective, int selectedStyleId,
                     const std::wstring &mode) const;

--- a/toonz/sources/tnztools/fingertool.cpp
+++ b/toonz/sources/tnztools/fingertool.cpp
@@ -75,7 +75,7 @@ public:
     TToonzImageP image = m_level->getFrame(m_frameId, true);
     TRasterCM32P ras   = image->getRaster();
     RasterStrokeGenerator m_rasterTrack(ras, FINGER, INK, m_styleId,
-                                        m_points[0], m_invert, 0, false);
+                                        m_points[0], m_invert, 0, false, false);
     m_rasterTrack.setPointsSequence(m_points);
     m_rasterTrack.generateStroke(true);
     image->setSavebox(image->getSavebox() +
@@ -409,7 +409,7 @@ void FingerTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
       m_rasterTrack         = new RasterStrokeGenerator(
           ras, FINGER, INK, styleId,
           TThickPoint(pos + convert(ras->getCenter()), thickness),
-          m_invert.getValue(), 0, false);
+          m_invert.getValue(), 0, false, false);
 
       /*-- 作業中Fidを現在のFIDにする --*/
       m_workingFrameId = getFrameId();

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -121,7 +121,7 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
     , m_modifierSize("ModifierSize", -3, 3, 0, true)
     , m_modifierOpacity("ModifierOpacity", 0, 100, 100, true)
     , m_modifierEraser("ModifierEraser", false)
-    , m_modifierLockAlpha("ModifierLockAlpha", false)
+    , m_modifierLockAlpha("Lock Alpha", false)
     , m_preset("Preset:")
     , m_minCursorThick(0)
     , m_maxCursorThick(0)
@@ -889,6 +889,10 @@ void FullColorBrushTool::applyClassicToonzBrushSettings(
     mypaintBrush.setMappingPoint(MYPAINT_BRUSH_SETTING_OPAQUE,
                                  MYPAINT_BRUSH_INPUT_PRESSURE, 1, 1.0,
                                  maxOpacity - minOpacity);
+  }
+
+  if (m_modifierLockAlpha.getValue()) {
+    mypaintBrush.setBaseValue(MYPAINT_BRUSH_SETTING_LOCK_ALPHA, 1.0);
   }
 }
 

--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -181,7 +181,7 @@ static TRect drawBluredBrush(const TToonzImageP &ti, TStroke *stroke, int thick,
     TRect chunkBox = brush.getBoundFromPoints(points);
     brush.addArc(points[0], points[1], points[2], 1, 1);
     brush.updateDrawing(ti->getRaster(), backupRas, chunkBox, styleId,
-                        selective);
+                        selective, false);
   }
 
   delete s;

--- a/toonz/sources/tnztools/mypainttoonzbrush.h
+++ b/toonz/sources/tnztools/mypainttoonzbrush.h
@@ -130,7 +130,7 @@ public:
 
   // colormapped
   void updateDrawing(const TRasterCM32P rasCM, const TRasterCM32P rasBackupCM,
-                     const TRect &bbox, int styleId) const;
+                     const TRect &bbox, int styleId, bool lockAlpha) const;
 };
 
 #endif  // T_BLUREDBRUSH

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -178,7 +178,7 @@ public:
     TToonzImageP image = m_level->getFrame(m_frameId, true);
     TRasterCM32P ras   = image->getRaster();
     RasterStrokeGenerator m_rasterTrack(ras, ERASE, m_colorType, 0, m_points[0],
-                                        m_selective, m_colorSelected,
+                                        m_selective, m_colorSelected, false,
                                         !m_isPencil);
     m_rasterTrack.setPointsSequence(m_points);
     m_rasterTrack.generateStroke(m_isPencil);
@@ -939,7 +939,7 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
         if (m_colorType.getValue() == ALL) m_colorTypeEraser   = INKNPAINT;
         m_normalEraser = new RasterStrokeGenerator(
             raster, ERASE, m_colorTypeEraser, 0, intPos,
-            m_currentStyle.getValue(), currentStyle,
+            m_currentStyle.getValue(), currentStyle, false,
             !(m_pencil.getValue() || m_colorType.getValue() == AREAS));
         m_tileSaver->save(m_normalEraser->getLastRect());
         m_normalEraser->generateLastPieceOfStroke(

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1486,9 +1486,13 @@ PaintbrushToolOptionsBox::PaintbrushToolOptionsBox(QWidget *parent, TTool *tool,
   m_colorMode = dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
   m_selectiveMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Selective"));
+  m_lockAlphaMode =
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Lock Alpha"));
 
-  if (m_colorMode->getProperty()->getValue() == L"Lines")
+  if (m_colorMode->getProperty()->getValue() == L"Lines") {
     m_selectiveMode->setVisible(false);
+    m_lockAlphaMode->setVisible(false);
+  }
 
   bool ret = connect(m_colorMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onColorModeChanged(int)));
@@ -1509,6 +1513,7 @@ void PaintbrushToolOptionsBox::onColorModeChanged(int index) {
   const TEnumProperty::Range &range = m_colorMode->getProperty()->getRange();
   bool enabled                      = range[index] != L"Lines";
   m_selectiveMode->setVisible(enabled);
+  m_lockAlphaMode->setVisible(enabled);
 }
 
 //=============================================================================

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1784,16 +1784,18 @@ void BrushToolOptionsBox::filterControls() {
   for (QMap<std::string, QLabel *>::iterator it = m_labels.begin();
        it != m_labels.end(); it++) {
     bool isModifier = (it.key().substr(0, 8) == "Modifier");
-    bool isCommon   = (it.key() == "Pressure" || it.key() == "Preset:");
-    bool visible    = isCommon || (isModifier == showModifiers);
+    bool isCommon   = (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
+                     it.key() == "Preset:");
+    bool visible = isCommon || (isModifier == showModifiers);
     it.value()->setVisible(visible);
   }
 
   for (QMap<std::string, ToolOptionControl *>::iterator it = m_controls.begin();
        it != m_controls.end(); it++) {
     bool isModifier = (it.key().substr(0, 8) == "Modifier");
-    bool isCommon   = (it.key() == "Pressure" || it.key() == "Preset:");
-    bool visible    = isCommon || (isModifier == showModifiers);
+    bool isCommon   = (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
+                     it.key() == "Preset:");
+    bool visible = isCommon || (isModifier == showModifiers);
     if (QWidget *widget = dynamic_cast<QWidget *>(it.value()))
       widget->setVisible(visible);
   }

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1335,7 +1335,7 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
       if (!updateRect.isEmpty()) {
         // ras->extract(updateRect)->copy(m_workRas->extract(updateRect));
         m_toonz_brush->updateDrawing(ri->getRaster(), m_backupRas, m_strokeRect,
-                                     m_styleId);
+                                     m_styleId, m_modifierLockAlpha.getValue());
       }
       m_lastRect = m_strokeRect;
 
@@ -1439,7 +1439,7 @@ void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
     if (!updateRect.isEmpty()) {
       // ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
       m_toonz_brush->updateDrawing(ras, m_backupRas, m_strokeSegmentRect,
-                                   m_styleId);
+                                   m_styleId, m_modifierLockAlpha.getValue());
     }
     m_lastRect = m_strokeRect;
 
@@ -1594,7 +1594,7 @@ void ToonzRasterBrushTool::finishRasterBrush(const TPointD &pos,
     if (!updateRect.isEmpty()) {
       // ras->extract(updateRect)->copy(m_workRaster->extract(updateRect));
       m_toonz_brush->updateDrawing(ras, m_backupRas, m_strokeSegmentRect,
-                                   m_styleId);
+                                   m_styleId, m_modifierLockAlpha.getValue());
     }
     TPointD thickOffset(m_maxCursorThick * 0.5,
                         m_maxCursorThick * 0.5);  // TODO

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -454,7 +454,7 @@ public:
     TToonzImageP image = getImage();
     TRasterCM32P ras   = image->getRaster();
     RasterStrokeGenerator m_rasterTrack(ras, BRUSH, NONE, m_styleId,
-                                        m_points[0], m_selective, 0,
+                                        m_points[0], m_selective, 0, false,
                                         !m_isPencil, m_isPaletteOrder);
     if (m_isPaletteOrder) {
       QSet<int> aboveStyleIds;
@@ -1341,7 +1341,7 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
                              thickness);
       m_rasterTrack = new RasterStrokeGenerator(
           ras, BRUSH, NONE, m_styleId, thickPoint, drawOrder != OverAll, 0,
-          !m_pencil.getValue(), drawOrder == PaletteOrder);
+          false, !m_pencil.getValue(), drawOrder == PaletteOrder);
 
       if (drawOrder == PaletteOrder)
         m_rasterTrack->setAboveStyleIds(aboveStyleIds);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -182,6 +182,7 @@ protected:
   TBoolProperty m_pencil;
   TBoolProperty m_pressure;
   TDoubleProperty m_modifierSize;
+  TBoolProperty m_modifierLockAlpha;
 
   RasterStrokeGenerator *m_rasterTrack;
   TTileSetCM32 *m_tileSet;

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -9,7 +9,7 @@ RasterStrokeGenerator::RasterStrokeGenerator(const TRasterCM32P &raster,
                                              Tasks task, ColorType colorType,
                                              int styleId, const TThickPoint &p,
                                              bool selective, int selectedStyle,
-                                             bool keepAntialias,
+                                             bool lockAlpha, bool keepAntialias,
                                              bool isPaletteOrder)
     : m_raster(raster)
     , m_boxOfRaster(TRect(raster->getSize()))
@@ -21,7 +21,8 @@ RasterStrokeGenerator::RasterStrokeGenerator(const TRasterCM32P &raster,
     , m_selectedStyle(selectedStyle)
     , m_keepAntiAlias(keepAntialias)
     , m_doAnArc(false)
-    , m_isPaletteOrder(isPaletteOrder) {
+    , m_isPaletteOrder(isPaletteOrder)
+    , m_modifierLockAlpha(lockAlpha) {
   TThickPoint pp = p;
   m_points.push_back(pp);
   if (task == ERASE) m_styleId = m_eraseStyle;
@@ -243,8 +244,10 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
         }
       } else if (m_task == PAINTBRUSH) {
         if (!inPix->isPureInk()) continue;
-        bool changePaint =
-            !m_selective || (m_selective && outPix->getPaint() == 0);
+        int paintIdx     = outPix->getPaint();
+        bool changePaint = (!m_selective && !m_modifierLockAlpha) ||
+                           (m_selective && paintIdx == 0) ||
+                           (m_modifierLockAlpha && paintIdx != 0);
         if (m_colorType == INK)
           *outPix = TPixelCM32(inPix->getInk(), outPix->getPaint(),
                                outPix->getTone());

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -189,8 +189,13 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
       if (m_task == BRUSH) {
         int inTone  = inPix->getTone();
         int outTone = outPix->getTone();
-        if (inPix->isPureInk() && !m_selective) {
+        if (inPix->isPureInk() && !m_selective && !m_modifierLockAlpha) {
           *outPix = TPixelCM32(inPix->getInk(), outPix->getPaint(), inTone);
+          continue;
+        }
+        if (m_modifierLockAlpha && !outPix->isPureInk() &&
+            outPix->getPaint() == 0 && outPix->getTone() == 255) {
+          *outPix = TPixelCM32(outPix->getInk(), outPix->getPaint(), outTone);
           continue;
         }
         if (outPix->isPureInk() && m_selective) {


### PR DESCRIPTION
A requested port of my Lock Alpha PR from Tahoma2D.

This PR adds Lock Alpha toolbar option to the following raster based brush tools

- Paint Brush Tool
- Toonz Raster Brush Tool
  - Standard brush (Hardness 100%)
  - Standard brush (blurred - Hardness < 100%)
  - MyPaint brush
- Raster Brush Tool
  - Standard brush
  - MyPaint brush - no change already has Lock Alpha