### PR TITLE
Deactivate Edit Shift mode when deactivating Shift and Trace

### DIFF
--- a/toonz/sources/tnztools/shifttracetool.cpp
+++ b/toonz/sources/tnztools/shifttracetool.cpp
@@ -348,6 +348,10 @@ void ShiftTraceTool::onActivate() {
 }
 
 void ShiftTraceTool::onDeactivate() {
+  // Deactivating Shift and Trace mode resets the pseudo tool with keeping the
+  // Edit Shift checkbox unchanged
+  QAction *shiftTrace = CommandManager::instance()->getAction("MI_ShiftTrace");
+  if (!shiftTrace->isChecked()) return;
   QAction *action = CommandManager::instance()->getAction("MI_EditShift");
   action->setChecked(false);
 }

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -404,7 +404,17 @@ public:
     if (std::string(m_cmdId) == MI_ShiftTrace) {
       cm->enable(MI_EditShift, checked);
       cm->enable(MI_NoShift, checked);
-      if (checked) OnioniSkinMaskGUI::resetShiftTraceFrameOffset();
+      if (checked) {
+        OnioniSkinMaskGUI::resetShiftTraceFrameOffset();
+        // activate edit shift
+        if (isChecked(MI_EditShift))
+          TApp::instance()->getCurrentTool()->setPseudoTool("T_ShiftTrace");
+      } else {
+        // deactivate edit shift
+        if (isChecked(MI_EditShift))
+          TApp::instance()->getCurrentTool()->unsetPseudoTool();
+      }
+
       //     cm->getAction(MI_NoShift)->setChecked(false);
       TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
     } else if (std::string(m_cmdId) == MI_EditShift) {


### PR DESCRIPTION
This PR resolves #4315 .
Now the `Edit Shift` mode will be released when the Shift and Trace mode is deactivatied, with keeping the `Edit Shift` checkbox state unchanged.