### PR TITLE
Toggle Blank Frames menu command

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -224,6 +224,7 @@ public:
     eFlipHorizontal,
     eFlipVertical,
     eResetView,
+    eBlankFrames,
     // following values are hard-coded in ImagePainter
     eBlackBg = 0x40000,
     eWhiteBg = 0x80000,

--- a/toonz/sources/toonz/icons/dark/actions/16/blankframes.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/blankframes.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg16"
+   sodipodi:docname="blankframes.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   id="metadata22"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs20">
+        
+    
+            
+            
+            
+        
+                
+            <mask
+   maskUnits="userSpaceOnUse"
+   id="mask4666"><g
+     id="g4676"
+     style="stroke-width:0.11565093"
+     transform="matrix(9.0624858,0,0,8.2500083,146.99986,155.99941)"><rect
+       y="0"
+       x="0"
+       height="16"
+       width="16"
+       id="rect4668"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.23130186;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" /><g
+       style="fill:#000000;fill-opacity:1;stroke-width:0.11565093"
+       id="g4674"><path
+         inkscape:connector-curvature="0"
+         id="path4670"
+         d="m 2,4 v 8 H 4 V 11 H 3 V 5 H 4 V 4 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.11565093px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /><path
+         inkscape:connector-curvature="0"
+         id="path4672"
+         d="m 12,4 v 1 h 1 v 6 h -1 v 1 h 2 V 4 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:evenodd;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.11565093px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" /></g></g></mask><clipPath
+   clipPathUnits="userSpaceOnUse"
+   id="clipPath4699"><g
+     id="g4703"
+     transform="matrix(0.110345,0,0,0.121212,-16.2207,-18.909)"
+     mask="url(#mask4666)">
+                <rect
+   x="147"
+   y="156"
+   width="145"
+   height="132"
+   style="fill:#878787;fill-opacity:0"
+   id="rect4701" />
+            </g></clipPath><clipPath
+   clipPathUnits="userSpaceOnUse"
+   id="clipPath4723"><g
+     mask="url(#mask4666)"
+     transform="matrix(0.110345,0,0,0.121212,-16.2207,-18.909)"
+     id="g4727">
+                <rect
+   id="rect4725"
+   style="fill:#878787;fill-opacity:0"
+   height="132"
+   width="145"
+   y="156"
+   x="147" />
+            </g></clipPath><clipPath
+   clipPathUnits="userSpaceOnUse"
+   id="clipPath4729"><g
+     mask="url(#mask4666)"
+     transform="matrix(0.110345,0,0,0.121212,-16.2207,-18.909)"
+     id="g4733">
+                <rect
+   id="rect4731"
+   style="fill:#878787;fill-opacity:0"
+   height="132"
+   width="145"
+   y="156"
+   x="147" />
+            </g></clipPath><clipPath
+   clipPathUnits="userSpaceOnUse"
+   id="clipPath4735"><g
+     mask="url(#mask4666)"
+     transform="matrix(0.110345,0,0,0.121212,-16.2207,-18.909)"
+     id="g4739">
+                <rect
+   id="rect4737"
+   style="fill:#878787;fill-opacity:0"
+   height="132"
+   width="145"
+   y="156"
+   x="147" />
+            </g></clipPath></defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1094"
+   inkscape:window-height="672"
+   id="namedview18"
+   showgrid="true"
+   inkscape:zoom="14.75"
+   inkscape:cx="13.987729"
+   inkscape:cy="1.1579829"
+   inkscape:window-x="0"
+   inkscape:window-y="17"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg16"
+   showguides="false"><inkscape:grid
+     type="xygrid"
+     id="grid4546" /></sodipodi:namedview>
+    
+<path
+   mask="none"
+   clip-path="url(#clipPath4735)"
+   d="M 1 0 C 0.448 0 0 0.448 0 1 L 0 15 C 0 15.552 0.448 16 1 16 L 15 16 C 15.552 16 16 15.552 16 15 L 16 1 C 16 0.448 15.552 0 15 0 L 1 0 z M 1 1 L 3 1 L 3 2 L 1 2 L 1 1 z M 4 1 L 6 1 L 6 2 L 4 2 L 4 1 z M 7 1 L 9 1 L 9 2 L 7 2 L 7 1 z M 10 1 L 12 1 L 12 2 L 10 2 L 10 1 z M 13 1 L 15 1 L 15 2 L 13 2 L 13 1 z M 2 4 L 4 4 L 4 5 L 3 5 L 3 11 L 4 11 L 4 12 L 2 12 L 2 4 z M 12 4 L 14 4 L 14 12 L 12 12 L 12 11 L 13 11 L 13 5 L 12 5 L 12 4 z M 1 14 L 3 14 L 3 15 L 1 15 L 1 14 z M 4 14 L 6 14 L 6 15 L 4 15 L 4 14 z M 7 14 L 9 14 L 9 15 L 7 15 L 7 14 z M 10 14 L 12 14 L 12 15 L 10 15 L 10 14 z M 13 14 L 15 14 L 15 15 L 13 15 L 13 14 z "
+   id="path5" /></svg>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1992,6 +1992,8 @@ void MainWindow::defineActions() {
                        "nextkey");
   createMenuPlayAction(MI_PrevKeyframe, QT_TR_NOOP("Previous Key"), "Ctrl+,",
                        "prevkey");
+  createMenuPlayAction(MI_ToggleBlankFrames, QT_TR_NOOP("Toggle Blank Frames"),
+                       "", "blankframes");
 
   // Menu - Render
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -207,6 +207,7 @@
 #define MI_PrevStep "MI_PrevStep"
 #define MI_NextKeyframe "MI_NextKeyframe"
 #define MI_PrevKeyframe "MI_PrevKeyframe"
+#define MI_ToggleBlankFrames "MI_ToggleBlankFrames"
 
 #define MI_RedChannel "MI_RedChannel"
 #define MI_GreenChannel "MI_GreenChannel"

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -215,7 +215,8 @@
 		<file>icons/dark/actions/16/nextstep.svg</file>
 		<file>icons/dark/actions/16/prevstep.svg</file>
 		<file>icons/dark/actions/16/nextkey.svg</file>
-		<file>icons/dark/actions/16/prevkey.svg</file>
+    <file>icons/dark/actions/16/prevkey.svg</file>
+    <file>icons/dark/actions/16/blankframes.svg</file>
 
 		<file>icons/dark/actions/16/snapshot.svg</file>
 		<file>icons/dark/actions/16/compare.svg</file>

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -137,12 +137,11 @@ public:
   ShortPlayCommand() : MenuItemHandler(MI_ShortPlay) {}
 
   void execute() override {
-    int row = TApp::instance()->getCurrentFrame()->getFrame();
+    int row                 = TApp::instance()->getCurrentFrame()->getFrame();
     int shortPlayFrameCount = Preferences::instance()->getShortPlayFrameCount();
     int count =
         TApp::instance()->getCurrentXsheet()->getXsheet()->getFrameCount();
-    int newFrame = std::max(
-      0, count - shortPlayFrameCount);
+    int newFrame = std::max(0, count - shortPlayFrameCount);
     TApp::instance()->getCurrentFrame()->setFrame(newFrame);
     CommandManager::instance()->execute(MI_Play);
   }
@@ -159,7 +158,7 @@ public:
                                  "FunctionEditor", "FxSettings",
                                  "ComboViewer",    "SceneViewer"};
 
-    QWidget *panel    = QApplication::focusWidget();
+    QWidget *panel = QApplication::focusWidget();
     if (!panel) panel = TApp::instance()->getActiveViewer();
     while (panel) {
       QString pane = panel->objectName();
@@ -188,7 +187,7 @@ public:
                                  "FunctionEditor", "FxSettings",
                                  "ComboViewer",    "SceneViewer"};
 
-    QWidget *panel    = QApplication::focusWidget();
+    QWidget *panel = QApplication::focusWidget();
     if (!panel) panel = TApp::instance()->getActiveViewer();
     while (panel) {
       QString pane = panel->objectName();
@@ -227,7 +226,8 @@ VcrCommand playCommand(MI_Play, FlipConsole::ePlay),
     greenChannelGComman(MI_GreenChannelGreyscale, FlipConsole::eGGreen),
     blueChannelGCommand(MI_BlueChannelGreyscale, FlipConsole::eGBlue),
 
-    compareCommand(MI_CompareToSnapshot, FlipConsole::eCompare);
+    compareCommand(MI_CompareToSnapshot, FlipConsole::eCompare),
+    blankFramesCommand(MI_ToggleBlankFrames, FlipConsole::eBlankFrames);
 
 NextDrawingCommand nextDrawingCommand;
 PrevDrawingCommand prevDrawingCommand;

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -169,7 +169,7 @@ void PlaybackExecutor::run() {
   qint64 nextSampleInstant = timeResolution;
 
   qint64 lastFrameCounts[4]    = {0, 0, 0,
-                               0};  // Keep the last 4 'played frames' counts.
+                                  0};  // Keep the last 4 'played frames' counts.
   qint64 lastSampleInstants[4] = {0, 0, 0,
                                   0};  // Same for the last sampling instants
 
@@ -189,7 +189,7 @@ void PlaybackExecutor::run() {
       qint64 framesCount = playedFramesCount - lastFrameCounts[currSample];
       qint64 elapsedTime = emissionInstant - lastSampleInstants[currSample];
       fps                = troundp((long double)(1000000000 * framesCount) /
-                    (long double)elapsedTime);
+                                   (long double)elapsedTime);
 
       targetFrameTime =
           1000000000 / (qint64)abs(m_fps);  // m_fps could have changed...
@@ -294,11 +294,10 @@ void FlipSlider::paintEvent(QPaintEvent *ev) {
                 PBMarkerMarginLeft;
       if (i == pbStatusSize - 1) nextPos += PBMarkerMarginRight;
       p.fillRect(currPos, PBColorMarginTop, nextPos - currPos, colorHeight,
-                 ((*m_progressBarStatus)[i] == PBFrameStarted)
-                     ? PBStartedColor
-                     : ((*m_progressBarStatus)[i] == PBFrameFinished)
-                           ? PBFinishedColor
-                           : PBNotStartedColor);
+                 ((*m_progressBarStatus)[i] == PBFrameStarted) ? PBStartedColor
+                 : ((*m_progressBarStatus)[i] == PBFrameFinished)
+                     ? PBFinishedColor
+                     : PBNotStartedColor);
       currPos = nextPos;
     }
 
@@ -1026,7 +1025,7 @@ void FlipConsole::applyCustomizeMask() {
         std::find(m_gadgetsMask.begin(), m_gadgetsMask.end(), eDefineLoadBox) ==
         m_gadgetsMask.end();
     bool hasUseLoadBox   = std::find(m_gadgetsMask.begin(), m_gadgetsMask.end(),
-                                   eUseLoadBox) == m_gadgetsMask.end();
+                                     eUseLoadBox) == m_gadgetsMask.end();
     bool hasDefineSubCam = std::find(m_gadgetsMask.begin(), m_gadgetsMask.end(),
                                      eDefineSubCamera) == m_gadgetsMask.end();
     m_subcamSep->setVisible(
@@ -1766,6 +1765,8 @@ QFrame *FlipConsole::createFrameSlider() {
     m_enableBlankFrameButton->setFixedHeight(24);
     m_enableBlankFrameButton->setFixedWidth(66);
     m_enableBlankFrameButton->setObjectName("enableBlankFrameButton");
+
+    m_buttons[eBlankFrames] = m_enableBlankFrameButton;
   }
 
   // layout


### PR DESCRIPTION
This PR adds a new command `Toggle Blank Frames` which will toggle the blank frame button in the current viewer / flipbook console so that the button can be controlled via shortcut key, custom toolbar and custom panels.
The `Toggle Blank Frames` command is added in `Menu Commands > Play` category.