### PR TITLE
Modify hiding and showing controls in fx settings

### DIFF
--- a/toonz/sources/common/tfx/tfx.cpp
+++ b/toonz/sources/common/tfx/tfx.cpp
@@ -1002,7 +1002,10 @@ TFx *TFx::getLinkedFx() const {
 
 //--------------------------------------------------
 
-void TFx::setFxVersion(int v) { m_imp->m_attributes.setFxVersion(v); }
+void TFx::setFxVersion(int v) {
+  m_imp->m_attributes.setFxVersion(v);
+  onFxVersionSet();
+}
 
 //--------------------------------------------------
 

--- a/toonz/sources/include/tfx.h
+++ b/toonz/sources/include/tfx.h
@@ -505,6 +505,7 @@ public:
 
   void setFxVersion(int);
   int getFxVersion() const;
+  virtual void onFxVersionSet() {}
 
 public:
   // Id-related functions

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -194,7 +194,10 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
       is.matchEndTag();
       /*-- Layout設定名とFxParameterの名前が一致するものを取得 --*/
       TParamP param = fx->getParams()->getParam(name);
-      if (param) {
+      bool isHidden =
+          (param) ? fx->getParams()->getParamVar(name)->isHidden() : true;
+
+      if (param && !isHidden) {
         std::string paramName = fx->getFxType() + "." + name;
         QString str =
             QString::fromStdWString(TStringTable::translate(paramName));
@@ -314,6 +317,17 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
               continue;
             modeChanger = field;
             break;
+          }
+          // modeChanger may be in another vbox in the page
+          if (!modeChanger) {
+            QList<ModeChangerParamField *> allModeChangers =
+                findChildren<ModeChangerParamField *>();
+            for (auto field : allModeChangers) {
+              if (field->getParamName().toStdString() == modeSensitiveStr) {
+                modeChanger = field;
+                break;
+              }
+            }
           }
           assert(modeChanger);
           tmpWidget = new ModeSensitiveBox(this, modeChanger, modes);
@@ -567,8 +581,7 @@ void ParamsPage::setFx(const TFxP &currentFx, const TFxP &actualFx, int frame) {
   for (int i = 0; i < (int)m_fields.size(); i++) {
     ParamField *field = m_fields[i];
     QString fieldName = field->getParamName();
-
-    TFxP fx = getCurrentFx(currentFx, actualFx->getFxId());
+    TFxP fx           = getCurrentFx(currentFx, actualFx->getFxId());
     assert(fx.getPointer());
     TParamP currentParam =
         currentFx->getParams()->getParam(fieldName.toStdString());
@@ -1096,6 +1109,8 @@ void ParamViewer::setFx(const TFxP &currentFx, const TFxP &actualFx, int frame,
   if (name == "macroFx") {
     TMacroFx *macroFx = dynamic_cast<TMacroFx *>(currentFx.getPointer());
     if (macroFx) name = macroFx->getMacroFxType();
+  } else {
+    name += std::to_string(actualFx->getFxVersion());
   }
 
   int currentIndex = -1;

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -1320,7 +1320,7 @@ ModeSensitiveBox::ModeSensitiveBox(QWidget *parent, QCheckBox *checkBox)
 //-----------------------------------------------------------------------------
 
 void ModeSensitiveBox::onModeChanged(int modeValue) {
-  bool wasVisible = isVisible();
+  bool wasVisible = isVisibleTo(parentWidget());
   m_currentMode   = modeValue;
   if (wasVisible == m_modes.contains(modeValue)) return;
   setVisible(!wasVisible);


### PR DESCRIPTION
This PR will modify the fx settings popup as follows:

#### Modification in the visibility tag
Consider there is an fx parameter which only have meanings when the fx is in some state specified with another parameter.
( For instance, the `Gamma` parameter of  `Over Ino` is only used when the `Linear Color Space` checkbox is activated. )
In such case, unused fields under the current state should be hidden in order to keep the fx settings simple.

Currently there are two ways to realize such behavior; using the `modeSensitive` tag attribure and using the `visibleToggle` tag.
This PR will fix the `modeSensitive` tag attribure to work even if the "controller" and the "controlled" fields are not in the same layout.

#### Recycling the unused `isHidden` flag of the fx parameter
When there is an update in some fx, such update sometimes alters an fx version. It will enable the fx to work in different ways, the updated and the convintional ways, according to the version so that the old scene containing the fx will render the same result as before.
Consider that there may be a case that a new parameter will be introduced which is needed only for version 2.
Such parameter  should be hidden from the fx settings when using the same fx version 1.

In order to achieve such behavior, I decided to recycle a flag `TParamVar::m_isHidden` which seems to not be used in anywhere in the source.
Now, setting `m_isHidden` to `true` will hide the parameter from the fx settings.
Setting the flag in `TFx::onFxVersionSet()` will enable parameter to change its visibility by versions.