### PR TITLE
Update Bokeh Advanced Iwa Fx

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1327,30 +1327,40 @@
   <item>"STD_iwa_BokehAdvancedFx.hardness1"		"Source1 Hardness"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref1"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange1"	"Source1 Depth Range"</item>
+  <item>"STD_iwa_BokehAdvancedFx.fillGap1"	"Fill Gap"</item>
+  <item>"STD_iwa_BokehAdvancedFx.doMedian1"	"Use Median"</item>
 
   <item>"STD_iwa_BokehAdvancedFx.distance2"		"Source2 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment2"	"Source2 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness2"		"Source2 Hardness"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref2"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange2"	"Source2 Depth Range"</item>
+  <item>"STD_iwa_BokehAdvancedFx.fillGap2"	"Fill Gap"</item>
+  <item>"STD_iwa_BokehAdvancedFx.doMedian2"	"Use Median"</item>
 
   <item>"STD_iwa_BokehAdvancedFx.distance3"		"Source3 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment3"	"Source3 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness3"		"Source3 Hardness"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref3"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange3"	"Source3 Depth Range"</item>
+  <item>"STD_iwa_BokehAdvancedFx.fillGap3"	"Fill Gap"</item>
+  <item>"STD_iwa_BokehAdvancedFx.doMedian3"	"Use Median"</item>
 
   <item>"STD_iwa_BokehAdvancedFx.distance4"		"Source4 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment4"	"Source4 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness4"		"Source4 Hardness"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref4"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange4"	"Source4 Depth Range"</item>
+  <item>"STD_iwa_BokehAdvancedFx.fillGap4"	"Fill Gap"</item>
+  <item>"STD_iwa_BokehAdvancedFx.doMedian4"	"Use Median"</item>
 
   <item>"STD_iwa_BokehAdvancedFx.distance5"		"Source5 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment5"	"Source5 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness5"		"Source5 Hardness"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref5"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange5"	"Source5 Depth Range"</item>
+  <item>"STD_iwa_BokehAdvancedFx.fillGap5"	"Fill Gap"</item>
+  <item>"STD_iwa_BokehAdvancedFx.doMedian5"	"Use Median"</item>
 
   <item>"STD_iwa_TimeCodeFx"	"TimeCode Iwa"</item>
   <item>"STD_iwa_TimeCodeFx.displayType"	"Display Type"</item>

--- a/stuff/profiles/layouts/fxs/STD_iwa_BokehAdvancedFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_BokehAdvancedFx.xml
@@ -11,7 +11,11 @@
 		<control>distance1</control>
 		<control>bokeh_adjustment1</control>
 		<control>hardness1</control>
-		<control>depth_ref1</control>
+		<hbox>
+			<control>depth_ref1</control>
+			<control>fillGap1</control>
+			<control>doMedian1</control>
+		</hbox>
 		<control>depthRange1</control>
    	</vbox>
 
@@ -19,7 +23,11 @@
 		<control>distance2</control>
 		<control>bokeh_adjustment2</control>
 		<control>hardness2</control>
-		<control>depth_ref2</control>
+		<hbox>
+			<control>depth_ref2</control>
+			<control>fillGap2</control>
+			<control>doMedian2</control>
+		</hbox>
 		<control>depthRange2</control>
    	</vbox>
 
@@ -27,7 +35,11 @@
 		<control>distance3</control>
 		<control>bokeh_adjustment3</control>
 		<control>hardness3</control>
-		<control>depth_ref3</control>
+		<hbox>
+			<control>depth_ref3</control>
+			<control>fillGap3</control>
+			<control>doMedian3</control>
+		</hbox>
 		<control>depthRange3</control>
    	</vbox>
 
@@ -35,7 +47,11 @@
 		<control>distance4</control>
 		<control>bokeh_adjustment4</control>
 		<control>hardness4</control>
-		<control>depth_ref4</control>
+		<hbox>
+			<control>depth_ref4</control>
+			<control>fillGap4</control>
+			<control>doMedian4</control>
+		</hbox>
 		<control>depthRange4</control>
    	</vbox>
 
@@ -43,7 +59,11 @@
 		<control>distance5</control>
 		<control>bokeh_adjustment5</control>
 		<control>hardness5</control>
-		<control>depth_ref5</control>
+		<hbox>
+			<control>depth_ref5</control>
+			<control>fillGap5</control>
+			<control>doMedian5</control>
+		</hbox>
 		<control>depthRange5</control>
    	</vbox>
 
@@ -55,6 +75,27 @@
 		<on>hardness4</on>
 		<on>hardness5</on>
 	</visibleToggle>
+	<visibleToggle>
+		<controller>fillGap1</controller>
+		<on>doMedian1</on>
+	</visibleToggle>
+	<visibleToggle>
+		<controller>fillGap2</controller>
+		<on>doMedian2</on>
+	</visibleToggle>
+	<visibleToggle>
+		<controller>fillGap3</controller>
+		<on>doMedian3</on>
+	</visibleToggle>
+	<visibleToggle>
+		<controller>fillGap4</controller>
+		<on>doMedian4</on>
+	</visibleToggle>
+	<visibleToggle>
+		<controller>fillGap5</controller>
+		<on>doMedian5</on>
+	</visibleToggle>
+
 
 	</page>
 </fxlayout>

--- a/toonz/sources/stdfx/iwa_bokeh_advancedfx.cpp
+++ b/toonz/sources/stdfx/iwa_bokeh_advancedfx.cpp
@@ -144,6 +144,8 @@ Iwa_BokehAdvancedFx::Iwa_BokehAdvancedFx()
     m_layerParams[layer].m_hardness   = TDoubleParamP(0.3);
     m_layerParams[layer].m_depth_ref  = TIntParamP(0);
     m_layerParams[layer].m_depthRange = TDoubleParamP(1.0);
+    m_layerParams[layer].m_fillGap    = TBoolParamP(true);
+    m_layerParams[layer].m_doMedian   = TBoolParamP(false);
 
     std::string str = QString("Source%1").arg(layer + 1).toStdString();
     addInputPort(str, m_layerParams[layer].m_source);
@@ -158,6 +160,10 @@ Iwa_BokehAdvancedFx::Iwa_BokehAdvancedFx()
               m_layerParams[layer].m_depth_ref);
     bindParam(this, QString("depthRange%1").arg(layer + 1).toStdString(),
               m_layerParams[layer].m_depthRange);
+    bindParam(this, QString("fillGap%1").arg(layer + 1).toStdString(),
+              m_layerParams[layer].m_fillGap);
+    bindParam(this, QString("doMedian%1").arg(layer + 1).toStdString(),
+              m_layerParams[layer].m_doMedian);
 
     m_layerParams[layer].m_distance->setValueRange(0.0, 1.0);
     m_layerParams[layer].m_bokehAdjustment->setValueRange(0.0, 2.0);
@@ -303,8 +309,8 @@ void Iwa_BokehAdvancedFx::doCompute(TTile& tile, double frame,
         m_layerParams[index].m_bokehAdjustment->getValue(frame);
     layerValue.depthRange = m_layerParams[index].m_depthRange->getValue(frame);
     layerValue.distancePrecision = 10;
-    layerValue.fillGap           = true;
-    layerValue.doMedian          = false;
+    layerValue.fillGap           = m_layerParams[index].m_fillGap->getValue();
+    layerValue.doMedian          = m_layerParams[index].m_doMedian->getValue();
 
     layerValues.append(layerValue);
   }

--- a/toonz/sources/stdfx/iwa_bokeh_advancedfx.h
+++ b/toonz/sources/stdfx/iwa_bokeh_advancedfx.h
@@ -41,6 +41,8 @@ protected:
     TIntParamP m_depth_ref;           // port index of depth reference image
     TDoubleParamP m_depthRange;       // distance range varies depends on the
                                       // brightness of the reference image (0-1)
+    TBoolParamP m_fillGap;
+    TBoolParamP m_doMedian;
   };
   std::array<LAYERPARAM, LAYER_NUM> m_layerParams;
 

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -102,6 +102,36 @@ inputFx);
         }
 }
 */
+
+// find the field by parameter name and register the field and its label widget
+bool findItemByParamName(QLayout *layout, std::string name,
+                         QList<QWidget *> &ret) {
+  for (int i = 0; i < layout->count(); i++) {
+    QLayoutItem *item = layout->itemAt(i);
+    if (!item) continue;
+    if (item->widget()) {
+      ParamField *pf = dynamic_cast<ParamField *>(item->widget());
+      if (pf && pf->getParamName().toStdString() == name) {
+        ret.push_back(pf);
+        if (i > 0 && layout->itemAt(i - 1)->widget()) {
+          QLabel *label =
+              dynamic_cast<QLabel *>(layout->itemAt(i - 1)->widget());
+          if (label) ret.push_back(label);
+        }
+        return true;
+      }
+      // the widget may be a container of another layout
+      else if (item->widget()->layout()) {
+        if (findItemByParamName(item->widget()->layout(), name, ret))
+          return true;
+      }
+    } else if (item->layout()) {
+      if (findItemByParamName(item->layout(), name, ret)) return true;
+    }
+  }
+  return false;
+};
+
 }  // namespace
 
 //=============================================================================
@@ -369,52 +399,15 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
           std::string name;
           is >> name;
           is.matchEndTag();
-          for (int r = 0; r < m_mainLayout->rowCount(); r++) {
-            QLayoutItem *li = m_mainLayout->itemAtPosition(r, 1);
-            if (!li) continue;
-            QWidget *w = li->widget();
-            if (!w) continue;
-            ParamField *pf = dynamic_cast<ParamField *>(w);
-            if (pf) {
-              if (pf->getParamName().toStdString() == name) {
-                if (tagName == "controller")
-                  controller_bpf = dynamic_cast<BoolParamField *>(pf);
-                else if (tagName == "on") {
-                  on_items.push_back(w);
-                  on_items.push_back(
-                      m_mainLayout->itemAtPosition(r, 0)->widget());
-                } else if (tagName == "off") {
-                  off_items.push_back(w);
-                  off_items.push_back(
-                      m_mainLayout->itemAtPosition(r, 0)->widget());
-                }
-              }
-            }
-            /*-- 入れ子のLayoutも１段階探す --*/
-            else {
-              QGridLayout *gridLay = dynamic_cast<QGridLayout *>(w->layout());
-              if (!gridLay) continue;
-              for (int r_s = 0; r_s < gridLay->rowCount(); r_s++) {
-                QLayoutItem *li_s = gridLay->itemAtPosition(r_s, 1);
-                if (!li_s) continue;
-                ParamField *pf_s = dynamic_cast<ParamField *>(li_s->widget());
-                if (pf_s) {
-                  if (pf_s->getParamName().toStdString() == name) {
-                    if (tagName == "controller")
-                      controller_bpf = dynamic_cast<BoolParamField *>(pf_s);
-                    else if (tagName == "on") {
-                      on_items.push_back(pf_s);
-                      on_items.push_back(
-                          gridLay->itemAtPosition(r_s, 0)->widget());
-                    } else if (tagName == "off") {
-                      off_items.push_back(pf_s);
-                      off_items.push_back(
-                          gridLay->itemAtPosition(r_s, 0)->widget());
-                    }
-                  }
-                }
-              }
-            }
+
+          QList<QWidget *> widgets;
+          if (findItemByParamName(m_mainLayout, name, widgets)) {
+            if (tagName == "controller") {
+              controller_bpf = dynamic_cast<BoolParamField *>(widgets[0]);
+            } else if (tagName == "on")
+              on_items.append(widgets);
+            else if (tagName == "off")
+              off_items.append(widgets);
           }
         } else
           throw TException("unexpected tag " + tagName);
@@ -866,8 +859,8 @@ void ParamsPageSet::addParamsPage(ParamsPage *page, const char *name) {
   /*-- このFxで最大サイズのページに合わせてダイアログをリサイズ --*/
   QSize pagePreferredSize = page->getPreferredSize();
   m_preferredSize         = m_preferredSize.expandedTo(
-      pagePreferredSize + QSize(m_tabBarContainer->height() + 2,
-                                2)); /*-- 2は上下左右のマージン --*/
+              pagePreferredSize + QSize(m_tabBarContainer->height() + 2,
+                                        2)); /*-- 2は上下左右のマージン --*/
 
   QScrollArea *pane = new QScrollArea(this);
   pane->setWidgetResizable(true);
@@ -970,8 +963,8 @@ void ParamsPageSet::createPage(TIStream &is, const TFxP &fx, int index) {
   /*-- このFxで最大サイズのページに合わせてダイアログをリサイズ --*/
   QSize pagePreferredSize = paramsPage->getPreferredSize();
   m_preferredSize         = m_preferredSize.expandedTo(
-      pagePreferredSize + QSize(m_tabBarContainer->height() + 2,
-                                2)); /*-- 2は上下左右のマージン --*/
+              pagePreferredSize + QSize(m_tabBarContainer->height() + 2,
+                                        2)); /*-- 2は上下左右のマージン --*/
 
   QScrollArea *scrollAreaPage = new QScrollArea(this);
   scrollAreaPage->setWidgetResizable(true);
@@ -996,7 +989,7 @@ void ParamsPageSet::recomputePreferredSize() {
     if (!page) continue;
     QSize pagePreferredSize = page->getPreferredSize();
     newSize                 = newSize.expandedTo(pagePreferredSize +
-                                 QSize(m_tabBarContainer->height() + 2, 2));
+                                                 QSize(m_tabBarContainer->height() + 2, 2));
   }
   if (!newSize.isEmpty()) {
     m_preferredSize = newSize;
@@ -1235,7 +1228,7 @@ FxSettings::FxSettings(QWidget *parent, const TPixel32 &checkCol1,
   //---signal-slot connections
   bool ret = true;
   ret      = ret && connect(m_paramViewer, SIGNAL(currentFxParamChanged()),
-                       SLOT(updateViewer()));
+                            SLOT(updateViewer()));
   ret      = ret &&
         connect(m_viewer, SIGNAL(pointPositionChanged(int, const TPointD &)),
                 SLOT(onPointChanged(int, const TPointD &)));


### PR DESCRIPTION
This PR will update the Bokeh Advanced Iwa Fx, enabling to specify whether to expand the border of the separated images when the reference depth image is used in some layer. The check boxes `Fill Gap`  and `Use Median (Filter)` are added to each layer. They work just like as the ones in the Bokeh Ref Iwa Fx.