### PR TITLE
Fix dynamic conical fractal noise

### DIFF
--- a/toonz/sources/stdfx/iwa_fractalnoisefx.cpp
+++ b/toonz/sources/stdfx/iwa_fractalnoisefx.cpp
@@ -384,8 +384,11 @@ void Iwa_FractalNoiseFx::doCompute(TTile &tile, double frame,
           // obtain sampling position
           // For Dynamic and Dynamic Twist patterns, the position offsets using
           // gradient / rotation of the parent pattern
+          TPointD samplePosOffset =
+              getSamplePos(x, y, outDim, out_buf, gen, scale, param) -
+              TPointD(x, y);
           TPointD samplePos =
-              getSamplePos(dx, dy, outDim, out_buf, gen, scale, param);
+              TPointD(dx, dy) + samplePosOffset * (D / (D + dz));
           // multiply affine transformation
           samplePos = currentAff * samplePos;
           // adjust position for the block pattern


### PR DESCRIPTION
This PR fixes the Fractal Noise Fx Iwa with the conical transform option (again). Now it can generate better result when `Fractal Type` is set to `Dynamic` or `Dynamic Twist` .
