### PR TITLE
Camera capture: Subcamera preset feature

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -172,9 +172,9 @@ public:
     m_applicationFullName = m_version.getAppName() + " " + m_applicationVersion;
     if (m_version.hasAppNote())
       m_applicationFullName += " " + m_version.getAppNote();
-      
-    m_moduleName          = m_version.getAppName();
-    m_rootVarName         = toUpper(m_version.getAppName()) + "ROOT";
+
+    m_moduleName  = m_version.getAppName();
+    m_rootVarName = toUpper(m_version.getAppName()) + "ROOT";
 #ifdef _WIN32
     // from v1.3, registry root is moved to SOFTWARE\\OpenToonz\\OpenToonz
     m_registryRoot =
@@ -694,8 +694,7 @@ std::string toString2(T value) {
 template <>
 std::string toString2(TRect value) {
   std::ostringstream ss;
-  ss << value.x0 << " " << value.y0 << " " << value.x1 << " " << value.y1
-     << '\0';
+  ss << value.x0 << " " << value.y0 << " " << value.x1 << " " << value.y1;
   return ss.str();
 }
 

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -646,9 +646,9 @@ void MyVideoWidget::mouseMoveEvent(QMouseEvent* event) {
 
     if (m_activeSubHandle == HandleFrame) {
       clampPoint(offset, -m_preSubCameraRect.left(),
-                 camSize.width() - m_preSubCameraRect.right(),
+                 camSize.width() - m_preSubCameraRect.right() - 1,
                  -m_preSubCameraRect.top(),
-                 camSize.height() - m_preSubCameraRect.bottom());
+                 camSize.height() - m_preSubCameraRect.bottom() - 1);
       m_subCameraRect = m_preSubCameraRect.translated(offset);
     } else {
       if (m_activeSubHandle == HandleTopLeft ||
@@ -661,7 +661,7 @@ void MyVideoWidget::mouseMoveEvent(QMouseEvent* event) {
                  m_activeSubHandle == HandleBottomRight ||
                  m_activeSubHandle == HandleRight) {
         clampVal(offset.rx(), -m_preSubCameraRect.width() + minimumSize,
-                 camSize.width() - m_preSubCameraRect.right());
+                 camSize.width() - m_preSubCameraRect.right() - 1);
         m_subCameraRect.setRight(m_preSubCameraRect.right() + offset.x());
       }
 
@@ -675,7 +675,7 @@ void MyVideoWidget::mouseMoveEvent(QMouseEvent* event) {
                  m_activeSubHandle == HandleBottomLeft ||
                  m_activeSubHandle == HandleBottom) {
         clampVal(offset.ry(), -m_preSubCameraRect.height() + minimumSize,
-                 camSize.height() - m_preSubCameraRect.bottom());
+                 camSize.height() - m_preSubCameraRect.bottom() - 1);
         m_subCameraRect.setBottom(m_preSubCameraRect.bottom() + offset.y());
       }
     }
@@ -1299,7 +1299,7 @@ bool strToSubCamera(const QString& str, QRect& subCamera, double& dpi) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
   QStringList values = str.split(',', Qt::SkipEmptyParts);
 #else
-  QStringList values = str.split(',', QString::SkipEmptyParts);
+  QStringList values         = str.split(',', QString::SkipEmptyParts);
 #endif
   if (values.count() != 4 && values.count() != 5) return false;
   subCamera = QRect(values[0].toInt(), values[1].toInt(), values[2].toInt(),

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -14,6 +14,7 @@
 #include <QAbstractVideoSurface>
 #include <QRunnable>
 #include <QLineEdit>
+#include <QPushButton>
 
 // forward decl.
 class QCamera;
@@ -22,7 +23,6 @@ class QCameraImageCapture;
 class QComboBox;
 class QSlider;
 class QCheckBox;
-class QPushButton;
 class QVideoFrame;
 class QTimer;
 class QIntValidator;
@@ -93,7 +93,7 @@ public:
     repaint();
   }
 
-  void setSubCameraSize(QSize size);
+  void setSubCameraRect(QRect rect);
   QRect subCameraRect() { return m_subCameraRect; }
 
   void computeTransform(QSize imgSize);
@@ -112,7 +112,7 @@ protected slots:
 signals:
   void startCamera();
   void stopCamera();
-  void subCameraResized(bool isDragging);
+  void subCameraChanged(bool isDragging);
 };
 
 //=============================================================================
@@ -220,6 +220,33 @@ protected slots:
 };
 
 //=============================================================================
+// SubCameraButton
+// button with context menu to open preset
+//-----------------------------------------------------------------------------
+
+class SubCameraButton : public QPushButton {
+  Q_OBJECT
+  std::unique_ptr<QSettings> m_settings;
+
+  QSize m_curResolution;
+  QRect m_curSubCamera;
+
+public:
+  SubCameraButton(const QString& text, QWidget* parent = 0);
+  void setCurResolution(const QSize& size) { m_curResolution = size; }
+  void setCurSubCamera(const QRect& rect) { m_curSubCamera = rect; }
+
+protected:
+  void contextMenuEvent(QContextMenuEvent* event) override;
+protected slots:
+  void onSubCameraAct();
+  void onSaveSubCamera();
+  void onDeletePreset();
+signals:
+  void subCameraPresetSelected(const QRect&);
+};
+
+//=============================================================================
 // PencilTestPopup
 //-----------------------------------------------------------------------------
 
@@ -262,8 +289,9 @@ class PencilTestPopup : public DVGui::Dialog {
 
   QToolButton* m_previousLevelButton;
 
-  QPushButton* m_subcameraButton;
+  SubCameraButton* m_subcameraButton;
   DVGui::IntLineEdit *m_subWidthFld, *m_subHeightFld;
+  DVGui::IntLineEdit *m_subXPosFld, *m_subYPosFld;
   QSize m_allowedCameraSize;
 
   bool m_captureWhiteBGCue;
@@ -353,8 +381,9 @@ protected slots:
   void onSceneSwitched();
 
   void onSubCameraToggled(bool);
-  void onSubCameraResized(bool isDragging);
-  void onSubCameraSizeEdited();
+  void onSubCameraChanged(bool isDragging);
+  void onSubCameraRectEdited();
+  void onSubCameraPresetSelected(const QRect&);
 
   void onTimeout();
 

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -27,9 +27,9 @@ class QVideoFrame;
 class QTimer;
 class QIntValidator;
 class QRegExpValidator;
-class QPushButton;
 class QLabel;
 class QGroupBox;
+class QRadioButton;
 #ifdef MACOSX
 class QCameraViewfinder;
 #endif
@@ -230,11 +230,13 @@ class SubCameraButton : public QPushButton {
 
   QSize m_curResolution;
   QRect m_curSubCamera;
+  double m_currentDpi;
 
 public:
   SubCameraButton(const QString& text, QWidget* parent = 0);
   void setCurResolution(const QSize& size) { m_curResolution = size; }
   void setCurSubCamera(const QRect& rect) { m_curSubCamera = rect; }
+  void setCurDpi(const double& dpi) { m_currentDpi = dpi; }
 
 protected:
   void contextMenuEvent(QContextMenuEvent* event) override;
@@ -243,7 +245,7 @@ protected slots:
   void onSaveSubCamera();
   void onDeletePreset();
 signals:
-  void subCameraPresetSelected(const QRect&);
+  void subCameraPresetSelected(const QRect&, const double dpi);
 };
 
 //=============================================================================
@@ -323,6 +325,7 @@ class PencilTestPopup : public DVGui::Dialog {
   double m_customDpi;
   QWidget* m_dpiMenuWidget;
   QPushButton* m_dpiBtn;
+  QRadioButton *m_autoDpiRadioBtn, *m_customDpiRadioBtn;
   QLineEdit* m_customDpiField;
 
   void captureCalibrationRefImage(cv::Mat& procImage);
@@ -383,7 +386,7 @@ protected slots:
   void onSubCameraToggled(bool);
   void onSubCameraChanged(bool isDragging);
   void onSubCameraRectEdited();
-  void onSubCameraPresetSelected(const QRect&);
+  void onSubCameraPresetSelected(const QRect&, const double);
 
   void onTimeout();
 


### PR DESCRIPTION
**Please review & merge this PR after releasing V1.6**
![subcamera_preset](https://user-images.githubusercontent.com/17974955/160370009-6ebd8cc5-9561-4fca-ad8d-3eb89de3c413.png)

This PR will enhance the Subcamera option in the Camera Capture popup as follows:
- Added the position (X and Y) fields.
- Enabled to save / load preset from the context menu of the Subcamera button. 
    - The presets will be saved in `$TOONZPROFILES/layouts/settings.username/camera_capture_subcamera.ini` .

**EDIT**
- Now the preset will save not only the subcamera geometry but also the dpi as well.
- Subcamera geometry are now stored in the user .env file and it reproduces the previous position & size on launch.
