### PR TITLE
Actions: Fix MacOS runner

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -25,7 +25,6 @@ jobs:
         }
         brew update
         checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo qt@5 boost libusb libmypaint ccache jpeg-turbo ninja
-        brew unlink gcc@9
         checkPkgAndInstall opencv
         
     - uses: actions/cache@v1


### PR DESCRIPTION
This PR will fix recent failure in MacOS runner of GitHub Actions.
Removed a line unlinking gcc v9 as it seems to be no longer used.