### PR TITLE
A new option for the Fractal Noise Fx Iwa : Conical Transform

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1450,6 +1450,11 @@
   <item>"STD_iwa_FractalNoiseFx.cycleEvolution"	"Cycle Evolution"	</item>
   <item>"STD_iwa_FractalNoiseFx.cycleEvolutionRange"	"Cycle (in Evolution)"	</item>
   <item>"STD_iwa_FractalNoiseFx.dynamicIntensity"	"Dynamic Intensity"	</item>
+  <item>"STD_iwa_FractalNoiseFx.doConical"	"Do Conical Transform"	</item>
+  <item>"STD_iwa_FractalNoiseFx.conicalAngle"	"Conical Angle"	</item>
+  <item>"STD_iwa_FractalNoiseFx.cameraFov"	"Camera FoV"	</item>
+  <item>"STD_iwa_FractalNoiseFx.zScale"	"Scale Depth"	</item>
+  <item>"STD_iwa_FractalNoiseFx.conicalEvolution"	"Conical Evolution"	</item>
   <item>"STD_iwa_FractalNoiseFx.alphaRendering"	"Alpha Rendering"	</item>
   
   <item>"STD_iwa_BloomFx" 			"Bloom Iwa" 	</item>

--- a/stuff/profiles/layouts/fxs/STD_iwa_FractalNoiseFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_FractalNoiseFx.xml
@@ -29,10 +29,22 @@
     <vbox modeSensitive="cycleEvolution" mode="1">
     <control>cycleEvolutionRange</control>
     </vbox>
-<separator/>
     <vbox modeSensitive="fractalType" mode="4,5">
     <control>dynamicIntensity</control>
     </vbox>
+<separator label="Conical Transform"/>
+    <control>doConical</control>
+    <vbox modeSensitive="doConical" mode="1">
+    <control>conicalAngle</control>
+    <control>cameraFov</control>
+    <control>zScale</control>
+    <control>conicalEvolution</control>
+    </vbox>
+<separator/>
     <control>alphaRendering</control>
+    <visibleToggle> 
+        <controller>doConical</controller>
+        <off>perspectiveOffset</off>
+    </visibleToggle>
 	</page>
 </fxlayout>

--- a/toonz/sources/stdfx/iwa_fractalnoisefx.h
+++ b/toonz/sources/stdfx/iwa_fractalnoisefx.h
@@ -46,6 +46,13 @@ class Iwa_FractalNoiseFx final : public TStandardZeraryFx {
     bool cycleEvolution;
     double cycleEvolutionRange;
     double dynamicIntensity;
+
+    bool doConical;
+    double conicalEvolution;
+    double conicalAngle;
+    double cameraFov;
+    double zScale;
+
     bool alphaRendering;
   };
 
@@ -106,6 +113,13 @@ protected:
   // ダイナミックの度合い
   TDoubleParamP m_dynamicIntensity;
 
+  //- - - Conical Noise - - - 
+  TBoolParamP m_doConical;
+  TDoubleParamP m_conicalEvolution;
+  TDoubleParamP m_conicalAngle;
+  TDoubleParamP m_cameraFov;
+  TDoubleParamP m_zScale;
+
   // - - - additional parameters - - -
   TBoolParamP m_alphaRendering;
 
@@ -127,7 +141,7 @@ public:
 
   // For Dynamic and Dynamic Twist patterns, the position offsets using gradient
   // / rotation of the parent pattern
-  TPointD getSamplePos(int x, int y, const TDimension outDim,
+  TPointD getSamplePos(double x, double y, const TDimension outDim,
                        const double *out_buf, const int gen, const double scale,
                        const FNParam &param);
   // convert the noise


### PR DESCRIPTION
This PR adds a new option to the Fractal Noise Fx Iwa: Conical Transform. It can generate radially propagating noise pattern. 

<img src="https://user-images.githubusercontent.com/17974955/148518204-17345286-c2b7-4cc2-b011-5f638b26732f.gif" width=300>  <img src="https://user-images.githubusercontent.com/17974955/148518234-21ec7e50-cdd3-4413-bbf2-48a89b882df3.gif" width=300>
**Left** : Conventional noise pattern    **Right**:  (new) Conical noise pattern

The concept of this option is as follows: The conventional, regular noise pattern is sampled from flat plane. OTOH the conical noise pattern is sampled from the cone shape in the +1 dimensional noise space, with the "conical evolution" axis.
<img src="https://user-images.githubusercontent.com/17974955/148519008-2607f5c7-06e5-4c4c-9d58-b744b8870f00.png" width=500>

### New Parameters
- **Do Conical Transform** : enables conical transform of the noise. Unchecking this option will generate conventional noise.
- **Conical Angle** : specifies the slope angle of the sampling cone. (in degree)
    ![conical_angle](https://user-images.githubusercontent.com/17974955/148519519-975e5b74-201c-47e4-904f-1a7a414ca105.png)
- **Camera Fov** : specifies the vertical field of view of the camera. (in degree) 
    ![conical_fov](https://user-images.githubusercontent.com/17974955/148519659-d9d9313b-9556-4917-b9cf-d639adaf0280.png)
- **Scale Depth** : specifies the exponential scale of the noise pattern along direction of the `conical evolution` axis.
    ![conical_depthscale](https://user-images.githubusercontent.com/17974955/148519935-c5ee6323-6c67-4c24-9b4e-245334a64e71.png)

- **Conical Evolution** : specifies the noise evolution in the `conical evolution` axis.

Please note that when the Conical Transform is active, the `Offset Turbulence` parameter acts completely different: It offsets the peak position of the cone from the center of the camera, like this:

![fractal_noise_offset](https://user-images.githubusercontent.com/17974955/148520428-df5fead0-30b2-4c3b-9781-b536465f7439.gif)

Please be forewarned that the parameter may altered before releasing the next version according to the feedback from our studio.