### PR TITLE
Revise Spin Blur Fx Ino

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1172,6 +1172,8 @@
   <item>"STD_inoSpinBlurFx.alpha_rendering"	"Alpha Rendering"	</item>
   <item>"STD_inoSpinBlurFx.anti_alias"	"Anti Alias"	</item>
   <item>"STD_inoSpinBlurFx.reference"	"Reference"	</item>
+  <item>"STD_inoSpinBlurFx.ellipse_aspect_ratio"	"Ellipse Aspect Ratio"	</item>
+  <item>"STD_inoSpinBlurFx.ellipse_angle"	"Ellipse Angle"	</item>
   <item>"STD_inoWarphvFx"	"Warp HV Ino"	</item>
   <item>"STD_inoWarphvFx.h_maxlen"	"H MaxLen"	</item>
   <item>"STD_inoWarphvFx.v_maxlen"	"V MaxLen"	</item>

--- a/stuff/profiles/layouts/fxs/STD_inoSpinBlurFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoSpinBlurFx.xml
@@ -5,6 +5,8 @@
     <control>blur</control>
     <control>type</control>
     <control>alpha_rendering</control>
+    <control>ellipse_aspect_ratio</control>
+    <control>ellipse_angle</control>
     <separator label=""/>
       <control>anti_alias</control>
       <control>reference</control>

--- a/toonz/sources/include/tparamuiconcept.h
+++ b/toonz/sources/include/tparamuiconcept.h
@@ -70,6 +70,8 @@ public:
 
     RAINBOW_WIDTH,
 
+    ELLIPSE,  // used in spin blur ino
+
     TYPESCOUNT
   };
 

--- a/toonz/sources/stdfx/igs_rotate_blur.h
+++ b/toonz/sources/stdfx/igs_rotate_blur.h
@@ -7,38 +7,23 @@
 #define IGS_ROTATE_BLUR_EXPORT
 #endif
 
+#include "tgeometry.h"
+
 namespace igs {
 namespace rotate_blur {
 IGS_ROTATE_BLUR_EXPORT void convert(
-    const unsigned char *in, const int margin /* 参照画像(in)がもつ余白 */
-
-    ,
-    const unsigned char *ref /* outと同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_bits, const int ref_mode  // R,G,B,A,luminance
-
-    ,
-    unsigned char *out
-
-    ,
-    const int height /* 求める画像(out)の高さ */
-    ,
-    const int width /* 求める画像(out)の幅 */
-    ,
-    const int channels, const int bits
-
-    ,
-    const double cx, const double cy,
-    const double degree = 30.0 /* ぼかしの回転角度 */
-    ,
-    const double blur_radius = 0.0 /* ぼかしの始まる半径 */
-    ,
-    const double spin_radius = 0.0 /* ゼロ以上でspin指定となり、
+    const float* in, float* out, const int margin,
+    const TDimension out_dim,             /* 求める画像(out)のサイズ */
+    const int channels, const float* ref, /* outと同じ高さ、幅 */
+    const TPointD center, const double degree = 30.0, /* ぼかしの回転角度 */
+    const double blur_radius = 0.0, /* ぼかしの始まる半径 */
+    const double spin_radius = 0.0, /* ゼロ以上でspin指定となり、
                             かつぼかし強弱の一定になる半径となる */
-    ,
-    const int sub_div = 4 /* 1ならJaggy、2以上はAntialias */
-    ,
-    const bool alpha_rendering_sw = true);
+    const int type = 0,  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
+    const bool antialias_sw =
+        true, /* when true, sampled pixel will be bilinear-interpolated */
+    const bool alpha_rendering_sw     = true,
+    const double ellipse_aspect_ratio = 1.0, const double ellipse_angle = 0.0);
 #if 0   //------------------- comment out start ------------------------
   IGS_ROTATE_BLUR_EXPORT int enlarge_margin(
 	 const int height	/* 求める画像(out)の高さ */
@@ -53,20 +38,15 @@ IGS_ROTATE_BLUR_EXPORT void convert(
   );
 #endif  //------------------- comment out end -------------------------
 IGS_ROTATE_BLUR_EXPORT int reference_margin(
-    const int height /* 求める画像(out)の高さ */
-    ,
-    const int width /* 求める画像(out)の幅 */
-    ,
-    const double xc, const double yc, const double degree /* ぼかしの回転角度 */
-    ,
-    const double blur_radius /* ぼかしの始まる半径 */
-    ,
-    const double spin_radius /* ゼロ以上でspin指定となり、
+    const int height, /* 求める画像(out)の高さ */
+    const int width,  /* 求める画像(out)の幅 */
+    const TPointD center, const double degree, /* ぼかしの回転角度 */
+    const double blur_radius,                  /* ぼかしの始まる半径 */
+    const double spin_radius, /* ゼロ以上でspin指定となり、
                             かつぼかし強弱の一定になる半径となる */
-    ,
-    const int sub_div /* 1ならJaggy、2以上はAntialias */
-    );
-}
-}
+    const int type  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
+);
+}  // namespace rotate_blur
+}  // namespace igs
 
 #endif /* !igs_rotate_blur_h */

--- a/toonz/sources/stdfx/ino_common.h
+++ b/toonz/sources/stdfx/ino_common.h
@@ -11,12 +11,19 @@ namespace ino {
 /* 一時バッファとの変換機能 */
 void ras_to_arr(const TRasterP in_ras, const int channels,
                 unsigned char* out_arr);
+void ras_to_float_arr(const TRasterP in_ras, const int channels,
+                      float* out_arr);
 void arr_to_ras(const unsigned char* in_arr, const int channels,
                 TRasterP out_ras, const int margin);
+void float_arr_to_ras(const unsigned char* in_arr, const int channels,
+                      TRasterP out_ras, const int margin);
 void ras_to_vec(const TRasterP ras, const int channels,
                 std::vector<unsigned char>& vec);
 void vec_to_ras(std::vector<unsigned char>& vec, const int channels,
                 TRasterP ras, const int margin = 0);
+void ras_to_ref_float_arr(const TRasterP in_ras, float* out_arr,
+                          const int refer_mode);
+
 // void Lx_to_wrap( TRasterP ras );
 
 /* logのserverアクセスON/OFF,install時設定をするための機能 */

--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -21,6 +21,7 @@
 
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QVector2D>
 
 using namespace EditToolGadgets;
 
@@ -29,6 +30,85 @@ GLdouble FxGadget::m_selectedColor[3] = {0.2, 0.8, 0.1};
 namespace {
 TPointD hadamard(const TPointD &v1, const TPointD &v2) {
   return TPointD(v1.x * v2.x, v1.y * v2.y);
+}
+
+#define SPIN_NUMVERTS 72
+
+void drawSpinField(const TRectD geom, const TPointD center,
+                   const double lineInterval, const double e_aspect_ratio,
+                   const double e_angle) {
+  static GLdouble vertices[SPIN_NUMVERTS * 2];
+  static bool isInitialized = false;
+  if (!isInitialized) {
+    isInitialized = true;
+    for (int r = 0; r < SPIN_NUMVERTS; r++) {
+      double theta        = 2.0 * M_PI * (double)r / (double)SPIN_NUMVERTS;
+      vertices[r * 2]     = std::cos(theta);
+      vertices[r * 2 + 1] = std::sin(theta);
+    }
+  }
+  // obtain the nearest and the furthest pos inside the geom
+  TPointD nearestPos;
+  nearestPos.x = (center.x <= geom.x0)
+                     ? geom.x0
+                     : (center.x >= geom.x1) ? geom.x1 : center.x;
+  nearestPos.y = (center.y <= geom.y0)
+                     ? geom.y0
+                     : (center.y >= geom.y1) ? geom.y1 : center.y;
+  double minDist = norm(nearestPos - center);
+  TPointD farthestPos;
+  farthestPos.x = (center.x <= geom.x0)
+                      ? geom.x1
+                      : (center.x >= geom.x1)
+                            ? geom.x0
+                            : ((center.x - geom.x0) >= (geom.x1 - center.x))
+                                  ? geom.x0
+                                  : geom.x1;
+  farthestPos.y = (center.y <= geom.y0)
+                      ? geom.y1
+                      : (center.y >= geom.y1)
+                            ? geom.y0
+                            : ((center.y - geom.y0) >= (geom.y1 - center.y))
+                                  ? geom.y0
+                                  : geom.y1;
+  double maxDist  = norm(farthestPos - center);
+  double scale[2] = {1.0, 1.0};
+  // adjust size for ellipse
+  if (e_aspect_ratio != 1.0) {
+    scale[0] = 2.0 * e_aspect_ratio / (e_aspect_ratio + 1);
+    scale[1] = scale[0] / e_aspect_ratio;
+    minDist *= std::min(scale[0], scale[1]);
+    maxDist *= std::max(scale[0], scale[1]);
+  }
+  // obtain id range
+  int minId = (int)std::ceil(minDist / lineInterval);
+  int maxId = (int)std::floor(maxDist / lineInterval);
+
+  glColor3d(0, 0, 1);
+  glEnableClientState(GL_VERTEX_ARRAY);
+  glLineStipple(1, 0x00FF);
+  glEnable(GL_LINE_STIPPLE);
+
+  glVertexPointer(2, GL_DOUBLE, 0, vertices);
+
+  glPushMatrix();
+
+  glTranslated(center.x, center.y, 0.0);
+  glRotated(e_angle, 0., 0., 1.);
+  glScaled(scale[0] * lineInterval, scale[1] * lineInterval, 1.);
+
+  for (int id = minId; id <= maxId; id++) {
+    if (id == 0) continue;
+    glPushMatrix();
+    glScaled((double)id, (double)id, 1.);
+    // draw using vertex array
+    glDrawArrays(GL_LINE_LOOP, 0, SPIN_NUMVERTS);
+    glPopMatrix();
+  }
+
+  glDisable(GL_LINE_STIPPLE);
+  glDisableClientState(GL_VERTEX_ARRAY);
+  glPopMatrix();
 }
 
 }  // namespace
@@ -1497,6 +1577,8 @@ void LinearRangeFxGadget::leftButtonUp() { m_handle = None; }
 
 class CompassFxGadget final : public FxGadget {
   TPointParamP m_center;
+  TDoubleParamP m_ellipse_aspect_ratio;
+  TDoubleParamP m_ellipse_angle;
 
   enum HANDLE { Body = 0, Near, Far, None } m_handle = None;
 
@@ -1507,7 +1589,9 @@ class CompassFxGadget final : public FxGadget {
 
 public:
   CompassFxGadget(FxGadgetController *controller,
-                  const TPointParamP &centerPoint, bool isSpin = false);
+                  const TPointParamP &centerPoint, bool isSpin = false,
+                  const TDoubleParamP &ellipse_aspect_ratio = TDoubleParamP(),
+                  const TDoubleParamP &ellipse_angle        = TDoubleParamP());
 
   void draw(bool picking) override;
 
@@ -1519,10 +1603,18 @@ public:
 //---------------------------------------------------------------------------
 
 CompassFxGadget::CompassFxGadget(FxGadgetController *controller,
-                                 const TPointParamP &centerPoint, bool isSpin)
-    : FxGadget(controller, 3), m_center(centerPoint), m_isSpin(isSpin) {
+                                 const TPointParamP &centerPoint, bool isSpin,
+                                 const TDoubleParamP &ellipse_aspect_ratio,
+                                 const TDoubleParamP &ellipse_angle)
+    : FxGadget(controller, 3)
+    , m_center(centerPoint)
+    , m_isSpin(isSpin)
+    , m_ellipse_aspect_ratio(ellipse_aspect_ratio)
+    , m_ellipse_angle(ellipse_angle) {
   addParam(centerPoint->getX());
   addParam(centerPoint->getY());
+  if (ellipse_aspect_ratio) addParam(ellipse_aspect_ratio);
+  if (ellipse_angle) addParam(ellipse_angle);
 }
 
 //---------------------------------------------------------------------------
@@ -1566,6 +1658,10 @@ void CompassFxGadget::draw(bool picking) {
 
   TPointD center = getValue(m_center);
   double dCenter = norm(center);
+  double e_aspect_ratio =
+      (m_ellipse_aspect_ratio) ? getValue(m_ellipse_aspect_ratio) : 1.0;
+  double e_angle = (m_ellipse_angle) ? getValue(m_ellipse_angle) : 0.0;
+
   TPointD handleVec;
   if (dCenter > lineHalf) {
     handleVec = normalize(center) * lineHalf;
@@ -1580,33 +1676,73 @@ void CompassFxGadget::draw(bool picking) {
     double angle = std::atan2(-center.y, -center.x) * M_180_PI;
     double theta = M_180_PI * lineInterval / dCenter;
 
-    // draw guides
-    glColor3d(0, 0, 1);
-    glLineStipple(1, 0x00FF);
-    glEnable(GL_LINE_STIPPLE);
-    glPushMatrix();
-    glTranslated(center.x, center.y, 0);
-    glRotated(angle, 0, 0, 1);
-    for (int i = -3; i <= 3; i++) {
+    // draw spin lines field
+    if (isSelected() && !isSelected(None) && m_isSpin &&
+        m_ellipse_aspect_ratio && m_ellipse_angle) {
+      TRectD geom = m_controller->getGeometry();
+
+      drawSpinField(geom, center, lineInterval, e_aspect_ratio, e_angle);
+    } else {
+      // draw guides
+      glColor3d(0, 0, 1);
+      glLineStipple(1, 0x00FF);
+      glEnable(GL_LINE_STIPPLE);
+      glPushMatrix();
+      glTranslated(center.x, center.y, 0);
       if (!m_isSpin) {  // radial direction
-        if (i == 0) continue;
-        glPushMatrix();
-        glRotated(theta * (double)i, 0, 0, 1);
-        glBegin(GL_LINES);
-        glVertex2d(dCenter - lineHalf, 0.0);
-        glVertex2d(dCenter + lineHalf, 0.0);
-        glEnd();
-        glPopMatrix();
-      } else {  // rotational direction
-        if (i == 3 || i == -3) continue;
-        double tmpRad  = dCenter + (double)i * lineInterval;
-        double d_angle = (lineInterval / dCenter) * 6.0 / 10.0;
-        glBegin(GL_LINE_STRIP);
-        for (int r = -5; r <= 5; r++) {
-          double tmpAngle = (double)r * d_angle;
-          glVertex2d(tmpRad * std::cos(tmpAngle), tmpRad * std::sin(tmpAngle));
+        for (int i = -3; i <= 3; i++) {
+          if (i == 0) continue;
+          glPushMatrix();
+          glRotated(theta * (double)i + angle, 0, 0, 1);
+          glBegin(GL_LINES);
+          glVertex2d(dCenter - lineHalf, 0.0);
+          glVertex2d(dCenter + lineHalf, 0.0);
+          glEnd();
+          glPopMatrix();
         }
-        glEnd();
+      } else {  // rotational direction
+        if (areAlmostEqual(e_aspect_ratio, 1.0)) {
+          for (int i = -2; i <= 2; i++) {
+            double tmpRad  = dCenter + (double)i * lineInterval;
+            double d_angle = (lineInterval / dCenter) * 6.0 / 10.0;
+            glBegin(GL_LINE_STRIP);
+            for (int r = -5; r <= 5; r++) {
+              double tmpAngle = (double)r * d_angle + angle * M_PI_180;
+              glVertex2d(tmpRad * std::cos(tmpAngle),
+                         tmpRad * std::sin(tmpAngle));
+            }
+            glEnd();
+          }
+        } else {
+          double scale[2];
+          scale[0] = 2.0 * e_aspect_ratio / (e_aspect_ratio + 1);
+          scale[1] = scale[0] / e_aspect_ratio;
+          glRotated(e_angle, 0., 0., 1.);
+          glScaled(scale[0], scale[1], 1.);
+
+          QTransform tr = QTransform()
+                              .translate(center.x, center.y)
+                              .rotate(e_angle)
+                              .scale(scale[0], scale[1])
+                              .inverted();
+          QPointF begin = tr.map(QPointF(handleVec.x, handleVec.y));
+          QPointF end   = tr.map(QPointF(-handleVec.x, -handleVec.y));
+
+          angle            = std::atan2(begin.y(), begin.x());
+          double distBegin = QVector2D(begin).length();
+          double distEnd   = QVector2D(end).length();
+          for (int i = 0; i <= 4; i++) {
+            double tmpRad  = distBegin + (double)i * (distEnd - distBegin) / 4.;
+            double d_angle = (lineInterval / dCenter) * 6.0 / 10.0;
+            glBegin(GL_LINE_STRIP);
+            for (int r = -5; r <= 5; r++) {
+              double tmpAngle = (double)r * d_angle + angle;
+              glVertex2d(tmpRad * std::cos(tmpAngle),
+                         tmpRad * std::sin(tmpAngle));
+            }
+            glEnd();
+          }
+        }
       }
     }
 
@@ -1763,6 +1899,227 @@ void RainbowWidthFxGadget::leftButtonDrag(const TPointD &pos,
 
   setValue(m_widthScale, std::min(max, std::max(min, scale)));
 }
+
+//=============================================================================
+
+class EllipseFxGadget final : public FxGadget {
+  TDoubleParamP m_radius;
+  TDoubleParamP m_xParam, m_yParam;
+  TDoubleParamP m_aspect_ratio;
+  TDoubleParamP m_angle;
+
+  TPointD m_pos;
+
+  enum HANDLE { Radius = 0, Center, AngleAndAR, None } m_handle = None;
+
+public:
+  EllipseFxGadget(FxGadgetController *controller, const TDoubleParamP &radius,
+                  const TPointParamP &center, const TDoubleParamP &aspect_ratio,
+                  const TDoubleParamP &angle)
+      : FxGadget(controller, 4)
+      , m_radius(radius)
+      , m_xParam(center->getX())
+      , m_yParam(center->getY())
+      , m_aspect_ratio(aspect_ratio)
+      , m_angle(angle) {
+    addParam(radius);
+    addParam(m_xParam);
+    addParam(m_yParam);
+    addParam(m_aspect_ratio);
+    addParam(m_angle);
+  }
+
+  TPointD getCenter() const;
+
+  void draw(bool picking) override;
+
+  void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonUp() override;
+};
+
+//---------------------------------------------------------------------------
+
+TPointD EllipseFxGadget::getCenter() const {
+  return TPointD(getValue(m_xParam), getValue(m_yParam));
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::draw(bool picking) {
+  int idBase = getId();
+
+  auto setColorById = [&](int id) {
+    if (isSelected(id))
+      glColor3dv(m_selectedColor);
+    else
+      glColor3d(0, 0, 1);
+  };
+
+  setPixelSize();
+  glPushMatrix();
+
+  TPointD center      = getCenter();
+  double aspect_ratio = getValue(m_aspect_ratio);
+  double angle        = getValue(m_angle);
+
+  // draw spin lines field
+  if (isSelected() && !isSelected(None)) {
+    double lineInterval = getPixelSize() * 50;
+    TRectD geom         = m_controller->getGeometry();
+    drawSpinField(geom, center, lineInterval, aspect_ratio, angle);
+  }
+
+  double unit = getPixelSize();
+  glTranslated(center.x, center.y, 0);
+
+  //--- radius ---
+  setColorById(Radius);
+  glPushName(idBase + Radius);
+  double radius = getValue(m_radius);
+
+  double scale[2] = {1.0, 1.0};
+  if (!areAlmostEqual(aspect_ratio, 1.0)) {
+    scale[0] = 2.0 * aspect_ratio / (aspect_ratio + 1.0);
+    scale[1] = scale[0] / aspect_ratio;
+  }
+  glPushMatrix();
+
+  glRotated(angle, 0., 0., 1.);
+  glScaled(scale[0], scale[1], 1.0);
+
+  glLineStipple(1, 0xAAAA);
+  glEnable(GL_LINE_STIPPLE);
+  tglDrawCircle(TPointD(), radius);
+  glDisable(GL_LINE_STIPPLE);
+
+  glPopMatrix();
+
+  QTransform transform = QTransform().rotate(angle).scale(scale[0], scale[1]);
+  QPointF radiusHandlePos = transform.map(QPointF(0.0, radius));
+  drawDot(TPointD(radiusHandlePos.x(), radiusHandlePos.y()));
+  glPopName();
+
+  if (isSelected(Radius)) {
+    QPointF namePos = transform.map(QPointF(0.707, 0.707) * radius);
+    drawTooltip(TPointD(namePos.x(), namePos.y()), getLabel());
+  }
+
+  //--- center ---
+  setColorById(Center);
+  glPushName(idBase + Center);
+  double d = unit * 8;
+  tglDrawCircle(TPointD(), d);
+
+  if (radius > d) {
+    glBegin(GL_LINES);
+    glVertex2d(-d, 0);
+    glVertex2d(d, 0);
+    glVertex2d(0, -d);
+    glVertex2d(0, d);
+    glEnd();
+  }
+
+  glPopName();
+  if (isSelected(Center)) {
+    drawTooltip(TPointD(), "Center");
+  }
+
+  //---- AR and rotate
+  double handleLength = unit * 100;
+  radius              = std::max(radius, unit * 10);
+  setColorById(AngleAndAR);
+  QPointF qHandleRoot = transform.map(QPointF(radius, 0.0));
+  glPushMatrix();
+  glPushName(idBase + AngleAndAR);
+  glTranslated(qHandleRoot.x(), qHandleRoot.y(), 0.);
+  glRotated(angle, 0., 0., 1.);
+  glBegin(GL_LINES);
+  glVertex2d(0., 0.);
+  glVertex2d(handleLength, 0.);
+  glEnd();
+  drawDot(TPointD(handleLength, 0.));
+
+  glPopMatrix();
+  glPopName();
+
+  if (isSelected(AngleAndAR)) {
+    double angle_radian = angle * M_PI_180;
+    TPointD namePos(qHandleRoot.x() + std::cos(angle_radian) * handleLength,
+                    qHandleRoot.y() + std::sin(angle_radian) * handleLength);
+    drawTooltip(namePos, "Angle and Aspect");
+  }
+
+  glPopMatrix();  // cancel translation to center
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::leftButtonDown(const TPointD &pos, const TMouseEvent &) {
+  m_handle = (HANDLE)m_selected;
+  m_pos    = pos;
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
+  if (m_handle == None) return;
+  if (m_handle == Radius) {
+    double aspect_ratio = getValue(m_aspect_ratio);
+    double angle        = getValue(m_angle);
+    double scale[2]     = {1.0, 1.0};
+    if (!areAlmostEqual(aspect_ratio, 1.0)) {
+      scale[0] = 2.0 * aspect_ratio / (aspect_ratio + 1.0);
+      scale[1] = scale[0] / aspect_ratio;
+    }
+    TPointD center       = getCenter();
+    QTransform transform = QTransform()
+                               .translate(center.x, center.y)
+                               .rotate(angle)
+                               .scale(scale[0], scale[1])
+                               .inverted();
+    QPointF transformedP = transform.map(QPointF(pos.x, pos.y));
+    setValue(m_radius, QVector2D(transformedP).length());
+  } else if (m_handle == Center) {
+    setValue(m_xParam, pos.x);
+    setValue(m_yParam, pos.y);
+  } else if (m_handle == AngleAndAR) {
+    // âÒì]Ç∆êLèkÇ…ï™ÇØÇÈ
+    TPointD center = getCenter();
+    TPointD old_v  = m_pos - center;
+    TPointD new_v  = pos - center;
+    if (old_v == TPointD() || new_v == TPointD()) return;
+    // AR
+    double aspect_ratio   = getValue(m_aspect_ratio);
+    double pre_axisLength = 2.0 * aspect_ratio / (aspect_ratio + 1.0);
+    double ratio          = norm(new_v) / norm(old_v);
+    if (ratio == 0.) return;
+    double new_axisLength = pre_axisLength * ratio;
+    double new_ar         = new_axisLength / (2.0 - new_axisLength);
+    if (new_ar < 0.1)
+      new_ar = 0.1;
+    else if (new_ar > 10.0)
+      new_ar = 10.0;
+    setValue(m_aspect_ratio, new_ar);
+
+    // angle
+    double angle = getValue(m_angle);
+    double d_angle =
+        std::atan2(new_v.y, new_v.x) - std::atan2(old_v.y, old_v.x);
+    double new_angle = angle + d_angle * M_180_PI;
+    if (new_angle < -180.0)
+      new_angle += 360.0;
+    else if (new_angle > 180.0)
+      new_angle -= 360.0;
+    setValue(m_angle, new_angle);
+
+    m_pos = pos;
+  }
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::leftButtonUp() { m_handle = None; }
 
 //*************************************************************************************
 //    FxGadgetController  implementation
@@ -1957,8 +2314,15 @@ FxGadget *FxGadgetController::allocateGadget(const TParamUIConcept &uiConcept) {
   }
 
   case TParamUIConcept::COMPASS_SPIN: {
-    assert(uiConcept.m_params.size() == 1);
-    gadget = new CompassFxGadget(this, uiConcept.m_params[0], true);
+    assert(uiConcept.m_params.size() == 1 || uiConcept.m_params.size() == 3);
+
+    if (uiConcept.m_params.size() == 3)
+      gadget =
+          new CompassFxGadget(this, uiConcept.m_params[0], true,
+                              uiConcept.m_params[1], uiConcept.m_params[2]);
+    else
+      gadget = new CompassFxGadget(this, uiConcept.m_params[0], true);
+
     break;
   }
 
@@ -1969,6 +2333,15 @@ FxGadget *FxGadgetController::allocateGadget(const TParamUIConcept &uiConcept) {
                                  uiConcept.m_params[1], uiConcept.m_params[2]);
     break;
   }
+
+  case TParamUIConcept::ELLIPSE: {
+    assert(uiConcept.m_params.size() == 4);
+    gadget =
+        new EllipseFxGadget(this, uiConcept.m_params[0], uiConcept.m_params[1],
+                            uiConcept.m_params[2], uiConcept.m_params[3]);
+    break;
+  }
+
   default:
     break;
   }
@@ -2060,6 +2433,14 @@ int FxGadgetController::getCurrentFrame() const { return m_tool->getFrame(); }
 
 void FxGadgetController::invalidateViewer() { m_tool->invalidate(); }
 
+//---------------------------------------------------------------------------
+
 int FxGadgetController::getDevPixRatio() {
   return getDevicePixelRatio(m_tool->getViewer()->viewerWidget());
+}
+
+//---------------------------------------------------------------------------
+
+TRectD FxGadgetController::getGeometry() {
+  return (m_tool->getViewer()) ? m_tool->getViewer()->getGeometry() : TRectD();
 }

--- a/toonz/sources/tnztools/edittoolgadgets.h
+++ b/toonz/sources/tnztools/edittoolgadgets.h
@@ -153,6 +153,9 @@ public:
 
   int getDevPixRatio();
 
+  // get the current viewer geometry
+  TRectD getGeometry();
+
 public slots:
 
   void onFxSwitched();


### PR DESCRIPTION
**Please review & merge this PR after releasing V1.6**

This PR will revise the Spin Blur Fx Ino according to the request from our studio.

1. Added a new option `Uniform Length` to the `Type` parameter. 

    Here is an example :
    <img src="https://user-images.githubusercontent.com/17974955/155082177-350403c5-5ebf-46fc-81fe-7b1fc6f95532.jpg" width=250>
    Source Image

    ![spin_blur1](https://user-images.githubusercontent.com/17974955/155082142-a83538fa-0fca-49fe-8b44-7a7444d37c8e.jpg)
    - **Accelerator** :  The spin angle is zero at `radius` position and becomes larger outward. 
    - **Uniform Angle** : Former `Uniform` . The spin angle is the same in all distance.
    - **Uniform Length** : A new option. The spin angle becomes smaller outward so that the blur length becomes the same in all distance.

2.  Added new parameters; **Ellipse Aspect Ratio** and **Ellipse Angle** to make elliptical blur.

    <img src="https://user-images.githubusercontent.com/17974955/155083471-39dffddb-0738-450e-9bab-826fc269b889.jpg" width=350>

    - **Ellipse Aspect Ratio** : specifies the ellipticity of the blur direction.
    - **Ellipse Angle** : specifies how the ellipse is inclined in degrees.

3. Revised the Fx gadgets.

    <img src="https://user-images.githubusercontent.com/17974955/155084104-cb5ee480-9710-4276-b148-f14f4e7dfa54.jpg" width=500>

    - Added a handle for changing Ellipse Aspect Ratio and Ellipse Angle.
    - Added a dashed-line field in the entire window which indicates the blur direction. The field is displayed only when the mouse cursor overs the gadget.
    
      ![spin_blur5](https://user-images.githubusercontent.com/17974955/155084767-5649ea2f-45c4-41e5-ae8b-3a7305b7751b.jpg)

    - Modified the `Center` gadget shape so that it can be easily grabbed when the `Radius` is set to 0.
 