### PR TITLE
Fix cropped input fields

### DIFF
--- a/toonz/sources/toonzqt/intfield.cpp
+++ b/toonz/sources/toonzqt/intfield.cpp
@@ -128,7 +128,7 @@ void RollerField::removeValue(bool isDragging) {
 IntLineEdit::IntLineEdit(QWidget *parent, int value, int minValue, int maxValue,
                          int showedDigits)
     : LineEdit(parent), m_showedDigits(showedDigits) {
-  setFixedWidth(54);
+  setFixedWidth(40);
 
   m_validator = new QIntValidator(this);
   setValue(value);


### PR DESCRIPTION
Many input fields are being cut off on the right side. This fixes the recurring visual bug.


![Iputbox](https://user-images.githubusercontent.com/11843239/129622809-ccb2aa77-bc8f-4146-8dea-c40e9ee111e2.jpg)


Tool / Window | Input Box | Condition
---               | ---        | --- 
Selection Tool   | **`Miter`**     | Vector Level  
|             |             |        
Brush Tool   | **`Miter`**       | Vector Level  
|             |             |                 
Geometric Tool | **`Thickness`** | Toonz Raster Level, Raster Level
Geometric Tool | **`Polygon Slides`** and **`Miter`** | Toonz Raster Level, Raster Level, Vector Level
|             |             |        
Paint Brush Tool | **`Size`** | Toonz Raster Level
|             |             |  
Eraser Tool        | **`Size`**  | Toonz Raster Level, Raster Level
|             |             |
Tape Tool      | **`Opacity`** | Toonz Raster Level
|             |             |
Finger Tool         | **`Size`** | Toonz Raster Level
|             |             |
Pump Tool         | **`Accurracy`** | Vector Level                            
|             |             |
Tracker Tool        | **`X`** and **`Y`**| Vector Level     
 |             |             |
Cleanup Settings (Global)       | **`Despeckling`**|  
 |             |             |          
Stop Motion Control       | **`Opacity`**|      
Stop Motion Control       | **`interval(sec)`** and **`Capture Review Time)`**| _Options tab_ 
 |             |             |   


Ref: #4044 



