### PR TITLE
Fix missing mouse release

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -509,6 +509,14 @@ void SceneViewer::mouseMoveEvent(QMouseEvent *event) {
 void SceneViewer::onMove(const TMouseEvent &event) {
   if (m_freezedStatus != NO_FREEZED) return;
 
+  // in case mouseReleaseEvent is not called, finish the action for the previous
+  // button first.
+  if (m_mouseButton != Qt::NoButton && event.m_buttons == Qt::NoButton) {
+    TMouseEvent preEvent = event;
+    preEvent.m_button    = m_mouseButton;
+    onRelease(preEvent);
+  }
+
   int devPixRatio = getDevPixRatio();
   QPointF curPos  = event.mousePos() * devPixRatio;
   bool cursorSet  = false;


### PR DESCRIPTION
This PR fixes #4355 .
When the menu opens with the left click, `mouseReleaseEvent` is not called properly which causes OT to misunderstand that the mouse button is not released.

I added a check in `SceneViewer::onMove()` if the mouse button is actually pressed.