### PR TITLE
Fix Lazy Nezumi Pro hooking Bug

### DIFF
--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -895,6 +895,10 @@ FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
   layout->setSpacing(0);
 
   setLayout(layout);
+  
+#ifdef _WIN32
+  this->winId();
+#endif
 }
 
 //---------------------------------------------------------------------------------
@@ -1035,7 +1039,6 @@ bool FullScreenWidget::toggleFullScreen(
             this->window()->windowHandle()->setScreen(ptrScreenThisWindowIsOn);
 
             // http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
-            this->winId();
             QWindowsWindowFunctions::setHasBorderInFullScreen(
                 this->windowHandle(), true);
 


### PR DESCRIPTION


This PR fixes the issue with Lazy Nezumi Pro incorrectly hooking to the main window instead of the canvas.

this should fix: https://github.com/opentoonz/opentoonz/issues/3812

Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>

Thanks @manongjohn again!