### PR TITLE
Fix build with clang 13: no member named 'copy' in namespace 'std'

### DIFF
--- a/toonz/sources/include/tcg/poly_ops.h
+++ b/toonz/sources/include/tcg/poly_ops.h
@@ -5,6 +5,7 @@
 
 // tcg includes
 #include "macros.h"
+#include <algorithm>
 
 /*!
   \file     tcg_poly_ops.h


### PR DESCRIPTION
https://github.com/opentoonz/opentoonz/issues/4170