### PR TITLE
Add search command list for customize popups

### DIFF
--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -396,6 +396,66 @@ void CommandBarListTree::mousePressEvent(QMouseEvent* event) {
   QTreeWidget::mousePressEvent(event);
 }
 
+/-----------------------------------------------------------------------------
+
+void CommandBarListTree::displayAll(QTreeWidgetItem* item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    displayAll(item->child(i));
+  }
+  item->setHidden(false);
+  item->setExpanded(false);
+}
+
+//-------------------------------------------------------------------
+
+void CommandBarListTree::hideAll(QTreeWidgetItem* item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    hideAll(item->child(i));
+  }
+  item->setHidden(true);
+  item->setExpanded(false);
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBarListTree::searchItems(const QString& searchWord) {
+  // if search word is empty, show all items
+  if (searchWord.isEmpty()) {
+    int itemCount = topLevelItemCount();
+    for (int i = 0; i < itemCount; ++i) {
+      displayAll(topLevelItem(i));
+    }
+    update();
+    return;
+  }
+
+  // hide all items first
+  int itemCount = topLevelItemCount();
+  for (int i = 0; i < itemCount; ++i) {
+    hideAll(topLevelItem(i));
+  }
+
+  QList<QTreeWidgetItem*> foundItems =
+      findItems(searchWord, Qt::MatchContains | Qt::MatchRecursive, 0);
+  if (foundItems.isEmpty()) {  // if nothing is found, do nothing but update
+    update();
+    return;
+  }
+
+  // for each item found, show it and show its parent
+  for (auto item : foundItems) {
+    while (item) {
+      item->setHidden(false);
+      item->setExpanded(true);
+      item = item->parent();
+    }
+  }
+
+  update();
+}
+
 //=============================================================================
 // CommandBarPopup
 //-----------------------------------------------------------------------------
@@ -436,6 +496,8 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
   QFont nf("Arial", 9, QFont::Normal);
   nf.setItalic(true);
   noticeLabel->setFont(nf);
+      
+  QLineEdit* searchEdit = new QLineEdit(this);
 
   //--- layout
   QVBoxLayout* mainLay = new QVBoxLayout();
@@ -449,10 +511,20 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
     {
       mainUILay->addWidget(commandBarLabel, 0, 0);
       mainUILay->addWidget(commandItemListLabel, 0, 1);
-      mainUILay->addWidget(m_menuBarTree, 1, 0);
-      mainUILay->addWidget(m_commandListTree, 1, 1);
 
-      mainUILay->addWidget(noticeLabel, 2, 0, 1, 2);
+      mainUILay->addWidget(m_menuBarTree, 1, 0, 2, 1);
+
+      QHBoxLayout* searchLay = new QHBoxLayout();
+      searchLay->setMargin(0);
+      searchLay->setSpacing(5);
+      {
+        searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
+        searchLay->addWidget(searchEdit);
+      }
+      mainUILay->addLayout(searchLay, 1, 1);
+      mainUILay->addWidget(m_commandListTree, 2, 1);
+
+      mainUILay->addWidget(noticeLabel, 3, 0, 1, 2);
     }
     mainUILay->setRowStretch(0, 0);
     mainUILay->setRowStretch(1, 1);
@@ -476,6 +548,9 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
 
   bool ret = connect(okBtn, SIGNAL(clicked()), this, SLOT(onOkPressed()));
   ret      = ret && connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
+  ret = ret && connect(searchEdit, SIGNAL(textChanged(const QString&)), this,
+                       SLOT(onSearchTextChanged(const QString&)));   
+      
   assert(ret);
 }
 
@@ -486,3 +561,17 @@ void CommandBarPopup::onOkPressed() {
 
   accept();
 }
+}
+
+void CommandBarPopup::onSearchTextChanged(const QString& text) {
+  static bool busy = false;
+  if (busy) return;
+  busy = true;
+  m_commandListTree->searchItems(text);
+  busy = false;
+}
+
+
+
+
+

--- a/toonz/sources/toonz/commandbarpopup.h
+++ b/toonz/sources/toonz/commandbarpopup.h
@@ -50,6 +50,12 @@ class CommandBarListTree final : public QTreeWidget {
 public:
   CommandBarListTree(QWidget* parent = 0);
 
+  void searchItems(const QString& searchWord = QString());
+
+private:
+  void displayAll(QTreeWidgetItem* item);
+  void hideAll(QTreeWidgetItem* item);
+  
 protected:
   void mousePressEvent(QMouseEvent*) override;
 };
@@ -68,6 +74,7 @@ public:
   CommandBarPopup(bool isXsheetToolbar = false);
 protected slots:
   void onOkPressed();
+  void onSearchTextChanged(const QString& text);
 };
 
 #endif


### PR DESCRIPTION
Adds a Search box above the Toolbar Items list in Customize Command Bar (shown) and Customize X-Sheet Toolbar popups.

Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>


for more info: https://github.com/tahoma2d/tahoma2d/pull/101

Special Thanks: @manongjohn
![88461460-a7333a00-ce71-11ea-9853-850daffbaa8a](https://user-images.githubusercontent.com/74626650/165653438-2af5dd05-b9f5-403e-a96e-54adc4c5e600.png)
