### PR TITLE
Fix RGB key fx affine transformation handling

### DIFF
--- a/toonz/sources/stdfx/rgbkeyfx.cpp
+++ b/toonz/sources/stdfx/rgbkeyfx.cpp
@@ -51,7 +51,7 @@ public:
   void doCompute(TTile &tile, double frame, const TRenderSettings &) override;
 
   bool canHandle(const TRenderSettings &info, double frame) override {
-    return true;
+    return false;
   }
 };
 


### PR DESCRIPTION
This PR will resolve a problem reported by @F-Burning in [this comment](https://github.com/opentoonz/opentoonz/issues/4349#issuecomment-1073268304) .
Modified a return value of the function `RGBKeyFx::canHandle()` so that the effect is applied before the column's transformation.