### PR TITLE
Zoom in/out and fit floating panel geometry commands

### DIFF
--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -2117,7 +2117,7 @@ QPointF newViewerGeomCenter(
 
 //-----------------------------------------------------------------------------
 
-void FlipBook::onDoubleClick(QMouseEvent *me) {
+void FlipBook::adaptGeometryToCurrentSize() {
   TImageP img(m_imageViewer->getImage());
   if (!img) return;
 
@@ -2140,6 +2140,17 @@ void FlipBook::onDoubleClick(QMouseEvent *me) {
   // performing the inverse.
 
   adaptWidGeometry(pixGeom, pixGeom, false);
+}
+
+//-----------------------------------------------------------------------------
+
+void FlipBook::onDoubleClick(QMouseEvent *me) { adaptGeometryToCurrentSize(); }
+
+//-----------------------------------------------------------------------------
+
+void FlipBook::zoomAndAdaptGeometry(bool forward) {
+  m_imageViewer->zoomQt(forward, false);
+  adaptGeometryToCurrentSize();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/flipbook.h
+++ b/toonz/sources/toonz/flipbook.h
@@ -236,6 +236,9 @@ public:
   // zoom-out the rendered image.
   void adaptGeometryForFullPreview(const TRect &imgRect);
 
+  void adaptGeometryToCurrentSize();
+  void zoomAndAdaptGeometry(bool forward);
+
   void reset();
 
   void onDrawFrame(int frame, const ImagePainter::VisualSettings &vs,

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2738,6 +2738,12 @@ void MainWindow::defineActions() {
                                              tr("Exit Full Screen Mode"));
   createViewerAction(MI_CompareToSnapshot, QT_TR_NOOP("Compare to Snapshot"),
                      "");
+  createViewerAction(MI_ZoomInAndFitPanel,
+                     QT_TR_NOOP("Zoom In And Fit Floating Panel"),
+                     "Ctrl+Alt++");
+  createViewerAction(MI_ZoomOutAndFitPanel,
+                     QT_TR_NOOP("Zoom Out And Fit Floating Panel"),
+                     "Ctrl+Alt+-");
 
   // Following actions are for adding "Visualization" menu items to the command
   // bar. They are separated from the original actions in order to avoid

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -458,4 +458,8 @@
 
 // mark id is added for each actual command (i.g. MI_SetCellMark1)
 #define MI_SetCellMark "MI_SetCellMark"
+
+#define MI_ZoomInAndFitPanel "MI_ZoomInAndFitPanel"
+#define MI_ZoomOutAndFitPanel "MI_ZoomOutAndFitPanel"
+
 #endif

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -33,6 +33,7 @@
 #include <QDesktopWidget>
 #include <QDialog>
 #include <QLineEdit>
+#include <QScreen>
 
 extern TEnv::StringVar EnvSafeAreaName;
 
@@ -173,6 +174,58 @@ void TPanel::restoreFloatingPanelState() {
   if (SaveLoadQSettings *persistent =
           dynamic_cast<SaveLoadQSettings *>(widget()))
     persistent->load(settings);
+}
+
+//-----------------------------------------------------------------------------
+// if the panel has no contents to be zoomed, simply resize the panel here
+// currently only Flipbook and Color Model panels support resizing of contents
+void TPanel::zoomContentsAndFitGeometry(bool forward) {
+  if (!m_floating) return;
+
+  auto getScreen = [&]() {
+    QScreen *ret = nullptr;
+    ret          = QGuiApplication::screenAt(geometry().topLeft());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().topRight());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().center());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().bottomLeft());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().bottomRight());
+    return ret;
+  };
+
+  // Get screen geometry
+  QScreen *screen = getScreen();
+  if (!screen) return;
+  QRect screenGeom = screen->availableGeometry();
+
+  QSize newSize;
+  if (forward)
+    // x1.2 scale
+    newSize = QSize(width() * 6 / 5, height() * 6 / 5);
+  else
+    // 1/1.2 scale
+    newSize = QSize(width() * 5 / 6, height() * 5 / 6);
+
+  QRect newGeom(geometry().topLeft(), newSize);
+  if (!screenGeom.contains(newGeom)) {
+    if (newGeom.width() > screenGeom.width())
+      newGeom.setWidth(screenGeom.width());
+    if (newGeom.right() > screenGeom.right())
+      newGeom.moveRight(screenGeom.right());
+    else if (newGeom.left() < screenGeom.left())
+      newGeom.moveLeft(screenGeom.left());
+
+    if (newGeom.height() > screenGeom.height())
+      newGeom.setHeight(screenGeom.height());
+    if (newGeom.bottom() > screenGeom.bottom())
+      newGeom.moveBottom(screenGeom.bottom());
+    else if (newGeom.top() < screenGeom.top())
+      newGeom.moveTop(screenGeom.top());
+  }
+  setGeometry(newGeom);
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -237,6 +237,7 @@ public:
   };
 
   virtual void restoreFloatingPanelState();
+  virtual void zoomContentsAndFitGeometry(bool forward);
 
 protected:
   void paintEvent(QPaintEvent *) override;

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -97,6 +97,7 @@
 
 // Qt includes
 #include <QAction>
+#include <QScreen>
 
 //=============================================================================
 // XsheetViewer
@@ -1039,7 +1040,51 @@ OpenFloatingPanel openToolOptionsCommand(MI_OpenToolOptionBar, "ToolOptions",
 // FlipbookFactory
 //-----------------------------------------------------------------------------
 
-FlipbookPanel::FlipbookPanel(QWidget *parent) : TPanel(parent) {
+void FlipbookBasePanel::zoomContentsAndFitGeometry(bool forward) {
+  if (!isFloating()) return;
+  if (!m_flipbook->getImageViewer()->getImage()) {
+    TPanel::zoomContentsAndFitGeometry(forward);
+    return;
+  }
+  // resize the window leaving the top-left corner position unchanged
+  // in order to gain consistency with Photoshop
+  auto getScreen = [&]() {
+    QScreen *ret = nullptr;
+    ret          = QGuiApplication::screenAt(geometry().topLeft());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().topRight());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().center());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().bottomLeft());
+    if (ret) return ret;
+    ret = QGuiApplication::screenAt(geometry().bottomRight());
+    return ret;
+  };
+  // Get screen geometry
+  QScreen *screen = getScreen();
+  if (!screen) return;
+  QRect screenGeom  = screen->availableGeometry();
+  QPoint oldTopLeft = geometry().topLeft();
+
+  m_flipbook->zoomAndAdaptGeometry(forward);
+
+  QRect newGeom(geometry());
+  newGeom.moveTopLeft(oldTopLeft);
+  if (newGeom.right() > screenGeom.right())
+    newGeom.moveRight(screenGeom.right());
+  else if (newGeom.left() < screenGeom.left())
+    newGeom.moveLeft(screenGeom.left());
+  if (newGeom.bottom() > screenGeom.bottom())
+    newGeom.moveBottom(screenGeom.bottom());
+  else if (newGeom.top() < screenGeom.top())
+    newGeom.moveTop(screenGeom.top());
+  setGeometry(newGeom);
+}
+
+//-----------------------------------------------------------------------------
+
+FlipbookPanel::FlipbookPanel(QWidget *parent) : FlipbookBasePanel(parent) {
   m_flipbook = new FlipBook(this);
   setWidget(m_flipbook);
   // minimize button and safearea toggle
@@ -1216,10 +1261,18 @@ public:
 class ColorModelViewerFactory final : public TPanelFactory {
 public:
   ColorModelViewerFactory() : TPanelFactory("ColorModel") {}
-  void initialize(TPanel *panel) override {
-    panel->setWidget(new ColorModelViewer(panel));
-    panel->resize(400, 300);
+
+  TPanel *createPanel(QWidget *parent) override {
+    FlipbookBasePanel *panel     = new FlipbookBasePanel(parent);
+    ColorModelViewer *colorModel = new ColorModelViewer(panel);
+    panel->setWidget(colorModel);
+    panel->setFlipbook(colorModel);
+    panel->setObjectName(getPanelType());
+    panel->setWindowTitle(getPanelType());
+    return panel;
   }
+
+  void initialize(TPanel *panel) override { assert(0); }
 } colorModelViewerFactory;
 
 //=============================================================================
@@ -1550,3 +1603,26 @@ public:
 OpenFloatingPanel openVectorGuidedDrawingPanelCommand(
     MI_OpenGuidedDrawingControls, "VectorGuidedDrawingPanel",
     QObject::tr("Vector Guided Drawing"));
+
+//-----------------------------------------------------------------------------
+
+namespace {
+
+void zoomAndFitPanel(bool forward) {
+  TPanel *panel = dynamic_cast<TPanel *>(qApp->activeWindow());
+  if (panel) panel->zoomContentsAndFitGeometry(forward);
+}
+
+}  // namespace
+
+class ZoomInAndFitPanel final : public MenuItemHandler {
+public:
+  ZoomInAndFitPanel() : MenuItemHandler("MI_ZoomInAndFitPanel") {}
+  void execute() override { zoomAndFitPanel(true); }
+} zoomInAndFitPanel;
+
+class ZoomOutAndFitPanel final : public MenuItemHandler {
+public:
+  ZoomOutAndFitPanel() : MenuItemHandler("MI_ZoomOutAndFitPanel") {}
+  void execute() override { zoomAndFitPanel(false); }
+} zoomOutAndFitPanel;

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -249,10 +249,20 @@ public:
 //=========================================================
 // FlipbookPanel
 //---------------------------------------------------------
-
-class FlipbookPanel final : public TPanel {
+// share the base class between Flipbook and Color Model panels
+class FlipbookBasePanel : public TPanel {
   Q_OBJECT
+protected:
   FlipBook *m_flipbook;
+
+public:
+  FlipbookBasePanel(QWidget *parent) : TPanel(parent) {}
+  void zoomContentsAndFitGeometry(bool forward) override;
+  void setFlipbook(FlipBook *fb) { m_flipbook = fb; }
+};
+
+class FlipbookPanel final : public FlipbookBasePanel {
+  Q_OBJECT
 
   QSize m_floatingSize;
   TPanelTitleBarButton *m_button;


### PR DESCRIPTION
This PR adds new commands `Zoom In/Out And Fit Floating Panel` , which will resize the top-level floating panel.
- If the top level floating panel is Flipbook or Color Model, these commands will zoom in/out the content and then fit the window geometry to it.
- If the top level floating panel is another type, these commands will just resize the window.
- If there is no floating panel (or the top level window is not a floating panel), these commands will do nothing.

This feature is just like the same feature in Photoshop. The default shortcuts are `Ctrl+Alt++` and `Ctrl+Alt+-` respectively (which are also consistent with Photoshop).