### PR TITLE
Enable to Cleanup Without Line Processing

### DIFF
--- a/toonz/sources/include/toonz/cleanupparameters.h
+++ b/toonz/sources/include/toonz/cleanupparameters.h
@@ -160,6 +160,12 @@ public:
   /*--- オフセットを軸ごとにロックする ---*/
   bool m_offx_lock, m_offy_lock;
 
+  // hold brightness and contrast values for each line processing modes (grey
+  // and color).
+  double m_altBrightness, m_altContrast;
+  // exporting file format when Line Processing = None
+  std::string m_lpNoneFormat;
+
 public:
   CleanupParameters();
   CleanupParameters(const CleanupParameters &p) { assign(&p); }

--- a/toonz/sources/include/toonz/tcleanupper.h
+++ b/toonz/sources/include/toonz/tcleanupper.h
@@ -89,10 +89,11 @@ time, to unlock a possibly useful memory block.
 */
   CleanupPreprocessedImage *process(TRasterImageP &image, bool first_image,
                                     TRasterImageP &onlyResampledImage,
-                                    bool isCameraTest    = false,
-                                    bool returnResampled = false,
-                                    bool onlyForSwatch   = false,
-                                    TAffine *aff         = 0);
+                                    bool isCameraTest             = false,
+                                    bool returnResampled          = false,
+                                    bool onlyForSwatch            = false,
+                                    TAffine *aff                  = 0,
+                                    TRasterP templateForResampled = 0);
 
   void finalize(const TRaster32P &dst, CleanupPreprocessedImage *src);
   TToonzImageP finalize(CleanupPreprocessedImage *src,

--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -202,7 +202,8 @@ table) it returns the proper insertion index
   // load icon (and image) data of all frames into cache
   void loadAllIconsAndPutInCache(bool cacheImagesAsWell);
 
-  TRasterImageP getFrameToCleanup(const TFrameId &fid) const;
+  TRasterImageP getFrameToCleanup(const TFrameId &fid,
+                                  bool toBeLineProcessed) const;
 
   std::string getImageId(const TFrameId &fid, int frameStatus = -1) const;
   std::string getIconId(const TFrameId &fid, int frameStatus = -1) const;

--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -411,7 +411,10 @@ static void cleanupLevel(TXshSimpleLevel *xl, std::set<TFrameId> fidsInXsheet,
                   QString::fromStdString(fid.expand()));
       continue;
     }
-    TRasterImageP original = xl->getFrameToCleanup(fid);
+    CleanupParameters *params = scene->getProperties()->getCleanupParameters();
+    // if lines are not processed, obtain the original sampled image
+    bool toBeLineProcessed = params->m_lineProcessingMode != lpNone;
+    TRasterImageP original = xl->getFrameToCleanup(fid, toBeLineProcessed);
     if (!original) {
       string err = "    *error* missed frame";
       m_userLog.error(err);
@@ -419,11 +422,9 @@ static void cleanupLevel(TXshSimpleLevel *xl, std::set<TFrameId> fidsInXsheet,
       continue;
     }
 
-    CleanupParameters *params = scene->getProperties()->getCleanupParameters();
-
     if (params->m_lineProcessingMode == lpNone) {
-      TRasterImageP ri;
-      if (params->m_autocenterType == CleanupTypes::AUTOCENTER_NONE)
+      TRasterImageP ri(original);
+      /*if (params->m_autocenterType == CleanupTypes::AUTOCENTER_NONE)
         ri = original;
       else {
         bool autocentered;
@@ -432,7 +433,9 @@ static void cleanupLevel(TXshSimpleLevel *xl, std::set<TFrameId> fidsInXsheet,
           m_userLog.error("The autocentering failed on the current drawing.");
           cout << "The autocentering failed on the current drawing." << endl;
         }
-      }
+      }*/
+      cl->process(original, false, ri, false, true, true, nullptr,
+                  ri->getRaster());
       updater.update(fid, ri);
       continue;
     }

--- a/toonz/sources/toonz/cleanuppopup.h
+++ b/toonz/sources/toonz/cleanuppopup.h
@@ -144,6 +144,7 @@ public:
   OverwriteDialog();
 
   void reset() override;
+  void enableOptions(bool writingOnSource);
 
 private:
   DVGui::LineEdit *m_suffix;

--- a/toonz/sources/toonz/cleanupsettingsmodel.cpp
+++ b/toonz/sources/toonz/cleanupsettingsmodel.cpp
@@ -405,7 +405,7 @@ void CleanupSettingsModel::rebuildPreview() {
 void CleanupSettingsModel::processFrame(TXshSimpleLevel *sl, TFrameId fid) {
   assert(sl);
 
-  TRasterImageP imageToCleanup = sl->getFrameToCleanup(fid);
+  TRasterImageP imageToCleanup = sl->getFrameToCleanup(fid, true);
   if (!imageToCleanup) return;
 
   // Store the original image
@@ -741,5 +741,6 @@ TFilePath CleanupSettingsModel::getOutputPath(TXshSimpleLevel *sl,
   const TFilePath &outDir = params->getPath(scene);
 
   return lineProcessing ? (outDir + inPath.getWideName()).withType("tlv")
-                        : (outDir + inPath.getLevelNameW()).withType("tif");
+                        : (outDir + inPath.getLevelNameW())
+                              .withType(params->m_lpNoneFormat);
 }

--- a/toonz/sources/toonz/cleanupsettingspane.h
+++ b/toonz/sources/toonz/cleanupsettingspane.h
@@ -62,6 +62,8 @@ private:
   QLabel *m_aaValueLabel;
   DVGui::IntField *m_aaValue;
   QComboBox *m_lineProcessing;
+  QLabel *m_lpNoneFormatLabel;
+  QComboBox *m_lpNoneFormat;
   //----Cleanup Palette
   CleanupPaletteViewer *m_paletteViewer;
   //----Bottom Parts

--- a/toonz/sources/toonzlib/tcleanupper.cpp
+++ b/toonz/sources/toonzlib/tcleanupper.cpp
@@ -160,7 +160,7 @@ HSVColor HSVColor::fromRGB(double r, double g, double b) {
       h = 2.0 + (b - r) / delta;
     else if (b == max)
       h = 4.0 + (r - g) / delta;
-    h   = h * 60.0;
+    h = h * 60.0;
     if (h < 0) h += 360.0;
   }
 
@@ -569,7 +569,7 @@ TRasterP TCleanupper::processColors(const TRasterP &rin) {
 CleanupPreprocessedImage *TCleanupper::process(
     TRasterImageP &image, bool first_image, TRasterImageP &onlyResampledImage,
     bool isCameraTest, bool returnResampled, bool onlyForSwatch,
-    TAffine *resampleAff) {
+    TAffine *resampleAff, TRasterP templateForResampled) {
   TAffine aff;
   double blur;
   TDimension outDim(0, 0);
@@ -682,7 +682,9 @@ CleanupPreprocessedImage *TCleanupper::process(
   TRasterP tmp_ras;
 
   if (returnResampled || (fromGr8 && toGr8)) {
-    if (fromGr8 && toGr8)
+    if (templateForResampled)
+      tmp_ras = templateForResampled->create(outDim.lx, outDim.ly);
+    else if (fromGr8 && toGr8)
       tmp_ras = TRasterGR8P(outDim);
     else
       tmp_ras = TRaster32P(outDim);
@@ -709,7 +711,7 @@ CleanupPreprocessedImage *TCleanupper::process(
     flt_type = TRop::Hann2;
   TRop::resample(tmp_ras, image->getRaster(), aff, flt_type, blur);
 
-  if ((TRaster32P)tmp_ras)
+  if ((TRaster32P)tmp_ras && !templateForResampled)
     // Add white background to deal with semitransparent pixels
     TRop::addBackground(tmp_ras, TPixel32::White);
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -642,7 +642,8 @@ void TXshSimpleLevel::loadAllIconsAndPutInCache(bool cacheImagesAsWell) {
 
 //-----------------------------------------------------------------------------
 
-TRasterImageP TXshSimpleLevel::getFrameToCleanup(const TFrameId &fid) const {
+TRasterImageP TXshSimpleLevel::getFrameToCleanup(const TFrameId &fid,
+                                                 bool toBeLineProcessed) const {
   assert(m_type != UNKNOWN_XSHLEVEL);
 
   FramesSet::const_iterator ft = m_frames.find(fid);
@@ -652,8 +653,12 @@ TRasterImageP TXshSimpleLevel::getFrameToCleanup(const TFrameId &fid) const {
   std::string imageId = getImageId(fid, flag ? Scanned : 0);
 
   ImageLoader::BuildExtData extData(this, fid, 1);
-  TRasterImageP img = ImageManager::instance()->getImage(
-      imageId, ImageManager::dontPutInCache, &extData);
+
+  UCHAR imFlags = ImageManager::dontPutInCache;
+  // if lines are not processed, obtain the original sampled image
+  if (!toBeLineProcessed) imFlags |= ImageManager::is64bitEnabled;
+  TRasterImageP img =
+      ImageManager::instance()->getImage(imageId, imFlags, &extData);
   if (!img) return img;
 
   double x_dpi, y_dpi;


### PR DESCRIPTION
This PR modifies the cleanup feature as follows:
- When the `Line Processing` is set to `None` , now OT will take into account all of the other cleanup settings (autocenter, rotate, flip and camera settings)  for cleanup. Before this PR only the autocenter settings had been used.
- When the `Line Processing` is set to `None` , now user can choose file format for saving cleaned up images. (in either of tif, png, jpg or tga)
- Separate the `Brightness / Contrast` values between in the `Greyscale` and in the `Color` line processing modes. This change was requested by ink & paint staffs in our studio in order to prevent inputting wrong values by mistake. 