### PR TITLE
Updated Mac OS build instructions to match working CI workflow

### DIFF
--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -34,7 +34,7 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 
 In a Terminal window, execute the following statements:
 ```
-$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt@5 boost jpeg-turbo
+$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt@5 boost jpeg-turbo opencv
 $ git lfs install
 ```
 
@@ -60,7 +60,7 @@ $ git lfs pull
 $ cd thirdparty/lzo
 $ cp -r 2.03/include/lzo driver
 $ cd ../tiff-4.0.3
-$ ./configure && make
+$ ./configure --disable-lzma && make
 ```
 
 If you downloaded and installed boost from https://boost.org instead of homebrew, move the package under `thirdparty/boost` as follows: 


### PR DESCRIPTION
Hi!

I'm new to the project and I had issues building the project on Mac OS while following the instructions in [`doc/how_to_build_macosx.md`](https://github.com/opentoonz/opentoonz/blob/master/doc/how_to_build_macosx.md). This PR is to update that doc, for future new-joiners.

1. My first issue was the following:
```
CMake Error at CMakeLists.txt:282 (find_package):
  By not providing "FindOpenCV.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "OpenCV", but
  CMake did not find one.

  Could not find a package configuration file provided by "OpenCV" (requested
  version 4.1) with any of the following names:

    OpenCVConfig.cmake
    opencv-config.cmake

  Add the installation prefix of "OpenCV" to CMAKE_PREFIX_PATH or set
  "OpenCV_DIR" to a directory containing one of the above files.  If "OpenCV"
  provides a separate development package or SDK, be sure it has been
  installed.
```
which was remedied by just installing `opencv` via `brew`. I've consequently added `brew install opencv` to the instructions.

2. My second issue was LZMA errors, exactly the same as #2496. As mentioned by @manongjohn, the fix is to add the `--disable-lzma` flag when building libtiff.

After I made these two changes, I was able to successfully build OT for the first time 🥳 

It turns out BOTH of these changes were already implemented in [`.github/workflows/workflow_macos.yml`](https://github.com/opentoonz/opentoonz/blob/master/.github/workflows/workflow_macos.yml) -- it seems like the dev docs were just lagging behind.