### PR TITLE
revert changing pinned center

### DIFF
--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -413,19 +413,22 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
 
   // lock/unlock: modalita IK
   if (TD_LockStageObject <= m_device && m_device < TD_LockStageObject + 1000) {
-    Skeleton *skeleton = new Skeleton();
-    buildSkeleton(*skeleton, currentColumnIndex);
     int columnIndex = m_device - TD_LockStageObject;
     int frame       = app->getCurrentFrame()->getFrame();
-    if (skeleton->getBoneByColumnIndex(columnIndex) ==
-        skeleton->getRootBone()) {
-      app->getCurrentColumn()->setColumnIndex(columnIndex);
-      m_device = TD_Translation;
-    } else if (e.isShiftPressed()) {
+    if (e.isCtrlPressed() || e.isShiftPressed()) {
+      // ctrl + click : toggle pinned center
+      // shift + click : toggle temporary pin
       togglePinnedStatus(columnIndex, frame, e.isShiftPressed());
       invalidate();
       m_dragTool = 0;
       return;
+    }
+    Skeleton *skeleton = new Skeleton();
+    buildSkeleton(*skeleton, currentColumnIndex);
+    if (skeleton->getBoneByColumnIndex(columnIndex) ==
+        skeleton->getRootBone()) {
+      app->getCurrentColumn()->setColumnIndex(columnIndex);
+      m_device = TD_Translation;
     } else
       return;
   }


### PR DESCRIPTION
This PR will revert a feature for changing pinned center in Inverse Kinematics mode of the Skeleton tool.
The feature was once removed in #3275 . According to the discussion starting [here](https://github.com/opentoonz/opentoonz/issues/4081#issuecomment-1031560318) , I reverted it but with ctrl modifier needed for the operation in order to prevent mishandling.

**Usage:**
- Ctrl + Click to toggle pinned center
- Shift + Click to toggle temporary pin

This PR will resolve #3616 and may resolve #3617 as well (as the workaround will no longer be necessary) .

@rabe01 @gab3d 
Can you please check if this will (at least) recover the functionality which was available in v1.4 and older versions?