### PR TITLE
Tile Fx Iwa : a new "Image Size" option for the Input Size parameter

### DIFF
--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -146,6 +146,11 @@ public:
   bool m_applyShrinkToViewer;  //!< Whether shrink must be considered.   \note
                                //! Should be moved to TOutputProperties.
 
+  // when this flag is true, TLevelColumnFx::doGetBBox returns full image sized
+  // box instead of the bounding box. It takes effect only for Toonz Raster /
+  // Raster levels. Currently used only in Tile Fx Iwa. (see iwa_tilefx.cpp)
+  bool m_getFullSizeBBox;
+
   /*-- カメラサイズ --*/
   TRectD m_cameraBox;
   /*-- 途中でPreview計算がキャンセルされたときのフラグ --*/

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -183,7 +183,7 @@ inline std::string traduce(const TAffine &aff) {
       (areAlmostEqual(aff.a23, 0.0) ? "0" : ::to_string(aff.a23, 5));
 }
 
-}  // Local namespace
+}  // namespace
 
 //------------------------------------------------------------------------------
 
@@ -1073,7 +1073,8 @@ TRenderSettings::TRenderSettings()
     , m_isSwatch(false)
     , m_applyShrinkToViewer(false)
     , m_userCachable(true)
-    , m_isCanceled(NULL) {}
+    , m_isCanceled(NULL)
+    , m_getFullSizeBBox(false) {}
 
 //------------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1408,16 +1408,19 @@ bool TLevelColumnFx::doGetBBox(double frame, TRectD &bBox,
     TImageInfo imageInfo;
     getImageInfo(imageInfo, sl, cell.m_frameId);
 
-    TRect imageSavebox(imageInfo.m_x0, imageInfo.m_y0, imageInfo.m_x1,
-                       imageInfo.m_y1);
     double cx = 0.5 * imageInfo.m_lx;
     double cy = 0.5 * imageInfo.m_ly;
-    double x0 = (imageSavebox.x0 - cx);
-    double y0 = (imageSavebox.y0 - cy);
-    double x1 = x0 + imageSavebox.getLx();
-    double y1 = y0 + imageSavebox.getLy();
-    bBox      = TRectD(x0, y0, x1, y1);
-
+    if (info.m_getFullSizeBBox) {
+      bBox = TRectD(-cx, -cy, cx, cy);
+    } else {
+      TRect imageSavebox(imageInfo.m_x0, imageInfo.m_y0, imageInfo.m_x1,
+                         imageInfo.m_y1);
+      double x0 = (imageSavebox.x0 - cx);
+      double y0 = (imageSavebox.y0 - cy);
+      double x1 = x0 + imageSavebox.getLx();
+      double y1 = y0 + imageSavebox.getLy();
+      bBox      = TRectD(x0, y0, x1, y1);
+    }
     dpi = imageInfo.m_dpix / Stage::inch;
   } else {
     TImageP img = m_levelColumn->getCell(row).getImage(false);


### PR DESCRIPTION
This PR will add a new option `Image Size` for the `Input Size` parameter. The new option will repeat image at the interval of the  image size of the input. Please note that it takes effect when you input Toonz Raster or Raster Levels. Other level types will return the same size as the `Bounding box` option.

This option is demanded for utilizing the Tile Fx Iwa for filling gap at camera boundary after blurring the image.

#### Example

Input image
<img src="https://user-images.githubusercontent.com/17974955/148507859-fd5c6ef4-dca0-4013-99be-37970af20f38.png" width=400>

The result when the `Image Size` is set to `Bounding Box` (existing option)
<img src="https://user-images.githubusercontent.com/17974955/148508021-2ac779a2-89c8-4b5f-a0e4-123c1827ac9d.png" width=400>

The result when the `Image Size` is set to `Image Size` (new option)
<img src="https://user-images.githubusercontent.com/17974955/148508095-eceedea0-3d04-4ccd-aef6-4c25bbf71d42.png" width=400>

