### PR TITLE
Display blank frames in camera stand view

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1448,6 +1448,15 @@ void SceneViewer::drawCameraStand() {
 
   TXshSimpleLevel::m_rasterizePli = rasterizePliToggle.getStatus();
 
+  // display blank frame
+  if (m_visualSettings.m_blankColor != TPixel::Transparent) {
+    glClearColor(m_visualSettings.m_blankColor.r / 255.0f,
+                 m_visualSettings.m_blankColor.g / 255.0f,
+                 m_visualSettings.m_blankColor.b / 255.0f, 1.0);
+    glClear(GL_COLOR_BUFFER_BIT);
+    return;
+  }
+
   // clear
   if (m_draw3DMode) {
     glEnable(GL_DEPTH_TEST);


### PR DESCRIPTION
**Please review & merge this PR after releasing V1.6**

This PR will enable to display blank frames between each viewer playback even if the viewer is in the camera stand view (i.e. non-preview) mode.
When the blank frame is set & activated, the whole viewer will now be filled with the blank frame's color instead of "frozen" at the last frame.