### PR TITLE
Fix Bokeh Fx White Artifacts

### DIFF
--- a/toonz/sources/stdfx/iwa_bokeh_util.cpp
+++ b/toonz/sources/stdfx/iwa_bokeh_util.cpp
@@ -163,9 +163,9 @@ void BokehUtils::MyThread::setLayerRaster(const RASTER srcRas,
     PIXEL* pix = srcRas->pixels(j);
     for (int i = 0; i < dim.lx; i++, pix++) {
       if (pix->m != 0) {
-        double val = (m_channel == Red) ? (double)pix->r
-                                        : (m_channel == Green) ? (double)pix->g
-                                                               : (double)pix->b;
+        double val = (m_channel == Red)     ? (double)pix->r
+                     : (m_channel == Green) ? (double)pix->g
+                                            : (double)pix->b;
         // multiply the exposure by alpha channel value
         dstMem[j * dim.lx + i].r =
             valueToExposure(val / (double)PIXEL::maxChannelValue,
@@ -264,9 +264,9 @@ void BokehUtils::MyThread::run() {
             std::pow(exposure / (*alp_p), m_layerHardness / m_masterHardness) *
             (*alp_p);
 
-      double* res = (m_channel == Red) ? (&((*res_p).x))
-                                       : (m_channel == Green) ? (&((*res_p).y))
-                                                              : (&((*res_p).z));
+      double* res = (m_channel == Red)     ? (&((*res_p).x))
+                    : (m_channel == Green) ? (&((*res_p).y))
+                                           : (&((*res_p).z));
 
       // composite exposure
       if ((*alp_p) >= 1.0 || (*res) == 0.0)
@@ -1280,22 +1280,26 @@ void BokehUtils::setOutputRaster(double4* src, const RASTER dstRas,
       outPix->r =
           (typename PIXEL::Channel)((val > (double)PIXEL::maxChannelValue)
                                         ? (double)PIXEL::maxChannelValue
-                                        : val);
+                                    : (val < 0.) ? 0.
+                                                 : val);
       val = (*src_p).y * (double)PIXEL::maxChannelValue + 0.5;
       outPix->g =
           (typename PIXEL::Channel)((val > (double)PIXEL::maxChannelValue)
                                         ? (double)PIXEL::maxChannelValue
-                                        : val);
+                                    : (val < 0.) ? 0.
+                                                 : val);
       val = (*src_p).z * (double)PIXEL::maxChannelValue + 0.5;
       outPix->b =
           (typename PIXEL::Channel)((val > (double)PIXEL::maxChannelValue)
                                         ? (double)PIXEL::maxChannelValue
-                                        : val);
+                                    : (val < 0.) ? 0.
+                                                 : val);
       val = (*src_p).w * (double)PIXEL::maxChannelValue + 0.5;
       outPix->m =
           (typename PIXEL::Channel)((val > (double)PIXEL::maxChannelValue)
                                         ? (double)PIXEL::maxChannelValue
-                                        : val);
+                                    : (val < 0.) ? 0.
+                                                 : val);
     }
     src_p += margin.x;
   }

--- a/toonz/sources/stdfx/iwa_bokehfx.cpp
+++ b/toonz/sources/stdfx/iwa_bokehfx.cpp
@@ -163,9 +163,8 @@ void Iwa_BokehFx::doCompute(TTile& tile, double frame,
   QList<LayerValue> layerValues;
   for (auto index : sourceIndices) {
     LayerValue layerValue;
-    layerValue.sourceTile = sourceTiles[index];
-    layerValue.premultiply =
-        m_layerParams[index].m_premultiply->getValue() ? 1 : 0;
+    layerValue.sourceTile    = sourceTiles[index];
+    layerValue.premultiply   = m_layerParams[index].m_premultiply->getValue();
     layerValue.layerHardness = masterHardness;
     layerValue.depth_ref     = 0;
     layerValue.irisSize      = irisSizes.value(index);

--- a/toonz/sources/stdfx/iwa_bokehreffx.cpp
+++ b/toonz/sources/stdfx/iwa_bokehreffx.cpp
@@ -214,7 +214,7 @@ void Iwa_BokehRefFx::doCompute(TTile& tile, double frame,
   }
   ctrls[1] = depth_buff;
 
-  layerValue.premultiply       = 2;  // auto
+  layerValue.premultiply       = false;
   layerValue.layerHardness     = m_hardness->getValue(frame);
   layerValue.depth_ref         = 1;
   layerValue.distance          = 0.5;


### PR DESCRIPTION
This PR fixes the following problem occurred in our studio:

- When rendering in 16bit per channel, a white pixels artifact sometimes appears in the result of Bokeh Advanced Fx Iwa, especially at a layer using the Depth reference image.

I found that there is a case the RGB value becomes negative in the fx result. And the fx had no way to handle negative values on converting them to 16bpc channel values, which cannot be negative. In such case the pixels becomes 65535 (16bit max) and turned into white pixels artifacts.
I made an additional condition to make the negative RGB values to be clamped to 0.