### PR TITLE
Function Editor Curve Graph: Bigger Handles & Improved Contrast

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1544,10 +1544,10 @@ QStatusBar #StatusBarLabel {
   qproperty-BGColor: #414345;
 }
 #StyleChooserPage {
-  qproperty-CommonChipBoxColor: #000000;
+  qproperty-CommonChipBoxColor: black;
   qproperty-PinnedChipBoxColor: #a0a0a0;
   qproperty-SolidChipBoxColor: #e41000;
-  qproperty-SelectedChipBoxColor: #ffffff;
+  qproperty-SelectedChipBoxColor: white;
   qproperty-SelectedChipBox2Color: #c7ca32;
 }
 /* -------------------------------------------------------------------------- */
@@ -2289,9 +2289,9 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #d6d8dd;
   qproperty-ErrorTextColor: #ff7b7b;
+  qproperty-BGColor: #3a3b3d;
   qproperty-SelectedTextColor: #d6d8dd;
   qproperty-CurrentFrameTextColor: #d6d8dd;
-  qproperty-BGColor: #3a3b3d;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
   qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
@@ -2429,13 +2429,13 @@ FunctionTreeView {
   padding-left: 2;
 }
 FunctionPanel {
-  qproperty-BGColor: #3a3b3d;
-  qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);
-  qproperty-FrameLineColor: rgba(0, 0, 0, 0.1);
-  qproperty-OtherCurvesColor: #84888b;
-  qproperty-RulerBackground: #323435;
+  qproperty-BGColor: #353638;
+  qproperty-ValueLineColor: #3f4042;
+  qproperty-FrameLineColor: #484b4d;
+  qproperty-OtherCurvesColor: #7f8386;
+  qproperty-RulerBackground: #2d2f30;
   qproperty-TextColor: #d6d8dd;
-  qproperty-SubColor: #3a3b3d;
+  qproperty-SubColor: #353638;
   qproperty-SelectedColor: #FFA500;
 }
 SpreadsheetViewer {

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1544,10 +1544,10 @@ QStatusBar #StatusBarLabel {
   qproperty-BGColor: #303030;
 }
 #StyleChooserPage {
-  qproperty-CommonChipBoxColor: #000000;
+  qproperty-CommonChipBoxColor: black;
   qproperty-PinnedChipBoxColor: #a0a0a0;
   qproperty-SolidChipBoxColor: #e41000;
-  qproperty-SelectedChipBoxColor: #ffffff;
+  qproperty-SelectedChipBoxColor: white;
   qproperty-SelectedChipBox2Color: #c7ca32;
 }
 /* -------------------------------------------------------------------------- */
@@ -2289,9 +2289,9 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #e6e6e6;
   qproperty-ErrorTextColor: #ff7b7b;
+  qproperty-BGColor: #303030;
   qproperty-SelectedTextColor: #e6e6e6;
   qproperty-CurrentFrameTextColor: #e6e6e6;
-  qproperty-BGColor: #303030;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.3);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
   qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
@@ -2430,8 +2430,8 @@ FunctionTreeView {
 }
 FunctionPanel {
   qproperty-BGColor: #303030;
-  qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);
-  qproperty-FrameLineColor: rgba(0, 0, 0, 0.1);
+  qproperty-ValueLineColor: #3a3a3a;
+  qproperty-FrameLineColor: #444444;
   qproperty-OtherCurvesColor: #7d7d7d;
   qproperty-RulerBackground: #282828;
   qproperty-TextColor: #e6e6e6;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1544,10 +1544,10 @@ QStatusBar #StatusBarLabel {
   qproperty-BGColor: #484848;
 }
 #StyleChooserPage {
-  qproperty-CommonChipBoxColor: #000000;
+  qproperty-CommonChipBoxColor: black;
   qproperty-PinnedChipBoxColor: #a0a0a0;
   qproperty-SolidChipBoxColor: #e41000;
-  qproperty-SelectedChipBoxColor: #ffffff;
+  qproperty-SelectedChipBoxColor: white;
   qproperty-SelectedChipBox2Color: #c7ca32;
 }
 /* -------------------------------------------------------------------------- */
@@ -2289,9 +2289,9 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #e6e6e6;
   qproperty-ErrorTextColor: #ff7b7b;
+  qproperty-BGColor: #404040;
   qproperty-SelectedTextColor: #e6e6e6;
   qproperty-CurrentFrameTextColor: #e6e6e6;
-  qproperty-BGColor: #404040;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
   qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.25);
@@ -2429,13 +2429,13 @@ FunctionTreeView {
   padding-left: 2;
 }
 FunctionPanel {
-  qproperty-BGColor: #404040;
-  qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);
-  qproperty-FrameLineColor: rgba(0, 0, 0, 0.1);
-  qproperty-OtherCurvesColor: #8d8d8d;
-  qproperty-RulerBackground: #393939;
+  qproperty-BGColor: #3b3b3b;
+  qproperty-ValueLineColor: #454545;
+  qproperty-FrameLineColor: #505050;
+  qproperty-OtherCurvesColor: #888888;
+  qproperty-RulerBackground: #343434;
   qproperty-TextColor: #e6e6e6;
-  qproperty-SubColor: #404040;
+  qproperty-SubColor: #3b3b3b;
   qproperty-SelectedColor: #FFA500;
 }
 SpreadsheetViewer {

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -107,7 +107,7 @@
 // -----------------------------------------------------------------------------
 // Palette Window
 // -----------------------------------------------------------------------------
- 
+
 // All views (except list)
 @palette-SelectedBorderColor: rgb(255, 255, 255);
 @palette-NumpadShortcutBgColor: rgba(0, 0, 0, 0.3);
@@ -556,9 +556,9 @@
 @function-treeview-text-color: @text-color;
 
 // Function Curve Panel
-@function-panel-bg-color: @xsheet-NotEmptyColumn-color;
-@function-panel-ValueLine-color: fade(@xsheet-LightLine-color, 10);
-@function-panel-FrameLine-color: fade(@xsheet-VerticalLine-color, 10);
+@function-panel-bg-color: darken(@bg, 5);
+@function-panel-ValueLine-color: lighten(@function-panel-bg-color, 4);
+@function-panel-FrameLine-color: lighten(@function-panel-bg-color, 8);
 @function-panel-OtherCurves-color: lighten(@function-panel-bg-color, 30);
 @function-panel-RulerBG-color: darken(@function-panel-bg-color, 3);
 @function-panel-Text-color: @text-color;

--- a/stuff/config/qss/Default/less/layouts/palette.less
+++ b/stuff/config/qss/Default/less/layouts/palette.less
@@ -20,10 +20,10 @@
 
 #StyleChooserPage {
   qproperty-CommonChipBoxColor: @palette-CommonChipBoxColor;
-  qproperty-PinnedChipBoxColor: @palette-PinnedChipBorderColor;
-  qproperty-SolidChipBoxColor: @palette-SolidChipBorderColor;
-  qproperty-SelectedChipBoxColor: @palette-SelectedChipBorderColor;
-  qproperty-SelectedChipBox2Color: @palette-SelectedChipBorder2Color;
+  qproperty-PinnedChipBoxColor: @palette-PinnedChipBoxColor;
+  qproperty-SolidChipBoxColor: @palette-SolidChipBoxColor;
+  qproperty-SelectedChipBoxColor: @palette-SelectedChipBoxColor;
+  qproperty-SelectedChipBox2Color: @palette-SelectedChipBox2Color;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/less/themes/Dark.less
+++ b/stuff/config/qss/Default/less/themes/Dark.less
@@ -106,6 +106,8 @@
 // Function Editor
 // -----------------------------------------------------------------------------
 
+@function-panel-bg-color: darken(@bg, 0);
+
 // Function Curve Panel
 @function-panel-OtherCurves-color: lighten(@function-panel-bg-color, 30);
 

--- a/stuff/config/qss/Default/less/themes/Light.less
+++ b/stuff/config/qss/Default/less/themes/Light.less
@@ -241,7 +241,7 @@
 // -----------------------------------------------------------------------------
 
 // Function Curve Panel
-@function-panel-bg-color: @schematic-viewer-bg-color;
+@function-panel-bg-color: darken(@bg, 35);
 @function-panel-OtherCurves-color: rgb(218, 218, 218);
 @function-panel-Text-color: @text-color;
 

--- a/stuff/config/qss/Default/less/themes/Neutral.less
+++ b/stuff/config/qss/Default/less/themes/Neutral.less
@@ -267,6 +267,8 @@
 
 // Function Curve Panel
 @function-panel-bg-color: darken(@bg, 15);
+@function-panel-ValueLine-color: darken(@function-panel-bg-color, 4);
+@function-panel-FrameLine-color: darken(@function-panel-bg-color, 8);
 @function-panel-OtherCurves-color: rgb(197, 197, 197);
 @function-panel-RulerBG-color: darken(@bg, 10);
 @function-panel-Sub-color: rgb(255, 255, 255);

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1545,11 +1545,11 @@ QStatusBar #StatusBarLabel {
 }
 #StyleChooserPage {
   qproperty-CommonChipBoxColor: #c0c0c0;
-  qproperty-PinnedChipBoxColor: #6080a0;
+  qproperty-PinnedChipBoxColor: #607080;
   qproperty-SolidChipBoxColor: #e49080;
-  qproperty-SelectedChipBoxColor: #000000;
+  qproperty-SelectedChipBoxColor: black;
   qproperty-SelectedChipBox2Color: #c7ca32;
-}}
+}
 /* -------------------------------------------------------------------------- */
 /* Horizontal QSlider */
 #colorSlider::groove:horizontal {
@@ -2289,9 +2289,9 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #000;
   qproperty-ErrorTextColor: #c01111;
+  qproperty-BGColor: #cecece;
   qproperty-SelectedTextColor: #000;
   qproperty-CurrentFrameTextColor: #000;
-  qproperty-BGColor: #cecece;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(0, 0, 0, 0.3);
   qproperty-SecMarkerLineColor: rgba(0, 0, 0, 0.5);
@@ -2429,9 +2429,9 @@ FunctionTreeView {
   padding-left: 2;
 }
 FunctionPanel {
-  qproperty-BGColor: #808080;
-  qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);
-  qproperty-FrameLineColor: rgba(0, 0, 0, 0.1);
+  qproperty-BGColor: #828282;
+  qproperty-ValueLineColor: #787878;
+  qproperty-FrameLineColor: #6d6d6d;
   qproperty-OtherCurvesColor: #dadada;
   qproperty-RulerBackground: #c2c2c2;
   qproperty-TextColor: #000;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1544,10 +1544,10 @@ QStatusBar #StatusBarLabel {
   qproperty-BGColor: #808080;
 }
 #StyleChooserPage {
-  qproperty-CommonChipBoxColor: #000000;
+  qproperty-CommonChipBoxColor: black;
   qproperty-PinnedChipBoxColor: #405060;
   qproperty-SolidChipBoxColor: #e41000;
-  qproperty-SelectedChipBoxColor: #ffffff;
+  qproperty-SelectedChipBoxColor: white;
   qproperty-SelectedChipBox2Color: #c7ca32;
 }
 /* -------------------------------------------------------------------------- */
@@ -2289,9 +2289,9 @@ Ruler {
 XsheetViewer {
   qproperty-TextColor: #000;
   qproperty-ErrorTextColor: #c01111;
+  qproperty-BGColor: #767676;
   qproperty-SelectedTextColor: #000;
   qproperty-CurrentFrameTextColor: #000;
-  qproperty-BGColor: #767676;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.2);
   qproperty-SecMarkerLineColor: rgba(255, 255, 255, 0.35);
@@ -2430,8 +2430,8 @@ FunctionTreeView {
 }
 FunctionPanel {
   qproperty-BGColor: #5a5a5a;
-  qproperty-ValueLineColor: rgba(0, 0, 0, 0.1);
-  qproperty-FrameLineColor: rgba(0, 0, 0, 0.1);
+  qproperty-ValueLineColor: #505050;
+  qproperty-FrameLineColor: #454545;
   qproperty-OtherCurvesColor: #c5c5c5;
   qproperty-RulerBackground: #676767;
   qproperty-TextColor: #000;

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -664,10 +664,10 @@ void FunctionPanel::drawOtherCurves(QPainter &painter) {
       for (int k = 0; k < kCount; k++) {
         double frame = curve->keyframeIndexToFrame(k);
         QPointF p    = getWinPos(curve, frame, curve->getValue(frame));
-        painter.drawRect(p.x() - 1, p.y() - 1, 3, 3);
+        painter.drawRect(p.x() - 2, p.y() - 2, 5, 5);
         QPointF p2 = getWinPos(curve, frame, curve->getValue(frame, true));
         if (p2.y() != p.y()) {
-          painter.drawRect(p2.x() - 1, p2.y() - 1, 3, 3);
+          painter.drawRect(p2.x() - 2, p2.y() - 2, 5, 5);
           painter.setPen(solidPen);
           painter.drawLine(p, p2);
           painter.setPen(m_textColor);
@@ -965,7 +965,7 @@ void FunctionPanel::drawCurrentCurve(QPainter &painter) {
     case Point:
       painter.setBrush(isSelected ? QColor(255, 126, 0) : m_subColor);
       painter.setPen(m_textColor);
-      r = isHighlighted ? 3 : 2;
+      r = isHighlighted ? 4 : 3;
       drawSquare(painter, p, r);
       break;
 
@@ -973,8 +973,8 @@ void FunctionPanel::drawCurrentCurve(QPainter &painter) {
     case SpeedOut:
       painter.setBrush(m_subColor);
       painter.setPen(m_textColor);
-      r = isHighlighted ? 3 : 2;
-      drawRoundedSquare(painter, p, r);
+      r = isHighlighted ? 4 : 3;
+      drawCircle(painter, p, r);
       break;
 
     case EaseIn:


### PR DESCRIPTION
Requested by some colleagues, they wanted improvements to the curve graph, better contrast and bigger handles. So, I made the lines lighter for the dark themes, and the speed in speed out handle is now drawn as a circle.

![Screenshot 2022-12-02 000527](https://user-images.githubusercontent.com/19820721/205188195-da20869d-99db-4549-813f-b27b406bc215.png)

- Fixes an issue introduced in #4572, where `#StyleChooserPage` properties were misnamed compared to the ones set in the theme variables, this caused the light theme to break and become unreadable.