### PR TITLE
Fix QTabWidget Pane Border in Stylesheets

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -98,6 +98,7 @@ PaletteViewer QToolBar QToolButton:pressed {
    Component: Frames
 ----------------------------------------------------------------------------- */
 .frame,
+QTabWidget::Pane,
 .GroupBox,
 #LoadLevelFrame,
 #PsdSettingsGroupBox,
@@ -666,12 +667,16 @@ DvScrollWidget {
   qproperty-BottomAboveLineColor: #323435;
   qproperty-BottomBelowLineColor: #262728;
 }
-QTabBar {
-  background-color: #323435;
+QTabWidget::Pane {
+  position: absolute;
+  top: -1;
 }
 /* -----------------------------------------------------------------------------
    Tabs
 ----------------------------------------------------------------------------- */
+QTabBar {
+  background-color: #323435;
+}
 QTabBar QToolButton {
   /* Scroll buttons */
   margin: 0;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -98,6 +98,7 @@ PaletteViewer QToolBar QToolButton:pressed {
    Component: Frames
 ----------------------------------------------------------------------------- */
 .frame,
+QTabWidget::Pane,
 .GroupBox,
 #LoadLevelFrame,
 #PsdSettingsGroupBox,
@@ -666,12 +667,16 @@ DvScrollWidget {
   qproperty-BottomAboveLineColor: #262626;
   qproperty-BottomBelowLineColor: #111111;
 }
-QTabBar {
-  background-color: #262626;
+QTabWidget::Pane {
+  position: absolute;
+  top: -1;
 }
 /* -----------------------------------------------------------------------------
    Tabs
 ----------------------------------------------------------------------------- */
+QTabBar {
+  background-color: #262626;
+}
 QTabBar QToolButton {
   /* Scroll buttons */
   margin: 0;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -98,6 +98,7 @@ PaletteViewer QToolBar QToolButton:pressed {
    Component: Frames
 ----------------------------------------------------------------------------- */
 .frame,
+QTabWidget::Pane,
 .GroupBox,
 #LoadLevelFrame,
 #PsdSettingsGroupBox,
@@ -666,12 +667,16 @@ DvScrollWidget {
   qproperty-BottomAboveLineColor: #393939;
   qproperty-BottomBelowLineColor: #2c2c2c;
 }
-QTabBar {
-  background-color: #393939;
+QTabWidget::Pane {
+  position: absolute;
+  top: -1;
 }
 /* -----------------------------------------------------------------------------
    Tabs
 ----------------------------------------------------------------------------- */
+QTabBar {
+  background-color: #393939;
+}
 QTabBar QToolButton {
   /* Scroll buttons */
   margin: 0;

--- a/stuff/config/qss/Default/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Default/less/layouts/mainwindow.less
@@ -523,8 +523,10 @@ DvScrollWidget {
   .tab-container;
 }
 
-QTabBar {
-  background-color: @tabbar-bg-color;
+QTabWidget::Pane {
+  position: absolute;
+  top: -1; // move border under tabs
+  &:extend(.frame all); // frame border
 }
 
 /* -----------------------------------------------------------------------------
@@ -532,6 +534,7 @@ QTabBar {
 ----------------------------------------------------------------------------- */
 
 QTabBar {
+  background-color: @tabbar-bg-color;
   &::tab {
     &:extend(.tab-flat all);
   }

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -98,6 +98,7 @@ PaletteViewer QToolBar QToolButton:pressed {
    Component: Frames
 ----------------------------------------------------------------------------- */
 .frame,
+QTabWidget::Pane,
 .GroupBox,
 #LoadLevelFrame,
 #PsdSettingsGroupBox,
@@ -666,12 +667,16 @@ DvScrollWidget {
   qproperty-BottomAboveLineColor: #c4c4c4;
   qproperty-BottomBelowLineColor: #a8a8a8;
 }
-QTabBar {
-  background-color: #c4c4c4;
+QTabWidget::Pane {
+  position: absolute;
+  top: -1;
 }
 /* -----------------------------------------------------------------------------
    Tabs
 ----------------------------------------------------------------------------- */
+QTabBar {
+  background-color: #c4c4c4;
+}
 QTabBar QToolButton {
   /* Scroll buttons */
   margin: 0;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -98,6 +98,7 @@ PaletteViewer QToolBar QToolButton:pressed {
    Component: Frames
 ----------------------------------------------------------------------------- */
 .frame,
+QTabWidget::Pane,
 .GroupBox,
 #LoadLevelFrame,
 #PsdSettingsGroupBox,
@@ -666,12 +667,16 @@ DvScrollWidget {
   qproperty-BottomAboveLineColor: #717171;
   qproperty-BottomBelowLineColor: #5a5a5a;
 }
-QTabBar {
-  background-color: #717171;
+QTabWidget::Pane {
+  position: absolute;
+  top: -1;
 }
 /* -----------------------------------------------------------------------------
    Tabs
 ----------------------------------------------------------------------------- */
+QTabBar {
+  background-color: #717171;
+}
 QTabBar QToolButton {
   /* Scroll buttons */
   margin: 0;


### PR DESCRIPTION
Seen in the New Project window popup, currently has no style, this adds a style. It's not perfect but nicer than before.

![OTfix](https://user-images.githubusercontent.com/19820721/162084211-7f609686-5934-4055-bdc7-fb0430620f3e.png)

