### PR TITLE
Fix Spectrum

### DIFF
--- a/toonz/sources/include/tspectrum.h
+++ b/toonz/sources/include/tspectrum.h
@@ -38,7 +38,11 @@ private:
     assert(!m_sortedKeys.empty());
     typename std::vector<ColorKey>::const_iterator b;
     b = std::lower_bound(m_sortedKeys.begin(), m_sortedKeys.end(),
-                         ColorKey(s, T()));
+                         ColorKey(s, T()),
+                         [](const ColorKey &a, const ColorKey &b) {
+                           return a.first < b.first;
+                         });  // compare only key postions
+
     if (b == m_sortedKeys.end())
       return m_sortedKeys.rbegin()->second;
     else if (b == m_sortedKeys.begin() || areAlmostEqual(b->first, s))


### PR DESCRIPTION
This PR does not affect a behavior of the release version of the software, but fixes following assertion failure when running on the debug mode.
- When rendering a scene containing the Linear Gradient Fx, if the alpha channel value of the `Start Color` is less than 255, OT aborts with assertion failure at [line 49](https://github.com/opentoonz/opentoonz/blob/master/toonz/sources/include/tspectrum.h#L49) .