### PR TITLE
Camera Capture : Show subcamera center on mouse hover

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -546,6 +546,15 @@ void MyVideoWidget::drawSubCamera(QPainter& p) {
   drawHandle(HandleTopRight, vidSubRect.topRight());
   drawHandle(HandleBottomLeft, vidSubRect.bottomLeft());
   drawHandle(HandleBottomRight, vidSubRect.bottomRight());
+
+  // draw cross mark at subcamera center when the cursor is in the frame
+  if (m_activeSubHandle != HandleNone) {
+    p.setPen(QPen(Qt::magenta, 1, Qt::DashLine));
+    QPoint crossP(vidSubRect.width() / 40, vidSubRect.height() / 40);
+    p.drawLine(vidSubRect.center() - crossP, vidSubRect.center() + crossP);
+    crossP.setX(-crossP.x());
+    p.drawLine(vidSubRect.center() - crossP, vidSubRect.center() + crossP);
+  }
 }
 
 void MyVideoWidget::mouseMoveEvent(QMouseEvent* event) {

--- a/toonz/sources/toonz/penciltestpopup_qt.cpp
+++ b/toonz/sources/toonz/penciltestpopup_qt.cpp
@@ -713,6 +713,15 @@ void MyVideoWidget::drawSubCamera(QPainter& p) {
   drawHandle(HandleTopRight, vidSubRect.topRight());
   drawHandle(HandleBottomLeft, vidSubRect.bottomLeft());
   drawHandle(HandleBottomRight, vidSubRect.bottomRight());
+
+  // draw cross mark at subcamera center when the cursor is in the frame
+  if (m_activeSubHandle != HandleNone) {
+    p.setPen(QPen(Qt::magenta, 1, Qt::DashLine));
+    QPoint crossP(vidSubRect.width() / 40, vidSubRect.height() / 40);
+    p.drawLine(vidSubRect.center() - crossP, vidSubRect.center() + crossP);
+    crossP.setX(-crossP.x());
+    p.drawLine(vidSubRect.center() - crossP, vidSubRect.center() + crossP);
+  }
 }
 
 void MyVideoWidget::mouseMoveEvent(QMouseEvent* event) {
@@ -1790,9 +1799,9 @@ PencilTestPopup::PencilTestPopup()
   //---- signal-slot connections ----
   bool ret = true;
   ret      = ret && connect(refreshCamListButton, SIGNAL(pressed()), this,
-                       SLOT(refreshCameraList()));
+                            SLOT(refreshCameraList()));
   ret      = ret && connect(m_cameraListCombo, SIGNAL(activated(int)), this,
-                       SLOT(onCameraListComboActivated(int)));
+                            SLOT(onCameraListComboActivated(int)));
   ret = ret && connect(m_resolutionCombo, SIGNAL(activated(const QString&)),
                        this, SLOT(onResolutionComboActivated(const QString&)));
   ret = ret && connect(m_fileFormatOptionButton, SIGNAL(pressed()), this,


### PR DESCRIPTION
This PR will improve the `Camera Capture` popup, showing a small cross mark at the center of subcamera when the mouse cursor is inside of the subcamera frame. It will enable users to adjust the subcamera position more precisely. 

![penciltest_subcamera_center_cross](https://user-images.githubusercontent.com/17974955/183599791-374ecf5a-46a1-486e-90ec-131ed7336c4f.png)

