### PR TITLE
Missing Menu Entry for #4611 and #3665

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -311,6 +311,7 @@
         <command>MI_OpenFilmStrip</command>
         <separator/>
         <command>MI_OpenFileBrowser</command>
+        <command>MI_OpenPreproductionBoard</command>
         <command>MI_OpenFileBrowser2</command>
         <separator/>
         <command>MI_OpenCleanupSettings</command>


### PR DESCRIPTION
Added missing menu entry for #4611 and #3665 that caused `Preproduction Board` to be listed on first launch and never again.

Note that this entry will still be missing on all personal rooms, it requires either creating new rooms or deleting all menu XML files in `...stuff\profiles\layouts\personal\Default.(your user name here)`