### PR TITLE
Fix selecting previous xsheet frames/layers with the arrow keys

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1250,12 +1250,21 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
     stride.setFrame(cellSel->getSelectedCells().getRowCount());
 
     if (m_cellArea->isControlPressed()) {  // resize
-      if (r0 == r1 && shift.frame() < 0) return;
+
       if (c0 == c1 && shift.layer() < firstCol) return;
-      cellSel->selectCells(r0, c0, r1 + shift.frame(), c1 + shift.layer());
+
+      bool prevRow = r0 < getCurrentRow();
+      bool prevCol = c0 < getCurrentColumn();
+
+      if (!prevRow and !prevCol)  cellSel->selectCells(r0, c0, r1 + shift.frame(), c1 + shift.layer());
+      if ( prevRow and !prevCol)  cellSel->selectCells(r0 + shift.frame(), c0, r1, c1 + shift.layer());
+      if (!prevRow and  prevCol)  cellSel->selectCells(r0, c0 + shift.layer(), r1 + shift.frame(), c1);
+      if ( prevRow and  prevCol)  cellSel->selectCells(r0 + shift.frame(), c0 + shift.layer(), r1, c1);
+
       updateCells();
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
       return;
+
     } else {  // shift
       CellPosition offset(shift * stride);
       int movedR0   = std::max(0, r0 + offset.frame());

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1251,16 +1251,23 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
 
     if (m_cellArea->isControlPressed()) {  // resize
 
-      if (c0 == c1 && shift.layer() < firstCol) return;
+      // resize selection of frames/rows forward or backwards
+      if (r0 < getCurrentRow())
+        r0 += shift.frame();
+      else
+        r1 += shift.frame();
 
-      bool prevRow = r0 < getCurrentRow();
-      bool prevCol = c0 < getCurrentColumn();
+      // resize selection of layers/columns "up" or "down"
+      if (c0 < getCurrentColumn())
+        c0 += shift.layer();
+      else
+        c1 += shift.layer();
 
-      if (!prevRow and !prevCol)  cellSel->selectCells(r0, c0, r1 + shift.frame(), c1 + shift.layer());
-      if ( prevRow and !prevCol)  cellSel->selectCells(r0 + shift.frame(), c0, r1, c1 + shift.layer());
-      if (!prevRow and  prevCol)  cellSel->selectCells(r0, c0 + shift.layer(), r1 + shift.frame(), c1);
-      if ( prevRow and  prevCol)  cellSel->selectCells(r0 + shift.frame(), c0 + shift.layer(), r1, c1);
+      // keep selection inside the xsheet/timeline
+      if (c0 < firstCol || c1 < firstCol || r0 < 0 || r1 < 0) return;
 
+      // apply new selection rectangle
+      cellSel->selectCells(r0, c0, r1, c1);
       updateCells();
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
       return;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1245,41 +1245,41 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
   // selection range.
   if (Preferences::instance()->isUseArrowKeyToShiftCellSelectionEnabled() &&
       cellSel && !cellSel->isEmpty()) {
-    int r0, c0, r1, c1;
-    cellSel->getSelectedCells(r0, c0, r1, c1);
+    int rowA, colA, rowB, colB;
+    cellSel->getSelectedCells(rowA, colA, rowB, colB);
     stride.setFrame(cellSel->getSelectedCells().getRowCount());
 
     if (m_cellArea->isControlPressed()) {  // resize
 
       // resize selection of frames/rows forward or backwards
-      if (r0 < getCurrentRow())
-        r0 += shift.frame();
+      if (rowA < getCurrentRow())
+        rowA += shift.frame();
       else
-        r1 += shift.frame();
+        rowB += shift.frame();
 
       // resize selection of layers/columns "up" or "down"
-      if (c0 < getCurrentColumn())
-        c0 += shift.layer();
+      if (colA < getCurrentColumn())
+        colA += shift.layer();
       else
-        c1 += shift.layer();
+        colB += shift.layer();
 
       // keep selection inside the xsheet/timeline
-      if (c0 < firstCol || c1 < firstCol || r0 < 0 || r1 < 0) return;
+      if (colA < firstCol || colB < firstCol || rowA < 0 || rowB < 0) return;
 
       // apply new selection rectangle
-      cellSel->selectCells(r0, c0, r1, c1);
+      cellSel->selectCells(rowA, colA, rowB, colB);
       updateCells();
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
       return;
 
     } else {  // shift
       CellPosition offset(shift * stride);
-      int movedR0   = std::max(0, r0 + offset.frame());
-      int movedC0   = std::max(firstCol, c0 + offset.layer());
-      int diffFrame = movedR0 - r0;
-      int diffLayer = movedC0 - c0;
-      cellSel->selectCells(r0 + diffFrame, c0 + diffLayer, r1 + diffFrame,
-                           c1 + diffLayer);
+      int movedRow0   = std::max(0, rowA + offset.frame());
+      int movedCol0   = std::max(firstCol, colA + offset.layer());
+      int diffRow = movedRow0 - rowA;
+      int diffCol = movedCol0 - colA;
+      cellSel->selectCells(rowA + diffRow, colA + diffCol, rowB + diffRow,
+                           colB + diffCol);
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
     }
   }


### PR DESCRIPTION
Previous behavior: ![Peek 2022-11-05 22-48](https://user-images.githubusercontent.com/3645797/200142644-0833ace5-b730-4f7b-a2a0-7efe3584ab97.gif)

