### PR TITLE
Fix crush on showing snapshot in flipbook

### DIFF
--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -791,8 +791,10 @@ void FlipBook::onButtonPressed(FlipConsole::EGadget button) {
     TImageP clonedImg;
     if (ri)
       clonedImg = TRasterImageP(ri->getRaster()->clone());
-    else
+    else {
       clonedImg = TToonzImageP(ti->getRaster()->clone(), ti->getSavebox());
+      clonedImg->setPalette(ti->getPalette());
+    }
     TImageCache::instance()->add(QString("TnzCompareImg"), clonedImg);
     break;
   }

--- a/toonz/sources/toonzlib/imagepainter.cpp
+++ b/toonz/sources/toonzlib/imagepainter.cpp
@@ -268,9 +268,10 @@ void Painter::flushRasterImages(const TRect &loadbox, double compareX,
     if ((TToonzImageP)refimg || (TRasterImageP)refimg) {
       // draw left/up part of the screen...
       TRasterP raux, rref;
-      if ((TToonzImageP)refimg)
-        rref = ((TToonzImageP)refimg)->getCMapped();
-      else
+      if ((TToonzImageP)refimg) {
+        rref      = ((TToonzImageP)refimg)->getCMapped();
+        m_palette = refimg->getPalette();
+      } else
         rref = ((TRasterImageP)refimg)->getRaster();
 
       TRect rect = loadbox;


### PR DESCRIPTION
This PR fixes #4104 by keeping palette data along with image when taking a snapshot of toonz raster.