### PR TITLE
Expand xsheet frame area

### DIFF
--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -154,7 +154,9 @@ enum class PredefinedDimension {
   QBOXLAYOUT_DIRECTION,  //! direction of QBoxLayout
   CENTER_ALIGN,          //! horizontal / vertical align
   CAMERA_LAYER,          //! width of a camera column / height of camera row
-  SCALE_THRESHOLD        //! scale threshold to simplify the view
+  SCALE_THRESHOLD,       //! scale threshold to simplify the view
+  FRAME_AREA_EXPANSION   //! expansion of the frame area if it can have extra
+                         //! space
 };
 enum class PredefinedPath {
   DRAG_HANDLE_CORNER,   //! triangle corner at drag sidebar
@@ -169,8 +171,8 @@ enum class PredefinedPath {
 };
 enum class PredefinedPoint {
   KEY_HIDDEN,  //! move extender handle that much if key icons are disabled
-  EXTENDER_XY_RADIUS,        //! x and y radius for rounded rectangle
-  VOLUME_DIVISIONS_TOP_LEFT  //! where to draw volume slider
+  EXTENDER_XY_RADIUS,         //! x and y radius for rounded rectangle
+  VOLUME_DIVISIONS_TOP_LEFT,  //! where to draw volume slider
 };
 enum class PredefinedRange {
   HEADER_FRAME,  //! size of of column header height(v) / row header width(h)

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -79,6 +79,14 @@ void RowArea::setDragTool(DragTool *dragTool) {
 }
 
 //-----------------------------------------------------------------------------
+// returns true if the frame area can have extra space
+bool RowArea::checkExpandFrameArea() {
+  return m_viewer->orientation()->isVerticalTimeline() &&
+         !Preferences::instance()->isOnionSkinEnabled() &&
+         !CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked();
+}
+
+//-----------------------------------------------------------------------------
 
 void RowArea::drawRows(QPainter &p, int r0, int r1) {
   const Orientation *o = m_viewer->orientation();
@@ -149,6 +157,14 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
       if (!isAfterMarkers) p.setPen(m_viewer->getFrameRangeMarkerLineColor());
     }
     p.drawLine(horizontalLine);
+  }
+
+  int extraSpaces = 0;
+  if (checkExpandFrameArea()) {
+    extraSpaces =
+        std::max(0, o->rect(PredefinedRect::FRAME_LABEL).width() /
+                            QFontMetrics(p.font()).boundingRect("0").width() -
+                        6);
   }
 
   int z = 0;
@@ -227,8 +243,9 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
       int koma = (r + 1) % (frameRate * 6);
       if ((r + 1) % frameRate == 1) {
         int page = (r + 1) / (frameRate * 6) + 1;
-        str      = QString("p%1 %2")
+        str      = QString("p%1%2%3")
                   .arg(QString::number(page))
+                  .arg(QString().leftJustified(1 + extraSpaces, ' '))
                   .arg(QString::number(koma).rightJustified(3, '0'));
         z = 0;
       } else {
@@ -256,8 +273,9 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
       int koma = (r + 1) % (frameRate * 3);
       if ((r + 1) % frameRate == 1) {
         int page = (r + 1) / (frameRate * 3) + 1;
-        str      = QString("p%1 %2")
+        str      = QString("p%1%2%3")
                   .arg(QString::number(page))
+                  .arg(QString().leftJustified(2 + extraSpaces, ' '))
                   .arg(QString::number(koma).rightJustified(2, '0'));
         z = 0;
       } else {
@@ -286,6 +304,12 @@ void RowArea::drawPlayRangeBackground(QPainter &p, int r0, int r1) {
   int playR0, playR1, step;
   XsheetGUI::getPlayRange(playR0, playR1, step);
 
+  int hExpansion = 0;
+  if (checkExpandFrameArea()) {
+    hExpansion = m_viewer->orientation()->dimension(
+        PredefinedDimension::FRAME_AREA_EXPANSION);
+  }
+
   for (int r = r0; r <= r1; r++) {
     if (!(playR0 <= r && r <= playR1) && ((r - m_r0) % step == 0)) continue;
 
@@ -295,9 +319,10 @@ void RowArea::drawPlayRangeBackground(QPainter &p, int r0, int r1) {
     else
       basePoint.setX(0);
 
-    QRect previewBoxRect = o->rect(PredefinedRect::PREVIEW_FRAME_AREA)
-                               .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
-                               .translated(basePoint);
+    QRect previewBoxRect =
+        o->rect(PredefinedRect::PREVIEW_FRAME_AREA)
+            .adjusted(-hExpansion, 0, -frameAdj.x(), -frameAdj.y())
+            .translated(basePoint);
     p.fillRect(previewBoxRect, m_viewer->getPlayRangeColor());
 
     if (!o->isVerticalTimeline()) {
@@ -334,6 +359,12 @@ void RowArea::drawPlayRange(QPainter &p, int r0, int r1) {
     m_r0 = 0;
   }
 
+  int hOffset = 0;
+  if (checkExpandFrameArea()) {
+    hOffset = m_viewer->orientation()->dimension(
+        PredefinedDimension::FRAME_AREA_EXPANSION);
+  }
+
   QColor ArrowColor = (playRangeEnabled) ? QColor(255, 255, 255) : grey150;
   p.setBrush(QBrush(ArrowColor));
 
@@ -342,7 +373,7 @@ void RowArea::drawPlayRange(QPainter &p, int r0, int r1) {
     if (!m_viewer->orientation()->isVerticalTimeline())
       topLeft.setY(0);
     else
-      topLeft.setX(0);
+      topLeft.setX(-hOffset);
     m_viewer->drawPredefinedPath(p, PredefinedPath::BEGIN_PLAY_RANGE, topLeft,
                                  ArrowColor, QColor(Qt::black));
   }
@@ -353,7 +384,7 @@ void RowArea::drawPlayRange(QPainter &p, int r0, int r1) {
     if (!m_viewer->orientation()->isVerticalTimeline())
       topLeft.setY(0);
     else
-      topLeft.setX(0);
+      topLeft.setX(-hOffset);
     m_viewer->drawPredefinedPath(p, PredefinedPath::END_PLAY_RANGE, topLeft,
                                  ArrowColor, QColor(Qt::black));
   }
@@ -373,6 +404,7 @@ void RowArea::drawCurrentRowGadget(QPainter &p, int r0, int r1) {
   QRect header = m_viewer->orientation()
                      ->rect(PredefinedRect::FRAME_HEADER)
                      .translated(topLeft);
+
   QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
   header.adjust(1, 1, -frameAdj.x(), -frameAdj.y());
   p.fillRect(header, m_viewer->getCurrentRowBgColor());
@@ -680,8 +712,8 @@ void RowArea::drawShiftTraceMarker(QPainter &p) {
 
   QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
   int frameAdj_i  = (m_viewer->orientation()->isVerticalTimeline())
-                       ? frameAdj.y()
-                       : frameAdj.x();
+                        ? frameAdj.y()
+                        : frameAdj.x();
 
   // get onion colors
   TPixel frontPixel, backPixel;
@@ -1006,12 +1038,19 @@ void RowArea::mousePressEvent(QMouseEvent *event) {
         playR0       = 0;
       }
 
+      int playRangeHOffset = 0;
+      if (checkExpandFrameArea()) {
+        playRangeHOffset = m_viewer->orientation()->dimension(
+            PredefinedDimension::FRAME_AREA_EXPANSION);
+      }
+
       if (playR1 == -1) {  // getFrameCount = 0 i.e. xsheet is empty
         setDragTool(
             XsheetGUI::DragTool::makeCurrentFrameModifierTool(m_viewer));
         frameAreaIsClicked = true;
       } else if (o->rect(PredefinedRect::PLAY_RANGE)
                      .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
+                     .translated(-playRangeHOffset, 0)
                      .contains(mouseInCell) &&
                  (row == playR0 || row == playR1)) {
         if (!playRangeEnabled) XsheetGUI::setPlayRange(playR0, playR1, step);
@@ -1169,16 +1208,22 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
 
   update();
 
+  int hOffset = 0;
+  if (checkExpandFrameArea()) {
+    hOffset = m_viewer->orientation()->dimension(
+        PredefinedDimension::FRAME_AREA_EXPANSION);
+  }
+
   QPoint base0 = m_viewer->positionToXY(CellPosition(m_r0, -1));
   if (!m_viewer->orientation()->isVerticalTimeline())
     base0.setY(0);
   else
-    base0.setX(0);
+    base0.setX(-hOffset);
   QPoint base1 = m_viewer->positionToXY(CellPosition(m_r1, -1));
   if (!m_viewer->orientation()->isVerticalTimeline())
     base1.setY(0);
   else
-    base1.setX(0);
+    base1.setX(-hOffset);
   QPainterPath startArrow =
       o->path(PredefinedPath::BEGIN_PLAY_RANGE).translated(base0);
   QPainterPath endArrow =

--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -44,6 +44,8 @@ class RowArea final : public QWidget {
   // panning by middle-drag
   bool m_isPanning;
 
+  // returns true if the frame area can have extra space
+  bool checkExpandFrameArea();
   void drawRows(QPainter &p, int r0, int r1);
   void drawPlayRangeBackground(QPainter &p, int r0, int r1);
   void drawPlayRange(QPainter &p, int r0, int r1);

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -918,6 +918,7 @@ TopToBottomOrientation::TopToBottomOrientation() {
   addDimension(PredefinedDimension::CENTER_ALIGN, Qt::AlignHCenter);
   addDimension(PredefinedDimension::CAMERA_LAYER, CAMERA_CELL_WIDTH);
   addDimension(PredefinedDimension::SCALE_THRESHOLD, 57);
+  addDimension(PredefinedDimension::FRAME_AREA_EXPANSION, PLAY_RANGE_X);
 
   //
   // Paths
@@ -1338,6 +1339,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addDimension(PredefinedDimension::CENTER_ALIGN, Qt::AlignVCenter);
   addDimension(PredefinedDimension::CAMERA_LAYER, CAMERA_CELL_HEIGHT);
   addDimension(PredefinedDimension::SCALE_THRESHOLD, 50);
+  addDimension(PredefinedDimension::FRAME_AREA_EXPANSION, 0);  // not used
 
   //
   // Paths


### PR DESCRIPTION
![frame_area](https://user-images.githubusercontent.com/17974955/183848558-d44fc23d-f32b-46a2-a9b7-4f006685e734.png)

This PR is to resolve a request by some Japanese animation studio as follows:
- Regarding the frame number in the Xsheet row area, when the display mode is in "3sec sheet" or "6sec sheet", it should have more spacing between the page number and the frame number for better visibility.

To achieve this, this PR will expand the frame number region in the Xsheet row area when the onion skin and the shift&trace features are both disabled.

Please note that the appearance of Timeline is kept unchanged.