### PR TITLE
Fix PSD loading and level format preferences

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2253,7 +2253,7 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
     assert(childLevel);
     childXsh = childLevel->getXsheet();
   }
-  int subCol0 = args.col0;
+  int subCol0 = 0;
   loadedPsdLevelIndex.clear();
   // for each layer in psd
   for (int i = 0; i < popup->getPsdLevelCount(); i++) {
@@ -2265,7 +2265,7 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
         count +=
             createSubXSheetFromPSDFolder(args, childXsh, subCol0, i, popup);
       else
-        count += createSubXSheetFromPSDFolder(args, xsh, subCol0, i, popup);
+        count += createSubXSheetFromPSDFolder(args, xsh, col0, i, popup);
     } else {
       TFilePath psdpath = popup->getPsdPath(i);
       TXshLevel *xl     = 0;
@@ -2280,14 +2280,14 @@ static int loadPSDResource(IoCmd::LoadResourceArguments &args,
         // lo importo nell'xsheet
         if (popup->subxsheet() && childXsh) {
           childXsh->exposeLevel(0, subCol0, xl);
+          subCol0++;
+        } else {
+          // move the current column to the right
+          col0++;
+          app->getCurrentColumn()->setColumnIndex(col0);
         }
         args.loadedLevels.push_back(xl);
-        subCol0++;
         count++;
-
-        // move the current column to the right
-        col0++;
-        app->getCurrentColumn()->setColumnIndex(col0);
       }
     }
   }

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -94,7 +94,7 @@ inline bool formatLess(const Preferences::LevelFormat &a,
 //=================================================================
 
 void getDefaultLevelFormats(LevelFormatVector &lfv) {
-  lfv.resize(3);
+  lfv.resize(2);
   {
     LevelFormat &lf = lfv[0];
 
@@ -214,6 +214,13 @@ void getValue(QSettings &settings,
         (*it).m_options.m_premultiply = false;
         ++it;
       }
+      changed = true;
+    }
+    // remove the "empty" condition which may inserted due to the previous bug
+    else if ((*it).m_name.isEmpty() &&
+             (*it).m_pathFormat == QRegExp(".*", Qt::CaseInsensitive) &&
+             (*it).m_priority == 1 && (*it).m_options == LevelOptions()) {
+      it      = lfv.erase(it);
       changed = true;
     } else
       ++it;


### PR DESCRIPTION
This PR fixes two problems (the missing premultipy option and the insertion of empty columns) reported by @artisteacher in [this comment](https://github.com/opentoonz/opentoonz/issues/3994#issuecomment-982102520).