### PR TITLE
Fix Custom Panel Registration

### DIFF
--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -569,7 +569,10 @@ void DVMenuAction::onTriggered(QAction *action) {
   CommandManager::instance()->execute(action, menuAction());
 
   // simply execute the menu item and return
-  if (!m_isForRecentFiles) return;
+  if (!m_isForRecentFiles) {
+    m_triggeredActionIndex = -1;
+    return;
+  }
 
   int oldIndex = m_triggeredActionIndex;
   if (m_triggeredActionIndex != -1) m_triggeredActionIndex = -1;


### PR DESCRIPTION
This PR fixes the following problem:

- After registering / updating the custom panel by the Custom Panel Editor, the `Custom Panel` submenu in the main menu bar fails to update with new items.