### PR TITLE
Fix crash on replacing level's parent directory while opening preview

### DIFF
--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -747,7 +747,7 @@ LevelSettingsValues LevelSettingsPopup::getValues(TXshLevelP level) {
       values.doAntialias = (sl->getProperties()->antialiasSoftness() > 0)
                                ? Qt::Checked
                                : Qt::Unchecked;
-      values.softness = sl->getProperties()->antialiasSoftness();
+      values.softness    = sl->getProperties()->antialiasSoftness();
     }
   }
 
@@ -1438,6 +1438,7 @@ void LevelSettingsPopup::onSubsamplingChanged() {
     return;
   }
 
+  bool somethingChanged = false;
   TUndoManager::manager()->beginBlock();
   QSetIterator<TXshLevelP> levelItr(m_selectedLevels);
   while (levelItr.hasNext()) {
@@ -1454,8 +1455,10 @@ void LevelSettingsPopup::onSubsamplingChanged() {
     TUndoManager::manager()->add(new LevelSettingsUndo(
         levelP.getPointer(), LevelSettingsUndo::Subsampling, oldSubsampling,
         subsampling));
+    somethingChanged = true;
   }
   TUndoManager::manager()->endBlock();
+  if (!somethingChanged) return;
 
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   TApp::instance()

--- a/toonz/sources/toonz/previewfxmanager.cpp
+++ b/toonz/sources/toonz/previewfxmanager.cpp
@@ -1456,6 +1456,7 @@ void PreviewFxManager::onLevelChanged() {
     // Build the level name as an alias keyword. All cache images associated
     // with an alias containing the level name will be updated.
     TXshLevel *xl = TApp::instance()->getCurrentLevel()->getLevel();
+    if (!xl) return;
     std::string aliasKeyword;
     TFilePath fp = xl->getPath();
     aliasKeyword = ::to_string(fp.withType(""));


### PR DESCRIPTION
This PR fixes following 2 crash scenarios while opening preview flipbook:

#### Scenario 1

1. Load some level to column1.
2. Preview the scene. (the Flipbook opens)
3. Select cells containing column1 and 2.
4. Right click an empty cell at column 2 in the cell selection then select `Replace Level > Replace Parent Directory...` .
5. Select some folder containing a level with the same name. Click `Replace` .
6. OT crashes.

#### Scenario 2

1. Load some level to column1.
2. Preview the scene. (the Flipbook opens)
3. Right click a level and select `Level Settings` . (The level settings popup opens)
4. Select cells containing column1 and 2, by dragging from a cell at column2 to a cell at column1. (i.e. the current column will be column 2)
5. Close the level settings popup.
6. OT crashes.

Both operations will emit `LevelChanged` signal.
`PreviewFxManager` receives the signal and try to updat the preview if needed. `PreviewFxManager` tries to access the current level to obtain the file path of changed level. If there is no current level, OT crashes as it tries to access the null pointer.