### PR TITLE
Fix implicit hold cell dragging

### DIFF
--- a/toonz/sources/toonz/xshcellmover.h
+++ b/toonz/sources/toonz/xshcellmover.h
@@ -33,6 +33,9 @@ class CellsMover {
 
   const Orientation *m_orientation;
 
+  // keeping the implicit cell arrangement when start shift + dragging
+  QList<QMap<int, TXshCell>> m_implicitCellInfo;
+
   // helper method
   TXsheet *getXsheet() const;
 
@@ -44,6 +47,8 @@ class CellsMover {
 
   // m_columnsData <- xsheet columns data
   void getColumnsData(int c0, int c1);
+
+  void getImplicitCellInfo();
 
 public:
   enum Qualifier {


### PR DESCRIPTION
This PR fixes bug reported by @manongjohn in [this comment](https://github.com/opentoonz/opentoonz/pull/4214#issuecomment-1017104945).

Now the original cell arrangement will be stored when start dragging so that the modification on-the-go won't affect the subsequent results.