### PR TITLE
Appveyor: Update OpenCV to 4.6.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ after_build:
     
     copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%\OpenToonz
 
-    copy /Y "C:\Tools\opencv\build\x64\vc15\bin\opencv_world455.dll" %CONFIGURATION%\OpenToonz
+    copy /Y "C:\Tools\opencv\build\x64\vc15\bin\opencv_world460.dll" %CONFIGURATION%\OpenToonz
 
     mkdir "%CONFIGURATION%\OpenToonz stuff"
 


### PR DESCRIPTION
This PR is to resolve recent failure in Appveyor.
From Sep 23 [OpenCV version supported in Chocolatey had been updated to 4.6.0](https://community.chocolatey.org/packages/OpenCV).