### PR TITLE
Fix missing PSD layer

### DIFF
--- a/toonz/sources/common/psdlib/psd.cpp
+++ b/toonz/sources/common/psdlib/psd.cpp
@@ -220,8 +220,8 @@ bool TPSDReader::doLayersInfo() {
     m_headerInfo.layersCount = -m_headerInfo.layersCount;
   }
   if (!m_headerInfo.linfoBlockEmpty) {
-    m_headerInfo.linfo = (TPSDLayerInfo *)mymalloc(
-        m_headerInfo.layersCount * sizeof(struct TPSDLayerInfo));
+    m_headerInfo.linfo = (TPSDLayerInfo *)mycalloc(
+        m_headerInfo.layersCount, sizeof(struct TPSDLayerInfo));
     int i = 0;
     for (i = 0; i < m_headerInfo.layersCount; i++) {
       readLayerInfo(i);
@@ -306,7 +306,9 @@ bool TPSDReader::readLayerInfo(int i) {
     }
 
     // process layer's 'additional info'
-
+    // Assumption: File will provide all layerIds or none at all.
+    // Set layer id, for now, knowing it may be overwritten if found in file
+    li->layerId = i + 1;
     li->additionalpos = ftell(m_file);
     li->additionallen = extrastart + extralen - li->additionalpos;
     doExtraData(li, li->additionallen);

--- a/toonz/sources/common/psdlib/psdutils.cpp
+++ b/toonz/sources/common/psdlib/psdutils.cpp
@@ -136,6 +136,15 @@ void *mymalloc(long n) {
   return NULL;
 }
 
+void *mycalloc(long n, int size) {
+  void *p = calloc(n, size);
+  if (p)
+    return p;
+  else {
+    // ALLOCATION ERROR
+  }
+  return NULL;
+}
 // ZIP COMPRESSION
 
 // ZIP WITHOUT PREDICTION

--- a/toonz/sources/common/psdlib/psdutils.h
+++ b/toonz/sources/common/psdlib/psdutils.h
@@ -36,6 +36,7 @@ void readrow(FILE *psd, TPSDChannelInfo *chan, psdPixel rowIndex,
 void skipBlock(FILE *f);
 
 void *mymalloc(long n);
+void *mycalloc(long n, int size);
 unsigned read2UBytes(FILE *f);
 int read2Bytes(FILE *f);
 long read4Bytes(FILE *f);


### PR DESCRIPTION
Whatever created the PSD file might not have written out Layer Ids and certain layer information when saving.

Due to the missing Layer Ids, the software was effectively assigning random values to layer ids and several other layer data elements every time it read the file for information. This is a problem for consistency between file reads and also if the layer id was negative, the layer would not be loaded into T2D.

Modified the logic to effectively initialize all layer data elements to 0 and assign a layer Id based on layer read order when reading the file. If the file contains layer ids, it will replace it with the layer id found.

Assumption: PSD file will either provide layer ids for all layers or none at all.
this was co- authored by @manongjohn https://github.com/tahoma2d/tahoma2d/pull/984