### PR TITLE
Fix crash on switching scenes while selecting raster level frame

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1316,6 +1316,10 @@ void IoCmd::newScene() {
 
   if (!saveSceneIfNeeded(QApplication::tr("New Scene"))) return;
 
+  // temporary clear the current level to prevent UI to access deleted level
+  // while switching scenes
+  app->getCurrentLevel()->setLevel(nullptr);
+
   IconGenerator::instance()->clearRequests();
   IconGenerator::instance()->clearSceneIcons();
   ImageManager::instance()->clear();
@@ -1909,6 +1913,11 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   }
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
+  TApp *app = TApp::instance();
+  // temporary clear the current level to prevent UI to access deleted level
+  // while switching scenes
+  app->getCurrentLevel()->setLevel(nullptr);
+
   TUndoManager::manager()->reset();
   IconGenerator::instance()->clearRequests();
   IconGenerator::instance()->clearSceneIcons();
@@ -1963,7 +1972,6 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
     project->setFolder("project", scenePath);
     scene->setProject(project);
   }
-  TApp *app = TApp::instance();
   app->getCurrentScene()->setScene(scene);
   app->getCurrentScene()->notifyNameSceneChange();
   app->getCurrentFrame()->setFrame(0);


### PR DESCRIPTION
This PR fixes #3940 .
The crash occurs when switching scenes the Toolbar tries to access invalid current level to update tool availability. 
In most of the cases except the one reported in the issue, the current level is properly updated before using it.
To avoid crash, I added lines to temporary clear the current level before switching scenes. 
Thank you @beeheemooth for reporting the crash!

@manongjohn 
I've tested the current nightly build of Tahoma2D and confirmed the same issue.