### PR TITLE
Simplify uneditable check code

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -794,10 +794,14 @@ TFrameId TFilePath::getFrame() const {
 
 bool TFilePath::isFfmpegType() const {
   QString type = QString::fromStdString(getType()).toLower();
-  if (type == "gif" || type == "mp4" || type == "webm")
-    return true;
-  else
-    return false;
+  return (type == "gif" || type == "mp4" || type == "webm");
+}
+
+//-----------------------------------------------------------------------------
+
+bool TFilePath::isUneditable() const {
+  QString type = QString::fromStdString(getType()).toLower();
+  return (type == "psd" || type == "gif" || type == "mp4" || type == "webm");
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/tfilepath.h
+++ b/toonz/sources/include/tfilepath.h
@@ -245,6 +245,7 @@ If the path is "<alpha>:" a slash will be added*/
 
   TFrameId getFrame() const;
   bool isFfmpegType() const;
+  bool isUneditable() const;
   bool isLevelName()
       const;  //{return getFrame() == TFrameId(TFrameId::EMPTY_FRAME);};
   bool isAbsolute() const;

--- a/toonz/sources/include/tlevel_io.h
+++ b/toonz/sources/include/tlevel_io.h
@@ -245,6 +245,19 @@ inline bool isMovieType(const TFilePath &fp) {
 
 //-----------------------------------------------------------
 
+inline bool isMovieTypeOpaque(std::string type) {
+  return (type == "avi" || type == "3gp" || type == "mp4");
+}
+
+//-----------------------------------------------------------
+
+inline bool isMovieTypeOpaque(const TFilePath &fp) {
+  std::string type(fp.getType());
+  return isMovieTypeOpaque(type);
+}
+
+//-----------------------------------------------------------
+
 inline bool isSequencialRequired(std::string type) {
   return (type == "mov" || type == "avi" || type == "3gp");
 }
@@ -254,6 +267,21 @@ inline bool isSequencialRequired(std::string type) {
 inline bool isSequencialRequired(const TFilePath &fp) {
   std::string type(fp.getType());
   return isSequencialRequired(type);
+}
+
+//-----------------------------------------------------------
+
+inline bool isMultipleFrameType(std::string type) {
+  return (type == "tlv" || type == "tzl" || type == "pli" || type == "mov" ||
+          type == "avi" || type == "3gp" || type == "gif" || type == "mp4" ||
+          type == "webm");
+}
+
+//-----------------------------------------------------------
+
+inline bool isMultipleFrameType(const TFilePath &fp) {
+  std::string type(fp.getType());
+  return isMultipleFrameType(type);
 }
 
 //-----------------------------------------------------------

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1055,11 +1055,7 @@ QString TTool::updateEnabled(int rowIndex, int columnIndex) {
                     "The current frame is locked: any editing is forbidden."));
 
       // Check level type write support
-      if (sl->getPath().getType() ==
-              "psd" ||  // We don't have the API to write psd files
-          sl->getPath().getType() == "gif" ||
-          sl->getPath().getType() == "mp4" ||
-          sl->getPath().getType() == "webm" ||
+      if (sl->getPath().isUneditable() ||
           sl->is16BitChannelLevel() ||  // Inherited by previous
                                         // implementation.
                                         // Could be fixed?

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -468,9 +468,7 @@ bool pasteStrokesInCellWithoutUndo(
   } else {
     vi = cell.getImage(true);
     sl = cell.getSimpleLevel();
-    if (sl->getType() == OVL_XSHLEVEL &&
-        (sl->getPath().getType() == "psd" || sl->getPath().getType() == "gif" ||
-         sl->getPath().getType() == "mp4" || sl->getPath().getType() == "webm"))
+    if (sl->getType() == OVL_XSHLEVEL && sl->getPath().isUneditable())
       return false;
     fid = cell.getFrameId();
     if (!vi) {
@@ -1660,9 +1658,7 @@ static void pasteRasterImageInCell(int row, int col,
     if (sl) oldPalette = sl->getPalette();
   } else {
     TXshSimpleLevel *sl = cell.getSimpleLevel();
-    if (sl->getType() == OVL_XSHLEVEL &&
-        (sl->getPath().getType() == "psd" || sl->getPath().getType() == "gif" ||
-         sl->getPath().getType() == "mp4" || sl->getPath().getType() == "webm"))
+    if (sl->getType() == OVL_XSHLEVEL && sl->getPath().isUneditable())
       return;
     oldPalette = sl->getPalette();
   }

--- a/toonz/sources/toonz/cellselectioncommand.cpp
+++ b/toonz/sources/toonz/cellselectioncommand.cpp
@@ -1531,10 +1531,7 @@ void CloneLevelUndo::cloneLevels() const {
       assert(lt->first && !lt->second.empty());
 
       TXshSimpleLevel *srcSl = lt->first;
-      if (srcSl->getPath().getType() == "psd" ||
-          srcSl->getPath().getType() == "gif" ||
-          srcSl->getPath().getType() == "mp4" ||
-          srcSl->getPath().getType() == "webm")
+      if (srcSl->getPath().isUneditable())
         continue;
 
       const TFilePath &srcPath = srcSl->getPath();

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -248,10 +248,7 @@ static bool canMergeColumns(int column, int mColumn, bool forMatchlines) {
         return false;
       // Check level type write support. Based on TTool::updateEnabled()
       if (level->getType() == OVL_XSHLEVEL &&
-          (level->getPath().getType() == "psd" ||  // PSD files.
-           level->getPath().getType() == "gif" ||
-           level->getPath().getType() == "mp4" ||
-           level->getPath().getType() == "webm" ||
+          (level->getPath().isUneditable() ||
            level->is16BitChannelLevel() ||            // 16bpc images.
            level->getProperties()->getBpp() == 1)) {  // Black & White images.
         return false;

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -171,7 +171,7 @@ bool RenderController::addScene(MovieGenerator &g, ToonzScene *scene) {
   }
   if (r1 < r0) return false;
   TPixel color = scene->getProperties()->getBgColor();
-  if (m_movieExt == "mp4" || m_movieExt == "webm") color.m = 255;
+  if (isMovieTypeOpaque(m_movieExt)) color.m = 255;
   g.setBackgroundColor(color);
   g.addScene(*scene, r0, r1);
   return true;

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -144,12 +144,6 @@ QMutex levelFileMutex;
 
 }  // namespace
 
-inline bool isMultipleFrameType(std::string type) {
-  return (type == "tlv" || type == "tzl" || type == "pli" || type == "mov" ||
-          type == "avi" || type == "3gp" || type == "gif" || type == "mp4" ||
-          type == "webm");
-}
-
 //=============================================================================
 // FileBrowser
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1269,8 +1269,7 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   }
   if (sl &&
       (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL ||
-       (sl->getType() == OVL_XSHLEVEL && sl->getPath().getType() != "gif" &&
-        sl->getPath().getType() != "mp4" && sl->getPath().getType() != "webm")))
+       (sl->getType() == OVL_XSHLEVEL && !sl->getPath().isUneditable())))
     menu->addAction(cm->getAction(MI_RevertToLastSaved));
   menu->addSeparator();
   createSelectLevelMenu(menu);

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -57,9 +57,7 @@ void TFilmstripSelection::enableCommands() {
 
   bool doEnable =
       (type == PLI_XSHLEVEL || type == TZP_XSHLEVEL || type == MESH_XSHLEVEL ||
-       (type == OVL_XSHLEVEL && path.getType() != "psd" &&
-        path.getType() != "gif" && path.getType() != "mp4" &&
-        path.getType() != "webm"));
+       (type == OVL_XSHLEVEL && !path.isUneditable()));
 
   TRasterImageP ri = (TRasterImageP)sl->getSimpleLevel()->getFrame(
       sl->getSimpleLevel()->getFirstFid(), false);

--- a/toonz/sources/toonz/matchlinecommand.cpp
+++ b/toonz/sources/toonz/matchlinecommand.cpp
@@ -335,10 +335,7 @@ void doCloneLevelNoSave(const TCellSelection::Range &range,
       fid = cell.getFrameId();
 
       if (cell.getSimpleLevel() == 0 ||
-          cell.getSimpleLevel()->getPath().getType() == "psd" ||
-          cell.getSimpleLevel()->getPath().getType() == "gif" ||
-          cell.getSimpleLevel()->getPath().getType() == "mp4" ||
-          cell.getSimpleLevel()->getPath().getType() == "webm")
+          cell.getSimpleLevel()->getPath().isUneditable())
         continue;
 
       std::map<TXshSimpleLevel *, TXshLevelP>::iterator it =

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -482,7 +482,7 @@ void RenderCommand::rasterRender(bool isPreview) {
   // depth). I tried to make OT to detect the mov settings and adaptively switch
   // the behavior, but ended in vain :-(
   // So I just omitted every mov from applying solid background as a quick fix.
-  if (isMovieType(ext) && ext != "mov") {
+  if (isMovieTypeOpaque(ext)) {
     scene->getProperties()->setBgColor(currBgColor);
   }
   // for non alpha-enabled images (like jpg), background color will be inserted

--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -16,6 +16,7 @@
 
 // TnzCore includes
 #include "tconvert.h"
+#include "tlevel_io.h"
 
 // Qt includes
 #include <QTreeWidget>
@@ -31,15 +32,6 @@
 #include <QComboBox>
 
 using namespace DVGui;
-
-//=============================================================================
-
-namespace {
-bool isMovieType(std::string type) {
-  return (type == "mov" || type == "avi" || type == "3gp" || type == "mp4" ||
-          type == "webm");
-}
-};  // namespace
 
 //=============================================================================
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -119,8 +119,7 @@ bool isAreadOnlyLevel(const TFilePath &path) {
   if (path.getDots() == "." ||
       (path.getDots() == ".." &&
        (path.getType() == "tlv" || path.getType() == "tpl"))) {
-    if (path.getType() == "psd" || path.getType() == "gif" ||
-        path.getType() == "mp4" || path.getType() == "webm")
+    if (path.isUneditable())
       return true;
     if (!TSystem::doesExistFileOrLevel(path)) return false;
     TFileStatus fs(path);
@@ -2428,9 +2427,7 @@ bool TXshSimpleLevel::isFrameReadOnly(TFrameId fid) {
       getType() == MESH_XSHLEVEL) {
     if (getProperties()->isStopMotionLevel()) return true;
     TFilePath fullPath   = getScene()->decodeFilePath(m_path);
-    std::string fileType = fullPath.getType();
-    if (fileType == "psd" || fileType == "gif" || fileType == "mp4" ||
-        fileType == "webm")
+    if (fullPath.isUneditable())
       return true;
     TFilePath path =
         fullPath.getDots() == ".." ? fullPath.withFrame(fid) : fullPath;


### PR DESCRIPTION
This simplify source code for checking uneditables formats, avoiding duplicated hard-coded checks across multiple source files.

Additionally together with #4486 will fix WebM transparency.
