### PR TITLE
Project Settings-aware Frame Number Field Width

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -44,6 +44,7 @@
 #include "toonz/levelproperties.h"
 #include "toonz/tcamera.h"
 #include "toonz/preferences.h"
+#include "toonz/filepathproperties.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -688,7 +689,6 @@ void MyVideoWidget::mouseReleaseEvent(QMouseEvent* event) {
 FrameNumberLineEdit::FrameNumberLineEdit(QWidget* parent, TFrameId fId,
                                          bool acceptLetter)
     : LineEdit(parent) {
-  setFixedWidth(60);
   if (acceptLetter) {
     QString regExpStr   = QString("^%1$").arg(TFilePath::fidRegExpStr());
     m_regexpValidator   = new QRegExpValidator(QRegExp(regExpStr), this);
@@ -701,6 +701,7 @@ FrameNumberLineEdit::FrameNumberLineEdit(QWidget* parent, TFrameId fId,
       new QRegExpValidator(QRegExp("^\\d{1,3}[A-Ia-i]?$"), this);
 
   updateValidator();
+  updateSize();
 
   setValue(fId);
 }
@@ -714,6 +715,22 @@ void FrameNumberLineEdit::updateValidator() {
     setValidator(m_regexpValidator);
 }
 
+//-----------------------------------------------------------------------------
+
+void FrameNumberLineEdit::updateSize() {
+  FilePathProperties* fpProp =
+      TProjectManager::instance()->getCurrentProject()->getFilePathProperties();
+  bool useStandard = fpProp->useStandard();
+  int letterCount  = fpProp->letterCountForSuffix();
+  if (useStandard)
+    setFixedWidth(60);
+  else {
+    // 4 digits + letters reserve 12 px each
+    int lc = (letterCount == 0) ? 9 : letterCount + 4;
+    setFixedWidth(12 * lc);
+  }
+  updateGeometry();
+}
 //-----------------------------------------------------------------------------
 
 void FrameNumberLineEdit::setValue(TFrameId fId) {
@@ -764,6 +781,7 @@ void FrameNumberLineEdit::onProjectSwitched() {
   m_regexpValidator = new QRegExpValidator(QRegExp(regExpStr), this);
   updateValidator();
   if (oldValidator) delete oldValidator;
+  updateSize();
 }
 
 void FrameNumberLineEdit::onProjectChanged() { onProjectSwitched(); }

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -126,6 +126,7 @@ class FrameNumberLineEdit : public DVGui::LineEdit,
   QRegExpValidator *m_regexpValidator, *m_regexpValidator_alt;
 
   void updateValidator();
+  void updateSize();
   QString m_textOnFocusIn;
 
 public:

--- a/toonz/sources/toonz/penciltestpopup_qt.cpp
+++ b/toonz/sources/toonz/penciltestpopup_qt.cpp
@@ -32,6 +32,7 @@
 #include "toonz/levelproperties.h"
 #include "toonz/tcamera.h"
 #include "toonz/preferences.h"
+#include "toonz/filepathproperties.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -886,7 +887,6 @@ void MyVideoWidget::mouseReleaseEvent(QMouseEvent* event) {
 FrameNumberLineEdit::FrameNumberLineEdit(QWidget* parent, TFrameId fId,
                                          bool acceptLetter)
     : LineEdit(parent) {
-  setFixedWidth(60);
   if (acceptLetter) {
     QString regExpStr   = QString("^%1$").arg(TFilePath::fidRegExpStr());
     m_regexpValidator   = new QRegExpValidator(QRegExp(regExpStr), this);
@@ -899,6 +899,7 @@ FrameNumberLineEdit::FrameNumberLineEdit(QWidget* parent, TFrameId fId,
       new QRegExpValidator(QRegExp("^\\d{1,3}[A-Ia-i]?$"), this);
 
   updateValidator();
+  updateSize();
 
   setValue(fId);
 }
@@ -910,6 +911,23 @@ void FrameNumberLineEdit::updateValidator() {
     setValidator(m_regexpValidator_alt);
   else
     setValidator(m_regexpValidator);
+}
+
+//-----------------------------------------------------------------------------
+
+void FrameNumberLineEdit::updateSize() {
+  FilePathProperties* fpProp =
+      TProjectManager::instance()->getCurrentProject()->getFilePathProperties();
+  bool useStandard = fpProp->useStandard();
+  int letterCount  = fpProp->letterCountForSuffix();
+  if (useStandard)
+    setFixedWidth(60);
+  else {
+    // 4 digits + letters reserve 12 px each
+    int lc = (letterCount == 0) ? 9 : letterCount + 4;
+    setFixedWidth(12 * lc);
+  }
+  updateGeometry();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/penciltestpopup_qt.h
+++ b/toonz/sources/toonz/penciltestpopup_qt.h
@@ -192,6 +192,7 @@ class FrameNumberLineEdit : public DVGui::LineEdit,
   QRegExpValidator *m_regexpValidator, *m_regexpValidator_alt;
 
   void updateValidator();
+  void updateSize();
   QString m_textOnFocusIn;
 
 public:


### PR DESCRIPTION
This PR modifies the frame number field in the Pencil Test popup.
It is now aware of the file path properties of the project settings and changes its width according to the maximum letter count for suffix.

![framenumberfield](https://user-images.githubusercontent.com/17974955/147313853-e54e3979-acd5-4263-9721-fb94bc962596.png)

