### PR TITLE
Custom dpi option for Camera Capture

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -290,6 +290,13 @@ class PencilTestPopup : public DVGui::Dialog {
     QGroupBox* groupBox;
   } m_calibration;
 
+  // dpi settings
+  bool m_doAutoDpi;
+  double m_customDpi;
+  QWidget* m_dpiMenuWidget;
+  QPushButton* m_dpiBtn;
+  QLineEdit* m_customDpiField;
+
   void captureCalibrationRefImage(cv::Mat& procImage);
 
   void processImage(cv::Mat& procImage);
@@ -305,6 +312,8 @@ class PencilTestPopup : public DVGui::Dialog {
   int translateIndex(int camIndex);
 
   QString getCurrentCalibFilePath();
+
+  QWidget* createDpiMenuWidget();
 
 public:
   PencilTestPopup();
@@ -355,6 +364,7 @@ protected slots:
   void onCalibLoadBtnClicked();
   void onCalibExportBtnClicked();
   void onCalibReadme();
+  void onPreferenceChanged(const QString&);
 
 public slots:
   void openSaveInFolderPopup();


### PR DESCRIPTION
**Please review & merge this PR after releasing V1.6**

This PR will add an option to specify the dpi value to the captured image by the Camera Capture feature.

Now the DPI option can be selected from the following items:
- **Auto** : Conventional behavior. If the subcamera is not active, apply the current camera dpi. If the subcamera is active, compute the dpi so that the image will fit to the camera frame.
- **Custom** : A new option. Always use the custom dpi specified in the field.

The new option was introduced based on a situation in some animation studio; they draw characters on the paper which is smaller than the actual camera frame size so that they can handle the papers easier. (For instance, the camera frame size is in "cinema scope" but the characters are drawn on "vista vision" sized paper.)