### PR TITLE
Fix pressing Shift key loses focus when renaming cell

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1046,6 +1046,11 @@ void RenameCellField::keyPressEvent(QKeyEvent *event) {
     }
     offset = m_viewer->orientation()->arrowShift(key);
     break;
+  case Qt::Key_Shift:
+    // prevent the field to lose focus when typing shift key
+    event->accept();
+    return;
+    break;
   default:
     QLineEdit::keyPressEvent(event);
     return;


### PR DESCRIPTION
This PR fixes the following problem:

#### To reproduce ####
- Activate 'Preferences > Xsheet > Enable to Input Cells without Double Clicking' .
- Load or create some level in the xsheet.
- Click a cell in the column. (Renaming field opens.)
- Try to type '1A' (type "1" then "Shift+A") .

The field loses focus when typing the Shift key and the input is unexpectedly canceled.