### PR TITLE
Fix crashes with preview in Fx Settings popup

### DIFF
--- a/toonz/sources/include/toonzqt/swatchviewer.h
+++ b/toonz/sources/include/toonzqt/swatchviewer.h
@@ -161,6 +161,8 @@ public:
     SwatchViewer *m_viewer;
     bool m_started;
 
+    TRenderSettings m_info;
+
     ContentRender(TRasterFx *fx, int frame, const TDimension &size,
                   SwatchViewer *viewer);
     ~ContentRender();


### PR DESCRIPTION
This PR fixes #2704 , providing necessary `QOffscreenSurface` for computing plastic deformation with OpenGL.

This PR also resolves #2745 as per the crash , but it still fails to render a proper result.