### PR TITLE
Fix Margin of Spin Blur Ino Fx

### DIFF
--- a/toonz/sources/stdfx/igs_rotate_blur.cpp
+++ b/toonz/sources/stdfx/igs_rotate_blur.cpp
@@ -362,8 +362,8 @@ int igs::rotate_blur::reference_margin(
     const double blur_radius,                  /* ぼかしの始まる半径 */
     const double spin_radius, /* ゼロ以上でspin指定となり、
                             かつぼかし強弱の一定になる半径となる */
-    const int type  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
-) {
+    const int type,  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
+    const double ellipse_aspect_ratio) {
   /* 強度のないとき、なにもしない */
   if (degree <= 0.0) {
     return 0;
@@ -400,6 +400,14 @@ int igs::rotate_blur::reference_margin(
                                deg * M_PI_180, blur_radius, spin_radius, type);
   if (margin1 < margin2) {
     margin1 = margin2;
+  }
+
+  // Consider ellipse deformation.
+  // Instead of precise computing, return the maximum possible value.
+  if (ellipse_aspect_ratio != 1.0) {
+    double axis_x = 2.0 * ellipse_aspect_ratio / (ellipse_aspect_ratio + 1.0);
+    double axis_y = axis_x / ellipse_aspect_ratio;
+    margin1 *= std::max(axis_x, axis_y);
   }
 
   return static_cast<int>(ceil(margin1));

--- a/toonz/sources/stdfx/igs_rotate_blur.h
+++ b/toonz/sources/stdfx/igs_rotate_blur.h
@@ -44,8 +44,8 @@ IGS_ROTATE_BLUR_EXPORT int reference_margin(
     const double blur_radius,                  /* ぼかしの始まる半径 */
     const double spin_radius, /* ゼロ以上でspin指定となり、
                             かつぼかし強弱の一定になる半径となる */
-    const int type  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
-);
+    const int type,  // 0: Accelerator, 1: Uniform Angle, 2: Uniform Length
+    const double ellipse_aspect_ratio = 1.0);
 }  // namespace rotate_blur
 }  // namespace igs
 

--- a/toonz/sources/stdfx/ino_spin_blur.cpp
+++ b/toonz/sources/stdfx/ino_spin_blur.cpp
@@ -86,8 +86,8 @@ public:
         static_cast<int>(ceil(bBox.getLy())),
         static_cast<int>(ceil(bBox.getLx())), center,
         this->m_blur->getValue(frame), this->m_radius->getValue(frame) * scale,
-        ((0 < this->m_type->getValue()) ? 0.0 : (bBox.getLy() / 2.0)),
-        this->m_type->getValue());
+        bBox.getLy() / 2.0, this->m_type->getValue(),
+        this->m_ellipse_aspect_ratio->getValue(frame));
   }
   void get_render_enlarge(const double frame, const TAffine affine,
                           TRectD &bBox) {


### PR DESCRIPTION
This PR fixes Spin Blur Ino Fx, modifying the margin computation so that the blurred result won't cut off at the border of the source image's bounding box.