### PR TITLE
Fix tile fxs & bounding box handling

### DIFF
--- a/toonz/sources/stdfx/iwa_tilefx.cpp
+++ b/toonz/sources/stdfx/iwa_tilefx.cpp
@@ -134,6 +134,11 @@ void Iwa_TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
                            TRectD &rectOnInput, TRenderSettings &infoOnInput) {
   infoOnInput = infoOnOutput;
 
+  if (!m_input.isConnected()) {
+    rectOnInput.empty();
+    return;
+  }
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, infoOnOutput);
 
@@ -161,6 +166,8 @@ void Iwa_TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
 
 int Iwa_TileFx::getMemoryRequirement(const TRectD &rect, double frame,
                                      const TRenderSettings &info) {
+  if (!m_input.isConnected()) return 0;
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, info);
 

--- a/toonz/sources/stdfx/tilefx.cpp
+++ b/toonz/sources/stdfx/tilefx.cpp
@@ -90,6 +90,11 @@ void TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
                        TRenderSettings &infoOnInput) {
   infoOnInput = infoOnOutput;
 
+  if (!m_input.isConnected()) {
+    rectOnInput.empty();
+    return;
+  }
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, infoOnOutput);
 
@@ -116,6 +121,8 @@ void TileFx::transform(double frame, int port, const TRectD &rectOnOutput,
 
 int TileFx::getMemoryRequirement(const TRectD &rect, double frame,
                                  const TRenderSettings &info) {
+  if (!m_input.isConnected()) return 0;
+
   TRectD inputBox;
   m_input->getBBox(frame, inputBox, info);
 
@@ -157,7 +164,7 @@ void TileFx::doCompute(TTile &tile, double frame, const TRenderSettings &ri) {
 //------------------------------------------------------------------------------
 //! Make the tile of the image contained in \b inputTile in \b tile
 /*
-*/
+ */
 void TileFx::makeTile(const TTile &inputTile, const TTile &tile) const {
   // Build the mirroring pattern. It obviously repeats itself out of 2x2 tile
   // blocks.

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -541,8 +541,11 @@ TAffine TRasterFx::handledAffine(const TRenderSettings &info, double frame) {
 bool TRasterFx::getBBox(double frame, TRectD &bBox,
                         const TRenderSettings &info) {
   bool ret = doGetBBox(frame, bBox, info);
-  bBox     = info.m_affine * bBox;
-  enlargeToI(bBox);
+  if (!bBox.isEmpty()) {  // TODO: check if bbox can always be empty when ret ==
+                          // false
+    bBox = info.m_affine * bBox;
+    enlargeToI(bBox);
+  }
   return ret;
 }
 


### PR DESCRIPTION
This PR fixes #4321 , adding check if the source input of the Tile Fx Iwa is empty.
Also modified `TRasterFx::getBBox` to convert the bounding box only when the bounding box is not empty in order to prevent unnecessary further computation.