### PR TITLE
Allow svn versions over 1.10

### DIFF
--- a/toonz/sources/toonz/versioncontrol.cpp
+++ b/toonz/sources/toonz/versioncontrol.cpp
@@ -611,10 +611,10 @@ bool VersionControl::testSetup() {
 
     if (!list.isEmpty()) {
       QString firstLine = list.first();
-      firstLine         = firstLine.remove("svn, version ");
+      firstLine         = firstLine.remove("svn, version 1."); //ignore the 1. since SVN decimal versions are not zero padded
 
       double version = firstLine.left(3).toDouble();
-      if (version <= 1.5) {
+      if (version < 5) { // only check decimal version 1.xx
         DVGui::warning(
             tr("The version control client application installed on your "
                "computer needs to be updated, otherwise some features may not "


### PR DESCRIPTION
SVN decimal versions are not zero padded and instead goes: 
1.8 
1.9 
1.10
1.11