### PR TITLE
Revise Radial Blur Fx Ino

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1172,6 +1172,8 @@
   <item>"STD_inoSpinBlurFx.alpha_rendering"	"Alpha Rendering"	</item>
   <item>"STD_inoSpinBlurFx.anti_alias"	"Anti Alias"	</item>
   <item>"STD_inoSpinBlurFx.reference"	"Reference"	</item>
+  <item>"STD_inoSpinBlurFx.ellipse_aspect_ratio"	"Ellipse Aspect Ratio"	</item>
+  <item>"STD_inoSpinBlurFx.ellipse_angle"	"Ellipse Angle"	</item>
   <item>"STD_inoWarphvFx"	"Warp HV Ino"	</item>
   <item>"STD_inoWarphvFx.h_maxlen"	"H MaxLen"	</item>
   <item>"STD_inoWarphvFx.v_maxlen"	"V MaxLen"	</item>

--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1160,10 +1160,14 @@
   <item>"STD_inoRadialBlurFx.center"	"Center"	</item>
   <item>"STD_inoRadialBlurFx.radius"	"Radius"	</item>
   <item>"STD_inoRadialBlurFx.blur"	"Blur"	</item>
+  <item>"STD_inoRadialBlurFx.type"	"Type"	</item>
   <item>"STD_inoRadialBlurFx.twist"	"Twist"	</item>
   <item>"STD_inoRadialBlurFx.alpha_rendering"	"Alpha Rendering"	</item>
   <item>"STD_inoRadialBlurFx.anti_alias"	"Anti Alias"	</item>
   <item>"STD_inoRadialBlurFx.reference"	"Reference"	</item>
+  <item>"STD_inoRadialBlurFx.ellipse_aspect_ratio"	"Ellipse Aspect Ratio"	</item>
+  <item>"STD_inoRadialBlurFx.ellipse_angle"	"Ellipse Angle"	</item>
+  <item>"STD_inoRadialBlurFx.intensity_correlation_with_ellipse"	"Intensity Correlation"	</item>
   <item>"STD_inoSpinBlurFx"	"Spin Blur Ino"	</item>
   <item>"STD_inoSpinBlurFx.center"	"Center"	</item>
   <item>"STD_inoSpinBlurFx.radius"	"Radius"	</item>

--- a/stuff/profiles/layouts/fxs/STD_inoRadialBlurFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoRadialBlurFx.xml
@@ -3,8 +3,13 @@
     <control>center</control>
     <control>radius</control>
     <control>blur</control>
+    <control>type</control>
     <control>twist</control>
     <control>alpha_rendering</control>
+    <separator label="Ellipse"/>
+      <control>ellipse_aspect_ratio</control>
+      <control>ellipse_angle</control>
+      <control>intensity_correlation_with_ellipse</control>
     <separator label=""/>
       <control>anti_alias</control>
       <control>reference</control>

--- a/stuff/profiles/layouts/fxs/STD_inoSpinBlurFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoSpinBlurFx.xml
@@ -5,8 +5,9 @@
     <control>blur</control>
     <control>type</control>
     <control>alpha_rendering</control>
-    <control>ellipse_aspect_ratio</control>
-    <control>ellipse_angle</control>
+    <separator label="Ellipse"/>
+      <control>ellipse_aspect_ratio</control>
+      <control>ellipse_angle</control>
     <separator label=""/>
       <control>anti_alias</control>
       <control>reference</control>

--- a/stuff/profiles/layouts/fxs/STD_inoSpinBlurFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoSpinBlurFx.xml
@@ -5,6 +5,8 @@
     <control>blur</control>
     <control>type</control>
     <control>alpha_rendering</control>
+    <control>ellipse_aspect_ratio</control>
+    <control>ellipse_angle</control>
     <separator label=""/>
       <control>anti_alias</control>
       <control>reference</control>

--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -677,6 +677,7 @@ public:
 
   /*-- Toolで画面の内外を判断するため --*/
   virtual TRectD getGeometry() const = 0;
+  virtual TRectD getCameraRect() const { return TRectD(); }
 
   virtual void bindFBO() {}
   virtual void releaseFBO() {}

--- a/toonz/sources/include/tparamuiconcept.h
+++ b/toonz/sources/include/tparamuiconcept.h
@@ -70,7 +70,7 @@ public:
 
     RAINBOW_WIDTH,
 
-    ELLIPSE,  // used in spin blur ino
+    ELLIPSE,  // used in spin blur ino and radial blur ino
 
     TYPESCOUNT
   };

--- a/toonz/sources/include/tparamuiconcept.h
+++ b/toonz/sources/include/tparamuiconcept.h
@@ -70,6 +70,8 @@ public:
 
     RAINBOW_WIDTH,
 
+    ELLIPSE,  // used in spin blur ino
+
     TYPESCOUNT
   };
 

--- a/toonz/sources/stdfx/igs_radial_blur.h
+++ b/toonz/sources/stdfx/igs_radial_blur.h
@@ -7,39 +7,23 @@
 #define IGS_RADIAL_BLUR_EXPORT
 #endif
 
+#include "tgeometry.h"
+
 namespace igs {
 namespace radial_blur {
 IGS_RADIAL_BLUR_EXPORT void convert(
-    const unsigned char *in /* 余白付き */
-    ,
-    const int margin /* 参照画像(in)がもつ余白 */
-
-    ,
-    const unsigned char *ref /* outと同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_bits,
-    const int ref_mode  // R,G,B,A,luminance or R,G,B,luminance
-
-    ,
-    unsigned char *out /* 余白なし */
-
-    ,
-    const int height /* 求める画像(out)の高さ */
-    ,
-    const int width /* 求める画像(out)の幅 */
-    ,
-    const int channels, const int bits
-
-    ,
-    const double xc, const double yc, const double twist_radian = 0.0,
+    const float* in, float* out, const int margin, /* 参照画像(in)がもつ余白 */
+    const TDimension out_dim,             /* 求める画像(out)の大きさ*/
+    const int channels, const float* ref, /* outと同じ高さ、幅 */
+    const TPointD center, const double twist_radian = 0.0,
     const double twist_radius = 0.0,
-    const double intensity    = 0.2 /* 強度。ゼロより大きく2以下 */
-    ,
-    const double radius = 0.0 /* ぼかしの始まる半径 */
-    ,
-    const int sub_div = 4 /* 1ならJaggy、2以上はAntialias */
-    ,
-    const bool alpha_rendering_sw = true);
+    const double intensity    = 0.2, /* 強度。ゼロより大きく2以下 */
+    /* radius円境界での平均値ぼかしゼロとするためintensityは2より小さい */
+    const double radius = 0.0, /* 平均値ぼかしの始まる半径 */
+    const int type = 0, const bool antialias_sw = true,
+    const bool alpha_rendering_sw     = true,
+    const double ellipse_aspect_ratio = 1.0, const double ellipse_angle = 0.0,
+    const double intensity_correlation_with_ellipse = 0.0);
 #if 0   //-------------------- comment out start ------------------------
   IGS_RADIAL_BLUR_EXPORT int enlarge_margin( /* Twist時正確でない... */
 	 const int height
@@ -56,18 +40,16 @@ IGS_RADIAL_BLUR_EXPORT void convert(
 #endif  //-------------------- comment out end -------------------------
 IGS_RADIAL_BLUR_EXPORT int
 reference_margin(/* Twist時正確でない... */
-                 const int height, const int width, const double xc,
-                 const double yc, const double twist_radian,
-                 const double twist_radius,
-                 const double intensity = 0.2 /* 強度。ゼロより大きく2以下 */
+                 const int height, const int width, const TPointD center,
+                 const double twist_radian, const double twist_radius,
+                 const double intensity = 0.2, /* 強度。ゼロより大きく2以下 */
                  /* radius円境界での平均値ぼかしゼロとするためintensityは2以下
-                    */
-                 ,
-                 const double radius = 0.0 /* 平均値ぼかしの始まる半径 */
-                 ,
-                 const int sub_div = 4 /* 1ならJaggy、2以上はAntialias */
-                 );
-}
-}
+                  */
+                 const double radius = 0.0, /* 平均値ぼかしの始まる半径 */
+                 const int type = 0, const double ellipse_aspect_ratio = 1.0,
+                 const double ellipse_angle                      = 0.0,
+                 const double intensity_correlation_with_ellipse = 0.0);
+}  // namespace radial_blur
+}  // namespace igs
 
 #endif /* !igs_radial_blur_h */

--- a/toonz/sources/stdfx/igs_rotate_blur.h
+++ b/toonz/sources/stdfx/igs_rotate_blur.h
@@ -7,38 +7,23 @@
 #define IGS_ROTATE_BLUR_EXPORT
 #endif
 
+#include "tgeometry.h"
+
 namespace igs {
 namespace rotate_blur {
 IGS_ROTATE_BLUR_EXPORT void convert(
-    const unsigned char *in, const int margin /* 参照画像(in)がもつ余白 */
-
-    ,
-    const unsigned char *ref /* outと同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_bits, const int ref_mode  // R,G,B,A,luminance
-
-    ,
-    unsigned char *out
-
-    ,
-    const int height /* 求める画像(out)の高さ */
-    ,
-    const int width /* 求める画像(out)の幅 */
-    ,
-    const int channels, const int bits
-
-    ,
-    const double cx, const double cy,
-    const double degree = 30.0 /* ぼかしの回転角度 */
-    ,
-    const double blur_radius = 0.0 /* ぼかしの始まる半径 */
-    ,
-    const double spin_radius = 0.0 /* ゼロ以上でspin指定となり、
+    const float* in, float* out, const int margin,
+    const TDimension out_dim,             /* 求める画像(out)のサイズ */
+    const int channels, const float* ref, /* outと同じ高さ、幅 */
+    const TPointD center, const double degree = 30.0, /* ぼかしの回転角度 */
+    const double blur_radius = 0.0, /* ぼかしの始まる半径 */
+    const double spin_radius = 0.0, /* ゼロ以上でspin指定となり、
                             かつぼかし強弱の一定になる半径となる */
-    ,
-    const int sub_div = 4 /* 1ならJaggy、2以上はAntialias */
-    ,
-    const bool alpha_rendering_sw = true);
+    const int type = 0,  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
+    const bool antialias_sw =
+        true, /* when true, sampled pixel will be bilinear-interpolated */
+    const bool alpha_rendering_sw     = true,
+    const double ellipse_aspect_ratio = 1.0, const double ellipse_angle = 0.0);
 #if 0   //------------------- comment out start ------------------------
   IGS_ROTATE_BLUR_EXPORT int enlarge_margin(
 	 const int height	/* 求める画像(out)の高さ */
@@ -53,20 +38,15 @@ IGS_ROTATE_BLUR_EXPORT void convert(
   );
 #endif  //------------------- comment out end -------------------------
 IGS_ROTATE_BLUR_EXPORT int reference_margin(
-    const int height /* 求める画像(out)の高さ */
-    ,
-    const int width /* 求める画像(out)の幅 */
-    ,
-    const double xc, const double yc, const double degree /* ぼかしの回転角度 */
-    ,
-    const double blur_radius /* ぼかしの始まる半径 */
-    ,
-    const double spin_radius /* ゼロ以上でspin指定となり、
+    const int height, /* 求める画像(out)の高さ */
+    const int width,  /* 求める画像(out)の幅 */
+    const TPointD center, const double degree, /* ぼかしの回転角度 */
+    const double blur_radius,                  /* ぼかしの始まる半径 */
+    const double spin_radius, /* ゼロ以上でspin指定となり、
                             かつぼかし強弱の一定になる半径となる */
-    ,
-    const int sub_div /* 1ならJaggy、2以上はAntialias */
-    );
-}
-}
+    const int type  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
+);
+}  // namespace rotate_blur
+}  // namespace igs
 
 #endif /* !igs_rotate_blur_h */

--- a/toonz/sources/stdfx/ino_common.h
+++ b/toonz/sources/stdfx/ino_common.h
@@ -11,12 +11,19 @@ namespace ino {
 /* 一時バッファとの変換機能 */
 void ras_to_arr(const TRasterP in_ras, const int channels,
                 unsigned char* out_arr);
+void ras_to_float_arr(const TRasterP in_ras, const int channels,
+                      float* out_arr);
 void arr_to_ras(const unsigned char* in_arr, const int channels,
                 TRasterP out_ras, const int margin);
+void float_arr_to_ras(const unsigned char* in_arr, const int channels,
+                      TRasterP out_ras, const int margin);
 void ras_to_vec(const TRasterP ras, const int channels,
                 std::vector<unsigned char>& vec);
 void vec_to_ras(std::vector<unsigned char>& vec, const int channels,
                 TRasterP ras, const int margin = 0);
+void ras_to_ref_float_arr(const TRasterP in_ras, float* out_arr,
+                          const int refer_mode);
+
 // void Lx_to_wrap( TRasterP ras );
 
 /* logのserverアクセスON/OFF,install時設定をするための機能 */

--- a/toonz/sources/stdfx/ino_radial_blur.cpp
+++ b/toonz/sources/stdfx/ino_radial_blur.cpp
@@ -24,6 +24,11 @@ class ino_radial_blur final : public TStandardRasterFx {
   TBoolParamP m_alpha_rendering;
   TBoolParamP m_anti_alias;
   TIntEnumParamP m_ref_mode;
+  TIntEnumParamP m_type;
+  // elliptical shape
+  TDoubleParamP m_ellipse_aspect_ratio;
+  TDoubleParamP m_ellipse_angle;
+  TDoubleParamP m_intensity_correlation_with_ellipse;
 
 public:
   ino_radial_blur()
@@ -34,7 +39,11 @@ public:
       // ,m_twist_radius(0.0)
       , m_alpha_rendering(true)
       , m_anti_alias(false)
-      , m_ref_mode(new TIntEnumParam(0, "Red")) {
+      , m_ref_mode(new TIntEnumParam(0, "Red"))
+      , m_type(new TIntEnumParam(0, "Accelerator"))
+      , m_ellipse_aspect_ratio(1.0)
+      , m_ellipse_angle(0.0)
+      , m_intensity_correlation_with_ellipse(0.0) {
     this->m_center->getX()->setMeasureName("fxLength");
     this->m_center->getY()->setMeasureName("fxLength");
     this->m_radius->setMeasureName("fxLength");
@@ -50,10 +59,17 @@ public:
     bindParam(this, "alpha_rendering", this->m_alpha_rendering);
     bindParam(this, "anti_alias", this->m_anti_alias);
     bindParam(this, "reference", this->m_ref_mode);
+    bindParam(this, "type", this->m_type);
+    bindParam(this, "ellipse_aspect_ratio", this->m_ellipse_aspect_ratio);
+    bindParam(this, "ellipse_angle", this->m_ellipse_angle);
+    bindParam(this, "intensity_correlation_with_ellipse",
+              this->m_intensity_correlation_with_ellipse);
 
     this->m_radius->setValueRange(0, (std::numeric_limits<double>::max)());
     /* 拡大のしすぎを防ぐためにMaxを制限する */
     this->m_blur->setValueRange(0.0 * ino_param_range, 1.0 * ino_param_range);
+    this->m_ellipse_aspect_ratio->setValueRange(0.1, 10.0);
+    this->m_ellipse_angle->setValueRange(-180.0, 180.0);
     this->m_twist->setValueRange(-180.0, 180.0);
     // this->m_twist_radius->setValueRange(0.0,1000.0);
     this->m_ref_mode->addItem(1, "Green");
@@ -61,6 +77,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+    this->m_type->addItem(1, "Uniform Length");
+    this->m_intensity_correlation_with_ellipse->setValueRange(-1.0, 1.0);
   }
   //------------------------------------------------------------
   TPointD get_render_center(const double frame, const TPointD &pos,
@@ -75,30 +93,26 @@ public:
     return center - pos;
   }
   int get_render_int_margin(const double frame, const TRectD &bBox,
-                            const TAffine affine, TPointD center) {
+                            const TAffine affine, TPointD center,
+                            double blur_radius, double pivot_radius) {
     /*--- 単位変換(mm-->render用pixel)と長さ(scale)変換 ---*/
     const double scale = ino::pixel_per_mm() * sqrt(fabs(affine.det()));
     /*--- margin計算...Twist時正確でない ---*/
     return igs::radial_blur::reference_margin(
         static_cast<int>(ceil(bBox.getLy())),
-        static_cast<int>(ceil(bBox.getLx())), center.x, center.y,
-        this->m_twist->getValue(frame) * 3.14159265358979 / 180.0,
-        0.0  // this->m_twist_radius->getValue(frame) * scale
-        ,
-        this->m_blur->getValue(frame) / ino_param_range
-
-        //,this->m_radius->getValue(frame) * scale
-        ,
-        0 /* debug:2012-02-01:ゼロ以上だとmarginが小さすぎになり画像が切れてしまう
-           */
-
-        ,
-        (this->m_anti_alias->getValue() ? 4 : 1));
+        static_cast<int>(ceil(bBox.getLx())), center,
+        this->m_twist->getValue(frame) * M_PI_180, pivot_radius,
+        this->m_blur->getValue(frame) / ino_param_range, blur_radius,
+        this->m_type->getValue(), this->m_ellipse_aspect_ratio->getValue(frame),
+        this->m_ellipse_angle->getValue(frame),
+        this->m_intensity_correlation_with_ellipse->getValue(frame));
   }
   void get_render_enlarge(const double frame, const TAffine affine,
-                          TRectD &bBox) {
+                          TRectD &bBox, double blur_radius,
+                          double pivot_radius) {
     TPointD center(this->get_render_center(frame, bBox.getP00(), affine));
-    int margin = this->get_render_int_margin(frame, bBox, affine, center);
+    int margin = this->get_render_int_margin(frame, bBox, affine, center,
+                                             blur_radius, pivot_radius);
     if (0 < margin) {
       /* 拡大のしすぎを防ぐテキトーな制限 */
       if (4096 < margin) {
@@ -114,14 +128,20 @@ public:
       bBox = TRectD();
       return false;
     }
-    const bool ret = this->m_input->doGetBBox(frame, bBox, info);
-    this->get_render_enlarge(frame, info.m_affine, bBox);
+    const bool ret      = this->m_input->doGetBBox(frame, bBox, info);
+    const double scale  = ino::pixel_per_mm() * sqrt(fabs(info.m_affine.det()));
+    const double radius = this->m_radius->getValue(frame) * scale;
+    const double pivot_radius = info.m_cameraBox.getLy() / 2.0;
+    this->get_render_enlarge(frame, info.m_affine, bBox, radius, pivot_radius);
     return ret;
   }
   int getMemoryRequirement(const TRectD &rect, double frame,
                            const TRenderSettings &info) override {
     TRectD bBox(rect);
-    this->get_render_enlarge(frame, info.m_affine, bBox);
+    const double scale  = ino::pixel_per_mm() * sqrt(fabs(info.m_affine.det()));
+    const double radius = this->m_radius->getValue(frame) * scale;
+    const double pivot_radius = info.m_cameraBox.getLy() / 2.0;
+    this->get_render_enlarge(frame, info.m_affine, bBox, radius, pivot_radius);
     return TRasterFx::memorySize(bBox, info.m_bpp);
   }
   void transform(double frame, int port, const TRectD &rectOnOutput,
@@ -129,7 +149,12 @@ public:
                  TRenderSettings &infoOnInput) override {
     rectOnInput = rectOnOutput;
     infoOnInput = infoOnOutput;
-    this->get_render_enlarge(frame, infoOnOutput.m_affine, rectOnInput);
+    const double scale =
+        ino::pixel_per_mm() * sqrt(fabs(infoOnInput.m_affine.det()));
+    const double radius       = this->m_radius->getValue(frame) * scale;
+    const double pivot_radius = infoOnInput.m_cameraBox.getLy() / 2.0;
+    this->get_render_enlarge(frame, infoOnOutput.m_affine, rectOnInput, radius,
+                             pivot_radius);
   }
   bool canHandle(const TRenderSettings &info, double frame) override {
     // return false; // toonz has geometry control
@@ -143,75 +168,69 @@ public:
 
   // add 20140130
   void getParamUIs(TParamUIConcept *&concepts, int &length) override {
-    concepts = new TParamUIConcept[length = 3];
-
-    concepts[0].m_type  = TParamUIConcept::POINT;
-    concepts[0].m_label = "Center";
+    concepts            = new TParamUIConcept[length = 2];
+    concepts[0].m_type  = TParamUIConcept::ELLIPSE;
+    concepts[0].m_label = "Radius";
+    concepts[0].m_params.push_back(m_radius);
     concepts[0].m_params.push_back(m_center);
+    concepts[0].m_params.push_back(m_ellipse_aspect_ratio);
+    concepts[0].m_params.push_back(m_ellipse_angle);
+    concepts[0].m_params.push_back(m_twist);
 
-    concepts[1].m_type  = TParamUIConcept::RADIUS;
-    concepts[1].m_label = "Radius";
-    concepts[1].m_params.push_back(m_radius);
+    concepts[1].m_type = TParamUIConcept::COMPASS;
     concepts[1].m_params.push_back(m_center);
-
-    concepts[2].m_type = TParamUIConcept::COMPASS;
-    concepts[2].m_params.push_back(m_center);
+    concepts[1].m_params.push_back(m_ellipse_aspect_ratio);
+    concepts[1].m_params.push_back(m_ellipse_angle);
+    concepts[1].m_params.push_back(m_twist);
   }
   // add 20140130
 };
 FX_PLUGIN_IDENTIFIER(ino_radial_blur, "inoRadialBlurFx");
 //--------------------------------------------------------------------
 namespace {
-void fx_(const TRasterP in_ras  // with margin
-         ,
-         const int margin
+void fx_(const TRasterP in_ras,  // with margin
+         const int margin, /* ここではinとrefは同サイズで使用している */
+         const TRasterP refer_ras,  // no margin
+         const int refer_mode,
+         TRasterP out_ras,  // no margin
+         const TPointD center, const double twist, const double blur,
+         const double radius, const double pivot_radius,
+         const bool alpha_rendering_sw, const bool anti_alias_sw,
+         const int type, const double ellipse_aspect_ratio,
+         const double ellipse_angle,
+         const double intensity_correlation_with_ellipse) {
+  TRasterGR8P ref_gr8;
+  if ((refer_ras != nullptr) && (0 <= refer_mode)) {
+    ref_gr8 = TRasterGR8P(out_ras->getLy(), out_ras->getLx() * sizeof(float));
+    ref_gr8->lock();
+    ino::ras_to_ref_float_arr(refer_ras,
+                              reinterpret_cast<float *>(ref_gr8->getRawData()),
+                              refer_mode);
+  }
 
-         /* ここではinとrefは同サイズで使用している */
-         ,
-         const TRasterP refer_ras  // no margin
-         ,
-         const int refer_mode
-
-         ,
-         TRasterP out_ras  // no margin
-
-         ,
-         const double xp, const double yp, const double twist,
-         const double twist_radius, const double blur, const double radius,
-         const bool alpha_rendering_sw, const bool anti_alias_sw) {
   TRasterGR8P in_gr8(in_ras->getLy(),
-                     in_ras->getLx() * ino::channels() *
-                         ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                             : sizeof(unsigned char)));
+                     in_ras->getLx() * ino::channels() * sizeof(float));
   in_gr8->lock();
+  ino::ras_to_float_arr(in_ras, ino::channels(),
+                        reinterpret_cast<float *>(in_gr8->getRawData()));
+
+  TRasterGR8P out_buffer(out_ras->getLy(),
+                         out_ras->getLx() * ino::channels() * sizeof(float));
+  out_buffer->lock();
 
   igs::radial_blur::convert(
-      in_ras->getRawData()  // BGRA
-      ,
-      0 /* margin機能は使っていない、のでinとref画像は同サイズ */
+      reinterpret_cast<float *>(in_gr8->getRawData()),
+      reinterpret_cast<float *>(out_buffer->getRawData()), margin,
+      out_ras->getSize(), ino::channels(),
+      (ref_gr8) ? reinterpret_cast<float *>(ref_gr8->getRawData()) : nullptr,
+      center + TPointD(margin, margin), twist, pivot_radius, blur, radius, type,
+      anti_alias_sw, alpha_rendering_sw, ellipse_aspect_ratio, ellipse_angle,
+      intensity_correlation_with_ellipse);
 
-      ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? refer_ras->getRawData()
-                                                     : nullptr)  // BGRA
-      ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? ino::bits(refer_ras)
-                                                     : 0),
-      refer_mode
-
-      ,
-      in_gr8->getRawData()  // BGRA
-
-      ,
-      in_ras->getLy(), in_ras->getLx(), ino::channels(), ino::bits(out_ras)
-
-                                                             ,
-      xp + margin, yp + margin, twist, twist_radius, blur, radius
-
-      ,
-      (anti_alias_sw ? 4 : 1), alpha_rendering_sw);
-
-  ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), out_ras, margin);
   in_gr8->unlock();
+  ino::float_arr_to_ras(out_buffer->getRawData(), ino::channels(), out_ras, 0);
+  out_buffer->unlock();
+  if (ref_gr8) ref_gr8->unlock();
 }
 }  // namespace
 //------------------------------------------------------------
@@ -236,6 +255,13 @@ void ino_radial_blur::doCompute(TTile &tile, double frame,
   const bool alpha_rend_sw = this->m_alpha_rendering->getValue();
   const bool anti_alias_sw = this->m_anti_alias->getValue();
   const int refer_mode     = this->m_ref_mode->getValue();
+  const int type           = this->m_type->getValue();
+  const double ellipse_aspect_ratio =
+      this->m_ellipse_aspect_ratio->getValue(frame);
+  const double ellipse_angle = this->m_ellipse_angle->getValue(frame);
+  const double pivot_radius  = ri.m_cameraBox.getLy() / 2.0;
+  const double intensity_correlation_with_ellipse =
+      this->m_intensity_correlation_with_ellipse->getValue(frame);
 
   TPointD center = this->m_center->getValue(frame);
   TPointD render_center(
@@ -248,7 +274,7 @@ void ino_radial_blur::doCompute(TTile &tile, double frame,
                          tile.getRaster()->getLx(), tile.getRaster()->getLy()));
   /*------ 入力画像のエリアの拡大 ----------------------------*/
   int margin = this->get_render_int_margin(frame, tile_with_margin, ri.m_affine,
-                                           render_center);
+                                           render_center, radius, pivot_radius);
   if (0 < margin) {
     /* 拡大のしすぎを防ぐテキトーな制限 */
     if (4096 < margin) {
@@ -270,10 +296,8 @@ void ino_radial_blur::doCompute(TTile &tile, double frame,
   if (this->m_refer.isConnected()) {
     refer_sw = true;
     this->m_refer->allocateAndCompute(
-        refer_tile, tile_with_margin.getP00(),
-        TDimensionI(/* Pixel単位で四捨五入 */
-                    static_cast<int>(tile_with_margin.getLx() + 0.5),
-                    static_cast<int>(tile_with_margin.getLy() + 0.5)),
+        refer_tile, tile.m_pos,
+        TDimension(tile.getRaster()->getLx(), tile.getRaster()->getLy()),
         tile.getRaster(), frame, ri);
   }
   /* ------ 保存すべき画像メモリを塗りつぶしクリア ---------- */
@@ -313,18 +337,10 @@ void ino_radial_blur::doCompute(TTile &tile, double frame,
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->lock();
     }
-    fx_(enlarge_tile.getRaster(), margin
-
-        ,
-        refer_tile.getRaster(), refer_mode
-
-        ,
-        tile.getRaster()
-
-            ,
-        render_center.x, render_center.y, twist, 0.0  // twist_radius
-        ,
-        blur, radius, alpha_rend_sw, anti_alias_sw);
+    fx_(enlarge_tile.getRaster(), margin, refer_tile.getRaster(), refer_mode,
+        tile.getRaster(), render_center, twist, blur, radius, pivot_radius,
+        alpha_rend_sw, anti_alias_sw, type, ellipse_aspect_ratio, ellipse_angle,
+        intensity_correlation_with_ellipse);
     if (refer_tile.getRaster() != nullptr) {
       refer_tile.getRaster()->unlock();
     }

--- a/toonz/sources/tnztools/edittoolgadgets.cpp
+++ b/toonz/sources/tnztools/edittoolgadgets.cpp
@@ -21,6 +21,7 @@
 
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QVector2D>
 
 using namespace EditToolGadgets;
 
@@ -29,6 +30,85 @@ GLdouble FxGadget::m_selectedColor[3] = {0.2, 0.8, 0.1};
 namespace {
 TPointD hadamard(const TPointD &v1, const TPointD &v2) {
   return TPointD(v1.x * v2.x, v1.y * v2.y);
+}
+
+#define SPIN_NUMVERTS 72
+
+void drawSpinField(const TRectD geom, const TPointD center,
+                   const double lineInterval, const double e_aspect_ratio,
+                   const double e_angle) {
+  static GLdouble vertices[SPIN_NUMVERTS * 2];
+  static bool isInitialized = false;
+  if (!isInitialized) {
+    isInitialized = true;
+    for (int r = 0; r < SPIN_NUMVERTS; r++) {
+      double theta        = 2.0 * M_PI * (double)r / (double)SPIN_NUMVERTS;
+      vertices[r * 2]     = std::cos(theta);
+      vertices[r * 2 + 1] = std::sin(theta);
+    }
+  }
+  // obtain the nearest and the furthest pos inside the geom
+  TPointD nearestPos;
+  nearestPos.x = (center.x <= geom.x0)
+                     ? geom.x0
+                     : (center.x >= geom.x1) ? geom.x1 : center.x;
+  nearestPos.y = (center.y <= geom.y0)
+                     ? geom.y0
+                     : (center.y >= geom.y1) ? geom.y1 : center.y;
+  double minDist = norm(nearestPos - center);
+  TPointD farthestPos;
+  farthestPos.x = (center.x <= geom.x0)
+                      ? geom.x1
+                      : (center.x >= geom.x1)
+                            ? geom.x0
+                            : ((center.x - geom.x0) >= (geom.x1 - center.x))
+                                  ? geom.x0
+                                  : geom.x1;
+  farthestPos.y = (center.y <= geom.y0)
+                      ? geom.y1
+                      : (center.y >= geom.y1)
+                            ? geom.y0
+                            : ((center.y - geom.y0) >= (geom.y1 - center.y))
+                                  ? geom.y0
+                                  : geom.y1;
+  double maxDist  = norm(farthestPos - center);
+  double scale[2] = {1.0, 1.0};
+  // adjust size for ellipse
+  if (e_aspect_ratio != 1.0) {
+    scale[0] = 2.0 * e_aspect_ratio / (e_aspect_ratio + 1);
+    scale[1] = scale[0] / e_aspect_ratio;
+    minDist *= std::min(scale[0], scale[1]);
+    maxDist *= std::max(scale[0], scale[1]);
+  }
+  // obtain id range
+  int minId = (int)std::ceil(minDist / lineInterval);
+  int maxId = (int)std::floor(maxDist / lineInterval);
+
+  glColor3d(0, 0, 1);
+  glEnableClientState(GL_VERTEX_ARRAY);
+  glLineStipple(1, 0x00FF);
+  glEnable(GL_LINE_STIPPLE);
+
+  glVertexPointer(2, GL_DOUBLE, 0, vertices);
+
+  glPushMatrix();
+
+  glTranslated(center.x, center.y, 0.0);
+  glRotated(e_angle, 0., 0., 1.);
+  glScaled(scale[0] * lineInterval, scale[1] * lineInterval, 1.);
+
+  for (int id = minId; id <= maxId; id++) {
+    if (id == 0) continue;
+    glPushMatrix();
+    glScaled((double)id, (double)id, 1.);
+    // draw using vertex array
+    glDrawArrays(GL_LINE_LOOP, 0, SPIN_NUMVERTS);
+    glPopMatrix();
+  }
+
+  glDisable(GL_LINE_STIPPLE);
+  glDisableClientState(GL_VERTEX_ARRAY);
+  glPopMatrix();
 }
 
 }  // namespace
@@ -1497,6 +1577,8 @@ void LinearRangeFxGadget::leftButtonUp() { m_handle = None; }
 
 class CompassFxGadget final : public FxGadget {
   TPointParamP m_center;
+  TDoubleParamP m_ellipse_aspect_ratio;
+  TDoubleParamP m_ellipse_angle;
 
   enum HANDLE { Body = 0, Near, Far, None } m_handle = None;
 
@@ -1507,7 +1589,9 @@ class CompassFxGadget final : public FxGadget {
 
 public:
   CompassFxGadget(FxGadgetController *controller,
-                  const TPointParamP &centerPoint, bool isSpin = false);
+                  const TPointParamP &centerPoint, bool isSpin = false,
+                  const TDoubleParamP &ellipse_aspect_ratio = TDoubleParamP(),
+                  const TDoubleParamP &ellipse_angle        = TDoubleParamP());
 
   void draw(bool picking) override;
 
@@ -1519,10 +1603,18 @@ public:
 //---------------------------------------------------------------------------
 
 CompassFxGadget::CompassFxGadget(FxGadgetController *controller,
-                                 const TPointParamP &centerPoint, bool isSpin)
-    : FxGadget(controller, 3), m_center(centerPoint), m_isSpin(isSpin) {
+                                 const TPointParamP &centerPoint, bool isSpin,
+                                 const TDoubleParamP &ellipse_aspect_ratio,
+                                 const TDoubleParamP &ellipse_angle)
+    : FxGadget(controller, 3)
+    , m_center(centerPoint)
+    , m_isSpin(isSpin)
+    , m_ellipse_aspect_ratio(ellipse_aspect_ratio)
+    , m_ellipse_angle(ellipse_angle) {
   addParam(centerPoint->getX());
   addParam(centerPoint->getY());
+  if (ellipse_aspect_ratio) addParam(ellipse_aspect_ratio);
+  if (ellipse_angle) addParam(ellipse_angle);
 }
 
 //---------------------------------------------------------------------------
@@ -1566,6 +1658,10 @@ void CompassFxGadget::draw(bool picking) {
 
   TPointD center = getValue(m_center);
   double dCenter = norm(center);
+  double e_aspect_ratio =
+      (m_ellipse_aspect_ratio) ? getValue(m_ellipse_aspect_ratio) : 1.0;
+  double e_angle = (m_ellipse_angle) ? getValue(m_ellipse_angle) : 0.0;
+
   TPointD handleVec;
   if (dCenter > lineHalf) {
     handleVec = normalize(center) * lineHalf;
@@ -1580,33 +1676,73 @@ void CompassFxGadget::draw(bool picking) {
     double angle = std::atan2(-center.y, -center.x) * M_180_PI;
     double theta = M_180_PI * lineInterval / dCenter;
 
-    // draw guides
-    glColor3d(0, 0, 1);
-    glLineStipple(1, 0x00FF);
-    glEnable(GL_LINE_STIPPLE);
-    glPushMatrix();
-    glTranslated(center.x, center.y, 0);
-    glRotated(angle, 0, 0, 1);
-    for (int i = -3; i <= 3; i++) {
+    // draw spin lines field
+    if (isSelected() && !isSelected(None) && m_isSpin &&
+        m_ellipse_aspect_ratio && m_ellipse_angle) {
+      TRectD geom = m_controller->getGeometry();
+
+      drawSpinField(geom, center, lineInterval, e_aspect_ratio, e_angle);
+    } else {
+      // draw guides
+      glColor3d(0, 0, 1);
+      glLineStipple(1, 0x00FF);
+      glEnable(GL_LINE_STIPPLE);
+      glPushMatrix();
+      glTranslated(center.x, center.y, 0);
       if (!m_isSpin) {  // radial direction
-        if (i == 0) continue;
-        glPushMatrix();
-        glRotated(theta * (double)i, 0, 0, 1);
-        glBegin(GL_LINES);
-        glVertex2d(dCenter - lineHalf, 0.0);
-        glVertex2d(dCenter + lineHalf, 0.0);
-        glEnd();
-        glPopMatrix();
-      } else {  // rotational direction
-        if (i == 3 || i == -3) continue;
-        double tmpRad  = dCenter + (double)i * lineInterval;
-        double d_angle = (lineInterval / dCenter) * 6.0 / 10.0;
-        glBegin(GL_LINE_STRIP);
-        for (int r = -5; r <= 5; r++) {
-          double tmpAngle = (double)r * d_angle;
-          glVertex2d(tmpRad * std::cos(tmpAngle), tmpRad * std::sin(tmpAngle));
+        for (int i = -3; i <= 3; i++) {
+          if (i == 0) continue;
+          glPushMatrix();
+          glRotated(theta * (double)i + angle, 0, 0, 1);
+          glBegin(GL_LINES);
+          glVertex2d(dCenter - lineHalf, 0.0);
+          glVertex2d(dCenter + lineHalf, 0.0);
+          glEnd();
+          glPopMatrix();
         }
-        glEnd();
+      } else {  // rotational direction
+        if (areAlmostEqual(e_aspect_ratio, 1.0)) {
+          for (int i = -2; i <= 2; i++) {
+            double tmpRad  = dCenter + (double)i * lineInterval;
+            double d_angle = (lineInterval / dCenter) * 6.0 / 10.0;
+            glBegin(GL_LINE_STRIP);
+            for (int r = -5; r <= 5; r++) {
+              double tmpAngle = (double)r * d_angle + angle * M_PI_180;
+              glVertex2d(tmpRad * std::cos(tmpAngle),
+                         tmpRad * std::sin(tmpAngle));
+            }
+            glEnd();
+          }
+        } else {
+          double scale[2];
+          scale[0] = 2.0 * e_aspect_ratio / (e_aspect_ratio + 1);
+          scale[1] = scale[0] / e_aspect_ratio;
+          glRotated(e_angle, 0., 0., 1.);
+          glScaled(scale[0], scale[1], 1.);
+
+          QTransform tr = QTransform()
+                              .translate(center.x, center.y)
+                              .rotate(e_angle)
+                              .scale(scale[0], scale[1])
+                              .inverted();
+          QPointF begin = tr.map(QPointF(handleVec.x, handleVec.y));
+          QPointF end   = tr.map(QPointF(-handleVec.x, -handleVec.y));
+
+          angle            = std::atan2(begin.y(), begin.x());
+          double distBegin = QVector2D(begin).length();
+          double distEnd   = QVector2D(end).length();
+          for (int i = 0; i <= 4; i++) {
+            double tmpRad  = distBegin + (double)i * (distEnd - distBegin) / 4.;
+            double d_angle = (lineInterval / dCenter) * 6.0 / 10.0;
+            glBegin(GL_LINE_STRIP);
+            for (int r = -5; r <= 5; r++) {
+              double tmpAngle = (double)r * d_angle + angle;
+              glVertex2d(tmpRad * std::cos(tmpAngle),
+                         tmpRad * std::sin(tmpAngle));
+            }
+            glEnd();
+          }
+        }
       }
     }
 
@@ -1763,6 +1899,227 @@ void RainbowWidthFxGadget::leftButtonDrag(const TPointD &pos,
 
   setValue(m_widthScale, std::min(max, std::max(min, scale)));
 }
+
+//=============================================================================
+
+class EllipseFxGadget final : public FxGadget {
+  TDoubleParamP m_radius;
+  TDoubleParamP m_xParam, m_yParam;
+  TDoubleParamP m_aspect_ratio;
+  TDoubleParamP m_angle;
+
+  TPointD m_pos;
+
+  enum HANDLE { Radius = 0, Center, AngleAndAR, None } m_handle = None;
+
+public:
+  EllipseFxGadget(FxGadgetController *controller, const TDoubleParamP &radius,
+                  const TPointParamP &center, const TDoubleParamP &aspect_ratio,
+                  const TDoubleParamP &angle)
+      : FxGadget(controller, 4)
+      , m_radius(radius)
+      , m_xParam(center->getX())
+      , m_yParam(center->getY())
+      , m_aspect_ratio(aspect_ratio)
+      , m_angle(angle) {
+    addParam(radius);
+    addParam(m_xParam);
+    addParam(m_yParam);
+    addParam(m_aspect_ratio);
+    addParam(m_angle);
+  }
+
+  TPointD getCenter() const;
+
+  void draw(bool picking) override;
+
+  void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonUp() override;
+};
+
+//---------------------------------------------------------------------------
+
+TPointD EllipseFxGadget::getCenter() const {
+  return TPointD(getValue(m_xParam), getValue(m_yParam));
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::draw(bool picking) {
+  int idBase = getId();
+
+  auto setColorById = [&](int id) {
+    if (isSelected(id))
+      glColor3dv(m_selectedColor);
+    else
+      glColor3d(0, 0, 1);
+  };
+
+  setPixelSize();
+  glPushMatrix();
+
+  TPointD center      = getCenter();
+  double aspect_ratio = getValue(m_aspect_ratio);
+  double angle        = getValue(m_angle);
+
+  // draw spin lines field
+  if (isSelected() && !isSelected(None)) {
+    double lineInterval = getPixelSize() * 50;
+    TRectD geom         = m_controller->getGeometry();
+    drawSpinField(geom, center, lineInterval, aspect_ratio, angle);
+  }
+
+  double unit = getPixelSize();
+  glTranslated(center.x, center.y, 0);
+
+  //--- radius ---
+  setColorById(Radius);
+  glPushName(idBase + Radius);
+  double radius = getValue(m_radius);
+
+  double scale[2] = {1.0, 1.0};
+  if (!areAlmostEqual(aspect_ratio, 1.0)) {
+    scale[0] = 2.0 * aspect_ratio / (aspect_ratio + 1.0);
+    scale[1] = scale[0] / aspect_ratio;
+  }
+  glPushMatrix();
+
+  glRotated(angle, 0., 0., 1.);
+  glScaled(scale[0], scale[1], 1.0);
+
+  glLineStipple(1, 0xAAAA);
+  glEnable(GL_LINE_STIPPLE);
+  tglDrawCircle(TPointD(), radius);
+  glDisable(GL_LINE_STIPPLE);
+
+  glPopMatrix();
+
+  QTransform transform = QTransform().rotate(angle).scale(scale[0], scale[1]);
+  QPointF radiusHandlePos = transform.map(QPointF(0.0, radius));
+  drawDot(TPointD(radiusHandlePos.x(), radiusHandlePos.y()));
+  glPopName();
+
+  if (isSelected(Radius)) {
+    QPointF namePos = transform.map(QPointF(0.707, 0.707) * radius);
+    drawTooltip(TPointD(namePos.x(), namePos.y()), getLabel());
+  }
+
+  //--- center ---
+  setColorById(Center);
+  glPushName(idBase + Center);
+  double d = unit * 8;
+  tglDrawCircle(TPointD(), d);
+
+  if (radius > d) {
+    glBegin(GL_LINES);
+    glVertex2d(-d, 0);
+    glVertex2d(d, 0);
+    glVertex2d(0, -d);
+    glVertex2d(0, d);
+    glEnd();
+  }
+
+  glPopName();
+  if (isSelected(Center)) {
+    drawTooltip(TPointD(), "Center");
+  }
+
+  //---- AR and rotate
+  double handleLength = unit * 100;
+  radius              = std::max(radius, unit * 10);
+  setColorById(AngleAndAR);
+  QPointF qHandleRoot = transform.map(QPointF(radius, 0.0));
+  glPushMatrix();
+  glPushName(idBase + AngleAndAR);
+  glTranslated(qHandleRoot.x(), qHandleRoot.y(), 0.);
+  glRotated(angle, 0., 0., 1.);
+  glBegin(GL_LINES);
+  glVertex2d(0., 0.);
+  glVertex2d(handleLength, 0.);
+  glEnd();
+  drawDot(TPointD(handleLength, 0.));
+
+  glPopMatrix();
+  glPopName();
+
+  if (isSelected(AngleAndAR)) {
+    double angle_radian = angle * M_PI_180;
+    TPointD namePos(qHandleRoot.x() + std::cos(angle_radian) * handleLength,
+                    qHandleRoot.y() + std::sin(angle_radian) * handleLength);
+    drawTooltip(namePos, "Angle and Aspect");
+  }
+
+  glPopMatrix();  // cancel translation to center
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::leftButtonDown(const TPointD &pos, const TMouseEvent &) {
+  m_handle = (HANDLE)m_selected;
+  m_pos    = pos;
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
+  if (m_handle == None) return;
+  if (m_handle == Radius) {
+    double aspect_ratio = getValue(m_aspect_ratio);
+    double angle        = getValue(m_angle);
+    double scale[2]     = {1.0, 1.0};
+    if (!areAlmostEqual(aspect_ratio, 1.0)) {
+      scale[0] = 2.0 * aspect_ratio / (aspect_ratio + 1.0);
+      scale[1] = scale[0] / aspect_ratio;
+    }
+    TPointD center       = getCenter();
+    QTransform transform = QTransform()
+                               .translate(center.x, center.y)
+                               .rotate(angle)
+                               .scale(scale[0], scale[1])
+                               .inverted();
+    QPointF transformedP = transform.map(QPointF(pos.x, pos.y));
+    setValue(m_radius, QVector2D(transformedP).length());
+  } else if (m_handle == Center) {
+    setValue(m_xParam, pos.x);
+    setValue(m_yParam, pos.y);
+  } else if (m_handle == AngleAndAR) {
+    // âÒì]Ç∆êLèkÇ…ï™ÇØÇÈ
+    TPointD center = getCenter();
+    TPointD old_v  = m_pos - center;
+    TPointD new_v  = pos - center;
+    if (old_v == TPointD() || new_v == TPointD()) return;
+    // AR
+    double aspect_ratio   = getValue(m_aspect_ratio);
+    double pre_axisLength = 2.0 * aspect_ratio / (aspect_ratio + 1.0);
+    double ratio          = norm(new_v) / norm(old_v);
+    if (ratio == 0.) return;
+    double new_axisLength = pre_axisLength * ratio;
+    double new_ar         = new_axisLength / (2.0 - new_axisLength);
+    if (new_ar < 0.1)
+      new_ar = 0.1;
+    else if (new_ar > 10.0)
+      new_ar = 10.0;
+    setValue(m_aspect_ratio, new_ar);
+
+    // angle
+    double angle = getValue(m_angle);
+    double d_angle =
+        std::atan2(new_v.y, new_v.x) - std::atan2(old_v.y, old_v.x);
+    double new_angle = angle + d_angle * M_180_PI;
+    if (new_angle < -180.0)
+      new_angle += 360.0;
+    else if (new_angle > 180.0)
+      new_angle -= 360.0;
+    setValue(m_angle, new_angle);
+
+    m_pos = pos;
+  }
+}
+
+//---------------------------------------------------------------------------
+
+void EllipseFxGadget::leftButtonUp() { m_handle = None; }
 
 //*************************************************************************************
 //    FxGadgetController  implementation
@@ -1957,8 +2314,15 @@ FxGadget *FxGadgetController::allocateGadget(const TParamUIConcept &uiConcept) {
   }
 
   case TParamUIConcept::COMPASS_SPIN: {
-    assert(uiConcept.m_params.size() == 1);
-    gadget = new CompassFxGadget(this, uiConcept.m_params[0], true);
+    assert(uiConcept.m_params.size() == 1 || uiConcept.m_params.size() == 3);
+
+    if (uiConcept.m_params.size() == 3)
+      gadget =
+          new CompassFxGadget(this, uiConcept.m_params[0], true,
+                              uiConcept.m_params[1], uiConcept.m_params[2]);
+    else
+      gadget = new CompassFxGadget(this, uiConcept.m_params[0], true);
+
     break;
   }
 
@@ -1969,6 +2333,15 @@ FxGadget *FxGadgetController::allocateGadget(const TParamUIConcept &uiConcept) {
                                  uiConcept.m_params[1], uiConcept.m_params[2]);
     break;
   }
+
+  case TParamUIConcept::ELLIPSE: {
+    assert(uiConcept.m_params.size() == 4);
+    gadget =
+        new EllipseFxGadget(this, uiConcept.m_params[0], uiConcept.m_params[1],
+                            uiConcept.m_params[2], uiConcept.m_params[3]);
+    break;
+  }
+
   default:
     break;
   }
@@ -2060,6 +2433,14 @@ int FxGadgetController::getCurrentFrame() const { return m_tool->getFrame(); }
 
 void FxGadgetController::invalidateViewer() { m_tool->invalidate(); }
 
+//---------------------------------------------------------------------------
+
 int FxGadgetController::getDevPixRatio() {
   return getDevicePixelRatio(m_tool->getViewer()->viewerWidget());
+}
+
+//---------------------------------------------------------------------------
+
+TRectD FxGadgetController::getGeometry() {
+  return (m_tool->getViewer()) ? m_tool->getViewer()->getGeometry() : TRectD();
 }

--- a/toonz/sources/tnztools/edittoolgadgets.h
+++ b/toonz/sources/tnztools/edittoolgadgets.h
@@ -153,6 +153,9 @@ public:
 
   int getDevPixRatio();
 
+  // get the current viewer geometry
+  TRectD getGeometry();
+
 public slots:
 
   void onFxSwitched();

--- a/toonz/sources/tnztools/edittoolgadgets.h
+++ b/toonz/sources/tnztools/edittoolgadgets.h
@@ -156,6 +156,8 @@ public:
   // get the current viewer geometry
   TRectD getGeometry();
 
+  TRectD getCameraRect();
+
 public slots:
 
   void onFxSwitched();

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -3273,6 +3273,20 @@ TRectD SceneViewer::getGeometry() const {
 }
 
 //-----------------------------------------------------------------------------
+
+TRectD SceneViewer::getCameraRect() const {
+  TRectD cameraRect = TApp::instance()
+                          ->getCurrentScene()
+                          ->getScene()
+                          ->getCurrentCamera()
+                          ->getStageRect();
+
+  // return m_drawCameraAff * TRectD(cameraRect.x0, cameraRect.y0, cameraRect.x1
+  // - m_pixelSize, cameraRect.y1 - m_pixelSize);
+  return m_drawCameraAff * cameraRect;
+}
+
+//-----------------------------------------------------------------------------
 /*! delete preview - subcamera executed from context menu
  */
 void SceneViewer::doDeleteSubCamera() {

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -278,6 +278,7 @@ public:
   // the viewer
   // when using the stylepicker and the finger tools
   TRectD getGeometry() const override;
+  TRectD getCameraRect() const override;
 
   void setFocus(Qt::FocusReason reason) { QWidget::setFocus(reason); };
 


### PR DESCRIPTION
**Please review & merge this PR after releasing V1.6**

This PR will revise the Radial Blur Fx Ino.
This PR is based on #4272 (thus, merging this PR will automatically merge #4272) .

1. Added a new parameter `Type` with 2 options as follows:
    <img src="https://user-images.githubusercontent.com/17974955/156965723-16f0b4fc-d1d0-4699-b509-d9f96a7a8377.png" width=500>
    - **Accelerator** : The blur intensity is zero at `radius` position and becomes larger outward. (Conventional behavior)
    - **Uniform Length** : A new behavior. The blur intensity becomes the same in all distance.

2. Added new parameters; **Ellipse Aspect Ratio**, **Ellipse Angle** and **Intensity Correlation** to make elliptical blur.
    <img src="https://user-images.githubusercontent.com/17974955/156971434-208671b9-d367-4c3c-80af-a9cda33da40c.png" width=500>

    - **Ellipse Aspect Ratio** : specifies the ellipticity of the blur direction.
    - **Ellipse Angle** : specifies how the ellipse is inclined in degrees.
    - **Intensity Correlation** : specifies relation between the ellipse shape and the blur intensity. When more than 0, the blur intensity along the long axis becomes bigger and vice versa.
        <img src="https://user-images.githubusercontent.com/17974955/156971863-5114038e-dcdc-45f5-bc5f-785b60261107.png" width=600>

3. Revised the Fx gadgets.

    <img src="https://user-images.githubusercontent.com/17974955/156972038-e93f003b-0dad-4d42-893a-351ba8777d1b.png" width=500>

    - Added a handle for changing Ellipse Aspect Ratio and Ellipse Angle.

    - Added a handle for changing Twist.

    - Added a dashed-line field in the entire window which indicates the blur direction. The field is displayed only when the mouse cursor overs the gadget. 

 