### PR TITLE
Modify Flipbook Histogram

### DIFF
--- a/toonz/sources/include/tools/stylepicker.h
+++ b/toonz/sources/include/tools/stylepicker.h
@@ -66,7 +66,10 @@ public:
   // per pli come sopra, ma ritorna il maincolor
   // per tzp e fullcolor ritorna il colore effettivo del pixel
   TPixel32 pickColor(const TPointD &point, double radius, double scale2) const;
+  TPixel64 pickColor16(const TPointD &point, double radius,
+                       double scale2) const;
   TPixel32 pickAverageColor(const TRectD &rect) const;
+  TPixel64 pickAverageColor16(const TRectD &rect) const;
 
   // ritorna il colore medio presente nell'area della finestra corrente openGL
   TPixel32 pickColor(const TRectD &area) const;
@@ -80,5 +83,4 @@ public:
   // il valore di ritorno si riferisce all'eventuale raster: (0,0)==leftbottom
   TPoint getRasterPoint(const TPointD &p) const;
 };
-
 #endif

--- a/toonz/sources/tnztools/stylepicker.cpp
+++ b/toonz/sources/tnztools/stylepicker.cpp
@@ -172,6 +172,27 @@ TPixel32 StylePicker::pickColor(const TPointD &pos, double radius,
 
 //---------------------------------------------------------
 
+TPixel64 StylePicker::pickColor16(const TPointD &pos, double radius,
+                                  double scale2) const {
+  TToonzImageP ti  = m_image;
+  TRasterImageP ri = m_image;
+  TVectorImageP vi = m_image;
+  assert(ri && !ti && !vi);
+  if (!ri || ti || vi) return TPixel64::Transparent;
+
+  TRasterP raster = ri->getRaster();
+  if (raster->getPixelSize() != 8) return TPixel64::Transparent;
+
+  TPoint point = getRasterPoint(pos);
+  if (!raster->getBounds().contains(point)) return TPixel64::Transparent;
+
+  TRaster64P raster64 = raster;
+  if (!raster64) return TPixel64::Transparent;
+
+  return raster64->pixels(point.y)[point.x];
+}
+//---------------------------------------------------------
+
 TPixel32 StylePicker::pickAverageColor(const TRectD &rect) const {
   TRasterImageP ri = m_image;
   assert(ri);
@@ -216,8 +237,50 @@ TPixel32 StylePicker::pickAverageColor(const TRectD &rect) const {
 
 //---------------------------------------------------------
 
-namespace {
+TPixel64 StylePicker::pickAverageColor16(const TRectD &rect) const {
+  TRasterImageP ri = m_image;
+  assert(ri);
+  if (!ri) return TPixel64::Transparent;
+  TRasterP raster;
+  raster = ri->getRaster();
+  if (raster->getPixelSize() != 8) return TPixel64::Transparent;
 
+  TPoint topLeft     = getRasterPoint(rect.getP00());
+  TPoint bottomRight = getRasterPoint(rect.getP11());
+
+  if (!raster->getBounds().overlaps(TRect(topLeft, bottomRight)))
+    return TPixel64::Transparent;
+
+  topLeft.x     = std::max(0, topLeft.x);
+  topLeft.y     = std::max(0, topLeft.y);
+  bottomRight.x = std::min(raster->getLx(), bottomRight.x);
+  bottomRight.y = std::min(raster->getLy(), bottomRight.y);
+
+  TRaster64P raster64 = raster;
+  assert(raster64);
+  if (!raster64) return TPixel64::Transparent;
+
+  UINT r = 0, g = 0, b = 0, m = 0, size = 0;
+  for (int y = topLeft.y; y < bottomRight.y; y++) {
+    TPixel64 *p = &raster64->pixels(y)[topLeft.x];
+    for (int x = topLeft.x; x < bottomRight.x; x++, p++) {
+      r += p->r;
+      g += p->g;
+      b += p->b;
+      m += p->m;
+      size++;
+    }
+  }
+
+  if (size)
+    return TPixel64(r / size, g / size, b / size, m / size);
+  else
+    return TPixel64::Transparent;
+}
+
+//---------------------------------------------------------
+
+namespace {
 TPixel32 getAverageColor(const TRect &rect) {
   GLenum fmt =
 #if defined(TNZ_MACHINE_CHANNEL_ORDER_BGRM)
@@ -234,8 +297,8 @@ TPixel32 getAverageColor(const TRect &rect) {
 #endif
   UINT r = 0, g = 0, b = 0, m = 0;
   std::vector<TPixel32> buffer(rect.getLx() * rect.getLy());
-  glReadPixels(rect.x0, rect.y0, rect.getLx(), rect.getLy(), fmt,
-               GL_UNSIGNED_BYTE, &buffer[0]);
+  glReadPixels(rect.x0, rect.y0, rect.getLx(), rect.getLy(), fmt, TGL_TYPE,
+               &buffer[0]);
   int size = rect.getLx() * rect.getLy();
   for (int i = 0; i < size; i++) {
     r += buffer[i].r;
@@ -243,7 +306,7 @@ TPixel32 getAverageColor(const TRect &rect) {
     b += buffer[i].b;
   }
 
-  return TPixel32(b / size, g / size, r / size, 255);
+  return TPixel32(b / size, g / size, r / size, TPixel32::maxChannelValue);
 }
 
 //---------------------------------------------------------

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -796,15 +796,19 @@ void FlipBook::onButtonPressed(FlipConsole::EGadget button) {
       clonedImg->setPalette(ti->getPalette());
     }
     TImageCache::instance()->add(QString("TnzCompareImg"), clonedImg);
+    // to update the histogram of compare snapshot image
+    m_imageViewer->invalidateCompHisto();
     break;
   }
 
   case FlipConsole::eCompare:
-    if ((TVectorImageP)getCurrentImage(m_flipConsole->getCurrentFrame())) {
+    if (m_flipConsole->isChecked(FlipConsole::eCompare) &&
+        (TVectorImageP)getCurrentImage(m_flipConsole->getCurrentFrame())) {
       DVGui::warning(
           tr("It is not possible to take or compare snapshots for Toonz vector "
              "levels."));
-      m_flipConsole->setChecked(FlipConsole::eCompare, false);
+      // cancel the button pressing
+      m_flipConsole->pressButton(FlipConsole::eCompare);
       return;
     }
     break;

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -45,6 +45,7 @@ HistogramPopup::HistogramPopup(QString title)
   mainLay->setSpacing(0);
   { mainLay->addWidget(m_histogram); }
   setLayout(mainLay);
+  mainLay->setSizeConstraint(QLayout::SetFixedSize);
   setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 }
 
@@ -74,16 +75,35 @@ void HistogramPopup::setImage(TImageP image) {
 }
 //-----------------------------------------------------------------------------
 /*! show the picked color
-*/
+ */
 void HistogramPopup::updateInfo(const TPixel32 &pix, const TPointD &imagePos) {
+  m_histogram->updateInfo(pix, imagePos);
+}
+
+void HistogramPopup::updateInfo(const TPixel64 &pix, const TPointD &imagePos) {
   m_histogram->updateInfo(pix, imagePos);
 }
 
 //-----------------------------------------------------------------------------
 /*! show the average-picked color
-*/
+ */
 void HistogramPopup::updateAverageColor(const TPixel32 &pix) {
   m_histogram->updateAverageColor(pix);
+}
+
+void HistogramPopup::updateAverageColor(const TPixel64 &pix) {
+  m_histogram->updateAverageColor(pix);
+}
+//-----------------------------------------------------------------------------
+
+void HistogramPopup::setShowCompare(bool on) {
+  m_histogram->setShowCompare(on);
+}
+
+//-----------------------------------------------------------------------------
+
+void HistogramPopup::invalidateCompHisto() {
+  m_histogram->invalidateCompHisto();
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/histogrampopup.h
+++ b/toonz/sources/toonz/histogrampopup.h
@@ -27,7 +27,11 @@ public:
   void setImage(TImageP image);
 
   void updateInfo(const TPixel32 &pix, const TPointD &imagePos);
+  void updateInfo(const TPixel64 &pix, const TPointD &imagePos);
   void updateAverageColor(const TPixel32 &pix);
+  void updateAverageColor(const TPixel64 &pix);
+  void setShowCompare(bool on);
+  void invalidateCompHisto();
 };
 
 //=============================================================================

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -373,6 +373,10 @@ void ImageViewer::contextMenuEvent(QContextMenuEvent *event) {
 //-----------------------------------------------------------------------------
 
 void ImageViewer::setVisual(const ImagePainter::VisualSettings &settings) {
+  if (m_isHistogramEnable && m_histogramPopup &&
+      settings.m_doCompare != m_visualSettings.m_doCompare) {
+    m_histogramPopup->setShowCompare(settings.m_doCompare);
+  }
   m_visualSettings = settings;
   m_visualSettings.m_sceneProperties =
       TApp::instance()->getCurrentScene()->getScene()->getProperties();
@@ -866,7 +870,10 @@ void ImageViewer::mouseMoveEvent(QMouseEvent *event) {
 
       if (m_rectRGBPick) {
         update();
-        rectPickColor();
+        // do not pick vector image while dragging as a portion of the red
+        // rubber band may affect the result
+        TImageP img = getPickedImage(m_pos);
+        if (img && img->raster()) rectPickColor();
       }
     }
 
@@ -950,34 +957,48 @@ void ImageViewer::pickColor(QMouseEvent *event, bool putValueToStyleEditor) {
 
   StylePicker picker(img);
 
-  TPointD mousePos = TPointD(curPos.x(), height() - 1 - curPos.y());
-  TRectD area      = TRectD(mousePos.x, mousePos.y, mousePos.x, mousePos.y);
-
   TPointD pos =
       getViewAff().inv() * TPointD(curPos.x() - (qreal)(width()) / 2,
                                    -curPos.y() + (qreal)(height()) / 2);
 
   TRectD imgRect = (img->raster()) ? convert(TRect(img->raster()->getSize()))
                                    : img->getBBox();
-  TPointD imagePos =
-      TPointD(0.5 * imgRect.getLx() + pos.x, 0.5 * imgRect.getLy() + pos.y);
+  TPointD imagePos = (img->raster()) ? TPointD(0.5 * imgRect.getLx() + pos.x,
+                                               0.5 * imgRect.getLy() + pos.y)
+                                     : pos;
 
-  TPixel32 pix;
-  if (m_lutCalibrator && m_lutCalibrator->isValid()) {
+  if (!imgRect.contains(imagePos)) {
+    // throw transparent color if picking outside of the image
+    m_histogramPopup->updateInfo(TPixel32::Transparent, TPointD(-1, -1));
+  } else if (!img->raster()) {  // vector image
+    // For unknown reasons, glReadPixels is covering the entire window not the
+    // OpenGL widget.
+    QPointF winPos = event->windowPos() * getDevPixRatio();
+    TPointD mousePos =
+        TPointD(winPos.x(), (double)(window()->height()) - winPos.y());
+    TRectD area  = TRectD(mousePos.x, mousePos.y, mousePos.x, mousePos.y);
+    TPixel32 pix = picker.pickColor(area);
+    m_histogramPopup->updateInfo(pix, imagePos);
+    if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
+  } else if (img->raster()->getPixelSize() == 8)  // 16bpc raster
+  {
     // for specifying pixel range on picking vector
     double scale2 = getViewAff().det();
-    pix           = picker.pickColor(pos + TPointD(-0.5, -0.5), 10.0, scale2);
-  } else
-    pix = picker.pickColor(area);
+    TPixel64 pix  = picker.pickColor16(pos + TPointD(-0.5, -0.5), 10.0, scale2);
 
-  if (!img->raster() || imgRect.contains(imagePos)) {
+    // throw the picked color to the histogram
+    m_histogramPopup->updateInfo(pix, imagePos);
+    // throw it to the style editor as well
+    if (putValueToStyleEditor) setPickedColorToStyleEditor(toPixel32(pix));
+  } else {  // 8bpc raster
+    // for specifying pixel range on picking vector
+    double scale2 = getViewAff().det();
+    TPixel32 pix  = picker.pickColor(pos + TPointD(-0.5, -0.5), 10.0, scale2);
+
     // throw the picked color to the histogram
     m_histogramPopup->updateInfo(pix, imagePos);
     // throw it to the style editor as well
     if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
-  } else {
-    // throw transparent color if picking outside of the image
-    m_histogramPopup->updateInfo(TPixel32::Transparent, TPointD(-1, -1));
   }
 }
 
@@ -1005,6 +1026,28 @@ void ImageViewer::rectPickColor(bool putValueToStyleEditor) {
 
   StylePicker picker(img);
 
+  if (!img->raster()) {  // vector image
+    TPointD pressedWinPos = convert(m_pressedMousePos) + m_winPosMousePosOffset;
+    TPointD startPos      = TPointD(pressedWinPos.x,
+                               (double)(window()->height()) - pressedWinPos.y);
+    TPointD currentWinPos =
+        TPointD(m_pos.x(), m_pos.y()) + m_winPosMousePosOffset;
+    TPointD endPos = TPointD(currentWinPos.x,
+                             (double)(window()->height()) - currentWinPos.y);
+    TRectD area    = TRectD(startPos, endPos);
+    area           = area.enlarge(-4, -4);
+    if (area.getLx() < 2 || area.getLy() < 2) {
+      m_histogramPopup->updateAverageColor(TPixel32::Transparent);
+      return;
+    }
+    TPixel32 pix = picker.pickColor(area);
+    // throw the picked color to the histogram
+    m_histogramPopup->updateAverageColor(pix);
+    // throw it to the style editor as well
+    if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
+    return;
+  }
+
   TPoint startPos =
       TPoint(m_pressedMousePos.x, height() - 1 - m_pressedMousePos.y);
   TPoint endPos = TPoint(m_pos.x(), height() - 1 - m_pos.y());
@@ -1014,21 +1057,25 @@ void ImageViewer::rectPickColor(bool putValueToStyleEditor) {
     m_histogramPopup->updateAverageColor(TPixel32::Transparent);
     return;
   }
+  TPointD start = getViewAff().inv() *
+                  TPointD(startPos.x - width() / 2, startPos.y - height() / 2);
+  TPointD end = getViewAff().inv() *
+                TPointD(endPos.x - width() / 2, endPos.y - height() / 2);
 
-  TPixel32 pix;
-  if (m_lutCalibrator && m_lutCalibrator->isValid() && isRas32(img)) {
-    TPointD start = getViewAff().inv() * TPointD(startPos.x - width() / 2,
-                                                 startPos.y - height() / 2);
-    TPointD end   = getViewAff().inv() *
-                  TPointD(endPos.x - width() / 2, endPos.y - height() / 2);
-    pix = picker.pickAverageColor(TRectD(start, end));
-  } else
-    pix = picker.pickColor(area.enlarge(-1, -1));
-
-  // throw the picked color to the histogram
-  m_histogramPopup->updateAverageColor(pix);
-  // throw it to the style editor as well
-  if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
+  if (img->raster()->getPixelSize() == 8)  // 16bpc raster
+  {
+    TPixel64 pix = picker.pickAverageColor16(TRectD(start, end));
+    // throw the picked color to the histogram
+    m_histogramPopup->updateAverageColor(pix);
+    // throw it to the style editor as well
+    if (putValueToStyleEditor) setPickedColorToStyleEditor(toPixel32(pix));
+  } else {  // 8bpc raster
+    TPixel32 pix = picker.pickAverageColor(TRectD(start, end));
+    // throw the picked color to the histogram
+    m_histogramPopup->updateAverageColor(pix);
+    // throw it to the style editor as well
+    if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1095,6 +1142,9 @@ void ImageViewer::mousePressEvent(QMouseEvent *event) {
   m_pressedMousePos       = TPoint(m_pos.x(), m_pos.y());
   m_mouseButton           = event->button();
   m_draggingZoomSelection = false;
+
+  QPointF winPosMousePos = event->windowPos() * getDevPixRatio() - m_pos;
+  m_winPosMousePosOffset = TPointD(winPosMousePos.x(), winPosMousePos.y());
 
   if (m_mouseButton != Qt::LeftButton) {
     event->ignore();
@@ -1337,6 +1387,13 @@ void ImageViewer::doSwapBuffers() { glFlush(); }
 void ImageViewer::changeSwapBehavior(bool enable) {
   // do nothing for now as setUpdateBehavior is not available with QGLWidget
   // setUpdateBehavior(enable ? PartialUpdate : NoPartialUpdate);
+}
+
+//-----------------------------------------------------------------------------
+
+void ImageViewer::invalidateCompHisto() {
+  if (!m_isHistogramEnable || !m_histogramPopup) return;
+  m_histogramPopup->invalidateCompHisto();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -38,6 +38,11 @@ class ImageViewer final : public GLWidgetForHighDpi {
   FlipBook *m_flipbook;
   TPoint m_pressedMousePos;
 
+  // Modifying rect-picking positon offset for vector image.
+  // For unknown reasons, glReadPixels is covering the entire window not the
+  // OpenGL widget.
+  TPointD m_winPosMousePosOffset;
+
   Qt::MouseButton m_mouseButton;
   bool m_draggingZoomSelection;
 
@@ -125,6 +130,7 @@ public:
 
   void doSwapBuffers();
   void changeSwapBehavior(bool enable);
+  void invalidateCompHisto();
 
 protected:
   void contextMenuEvent(QContextMenuEvent *event) override;


### PR DESCRIPTION
This PR modifies the Histogram popup as follows:

- Fixed Histogram to display the picked color properly when both the `10bit Display` and the `Color Calibration using 3D Look-up Table` preference options are ON.
- Fixed picked position offset when viewing the vector level file.
- Fixed layout not to allow to resize the popup manually.
- Added an option to select a display format of the picked color. ( Either `8bit (0-255)` , `16bit (0-65535)`, or `0.0-1.0` )
- Histogram of the snapshot image is now displayed (overlapping the original one) when `Compare to Snapshot` is ON in the parent Flipbook.

<img src="https://user-images.githubusercontent.com/17974955/137663114-804cc770-65b8-4c31-a4e0-ab94e98c1389.png" height=400>
