### PR TITLE
Fix crashes when using Type tool

### DIFF
--- a/toonz/sources/common/tvrender/tfont_qt.cpp
+++ b/toonz/sources/common/tvrender/tfont_qt.cpp
@@ -171,15 +171,15 @@ TPoint TFont::drawChar(QImage &outImage, TPoint &unused, wchar_t charcode,
   // alphaMapForGlyph with a space character returns an invalid
   // QImage for some reason.
   // Bug 3604: https://github.com/opentoonz/opentoonz/issues/3604
-#ifdef Q_OS_UNIX
-  if (chars[0] == L' ') {
-      outImage = QImage(raw.averageCharWidth(), raw.ascent() + raw.descent(),
-                        QImage::Format_Grayscale8);
-      outImage.fill(255);
-      return getDistance(charcode, nextCharCode);
+  // (21/1/2022) Use this workaround for all platforms as the crash also occured
+  // in windows when the display is scaled up.
+  if (chars[0].isSpace()) {
+    int w = QFontMetrics(m_pimpl->m_font).horizontalAdvance(chars[0]);
+    outImage =
+        QImage(w, raw.ascent() + raw.descent(), QImage::Format_Grayscale8);
+    outImage.fill(255);
+    return getDistance(charcode, nextCharCode);
   }
-#endif
-
   QImage image = raw.alphaMapForGlyph(indices[0], QRawFont::PixelAntialiasing);
   if (image.format() != QImage::Format_Indexed8 &&
       image.format() != QImage::Format_Alpha8)

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -1308,7 +1308,16 @@ void TypeTool::replaceText(std::wstring text, int from, int to) {
   for (unsigned int i = 0; i < (unsigned int)text.size(); i++) {
     wchar_t character = text[i];
 
-    if (vi) {
+    // line break case. This can happen when pasting text including the line
+    // break
+    if (character == '\r') {
+      TVectorImageP vi(new TVectorImage);
+      unsigned int index = from + i;
+      m_string.insert(m_string.begin() + index,
+                      StrokeChar(vi, -1., (int)(QChar('\r').unicode()), 0));
+    }
+
+    else if (vi) {
       TVectorImageP characterImage(new TVectorImage());
       unsigned int index = from + i;
       // se il font ha kerning bisogna tenere conto del carattere successivo
@@ -1334,7 +1343,7 @@ void TypeTool::replaceText(std::wstring text, int from, int to) {
       unsigned int index = from + i;
 
       if (instance->hasKerning() && (UINT)m_cursorIndex < m_string.size() &&
-          !m_string[index].isReturn())
+          index < m_string.size() - 1 && !m_string[index].isReturn())
         adv = instance->drawChar((TRasterCM32P &)newRasterCM, p, styleId,
                                  (wchar_t)character,
                                  (wchar_t)m_string[index].m_key);


### PR DESCRIPTION
This PR resolves #3805 and also resolves #4221 .

Regarding #4221 , the fix was already included for Linux only ( #3721 ) , since the problem had not occured in other OSs. Now I made the fix to be used regardless of platform. Also I modified the fix to avoid crash when typing not only single space, but also any other space-type characters (such as two-byte `Ideographic Space` for Japanese texts).