### PR TITLE
Make style editor textfield expandable

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1512,7 +1512,7 @@ QStatusBar #StatusBarLabel {
   padding: 3 2 8 3;
 }
 #StyleEditor #bottomWidget QPushButton {
-  padding: 3 5;
+  padding: 13 5;
 }
 #HexagonalColorWheel {
   qproperty-BGColor: #414345;
@@ -1547,6 +1547,7 @@ QStatusBar #StatusBarLabel {
 }
 #PlainColorPageParts QLineEdit {
   max-width: 35;
+  height: 100%;
 }
 /* -----------------------------------------------------------------------------
    Palette Viewer / Studio Palette

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1512,7 +1512,7 @@ QStatusBar #StatusBarLabel {
   padding: 3 2 8 3;
 }
 #StyleEditor #bottomWidget QPushButton {
-  padding: 3 5;
+  padding: 13 5;
 }
 #HexagonalColorWheel {
   qproperty-BGColor: #303030;
@@ -1547,6 +1547,7 @@ QStatusBar #StatusBarLabel {
 }
 #PlainColorPageParts QLineEdit {
   max-width: 35;
+  height: 100%;
 }
 /* -----------------------------------------------------------------------------
    Palette Viewer / Studio Palette

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1512,7 +1512,7 @@ QStatusBar #StatusBarLabel {
   padding: 3 2 8 3;
 }
 #StyleEditor #bottomWidget QPushButton {
-  padding: 3 5;
+  padding: 13 5;
 }
 #HexagonalColorWheel {
   qproperty-BGColor: #484848;
@@ -1547,6 +1547,7 @@ QStatusBar #StatusBarLabel {
 }
 #PlainColorPageParts QLineEdit {
   max-width: 35;
+  height: 100%;
 }
 /* -----------------------------------------------------------------------------
    Palette Viewer / Studio Palette

--- a/stuff/config/qss/Default/less/layouts/palette.less
+++ b/stuff/config/qss/Default/less/layouts/palette.less
@@ -7,7 +7,7 @@
     border-top: 1 solid @accent;
     padding: 3 2 8 3;
     & QPushButton {
-      padding: 3 5;
+      padding: 13 5;
     }
   }
 }
@@ -60,6 +60,7 @@
   border-bottom: 1 solid @accent;
   & QLineEdit {
     max-width: 35;
+    height: 100%;
   }
 }
 

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1512,7 +1512,7 @@ QStatusBar #StatusBarLabel {
   padding: 3 2 8 3;
 }
 #StyleEditor #bottomWidget QPushButton {
-  padding: 3 5;
+  padding: 13 5;
 }
 #HexagonalColorWheel {
   qproperty-BGColor: #DBDBDB;
@@ -1547,6 +1547,7 @@ QStatusBar #StatusBarLabel {
 }
 #PlainColorPageParts QLineEdit {
   max-width: 35;
+  height: 100%;
 }
 /* -----------------------------------------------------------------------------
    Palette Viewer / Studio Palette

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1512,7 +1512,7 @@ QStatusBar #StatusBarLabel {
   padding: 3 2 8 3;
 }
 #StyleEditor #bottomWidget QPushButton {
-  padding: 3 5;
+  padding: 13 5;
 }
 #HexagonalColorWheel {
   qproperty-BGColor: #808080;
@@ -1547,6 +1547,7 @@ QStatusBar #StatusBarLabel {
 }
 #PlainColorPageParts QLineEdit {
   max-width: 35;
+  height: 100%;
 }
 /* -----------------------------------------------------------------------------
    Palette Viewer / Studio Palette


### PR DESCRIPTION
This makes the textfield in the style editor expandable like the sliders.

I also increased the padding on the buttons on the bottom for extra height since there's a lot of unused space. I think it was like this before and honestly can't recall why they were shrunk. Let me know if there's any problem.

Basically, I did this to increase the 'hit box' when using a small screen, like Cintiq 16 (we mostly use those now without second displays). Since we all don't work in-house, trying to communicate how to change the sizes using custom stylesheet function is not easy to communicate.

![Before_StyleEditor](https://user-images.githubusercontent.com/19820721/163482470-3ec8a21e-59cb-4d90-ac32-ad75ef738efd.png) ![After_StyleEditor](https://user-images.githubusercontent.com/19820721/163482477-c1b3c84d-8ce3-47f5-8be5-1617875bb73d.png)

