### PR TITLE
Fix memory corruption caused by rapid project/scene change

### DIFF
--- a/toonz/sources/toonzlib/tscenehandle.cpp
+++ b/toonz/sources/toonzlib/tscenehandle.cpp
@@ -1,4 +1,4 @@
-
+#include <QTimer>
 
 #include "toonz/tscenehandle.h"
 
@@ -23,7 +23,22 @@ ToonzScene *TSceneHandle::getScene() const { return m_scene; }
 
 void TSceneHandle::setScene(ToonzScene *scene) {
   if (m_scene == scene) return;
-  delete m_scene;
+  ToonzScene *oldscene = m_scene;
   m_scene = scene;
   if (m_scene) emit sceneSwitched();
+
+  // Prevent memory corruption caused by delayed signals writing into the
+  // discarded old scene while that memory was freed.
+  // That made OT had a chance of crashing when project or scene changed rapidly.
+  // Note: This is not the best solution but "it just works"
+  if (oldscene) {
+    QTimer *delayedTimer = new QTimer(this);
+    delayedTimer->setSingleShot(true);
+
+    connect(delayedTimer, &QTimer::timeout, [=]() {
+      delete oldscene;
+      delayedTimer->deleteLater();
+    });
+    delayedTimer->start(3000);  // 1 sec was enough, but... dunno about toasters
+  }
 }


### PR DESCRIPTION
This one is really weird... 😕 

Each time a project changes, a new scene is created and the old scene gets immediately deleted from memory.

From what I undestand the issue seems that Qt signals can occur after that and OT will be accessing and/or modifying memory that is supposed to be now free and reused for something else, causing memory corruption that could lead to weird behaviors or ultimately crashing OT.

**To reproduce the crash:**
Have a couple of projects in your stuff directory, the more the easier for the crash to occur.
In Startup Popup select the Current Project ComboBox and hold UP and DOWN arrows on keyboard to cause OT to rapidly change projects as fast as it can.
After so many project changes in quick succession there's a chance for OT to crash.

This PR delay the deletion of the old scene by a few secs, enough for the large spam of signals to finish in time. This is more than a hack than a proper solution sadly, on my computer at least the crash stopped with this patch but mileage may vary.
