### PR TITLE
Fix preview range not to be negative

### DIFF
--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -680,8 +680,8 @@ void RowArea::drawShiftTraceMarker(QPainter &p) {
 
   QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
   int frameAdj_i  = (m_viewer->orientation()->isVerticalTimeline())
-                       ? frameAdj.y()
-                       : frameAdj.x();
+                        ? frameAdj.y()
+                        : frameAdj.x();
 
   // get onion colors
   TPixel frontPixel, backPixel;
@@ -1066,7 +1066,8 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
     return;
   }
 
-  m_row = m_viewer->xyToPosition(pos).frame();
+  m_row = std::max(0, m_viewer->xyToPosition(pos).frame());
+
   int x = pos.x();
 
   if ((event->buttons() & Qt::LeftButton) != 0 &&


### PR DESCRIPTION
This PR will fix a problem that the preview range markers can be set to negative frames (therefore, the markers disappear from the xsheet).

**To reproduce:**
1. Right click frame1 in the xsheet row area.
2. Drag the mouse pointer upward with keeping the right mouse button pressed.
3. Release the button and select `Preview This` from the context menu.
4. The preview range markers will disapper.