### PR TITLE
Actions: temporary disable clcache

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: windows-2019
     env:
       vcpkg_ref: 14e7bb4ae24616ec54ff6b2f6ef4e8659434ea44
-      CLCACHE_CL: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl_original.exe'
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
       QT_ROOT: ${{github.workspace}}/3rdparty/qt
@@ -94,19 +93,6 @@ jobs:
       with:
         python-version: '3.9.1'
 
-    - name: Install clcache
-      run: |
-        pip install clcache
-        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe' -NewName 'cl_original.exe'
-        Rename-Item -Path 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe.config' -NewName 'cl_original.exe.config'
-        cp 'C:/hostedtoolcache/windows/Python/3.9.1/x64/Scripts/clcache.exe' 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe'
-
-    - uses: actions/cache@v1
-      with:
-       path: C:/Users/runneradmin/clcache
-       key: ${{ runner.os }}-clcache-${{ github.sha }}
-       restore-keys: ${{ runner.os }}-clcache-
-
     - name: Build libtiff
       run: |
         cd thirdparty/tiff-4.0.3
@@ -114,7 +100,6 @@ jobs:
         cp libtiff/tiffconf.vc.h libtiff/tiffconf.h
         cd prj/LibTIFF
         $env:Path += ';C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin'
-        $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
         msbuild LibTIFF.vcxproj /p:PlatformToolset=v142 /p:Platform=x64 /p:Configuration=Release -maxcpucount:3
 
     - name: Build mypaint/libmypaint
@@ -125,7 +110,6 @@ jobs:
         python generate.py mypaint-brush-settings-gen.h brushsettings-gen.h
         mkdir build | Out-Null
         cd build
-        $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
         cmake ../ -G 'Visual Studio 16 2019' -Ax64 -Djson-c_DIR='C:/vcpkg/installed/x64-windows-static/share/json-c/' -DJSON-C_INCLUDE_DIR='C:/vcpkg/installed/x64-windows-static/include/json-c/'
         cmake --build . --config Release
         cp C:/vcpkg/installed/x64-windows-static/lib/json-c.lib .
@@ -138,7 +122,6 @@ jobs:
         cd superlu
         mkdir build | Out-Null
         cd build
-        $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
         cmake ../ -G 'Visual Studio 16 2019' -Ax64 -DXSDK_ENABLE_Fortran=OFF -Denable_tests=OFF
         cmake --build . --config Release
 
@@ -168,7 +151,6 @@ jobs:
         cd toonz
         mkdir build | Out-Null
         cd build
-        $env:CLCACHE_CL = '${{ env.CLCACHE_CL }}'
         $env:BOOST_ROOT = '${{ env.BOOST_ROOT }}'
         $env:QT_PATH = '${{ env.QT_ROOT }}/Qt5.15.2_wintab/5.15.2_wintab/msvc2019_64'
         cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH="$env:QT_PATH" -DOpenCV_DIR='C:/vcpkg/installed/x64-windows/share/opencv' -DBOOST_ROOT="$env:BOOST_ROOT" -DWITH_WINTAB=ON


### PR DESCRIPTION
This PR will temporary disable clcache used in Windows runner of GitHub Actions in order to resolve recent failure.
I've tried to fix the problem but unfortunately could not find a good way so far.

Disabling clcache slows the build but at least it can complete the build.
(Please note that the build triggered by this PR will take long time than usual to complete since I tried removing all caches, some of them are not related to clcache and will be reused in subsequent builds.)