### PR TITLE
Fix crash on saving scene containing missing palette level

### DIFF
--- a/toonz/sources/toonzlib/sceneresources.cpp
+++ b/toonz/sources/toonzlib/sceneresources.cpp
@@ -407,7 +407,9 @@ void ScenePalette::rollbackPath() { m_pl->setPath(m_oldPath); }
 
 //-----------------------------------------------------------------------------
 
-bool ScenePalette::isDirty() { return m_pl->getPalette()->getDirtyFlag(); }
+bool ScenePalette::isDirty() {
+  return m_pl->getPalette() && m_pl->getPalette()->getDirtyFlag();
+}
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes #4237 .
The crash occured when opening a scene which contains a palette level whose file does not exist and then trying to save the scene.