### PR TITLE
Fix Mov Settings Updating

### DIFF
--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -164,6 +164,8 @@ TPropertyGroup *TOutputProperties::getFileFormatProperties(std::string ext) {
     TPropertyGroup *ret     = Tiio::makeWriterProperties(ext);
     m_formatProperties[ext] = ret;
     return ret;
+  } else if (ext == "mov" || ext == "3gp") {
+    return it->second;
   } else {
     // Try to merge settings instead of overriding them
     TPropertyGroup *ret = Tiio::makeWriterProperties(ext);


### PR DESCRIPTION
This PR fixes a problem which appears after introducing #4200 as follows:

- In the Output Settings, changes in the file format options of the Quicktime (.mov) are not saved. The options seems to be reset every time you open the format options popup.