### PR TITLE
Fix the parent object label in xsheet column header translatable

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -118,6 +118,8 @@ public:
 
   void refresh() override;
 
+  static QString getNameTr(const TStageObjectId id);
+
 protected slots:
   void onTextSelected(const QString &) override;
 };


### PR DESCRIPTION
This PR resolves a problem pointed by @gab3d in [this comment](https://github.com/opentoonz/opentoonz/pull/4282#issuecomment-1078676677) .

Now the column header and the context menu share the same string (obtained by `ChangeObjectParent::getNameTr()`) with the same translation.