### PR TITLE
"Implicit hold" move by Shift+dragging cells

### DIFF
--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -89,7 +89,7 @@ TXsheet *CellsMover::getXsheet() const {
 
 void CellsMover::getCells(std::vector<TXshCell> &cells, int r, int c) const {
   for (int i = 0; i < (int)cells.size(); i++) cells[i] = TXshCell();
-  TXsheet *xsh                                         = getXsheet();
+  TXsheet *xsh = getXsheet();
   for (int i = 0; i < m_colCount; i++) {
     TXshColumn *column = xsh->getColumn(c + i);
     if (column && column->isLocked()) continue;
@@ -145,6 +145,31 @@ void CellsMover::moveCells(const TPoint &pos) const {
     }
   }
   setCells(m_cells, r, c);
+
+  // Act like implicit hold when dragging cells with pressing Shift key
+  // ( and WITHOUT Alt key ) and dragging within the same column.
+  if (m_qualifiers & eInsertCells && !(m_qualifiers & eOverwriteCells)) {
+    int startCol =
+        (m_orientation->isVerticalTimeline()) ? m_startPos.x : m_startPos.y;
+    if (startCol == c) {
+      for (int i = 0; i < m_colCount; i++) {
+        TXshColumn *column = xsh->getColumn(c + i);
+        if (!column || column->getCellColumn() == 0 || column->isLocked())
+          continue;
+        // a cell above inserted cells
+        TXshCell upperCell = xsh->getCell(r - 1, c + i);
+        if (upperCell.isEmpty()) continue;
+        // a cell at the bottom of the inserted cells
+        TXshCell bottomCell = xsh->getCell(r + m_rowCount - 1, c + i);
+        if (bottomCell.isEmpty()) continue;
+        int tmp_r = r + m_rowCount;
+        while (xsh->getCell(tmp_r, c + i) == upperCell) {
+          xsh->setCell(tmp_r, c + i, bottomCell);
+          tmp_r++;
+        }
+      }
+    }
+  }
 }
 
 void CellsMover::undoMoveCells(const TPoint &pos) const {
@@ -156,6 +181,28 @@ void CellsMover::undoMoveCells(const TPoint &pos) const {
     c = pos.y;
   }
   if (m_qualifiers & eInsertCells) {
+    // Act like implicit hold when dragging cells with pressing Shift key
+    // ( and WITHOUT Alt key ) and dragging within the same column.
+    if (!(m_qualifiers & eOverwriteCells) && r > 0) {
+      int startCol =
+          (m_orientation->isVerticalTimeline()) ? m_startPos.x : m_startPos.y;
+      if (startCol == c) {
+        for (int i = 0; i < m_colCount; i++) {
+          // a cell above selected cells
+          TXshCell upperCell = xsh->getCell(r - 1, c + i);
+          if (upperCell.isEmpty()) continue;
+          // a cell at the bottom of the selected cells
+          TXshCell bottomCell = xsh->getCell(r + m_rowCount - 1, c + i);
+          if (bottomCell.isEmpty()) continue;
+          int tmp_r = r + m_rowCount;
+          while (xsh->getCell(tmp_r, c + i) == bottomCell) {
+            xsh->setCell(tmp_r, c + i, upperCell);
+            tmp_r++;
+          }
+        }
+      }
+    }
+
     for (int i = 0; i < m_colCount; i++) xsh->removeCells(r, c + i, m_rowCount);
   } else {
     for (int i = 0; i < m_colCount; i++) xsh->clearCells(r, c + i, m_rowCount);
@@ -234,7 +281,7 @@ void CellsMover::getColumnsData(int c0, int c1) {
 
 void CellsMover::restoreColumns(int c) const {
   std::set<int> ii;
-  for (int i   = 0; i < m_colCount; i++) ii.insert(c + i);
+  for (int i = 0; i < m_colCount; i++) ii.insert(c + i);
   TXsheet *xsh = getXsheet();
   for (int i = 0; i < m_colCount; i++) xsh->removeColumn(c);
   std::list<int> restoredSplineIds;
@@ -337,7 +384,7 @@ public:
       int c, ra = m_cellsMover.getStartPos().y,
              rowCount = m_cellsMover.getRowCount();
       if (!m_cellsMover.getOrientation()->isVerticalTimeline())
-        ra         = m_cellsMover.getStartPos().x;
+        ra = m_cellsMover.getStartPos().x;
       TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
       for (c = ca; c < ca + colCount; c++) xsh->clearCells(ra, c, rowCount);
     }
@@ -413,7 +460,7 @@ bool LevelMoverTool::canMoveColumns(const TPoint &pos) {
       if (srcColumn && srcColumn->isLocked()) continue;
       TXshColumn *dstColumn          = xsh->getColumn(dstIndex);
       TXshColumn::ColumnType srcType = TXshColumn::eLevelType;
-      if (srcColumn) srcType         = srcColumn->getColumnType();
+      if (srcColumn) srcType = srcColumn->getColumnType();
       if (srcType == TXshColumn::eZeraryFxType) return false;
       /*
       qDebug() << "check: " << srcIndex << ":" <<
@@ -515,8 +562,8 @@ void LevelMoverTool::onCellChange(int row, int col) {
 
   if (pos.x < 0) pos.x = 0;
 
-  TPoint delta                       = pos - m_aimedPos;
-  int dCol                           = delta.x;
+  TPoint delta = pos - m_aimedPos;
+  int dCol     = delta.x;
   if (!o->isVerticalTimeline()) dCol = delta.y;
 
   CellsMover *cellsMover = m_undo->getCellsMover();


### PR DESCRIPTION
This PR resolves #4078 .

When you Shift + dragging cells within the same column, cells will be moved as if it is implicitly held.
Please note that the conventional behavior of Shift + dragging cells can still be performed by Shift + Alt + dragging.