### PR TITLE
Fix undo of moving cells with Shift+Ctrl

### DIFF
--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -89,7 +89,7 @@ TXsheet *CellsMover::getXsheet() const {
 
 void CellsMover::getCells(std::vector<TXshCell> &cells, int r, int c) const {
   for (int i = 0; i < (int)cells.size(); i++) cells[i] = TXshCell();
-  TXsheet *xsh                                         = getXsheet();
+  TXsheet *xsh = getXsheet();
   for (int i = 0; i < m_colCount; i++) {
     TXshColumn *column = xsh->getColumn(c + i);
     if (column && column->isLocked()) continue;
@@ -234,7 +234,7 @@ void CellsMover::getColumnsData(int c0, int c1) {
 
 void CellsMover::restoreColumns(int c) const {
   std::set<int> ii;
-  for (int i   = 0; i < m_colCount; i++) ii.insert(c + i);
+  for (int i = 0; i < m_colCount; i++) ii.insert(c + i);
   TXsheet *xsh = getXsheet();
   for (int i = 0; i < m_colCount; i++) xsh->removeColumn(c);
   std::list<int> restoredSplineIds;
@@ -302,13 +302,17 @@ public:
       if (m_cellsMover.m_uffa & 2) m_cellsMover.emptyColumns(cb);
       if (m_cellsMover.m_uffa & 1) m_cellsMover.restoreColumns(ca);
     }
-    if (m_cellsMover.getOrientation()->isVerticalTimeline())
-      m_cellsMover.moveCells(m_cellsMover.getStartPos());
-    else {
-      int rStart = m_cellsMover.getStartPos().x;
-      int cStart = m_cellsMover.getStartPos().y;
-      const TPoint useStart(rStart, cStart);
-      m_cellsMover.moveCells(useStart);
+    // Undo of moving cells with copy qualifiers does not need to restore the
+    // cells at start pos
+    if (!(m_cellsMover.getQualifiers() & CellsMover::eCopyCells)) {
+      if (m_cellsMover.getOrientation()->isVerticalTimeline())
+        m_cellsMover.moveCells(m_cellsMover.getStartPos());
+      else {
+        int rStart = m_cellsMover.getStartPos().x;
+        int cStart = m_cellsMover.getStartPos().y;
+        const TPoint useStart(rStart, cStart);
+        m_cellsMover.moveCells(useStart);
+      }
     }
     TApp::instance()->getCurrentXsheet()->getXsheet()->updateFrameCount();
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -337,7 +341,7 @@ public:
       int c, ra = m_cellsMover.getStartPos().y,
              rowCount = m_cellsMover.getRowCount();
       if (!m_cellsMover.getOrientation()->isVerticalTimeline())
-        ra         = m_cellsMover.getStartPos().x;
+        ra = m_cellsMover.getStartPos().x;
       TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
       for (c = ca; c < ca + colCount; c++) xsh->clearCells(ra, c, rowCount);
     }
@@ -413,7 +417,7 @@ bool LevelMoverTool::canMoveColumns(const TPoint &pos) {
       if (srcColumn && srcColumn->isLocked()) continue;
       TXshColumn *dstColumn          = xsh->getColumn(dstIndex);
       TXshColumn::ColumnType srcType = TXshColumn::eLevelType;
-      if (srcColumn) srcType         = srcColumn->getColumnType();
+      if (srcColumn) srcType = srcColumn->getColumnType();
       if (srcType == TXshColumn::eZeraryFxType) return false;
       /*
       qDebug() << "check: " << srcIndex << ":" <<
@@ -515,8 +519,8 @@ void LevelMoverTool::onCellChange(int row, int col) {
 
   if (pos.x < 0) pos.x = 0;
 
-  TPoint delta                       = pos - m_aimedPos;
-  int dCol                           = delta.x;
+  TPoint delta = pos - m_aimedPos;
+  int dCol     = delta.x;
   if (!o->isVerticalTimeline()) dCol = delta.y;
 
   CellsMover *cellsMover = m_undo->getCellsMover();
@@ -636,7 +640,10 @@ void LevelMoverTool::onRelease(const CellPosition &pos) {
   int startY            = cellMover->getStartPos().y;
   int posX              = cellMover->getPos().x;
   int posY              = cellMover->getPos().y;
-  if (m_lastPos != m_startPos) TUndoManager::manager()->add(m_undo);
+  bool copyInserted     = m_qualifiers & CellsMover::eCopyCells &&
+                      m_qualifiers & CellsMover::eInsertCells;
+  if (m_lastPos != m_startPos || copyInserted)
+    TUndoManager::manager()->add(m_undo);
   m_undo = 0;
 
   if (!getViewer()->orientation()->isVerticalTimeline())


### PR DESCRIPTION
This PR will fix the problem reported in [this comment](https://github.com/opentoonz/opentoonz/pull/4214#issuecomment-1010285445) by @manongjohn .
When clicking the side bar holding Shift+Ctrl (i.e. Copy+Insert options), it seems to be not a problem that the copy of the selected cells are immediately duplicated. The problem is that such duplication is not undoable.