### PR TITLE
Fix Lazy Nezumi Pro hooking Bug

### DIFF
--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -895,6 +895,10 @@ FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
   layout->setSpacing(0);
 
   setLayout(layout);
+  
+#ifdef _WIN32
+  this->winId();
+#endif
 }
 
 //---------------------------------------------------------------------------------


### PR DESCRIPTION
Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>

This PR fixes the issue with Lazy Nezumi Pro incorrectly hooking to the main window instead of the canvas.


this should fix: https://github.com/opentoonz/opentoonz/issues/3812