### PR TITLE
Fix Convert to TLV Palette Saving

### DIFF
--- a/toonz/sources/toonzlib/convert2tlv.cpp
+++ b/toonz/sources/toonzlib/convert2tlv.cpp
@@ -539,6 +539,8 @@ void Convert2Tlv::buildToonzRaster(TRasterCM32P &rout, const TRasterP &rin1,
 //----------------------------------------------
 
 TPalette *Convert2Tlv::buildPalette() {
+  m_palette->setDirtyFlag(true);  // make sure to be overwritten
+
   std::map<TPixel, int>::const_iterator it = m_colorMap.begin();
   TPalette::Page *page                     = m_palette->getPage(0);
 


### PR DESCRIPTION
This PR fixes the following problem:

- When converting a file to TLV using `Convert...` command, if the palette file already exists, it is not overwritten by the new one.