### PR TITLE
Fix "Show Folder Contents" command for UNC path

### DIFF
--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -327,12 +327,16 @@ void FileSelection::showFolderContents() {
     if (!model) return;
     folderPath = model->getFolder();
   }
-  if (TSystem::isUNC(folderPath))
-    QDesktopServices::openUrl(
+  if (TSystem::isUNC(folderPath)) {
+    bool ok = QDesktopServices::openUrl(
         QUrl(QString::fromStdWString(folderPath.getWideString())));
-  else
-    QDesktopServices::openUrl(QUrl::fromLocalFile(
-        QString::fromStdWString(folderPath.getWideString())));
+    if (ok) return;
+    // If the above fails, then try opening UNC path with the same way as the
+    // local files.. QUrl::fromLocalFile() seems to work for UNC path as well in
+    // our environment. (8/10/2021 shun-iwasawa)
+  }
+  QDesktopServices::openUrl(
+      QUrl::fromLocalFile(QString::fromStdWString(folderPath.getWideString())));
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the following problem:
- `Show Folder Contents` command in the RMB menu of the File Browser does not work if the current folder is written in UNC path (like `\\server-name\shared-folder-name`).