### PR TITLE
Fix crash on cleaning up zerary column

### DIFF
--- a/toonz/sources/toonz/cleanuppopup.cpp
+++ b/toonz/sources/toonz/cleanuppopup.cpp
@@ -476,7 +476,7 @@ void CleanupPopup::buildCleanupList() {
         const TXshCell &cell = xsh->getCell(r, c);
         if (cell.isEmpty()) continue;
         TXshSimpleLevel *sl = cell.getSimpleLevel();
-        if (!sl && locals::supportsCleanup(sl)) continue;
+        if (!(sl && locals::supportsCleanup(sl))) continue;
         /*---もし新しいLevelなら、Levelのリストに登録---*/
         std::map<TXshSimpleLevel *, FramesList>::iterator it =
             cleanupList.find(sl);


### PR DESCRIPTION
This PR fixes #3152 .
The crash occurs not only when selecting the zerary fx column, but also other types of the columns which cannot be cleaned up (e.g. Palette level column).
Again, thank you @WolfInABowl for reporting the crash!