### PR TITLE
Fix Starting frame Multi-thread FFMPEG

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -47,7 +47,7 @@ public:
 private:
   QString m_intermediateFormat, m_ffmpegPath, m_audioPath, m_audioFormat;
   int m_frameCount    = 0, m_lx, m_ly, m_bpp, m_bitsPerSample, m_channelCount,
-      m_ffmpegTimeout = 30000, m_frameNumberOffset = -1;
+      m_ffmpegTimeout = 30000, m_startNumber = 2147483647;
   double m_frameRate  = 24.0;
   bool m_ffmpegExists = false, m_ffprobeExists = false, m_hasSoundTrack = false;
   TFilePath m_path;


### PR DESCRIPTION
This fix the miss of few starting frames on exported FFMPEG movie formats

The amount lost was related to the number of cores of the CPU (and RNG mostly!), this is caused by race condition with logic that was designed for single threading.

Patch only affects when Multi-thread FFMPEG is enabled, does not affect non-FFMPEG formats.
