### PR TITLE
Patch for #4591

### DIFF
--- a/toonz/sources/common/tiio/tiio.cpp
+++ b/toonz/sources/common/tiio/tiio.cpp
@@ -263,3 +263,13 @@ void Tiio::Writer::getSupportedFormats(QStringList &formats,
 void Tiio::Writer::setProperties(TPropertyGroup *properties) {
   m_properties = properties ? properties->clone() : 0;
 }
+
+//-----------------------------------------------------
+
+bool Tiio::useQuicktime(bool enable) {
+  static bool state = false;
+  if (enable) state = true;
+  return state;
+}
+
+//-----------------------------------------------------

--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -247,6 +247,8 @@ void initImageIo(bool lightVersion) {
 #endif  // _WIN32
 
     if (IsQuickTimeInstalled()) {
+      Tiio::useQuicktime(true);
+
       TLevelWriter::define("mov", TLevelWriterMov::create, true);
       TLevelReader::define("mov", TLevelReaderMov::create);
       TFileType::declare("mov", TFileType::RASTER_LEVEL);

--- a/toonz/sources/include/tiio.h
+++ b/toonz/sources/include/tiio.h
@@ -172,6 +172,8 @@ DVAPI void defineWriterProperties(const char *ext, TPropertyGroup *);
 
 DVAPI bool isQuicktimeInstalled();
 
+DVAPI bool useQuicktime(bool enable = false);
+
 DVAPI void updateFileWritersPropertiesTranslation();
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/formatsettingspopups.cpp
+++ b/toonz/sources/toonz/formatsettingspopups.cpp
@@ -404,8 +404,7 @@ void FormatSettingsPopup::onPaddingCBChanged() {
 bool openFormatSettingsPopup(QWidget *parent, const std::string &format,
                              TPropertyGroup *props, TFrameId *tmplFId,
                              bool forInput, const TFilePath &levelPath) {
-  bool quicktime =
-      (format == "mov" || format == "3gp") && Tiio::isQuicktimeInstalled();
+  bool quicktime = (format == "mov" || format == "3gp") && Tiio::useQuicktime();
   if (quicktime)  // trattato diversamente; il format
                   // popup dei mov e' quello di
                   // quicktime


### PR DESCRIPTION
Small patch to workaround QuickTime state because `isQuicktimeInstalled` always reports false in Toonz:
```C++
bool Tiio::isQuicktimeInstalled() {
  // NOTE: This is *NOT* the same function as IsQuickTimeInstalled(), which is
  // implemented locally in the image lib and used there. This function here is
  // actually NEVER USED throughout Toonz, so we're placing a dummy
  // implementation here.

  assert(false);
  return false;
}
```

This causes OpenToonz to assume QuickTime wasn't installed and opened the wrong interface for the MOV options after #4591:
![](https://user-images.githubusercontent.com/2576432/200561672-f02d5c84-4cf6-4e7d-9e58-b0fc739dd7a5.png)

Thanks for @RodneyBaker for discovering this bug.