### PR TITLE
Style Selection .isEmpty logic fix

### DIFF
--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -568,7 +568,7 @@ void TStyleSelection::selectNone() {
 //-------------------------------------------------------------------
 
 bool TStyleSelection::isEmpty() const {
-  return m_pageIndex < 0 && m_styleIndicesInPage.empty();
+  return m_pageIndex < 0 || m_styleIndicesInPage.empty();
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Mainly fixes Palette Gizmo not being able to modify color if there's no styles selected.

Now the user can open Palette Gizmo anywhere on the Level Palette and the current style will be affected.
