### PR TITLE
Fixes toward Xsheet parenting + enhancements

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2293,6 +2293,8 @@ XsheetViewer {
   qproperty-MeshColumnColor: #594d75;
   qproperty-MeshColumnBorderColor: #423956;
   qproperty-SelectedMeshColumnColor: #656692;
+  qproperty-TableColor: #62628c;
+  qproperty-PegColor: #9f6e3c;
   qproperty-SoundTextColumnColor: #a7a7a7;
   qproperty-SoundTextColumnBorderColor: #8e8e8e;
   qproperty-SelectedSoundTextColumnColor: #adb9c0;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2293,6 +2293,8 @@ XsheetViewer {
   qproperty-MeshColumnColor: #594d75;
   qproperty-MeshColumnBorderColor: #423956;
   qproperty-SelectedMeshColumnColor: #656692;
+  qproperty-TableColor: #62628c;
+  qproperty-PegColor: #9f6e3c;
   qproperty-SoundTextColumnColor: #a7a7a7;
   qproperty-SoundTextColumnBorderColor: #8e8e8e;
   qproperty-SelectedSoundTextColumnColor: #adb9c0;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2293,6 +2293,8 @@ XsheetViewer {
   qproperty-MeshColumnColor: #594d75;
   qproperty-MeshColumnBorderColor: #423956;
   qproperty-SelectedMeshColumnColor: #656692;
+  qproperty-TableColor: #62628c;
+  qproperty-PegColor: #9f6e3c;
   qproperty-SoundTextColumnColor: #a7a7a7;
   qproperty-SoundTextColumnBorderColor: #8e8e8e;
   qproperty-SelectedSoundTextColumnColor: #adb9c0;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2293,6 +2293,8 @@ XsheetViewer {
   qproperty-MeshColumnColor: #b8a2cf;
   qproperty-MeshColumnBorderColor: #9278ac;
   qproperty-SelectedMeshColumnColor: #a49dc2;
+  qproperty-TableColor: #cbcbe4;
+  qproperty-PegColor: #dfb081;
   qproperty-SoundTextColumnColor: #c2c2c2;
   qproperty-SoundTextColumnBorderColor: #9c9c9c;
   qproperty-SelectedSoundTextColumnColor: #abb3b9;
@@ -2301,10 +2303,10 @@ XsheetViewer {
   qproperty-SelectedSoundColumnColor: #9bc1c7;
   qproperty-SoundColumnHlColor: #f5ffe6;
   qproperty-SoundColumnTrackColor: rgba(0, 0, 0, 0.8);
-  qproperty-ActiveCameraColor: #79b5ee;
-  qproperty-SelectedActiveCameraColor: #79aad8;
-  qproperty-OtherCameraColor: #6eb7c2;
-  qproperty-SelectedOtherCameraColor: #71abb9;
+  qproperty-ActiveCameraColor: #b7dbfc;
+  qproperty-SelectedActiveCameraColor: #79b5ee;
+  qproperty-OtherCameraColor: #9ad9e2;
+  qproperty-SelectedOtherCameraColor: #6eb7c2;
   qproperty-LightLightBGColor: #c2c2c2;
   qproperty-LightBGColor: #ffffff;
   qproperty-DarkBGColor: #ffffff;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2293,6 +2293,8 @@ XsheetViewer {
   qproperty-MeshColumnColor: #8b73a7;
   qproperty-MeshColumnBorderColor: #654f7e;
   qproperty-SelectedMeshColumnColor: #a18fc3;
+  qproperty-TableColor: #a4a4bf;
+  qproperty-PegColor: #be8a56;
   qproperty-SoundTextColumnColor: #a7a7a7;
   qproperty-SoundTextColumnBorderColor: #818181;
   qproperty-SelectedSoundTextColumnColor: #bbbfc3;

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -392,6 +392,9 @@ public:
   bool isShowColumnNumbersEnabled() const {
     return getBoolValue(showColumnNumbers);
   }
+  bool isParentColorsInXsheetColumnEnabled() const {
+    return getBoolValue(parentColorsInXsheetColumn);
+  }
   bool isSyncLevelRenumberWithXsheetEnabled() const {
     return getBoolValue(syncLevelRenumberWithXsheet);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -129,6 +129,7 @@ enum PreferencesItemId {
   showXSheetToolbar,
   expandFunctionHeader,
   showColumnNumbers,
+  parentColorsInXsheetColumn,
   syncLevelRenumberWithXsheet,
   currentTimelineEnabled,
   currentColumnColor,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1255,6 +1255,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {expandFunctionHeader,
        tr("Expand Function Editor Header to Match Xsheet Toolbar Height*")},
       {showColumnNumbers, tr("Show Column Numbers in Column Headers")},
+      {parentColorsInXsheetColumn,
+       tr("Show Column Parent's Color in the Xsheet")},
       {syncLevelRenumberWithXsheet,
        tr("Sync Level Strip Drawing Number Changes with the Xsheet")},
       {currentTimelineEnabled,
@@ -1965,6 +1967,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   QGridLayout* xshToolbarLay = insertGroupBoxUI(showXSheetToolbar, lay);
   { insertUI(expandFunctionHeader, xshToolbarLay); }
   insertUI(showColumnNumbers, lay);
+  insertUI(parentColorsInXsheetColumn, lay);
   insertUI(syncLevelRenumberWithXsheet, lay);
   insertUI(currentTimelineEnabled, lay);
   insertUI(currentColumnColor, lay);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -318,10 +318,14 @@ void MotionPathMenu::leaveEvent(QEvent *event) { hide(); }
 //-----------------------------------------------------------------------------
 
 ChangeObjectWidget::ChangeObjectWidget(QWidget *parent)
-    : QListWidget(parent), m_width(40) {
+    : QListWidget(parent), m_width(40), m_objectHandle(0), m_xsheetHandle(0) {
   setMouseTracking(true);
   setObjectName("XshColumnChangeObjectWidget");
   setAutoFillBackground(true);
+
+  bool ret = connect(this, SIGNAL(itemClicked(QListWidgetItem *)), this,
+                     SLOT(onItemSelected(QListWidgetItem *)));
+  assert(ret);
 }
 
 //-----------------------------------------------------------------------------
@@ -332,12 +336,16 @@ ChangeObjectWidget::~ChangeObjectWidget() {}
 
 void ChangeObjectWidget::show(const QPoint &pos) {
   refresh();
+  int scrollbarW = qApp->style()->pixelMetric(QStyle::PM_ScrollBarExtent);
   int itemNumber = count();
   if (itemNumber > 10) {
     itemNumber = 10;
-    m_width += 15;
+    m_width += scrollbarW;
   }
-  setGeometry(pos.x(), pos.y(), m_width, itemNumber * 16 + 2);
+  int height = 0;
+  for (int i = 0; i < itemNumber; i++)
+    height += sizeHintForRow(i);
+  setGeometry(pos.x(), pos.y(), m_width, height + 2);
   QListWidget::show();
   raise();
   setFocus();
@@ -385,11 +393,55 @@ void ChangeObjectWidget::focusOutEvent(QFocusEvent *e) {
 //-----------------------------------------------------------------------------
 
 void ChangeObjectWidget::selectCurrent(const QString &text) {
-  QList<QListWidgetItem *> itemList = findItems(text, Qt::MatchExactly);
   clearSelection();
-  if (itemList.size() < 1) return;
-  QListWidgetItem *currentWidgetItem = itemList.at(0);
-  setCurrentItem(currentWidgetItem);
+  int numRows = count();
+  for (int row = 0; row < numRows; row++) {
+    QListWidgetItem *it = item(row);
+    QVariant display    = it->data(Qt::UserRole);
+    if (text == (display.isValid() ? display.toString() : it->text())) {
+      setCurrentItem(it);
+      return;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::addText(const QString &text, const QString &display) {
+  QListWidgetItem *item = new QListWidgetItem(display);
+  item->setData(Qt::UserRole, text);
+  addItem(item);
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::addText(const QString &text, const QColor &textColor) {
+  QListWidgetItem *item = new QListWidgetItem(text);
+  item->setForeground(textColor);
+  addItem(item);
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::addText(const QString &text, const QString &display,
+                                 const QColor &identColor) {
+  QListWidgetItem *item = new QListWidgetItem(display);
+  QPixmap pixmap(4, 8);
+  pixmap.fill(identColor);
+  QIcon icon(pixmap);
+  item->setIcon(icon);
+  item->setData(Qt::UserRole, text);
+  addItem(item);
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectWidget::onItemSelected(QListWidgetItem *item) {
+  QVariant display = item->data(Qt::UserRole);
+  if (display.isValid())
+    onTextSelected(display.toString());
+  else
+    onTextSelected(item->text());
 }
 
 //=============================================================================
@@ -397,11 +449,7 @@ void ChangeObjectWidget::selectCurrent(const QString &text) {
 //-----------------------------------------------------------------------------
 
 ChangeObjectParent::ChangeObjectParent(QWidget *parent)
-    : ChangeObjectWidget(parent) {
-  bool ret = connect(this, SIGNAL(currentTextChanged(const QString &)), this,
-                     SLOT(onTextChanged(const QString &)));
-  assert(ret);
-}
+    : ChangeObjectWidget(parent) {}
 
 //-----------------------------------------------------------------------------
 
@@ -413,58 +461,86 @@ void ChangeObjectParent::refresh() {
   clear();
   assert(m_xsheetHandle);
   assert(m_objectHandle);
+  XsheetViewer *viewer           = TApp::instance()->getCurrentXsheetViewer();
   TXsheet *xsh                   = m_xsheetHandle->getXsheet();
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   TStageObjectId parentId = xsh->getStageObject(currentObjectId)->getParent();
-  TStageObjectTree *tree  = xsh->getStageObjectTree();
-  int objectCount         = tree->getStageObjectCount();
-  QString text;
-  QList<QString> pegbarList;
-  QList<QString> columnList;
+  TStageObject *currentObject        = xsh->getStageObject(currentObjectId);
+  std::list<TStageObject *> children = currentObject->getChildren();
+  TStageObjectTree *tree             = xsh->getStageObjectTree();
+  int objectCount                    = tree->getStageObjectCount();
+  QList<QString> pegbarListID, pegbarListTr;
+  QList<QString> columnListID, columnListTr;
+  QList<QColor> pegbarListColor, columnListColor;
+  QString currentText;
   QString theLongestTxt;
   int i;
   for (i = 0; i < objectCount; i++) {
     TStageObjectId id = tree->getStageObject(i)->getId();
     int index         = id.getIndex();
     QString indexStr(std::to_string(id.getIndex() + 1).c_str());
-    QString newText;
-    if (id == parentId) {
-      if (parentId.isTable())
-        text = QString("Table");
-      else if (parentId.isPegbar())
-        text = QString("Peg ") + indexStr;
-      else if (parentId.isColumn()) {
-        text             = QString("Col ") + indexStr;
-        QString tempText = newText;
-        std::string name = tree->getStageObject(i)->getName();
-        if (name != tempText.replace(" ", "").toStdString()) {
-          text += " (" + QString::fromStdString(name) + " )";
-        }
-      }
-    }
-    if (id == currentObjectId) continue;
+    QString newTextID, newTextTr;
+    QColor newTextBG;
+
+    // Remove childs from parent list
+    bool found = (std::find(children.begin(), children.end(),
+                            xsh->getStageObject(id)) != children.end());
+    if (id == currentObjectId || found) continue;
+
     if (id.isTable()) {
-      newText = QString("Table");
-      pegbarList.append(newText);
+      newTextID = QString("Table");
+      newTextTr = tr("Table");
+      newTextBG = viewer->getTableColor();
     }
     if (id.isPegbar()) {
-      newText = QString("Peg ") + indexStr;
-      pegbarList.append(newText);
-    }
-    if (id.isColumn() && (!xsh->isColumnEmpty(index) || index < 2)) {
-      newText          = QString("Col ") + indexStr;
-      QString tempText = newText;
+      newTextID = QString("Peg ") + indexStr;
+      newTextTr = QString("Peg") + indexStr;
+      newTextBG = viewer->getPegColor();
+      //
       std::string name = tree->getStageObject(i)->getName();
-      if (name.length() > 0 &&
-          name != tempText.replace(" ", "").toStdString()) {
-        newText += " (" + QString::fromStdString(name) + " )";
-      }
-      columnList.append(newText);
+      if (name.length() > 0) newTextTr = QString::fromStdString(name);
     }
-    if (newText.length() > theLongestTxt.length()) theLongestTxt = newText;
+    if (id.isCamera()) {
+      bool isActive =
+          (id == xsh->getStageObjectTree()->getCurrentCameraId());
+      newTextID = QString("Cam ") + indexStr;
+      newTextTr = QString("Camera") + indexStr;
+      newTextBG = isActive ? viewer->getActiveCameraColor()
+                           : viewer->getOtherCameraColor();
+      //
+      std::string name = tree->getStageObject(i)->getName();
+      if (name.length() > 0) newTextTr = QString::fromStdString(name);
+    }
+    if (id.isColumn() && (!xsh->isColumnEmpty(index))) {
+      TXshColumn *colx = xsh->getColumn(index);
+      if (colx->getColumnType() != TXshColumn::eSoundTextType &&
+          colx->getColumnType() != TXshColumn::eSoundType) {
+        newTextID = QString("Col ") + indexStr;
+        newTextTr = QString("Col") + indexStr;
+        QColor unused;
+        viewer->getColumnColor(newTextBG, unused, id.getIndex(), xsh);
+        std::string name = tree->getStageObject(i)->getName();
+        if (name.length() > 0) newTextTr = QString::fromStdString(name);
+      }
+    }
+    if (id == parentId) currentText = newTextID;
+    if (newTextTr.length() > theLongestTxt.length()) theLongestTxt = newTextTr;
+    if (!newTextID.isEmpty()) {
+      if (id.isColumn()) {
+        columnListID.append(newTextID);
+        columnListTr.append(newTextTr);
+        columnListColor.append(newTextBG);
+      } else {
+        pegbarListID.append(newTextID);
+        pegbarListTr.append(newTextTr);
+        pegbarListColor.append(newTextBG);
+      }
+    }
   }
-  for (i = 0; i < columnList.size(); i++) addItem(columnList.at(i));
-  for (i = 0; i < pegbarList.size(); i++) addItem(pegbarList.at(i));
+  for (i = 0; i < columnListID.size(); i++)
+    addText(columnListID.at(i), columnListTr.at(i), columnListColor.at(i));
+  for (i = 0; i < pegbarListID.size(); i++)
+    addText(pegbarListID.at(i), pegbarListTr.at(i), pegbarListColor.at(i));
 
   QString fontName = Preferences::instance()->getInterfaceFont();
   if (fontName == "") {
@@ -478,14 +554,13 @@ void ChangeObjectParent::refresh() {
   // set font size in pixel
   font.setPixelSize(XSHEET_FONT_PX_SIZE);
 
-  m_width             = QFontMetrics(font).width(theLongestTxt) + 22;
-  std::string strText = text.toStdString();
-  selectCurrent(text);
+  m_width = QFontMetrics(font).width(theLongestTxt) + 32;
+  selectCurrent(currentText);
 }
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectParent::onTextChanged(const QString &text) {
+void ChangeObjectParent::onTextSelected(const QString &text) {
   assert(m_xsheetHandle);
   assert(m_objectHandle);
   if (text.isEmpty()) {
@@ -494,6 +569,8 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
   }
   bool isPegbar = false;
   if (text.startsWith("Peg")) isPegbar = true;
+  bool isCamera = false;
+  if (text.startsWith("Cam")) isCamera = true;
   bool isTable = false;
   if (text == "Table") isTable = true;
   QString number = text;
@@ -513,6 +590,8 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
   TStageObjectId newStageObjectId;
   if (isPegbar)
     newStageObjectId = TStageObjectId::PegbarId(index);
+  else if (isCamera)
+    newStageObjectId = TStageObjectId::CameraId(index);
   else if (isTable)
     newStageObjectId = TStageObjectId::TableId;
   else
@@ -520,7 +599,10 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
 
   if (newStageObjectId == currentObjectId) return;
 
-  if (newStageObjectId == currentParentId) return;
+  if (newStageObjectId == currentParentId) {
+    hide();
+    return;
+  }
 
   TStageObject *stageObject =
       m_xsheetHandle->getXsheet()->getStageObject(currentObjectId);
@@ -537,11 +619,7 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
 //-----------------------------------------------------------------------------
 
 ChangeObjectHandle::ChangeObjectHandle(QWidget *parent)
-    : ChangeObjectWidget(parent) {
-  bool ret = connect(this, SIGNAL(currentTextChanged(const QString &)), this,
-                     SLOT(onTextChanged(const QString &)));
-  assert(ret);
-}
+    : ChangeObjectWidget(parent) {}
 
 //-----------------------------------------------------------------------------
 
@@ -553,7 +631,8 @@ void ChangeObjectHandle::refresh() {
   clear();
   assert(m_xsheetHandle);
   assert(m_objectHandle);
-  TXsheet *xsh = m_xsheetHandle->getXsheet();
+  XsheetViewer *viewer = TApp::instance()->getCurrentXsheetViewer();
+  TXsheet *xsh         = m_xsheetHandle->getXsheet();
   assert(xsh);
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   TStageObject *stageObject      = xsh->getStageObject(currentObjectId);
@@ -561,10 +640,18 @@ void ChangeObjectHandle::refresh() {
 
   int i;
   QString str;
+  QColor colorHndHook = viewer->getPreviewFrameTextColor();
+  QColor colorHndDef  = viewer->getSelectedColumnTextColor();
+  QColor colorHndNone = viewer->getTextColor();
   if (stageObject->getParent().isColumn()) {
-    for (i = 0; i < 20; i++) addItem(str.number(20 - i));
+    for (i = 0; i < 20; i++) addText(str.number(20 - i), colorHndHook);
   }
-  for (i = 0; i < 26; i++) addItem(QString(char('A' + i)));
+  for (i = 0; i < 26; i++) {
+    if (i == 1)
+      addText(QString("B"), colorHndDef);
+    else
+      addText(QString(char('A' + i)), colorHndNone);
+  }
 
   std::string handle = stageObject->getParentHandle();
   if (handle[0] == 'H' && handle.length() > 1) handle = handle.substr(1);
@@ -574,7 +661,7 @@ void ChangeObjectHandle::refresh() {
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectHandle::onTextChanged(const QString &text) {
+void ChangeObjectHandle::onTextSelected(const QString &text) {
   assert(m_xsheetHandle);
   assert(m_objectHandle);
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
@@ -1187,9 +1274,13 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   // set font size in pixel
   font.setPixelSize(XSHEET_FONT_PX_SIZE);
 
+  int handleWidth = 20;
+  std::string handle = xsh->getStageObject(columnId)->getParentHandle();
+  if (handle == "B") handleWidth = 0; // Default handle
+
   int width = QFontMetrics(font).width(name);
 
-  while (width > o->rect(PredefinedRect::PEGBAR_NAME).width() - 20) {
+  while (width > o->rect(PredefinedRect::PEGBAR_NAME).width() - handleWidth) {
     name.remove(-1, 1000);
     width = QFontMetrics(font).width(name);
   }
@@ -1202,6 +1293,30 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   if (column->getSoundColumn() || column->getSoundTextColumn() ||
       column->getPaletteColumn())
     return;
+
+  if (Preferences::instance()->isParentColorsInXsheetColumnEnabled() &&
+      column->isPreviewVisible()) {
+    QColor parentColor = Qt::transparent;
+    if (parentId.isCamera()) {
+      bool isActive =
+          (parentId == xsh->getStageObjectTree()->getCurrentCameraId());
+      parentColor = isActive ? m_viewer->getActiveCameraColor()
+                             : m_viewer->getOtherCameraColor();
+    } else if (parentId.isPegbar()) {
+      parentColor = m_viewer->getPegColor();
+    } else if (parentId.isTable()) {
+      parentColor = m_viewer->getTableColor();
+    } else if (parentId.isColumn()) {
+      int columnIndex = parentId.getIndex();
+      QColor unused;
+      m_viewer->getColumnColor(parentColor, unused, columnIndex, xsh);
+    }
+    if (parentColor != Qt::transparent) {
+      QRect parentrect = pegbarnamerect;
+      parentrect.adjust(1, 1, 0, 0);
+      p.fillRect(parentrect, parentColor);
+    }
+  }
 
   p.setPen(m_viewer->getTextColor());
 
@@ -1224,16 +1339,25 @@ void ColumnArea::DrawHeader::drawParentHandleName() const {
 
   TStageObjectId columnId = m_viewer->getObjectId(col);
   TStageObjectId parentId = xsh->getStageObjectParent(columnId);
-  // p.setPen(m_viewer->getVerticalLineColor());
-  // p.drawRect(parenthandleRect.adjusted(2, 0, 0, 0));
-  p.setPen(m_viewer->getTextColor());
-
   std::string handle = xsh->getStageObject(columnId)->getParentHandle();
   if (handle[0] == 'H' && handle.length() > 1) handle = handle.substr(1);
-  if (parentId != TStageObjectId::TableId || handle != "B")
-    p.drawText(parenthandleRect,
-               Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextSingleLine,
-               QString::fromStdString(handle));
+
+  if (handle == "B") { // Default handle
+    QPen pen(m_viewer->getVerticalLineColor());
+    pen.setStyle(Qt::PenStyle::DotLine);
+    p.setPen(pen);
+    int offset = parenthandleRect.x() + 2;
+    p.drawLine(offset, parenthandleRect.y(), offset, parenthandleRect.bottom());
+    return;
+  }
+
+  p.setPen(m_viewer->getVerticalLineColor());
+  p.drawRect(parenthandleRect.adjusted(2, 0, 0, 0));
+
+  p.setPen(m_viewer->getTextColor());
+  p.drawText(parenthandleRect,
+             Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextSingleLine,
+             QString::fromStdString(handle));
 }
 
 void ColumnArea::DrawHeader::drawFilterColor() const {
@@ -2271,14 +2395,16 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     // clicking on the camera column
     if (m_col < 0) {
       // lock button
-      if (o->rect(PredefinedRect::CAMERA_LOCK_AREA).contains(mouseInCell) &&
-          event->button() == Qt::LeftButton)
+      if (o->rect(PredefinedRect::CAMERA_LOCK_AREA).contains(mouseInCell)) {
+        if (event->button() != Qt::LeftButton) return;
         m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
+      }
       // config button
       else if (o->rect(PredefinedRect::CAMERA_CONFIG_AREA)
-                   .contains(mouseInCell) &&
-               event->button() == Qt::LeftButton)
+                     .contains(mouseInCell)) {
+        if (event->button() != Qt::LeftButton) return;
         m_doOnRelease = OpenSettings;
+      }
       // clicking another area means column selection
       else {
         if (m_viewer->getColumnSelection()->isColumnSelected(m_col) &&
@@ -2299,13 +2425,13 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
         setDragTool(XsheetGUI::DragTool::makeColumnMoveTool(m_viewer));
       }
       // lock button
-      else if (o->rect(PredefinedRect::LOCK_AREA).contains(mouseInCell) &&
-               event->button() == Qt::LeftButton) {
+      else if (o->rect(PredefinedRect::LOCK_AREA).contains(mouseInCell)) {
+        if (event->button() != Qt::LeftButton) return;
         m_doOnRelease = isCtrlPressed ? ToggleAllLock : ToggleLock;
       }
       // preview button
-      else if (o->rect(PredefinedRect::EYE_AREA).contains(mouseInCell) &&
-               event->button() == Qt::LeftButton) {
+      else if (o->rect(PredefinedRect::EYE_AREA).contains(mouseInCell)) {
+        if (event->button() != Qt::LeftButton) return;
         if (column->getSoundTextColumn()) {
           // do nothing
         } else {
@@ -2317,8 +2443,8 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
       }
       // camstand button
       else if (o->rect(PredefinedRect::PREVIEW_LAYER_AREA)
-                   .contains(mouseInCell) &&
-               event->button() == Qt::LeftButton) {
+                   .contains(mouseInCell)) {
+        if (event->button() != Qt::LeftButton) return;
         if (column->getPaletteColumn() || column->getSoundTextColumn()) {
           // do nothing
         } else {
@@ -2330,8 +2456,8 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
         }
       }
       // config button
-      else if (o->rect(PredefinedRect::CONFIG_AREA).contains(mouseInCell) &&
-               event->button() == Qt::LeftButton) {
+      else if (o->rect(PredefinedRect::CONFIG_AREA).contains(mouseInCell)) {
+        if (event->button() != Qt::LeftButton) return;
         TXshZeraryFxColumn *zColumn =
             dynamic_cast<TXshZeraryFxColumn *>(column);
 
@@ -2375,18 +2501,19 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
       }
       // clicking another area means column selection
       else {
-        if (m_viewer->getColumnSelection()->isColumnSelected(m_col) &&
-            event->button() == Qt::RightButton)
-          return;
+        if (event->button() != Qt::LeftButton) return;
+        if (xsh->getColumn(m_col)->getSoundTextColumn()) return;
 
+        int y = Preferences::instance()->isShowXSheetToolbarEnabled() ? 30 : 0;
         if (o->rect(PredefinedRect::PEGBAR_NAME)
                 .adjusted(0, 0, -20, 0)
                 .contains(mouseInCell)) {
           m_changeObjectParent->refresh();
           m_changeObjectParent->show(
               QPoint(o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
+                     QPoint(o->rect(PredefinedRect::CAMERA_CELL).width(), 0) +
                      m_viewer->positionToXY(CellPosition(0, m_col)) +
-                     QPoint(o->rect(PredefinedRect::CAMERA_CELL).width(), 4)));
+                     QPoint(-m_viewer->getColumnScrollValue(), y)));
           return;
         }
         if (o->rect(PredefinedRect::PARENT_HANDLE_NAME).contains(mouseInCell)) {
@@ -2394,7 +2521,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
           m_changeObjectHandle->show(
               QPoint(o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
                      m_viewer->positionToXY(CellPosition(0, m_col + 1)) +
-                     QPoint(2, 0)));
+                     QPoint(-m_viewer->getColumnScrollValue() + 2, y)));
           return;
         }
 
@@ -2665,16 +2792,21 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
     // signal XsheetChanged will invoke PreviewFxManager to all rendered frames,
     // if necessary. it causes slowness when opening preview flipbook of large
     // scene.
+    // KNOWN BUG: Side effect, transparency doesn't sync in schematic if false.
     bool isTransparencyRendered = app->getCurrentScene()
                                       ->getScene()
                                       ->getProperties()
                                       ->isColumnColorFilterOnRenderEnabled();
-    if ((isTransparencyRendered && (m_doOnRelease == ToggleTransparency ||
+    bool isStateChanged = m_doOnRelease == TogglePreviewVisible ||
+                          m_doOnRelease == ToggleAllPreviewVisible ||
+                          m_doOnRelease == ToggleLock ||
+                          m_doOnRelease == ToggleAllLock;
+    if (isStateChanged ||
+        (isTransparencyRendered && (m_doOnRelease == ToggleTransparency ||
                                     m_doOnRelease == ToggleAllTransparency ||
-                                    m_doOnRelease == OpenSettings)) ||
-        m_doOnRelease == TogglePreviewVisible ||
-        m_doOnRelease == ToggleAllPreviewVisible)
+                                    m_doOnRelease == OpenSettings))) {
       app->getCurrentXsheet()->notifyXsheetChanged();
+    }
     update();
     m_doOnRelease = 0;
   }

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -95,8 +95,14 @@ protected:
   void focusInEvent(QFocusEvent *e) override {}
   void selectCurrent(const QString &text);
 
+  void addText(const QString &text, const QString &display);
+  void addText(const QString &text, const QColor &textColor);
+  void addText(const QString &text, const QString &display,
+               const QColor &identColor);
+  virtual void onTextSelected(const QString &) = 0;
+
 protected slots:
-  virtual void onTextChanged(const QString &) = 0;
+  void onItemSelected(QListWidgetItem *);
 };
 
 //=============================================================================
@@ -113,7 +119,7 @@ public:
   void refresh() override;
 
 protected slots:
-  void onTextChanged(const QString &) override;
+  void onTextSelected(const QString &) override;
 };
 
 //=============================================================================
@@ -130,7 +136,7 @@ public:
   void refresh() override;
 
 protected slots:
-  void onTextChanged(const QString &) override;
+  void onTextSelected(const QString &) override;
 };
 
 //=============================================================================

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -507,7 +507,7 @@ TStageObjectId XsheetViewer::getObjectId(int col) const {
 
 void XsheetViewer::setCurrentColumn(int col) {
   TColumnHandle *columnHandle = TApp::instance()->getCurrentColumn();
-  if (col != columnHandle->getColumnIndex()) {
+  if (col != columnHandle->getColumnIndex() || !columnHandle->getColumn()) {
     columnHandle->setColumnIndex(col);
     // E' necessario per il caso in cui si passa da colonna di camera a altra
     // colonna
@@ -588,6 +588,12 @@ void XsheetViewer::scroll(QPoint delta) {
 
   m_cellScrollArea->horizontalScrollBar()->setValue(valueH);
   m_cellScrollArea->verticalScrollBar()->setValue(valueV);
+}
+
+//-----------------------------------------------------------------------------
+
+int XsheetViewer::getColumnScrollValue() {
+  return m_columnScrollArea->horizontalScrollBar()->value();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -348,6 +348,12 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
                  setMeshColumnBorderColor)
   Q_PROPERTY(QColor SelectedMeshColumnColor READ getSelectedMeshColumnColor
                  WRITE setSelectedMeshColumnColor)
+  // Table color
+  QColor m_tableColor;
+  Q_PROPERTY(QColor TableColor READ getTableColor WRITE setTableColor)
+  // Peg node
+  QColor m_pegColor;
+  Q_PROPERTY(QColor PegColor READ getPegColor WRITE setPegColor)
   // SoundText column
   QColor m_soundTextColumnColor;
   QColor m_soundTextColumnBorderColor;
@@ -672,6 +678,7 @@ public:
   void setCurrentRow(int row);
 
   void scroll(QPoint delta);
+  int getColumnScrollValue();
 
   void setAutoPanSpeed(const QPoint &speed);
   void setAutoPanSpeed(const QRect &widgetBounds, const QPoint &mousePos);
@@ -935,6 +942,12 @@ public:
   QColor getSelectedMeshColumnColor() const {
     return m_selectedMeshColumnColor;
   }
+  // Table node
+  void setTableColor(const QColor &color) { m_tableColor = color; }
+  QColor getTableColor() const { return m_tableColor; }
+  // Peg node
+  void setPegColor(const QColor &color) { m_pegColor = color; }
+  QColor getPegColor() const { return m_pegColor; }
   // SoundText column
   void setSoundTextColumnColor(const QColor &color) {
     m_soundTextColumnColor = color;

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -578,6 +578,8 @@ void Preferences::definePreferenceItems() {
   define(showXSheetToolbar, "showXSheetToolbar", QMetaType::Bool, true);
   define(expandFunctionHeader, "expandFunctionHeader", QMetaType::Bool, false);
   define(showColumnNumbers, "showColumnNumbers", QMetaType::Bool, false);
+  define(parentColorsInXsheetColumn, "parentColorsInXsheetColumn",
+         QMetaType::Bool, false);
   define(syncLevelRenumberWithXsheet, "syncLevelRenumberWithXsheet",
          QMetaType::Bool, true);
   define(currentTimelineEnabled, "currentTimelineEnabled", QMetaType::Bool,

--- a/toonz/sources/translations/chinese/toonz.ts
+++ b/toonz/sources/translations/chinese/toonz.ts
@@ -9283,6 +9283,10 @@ but a random crash might occur, use at your own risk.</source>
         <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -15778,6 +15782,13 @@ Please refer to the user guide for details.</source>
     <message>
         <source>None</source>
         <translation type="unfinished">无</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>动画台</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/czech/toonz.ts
+++ b/toonz/sources/translations/czech/toonz.ts
@@ -9343,6 +9343,10 @@ but a random crash might occur, use at your own risk.</source>
         <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup:: FormatProperties</name>
@@ -15797,6 +15801,13 @@ Podrobnosti najdete v uživatelské příručce.</translation>
     <message>
         <source>None</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>Tabulka</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/french/toonz.ts
+++ b/toonz/sources/translations/french/toonz.ts
@@ -13381,6 +13381,13 @@ S&apos;il vous plaît se référer à la guide de l&apos;utilisateur pour plus d
     </message>
 </context>
 <context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>Table</translation>
+    </message>
+</context>
+<context>
     <name>XsheetGUI::ColumnArea</name>
     <message>
         <source>Click to select camera</source>

--- a/toonz/sources/translations/german/toonz.ts
+++ b/toonz/sources/translations/german/toonz.ts
@@ -9175,6 +9175,10 @@ but a random crash might occur, use at your own risk.</source>
         <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup:: FormatProperties</name>
@@ -15499,6 +15503,13 @@ Genaueres können Sie aus der Nutzerhilfe entnehmen.</translation>
     <message>
         <source>None</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>Tabelle</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/italian/toonz.ts
+++ b/toonz/sources/translations/italian/toonz.ts
@@ -8802,6 +8802,10 @@ but a random crash might occur, use at your own risk.</source>
         <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -15015,6 +15019,13 @@ Per favore fai riferimento alla Guida utente per i dettagli.</translation>
     <message>
         <source>None</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>Tavolo</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/japanese/toonz.ts
+++ b/toonz/sources/translations/japanese/toonz.ts
@@ -9252,6 +9252,10 @@ but a random crash might occur, use at your own risk.</source>
         <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -15696,6 +15700,13 @@ Please refer to the user guide for details.</source>
     <message>
         <source>None</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>テーブル</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/korean/toonz.ts
+++ b/toonz/sources/translations/korean/toonz.ts
@@ -8624,6 +8624,10 @@ but a random crash might occur, use at your own risk.</source>
         <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -14860,6 +14864,13 @@ Please refer to the user guide for details.</source>
     <message>
         <source>None</source>
         <translation type="unfinished">없음</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>테이블</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/russian/toonz.ts
+++ b/toonz/sources/translations/russian/toonz.ts
@@ -11137,6 +11137,10 @@ but a random crash might occur, use at your own risk.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../toonz/preferencespopup.cpp" line="2141"/>
         <source>Enable Touch Gesture Controls</source>
         <translation>Включить сенсорные жесты</translation>
@@ -19366,6 +19370,13 @@ Please refer to the user guide for details.</source>
         <location filename="../../toonz/xshcellviewer.cpp" line="4164"/>
         <source>Delete Memo</source>
         <translation>Удалить мемо</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>Таблица</translation>
     </message>
 </context>
 <context>

--- a/toonz/sources/translations/spanish/toonz.ts
+++ b/toonz/sources/translations/spanish/toonz.ts
@@ -9249,6 +9249,10 @@ but a random crash might occur, use at your own risk.</source>
         <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Column Parent&apos;s Color in the Xsheet</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPopup::AdditionalStyleEdit</name>
@@ -15653,6 +15657,13 @@ Por favor ver la guía de usuario para obtener más detalles.</translation>
     <message>
         <source>None</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>Mesa</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fixes #4273 crash by removing extra invalid column on parent list if scene only have 1 column.
Additionally this PR does:
- User can click the current parent/handle to close the list, previously it only closed after a change.
- `Table` is now translated.
- All cameras now show on parent's list.
- Removed object type and index to simplify reading, e.g. `Steve` instead of `Col 1 (Steve )`.
- Show a tiny color bar next to names to see the object type.
- Correct list height is now calculated.
- Handle B acts as default and won't show up in the column.
- Show a separator on parent handle location, dashed means default handle.

Other bugs were solved by borrowing code from Tahoma2D, additionally also does:
- Have parent color box match the column type of the parent. (Optional, can be toggled)
- Don't show sound and note columns into the parent list.
- Don't show any childs on the parent list.
- Don't show parent list on note column.
- List offset positioned right below the column header.
- List in scrolled Xsheet shows up in correct spot.

Column parent colors is disabled by default, to toggle go to `File > Preferences...`, `Xsheet` category and `Show Column Parent's Color in the Xsheet`.
