### PR TITLE
Paste external clipboard images

### DIFF
--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -56,7 +56,7 @@ class DVAPI RasterSelection final : public TSelection {
   bool m_noAntialiasing;
 
 private:
-  void pasteSelection(const RasterImageData *data);
+  bool pasteSelection(const RasterImageData *data);
 
 public:
   RasterSelection();

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -533,12 +533,15 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
     m_level->eraseFrame(m_frameId);
     if (!m_isEditingLevel) {
       TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+      TXshCell cell;
       for (const TTool::CellOps &cellOps : m_cellsData) {
-        TXshCell cell;
         if (cellOps.type == TTool::CellOps::ExistingToNew)
           cell = xsh->getCell(cellOps.r0 - 1, m_col);
         for (int r = cellOps.r0; r <= cellOps.r1; r++)
           xsh->setCell(r, m_col, cell);
+      }
+      if (m_cellsData.size() < 1) {
+        xsh->setCell(m_row, m_col, cell);
       }
     }
     if (m_createdLevel) {
@@ -666,6 +669,9 @@ void ToolUtils::TRasterUndo::undo() const {
 
   removeLevelAndFrameIfNeeded();
 
+  if (m_level) {
+    m_level->setDirtyFlag(true);
+  }
   app->getCurrentXsheet()->notifyXsheetChanged();
   notifyImageChanged();
 }


### PR DESCRIPTION
This is a Tahoma2D port with the following changes:
- Pasting on a `Raster` level cell or the empty X cell in front will automatically paste in the center instead of nagging the user by always asking if want to `Paste in place` or `Create new level` on each paste.
- Attempting to paste on non `Raster` level cell or empty column/location will ask the user if wants to create a new level instead of creating a new level automatically without user's consent, this is to avoid polluting the project with extra files as undo does not delete them.

More information about the T2D implementation:

- External images do require `Raster` level.
- Selection Tool must be active to be able to control and transform the pasted image, otherwise the image will be instantly pasted in the center.
- If the image is bigger than the level canvas then the paste will be scaled down to fit the canvas.

Resolves #3503
