### PR TITLE
Stop motion patch for non-windows platforms

### DIFF
--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -1276,7 +1276,6 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
 
 #ifndef _WIN32
   m_directShowCB->hide();
-  m_directShowLabel->hide();
 #endif
 }
 

--- a/toonz/sources/stopmotion/stopmotioncontroller.h
+++ b/toonz/sources/stopmotion/stopmotioncontroller.h
@@ -83,7 +83,7 @@ class StopMotionController final : public QWidget {
       *m_focusFar3Button, *m_captureFilterSettingsBtn, *m_testLightsButton;
   QHBoxLayout *m_focusAndZoomLayout;
   QLabel *m_frameInfoLabel, *m_cameraSettingsLabel, *m_cameraModeLabel,
-      *m_resolutionLabel, *m_directShowLabel, *m_cameraStatusLabel,
+      *m_resolutionLabel, *m_cameraStatusLabel,
       *m_apertureLabel, *m_kelvinValueLabel, *m_isoLabel, *m_shutterSpeedLabel,
       *m_webcamLabel;
   QToolButton *m_previousLevelButton, *m_previousFrameButton,


### PR DESCRIPTION
Small fix for #4233 that made non-windows platforms crash when opening the Stop Motion window.

Thanks @artisteacher for crash report and @manongjohn for finding the cause of the issue. 👍