### PR TITLE
Allow Renaming Pass Through Nodes

### DIFF
--- a/toonz/sources/include/toonzqt/fxschematicnode.h
+++ b/toonz/sources/include/toonzqt/fxschematicnode.h
@@ -609,17 +609,21 @@ class FxPassThroughPainter final : public QObject, public QGraphicsItem {
   Q_INTERFACES(QGraphicsItem)
 
   double m_width, m_height;
+  QString m_name;
+  bool m_showName;
 
   FxSchematicPassThroughNode *m_parent;
 
 public:
   FxPassThroughPainter(FxSchematicPassThroughNode *parent, double width,
-                       double height);
+                       double height, const QString &name, bool showName);
   ~FxPassThroughPainter();
 
   QRectF boundingRect() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
              QWidget *widget = 0) override;
+  void setName(const QString &name) { m_name = name; }
+  void setShowName(bool showName) { m_showName = showName; }
 
 protected:
   void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
@@ -632,6 +636,8 @@ protected:
 class FxSchematicPassThroughNode final : public FxSchematicNode {
   Q_OBJECT
 
+  bool m_showName;
+
   FxPassThroughPainter *m_passThroughPainter;
 
 public:
@@ -641,9 +647,15 @@ public:
   QRectF boundingRect() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
              QWidget *widget = 0) override;
+  bool isOpened() override { return false; }
 
 protected:
+  void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *me) override;
   void mousePressEvent(QGraphicsSceneMouseEvent *me) override;
+
+protected slots:
+
+  void onNameChanged();
 };
 
 #endif  // FXSCHEMATICNODE_H

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -2483,6 +2483,7 @@ FxSchematicNormalFxNode::FxSchematicNormalFxNode(FxSchematicScene *scene,
 
   m_linkedNode = 0;
   //-----
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_renderToggle->setIsActive(m_fx->getAttributes()->isEnabled());
 
@@ -2755,6 +2756,7 @@ FxSchematicZeraryNode::FxSchematicZeraryNode(FxSchematicScene *scene,
   m_linkedNode = 0;
 
   //---
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->hide();
 
@@ -3010,6 +3012,7 @@ FxSchematicColumnNode::FxSchematicColumnNode(FxSchematicScene *scene,
   m_linkDock   = 0;
 
   //-----
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
 
   int levelType;
@@ -3298,6 +3301,7 @@ FxSchematicPaletteNode::FxSchematicPaletteNode(FxSchematicScene *scene,
   QString paletteName = getPaletteName();
   setToolTip(QString("%1 : %2").arg(m_name, paletteName));
 
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
 
   addPort(0, m_outDock->getPort());
@@ -3494,6 +3498,7 @@ FxGroupNode::FxGroupNode(FxSchematicScene *scene, const QList<TFxP> &groupedFx,
   m_linkDock   = 0;
 
   //-----
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_renderToggle->setIsActive(m_fx->getAttributes()->isEnabled());
 
@@ -3727,10 +3732,13 @@ bool FxGroupNode::isCached() const {
 //*****************************************************
 
 FxPassThroughPainter::FxPassThroughPainter(FxSchematicPassThroughNode *parent,
-                                           double width, double height)
+                                           double width, double height,
+                                           const QString &name, bool showName)
     : QGraphicsItem(parent)
     , m_width(width)
     , m_height(height)
+    , m_name(name)
+    , m_showName(showName)
     , m_parent(parent) {
   setFlag(QGraphicsItem::ItemIsMovable, false);
   setFlag(QGraphicsItem::ItemIsSelectable, false);
@@ -3760,6 +3768,30 @@ void FxPassThroughPainter::paint(QPainter *painter,
   painter->setBrush(viewer->getPassThroughColor());
   painter->setPen(Qt::NoPen);
   painter->drawRoundedRect(QRectF(0, 0, m_width, m_height), 5, 5);
+
+  if (!m_showName) return;
+
+  QFont fnt = painter->font();
+  int width = QFontMetrics(fnt).width(m_name) + 1;
+  QRectF nameArea(0, 0, width, 14);
+
+  if (m_parent->isNormalIconView()) {
+    nameArea.adjust(-(width / 2) + 6, -51, 0, 0);
+  } else {
+    nameArea = QRect(4, 2, 78, 22);
+
+    fnt.setPixelSize(fnt.pixelSize() * 2);
+    painter->setFont(fnt);
+  }
+
+  painter->setPen(viewer->getTextColor());
+
+  if (!m_parent->isNameEditing()) {
+    // if this is a current object
+    if (sceneFx->getCurrentFx() == m_parent->getFx())
+      painter->setPen(viewer->getSelectedNodeTextColor());
+    painter->drawText(nameArea, Qt::AlignLeft | Qt::AlignVCenter, m_name);
+  }
 }
 
 //-----------------------------------------------------
@@ -3809,12 +3841,19 @@ void FxPassThroughPainter::contextMenuEvent(
 FxSchematicPassThroughNode::FxSchematicPassThroughNode(FxSchematicScene *scene,
                                                        TFx *fx)
     : FxSchematicNode(scene, fx, 15, 15, eNormalFx) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
+
   m_linkedNode = 0;
   m_linkDock   = 0;
+  m_showName   = false;
 
+  m_name = QString::fromStdWString(fx->getName());
+
+  m_nameItem              = new SchematicName(this, 72, 20);  // for rename
   m_outDock               = new FxSchematicDock(this, "", 0, eFxOutputPort);
   FxSchematicDock *inDock = new FxSchematicDock(this, "", 0, eFxInputPort);
-  m_passThroughPainter    = new FxPassThroughPainter(this, m_width, m_height);
+  m_passThroughPainter =
+      new FxPassThroughPainter(this, m_width, m_height, m_name, false);
 
   m_outDock->getPort()->setIsPassThrough();
   inDock->getPort()->setIsPassThrough();
@@ -3831,7 +3870,36 @@ FxSchematicPassThroughNode::FxSchematicPassThroughNode(FxSchematicScene *scene,
   inDock->setZValue(2);
   m_passThroughPainter->setZValue(1);
 
-  setToolTip(tr("Pass Through"));
+  if (!m_name.contains("PassThrough")) {
+    setToolTip(m_name + tr(" (Pass Through)"));
+    m_showName = true;
+  } else {
+    setToolTip(m_name);
+    m_showName = false;
+  }
+
+  m_passThroughPainter->setShowName(m_showName);
+
+  //---
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
+  m_nameItem->setName(m_name);
+  m_nameItem->hide();
+
+  // define positions
+  if (m_isNormalIconView) {
+    QRectF recF = m_nameItem->boundingRect();
+    m_nameItem->setPos(-(recF.width() / 2) + 6, -30);
+  } else {
+    QFont fnt = m_nameItem->font();
+    fnt.setPixelSize(fnt.pixelSize() * 2);
+    m_nameItem->setFont(fnt);
+
+    m_nameItem->setPos(-1, 0);
+  }
+
+  m_nameItem->setZValue(3);
+
+  connect(m_nameItem, SIGNAL(focusOut()), this, SLOT(onNameChanged()));
 }
 
 //-----------------------------------------------------
@@ -3841,7 +3909,17 @@ FxSchematicPassThroughNode::~FxSchematicPassThroughNode() {}
 //-----------------------------------------------------
 
 QRectF FxSchematicPassThroughNode::boundingRect() const {
-  return QRectF(-5, -5, m_width + 10, m_height + 10);
+  int xAdj    = 0;
+  int yAdj    = 0;
+  qreal width = m_width;
+  QRectF recF = m_nameItem->boundingRect();
+  if (m_showName) {
+    width                     = recF.width();
+    if (width > m_width) xAdj = (width - m_width) / 2;
+    yAdj                      = 30;
+  }
+  return QRectF(-5 - xAdj, -5 - yAdj, std::max(m_width, width) + 10,
+                m_height + 10 + yAdj);
 }
 
 //-----------------------------------------------------
@@ -3854,6 +3932,28 @@ void FxSchematicPassThroughNode::paint(QPainter *painter,
 
 //-----------------------------------------------------
 
+void FxSchematicPassThroughNode::mouseDoubleClickEvent(
+    QGraphicsSceneMouseEvent *me) {
+  QString fontName = Preferences::instance()->getInterfaceFont();
+  if (fontName == "") {
+#ifdef _WIN32
+    fontName = "Arial";
+#else
+    fontName = "Helvetica";
+#endif
+  }
+  static QFont font(fontName, 10, QFont::Normal);
+  int width = QFontMetrics(font).width(m_name);
+  QRectF nameArea(0, 0, width, 14);
+
+  m_nameItem->setPlainText(m_name);
+  m_nameItem->show();
+  m_nameItem->setFocus();
+  setFlag(QGraphicsItem::ItemIsSelectable, false);
+}
+
+//-----------------------------------------------------
+
 void FxSchematicPassThroughNode::mousePressEvent(QGraphicsSceneMouseEvent *me) {
   FxSchematicNode::mousePressEvent(me);
 
@@ -3861,4 +3961,43 @@ void FxSchematicPassThroughNode::mousePressEvent(QGraphicsSceneMouseEvent *me) {
       CommandManager::instance()->getAction(MI_FxParamEditor);
   // this signal cause the update the contents of the FxSettings
   if (fxEditorPopup->isVisible()) emit fxNodeDoubleClicked();
+}
+
+//-----------------------------------------------------
+
+void FxSchematicPassThroughNode::onNameChanged() {
+  m_nameItem->hide();
+  m_name = m_nameItem->toPlainText();
+
+  if (m_name.isEmpty()) {
+    m_name = QString::fromStdWString(m_fx->getFxId());
+    m_nameItem->setPlainText(m_name);
+  }
+
+  m_passThroughPainter->setName(m_name);
+
+  if (m_isNormalIconView) {
+    QRectF recF = m_nameItem->boundingRect();
+    m_nameItem->setPos(-(recF.width() / 2) + 6, -30);
+  }
+
+  if (!m_name.contains("PassThrough")) {
+    setToolTip(m_name + tr(" (Pass Through)"));
+    m_showName = true;
+  } else {
+    setToolTip(m_name);
+    m_showName = false;
+  }
+  m_passThroughPainter->setShowName(m_showName);
+
+  setFlag(QGraphicsItem::ItemIsSelectable, true);
+
+  FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
+  if (!fxScene) return;
+  TFxCommand::renameFx(m_fx.getPointer(), m_name.toStdWString(),
+                       fxScene->getXsheetHandle());
+  updateOutputDockToolTips(m_name);
+
+  prepareGeometryChange();
+  update();
 }

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1560,10 +1560,12 @@ void StageSchematicNode::onHandleReleased() {
 StageSchematicPegbarNode::StageSchematicPegbarNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
     : StageSchematicNode(scene, pegbar, 90, 18) {
+      SchematicViewer *viewer = scene->getSchematicViewer();
   std::string name = m_stageObject->getFullName();
   std::string id   = m_stageObject->getId().toString();
   m_name           = QString::fromStdString(name);
   m_nameItem       = new SchematicName(this, 72, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);
@@ -1705,6 +1707,7 @@ StageSchematicColumnNode::StageSchematicColumnNode(StageSchematicScene *scene,
                        SLOT(onChangedSize(bool)));
 
   m_nameItem = new SchematicName(this, 54, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);
@@ -2004,10 +2007,12 @@ void StageSchematicColumnNode::onCameraStandToggleClicked(int state) {
 StageSchematicCameraNode::StageSchematicCameraNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
     : StageSchematicNode(scene, pegbar, 90, 18) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
   std::string name = m_stageObject->getFullName();
   m_name           = QString::fromStdString(name);
 
   m_nameItem = new SchematicName(this, 54, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
 
   m_nameItem->setPos(16, -2);
@@ -2083,6 +2088,7 @@ void StageSchematicCameraNode::onNameChanged() {
 StageSchematicSplineNode::StageSchematicSplineNode(StageSchematicScene *scene,
                                                    TStageObjectSpline *spline)
     : SchematicNode(scene), m_spline(spline), m_isOpened(false) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
   m_width  = 90;
   m_height = 18;
   assert(spline);
@@ -2100,6 +2106,7 @@ StageSchematicSplineNode::StageSchematicSplineNode(StageSchematicScene *scene,
   std::string name = m_spline->getName();
   m_splineName     = QString::fromStdString(name);
   m_nameItem       = new SchematicName(this, 72, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_splineName);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);
@@ -2213,6 +2220,7 @@ StageSchematicGroupNode::StageSchematicGroupNode(
     : StageSchematicNode(scene, root, 90, 18, true)
     , m_root(root)
     , m_groupedObj(groupedObj) {
+  SchematicViewer *viewer = scene->getSchematicViewer();
   int i;
   for (i   = 0; i < m_groupedObj.size(); i++) m_groupedObj[i]->addRef();
   bool ret = true;
@@ -2220,6 +2228,7 @@ StageSchematicGroupNode::StageSchematicGroupNode(
   m_name            = QString::fromStdWString(name);
 
   m_nameItem = new SchematicName(this, 72, 20);
+  m_nameItem->setDefaultTextColor(viewer->getTextColor());
   m_nameItem->setName(m_name);
   m_nameItem->setPos(16, -1);
   m_nameItem->setZValue(2);


### PR DESCRIPTION
This is a port from Tahoma2D, it will restore the ability to rename Pass Through nodes, this was useful for naming ports for MacroFx that are used in many scenes, the regression came about due to #4036.

![renamepassthru1](https://user-images.githubusercontent.com/19820721/144799473-41a274f8-ea4f-418b-9f17-940041994b91.gif)

The node has no name displayed by default, double-click to rename and it will show after hitting enter, thanks and credit to @manongjohn for developing it.

I love the redesigned node, just needed the port naming. 😄 

Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>