### PR TITLE
Enable To View Palette Files From the File Browser

### DIFF
--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -1192,7 +1192,9 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
   }
 
   for (i = 0; i < files.size(); i++)
-    if (!TFileType::isViewable(TFileType::getInfo(files[i]))) break;
+    if (!TFileType::isViewable(TFileType::getInfo(files[i])) &&
+        files[i].getType() != "tpl")
+      break;
   if (i == files.size()) {
     std::string type = files[0].getType();
     for (j = 0; j < files.size(); j++)

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -569,6 +569,7 @@ void PaletteViewerPanel::onFreezeButtonToggled(bool frozen) {
 
   // Cambio il livello corrente
   if (!frozen) {
+    m_frozenPalette = nullptr;
     std::set<TXshSimpleLevel *> levels;
     TXsheet *xsheet = app->getCurrentXsheet()->getXsheet();
     int row, column;
@@ -600,6 +601,7 @@ void PaletteViewerPanel::onFreezeButtonToggled(bool frozen) {
     app->getCurrentLevel()->setLevel(level);
     m_paletteViewer->setPaletteHandle(ph);
   } else {
+    m_frozenPalette = ph->getPalette();
     m_paletteHandle->setPalette(ph->getPalette());
     m_paletteViewer->setPaletteHandle(m_paletteHandle);
   }

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -44,6 +44,7 @@ class PaletteViewerPanel final : public StyleShortcutSwitchablePanel {
 
   TPanelTitleBarButton *m_freezeButton;
   bool m_isFrozen;
+  TPaletteP m_frozenPalette;
 
 public:
   PaletteViewerPanel(QWidget *parent);


### PR DESCRIPTION
This PR enables to view contents of palette files by using the `View...` command in the right-click menu of File Browser.