### PR TITLE
Fix crash on undoing tool

### DIFF
--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -182,6 +182,8 @@ public:
         .arg(QString::fromStdWString(m_level->getName()))
         .arg(QString::number(m_frameId.getNumber()));
   }
+
+  void onAdd() override;
 };
 
 //================================================================================================

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -603,6 +603,17 @@ void ToolUtils::TToolUndo::notifyImageChanged() const {
   }
 }
 
+//------------------------------------------------------------------------------------------
+
+void ToolUtils::TToolUndo::onAdd() {
+  // clean up the flags after registering undo
+  TTool::m_isLevelCreated     = false;
+  TTool::m_isFrameCreated     = false;
+  TTool::m_isLevelRenumbererd = false;
+}
+
+//------------------------------------------------------------------------------------------
+
 int ToolUtils::TToolUndo::m_idCount = 0;
 
 //================================================================================================


### PR DESCRIPTION
This PR fixes #4249 . Step to reproduce the crash is described in [this comment](https://github.com/opentoonz/opentoonz/issues/4249#issuecomment-1033309414).

Actually the crash can occur not only with the Fill tool but also with many other tools such as Paint Brush, Eraser, Tape, etc.
All of them does not call `TTool::touchImage()` therefore the flags like `TTool::m_isLevelRenumbererd` does not reset to false.

I added the function to reset all flags on adding the undo so that they won't affect to subsequent operations.
