### PR TITLE
Histogram popup enhancements

### DIFF
--- a/toonz/sources/include/toonzqt/combohistogram.h
+++ b/toonz/sources/include/toonzqt/combohistogram.h
@@ -51,6 +51,7 @@ private:
   QColor m_color;
 
   DisplayMode m_mode;
+  bool m_alphaVisible;
 
 public:
   ComboHistoRGBLabel(QColor color, QWidget *parent);
@@ -59,6 +60,7 @@ public:
 
   void setColorAndUpdate(QColor color);
   void setDisplayMode(DisplayMode mode) { m_mode = mode; }
+  void setAlphaVisible(bool visible) { m_alphaVisible = visible; }
 
 protected:
   void paintEvent(QPaintEvent *pe) override;
@@ -142,6 +144,9 @@ public:
 
 protected slots:
   void onShowAlphaButtonToggled(bool visible);
+
+signals:
+  void showButtonToggled(bool);
 };
 
 //-----------------------------------------------------------------------------
@@ -199,6 +204,7 @@ protected:
 
 protected slots:
   void onDisplayModeChanged();
+  void onShowAlphaButtonToggled(bool);
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/menubarcommand.h
+++ b/toonz/sources/include/toonzqt/menubarcommand.h
@@ -63,10 +63,11 @@ enum CommandType {
   ToolModifierCommandType,
   ZoomCommandType,
   MiscCommandType,
+  StopMotionCommandType,
+  CellMarkCommandType,
   MenuCommandType,
   VisualizationButtonCommandType,
-  StopMotionCommandType,
-  CellMarkCommandType
+  HiddenCommandType
 };
 
 //-----------------------------------------------------------------------------
@@ -246,9 +247,15 @@ public:
 
   void execute() override {
     if (!m_popup) m_popup = new T();
-    m_popup->show();
-    m_popup->raise();
-    m_popup->activateWindow();
+
+    // close popup when using the command while open
+    if (m_popup->isVisible())
+      m_popup->hide();
+    else {
+      m_popup->show();
+      m_popup->raise();
+      m_popup->activateWindow();
+    }
   }
 };
 

--- a/toonz/sources/tnztools/stylepicker.cpp
+++ b/toonz/sources/tnztools/stylepicker.cpp
@@ -261,7 +261,7 @@ TPixel64 StylePicker::pickAverageColor16(const TRectD &rect) const {
   assert(raster64);
   if (!raster64) return TPixel64::Transparent;
 
-  UINT r = 0, g = 0, b = 0, m = 0, size = 0;
+  uint64_t r = 0, g = 0, b = 0, m = 0, size = 0;
   for (int y = topLeft.y; y < bottomRight.y; y++) {
     TPixel64 *p = &raster64->pixels(y)[topLeft.x];
     for (int x = topLeft.x; x < bottomRight.x; x++, p++) {

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -266,7 +266,7 @@ void FlipBook::addFreezeButtonToTitleBar() {
   if (panel) {
     TPanelTitleBar *titleBar = panel->getTitleBar();
     m_freezeButton           = new TPanelTitleBarButton(
-        titleBar, getIconThemePath("actions/20/pane_freeze.svg"));
+                  titleBar, getIconThemePath("actions/20/pane_freeze.svg"));
     m_freezeButton->setToolTip("Freeze");
     titleBar->add(QPoint(-64, 0), m_freezeButton);
     connect(m_freezeButton, SIGNAL(toggled(bool)), this, SLOT(freeze(bool)));
@@ -1763,9 +1763,12 @@ void FlipBook::onCloseButtonPressed() {
 
 void ImageViewer::showHistogram() {
   if (!m_isHistogramEnable) return;
+
+  // close the popup when using the command while open
   if (m_histogramPopup->isVisible())
-    m_histogramPopup->raise();
+    m_histogramPopup->hide();
   else {
+    m_histogramPopup->moveNextToWidget(this);
     m_histogramPopup->setImage(getImage());
     m_histogramPopup->show();
   }

--- a/toonz/sources/toonz/histogrampopup.h
+++ b/toonz/sources/toonz/histogrampopup.h
@@ -32,6 +32,7 @@ public:
   void updateAverageColor(const TPixel64 &pix);
   void setShowCompare(bool on);
   void invalidateCompHisto();
+  void moveNextToWidget(QWidget *widget);
 };
 
 //=============================================================================

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2217,7 +2217,13 @@ void MainWindow::defineActions() {
                              "", "shift_keys_up");
   createRightClickMenuAction(MI_PasteNumbers, QT_TR_NOOP("&Paste Numbers"), "",
                              "paste_numbers");
+
   createRightClickMenuAction(MI_Histogram, QT_TR_NOOP("&Histogram"), "");
+  // MI_ViewerHistogram command is used as a proxy. It will be called when
+  // the MI_Histogram is used while the current flip console is in viewer.
+  createAction(MI_ViewerHistogram, QT_TR_NOOP("&Viewer Histogram"), "",
+               HiddenCommandType);
+
   createRightClickMenuAction(MI_BlendColors, QT_TR_NOOP("&Blend colors"), "");
   createToggle(MI_OnionSkin, QT_TR_NOOP("Onion Skin Toggle"), "/", false,
                RightClickMenuCommandType, "onionskin_toggle");

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -190,6 +190,7 @@
 #define MI_NoShift "MI_NoShift"
 #define MI_ResetShift "MI_ResetShift"
 #define MI_Histogram "MI_Histogram"
+#define MI_ViewerHistogram "MI_ViewerHistogram"
 #define MI_FxParamEditor "MI_FxParamEditor"
 
 #define MI_Link "MI_Link"

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -77,7 +77,7 @@ namespace {
 void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
                     int widgetHeight, double pressure, int devPixRatio) {
   toonzEvent.m_pos      = TPointD(event->pos().x() * devPixRatio,
-                             widgetHeight - 1 - event->pos().y() * devPixRatio);
+                                  widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
   toonzEvent.m_pressure = 1.0;
 
@@ -205,7 +205,7 @@ void SceneViewer::onButtonPressed(FlipConsole::EGadget button) {
     break;
 
   case FlipConsole::eHisto: {
-    QAction *action = CommandManager::instance()->getAction(MI_Histogram);
+    QAction *action = CommandManager::instance()->getAction(MI_ViewerHistogram);
     action->trigger();
     break;
   }

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -227,7 +227,8 @@ VcrCommand playCommand(MI_Play, FlipConsole::ePlay),
     blueChannelGCommand(MI_BlueChannelGreyscale, FlipConsole::eGBlue),
 
     compareCommand(MI_CompareToSnapshot, FlipConsole::eCompare),
-    blankFramesCommand(MI_ToggleBlankFrames, FlipConsole::eBlankFrames);
+    blankFramesCommand(MI_ToggleBlankFrames, FlipConsole::eBlankFrames),
+    histogramCommand(MI_Histogram, FlipConsole::eHisto);
 
 NextDrawingCommand nextDrawingCommand;
 PrevDrawingCommand prevDrawingCommand;


### PR DESCRIPTION
This PR will enhance the Histogram popup as follows: 
 - Now the histogram popup will open next to the viewer in order not to hover over the image.
 - Clicking the Histogram button or using the `Histogram` command  via shortcut key while the popup is visible will now hide the popup, instead of raise the popup on top. (*)
 - Alpha channel value will be shown in the `Picked Color` and the `Average Color` labels when the Alpha histogram is visible.
 - The `Histogram` command shortcut key now can open the Flipbook histogram as well as the Viewer histogram. (Which to open is depending on which console is active.)
 - Fixed picking average color (Ctrl + Drag) may shows wrong value when displaying 16bpc image (due to overflow).

(*)  **PLEASE NOTE** : I applied this behavior to ALL popup-opening commands such as `Scene Settings`, `Preferences`, `Configure Shortcuts`, etc.. Now the commands will hide the popups if the popups are already shown.