### PR TITLE
Xsheet Minimum Layout

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -199,7 +199,8 @@ enum class PredefinedFlag {
   THUMBNAIL_AREA_BORDER,
   THUMBNAIL_AREA_VISIBLE,
   CAMERA_ICON_VISIBLE,
-  VOLUME_AREA_VERTICAL
+  VOLUME_AREA_VERTICAL,
+  NOTE_AREA_IN_POPUP
 };
 
 // Knows everything about geometry of a particular orientation.

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -112,6 +112,12 @@ public:
     ToggleBetweenGraphAndSpreadsheet
   };
 
+  enum LevelNameDisplayType {
+    ShowLevelName_Default = 0,
+    ShowLevelNameOnEachMarker,
+    ShowLevelNameOnColumnHeader
+  };
+
   //--- callbacks
   // General
   void enableAutosave();
@@ -213,14 +219,8 @@ public:
   bool isActualPixelViewOnSceneEditingModeEnabled() const {
     return getBoolValue(actualPixelViewOnSceneEditingMode);
   }
-  bool isLevelNameOnEachMarkerEnabled() const {
-    return getBoolValue(levelNameOnEachMarkerEnabled);
-  }
   bool isShowRasterImagesDarkenBlendedInViewerEnabled() const {
     return getBoolValue(showRasterImagesDarkenBlendedInViewer);
-  }
-  bool isShowFrameNumberWithLettersEnabled() const {
-    return getBoolValue(showFrameNumberWithLetters);
   }
   TDimension getIconSize() const { return getSizeValue(iconSize); }
   void getViewValues(int &shrink, int &step) const {
@@ -396,6 +396,16 @@ public:
   }
   void getCurrentColumnData(TPixel &color) const {
     color = getColorValue(currentColumnColor);
+  }
+
+  LevelNameDisplayType getLevelNameDisplayType() const {
+    return LevelNameDisplayType(getIntValue(levelNameDisplayType));
+  }
+  bool isLevelNameOnEachMarkerEnabled() const {
+    return getLevelNameDisplayType() == ShowLevelNameOnEachMarker;
+  }
+  bool isShowFrameNumberWithLettersEnabled() const {
+    return getBoolValue(showFrameNumberWithLetters);
   }
 
   // Animation  tab

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -28,9 +28,7 @@ enum PreferencesItemId {
   functionEditorToggle,
   moveCurrentFrameByClickCellArea,
   actualPixelViewOnSceneEditingMode,
-  levelNameOnEachMarkerEnabled,
   showRasterImagesDarkenBlendedInViewer,
-  showFrameNumberWithLetters,
   iconSize,
   viewShrink,
   viewStep,
@@ -130,6 +128,8 @@ enum PreferencesItemId {
   syncLevelRenumberWithXsheet,
   currentTimelineEnabled,
   currentColumnColor,
+  levelNameDisplayType,
+  showFrameNumberWithLetters,
 
   //----------
   // Animation

--- a/toonz/sources/include/toonz/tstageobject.h
+++ b/toonz/sources/include/toonz/tstageobject.h
@@ -175,6 +175,7 @@ the tree or
 
   void setName(const std::string &name);
   std::string getName() const;
+  bool hasSpecifiedName() { return m_name != ""; }
 
   bool hasSpecifiedName() const { return m_name != ""; }
 

--- a/toonz/sources/include/toonzqt/functionviewer.h
+++ b/toonz/sources/include/toonzqt/functionviewer.h
@@ -151,6 +151,7 @@ public slots:
   void onCurveChanged(bool isDragging);
   void onCurveSelected(TDoubleParam *);
   void onSelectionChanged();
+  void onPreferenceChanged(const QString &);
 
   void doSwitchCurrentObject(TStageObject *obj);
   void doSwitchCurrentFx(TFx *fx);

--- a/toonz/sources/include/toonzqt/spreadsheetviewer.h
+++ b/toonz/sources/include/toonzqt/spreadsheetviewer.h
@@ -473,6 +473,9 @@ public:
 
   virtual int getFrameZoomFactor() const { return 100; }
 
+  bool isSmallHeader();
+  void updateHeaderHeight();
+
 protected:
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;

--- a/toonz/sources/toonz/layerfooterpanel.cpp
+++ b/toonz/sources/toonz/layerfooterpanel.cpp
@@ -47,6 +47,9 @@ LayerFooterPanel::LayerFooterPanel(XsheetViewer *viewer, QWidget *parent,
   m_frameZoomSlider->setInvertedAppearance(invDirection);
   m_frameZoomSlider->setInvertedControls(invDirection);
 
+  // for minimal layout, hide the slider
+  if (o->rect(PredefinedRect::ZOOM_SLIDER).isEmpty()) m_frameZoomSlider->hide();
+
   connect(m_frameZoomSlider, SIGNAL(valueChanged(int)), this,
           SLOT(onFrameZoomSliderValueChanged(int)));
 }
@@ -130,6 +133,12 @@ void LayerFooterPanel::showOrHide(const Orientation *o) {
   m_frameZoomSlider->setToolTip(tooltipStr);
   m_frameZoomSlider->setInvertedAppearance(invDirection);
   m_frameZoomSlider->setInvertedControls(invDirection);
+
+  // for minimal layout, hide the slider
+  if (o->rect(PredefinedRect::ZOOM_SLIDER).isEmpty())
+    m_frameZoomSlider->hide();
+  else
+    m_frameZoomSlider->show();
 
   show();
 }

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1131,11 +1131,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
           "Area")},
       {actualPixelViewOnSceneEditingMode,
        tr("Enable Actual Pixel View on Scene Editing Mode")},
-      {levelNameOnEachMarkerEnabled, tr("Display Level Name on Each Marker")},
       {showRasterImagesDarkenBlendedInViewer,
        tr("Show Raster Images Darken Blended")},
-      {showFrameNumberWithLetters,
-       tr("Show \"ABC\" Appendix to the Frame Number in Xsheet Cell")},
       {iconSize, tr("Level Strip Thumbnail Size*:")},
       {viewShrink, tr("Viewer Shrink:")},
       {viewStep, tr("Step:")},
@@ -1240,6 +1237,11 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {currentTimelineEnabled,
        tr("Show Current Time Indicator (Timeline Mode only)")},
       {currentColumnColor, tr("Current Column Color:")},
+      //{ levelNameOnEachMarkerEnabled, tr("Display Level Name on Each Marker")
+      //},
+      {levelNameDisplayType, tr("Level Name Display:")},
+      {showFrameNumberWithLetters,
+       tr("Show \"ABC\" Appendix to the Frame Number in Xsheet Cell")},
 
       // Animation
       {keyframeType, tr("Default Interpolation:")},
@@ -1364,7 +1366,13 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
       {xsheetLayoutPreference,
        {{tr("Classic"), "Classic"},
         {tr("Classic-revised"), "Classic-revised"},
-        {tr("Compact"), "Compact"}}},
+        {tr("Compact"), "Compact"},
+        {tr("Minimum"), "Minimum"}}},
+      {levelNameDisplayType,
+       {{tr("Default"), Preferences::ShowLevelName_Default},
+        {tr("Display on Each Marker"), Preferences::ShowLevelNameOnEachMarker},
+        {tr("Display on Column Header"),
+         Preferences::ShowLevelNameOnColumnHeader}}},
       {DragCellsBehaviour,
        {{tr("Cells Only"), 0}, {tr("Cells and Column Data"), 1}}},
       {keyframeType,  // note that the value starts from 1, not 0
@@ -1594,9 +1602,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   insertUI(functionEditorToggle, lay, getComboItemList(functionEditorToggle));
   insertUI(moveCurrentFrameByClickCellArea, lay);
   insertUI(actualPixelViewOnSceneEditingMode, lay);
-  insertUI(levelNameOnEachMarkerEnabled, lay);
   insertUI(showRasterImagesDarkenBlendedInViewer, lay);
-  insertUI(showFrameNumberWithLetters, lay);
   insertUI(iconSize, lay);
   insertDualUIs(viewShrink, viewStep, lay);
   insertUI(viewerZoomCenter, lay, getComboItemList(viewerZoomCenter));
@@ -1881,6 +1887,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
 
   insertUI(xsheetLayoutPreference, lay,
            getComboItemList(xsheetLayoutPreference));
+  insertUI(levelNameDisplayType, lay, getComboItemList(levelNameDisplayType));
   insertUI(xsheetStep, lay);
   insertUI(xsheetAutopanEnabled, lay);
   insertUI(DragCellsBehaviour, lay, getComboItemList(DragCellsBehaviour));
@@ -1897,6 +1904,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   insertUI(syncLevelRenumberWithXsheet, lay);
   insertUI(currentTimelineEnabled, lay);
   insertUI(currentColumnColor, lay);
+  insertUI(showFrameNumberWithLetters, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -76,6 +76,26 @@
 
 namespace {
 
+const bool checkContainsSingleLevel(TXshColumn *column) {
+  TXshLevel *level           = nullptr;
+  TXshCellColumn *cellColumn = column->getCellColumn();
+  if (cellColumn) {
+    int i, r0, r1;
+    cellColumn->getRange(r0, r1);
+    for (i = r0; i <= r1; i++) {
+      TXshCell cell = cellColumn->getCell(i);
+      if (cell.isEmpty()) continue;
+      TXshLevel *lvl = cell.m_level.getPointer();
+      if (!level)
+        level = lvl;
+      else if (lvl != level)
+        return false;
+    }
+    return level != nullptr;
+  }
+  return false;
+}
+
 bool selectionContainTlvImage(TCellSelection *selection, TXsheet *xsheet,
                               bool onlyTlv = false) {
   int r0, r1, c0, c1;
@@ -1162,10 +1182,16 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
     bool isSoundColumn     = false;
     bool isPaletteColumn   = false;
     bool isSoundTextColumn = false;
+    bool showLevelName     = true;
     if (isColumn) {
       isSoundColumn     = column->getSoundColumn() != 0;
       isPaletteColumn   = column->getPaletteColumn() != 0;
       isSoundTextColumn = column->getSoundTextColumn() != 0;
+      if (Preferences::instance()->getLevelNameDisplayType() ==
+          Preferences::ShowLevelNameOnColumnHeader)
+        showLevelName =
+            (isSoundColumn || isPaletteColumn || isSoundTextColumn ||
+             !checkContainsSingleLevel(column));
     }
     // check if the column is reference
     bool isReference = true;
@@ -1204,7 +1230,7 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
       else if (isSoundTextColumn)
         drawSoundTextCell(p, row, col);
       else
-        drawLevelCell(p, row, col, isReference);
+        drawLevelCell(p, row, col, isReference, showLevelName);
     }
 
     // draw vertical line
@@ -1653,7 +1679,8 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
 
 //-----------------------------------------------------------------------------
 
-void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
+void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
+                             bool showLevelName) {
   const Orientation *o = m_viewer->orientation();
 
   TXsheet *xsh  = m_viewer->getXsheet();
@@ -1873,6 +1900,12 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
 
     QLine continueLine = o->line(which).translated(xy);
     continueLine.setP2(QPoint(continueLine.x2(), continueLine.y2()) - frameAdj);
+
+    if (!showLevelName) {
+      penColor.setAlphaF(0.5);
+      p.setPen(penColor);
+    }
+
     p.drawLine(continueLine);
   }
   // draw frame number
@@ -1903,13 +1936,16 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference) {
       fnum = QString::fromStdString(frameNumber);
     }
 
-    p.drawText(nameRect, Qt::AlignRight | Qt::AlignBottom, fnum);
+    int alignFlag =
+        ((showLevelName) ? Qt::AlignRight | Qt::AlignBottom : Qt::AlignCenter);
+    p.drawText(nameRect, alignFlag, fnum);
   }
 
   // draw level name
-  if (!sameLevel ||
-      (isAfterMarkers && !isSimpleView &&
-       Preferences::instance()->isLevelNameOnEachMarkerEnabled())) {
+  if (showLevelName &&
+      (!sameLevel ||
+       (isAfterMarkers && !isSimpleView &&
+        Preferences::instance()->isLevelNameOnEachMarkerEnabled()))) {
     std::wstring levelName = cell.m_level->getName();
     QString text           = QString::fromStdWString(levelName);
     QFontMetrics fm(font);
@@ -2902,9 +2938,8 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
       double e0, e1;
       int rh0, rh1;
       if (pegbar->getKeyframeSpan(row, r0, e0, r1, e1) &&
-          getEaseHandles(
-              r0, r1, e0, e1, rh0,
-              rh1)) {  // triangles in the segment between key frames
+          getEaseHandles(r0, r1, e0, e1, rh0,
+                         rh1)) {  // triangles in the segment between key frames
         if (rh0 == row)
           m_tooltip = tr("Click and drag to set the acceleration range");
         else if (rh1 == row)

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -90,7 +90,10 @@ class CellArea final : public QWidget {
 
   void drawFrameSeparator(QPainter &p, int row, int col, bool emptyFrame,
                           bool heldFrame = false);
-  void drawLevelCell(QPainter &p, int row, int col, bool isReference = false);
+  // showLevelName can be OFF only when Preferences::getLevelNameDisplayType()
+  // == ShowLevelNameOnColumnHeader
+  void drawLevelCell(QPainter &p, int row, int col, bool isReference = false,
+                     bool showLevelName = true);
   void drawSoundTextCell(QPainter &p, int row, int col);
   void drawSoundCell(QPainter &p, int row, int col, bool isReference = false);
   void drawPaletteCell(QPainter &p, int row, int col, bool isReference = false);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -62,23 +62,26 @@
 #include <QTimer>
 #include <QLabel>
 #include <QComboBox>
+#include <QCheckBox>
 #include <QPushButton>
 #include <QDesktopWidget>
 
 #include <QBitmap>
+
 //=============================================================================
 
 namespace {
-const QSet<TXshSimpleLevel *> getLevels(TXshColumn *column) {
-  QSet<TXshSimpleLevel *> levels;
+const QSet<TXshLevel *> getLevels(TXshColumn *column) {
+  QSet<TXshLevel *> levels;
+
   TXshCellColumn *cellColumn = column->getCellColumn();
   if (cellColumn) {
     int i, r0, r1;
     cellColumn->getRange(r0, r1);
     for (i = r0; i <= r1; i++) {
-      TXshCell cell       = cellColumn->getCell(i);
-      TXshSimpleLevel *sl = cell.getSimpleLevel();
-      if (sl) levels.insert(sl);
+      TXshCell cell = cellColumn->getCell(i);
+      // TXshSimpleLevel *sl = cell.getSimpleLevel();
+      if (!cell.isEmpty()) levels.insert(cell.m_level.getPointer());
     }
   }
   return levels;
@@ -123,18 +126,37 @@ bool containsVectorLevel(int col) {
   TXshColumn::ColumnType type = column->getColumnType();
   if (type != TXshColumn::eLevelType) return false;
 
-  const QSet<TXshSimpleLevel *> levels = getLevels(column);
-  QSet<TXshSimpleLevel *>::const_iterator it2;
+  const QSet<TXshLevel *> levels = getLevels(column);
+  QSet<TXshLevel *>::const_iterator it2;
   bool isVector = false;
   for (it2 = levels.begin(); it2 != levels.end(); it2++) {
-    TXshSimpleLevel *sl = *it2;
-    int type            = sl->getType();
+    TXshLevel *lvl = *it2;
+    int type       = lvl->getType();
     if (type == PLI_XSHLEVEL) {
       isVector = true;
       return true;
     }
   }
   return false;
+}
+
+QIcon createLockIcon(XsheetViewer *viewer) {
+  QImage icon_on, icon_off;
+  QColor bgColor_on, bgColor_off;
+  viewer->getButton(LOCK_ON_XSHBUTTON, bgColor_on, icon_on);
+  viewer->getButton(LOCK_OFF_XSHBUTTON, bgColor_off, icon_off);
+  QPainter p_on(&icon_on);
+  p_on.setCompositionMode(QPainter::CompositionMode_DestinationOver);
+  p_on.fillRect(0, 0, icon_on.width(), icon_on.height(), bgColor_on);
+  p_on.end();
+  QPainter p_off(&icon_off);
+  p_off.setCompositionMode(QPainter::CompositionMode_DestinationOver);
+  p_off.fillRect(0, 0, icon_off.width(), icon_off.height(), bgColor_off);
+  p_off.end();
+  QIcon lockIcon;
+  lockIcon.addPixmap(QPixmap::fromImage(icon_off));
+  lockIcon.addPixmap(QPixmap::fromImage(icon_on), QIcon::Normal, QIcon::On);
+  return lockIcon;
 }
 
 bool isCtrlPressed = false;
@@ -948,6 +970,14 @@ void ColumnArea::DrawHeader::drawColumnName() const {
 
   // Build column name
   std::string name(columnObject->getName());
+
+  // if a single level is in the column, show the level name instead
+  if (column && !columnObject->hasSpecifiedName() &&
+      Preferences::instance()->getLevelNameDisplayType() ==
+          Preferences::ShowLevelNameOnColumnHeader) {
+    QSet<TXshLevel *> levels = getLevels(column);
+    if (levels.size() == 1) name = to_string((*levels.begin())->getName());
+  }
   //  if (col < 0) name = std::string("Camera");
 
   // ZeraryFx columns store name elsewhere
@@ -1024,6 +1054,10 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
   QRect thumbnailRect = o->rect((col < 0) ? PredefinedRect::CAMERA_ICON_AREA
                                           : PredefinedRect::THUMBNAIL_AREA)
                             .translated(orig);
+
+  // Minimum layout has no thumbnail area
+  if (thumbnailRect.isEmpty()) return;
+
   p.setPen(m_viewer->getVerticalLineColor());
   if (o->flag(PredefinedFlag::THUMBNAIL_AREA_BORDER)) p.drawRect(thumbnailRect);
 
@@ -1074,16 +1108,16 @@ void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
       col >= 0) {
     // display nothing
   } else {
-      if (!iconPixmap.isNull()) {
-        p.drawPixmap(thumbnailImageRect, iconPixmap);
-      }
-      // notify that the column icon is already shown
-      if (levelColumn)
-        levelColumn->setIconVisible(true);
-      else if (meshColumn)
-        meshColumn->setIconVisible(true);
-      else if (zColumn)
-        zColumn->setIconVisible(true);
+    if (!iconPixmap.isNull()) {
+      p.drawPixmap(thumbnailImageRect, iconPixmap);
+    }
+    // notify that the column icon is already shown
+    if (levelColumn)
+      levelColumn->setIconVisible(true);
+    else if (meshColumn)
+      meshColumn->setIconVisible(true);
+    else if (zColumn)
+      zColumn->setIconVisible(true);
   }
 }
 
@@ -1200,8 +1234,7 @@ void ColumnArea::DrawHeader::drawVolumeControl(double volume) const {
                                      NumberRange(layerAxis, layerAxis + 2)));
   }
 
-
-  // slider track 
+  // slider track
   QPainterPath track =
       o->path(PredefinedPath::VOLUME_SLIDER_TRACK).translated(orig);
   p.drawPath(track);
@@ -1434,7 +1467,7 @@ void ColumnArea::drawLevelColumnHead(QPainter &p, int col) {
 
   bool isSelected =
       m_viewer->getColumnSelection()->isColumnSelected(col) && !isEditingSpline;
-  bool isCameraSelected = col == -1 && isCurrent && !isEditingSpline;
+  // bool isCameraSelected = col == -1 && isCurrent && !isEditingSpline;
 
   // Draw column
   DrawHeader drawHeader(this, p, col);
@@ -1445,14 +1478,14 @@ void ColumnArea::drawLevelColumnHead(QPainter &p, int col) {
   drawHeader.drawEye();
   drawHeader.drawPreviewToggle(column ? column->getOpacity() : 0);
   drawHeader.drawLock();
-  drawHeader.drawConfig();
   drawHeader.drawColumnName();
   drawHeader.drawColumnNumber();
   QPixmap iconPixmap = getColumnIcon(col);
   drawHeader.drawThumbnail(iconPixmap);
+  drawHeader.drawFilterColor();
+  drawHeader.drawConfig();
   drawHeader.drawPegbarName();
   drawHeader.drawParentHandleName();
-  drawHeader.drawFilterColor();
 }
 
 //-----------------------------------------------------------------------------
@@ -1507,7 +1540,7 @@ void ColumnArea::drawSoundColumnHead(QPainter &p, int col) {  // AREA
   drawHeader.drawThumbnail(iconignored);
   drawHeader.drawPegbarName();
   drawHeader.drawParentHandleName();
-  drawHeader.drawFilterColor();
+  // drawHeader.drawFilterColor();
 }
 
 //-----------------------------------------------------------------------------
@@ -1558,7 +1591,7 @@ void ColumnArea::drawPaletteColumnHead(QPainter &p, int col) {  // AREA
   drawHeader.drawThumbnail(iconPixmap);
   drawHeader.drawPegbarName();
   drawHeader.drawParentHandleName();
-  drawHeader.drawFilterColor();
+  // drawHeader.drawFilterColor();
 }
 
 //-----------------------------------------------------------------------------
@@ -1615,7 +1648,7 @@ void ColumnArea::drawSoundTextColumnHead(QPainter &p, int col) {  // AREA
   drawHeader.drawThumbnail(iconPixmap);
   drawHeader.drawPegbarName();
   drawHeader.drawParentHandleName();
-  drawHeader.drawFilterColor();
+  // drawHeader.drawFilterColor();
 }
 
 //-----------------------------------------------------------------------------
@@ -1650,7 +1683,6 @@ QPixmap ColumnArea::getColumnIcon(int columnIndex) {
         Preferences::LoadOnDemand) {
       onDemand = m_viewer->getCurrentColumn() != columnIndex;
       if (!onDemand) {
-        
         TXshLevelColumn *levelColumn = column->getLevelColumn();
         TXshMeshColumn *meshColumn   = column->getMeshColumn();
         if ((levelColumn && !levelColumn->isIconVisible()) ||
@@ -1660,11 +1692,10 @@ QPixmap ColumnArea::getColumnIcon(int columnIndex) {
       }
     }
     QPixmap icon =
-        zColumn
-            ? FxIconPixmapManager::instance()->getFxIconPm(
-                  zColumn->getZeraryColumnFx()->getZeraryFx()->getFxType())
-            : IconGenerator::instance()->getIcon(xl, cell.m_frameId, false,
-                                                 onDemand);
+        zColumn ? FxIconPixmapManager::instance()->getFxIconPm(
+                      zColumn->getZeraryColumnFx()->getZeraryFx()->getFxType())
+                : IconGenerator::instance()->getIcon(xl, cell.m_frameId, false,
+                                                     onDemand);
     QRect thumbnailImageRect = o->rect(PredefinedRect::THUMBNAIL);
     if (thumbnailImageRect.isEmpty()) return QPixmap();
     return scalePixmapKeepingAspectRatio(icon, thumbnailImageRect.size());
@@ -1731,8 +1762,9 @@ void ColumnArea::paintEvent(QPaintEvent *event) {  // AREA
 //-----------------------------------------------------------------------------
 using namespace DVGui;
 
-ColumnTransparencyPopup::ColumnTransparencyPopup(QWidget *parent)
-    : QWidget(parent, Qt::Popup) {
+ColumnTransparencyPopup::ColumnTransparencyPopup(XsheetViewer *viewer,
+                                                 QWidget *parent)
+    : QWidget(parent, Qt::Popup), m_viewer(viewer), m_lockBtn(nullptr) {
   setFixedWidth(8 + 78 + 8 + 100 + 8 + 8 + 8 + 7);
 
   m_slider = new QSlider(Qt::Horizontal, this);
@@ -1758,31 +1790,58 @@ m_value->setFont(font);*/
       m_filterColorCombo->addItem(getColorChipIcon(info.second), info.first, f);
   }
 
-  QLabel *filterLabel = new QLabel(tr("Filter:"), this);
-  QLabel *sliderLabel = new QLabel(tr("Opacity:"), this);
+  // Lock button is moved in the popup for Minimum layout
+  QPushButton *lockExtraBtn = nullptr;
+  if (m_viewer->getXsheetLayout() == "Minimum") {
+    m_lockBtn = new QPushButton(tr("Lock Column"), this);
+    m_lockBtn->setCheckable(true);
+    m_lockBtn->setIcon(createLockIcon(m_viewer));
+    lockExtraBtn = new QPushButton(this);
+    QMenu *menu  = new QMenu();
+    menu->setObjectName("xsheetColumnAreaMenu_Lock");
+    CommandManager *cmdManager = CommandManager::instance();
+    menu->addAction(cmdManager->getAction("MI_LockThisColumnOnly"));
+    menu->addAction(cmdManager->getAction("MI_LockSelectedColumns"));
+    menu->addAction(cmdManager->getAction("MI_LockAllColumns"));
+    menu->addAction(cmdManager->getAction("MI_UnlockSelectedColumns"));
+    menu->addAction(cmdManager->getAction("MI_UnlockAllColumns"));
+    menu->addAction(cmdManager->getAction("MI_ToggleColumnLocks"));
+    lockExtraBtn->setMenu(menu);
+    lockExtraBtn->setFixedSize(20, 20);
+  }
 
-  QVBoxLayout *mainLayout = new QVBoxLayout();
+  QGridLayout *mainLayout = new QGridLayout();
   mainLayout->setMargin(3);
-  mainLayout->setSpacing(3);
+  mainLayout->setHorizontalSpacing(6);
+  mainLayout->setVerticalSpacing(6);
   {
+    mainLayout->addWidget(new QLabel(tr("Opacity:"), this), 0, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
     QHBoxLayout *hlayout = new QHBoxLayout;
-    // hlayout->setContentsMargins(0, 3, 0, 3);
     hlayout->setMargin(0);
     hlayout->setSpacing(3);
-    hlayout->addWidget(sliderLabel, 0);
-    hlayout->addWidget(m_slider);
-    hlayout->addWidget(m_value);
-    hlayout->addWidget(new QLabel("%"));
-    mainLayout->addLayout(hlayout, 0);
-
-    QHBoxLayout *filterColorLay = new QHBoxLayout();
-    filterColorLay->setMargin(0);
-    filterColorLay->setSpacing(2);
     {
-      filterColorLay->addWidget(filterLabel, 0);
-      filterColorLay->addWidget(m_filterColorCombo, 1);
+      hlayout->addWidget(m_slider);
+      hlayout->addWidget(m_value);
+      hlayout->addWidget(new QLabel("%"));
     }
-    mainLayout->addLayout(filterColorLay, 0);
+    mainLayout->addLayout(hlayout, 0, 1);
+
+    mainLayout->addWidget(new QLabel(tr("Filter:"), this), 1, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
+    mainLayout->addWidget(m_filterColorCombo, 1, 1,
+                          Qt::AlignLeft | Qt::AlignVCenter);
+
+    if (m_lockBtn) {
+      QHBoxLayout *lockLay = new QHBoxLayout();
+      lockLay->setMargin(0);
+      lockLay->setSpacing(3);
+      {
+        lockLay->addWidget(m_lockBtn, 0);
+        lockLay->addWidget(lockExtraBtn, 0);
+      }
+      mainLayout->addLayout(lockLay, 2, 1, Qt::AlignLeft | Qt::AlignVCenter);
+    }
   }
   setLayout(mainLayout);
 
@@ -1797,6 +1856,10 @@ m_value->setFont(font);*/
 
   ret = ret && connect(m_filterColorCombo, SIGNAL(activated(int)), this,
                        SLOT(onFilterColorChanged(int)));
+  if (m_lockBtn)
+    ret = ret && connect(m_lockBtn, SIGNAL(clicked(bool)), this,
+                         SLOT(onLockButtonClicked(bool)));
+
   assert(ret);
 }
 
@@ -1847,6 +1910,17 @@ void ColumnTransparencyPopup::onFilterColorChanged(int id) {
 
 //----------------------------------------------------------------
 
+void ColumnTransparencyPopup::onLockButtonClicked(bool on) {
+  assert(m_lockBtn);
+  if (!m_lockBtn) return;
+  m_column->lock(on);
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  ((ColumnArea *)parent())->update();
+}
+
+//----------------------------------------------------------------
+
 void ColumnTransparencyPopup::setColumn(TXshColumn *column) {
   m_column = column;
   assert(m_column);
@@ -1858,6 +1932,8 @@ void ColumnTransparencyPopup::setColumn(TXshColumn *column) {
           SLOT(onValueChanged(const QString &)));
 
   m_filterColorCombo->setCurrentIndex(m_column->getFilterColorId());
+
+  if (m_lockBtn) m_lockBtn->setChecked(m_column->isLocked());
 }
 
 /*void ColumnTransparencyPopup::mouseMoveEvent ( QMouseEvent * e )
@@ -2024,6 +2100,19 @@ void ColumnArea::openCameraColumnPopup(QPoint pos) {
             SLOT(onCameraColumnChangedTriggered()));
     menu.addAction(action);
   }
+  // Lock button is moved in this menu for Minimum layout
+  if (m_viewer->getXsheetLayout() == "Minimum") {
+    menu.addSeparator();
+    bool isLocked = m_viewer->getXsheet()->getColumn(-1)->isLocked();
+    QAction *lockAction =
+        new QAction((isLocked) ? tr("Unlock") : tr("Lock"), this);
+    lockAction->setCheckable(true);
+    lockAction->setChecked(isLocked);
+    lockAction->setIcon(createLockIcon(m_viewer));
+    menu.addAction(lockAction);
+    connect(lockAction, SIGNAL(toggled(bool)), this,
+            SLOT(onCameraColumnLockToggled(bool)));
+  }
 
   menu.exec(pos);
 }
@@ -2031,6 +2120,10 @@ void ColumnArea::openCameraColumnPopup(QPoint pos) {
 void ColumnArea::onCameraColumnChangedTriggered() {
   int newIndex = qobject_cast<QAction *>(sender())->data().toInt();
   onXsheetCameraChange(newIndex);
+}
+
+void ColumnArea::onCameraColumnLockToggled(bool lock) {
+  m_viewer->getXsheet()->getColumn(-1)->lock(lock);
 }
 
 //----------------------------------------------------------------
@@ -2051,8 +2144,7 @@ void ColumnArea::onXsheetCameraChange(int newIndex) {
 
 void ColumnArea::startTransparencyPopupTimer(QMouseEvent *e) {  // AREA
   if (!m_columnTransparencyPopup)
-    m_columnTransparencyPopup = new ColumnTransparencyPopup(
-        this);  // Qt::ToolTip|Qt::MSWindowsFixedSizeDialogHint);//Qt::MSWindowsFixedSizeDialogHint|Qt::Tool);
+    m_columnTransparencyPopup = new ColumnTransparencyPopup(m_viewer, this);
 
   m_columnTransparencyPopup->move(e->globalPos().x(), e->globalPos().y());
 
@@ -2422,7 +2514,8 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
         openSoundColumnPopup();
       } else {
         if (!m_columnTransparencyPopup)
-          m_columnTransparencyPopup = new ColumnTransparencyPopup(this);
+          m_columnTransparencyPopup =
+              new ColumnTransparencyPopup(m_viewer, this);
 
         m_columnTransparencyPopup->move(event->globalPos().x() + x,
                                         event->globalPos().y() - y);
@@ -2768,11 +2861,11 @@ void ColumnArea::onSubSampling(QAction *action) {
     TXshColumn *column          = xsh->getColumn(e);
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) continue;
-    const QSet<TXshSimpleLevel *> levels = getLevels(column);
-    QSet<TXshSimpleLevel *>::const_iterator it2;
+    const QSet<TXshLevel *> levels = getLevels(column);
+    QSet<TXshLevel *>::const_iterator it2;
     for (it2 = levels.begin(); it2 != levels.end(); it2++) {
-      TXshSimpleLevel *sl = *it2;
-      if (sl->getProperties()->getDirtyFlag()) continue;
+      TXshSimpleLevel *sl = (*it2)->getSimpleLevel();
+      if (!sl || sl->getProperties()->getDirtyFlag()) continue;
       int type = sl->getType();
       if (type == TZI_XSHLEVEL || type == TZP_XSHLEVEL ||
           type == OVL_XSHLEVEL) {

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -27,6 +27,7 @@ class TXsheetHandle;
 class TStageObjectId;
 class TXshColumn;
 class QComboBox;
+class QPushButton;
 class Orientation;
 class TApp;
 class TXsheet;
@@ -214,8 +215,11 @@ class ColumnTransparencyPopup final : public QWidget {
 
   QComboBox *m_filterColorCombo;
 
+  XsheetViewer *m_viewer;
+  QPushButton *m_lockBtn;
+
 public:
-  ColumnTransparencyPopup(QWidget *parent);
+  ColumnTransparencyPopup(XsheetViewer *viewer, QWidget *parent);
   void setColumn(TXshColumn *column);
 
 protected:
@@ -229,6 +233,7 @@ protected slots:
   void onValueChanged(const QString &);
 
   void onFilterColorChanged(int id);
+  void onLockButtonClicked(bool on);
 };
 
 class SoundColumnPopup final : public QWidget {
@@ -381,12 +386,13 @@ protected slots:
   void openSoundColumnPopup();
   void openCameraColumnPopup(QPoint pos);
   void onCameraColumnChangedTriggered();
+  void onCameraColumnLockToggled(bool);
   void onXsheetCameraChange(int);
   void onSetMask(int);
 };
 
 //-----------------------------------------------------------------------------
-}  // namespace XsheetGUI;
+}  // namespace XsheetGUI
 //-----------------------------------------------------------------------------
 
 #endif  // XSHCOLUMNVIEWER_H

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -144,8 +144,8 @@ void XsheetViewer::getColumnColor(QColor &color, QColor &sideColor, int index,
 
 //-----------------------------------------------------------------------------
 
-void XsheetViewer::getButton(int &btype, QColor &bgColor, QImage &iconImage,
-                             bool isTimeline) {
+void XsheetViewer::getButton(const int &btype, QColor &bgColor,
+                             QImage &iconImage, bool isTimeline) {
   switch (btype) {
   case PREVIEW_ON_XSHBUTTON:
     bgColor = (isTimeline) ? getTimelinePreviewButtonBgOnColor()
@@ -247,7 +247,6 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WFlags flags)
   m_toolbar = new XsheetGUI::XSheetToolbar(this, 0, true);
   m_toolbarScrollArea->setWidget(m_toolbar);
 
-  QRect noteArea(0, 0, 75, 120);
   m_noteArea       = new XsheetGUI::NoteArea(this);
   m_noteScrollArea = new XsheetScrollArea(this);
   m_noteScrollArea->setObjectName("xsheetArea");

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -1238,7 +1238,7 @@ public:
     return m_layerHeaderLockOverImage;
   }
 
-  void getButton(int &btype, QColor &bgColor, QImage &iconImage,
+  void getButton(const int &btype, QColor &bgColor, QImage &iconImage,
                  bool isTimeline = false);
 
   // convert the last one digit of the frame number to alphabet

--- a/toonz/sources/toonz/xshnoteviewer.h
+++ b/toonz/sources/toonz/xshnoteviewer.h
@@ -130,6 +130,10 @@ class NoteArea final : public QFrame {
 
   LayerHeaderPanel *m_layerHeaderPanel;
 
+  QPushButton *m_hamburgerButton;
+  QWidget *m_popup;
+  QLayout *m_currentLayout;
+
 public:
 #if QT_VERSION >= 0x050500
   NoteArea(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0);
@@ -149,11 +153,13 @@ protected slots:
   void onFrameDisplayStyleChanged(int id);
   void onXsheetOrientationChanged(const Orientation *orientation);
 
+  void onClickHamburger();
+
 protected:
   void removeLayout();
   void createLayout();
 };
 
-}  // namespace XsheetGUI;
+}  // namespace XsheetGUI
 
 #endif  // XSHNOTEVIEWER_H

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -156,17 +156,15 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
       p.setPen(m_viewer->getTextColor());
 
     QPoint basePoint = m_viewer->positionToXY(CellPosition(r, -1));
-    if (!m_viewer->orientation()->isVerticalTimeline())
+    if (!o->isVerticalTimeline())
       basePoint.setY(0);
     else
       basePoint.setX(0);
-    QRect labelRect = m_viewer->orientation()
-                          ->rect(PredefinedRect::FRAME_LABEL)
-                          .translated(basePoint);
+    QRect labelRect =
+        o->rect(PredefinedRect::FRAME_LABEL).translated(basePoint);
     labelRect.adjust(-frameAdj.x() / 2, -frameAdj.y() / 2, -frameAdj.x() / 2,
                      -frameAdj.y() / 2);
-    int align = m_viewer->orientation()->dimension(
-        PredefinedDimension::FRAME_LABEL_ALIGN);
+    int align = o->dimension(PredefinedDimension::FRAME_LABEL_ALIGN);
     // display time and/or frame number
     z++;
     switch (m_viewer->getFrameDisplayStyle()) {
@@ -277,7 +275,6 @@ void RowArea::drawPlayRangeBackground(QPainter &p, int r0, int r1) {
   const Orientation *o = m_viewer->orientation();
   TXsheet *xsh         = m_viewer->getXsheet();
   QPoint frameAdj      = m_viewer->getFrameZoomAdjustment();
-  QRect playRangeRect  = o->rect(PredefinedRect::PLAY_RANGE);
 
   int playR0, playR1, step;
   XsheetGUI::getPlayRange(playR0, playR1, step);

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -12,8 +12,6 @@ const int KEY_ICON_WIDTH      = 11;
 const int KEY_ICON_HEIGHT     = 13;
 const int EASE_TRIANGLE_SIZE  = 4;
 const int PLAY_MARKER_SIZE    = 10;
-const int ONION_SIZE          = 19;
-const int ONION_DOT_SIZE      = 8;
 const int PINNED_SIZE         = 10;
 const int FRAME_MARKER_SIZE   = 4;
 const int FOLDED_CELL_SIZE    = 9;
@@ -30,7 +28,8 @@ QRect iconRect(const QRect &areaRect, const int iconWidth, const int iconHeight,
 }  // namespace
 
 class TopToBottomOrientation : public Orientation {
-  const int CELL_WIDTH                 = 74;
+  int CELL_WIDTH = 74;
+  // const int CELL_WIDTH                 = 74;
   const int CELL_HEIGHT                = 20;
   const int CELL_DRAG_WIDTH            = 7;
   const int EXTENDER_WIDTH             = 20;
@@ -39,15 +38,20 @@ class TopToBottomOrientation : public Orientation {
   const int LAYER_HEADER_HEIGHT        = 119;
   const int FOLDED_LAYER_HEADER_HEIGHT = LAYER_HEADER_HEIGHT;
   const int FOLDED_LAYER_HEADER_WIDTH  = 8;
-  const int FRAME_HEADER_WIDTH         = CELL_WIDTH;
-  const int PLAY_RANGE_X = FRAME_HEADER_WIDTH / 2 - PLAY_MARKER_SIZE;
-  const int ONION_X = 0, ONION_Y = 0;
-  const int ICON_WIDTH               = 18;
-  const int ICON_HEIGHT              = 18;
+  int FRAME_HEADER_WIDTH               = CELL_WIDTH;
+  int PLAY_RANGE_X  = FRAME_HEADER_WIDTH / 2 - PLAY_MARKER_SIZE;
+  const int ONION_X = 0;
+  int ONION_Y       = 0;
+  // const int ICON_WIDTH               = 18;
+  // const int ICON_HEIGHT              = 18;
+  int ICON_WIDTH                     = 18;
+  int ICON_HEIGHT                    = 18;
   const int TRACKLEN                 = 60;
   const int SHIFTTRACE_DOT_OFFSET    = 3;
   const int CAMERA_CELL_WIDTH        = 22;
   const int LAYER_FOOTER_PANEL_WIDTH = 16;
+  int ONION_SIZE                     = 19;
+  int ONION_DOT_SIZE                 = 8;
 
 public:
   TopToBottomOrientation();
@@ -96,6 +100,8 @@ class LeftToRightOrientation : public Orientation {
   const int SOUND_PREVIEW_HEIGHT = 6;
   const int FRAME_HEADER_HEIGHT  = 50;
   const int ONION_X = 0, ONION_Y = 0;
+  const int ONION_SIZE         = 19;
+  const int ONION_DOT_SIZE     = 8;
   const int PLAY_RANGE_Y       = ONION_SIZE;
   const int ICON_WIDTH         = 20;
   const int ICON_HEIGHT        = 20;
@@ -277,9 +283,23 @@ TopToBottomOrientation::TopToBottomOrientation() {
 
   int use_header_height = LAYER_HEADER_HEIGHT;
 
-  if (layout == QString("Compact")) use_header_height -= 18;
+  if (layout == QString("Compact"))
+    use_header_height -= 18;
+  else if (layout == QString("Minimum"))
+    use_header_height = CELL_HEIGHT * 2;
 
   int user_folded_header_height = use_header_height;
+
+  if (layout == QString("Minimum")) {
+    CELL_WIDTH         = 50;
+    ICON_WIDTH         = 16;
+    ICON_HEIGHT        = 16;
+    FRAME_HEADER_WIDTH = 45;
+    ONION_SIZE         = 15;
+    ONION_DOT_SIZE     = 6;
+    PLAY_RANGE_X       = ONION_SIZE;
+    ONION_Y            = (CELL_HEIGHT - ONION_SIZE) / 2;
+  }
 
   //
   // Area rectangles
@@ -336,9 +356,8 @@ TopToBottomOrientation::TopToBottomOrientation() {
           cameraKeyRect.translated(-1, 0));
 
   // Note viewer
-  addRect(
-      PredefinedRect::NOTE_AREA,
-      QRect(QPoint(0, 0), QSize(FRAME_HEADER_WIDTH, use_header_height - 1)));
+  addRect(PredefinedRect::NOTE_AREA,
+          QRect(QPoint(0, 0), QSize(FRAME_HEADER_WIDTH, use_header_height)));
   addRect(PredefinedRect::NOTE_ICON,
           QRect(QPoint(0, 0), QSize(CELL_WIDTH - 2, CELL_HEIGHT - 2)));
 
@@ -350,8 +369,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
   addRect(PredefinedRect::PANEL_LAYER_NAME, QRect(0, 0, -1, -1));     // hide
 
   // Row viewer
-  addRect(PredefinedRect::FRAME_LABEL,
-          QRect(0, 0, CELL_WIDTH - 4, CELL_HEIGHT));
+  if (layout == QString("Minimum"))
+    addRect(PredefinedRect::FRAME_LABEL,
+            QRect(0, 0, FRAME_HEADER_WIDTH - 2, CELL_HEIGHT));
+  else
+    addRect(PredefinedRect::FRAME_LABEL,
+            QRect(0, 0, CELL_WIDTH - 4, CELL_HEIGHT));
   addRect(PredefinedRect::FRAME_HEADER,
           QRect(0, 0, FRAME_HEADER_WIDTH, CELL_HEIGHT));
   addRect(PredefinedRect::PLAY_RANGE,
@@ -411,7 +434,89 @@ TopToBottomOrientation::TopToBottomOrientation() {
       volumeArea;
   QPoint soundTopLeft;
 
-  if (layout == QString("Compact")) {
+  if (layout == QString("Minimum")) {
+    THUMBNAIL_HEIGHT = -1;
+    HDRROW_HEIGHT    = CELL_HEIGHT - 1;
+    INDENT           = 0;
+    HDRROW1          = 1;                        // Name, number
+    HDRROW2          = HDRROW1 + HDRROW_HEIGHT;  // eye, preview, config
+
+    addRect(PredefinedRect::DRAG_LAYER, QRect(0, 0, -1, -1));
+
+    addRect(PredefinedRect::RENAME_COLUMN,
+            QRect(0, HDRROW1, CELL_WIDTH, HDRROW_HEIGHT));
+
+    layername =
+        QRect(INDENT + 1, HDRROW1 + 1, CELL_WIDTH - 1, HDRROW_HEIGHT - 1);
+    addRect(PredefinedRect::LAYER_NAME, layername);
+    addRect(PredefinedRect::CAMERA_LAYER_NAME, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::LAYER_NUMBER,
+            QRect(INDENT + layername.width() - 20, HDRROW1, 20, HDRROW_HEIGHT));
+
+    eyeArea = QRect(INDENT, HDRROW2, ICON_WIDTH + 1, HDRROW_HEIGHT);  // Compact
+    addRect(PredefinedRect::EYE_AREA, eyeArea);
+    addRect(PredefinedRect::EYE,
+            iconRect(eyeArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
+
+    previewArea =
+        QRect(INDENT + eyeArea.width(), HDRROW2, ICON_WIDTH + 1, HDRROW_HEIGHT);
+    addRect(PredefinedRect::PREVIEW_LAYER_AREA, previewArea);
+    addRect(PredefinedRect::PREVIEW_LAYER,
+            iconRect(previewArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
+
+    addRect(PredefinedRect::LOCK_AREA, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::LOCK, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::CAMERA_LOCK_AREA, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::CAMERA_LOCK, QRect(0, 0, -1, -1));
+
+    configArea = QRect(INDENT + eyeArea.width() + previewArea.width(), HDRROW2,
+                       ICON_WIDTH, HDRROW_HEIGHT);
+    addRect(PredefinedRect::CONFIG_AREA, configArea);
+    addRect(PredefinedRect::CONFIG,
+            iconRect(configArea, ICON_WIDTH - 1, ICON_HEIGHT - 1));
+    cameraConfigArea = QRect(INDENT, HDRROW2, CAMERA_CELL_WIDTH, HDRROW_HEIGHT);
+    addRect(PredefinedRect::CAMERA_CONFIG_AREA, cameraConfigArea);
+    addRect(PredefinedRect::CAMERA_CONFIG,
+            iconRect(cameraConfigArea, ICON_WIDTH - 1, ICON_HEIGHT - 1));
+    addRect(PredefinedRect::THUMBNAIL_AREA, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::THUMBNAIL, QRect(0, 0, -1, -1));
+    cameraIconArea = QRect(INDENT, HDRROW1, CAMERA_CELL_WIDTH, HDRROW_HEIGHT);
+    addRect(PredefinedRect::CAMERA_ICON_AREA, cameraIconArea);
+    addRect(PredefinedRect::CAMERA_ICON,
+            iconRect(cameraIconArea, ICON_WIDTH, ICON_HEIGHT));
+
+    addRect(PredefinedRect::FILTER_COLOR, rect(PredefinedRect::CONFIG));
+    addRect(PredefinedRect::SOUND_ICON, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::VOLUME_AREA, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::PEGBAR_NAME, QRect(0, 0, -1, -1));
+    addRect(PredefinedRect::PARENT_HANDLE_NAME, QRect(0, 0, -1, -1));
+
+    addFlag(PredefinedFlag::DRAG_LAYER_BORDER, false);
+    addFlag(PredefinedFlag::DRAG_LAYER_VISIBLE, false);
+    addFlag(PredefinedFlag::LAYER_NAME_BORDER, false);
+    addFlag(PredefinedFlag::LAYER_NAME_VISIBLE, true);
+    addFlag(PredefinedFlag::LAYER_NUMBER_BORDER, false);
+    addFlag(PredefinedFlag::LAYER_NUMBER_VISIBLE, false);
+    addFlag(PredefinedFlag::EYE_AREA_BORDER, true);
+    addFlag(PredefinedFlag::EYE_AREA_VISIBLE, true);
+    addFlag(PredefinedFlag::LOCK_AREA_BORDER, false);
+    addFlag(PredefinedFlag::LOCK_AREA_VISIBLE, false);
+    addFlag(PredefinedFlag::PREVIEW_LAYER_AREA_BORDER, true);
+    addFlag(PredefinedFlag::PREVIEW_LAYER_AREA_VISIBLE, true);
+    addFlag(PredefinedFlag::CONFIG_AREA_BORDER, true);
+    addFlag(PredefinedFlag::CAMERA_CONFIG_AREA_BORDER, true);
+    addFlag(PredefinedFlag::CONFIG_AREA_VISIBLE, true);
+    addFlag(PredefinedFlag::CAMERA_CONFIG_AREA_VISIBLE, true);
+    addFlag(PredefinedFlag::PEGBAR_NAME_BORDER, false);
+    addFlag(PredefinedFlag::PEGBAR_NAME_VISIBLE, false);
+    addFlag(PredefinedFlag::PARENT_HANDLE_NAME_BORDER, false);
+    addFlag(PredefinedFlag::PARENT_HANDLE_NAME_VISIBILE, true);
+    addFlag(PredefinedFlag::THUMBNAIL_AREA_BORDER, false);
+    addFlag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE, false);
+    addFlag(PredefinedFlag::CAMERA_ICON_VISIBLE, true);
+    addFlag(PredefinedFlag::VOLUME_AREA_VERTICAL, false);
+    addFlag(PredefinedFlag::NOTE_AREA_IN_POPUP, true);
+  } else if (layout == QString("Compact")) {
     THUMBNAIL_HEIGHT = 44;
     HDRROW_HEIGHT    = CELL_HEIGHT - 2;
     INDENT           = 0;
@@ -519,6 +624,7 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addFlag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE, true);
     addFlag(PredefinedFlag::CAMERA_ICON_VISIBLE, false);
     addFlag(PredefinedFlag::VOLUME_AREA_VERTICAL, false);
+    addFlag(PredefinedFlag::NOTE_AREA_IN_POPUP, false);
   } else if (layout == QString("Classic-revised")) {
     THUMBNAIL_HEIGHT = 44;
     HDRROW_HEIGHT    = CELL_HEIGHT - 2;
@@ -630,6 +736,7 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addFlag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE, true);
     addFlag(PredefinedFlag::CAMERA_ICON_VISIBLE, true);
     addFlag(PredefinedFlag::VOLUME_AREA_VERTICAL, false);
+    addFlag(PredefinedFlag::NOTE_AREA_IN_POPUP, false);
   } else {
     THUMBNAIL_HEIGHT = 43;
     HDRROW_HEIGHT    = CELL_HEIGHT - 2;
@@ -736,6 +843,7 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addFlag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE, true);
     addFlag(PredefinedFlag::CAMERA_ICON_VISIBLE, true);
     addFlag(PredefinedFlag::VOLUME_AREA_VERTICAL, true);
+    addFlag(PredefinedFlag::NOTE_AREA_IN_POPUP, false);
   }
 
   if (flag(PredefinedFlag::VOLUME_AREA_VERTICAL)) {
@@ -757,7 +865,10 @@ TopToBottomOrientation::TopToBottomOrientation() {
 
   zoomSlider = QRect(0, 17, LAYER_FOOTER_PANEL_WIDTH, use_header_height - 34);
   addRect(PredefinedRect::ZOOM_SLIDER_AREA, zoomSlider);
-  addRect(PredefinedRect::ZOOM_SLIDER, zoomSlider.adjusted(0, 1, 0, 0));
+  if (layout == QString("Minimum"))
+    addRect(PredefinedRect::ZOOM_SLIDER, QRect(0, 0, -1, -1));
+  else
+    addRect(PredefinedRect::ZOOM_SLIDER, zoomSlider.adjusted(0, 1, 0, 0));
 
   zoomIn = QRect(0, zoomSlider.bottom() + 1, LAYER_FOOTER_PANEL_WIDTH, 16);
   addRect(PredefinedRect::ZOOM_IN_AREA, zoomIn);
@@ -766,6 +877,7 @@ TopToBottomOrientation::TopToBottomOrientation() {
   zoomOut = QRect(0, zoomSlider.top() - 17, LAYER_FOOTER_PANEL_WIDTH, 16);
   addRect(PredefinedRect::ZOOM_OUT_AREA, zoomOut);
   addRect(PredefinedRect::ZOOM_OUT, zoomOut.adjusted(1, 1, 0, 0));
+
   /*
   // Layer footer panel
   addRect(PredefinedRect::LAYER_FOOTER_PANEL, QRect(0, 0, -1, -1));  // hide
@@ -1189,6 +1301,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addFlag(PredefinedFlag::THUMBNAIL_AREA_VISIBLE, true);
   addFlag(PredefinedFlag::CAMERA_ICON_VISIBLE, true);
   addFlag(PredefinedFlag::VOLUME_AREA_VERTICAL, false);
+  addFlag(PredefinedFlag::NOTE_AREA_IN_POPUP, false);
 
   //
   // Lines

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -407,12 +407,8 @@ void Preferences::definePreferenceItems() {
          QMetaType::Bool, true);
   define(actualPixelViewOnSceneEditingMode, "actualPixelViewOnSceneEditingMode",
          QMetaType::Bool, false);
-  define(levelNameOnEachMarkerEnabled, "levelNameOnEachMarkerEnabled",
-         QMetaType::Bool, false);
   define(showRasterImagesDarkenBlendedInViewer,
          "showRasterImagesDarkenBlendedInViewer", QMetaType::Bool, false);
-  define(showFrameNumberWithLetters, "showFrameNumberWithLetters",
-         QMetaType::Bool, false);
   define(iconSize, "iconSize", QMetaType::QSize, QSize(80, 45), QSize(10, 10),
          QSize(400, 400));
   define(viewShrink, "viewShrink", QMetaType::Int, 1, 1, 20);
@@ -577,6 +573,12 @@ void Preferences::definePreferenceItems() {
          true);
   define(currentColumnColor, "currentColumnColor", QMetaType::QColor,
          QColor(Qt::yellow));
+  // define(levelNameOnEachMarkerEnabled, "levelNameOnEachMarkerEnabled",
+  //  QMetaType::Bool, false);
+  define(levelNameDisplayType, "levelNameDisplayType", QMetaType::Int,
+         0);  // default
+  define(showFrameNumberWithLetters, "showFrameNumberWithLetters",
+         QMetaType::Bool, false);
 
   // Animation
   define(keyframeType, "keyframeType", QMetaType::Int, 2);  // Linear
@@ -760,6 +762,16 @@ void Preferences::resolveCompatibility() {
       setValue(NumberingSystem, 1);
       break;
     }
+  }
+  // "levelNameOnEachMarkerEnabled" is changed to "levelNameDisplayType", adding
+  // a new option
+  if (m_settings->contains("levelNameOnEachMarkerEnabled") &&
+      !m_settings->contains("levelNameDisplayType")) {
+    if (m_settings->value("levelNameOnEachMarkerEnabled")
+            .toBool())  // show level name on each marker
+      setValue(levelNameDisplayType, ShowLevelNameOnEachMarker);
+    else  // Default (level name on top of each cell block)
+      setValue(levelNameDisplayType, ShowLevelName_Default);
   }
 }
 

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -328,8 +328,8 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
 
   int y0 = 0;
   int y1 = 17;  // needs work
-  int y2 = 34;
   int y3 = 53;
+  if (m_sheet->isSmallHeader()) y3 = 34;
 
   /*--- Fill header with background color ---*/
   for (int c = c0; c <= c1; c++) {
@@ -401,9 +401,9 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
 
     QString text = channel->getShortName();
     int d        = 8;
-    painter.drawText(x0 + d, y1, width - d, y3 - y1 + 1,
-                     Qt::TextWrapAnywhere | Qt::AlignLeft | Qt::AlignVCenter,
-                     text);
+    int flags    = Qt::AlignLeft | Qt::AlignVCenter;
+    if (!m_sheet->isSmallHeader()) flags |= Qt::TextWrapAnywhere;
+    painter.drawText(x0 + d, y1, width - d, y3 - y1 + 1, flags, text);
 
     // warning of losing expression reference
     TXsheet *xsh = m_sheet->getViewer()->getXsheetHandle()->getXsheet();

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -126,19 +126,25 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
 
   //---- layout
 
+  QString layout = Preferences::instance()->getLoadedXsheetLayout();
+  bool toolBarOnBottom =
+      layout == QString("Minimum") &&
+      Preferences::instance()->isExpandFunctionHeaderEnabled() &&
+      m_toggleStart !=
+          Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup;
+
   m_leftLayout = new QVBoxLayout();
   m_leftLayout->setMargin(0);
   m_leftLayout->setSpacing(0);
   {
-    m_leftLayout->addWidget(m_toolbar);
-    if (Preferences::instance()->isShowXSheetToolbarEnabled() &&
-        Preferences::instance()->isExpandFunctionHeaderEnabled()) {
-      m_spacing = 65;
-    } else
-      m_spacing = 35;
-
-    QString layout = Preferences::instance()->getLoadedXsheetLayout();
-    if (layout == QString("Compact")) m_spacing -= 18;
+    if (!toolBarOnBottom) m_leftLayout->addWidget(m_toolbar);
+    m_spacing = 35;
+    if (layout == QString("Compact"))
+      m_spacing -= 18;
+    else if (toolBarOnBottom) {
+      m_spacing = 3;  // m_spacing is used for the height of spacer widget
+      m_leftLayout->addSpacing(m_spacing);
+    }
 
     if (m_toggleStart !=
         Preferences::FunctionEditorToggle::ShowGraphEditorInPopup)
@@ -146,6 +152,8 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
     if (m_toggleStart !=
         Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
       m_leftLayout->addWidget(m_numericalColumns);
+    // display the toolbar on the bottom in Minimum layout
+    if (toolBarOnBottom) m_leftLayout->addWidget(m_toolbar);
   }
 
   leftPanel->setLayout(m_leftLayout);
@@ -208,13 +216,25 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
 
   assert(ret);
   if (m_toggleStart ==
-      Preferences::FunctionEditorToggle::ShowGraphEditorInPopup) {
-    m_functionGraph->hide();
-    m_leftLayout->setSpacing(m_spacing);
-  }
-  if (m_toggleStart ==
-      Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
+      Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup) {
     m_numericalColumns->hide();
+    if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem())
+      spacer->changeSize(0, 0);
+  } else {
+    bool toolBarVisible =
+        Preferences::instance()->isShowXSheetToolbarEnabled() &&
+        Preferences::instance()->isExpandFunctionHeaderEnabled();
+    if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
+      spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0),
+                         QSizePolicy::Fixed, QSizePolicy::Fixed);
+      spacer->invalidate();
+    } else
+      m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0));
+    if (m_toggleStart ==
+        Preferences::FunctionEditorToggle::ShowGraphEditorInPopup) {
+      m_functionGraph->hide();
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -233,46 +253,40 @@ void FunctionViewer::showEvent(QShowEvent *) {
   bool ret = true;
 
   if (m_xshHandle) {
-    ret = connect(m_xshHandle, SIGNAL(xsheetChanged()), this,
-                  SLOT(refreshModel())) &&
-          ret;
-    ret = connect(m_xshHandle, SIGNAL(xsheetSwitched()), this,
-                  SLOT(rebuildModel())) &&
-          ret;
+    ret = ret && connect(m_xshHandle, SIGNAL(xsheetChanged()), this,
+                         SLOT(refreshModel()));
+    ret = ret && connect(m_xshHandle, SIGNAL(xsheetSwitched()), this,
+                         SLOT(rebuildModel()));
   }
 
   if (m_frameHandle) {
-    ret = connect(m_frameHandle, SIGNAL(frameSwitched()), this,
-                  SLOT(propagateExternalSetFrame())) &&
-          ret;
-
-    ret = connect(m_frameHandle, SIGNAL(triggerNextKeyframe(QWidget *)),
-                  m_toolbar, SLOT(onNextKeyframe(QWidget *))) &&
-          ret;
-    ret = connect(m_frameHandle, SIGNAL(triggerPrevKeyframe(QWidget *)),
-                  m_toolbar, SLOT(onPrevKeyframe(QWidget *))) &&
-          ret;
+    ret = ret && connect(m_frameHandle, SIGNAL(frameSwitched()), this,
+                         SLOT(propagateExternalSetFrame()));
+    ret = ret && connect(m_frameHandle, SIGNAL(triggerNextKeyframe(QWidget *)),
+                         m_toolbar, SLOT(onNextKeyframe(QWidget *)));
+    ret = ret && connect(m_frameHandle, SIGNAL(triggerPrevKeyframe(QWidget *)),
+                         m_toolbar, SLOT(onPrevKeyframe(QWidget *)));
   }
 
   if (m_objectHandle) {
-    ret = connect(m_objectHandle, SIGNAL(objectSwitched()), this,
-                  SLOT(onStageObjectSwitched())) &&
-          ret;
-    ret = connect(m_objectHandle, SIGNAL(objectChanged(bool)), this,
-                  SLOT(onStageObjectChanged(bool))) &&
-          ret;
+    ret = ret && connect(m_objectHandle, SIGNAL(objectSwitched()), this,
+                         SLOT(onStageObjectSwitched()));
+    ret = ret && connect(m_objectHandle, SIGNAL(objectChanged(bool)), this,
+                         SLOT(onStageObjectChanged(bool)));
   }
 
   if (m_fxHandle)
-    ret =
-        connect(m_fxHandle, SIGNAL(fxSwitched()), this, SLOT(onFxSwitched())) &&
-        ret;
+    ret = ret &&
+          connect(m_fxHandle, SIGNAL(fxSwitched()), this, SLOT(onFxSwitched()));
 
   // display animated channels when the scene is switched
-  if (m_sceneHandle)
-    ret = connect(m_sceneHandle, SIGNAL(sceneSwitched()), m_treeView,
-                  SLOT(displayAnimatedChannels())) &&
-          ret;
+  if (m_sceneHandle) {
+    ret = ret && connect(m_sceneHandle, SIGNAL(sceneSwitched()), m_treeView,
+                         SLOT(displayAnimatedChannels()));
+    ret = ret &&
+          connect(m_sceneHandle, SIGNAL(preferenceChanged(const QString &)),
+                  this, SLOT(onPreferenceChanged(const QString &)));
+  }
 
   assert(ret);
 
@@ -293,18 +307,7 @@ void FunctionViewer::showEvent(QShowEvent *) {
   }
 
   if (m_fxHandle) ftm->setCurrentFx(m_fxHandle->getFx());
-  if (m_toggleStart ==
-      Preferences::FunctionEditorToggle::ToggleBetweenGraphAndSpreadsheet) {
-    if (m_toggleStatus == 1) {
-      m_numericalColumns->hide();
-      m_functionGraph->show();
-      m_leftLayout->setSpacing(0);
-    } else {
-      m_functionGraph->hide();
-      m_numericalColumns->show();
-      m_leftLayout->setSpacing(m_spacing);
-    }
-  }
+  onPreferenceChanged("");
 }
 
 //-----------------------------------------------------------------------------
@@ -506,12 +509,27 @@ void FunctionViewer::toggleMode() {
     if (m_functionGraph->isVisible()) {
       m_functionGraph->hide();
       m_numericalColumns->show();
-      m_leftLayout->setSpacing(m_spacing);
+      bool toolBarVisible =
+          Preferences::instance()->isShowXSheetToolbarEnabled() &&
+          Preferences::instance()->isExpandFunctionHeaderEnabled();
+      if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
+        spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0),
+                           QSizePolicy::Fixed, QSizePolicy::Fixed);
+        spacer->invalidate();
+        m_numericalColumns->updateHeaderHeight();
+        m_leftLayout->setSpacing(0);
+      } else
+        m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0));
+      updateGeometry();
       m_toggleStatus = 0;
     } else {
       m_functionGraph->show();
       m_numericalColumns->hide();
       m_leftLayout->setSpacing(0);
+      if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
+        spacer->changeSize(0, 0);
+        spacer->invalidate();
+      }
       m_toggleStatus = 1;
     }
   }
@@ -641,6 +659,45 @@ void FunctionViewer::doSwitchCurrentObject(TStageObject *obj) {
     m_columnHandle->setColumnIndex(id.getIndex());
   else
     m_objectHandle->setObjectId(id);
+}
+
+//-----------------------------------------------------------------------------
+
+void FunctionViewer::onPreferenceChanged(const QString &prefName) {
+  if (prefName != "XSheetToolbar" && !prefName.isEmpty()) return;
+  if (!Preferences::instance()->isExpandFunctionHeaderEnabled()) return;
+  if (m_toggleStart ==
+      Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
+    return;
+
+  if (m_toggleStart ==
+          Preferences::FunctionEditorToggle::ToggleBetweenGraphAndSpreadsheet &&
+      m_toggleStatus == 1) {
+    m_numericalColumns->hide();
+    m_functionGraph->show();
+    m_leftLayout->setSpacing(0);
+    if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
+      spacer->changeSize(0, 0);
+      spacer->invalidate();
+    }
+    return;
+  }
+
+  // spreadsheet is shown
+  bool toolBarVisible =
+      Preferences::instance()->isShowXSheetToolbarEnabled() &&
+      Preferences::instance()->isExpandFunctionHeaderEnabled();
+  m_functionGraph->hide();
+  m_numericalColumns->show();
+  if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
+    spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0),
+                       QSizePolicy::Fixed, QSizePolicy::Fixed);
+    spacer->invalidate();
+    m_numericalColumns->updateHeaderHeight();
+    m_leftLayout->setSpacing(0);
+  } else
+    m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0));
+  updateGeometry();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -563,8 +563,15 @@ SpreadsheetViewer::SpreadsheetViewer(QWidget *parent)
       QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Ignored));
 
   m_rowScrollArea->setFixedWidth(30);
-  m_columnScrollArea->setFixedHeight(m_rowHeight * 3 - 4);
-  // m_columnScrollArea->setFixedHeight(m_rowHeight * 3 + 60 - 63);
+
+  if (Preferences::instance()->getLoadedXsheetLayout() == QString("Minimum") &&
+      !Preferences::instance()->isShowXSheetToolbarEnabled() &&
+      Preferences::instance()->isExpandFunctionHeaderEnabled() &&
+      Preferences::instance()->getFunctionEditorToggle() !=
+          Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
+    m_columnScrollArea->setFixedHeight(m_rowHeight * 2 - 4);
+  else
+    m_columnScrollArea->setFixedHeight(m_rowHeight * 3 - 4);
 
   m_frameScroller.setFrameScrollArea(m_cellScrollArea);
   connect(&m_frameScroller, &Spreadsheet::FrameScroller::prepareToScrollOffset,
@@ -1023,4 +1030,20 @@ void SpreadsheetViewer::ensureVisibleCol(int col) {
 
   int vertValue = m_cellScrollArea->verticalScrollBar()->value();
   m_cellScrollArea->ensureVisible(x, vertValue, m_columnWidth / 2, 0);
+}
+
+bool SpreadsheetViewer::isSmallHeader() {
+  return (
+      Preferences::instance()->getLoadedXsheetLayout() == QString("Minimum") &&
+      !Preferences::instance()->isShowXSheetToolbarEnabled() &&
+      Preferences::instance()->isExpandFunctionHeaderEnabled() &&
+      Preferences::instance()->getFunctionEditorToggle() !=
+          Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup);
+}
+
+void SpreadsheetViewer::updateHeaderHeight() {
+  if (isSmallHeader())
+    m_columnScrollArea->setFixedHeight(m_rowHeight * 2 - 4);
+  else
+    m_columnScrollArea->setFixedHeight(m_rowHeight * 3 - 4);
 }


### PR DESCRIPTION
**UPDATE** I modified the row area and note area to be narrower, by putting buttons in the note area into a hamburger menu.

![minimum_layout_mod](https://user-images.githubusercontent.com/17974955/140264752-c593d54e-cf17-4ac6-bd8b-c54d593156dd.png)

This PR introduces new 2 options to display Xsheet simpler & smaller suitable for pencil testing workflow.
![minimum_layout](https://user-images.githubusercontent.com/17974955/139029457-48e670bb-99da-40f3-a100-3e7ce9597874.png)
- Added a new option `Minimum` to `Preferences > Xsheet > Column Header Layout` .
     - This layout has the minimum-sized column header (no thumbail, parent object name or lock button) and narrower column width.
     - In the Minimum layout the lock button moves in the column option popup.
        ![column_option](https://user-images.githubusercontent.com/17974955/139030569-7aa473e4-e458-445b-b372-d0a0c15b83a5.png)
- Added a new preference item `Level Name Display` to `Preferences > Xsheet` category.
    - The item `Preferences > Interface > Display Level Name on Each Marker` is removed instead.
    - `Level Name Display` has 3 options:
        - **Default** : corresponds to the former `Display Level Name on Each Marker = OFF`
        - **Display on Each Marker** : corresponds to the former `Display Level Name on Each Marker = ON`
        - **Display on Column Header** : a new option. If the column contains single level, the level name will be displayed in the column header instead of cells. If the column contains multiple levels, columns displays level name just like the same way as the `Default` option. In the above image, the column 6 contains 2 levels so the level names are displayed in the cell area.

