### PR TITLE
Fix Zerary Fx bugs

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -323,7 +323,8 @@ bool beforeCellsInsert(TXsheet *xsh, int row, int &col, int rowCount,
 
   for (i = 0; i < rowCount && xsh->getCell(row + i, col).isEmpty(); i++) {
   }
-  int type = column ? column->getColumnType() : newLevelColumnType;
+  int type = (column && !column->isEmpty()) ? column->getColumnType()
+                                            : newLevelColumnType;
   // If some used cells in range or column type mismatch must insert a column.
   if (col < 0 || i < rowCount || newLevelColumnType != type) {
     col += 1;

--- a/toonz/sources/toonz/levelcommand.cpp
+++ b/toonz/sources/toonz/levelcommand.cpp
@@ -511,6 +511,14 @@ void LevelCmd::addMissingLevelsToCast(const QList<TXshColumnP> &columns) {
 }
 
 void LevelCmd::addMissingLevelsToCast(std::set<TXshLevel *> &levels) {
+  // remove zerary fx levels which are not registered in the cast
+  for (auto it = levels.begin(); it != levels.end();) {
+    if ((*it)->getZeraryFxLevel())
+      it = levels.erase(it);
+    else
+      ++it;
+  }
+
   if (levels.empty()) return;
   TUndoManager::manager()->beginBlock();
   TLevelSet *levelSet =

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1023,7 +1023,7 @@ void ColumnArea::DrawHeader::drawColumnName() const {
 
   // ZeraryFx columns store name elsewhere
   TXshZeraryFxColumn *zColumn = dynamic_cast<TXshZeraryFxColumn *>(column);
-  if (zColumn)
+  if (zColumn && !isEmpty)
     name = ::to_string(zColumn->getZeraryColumnFx()->getZeraryFx()->getName());
 
   QRect columnName = o->rect((col < 0) ? PredefinedRect::CAMERA_LAYER_NAME

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -29,7 +29,8 @@ TXshZeraryFxColumn::TXshZeraryFxColumn(int frameCount)
 
 TXshZeraryFxColumn::TXshZeraryFxColumn(const TXshZeraryFxColumn &src)
     : m_zeraryColumnFx(new TZeraryColumnFx())
-    , m_zeraryFxLevel(new TXshZeraryFxLevel()) {
+    , m_zeraryFxLevel(new TXshZeraryFxLevel())
+    , m_iconVisible(false) {
   m_zeraryColumnFx->addRef();
   m_zeraryColumnFx->setColumn(this);
   m_zeraryFxLevel->addRef();


### PR DESCRIPTION
This PR fixes the following problems related to zerary fxs:
#### Copying and pasting zerary fx column causes irregular characters to appear in the cell. ####
[To reproduce]
1. Create Linear Gradient Fx in column 1
2. Copy column 1 and paste multiple times
3. letter `_1` , `_2` ... appear in the secondly and thirdly pasted columns.
  ![zerary_bug1](https://user-images.githubusercontent.com/17974955/144555191-05b1356c-a12f-4b3d-881d-3cd762d69660.png)
  
#### Undoing of pasting zerary fx cells does not clear the column name ####
[To reproduce]
1. Create Linear Gradient Fx in column 1
2. Copy several cells in column 1.
3. Paste cells into column 2.
4. Undo the pasting operation. The letter `LinearGradientFx` remains in the empty column header.
  ![zerary_bug2](https://user-images.githubusercontent.com/17974955/144555625-ab45b854-1ccf-4529-8ebb-6ee374d826f7.png)
  