### PR TITLE
Fix fx gadget picking

### DIFF
--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -1831,15 +1831,16 @@ void FxGadgetController::draw(bool picking) {
 //---------------------------------------------------------------------------
 
 void FxGadgetController::selectById(unsigned int id) {
-  std::map<GLuint, FxGadget *>::iterator it;
-  it                       = m_idTable.find(id);
-  FxGadget *selectedGadget = it != m_idTable.end() ? it->second : 0;
+  std::map<GLuint, FxGadget *>::iterator it = m_idTable.find(id);
+  FxGadget *selectedGadget = it != m_idTable.end() ? it->second : nullptr;
   if (selectedGadget != m_selectedGadget) {
     if (m_selectedGadget) m_selectedGadget->select(-1);
     m_selectedGadget = selectedGadget;
-    if (m_selectedGadget)
-      m_selectedGadget->select(id - m_selectedGadget->getId());
   }
+  if (!m_selectedGadget) return;
+  int handleId = id - m_selectedGadget->getId();
+  if (!m_selectedGadget->isSelected(handleId))
+    m_selectedGadget->select(handleId);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes logic for picking the fx gadget (i.e. finding the gadget under the cursor position) , especially for the gadgets with more than one handles.

Before the fix, the current handles did not switch without switching the current gadget. You cannot select different handle in the same gadget without moving the cursor off the gadget once. 

The change would be prominent, for instance, in the gadget for `Corridor Gradient Fx Iwa` .
With this PR you can dynamically switch the highlighted handles while hovering on the gadget.