### PR TITLE
Fix crash after starting a pen stroke from inactive window

### DIFF
--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -748,7 +748,7 @@ bool TApp::eventFilter(QObject *watched, QEvent *e) {
     // if the user is painting very quickly with the pen, a number of events
     // could be still in the queue
     // the must be processed as tabled events (not mouse events)
-    qApp->processEvents();
+    if (m_isPenCloseToTablet) qApp->processEvents();
 
     m_isPenCloseToTablet = false;
     emit tabletLeft();


### PR DESCRIPTION
Fixes #4184 

Got report from @DarrenTAnims that this patch stop crashes.

**Result of crash:**
Always calling `processEvents` together with `emit` could cause infinite recursive calls resulting in a Stack overflow.