### PR TITLE
Sampling Size for Gradient Warp Iwa Fx

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1205,6 +1205,7 @@
   <item>"STD_iwa_GradientWarpFx.h_maxlen"		"H Length"</item>
   <item>"STD_iwa_GradientWarpFx.v_maxlen"		"V Length"</item>
   <item>"STD_iwa_GradientWarpFx.scale"			"Scale"</item>
+  <item>"STD_iwa_GradientWarpFx.sampling_size"			"Sampling Size"</item>
 
   <item>"STD_iwa_MotionBlurCompFx"	"Motion Blur Iwa"	</item>
   <item>"STD_iwa_MotionBlurCompFx.hardness"	"Hardness"	</item>

--- a/stuff/profiles/layouts/fxs/STD_iwa_GradientWarpFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_GradientWarpFx.xml
@@ -3,5 +3,6 @@
 	<control>h_maxlen</control>
 	<control>v_maxlen</control>
 	<control>scale</control>
+	<control>sampling_size</control>
   </page>
 </fxlayout>

--- a/toonz/sources/stdfx/iwa_gradientwarpfx.h
+++ b/toonz/sources/stdfx/iwa_gradientwarpfx.h
@@ -33,6 +33,7 @@ protected:
   TDoubleParamP
       m_scale; /*- ワープ量を増やすスカラー値。この値はマージン値には影響しない
                   -*/
+  TDoubleParamP m_sampling_size;
 
   void get_render_real_hv(const double frame, const TAffine affine,
                           double &h_maxlen, double &v_maxlen);
@@ -57,7 +58,8 @@ protected:
                      const TRenderSettings &settings, double hLength,
                      double vLength, int margin, TDimensionI &enlargedDim,
                      float4 *source_host, float *warper_host,
-                     float4 *result_host);
+                     float4 *result_host, double sampling_size,
+                     double grad_factor);
 
   float4 getSourceVal_CPU(float4 *source_host, TDimensionI &enlargedDim,
                           int pos_x, int pos_y);
@@ -74,6 +76,8 @@ public:
                  const TRenderSettings &info) override;
 
   bool canHandle(const TRenderSettings &info, double frame) override;
+
+  void onFxVersionSet() final override;
 };
 
 #endif


### PR DESCRIPTION
This PR will introduce a new parameter `Sampling Size` to the Gradient Warp Iwa Fx, which specifies a distance of the sampling point for computing gradient of the Warper image.

Before this PR, sampling distance had been always 1 pixel regardless of the camera size. Which is to say, the rendered results had been not identical when you set different shrink values in the Preview or Render Settings.

This PR will advance the fx version to 2. Version 1 fxs (made in the previous versions) won't show the `Sampling Size` control in the fx settings and will render the same result as before.