### PR TITLE
Fix Stage Schematic Column (Right click) now w/Context Menu

### DIFF
--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -19,6 +19,7 @@ class SchematicName final : public QGraphicsTextItem {
   Q_OBJECT
   double m_width;
   double m_height;
+  bool m_noAllSelect;
 
 public:
   SchematicName(QGraphicsItem *parent, double width, double height);
@@ -35,11 +36,17 @@ protected:
   void keyPressEvent(QKeyEvent *ke) override;
   void contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) override;
 
+  void reFocus();
+
 signals:
   void focusOut();
 
 protected slots:
   void onContentsChanged();
+  void onCopy();
+  void onPaste();
+  void onCut();
+  void onSelectAll();
 };
 
 //========================================================


### PR DESCRIPTION
While I've provided a quick fix in #4256 for #4255, it prevents opening any context menu inside rename widget in the node.

This PR try to simulate the most common commands such as Cut, Copy, Paste and Select as a workaround for the Qt 5.15 bug.
