### PR TITLE
Fix wheel scrolling on the output settings popup

### DIFF
--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -50,6 +50,7 @@
 #include <QScrollArea>
 #include <QPropertyAnimation>
 #include <QSpacerItem>
+#include <QEvent>
 //-----------------------------------------------------------------------------
 namespace {
 
@@ -338,6 +339,8 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
     m_cameraSettings    = new CameraSettingsPopup();
     cameraParametersBox = new QFrame(this);
     cameraParametersBox->setObjectName("OutputSettingsCameraBox");
+    m_outputCameraOm->setFocusPolicy(Qt::StrongFocus);
+    m_outputCameraOm->installEventFilter(this);
   } else {
     // Subcamera checkbox
     m_subcameraChk = new DVGui::CheckBox(tr("Use Sub-Camera"));
@@ -482,6 +485,16 @@ QFrame *OutputSettingsPopup::createFileSettingsBox(bool isPreview) {
     Tiio::Writer::getSupportedFormats(formats, true);
     formats.sort();
     m_fileFormat->addItems(formats);
+    m_fileFormat->setFocusPolicy(Qt::StrongFocus);
+    m_resampleBalanceOm->setFocusPolicy(Qt::StrongFocus);
+    m_channelWidthOm->setFocusPolicy(Qt::StrongFocus);
+    m_threadsComboOm->setFocusPolicy(Qt::StrongFocus);
+    m_rasterGranularityOm->setFocusPolicy(Qt::StrongFocus);
+    m_fileFormat->installEventFilter(this);
+    m_resampleBalanceOm->installEventFilter(this);
+    m_channelWidthOm->installEventFilter(this);
+    m_threadsComboOm->installEventFilter(this);
+    m_rasterGranularityOm->installEventFilter(this);
   }
 
   //-----
@@ -605,6 +618,8 @@ QFrame *OutputSettingsPopup::createMoreSettingsBox() {
   QStringList dominantField;
   dominantField << tr("Odd (NTSC)") << tr("Even (PAL)") << tr("None");
   m_dominantFieldOm->addItems(dominantField);
+  m_dominantFieldOm->setFocusPolicy(Qt::StrongFocus);
+  m_dominantFieldOm->installEventFilter(this);
   m_stretchFromFld->setRange(1, 1000);
   m_stretchToFld->setRange(1, 1000);
   m_stretchFromFld->setDecimals(2);
@@ -614,6 +629,8 @@ QFrame *OutputSettingsPopup::createMoreSettingsBox() {
   multimediaTypes << tr("None") << tr("Fx Schematic Flows")
                   << tr("Fx Schematic Terminal Nodes");
   m_multimediaOm->addItems(multimediaTypes);
+  m_multimediaOm->setFocusPolicy(Qt::StrongFocus);
+  m_multimediaOm->installEventFilter(this);
   m_stereoShift->setEnabled(false);
 
   //-----
@@ -745,6 +762,16 @@ void OutputSettingsPopup::hideEvent(QHideEvent *e) {
                           SLOT(updateField()));
   assert(ret);
   Dialog::hideEvent(e);
+}
+
+//-----------------------------------------------------------------------------
+// ignore wheelevent on comboboxes
+bool OutputSettingsPopup::eventFilter(QObject *obj, QEvent *e) {
+  if (e->type() == QEvent::Wheel) {
+    QComboBox *combo = qobject_cast<QComboBox *>(obj);
+    if (combo && !combo->hasFocus()) return true;
+  }
+  return QObject::eventFilter(obj, e);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -99,6 +99,7 @@ protected:
   TOutputProperties *getProperties() const;
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;
+  bool eventFilter(QObject *, QEvent *) override;
 
 protected slots:
 

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -257,6 +257,9 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
   m_fspChk->setToolTip(tr("Force Squared Pixel"));
   m_fspChk->setObjectName("ForceSquaredPixelButton");
   m_fspChk->setIcon(createQIcon("squarepixel"));
+
+  m_presetListOm->setFocusPolicy(Qt::StrongFocus);
+  m_presetListOm->installEventFilter(this);
   m_addPresetBtn->setObjectName("PushButton_NoPadding");
   m_removePresetBtn->setObjectName("PushButton_NoPadding");
 
@@ -540,6 +543,11 @@ bool CameraSettingsWidget::eventFilter(QObject *obj, QEvent *e) {
              (obj == m_xResFld ||
               obj == m_yResFld))  // dotPrev, fld = xres|yres
       m_inchPrev->setChecked(true);
+  }
+  // ignore wheelevent on the combobox
+  else if (e->type() == QEvent::Wheel) {
+    QComboBox *combo = qobject_cast<QComboBox *>(obj);
+    if (combo && !combo->hasFocus()) return true;
   }
 
   return QObject::eventFilter(obj, e);


### PR DESCRIPTION
This PR fixes #4131 .
Now all combo boxes in the output settings ignore mouse wheel input unless they have the input focus.