### PR TITLE
Fix GIF rendering on older versions

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_gif.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_gif.cpp
@@ -134,6 +134,8 @@ TLevelWriterGif::~TLevelWriterGif() {
     break;
   }
 
+  preIArgs << "-r";
+  preIArgs << QString::number(framerate);
   preIArgs << "-v";
   preIArgs << "warning";
   postIArgs << "-vf";
@@ -285,6 +287,7 @@ TImageP TLevelReaderGif::load(int frameIndex) {
 Tiio::GifWriterProperties::GifWriterProperties()
     : m_scale("Scale", 1, 100, 100)
     , m_looping("Looping", true)
+    , m_palette("Generate Palette", true)
     , m_mode("Mode")
     , m_maxcolors("Max Colors", 2, 256, 256) {
 
@@ -318,8 +321,12 @@ Tiio::GifWriterProperties::GifWriterProperties()
   m_mode.setItemUIName(L"NEW3", tr("New Pal Per Frame + Bayer1 Dither"));
   m_mode.setItemUIName(L"NOPAL", tr("Opaque, Dither, 256 Colors Only"));
 
+  // Doesn't make Generate Palette property visible in the popup
+  m_palette.setVisible(false);
+
   bind(m_scale);
   bind(m_looping);
+  bind(m_palette);
   bind(m_mode);
   bind(m_maxcolors);
 }

--- a/toonz/sources/image/ffmpeg/tiio_gif.h
+++ b/toonz/sources/image/ffmpeg/tiio_gif.h
@@ -82,6 +82,7 @@ class GifWriterProperties : public TPropertyGroup {
 public:
   TIntProperty m_scale;
   TBoolProperty m_looping;
+  TBoolProperty m_palette;
   TEnumProperty m_mode;
   TIntProperty m_maxcolors;
 

--- a/toonz/sources/include/tproperty.h
+++ b/toonz/sources/include/tproperty.h
@@ -93,11 +93,15 @@ public:
   std::string getId() const { return m_id; }
   void setId(std::string id) { m_id = id; }
 
+  bool getVisible() const { return m_visible; }
+  void setVisible(bool state) { m_visible = state; }
+
 private:
   std::string m_name;
   QString m_qstringName;
   std::string m_id;
   std::vector<Listener *> m_listeners;
+  bool m_visible;
 };
 
 //---------------------------------------------------------

--- a/toonz/sources/toonz/formatsettingspopups.cpp
+++ b/toonz/sources/toonz/formatsettingspopups.cpp
@@ -76,15 +76,17 @@ FormatSettingsPopup::FormatSettingsPopup(QWidget *parent,
   if (m_props) {
     int i = 0;
     for (i = 0; i < m_props->getPropertyCount(); i++) {
-      if (dynamic_cast<TEnumProperty *>(m_props->getProperty(i)))
+      TProperty *prop = m_props->getProperty(i);
+      if (prop && !prop->getVisible()) continue;
+      if (dynamic_cast<TEnumProperty *>(prop))
         buildPropertyComboBox(i, m_props);
-      else if (dynamic_cast<TIntProperty *>(m_props->getProperty(i)))
+      else if (dynamic_cast<TIntProperty *>(prop))
         buildValueField(i, m_props);
-      else if (dynamic_cast<TDoubleProperty *>(m_props->getProperty(i)))
+      else if (dynamic_cast<TDoubleProperty *>(prop))
         buildDoubleField(i, m_props);
-      else if (dynamic_cast<TBoolProperty *>(m_props->getProperty(i)))
+      else if (dynamic_cast<TBoolProperty *>(prop))
         buildPropertyCheckBox(i, m_props);
-      else if (dynamic_cast<TStringProperty *>(m_props->getProperty(i)))
+      else if (dynamic_cast<TStringProperty *>(prop))
         buildPropertyLineEdit(i, m_props);
       else
         assert(false);


### PR DESCRIPTION
Port of tahoma2d/tahoma2d#893 but re-implemented with a less hacky way, plus now properties can be invisible.
Also restored '-r' flag to avoid FFmpeg messing with the number of frames.
