### PR TITLE
Fix Undo Malfunction

### DIFF
--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -123,7 +123,11 @@ public:
         ->setCenter(m_objId, m_frame, m_center);
   }
   void leftButtonUp(const TPointD &pos, const TMouseEvent &) override {
-    if ((m_lockCenterX && m_lockCenterY) || m_firstPos == pos) return;
+    if (m_firstPos == pos) return;
+    leftButtonUp();
+  }
+  void leftButtonUp() override {
+    if (m_lockCenterX && m_lockCenterY) return;
     UndoStageObjectCenterMove *undo =
         new UndoStageObjectCenterMove(m_objId, m_frame, m_oldCenter, m_center);
     TTool::Application *app = TTool::getApplication();
@@ -229,7 +233,11 @@ public:
   }
 
   void leftButtonUp(const TPointD &pos, const TMouseEvent &) override {
-    if (!m_isStarted || m_firstPos == pos)
+    if (m_firstPos == pos) return;
+    leftButtonUp();
+  }
+  void leftButtonUp() override {
+    if (!m_isStarted)
       return;
     else
       m_isStarted = false;
@@ -1620,7 +1628,14 @@ m_foo.setFxHandle(getApplication()->getCurrentFx());
 
 //=============================================================================
 
-void EditTool::onDeactivate() {}
+void EditTool::onDeactivate() {
+  if (m_dragTool) {
+    m_dragTool->leftButtonUp();
+    TUndoManager::manager()->endBlock();
+    delete m_dragTool;
+    m_dragTool = nullptr;
+  }
+}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -134,12 +134,11 @@ public:
   }
 
   void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override {
-    // precise control with pressing Alt key
-    if (e.isAltPressed()) {
-      TPointD precisePos = m_firstPos + (pos - m_firstPos) * 0.1;
-      m_gadget->leftButtonUp(getMatrix() * precisePos, e);
-    } else
-      m_gadget->leftButtonUp(getMatrix() * pos, e);
+    leftButtonUp();
+  }
+
+  void leftButtonUp() override {
+    m_gadget->leftButtonUp();
     m_gadget->commitUndo();
   }
 };
@@ -274,7 +273,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
 };
 
 //---------------------------------------------------------------------------
@@ -322,10 +320,6 @@ void PointFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
   if (m_yParam) setValue(m_yParam, pos.y);
 }
 
-//---------------------------------------------------------------------------
-
-void PointFxGadget::leftButtonUp(const TPointD &pos, const TMouseEvent &) {}
-
 //=============================================================================
 
 class RadiusFxGadget final : public FxGadget {
@@ -345,7 +339,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
 };
 
 //---------------------------------------------------------------------------
@@ -390,10 +383,6 @@ void RadiusFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
   setValue(m_radius, norm(pos - getCenter()));
 }
 
-//---------------------------------------------------------------------------
-
-void RadiusFxGadget::leftButtonUp(const TPointD &pos, const TMouseEvent &) {}
-
 //=============================================================================
 
 class DistanceFxGadget final : public FxGadget {
@@ -422,7 +411,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
 };
 
 //---------------------------------------------------------------------------
@@ -474,10 +462,6 @@ void DistanceFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
   setValue(m_distance, v);
 }
 
-//---------------------------------------------------------------------------
-
-void DistanceFxGadget::leftButtonUp(const TPointD &pos, const TMouseEvent &) {}
-
 //=============================================================================
 
 class AngleFxGadget final : public FxGadget {
@@ -492,7 +476,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
 };
 
 //---------------------------------------------------------------------------
@@ -547,10 +530,6 @@ void AngleFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &) {
   setValue(m_param, phi * M_180_PI);
 }
 
-//---------------------------------------------------------------------------
-
-void AngleFxGadget::leftButtonUp(const TPointD &pos, const TMouseEvent &) {}
-
 //=============================================================================
 
 class AngleRangeFxGadget final : public FxGadget {
@@ -571,7 +550,7 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonUp() override;
 };
 
 //---------------------------------------------------------------------------
@@ -712,9 +691,7 @@ void AngleRangeFxGadget::leftButtonDrag(const TPointD &pos,
 
 //---------------------------------------------------------------------------
 
-void AngleRangeFxGadget::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
-  m_handle = None;
-}
+void AngleRangeFxGadget::leftButtonUp() { m_handle = None; }
 
 //=============================================================================
 
@@ -731,7 +708,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override {}
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override {}
 };
 
 //---------------------------------------------------------------------------
@@ -797,7 +773,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override {}
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override {}
 };
 
 //---------------------------------------------------------------------------
@@ -876,7 +851,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override {}
 };
 
 //---------------------------------------------------------------------------
@@ -1017,7 +991,6 @@ public:
     setValue(m_phiParam, phi * M_180_PI);
     setValue(m_lengthParam, length);
   }
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override {}
 };
 
 //=============================================================================
@@ -1073,7 +1046,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override {}
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override {}
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override {}
 };
 
 //=============================================================================
@@ -1196,7 +1168,7 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonUp() override;
 };
 
 //---------------------------------------------------------------------------
@@ -1338,9 +1310,7 @@ void QuadFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
 
 //---------------------------------------------------------------------------
 
-void QuadFxGadget::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
-  m_handle = None;
-}
+void QuadFxGadget::leftButtonUp() { m_handle = None; }
 
 //=============================================================================
 
@@ -1361,7 +1331,7 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonUp() override;
 };
 
 //---------------------------------------------------------------------------
@@ -1525,10 +1495,7 @@ void LinearRangeFxGadget::leftButtonDrag(const TPointD &pos,
 
 //---------------------------------------------------------------------------
 
-void LinearRangeFxGadget::leftButtonUp(const TPointD &pos,
-                                       const TMouseEvent &) {
-  m_handle = None;
-}
+void LinearRangeFxGadget::leftButtonUp() { m_handle = None; }
 
 //=============================================================================
 
@@ -1550,7 +1517,7 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonUp() override;
 };
 
 //---------------------------------------------------------------------------
@@ -1710,9 +1677,7 @@ void CompassFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
 
 //---------------------------------------------------------------------------
 
-void CompassFxGadget::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
-  m_handle = None;
-}
+void CompassFxGadget::leftButtonUp() { m_handle = None; }
 
 //=============================================================================
 
@@ -1738,7 +1703,6 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
 };
 
 //---------------------------------------------------------------------------
@@ -1803,11 +1767,6 @@ void RainbowWidthFxGadget::leftButtonDrag(const TPointD &pos,
 
   setValue(m_widthScale, std::min(max, std::max(min, scale)));
 }
-
-//---------------------------------------------------------------------------
-
-void RainbowWidthFxGadget::leftButtonUp(const TPointD &pos,
-                                        const TMouseEvent &) {}
 
 //*************************************************************************************
 //    FxGadgetController  implementation

--- a/toonz/sources/tnztools/edittoolgadgets.h
+++ b/toonz/sources/tnztools/edittoolgadgets.h
@@ -85,7 +85,7 @@ public:
 
   virtual void leftButtonDown(const TPointD &pos, const TMouseEvent &) {}
   virtual void leftButtonDrag(const TPointD &pos, const TMouseEvent &) {}
-  virtual void leftButtonUp(const TPointD &pos, const TMouseEvent &) {}
+  virtual void leftButtonUp() {}
 
   void onChange(const TParamChange &) override;
   void createUndo();
@@ -106,6 +106,7 @@ public:
   virtual void leftButtonDown(const TPointD &pos, const TMouseEvent &) = 0;
   virtual void leftButtonDrag(const TPointD &pos, const TMouseEvent &) = 0;
   virtual void leftButtonUp(const TPointD &pos, const TMouseEvent &)   = 0;
+  virtual void leftButtonUp()                                          = 0;
   virtual ~DragTool() {}
 
   virtual void enableGlobalKeyframes(bool enabled) {}

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1879,14 +1879,14 @@ void TCellSelection::pasteCells() {
         dynamic_cast<const FullColorImageData *>(rasterImageData);
     TToonzImageP ti(img);
     TVectorImageP vi(img);
-    if (!initUndo) {
-      initUndo = true;
-      TUndoManager::manager()->beginBlock();
-    }
     if (fullColData && (vi || ti)) {
       DVGui::error(QObject::tr(
           "The copied selection cannot be pasted in the current drawing."));
       return;
+    }
+    if (!initUndo) {
+      initUndo = true;
+      TUndoManager::manager()->beginBlock();
     }
     if (vi) {
       TXshSimpleLevel *sl = xsh->getCell(r0, c0).getSimpleLevel();

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -968,6 +968,7 @@ void LevelSettingsPopup::onNameChanged() {
           " you entered for the level is already used.\nPlease enter a "
           "different name.");
     m_nameFld->setFocus();
+    TUndoManager::manager()->endBlock();
     return;
   }
 

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -520,9 +520,9 @@ QPainterPath FunctionPanel::getSegmentPainterPath(TDoubleParam *curve,
 //-----------------------------------------------------------------------------
 
 void FunctionPanel::drawCurrentFrame(QPainter &painter) {
-  int currentframe                = 0;
+  int currentframe = 0;
   if (m_frameHandle) currentframe = m_frameHandle->getFrame();
-  int x                           = frameToX(currentframe);
+  int x = frameToX(currentframe);
   if (m_currentFrameStatus == 0)
     painter.setPen(Qt::magenta);
   else if (m_currentFrameStatus == 1)
@@ -863,8 +863,9 @@ void FunctionPanel::updateGadgets(TDoubleParam *curve) {
     //       So, keyframe data could be shared, but adjacent segment lengths
     //       could not...
 
-    if (it != iLast && (kf.m_type == TDoubleKeyframe::SpeedInOut ||
-                        kf.m_type == TDoubleKeyframe::EaseInOut) &&
+    if (it != iLast &&
+        (kf.m_type == TDoubleKeyframe::SpeedInOut ||
+         kf.m_type == TDoubleKeyframe::EaseInOut) &&
         kf.m_speedOut.x != 0) {
       QPointF p(frameToX(frame + kf.m_speedOut.x), groupHandleY);
       Gadget gadget((FunctionPanel::Handle)101, -1, p, 6, 15);  // type value...
@@ -1146,8 +1147,8 @@ void FunctionPanel::paintEvent(QPaintEvent *e) {
     if (currentCurve) {
       const TUnit *unit = 0;
       if (currentCurve->getMeasure())
-        unit                 = currentCurve->getMeasure()->getCurrentUnit();
-      double displayValue    = m_cursor.value;
+        unit = currentCurve->getMeasure()->getCurrentUnit();
+      double displayValue = m_cursor.value;
       if (unit) displayValue = unit->convertTo(displayValue);
       // painter.setClipRect(0,oy0,height(),height()-oy0);
       int y = valueToY(currentCurve, m_cursor.value);
@@ -1180,9 +1181,13 @@ void FunctionPanel::paintEvent(QPaintEvent *e) {
 void FunctionPanel::mousePressEvent(QMouseEvent *e) {
   m_cursor.visible = false;
 
-  // m_dragTool should be 0. just in case...
-  assert(m_dragTool == 0);
-  m_dragTool = 0;
+  // m_dragTool can be non-zero when both the left and the mid buttons are
+  // pressed
+  if (m_dragTool) {
+    m_dragTool->release(e);
+    delete m_dragTool;
+    m_dragTool = nullptr;
+  }
 
   if (e->button() == Qt::MidButton) {
     // mid mouse click => panning
@@ -1237,7 +1242,7 @@ void FunctionPanel::mousePressEvent(QMouseEvent *e) {
       m_functionTreeModel ? m_functionTreeModel->getCurrentChannel() : 0;
   if (!currentChannel ||
       (getCurveDistance(currentChannel->getParam(), winPos) > maxDistance &&
-          closestGadgetId < 0)) {
+       closestGadgetId < 0)) {
     // if current channel is undefined or its curve is too far from the clicked
     // point
     // the user is possibly trying to select a different curve
@@ -1348,9 +1353,11 @@ int kIndex = dragTool->createKeyframe(frame);
 //-----------------------------------------------------------------------------
 
 void FunctionPanel::mouseReleaseEvent(QMouseEvent *e) {
-  if (m_dragTool) m_dragTool->release(e);
-  delete m_dragTool;
-  m_dragTool           = 0;
+  if (m_dragTool) {
+    m_dragTool->release(e);
+    delete m_dragTool;
+    m_dragTool = nullptr;
+  }
   m_cursor.visible     = true;
   m_currentFrameStatus = 0;
   update();
@@ -1454,11 +1461,11 @@ void FunctionPanel::fitGraphToWindow(bool currentCurveOnly) {
     TDoubleParam *curve = channel->getParam();
     if (currentCurveOnly && curve != getCurrentCurve()) continue;
 
-    const TUnit *unit             = 0;
+    const TUnit *unit = 0;
     if (curve->getMeasure()) unit = curve->getMeasure()->getCurrentUnit();
-    int n                         = curve->getKeyframeCount();
+    int n = curve->getKeyframeCount();
     if (n == 0) {
-      double v    = curve->getDefaultValue();
+      double v = curve->getDefaultValue();
       if (unit) v = unit->convertTo(v);
       if (v0 > v1)
         v0 = v1 = v;
@@ -1478,16 +1485,16 @@ void FunctionPanel::fitGraphToWindow(bool currentCurveOnly) {
         f0 = std::min(f0, fa);
         f1 = std::max(f1, fb);
       }
-      double v        = curve->getValue(fa);
-      if (unit) v     = unit->convertTo(v);
+      double v = curve->getValue(fa);
+      if (unit) v = unit->convertTo(v);
       if (v0 > v1) v0 = v1 = v;
-      int m                = 50;
+      int m = 50;
       for (int j = 0; j < m; j++) {
-        double t    = (double)j / (double)(m - 1);
-        double v    = curve->getValue((1 - t) * fa + t * fb);
+        double t = (double)j / (double)(m - 1);
+        double v = curve->getValue((1 - t) * fa + t * fb);
         if (unit) v = unit->convertTo(v);
-        v0          = std::min(v0, v);
-        v1          = std::max(v1, v);
+        v0 = std::min(v0, v);
+        v1 = std::max(v1, v);
       }
     }
   }


### PR DESCRIPTION
This PR fixes a problem that undo stops working after one of the following operations:
1. 1. Select some region of a raster level image with the Selection tool and copy. 
    1. Select a cell containing either Toonz Raster or Toonz Vector level and try to paste. (An error message opens.)
2. 1. Select the Animate tool. Start dragging to change a column transformation.
    1. While pressing the left mouse button, switch tools via shortcut key.
3. 1. On Function Curves panel, start dragging some point in a curve.
    1. While pressing the left mouse button, press either middle or right mouse button.
4. 1. Open the Level Settings popup.
    1. Try to change the level name to the one of another existing level. (An error message opens.) 

As you can see in the History panel, after doing one of the above operations, OT stops to register subsequent operations.

The problem was due to missing of calling the function `TUndoManager::endBlock()` .
OT can combine more than one undo-able operations as one undo block. The operations registered between the functions `beginBlock()` and `endBlock()` are combined into one block. However, if the call of `endBlock()` is bypassed somehow, all subsequent operations are wrongly registered in one block and fails to work.
