### PR TITLE
Fix Custom File Path Rule Bugs

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -1,7 +1,7 @@
 
 
 #ifdef _WIN32
-//#define UNICODE  // per le funzioni di conversione da/a UNC
+// #define UNICODE  // per le funzioni di conversione da/a UNC
 #include <windows.h>
 #include <lm.h>
 
@@ -277,8 +277,7 @@ void TFilePath::setPath(std::wstring path) {
       }
     } else if (isSlash(path[pos])) {
       int firstSlashPos = pos;
-      do
-        pos++;
+      do pos++;
       while (pos < length && isSlash(path[pos]));
       if (firstSlashPos == 0 && pos == 4)  // Caso "\\\\MachineName"
         m_path.append(2, wslash);
@@ -1060,9 +1059,9 @@ QString TFilePath::fidRegExpStr() {
   QString suffixLetter = (m_acceptNonAlphabetSuffix)
                              ? "[^\\._ \\\\/:,;*?\"<>|0123456789]"
                              : "[a-zA-Z]";
-  QString countLetter = (m_letterCountForSuffix == 0)
-                            ? "{0,}"
-                            : (QString("{0,%1}").arg(m_letterCountForSuffix));
+  QString countLetter  = (m_letterCountForSuffix == 0)
+                             ? "{0,}"
+                             : (QString("{0,%1}").arg(m_letterCountForSuffix));
   return QString("(\\d+)(%1%2)").arg(suffixLetter).arg(countLetter);
   // const QString fIdRegExp("(\\d+)([a-zA-Z]?)");
 }
@@ -1107,8 +1106,9 @@ TFilePath::TFilePathInfo TFilePath::analyzePath() const {
 
   // hogehoge.0001a.jpg
   // empty frame case : hogehoge..jpg
-  QRegExp rx("^" + levelNameRegExp + sepCharRegExp + "(?:" + fIdRegExp + ")?" +
-             "\\." + extensionRegExp + "$");
+  // empty level name case : ..jpg   .0001a.jpg
+  QRegExp rx("^(?:" + levelNameRegExp + ")?" + sepCharRegExp +
+             "(?:" + fIdRegExp + ")?" + "\\." + extensionRegExp + "$");
   if (rx.indexIn(fileName) != -1) {
     assert(rx.captureCount() == 5);
     info.levelName = rx.cap(1);

--- a/toonz/sources/tcleanupper/tcleanupper.cpp
+++ b/toonz/sources/tcleanupper/tcleanupper.cpp
@@ -22,6 +22,7 @@
 #include "toonz/txshcolumn.h"
 #include "toonz/tlog.h"
 #include "toonz/imagestyles.h"
+#include "toonz/filepathproperties.h"
 
 // TnzBase includes
 #include "tcli.h"
@@ -595,6 +596,12 @@ int main(int argc, char *argv[]) {
   }
 
   cout << "project:" << project->getName() << endl;
+
+  // update TFilePath condition on loading the current project
+  FilePathProperties *fpProp = project->getFilePathProperties();
+  TFilePath::setFilePathProperties(fpProp->useStandard(),
+                                   fpProp->acceptNonAlphabetSuffix(),
+                                   fpProp->letterCountForSuffix());
 
   TFilePath fp = srcName;
 

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -33,6 +33,7 @@
 #include "toonz/levelset.h"
 #include "toonz/txshsimplelevel.h"
 #include "toonz/levelproperties.h"
+#include "toonz/filepathproperties.h"
 
 // TnzSound includes
 #include "tnzsound.h"
@@ -50,7 +51,7 @@
 #include "tunit.h"
 #include "tenv.h"
 #include "tpassivecachemanager.h"
-//#include "tcacheresourcepool.h"
+// #include "tcacheresourcepool.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -798,7 +799,7 @@ int main(int argc, char *argv[]) {
     loadShaderInterfaces(ToonzFolder::getLibraryFolder() +
                          TFilePath("shaders"));
 
-    //#endif
+    // #endif
 
     //---------------------------------------------------------
 
@@ -827,6 +828,12 @@ int main(int argc, char *argv[]) {
     cout << msg << endl;
     m_userLog->info(msg);
     // pm->setCurrentProject(project, false); // false => temporaneamente
+
+    // update TFilePath condition on loading the current project
+    FilePathProperties *fpProp = project->getFilePathProperties();
+    TFilePath::setFilePathProperties(fpProp->useStandard(),
+                                     fpProp->acceptNonAlphabetSuffix(),
+                                     fpProp->letterCountForSuffix());
 
     Sw1.start();
 
@@ -927,13 +934,10 @@ int main(int argc, char *argv[]) {
     const int threadCounts[3] = {1, procCount / 2, procCount};
     if (nthreads.isSelected()) {
       QString threadCountStr = QString::fromStdString(nthreads.getValue());
-      threadCount            = (threadCountStr == "single")
-                        ? threadCounts[0]
-                        : (threadCountStr == "half")
-                              ? threadCounts[1]
-                              : (threadCountStr == "all")
-                                    ? threadCounts[2]
-                                    : threadCountStr.toInt();
+      threadCount            = (threadCountStr == "single") ? threadCounts[0]
+                               : (threadCountStr == "half") ? threadCounts[1]
+                               : (threadCountStr == "all")  ? threadCounts[2]
+                                                           : threadCountStr.toInt();
 
       if (threadCount <= 0) {
         cout << "Qualifier 'nthreads': bad input" << endl;
@@ -953,15 +957,11 @@ int main(int argc, char *argv[]) {
         TOutputProperties::MediumVal, TOutputProperties::SmallVal};
     if (tileSize.isSelected()) {
       QString tileSizeStr = QString::fromStdString(tileSize.getValue());
-      maxTileSize         = (tileSizeStr == "none")
-                        ? maxTileSizes[0]
-                        : (tileSizeStr == "large")
-                              ? maxTileSizes[1]
-                              : (tileSizeStr == "medium")
-                                    ? maxTileSizes[2]
-                                    : (tileSizeStr == "small")
-                                          ? maxTileSizes[3]
-                                          : tileSizeStr.toInt();
+      maxTileSize         = (tileSizeStr == "none")     ? maxTileSizes[0]
+                            : (tileSizeStr == "large")  ? maxTileSizes[1]
+                            : (tileSizeStr == "medium") ? maxTileSizes[2]
+                            : (tileSizeStr == "small")  ? maxTileSizes[3]
+                                                        : tileSizeStr.toInt();
 
       if (maxTileSize <= 0) {
         cout << "Qualifier 'maxtilesize': bad input" << endl;


### PR DESCRIPTION
This PR fixes the following problems occur when the `Project Settings > File Path Rules` are set to `Custom` :

1. `Output Settings > File Settings > Name` (i.e. output file name) becomes `.` (dot) when no file name is manually specified. It should automatically be synchronized with the current scene name.
2. When batch rendered using `tcomposer`, the File Path Rules of the `sandbox` project are always used regardless of the project which the target scene is belonging to.