### PR TITLE
Actions MacOS runner: Remove symlinks before installing Python

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -23,6 +23,12 @@ jobs:
             shift
           done
         }
+        # remove existing symlinks before installing python@3.10
+        rm /usr/local/bin/idle3
+        rm /usr/local/bin/pydoc3
+        rm /usr/local/bin/python3
+        rm /usr/local/bin/python3-config
+
         brew update
         checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo qt@5 boost libusb libmypaint ccache jpeg-turbo ninja
         checkPkgAndInstall opencv


### PR DESCRIPTION
This PR will fix recent failures in Github Actions MacOS runner.
When installing Qt 5 via homebrew, it failed when linking the dependent python (v3.10) library since there is a pre-installed newer version (v3.11) in MacOS runner environment.
This PR will remove existing symlinks before installing python.