### PR TITLE
Fix parent object field in the xsheet column header

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -391,21 +391,6 @@ void ChangeObjectWidget::focusOutEvent(QFocusEvent *e) {
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectWidget::selectCurrent(const QString &text) {
-  clearSelection();
-  int numRows = count();
-  for (int row = 0; row < numRows; row++) {
-    QListWidgetItem *it = item(row);
-    QVariant display    = it->data(Qt::UserRole);
-    if (text == (display.isValid() ? display.toString() : it->text())) {
-      setCurrentItem(it);
-      return;
-    }
-  }
-}
-
-//-----------------------------------------------------------------------------
-
 void ChangeObjectWidget::addText(const QString &text, const QString &display) {
   QListWidgetItem *item = new QListWidgetItem(display);
   item->setData(Qt::UserRole, text);
@@ -422,25 +407,16 @@ void ChangeObjectWidget::addText(const QString &text, const QColor &textColor) {
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectWidget::addText(const QString &text, const QString &display,
+void ChangeObjectWidget::addText(const TStageObjectId &id,
+                                 const QString &display,
                                  const QColor &identColor) {
   QListWidgetItem *item = new QListWidgetItem(display);
   QPixmap pixmap(4, 8);
   pixmap.fill(identColor);
   QIcon icon(pixmap);
   item->setIcon(icon);
-  item->setData(Qt::UserRole, text);
+  item->setData(Qt::UserRole, id.getCode());
   addItem(item);
-}
-
-//-----------------------------------------------------------------------------
-
-void ChangeObjectWidget::onItemSelected(QListWidgetItem *item) {
-  QVariant display = item->data(Qt::UserRole);
-  if (display.isValid())
-    onTextSelected(display.toString());
-  else
-    onTextSelected(item->text());
 }
 
 //=============================================================================
@@ -468,10 +444,10 @@ void ChangeObjectParent::refresh() {
   std::list<TStageObject *> children = currentObject->getChildren();
   TStageObjectTree *tree             = xsh->getStageObjectTree();
   int objectCount                    = tree->getStageObjectCount();
-  QList<QString> pegbarListID, pegbarListTr;
-  QList<QString> columnListID, columnListTr;
+  QList<TStageObjectId> pegbarListID, columnListID;
+  QList<QString> pegbarListTr, columnListTr;
   QList<QColor> pegbarListColor, columnListColor;
-  QString currentText;
+  TStageObjectId currentId;
   QString theLongestTxt;
   int i;
   for (i = 0; i < objectCount; i++) {
@@ -485,7 +461,7 @@ void ChangeObjectParent::refresh() {
                             xsh->getStageObject(id)) != children.end());
     if (id == currentObjectId || found) continue;
 
-    QString newTextID = QString::fromStdString(id.toString());
+    TStageObjectId newTextID = id;
     QString newTextTr;
     if (tree->getStageObject(i)->hasSpecifiedName())
       newTextTr = QString::fromStdString(tree->getStageObject(i)->getName());
@@ -510,7 +486,7 @@ void ChangeObjectParent::refresh() {
     } else
       continue;
 
-    if (id == parentId) currentText = newTextID;
+    if (id == parentId) currentId = newTextID;
     if (newTextTr.length() > theLongestTxt.length()) theLongestTxt = newTextTr;
     if (id.isColumn()) {
       columnListID.append(newTextID);
@@ -528,7 +504,7 @@ void ChangeObjectParent::refresh() {
     addText(pegbarListID.at(i), pegbarListTr.at(i), pegbarListColor.at(i));
 
   m_width = fontMetrics().width(theLongestTxt) + 32;
-  selectCurrent(currentText);
+  selectCurrent(currentId);
 }
 
 //-----------------------------------------------------------------------------
@@ -542,42 +518,20 @@ QString ChangeObjectParent::getNameTr(const TStageObjectId id) {
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectParent::onTextSelected(const QString &text) {
+void ChangeObjectParent::onItemSelected(QListWidgetItem *item) {
   assert(m_xsheetHandle);
   assert(m_objectHandle);
-  if (text.isEmpty()) {
-    hide();
-    return;
-  }
-  bool isPegbar = false;
-  if (text.startsWith("Peg")) isPegbar = true;
-  bool isCamera = false;
-  if (text.startsWith("Cam")) isCamera = true;
-  bool isTable = false;
-  if (text == "Table") isTable = true;
-  QString number = text;
-  number.remove(0, 3);
-  // Remove names from the index
-  int spaceIndex = number.indexOf(" ");
-  if (spaceIndex > -1) number.remove(spaceIndex, 1000);
-  int index = number.toInt() - 1;
-  if (!isTable && index < 0) {
-    hide();
-    return;
-  }
+
+  QVariant data = item->data(Qt::UserRole);
+  if (!data.isValid()) return;
+
+  TStageObjectId newStageObjectId;
+  newStageObjectId.setCode(data.toUInt());
+
   TXsheet *xsh                   = m_xsheetHandle->getXsheet();
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   TStageObjectId currentParentId =
       xsh->getStageObject(currentObjectId)->getParent();
-  TStageObjectId newStageObjectId;
-  if (isPegbar)
-    newStageObjectId = TStageObjectId::PegbarId(index);
-  else if (isCamera)
-    newStageObjectId = TStageObjectId::CameraId(index);
-  else if (isTable)
-    newStageObjectId = TStageObjectId::TableId;
-  else
-    newStageObjectId = TStageObjectId::ColumnId(index);
 
   if (newStageObjectId == currentObjectId) return;
 
@@ -594,6 +548,22 @@ void ChangeObjectParent::onTextSelected(const QString &text) {
   hide();
   m_objectHandle->notifyObjectIdChanged(false);
   m_xsheetHandle->notifyXsheetChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectParent::selectCurrent(const TStageObjectId &id) {
+  clearSelection();
+  int numRows = count();
+  for (int row = 0; row < numRows; row++) {
+    QListWidgetItem *it = item(row);
+    QVariant display    = it->data(Qt::UserRole);
+    if (!display.isValid()) continue;
+    if (id.getCode() == display.toUInt()) {
+      setCurrentItem(it);
+      return;
+    }
+  }
 }
 
 //=============================================================================
@@ -643,9 +613,10 @@ void ChangeObjectHandle::refresh() {
 
 //-----------------------------------------------------------------------------
 
-void ChangeObjectHandle::onTextSelected(const QString &text) {
+void ChangeObjectHandle::onItemSelected(QListWidgetItem *item) {
   assert(m_xsheetHandle);
   assert(m_objectHandle);
+  QString text                   = item->text();
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   QString handle                 = text;
   if (text.toInt() != 0) handle = QString("H") + handle;
@@ -656,6 +627,20 @@ void ChangeObjectHandle::onTextSelected(const QString &text) {
   hide();
   m_objectHandle->notifyObjectIdChanged(false);
   m_xsheetHandle->notifyXsheetChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+void ChangeObjectHandle::selectCurrent(const QString &text) {
+  clearSelection();
+  int numRows = count();
+  for (int row = 0; row < numRows; row++) {
+    QListWidgetItem *it = item(row);
+    if (text == it->text()) {
+      setCurrentItem(it);
+      return;
+    }
+  }
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -93,16 +93,14 @@ protected:
   void wheelEvent(QWheelEvent *event) override;
   void focusOutEvent(QFocusEvent *e) override;
   void focusInEvent(QFocusEvent *e) override {}
-  void selectCurrent(const QString &text);
 
   void addText(const QString &text, const QString &display);
   void addText(const QString &text, const QColor &textColor);
-  void addText(const QString &text, const QString &display,
+  void addText(const TStageObjectId &id, const QString &display,
                const QColor &identColor);
-  virtual void onTextSelected(const QString &) = 0;
 
 protected slots:
-  void onItemSelected(QListWidgetItem *);
+  virtual void onItemSelected(QListWidgetItem *) = 0;
 };
 
 //=============================================================================
@@ -119,9 +117,10 @@ public:
   void refresh() override;
 
   static QString getNameTr(const TStageObjectId id);
+  void selectCurrent(const TStageObjectId &id);
 
 protected slots:
-  void onTextSelected(const QString &) override;
+  void onItemSelected(QListWidgetItem *) override;
 };
 
 //=============================================================================
@@ -136,9 +135,10 @@ public:
   ~ChangeObjectHandle();
 
   void refresh() override;
+  void selectCurrent(const QString &text);
 
 protected slots:
-  void onTextSelected(const QString &) override;
+  void onItemSelected(QListWidgetItem *) override;
 };
 
 //=============================================================================


### PR DESCRIPTION
This PR fixes #4365 .
Changed the field to directly keep `TStageObjectId` (which is actually unsigned int) as an item data instead of the text for it.