### PR TITLE
Current frame indicator for Xsheet

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2362,6 +2362,7 @@ XsheetViewer {
   qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
   qproperty-XsheetConfigButtonImage: url('../Default/imgs/white/x_config.svg');
   qproperty-FrameRangeMarkerLineColor: #66696c;
+  qproperty-CurrentTimeIndicatorColor: #ff0000;
   qproperty-TimelinePreviewButtonBgOnColor: #414345;
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/white/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #414345;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2362,6 +2362,7 @@ XsheetViewer {
   qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
   qproperty-XsheetConfigButtonImage: url('../Default/imgs/white/x_config.svg');
   qproperty-FrameRangeMarkerLineColor: #565656;
+  qproperty-CurrentTimeIndicatorColor: #ff0000;
   qproperty-TimelinePreviewButtonBgOnColor: #303030;
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/white/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #303030;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2362,6 +2362,7 @@ XsheetViewer {
   qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
   qproperty-XsheetConfigButtonImage: url('imgs/white/x_config.svg');
   qproperty-FrameRangeMarkerLineColor: #6e6e6e;
+  qproperty-CurrentTimeIndicatorColor: #ff0000;
   qproperty-TimelinePreviewButtonBgOnColor: #484848;
   qproperty-TimelinePreviewButtonOnImage: url('imgs/white/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #484848;

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -414,6 +414,7 @@
 
 @xsheet-FoldedColumnBG-color:               lighten(@bg, 10);
 @xsheet-FoldedColumnLine-color:             darken(@bg, 5);
+@xsheet-CurrentTimeIndicator-color:         rgb(255, 0, 0);
 
 // Level Type Colors Adjustment
 @columnBorderDesaturation:                  0;

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -177,6 +177,7 @@ XsheetViewer {
   qproperty-XsheetConfigButtonImage: url('@{img-url}/x_config.svg');
 
   qproperty-FrameRangeMarkerLineColor: @timeline-FrameRangeMarkerLine-color;
+  qproperty-CurrentTimeIndicatorColor: @xsheet-CurrentTimeIndicator-color;
 
   // Column Header: Horizontal
   qproperty-TimelinePreviewButtonBgOnColor: @bg;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2362,6 +2362,7 @@ XsheetViewer {
   qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
   qproperty-XsheetConfigButtonImage: url('../Default/imgs/black/x_config.svg');
   qproperty-FrameRangeMarkerLineColor: rgba(0, 0, 0, 0.3);
+  qproperty-CurrentTimeIndicatorColor: #ff0000;
   qproperty-TimelinePreviewButtonBgOnColor: #DBDBDB;
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/black/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #DBDBDB;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2362,6 +2362,7 @@ XsheetViewer {
   qproperty-XsheetConfigButtonBgColor: rgba(255, 255, 255, 0);
   qproperty-XsheetConfigButtonImage: url('../Default/imgs/black/x_config.svg');
   qproperty-FrameRangeMarkerLineColor: #5a5a5a;
+  qproperty-CurrentTimeIndicatorColor: #ff0000;
   qproperty-TimelinePreviewButtonBgOnColor: #808080;
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/black/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #808080;

--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -142,7 +142,8 @@ enum class PredefinedLine {
   SEE_MARKER_THROUGH,  //! horizontal marker visible through drag handle
   CONTINUE_LEVEL,      //! level with the same name represented by vertical line
   CONTINUE_LEVEL_WITH_NAME,  //! adjusted when level name is on each marker
-  EXTENDER_LINE              //! see grid through extender handle
+  EXTENDER_LINE,             //! see grid through extender handle
+  CURRENT_TIME_INDICATOR     // current time indicator
 };
 enum class PredefinedDimension {
   LAYER,                 //! width of a layer column / height of layer row

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -103,9 +103,9 @@ SizeField::SizeField(QSize min, QSize max, QSize value, QWidget* parent)
 
   bool ret = true;
   ret      = ret && connect(m_fieldX, SIGNAL(editingFinished()), this,
-                       SIGNAL(editingFinished()));
+                            SIGNAL(editingFinished()));
   ret      = ret && connect(m_fieldY, SIGNAL(editingFinished()), this,
-                       SIGNAL(editingFinished()));
+                            SIGNAL(editingFinished()));
   assert(ret);
 }
 
@@ -255,9 +255,9 @@ Preferences::LevelFormat PreferencesPopup::FormatProperties::levelFormat()
   lf.m_priority = m_priority->getValue();
 
   // Assign level format values
-  lf.m_options.m_dpiPolicy = (m_dpiPolicy->currentIndex() == DP_ImageDpi)
-                                 ? LevelOptions::DP_ImageDpi
-                                 : LevelOptions::DP_CustomDpi;
+  lf.m_options.m_dpiPolicy   = (m_dpiPolicy->currentIndex() == DP_ImageDpi)
+                                   ? LevelOptions::DP_ImageDpi
+                                   : LevelOptions::DP_CustomDpi;
   lf.m_options.m_dpi         = m_dpi->getValue();
   lf.m_options.m_subsampling = m_subsampling->getValue();
   lf.m_options.m_antialias =
@@ -374,7 +374,7 @@ PreferencesPopup::Display30bitChecker::Display30bitChecker(
   GLView* view10bit     = new GLView(this, true);
   QPushButton* closeBtn = new QPushButton(tr("Close"), this);
   QString infoLabel     = tr(
-      "If the lower gradient looks smooth and has no banding compared to the upper gradient,\n\
+          "If the lower gradient looks smooth and has no banding compared to the upper gradient,\n\
 30bit display is available in the current configuration.");
 
   QVBoxLayout* lay = new QVBoxLayout();
@@ -908,7 +908,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
         combo->addItem(item.first, item.second);
       combo->setCurrentIndex(combo->findData(item.value));
       ret    = connect(combo, SIGNAL(currentIndexChanged(int)), this,
-                    SLOT(onChange()));
+                       SLOT(onChange()));
       widget = combo;
     } else {  // create IntLineEdit
       assert(item.max.toInt() != -1);
@@ -945,7 +945,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
       QFontComboBox* combo = new QFontComboBox(this);
       combo->setCurrentText(item.value.toString());
       ret    = connect(combo, SIGNAL(currentIndexChanged(const QString&)), this,
-                    SLOT(onInterfaceFontChanged(const QString&)));
+                       SLOT(onInterfaceFontChanged(const QString&)));
       widget = combo;
     } else if (!comboItems.isEmpty()) {  // create QComboBox
       QComboBox* combo = new QComboBox(this);
@@ -953,7 +953,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
         combo->addItem(item.first, item.second);
       combo->setCurrentIndex(combo->findData(item.value));
       ret    = connect(combo, SIGNAL(currentIndexChanged(int)), this,
-                    SLOT(onChange()));
+                       SLOT(onChange()));
       widget = combo;
     } else {  // create FileField
       DVGui::FileField* field =
@@ -976,7 +976,7 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
     ColorField* field =
         new ColorField(this, false, colorToTPixel(item.value.value<QColor>()));
     ret    = connect(field, SIGNAL(colorChanged(const TPixel32&, bool)), this,
-                  SLOT(onColorFieldChanged(const TPixel32&, bool)));
+                     SLOT(onColorFieldChanged(const TPixel32&, bool)));
     widget = field;
   } break;
 
@@ -1260,8 +1260,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {highlightLineEverySecond, tr("Highlight Line Every Second")},
       {syncLevelRenumberWithXsheet,
        tr("Sync Level Strip Drawing Number Changes with the Xsheet")},
-      {currentTimelineEnabled,
-       tr("Show Current Time Indicator (Timeline Mode only)")},
+      {currentTimelineEnabled, tr("Show Current Time Indicator")},
       {currentColumnColor, tr("Current Column Color:")},
       //{ levelNameOnEachMarkerEnabled, tr("Display Level Name on Each Marker")
       //},
@@ -1566,11 +1565,11 @@ QWidget* PreferencesPopup::createGeneralPage() {
 
   bool ret = true;
   ret      = ret && connect(m_pref, SIGNAL(stopAutoSave()), this,
-                       SLOT(onAutoSaveExternallyChanged()));
+                            SLOT(onAutoSaveExternallyChanged()));
   ret      = ret && connect(m_pref, SIGNAL(startAutoSave()), this,
-                       SLOT(onAutoSaveExternallyChanged()));
+                            SLOT(onAutoSaveExternallyChanged()));
   ret      = ret && connect(m_pref, SIGNAL(autoSavePeriodChanged()), this,
-                       SLOT(onAutoSavePeriodExternallyChanged()));
+                            SLOT(onAutoSavePeriodExternallyChanged()));
 
   ret = ret && connect(m_projectRootDocuments, SIGNAL(stateChanged(int)),
                        SLOT(onProjectRootChanged()));
@@ -1660,12 +1659,12 @@ QWidget* PreferencesPopup::createInterfacePage() {
   // IoCmd::loadScene())
   bool ret = true;
   ret      = ret && connect(TApp::instance()->getCurrentScene(),
-                       SIGNAL(pixelUnitSelected(bool)), this,
-                       SLOT(onPixelUnitExternallySelected(bool)));
+                            SIGNAL(pixelUnitSelected(bool)), this,
+                            SLOT(onPixelUnitExternallySelected(bool)));
   ret      = ret && connect(additionalStyleSheetBtn, SIGNAL(clicked()), this,
-                       SLOT(onEditAdditionalStyleSheet()));
+                            SLOT(onEditAdditionalStyleSheet()));
   ret      = ret && connect(check30bitBtn, SIGNAL(clicked()), this,
-                       SLOT(onCheck30bitDisplay()));
+                            SLOT(onCheck30bitDisplay()));
   assert(ret);
 
   m_onEditedFuncMap.insert(CurrentStyleSheetName,

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -676,13 +676,12 @@ void RenameCellField::showInRowCol(int row, int col, bool multiColumnSelected) {
     // Ex.  12 -> 1B    21 -> 2A   30 -> 3
     if (Preferences::instance()->isShowFrameNumberWithLettersEnabled() &&
         cell.m_level->getType() != TXshLevelType::SND_TXT_XSHLEVEL)
-      setText(
-          (fid.isEmptyFrame() || fid.isNoFrame())
-              ? QString::fromStdWString(levelName)
+      setText((fid.isEmptyFrame() || fid.isNoFrame())
+                  ? QString::fromStdWString(levelName)
               : (multiColumnSelected)
-                    ? m_viewer->getFrameNumberWithLetters(fid.getNumber())
-                    : QString::fromStdWString(levelName) + QString(" ") +
-                          m_viewer->getFrameNumberWithLetters(fid.getNumber()));
+                  ? m_viewer->getFrameNumberWithLetters(fid.getNumber())
+                  : QString::fromStdWString(levelName) + QString(" ") +
+                        m_viewer->getFrameNumberWithLetters(fid.getNumber()));
     else {
       QString frameNumber("");
       if (fid.getNumber() > 0) frameNumber = QString::number(fid.getNumber());
@@ -699,12 +698,10 @@ void RenameCellField::showInRowCol(int row, int col, bool multiColumnSelected) {
       }
       // other level types
       else {
-        setText((frameNumber.isEmpty())
-                    ? QString::fromStdWString(levelName)
-                    : (multiColumnSelected)
-                          ? frameNumber
-                          : QString::fromStdWString(levelName) + QString(" ") +
-                                frameNumber);
+        setText((frameNumber.isEmpty()) ? QString::fromStdWString(levelName)
+                : (multiColumnSelected) ? frameNumber
+                                        : QString::fromStdWString(levelName) +
+                                              QString(" ") + frameNumber);
       }
     }
     selectAll();
@@ -1187,20 +1184,19 @@ void CellArea::drawFrameSeparator(QPainter &p, int row, int col,
   bool isAfterSecMarkers =
       secDistance > 0 && ((row - offset) % secDistance) == 0 && row != 0;
 
-  QColor color = (isAfterMarkers || isAfterSecMarkers)
-                     ? m_viewer->getMarkerLineColor()
-                     : m_viewer->getLightLineColor();
+  QColor color     = (isAfterMarkers || isAfterSecMarkers)
+                         ? m_viewer->getMarkerLineColor()
+                         : m_viewer->getLightLineColor();
   double lineWidth = (isAfterSecMarkers) ? 3. : 1.;
 
   int frameAxis = m_viewer->rowToFrameAxis(row);
   int handleSize =
-      (emptyFrame)
-          ? 0
-          : (o->isVerticalTimeline())
-                ? (isAfterMarkers || isAfterSecMarkers)
-                      ? 0
-                      : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).width()
-                : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).height();
+      (emptyFrame) ? 0
+      : (o->isVerticalTimeline())
+          ? (isAfterMarkers || isAfterSecMarkers)
+                ? 0
+                : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).width()
+          : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).height();
 
   QLine horizontalLine = m_viewer->orientation()->horizontalLine(
       frameAxis, layerAxisRange.adjusted(handleSize - 1, 1));
@@ -1265,7 +1261,6 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
       drawFoldedColumns(p, layerAxis, frameSide);
 
       if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-          !m_viewer->orientation()->isVerticalTimeline() &&
           Preferences::instance()->isCurrentTimelineIndicatorEnabled()) {
         row       = m_viewer->getCurrentRow();
         QPoint xy = m_viewer->positionToXY(CellPosition(row, col));
@@ -1314,7 +1309,6 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
         if (col >= 0 && !isColumn) {
           drawFrameSeparator(p, row, col, true);
           if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-              !m_viewer->orientation()->isVerticalTimeline() &&
               row == m_viewer->getCurrentRow() &&
               Preferences::instance()->isCurrentTimelineIndicatorEnabled()) {
             QPoint xy = m_viewer->positionToXY(CellPosition(row, col));
@@ -1326,7 +1320,7 @@ void CellArea::drawCells(QPainter &p, const QRect toBeUpdated) {
               else
                 xy.setX(xy.x() + 1);
             }
-            drawCurrentTimeIndicator(p, xy);
+            drawCurrentTimeIndicator(p, xy, col);
           }
           continue;
         }
@@ -1420,8 +1414,8 @@ void CellArea::drawSelectionBackground(QPainter &p) const {
     int newSelCol0 = std::max(selCol0, selCol1);
     int newSelCol1 = std::min(selCol0, selCol1);
     selectionRect  = m_viewer->rangeToXYRect(
-        CellRange(CellPosition(selRow0, newSelCol0),
-                  CellPosition(selRow1 + 1, newSelCol1 - 1)));
+         CellRange(CellPosition(selRow0, newSelCol0),
+                   CellPosition(selRow1 + 1, newSelCol1 - 1)));
   }
 
   p.fillRect(selectionRect, QBrush(m_viewer->getSelectedEmptyCellColor()));
@@ -1558,10 +1552,9 @@ void CellArea::drawSoundCell(QPainter &p, int row, int col, bool isReference) {
       row < startFrame) {
     drawFrameSeparator(p, row, col, true);
     if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-        !m_viewer->orientation()->isVerticalTimeline() &&
         row == m_viewer->getCurrentRow() &&
         Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-      drawCurrentTimeIndicator(p, xy);
+      drawCurrentTimeIndicator(p, xy, col);
     return;
   }
 
@@ -1608,10 +1601,9 @@ void CellArea::drawSoundCell(QPainter &p, int row, int col, bool isReference) {
     p.fillRect(rect, QBrush(cellColor));
 
   if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-      !m_viewer->orientation()->isVerticalTimeline() &&
       row == m_viewer->getCurrentRow() &&
       Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-    drawCurrentTimeIndicator(p, xy);
+    drawCurrentTimeIndicator(p, xy, col);
 
   drawDragHandle(p, xy, sideColor);
   drawEndOfDragHandle(p, isLastRow, xy, cellColor);
@@ -1749,26 +1741,39 @@ void CellArea::drawLockedDottedLine(QPainter &p, bool isLocked,
   p.drawLine(dottedLine);
 }
 
-void CellArea::drawCurrentTimeIndicator(QPainter &p, const QPoint &xy,
+void CellArea::drawCurrentTimeIndicator(QPainter &p, const QPoint &xy, int col,
                                         bool isFolded) {
-  QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
-  QRect cell      = m_viewer->orientation()
-                   ->rect(PredefinedRect::CELL)
-                   .translated(xy)
-                   .translated(-frameAdj / 2);
+  QPoint frameAdj       = m_viewer->getFrameZoomAdjustment();
+  QColor indicatorColor = m_viewer->getCurrentTimeIndicatorColor();
+  if (!m_viewer->orientation()->isVerticalTimeline()) {
+    QLine line = m_viewer->orientation()
+                     ->line(PredefinedLine::CURRENT_TIME_INDICATOR)
+                     .translated(xy)
+                     .translated(-frameAdj / 2);
+    // Adjust for 1st row
+    if (xy.x() <= 1) line.translate(-1, 0);
+    if (isFolded)
+      line.setP2(line.p1() +
+                 QPoint(0, m_viewer->orientation()->foldedCellSize() - 1));
+    p.setPen(indicatorColor);
+    p.drawLine(line);
+  } else {
+    QRect cellRect = m_viewer->orientation()
+                         ->rect((col < 0) ? PredefinedRect::CAMERA_CELL
+                                          : PredefinedRect::CELL)
+                         .translated(xy)
+                         .adjusted(1, 1, -frameAdj.x(), -frameAdj.y());
+    // Adjust for 1st row
+    if (xy.y() <= 1) cellRect.adjust(0, -1, 0, -1);
+    if (isFolded)
+      cellRect.setRight(cellRect.left() +
+                        m_viewer->orientation()->foldedCellSize() - 1);
 
-  int cellMid    = cell.left() + (cell.width() / 2) - 1;
-  int cellTop    = cell.top();
-  int cellBottom = cell.bottom();
-
-  // Adjust left for 1st row
-  if (xy.x() <= 1) cellMid -= 1;
-
-  if (isFolded)
-    cellBottom = cell.top() + m_viewer->orientation()->foldedCellSize() - 1;
-
-  p.setPen(Qt::red);
-  p.drawLine(cellMid, cellTop, cellMid, cellBottom);
+    p.setPen(
+        QPen(indicatorColor, 1, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin));
+    p.drawLine(cellRect.topLeft(), cellRect.topRight());
+    p.drawLine(cellRect.bottomLeft(), cellRect.bottomRight());
+  }
 }
 
 void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
@@ -1776,11 +1781,11 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
   QColor outlineColor = Qt::black;
   QPoint frameAdj     = m_viewer->getFrameZoomAdjustment();
   QRect dotRect       = (isCamera)
-                      ? m_viewer->orientation()
+                            ? m_viewer->orientation()
                             ->rect(PredefinedRect::CAMERA_FRAME_MARKER_AREA)
                             .translated(xy)
                             .translated(-frameAdj / 2)
-                      : m_viewer->orientation()
+                            : m_viewer->orientation()
                             ->rect(PredefinedRect::FRAME_MARKER_AREA)
                             .translated(xy)
                             .translated(-frameAdj / 2);
@@ -1805,6 +1810,25 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
     p.drawEllipse(dotRect);
     p.setBrush(Qt::NoBrush);
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void CellArea::drawFocusCellBorder(QPainter &p) {
+  QColor color = m_viewer->getCellFocusColor();
+  if (color.alpha() == 0) return;
+  QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
+  int row         = m_viewer->getCurrentRow();
+  int col         = m_viewer->getCurrentColumn();
+  QPoint xy       = m_viewer->positionToXY(CellPosition(row, col));
+  QRect rect =
+      m_viewer->orientation()
+          ->rect((col < 0) ? PredefinedRect::CAMERA_CELL : PredefinedRect::CELL)
+          .translated(xy)
+          .adjusted(1, 1, -1 - frameAdj.x(), -frameAdj.y());
+  p.setPen(QPen(color, 2, Qt::SolidLine, Qt::SquareCap, Qt::MiterJoin));
+  p.setBrush(Qt::NoBrush);
+  p.drawRect(rect);
 }
 
 //-----------------------------------------------------------------------------
@@ -1909,10 +1933,9 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     drawFrameSeparator(p, row, col, true);
 
     if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-        !m_viewer->orientation()->isVerticalTimeline() &&
         row == m_viewer->getCurrentRow() &&
         Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-      drawCurrentTimeIndicator(p, xy);
+      drawCurrentTimeIndicator(p, xy, col);
     return;
   }
 
@@ -1937,10 +1960,9 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     p.drawLine(rect.topRight(), rect.bottomLeft());
 
     if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-        !m_viewer->orientation()->isVerticalTimeline() &&
         row == m_viewer->getCurrentRow() &&
         Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-      drawCurrentTimeIndicator(p, xy);
+      drawCurrentTimeIndicator(p, xy, col);
 
     return;
   }
@@ -1986,10 +2008,9 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
   }
 
   if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-      !m_viewer->orientation()->isVerticalTimeline() &&
       row == m_viewer->getCurrentRow() &&
       Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-    drawCurrentTimeIndicator(p, xy);
+    drawCurrentTimeIndicator(p, xy, col);
 
   drawDragHandle(p, xy, sideColor);
 
@@ -2197,10 +2218,9 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
   if (cell.isEmpty() && prevCell.isEmpty()) {
     drawFrameSeparator(p, row, col, true);
     if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-        !m_viewer->orientation()->isVerticalTimeline() &&
         row == m_viewer->getCurrentRow() &&
         Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-      drawCurrentTimeIndicator(p, xy);
+      drawCurrentTimeIndicator(p, xy, col);
 
     // only draw mark
     if (markId >= 0) {
@@ -2231,10 +2251,9 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
       p.drawEllipse(markRect);
     }
     if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-        !m_viewer->orientation()->isVerticalTimeline() &&
         row == m_viewer->getCurrentRow() &&
         Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-      drawCurrentTimeIndicator(p, xy);
+      drawCurrentTimeIndicator(p, xy, col);
 
     return;
   }
@@ -2254,10 +2273,9 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
     p.fillRect(rect, QBrush(cellColor));
 
   if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-      !m_viewer->orientation()->isVerticalTimeline() &&
       row == m_viewer->getCurrentRow() &&
       Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-    drawCurrentTimeIndicator(p, xy);
+    drawCurrentTimeIndicator(p, xy, col);
 
   drawDragHandle(p, xy, sideColor);
 
@@ -2436,10 +2454,9 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
         p.drawLine(info.rect.topRight(), info.rect.bottomLeft());
       }
       if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-          !m_viewer->orientation()->isVerticalTimeline() &&
           row == m_viewer->getCurrentRow() &&
           Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-        drawCurrentTimeIndicator(p, info.xy);
+        drawCurrentTimeIndicator(p, info.xy, col);
       // draw mark
       if (info.markId >= 0) {
         p.setBrush(info.markColor);
@@ -2472,9 +2489,9 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
       p.fillRect(info.rect, QBrush(tmpCellColor));
 
       if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-          !o->isVerticalTimeline() && info.row == m_viewer->getCurrentRow() &&
+          info.row == m_viewer->getCurrentRow() &&
           Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-        drawCurrentTimeIndicator(p, info.xy);
+        drawCurrentTimeIndicator(p, info.xy, col);
 
       drawDragHandle(p, info.xy, sideColor);
       drawEndOfDragHandle(p, info.row == rowTo, info.xy, tmpCellColor);
@@ -2658,10 +2675,9 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
   if (cell.isEmpty() && prevCell.isEmpty()) {
     drawFrameSeparator(p, row, col, true);
     if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-        !m_viewer->orientation()->isVerticalTimeline() &&
         row == m_viewer->getCurrentRow() &&
         Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-      drawCurrentTimeIndicator(p, xy);
+      drawCurrentTimeIndicator(p, xy, col);
 
     // only draw mark
     if (markId >= 0) {
@@ -2699,10 +2715,9 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
       p.drawEllipse(markRect);
     }
     if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-        !m_viewer->orientation()->isVerticalTimeline() &&
         row == m_viewer->getCurrentRow() &&
         Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-      drawCurrentTimeIndicator(p, xy);
+      drawCurrentTimeIndicator(p, xy, col);
 
     return;
   }
@@ -2728,10 +2743,9 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
     p.fillRect(rect, QBrush(cellColor));
 
   if (TApp::instance()->getCurrentFrame()->isEditingScene() &&
-      !m_viewer->orientation()->isVerticalTimeline() &&
       row == m_viewer->getCurrentRow() &&
       Preferences::instance()->isCurrentTimelineIndicatorEnabled())
-    drawCurrentTimeIndicator(p, xy);
+    drawCurrentTimeIndicator(p, xy, col);
 
   drawDragHandle(p, xy, sideColor);
   bool isLastRow = nextCell.isEmpty() ||
@@ -3114,20 +3128,7 @@ void CellArea::paintEvent(QPaintEvent *event) {
   drawNotes(p, toBeUpdated);
 
   // focus cell border
-  QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
-  int row         = m_viewer->getCurrentRow();
-  int col         = m_viewer->getCurrentColumn();
-  QPoint xy       = m_viewer->positionToXY(CellPosition(row, col));
-  QRect rect =
-      m_viewer->orientation()
-          ->rect((col < 0) ? PredefinedRect::CAMERA_CELL : PredefinedRect::CELL)
-          .translated(xy)
-          .adjusted(0, 0, -1 - frameAdj.x(), -frameAdj.y());
-  p.setPen(m_viewer->getCellFocusColor());
-  p.setBrush(Qt::NoBrush);
-  for (int i = 0; i < 2; i++)  // thick border within cell
-    p.drawRect(QRect(rect.topLeft() + QPoint(i, i),
-                     rect.size() - QSize(2 * i, 2 * i)));
+  drawFocusCellBorder(p);
 
   if (getDragTool()) getDragTool()->drawCellsArea(p);
 }

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -119,11 +119,13 @@ class CellArea final : public QWidget {
 
   void drawNotes(QPainter &p, const QRect toBeUpdated);
 
-  void drawCurrentTimeIndicator(QPainter &p, const QPoint &xy,
+  void drawCurrentTimeIndicator(QPainter &p, const QPoint &xy, int col,
                                 bool isFolded = false);
 
   void drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
                        bool isKeyFrame = false, bool isCamera = false);
+
+  void drawFocusCellBorder(QPainter &p);
 
   // Restistusce true
   bool getEaseHandles(int r0, int r1, double e0, double e1, int &rh0, int &rh1);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -221,6 +221,7 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   QColor m_previewFrameTextColor;  // frame number in preview range (blue)
   QColor m_onionSkinAreaBgColor;
   QColor m_frameRangeMarkerLineColor;  // timeline frame markers
+  QColor m_currentTimeIndicatorColor;  // current time indicator
   Q_PROPERTY(QColor CurrentRowBgColor READ getCurrentRowBgColor WRITE
                  setCurrentRowBgColor)
   Q_PROPERTY(
@@ -238,6 +239,8 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
                  setOnionSkinAreaBgColor)
   Q_PROPERTY(QColor FrameRangeMarkerLineColor READ getFrameRangeMarkerLineColor
                  WRITE setFrameRangeMarkerLineColor)
+  Q_PROPERTY(QColor CurrentTimeIndicatorColor READ getCurrentTimeIndicatorColor
+                 WRITE setCurrentTimeIndicatorColor)
   // Column
   QColor m_emptyColumnHeadColor;  // empty column header (200,200,200)
   Q_PROPERTY(QColor EmptyColumnHeadColor READ getEmptyColumnHeadColor WRITE
@@ -765,6 +768,12 @@ public:
   }
   void setFrameRangeMarkerLineColor(const QColor &color) {
     m_frameRangeMarkerLineColor = color;
+  }
+  QColor getCurrentTimeIndicatorColor() const {
+    return m_currentTimeIndicatorColor;
+  }
+  void setCurrentTimeIndicatorColor(const QColor &color) {
+    m_currentTimeIndicatorColor = color;
   }
 
   // Row

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -901,6 +901,8 @@ TopToBottomOrientation::TopToBottomOrientation() {
           verticalLine(CELL_WIDTH - 14, NumberRange(0, CELL_HEIGHT)));
   addLine(PredefinedLine::EXTENDER_LINE,
           horizontalLine(0, NumberRange(-EXTENDER_WIDTH - KEY_ICON_WIDTH, 0)));
+  addLine(PredefinedLine::CURRENT_TIME_INDICATOR,
+          horizontalLine(CELL_HEIGHT / 2, NumberRange(0, CELL_WIDTH)));
 
   //
   // Dimensions
@@ -1323,6 +1325,8 @@ LeftToRightOrientation::LeftToRightOrientation() {
           verticalLine(CELL_HEIGHT / 2, NumberRange(0, CELL_WIDTH)));
   addLine(PredefinedLine::EXTENDER_LINE,
           horizontalLine(0, NumberRange(-EXTENDER_WIDTH - KEY_ICON_WIDTH, 0)));
+  addLine(PredefinedLine::CURRENT_TIME_INDICATOR,
+          horizontalLine(CELL_WIDTH / 2 - 1, NumberRange(0, CELL_HEIGHT)));
 
   //
   // Dimensions


### PR DESCRIPTION
This PR will show the current frame indicator in Xsheet.
In the Xsheet mode, the indicator will be top and bottom border lines at the current row instead of the middle line, in order to keep the cell numbers visible.
![current_frame_indicator](https://user-images.githubusercontent.com/17974955/185830481-a5289cd8-da7d-409c-8ae4-20add652c5e1.png)

Also made the color of indicator editable in the style sheet ( with property name `qproperty-CurrentTimeIndicatorColor` ).
For instance, type the additional style sheet as follows to make the indicator semi-transparent yellow:
````
XsheetViewer {
    qproperty-CurrentTimeIndicatorColor: rgba(255, 255, 0, 0.7);
}
````
![current_frame_indicator_yellow](https://user-images.githubusercontent.com/17974955/185830504-b16d1870-f534-46fa-ba6b-10323c19b9fc.png)

