### PR TITLE
solving linker issue on customized libtiff

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.sourceDirectory": "${workspaceFolder}/toonz/sources"
+}

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -66,7 +66,8 @@ $ ./configure && make
 If you install libtiff through brew before, linker tool couses fail. In order to solve this problem use install_name_tool.
 ```
 $ cd opentoonz/thirdparty/tiff-4.0.3/libtiff/.libs/
-$ install_name_tool -id $PWD/libtiff.5.dylib libtiff.5.dylib 
+$ install_name_tool -id $PWD/libtiff.5.dylib libtiff.5.dylib
+ 
 ```
 
 

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -63,6 +63,13 @@ $ cd ../tiff-4.0.3
 $ ./configure && make
 ```
 
+If you install libtiff through brew before, linker tool couses fail. In order to solve this problem use install_name_tool
+```
+$ cd opentoonz/thirdparty/tiff-4.0.3/libtiff/.libs/
+$ install_name_tool -id $PWD/libtiff.5.dylib libtiff.5.dylib 
+```
+
+
 If you downloaded and installed boost from https://boost.org instead of homebrew, move the package under `thirdparty/boost` as follows: 
 ```
 $ cd thirdparty/boost

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -63,7 +63,7 @@ $ cd ../tiff-4.0.3
 $ ./configure && make
 ```
 
-If you install libtiff through brew before, linker tool couses fail. In order to solve this problem use install_name_tool
+If you install libtiff through brew before, linker tool couses fail. In order to solve this problem use install_name_tool.
 ```
 $ cd opentoonz/thirdparty/tiff-4.0.3/libtiff/.libs/
 $ install_name_tool -id $PWD/libtiff.5.dylib libtiff.5.dylib 

--- a/toonz/cmake/FindTIFF.cmake
+++ b/toonz/cmake/FindTIFF.cmake
@@ -20,7 +20,7 @@ find_library(
     TIFF_LIBRARY
     NAMES
         # libtiff.a 
-        #use shared library instead of static
+        # use shared library instead of static
         libtiff.dylib
     HINTS
         ${SDKROOT}

--- a/toonz/cmake/FindTIFF.cmake
+++ b/toonz/cmake/FindTIFF.cmake
@@ -1,16 +1,12 @@
-#we should use brew configuration
 # looks for libtiff(4.0.3 modified)
-set(BREW /usr/local/opt)
-set(TIFF_INCLUDE_DIR ${BREW}/libtiff/include)
 find_path(
     TIFF_INCLUDE_DIR
     NAMES
         tiffio.h
     HINTS
-        ${BREW}
+        ${SDKROOT}
     PATH_SUFFIXES
-        # tiff-4.0.3/libtiff/
-        /libtiff/include
+        tiff-4.0.3/libtiff/
 # if mono or another framework with a tif library
 # is installed, ignore it.
 if(BUILD_ENV_APPLE)
@@ -20,15 +16,14 @@ if(BUILD_ENV_APPLE)
 endif()
 )
 
-
 find_library(
     TIFF_LIBRARY
     NAMES
         libtiff.a
     HINTS
-        ${BREW}
+        ${SDKROOT}
     PATH_SUFFIXES
-        /libtiff/lib
+        tiff-4.0.3/libtiff/.libs
     NO_DEFAULT_PATH
 )
 

--- a/toonz/cmake/FindTIFF.cmake
+++ b/toonz/cmake/FindTIFF.cmake
@@ -1,12 +1,16 @@
+#we should use brew configuration
 # looks for libtiff(4.0.3 modified)
+set(BREW /usr/local/opt)
+set(TIFF_INCLUDE_DIR ${BREW}/libtiff/include)
 find_path(
     TIFF_INCLUDE_DIR
     NAMES
         tiffio.h
     HINTS
-        ${SDKROOT}
+        ${BREW}
     PATH_SUFFIXES
-        tiff-4.0.3/libtiff/
+        # tiff-4.0.3/libtiff/
+        /libtiff/include
 # if mono or another framework with a tif library
 # is installed, ignore it.
 if(BUILD_ENV_APPLE)
@@ -16,14 +20,15 @@ if(BUILD_ENV_APPLE)
 endif()
 )
 
+
 find_library(
     TIFF_LIBRARY
     NAMES
         libtiff.a
     HINTS
-        ${SDKROOT}
+        ${BREW}
     PATH_SUFFIXES
-        tiff-4.0.3/libtiff/.libs
+        /libtiff/lib
     NO_DEFAULT_PATH
 )
 

--- a/toonz/cmake/FindTIFF.cmake
+++ b/toonz/cmake/FindTIFF.cmake
@@ -19,14 +19,15 @@ endif()
 find_library(
     TIFF_LIBRARY
     NAMES
-        libtiff.a
+        # libtiff.a 
+        #use shared library instead of static
+        libtiff.dylib
     HINTS
         ${SDKROOT}
     PATH_SUFFIXES
         tiff-4.0.3/libtiff/.libs
     NO_DEFAULT_PATH
 )
-
 message("***** libtiff Header path:" ${TIFF_INCLUDE_DIR})
 message("***** libtiff Library path:" ${TIFF_LIBRARY})
 


### PR DESCRIPTION
If you install libtiff through brew before, linker tool couses fail. In order to solve this problem use install_name_tool.
If libtiff library was installed through brew tool before, linker tool causes fail. In order to solve this problem customized libtool.dylib's id should be changed by install_name_tool