### PR TITLE
Fix vector levels to render aliased line

### DIFF
--- a/toonz/sources/common/tvrender/tstrokeprop.cpp
+++ b/toonz/sources/common/tvrender/tstrokeprop.cpp
@@ -247,7 +247,10 @@ void OutlineStrokeProp::draw(const TVectorRenderData &rd) {
       m_styleVersionNumber = m_colorStyle->getVersionNumber();
     }
 
-    m_colorStyle->drawStroke(rd.m_cf, &m_outline, m_stroke);
+    if (rd.m_antiAliasing)
+      m_colorStyle->drawStroke(rd.m_cf, &m_outline, m_stroke);
+    else
+      m_colorStyle->drawAliasedStroke(rd.m_cf, &m_outline, m_stroke);
   }
 
   glPopMatrix();

--- a/toonz/sources/include/tsimplecolorstyles.h
+++ b/toonz/sources/include/tsimplecolorstyles.h
@@ -118,6 +118,12 @@ public:
 
   virtual void drawStroke(const TColorFunction *cf, TStrokeOutline *outline,
                           const TStroke *stroke) const = 0;
+  // draw aliased stroke. currently reimplemented by TSolidColorStyle only
+  virtual void drawAliasedStroke(const TColorFunction *cf,
+                                 TStrokeOutline *outline,
+                                 const TStroke *stroke) const {
+    drawStroke(cf, outline, stroke);
+  };
 
 protected:
   // Not assignable
@@ -158,8 +164,17 @@ public:
   void drawRegion(const TColorFunction *cf, const bool antiAliasing,
                   TRegionOutline &outline) const override;
 
+  void doDrawStroke(const TColorFunction *cf, TStrokeOutline *outline,
+                    const TStroke *s, bool antialias) const;
+
   void drawStroke(const TColorFunction *cf, TStrokeOutline *outline,
-                  const TStroke *s) const override;
+                  const TStroke *s) const override {
+    doDrawStroke(cf, outline, s, true);
+  }
+  void drawAliasedStroke(const TColorFunction *cf, TStrokeOutline *outline,
+                         const TStroke *s) const override {
+    doDrawStroke(cf, outline, s, false);
+  }
 
   int getTagId() const override;
 

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -1042,6 +1042,10 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
       TVectorRenderData rd(TVectorRenderData::ProductionSettings(), aff,
                            TRect(size), vpalette);
 
+      // obtain jaggy image when the Closest Pixel is set
+      if (info.m_quality == TRenderSettings::ClosestPixel_FilterResampleQuality)
+        rd.m_antiAliasing = false;
+
       if (!m_offlineContext || m_offlineContext->getLx() < size.lx ||
           m_offlineContext->getLy() < size.ly) {
         if (m_offlineContext) delete m_offlineContext;


### PR DESCRIPTION
This PR fixes #3101 .
Now the `Export Level` command will output aliased line when `No Antialias` option is set.
I think the problem was due to my oversight when introducing the modification #2289 . I hadn't imagined that there is a case that aliased line is needed.
In this PR I reverted the previous code for drawing "aliased" outline of vector stroke.

And also I made OT to render jaggy image from vector levels if `Output/Preview Settings > Resample Balance` is set to `Closest Pixel (Nearest Neighbor)` .

**N.B. Please note that currently the fix is only applied to "normal" style. Vector image drawn with special styles will still be antialiased.**
