### PR TITLE
Patch Stylesheet (Tabs, Light Theme)

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -124,43 +124,51 @@ QGroupBox {
   qproperty-BottomBelowLineColor: #262728;
 }
 .tab-flat,
-QTabBar::tab {
+#TopBarTab::tab,
+#TabBarContainer QTabBar::tab {
   background-color: #323435;
   border-right: 1 solid #212223;
   border-bottom: 1 solid #262728;
+  border-top: 0;
+  border-left: 0;
+  border-radius: 0;
   color: #94969a;
   padding: 3 4 3 4;
+  margin: 0;
 }
 .tab-flat:hover,
-QTabBar::tab:hover {
+#TopBarTab::tab:hover,
+#TabBarContainer QTabBar::tab:hover {
   background-color: #3f4042;
   color: #94969a;
 }
 .tab-flat:selected,
-QTabBar::tab:selected {
+#TopBarTab::tab:selected,
+#TabBarContainer QTabBar::tab:selected {
   background-color: #414345;
   color: #fff;
   border-bottom-color: #414345;
 }
 .tab-flat:only-one,
-QTabBar::tab:only-one {
+#TopBarTab::tab:only-one,
+#TabBarContainer QTabBar::tab:only-one {
   margin: 0;
 }
-.tab-round {
+.tab-round,
+QTabBar::tab {
   background-color: #323435;
-  border-top: 1 solid #262728;
-  border-right: 1 solid #262728;
-  border-left: 1 solid #262728;
-  border-bottom: 1 solid #262728;
+  border: 1 solid #262728;
   color: #94969a;
   margin: 3 -1 0 0;
   padding: 2 7 1 7;
 }
-.tab-round:hover {
+.tab-round:hover,
+QTabBar::tab:hover {
   background-color: #3f4042;
   color: #94969a;
 }
-.tab-round:selected {
+.tab-round:selected,
+QTabBar::tab:selected {
   background-color: #414345;
   border-top-right-radius: 2;
   border-top-left-radius: 2;
@@ -169,15 +177,18 @@ QTabBar::tab:only-one {
   margin: 1 -1 -1 0;
   padding: 2 7 2 7;
 }
-.tab-round:only-one {
+.tab-round:only-one,
+QTabBar::tab:only-one {
   margin: 1 0 0 0;
   padding: 3 7 3 7;
 }
-.tab-round:last {
+.tab-round:last,
+QTabBar::tab:last {
   margin-right: 0;
   border-top-right-radius: 2;
 }
-.tab-round:first {
+.tab-round:first,
+QTabBar::tab:first {
   border-top-left-radius: 2;
 }
 /* -----------------------------------------------------------------------------
@@ -269,28 +280,18 @@ QMenuBar::item:pressed {
 #TopBarTab {
   margin: 0;
   padding: 0;
+  background-color: transparent;
 }
 #TopBarTab::tab {
-  background-color: #323435;
   border-top: 1 solid #212223;
-  border-right: 1 solid #212223;
-  color: #94969a;
   margin: 0 0 -1 0;
   padding: 2 8 3 8;
 }
-#TopBarTab::tab:hover {
-  background-color: #3f4042;
-  color: #94969a;
-}
 #TopBarTab::tab:selected {
   background-color: #5385a6;
-  color: #ffffff;
 }
 #TopBarTab::tab:first {
-  border-left: 1 solid #262728;
-}
-#TopBarTab::tab:last {
-  border-right: 1 solid #262728;
+  border-left: 1 solid #212223;
 }
 #TopBarTab QToolButton {
   border-left: 2 solid #262728;
@@ -660,22 +661,18 @@ DvScrollWidget {
   border-radius: 2;
 }
 /* -----------------------------------------------------------------------------
-   Tab Containers
+   Tabs
 ----------------------------------------------------------------------------- */
-#TabBarContainer {
-  background-color: #323435;
-  qproperty-BottomAboveLineColor: #323435;
-  qproperty-BottomBelowLineColor: #262728;
-}
 QTabWidget::Pane {
   position: absolute;
   top: -1;
+  margin: 0 3 3 3;
 }
-/* -----------------------------------------------------------------------------
-   Tabs
------------------------------------------------------------------------------ */
 QTabBar {
-  background-color: #323435;
+  background-color: transparent;
+}
+QTabBar::tab::first {
+  margin-left: 3px;
 }
 QTabBar QToolButton {
   /* Scroll buttons */
@@ -692,6 +689,11 @@ QTabBar QToolButton:pressed {
 }
 QTabBar QToolButton:disabled {
   color: rgba(214, 216, 221, 0.4);
+}
+#TabBarContainer {
+  background-color: #323435;
+  qproperty-BottomAboveLineColor: #323435;
+  qproperty-BottomBelowLineColor: #262728;
 }
 /* -----------------------------------------------------------------------------
    Item Tree
@@ -814,6 +816,20 @@ QListView {
   background-color: #4d5052;
   border-color: #414345;
   color: rgba(214, 216, 221, 0.4);
+}
+/* -----------------------------------------------------------------------------
+   QHeaderView
+----------------------------------------------------------------------------- */
+QHeaderView::section {
+  background-color: #353638;
+  border: 1 solid #262728;
+  padding-left: 4;
+  margin-left: -1;
+  margin-top: -1;
+}
+QTreeWidget {
+  background-color: #3c3e40;
+  border: 1 solid #262728;
 }
 /* -----------------------------------------------------------------------------
    Push Button

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -124,43 +124,51 @@ QGroupBox {
   qproperty-BottomBelowLineColor: #111111;
 }
 .tab-flat,
-QTabBar::tab {
+#TopBarTab::tab,
+#TabBarContainer QTabBar::tab {
   background-color: #262626;
   border-right: 1 solid #0c0c0c;
   border-bottom: 1 solid #111111;
+  border-top: 0;
+  border-left: 0;
+  border-radius: 0;
   color: #999999;
   padding: 3 4 3 4;
+  margin: 0;
 }
 .tab-flat:hover,
-QTabBar::tab:hover {
+#TopBarTab::tab:hover,
+#TabBarContainer QTabBar::tab:hover {
   background-color: #333333;
   color: #999999;
 }
 .tab-flat:selected,
-QTabBar::tab:selected {
+#TopBarTab::tab:selected,
+#TabBarContainer QTabBar::tab:selected {
   background-color: #303030;
   color: #fff;
   border-bottom-color: #303030;
 }
 .tab-flat:only-one,
-QTabBar::tab:only-one {
+#TopBarTab::tab:only-one,
+#TabBarContainer QTabBar::tab:only-one {
   margin: 0;
 }
-.tab-round {
+.tab-round,
+QTabBar::tab {
   background-color: #262626;
-  border-top: 1 solid #111111;
-  border-right: 1 solid #111111;
-  border-left: 1 solid #111111;
-  border-bottom: 1 solid #111111;
+  border: 1 solid #111111;
   color: #999999;
   margin: 3 -1 0 0;
   padding: 2 7 1 7;
 }
-.tab-round:hover {
+.tab-round:hover,
+QTabBar::tab:hover {
   background-color: #333333;
   color: #999999;
 }
-.tab-round:selected {
+.tab-round:selected,
+QTabBar::tab:selected {
   background-color: #303030;
   border-top-right-radius: 2;
   border-top-left-radius: 2;
@@ -169,15 +177,18 @@ QTabBar::tab:only-one {
   margin: 1 -1 -1 0;
   padding: 2 7 2 7;
 }
-.tab-round:only-one {
+.tab-round:only-one,
+QTabBar::tab:only-one {
   margin: 1 0 0 0;
   padding: 3 7 3 7;
 }
-.tab-round:last {
+.tab-round:last,
+QTabBar::tab:last {
   margin-right: 0;
   border-top-right-radius: 2;
 }
-.tab-round:first {
+.tab-round:first,
+QTabBar::tab:first {
   border-top-left-radius: 2;
 }
 /* -----------------------------------------------------------------------------
@@ -269,28 +280,18 @@ QMenuBar::item:pressed {
 #TopBarTab {
   margin: 0;
   padding: 0;
+  background-color: transparent;
 }
 #TopBarTab::tab {
-  background-color: #262626;
   border-top: 1 solid #0c0c0c;
-  border-right: 1 solid #0c0c0c;
-  color: #999999;
   margin: 0 0 -1 0;
   padding: 2 8 3 8;
 }
-#TopBarTab::tab:hover {
-  background-color: #333333;
-  color: #999999;
-}
 #TopBarTab::tab:selected {
   background-color: #5385a6;
-  color: #ffffff;
 }
 #TopBarTab::tab:first {
-  border-left: 1 solid #111111;
-}
-#TopBarTab::tab:last {
-  border-right: 1 solid #111111;
+  border-left: 1 solid #0c0c0c;
 }
 #TopBarTab QToolButton {
   border-left: 2 solid #111111;
@@ -660,22 +661,18 @@ DvScrollWidget {
   border-radius: 2;
 }
 /* -----------------------------------------------------------------------------
-   Tab Containers
+   Tabs
 ----------------------------------------------------------------------------- */
-#TabBarContainer {
-  background-color: #262626;
-  qproperty-BottomAboveLineColor: #262626;
-  qproperty-BottomBelowLineColor: #111111;
-}
 QTabWidget::Pane {
   position: absolute;
   top: -1;
+  margin: 0 3 3 3;
 }
-/* -----------------------------------------------------------------------------
-   Tabs
------------------------------------------------------------------------------ */
 QTabBar {
-  background-color: #262626;
+  background-color: transparent;
+}
+QTabBar::tab::first {
+  margin-left: 3px;
 }
 QTabBar QToolButton {
   /* Scroll buttons */
@@ -692,6 +689,11 @@ QTabBar QToolButton:pressed {
 }
 QTabBar QToolButton:disabled {
   color: rgba(230, 230, 230, 0.4);
+}
+#TabBarContainer {
+  background-color: #262626;
+  qproperty-BottomAboveLineColor: #262626;
+  qproperty-BottomBelowLineColor: #111111;
 }
 /* -----------------------------------------------------------------------------
    Item Tree
@@ -814,6 +816,20 @@ QListView {
   background-color: #3d3d3d;
   border-color: #303030;
   color: rgba(230, 230, 230, 0.4);
+}
+/* -----------------------------------------------------------------------------
+   QHeaderView
+----------------------------------------------------------------------------- */
+QHeaderView::section {
+  background-color: #232323;
+  border: 1 solid #111111;
+  padding-left: 4;
+  margin-left: -1;
+  margin-top: -1;
+}
+QTreeWidget {
+  background-color: #383838;
+  border: 1 solid #111111;
 }
 /* -----------------------------------------------------------------------------
    Push Button

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -124,43 +124,51 @@ QGroupBox {
   qproperty-BottomBelowLineColor: #2c2c2c;
 }
 .tab-flat,
-QTabBar::tab {
+#TopBarTab::tab,
+#TabBarContainer QTabBar::tab {
   background-color: #393939;
   border-right: 1 solid #272727;
   border-bottom: 1 solid #2c2c2c;
+  border-top: 0;
+  border-left: 0;
+  border-radius: 0;
   color: #a1a1a1;
   padding: 3 4 3 4;
+  margin: 0;
 }
 .tab-flat:hover,
-QTabBar::tab:hover {
+#TopBarTab::tab:hover,
+#TabBarContainer QTabBar::tab:hover {
   background-color: #454545;
   color: #a1a1a1;
 }
 .tab-flat:selected,
-QTabBar::tab:selected {
+#TopBarTab::tab:selected,
+#TabBarContainer QTabBar::tab:selected {
   background-color: #484848;
   color: #fff;
   border-bottom-color: #484848;
 }
 .tab-flat:only-one,
-QTabBar::tab:only-one {
+#TopBarTab::tab:only-one,
+#TabBarContainer QTabBar::tab:only-one {
   margin: 0;
 }
-.tab-round {
+.tab-round,
+QTabBar::tab {
   background-color: #393939;
-  border-top: 1 solid #2c2c2c;
-  border-right: 1 solid #2c2c2c;
-  border-left: 1 solid #2c2c2c;
-  border-bottom: 1 solid #2c2c2c;
+  border: 1 solid #2c2c2c;
   color: #a1a1a1;
   margin: 3 -1 0 0;
   padding: 2 7 1 7;
 }
-.tab-round:hover {
+.tab-round:hover,
+QTabBar::tab:hover {
   background-color: #454545;
   color: #a1a1a1;
 }
-.tab-round:selected {
+.tab-round:selected,
+QTabBar::tab:selected {
   background-color: #484848;
   border-top-right-radius: 2;
   border-top-left-radius: 2;
@@ -169,15 +177,18 @@ QTabBar::tab:only-one {
   margin: 1 -1 -1 0;
   padding: 2 7 2 7;
 }
-.tab-round:only-one {
+.tab-round:only-one,
+QTabBar::tab:only-one {
   margin: 1 0 0 0;
   padding: 3 7 3 7;
 }
-.tab-round:last {
+.tab-round:last,
+QTabBar::tab:last {
   margin-right: 0;
   border-top-right-radius: 2;
 }
-.tab-round:first {
+.tab-round:first,
+QTabBar::tab:first {
   border-top-left-radius: 2;
 }
 /* -----------------------------------------------------------------------------
@@ -269,28 +280,18 @@ QMenuBar::item:pressed {
 #TopBarTab {
   margin: 0;
   padding: 0;
+  background-color: transparent;
 }
 #TopBarTab::tab {
-  background-color: #393939;
   border-top: 1 solid #272727;
-  border-right: 1 solid #272727;
-  color: #a1a1a1;
   margin: 0 0 -1 0;
   padding: 2 8 3 8;
 }
-#TopBarTab::tab:hover {
-  background-color: #454545;
-  color: #a1a1a1;
-}
 #TopBarTab::tab:selected {
   background-color: #5385a6;
-  color: #ffffff;
 }
 #TopBarTab::tab:first {
-  border-left: 1 solid #2c2c2c;
-}
-#TopBarTab::tab:last {
-  border-right: 1 solid #2c2c2c;
+  border-left: 1 solid #272727;
 }
 #TopBarTab QToolButton {
   border-left: 2 solid #2c2c2c;
@@ -660,22 +661,18 @@ DvScrollWidget {
   border-radius: 2;
 }
 /* -----------------------------------------------------------------------------
-   Tab Containers
+   Tabs
 ----------------------------------------------------------------------------- */
-#TabBarContainer {
-  background-color: #393939;
-  qproperty-BottomAboveLineColor: #393939;
-  qproperty-BottomBelowLineColor: #2c2c2c;
-}
 QTabWidget::Pane {
   position: absolute;
   top: -1;
+  margin: 0 3 3 3;
 }
-/* -----------------------------------------------------------------------------
-   Tabs
------------------------------------------------------------------------------ */
 QTabBar {
-  background-color: #393939;
+  background-color: transparent;
+}
+QTabBar::tab::first {
+  margin-left: 3px;
 }
 QTabBar QToolButton {
   /* Scroll buttons */
@@ -692,6 +689,11 @@ QTabBar QToolButton:pressed {
 }
 QTabBar QToolButton:disabled {
   color: rgba(230, 230, 230, 0.4);
+}
+#TabBarContainer {
+  background-color: #393939;
+  qproperty-BottomAboveLineColor: #393939;
+  qproperty-BottomBelowLineColor: #2c2c2c;
 }
 /* -----------------------------------------------------------------------------
    Item Tree
@@ -814,6 +816,20 @@ QListView {
   background-color: #555555;
   border-color: #484848;
   color: rgba(230, 230, 230, 0.4);
+}
+/* -----------------------------------------------------------------------------
+   QHeaderView
+----------------------------------------------------------------------------- */
+QHeaderView::section {
+  background-color: #3b3b3b;
+  border: 1 solid #2c2c2c;
+  padding-left: 4;
+  margin-left: -1;
+  margin-top: -1;
+}
+QTreeWidget {
+  background-color: #434343;
+  border: 1 solid #2c2c2c;
 }
 /* -----------------------------------------------------------------------------
    Push Button

--- a/stuff/config/qss/Default/less/components/tabs.less
+++ b/stuff/config/qss/Default/less/components/tabs.less
@@ -15,12 +15,15 @@
 // -----------------------------------------------------------------------------
 
 .tab-flat {
-  @horizontal-padding: 4;
   background-color: @tab-bg-color;
   border-right: 1 solid @tab-border-color;
   border-bottom: 1 solid @accent;
+  border-top: 0;
+  border-left: 0;
+  border-radius: 0;
   color: @tab-text-color;
-  padding: 3 @horizontal-padding 3 @horizontal-padding;
+  padding: 3 4 3 4;
+  margin: 0;
   &:hover {
     background-color: @tab-bg-color-hover;
     color: @tab-text-color-hover;
@@ -41,10 +44,7 @@
 .tab-round {
   @horizontal-padding: 7;
   background-color: @tab-bg-color;
-  border-top: 1 solid @accent;
-  border-right: 1 solid @accent;
-  border-left: 1 solid @accent;
-  border-bottom: 1 solid @accent;
+  border: 1 solid @accent;
   color: @tab-text-color;
   margin: 3 -1 0 0;
   padding: 2 @horizontal-padding 1 @horizontal-padding;

--- a/stuff/config/qss/Default/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Default/less/layouts/mainwindow.less
@@ -97,26 +97,17 @@ QMenuBar {
 #TopBarTab {
   margin: 0;
   padding: 0;
+  background-color: transparent;
   &::tab {
-    background-color: @rooms-tab-bg-color;
+    &:extend(.tab-flat all);
     border-top: 1 solid @tab-border-color;
-    border-right: 1 solid @tab-border-color;
-    color: @rooms-tab-text-color;
     margin: 0 0 -1 0;
     padding: 2 8 3 8;
-    &:hover {
-      background-color: @rooms-tab-bg-color-hover;
-      color: @tab-text-color-hover;
-    }
     &:selected {
-      background-color: @rooms-tab-bg-color-selected;
-      color: @rooms-tab-text-color-selected;
+      background-color: @hl-bg-color;
     }
     &:first {
-      border-left: 1 solid @accent;
-    }
-    &:last {
-      border-right: 1 solid @accent;
+      border-left: 1 solid @tab-border-color;
     }
   }
   & QToolButton {
@@ -516,27 +507,23 @@ DvScrollWidget {
 }
 
 /* -----------------------------------------------------------------------------
-   Tab Containers
+   Tabs
 ----------------------------------------------------------------------------- */
-
-#TabBarContainer {
-  .tab-container;
-}
 
 QTabWidget::Pane {
   position: absolute;
   top: -1; // move border under tabs
   &:extend(.frame all); // frame border
+  margin: 0 3 3 3;
 }
 
-/* -----------------------------------------------------------------------------
-   Tabs
------------------------------------------------------------------------------ */
-
 QTabBar {
-  background-color: @tabbar-bg-color;
+  background-color: transparent;
   &::tab {
-    &:extend(.tab-flat all);
+    &:extend(.tab-round all);
+    &::first {
+      margin-left: 3px;
+    }
   }
   & QToolButton {
     /* Scroll buttons */
@@ -551,6 +538,16 @@ QTabBar {
     }
     &:disabled {
       color: @text-color-disabled;
+    }
+  }
+}
+
+#TabBarContainer {
+  // Panels: Palette, Style Editor, Fx Editor, etc.
+  .tab-container;
+  & QTabBar {
+    &::tab {
+      &:extend(.tab-flat all);
     }
   }
 }
@@ -666,4 +663,21 @@ QListView {
       color: @button-text-color-disabled;
     }
   }
+}
+
+/* -----------------------------------------------------------------------------
+   QHeaderView
+----------------------------------------------------------------------------- */
+
+QHeaderView::section {
+  background-color: @browser-itemview-col-color;
+  border: 1 solid @browser-itemview-col-border-color;
+  padding-left: 4;
+  margin-left: -1;
+  margin-top: -1;
+}
+
+QTreeWidget {
+  background-color: @browser-itemview-bg-color-alt;
+  border: 1 solid @accent;
 }

--- a/stuff/config/qss/Default/less/themes/Light.less
+++ b/stuff/config/qss/Default/less/themes/Light.less
@@ -5,8 +5,6 @@
 // -----------------------------------------------------------------------------
 // This inherits from NEUTRAL theme, when updating NEUTRAL make sure to check
 // changes against LIGHT.
-//
-// NOTE: Compile Neutral.less before this.
 // -----------------------------------------------------------------------------
 
 // Override
@@ -17,12 +15,10 @@
 
 @bg:                    #DBDBDB;
 @accent:                darken(@bg, 20);
-@dock-bg-color:         darken(@bg, 30);
+@dock-bg-color:         darken(@bg, 50);
 @hl-bg-color:           #a0c1dd;
 @hl-text-color:         #000;
 @hl-bg-color-secondary: darken(@bg, 15);
-
-@dialogButtonFrame-bg-color: @bg;
 
 // -----------------------------------------------------------------------------
 // Tabs
@@ -90,7 +86,7 @@
 @input-text-color:         #000;
 @input-border-color:       @accent;
 @input-border-color-focus: saturate(darken(@hl-bg-color, 20), 20);
-@input-bg-color-disabled:  lighten(@bg, 8);
+@input-bg-color-disabled:  lighten(@bg, 4);
 
 // -----------------------------------------------------------------------------
 // CheckBox
@@ -112,7 +108,7 @@
 @flipslider-img:              'flipslider_light.svg';
 @flipslider-base-color:       darken(@bg, 10);
 @flipslider-notstarted-color: rgb(195, 60, 60);
-@flipslider-started-color:    rgb(16, 221, 64);
+@flipslider-started-color:    rgb(30, 192, 68);
 
 // Ruler
 @viewer-ruler-handle-color:      black;
@@ -123,9 +119,9 @@
 // -----------------------------------------------------------------------------
 
 // All views (except list);
-@palette-SelectedBorderColor:           rgb(66, 82, 100);
-@palette-NumpadShortcutBgColor:         rgba(0, 0, 0, 0.15);
-@palette-NumpadShortcutBorderColor:     rgb(128, 128, 128);
+@palette-SelectedBorderColor:           #697C9E;
+@palette-NumpadShortcutBgColor:         rgba(0, 68, 255, 0.15);
+@palette-NumpadShortcutBorderColor:     black;
 
 // List view
 @palette-ListNumpadShortcutBorderColor: rgb(105, 105, 105);

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -124,43 +124,51 @@ QGroupBox {
   qproperty-BottomBelowLineColor: #a8a8a8;
 }
 .tab-flat,
-QTabBar::tab {
+#TopBarTab::tab,
+#TabBarContainer QTabBar::tab {
   background-color: #c4c4c4;
   border-right: 1 solid #a3a3a3;
   border-bottom: 1 solid #a8a8a8;
+  border-top: 0;
+  border-left: 0;
+  border-radius: 0;
   color: #000;
   padding: 3 4 3 4;
+  margin: 0;
 }
 .tab-flat:hover,
-QTabBar::tab:hover {
+#TopBarTab::tab:hover,
+#TabBarContainer QTabBar::tab:hover {
   background-color: #d1d1d1;
   color: #000;
 }
 .tab-flat:selected,
-QTabBar::tab:selected {
+#TopBarTab::tab:selected,
+#TabBarContainer QTabBar::tab:selected {
   background-color: #DBDBDB;
   color: #000;
   border-bottom-color: #DBDBDB;
 }
 .tab-flat:only-one,
-QTabBar::tab:only-one {
+#TopBarTab::tab:only-one,
+#TabBarContainer QTabBar::tab:only-one {
   margin: 0;
 }
-.tab-round {
+.tab-round,
+QTabBar::tab {
   background-color: #c4c4c4;
-  border-top: 1 solid #a8a8a8;
-  border-right: 1 solid #a8a8a8;
-  border-left: 1 solid #a8a8a8;
-  border-bottom: 1 solid #a8a8a8;
+  border: 1 solid #a8a8a8;
   color: #000;
   margin: 3 -1 0 0;
   padding: 2 7 1 7;
 }
-.tab-round:hover {
+.tab-round:hover,
+QTabBar::tab:hover {
   background-color: #d1d1d1;
   color: #000;
 }
-.tab-round:selected {
+.tab-round:selected,
+QTabBar::tab:selected {
   background-color: #DBDBDB;
   border-top-right-radius: 2;
   border-top-left-radius: 2;
@@ -169,15 +177,18 @@ QTabBar::tab:only-one {
   margin: 1 -1 -1 0;
   padding: 2 7 2 7;
 }
-.tab-round:only-one {
+.tab-round:only-one,
+QTabBar::tab:only-one {
   margin: 1 0 0 0;
   padding: 3 7 3 7;
 }
-.tab-round:last {
+.tab-round:last,
+QTabBar::tab:last {
   margin-right: 0;
   border-top-right-radius: 2;
 }
-.tab-round:first {
+.tab-round:first,
+QTabBar::tab:first {
   border-top-left-radius: 2;
 }
 /* -----------------------------------------------------------------------------
@@ -208,7 +219,7 @@ QToolTip,
 #DockSeparator,
 QMainWindow::separator,
 QSplitter::handle {
-  background-color: #8f8f8f;
+  background-color: #5b5b5b;
   height: 4;
   width: 4;
 }
@@ -216,7 +227,7 @@ QSplitter::handle {
   background-color: #f55454;
 }
 TPanel {
-  background-color: #8f8f8f;
+  background-color: #5b5b5b;
 }
 /* -----------------------------------------------------------------------------
    Topbar
@@ -269,28 +280,18 @@ QMenuBar::item:pressed {
 #TopBarTab {
   margin: 0;
   padding: 0;
+  background-color: transparent;
 }
 #TopBarTab::tab {
-  background-color: #c4c4c4;
   border-top: 1 solid #a3a3a3;
-  border-right: 1 solid #a3a3a3;
-  color: #000;
   margin: 0 0 -1 0;
   padding: 2 8 3 8;
 }
-#TopBarTab::tab:hover {
-  background-color: #d1d1d1;
-  color: #000;
-}
 #TopBarTab::tab:selected {
   background-color: #a0c1dd;
-  color: #000;
 }
 #TopBarTab::tab:first {
-  border-left: 1 solid #a8a8a8;
-}
-#TopBarTab::tab:last {
-  border-right: 1 solid #a8a8a8;
+  border-left: 1 solid #a3a3a3;
 }
 #TopBarTab QToolButton {
   border-left: 2 solid #a8a8a8;
@@ -660,22 +661,18 @@ DvScrollWidget {
   border-radius: 2;
 }
 /* -----------------------------------------------------------------------------
-   Tab Containers
+   Tabs
 ----------------------------------------------------------------------------- */
-#TabBarContainer {
-  background-color: #c4c4c4;
-  qproperty-BottomAboveLineColor: #c4c4c4;
-  qproperty-BottomBelowLineColor: #a8a8a8;
-}
 QTabWidget::Pane {
   position: absolute;
   top: -1;
+  margin: 0 3 3 3;
 }
-/* -----------------------------------------------------------------------------
-   Tabs
------------------------------------------------------------------------------ */
 QTabBar {
-  background-color: #c4c4c4;
+  background-color: transparent;
+}
+QTabBar::tab::first {
+  margin-left: 3px;
 }
 QTabBar QToolButton {
   /* Scroll buttons */
@@ -692,6 +689,11 @@ QTabBar QToolButton:pressed {
 }
 QTabBar QToolButton:disabled {
   color: rgba(0, 0, 0, 0.4);
+}
+#TabBarContainer {
+  background-color: #c4c4c4;
+  qproperty-BottomAboveLineColor: #c4c4c4;
+  qproperty-BottomBelowLineColor: #a8a8a8;
 }
 /* -----------------------------------------------------------------------------
    Item Tree
@@ -814,6 +816,20 @@ QListView {
   background-color: #d1d1d1;
   border-color: #b7b7b7;
   color: rgba(0, 0, 0, 0.4);
+}
+/* -----------------------------------------------------------------------------
+   QHeaderView
+----------------------------------------------------------------------------- */
+QHeaderView::section {
+  background-color: #cecece;
+  border: 1 solid #a8a8a8;
+  padding-left: 4;
+  margin-left: -1;
+  margin-top: -1;
+}
+QTreeWidget {
+  background-color: #e3e3e3;
+  border: 1 solid #a8a8a8;
 }
 /* -----------------------------------------------------------------------------
    Push Button
@@ -990,7 +1006,7 @@ QTextEdit:disabled,
 #TaskSheetItem:disabled,
 #tasksRemoveBox:disabled,
 #tasksAddBox:disabled {
-  background-color: #efefef;
+  background-color: #e5e5e5;
   border-color: #c2c2c2;
   color: rgba(0, 0, 0, 0.4);
 }
@@ -1594,9 +1610,9 @@ PaletteViewer QToolBar #keyFrameNavigator #KeyTotal {
 }
 #PageViewer {
   qproperty-TextColor: #000;
-  qproperty-SelectedBorderColor: #425264;
-  qproperty-NumpadShortcutBgColor: rgba(0, 0, 0, 0.15);
-  qproperty-NumpadShortcutBorderColor: #808080;
+  qproperty-SelectedBorderColor: #697C9E;
+  qproperty-NumpadShortcutBgColor: rgba(0, 68, 255, 0.15);
+  qproperty-NumpadShortcutBorderColor: black;
   qproperty-SeparatorColor: #a8a8a8;
   qproperty-CurrentCellColor: rgba(160, 193, 221, 0.5);
   qproperty-SelectedCellColor: #a0c1dd;
@@ -1630,7 +1646,7 @@ QDialog {
   background-color: #DBDBDB;
 }
 QDialog #dialogButtonFrame {
-  background-color: #DBDBDB;
+  background-color: #d1d1d1;
   border-top: 1 solid #a8a8a8;
 }
 QDialog #dialogButtonFrame QPushButton {
@@ -2173,7 +2189,7 @@ FlipSlider {
   qproperty-PBMarkerMarginLeft: 3;
   qproperty-PBMarkerMarginRight: 3;
   qproperty-notStartedColor: #c33c3c;
-  qproperty-startedColor: #10dd40;
+  qproperty-startedColor: #1ec044;
   qproperty-baseColor: #c2c2c2;
   qproperty-finishedColor: #c2c2c2;
 }
@@ -2419,7 +2435,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: rgba(146, 153, 158, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(146, 153, 158, 0.5);
   qproperty-TextColor: #000;
-  qproperty-ColumnHeaderBorderColor: #8f8f8f;
+  qproperty-ColumnHeaderBorderColor: #5b5b5b;
 }
 #ExpressionField {
   background-color: #ffffff;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -124,43 +124,51 @@ QGroupBox {
   qproperty-BottomBelowLineColor: #5a5a5a;
 }
 .tab-flat,
-QTabBar::tab {
+#TopBarTab::tab,
+#TabBarContainer QTabBar::tab {
   background-color: #717171;
   border-right: 1 solid #555555;
   border-bottom: 1 solid #5a5a5a;
+  border-top: 0;
+  border-left: 0;
+  border-radius: 0;
   color: #000;
   padding: 3 4 3 4;
+  margin: 0;
 }
 .tab-flat:hover,
-QTabBar::tab:hover {
+#TopBarTab::tab:hover,
+#TabBarContainer QTabBar::tab:hover {
   background-color: #7d7d7d;
   color: #000;
 }
 .tab-flat:selected,
-QTabBar::tab:selected {
+#TopBarTab::tab:selected,
+#TabBarContainer QTabBar::tab:selected {
   background-color: #808080;
   color: #000;
   border-bottom-color: #808080;
 }
 .tab-flat:only-one,
-QTabBar::tab:only-one {
+#TopBarTab::tab:only-one,
+#TabBarContainer QTabBar::tab:only-one {
   margin: 0;
 }
-.tab-round {
+.tab-round,
+QTabBar::tab {
   background-color: #717171;
-  border-top: 1 solid #5a5a5a;
-  border-right: 1 solid #5a5a5a;
-  border-left: 1 solid #5a5a5a;
-  border-bottom: 1 solid #5a5a5a;
+  border: 1 solid #5a5a5a;
   color: #000;
   margin: 3 -1 0 0;
   padding: 2 7 1 7;
 }
-.tab-round:hover {
+.tab-round:hover,
+QTabBar::tab:hover {
   background-color: #7d7d7d;
   color: #000;
 }
-.tab-round:selected {
+.tab-round:selected,
+QTabBar::tab:selected {
   background-color: #808080;
   border-top-right-radius: 2;
   border-top-left-radius: 2;
@@ -169,15 +177,18 @@ QTabBar::tab:only-one {
   margin: 1 -1 -1 0;
   padding: 2 7 2 7;
 }
-.tab-round:only-one {
+.tab-round:only-one,
+QTabBar::tab:only-one {
   margin: 1 0 0 0;
   padding: 3 7 3 7;
 }
-.tab-round:last {
+.tab-round:last,
+QTabBar::tab:last {
   margin-right: 0;
   border-top-right-radius: 2;
 }
-.tab-round:first {
+.tab-round:first,
+QTabBar::tab:first {
   border-top-left-radius: 2;
 }
 /* -----------------------------------------------------------------------------
@@ -269,28 +280,18 @@ QMenuBar::item:pressed {
 #TopBarTab {
   margin: 0;
   padding: 0;
+  background-color: transparent;
 }
 #TopBarTab::tab {
-  background-color: #717171;
   border-top: 1 solid #555555;
-  border-right: 1 solid #555555;
-  color: #000;
   margin: 0 0 -1 0;
   padding: 2 8 3 8;
 }
-#TopBarTab::tab:hover {
-  background-color: #7d7d7d;
-  color: #000;
-}
 #TopBarTab::tab:selected {
   background-color: #8FA0B2;
-  color: #000;
 }
 #TopBarTab::tab:first {
-  border-left: 1 solid #5a5a5a;
-}
-#TopBarTab::tab:last {
-  border-right: 1 solid #5a5a5a;
+  border-left: 1 solid #555555;
 }
 #TopBarTab QToolButton {
   border-left: 2 solid #5a5a5a;
@@ -660,22 +661,18 @@ DvScrollWidget {
   border-radius: 2;
 }
 /* -----------------------------------------------------------------------------
-   Tab Containers
+   Tabs
 ----------------------------------------------------------------------------- */
-#TabBarContainer {
-  background-color: #717171;
-  qproperty-BottomAboveLineColor: #717171;
-  qproperty-BottomBelowLineColor: #5a5a5a;
-}
 QTabWidget::Pane {
   position: absolute;
   top: -1;
+  margin: 0 3 3 3;
 }
-/* -----------------------------------------------------------------------------
-   Tabs
------------------------------------------------------------------------------ */
 QTabBar {
-  background-color: #717171;
+  background-color: transparent;
+}
+QTabBar::tab::first {
+  margin-left: 3px;
 }
 QTabBar QToolButton {
   /* Scroll buttons */
@@ -692,6 +689,11 @@ QTabBar QToolButton:pressed {
 }
 QTabBar QToolButton:disabled {
   color: rgba(0, 0, 0, 0.4);
+}
+#TabBarContainer {
+  background-color: #717171;
+  qproperty-BottomAboveLineColor: #717171;
+  qproperty-BottomBelowLineColor: #5a5a5a;
 }
 /* -----------------------------------------------------------------------------
    Item Tree
@@ -814,6 +816,20 @@ QListView {
   background-color: #8d8d8d;
   border-color: #737373;
   color: rgba(0, 0, 0, 0.4);
+}
+/* -----------------------------------------------------------------------------
+   QHeaderView
+----------------------------------------------------------------------------- */
+QHeaderView::section {
+  background-color: #737373;
+  border: 1 solid #5a5a5a;
+  padding-left: 4;
+  margin-left: -1;
+  margin-top: -1;
+}
+QTreeWidget {
+  background-color: #888888;
+  border: 1 solid #5a5a5a;
 }
 /* -----------------------------------------------------------------------------
    Push Button


### PR DESCRIPTION
This is the second part to patching the tabs (#4390), so they don't look so broken in the New Project window, since we already had a rounded tabs class I swapped this to be the default, the flat style is then applied to the custom `TabBarContainer` widget which is utilized by Palette, Style Editor etc.

Also some very minor color balancing for the Light Theme only (*) I might as well include here.
- Darkens palette numpad group border so it's easier to see (like Retas PaintMan)*
- Makes text field disabled color look more faded*
- Darkens dock border (gap between panels) to give it more contrast against the viewer gray color*
- Add some styling for QHeaderView, QTreeWidget (these are found in Hex name editor panel)

![image](https://user-images.githubusercontent.com/19820721/164114337-47a557be-7894-458b-8e21-9c20d732387f.png)
