### PR TITLE
Fix Rendered Sound starting too soon. 

### DIFF
--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -81,6 +81,10 @@ void getRange(ToonzScene *scene, bool isPreview, int &from, int &to) {
       int r0, r1;
       xs->getCellRange(k, r0, r1);
 
+       TXshColumn *col         = xs->getColumn(k);
+      TXshSoundColumn *sndCol = col ? col->getSoundColumn() : 0;
+
+      if (sndCol) r0  = 0;
       from = std::min(from, r0), to = std::max(to, r1);
     }
   }


### PR DESCRIPTION
Co-authored-by: manongjohn <19245851+manongjohn@users.noreply.github.com>

this fixes an issue where rendered sound  starts to early in a scene. 
 

for more info: https://github.com/tahoma2d/tahoma2d/pull/981