### PR TITLE
Multi-Thread FFMPEG and responsive finalizing window

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -8,6 +8,7 @@
 #include "trasterimage.h"
 #include <QVector>
 #include <QStringList>
+#include <QProcess>
 
 struct ffmpegFileInfo {
   int m_lx, m_ly, m_frameCount;
@@ -54,6 +55,7 @@ private:
   QStringList m_audioArgs;
   TUINT32 m_sampleRate;
   QString cleanPathSymbols();
+  bool waitFfmpeg(const QProcess &ffmpeg);
 };
 
 #endif

--- a/toonz/sources/include/tlevel_io.h
+++ b/toonz/sources/include/tlevel_io.h
@@ -239,6 +239,19 @@ inline bool isMovieType(const TFilePath &fp) {
 
 //-----------------------------------------------------------
 
+inline bool isSequencialRequired(std::string type) {
+  return (type == "mov" || type == "avi" || type == "3gp");
+}
+
+//-----------------------------------------------------------
+
+inline bool isSequencialRequired(const TFilePath &fp) {
+  std::string type(fp.getType());
+  return isSequencialRequired(type);
+}
+
+//-----------------------------------------------------------
+
 inline bool doesSupportRandomAccess(const TFilePath &fp,
                                     bool isToonzOutput = false) {
   return (fp.getDots() == "..") || (isToonzOutput && fp.getType() == "mov");

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -283,6 +283,7 @@ public:
   QString getFfmpegPath() const { return getStringValue(ffmpegPath); }
   int getFfmpegTimeout() { return getIntValue(ffmpegTimeout); }
   QString getFastRenderPath() const { return getStringValue(fastRenderPath); }
+  bool getFfmpegMultiThread() const { return getBoolValue(ffmpegMultiThread); }
 
   // Drawing  tab
   QString getScanLevelType() const { return getStringValue(scanLevelType); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -75,6 +75,7 @@ enum PreferencesItemId {
   ffmpegPath,
   ffmpegTimeout,
   fastRenderPath,
+  ffmpegMultiThread,
 
   //----------
   // Drawing

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -172,6 +172,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     , m_applyShrinkChk(nullptr)
     , m_outputCameraOm(nullptr)
     , m_isPreviewSettings(isPreview)
+    , m_allowMT(Preferences::instance()->getFfmpegMultiThread())
     , m_presetCombo(nullptr) {
   setWindowTitle(isPreview ? tr("Preview Settings") : tr("Output Settings"));
   if (!isPreview) setObjectName("OutputSettingsPopup");
@@ -843,6 +844,11 @@ void OutputSettingsPopup::updateField() {
     m_multimediaOm->setCurrentIndex(prop->getMultimediaRendering());
   }
 
+  // Refresh format if allow-multithread was toggled
+  if (m_allowMT != Preferences::instance()->getFfmpegMultiThread()) {
+    onFormatChanged(m_fileFormat->currentText());
+  }
+
   // camera
   if (m_outputCameraOm) {
     m_outputCameraOm->blockSignals(true);
@@ -1046,19 +1052,21 @@ void OutputSettingsPopup::onNameChanged() {
 /*! Set current scene output format to new format set in popup field.
  */
 void OutputSettingsPopup::onFormatChanged(const QString &str) {
-  auto isMultiRenderInvalid = [](std::string ext) -> bool {
-    return ext == "mp4" || ext == "gif" || ext == "webm" ||
+  auto isMultiRenderInvalid = [](std::string ext, bool allowMT) -> bool {
+    return (!allowMT && (ext == "mp4" || ext == "gif" || ext == "webm")) ||
            ext == "spritesheet";
   };
 
   TOutputProperties *prop    = getProperties();
-  bool wasMultiRenderInvalid = isMultiRenderInvalid(prop->getPath().getType());
-  TFilePath fp               = prop->getPath().withType(str.toStdString());
+  bool wasMultiRenderInvalid =
+      isMultiRenderInvalid(prop->getPath().getType(), m_allowMT);
+  TFilePath fp = prop->getPath().withType(str.toStdString());
   prop->setPath(fp);
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+  m_allowMT = Preferences::instance()->getFfmpegMultiThread();
 
   if (m_presetCombo) m_presetCombo->setCurrentIndex(0);
-  if (isMultiRenderInvalid(str.toStdString())) {
+  if (isMultiRenderInvalid(str.toStdString(), m_allowMT)) {
     m_threadsComboOm->setDisabled(true);
     m_threadsComboOm->setCurrentIndex(0);
   } else {

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -67,6 +67,7 @@ class OutputSettingsPopup : public DVGui::Dialog {
   DVGui::DoubleLineEdit *m_stereoShift;
   QComboBox *m_rasterGranularityOm;
   QComboBox *m_threadsComboOm;
+  bool m_allowMT;
 
   DVGui::DoubleLineEdit *m_frameRateFld;
   QPushButton *m_fileFormatButton;

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1173,6 +1173,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {ffmpegPath, tr("FFmpeg Path:")},
       {ffmpegTimeout, tr("FFmpeg Timeout:")},
       {fastRenderPath, tr("Fast Render Path:")},
+      {ffmpegMultiThread, tr("Allow Multi-Thread in FFMPEG Rendering (UNSTABLE)")},
 
       // Drawing
       {scanLevelType, tr("Scan File Format:")},
@@ -1786,6 +1787,13 @@ QWidget* PreferencesPopup::createImportExportPage() {
               "Render (MP4) to go."),
            lay);
   insertUI(fastRenderPath, lay);
+
+  putLabel("", lay);
+  putLabel(
+      tr("Enabling multi-thread rendering will render significantly faster "
+         "but a random crash might occur, use at your own risk."),
+      lay);
+  insertUI(ffmpegMultiThread, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -364,7 +364,14 @@ class RenderListener final : public DVGui::ProgressDialog,
         , m_labelText(labelText) {}
     TThread::Message *clone() const override { return new Message(*this); }
     void onDeliver() override {
-      if (m_frame == -1)
+      if (m_frame == -2) {
+        m_pb->setLabelText(
+            QObject::tr("Finalizing render, please wait.", "RenderListener"));
+        // Set busy indicator to progress bar
+        m_pb->setMinimum(0);
+        m_pb->setMaximum(0);
+        m_pb->setValue(0);
+      } else if (m_frame == -1)
         m_pb->hide();
       else {
         m_pb->setLabelText(
@@ -411,8 +418,7 @@ public:
     if (m_frameCounter + 1 < m_totalFrames)
       Message(this, ret ? -1 : ++m_frameCounter, m_progressBarString).send();
     else
-      setLabelText(
-          QObject::tr("Finalizing render, please wait.", "RenderListener"));
+      Message(this, -2, "").send();
     return !ret;
   }
   bool onFrameFailed(int frame, TException &) override {

--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -27,6 +27,7 @@
 
 // Qt includes
 #include <QCoreApplication>
+#include <QTimer>
 
 #include "toonz/movierenderer.h"
 
@@ -131,6 +132,8 @@ public:
   bool m_cacheResults;
   bool m_preview;
   bool m_movieType;
+  bool m_seqRequired;
+  bool m_waitAfterFinish;
 
 public:
   Imp(ToonzScene *scene, const TFilePath &moviePath, int threadCount,
@@ -185,13 +188,15 @@ MovieRenderer::Imp::Imp(ToonzScene *scene, const TFilePath &moviePath,
     , m_failure(false)  //  AFTER the first completed raster gets processed
     , m_cacheResults(cacheResults)
     , m_preview(moviePath.isEmpty())
-    , m_movieType(isMovieType(moviePath)) {
+    , m_movieType(isMovieType(moviePath))
+    , m_seqRequired(isSequencialRequired(moviePath)) {
   m_renderCacheId =
       m_fp.withName(m_fp.getName() + "#RENDERID" +
                     QString::number(m_renderSessionId).toStdString())
           .getLevelName();
 
   m_renderer.addPort(this);
+  m_waitAfterFinish = m_movieType && !m_seqRequired && threadCount > 1;
 }
 
 //---------------------------------------------------------
@@ -470,6 +475,9 @@ void MovieRenderer::Imp::doRenderRasterCompleted(const RenderData &renderData) {
 
   QMutexLocker locker(&m_mutex);
 
+  bool allowMT    = Preferences::instance()->getFfmpegMultiThread();
+  bool requireSeq = allowMT ? m_seqRequired : m_movieType;
+
   // Build soundtrack at the first time a frame is completed - and the filetype
   // is that of a movie.
   if (m_firstCompletedRaster && m_movieType && !m_st) {
@@ -523,7 +531,7 @@ void MovieRenderer::Imp::doRenderRasterCompleted(const RenderData &renderData) {
     // In the *movie type* case, frames must be saved sequentially.
     // If the frame is not the next one in the sequence, wait until *that* frame
     // is available.
-    if (m_movieType &&
+    if (requireSeq &&
         (ft->first != m_framesToBeRendered[m_nextFrameIdxToSave].first))
       break;
 
@@ -557,8 +565,8 @@ void MovieRenderer::Imp::doRenderRasterCompleted(const RenderData &renderData) {
         ~MutexUnlocker() {
           if (m_locker) m_locker->relock();
         }
-      } unlocker = {m_movieType ? (QMutexLocker *)0
-                                : (locker.unlock(), &locker)};
+      } unlocker = {requireSeq ? (QMutexLocker *)0
+                               : (locker.unlock(), &locker)};
 
       savedFrame = saveFrame(frame, rasters);
     }
@@ -683,6 +691,9 @@ void MovieRenderer::Imp::onRenderFailure(const RenderData &renderData,
                               // No sense making it later in this case!
   m_failure = true;
 
+  bool allowMT    = Preferences::instance()->getFfmpegMultiThread();
+  bool requireSeq = allowMT ? m_seqRequired : m_movieType;
+
   // If the saver object has already been destroyed - or it was never
   // created to begin with, nothing to be done
   if (!m_levelUpdaterA.get()) return;  // The preview case would fall here
@@ -694,7 +705,7 @@ void MovieRenderer::Imp::onRenderFailure(const RenderData &renderData,
   std::map<double, std::pair<TRasterP, TRasterP>>::iterator it =
       m_toBeSaved.begin();
   while (it != m_toBeSaved.end()) {
-    if (m_movieType &&
+    if (requireSeq &&
         (it->first != m_framesToBeRendered[m_nextFrameIdxToSave].first))
       break;
 
@@ -734,6 +745,15 @@ void MovieRenderer::Imp::onRenderFinished(bool isCanceled) {
       m_levelUpdaterA.get()
           ? m_fp
           : TFilePath(getPreviewName(m_renderSessionId).toStdWString()));
+
+  if (m_waitAfterFinish) {
+    // Wait half a second to add some stability before finalizing
+    QEventLoop eloop;
+    QTimer timer;
+    timer.connect(&timer, &QTimer::timeout, &eloop, &QEventLoop::quit);
+    timer.start(500);
+    eloop.exec();
+  }
 
   // Close updaters. After this, the output levels should be finalized on disk.
   m_levelUpdaterA.reset();

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -498,6 +498,7 @@ void Preferences::definePreferenceItems() {
   define(ffmpegTimeout, "ffmpegTimeout", QMetaType::Int, 600, 1,
          std::numeric_limits<int>::max());
   define(fastRenderPath, "fastRenderPath", QMetaType::QString, "desktop");
+  define(ffmpegMultiThread, "ffmpegMultiThread", QMetaType::Bool, false);
 
   // Drawing
   define(scanLevelType, "scanLevelType", QMetaType::QString, "tif");


### PR DESCRIPTION
This PR allows to enable Multi-Thread FFMPEG rendering and have finalizing window responsive.

Multi-Thread FFMPEG will be **disabled by default** and must be enabled in `Preferences... > Import/Export`.
Enabling multi-thread rendering will render significantly faster but a random crash might occur, it's even more unstable when plastic tool is involved... in order to use multi-thread rendering the option `Dedicated CPUs` must be either `Half` or `All`.
Note: Is possible to Multi-Thread render in Tasks regardless of this patch.

Anyway in my opinion the speed gain is worth the risk as long the scene is always saved before rendering... I've got some users reporting gains between 6x to 8x with Dedicated CPU as All, also since the option can be enabled it will encourage developers to make multi-threading more stable.

Last but not least, the PR also makes the finalizing window responsive to the user instead of freezing OT window completely.
Progress bar will also perform a busy indicator while waiting for FFMPEG to finish.