### PR TITLE
Fix Flipbook wobbling when dragging while playing

### DIFF
--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -330,9 +330,7 @@ void ComboViewerPanel::onDrawFrame(int frame,
 
   // make sure to redraw the frame here.
   // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying())
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
-                        QEventLoop::ExcludeSocketNotifiers);
+  if (frameHandle->isPlaying()) qApp->processEvents();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -420,9 +420,7 @@ void ImageViewer::setImage(TImageP image) {
   // make sure to redraw the frame here.
   // repaint() does NOT immediately redraw the frame for QOpenGLWidget
   update();
-  if (!isColorModel())
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
-                        QEventLoop::ExcludeSocketNotifiers);
+  if (!isColorModel()) qApp->processEvents();
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -304,9 +304,7 @@ void SceneViewerPanel::onDrawFrame(int frame,
 
   // make sure to redraw the frame here.
   // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying())
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents |
-                        QEventLoop::ExcludeSocketNotifiers);
+  if (frameHandle->isPlaying()) qApp->processEvents();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the known problem after introducing #4197 : Flipbook and Viewer wobble when dragging floating window while playing.