### PR TITLE
Fix viewer playback

### DIFF
--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -288,10 +288,9 @@ void ComboViewerPanel::onShowHideActionTriggered(QAction *act) {
 
 void ComboViewerPanel::onDrawFrame(int frame,
                                    const ImagePainter::VisualSettings &settings,
-                                   QElapsedTimer *timer, qint64 targetInstant) {
+                                   QElapsedTimer *, qint64) {
   TApp *app = TApp::instance();
   m_sceneViewer->setVisual(settings);
-  m_sceneViewer->setTimerAndTargetInstant(timer, targetInstant);
 
   TFrameHandle *frameHandle = app->getCurrentFrame();
 
@@ -327,10 +326,6 @@ void ComboViewerPanel::onDrawFrame(int frame,
 
   else if (settings.m_blankColor != TPixel::Transparent)
     m_sceneViewer->update();
-
-  // make sure to redraw the frame here.
-  // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying()) qApp->processEvents();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -780,8 +780,7 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
     , m_editPreviewSubCamera(false)
     , m_locator(NULL)
     , m_isLocator(false)
-    , m_isBusyOnTabletMove(false)
-    , m_timer(nullptr) {
+    , m_isBusyOnTabletMove(false) {
   m_visualSettings.m_sceneProperties =
       TApp::instance()->getCurrentScene()->getScene()->getProperties();
 #if defined(x64)
@@ -1937,14 +1936,6 @@ void SceneViewer::paintGL() {
 
   if (!m_isPicking && m_lutCalibrator && m_lutCalibrator->isValid())
     m_lutCalibrator->onEndDraw(m_fbo);
-
-  // wait to achieve precise fps
-  if (m_timer && m_timer->isValid()) {
-    qint64 currentInstant = m_timer->nsecsElapsed();
-    while (currentInstant < m_targetInstant) {
-      currentInstant = m_timer->nsecsElapsed();
-    }
-  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -190,10 +190,6 @@ class SceneViewer final : public GLWidgetForHighDpi,
 
   bool m_firstInitialized = true;
 
-  // passed from PlaybackExecutor
-  QElapsedTimer *m_timer;
-  qint64 m_targetInstant;
-
 public:
   enum ReferenceMode {
     NORMAL_REFERENCE   = 1,
@@ -294,11 +290,6 @@ public:
 
   void bindFBO() override;
   void releaseFBO() override;
-
-  void setTimerAndTargetInstant(QElapsedTimer *timer, qint64 target) {
-    m_timer         = timer;
-    m_targetInstant = target;
-  }
 
 public:
   // SceneViewer's gadget public functions

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -263,10 +263,9 @@ void SceneViewerPanel::onShowHideActionTriggered(QAction *act) {
 
 void SceneViewerPanel::onDrawFrame(int frame,
                                    const ImagePainter::VisualSettings &settings,
-                                   QElapsedTimer *timer, qint64 targetInstant) {
+                                   QElapsedTimer *, qint64) {
   TApp *app = TApp::instance();
   m_sceneViewer->setVisual(settings);
-  m_sceneViewer->setTimerAndTargetInstant(timer, targetInstant);
 
   TFrameHandle *frameHandle = app->getCurrentFrame();
 
@@ -301,10 +300,6 @@ void SceneViewerPanel::onDrawFrame(int frame,
 
   else if (settings.m_blankColor != TPixel::Transparent)
     m_sceneViewer->update();
-
-  // make sure to redraw the frame here.
-  // repaint() does NOT immediately redraw the frame for QOpenGLWidget
-  if (frameHandle->isPlaying()) qApp->processEvents();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -219,9 +219,18 @@ void PlaybackExecutor::run() {
       shortTermDelayAdjuster -= delayAdjust;
 
       // Show the next frame, telling currently measured fps
-      // The wait time will be inserted at the end of paintGL in order to
-      // achieve precise playback
+      // For the Flipbook, the wait time will be inserted at the end of paintGL
+      // in order to achieve precise playback
       emit nextFrame(fps, &m_timer, targetInstant);
+
+      // Playing on Viewer / Combo Viewer will advance the current frame.
+      // Calling qApp->processEvents() on drawing frame causes repaint of other
+      // panels which slows playback. Therefore in Viewer / Combo Viewer panels
+      // it just calls update() and necessary wait will be inserted here.
+      qint64 currentInstant = m_timer.nsecsElapsed();
+      while (currentInstant < targetInstant) {
+        currentInstant = m_timer.nsecsElapsed();
+      }
 
       if (FlipConsole::m_areLinked) {
         // In case there are linked consoles, update them too.


### PR DESCRIPTION
This PR (hopefully) fixes #4253 .
Modified Viewer / Combo Viewer not to call  `qApp->processEvents()` on drawing frame.

#### Advantage
- The playback becomes faster. 
   Unlike Flipbook, playing on Viewer / Combo Viewer advance the current frame. Calling `qApp->processEvents()` on drawing frame caused repaint of other panels (such as Xsheet) which slows playback. Now the Viewer / Combo Viewer panels just call `update()` in specified interval and let the event handler repaint the frame at certain timing.

#### Disadvantage
- The playback may become uneven, just like before applying #4197 .

@manongjohn @melieconiek 
Can you please try this PR and see if it resolves the issue? Thanks!