### PR TITLE
Fix backtab key to work for moving styles shortcut scope

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1436,6 +1436,7 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
       if (m_isStyleShortcutSwitchable &&
           Preferences::instance()->isUseNumpadForSwitchingStylesEnabled() &&
           (event->modifiers() == Qt::NoModifier ||
+           event->modifiers() == Qt::ShiftModifier ||
            event->modifiers() == Qt::KeypadModifier) &&
           ((Qt::Key_0 <= key && key <= Qt::Key_9) || key == Qt::Key_Tab ||
            key == Qt::Key_Backtab)) {

--- a/toonz/sources/toonz/styleshortcutswitchablepanel.cpp
+++ b/toonz/sources/toonz/styleshortcutswitchablepanel.cpp
@@ -26,11 +26,11 @@ void StyleShortcutSwitchablePanel::onKeyPress(QKeyEvent *event) {
   TTool *tool = TApp::instance()->getCurrentTool()->getTool();
   if (!tool) return;
   if (tool->getName() == T_Type && tool->isActive()) return;
-  if (event->modifiers() != Qt::NoModifier &&
-      event->modifiers() != Qt::KeypadModifier)
-    return;
   int key = event->key();
   if (Qt::Key_0 <= key && key <= Qt::Key_9) {
+    if (event->modifiers() != Qt::NoModifier &&
+        event->modifiers() != Qt::KeypadModifier)
+      return;
     TPaletteHandle *ph =
         TApp::instance()->getPaletteController()->getCurrentLevelPalette();
 
@@ -46,6 +46,9 @@ void StyleShortcutSwitchablePanel::onKeyPress(QKeyEvent *event) {
     }
     event->accept();
   } else if (key == Qt::Key_Tab || key == Qt::Key_Backtab) {
+    if (event->modifiers() != Qt::NoModifier &&
+        event->modifiers() != Qt::ShiftModifier)
+      return;
     TPaletteHandle *ph =
         TApp::instance()->getPaletteController()->getCurrentLevelPalette();
 


### PR DESCRIPTION
This PR fixes the following problem:
- When the preferences option `Use Numpad and Tab keys for Switching Styles` is ON, pressing backtab (Shift+tab) key fails to move the styles shortcut scope upward.