### PR TITLE
Fix TVP JSON export

### DIFF
--- a/toonz/sources/toonz/tvpjson_io.cpp
+++ b/toonz/sources/toonz/tvpjson_io.cpp
@@ -366,7 +366,7 @@ void TvpJsonClip::build(ToonzScene* scene, TXsheet* xsheet) {
       continue;
     }
     TvpJsonLayer layer;
-    layer.build(col, scene, column);
+    layer.build(m_layers.size(), scene, column);
     if (!layer.isEmpty()) m_layers.append(layer);
   }
 }


### PR DESCRIPTION
This small PR fixes the problem as follows:
- The layer order goes wrong when loading JSON data on TV Paint