### PR TITLE
Fix file browser assertion failure

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -194,7 +194,8 @@ DvDirModelFileFolderNode::DvDirModelFileFolderNode(DvDirModelNode *parent,
 //-----------------------------------------------------------------------------
 
 bool DvDirModelFileFolderNode::exists() {
-  return m_existsChecked ? m_exists : m_peeks
+  return m_existsChecked ? m_exists
+                         : m_peeks
              ? m_existsChecked = true,
                m_exists        = TFileStatus(m_path).doesExist() : true;
 }
@@ -1235,12 +1236,12 @@ void DvDirModelRootNode::updateSceneFolderNodeVisibility(bool forceHide) {
   bool show = (forceHide) ? false : !m_sceneFolderNode->getPath().isEmpty();
   if (show && m_sceneFolderNode->getRow() == -1) {
     int row = getChildCount();
-    DvDirModel::instance()->notifyBeginInsertRows(QModelIndex(), row, row + 1);
+    DvDirModel::instance()->notifyBeginInsertRows(QModelIndex(), row, row);
     addChild(m_sceneFolderNode);
     DvDirModel::instance()->notifyEndInsertRows();
   } else if (!show && m_sceneFolderNode->getRow() != -1) {
     int row = m_sceneFolderNode->getRow();
-    DvDirModel::instance()->notifyBeginRemoveRows(QModelIndex(), row, row + 1);
+    DvDirModel::instance()->notifyBeginRemoveRows(QModelIndex(), row, row);
     // remove the last child of the root node
     m_children.erase(m_children.begin() + row, m_children.begin() + row + 1);
     DvDirModel::instance()->notifyEndRemoveRows();
@@ -1335,7 +1336,7 @@ DvDirModelNode *DvDirModel::getNode(const QModelIndex &index) const {
 QModelIndex DvDirModel::index(int row, int column,
                               const QModelIndex &parent) const {
   if (column != 0) return QModelIndex();
-  DvDirModelNode *parentNode       = m_root;
+  DvDirModelNode *parentNode = m_root;
   if (parent.isValid()) parentNode = getNode(parent);
   if (row < 0 || row >= parentNode->getChildCount()) return QModelIndex();
   DvDirModelNode *node = parentNode->getChild(row);


### PR DESCRIPTION
This PR resolves an assertion failure when switching a scene while opening the File Browser.
The failure is just skipped when running in the Release mode (so this has not been a problem in the released software) but was quite troublesome for me when developing in the Debug mode.

The failure had been occurred in `DvDirModelRootNode::updateSceneFolderNodeVisibility()` .

According to [the c++ manual](https://www.cplusplus.com/reference/vector/vector/erase/) :

> **iterator std::vector::erase (iterator _first_, iterator _last_)**
> Iterators specifying a range within the vector to be removed: [_first_,_last_). i.e., the range includes all the elements between _first_ and _last_, including the element pointed by _first_ **but not the one pointed by _last_**.


And, according to [the Qt manual](https://doc.qt.io/qt-5/qabstractitemmodel.html#beginRemoveRows) : 

> **void QAbstractItemModel::beginRemoveRows(const QModelIndex &_parent_, int _first_, int _last_)**
> The _parent_ index corresponds to the parent from which the new rows are removed; **_first_ and _last_ are the row numbers of the rows to be removed.**

Therefore, the _last_ positions specified in the above functions should not be the same.