### PR TITLE
Tahoma2D Motion Path data compatibility

### DIFF
--- a/toonz/sources/include/toonz/tstageobjectspline.h
+++ b/toonz/sources/include/toonz/tstageobjectspline.h
@@ -6,6 +6,7 @@
 #include "tsmartpointer.h"
 #include "tgeometry.h"
 #include "tpersist.h"
+#include <QObject>
 
 #undef DVAPI
 #undef DVVAR
@@ -45,6 +46,14 @@ class DVAPI TStageObjectSpline final : public TSmartObject, public TPersist {
   bool m_isOpened;
   std::vector<TDoubleParam *> m_posPathParams;
 
+  // For Tahoma2D Motion Path compatibility
+  bool m_externalDataFound;
+  QList<TPointD> m_interpolationStroke;
+  bool m_active;
+  int m_color;
+  int m_steps;
+  int m_width;
+
 public:
   TStageObjectSpline();
   ~TStageObjectSpline();
@@ -56,6 +65,7 @@ Return spline stroke.
 \sa setStroke()
 */
   const TStroke *getStroke() const;
+  QList<TPointD> getInterpolationStroke();  // Needed for T2D compatibility
   /*!
 Set spline stroke to \b stroke.
 \sa getStroke()

--- a/toonz/sources/include/toonz/tstageobjectspline.h
+++ b/toonz/sources/include/toonz/tstageobjectspline.h
@@ -65,7 +65,6 @@ Return spline stroke.
 \sa setStroke()
 */
   const TStroke *getStroke() const;
-  QList<TPointD> getInterpolationStroke();  // Needed for T2D compatibility
   /*!
 Set spline stroke to \b stroke.
 \sa getStroke()

--- a/toonz/sources/toonzlib/tstageobjectspline.cpp
+++ b/toonz/sources/toonzlib/tstageobjectspline.cpp
@@ -125,19 +125,6 @@ TStageObjectSpline::TStageObjectSpline()
   points.push_back(TPointD(d, 0));
   points.push_back(TPointD(2.0 * d, 0));
   m_stroke = new TStroke(points);
-
-  // Needed for T2D compatibility
-  m_interpolationStroke.push_back(TPointD(-40, 0));
-  m_interpolationStroke.push_back(TPointD(-20, 0));
-  m_interpolationStroke.push_back(TPointD(-20, 0));
-  m_interpolationStroke.push_back(TPointD(0, 0));
-  m_interpolationStroke.push_back(TPointD(65, 65));
-
-  m_interpolationStroke.push_back(TPointD(935, 935));
-  m_interpolationStroke.push_back(TPointD(1000, 1000));
-  m_interpolationStroke.push_back(TPointD(1020, 1000));
-  m_interpolationStroke.push_back(TPointD(1020, 1000));
-  m_interpolationStroke.push_back(TPointD(1040, 1000));
 }
 
 //-----------------------------------------------------------------------------
@@ -171,13 +158,6 @@ TStageObjectSpline *TStageObjectSpline::clone() const {
 //-----------------------------------------------------------------------------
 
 const TStroke *TStageObjectSpline::getStroke() const { return m_stroke; }
-
-//-----------------------------------------------------------------------------
-
-// Needed for T2D compatibility
-QList<TPointD> TStageObjectSpline::getInterpolationStroke() {
-  return m_interpolationStroke;
-}
 
 //-----------------------------------------------------------------------------
 
@@ -270,8 +250,6 @@ void TStageObjectSpline::loadData(TIStream &is) {
 
 void TStageObjectSpline::saveData(TOStream &os) {
   const TStroke *stroke = getStroke();
-  QList<TPointD> interpStroke =
-      getInterpolationStroke();  // Needed for T2D compatibility
   os.child("splineId") << (int)m_id;
   if (!m_name.empty()) os.child("name") << m_name;
   os.child("isOpened") << (int)m_isOpened;
@@ -291,13 +269,15 @@ void TStageObjectSpline::saveData(TOStream &os) {
   }
   os.closeChild();
   if (m_externalDataFound) {  // Needed for T2D compatibility
-    os.openChild("interpolationStroke");
-    n = interpStroke.size();
-    os << n;
-    for (auto p : interpStroke) {
-      os << p.x << p.y;
+    n = m_interpolationStroke.size();
+    if (n) {
+      os.openChild("interpolationStroke");
+      os << n;
+      for (auto p : m_interpolationStroke) {
+        os << p.x << p.y;
+      }
+      os.closeChild();
     }
-    os.closeChild();
   }
 }
 

--- a/toonz/sources/toonzlib/tstageobjectspline.cpp
+++ b/toonz/sources/toonzlib/tstageobjectspline.cpp
@@ -113,6 +113,11 @@ TStageObjectSpline::TStageObjectSpline()
     , m_id(-1)
     , m_idBase(std::to_string(idBaseCode++))
     , m_name("")
+    , m_active(false)             // Needed for T2D compatibility
+    , m_color(0)                  // Needed for T2D compatibility
+    , m_steps(10)                 // Needed for T2D compatibility
+    , m_width(1)                  // Needed for T2D compatibility
+    , m_externalDataFound(false)  // Needed for T2D compatibility
     , m_isOpened(false) {
   double d = 30;
   std::vector<TThickPoint> points;
@@ -120,6 +125,19 @@ TStageObjectSpline::TStageObjectSpline()
   points.push_back(TPointD(d, 0));
   points.push_back(TPointD(2.0 * d, 0));
   m_stroke = new TStroke(points);
+
+  // Needed for T2D compatibility
+  m_interpolationStroke.push_back(TPointD(-40, 0));
+  m_interpolationStroke.push_back(TPointD(-20, 0));
+  m_interpolationStroke.push_back(TPointD(-20, 0));
+  m_interpolationStroke.push_back(TPointD(0, 0));
+  m_interpolationStroke.push_back(TPointD(65, 65));
+
+  m_interpolationStroke.push_back(TPointD(935, 935));
+  m_interpolationStroke.push_back(TPointD(1000, 1000));
+  m_interpolationStroke.push_back(TPointD(1020, 1000));
+  m_interpolationStroke.push_back(TPointD(1020, 1000));
+  m_interpolationStroke.push_back(TPointD(1040, 1000));
 }
 
 //-----------------------------------------------------------------------------
@@ -138,6 +156,12 @@ TStageObjectSpline *TStageObjectSpline::clone() const {
   clonedSpline->m_id               = m_id;
   clonedSpline->m_name             = m_name;
   clonedSpline->m_stroke           = new TStroke(*m_stroke);
+  clonedSpline->m_interpolationStroke =
+      m_interpolationStroke;          // Needed for T2D compatibility
+  clonedSpline->m_color  = m_color;   // Needed for T2D compatibility
+  clonedSpline->m_active = m_active;  // Needed for T2D compatibility
+  clonedSpline->m_steps  = m_steps;   // Needed for T2D compatibility
+  clonedSpline->m_width  = m_width;   // Needed for T2D compatibility
   for (int i = 0; i < (int)m_posPathParams.size(); i++)
     clonedSpline->m_posPathParams.push_back(
         (TDoubleParam *)m_posPathParams[i]->clone());
@@ -147,6 +171,13 @@ TStageObjectSpline *TStageObjectSpline::clone() const {
 //-----------------------------------------------------------------------------
 
 const TStroke *TStageObjectSpline::getStroke() const { return m_stroke; }
+
+//-----------------------------------------------------------------------------
+
+// Needed for T2D compatibility
+QList<TPointD> TStageObjectSpline::getInterpolationStroke() {
+  return m_interpolationStroke;
+}
 
 //-----------------------------------------------------------------------------
 
@@ -190,10 +221,24 @@ void TStageObjectSpline::loadData(TIStream &is) {
         is >> m_name;
       else if (tagName == "pos")
         is >> m_dagNodePos.x >> m_dagNodePos.y;
-      else if (tagName == "isOpened") {
+      else if (tagName == "color") {  // Needed for T2D compatibility
+        m_externalDataFound = true;
+        is >> m_color;
+      } else if (tagName == "width") {  // Needed for T2D compatibility
+        m_externalDataFound = true;
+        is >> m_width;
+      } else if (tagName == "steps") {  // Needed for T2D compatibility
+        m_externalDataFound = true;
+        is >> m_steps;
+      } else if (tagName == "isOpened") {
         int v = 0;
         is >> v;
         m_isOpened = (bool)v;
+      } else if (tagName == "active") {  // Needed for T2D compatibility
+        m_externalDataFound = true;
+        int v               = 0;
+        is >> v;
+        m_active = (bool)v;
       } else if (tagName == "stroke") {
         int i, n = 0;
         is >> n;
@@ -201,6 +246,17 @@ void TStageObjectSpline::loadData(TIStream &is) {
           TThickPoint p;
           is >> p.x >> p.y >> p.thick;
           points.push_back(p);
+        }
+      } else if (tagName ==
+                 "interpolationStroke") {  // Needed for T2D compatibility
+        m_externalDataFound = true;
+        m_interpolationStroke.clear();
+        int i, n = 0;
+        is >> n;
+        for (i = 0; i < n; i++) {
+          TPointD p;
+          is >> p.x >> p.y;
+          m_interpolationStroke.push_back(p);
         }
       }
       is.matchEndTag();
@@ -214,10 +270,18 @@ void TStageObjectSpline::loadData(TIStream &is) {
 
 void TStageObjectSpline::saveData(TOStream &os) {
   const TStroke *stroke = getStroke();
+  QList<TPointD> interpStroke =
+      getInterpolationStroke();  // Needed for T2D compatibility
   os.child("splineId") << (int)m_id;
   if (!m_name.empty()) os.child("name") << m_name;
   os.child("isOpened") << (int)m_isOpened;
   os.child("pos") << m_dagNodePos.x << m_dagNodePos.y;
+  if (m_externalDataFound) {  // Needed for T2D compatibility
+    os.child("color") << (int)m_color;
+    os.child("active") << (int)m_active;
+    os.child("steps") << (int)m_steps;
+    os.child("width") << (int)m_width;
+  }
   os.openChild("stroke");
   int n = stroke->getControlPointCount();
   os << n;
@@ -226,6 +290,15 @@ void TStageObjectSpline::saveData(TOStream &os) {
     os << p.x << p.y << p.thick;
   }
   os.closeChild();
+  if (m_externalDataFound) {  // Needed for T2D compatibility
+    os.openChild("interpolationStroke");
+    n = interpStroke.size();
+    os << n;
+    for (auto p : interpStroke) {
+      os << p.x << p.y;
+    }
+    os.closeChild();
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
I try to ensure scene compatibility between Tahoma2D and OpenToonz, however new scene tags were added for Motion Paths that causes OT to fail to load the scene if it was saved by T2D. 

The following `pegbarspline` child tags were added to T2D: `color`, `active`, `steps`, `width`, `interpolationStroke`

This PR restores Motion Path compatibility by doing the following:
- T2D Motion Path data from the scene file will be read and stored, even though OT does not use or display it.
- OT will write out T2D Motion Path data using whatever data was previously read.
  - For new paths or if no data was read, OT will default the information similarly to T2D.

NOTE: This change will make scenes containing Motion Path data saved with this fix incompatible with prior versions.
