### PR TITLE
Fix FrameIds Inconsistency in Level Strip Commands

### DIFF
--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -48,7 +48,8 @@
 //=============================================================================
 
 TFrameId operator+(const TFrameId &fid, int d) {
-  return TFrameId(fid.getNumber() + d, fid.getLetter());
+  return TFrameId(fid.getNumber() + d, fid.getLetter(), fid.getZeroPadding(),
+                  fid.getStartSeqInd());
 }
 
 //-----------------------------------------------------------------------------
@@ -1255,10 +1256,14 @@ void FilmstripCmd::addFrames(TXshSimpleLevel *sl, int start, int end,
   std::vector<TFrameId> oldFids;
   sl->getFids(oldFids);
 
+  TFrameId tmplFid;
+  if (!oldFids.empty()) tmplFid = oldFids.front();
+
   std::set<TFrameId> fidsToInsert;
   int frame = 0;
   for (frame = start; frame <= end; frame += step)
-    fidsToInsert.insert(TFrameId(frame));
+    fidsToInsert.insert(TFrameId(frame, "", tmplFid.getZeroPadding(),
+                                 tmplFid.getStartSeqInd()));
 
   makeSpaceForFids(sl, fidsToInsert);
 
@@ -1398,7 +1403,8 @@ void FilmstripCmd::renumber(
       if (tmp.count(tarFid) > 0) {
         do {
           tarFid =
-              TFrameId(tarFid.getNumber(), getNextLetter(tarFid.getLetter()));
+              TFrameId(tarFid.getNumber(), getNextLetter(tarFid.getLetter()),
+                       tarFid.getZeroPadding(), tarFid.getStartSeqInd());
         } while (!tarFid.getLetter().isEmpty() && tmp.count(tarFid) > 0);
         if (tarFid.getLetter().isEmpty()) {
           // todo: error message
@@ -1456,7 +1462,8 @@ void FilmstripCmd::renumber(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
   std::vector<TFrameId>::iterator j = fids.begin();
   for (it = frames.begin(); it != frames.end(); ++it) {
     TFrameId srcFid(*it);
-    TFrameId dstFid(frame);
+    TFrameId dstFid(frame, "", srcFid.getZeroPadding(),
+                    srcFid.getStartSeqInd());
     frame += stepFrame;
     // faccio il controllo su tmp e non su fids. considera:
     // fids = [1,2,3,4], renumber = [2->3,3->5]
@@ -1489,7 +1496,8 @@ void FilmstripCmd::renumber(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
   it2 = frames.begin();
   std::set<TFrameId> newFrames;
   for (i = 0; i < frames.size(); i++, it2++)
-    newFrames.insert(TFrameId(startFrame + (i * stepFrame), it2->getLetter()));
+    newFrames.insert(TFrameId(startFrame + (i * stepFrame), it2->getLetter(),
+                              it2->getZeroPadding(), it2->getStartSeqInd()));
   assert(frames.size() == newFrames.size());
   frames.swap(newFrames);
 


### PR DESCRIPTION
This PR fixes the following problem regarding the right-click menu commands of Level Strip :
#### To Reproduce
1. Prepare raster image file named `A.3.jpg` and load the image to a scene.
1. Open Level Strip.
1. Right click the frame `0003` and select `Renumber...` command.
1. Set `Start =1` and `Step = 1` then click `Renumber`. (The frame 3 is renumbered to 1)
1. Save the level. 
1. The image file name becomes `A.0001.jpg` losing zero-padding information. It should be `A.1.jpg` instead.

    Other Level Strip commands such as `Duplicate Drawing`, `Add Frames` and `Swing` have the same problem (frame numbers become inconsist in zero-padding) . This PR will resolve such problems.