### PR TITLE
Thicken Xsheet marker lines

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2282,9 +2282,13 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #d6d8dd;
   qproperty-ErrorTextColor: #ff7b7b;
+  qproperty-SelectedTextColor: #d6d8dd;
+  qproperty-CurrentFrameTextColor: #d6d8dd;
   qproperty-BGColor: #3a3b3d;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
+  qproperty-SelectedMarkerLineColor: rgba(255, 255, 255, 0.15);
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-VerticalLineHeadColor: #212223;
   qproperty-PreviewFrameTextColor: #9fdaff;
@@ -2432,6 +2436,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: rgba(83, 133, 166, 0.7);
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
   qproperty-BGColor: #3a3b3d;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-KeyFrameColor: #995d1d;
@@ -2447,6 +2452,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: rgba(96, 109, 118, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(96, 109, 118, 0.5);
   qproperty-TextColor: #d6d8dd;
+  qproperty-CurrentRowTextColor: #d6d8dd;
   qproperty-ColumnHeaderBorderColor: #212223;
 }
 #ExpressionField {

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2282,9 +2282,13 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #e6e6e6;
   qproperty-ErrorTextColor: #ff7b7b;
+  qproperty-SelectedTextColor: #e6e6e6;
+  qproperty-CurrentFrameTextColor: #e6e6e6;
   qproperty-BGColor: #303030;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.3);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
+  qproperty-SelectedMarkerLineColor: rgba(255, 255, 255, 0.15);
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.4);
   qproperty-VerticalLineHeadColor: #0f0f0f;
   qproperty-PreviewFrameTextColor: #9fdaff;
@@ -2432,6 +2436,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: rgba(83, 133, 166, 0.7);
   qproperty-LightLineColor: rgba(0, 0, 0, 0.3);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
   qproperty-BGColor: #262626;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.4);
   qproperty-KeyFrameColor: #995d1d;
@@ -2447,6 +2452,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: rgba(90, 100, 106, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(90, 100, 106, 0.5);
   qproperty-TextColor: #e6e6e6;
+  qproperty-CurrentRowTextColor: #e6e6e6;
   qproperty-ColumnHeaderBorderColor: #4a4a4a;
 }
 #ExpressionField {

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2282,9 +2282,13 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #e6e6e6;
   qproperty-ErrorTextColor: #ff7b7b;
+  qproperty-SelectedTextColor: #e6e6e6;
+  qproperty-CurrentFrameTextColor: #e6e6e6;
   qproperty-BGColor: #404040;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
+  qproperty-SelectedMarkerLineColor: rgba(255, 255, 255, 0.15);
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-VerticalLineHeadColor: #272727;
   qproperty-PreviewFrameTextColor: #9fdaff;
@@ -2432,6 +2436,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: rgba(83, 133, 166, 0.7);
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
   qproperty-BGColor: #404040;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-KeyFrameColor: #995d1d;
@@ -2447,6 +2452,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: rgba(103, 113, 119, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(103, 113, 119, 0.5);
   qproperty-TextColor: #e6e6e6;
+  qproperty-CurrentRowTextColor: #e6e6e6;
   qproperty-ColumnHeaderBorderColor: #272727;
 }
 #ExpressionField {

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -391,10 +391,14 @@
 // XSheet Spreadsheet Viewer
 @xsheet-text-color:                         @text-color;
 @xsheet-error-text-color:                   rgb(255, 123, 123);
+@xsheet-selected-text-color:                @text-color;
+@xsheet-currentFrame-text-color:            @text-color;
 @xsheet-bg-color:                           darken(@bg, 3);
 @xsheet-empty-bg-color:                     @bg;
 @xsheet-LightLine-color:                    rgba(0, 0, 0, 0.2);
 @xsheet-MarkerLine-color:                   rgba(255, 255, 255, 0.15);
+@xsheet-SecMarkerLine-color:                rgba(255, 255, 255, 0.25);
+@xsheet-SelectedMarkerLine-color:           @xsheet-MarkerLine-color;
 @xsheet-VerticalLine-color:                 rgba(0, 0, 0, 0.3);
 @xsheet-VerticalLineHead-color:             darken(@bg, 13);
 @xsheet-PreviewFrameText-color:             @label-title;

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -75,9 +75,13 @@
 XsheetViewer {
   qproperty-TextColor: @xsheet-text-color;
   qproperty-ErrorTextColor: @xsheet-error-text-color;
+  qproperty-SelectedTextColor: @xsheet-selected-text-color;
+  qproperty-CurrentFrameTextColor: @xsheet-currentFrame-text-color;
   qproperty-BGColor: @xsheet-bg-color;
   qproperty-LightLineColor: @xsheet-LightLine-color;
   qproperty-MarkerLineColor: @xsheet-MarkerLine-color;
+  qproperty-SecMarkerLineColor: @xsheet-SecMarkerLine-color;
+  qproperty-SelectedMarkerLineColor: @xsheet-SelectedMarkerLine-color;
   qproperty-VerticalLineColor: @xsheet-VerticalLine-color;
   qproperty-VerticalLineHeadColor: @xsheet-VerticalLineHead-color;
   qproperty-PreviewFrameTextColor: @xsheet-PreviewFrameText-color;
@@ -275,6 +279,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: @xsheet-CurrentRowBG-color; // paired
   qproperty-LightLineColor: @xsheet-LightLine-color; // paired
   qproperty-MarkerLineColor: @xsheet-MarkerLine-color; // paired
+  qproperty-SecMarkerLineColor: @xsheet-SecMarkerLine-color;
   qproperty-BGColor: @function-ColumnHeaderBG-color;
   qproperty-VerticalLineColor: @xsheet-VerticalLine-color; // paired
   qproperty-KeyFrameColor: @function-KeyFrame-color;
@@ -290,6 +295,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: @xsheet-SelectedEmptyCell-color; // paired
   qproperty-SelectedSceneRangeEmptyColor: @function-SelectedSceneRangeEmpty-color;
   qproperty-TextColor: @xsheet-text-color; // paired
+  qproperty-CurrentRowTextColor: @xsheet-currentFrame-text-color; // paired
   qproperty-ColumnHeaderBorderColor: @function-ColumnHeaderBorder-color; // paired
 }
 

--- a/stuff/config/qss/Default/less/themes/Light.less
+++ b/stuff/config/qss/Default/less/themes/Light.less
@@ -173,6 +173,7 @@
 @xsheet-VerticalLine-color:                 rgba(0, 0, 0, 0.15);
 @xsheet-ColumnIconLine-color:               rgb(112, 112, 112);
 @xsheet-MarkerLine-color:                   rgba(0, 0, 0, 0.3);
+@xsheet-SecMarkerLine-color:                rgba(0, 0, 0, 0.5);
 @xsheet-OnionSkinAreaBG-color:              darken(@bg, 10);
 @xsheet-PreviewFrameText-color:             #2d42b9;
 @xsheet-CurrentRowBG-color:                 saturate(lighten(fade(@hl-bg-color, 70), -8), 8);

--- a/stuff/config/qss/Default/less/themes/Neutral.less
+++ b/stuff/config/qss/Default/less/themes/Neutral.less
@@ -199,6 +199,7 @@
 @xsheet-bg-color:                           darken(@bg, 4);
 @xsheet-LightLine-color:                    rgba(0, 0, 0, 0.15);
 @xsheet-MarkerLine-color:                   rgba(255, 255, 255, 0.2);
+@xsheet-SecMarkerLine-color:                rgba(255, 255, 255, 0.35);
 @xsheet-PreviewFrameText-color:             #17239c;
 @xsheet-OnionSkinAreaBG-color:              darken(@bg, 8);
 @xsheet-EmptyCell-color:                    @xsheet-OnionSkinAreaBG-color;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2282,9 +2282,13 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #000;
   qproperty-ErrorTextColor: #c01111;
+  qproperty-SelectedTextColor: #000;
+  qproperty-CurrentFrameTextColor: #000;
   qproperty-BGColor: #cecece;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(0, 0, 0, 0.3);
+  qproperty-SecMarkerLineColor: rgba(0, 0, 0, 0.5);
+  qproperty-SelectedMarkerLineColor: rgba(0, 0, 0, 0.3);
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.15);
   qproperty-VerticalLineHeadColor: rgba(0, 0, 0, 0.3);
   qproperty-PreviewFrameTextColor: #2d42b9;
@@ -2432,6 +2436,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: rgba(123, 174, 217, 0.7);
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(0, 0, 0, 0.3);
+  qproperty-SecMarkerLineColor: rgba(0, 0, 0, 0.5);
   qproperty-BGColor: #cecece;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.15);
   qproperty-KeyFrameColor: #edaa64;
@@ -2447,6 +2452,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: rgba(146, 153, 158, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(146, 153, 158, 0.5);
   qproperty-TextColor: #000;
+  qproperty-CurrentRowTextColor: #000;
   qproperty-ColumnHeaderBorderColor: #5b5b5b;
 }
 #ExpressionField {

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2282,9 +2282,13 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #000;
   qproperty-ErrorTextColor: #c01111;
+  qproperty-SelectedTextColor: #000;
+  qproperty-CurrentFrameTextColor: #000;
   qproperty-BGColor: #767676;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.2);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.35);
+  qproperty-SelectedMarkerLineColor: rgba(255, 255, 255, 0.2);
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-VerticalLineHeadColor: #4d4d4d;
   qproperty-PreviewFrameTextColor: #17239c;
@@ -2432,6 +2436,7 @@ SpreadsheetViewer {
   qproperty-CurrentRowBgColor: rgba(182, 211, 241, 0.7);
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.2);
+  qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.35);
   qproperty-BGColor: #767676;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-KeyFrameColor: #c4833e;
@@ -2447,6 +2452,7 @@ SpreadsheetViewer {
   qproperty-SelectedEmptyColor: rgba(155, 159, 162, 0.5);
   qproperty-SelectedSceneRangeEmptyColor: rgba(155, 159, 162, 0.5);
   qproperty-TextColor: #000;
+  qproperty-CurrentRowTextColor: #000;
   qproperty-ColumnHeaderBorderColor: #343434;
 }
 #ExpressionField {

--- a/toonz/sources/include/toonzqt/spreadsheetviewer.h
+++ b/toonz/sources/include/toonzqt/spreadsheetviewer.h
@@ -238,15 +238,22 @@ class DVAPI SpreadsheetViewer : public QDialog {
   Q_PROPERTY(
       QColor LightLineColor READ getLightLineColor WRITE setLightLineColor)
 
-  QColor m_currentRowBgColor;  // current frame, column
-  QColor m_markerLineColor;    // marker interval (0, 255, 246)
-  QColor m_textColor;          // text (black)
-  QColor m_verticalLineColor;  // vertical line (black)
+  QColor m_currentRowBgColor;    // current frame, column
+  QColor m_markerLineColor;      // marker interval (0, 255, 246)
+  QColor m_secMarkerLineColor;   // second marker lines
+  QColor m_textColor;            // text (black)
+  QColor m_currentRowTextColor;  // text color for the current row
+  QColor m_verticalLineColor;    // vertical line (black)
+
   Q_PROPERTY(QColor CurrentRowBgColor READ getCurrentRowBgColor WRITE
                  setCurrentRowBgColor)
   Q_PROPERTY(
       QColor MarkerLineColor READ getMarkerLineColor WRITE setMarkerLineColor)
+  Q_PROPERTY(QColor SecMarkerLineColor READ getSecMarkerLineColor WRITE
+                 setSecMarkerLineColor)
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
+  Q_PROPERTY(QColor CurrentRowTextColor READ getCurrentRowTextColor WRITE
+                 setCurrentRowTextColor)
   Q_PROPERTY(QColor VerticalLineColor READ getVerticalLineColor WRITE
                  setVerticalLineColor)
 
@@ -354,8 +361,16 @@ public:
   QColor getCurrentRowBgColor() const { return m_currentRowBgColor; }
   void setMarkerLineColor(const QColor &color) { m_markerLineColor = color; }
   QColor getMarkerLineColor() const { return m_markerLineColor; }
+  void setSecMarkerLineColor(const QColor &color) {
+    m_secMarkerLineColor = color;
+  }
+  QColor getSecMarkerLineColor() const { return m_secMarkerLineColor; }
   void setTextColor(const QColor &color) { m_textColor = color; }
   QColor getTextColor() const { return m_textColor; }
+  void setCurrentRowTextColor(const QColor &color) {
+    m_currentRowTextColor = color;
+  }
+  QColor getCurrentRowTextColor() const { return m_currentRowTextColor; }
   void setVerticalLineColor(const QColor &color) {
     m_verticalLineColor = color;
   }
@@ -470,6 +485,7 @@ public:
     return m_markSecRowDistance > 0 &&
            ((row - m_markRowOffset) % m_markSecRowDistance) == 0 && row > 0;
   }
+  bool isSecMarkerActive() const { return m_markSecRowDistance > 0; }
 
   void setFrameHandle(TFrameHandle *frameHandle);
   TFrameHandle *getFrameHandle() const { return m_frameHandle; }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -212,13 +212,17 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
                  setTimelineIconLineColor)
 
   // Row
-  QColor m_currentRowBgColor;      // current frame / column (210,210,210)
-  QColor m_markerLineColor;        // marker lines (0, 255, 246)
-  QColor m_verticalLineColor;      // vertical lines
-  QColor m_verticalLineHeadColor;  // vertical lines in column head
-  QColor m_textColor;              // text color (black)
-  QColor m_errorTextColor;         // error text color (red, probably)
-  QColor m_previewFrameTextColor;  // frame number in preview range (blue)
+  QColor m_currentRowBgColor;        // current frame / column (210,210,210)
+  QColor m_markerLineColor;          // marker lines (0, 255, 246)
+  QColor m_secMarkerLineColor;       // second marker lines
+  QColor m_selectedMarkerLineColor;  // marker lines in selected cells
+  QColor m_verticalLineColor;        // vertical lines
+  QColor m_verticalLineHeadColor;    // vertical lines in column head
+  QColor m_textColor;                // text color (black)
+  QColor m_errorTextColor;           // error text color (red, probably)
+  QColor m_selectedTextColor;        // text color for the selected cells
+  QColor m_currentFrameTextColor;    // text color for the current frame row
+  QColor m_previewFrameTextColor;    // frame number in preview range (blue)
   QColor m_onionSkinAreaBgColor;
   QColor m_frameRangeMarkerLineColor;  // timeline frame markers
   QColor m_currentTimeIndicatorColor;  // current time indicator
@@ -226,6 +230,10 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
                  setCurrentRowBgColor)
   Q_PROPERTY(
       QColor MarkerLineColor READ getMarkerLineColor WRITE setMarkerLineColor)
+  Q_PROPERTY(QColor SecMarkerLineColor READ getSecMarkerLineColor WRITE
+                 setSecMarkerLineColor)
+  Q_PROPERTY(QColor SelectedMarkerLineColor READ getSelectedMarkerLineColor
+                 WRITE setSelectedMarkerLineColor)
   Q_PROPERTY(QColor VerticalLineColor READ getVerticalLineColor WRITE
                  setVerticalLineColor)
   Q_PROPERTY(QColor VerticalLineHeadColor READ getVerticalLineHeadColor WRITE
@@ -233,6 +241,10 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
   Q_PROPERTY(
       QColor ErrorTextColor READ getErrorTextColor WRITE setErrorTextColor)
+  Q_PROPERTY(QColor SelectedTextColor READ getCurrentFrameTextColor WRITE
+                 setCurrentFrameTextColor)
+  Q_PROPERTY(QColor CurrentFrameTextColor READ getSelectedTextColor WRITE
+                 setSelectedTextColor)
   Q_PROPERTY(QColor PreviewFrameTextColor READ getPreviewFrameTextColor WRITE
                  setPreviewFrameTextColor)
   Q_PROPERTY(QColor OnionSkinAreaBgColor READ getOnionSkinAreaBgColor WRITE
@@ -783,6 +795,16 @@ public:
   QColor getCurrentRowBgColor() const { return m_currentRowBgColor; }
   void setMarkerLineColor(const QColor &color) { m_markerLineColor = color; }
   QColor getMarkerLineColor() const { return m_markerLineColor; }
+  void setSecMarkerLineColor(const QColor &color) {
+    m_secMarkerLineColor = color;
+  }
+  QColor getSecMarkerLineColor() const { return m_secMarkerLineColor; }
+  void setSelectedMarkerLineColor(const QColor &color) {
+    m_selectedMarkerLineColor = color;
+  }
+  QColor getSelectedMarkerLineColor() const {
+    return m_selectedMarkerLineColor;
+  }
   void setVerticalLineColor(const QColor &color) {
     m_verticalLineColor = color;
   }
@@ -795,6 +817,14 @@ public:
   QColor getTextColor() const { return m_textColor; }
   void setErrorTextColor(const QColor &color) { m_errorTextColor = color; }
   QColor getErrorTextColor() const { return m_errorTextColor; }
+  void setSelectedTextColor(const QColor &color) {
+    m_selectedTextColor = color;
+  }
+  QColor getSelectedTextColor() const { return m_selectedTextColor; }
+  void setCurrentFrameTextColor(const QColor &color) {
+    m_currentFrameTextColor = color;
+  }
+  QColor getCurrentFrameTextColor() const { return m_currentFrameTextColor; }
   void setPreviewFrameTextColor(const QColor &color) {
     m_previewFrameTextColor = color;
   }

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -133,6 +133,10 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
   bool simpleView = m_viewer->getFrameZoomFactor() <=
                     o->dimension(PredefinedDimension::SCALE_THRESHOLD);
 
+  int currentRow = m_viewer->getCurrentRow();
+  bool hasCurrentFrameTextColor =
+      m_viewer->getTextColor() != m_viewer->getCurrentFrameTextColor();
+
   for (int r = r0; r <= r1; r++) {
     int frameAxis = m_viewer->rowToFrameAxis(r);
 
@@ -142,12 +146,15 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
     bool isAfterSecMarkers =
         secDistance > 0 && ((r - offset) % secDistance) == 0 && r != 0;
 
-    QColor color = (isAfterSecMarkers || isAfterMarkers)
-                       ? m_viewer->getMarkerLineColor()
-                       : m_viewer->getLightLineColor();
+    QColor color = (isAfterSecMarkers)
+                       ? m_viewer->getSecMarkerLineColor()
+                       : (isAfterMarkers) ? m_viewer->getMarkerLineColor()
+                                          : m_viewer->getLightLineColor();
+    double lineWidth = (isAfterSecMarkers)
+                           ? 3.
+                           : (secDistance > 0 && isAfterMarkers) ? 2. : 1.;
 
-    p.setPen(
-        QPen(color, (isAfterSecMarkers) ? 3. : 1., Qt::SolidLine, Qt::FlatCap));
+    p.setPen(QPen(color, lineWidth, Qt::SolidLine, Qt::FlatCap));
     // p.setPen(color);
     QLine horizontalLine = o->horizontalLine(frameAxis, layerSide);
     if (!o->isVerticalTimeline()) {
@@ -170,7 +177,9 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
   int z = 0;
   for (int r = r0; r <= r1; r++) {
     // draw frame text
-    if (playR0 <= r && r <= playR1) {
+    if (hasCurrentFrameTextColor && r == currentRow)
+      p.setPen(m_viewer->getCurrentFrameTextColor());
+    else if (playR0 <= r && r <= playR1) {
       p.setPen(((r - m_r0) % step == 0) ? m_viewer->getPreviewFrameTextColor()
                                         : m_viewer->getTextColor());
     }
@@ -720,8 +729,8 @@ void RowArea::drawShiftTraceMarker(QPainter &p) {
 
   QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
   int frameAdj_i  = (m_viewer->orientation()->isVerticalTimeline())
-                        ? frameAdj.y()
-                        : frameAdj.x();
+                       ? frameAdj.y()
+                       : frameAdj.x();
 
   // get onion colors
   TPixel frontPixel, backPixel;

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -371,16 +371,24 @@ void RowPanel::drawRows(QPainter &p, int r0, int r1) {
   bool simpleView = getViewer()->getFrameZoomFactor() <=
                     Orientations::topToBottom()->dimension(
                         PredefinedDimension::SCALE_THRESHOLD);
+  int currentRow = getViewer()->getCurrentRow();
   int r;
   int y = getViewer()->rowToY(r0);
   for (r = r0; r <= r1; r++) {
     int next_y = getViewer()->rowToY(r + 1);
     // draw horizontal line
     bool isMarkSecRow = getViewer()->isMarkSecRow(r);
-    QColor color      = (isMarkSecRow || getViewer()->isMarkRow(r))
-                       ? getViewer()->getMarkerLineColor()
-                       : getViewer()->getLightLineColor();
-    p.setPen(QPen(color, (isMarkSecRow) ? 3. : 1., Qt::SolidLine, Qt::FlatCap));
+    bool isMarkRow    = getViewer()->isMarkRow(r);
+    QColor color      = (isMarkSecRow)
+                       ? getViewer()->getSecMarkerLineColor()
+                       : (isMarkRow) ? getViewer()->getMarkerLineColor()
+                                     : getViewer()->getLightLineColor();
+    p.setPen(
+        QPen(color,
+             (isMarkSecRow)
+                 ? 3.
+                 : (getViewer()->isSecMarkerActive() && isMarkRow) ? 2. : 1.,
+             Qt::SolidLine, Qt::FlatCap));
     p.drawLine(x0, y, x1, y);
 
     if (simpleView && r > 0 && !getViewer()->isMarkRow(r + 1)) {
@@ -389,7 +397,8 @@ void RowPanel::drawRows(QPainter &p, int r0, int r1) {
     }
 
     // draw numbers
-    p.setPen(getViewer()->getTextColor());
+    p.setPen((r == currentRow) ? getViewer()->getCurrentRowTextColor()
+                               : getViewer()->getTextColor());
 
     QString number = QString::number(r + 1);
     p.drawText(QRect(x0, y + 1, width() - 4, next_y - y - 1),
@@ -491,11 +500,17 @@ void CellPanel::paintEvent(QPaintEvent *e) {
   for (int r = r0; r <= r1; r++) {
     int y             = getViewer()->rowToY(r);
     bool isMarkSecRow = getViewer()->isMarkSecRow(r);
-    QColor color      = (isMarkSecRow || getViewer()->isMarkRow(r))
-                       ? getViewer()->getMarkerLineColor()
-                       : getViewer()->getLightLineColor();
+    bool isMarkRow    = getViewer()->isMarkRow(r);
+    QColor color      = (isMarkSecRow)
+                       ? getViewer()->getSecMarkerLineColor()
+                       : (isMarkRow) ? getViewer()->getMarkerLineColor()
+                                     : getViewer()->getLightLineColor();
     painter.setPen(
-        QPen(color, (isMarkSecRow) ? 3. : 1., Qt::SolidLine, Qt::FlatCap));
+        QPen(color,
+             (isMarkSecRow)
+                 ? 3.
+                 : (getViewer()->isSecMarkerActive() && isMarkRow) ? 2. : 1.,
+             Qt::SolidLine, Qt::FlatCap));
     painter.drawLine(x0, y, x1, y);
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17974955/192114966-8f64e7a8-d5eb-49f8-907e-d837e9630443.png)

This PR will thicken marker lines in Xsheet when the preference option `Xsheet > Highlight Line Every Second` is ON.
Also enabled to apply different colors to the marker lines at every second and other marker lines.

This PR will also enable to apply different colors to;
- Text color for the current frame number in the xsheet row area (separated from other frame numbers)
- Text color in the selected cells (separated from non-selected cells)
- Marker line color in the selected cells (separated from non-selected cells)

These properties will not affect the existing themes since they have the same colors as before.
They will be useful when making a custom theme in which the current frame indicator and selected cells are with "inverted" background colors, as seen in an Xsheet UI of Celsys QuickChecker (see the image below).

![image](https://user-images.githubusercontent.com/17974955/192116160-50ee380e-8d93-4ee2-949d-2903fee7dd70.png)

These modifications were requested by some Japanese animation studio.