### PR TITLE
Fix xsheet pdf export tick-marking bug

### DIFF
--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -1430,21 +1430,20 @@ void XSheetPDFTemplate::drawXsheetContents(QPainter& painter, int framePage,
       TXshCell cell = column->getCell(f);
       if (cell.m_level != level) cell.m_level = nullptr;
 
-      int markId = column->getCellMark(r);
+      int markId = column->getCellMark(f);
 
+      // draw tick mark
+      if ((prevCell == cell || cell.isEmpty()) && markId >= 0 &&
+          (m_info.tick1MarkId == markId || m_info.tick2MarkId == markId)) {
+        if (m_info.tick1MarkId == markId)
+          drawTickMark(painter, m_cellRects[c][r], m_info.tick1MarkType);
+        else
+          drawTickMark(painter, m_cellRects[c][r], m_info.tick2MarkType);
+        drawCLFlag = checkContinuous(column, f, r);
+      }
       // cotinuous line
-      if (r != 0 && r != 72 && prevCell == cell) {
-        // draw tick mark
-        if (markId >= 0 &&
-            (m_info.tick1MarkId == markId || m_info.tick2MarkId == markId)) {
-          if (m_info.tick1MarkId == markId)
-            drawTickMark(painter, m_cellRects[c][r], m_info.tick1MarkType);
-          else
-            drawTickMark(painter, m_cellRects[c][r], m_info.tick2MarkType);
-          drawCLFlag = checkContinuous(column, f, r);
-        }
-
-        else if (drawCLFlag)
+      else if (r != 0 && r != 72 && prevCell == cell) {
+        if (drawCLFlag)
           drawContinuousLine(painter, m_cellRects[c][r], cell.isEmpty());
       }
       // draw cell


### PR DESCRIPTION
This PR fixes following problems in the `Export Xsheet to PDF` feature:
- If the pdf has more than one page, tick marks in the first page duplicately appear at the same positions in subsequent pages. (For instance, when using 3-seconds template, a tick mark at the frame 4 wrongly appears at the frame 76 in the second page as well.)
- The tick mark does not appear overriding the x-mark indicating the beginning of empty cells.