### PR TITLE
Fix Preferences popup combobox size adjustment

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1637,6 +1637,9 @@ QWidget* PreferencesPopup::createInterfacePage() {
   insertUI(CurrentLanguageName, lay, languageItemList);
   insertUI(interfaceFont, lay);  // creates QFontComboBox
   insertUI(interfaceFontStyle, lay, buildFontStyleList());
+  qobject_cast<QComboBox*>(m_controlIdMap.key(interfaceFontStyle))
+      ->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+
   QGridLayout* colorCalibLay = insertGroupBoxUI(colorCalibrationEnabled, lay);
   { insertUI(colorCalibrationLutPaths, colorCalibLay); }
   insertUI(displayIn30bit, lay);
@@ -1697,7 +1700,8 @@ QWidget* PreferencesPopup::createVisualizationPage() {
 
 QWidget* PreferencesPopup::createLoadingPage() {
   m_levelFormatNames = new QComboBox;
-  m_editLevelFormat  = new QPushButton(tr("Edit"));
+  m_levelFormatNames->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+  m_editLevelFormat = new QPushButton(tr("Edit"));
 
   QPushButton* addLevelFormat    = new QPushButton("+");
   QPushButton* removeLevelFormat = new QPushButton("-");


### PR DESCRIPTION
This PR modifies size adjustment policy of the following comboboxes in the preferences popup so that they always adjust to their contents.
- `Interface > Font Style`  (Adjust size when the current font family is switched)
- `Loading > Level Settings by File Format` (Adjust size when a new entry is added or existing entry is removed)