### PR TITLE
Fix Crush On Inserting Fx

### DIFF
--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -2194,8 +2194,12 @@ bool FxSchematicScene::isAnEmptyZone_withParentFx(const QRectF &rect,
     if (fxNode && fxNode->isA(eXSheetFx)) continue;
     // check only the fxs sharing the same parent
     if (!fxNode) continue;
-    for (int p = 0; p < fxNode->getInputPortCount(); p++) {
-      if (parent == fxNode->getFx()->getInputPort(p)->getFx()) {
+    TFx *fx = fxNode->getFx();
+    if (TZeraryColumnFx *zfx = dynamic_cast<TZeraryColumnFx *>(fx))
+      fx = zfx->getZeraryFx();
+    if (!fx || fx == parent) continue;
+    for (int p = 0; p < fx->getInputPortCount(); p++) {
+      if (parent == fx->getInputPort(p)->getFx()) {
         if (node->boundingRect().translated(node->scenePos()).intersects(rect))
           return false;
         else


### PR DESCRIPTION
This PR fixes the following problem:
- In Fx Schematic, when trying to insert an fx after a Particles fx, OT crushes.
![insertfx_bug](https://user-images.githubusercontent.com/17974955/136513223-cdcd9063-1a4a-45d1-b791-d166b960c123.png)
 