### PR TITLE
Fix zoom scale display of ComboViewer's titlebar

### DIFF
--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -646,13 +646,12 @@ void ComboViewerPanel::changeWindowTitle() {
     name = name + tr("   ::   Level: ") + imageName;
 
     if (!m_sceneViewer->is3DView()) {
-      TAffine aff = m_sceneViewer->getViewMatrix();
+      TAffine aff = m_sceneViewer->getViewMatrix() *
+                    m_sceneViewer->getNormalZoomScale().inv();
       if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
       if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
       name = name + "  ::  Zoom : " +
-             QString::number((int)(100.0 * sqrt(aff.det()) *
-                                   m_sceneViewer->getDpiFactor())) +
-             "%";
+             QString::number(tround(100.0 * sqrt(aff.det()))) + "%";
     }
 
     // If the current level exists and some option is set in the preference,
@@ -666,13 +665,12 @@ void ComboViewerPanel::changeWindowTitle() {
                                               // neither
                      ->isEnabled() &&
              !m_sceneViewer->is3DView()) {
-      TAffine aff = m_sceneViewer->getViewMatrix();
+      TAffine aff = m_sceneViewer->getViewMatrix() *
+                    m_sceneViewer->getNormalZoomScale().inv();
       if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
       if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
       name = name + "  ::  Zoom : " +
-             QString::number((int)(100.0 * sqrt(aff.det()) *
-                                   m_sceneViewer->getDpiFactor())) +
-             "%";
+             QString::number(tround(100.0 * sqrt(aff.det()))) + "%";
     }
 
   }
@@ -686,13 +684,12 @@ void ComboViewerPanel::changeWindowTitle() {
 
       name = name + tr("Level: ") + imageName;
       if (!m_sceneViewer->is3DView()) {
-        TAffine aff = m_sceneViewer->getViewMatrix();
+        TAffine aff = m_sceneViewer->getViewMatrix() *
+                      m_sceneViewer->getNormalZoomScale().inv();
         if (m_sceneViewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
         if (m_sceneViewer->getIsFlippedY()) aff = aff * TScale(1, -1);
         name = name + "  ::  Zoom : " +
-               QString::number((int)(100.0 * sqrt(aff.det()) *
-                                     m_sceneViewer->getDpiFactor())) +
-               "%";
+               QString::number(tround(100.0 * sqrt(aff.det()))) + "%";
       }
     }
   }


### PR DESCRIPTION
This PR fixes zoom scale display of the ComboViewer's titlebar.
Before this PR decimals of the zoom factor had been truncated (i.e. 99.99999998 % was displayed as 99%).
Now the factor will be rounded to the nearest whole number.  It is consistent with the Viewer's titlebar.