### PR TITLE
Floating point & Linear color space rendering

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -822,7 +822,7 @@
   <item>"STD_particlesFx.pick_color_for_every_frame"	"Pick Control Image's Color for Every Frame"	</item>
   <item>"STD_particlesFx.perspective_distribution"	"Perspective Distribution"	</item>
   <item>"STD_particlesFx.motion_blur"	"Motion Blur"	</item>
-  <item>"STD_particlesFx.motion_blur_gamma"	"Gamma"	</item>
+  <item>"STD_particlesFx.motion_blur_gamma_adjust"	"Gamma Adjust"	</item>
 
   
  <!------------------------------ Function Editor ------------------------------------------->
@@ -844,134 +844,178 @@
   <item>"STD_inoAddFx.opacity"	"Opacity"	</item>
   <item>"STD_inoAddFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoAddFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoAddFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoAddFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoAddFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoAddFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoColorBurnFx"	"Color Burn Ino"	</item>
   <item>"STD_inoColorBurnFx.opacity"	"Opacity"	</item>
   <item>"STD_inoColorBurnFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoColorBurnFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoColorBurnFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoColorBurnFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoColorBurnFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoColorBurnFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoColorDodgeFx"	"Color Dodge Ino"	</item>
   <item>"STD_inoColorDodgeFx.opacity"	"Opacity"	</item>
   <item>"STD_inoColorDodgeFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoColorDodgeFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoColorDodgeFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoColorDodgeFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoColorDodgeFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoColorDodgeFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoCrossDissolveFx"	"Cross Dissolve Ino"	</item>
   <item>"STD_inoCrossDissolveFx.opacity"	"Opacity"	</item>
   <item>"STD_inoCrossDissolveFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoCrossDissolveFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoCrossDissolveFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoCrossDissolveFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoCrossDissolveFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoCrossDissolveFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoDarkenFx"	"Darken Ino"	</item>
   <item>"STD_inoDarkenFx.opacity"	"Opacity"	</item>
   <item>"STD_inoDarkenFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoDarkenFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoDarkenFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoDarkenFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoDarkenFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoDarkenFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoDarkerColorFx"	"Darker Color Ino"	</item>
   <item>"STD_inoDarkerColorFx.opacity"	"Opacity"	</item>
   <item>"STD_inoDarkerColorFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoDarkerColorFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoDarkerColorFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoDarkerColorFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoDarkerColorFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoDarkerColorFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoDivideFx"	"Divide Ino"	</item>
   <item>"STD_inoDivideFx.opacity"	"Opacity"	</item>
   <item>"STD_inoDivideFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoDivideFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoDivideFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoDivideFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoDivideFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoDivideFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoHardLightFx"	"Hard Light Ino"	</item>
   <item>"STD_inoHardLightFx.opacity"	"Opacity"	</item>
   <item>"STD_inoHardLightFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoHardLightFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoHardLightFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoHardLightFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoHardLightFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoHardLightFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoHardMixFx"	"Hard Mix Ino"	</item>
   <item>"STD_inoHardMixFx.opacity"	"Opacity"	</item>
   <item>"STD_inoHardMixFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoHardMixFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoHardMixFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoHardMixFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoHardMixFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoHardMixFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoLightenFx"	"Lighten Ino"	</item>
   <item>"STD_inoLightenFx.opacity"	"Opacity"	</item>
   <item>"STD_inoLightenFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoLightenFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoLightenFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoLightenFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoLightenFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoLightenFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoLighterColorFx"	"Lighter Color Ino"	</item>
   <item>"STD_inoLighterColorFx.opacity"	"Opacity"	</item>
   <item>"STD_inoLighterColorFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoLighterColorFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoLighterColorFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoLighterColorFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoLighterColorFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoLighterColorFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoLinearBurnFx"	"Linear Burn Ino"	</item>
   <item>"STD_inoLinearBurnFx.opacity"	"Opacity"	</item>
   <item>"STD_inoLinearBurnFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoLinearBurnFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoLinearBurnFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoLinearBurnFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoLinearBurnFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoLinearBurnFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoLinearDodgeFx"	"Linear Dodge Ino"	</item>
   <item>"STD_inoLinearDodgeFx.opacity"	"Opacity"	</item>
   <item>"STD_inoLinearDodgeFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoLinearDodgeFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoLinearDodgeFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoLinearDodgeFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoLinearDodgeFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoLinearDodgeFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoLinearLightFx"	"Linear Light Ino"	</item>
   <item>"STD_inoLinearLightFx.opacity"	"Opacity"	</item>
   <item>"STD_inoLinearLightFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoLinearLightFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoLinearLightFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoLinearLightFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoLinearLightFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoLinearLightFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoMultiplyFx"	"Multiply Ino"	</item>
   <item>"STD_inoMultiplyFx.opacity"	"Opacity"	</item>
   <item>"STD_inoMultiplyFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoMultiplyFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoMultiplyFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoMultiplyFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoMultiplyFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoMultiplyFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoOverFx"	"Over Ino"	</item>
   <item>"STD_inoOverFx.opacity"	"Opacity"	</item>
   <item>"STD_inoOverFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoOverFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoOverFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoOverFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoOverFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoOverFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoOverlayFx"	"Overlay Ino"	</item>
   <item>"STD_inoOverlayFx.opacity"	"Opacity"	</item>
   <item>"STD_inoOverlayFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoOverlayFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoOverlayFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoOverlayFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoOverlayFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoOverlayFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoPinLightFx"	"Pin Light Ino"	</item>
   <item>"STD_inoPinLightFx.opacity"	"Opacity"	</item>
   <item>"STD_inoPinLightFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoPinLightFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoPinLightFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoPinLightFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoPinLightFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoPinLightFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoScreenFx"	"Screen Ino"	</item>
   <item>"STD_inoScreenFx.opacity"	"Opacity"	</item>
   <item>"STD_inoScreenFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoScreenFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoScreenFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoScreenFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoScreenFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoScreenFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoSoftLightFx"	"Soft Light Ino"	</item>
   <item>"STD_inoSoftLightFx.opacity"	"Opacity"	</item>
   <item>"STD_inoSoftLightFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoSoftLightFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoSoftLightFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoSoftLightFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoSoftLightFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoSoftLightFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoSubtractFx"	"Subtract Ino"	</item>
   <item>"STD_inoSubtractFx.opacity"	"Opacity"	</item>
   <item>"STD_inoSubtractFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoSubtractFx.alpha_rendering"	"Alpha Rendering"	</item>
   <item>"STD_inoSubtractFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoSubtractFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoSubtractFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoSubtractFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoSubtractFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoVividLightFx"	"Vivid Light Ino"	</item>
   <item>"STD_inoVividLightFx.opacity"	"Opacity"	</item>
   <item>"STD_inoVividLightFx.clipping_mask"	"Clipping Mask"	</item>
   <item>"STD_inoVividLightFx.linear"	"Linear Color Space"	</item>
+  <item>"STD_inoVividLightFx.colorSpaceMode"	"Color Space"	</item>
   <item>"STD_inoVividLightFx.gamma"	"Gamma"	</item>
+  <item>"STD_inoVividLightFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_inoVividLightFx.premultiplied"	"Source is Premultiplied"	</item>
   <item>"STD_inoBlurFx"	"Blur Ino"	</item>
   <item>"STD_inoBlurFx.radius"	"Radius"	</item>
@@ -1192,6 +1236,8 @@
 
   <item>"STD_iwa_AdjustExposureFx"	"Adjust Exposure Iwa"	</item>
   <item>"STD_iwa_AdjustExposureFx.hardness"	"Hardness"	</item>
+  <item>"STD_iwa_AdjustExposureFx.gamma"	"Gamma"	</item>
+  <item>"STD_iwa_AdjustExposureFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_iwa_AdjustExposureFx.scale"	"Scale"	</item>
   <item>"STD_iwa_AdjustExposureFx.offset"	"Offset"	</item>
 
@@ -1209,6 +1255,8 @@
 
   <item>"STD_iwa_MotionBlurCompFx"	"Motion Blur Iwa"	</item>
   <item>"STD_iwa_MotionBlurCompFx.hardness"	"Hardness"	</item>
+  <item>"STD_iwa_MotionBlurCompFx.gamma"	"Gamma"	</item>
+  <item>"STD_iwa_MotionBlurCompFx.gammaAdjust"	"Gamma Adjust"	</item>
   <item>"STD_iwa_MotionBlurCompFx.shutterStart"	"Shutter Start"	</item>
   <item>"STD_iwa_MotionBlurCompFx.shutterEnd"	"Shutter End"	</item>
   <item>"STD_iwa_MotionBlurCompFx.traceResolution"	"Trace Resolution"	</item>
@@ -1300,6 +1348,9 @@
   <item>"STD_iwa_BokehFx.on_focus_distance"	"On-Focus Distance"</item>
   <item>"STD_iwa_BokehFx.bokeh_amount"	"Bokeh Amount"</item>
   <item>"STD_iwa_BokehFx.hardness"	"Hardness"</item>
+  <item>"STD_iwa_BokehFx.gamma"	"Gamma"</item>
+  <item>"STD_iwa_BokehFx.gammaAdjust"	"Gamma Adjust"</item>
+  <item>"STD_iwa_BokehFx.linearizeMode"	"Linearize Mode"</item>
   <item>"STD_iwa_BokehFx.distance1"		"Source1 Distance"</item>
   <item>"STD_iwa_BokehFx.bokeh_adjustment1"	"Source1 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehFx.distance2"		"Source2 Distance"</item>
@@ -1315,6 +1366,9 @@
   <item>"STD_iwa_BokehRefFx.on_focus_distance"	"On-Focus Distance"</item>
   <item>"STD_iwa_BokehRefFx.bokeh_amount"	"Bokeh Amount"</item>
   <item>"STD_iwa_BokehRefFx.hardness"	"Hardness"</item>
+  <item>"STD_iwa_BokehRefFx.gamma"	"Gamma"</item>
+  <item>"STD_iwa_BokehRefFx.gammaAdjust"	"Gamma Adjust"</item>
+  <item>"STD_iwa_BokehRefFx.linearizeMode"	"Linearize Mode"</item>
   <item>"STD_iwa_BokehRefFx.distance_precision"	"Distance Precision"</item>
   <item>"STD_iwa_BokehRefFx.fill_gap"	"Fill Gap"</item>
   <item>"STD_iwa_BokehRefFx.fill_gap_with_median_filter"	"Use Median Filter"</item>
@@ -1323,11 +1377,16 @@
   <item>"STD_iwa_BokehAdvancedFx.on_focus_distance"	"On-Focus Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_amount"		"Bokeh Amount"</item>
   <item>"STD_iwa_BokehAdvancedFx.masterHardness"	"Master Hardness"</item>
-  <item>"STD_iwa_BokehAdvancedFx.hardnessPerSource"	"Hardness per Source"</item>
+  <item>"STD_iwa_BokehAdvancedFx.masterGamma"	"Master Gamma"</item>
+  <item>"STD_iwa_BokehAdvancedFx.masterGammaAdjust"	"Master Gamma Adjust"</item>
+  <item>"STD_iwa_BokehAdvancedFx.linearizeMode"	"Linearize Mode"</item>
+  <item>"STD_iwa_BokehAdvancedFx.hardnessPerSource"	"Gamma/Hardness per Source"</item>
 
   <item>"STD_iwa_BokehAdvancedFx.distance1"		"Source1 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment1"	"Source1 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness1"		"Source1 Hardness"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gamma1"		"Source1 Gamma"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gammaAdjust1"		"Source1 Gamma Adjust"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref1"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange1"	"Source1 Depth Range"</item>
   <item>"STD_iwa_BokehAdvancedFx.fillGap1"	"Fill Gap"</item>
@@ -1336,6 +1395,8 @@
   <item>"STD_iwa_BokehAdvancedFx.distance2"		"Source2 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment2"	"Source2 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness2"		"Source2 Hardness"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gamma2"		"Source2 Gamma"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gammaAdjust2"		"Source2 Gamma Adjust"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref2"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange2"	"Source2 Depth Range"</item>
   <item>"STD_iwa_BokehAdvancedFx.fillGap2"	"Fill Gap"</item>
@@ -1344,6 +1405,8 @@
   <item>"STD_iwa_BokehAdvancedFx.distance3"		"Source3 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment3"	"Source3 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness3"		"Source3 Hardness"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gamma3"		"Source3 Gamma"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gammaAdjust3"		"Source3 Gamma Adjust"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref3"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange3"	"Source3 Depth Range"</item>
   <item>"STD_iwa_BokehAdvancedFx.fillGap3"	"Fill Gap"</item>
@@ -1352,6 +1415,8 @@
   <item>"STD_iwa_BokehAdvancedFx.distance4"		"Source4 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment4"	"Source4 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness4"		"Source4 Hardness"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gamma4"		"Source4 Gamma"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gammaAdjust4"		"Source4 Gamma Adjust"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref4"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange4"	"Source4 Depth Range"</item>
   <item>"STD_iwa_BokehAdvancedFx.fillGap4"	"Fill Gap"</item>
@@ -1360,6 +1425,8 @@
   <item>"STD_iwa_BokehAdvancedFx.distance5"		"Source5 Distance"</item>
   <item>"STD_iwa_BokehAdvancedFx.bokeh_adjustment5"	"Source5 Bokeh Adjustment"</item>
   <item>"STD_iwa_BokehAdvancedFx.hardness5"		"Source5 Hardness"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gamma5"		"Source5 Gamma"</item>
+  <item>"STD_iwa_BokehAdvancedFx.gammaAdjust5"		"Source5 Gamma Adjust"</item>
   <item>"STD_iwa_BokehAdvancedFx.depth_ref5"		"Depth Image"</item>
   <item>"STD_iwa_BokehAdvancedFx.depthRange5"	"Source5 Depth Range"</item>
   <item>"STD_iwa_BokehAdvancedFx.fillGap5"	"Fill Gap"</item>
@@ -1497,6 +1564,7 @@
   
   <item>"STD_iwa_BloomFx" 			"Bloom Iwa" 	</item>
   <item>"STD_iwa_BloomFx.gamma"	"Gamma"		</item>
+  <item>"STD_iwa_BloomFx.gammaAdjust"	"Gamma Adjust"		</item>
   <item>"STD_iwa_BloomFx.auto_gain"	"Auto Gain"		</item>
   <item>"STD_iwa_BloomFx.gain_adjust"	"Gain Adjustment"		</item>
   <item>"STD_iwa_BloomFx.gain"	"Gain"		</item>

--- a/stuff/profiles/layouts/fxs/STD_inoAddFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoAddFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoColorBurnFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoColorBurnFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoColorDodgeFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoColorDodgeFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoCrossDissolveFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoCrossDissolveFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoDarkenFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoDarkenFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoDarkerColorFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoDarkerColorFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoDivideFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoDivideFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoHardLightFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoHardLightFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoHardMixFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoHardMixFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoLightenFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoLightenFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoLighterColorFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoLighterColorFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoLinearBurnFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoLinearBurnFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoLinearDodgeFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoLinearDodgeFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoLinearLightFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoLinearLightFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoMultiplyFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoMultiplyFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoOverFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoOverFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoOverlayFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoOverlayFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoPinLightFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoPinLightFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoScreenFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoScreenFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoSoftLightFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoSoftLightFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoSubtractFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoSubtractFx.xml
@@ -4,9 +4,10 @@
     <control>clipping_mask</control>
     <control>alpha_rendering</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_inoVividLightFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_inoVividLightFx.xml
@@ -3,9 +3,10 @@
     <control>opacity</control>
     <control>clipping_mask</control>
     <separator/>
-    <control>linear</control>
-    <vbox modeSensitive="linear" mode="1">
+    <control>colorSpaceMode</control>
+    <vbox modeSensitive="colorSpaceMode" mode="1">
       <control>gamma</control>
+      <control>gammaAdjust</control>
       <control>premultiplied</control>
     </vbox>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_iwa_AdjustExposureFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_AdjustExposureFx.xml
@@ -1,6 +1,8 @@
 <fxlayout>
   <page name="Adjust Exposure Iwa">
     <control>hardness</control>
+    <control>gamma</control>
+    <control>gammaAdjust</control>
     <control>scale</control>
     <control>offset</control>
   </page>

--- a/stuff/profiles/layouts/fxs/STD_iwa_BloomFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_BloomFx.xml
@@ -1,6 +1,7 @@
 <fxlayout>
 	<page name="Bloom Iwa">
 		<control>gamma</control>
+		<control>gammaAdjust</control>
 		<control>auto_gain</control>
 		<control>gain_adjust</control>
 		<control>gain</control>

--- a/stuff/profiles/layouts/fxs/STD_iwa_BokehAdvancedFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_BokehAdvancedFx.xml
@@ -1,16 +1,29 @@
-<fxlayout help_command="iexplore" help_file="BokehAdvancedIwa.html">
+<fxlayout>
 	<page name="iwa Bokeh Advanced">
  	<vbox>
 		<control>on_focus_distance</control>
 		<control>bokeh_amount</control>
-		<control>masterHardness</control>
+		<control>linearizeMode</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
+			<control>masterHardness</control>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+			<control>masterGamma</control>
+			<control>masterGammaAdjust</control>
+		</vbox>
 		<control>hardnessPerSource</control>
   	</vbox>
   
    	<vbox shrink="1" label="Source1">
 		<control>distance1</control>
 		<control>bokeh_adjustment1</control>
-		<control>hardness1</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
+			<control>hardness1</control>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+			<control>gamma1</control>
+			<control>gammaAdjust1</control>
+		</vbox>
 		<hbox>
 			<control>depth_ref1</control>
 			<control>fillGap1</control>
@@ -22,7 +35,13 @@
    	<vbox shrink="0" label="Source2">
 		<control>distance2</control>
 		<control>bokeh_adjustment2</control>
-		<control>hardness2</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
+			<control>hardness2</control>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+			<control>gamma2</control>
+			<control>gammaAdjust2</control>
+		</vbox>
 		<hbox>
 			<control>depth_ref2</control>
 			<control>fillGap2</control>
@@ -34,7 +53,13 @@
    	<vbox shrink="0" label="Source3">
 		<control>distance3</control>
 		<control>bokeh_adjustment3</control>
-		<control>hardness3</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
+			<control>hardness3</control>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+			<control>gamma3</control>
+			<control>gammaAdjust3</control>
+		</vbox>
 		<hbox>
 			<control>depth_ref3</control>
 			<control>fillGap3</control>
@@ -46,7 +71,13 @@
    	<vbox shrink="0" label="Source4">
 		<control>distance4</control>
 		<control>bokeh_adjustment4</control>
-		<control>hardness4</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
+			<control>hardness4</control>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+			<control>gamma4</control>
+			<control>gammaAdjust4</control>
+		</vbox>
 		<hbox>
 			<control>depth_ref4</control>
 			<control>fillGap4</control>
@@ -58,7 +89,13 @@
    	<vbox shrink="0" label="Source5">
 		<control>distance5</control>
 		<control>bokeh_adjustment5</control>
-		<control>hardness5</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
+			<control>hardness5</control>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+			<control>gamma5</control>
+			<control>gammaAdjust5</control>
+		</vbox>
 		<hbox>
 			<control>depth_ref5</control>
 			<control>fillGap5</control>
@@ -74,6 +111,16 @@
 		<on>hardness3</on>
 		<on>hardness4</on>
 		<on>hardness5</on>
+		<on>gamma1</on>
+		<on>gamma2</on>
+		<on>gamma3</on>
+		<on>gamma4</on>
+		<on>gamma5</on>
+		<on>gammaAdjust1</on>
+		<on>gammaAdjust2</on>
+		<on>gammaAdjust3</on>
+		<on>gammaAdjust4</on>
+		<on>gammaAdjust5</on>
 	</visibleToggle>
 	<visibleToggle>
 		<controller>fillGap1</controller>

--- a/stuff/profiles/layouts/fxs/STD_iwa_BokehFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_BokehFx.xml
@@ -3,8 +3,15 @@
  	<vbox>
 		<control>on_focus_distance</control>
 		<control>bokeh_amount</control>
+		<control>linearizeMode</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
 		<control>hardness</control>
-  	</vbox>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+		<control>gamma</control>
+		<control>gammaAdjust</control>
+	</vbox>
+	</vbox>
   
       	<separator label="Source1"/>
    	<vbox>

--- a/stuff/profiles/layouts/fxs/STD_iwa_BokehRefFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_BokehRefFx.xml
@@ -3,7 +3,14 @@
  	<vbox>
 		<control>on_focus_distance</control>
 		<control>bokeh_amount</control>
-		<control>hardness</control>
+		<control>linearizeMode</control>
+    <vbox modeSensitive="linearizeMode" mode="1">
+			<control>hardness</control>
+		</vbox>
+    <vbox modeSensitive="linearizeMode" mode="0">
+			<control>gamma</control>
+			<control>gammaAdjust</control>
+		</vbox>
 		<control>distance_precision</control>
 		<control>fill_gap</control>
 		<control>fill_gap_with_median_filter</control>

--- a/stuff/profiles/layouts/fxs/STD_iwa_MotionBlurCompFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_MotionBlurCompFx.xml
@@ -1,10 +1,10 @@
 <fxlayout help_file="MotionBlurIwa.html">
 	<page name="Motion Blur Iwa">
  	<vbox>
+		<hbox>
 		<control>motionObjectType</control>
-		<vbox modeSensitive="motionObjectType" mode="1,2,4">
 		<control>motionObjectIndex</control>
-		</vbox>
+		</hbox>
 		<control>shutterStart</control>
 		<control>startValue</control>
 		<control>startCurve</control>
@@ -13,6 +13,8 @@
 		<control>endCurve</control>
 		<control>traceResolution</control>
 		<control>hardness</control>
+		<control>gamma</control>
+		<control>gammaAdjust</control>
 		<control>zanzoMode</control>
 		<control>premultiType</control>
   	</vbox>

--- a/stuff/profiles/layouts/fxs/STD_particlesFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_particlesFx.xml
@@ -122,7 +122,7 @@
         
         <hbox>
           <control>motion_blur</control>
-          <control>motion_blur_gamma</control>          
+          <control>motion_blur_gamma_adjust</control>          
         </hbox>
       <separator label="Size Increase"/>
         <control>scale_step</control>

--- a/toonz/sources/common/tcolor/tpixel.cpp
+++ b/toonz/sources/common/tcolor/tpixel.cpp
@@ -41,6 +41,17 @@ const TPixelD TPixelD::White(1, 1, 1);
 const TPixelD TPixelD::Black(0, 0, 0);
 const TPixelD TPixelD::Transparent(0, 0, 0, 0);
 //---------------------------------------------------
+const float TPixelF::maxChannelValue = 1.f;
+const TPixelF TPixelF::Red(1.f, 0.f, 0.f);
+const TPixelF TPixelF::Green(0.f, 1.f, 0.f);
+const TPixelF TPixelF::Blue(0.f, 0.f, 1.f);
+const TPixelF TPixelF::Yellow(1.f, 1.f, 0.f);
+const TPixelF TPixelF::Cyan(0.f, 1.f, 1.f);
+const TPixelF TPixelF::Magenta(1.f, 0.f, 1.f);
+const TPixelF TPixelF::White(1.f, 1.f, 1.f);
+const TPixelF TPixelF::Black(0.f, 0.f, 0.f);
+const TPixelF TPixelF::Transparent(0.f, 0.f, 0.f, 0.f);
+//---------------------------------------------------
 const TPixelGR8 TPixelGR8::White(maxChannelValue);
 const TPixelGR8 TPixelGR8::Black(0);
 
@@ -113,10 +124,17 @@ TPixelGR8 DVAPI TPixelGR8::from(const TPixel32 &pix) {
 }
 
 //-----------------------------------------------------------------------------
+
 TPixelGR16 DVAPI TPixelGR16::from(const TPixel64 &pix) {
   return TPixelGR16((((UINT)(pix.r) * 19594 + (UINT)(pix.g) * 38472 +
                       (UINT)(pix.b) * 7470 + (UINT)(1 << 15)) >>
                      16));
+}
+
+//-----------------------------------------------------------------------------
+
+TPixelGRF DVAPI TPixelGRF::from(const TPixelF &pix) {
+  return TPixelGRF(pix.r * 0.299f + pix.g * 0.587f + pix.b * 0.114f);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/common/tcolor/tpixelutils.cpp
+++ b/toonz/sources/common/tcolor/tpixelutils.cpp
@@ -31,8 +31,8 @@ void hsv2rgb(TPixel32 &dstRgb, int srcHsv[3], int maxHsv) {
 
   if (hue > 360) hue -= 360;
   if (hue < 0) hue += 360;
-  if (sat < 0) sat     = 0;
-  if (sat > 1) sat     = 1;
+  if (sat < 0) sat = 0;
+  if (sat > 1) sat = 1;
   if (value < 0) value = 0;
   if (value > 1) value = 1;
   if (sat == 0) {
@@ -86,8 +86,8 @@ void HSV2RGB(double hue, double sat, double value, double *red, double *green,
   //    hue=0;
   if (hue > 360) hue -= 360;
   if (hue < 0) hue += 360;
-  if (sat < 0) sat     = 0;
-  if (sat > 1) sat     = 1;
+  if (sat < 0) sat = 0;
+  if (sat > 1) sat = 1;
   if (value < 0) value = 0;
   if (value > 1) value = 1;
   if (sat == 0) {
@@ -164,7 +164,7 @@ void RGB2HSV(double r, double g, double b, double *h, double *s, double *v) {
       *h = 2 + (b - r) / delta;
     else if (b == max)
       *h = 4 + (r - g) / delta;
-    *h   = *h * 60;
+    *h = *h * 60;
     if (*h < 0) *h += 360;
   }
 }
@@ -198,7 +198,7 @@ void rgb2hsv(int dstHsv[3], const TPixel32 &srcRgb, int maxHsv) {
       h = 2 + (b - r) / delta;
     else if (b == max)
       h = 4 + (r - g) / delta;
-    h   = h * 60;
+    h = h * 60;
     if (h < 0) h += 360;
   }
 
@@ -227,7 +227,7 @@ inline double HLSValue(double n1, double n2, double h) {
   else
     return n1;
 }
-}
+}  // namespace
 void HLS2RGB(double h, double l, double s, double *r, double *g, double *b) {
   if (s == 0) {
     *r = *g = *b = l;
@@ -240,7 +240,7 @@ void HLS2RGB(double h, double l, double s, double *r, double *g, double *b) {
     m2 = l * (1 + s);
   else
     m2 = l + s + l * s;
-  m1   = 2 * l - m2;
+  m1 = 2 * l - m2;
 
   *r = HLSValue(m1, m2, h + 120);
   *g = HLSValue(m1, m2, h);
@@ -304,6 +304,15 @@ TPixel32 toPixel32(const TPixelGR8 &src) {
 
 //-----------------------------------------------------------------------------
 
+TPixel32 toPixel32(const TPixelF &src) {
+  const double factor = 255.0f;
+  return TPixel32(
+      byteCrop(tround(src.r * factor)), byteCrop(tround(src.g * factor)),
+      byteCrop(tround(src.b * factor)), byteCrop(tround(src.m * factor)));
+}
+
+//-----------------------------------------------------------------------------
+
 TPixel64 toPixel64(const TPixel32 &src) {
   return TPixelRGBM64(ushortFromByte(src.r), ushortFromByte(src.g),
                       ushortFromByte(src.b), ushortFromByte(src.m));
@@ -323,6 +332,15 @@ TPixel64 toPixel64(const TPixelD &src) {
 TPixel64 toPixel64(const TPixelGR8 &src) {
   int v = ushortFromByte(src.value);
   return TPixel64(v, v, v);
+}
+
+//-----------------------------------------------------------------------------
+
+TPixel64 toPixel64(const TPixelF &src) {
+  const float factor = 65535.0f;
+  return TPixel64(
+      wordCrop(tround(src.r * factor)), wordCrop(tround(src.g * factor)),
+      wordCrop(tround(src.b * factor)), wordCrop(tround(src.m * factor)));
 }
 
 //-----------------------------------------------------------------------------
@@ -349,7 +367,84 @@ TPixelD toPixelD(const TPixelGR8 &src) {
 }
 
 //-----------------------------------------------------------------------------
+
+TPixelD toPixelD(const TPixelF &src) {
+  return TPixelD(src.r, src.g, src.b, src.m);
+}
+
 //-----------------------------------------------------------------------------
+
+TPixelF toPixelF(const TPixel32 &src) {
+  const float factor = 1.f / 255.f;
+  return TPixelF(factor * src.r, factor * src.g, factor * src.b,
+                 factor * src.m);
+}
+
+//-----------------------------------------------------------------------------
+
+TPixelF toPixelF(const TPixelD &src) {
+  return TPixelF(src.r, src.g, src.b, src.m);
+}
+
+//-----------------------------------------------------------------------------
+
+TPixelF toPixelF(const TPixel64 &src) {
+  const float factor = 1.f / 65535.f;
+  return TPixelF(factor * src.r, factor * src.g, factor * src.b,
+                 factor * src.m);
+}
+
+//-----------------------------------------------------------------------------
+
+TPixelF toPixelF(const TPixelGR8 &src) {
+  const float v = (float)src.value / 255.f;
+  return TPixelF(v, v, v);
+}
+
+//-----------------------------------------------------------------------------
+namespace {
+template <class T, class Q>
+Q toLin(Q val, double gamma) {
+  return (Q)((T::maxChannelValue)*std::pow(
+                 (double)val / (double)(T::maxChannelValue), gamma) +
+             0.5);
+}
+template <>
+float toLin<TPixelF, float>(float val, double gamma) {
+  return (val < 0.f) ? val : std::pow(val, (float)gamma);
+}
+template <>
+double toLin<TPixelD, double>(double val, double gamma) {
+  return std::pow(val, gamma);
+}
+}  // namespace
+
+//-----------------------------------------------------------------------------
+
+TPixel32 toLinear(const TPixel32 &pix, const double gamma) {
+  return TPixel32(toLin<TPixel32, unsigned char>(pix.r, gamma),
+                  toLin<TPixel32, unsigned char>(pix.g, gamma),
+                  toLin<TPixel32, unsigned char>(pix.b, gamma), pix.m);
+}
+TPixel64 toLinear(const TPixel64 &pix, const double gamma) {
+  return TPixel64(toLin<TPixel64, unsigned short>(pix.r, gamma),
+                  toLin<TPixel64, unsigned short>(pix.g, gamma),
+                  toLin<TPixel64, unsigned short>(pix.b, gamma), pix.m);
+}
+TPixelD toLinear(const TPixelD &pix, const double gamma) {
+  return TPixelD(toLin<TPixelD, double>(pix.r, gamma),
+                 toLin<TPixelD, double>(pix.g, gamma),
+                 toLin<TPixelD, double>(pix.b, gamma), pix.m);
+}
+TPixelF toLinear(const TPixelF &pix, const double gamma) {
+  return TPixelF(toLin<TPixelF, float>(pix.r, gamma),
+                 toLin<TPixelF, float>(pix.g, gamma),
+                 toLin<TPixelF, float>(pix.b, gamma), pix.m);
+}
+TPixelGR8 toLinear(const TPixelGR8 &pix, const double gamma) {
+  return TPixelGR8(toLin<TPixelGR8, unsigned char>(pix.value, gamma));
+}
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/toonz/sources/common/tfx/binaryFx.cpp
+++ b/toonz/sources/common/tfx/binaryFx.cpp
@@ -24,7 +24,7 @@ void makeRectCoherent(TRectD &rect, const TPointD &pos) {
   rect.y1 = tceil(rect.y1);
   rect += pos;
 }
-}
+}  // namespace
 
 //******************************************************************************************
 //    TImageCombinationFx  declaration
@@ -82,6 +82,11 @@ public:
                                   std::string &portName) override;
 
   int getPreferredInputPort() override { return 1; }
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override {
+    return settingsIsLinear;
+  }
 };
 
 //******************************************************************************************
@@ -92,6 +97,7 @@ TImageCombinationFx::TImageCombinationFx() : m_group("Source", 2) {
   addInputPort("Source1", new TRasterFxPort, 0);
   addInputPort("Source2", new TRasterFxPort, 0);
   setName(L"ImageCombinationFx");
+  enableComputeInFloat(true);
 }
 
 //---------------------------------------------------------------------------
@@ -407,7 +413,7 @@ public:
 };
 
 //==================================================================
-
+/*
 class LinearBurnFx final : public TImageCombinationFx {
   FX_DECLARATION(LinearBurnFx)
 
@@ -435,7 +441,7 @@ public:
     TRop::overlay(up, down, down);
   }
 };
-
+*/
 //==================================================================
 
 class BlendFx final : public TImageCombinationFx {
@@ -476,6 +482,7 @@ public:
     addInputPort("Source", m_source);
     addInputPort("Matte", m_matte);
     setName(L"InFx");
+    enableComputeInFloat(true);
   }
 
   ~InFx() {}
@@ -540,6 +547,7 @@ public:
     addInputPort("Source", m_source);
     addInputPort("Matte", m_matte);
     setName(L"OutFx");
+    enableComputeInFloat(true);
   }
 
   ~OutFx() {}
@@ -607,6 +615,7 @@ public:
   AtopFx() {
     addInputPort("Up", m_up);
     addInputPort("Down", m_dn);
+    enableComputeInFloat(true);
   }
 
   bool canHandle(const TRenderSettings &info, double frame) override {
@@ -691,8 +700,8 @@ FX_IDENTIFIER(AtopFx, "atopFx")
 // FX_IDENTIFIER(XorFx,       "xorFx")
 FX_IDENTIFIER(MinFx, "minFx")
 FX_IDENTIFIER(MaxFx, "maxFx")
-FX_IDENTIFIER(LinearBurnFx, "linearBurnFx")
-FX_IDENTIFIER(OverlayFx, "overlayFx")
+// FX_IDENTIFIER(LinearBurnFx, "linearBurnFx")
+// FX_IDENTIFIER(OverlayFx, "overlayFx")
 FX_IDENTIFIER(BlendFx, "blendFx")
 FX_IDENTIFIER(ColorDodgeFx, "colorDodgeFx")
 FX_IDENTIFIER(ColorBurnFx, "colorBurnFx")

--- a/toonz/sources/common/tfx/tcacheresource.cpp
+++ b/toonz/sources/common/tfx/tcacheresource.cpp
@@ -16,7 +16,7 @@
 #include "trop.h"
 
 // File I/O includes
-//#include "tstream.h"
+// #include "tstream.h"
 
 // Qt classes
 #include <QRegion>
@@ -134,6 +134,8 @@ inline int getRasterType(const TRasterP &ras) {
     return TCacheResource::RGBM32;
   else if ((TRaster64P)ras)
     return TCacheResource::RGBM64;
+  else if ((TRasterFP)ras)
+    return TCacheResource::RGBMFloat;
   else if ((TRasterCM32P)ras)
     return TCacheResource::CM32;
 
@@ -210,6 +212,8 @@ inline void loadCompressed(const TFilePath &fp, TRasterP &ras,
     ras = TRaster32P(latticeStep, latticeStep);
   else if (rasType == TCacheResource::RGBM64)
     ras = TRaster64P(latticeStep, latticeStep);
+  else if (rasType == TCacheResource::RGBMFloat)
+    ras = TRasterFP(latticeStep, latticeStep);
   else
     assert(false);
 
@@ -227,7 +231,7 @@ inline void loadCompressed(const TFilePath &fp, TRasterP &ras,
 
   ras->unlock();
 }
-}
+}  // namespace
 
 //****************************************************************************************************
 //    TCacheResourceP implementation
@@ -336,6 +340,8 @@ TRasterP TCacheResource::buildCompatibleRaster(const TDimension &size) {
     result = TRaster32P(size);
   else if (m_tileType == RGBM64)
     result = TRaster64P(size);
+  else if (m_tileType == RGBMFloat)
+    result = TRasterFP(size);
   else if (m_tileType == CM32)
     result = TRasterCM32P(size);
 
@@ -392,6 +398,9 @@ inline TRasterP TCacheResource::createCellRaster(int rasterType,
     img    = TRasterImageP(result);
   } else if (rasterType == TCacheResource::RGBM64) {
     result = TRaster64P(latticeStep, latticeStep);
+    img    = TRasterImageP(result);
+  } else if (rasterType == TCacheResource::RGBMFloat) {
+    result = TRasterFP(latticeStep, latticeStep);
     img    = TRasterImageP(result);
   } else if (rasterType == TCacheResource::CM32) {
     result = TRasterCM32P(latticeStep, latticeStep);
@@ -791,9 +800,10 @@ int TCacheResource::size() const {
   // NOTE: It's better to store the size incrementally. This complies
   // with the possibility of specifying a bbox to fit the stored cells to...
 
-  return m_tileType == NONE ? 0
-                            : m_tileType == RGBM64 ? (m_cellsCount << 11)
-                                                   : (m_cellsCount << 10);
+  return m_tileType == NONE        ? 0
+         : m_tileType == RGBM64    ? (m_cellsCount << 11)
+         : m_tileType == RGBMFloat ? (m_cellsCount << 12)
+                                   : (m_cellsCount << 10);
 }
 
 //****************************************************************************************************

--- a/toonz/sources/common/tfx/tmacrofx.cpp
+++ b/toonz/sources/common/tfx/tmacrofx.cpp
@@ -200,7 +200,7 @@ bool TMacroFx::isaLeaf(TFx *fx) const {
 
 //--------------------------------------------------
 
-TMacroFx::TMacroFx() : m_isEditing(false) {}
+TMacroFx::TMacroFx() : m_isEditing(false) { enableComputeInFloat(true); }
 
 //--------------------------------------------------
 

--- a/toonz/sources/common/tfx/trenderer.cpp
+++ b/toonz/sources/common/tfx/trenderer.cpp
@@ -128,6 +128,8 @@ public:
       raster = TRaster32P(size);
     else if (bpp == 64)
       raster = TRaster64P(size);
+    else if (bpp == 128)
+      raster = TRasterFP(size);
     else
       assert(false);
 
@@ -1044,6 +1046,8 @@ void RenderTask::buildTile(TTile &tile) {
   tile.m_pos = m_framePos;
   tile.setRaster(
       m_rendererImp->m_rasterPool.getRaster(m_frameSize, m_info.m_bpp));
+  // set the linear flag
+  tile.getRaster()->setLinear(m_info.m_linearColorSpace);
 }
 
 //---------------------------------------------------------

--- a/toonz/sources/common/tfx/unaryFx.cpp
+++ b/toonz/sources/common/tfx/unaryFx.cpp
@@ -8,11 +8,14 @@
 #include "tfxparam.h"
 #include "tparamset.h"
 
-//#define ALLOW_SHEAR
+// #define ALLOW_SHEAR
 
 //==============================================================================
 
-TGeometryFx::TGeometryFx() { setName(L"Geometry"); }
+TGeometryFx::TGeometryFx() {
+  setName(L"Geometry");
+  enableComputeInFloat(true);
+}
 
 //---------------------------------------------------------------
 
@@ -28,7 +31,8 @@ void TGeometryFx::doCompute(TTile &tile, double frame,
     return;
   }
 
-  if (!TRaster32P(tile.getRaster()) && !TRaster64P(tile.getRaster()))
+  if (!TRaster32P(tile.getRaster()) && !TRaster64P(tile.getRaster()) &&
+      !TRasterFP(tile.getRaster()))
     throw TException("AffineFx unsupported pixel type");
 
   TAffine aff1 = getPlacement(frame);
@@ -109,6 +113,13 @@ void TGeometryFx::transform(double frame, int port, const TRectD &rectOnOutput,
 
   infoOnInput          = infoOnOutput;
   infoOnInput.m_affine = infoOnInput.m_affine * aff;
+}
+
+//--------------------------------------------------
+
+bool TGeometryFx::toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                                 bool tileIsLinear) const {
+  return tileIsLinear;
 }
 
 //==================================================
@@ -212,6 +223,7 @@ public:
     //   bindParam(this, "blue_channel" , m_blueChan);
     //   bindParam(this, "alpha_channel", m_alphaChan);
     setName(L"InvertFx");
+    enableComputeInFloat(true);
   };
 
   ~InvertFx(){};

--- a/toonz/sources/common/timage_io/timage_io.cpp
+++ b/toonz/sources/common/timage_io/timage_io.cpp
@@ -54,8 +54,10 @@ TImageReader::TImageReader(const TFilePath &path)
     , m_readGreytones(true)
     , m_file(NULL)
     , m_is64BitEnabled(false)
+    , m_isFloatEnabled(false)
     , m_shrink(1)
-    , m_region(TRect()) {}
+    , m_region(TRect())
+    , m_colorSpaceGamma(2.2) {}
 
 //-----------------------------------------------------------
 
@@ -177,6 +179,12 @@ template <>
 struct pixel_traits<TPixel64> {
   typedef TPixel64 rgbm_pixel_type;
   typedef short buffer_type;
+};
+
+template <>
+struct pixel_traits<TPixelF> {
+  typedef TPixelF rgbm_pixel_type;
+  typedef float buffer_type;
 };
 
 template <>
@@ -352,6 +360,9 @@ TImageP TImageReader::load0() {
       y1 -= (y1 - y0) % m_shrink;
     }
 
+    if (m_path.getType() == "exr")
+      m_reader->setColorSpaceGamma(m_colorSpaceGamma);
+
     assert(x0 <= x1 && y0 <= y1);
 
     TDimension imageDimension =
@@ -422,7 +433,16 @@ TImageP TImageReader::load0() {
       TRasterP _ras;
       // currently m_bitsPerSample == 32 is only possible when loading
       // full-float / uint EXR images
-      if (info.m_bitsPerSample == 16 || info.m_bitsPerSample == 32) {
+      // EDIT: half float EXR images also set m_bitsPerSample to 32
+      // to obtain floating point images
+      // ‰æ‘œ‘¤‚Ìî•ñ‚ªinfo
+      if (info.m_bitsPerSample == 32 && m_isFloatEnabled) {
+        // ‚¢‚Á‚½‚ñƒmƒ“ƒŠƒjƒA‚É•ÏŠ·‚µ‚Ä“Ç‚Ýž‚Þ
+        TRasterFP ras(imageDimension);
+        readRaster<TPixelF>(ras, m_reader, x0, y0, x1, y1, info.m_lx, info.m_ly,
+                            m_shrink);
+        _ras = ras;
+      } else if (info.m_bitsPerSample == 16 || info.m_bitsPerSample == 32) {
         if (m_is64BitEnabled || m_path.getType() != "tif") {
           //  Standard 64-bit case.
 
@@ -550,6 +570,11 @@ static void convertForWriting(TRasterP &ras, const TRasterP &rin, int bpp) {
     ras = TRaster64P(rin->getSize());
     TRop::convert(ras, rin);
     break;
+  case 96:
+  case 128:
+    ras = TRasterFP(rin->getSize());
+    TRop::convert(ras, rin);
+    break;
   default:
     assert(false);
   }
@@ -576,6 +601,7 @@ void TImageWriter::save(const TImageP &img) {
     TRasterGR8P rasGr = ri->getRaster();
     TRaster32P ras32  = ri->getRaster();
     TRaster64P ras64  = ri->getRaster();
+    TRasterFP rasF    = ri->getRaster();
 
     TEnumProperty *p =
         m_properties
@@ -589,19 +615,20 @@ void TImageWriter::save(const TImageP &img) {
 
     int bpp = p ? std::stoi(p->getValue()) : 32;
 
-    //  bpp       1  8  16 24 32 40  48 56  64
-    int spp[] = {
-        1, 1, 1, 4, 4,
-        0, 4, 0, 4};  // 0s are for pixel sizes which are normally unsupported
-    int bps[] = {
-        1, 8,  16, 8, 8,
-        0, 16, 0,  16};  // by image formats, let alone by Toonz raster ones.
+    //  bpp       1  8  16 24 32 40  48 56  64  96 128
+    int spp[] = {1, 1, 1, 4, 4, 0,
+                 4, 0, 4, 4, 4};  // 0s are for pixel sizes which are normally
+                                  // unsupported
+    int bps[] = {1,  8, 16, 8,  8, 0,
+                 16, 0, 16, 32, 32};  // by image formats, let alone by Toonz
+                                      // raster ones.
     // The 24 and 48 cases get automatically promoted to 32 and 64.
-    int bypp = bpp / 8;
-    assert(bypp < boost::size(spp) && spp[bypp] && bps[bypp]);
+    int bypp    = bpp / 8;
+    int bypp_id = (bpp <= 64) ? bypp : (bpp == 96) ? 9 : 10;
+    assert(bypp_id < boost::size(spp) && spp[bypp_id] && bps[bypp_id]);
 
-    info.m_samplePerPixel = spp[bypp];
-    info.m_bitsPerSample  = bps[bypp];
+    info.m_samplePerPixel = spp[bypp_id];
+    info.m_bitsPerSample  = bps[bypp_id];
 
     if (rasGr) {
       if (bypp < 2)   // Seems 16 bit greymaps are not handled... why?
@@ -618,6 +645,11 @@ void TImageWriter::save(const TImageP &img) {
         ras = ras64;
       else
         convertForWriting(ras, ras64, bpp);
+    } else if (rasF) {
+      if (bpp == 96 || bpp == 128)
+        ras = rasF;
+      else
+        convertForWriting(ras, rasF, bpp);
     } else {
       fclose(file);
       throw TImageException(m_path, "unsupported raster type");
@@ -634,13 +666,18 @@ void TImageWriter::save(const TImageP &img) {
     writer->open(file, info);
 
     // add background colors for non alpha-enabled image types
-    if ((ras32 || ras64) && !writer->writeAlphaSupported() &&
+    if ((ras32 || ras64 || rasF) && !writer->writeAlphaSupported() &&
         TImageWriter::getBackgroundColor() != TPixel::Black) {
       if (bpp == 32 || bpp == 24)
         TRop::addBackground(ras, TImageWriter::getBackgroundColor());
       else if (bpp == 64 || bpp == 48) {
         TRaster64P bgRas(ras->getSize());
         bgRas->fill(toPixel64(TImageWriter::getBackgroundColor()));
+        TRop::over(bgRas, ras);
+        ras = bgRas;
+      } else if (bpp == 96 || bpp == 128) {
+        TRasterFP bgRas(ras->getSize());
+        bgRas->fill(toPixelF(TImageWriter::getBackgroundColor()));
         TRop::over(bgRas, ras);
         ras = bgRas;
       }  // for other bpp values, do nothing for now
@@ -652,6 +689,9 @@ void TImageWriter::save(const TImageP &img) {
       if (bpp == 1 || bpp == 8 || bpp == 24 || bpp == 32 || bpp == 16)
         for (int i = 0; i < ras->getLy(); i++)
           writer->writeLine((char *)ras->getRawData(0, i));
+      else if (bpp == 96 || bpp == 128)
+        for (int i = 0; i < ras->getLy(); i++)
+          writer->writeLine((float *)ras->getRawData(0, i));
       else
         for (int i = 0; i < ras->getLy(); i++)
           writer->writeLine((short *)ras->getRawData(0, i));
@@ -659,6 +699,9 @@ void TImageWriter::save(const TImageP &img) {
       if (bpp == 1 || bpp == 8 || bpp == 24 || bpp == 32 || bpp == 16)
         for (int i = ras->getLy() - 1; i >= 0; i--)
           writer->writeLine((char *)ras->getRawData(0, i));
+      else if (bpp == 96 || bpp == 128)
+        for (int i = ras->getLy() - 1; i >= 0; i--)
+          writer->writeLine((float *)ras->getRawData(0, i));
       else
         for (int i = ras->getLy() - 1; i >= 0; i--)
           writer->writeLine((short *)ras->getRawData(0, i));
@@ -688,7 +731,6 @@ void TImageWriter::save(const TImageP &img) {
 }
 
 //-----------------------------------------------------------
-
 TImageWriterP::TImageWriterP(const TFilePath &path) {
   m_pointer = new TImageWriter(path);
   m_pointer->addRef();

--- a/toonz/sources/common/tparam/tpixelparam.cpp
+++ b/toonz/sources/common/tparam/tpixelparam.cpp
@@ -1,6 +1,6 @@
 
 
-//#include "tpixelparam.h"
+// #include "tpixelparam.h"
 #include "tparamset.h"
 #include "tdoubleparam.h"
 #include "texception.h"
@@ -112,6 +112,14 @@ TPixel32 TPixelParam::getValue(double frame) const {
 
 //---------------------------------------------------------
 
+TPixel32 TPixelParam::getValue(double frame, bool linear,
+                               double colorSpaceGamma) const {
+  if (!linear) return getValue(frame);
+  return toPixel32(toLinear(getValueD(frame), colorSpaceGamma));
+}
+
+//---------------------------------------------------------
+
 TPixel64 TPixelParam::getValue64(double frame) const {
   return toPixel64(getValueD(frame));
 }
@@ -200,7 +208,7 @@ TDoubleParamP &TPixelParam::getMatte() { return m_data->m_m; }
 //---------------------------------------------------------
 
 void TPixelParam::enableMatte(bool on) {
-  m_data->m_isMatteEnabled     = on;
+  m_data->m_isMatteEnabled = on;
   if (on == false) m_data->m_m = new TDoubleParam(255.0);
 }
 //---------------------------------------------------------

--- a/toonz/sources/common/tparam/tspectrumparam.cpp
+++ b/toonz/sources/common/tparam/tspectrumparam.cpp
@@ -181,6 +181,22 @@ TSpectrum64 TSpectrumParam::getValue64(double frame) const {
   }
   return TSpectrum64(keys.size(), &keys[0]);
 }
+
+//---------------------------------------------------------
+
+TSpectrumF TSpectrumParam::getValueF(double frame) const {
+  assert(m_imp);
+  std::vector<TSpectrumF::ColorKey> keys;
+  int keyCount = m_imp->getKeyCount();
+  for (int i = 0; i < keyCount; i++) {
+    ColorKeyParam paramKey = m_imp->getKey(i);
+    TSpectrumF::ColorKey key(paramKey.first->getValue(frame),
+                             toPixelF(paramKey.second->getValue(frame)));
+    keys.push_back(key);
+  }
+  return TSpectrumF(keys.size(), &keys[0]);
+}
+
 //---------------------------------------------------------
 
 void TSpectrumParam::setValue(double frame, const TSpectrum &spectrum,

--- a/toonz/sources/common/tproperty.cpp
+++ b/toonz/sources/common/tproperty.cpp
@@ -3,7 +3,7 @@
 #include "tproperty.h"
 #include "tstream.h"
 #include "texception.h"
-//#include "tconvert.h"
+// #include "tconvert.h"
 
 void TProperty::addListener(Listener *listener) {
   if (std::find(m_listeners.begin(), m_listeners.end(), listener) ==
@@ -230,8 +230,7 @@ void TPropertyGroup::loadData(TIStream &is) {
         double min = std::stod(is.getTagAttribute("min"));
         double max = std::stod(is.getTagAttribute("max"));
         add(new TDoubleProperty(name, min, max, std::stod(svalue)));
-      }
-      if (type == "pair") {
+      } else if (type == "pair") {
         double min = std::stod(is.getTagAttribute("min"));
         double max = std::stod(is.getTagAttribute("max"));
         TDoublePairProperty::Value v(0, 0);
@@ -302,7 +301,7 @@ void TEnumProperty::assignUIName(TProperty *refP) {
   if (!enumRefP) return;
   Items refItems = enumRefP->getItems();
   for (int i = 0; i < m_range.size(); i++) {
-    int refIndex                         = enumRefP->indexOf(m_range[i]);
+    int refIndex = enumRefP->indexOf(m_range[i]);
     if (0 <= refIndex) m_items[i].UIName = refItems[refIndex].UIName;
   }
 }

--- a/toonz/sources/common/traster/traster.cpp
+++ b/toonz/sources/common/traster/traster.cpp
@@ -9,7 +9,7 @@
 #include "tbigmemorymanager.h"
 #include "traster.h"
 #include "trastercm.h"
-//#include "tspecialstyleid.h"
+// #include "tspecialstyleid.h"
 #include "tpixel.h"
 #include "tpixelgr.h"
 #include "timagecache.h"
@@ -28,6 +28,7 @@ TRaster::TRaster(int lx, int ly, int pixelSize)
     , m_bufferOwner(true)
     , m_buffer(0)
     , m_lockCount(0)
+    , m_isLinear(false)
 #ifdef _DEBUG
     , m_cashed(false)
 #endif
@@ -83,15 +84,18 @@ TRaster::TRaster(int lx, int ly, int pixelSize, int wrap, UCHAR *buffer,
     , m_buffer(buffer)
     , m_bufferOwner(bufferOwner)
     , m_lockCount(0)
+    , m_isLinear(false)
 #ifdef _DEBUG
     , m_cashed(false)
 #endif
+    , m_parent(nullptr)
 
 {
   if (parent) {
     assert(bufferOwner == false);
     while (parent->m_parent) parent = parent->m_parent;
     parent->addRef();
+    setLinear(parent->isLinear());
   }
 #ifdef _DEBUG
   else if (bufferOwner)
@@ -288,6 +292,7 @@ void TRaster::copy(const TRasterP &src0, const TPoint &offset) {
       srcRow += srcWrapSize;
     }
   }
+  setLinear(src0->isLinear());
   dst->unlock();
   src0->unlock();
 }

--- a/toonz/sources/common/trop/quickput.cpp
+++ b/toonz/sources/common/trop/quickput.cpp
@@ -1165,6 +1165,456 @@ void doQuickPutNoFilter(const TRaster64P &dn, const TRaster64P &up,
   dn->unlock();
   up->unlock();
 }
+
+//=============================================================================
+
+void doQuickPutNoFilter(const TRaster64P &dn, const TRasterFP &up,
+                        const TAffine &aff, bool doPremultiply,
+                        bool firstColumn) {
+  //  se aff := TAffine(sx, 0, tx, 0, sy, ty) e' degenere la controimmagine
+  //  di up e' un segmento (o un punto)
+  if ((aff.a11 * aff.a22 - aff.a12 * aff.a21) == 0) return;
+
+  //  contatore bit di shift
+  const int PADN = 16;
+
+  //  max dimensioni di up gestibili (limite imposto dal numero di bit
+  //  disponibili per la parte intera di xL, yL)
+  assert(std::max(up->getLx(), up->getLy()) <
+         (1 << (8 * sizeof(int) - PADN - 1)));
+
+  TRectD boundingBoxD =
+      TRectD(convert(dn->getBounds())) *
+      (aff * TRectD(-0.5, -0.5, up->getLx() - 0.5, up->getLy() - 0.5));
+
+  //  clipping
+  if (boundingBoxD.x0 >= boundingBoxD.x1 || boundingBoxD.y0 >= boundingBoxD.y1)
+    return;
+
+  //  clipping y su dn
+  int yMin = std::max(tfloor(boundingBoxD.y0), 0);
+
+  //  clipping y su dn
+  int yMax = std::min(tceil(boundingBoxD.y1), dn->getLy() - 1);
+
+  //  clipping x su dn
+  int xMin = std::max(tfloor(boundingBoxD.x0), 0);
+
+  //  clipping x su dn
+  int xMax = std::min(tceil(boundingBoxD.x1), dn->getLx() - 1);
+
+  //  inversa di aff
+  TAffine invAff = inv(aff);
+
+  //  nel disegnare la y-esima scanline di dn, il passaggio al pixel
+  //  successivo comporta l'incremento (deltaXD, deltaYD) delle coordinate del
+  //  pixel corrispondente di up
+  double deltaXD = invAff.a11;
+  double deltaYD = invAff.a21;
+
+  //  deltaXD "TLonghizzato" (round)
+  int deltaXL = tround(deltaXD * (1 << PADN));
+
+  //  deltaYD "TLonghizzato" (round)
+  int deltaYL = tround(deltaYD * (1 << PADN));
+
+  //  se aff "TLonghizzata" (round) e' degenere la controimmagine di up e' un
+  //  segmento (o un punto)
+  if ((deltaXL == 0) && (deltaYL == 0)) return;
+
+  //  TINT32 predecessore di up->getLx()
+  int lxPred = up->getLx() * (1 << PADN) - 1;
+
+  //  TINT32 predecessore di up->getLy()
+  int lyPred = up->getLy() * (1 << PADN) - 1;
+
+  int dnWrap = dn->getWrap();
+  int upWrap = up->getWrap();
+  dn->lock();
+  up->lock();
+
+  TPixel64 *dnRow    = dn->pixels(yMin);
+  TPixelF *upBasePix = up->pixels();
+
+  //  scorre le scanline di boundingBoxD
+  for (int y = yMin; y <= yMax; y++, dnRow += dnWrap) {
+    //  (1)  equazione k-parametrica della y-esima scanline di boundingBoxD:
+    //       (xMin, y) + k*(1, 0),  k = 0, ..., (xMax - xMin)
+
+    //  (2)  equazione k-parametrica dell'immagine mediante invAff di (1):
+    //       invAff*(xMin, y) + k*(deltaXD, deltaYD),
+    //       k = kMin, ..., kMax con 0 <= kMin <= kMax <= (xMax - xMin)
+
+    //  calcola kMin, kMax per la scanline corrente
+    //  intersecando la (2) con i lati di up
+
+    //  il segmento [a, b] di up e' la controimmagine mediante aff della
+    //  porzione di scanline  [ (xMin, y), (xMax, y) ] di dn
+
+    //  TPointD b = invAff*TPointD(xMax, y);
+    TPointD a = invAff * TPointD(xMin, y);
+
+    //  (xL0, yL0) sono le coordinate di a (inizializzate per il round)
+    //  in versione "TLonghizzata"
+    //  0 <= xL0 + k*deltaXL
+    //    <  up->getLx()*(1<<PADN)
+    //
+    //  0 <= kMinX
+    //    <= kMin
+    //    <= k
+    //    <= kMax
+    //    <= kMaxX
+    //    <= (xMax - xMin)
+    //
+    //  0 <= yL0 + k*deltaYL
+    //    < up->getLy()*(1<<PADN)
+
+    //  0 <= kMinY
+    //    <= kMin
+    //    <= k
+    //    <= kMax
+    //    <= kMaxY
+    //    <= (xMax - xMin)
+
+    //  xL0 inizializzato per il round
+    int xL0 = tround((a.x + 0.5) * (1 << PADN));
+
+    //  yL0 inizializzato per il round
+    int yL0 = tround((a.y + 0.5) * (1 << PADN));
+
+    //  calcola kMinX, kMaxX, kMinY, kMaxY
+    int kMinX = 0, kMaxX = xMax - xMin;  //  clipping su dn
+    int kMinY = 0, kMaxY = xMax - xMin;  //  clipping su dn
+
+    //  0 <= xL0 + k*deltaXL
+    //    < up->getLx()*(1<<PADN)
+    //           <=>
+    //  0 <= xL0 + k*deltaXL
+    //    <= lxPred
+    //
+    //  0 <= yL0 + k*deltaYL
+    //    < up->getLy()*(1<<PADN)
+    //           <=>
+    //  0 <= yL0 + k*deltaYL
+    //    <= lyPred
+
+    //  calcola kMinX, kMaxX
+    if (deltaXL == 0) {
+      // [a, b] verticale esterno ad up+(bordo destro/basso)
+      if ((xL0 < 0) || (lxPred < xL0)) continue;
+      //  altrimenti usa solo
+      //  kMinY, kMaxY ((deltaXL != 0) || (deltaYL != 0))
+    } else if (deltaXL > 0) {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (lxPred < xL0) continue;
+
+      kMaxX = (lxPred - xL0) / deltaXL;  //  floor
+      if (xL0 < 0) {
+        kMinX = ((-xL0) + deltaXL - 1) / deltaXL;  //  ceil
+      }
+    } else  //  (deltaXL < 0)
+    {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (xL0 < 0) continue;
+
+      kMaxX = xL0 / (-deltaXL);  //  floor
+      if (lxPred < xL0) {
+        kMinX = (xL0 - lxPred - deltaXL - 1) / (-deltaXL);  //  ceil
+      }
+    }
+
+    //  calcola kMinY, kMaxY
+    if (deltaYL == 0) {
+      //  [a, b] orizzontale esterno ad up+(bordo destro/basso)
+      if ((yL0 < 0) || (lyPred < yL0)) continue;
+      // altrimenti usa solo
+      // kMinX, kMaxX ((deltaXL != 0) || (deltaYL != 0))
+    } else if (deltaYL > 0) {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (lyPred < yL0) continue;
+
+      kMaxY = (lyPred - yL0) / deltaYL;  //  floor
+      if (yL0 < 0) {
+        kMinY = ((-yL0) + deltaYL - 1) / deltaYL;  //  ceil
+      }
+    } else  //  (deltaYL < 0)
+    {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (yL0 < 0) continue;
+
+      kMaxY = yL0 / (-deltaYL);  //  floor
+      if (lyPred < yL0) {
+        kMinY = (yL0 - lyPred - deltaYL - 1) / (-deltaYL);  //  ceil
+      }
+    }
+
+    //  calcola kMin, kMax effettuando anche il clippind su dn
+    int kMin = std::max({kMinX, kMinY, (int)0});
+    int kMax = std::min({kMaxX, kMaxY, xMax - xMin});
+
+    TPixel64 *dnPix    = dnRow + xMin + kMin;
+    TPixel64 *dnEndPix = dnRow + xMin + kMax + 1;
+
+    //  (xL, yL) sono le coordinate (inizializzate per il round)
+    //  in versione "TLonghizzata" del pixel corrente di up
+    int xL = xL0 + (kMin - 1) * deltaXL;  //  inizializza xL
+    int yL = yL0 + (kMin - 1) * deltaYL;  //  inizializza yL
+
+    //  scorre i pixel sulla y-esima scanline di boundingBoxD
+    for (; dnPix < dnEndPix; ++dnPix) {
+      xL += deltaXL;
+      yL += deltaYL;
+
+      //  il punto di up TPointD(xL/(1<<PADN), yL/(1<<PADN)) e'
+      //  approssimato con (xI, yI)
+      int xI = xL >> PADN;  //  round
+      int yI = yL >> PADN;  //  round
+
+      assert((0 <= xI) && (xI <= up->getLx() - 1) && (0 <= yI) &&
+             (yI <= up->getLy() - 1));
+
+      TPixelF upPix = *(upBasePix + (yI * upWrap + xI));
+
+      if (firstColumn) upPix.m = 1.0;
+      if (upPix.m <= 0.0) continue;
+
+      TPixel64 upPix64 = toPixel64(upPix);
+      if (upPix.m >= 1.f)
+        *dnPix = upPix64;
+      else if (doPremultiply)
+        *dnPix = quickOverPixPremult(*dnPix, upPix64);
+      else
+        *dnPix = quickOverPix(*dnPix, upPix64);
+    }
+  }
+  dn->unlock();
+  up->unlock();
+}
+
+//=============================================================================
+
+void doQuickPutNoFilter(const TRasterFP &dn, const TRasterFP &up,
+                        const TAffine &aff, bool doPremultiply,
+                        bool firstColumn) {
+  //  se aff := TAffine(sx, 0, tx, 0, sy, ty) e' degenere la controimmagine
+  //  di up e' un segmento (o un punto)
+  if ((aff.a11 * aff.a22 - aff.a12 * aff.a21) == 0) return;
+
+  //  contatore bit di shift
+  const int PADN = 16;
+
+  //  max dimensioni di up gestibili (limite imposto dal numero di bit
+  //  disponibili per la parte intera di xL, yL)
+  assert(std::max(up->getLx(), up->getLy()) <
+         (1 << (8 * sizeof(int) - PADN - 1)));
+
+  TRectD boundingBoxD =
+      TRectD(convert(dn->getBounds())) *
+      (aff * TRectD(-0.5, -0.5, up->getLx() - 0.5, up->getLy() - 0.5));
+
+  //  clipping
+  if (boundingBoxD.x0 >= boundingBoxD.x1 || boundingBoxD.y0 >= boundingBoxD.y1)
+    return;
+
+  //  clipping y su dn
+  int yMin = std::max(tfloor(boundingBoxD.y0), 0);
+
+  //  clipping y su dn
+  int yMax = std::min(tceil(boundingBoxD.y1), dn->getLy() - 1);
+
+  //  clipping x su dn
+  int xMin = std::max(tfloor(boundingBoxD.x0), 0);
+
+  //  clipping x su dn
+  int xMax = std::min(tceil(boundingBoxD.x1), dn->getLx() - 1);
+
+  //  inversa di aff
+  TAffine invAff = inv(aff);
+
+  //  nel disegnare la y-esima scanline di dn, il passaggio al pixel
+  //  successivo comporta l'incremento (deltaXD, deltaYD) delle coordinate del
+  //  pixel corrispondente di up
+  double deltaXD = invAff.a11;
+  double deltaYD = invAff.a21;
+
+  //  deltaXD "TLonghizzato" (round)
+  int deltaXL = tround(deltaXD * (1 << PADN));
+
+  //  deltaYD "TLonghizzato" (round)
+  int deltaYL = tround(deltaYD * (1 << PADN));
+
+  //  se aff "TLonghizzata" (round) e' degenere la controimmagine di up e' un
+  //  segmento (o un punto)
+  if ((deltaXL == 0) && (deltaYL == 0)) return;
+
+  //  TINT32 predecessore di up->getLx()
+  int lxPred = up->getLx() * (1 << PADN) - 1;
+
+  //  TINT32 predecessore di up->getLy()
+  int lyPred = up->getLy() * (1 << PADN) - 1;
+
+  int dnWrap = dn->getWrap();
+  int upWrap = up->getWrap();
+  dn->lock();
+  up->lock();
+
+  TPixelF *dnRow     = dn->pixels(yMin);
+  TPixelF *upBasePix = up->pixels();
+
+  //  scorre le scanline di boundingBoxD
+  for (int y = yMin; y <= yMax; y++, dnRow += dnWrap) {
+    //  (1)  equazione k-parametrica della y-esima scanline di boundingBoxD:
+    //       (xMin, y) + k*(1, 0),  k = 0, ..., (xMax - xMin)
+
+    //  (2)  equazione k-parametrica dell'immagine mediante invAff di (1):
+    //       invAff*(xMin, y) + k*(deltaXD, deltaYD),
+    //       k = kMin, ..., kMax con 0 <= kMin <= kMax <= (xMax - xMin)
+
+    //  calcola kMin, kMax per la scanline corrente
+    //  intersecando la (2) con i lati di up
+
+    //  il segmento [a, b] di up e' la controimmagine mediante aff della
+    //  porzione di scanline  [ (xMin, y), (xMax, y) ] di dn
+
+    //  TPointD b = invAff*TPointD(xMax, y);
+    TPointD a = invAff * TPointD(xMin, y);
+
+    //  (xL0, yL0) sono le coordinate di a (inizializzate per il round)
+    //  in versione "TLonghizzata"
+    //  0 <= xL0 + k*deltaXL
+    //    <  up->getLx()*(1<<PADN)
+    //
+    //  0 <= kMinX
+    //    <= kMin
+    //    <= k
+    //    <= kMax
+    //    <= kMaxX
+    //    <= (xMax - xMin)
+    //
+    //  0 <= yL0 + k*deltaYL
+    //    < up->getLy()*(1<<PADN)
+
+    //  0 <= kMinY
+    //    <= kMin
+    //    <= k
+    //    <= kMax
+    //    <= kMaxY
+    //    <= (xMax - xMin)
+
+    //  xL0 inizializzato per il round
+    int xL0 = tround((a.x + 0.5) * (1 << PADN));
+
+    //  yL0 inizializzato per il round
+    int yL0 = tround((a.y + 0.5) * (1 << PADN));
+
+    //  calcola kMinX, kMaxX, kMinY, kMaxY
+    int kMinX = 0, kMaxX = xMax - xMin;  //  clipping su dn
+    int kMinY = 0, kMaxY = xMax - xMin;  //  clipping su dn
+
+    //  0 <= xL0 + k*deltaXL
+    //    < up->getLx()*(1<<PADN)
+    //           <=>
+    //  0 <= xL0 + k*deltaXL
+    //    <= lxPred
+    //
+    //  0 <= yL0 + k*deltaYL
+    //    < up->getLy()*(1<<PADN)
+    //           <=>
+    //  0 <= yL0 + k*deltaYL
+    //    <= lyPred
+
+    //  calcola kMinX, kMaxX
+    if (deltaXL == 0) {
+      // [a, b] verticale esterno ad up+(bordo destro/basso)
+      if ((xL0 < 0) || (lxPred < xL0)) continue;
+      //  altrimenti usa solo
+      //  kMinY, kMaxY ((deltaXL != 0) || (deltaYL != 0))
+    } else if (deltaXL > 0) {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (lxPred < xL0) continue;
+
+      kMaxX = (lxPred - xL0) / deltaXL;  //  floor
+      if (xL0 < 0) {
+        kMinX = ((-xL0) + deltaXL - 1) / deltaXL;  //  ceil
+      }
+    } else  //  (deltaXL < 0)
+    {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (xL0 < 0) continue;
+
+      kMaxX = xL0 / (-deltaXL);  //  floor
+      if (lxPred < xL0) {
+        kMinX = (xL0 - lxPred - deltaXL - 1) / (-deltaXL);  //  ceil
+      }
+    }
+
+    //  calcola kMinY, kMaxY
+    if (deltaYL == 0) {
+      //  [a, b] orizzontale esterno ad up+(bordo destro/basso)
+      if ((yL0 < 0) || (lyPred < yL0)) continue;
+      // altrimenti usa solo
+      // kMinX, kMaxX ((deltaXL != 0) || (deltaYL != 0))
+    } else if (deltaYL > 0) {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (lyPred < yL0) continue;
+
+      kMaxY = (lyPred - yL0) / deltaYL;  //  floor
+      if (yL0 < 0) {
+        kMinY = ((-yL0) + deltaYL - 1) / deltaYL;  //  ceil
+      }
+    } else  //  (deltaYL < 0)
+    {
+      //  [a, b] esterno ad up+(bordo destro/basso)
+      if (yL0 < 0) continue;
+
+      kMaxY = yL0 / (-deltaYL);  //  floor
+      if (lyPred < yL0) {
+        kMinY = (yL0 - lyPred - deltaYL - 1) / (-deltaYL);  //  ceil
+      }
+    }
+
+    //  calcola kMin, kMax effettuando anche il clippind su dn
+    int kMin = std::max({kMinX, kMinY, (int)0});
+    int kMax = std::min({kMaxX, kMaxY, xMax - xMin});
+
+    TPixelF *dnPix    = dnRow + xMin + kMin;
+    TPixelF *dnEndPix = dnRow + xMin + kMax + 1;
+
+    //  (xL, yL) sono le coordinate (inizializzate per il round)
+    //  in versione "TLonghizzata" del pixel corrente di up
+    int xL = xL0 + (kMin - 1) * deltaXL;  //  inizializza xL
+    int yL = yL0 + (kMin - 1) * deltaYL;  //  inizializza yL
+
+    //  scorre i pixel sulla y-esima scanline di boundingBoxD
+    for (; dnPix < dnEndPix; ++dnPix) {
+      xL += deltaXL;
+      yL += deltaYL;
+
+      //  il punto di up TPointD(xL/(1<<PADN), yL/(1<<PADN)) e'
+      //  approssimato con (xI, yI)
+      int xI = xL >> PADN;  //  round
+      int yI = yL >> PADN;  //  round
+
+      assert((0 <= xI) && (xI <= up->getLx() - 1) && (0 <= yI) &&
+             (yI <= up->getLy() - 1));
+
+      TPixelF upPix = *(upBasePix + (yI * upWrap + xI));
+
+      if (firstColumn) upPix.m = 1.0;
+      if (upPix.m <= 0.0) continue;
+
+      if (upPix.m >= 1.f)
+        *dnPix = upPix;
+      else if (doPremultiply)
+        *dnPix = quickOverPixPremult(*dnPix, upPix);
+      else
+        *dnPix = quickOverPix(*dnPix, upPix);
+    }
+  }
+  dn->unlock();
+  up->unlock();
+}
+
 //=============================================================================
 
 void doQuickPutNoFilter(const TRaster64P &dn, const TRaster32P &up,
@@ -4718,6 +5168,8 @@ void quickPut(const TRasterP &dn, const TRasterP &up, const TAffine &aff,
   TRasterGR8P up8 = up;
   TRaster64P dn64 = dn;
   TRaster64P up64 = up;
+  TRasterFP upF   = up;
+  TRasterFP dnF   = dn;
 
   if (up8 && dn32) {
     assert(filterType == TRop::ClosestPixel);
@@ -4747,6 +5199,10 @@ void quickPut(const TRasterP &dn, const TRasterP &up, const TAffine &aff,
     doQuickPutNoFilter(dn64, up64, aff, doPremultiply, firstColumn);
   else if (dn64 && up32)
     doQuickPutNoFilter(dn64, up32, aff, doPremultiply, firstColumn);
+  else if (dn64 && upF)
+    doQuickPutNoFilter(dn64, upF, aff, doPremultiply, firstColumn);
+  else if (dnF && upF)
+    doQuickPutNoFilter(dnF, upF, aff, doPremultiply, firstColumn);
   else
     throw TRopException("raster type mismatch");
 }

--- a/toonz/sources/common/trop/tblur.cpp
+++ b/toonz/sources/common/trop/tblur.cpp
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 #endif
 
-
 namespace {
 
 #ifdef _WIN32
@@ -172,10 +171,10 @@ inline void blur_code(PIXEL_SRC *row1, PIXEL_DST *row2, int length, float coeff,
     sigma2.b += pix2->b;
     sigma2.m += pix2->m;
 
-    sigma3.r += i * (pix1->r + pix2->r);
-    sigma3.g += i * (pix1->g + pix2->g);
-    sigma3.b += i * (pix1->b + pix2->b);
-    sigma3.m += i * (pix1->m + pix2->m);
+    sigma3.r += (T)i * (pix1->r + pix2->r);
+    sigma3.g += (T)i * (pix1->g + pix2->g);
+    sigma3.b += (T)i * (pix1->b + pix2->b);
+    sigma3.m += (T)i * (pix1->m + pix2->m);
 
     pix1++;
     pix2--;
@@ -522,6 +521,31 @@ void store_colRgb(T *buffer, int wrap, int r_ly, T *col, int ly, int x, int dy,
     assert(false);
 }
 
+template <>
+void store_colRgb<TPixelF>(TPixelF *buffer, int wrap, int r_ly, TPixelF *col,
+                           int ly, int x, int dy, int backlit, double blur) {
+  int i;
+  buffer += x;
+  if (backlit) {
+    double ampl    = 1.0 + blur / 15.0;
+    float crop_val = 204.f / 255.f;
+    for (i = ((dy >= 0) ? 0 : -dy); i < std::min(ly, r_ly - dy); i++) {
+      float val = col[i].r * ampl;
+      buffer->r = (val > crop_val) ? crop_val : val;
+      val       = col[i].g * ampl;
+      buffer->g = (val > crop_val) ? crop_val : val;
+      val       = col[i].b * ampl;
+      buffer->b = (val > crop_val) ? crop_val : val;
+      val       = col[i].m * ampl;
+      buffer->m = (val > crop_val) ? crop_val : val;
+      buffer += wrap;
+    }
+  } else
+    for (i = ((dy >= 0) ? 0 : -dy); i < std::min(ly, r_ly - dy); i++) {
+      *buffer = col[i];
+      buffer += wrap;
+    }
+}
 //-------------------------------------------------------------------
 template <class T>
 void store_colGray(T *buffer, int wrap, int r_ly, T *col, int ly, int x, int dy,
@@ -576,7 +600,19 @@ void do_filtering_chan(BlurPixel<P> *row1, T *row2, int length, float coeff,
     BLUR_CODE((P)0.5, Q)
   }
 }
+template <>
+void do_filtering_chan<TPixelF, float, double>(BlurPixel<double> *row1,
+                                               TPixelF *row2, int length,
+                                               float coeff, float coeffq,
+                                               int brad, float diff,
+                                               bool useSSE) {
+  int i;
+  double rsum, gsum, bsum, msum;
+  BlurPixel<double> sigma1, sigma2, sigma3, desigma;
+  BlurPixel<double> *pix1, *pix2, *pix3, *pix4;
 
+  BLUR_CODE(0.0, float)
+}
 //-------------------------------------------------------------------
 
 template <class T>
@@ -741,14 +777,14 @@ void load_rowGray(TRasterPT<T> &rin, T *row, int lx, int y, int brad, int bx1,
 template <class T, class P>
 void do_filtering_floatRgb(T *row1, BlurPixel<P> *row2, int length, float coeff,
                            float coeffq, int brad, float diff, bool useSSE) {
-/*
-  int i;
-  float rsum, gsum, bsum,  msum;
-  CASM_FPIXEL sigma1, sigma2, sigma3, desigma;
-  TPixel32 *pix1, *pix2, *pix3, *pix4;
+  /*
+    int i;
+    float rsum, gsum, bsum,  msum;
+    CASM_FPIXEL sigma1, sigma2, sigma3, desigma;
+    TPixel32 *pix1, *pix2, *pix3, *pix4;
 
-  BLUR_CODE(0, unsigned char)
-*/
+    BLUR_CODE(0, unsigned char)
+  */
 
 #ifdef USE_SSE2
   if (useSSE)
@@ -771,7 +807,7 @@ void doBlurRgb(TRasterPT<T> &dstRas, TRasterPT<T> &srcRas, double blur, int dx,
 
   // int border = brad*2; // per sicurezza
 
-  coeff = (float)(blur /
+  coeff  = (float)(blur /
                   (brad - brad * brad +
                    blur * (2 * brad -
                            1))); /*sum of the weights of triangolar filter. */
@@ -805,7 +841,7 @@ void doBlurRgb(TRasterPT<T> &dstRas, TRasterPT<T> &srcRas, double blur, int dx,
     r1->lock();
     fbuffer = (BlurPixel<P> *)r1->getRawData();  // new CASM_FPIXEL [llx *ly];
     row1    = new T[llx + 2 * brad];
-    col1    = new BlurPixel<P>[ lly + 2 * brad ];
+    col1    = new BlurPixel<P>[lly + 2 * brad];
     col2    = new T[lly];
   }
 
@@ -879,8 +915,8 @@ void doBlurGray(TRasterPT<T> &dstRas, TRasterPT<T> &srcRas, double blur, int dx,
   float coeff, coeffq, diff;
   int bx1 = 0, by1 = 0, bx2 = 0, by2 = 0;
 
-  brad  = (int)ceil(blur); /* number of pixels involved in the filtering */
-  coeff = (float)(blur /
+  brad   = (int)ceil(blur); /* number of pixels involved in the filtering */
+  coeff  = (float)(blur /
                   (brad - brad * brad +
                    blur * (2 * brad -
                            1))); /*sum of the weights of triangolar filter. */
@@ -958,30 +994,39 @@ void TRop::blur(const TRasterP &dstRas, const TRasterP &srcRas, double blur,
                 int dx, int dy, bool useSSE) {
   TRaster32P dstRas32 = dstRas;
   TRaster32P srcRas32 = srcRas;
-
-  if (dstRas32 && srcRas32)
+  if (dstRas32 && srcRas32) {
     doBlurRgb<TPixel32, UCHAR, float>(dstRas32, srcRas32, blur, dx, dy, useSSE);
-  else {
-    TRaster64P dstRas64 = dstRas;
-    TRaster64P srcRas64 = srcRas;
-    if (dstRas64 && srcRas64)
-      doBlurRgb<TPixel64, USHORT, double>(dstRas64, srcRas64, blur, dx, dy,
-                                          useSSE);
-    else {
-      TRasterGR8P dstRasGR8 = dstRas;
-      TRasterGR8P srcRasGR8 = srcRas;
-
-      if (dstRasGR8 && srcRasGR8)
-        doBlurGray<TPixelGR8>(dstRasGR8, srcRasGR8, blur, dx, dy);
-      else {
-        TRasterGR16P dstRasGR16 = dstRas;
-        TRasterGR16P srcRasGR16 = srcRas;
-
-        if (dstRasGR16 && srcRasGR16)
-          doBlurGray<TPixelGR16>(dstRasGR16, srcRasGR16, blur, dx, dy);
-        else
-          throw TException("TRop::blur unsupported pixel type");
-      }
-    }
+    return;
   }
+
+  TRaster64P dstRas64 = dstRas;
+  TRaster64P srcRas64 = srcRas;
+  if (dstRas64 && srcRas64) {
+    doBlurRgb<TPixel64, USHORT, double>(dstRas64, srcRas64, blur, dx, dy,
+                                        useSSE);
+    return;
+  }
+
+  TRasterFP dstRasF = dstRas;
+  TRasterFP srcRasF = srcRas;
+  if (dstRasF && srcRasF) {
+    doBlurRgb<TPixelF, float, double>(dstRasF, srcRasF, blur, dx, dy, useSSE);
+    return;
+  }
+
+  TRasterGR8P dstRasGR8 = dstRas;
+  TRasterGR8P srcRasGR8 = srcRas;
+  if (dstRasGR8 && srcRasGR8) {
+    doBlurGray<TPixelGR8>(dstRasGR8, srcRasGR8, blur, dx, dy);
+    return;
+  }
+
+  TRasterGR16P dstRasGR16 = dstRas;
+  TRasterGR16P srcRasGR16 = srcRas;
+  if (dstRasGR16 && srcRasGR16) {
+    doBlurGray<TPixelGR16>(dstRasGR16, srcRasGR16, blur, dx, dy);
+    return;
+  }
+
+  throw TException("TRop::blur unsupported pixel type");
 }

--- a/toonz/sources/common/trop/tcheckboard.cpp
+++ b/toonz/sources/common/trop/tcheckboard.cpp
@@ -82,14 +82,15 @@ void TRop::checkBoard(TRasterP rout, const TPixel32 &pix1, const TPixel32 &pix2,
   // assert(offset.x<=dim.lx && offset.y<=dim.ly);
 
   TRaster32P rout32 = rout;
+  TRaster64P rout64 = rout;
+  TRasterFP routF   = rout;
   if (rout32)
     do_checkBoard<TPixel32>(rout32, pix1, pix2, dim, offset);
-  else {
-    TRaster64P rout64 = rout;
-    if (rout64)
-      do_checkBoard<TPixel64>(rout64, toPixel64(pix1), toPixel64(pix2), dim,
-                              offset);
-    else
-      throw TRopException("unsupported pixel type");
-  }
+  else if (rout64)
+    do_checkBoard<TPixel64>(rout64, toPixel64(pix1), toPixel64(pix2), dim,
+                            offset);
+  else if (routF)
+    do_checkBoard<TPixelF>(routF, toPixelF(pix1), toPixelF(pix2), dim, offset);
+  else
+    throw TRopException("unsupported pixel type");
 }

--- a/toonz/sources/common/trop/tinvert.cpp
+++ b/toonz/sources/common/trop/tinvert.cpp
@@ -42,9 +42,9 @@ inline void do_invert(TRasterPT<PixType> ras, bool invRed, bool invGreen,
     pixIn  = rowIn;
     endPix = pixIn + lx;
     while (pixIn < endPix) {
-      if (invRed) pixIn->r   = pixIn->m - pixIn->r;
+      if (invRed) pixIn->r = pixIn->m - pixIn->r;
       if (invGreen) pixIn->g = pixIn->m - pixIn->g;
-      if (invBlue) pixIn->b  = pixIn->m - pixIn->b;
+      if (invBlue) pixIn->b = pixIn->m - pixIn->b;
       if (invMatte) pixIn->m = ~pixIn->m;
       ++pixIn;
     }
@@ -74,7 +74,34 @@ inline void do_invert<TPixelGR8>(TRasterPT<TPixelGR8> ras) {
     rowIn += wrap;
   }
 }
+
+//------------------------------------------------------------------------------
+
+template <>
+inline void do_invert<TPixelF>(TRasterFP ras, bool invRed, bool invGreen,
+                               bool invBlue, bool invMatte) {
+  int wrap         = ras->getWrap();
+  int lx           = ras->getLx();
+  TPixelF *rowIn   = ras->pixels();
+  TPixelF *lastPix = rowIn + wrap * ras->getLy();
+  TPixelF *pixIn   = 0;
+  TPixelF *endPix  = 0;
+
+  while (pixIn < lastPix) {
+    pixIn  = rowIn;
+    endPix = pixIn + lx;
+    while (pixIn < endPix) {
+      if (invRed) pixIn->r = pixIn->m - pixIn->r;
+      if (invGreen) pixIn->g = pixIn->m - pixIn->g;
+      if (invBlue) pixIn->b = pixIn->m - pixIn->b;
+      if (invMatte) pixIn->m = 1.f - pixIn->m;
+      ++pixIn;
+    }
+    rowIn += wrap;
+  }
 }
+
+}  // namespace
 
 //------------------------------------------------------------------------------
 
@@ -84,29 +111,33 @@ void TRop::invert(TRasterP ras, bool invRed, bool invGreen, bool invBlue,
   bool flag = invRed && invGreen && invBlue && !invMatte;
 
   TRaster32P ras32 = ras;
+  TRaster64P ras64 = ras;
+  TRasterFP rasF   = ras;
+  TRasterGR8P ras8 = ras;
   ras->lock();
-  if (ras32)
+
+  if (ras32) {
     if (flag)
       do_invert<TPixel32>(ras32);
     else
       do_invert<TPixel32>(ras, invRed, invGreen, invBlue, invMatte);
+  } else if (ras64) {
+    if (flag)
+      do_invert<TPixel64>(ras64);
+    else
+      do_invert<TPixel64>(ras64, invRed, invGreen, invBlue, invMatte);
+  } else if (rasF) {
+    if (flag)
+      do_invert<TPixelF>(rasF);
+    else
+      do_invert<TPixelF>(rasF, invRed, invGreen, invBlue, invMatte);
+  } else if (ras8)
+    do_invert<TPixelGR8>(ras8);
   else {
-    TRaster64P ras64 = ras;
-    if (ras64)
-      if (flag)
-        do_invert<TPixel64>(ras64);
-      else
-        do_invert<TPixel64>(ras64, invRed, invGreen, invBlue, invMatte);
-    else {
-      TRasterGR8P ras8 = ras;
-      if (ras8)
-        do_invert<TPixelGR8>(ras8);
-      else {
-        ras->unlock();
-        throw TRopException("unsupported pixel type");
-      }
-    }
+    ras->unlock();
+    throw TRopException("unsupported pixel type");
   }
+
   ras->unlock();
 }
 

--- a/toonz/sources/common/trop/toperators.cpp
+++ b/toonz/sources/common/trop/toperators.cpp
@@ -92,6 +92,18 @@ inline double luminance(TPixel64 *pix) {
 
 //-----------------------------------------------------------------------------
 
+#define FOR_EACH_PIXEL_F_BEGIN_LOOP                                            \
+  assert(upF &&downF &&outF);                                                  \
+  FOR_EACH_PIXEL_BEGIN_LOOP(TPixelF, upF, TPixelF, downF, TPixelF, outF)
+
+//-----------------------------------------------------------------------------
+
+#define FOR_EACH_PIXEL_F_END_LOOP                                              \
+  assert(upF &&downF &&outF);                                                  \
+  FOR_EACH_PIXEL_END_LOOP(upF, downF, outF)
+
+//-----------------------------------------------------------------------------
+
 #define FOR_EACH_PIXEL_8_BEGIN_LOOP                                            \
   assert(up8 &&down8 &&out8);                                                  \
   FOR_EACH_PIXEL_BEGIN_LOOP(TPixelGR8, up8, TPixelGR8, down8, TPixelGR8, out8)
@@ -128,43 +140,63 @@ void TRop::add(const TRasterP &rup, const TRasterP &rdown, const TRasterP &rout,
     }
 
     FOR_EACH_PIXEL_32_END_LOOP
-  } else {
-    TRaster64P up64   = rup;
-    TRaster64P down64 = rdown;
-    TRaster64P out64  = rout;
-
-    if (up64 && down64 && out64) {
-      FOR_EACH_PIXEL_64_BEGIN_LOOP
-
-      TINT32 r, g, b, m;
-      r = downPix->r + tround(upPix->r * v);
-      g = downPix->g + tround(upPix->g * v);
-      b = downPix->b + tround(upPix->b * v);
-      m = downPix->m + tround(upPix->m * v);
-
-      outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
-      outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
-      outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
-      outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
-
-      FOR_EACH_PIXEL_64_END_LOOP
-    } else {
-      TRasterGR8P up8   = rup;
-      TRasterGR8P down8 = rdown;
-      TRasterGR8P out8  = rout;
-
-      if (up8 && down8 && out8) {
-        FOR_EACH_PIXEL_8_BEGIN_LOOP
-
-        USHORT value = troundp(upPix->value * v) + downPix->value;
-
-        outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
-
-        FOR_EACH_PIXEL_8_END_LOOP
-      } else
-        throw TRopException("TRop::add invalid raster combination");
-    }
+    return;
   }
+
+  TRaster64P up64   = rup;
+  TRaster64P down64 = rdown;
+  TRaster64P out64  = rout;
+
+  if (up64 && down64 && out64) {
+    FOR_EACH_PIXEL_64_BEGIN_LOOP
+
+    TINT32 r, g, b, m;
+    r = downPix->r + tround(upPix->r * v);
+    g = downPix->g + tround(upPix->g * v);
+    b = downPix->b + tround(upPix->b * v);
+    m = downPix->m + tround(upPix->m * v);
+
+    outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
+    outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
+    outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
+    outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
+
+    FOR_EACH_PIXEL_64_END_LOOP
+    return;
+  }
+
+  TRasterFP upF   = rup;
+  TRasterFP downF = rdown;
+  TRasterFP outF  = rout;
+
+  if (upF && downF && outF) {
+    FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+    outPix->r = downPix->r + upPix->r * v;
+    outPix->g = downPix->g + upPix->g * v;
+    outPix->b = downPix->b + upPix->b * v;
+    outPix->m = tcrop<float>(downPix->m + upPix->m * v, 0.f, 1.f);
+
+    FOR_EACH_PIXEL_F_END_LOOP
+    return;
+  }
+
+  TRasterGR8P up8   = rup;
+  TRasterGR8P down8 = rdown;
+  TRasterGR8P out8  = rout;
+
+  if (up8 && down8 && out8) {
+    FOR_EACH_PIXEL_8_BEGIN_LOOP
+
+    USHORT value = troundp(upPix->value * v) + downPix->value;
+
+    outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
+
+    FOR_EACH_PIXEL_8_END_LOOP
+    return;
+  }
+
+  throw TRopException("TRop::add invalid raster combination");
 }
 
 //-----------------------------------------------------------------------------
@@ -190,43 +222,62 @@ void TRop::add(const TRasterP &rup, const TRasterP &rdown,
     outPix->m = (UCHAR)tcrop<USHORT>(m, 0, 255);
 
     FOR_EACH_PIXEL_32_END_LOOP
-  } else {
-    TRaster64P up64   = rup;
-    TRaster64P down64 = rdown;
-    TRaster64P out64  = rout;
-
-    if (up64 && down64 && out64) {
-      FOR_EACH_PIXEL_64_BEGIN_LOOP
-
-      TINT32 r, g, b, m;
-      r = downPix->r + upPix->r;
-      g = downPix->g + upPix->g;
-      b = downPix->b + upPix->b;
-      m = downPix->m + upPix->m;
-
-      outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
-      outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
-      outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
-      outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
-
-      FOR_EACH_PIXEL_64_END_LOOP
-    } else {
-      TRasterGR8P up8   = rup;
-      TRasterGR8P down8 = rdown;
-      TRasterGR8P out8  = rout;
-
-      if (up8 && down8 && out8) {
-        FOR_EACH_PIXEL_8_BEGIN_LOOP
-
-        USHORT value = upPix->value + downPix->value;
-
-        outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
-
-        FOR_EACH_PIXEL_8_END_LOOP
-      } else
-        throw TRopException("TRop::add invalid raster combination");
-    }
+    return;
   }
+  TRaster64P up64   = rup;
+  TRaster64P down64 = rdown;
+  TRaster64P out64  = rout;
+
+  if (up64 && down64 && out64) {
+    FOR_EACH_PIXEL_64_BEGIN_LOOP
+
+    TINT32 r, g, b, m;
+    r = downPix->r + upPix->r;
+    g = downPix->g + upPix->g;
+    b = downPix->b + upPix->b;
+    m = downPix->m + upPix->m;
+
+    outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
+    outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
+    outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
+    outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
+
+    FOR_EACH_PIXEL_64_END_LOOP
+    return;
+  }
+
+  TRasterFP upF   = rup;
+  TRasterFP downF = rdown;
+  TRasterFP outF  = rout;
+
+  if (upF && downF && outF) {
+    FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+    outPix->r = downPix->r + upPix->r;
+    outPix->g = downPix->g + upPix->g;
+    outPix->b = downPix->b + upPix->b;
+    outPix->m = tcrop<float>(downPix->m + upPix->m, 0.f, 1.f);
+
+    FOR_EACH_PIXEL_F_END_LOOP
+    return;
+  }
+
+  TRasterGR8P up8   = rup;
+  TRasterGR8P down8 = rdown;
+  TRasterGR8P out8  = rout;
+
+  if (up8 && down8 && out8) {
+    FOR_EACH_PIXEL_8_BEGIN_LOOP
+
+    USHORT value = upPix->value + downPix->value;
+
+    outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
+
+    FOR_EACH_PIXEL_8_END_LOOP
+    return;
+  }
+
+  throw TRopException("TRop::add invalid raster combination");
 }
 
 //-----------------------------------------------------------------------------
@@ -277,21 +328,36 @@ void TRop::colordodge(const TRasterP &rup, const TRasterP &rdown,
 
       FOR_EACH_PIXEL_64_END_LOOP
     } else {
-      TRasterGR8P up8   = rup;
-      TRasterGR8P down8 = rdown;
-      TRasterGR8P out8  = rout;
+      TRasterFP upF   = rup;
+      TRasterFP downF = rdown;
+      TRasterFP outF  = rout;
 
-      if (up8 && down8 && out8) {
-        FOR_EACH_PIXEL_8_BEGIN_LOOP
-        USHORT value;
-        if (downPix->value)
-          value = (USHORT)((downPix->value << 8) / (255.0 - upPix->value));
+      if (upF && downF && outF) {
+        FOR_EACH_PIXEL_F_BEGIN_LOOP
 
-        outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
+        outPix->r = downPix->r / (1.f - upPix->r);
+        outPix->g = downPix->g / (1.f - upPix->g);
+        outPix->b = downPix->b / (1.f - upPix->b);
+        outPix->m = tcrop<float>(downPix->m + upPix->m, 0.f, 1.f);
 
-        FOR_EACH_PIXEL_8_END_LOOP
-      } else
-        throw TRopException("TRop::color dodge invalid raster combination");
+        FOR_EACH_PIXEL_F_END_LOOP
+      } else {
+        TRasterGR8P up8   = rup;
+        TRasterGR8P down8 = rdown;
+        TRasterGR8P out8  = rout;
+
+        if (up8 && down8 && out8) {
+          FOR_EACH_PIXEL_8_BEGIN_LOOP
+          USHORT value;
+          if (downPix->value)
+            value = (USHORT)((downPix->value << 8) / (255.0 - upPix->value));
+
+          outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
+
+          FOR_EACH_PIXEL_8_END_LOOP
+        } else
+          throw TRopException("TRop::color dodge invalid raster combination");
+      }
     }
   }
 }
@@ -392,8 +458,50 @@ void TRop::colorburn(const TRasterP &rup, const TRasterP &rdown,
         outPix = downPix;
       }
       FOR_EACH_PIXEL_64_END_LOOP
-    } else
-      throw TRopException("TRop::color burn invalid raster combination");
+    } else {
+      TRasterFP upF   = rup;
+      TRasterFP downF = rdown;
+      TRasterFP outF  = rout;
+
+      if (upF && downF && outF) {
+        FOR_EACH_PIXEL_F_BEGIN_LOOP
+        float r, g, b;
+        if (upPix->m > 0.f) {
+          if (downPix->r <= 0.f || downPix->r >= 1.f)
+            r = downPix->r;
+          else if (upPix->r)
+            r = 1.f - (1.f - downPix->r) / upPix->r;
+          else
+            r = 0.f;
+          if (downPix->g <= 0.f || downPix->g >= 1.f)
+            g = downPix->g;
+          else if (upPix->g)
+            g = 1.f - (1.f - downPix->g) / upPix->g;
+          else
+            g = 0.f;
+          if (downPix->b <= 0.f || downPix->b >= 1.f)
+            b = downPix->b;
+          else if (upPix->b)
+            b = 1.f - (1.f - downPix->b) / upPix->b;
+          else
+            b = 0.f;
+
+          if (upPix->m < 1.f) {
+            overPix<TPixelF, float>(*outPix, *downPix,
+                                    TPixelF(r, g, b, upPix->m));
+          } else {
+            outPix->r = r;
+            outPix->g = g;
+            outPix->b = b;
+            outPix->m = downPix->m;
+          }
+        } else {
+          outPix = downPix;
+        }
+        FOR_EACH_PIXEL_F_END_LOOP
+      } else
+        throw TRopException("TRop::color burn invalid raster combination");
+    }
   }
 }
 
@@ -428,54 +536,86 @@ void TRop::screen(const TRasterP &rup, const TRasterP &rdown,
       outPix->m = upPix->m;
     }
     FOR_EACH_PIXEL_32_END_LOOP
-  } else {
-    TRaster64P up64   = rup;
-    TRaster64P down64 = rdown;
-    TRaster64P out64  = rout;
-
-    if (up64 && down64 && out64) {
-      FOR_EACH_PIXEL_64_BEGIN_LOOP
-
-      double r, g, b;
-      r = 65536 - (65536 - upPix->r) * ((65536 - downPix->r) / 65536.0);
-      g = 65536 - (65536 - upPix->g) * ((65536 - downPix->g) / 65536.0);
-      b = 65536 - (65536 - upPix->b) * ((65536 - downPix->b) / 65536.0);
-
-      if (upPix->m != 65535) {
-        double m;
-        m = 65536 - (65536 - upPix->m) * ((65536 - downPix->m) / 65536.0);
-        TPixel64 tmpPix;
-        tmpPix.r = (USHORT)tcrop<double>(r, 0, 65535);
-        tmpPix.g = (USHORT)tcrop<double>(g, 0, 65535);
-        tmpPix.b = (USHORT)tcrop<double>(b, 0, 65535);
-        tmpPix.m = (USHORT)tcrop<double>(m, 0, 65535);
-        overPix<TPixel64, USHORT>(*outPix, *downPix, tmpPix);
-      } else {
-        outPix->r = (USHORT)tcrop<double>(r, 0, 65535);
-        outPix->g = (USHORT)tcrop<double>(g, 0, 65535);
-        outPix->b = (USHORT)tcrop<double>(b, 0, 65535);
-        outPix->m = upPix->m;
-      }
-
-      FOR_EACH_PIXEL_64_END_LOOP
-    } else {
-      TRasterGR8P up8   = rup;
-      TRasterGR8P down8 = rdown;
-      TRasterGR8P out8  = rout;
-
-      if (up8 && down8 && out8) {
-        FOR_EACH_PIXEL_8_BEGIN_LOOP
-        USHORT value;
-        if (downPix->value)
-          value = (USHORT)((downPix->value << 8) / (255.0 - upPix->value));
-
-        outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
-
-        FOR_EACH_PIXEL_8_END_LOOP
-      } else
-        throw TRopException("TRop::color dodge invalid raster combination");
-    }
+    return;
   }
+
+  TRaster64P up64   = rup;
+  TRaster64P down64 = rdown;
+  TRaster64P out64  = rout;
+
+  if (up64 && down64 && out64) {
+    FOR_EACH_PIXEL_64_BEGIN_LOOP
+
+    double r, g, b;
+    r = 65536 - (65536 - upPix->r) * ((65536 - downPix->r) / 65536.0);
+    g = 65536 - (65536 - upPix->g) * ((65536 - downPix->g) / 65536.0);
+    b = 65536 - (65536 - upPix->b) * ((65536 - downPix->b) / 65536.0);
+
+    if (upPix->m != 65535) {
+      double m;
+      m = 65536 - (65536 - upPix->m) * ((65536 - downPix->m) / 65536.0);
+      TPixel64 tmpPix;
+      tmpPix.r = (USHORT)tcrop<double>(r, 0, 65535);
+      tmpPix.g = (USHORT)tcrop<double>(g, 0, 65535);
+      tmpPix.b = (USHORT)tcrop<double>(b, 0, 65535);
+      tmpPix.m = (USHORT)tcrop<double>(m, 0, 65535);
+      overPix<TPixel64, USHORT>(*outPix, *downPix, tmpPix);
+    } else {
+      outPix->r = (USHORT)tcrop<double>(r, 0, 65535);
+      outPix->g = (USHORT)tcrop<double>(g, 0, 65535);
+      outPix->b = (USHORT)tcrop<double>(b, 0, 65535);
+      outPix->m = upPix->m;
+    }
+
+    FOR_EACH_PIXEL_64_END_LOOP
+    return;
+  }
+
+  TRasterFP upF   = rup;
+  TRasterFP downF = rdown;
+  TRasterFP outF  = rout;
+
+  if (upF && downF && outF) {
+    FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+    float r, g, b;
+    r = 1.f - (1.f - upPix->r) * (1.f - downPix->r);
+    g = 1.f - (1.f - upPix->g) * (1.f - downPix->g);
+    b = 1.f - (1.f - upPix->b) * (1.f - downPix->b);
+
+    if (upPix->m <= 1.f) {
+      float m;
+      m = 1.f - (1.f - upPix->m) * (1.f - downPix->m);
+      TPixelF tmpPix(r, g, b, tcrop<float>(m, 0.f, 1.f));
+      overPix<TPixelF, float>(*outPix, *downPix, tmpPix);
+    } else {
+      outPix->r = r;
+      outPix->g = g;
+      outPix->b = b;
+      outPix->m = upPix->m;
+    }
+
+    FOR_EACH_PIXEL_F_END_LOOP
+    return;
+  }
+
+  TRasterGR8P up8   = rup;
+  TRasterGR8P down8 = rdown;
+  TRasterGR8P out8  = rout;
+
+  if (up8 && down8 && out8) {
+    FOR_EACH_PIXEL_8_BEGIN_LOOP
+    USHORT value;
+    if (downPix->value)
+      value = (USHORT)((downPix->value << 8) / (255.0 - upPix->value));
+
+    outPix->value = (UCHAR)tcrop<USHORT>(value, 0, 255);
+
+    FOR_EACH_PIXEL_8_END_LOOP
+    return;
+  }
+
+  throw TRopException("TRop::color dodge invalid raster combination");
 }
 
 //-----------------------------------------------------------------------------
@@ -500,40 +640,61 @@ void TRop::sub(const TRasterP &rup, const TRasterP &rdown, const TRasterP &rout,
       outPix->m = (UCHAR)tcrop<SHORT>(m, 0, 255);
 
       FOR_EACH_PIXEL_32_END_LOOP
-    } else {
-      TRaster64P up64   = rup;
-      TRaster64P down64 = rdown;
-      TRaster64P out64  = rout;
-
-      if (up64 && down64 && out64) {
-        FOR_EACH_PIXEL_64_BEGIN_LOOP
-
-        TINT32 r  = downPix->r - upPix->r;
-        TINT32 g  = downPix->g - upPix->g;
-        TINT32 b  = downPix->b - upPix->b;
-        TINT32 m  = downPix->m - upPix->m;
-        outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
-        outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
-        outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
-        outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
-
-        FOR_EACH_PIXEL_64_END_LOOP
-      } else {
-        TRasterGR8P up8   = rup;
-        TRasterGR8P down8 = rdown;
-        TRasterGR8P out8  = rout;
-
-        if (up8 && down8 && out8) {
-          FOR_EACH_PIXEL_8_BEGIN_LOOP
-
-          SHORT value   = upPix->value - downPix->value;
-          outPix->value = (UCHAR)tcrop<SHORT>(value, 0, 255);
-
-          FOR_EACH_PIXEL_8_END_LOOP
-        } else
-          throw TRopException("TRop::sub invalid raster combination");
-      }
+      return;
     }
+
+    TRaster64P up64   = rup;
+    TRaster64P down64 = rdown;
+    TRaster64P out64  = rout;
+
+    if (up64 && down64 && out64) {
+      FOR_EACH_PIXEL_64_BEGIN_LOOP
+
+      TINT32 r  = downPix->r - upPix->r;
+      TINT32 g  = downPix->g - upPix->g;
+      TINT32 b  = downPix->b - upPix->b;
+      TINT32 m  = downPix->m - upPix->m;
+      outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
+      outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
+      outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
+      outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
+
+      FOR_EACH_PIXEL_64_END_LOOP
+      return;
+    }
+
+    TRasterFP upF   = rup;
+    TRasterFP downF = rdown;
+    TRasterFP outF  = rout;
+
+    if (upF && downF && outF) {
+      FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+      outPix->r = downPix->r - upPix->r;
+      outPix->g = downPix->g - upPix->g;
+      outPix->b = downPix->b - upPix->b;
+      outPix->m = tcrop<float>(downPix->m - upPix->m, 0.f, 1.f);
+
+      FOR_EACH_PIXEL_F_END_LOOP
+      return;
+    }
+
+    TRasterGR8P up8   = rup;
+    TRasterGR8P down8 = rdown;
+    TRasterGR8P out8  = rout;
+
+    if (up8 && down8 && out8) {
+      FOR_EACH_PIXEL_8_BEGIN_LOOP
+
+      SHORT value   = upPix->value - downPix->value;
+      outPix->value = (UCHAR)tcrop<SHORT>(value, 0, 255);
+
+      FOR_EACH_PIXEL_8_END_LOOP
+      return;
+    }
+
+    throw TRopException("TRop::sub invalid raster combination");
+
   } else {
     if (up32 && down32 && out32) {
       FOR_EACH_PIXEL_32_BEGIN_LOOP
@@ -549,40 +710,60 @@ void TRop::sub(const TRasterP &rup, const TRasterP &rdown, const TRasterP &rout,
       outPix->m = (UCHAR)tcrop<SHORT>(m, 0, 255);
 
       FOR_EACH_PIXEL_32_END_LOOP
-    } else {
-      TRaster64P up64   = rup;
-      TRaster64P down64 = rdown;
-      TRaster64P out64  = rout;
-
-      if (up64 && down64 && out64) {
-        FOR_EACH_PIXEL_64_BEGIN_LOOP
-
-        TINT32 r  = downPix->r - upPix->r;
-        TINT32 g  = downPix->g - upPix->g;
-        TINT32 b  = downPix->b - upPix->b;
-        TINT32 m  = downPix->m;  // - upPix->m;
-        outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
-        outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
-        outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
-        outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
-
-        FOR_EACH_PIXEL_64_END_LOOP
-      } else {
-        TRasterGR8P up8   = rup;
-        TRasterGR8P down8 = rdown;
-        TRasterGR8P out8  = rout;
-
-        if (up8 && down8 && out8) {
-          FOR_EACH_PIXEL_8_BEGIN_LOOP
-
-          SHORT value   = upPix->value - downPix->value;
-          outPix->value = (UCHAR)tcrop<SHORT>(value, 0, 255);
-
-          FOR_EACH_PIXEL_8_END_LOOP
-        } else
-          throw TRopException("TRop::sub invalid raster combination");
-      }
+      return;
     }
+
+    TRaster64P up64   = rup;
+    TRaster64P down64 = rdown;
+    TRaster64P out64  = rout;
+
+    if (up64 && down64 && out64) {
+      FOR_EACH_PIXEL_64_BEGIN_LOOP
+
+      TINT32 r  = downPix->r - upPix->r;
+      TINT32 g  = downPix->g - upPix->g;
+      TINT32 b  = downPix->b - upPix->b;
+      TINT32 m  = downPix->m;  // - upPix->m;
+      outPix->r = (USHORT)tcrop<TINT32>(r, 0, 0xffff);
+      outPix->g = (USHORT)tcrop<TINT32>(g, 0, 0xffff);
+      outPix->b = (USHORT)tcrop<TINT32>(b, 0, 0xffff);
+      outPix->m = (USHORT)tcrop<TINT32>(m, 0, 0xffff);
+
+      FOR_EACH_PIXEL_64_END_LOOP
+      return;
+    }
+
+    TRasterFP upF   = rup;
+    TRasterFP downF = rdown;
+    TRasterFP outF  = rout;
+
+    if (upF && downF && outF) {
+      FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+      outPix->r = downPix->r - upPix->r;
+      outPix->g = downPix->g - upPix->g;
+      outPix->b = downPix->b - upPix->b;
+      outPix->m = tcrop<float>(downPix->m, 0.f, 1.f);
+
+      FOR_EACH_PIXEL_F_END_LOOP
+      return;
+    }
+
+    TRasterGR8P up8   = rup;
+    TRasterGR8P down8 = rdown;
+    TRasterGR8P out8  = rout;
+
+    if (up8 && down8 && out8) {
+      FOR_EACH_PIXEL_8_BEGIN_LOOP
+
+      SHORT value   = upPix->value - downPix->value;
+      outPix->value = (UCHAR)tcrop<SHORT>(value, 0, 255);
+
+      FOR_EACH_PIXEL_8_END_LOOP
+      return;
+    }
+
+    throw TRopException("TRop::sub invalid raster combination");
   }
 }
 
@@ -776,6 +957,76 @@ D_m)
     return;
   }
 
+  // 32-bit floating point images case
+  TRasterFP upF = rup, downF = rdown, outF = rout;
+
+  if (upF && downF && outF) {
+    float vf = (float)v / (float)(TPixel32::maxChannelValue);
+
+    if (matte) {
+      float outMf;
+
+      FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+      outMf = downPix->m * upPix->m;
+
+      outPix->r = tcrop((upPix->r / upPix->m + vf) * (downPix->r / downPix->m),
+                        0.f, outMf);
+      outPix->g = tcrop((upPix->g / upPix->m + vf) * (downPix->g / downPix->m),
+                        0.f, outMf);
+      outPix->b = tcrop((upPix->b / upPix->m + vf) * (downPix->b / downPix->m),
+                        0.f, outMf);
+      outPix->m = outMf;
+
+      FOR_EACH_PIXEL_F_END_LOOP
+    } else {
+      float umdmf_norm, outMf;
+      float mSumf, uf, df, ufdf, normalizer;
+
+      FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+      mSumf = upPix->m + downPix->m;
+      if (mSumf > 0.f) {
+        outMf = upPix->m + (1.f - upPix->m) * downPix->m;
+
+        normalizer = outMf / mSumf;
+        umdmf_norm = upPix->m * downPix->m;
+        ;
+
+        uf        = upPix->r + vf * umdmf_norm;
+        df        = downPix->r;
+        ufdf      = uf * df;
+        outPix->r = tcrop(
+            (uf * (1.f - downPix->m) + df * (1.f - upPix->m) + ufdf + ufdf) *
+                normalizer,
+            0.f, outMf);
+
+        uf        = upPix->g + vf * umdmf_norm;
+        df        = downPix->g;
+        ufdf      = uf * df;
+        outPix->g = tcrop(
+            (uf * (1.f - downPix->m) + df * (1.f - upPix->m) + ufdf + ufdf) *
+                normalizer,
+            0.f, outMf);
+
+        uf        = upPix->b + vf * umdmf_norm;
+        df        = downPix->b;
+        ufdf      = uf * df;
+        outPix->b = tcrop(
+            (uf * (1.f - downPix->m) + df * (1.f - upPix->m) + ufdf + ufdf) *
+                normalizer,
+            0.f, outMf);
+
+        outPix->m = outMf;
+      } else
+        *outPix = TPixelF::Transparent;
+
+      FOR_EACH_PIXEL_F_END_LOOP
+    }
+
+    return;
+  }
+
   // According to the specifics, throw an exception. I think it's not
   // appropriate, though.
   throw TRopException("TRop::mult invalid raster combination");
@@ -791,6 +1042,9 @@ void TRop::ropin(const TRasterP &source, const TRasterP &matte,
   TRaster64P source64 = source;
   TRaster64P matte64  = matte;
   TRaster64P out64    = rout;
+  TRasterFP sourceF   = source;
+  TRasterFP matteF    = matte;
+  TRasterFP outF      = rout;
 
   if (source32 && matte32 && out32) {
     FOR_EACH_PIXEL_BEGIN_LOOP(TPixelRGBM32, source32, TPixelRGBM32, matte32,
@@ -868,6 +1122,21 @@ outPix_packed_i = _mm_packus_epi16(outPix_packed_i, zeros);
     }
 
     FOR_EACH_PIXEL_END_LOOP(source64, matte64, out64)
+  } else if (sourceF && matteF && outF) {
+    FOR_EACH_PIXEL_BEGIN_LOOP(TPixelF, sourceF, TPixelF, matteF, TPixelF, outF)
+
+    if (downPix->m <= 0.f)
+      outPix->r = outPix->g = outPix->b = outPix->m = 0.f;
+    else if (downPix->m >= 1.f)
+      *outPix = *upPix;
+    else {
+      outPix->r = upPix->r * downPix->m;
+      outPix->g = upPix->g * downPix->m;
+      outPix->b = upPix->b * downPix->m;
+      outPix->m = upPix->m * downPix->m;
+    }
+
+    FOR_EACH_PIXEL_END_LOOP(sourceF, matteF, outF)
   } else
     throw TRopException("TRop::in invalid raster combination");
 }
@@ -882,6 +1151,9 @@ void TRop::ropout(const TRasterP &source, const TRasterP &matte,
   TRaster64P source64 = source;
   TRaster64P matte64  = matte;
   TRaster64P out64    = rout;
+  TRasterFP sourceF   = source;
+  TRasterFP matteF    = matte;
+  TRasterFP outF      = rout;
 
   if (source32 && matte32 && out32) {
     FOR_EACH_PIXEL_BEGIN_LOOP(TPixelRGBM32, source32, TPixelRGBM32, matte32,
@@ -920,6 +1192,23 @@ void TRop::ropout(const TRasterP &source, const TRasterP &matte,
     }
 
     FOR_EACH_PIXEL_END_LOOP(source64, matte64, out64)
+  } else if (sourceF && matteF && outF) {
+    FOR_EACH_PIXEL_BEGIN_LOOP(TPixelF, sourceF, TPixelF, matteF, TPixelF, outF)
+
+    if (downPix->m >= 1.f)
+      outPix->r = outPix->g = outPix->b = outPix->m = 0;
+    else if (downPix->m <= 0.f)
+      *outPix = *upPix;
+    else {
+      float fac = 1.f - downPix->m;
+
+      outPix->r = upPix->r * fac;
+      outPix->g = upPix->g * fac;
+      outPix->b = upPix->b * fac;
+      outPix->m = upPix->m * fac;
+    }
+
+    FOR_EACH_PIXEL_END_LOOP(sourceF, matteF, outF)
   } else
     throw TRopException("TRop::out invalid raster combination");
 }
@@ -937,6 +1226,9 @@ void TRop::atop(const TRasterP &rup, const TRasterP &rdown,
   TRaster64P up64   = rup;
   TRaster64P down64 = rdown;
   TRaster64P out64  = rout;
+  TRasterFP upF     = rup;
+  TRasterFP downF   = rdown;
+  TRasterFP outF    = rout;
 
   if (up32 && down32 && out32) {
     FOR_EACH_PIXEL_32_BEGIN_LOOP
@@ -971,6 +1263,19 @@ void TRop::atop(const TRasterP &rup, const TRasterP &rdown,
     overPix<TPixel64, USHORT>(*outPix, *downPix, tmpPix);
 
     FOR_EACH_PIXEL_64_END_LOOP
+  } else if (upF && downF && outF) {
+    FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+    TPixelF tmpPix = TPixelF::Transparent;
+    if (downPix->m >= 0.f) {
+      tmpPix.r = upPix->r * downPix->m;
+      tmpPix.g = upPix->g * downPix->m;
+      tmpPix.b = upPix->b * downPix->m;
+      tmpPix.m = upPix->m * downPix->m;
+    }
+
+    overPix<TPixelF, float>(*outPix, *downPix, tmpPix);
+    FOR_EACH_PIXEL_F_END_LOOP
   } else
     throw TRopException("TRop::atop invalid raster combination");
 }
@@ -1031,6 +1336,9 @@ void TRop::crossDissolve(const TRasterP &rup, const TRasterP &rdown,
   TRaster64P up64   = rup;
   TRaster64P down64 = rdown;
   TRaster64P out64  = rout;
+  TRasterFP upF     = rup;
+  TRasterFP downF   = rdown;
+  TRasterFP outF    = rout;
 
   if (up32 && down32 && out32) {
     FOR_EACH_PIXEL_32_BEGIN_LOOP
@@ -1052,6 +1360,16 @@ void TRop::crossDissolve(const TRasterP &rup, const TRasterP &rdown,
     outPix->m = (upPix->m * vv + downPix->m * (65535 - vv)) / 65535;
 
     FOR_EACH_PIXEL_64_END_LOOP
+  } else if (upF && downF && outF) {
+    float vv = (float)v / 255.0f;
+    FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+    outPix->r = upPix->r * vv + downPix->r * (1.f - vv);
+    outPix->g = upPix->g * vv + downPix->g * (1.f - vv);
+    outPix->b = upPix->b * vv + downPix->b * (1.f - vv);
+    outPix->m = upPix->m * vv + downPix->m * (1.f - vv);
+
+    FOR_EACH_PIXEL_F_END_LOOP
   } else
     throw TRopException("TRop::crossDissolve invalid raster combination");
 }
@@ -1200,59 +1518,102 @@ void TRop::ropmin(const TRasterP &rup, const TRasterP &rdown,
         *outPix = *downPix;
       FOR_EACH_PIXEL_32_END_LOOP
     }
-  } else {
-    TRaster64P up64   = rup;
-    TRaster64P down64 = rdown;
-    TRaster64P out64  = rout;
+    return;
+  }
 
-    if (up64 && down64 && out64) {
-      if (matte) {
-        FOR_EACH_PIXEL_64_BEGIN_LOOP
+  TRaster64P up64   = rup;
+  TRaster64P down64 = rdown;
+  TRaster64P out64  = rout;
 
+  if (up64 && down64 && out64) {
+    if (matte) {
+      FOR_EACH_PIXEL_64_BEGIN_LOOP
+
+      outPix->r = upPix->r < downPix->r ? upPix->r : downPix->r;
+      outPix->g = upPix->g < downPix->g ? upPix->g : downPix->g;
+      outPix->b = upPix->b < downPix->b ? upPix->b : downPix->b;
+      outPix->m = upPix->m < downPix->m ? upPix->m : downPix->m;
+
+      FOR_EACH_PIXEL_64_END_LOOP
+    } else {
+      FOR_EACH_PIXEL_32_BEGIN_LOOP
+      if (upPix->m >= 65535) {
         outPix->r = upPix->r < downPix->r ? upPix->r : downPix->r;
         outPix->g = upPix->g < downPix->g ? upPix->g : downPix->g;
         outPix->b = upPix->b < downPix->b ? upPix->b : downPix->b;
         outPix->m = upPix->m < downPix->m ? upPix->m : downPix->m;
 
-        FOR_EACH_PIXEL_64_END_LOOP
-      } else {
-        FOR_EACH_PIXEL_32_BEGIN_LOOP
-        if (upPix->m >= 65535) {
-          outPix->r = upPix->r < downPix->r ? upPix->r : downPix->r;
-          outPix->g = upPix->g < downPix->g ? upPix->g : downPix->g;
-          outPix->b = upPix->b < downPix->b ? upPix->b : downPix->b;
-          outPix->m = upPix->m < downPix->m ? upPix->m : downPix->m;
-
-        } else if (upPix->m) {
-          TPixel32 tmp;
-          tmp.r = upPix->r < downPix->r ? upPix->r : downPix->r;
-          tmp.g = upPix->g < downPix->g ? upPix->g : downPix->g;
-          tmp.b = upPix->b < downPix->b ? upPix->b : downPix->b;
-          // tmp.m = upPix->m < downPix->m ? upPix->m : downPix->m;
-          outPix->r = upPix->m * (tmp.r - downPix->r) / 65535.0 + downPix->r;
-          outPix->g = upPix->m * (tmp.g - downPix->g) / 65535.0 + downPix->g;
-          outPix->b = upPix->m * (tmp.b - downPix->b) / 65535.0 + downPix->b;
-          outPix->m = upPix->m * (tmp.m - downPix->m) / 65535.0 + downPix->m;
-        } else
-          *outPix = *downPix;
-        FOR_EACH_PIXEL_32_END_LOOP
-      }
-    } else {
-      TRasterGR8P up8   = rup;
-      TRasterGR8P down8 = rdown;
-      TRasterGR8P out8  = rout;
-
-      if (up8 && down8 && out8) {
-        FOR_EACH_PIXEL_8_BEGIN_LOOP
-
-        outPix->value =
-            upPix->value < downPix->value ? upPix->value : downPix->value;
-
-        FOR_EACH_PIXEL_8_END_LOOP
+      } else if (upPix->m) {
+        TPixel32 tmp;
+        tmp.r = upPix->r < downPix->r ? upPix->r : downPix->r;
+        tmp.g = upPix->g < downPix->g ? upPix->g : downPix->g;
+        tmp.b = upPix->b < downPix->b ? upPix->b : downPix->b;
+        // tmp.m = upPix->m < downPix->m ? upPix->m : downPix->m;
+        outPix->r = upPix->m * (tmp.r - downPix->r) / 65535.0 + downPix->r;
+        outPix->g = upPix->m * (tmp.g - downPix->g) / 65535.0 + downPix->g;
+        outPix->b = upPix->m * (tmp.b - downPix->b) / 65535.0 + downPix->b;
+        outPix->m = upPix->m * (tmp.m - downPix->m) / 65535.0 + downPix->m;
       } else
-        throw TRopException("TRop::min invalid raster combination");
+        *outPix = *downPix;
+      FOR_EACH_PIXEL_32_END_LOOP
     }
+    return;
   }
+
+  TRasterFP upF   = rup;
+  TRasterFP downF = rdown;
+  TRasterFP outF  = rout;
+
+  if (upF && downF && outF) {
+    if (matte) {
+      FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+      outPix->r = upPix->r < downPix->r ? upPix->r : downPix->r;
+      outPix->g = upPix->g < downPix->g ? upPix->g : downPix->g;
+      outPix->b = upPix->b < downPix->b ? upPix->b : downPix->b;
+      outPix->m = upPix->m < downPix->m ? upPix->m : downPix->m;
+
+      FOR_EACH_PIXEL_F_END_LOOP
+    } else {
+      FOR_EACH_PIXEL_F_BEGIN_LOOP
+      if (upPix->m >= 1.f) {
+        outPix->r = upPix->r < downPix->r ? upPix->r : downPix->r;
+        outPix->g = upPix->g < downPix->g ? upPix->g : downPix->g;
+        outPix->b = upPix->b < downPix->b ? upPix->b : downPix->b;
+        outPix->m = upPix->m < downPix->m ? upPix->m : downPix->m;
+
+      } else if (upPix->m > 0.f) {
+        TPixelF tmp;
+        tmp.r = upPix->r < downPix->r ? upPix->r : downPix->r;
+        tmp.g = upPix->g < downPix->g ? upPix->g : downPix->g;
+        tmp.b = upPix->b < downPix->b ? upPix->b : downPix->b;
+        // tmp.m = upPix->m < downPix->m ? upPix->m : downPix->m;
+        outPix->r = upPix->m * (tmp.r - downPix->r) + downPix->r;
+        outPix->g = upPix->m * (tmp.g - downPix->g) + downPix->g;
+        outPix->b = upPix->m * (tmp.b - downPix->b) + downPix->b;
+        outPix->m = upPix->m * (tmp.m - downPix->m) + downPix->m;
+      } else
+        *outPix = *downPix;
+      FOR_EACH_PIXEL_F_END_LOOP
+    }
+    return;
+  }
+
+  TRasterGR8P up8   = rup;
+  TRasterGR8P down8 = rdown;
+  TRasterGR8P out8  = rout;
+
+  if (up8 && down8 && out8) {
+    FOR_EACH_PIXEL_8_BEGIN_LOOP
+
+    outPix->value =
+        upPix->value < downPix->value ? upPix->value : downPix->value;
+
+    FOR_EACH_PIXEL_8_END_LOOP
+    return;
+  }
+
+  throw TRopException("TRop::min invalid raster combination");
 }
 
 //-----------------------------------------------------------------------------
@@ -1272,39 +1633,56 @@ void TRop::ropmax(const TRasterP &rup, const TRasterP &rdown,
     outPix->m = upPix->m > downPix->m ? upPix->m : downPix->m;
 
     FOR_EACH_PIXEL_32_END_LOOP
-  } else {
-    TRaster64P up64   = rup;
-    TRaster64P down64 = rdown;
-    TRaster64P out64  = rout;
-
-    if (up64 && down64 && out64) {
-      FOR_EACH_PIXEL_64_BEGIN_LOOP
-
-      outPix->r = upPix->r > downPix->r ? upPix->r : downPix->r;
-      outPix->g = upPix->g > downPix->g ? upPix->g : downPix->g;
-      outPix->b = upPix->b > downPix->b ? upPix->b : downPix->b;
-      outPix->m = upPix->m > downPix->m ? upPix->m : downPix->m;
-
-      FOR_EACH_PIXEL_64_END_LOOP
-    } else {
-      TRasterGR8P up8   = rup;
-      TRasterGR8P down8 = rdown;
-      TRasterGR8P out8  = rout;
-
-      if (up8 && down8 && out8) {
-        FOR_EACH_PIXEL_8_BEGIN_LOOP
-
-        outPix->value =
-            upPix->value > downPix->value ? upPix->value : downPix->value;
-
-        FOR_EACH_PIXEL_8_END_LOOP
-      } else
-        throw TRopException("TRop::max invalid raster combination");
-    }
+    return;
   }
+  TRaster64P up64   = rup;
+  TRaster64P down64 = rdown;
+  TRaster64P out64  = rout;
+
+  if (up64 && down64 && out64) {
+    FOR_EACH_PIXEL_64_BEGIN_LOOP
+
+    outPix->r = upPix->r > downPix->r ? upPix->r : downPix->r;
+    outPix->g = upPix->g > downPix->g ? upPix->g : downPix->g;
+    outPix->b = upPix->b > downPix->b ? upPix->b : downPix->b;
+    outPix->m = upPix->m > downPix->m ? upPix->m : downPix->m;
+
+    FOR_EACH_PIXEL_64_END_LOOP
+    return;
+  }
+  TRasterFP upF   = rup;
+  TRasterFP downF = rdown;
+  TRasterFP outF  = rout;
+
+  if (upF && downF && outF) {
+    FOR_EACH_PIXEL_F_BEGIN_LOOP
+
+    outPix->r = upPix->r > downPix->r ? upPix->r : downPix->r;
+    outPix->g = upPix->g > downPix->g ? upPix->g : downPix->g;
+    outPix->b = upPix->b > downPix->b ? upPix->b : downPix->b;
+    outPix->m = upPix->m > downPix->m ? upPix->m : downPix->m;
+
+    FOR_EACH_PIXEL_F_END_LOOP
+    return;
+  }
+  TRasterGR8P up8   = rup;
+  TRasterGR8P down8 = rdown;
+  TRasterGR8P out8  = rout;
+
+  if (up8 && down8 && out8) {
+    FOR_EACH_PIXEL_8_BEGIN_LOOP
+
+    outPix->value =
+        upPix->value > downPix->value ? upPix->value : downPix->value;
+
+    FOR_EACH_PIXEL_8_END_LOOP
+    return;
+  }
+
+  throw TRopException("TRop::max invalid raster combination");
 }
 //-----------------------------------------------------------------------------
-
+/*
 void TRop::linearburn(const TRasterP &rup, const TRasterP &rdown,
                       const TRasterP &rout) {
   TRaster32P up32   = rup;
@@ -1497,12 +1875,14 @@ void TRop::overlay(const TRasterP &rup, const TRasterP &rdown,
     }
   }
 }
-
+*/
 //-----------------------------------------------------------------------------
 
 void TRop::premultiply(const TRasterP &ras) {
   ras->lock();
   TRaster32P ras32 = ras;
+  TRaster64P ras64 = ras;
+  TRasterFP rasF   = ras;
   if (ras32) {
     TPixel32 *endPix, *upPix = 0, *upRow = ras32->pixels();
     TPixel32 *lastPix =
@@ -1517,27 +1897,39 @@ void TRop::premultiply(const TRasterP &ras) {
       }
       upRow += ras32->getWrap();
     }
-  } else {
-    TRaster64P ras64 = ras;
-    if (ras64) {
-      TPixel64 *endPix, *upPix = 0, *upRow = ras64->pixels();
-      TPixel64 *lastPix =
-          upRow + ras64->getWrap() * (ras64->getLy() - 1) + ras64->getLx();
+  } else if (ras64) {
+    TPixel64 *endPix, *upPix = 0, *upRow = ras64->pixels();
+    TPixel64 *lastPix =
+        upRow + ras64->getWrap() * (ras64->getLy() - 1) + ras64->getLx();
 
-      while (upPix < lastPix) {
-        upPix  = upRow;
-        endPix = upPix + ras64->getLx();
-        while (upPix < endPix) {
-          premult(*upPix);
-          ++upPix;
-        }
-        upRow += ras64->getWrap();
+    while (upPix < lastPix) {
+      upPix  = upRow;
+      endPix = upPix + ras64->getLx();
+      while (upPix < endPix) {
+        premult(*upPix);
+        ++upPix;
       }
-    } else {
-      ras->unlock();
-      throw TException("TRop::premultiply invalid raster type");
+      upRow += ras64->getWrap();
     }
+  } else if (rasF) {
+    TPixelF *endPix, *upPix = nullptr, *upRow = rasF->pixels();
+    TPixelF *lastPix =
+        upRow + rasF->getWrap() * (rasF->getLy() - 1) + rasF->getLx();
+
+    while (upPix < lastPix) {
+      upPix  = upRow;
+      endPix = upPix + rasF->getLx();
+      while (upPix < endPix) {
+        premult(*upPix);
+        ++upPix;
+      }
+      upRow += rasF->getWrap();
+    }
+  } else {
+    ras->unlock();
+    throw TException("TRop::premultiply invalid raster type");
   }
+
   ras->unlock();
 }
 
@@ -1546,6 +1938,8 @@ void TRop::premultiply(const TRasterP &ras) {
 void TRop::depremultiply(const TRasterP &ras) {
   ras->lock();
   TRaster32P ras32 = ras;
+  TRaster64P ras64 = ras;
+  TRasterFP rasF   = ras;
   if (ras32) {
     TPixel32 *endPix, *upPix = 0, *upRow = ras32->pixels();
     TPixel32 *lastPix =
@@ -1560,26 +1954,37 @@ void TRop::depremultiply(const TRasterP &ras) {
       }
       upRow += ras32->getWrap();
     }
-  } else {
-    TRaster64P ras64 = ras;
-    if (ras64) {
-      TPixel64 *endPix, *upPix = 0, *upRow = ras64->pixels();
-      TPixel64 *lastPix =
-          upRow + ras64->getWrap() * (ras64->getLy() - 1) + ras64->getLx();
+  } else if (ras64) {
+    TPixel64 *endPix, *upPix = 0, *upRow = ras64->pixels();
+    TPixel64 *lastPix =
+        upRow + ras64->getWrap() * (ras64->getLy() - 1) + ras64->getLx();
 
-      while (upPix < lastPix) {
-        upPix  = upRow;
-        endPix = upPix + ras64->getLx();
-        while (upPix < endPix) {
-          if (upPix->m != 0) depremult(*upPix);
-          ++upPix;
-        }
-        upRow += ras64->getWrap();
+    while (upPix < lastPix) {
+      upPix  = upRow;
+      endPix = upPix + ras64->getLx();
+      while (upPix < endPix) {
+        if (upPix->m != 0) depremult(*upPix);
+        ++upPix;
       }
-    } else {
-      ras->unlock();
-      throw TException("TRop::depremultiply invalid raster type");
+      upRow += ras64->getWrap();
     }
+  } else if (rasF) {
+    TPixelF *endPix, *upPix = nullptr, *upRow = rasF->pixels();
+    TPixelF *lastPix =
+        upRow + rasF->getWrap() * (rasF->getLy() - 1) + rasF->getLx();
+
+    while (upPix < lastPix) {
+      upPix  = upRow;
+      endPix = upPix + rasF->getLx();
+      while (upPix < endPix) {
+        if (upPix->m > 0.f) depremult(*upPix);
+        ++upPix;
+      }
+      upRow += rasF->getWrap();
+    }
+  } else {
+    ras->unlock();
+    throw TException("TRop::depremultiply invalid raster type");
   }
   ras->unlock();
 }
@@ -1651,6 +2056,8 @@ void TRop::expandColor(const TRaster32P &ras32, bool precise) {
 void TRop::whiteTransp(const TRasterP &ras) {
   ras->lock();
   TRaster32P ras32 = ras;
+  TRaster64P ras64 = ras;
+  TRasterFP rasF   = ras;
   if (ras32) {
     TPixel32 *endPix, *upPix = 0, *upRow = ras32->pixels();
     TPixel32 *lastPix =
@@ -1665,26 +2072,40 @@ void TRop::whiteTransp(const TRasterP &ras) {
       }
       upRow += ras32->getWrap();
     }
-  } else {
-    TRaster64P ras64 = ras;
-    if (ras64) {
-      TPixel64 *endPix, *upPix = 0, *upRow = ras64->pixels();
-      TPixel64 *lastPix =
-          upRow + ras64->getWrap() * (ras64->getLy() - 1) + ras64->getLx();
+  } else if (ras64) {
+    TPixel64 *endPix, *upPix = 0, *upRow = ras64->pixels();
+    TPixel64 *lastPix =
+        upRow + ras64->getWrap() * (ras64->getLy() - 1) + ras64->getLx();
 
-      while (upPix < lastPix) {
-        upPix  = upRow;
-        endPix = upPix + ras64->getLx();
-        while (upPix < endPix) {
-          if (*upPix == TPixel64::White) *upPix = TPixel64::Transparent;
-          ++upPix;
-        }
-        upRow += ras64->getWrap();
+    while (upPix < lastPix) {
+      upPix  = upRow;
+      endPix = upPix + ras64->getLx();
+      while (upPix < endPix) {
+        if (*upPix == TPixel64::White) *upPix = TPixel64::Transparent;
+        ++upPix;
       }
-    } else {
-      ras->unlock();
-      throw TException("TRop::premultiply invalid raster type");
+      upRow += ras64->getWrap();
     }
+  } else if (rasF) {
+    TPixelF *endPix, *upPix = 0, *upRow = rasF->pixels();
+    TPixelF *lastPix =
+        upRow + rasF->getWrap() * (rasF->getLy() - 1) + rasF->getLx();
+
+    while (upPix < lastPix) {
+      upPix  = upRow;
+      endPix = upPix + rasF->getLx();
+      while (upPix < endPix) {
+        if ((*upPix).r >= TPixelF::maxChannelValue &&
+            (*upPix).g >= TPixelF::maxChannelValue &&
+            (*upPix).b >= TPixelF::maxChannelValue)
+          *upPix = TPixelF::Transparent;
+        ++upPix;
+      }
+      upRow += rasF->getWrap();
+    }
+  } else {
+    ras->unlock();
+    throw TException("TRop::premultiply invalid raster type");
   }
   ras->unlock();
 }

--- a/toonz/sources/common/trop/tover.cpp
+++ b/toonz/sources/common/trop/tover.cpp
@@ -250,6 +250,28 @@ void do_over(TRasterGR8P rout, const TRaster32P &rup) {
   }
 }
 
+//-----------------------------------------------------------------------------
+
+void do_over(TRasterFP rout, const TRasterFP &rup) {
+  assert(rout->getSize() == rup->getSize());
+  for (int y = 0; y < rout->getLy(); y++) {
+    TPixelF *out_pix       = rout->pixels(y);
+    TPixelF *const out_end = out_pix + rout->getLx();
+    const TPixelF *up_pix  = rup->pixels(y);
+
+    for (; out_pix < out_end; ++out_pix, ++up_pix) {
+      if (up_pix->m >= 1.f)
+        *out_pix = *up_pix;
+      else if (up_pix->m > 0.f) {
+        out_pix->r = up_pix->r + out_pix->r * (1.f - up_pix->m);
+        out_pix->g = up_pix->g + out_pix->g * (1.f - up_pix->m);
+        out_pix->b = up_pix->b + out_pix->b * (1.f - up_pix->m);
+        out_pix->m = up_pix->m + out_pix->m * (1.f - up_pix->m);
+      }
+    }
+  }
+}
+
 }  // namespace
 
 //-----------------------------------------------------------------------------
@@ -325,6 +347,7 @@ void TRop::over(const TRasterP &rout, const TRasterP &rup, const TPoint &pos) {
 
   TRaster32P rout32 = cRout, rup32 = cRup;
   TRaster64P rout64 = cRout, rup64 = cRup;
+  TRasterFP routF = cRout, rupF = cRup;
 
   TRasterGR8P rout8 = cRout, rup8 = cRup;
 
@@ -356,6 +379,8 @@ void TRop::over(const TRasterP &rout, const TRasterP &rup, const TPoint &pos) {
     TRop::copy(rout8, rup8);
   else if (routCM32 && rupCM32)
     do_over(routCM32, rupCM32);
+  else if (routF && rupF)
+    do_over(routF, rupF);
   else {
     rout->unlock();
     rup->unlock();

--- a/toonz/sources/common/trop/traylit.cpp
+++ b/toonz/sources/common/trop/traylit.cpp
@@ -151,7 +151,7 @@ of the ray we're tracing
                               (rayPos.x * ratio *
                                pow((double)(sq(rayPos.x * ratio) +
                                             sq(rayPos.y * ratio) + sq_z),
-                                   decay)) +
+                                          decay)) +
                           0.5);  // * ^-d...  0.5 rounds
           }
         } else
@@ -170,6 +170,176 @@ of the ray we're tracing
         pixOut->r = (val_r > max) ? max : val_r;
         pixOut->g = (val_g > max) ? max : val_g;
         pixOut->b = (val_b > max) ? max : val_b;
+        pixOut->m = (val_m > max) ? max : val_m;
+      }
+
+      // Increment variables along the x-axis
+      pixIn += dxIn, pixOut += dxOut;
+
+      rayPos.x += rayPosIncrementX, rayPos.y += rayPosIncrementY;
+
+      // Increment variables along the y-axis
+      if ((yIncrementCounter += ray_final_y) >= yIncrementThreshold) {
+        ++y, pixIn += dyIn, pixOut += dyOut;
+        yIncrementCounter -= yIncrementThreshold;
+      }
+    }
+  }
+}
+
+// specialization for floating point pixel
+
+template <>
+void performStandardRaylit<TPixelF>(TPixelF *bufIn, TPixelF *bufOut, int dxIn,
+                                    int dyIn, int dxOut, int dyOut,
+                                    const TRect &srcRect, const TRect &dstRect,
+                                    const TRop::RaylitParams &params) {
+  /* NOTATION:  Diagram assuming octant 1
+
+  /                   |
+ /                    |
+/  - ray_final_y      | octLy
+/ 1                    |
++----                   |
+_____  octLx
+
+
+So, octLx and octLy are the octant's lx and ly;  ray_final_y is the final height
+of the ray we're tracing
+*/
+
+  // Build colors-related variables
+  float max = TPixelF::maxChannelValue;
+  /*-- 透明部分の色 --*/
+  float transp_val = (params.m_invert) ? max : 0.f,
+        opaque_val = max - transp_val;
+  float value, val_r, val_g, val_b, val_m;
+  double lightness, r_fac, g_fac, b_fac, m_fac;
+  /*-- 8bit/ 32bit-Float の違いを吸収する係数 --*/
+  double factor = max / 255.0;
+
+  // NOTE: These variable initializations are, well,
+  // heuristic at least. They were probably tested
+  // to be good, but didn't quite make any REAL sense.
+  // They could be done MUCH better, but changing them
+  // would alter the way raylit has been applied until now.
+  // Should be changed at some point, though...
+
+  double scale      = params.m_scale;
+  double decay      = log(params.m_decay / 100.0 + 1.0) + 1.0;
+  double intensity  = 1e8 * log(params.m_intensity / 100.0 + 1.0) / scale;
+  double smoothness = log(params.m_smoothness * 5.0 / 100.0 + 1.0);
+  double radius     = params.m_radius;
+
+  /*-- 1ステップ進んだ時、次のピクセルで光源が無かったときの光の弱まる割合 --*/
+  double neg_delta_p = smoothness * intensity;
+  /*-- 1ステップ進んだ時、次のピクセルで光源が有ったときの光の強まる割合 --*/
+  double quot_delta_p = intensity / max;  //
+
+  /*--
+   * m_colorはRaylitFxのColor値。r_fac、g_fac、b_facは各チャンネルをPremultiplyした値
+   * --*/
+  TPixelF colorF = toPixelF(params.m_color);
+  m_fac          = colorF.m;
+  r_fac          = m_fac * colorF.r;
+  g_fac          = m_fac * colorF.g;
+  b_fac          = m_fac * colorF.b;
+
+  // Geometry-related variables
+  int x, y, ray_final_y;
+  int octLx = dstRect.x1 - dstRect.x0;
+
+  double rayPosIncrementX = 1.0 / scale;
+
+  double sq_z = sq(params.m_lightOriginSrc.z);  // We'll be making square
+                                                // distances from p, so square
+                                                // it once now
+
+  // Perform raylit
+  TPixelF *pixIn, *pixOut;
+
+  for (ray_final_y = 0; ray_final_y < octLx; ++ray_final_y) {
+    // Initialize increment variables
+    lightness = 0.0;
+
+    double rayPosIncrementY = rayPosIncrementX * (ray_final_y / (double)octLx);
+
+    // Use an integer counter to know when y must increase. Will add ray_final_y
+    // as long as
+    // a multiple of octLx-1 is reached, then increase
+    int yIncrementCounter = 0, yIncrementThreshold = octLx - 1;
+
+    // Trace a single ray of light
+    TPointD rayPos(rayPosIncrementX, rayPosIncrementY);
+
+    for (x = dstRect.x0, y = dstRect.y0, pixIn = bufIn, pixOut = bufOut;
+         (x < dstRect.x1) && (y < dstRect.y1); ++x) {
+      bool insideSrc = (x >= srcRect.x0) && (x < srcRect.x1) &&
+                       (y >= srcRect.y0) && (y < srcRect.y1);
+      if (insideSrc) {
+        // Add a light component depending on source's matte
+        if (areAlmostEqual((double)pixIn->m, (double)opaque_val))
+          lightness = std::max(
+              0.0, lightness - neg_delta_p);  // No light source - ray fading
+        else {
+          if (areAlmostEqual((double)pixIn->m, (double)transp_val))
+            lightness += intensity;  // Full light source - ray enforcing
+          else
+            lightness = std::max(
+                0.0, lightness +  // Half light source
+                         (params.m_invert ? pixIn->m : (max - pixIn->m)) *
+                             quot_delta_p);  //   matte-linear enforcing
+        }
+
+        if (params.m_includeInput) {
+          val_r = pixIn->r;
+          val_g = pixIn->g;
+          val_b = pixIn->b;
+          val_m = pixIn->m;
+        } else
+          val_r = val_g = val_b = val_m = 0.f;
+      } else {
+        if (!params.m_invert)
+          lightness += intensity;
+        else
+          lightness = std::max(0.0, lightness - neg_delta_p);
+
+        val_r = val_g = val_b = val_m = 0.f;
+      }
+
+      bool insideDst = (x >= 0) && (y >= 0);
+      if (insideDst) {
+        // Write the corresponding destination pixel
+        if (lightness > 0.0) {
+          if (radius == 0.0) {
+            value =
+                factor * lightness /
+                (rayPos.x * pow((double)(sq(rayPos.x) + sq(rayPos.y) + sq_z),
+                                decay));  // * ^-d...
+          } else {
+            double ratio = std::max(0.001, 1.0 - radius / norm(rayPos));
+            value        = factor * lightness /
+                    (rayPos.x * ratio *
+                     pow((double)(sq(rayPos.x * ratio) + sq(rayPos.y * ratio) +
+                                  sq_z),
+                         decay));  // * ^-d...
+          }
+        } else
+          value = 0.f;
+
+        // NOTE: pow() could be slow. If that is the case, it could be cached
+        // for the whole octant along the longest ray at integer positions,
+        // and then linearly interpolated between those... Have to profile this
+        // before resorting to that...
+
+        val_r += value * r_fac;
+        val_g += value * g_fac;
+        val_b += value * b_fac;
+        val_m += value * m_fac;
+
+        pixOut->r = val_r;
+        pixOut->g = val_g;
+        pixOut->b = val_b;
         pixOut->m = (val_m > max) ? max : val_m;
       }
 
@@ -322,6 +492,141 @@ void performColorRaylit(T *bufIn, T *bufOut, int dxIn, int dyIn, int dxOut,
   }
 }
 
+// specialization for floating point pixel
+
+template <>
+void performColorRaylit<TPixelF>(TPixelF *bufIn, TPixelF *bufOut, int dxIn,
+                                 int dyIn, int dxOut, int dyOut,
+                                 const TRect &srcRect, const TRect &dstRect,
+                                 const TRop::RaylitParams &params) {
+  // Build colors-related variables
+  float max = TPixelF::maxChannelValue;
+
+  float val_r, val_g, val_b, val_m;
+  double lightness_r, lightness_g, lightness_b;
+  double factor = max / 255.0;
+
+  // NOTE: These variable initializations are, well,
+  // heuristic at least. They were probably tested
+  // to be good, but didn't quite make any REAL sense.
+  // They could be done MUCH better, but changing them
+  // would alter the way raylit has been applied until now.
+  // Should be changed at some point, though...
+
+  double scale      = params.m_scale;
+  double decay      = log(params.m_decay / 100.0 + 1.0) + 1.0;
+  double intensity  = 1e8 * log(params.m_intensity / 100.0 + 1.0) / scale;
+  double smoothness = log(params.m_smoothness * 5.0 / 100.0 + 1.0);
+  double radius     = params.m_radius;
+
+  double neg_delta_p =
+      smoothness *
+      intensity;  // would alter the way raylit has been applied until now.
+  double quot_delta_p = intensity / max;  //
+  // Should be changed at some point, though...
+
+  // Geometry-related variables
+  int x, y, ray_final_y;
+  int octLx = dstRect.x1 - dstRect.x0;
+
+  double rayPosIncrementX = 1.0 / scale;
+
+  double fac, sq_z = sq(params.m_lightOriginSrc.z);  // We'll be making square
+                                                     // distances from p, so
+                                                     // square it once now
+
+  // Perform raylit
+  TPixelF *pixIn, *pixOut;
+
+  for (ray_final_y = 0; ray_final_y < octLx; ++ray_final_y) {
+    // Initialize increment variables
+    lightness_r = lightness_g = lightness_b = 0.0;
+    double l, l_max;
+
+    double rayPosIncrementY = rayPosIncrementX * (ray_final_y / (double)octLx);
+
+    // Use an integer counter to know when y must increase. Will add ray_final_y
+    // as long as
+    // a multiple of octLx-1 is reached, then increase
+    int yIncrementCounter = 0, yIncrementThreshold = octLx - 1;
+
+    // Trace a single ray of light
+    TPointD rayPos(rayPosIncrementX, rayPosIncrementY);
+
+    for (x = dstRect.x0, y = dstRect.y0, pixIn = bufIn, pixOut = bufOut;
+         (x < dstRect.x1) && (y < dstRect.y1); ++x) {
+      bool insideSrc = (x >= srcRect.x0) && (x < srcRect.x1) &&
+                       (y >= srcRect.y0) && (y < srcRect.y1);
+      if (insideSrc) {
+        val_r = pixIn->r;
+        val_g = pixIn->g;
+        val_b = pixIn->b;
+        val_m = pixIn->m;
+
+        lightness_r = std::max(0.0, val_r ? lightness_r + val_r * quot_delta_p
+                                          : lightness_r - neg_delta_p);
+        lightness_g = std::max(0.0, val_g ? lightness_g + val_g * quot_delta_p
+                                          : lightness_g - neg_delta_p);
+        lightness_b = std::max(0.0, val_b ? lightness_b + val_b * quot_delta_p
+                                          : lightness_b - neg_delta_p);
+
+        if (!params.m_includeInput) val_r = val_g = val_b = val_m = 0.f;
+      } else {
+        lightness_r = std::max(0.0, lightness_r - neg_delta_p);
+        lightness_g = std::max(0.0, lightness_g - neg_delta_p);
+        lightness_b = std::max(0.0, lightness_b - neg_delta_p);
+
+        val_r = val_g = val_b = val_m = 0.f;
+      }
+
+      bool insideDst = (x >= 0) && (y >= 0);
+      if (insideDst) {
+        // Write the corresponding destination pixel
+        if (radius == 0.0) {
+          fac = factor /
+                (rayPos.x *
+                 pow((double)(sq(rayPos.x) + sq(rayPos.y) + sq_z), decay));
+        } else {
+          double ratio = std::max(0.001, 1.0 - radius / norm(rayPos));
+          fac =
+              factor /
+              (rayPos.x * ratio *
+               pow((double)(sq(rayPos.x * ratio) + sq(rayPos.y * ratio) + sq_z),
+                   decay));
+        }
+
+        // NOTE: pow() could be slow. If that is the case, it could be cached
+        // for the whole octant along the longest ray at integer positions,
+        // and then linearly interpolated between those... Have to profile this
+        // before resorting to that...
+
+        val_r += l = fac * lightness_r;
+        l_max      = l;
+        val_g += l = fac * lightness_g;
+        l_max      = std::max(l, l_max);
+        val_b += l = fac * lightness_b;
+        l_max      = std::max(l, l_max);
+        val_m += l_max;
+
+        pixOut->r = val_r;
+        pixOut->g = val_g;
+        pixOut->b = val_b;
+        pixOut->m = (val_m > max) ? max : val_m;
+      }
+
+      // Increment variables along the x-axis
+      pixIn += dxIn, pixOut += dxOut;
+
+      rayPos.x += rayPosIncrementX, rayPos.y += rayPosIncrementY;
+
+      // Increment variables along the y-axis
+      if ((yIncrementCounter += ray_final_y) >= yIncrementThreshold) {
+        ++y, pixIn += dyIn, pixOut += dyOut;
+        yIncrementCounter -= yIncrementThreshold;
+      }
+    }
+  }
+}
 //--------------------------------------------------------------------------------------------
 /*-- ピザ状に8分割された領域の1つを計算する --*/
 template <typename T>
@@ -461,6 +766,8 @@ void TRop::raylit(const TRasterP &dstRas, const TRasterP &srcRas,
   else if ((TRaster64P)dstRas && (TRaster64P)srcRas)
     doRaylit<TPixel64>(srcRas, dstRas, params,
                        &performStandardRaylit<TPixel64>);
+  else if ((TRasterFP)dstRas && (TRasterFP)srcRas)
+    doRaylit<TPixelF>(srcRas, dstRas, params, &performStandardRaylit<TPixelF>);
   else
     throw TException("TRop::raylit unsupported pixel type");
 }
@@ -473,6 +780,8 @@ void TRop::glassRaylit(const TRasterP &dstRas, const TRasterP &srcRas,
     doRaylit<TPixel32>(srcRas, dstRas, params, &performColorRaylit<TPixel32>);
   else if ((TRaster64P)dstRas && (TRaster64P)srcRas)
     doRaylit<TPixel64>(srcRas, dstRas, params, &performColorRaylit<TPixel64>);
+  else if ((TRasterFP)dstRas && (TRasterFP)srcRas)
+    doRaylit<TPixelF>(srcRas, dstRas, params, &performColorRaylit<TPixelF>);
   else
     throw TException("TRop::raylit unsupported pixel type");
 }

--- a/toonz/sources/common/trop/tresample.cpp
+++ b/toonz/sources/common/trop/tresample.cpp
@@ -4,12 +4,12 @@
 #include "tpixelgr.h"
 #include "quickputP.h"
 
-//#include "tspecialstyleid.h"
+// #include "tspecialstyleid.h"
 #include "tsystem.h"
 
 #include "tcolorstyles.h"
 #include "tpixelutils.h"
-//#include "tstopwatch.h"
+// #include "tstopwatch.h"
 #ifndef TNZCORE_LIGHT
 #include "tpalette.h"
 #include "trastercm.h"
@@ -159,7 +159,7 @@ inline TINT32 Double2Int(double val) {
   (d2iaux = D, d2iaux += _double2fixmagic,                                     \
    (((TINT32 *)&(d2iaux))[iman_] >> _shiftamt))
 
-//#define USE_DOUBLE_TO_INT
+// #define USE_DOUBLE_TO_INT
 
 //===========================================================================
 
@@ -598,7 +598,7 @@ static inline void get_flt_fun_rad(TRop::ResampleFilterType flt_type,
     break;
   }
   if (flt_fun) *flt_fun = fun;
-  flt_rad               = rad;
+  flt_rad = rad;
 }
 
 //---------------------------------------------------------------------------
@@ -624,9 +624,9 @@ static FILTER *create_filter(TRop::ResampleFilterType flt_type, double blur,
     nodedist_u = blur; /* magnification */
   else
     nodedist_u = du_dx * blur; /* minification */
-  rad_u        = flt_rad * nodedist_u;
-  rad_x        = rad_u * dx_du;
-  nodefreq_u   = 1 / nodedist_u;
+  rad_u      = flt_rad * nodedist_u;
+  rad_x      = rad_u * dx_du;
+  nodefreq_u = 1 / nodedist_u;
   /*
 mu = lu - 1;
 */
@@ -658,11 +658,11 @@ NOT_MORE_THAN(mu, uhi)
         if (f->w[uhi]) break;
       if (ulo < ulomin) ulomin = ulo;
       if (uhi > uhimax) uhimax = uhi;
-      n                        = uhi - ulo + 1;
-      if (n > nmax) nmax       = n;
-      f->first                 = ulo;
-      f->last                  = uhi;
-      norm                     = 1 / sum;
+      n = uhi - ulo + 1;
+      if (n > nmax) nmax = n;
+      f->first = ulo;
+      f->last  = uhi;
+      norm     = 1 / sum;
       for (u = ulo; u <= uhi; u++) f->w[u] *= (float)norm;
     } else {
       f->w_base = 0;
@@ -955,7 +955,7 @@ void create_calc(const TRasterPT<T> &rin, int min_pix_ref_u, int max_pix_ref_u,
   calc_bytewrap   = p_calc_bytewrap;
   calc_bytesize   = calc_bytewrap * lv;  // lv * ceil(lu/8)
   if (calc_bytesize > p_calc_allocsize) {
-    if (p_calc_allocsize) delete[](p_calc);
+    if (p_calc_allocsize) delete[] (p_calc);
     // TMALLOC (*p_calc, calc_bytesize)
     p_calc = new UCHAR[calc_bytesize];
     assert(p_calc);
@@ -1349,6 +1349,255 @@ void resample_main_rgbm(TRasterPT<T> rout, const TRasterPT<T> &rin,
 
 //---------------------------------------------------------------------------
 
+template <>
+void resample_main_rgbm<TPixelF, double>(
+    TRasterFP rout, const TRasterFP &rin, const TAffine &aff_xy2uv,
+    const TAffine &aff0_uv2fg, int min_pix_ref_u, int min_pix_ref_v,
+    int max_pix_ref_u, int max_pix_ref_v, int n_pix, int *pix_ref_u,
+    int *pix_ref_v, int *pix_ref_f, int *pix_ref_g, short *filter) {
+  const double max_filter_val = 32767.0;
+
+  const TPixelF *buffer_in;
+  TPixelF *buffer_out;
+  TPixelF *pix_out;
+  int lu, lv, wrap_in, mu, mv;
+  int lx, ly, wrap_out;
+  int out_x, out_y;
+  double out_x_, out_y_;
+  double out_u_, out_v_;
+  int ref_u, ref_v;
+  int pix_u, pix_v;
+  double ref_out_u_, ref_out_v_;
+  double ref_out_f_, ref_out_g_;
+  int ref_out_f, ref_out_g;
+  int pix_out_f, pix_out_g;
+  int filter_mu, filter_mv;
+  UINT inside_limit_u, inside_limit_v;
+  int inside_nonempty;
+  int outside_min_u, outside_min_v;
+  int outside_max_u, outside_max_v;
+  UCHAR *calc;
+  int calc_allocsize;
+  int calc_bytewrap;
+  UCHAR calc_value;
+  bool must_calc;
+  TPixelF pix_value, default_value(0.f, 0.f, 0.f, 0.f);
+  double weight, sum_weights;
+  double inv_sum_weights;
+  float sum_contribs_r, sum_contribs_g, sum_contribs_b, sum_contribs_m;
+  double out_fval_r, out_fval_g, out_fval_b, out_fval_m;
+  double out_value_r, out_value_g, out_value_b, out_value_m;
+  int i;
+
+#ifdef USE_DOUBLE_TO_INT
+  double d2iaux;
+#endif
+
+  if (!(rout->getLx() > 0 && rout->getLy() > 0)) return;
+
+  if (!(rin->getLx() > 0 && rin->getLy() > 0)) {
+    rout->clear();
+    return;
+  }
+
+  calc           = 0;
+  calc_allocsize = 0;
+
+  // Create a bit array, each indicating whether a pixel has to be calculated or
+  // not
+  create_calc(rin, min_pix_ref_u, max_pix_ref_u, min_pix_ref_v, max_pix_ref_v,
+              calc, calc_allocsize, calc_bytewrap);
+
+  buffer_in  = rin->pixels();
+  buffer_out = rout->pixels();
+  lu         = rin->getLx();
+  lx         = rout->getLx();
+  lv         = rin->getLy();
+  ly         = rout->getLy();
+  wrap_in    = rin->getWrap();
+  wrap_out   = rout->getWrap();
+  mu         = lu - 1;
+  mv         = lv - 1;
+
+  filter_mu       = max_pix_ref_u - min_pix_ref_u;
+  filter_mv       = max_pix_ref_v - min_pix_ref_v;
+  inside_limit_u  = lu - filter_mu;
+  inside_limit_v  = lv - filter_mv;
+  inside_nonempty = (int)inside_limit_u > 0 && (int)inside_limit_v > 0;
+  outside_min_u   = -max_pix_ref_u;
+  outside_min_v   = -max_pix_ref_v;
+  outside_max_u   = mu - min_pix_ref_u;
+  outside_max_v   = mv - min_pix_ref_v;
+
+  // For every pixel of the output image
+  for (out_y = 0, out_y_ = 0.5; out_y < ly; out_y++, out_y_ += 1.0) {
+    for (out_x = 0, out_x_ = 0.5; out_x < lx; out_x++, out_x_ += 1.0) {
+      pix_out = buffer_out + out_y * wrap_out + out_x;
+
+      // Take the pre-image of the pixel through the passed affine
+      out_u_ = affMV1(aff_xy2uv, out_x_, out_y_);
+      out_v_ = affMV2(aff_xy2uv, out_x_, out_y_);
+
+      // Convert to integer coordinates
+      ref_u = intLE(out_u_);
+      ref_v = intLE(out_v_);
+
+      // NOTE: The following condition is equivalent to:
+      // (ref_u + min_pix_ref_u >= 0 && ref_v + min_pix_ref_v >= 0 &&
+      //  ref_u + max_pix_ref_u < lu && ref_v + max_pix_ref_v < lv)
+      // - since the presence of (UINT) makes integeres < 0 become >> 0
+      if (inside_nonempty && (UINT)(ref_u + min_pix_ref_u) < inside_limit_u &&
+          (UINT)(ref_v + min_pix_ref_v) < inside_limit_v) {
+        // The filter mask starting around (ref_u, ref_v) is completely
+        // contained
+        // in the source raster
+
+        // Get the calculation array mask byte
+        calc_value = calc[(ref_u >> 3) + ref_v * calc_bytewrap];
+        if (calc_value && ((calc_value >> (ref_u & 7)) &
+                           1))  // If the mask bit for this pixel is on
+        {
+          ref_out_u_ = ref_u - out_u_;  // Fractionary part of the pre-image
+          ref_out_v_ = ref_v - out_v_;
+          ref_out_f_ = aff0MV1(aff0_uv2fg, ref_out_u_,
+                               ref_out_v_);  // Make the image of it into fg
+          ref_out_g_ = aff0MV2(aff0_uv2fg, ref_out_u_, ref_out_v_);
+          ref_out_f  = tround(ref_out_f_);  // Convert to integer coordinates
+          ref_out_g  = tround(ref_out_g_);
+
+          sum_weights    = 0;
+          sum_contribs_r = 0;
+          sum_contribs_g = 0;
+          sum_contribs_b = 0;
+          sum_contribs_m = 0;
+
+          // Make the weighted sum of source pixels
+          for (i = n_pix - 1; i >= 0; --i) {
+            // Build the weight for this pixel
+            pix_out_f = pix_ref_f[i] + ref_out_f;  // image of the integer part
+                                                   // + that of the fractionary
+                                                   // part
+            pix_out_g = pix_ref_g[i] + ref_out_g;
+            weight    = (double)filter[pix_out_f] * (double)filter[pix_out_g] /
+                     (max_filter_val * max_filter_val);
+
+            // Add the weighted pixel contribute
+            pix_u = pix_ref_u[i] + ref_u;
+            pix_v = pix_ref_v[i] + ref_v;
+
+            pix_value = buffer_in[pix_u + pix_v * wrap_in];
+            sum_contribs_r += pix_value.r * weight;
+            sum_contribs_g += pix_value.g * weight;
+            sum_contribs_b += pix_value.b * weight;
+            sum_contribs_m += pix_value.m * weight;
+            sum_weights += weight;
+          }
+
+          inv_sum_weights = 1.0 / sum_weights;
+          out_fval_r      = sum_contribs_r * inv_sum_weights;
+          out_fval_g      = sum_contribs_g * inv_sum_weights;
+          out_fval_b      = sum_contribs_b * inv_sum_weights;
+          out_fval_m      = sum_contribs_m * inv_sum_weights;
+          // notLessThan(0.0, out_fval_r);
+          // notLessThan(0.0, out_fval_g);
+          // notLessThan(0.0, out_fval_b);
+          notLessThan(0.0, out_fval_m);
+          out_value_r = out_fval_r;
+          out_value_g = out_fval_g;
+          out_value_b = out_fval_b;
+          out_value_m = out_fval_m;
+          // notMoreThan(T::maxChannelValue, out_value_r);
+          // notMoreThan(T::maxChannelValue, out_value_g);
+          // notMoreThan(T::maxChannelValue, out_value_b);
+          notMoreThan(1.f, out_value_m);
+          pix_out->r = out_value_r;
+          pix_out->g = out_value_g;
+          pix_out->b = out_value_b;
+          pix_out->m = out_value_m;
+        } else
+          // The pixel is copied from the corresponding source...
+          *pix_out = buffer_in[ref_u + ref_v * wrap_in];
+      } else if (outside_min_u <= ref_u && ref_u <= outside_max_u &&
+                 outside_min_v <= ref_v && ref_v <= outside_max_v) {
+        if ((UINT)ref_u >= (UINT)lu || (UINT)ref_v >= (UINT)lv)
+          must_calc = true;
+        else {
+          calc_value = calc[(ref_u >> 3) + ref_v * calc_bytewrap];
+          must_calc  = calc_value && ((calc_value >> (ref_u & 7)) & 1);
+        }
+
+        if (must_calc) {
+          ref_out_u_     = ref_u - out_u_;
+          ref_out_v_     = ref_v - out_v_;
+          ref_out_f_     = aff0MV1(aff0_uv2fg, ref_out_u_, ref_out_v_);
+          ref_out_g_     = aff0MV2(aff0_uv2fg, ref_out_u_, ref_out_v_);
+          ref_out_f      = tround(ref_out_f_);
+          ref_out_g      = tround(ref_out_g_);
+          sum_weights    = 0;
+          sum_contribs_r = 0;
+          sum_contribs_g = 0;
+          sum_contribs_b = 0;
+          sum_contribs_m = 0;
+
+          for (i = n_pix - 1; i >= 0; --i) {
+            pix_out_f = pix_ref_f[i] + ref_out_f;
+            pix_out_g = pix_ref_g[i] + ref_out_g;
+            weight    = (double)filter[pix_out_f] * (double)filter[pix_out_g] /
+                     (max_filter_val * max_filter_val);
+            pix_u = pix_ref_u[i] + ref_u;
+            pix_v = pix_ref_v[i] + ref_v;
+
+            if (pix_u < 0 || pix_u > mu || pix_v < 0 || pix_v > mv) {
+              sum_weights += weight;  // 0-padding
+              continue;
+            }
+
+            notLessThan(0, pix_u);  // Copy-padding
+            notLessThan(0, pix_v);
+            notMoreThan(mu, pix_u);
+            notMoreThan(mv, pix_v);
+
+            pix_value = buffer_in[pix_u + pix_v * wrap_in];
+            sum_contribs_r += pix_value.r * weight;
+            sum_contribs_g += pix_value.g * weight;
+            sum_contribs_b += pix_value.b * weight;
+            sum_contribs_m += pix_value.m * weight;
+            sum_weights += weight;
+          }
+
+          inv_sum_weights = 1.0 / sum_weights;
+          out_fval_r      = sum_contribs_r * inv_sum_weights;
+          out_fval_g      = sum_contribs_g * inv_sum_weights;
+          out_fval_b      = sum_contribs_b * inv_sum_weights;
+          out_fval_m      = sum_contribs_m * inv_sum_weights;
+          // notLessThan(0.0, out_fval_r);
+          // notLessThan(0.0, out_fval_g);
+          // notLessThan(0.0, out_fval_b);
+          notLessThan(0.0, out_fval_m);
+          out_value_r = out_fval_r;
+          out_value_g = out_fval_g;
+          out_value_b = out_fval_b;
+          out_value_m = out_fval_m;
+          // notMoreThan(T::maxChannelValue, out_value_r);
+          // notMoreThan(T::maxChannelValue, out_value_g);
+          // notMoreThan(T::maxChannelValue, out_value_b);
+          notMoreThan(1.f, out_value_m);
+          pix_out->r = out_value_r;
+          pix_out->g = out_value_g;
+          pix_out->b = out_value_b;
+          pix_out->m = out_value_m;
+        } else
+          *pix_out = buffer_in[ref_u + ref_v * wrap_in];
+      } else
+        *pix_out = default_value;
+    }
+  }
+
+  delete[] calc;
+}
+
+//---------------------------------------------------------------------------
+
 #ifdef USE_SSE2
 
 namespace {
@@ -1518,74 +1767,75 @@ void resample_main_rgbm_SSE2(TRasterPT<T> rout, const TRasterPT<T> &rin,
         } else
           *pix_out = buffer_in[ref_u + ref_v * wrap_in];
       } else
-          // if( outside_min_u_ <= out_u_ && out_u_ <= outside_max_u_ &&
-          //    outside_min_v_ <= out_v_ && out_v_ <= outside_max_v_ )
-          if (outside_min_u <= ref_u && ref_u <= outside_max_u &&
-              outside_min_v <= ref_v && ref_v <= outside_max_v) {
-        if ((UINT)ref_u >= (UINT)lu || (UINT)ref_v >= (UINT)lv)
-          must_calc = true;
-        else {
-          calc_value = calc[(ref_u >> 3) + ref_v * calc_bytewrap];
-          must_calc  = calc_value && ((calc_value >> (ref_u & 7)) & 1);
-        }
-
-        if (must_calc) {
-          ref_out_u_          = ref_u - out_u_;
-          ref_out_v_          = ref_v - out_v_;
-          ref_out_f_          = aff0MV1(aff0_uv2fg, ref_out_u_, ref_out_v_);
-          ref_out_g_          = aff0MV2(aff0_uv2fg, ref_out_u_, ref_out_v_);
-          ref_out_f           = tround(ref_out_f_);
-          ref_out_g           = tround(ref_out_g_);
-          sum_weights         = 0;
-          sum_contribs_packed = _mm_setzero_ps();
-
-          for (i = n_pix - 1; i >= 0; i--) {
-            pix_out_f = pix_ref_f[i] + ref_out_f;
-            pix_out_g = pix_ref_g[i] + ref_out_g;
-            weight    = (float)((filter[pix_out_f] * filter[pix_out_g]) >> 16);
-            pix_u     = pix_ref_u[i] + ref_u;
-            pix_v     = pix_ref_v[i] + ref_v;
-
-            if (pix_u < 0 || pix_u > mu || pix_v < 0 || pix_v > mv) {
-              sum_weights += weight;
-              continue;
-            }
-
-            notLessThan(0, pix_u);
-            notLessThan(0, pix_v);
-            notMoreThan(mu, pix_u);
-            notMoreThan(mv, pix_v);
-
-            pix_value          = buffer_in[pix_u + pix_v * wrap_in];
-            pix_value_packed_i = _mm_unpacklo_epi8(
-                _mm_cvtsi32_si128(*(DWORD *)&pix_value), zeros);
-            pix_value_packed =
-                _mm_cvtepi32_ps(_mm_unpacklo_epi16(pix_value_packed_i, zeros));
-
-            weight_packed = _mm_load1_ps(&weight);
-            sum_contribs_packed =
-                _mm_add_ps(sum_contribs_packed,
-                           _mm_mul_ps(pix_value_packed, weight_packed));
-
-            sum_weights += weight;
+        // if( outside_min_u_ <= out_u_ && out_u_ <= outside_max_u_ &&
+        //    outside_min_v_ <= out_v_ && out_v_ <= outside_max_v_ )
+        if (outside_min_u <= ref_u && ref_u <= outside_max_u &&
+            outside_min_v <= ref_v && ref_v <= outside_max_v) {
+          if ((UINT)ref_u >= (UINT)lu || (UINT)ref_v >= (UINT)lv)
+            must_calc = true;
+          else {
+            calc_value = calc[(ref_u >> 3) + ref_v * calc_bytewrap];
+            must_calc  = calc_value && ((calc_value >> (ref_u & 7)) & 1);
           }
-          inv_sum_weights = 1.0f / sum_weights;
 
-          __m128 inv_sum_weights_packed = _mm_load1_ps(&inv_sum_weights);
-          __m128 out_fval_packed =
-              _mm_mul_ps(sum_contribs_packed, inv_sum_weights_packed);
-          out_fval_packed = _mm_max_ps(out_fval_packed, zeros2);
-          out_fval_packed = _mm_min_ps(out_fval_packed, maxChanneValue_packed);
+          if (must_calc) {
+            ref_out_u_          = ref_u - out_u_;
+            ref_out_v_          = ref_v - out_v_;
+            ref_out_f_          = aff0MV1(aff0_uv2fg, ref_out_u_, ref_out_v_);
+            ref_out_g_          = aff0MV2(aff0_uv2fg, ref_out_u_, ref_out_v_);
+            ref_out_f           = tround(ref_out_f_);
+            ref_out_g           = tround(ref_out_g_);
+            sum_weights         = 0;
+            sum_contribs_packed = _mm_setzero_ps();
 
-          __m128i out_value_packed_i = _mm_cvtps_epi32(out_fval_packed);
-          out_value_packed_i  = _mm_packs_epi32(out_value_packed_i, zeros);
-          out_value_packed_i  = _mm_packus_epi16(out_value_packed_i, zeros);
-          *(DWORD *)(pix_out) = _mm_cvtsi128_si32(out_value_packed_i);
-        } else
-          *pix_out = buffer_in[ref_u + ref_v * wrap_in];
-      } else {
-        *pix_out = default_value;
-      }
+            for (i = n_pix - 1; i >= 0; i--) {
+              pix_out_f = pix_ref_f[i] + ref_out_f;
+              pix_out_g = pix_ref_g[i] + ref_out_g;
+              weight = (float)((filter[pix_out_f] * filter[pix_out_g]) >> 16);
+              pix_u  = pix_ref_u[i] + ref_u;
+              pix_v  = pix_ref_v[i] + ref_v;
+
+              if (pix_u < 0 || pix_u > mu || pix_v < 0 || pix_v > mv) {
+                sum_weights += weight;
+                continue;
+              }
+
+              notLessThan(0, pix_u);
+              notLessThan(0, pix_v);
+              notMoreThan(mu, pix_u);
+              notMoreThan(mv, pix_v);
+
+              pix_value          = buffer_in[pix_u + pix_v * wrap_in];
+              pix_value_packed_i = _mm_unpacklo_epi8(
+                  _mm_cvtsi32_si128(*(DWORD *)&pix_value), zeros);
+              pix_value_packed = _mm_cvtepi32_ps(
+                  _mm_unpacklo_epi16(pix_value_packed_i, zeros));
+
+              weight_packed = _mm_load1_ps(&weight);
+              sum_contribs_packed =
+                  _mm_add_ps(sum_contribs_packed,
+                             _mm_mul_ps(pix_value_packed, weight_packed));
+
+              sum_weights += weight;
+            }
+            inv_sum_weights = 1.0f / sum_weights;
+
+            __m128 inv_sum_weights_packed = _mm_load1_ps(&inv_sum_weights);
+            __m128 out_fval_packed =
+                _mm_mul_ps(sum_contribs_packed, inv_sum_weights_packed);
+            out_fval_packed = _mm_max_ps(out_fval_packed, zeros2);
+            out_fval_packed =
+                _mm_min_ps(out_fval_packed, maxChanneValue_packed);
+
+            __m128i out_value_packed_i = _mm_cvtps_epi32(out_fval_packed);
+            out_value_packed_i  = _mm_packs_epi32(out_value_packed_i, zeros);
+            out_value_packed_i  = _mm_packus_epi16(out_value_packed_i, zeros);
+            *(DWORD *)(pix_out) = _mm_cvtsi128_si32(out_value_packed_i);
+          } else
+            *pix_out = buffer_in[ref_u + ref_v * wrap_in];
+        } else {
+          *pix_out = default_value;
+        }
     }
   }
   if (calc) delete[] calc;
@@ -1691,9 +1941,9 @@ static void get_prow_gr8(const TRasterGR8P &rin, double a11, double a12,
       prow[p] = (float)troundp(
           fu * gv *
               (((UINT)(u + 1) < lu && (UINT)v < lv) ? in_gr8[du] : BORDER) +
-          fu * fv * (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv)
-                         ? in_gr8[du + dv]
-                         : BORDER) +
+          fu * fv *
+              (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv) ? in_gr8[du + dv]
+                                                          : BORDER) +
           gu * gv * (((UINT)u < lu && (UINT)v < lv) ? in_gr8[0] : BORDER) +
           gu * fv *
               (((UINT)u < lu && (UINT)(v + 1) < lv) ? in_gr8[dv] : BORDER));
@@ -1714,9 +1964,9 @@ static void get_prow_gr8(const TRasterGR8P &rin, double a11, double a12,
       prow[p] = (float)troundp(
           fu * gv *
               (((UINT)(u + 1) < lu && (UINT)v < lv) ? in_gr8[du] : BORDER) +
-          fu * fv * (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv)
-                         ? in_gr8[du + dv]
-                         : BORDER) +
+          fu * fv *
+              (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv) ? in_gr8[du + dv]
+                                                          : BORDER) +
           gu * gv * (((UINT)u < lu && (UINT)v < lv) ? in_gr8[0] : BORDER) +
           gu * fv *
               (((UINT)u < lu && (UINT)(v + 1) < lv) ? in_gr8[dv] : BORDER));
@@ -1789,14 +2039,16 @@ static void get_prow_gr8(const TRaster32P &rin, double a11, double a12,
       gv      = 1. - fv;
       in_32   = bufin_32 + (u * du + v * dv);
       prow[p] = (float)troundp(
-          fu * gv * (((UINT)(u + 1) < lu && (UINT)v < lv) ? grey(in_32[du])
+          fu * gv *
+              (((UINT)(u + 1) < lu && (UINT)v < lv) ? grey(in_32[du])
+                                                    : BORDER) +
+          fu * fv *
+              (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv) ? grey(in_32[du + dv])
                                                           : BORDER) +
-          fu * fv * (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv)
-                         ? grey(in_32[du + dv])
-                         : BORDER) +
           gu * gv * (((UINT)u < lu && (UINT)v < lv) ? grey(in_32[0]) : BORDER) +
-          gu * fv * (((UINT)u < lu && (UINT)(v + 1) < lv) ? grey(in_32[dv])
-                                                          : BORDER));
+          gu * fv *
+              (((UINT)u < lu && (UINT)(v + 1) < lv) ? grey(in_32[dv])
+                                                    : BORDER));
     }
   p1 = p;
   for (p = pmax; p > p1; p--)
@@ -1812,14 +2064,16 @@ static void get_prow_gr8(const TRaster32P &rin, double a11, double a12,
       gv      = 1. - fv;
       in_32   = bufin_32 + (u * du + v * dv);
       prow[p] = (float)troundp(
-          fu * gv * (((UINT)(u + 1) < lu && (UINT)v < lv) ? grey(in_32[du])
+          fu * gv *
+              (((UINT)(u + 1) < lu && (UINT)v < lv) ? grey(in_32[du])
+                                                    : BORDER) +
+          fu * fv *
+              (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv) ? grey(in_32[du + dv])
                                                           : BORDER) +
-          fu * fv * (((UINT)(u + 1) < lu && (UINT)(v + 1) < lv)
-                         ? grey(in_32[du + dv])
-                         : BORDER) +
           gu * gv * (((UINT)u < lu && (UINT)v < lv) ? grey(in_32[0]) : BORDER) +
-          gu * fv * (((UINT)u < lu && (UINT)(v + 1) < lv) ? grey(in_32[dv])
-                                                          : BORDER));
+          gu * fv *
+              (((UINT)u < lu && (UINT)(v + 1) < lv) ? grey(in_32[dv])
+                                                    : BORDER));
     }
   p2 = p;
   for (p = p1; p <= p2; p++)
@@ -1948,7 +2202,7 @@ TCALLOC (colval,    lu);*/
           flatcols = 1;
       else
         flatcols = 0;
-      flatval    = colval[u];
+      flatval = colval[u];
       if (flatcols >= flatdiamu) {
 #ifdef VECCHIA_MANIERA
         x_  = AFF_M_V_1(aff, u - flatradu, v - flatradv);
@@ -1967,7 +2221,7 @@ TCALLOC (colval,    lu);*/
         ylo = std::max(0, (int)ylo_);
         yhi = std::min(my, (int)yhi_);
         for (y = ylo; y <= yhi; y++)
-          for (x                        = xlo; x <= xhi; x++)
+          for (x = xlo; x <= xhi; x++)
             bufout_gr8[x + y * wrapout] = flatval, count++;
       }
       xlo_ += aff.a11;
@@ -2005,7 +2259,7 @@ TCALLOC (colval,    lu);*/
             nocheight[x] = 0;
       }
       if (topy < ly && colnoc[topy].first <= topq) {
-        for (x                                = 0; x < lx; x++)
+        for (x = 0; x < lx; x++)
           if (nocheight[x] < nocdiamy) xxx[x] = 1.0; /* 1.0 == calc */
       } else {
         for (x = 0; x < lx; x++) xxx[x] = 1.0; /* 1.0 == calc */
@@ -2020,7 +2274,7 @@ TCALLOC (colval,    lu);*/
         else {
           nocwidth++;
           if (nocwidth >= nocdiamx)
-            for (p    = rownoc[x].first; p <= rownoc[x].last; p++)
+            for (p = rownoc[x].first; p <= rownoc[x].last; p++)
               prow[p] = 1.0; /* 1.0 == nocalc */
         }
       get_prow_gr8(rin, invrot.a11, invrot.a12, invrot.a21, invrot.a22, pmin,
@@ -2157,7 +2411,7 @@ TCALLOC (colval,    lu);*/
           flatcols = 1;
       else
         flatcols = 0;
-      flatval    = colval[u];
+      flatval = colval[u];
       if (flatcols >= flatdiamu) {
 #ifdef VECCHIA_MANIERA
         x_  = AFF_M_V_1(aff, u - flatradu, v - flatradv);
@@ -2176,7 +2430,7 @@ TCALLOC (colval,    lu);*/
         ylo = std::max(0, (int)ylo_);
         yhi = std::min(my, (int)yhi_);
         for (y = ylo; y <= yhi; y++)
-          for (x                        = xlo; x <= xhi; x++)
+          for (x = xlo; x <= xhi; x++)
             bufout_gr8[x + y * wrapout] = flatval, count++;
       }
       xlo_ += aff.a11;
@@ -2214,7 +2468,7 @@ TCALLOC (colval,    lu);*/
             nocheight[x] = 0;
       }
       if (topy < ly && colnoc[topy].first <= topq) {
-        for (x                                = 0; x < lx; x++)
+        for (x = 0; x < lx; x++)
           if (nocheight[x] < nocdiamy) xxx[x] = 1.0; /* 1.0 == calc */
       } else {
         for (x = 0; x < lx; x++) xxx[x] = 1.0; /* 1.0 == calc */
@@ -2229,7 +2483,7 @@ TCALLOC (colval,    lu);*/
         else {
           nocwidth++;
           if (nocwidth >= nocdiamx)
-            for (p    = rownoc[x].first; p <= rownoc[x].last; p++)
+            for (p = rownoc[x].first; p <= rownoc[x].last; p++)
               prow[p] = 1.0; /* 1.0 == nocalc */
         }
       get_prow_gr8(rin, invrot.a11, invrot.a12, invrot.a21, invrot.a22, pmin,
@@ -2555,7 +2809,7 @@ void rop_resample_rgbm(TRasterPT<T> rout, const TRasterPT<T> &rin,
     if (min_pix_out_fg < min_filter_fg) {
       int delta = min_filter_fg - min_pix_out_fg;
 
-      for (f              = max_filter_fg; f >= min_filter_fg; f--)
+      for (f = max_filter_fg; f >= min_filter_fg; f--)
         filter[f + delta] = filter[f];
       filter += delta;
       for (f = min_filter_fg - 1; f >= min_pix_out_fg; f--) filter[f] = 0;
@@ -2576,7 +2830,12 @@ void rop_resample_rgbm(TRasterPT<T> rout, const TRasterPT<T> &rin,
                                pix_ref_f.get(), pix_ref_g.get(), filter);
   else
 #endif
-      if (n_pix >= 512 || T::maxChannelValue > 255)
+      if (std::is_same<T, TPixelF>::value)
+    resample_main_rgbm<T, double>(
+        rout, rin, aff_xy2uv, aff0_uv2fg, min_pix_ref_u, min_pix_ref_v,
+        max_pix_ref_u, max_pix_ref_v, n_pix, pix_ref_u.get(), pix_ref_v.get(),
+        pix_ref_f.get(), pix_ref_g.get(), filter);
+  else if (n_pix >= 512 || T::maxChannelValue > 255)
     resample_main_rgbm<T, TINT64>(
         rout, rin, aff_xy2uv, aff0_uv2fg, min_pix_ref_u, min_pix_ref_v,
         max_pix_ref_u, max_pix_ref_v, n_pix, pix_ref_u.get(), pix_ref_v.get(),
@@ -3014,7 +3273,7 @@ void do_resample(TRasterCM32P rout, const TRasterCM32P &rin,
         tone_tot                   = 0.0;
         some_pencil                = false;
         for (i = 0; i < 4; i++) {
-          tone                                        = tcm[i] & tone_mask;
+          tone = tcm[i] & tone_mask;
           if ((TUINT32)tone != tone_mask) some_pencil = true;
           tone_tot += tone * w[i];
           new_color_blob.val = tcm[i] & color_mask;
@@ -3059,8 +3318,8 @@ void do_resample(TRasterCM32P rout, const TRasterCM32P &rin,
                v * wrapin;  // Take the associated input pixel pointer
       tcm[0] = in_tcm[0];
       if (u < lu - 1 && v < lv - 1) {
-        // Also take their 4 next neighbours (we shall perform a kind of bilinear
-        // interpolation)
+        // Also take their 4 next neighbours (we shall perform a kind of
+        // bilinear interpolation)
         tcm[1] = in_tcm[1];
         tcm[2] = in_tcm[wrapin];
         tcm[3] = in_tcm[wrapin + 1];
@@ -3165,7 +3424,7 @@ void do_resample(TRasterCM32P rout, const TRasterCM32P &rin,
         tone_tot                   = 0.0;
         some_pencil                = false;
         for (i = 0; i < 4; i++) {
-          tone                                        = tcm[i] & tone_mask;
+          tone = tcm[i] & tone_mask;
           if ((TUINT32)tone != tone_mask) some_pencil = true;
           tone_tot += tone * w[i];
           new_color_blob.val = tcm[i] & color_mask;
@@ -3586,7 +3845,7 @@ void resample_main_cm32_rgbm_bigradius(
 
   std::vector<TPixel32> paints(colorCount);
   std::vector<TPixel32> inks(colorCount);
-  for (i      = 0; i < palette->getStyleCount(); i++)
+  for (i = 0; i < palette->getStyleCount(); i++)
     paints[i] = inks[i] =
         ::premultiply(palette->getStyle(i)->getAverageColor());
 
@@ -3775,7 +4034,7 @@ void resample_main_cm32_rgbm_bigradius(
 
   if (calc) delete[] calc;
 }
-}
+}  // namespace
 
 /*---------------------------------------------------------------------------*/
 
@@ -3871,7 +4130,7 @@ void resample_main_cm32_rgbm(TRasterPT<T> rout, const TRasterCM32P &rin,
 
   std::vector<TPixel32> paints(colorCount);
   std::vector<TPixel32> inks(colorCount);
-  for (i      = 0; i < palette->getStyleCount(); i++)
+  for (i = 0; i < palette->getStyleCount(); i++)
     paints[i] = inks[i] =
         ::premultiply(palette->getStyle(i)->getAverageColor());
 
@@ -4140,7 +4399,7 @@ resample_main_rgbm_bigradius<T>( rout, rin,
 
   std::vector<TPixel32> paints(colorCount);
   std::vector<TPixel32> inks(colorCount);
-  for (i      = 0; i < palette->getStyleCount(); i++)
+  for (i = 0; i < palette->getStyleCount(); i++)
     paints[i] = inks[i] =
         ::premultiply(palette->getStyle(i)->getAverageColor());
 
@@ -4585,7 +4844,7 @@ void rop_resample_rgbm_2(TRasterPT<T> rout, const TRasterCM32P &rin,
     if (min_pix_out_fg < min_filter_fg) {
       int delta = min_filter_fg - min_pix_out_fg;
 
-      for (f              = max_filter_fg; f >= min_filter_fg; f--)
+      for (f = max_filter_fg; f >= min_filter_fg; f--)
         filter[f + delta] = filter[f];
       filter += delta;
       for (f = min_filter_fg - 1; f >= min_pix_out_fg; f--) filter[f] = 0;
@@ -4663,42 +4922,49 @@ void TRop::resample(const TRasterP &rout, const TRasterP &rin,
   }
 
   TRaster32P rout32 = rout, rin32 = rin;
+  TRasterCM32P routCM32 = rout, rinCM32 = rin;
+  TRaster64P rout64 = rout, rin64 = rin;
+  TRasterGR8P routGR8 = rout, rinGR8 = rin;
+  TRasterFP routF = rout, rinF = rin;
+
   if (rout32) {
     if (!rin32) {
       rin32 = TRaster32P(rin->getLx(), rin->getLy());
       TRop::convert(rin32, rin);
     }
     do_resample<TPixel32>(rout32, rin32, aff, filterType, blur);
-  } else {
-#ifndef TNZCORE_LIGHT
-    TRasterCM32P routCM32 = rout, rinCM32 = rin;
-    if (routCM32 && rinCM32)
-      do_resample(routCM32, rinCM32, aff);
-    else
-#endif
-    {
-      TRaster64P rout64 = rout, rin64 = rin;
-      if (rout64) {
-        if (!rin64) {
-          rin64 = TRaster64P(rin->getLx(), rin->getLy());
-          TRop::convert(rin64, rin);
-        }
-        do_resample<TPixel64>(rout64, rin64, aff, filterType, blur);
-      } else {
-        TRasterGR8P routGR8 = rout, rinGR8 = rin;
-        TRaster32P rin32 = rin;
-        if (routGR8 && rinGR8)
-          do_resample(routGR8, rinGR8, aff, filterType, blur);
-        else if (routGR8 && rin32)
-          do_resample(routGR8, rin32, aff, filterType, blur);
-        else {
-          rin->unlock();
-          rout->unlock();
-          throw TRopException("unsupported pixel type");
-        }
-      }
+  } else if (routCM32 && rinCM32)
+    do_resample(routCM32, rinCM32, aff);
+  else if (rout64) {
+    if (!rin64) {
+      rin64 = TRaster64P(rin->getLx(), rin->getLy());
+      TRop::convert(rin64, rin);
     }
+    do_resample<TPixel64>(rout64, rin64, aff, filterType, blur);
+  } else if (routGR8) {
+    if (rinGR8)
+      do_resample(routGR8, rinGR8, aff, filterType, blur);
+    else if (routGR8 && rin32)
+      do_resample(routGR8, rin32, aff, filterType, blur);
+    else {
+      rin->unlock();
+      rout->unlock();
+      throw TRopException("unsupported pixel type");
+    }
+  } else if (routF) {
+    if (!rinF) {
+      rinF = TRasterFP(rin->getLx(), rin->getLy());
+      TRop::convert(rinF, rin);
+    }
+    do_resample<TPixelF>(routF, rinF, aff, filterType, blur);
+  } else {
+    rin->unlock();
+    rout->unlock();
+    throw TRopException("unsupported pixel type");
   }
+
+  rout->setLinear(rin->isLinear());
+
   rin->unlock();
   rout->unlock();
 }

--- a/toonz/sources/common/trop/trgbmscale.cpp
+++ b/toonz/sources/common/trop/trgbmscale.cpp
@@ -24,7 +24,7 @@ void buildLUT(Chan *lut, double a, double k, int chanLow, int chanHigh) {
   int i, max = (std::numeric_limits<Chan>::max)();
 
   a += 0.5;  // round rather than trunc
-  for (i   = 0; i <= max; ++i)
+  for (i = 0; i <= max; ++i)
     lut[i] = tcrop((int)(a + i * k), chanLow, chanHigh);
 }
 
@@ -94,18 +94,21 @@ void do_rgbmScale_lut(TRasterPT<T> rout, TRasterPT<T> rin, const double *a,
   int out0M = std::max(fac * out0[3], 0),
       out1M = std::min(fac * out1[3], T::maxChannelValue);
 
+  double aFac[4];
+  for (int i = 0; i < 4; i++) aFac[i] = a[i] * (double)fac;
+
   // Build luts
   Channel *lut_r = new Channel[chanValuesCount];
-  buildLUT(lut_r, a[0], k[0], out0R, out1R);
+  buildLUT(lut_r, aFac[0], k[0], out0R, out1R);
 
   Channel *lut_g = new Channel[chanValuesCount];
-  buildLUT(lut_g, a[1], k[1], out0G, out1G);
+  buildLUT(lut_g, aFac[1], k[1], out0G, out1G);
 
   Channel *lut_b = new Channel[chanValuesCount];
-  buildLUT(lut_b, a[2], k[2], out0B, out1B);
+  buildLUT(lut_b, aFac[2], k[2], out0B, out1B);
 
   Channel *lut_m = new Channel[chanValuesCount];
-  buildLUT(lut_m, a[3], k[3], out0M, out1M);
+  buildLUT(lut_m, aFac[3], k[3], out0M, out1M);
 
   // Retrieve de/premultiplication luts
   const double *lut_prem   = premultiplyTable<Channel>();
@@ -162,6 +165,9 @@ void do_rgbmScale(TRasterPT<T> rout, TRasterPT<T> rin, const double *a,
   const double *lut_deprem = depremultiplyTable<Channel>();
   double premFac, depremFac;
 
+  double aFac[4];
+  for (int i = 0; i < 4; i++) aFac[i] = a[i] * (double)fac;
+
   // Process raster
   int y, lx = rin->getLx(), ly = rin->getLy();
   T *in, *end, *out;
@@ -169,17 +175,110 @@ void do_rgbmScale(TRasterPT<T> rout, TRasterPT<T> rin, const double *a,
   for (y = 0; y < ly; ++y) {
     in = rin->pixels(y), end = in + lx, out = rout->pixels(y);
     for (; in < end; ++in, ++out) {
-      m         = tcrop((int)(a[3] + k[3] * in->m), out0M, out1M);
+      m         = tcrop((int)(aFac[3] + k[3] * in->m), out0M, out1M);
       depremFac = lut_deprem[in->m];
       premFac   = lut_prem[m];
 
-      out->r =
-          premFac * tcrop((int)(a[0] + k[0] * in->r * depremFac), out0R, out1R);
-      out->g =
-          premFac * tcrop((int)(a[1] + k[1] * in->g * depremFac), out0G, out1G);
-      out->b =
-          premFac * tcrop((int)(a[2] + k[2] * in->b * depremFac), out0B, out1B);
+      out->r = premFac *
+               tcrop((int)(aFac[0] + k[0] * in->r * depremFac), out0R, out1R);
+      out->g = premFac *
+               tcrop((int)(aFac[1] + k[1] * in->g * depremFac), out0G, out1G);
+      out->b = premFac *
+               tcrop((int)(aFac[2] + k[2] * in->b * depremFac), out0B, out1B);
       out->m = m;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+template <>
+void do_rgbmScale<TPixelF>(TRasterFP rout, TRasterFP rin, const double *a,
+                           const double *k, const int *out0, const int *out1) {
+  assert(rout->getSize() == rin->getSize());
+
+  float fac = 1.f / 255.f;
+
+  float out0R = std::max(fac * (float)out0[0], 0.f);
+  float out1R = std::min(fac * (float)out1[0], 1.f);
+  float out0G = std::max(fac * (float)out0[1], 0.f);
+  float out1G = std::min(fac * (float)out1[1], 1.f);
+  float out0B = std::max(fac * (float)out0[2], 0.f);
+  float out1B = std::min(fac * (float)out1[2], 1.f);
+  float out0M = std::max(fac * (float)out0[3], 0.f);
+  float out1M = std::min(fac * (float)out1[3], 1.f);
+
+  // Retrieve de/premultiplication luts
+  double premFac, depremFac;
+
+  float aFac[4];
+  for (int i = 0; i < 4; i++) aFac[i] = a[i] * (float)fac;
+
+  // Process raster
+  int y, lx = rin->getLx(), ly = rin->getLy();
+  TPixelF *in, *end, *out;
+  float m;
+
+  for (y = 0; y < ly; ++y) {
+    in = rin->pixels(y), end = in + lx, out = rout->pixels(y);
+    for (; in < end; ++in, ++out) {
+      m = tcrop(aFac[3] + (float)k[3] * in->m, out0M, out1M);
+
+      if (in->m <= 0.f) {
+        out->r = m * tcrop(aFac[0], out0R, out1R);
+        out->g = m * tcrop(aFac[1], out0G, out1G);
+        out->b = m * tcrop(aFac[2], out0B, out1B);
+        out->m = m;
+      } else {
+        out->r = m * tcrop(aFac[0] + (float)k[0] * in->r / in->m, out0R, out1R);
+        out->g = m * tcrop(aFac[1] + (float)k[1] * in->g / in->m, out0G, out1G);
+        out->b = m * tcrop(aFac[2] + (float)k[2] * in->b / in->m, out0B, out1B);
+        out->m = m;
+      }
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void do_rgbmScaleFloat(TRasterFP rout, TRasterFP rin, const double *a,
+                       const double *k, const int *out0, const int *out1) {
+  assert(rout->getSize() == rin->getSize());
+  float fac   = 1.f / 255.f;
+  float out0R = std::max(fac * (float)out0[0], 0.f);
+  float out1R = fac * (float)out1[0];
+  float out0G = std::max(fac * (float)out0[1], 0.f);
+  float out1G = fac * (float)out1[1];
+  float out0B = std::max(fac * (float)out0[2], 0.f);
+  float out1B = fac * (float)out1[2];
+  float out0M = std::max(fac * (float)out0[3], 0.f);
+  float out1M = fac * (float)out1[3];
+
+  float aFac[4];
+  for (int i = 0; i < 4; i++) aFac[i] = a[i] * fac;
+
+  // Process raster
+  for (int y = 0; y < rin->getLy(); ++y) {
+    TPixelF *in = rin->pixels(y), *out = rout->pixels(y);
+    TPixelF *end = in + rin->getLx();
+    for (; in < end; ++in, ++out) {
+      out->m = tcrop(aFac[3] + (float)k[3] * in->m, out0M, out1M);
+      if (out->m == 0.f) {
+        out->r = 0.f;
+        out->g = 0.f;
+        out->b = 0.f;
+      } else if (in->m == 0.f) {
+        out->r = out->m * tcrop(aFac[0], out0R, out1R);
+        out->g = out->m * tcrop(aFac[1], out0G, out1G);
+        out->b = out->m * tcrop(aFac[2], out0B, out1B);
+      } else {
+        out->r =
+            out->m * tcrop(aFac[0] + (float)k[0] * in->r / in->m, out0R, out1R);
+        out->g =
+            out->m * tcrop(aFac[1] + (float)k[1] * in->g / in->m, out0G, out1G);
+        out->b =
+            out->m * tcrop(aFac[2] + (float)k[2] * in->b / in->m, out0B, out1B);
+      }
     }
   }
 }
@@ -189,7 +288,7 @@ void do_rgbmScale(TRasterPT<T> rout, TRasterPT<T> rin, const double *a,
 template <typename T, typename ScaleFunc>
 void do_rgbmAdjust(TRasterPT<T> rout, TRasterPT<T> rin, ScaleFunc scaleFunc,
                    const int *in0, const int *in1, const int *out0,
-                   const int *out1) {
+                   const int *out1, bool doClamp = true) {
   assert(rout->getSize() == rin->getSize());
 
   double a[5], k[5];
@@ -207,16 +306,25 @@ void do_rgbmAdjust(TRasterPT<T> rout, TRasterPT<T> rin, ScaleFunc scaleFunc,
 
   // Ensure that the output is cropped according to output params
   int out0i[4], out1i[4];
+  if (doClamp) {
+    out0i[0] = std::max(out0[0], tcrop((int)(a[0] + k[0] * out0[1]), 0, 255));
+    out1i[0] = std::min(out1[0], tcrop((int)(a[0] + k[0] * out1[1]), 0, 255));
 
-  out0i[0] = std::max(out0[0], tcrop((int)(a[0] + k[0] * out0[1]), 0, 255));
-  out1i[0] = std::min(out1[0], tcrop((int)(a[0] + k[0] * out1[1]), 0, 255));
+    out0i[1] = std::max(out0[0], tcrop((int)(a[0] + k[0] * out0[2]), 0, 255));
+    out1i[1] = std::min(out1[0], tcrop((int)(a[0] + k[0] * out1[2]), 0, 255));
 
-  out0i[1] = std::max(out0[0], tcrop((int)(a[0] + k[0] * out0[2]), 0, 255));
-  out1i[1] = std::min(out1[0], tcrop((int)(a[0] + k[0] * out1[2]), 0, 255));
+    out0i[2] = std::max(out0[0], tcrop((int)(a[0] + k[0] * out0[3]), 0, 255));
+    out1i[2] = std::min(out1[0], tcrop((int)(a[0] + k[0] * out1[3]), 0, 255));
+  } else {
+    out0i[0] = std::max(out0[0], (int)(a[0] + k[0] * out0[1]));
+    out1i[0] = std::min(out1[0], (int)(a[0] + k[0] * out1[1]));
 
-  out0i[2] = std::max(out0[0], tcrop((int)(a[0] + k[0] * out0[3]), 0, 255));
-  out1i[2] = std::min(out1[0], tcrop((int)(a[0] + k[0] * out1[3]), 0, 255));
+    out0i[1] = std::max(out0[0], (int)(a[0] + k[0] * out0[2]));
+    out1i[1] = std::min(out1[0], (int)(a[0] + k[0] * out1[2]));
 
+    out0i[2] = std::max(out0[0], (int)(a[0] + k[0] * out0[3]));
+    out1i[2] = std::min(out1[0], (int)(a[0] + k[0] * out1[3]));
+  }
   out0i[3] = out0[4];
   out1i[3] = out1[4];
 
@@ -245,6 +353,8 @@ void TRop::rgbmScale(TRasterP rout, TRasterP rin, const double *k,
     do_greyScale_lut<TPixelGR8>(rout, rin, a[0], k[0], out0[0], out1[0]);
   else if ((TRasterGR16P)rout && (TRasterGR16P)rin)
     do_greyScale_lut<TPixelGR16>(rout, rin, a[0], k[0], out0[0], out1[0]);
+  else if ((TRasterFP)rout && (TRasterFP)rin)
+    do_rgbmScale<TPixelF>(rout, rin, a, k, out0, out1);
   else {
     rout->unlock();
     rin->unlock();
@@ -292,7 +402,10 @@ void TRop::rgbmAdjust(TRasterP rout, TRasterP rin, const int *in0,
     else
       do_rgbmAdjust<TPixel64>(rout, rin, &do_rgbmScale_lut<TPixel64>, in0, in1,
                               out0, out1);
-  } else if ((TRasterGR8P)rout && (TRasterGR8P)rin)
+  } else if ((TRasterFP)rout && (TRasterFP)rin)
+    do_rgbmAdjust<TPixelF>(rout, rin, &do_rgbmScaleFloat, in0, in1, out0, out1,
+                           false);
+  else if ((TRasterGR8P)rout && (TRasterGR8P)rin)
     do_greyAdjust<TPixelGR8>(rout, rin, in0[0], in1[0], out0[0], out1[0]);
   else if ((TRasterGR16P)rout && (TRasterGR16P)rin)
     do_greyAdjust<TPixelGR16>(rout, rin, in0[0], in1[0], out0[0], out1[0]);

--- a/toonz/sources/image/exr/tiio_exr.cpp
+++ b/toonz/sources/image/exr/tiio_exr.cpp
@@ -8,6 +8,7 @@
 #include "tpixel.h"
 
 #include <QMap>
+#include <QString>
 
 namespace {
 inline unsigned char ftouc(float f, float gamma = 2.2f) {
@@ -32,6 +33,16 @@ inline float ustof(unsigned short us, float gamma = 2.2f) {
   return powf(static_cast<float>(us) / 65535.0f, gamma);
 }
 
+inline float toNonlinear(float f, float gamma = 2.2f) {
+  if (f < 0.f) return f;
+  return std::pow(f, 1.f / gamma);
+}
+
+inline float toLinear(float f, float gamma = 2.2f) {
+  if (f < 0.f) return f;
+  return std::pow(f, gamma);
+}
+
 const QMap<int, std::wstring> ExrCompTypeStr = {
     {TINYEXR_COMPRESSIONTYPE_NONE, L"None"},
     {TINYEXR_COMPRESSIONTYPE_RLE, L"RLE"},
@@ -53,6 +64,8 @@ class ExrReader final : public Tiio::Reader {
   EXRHeader* m_exr_header;
   FILE* m_fp;
 
+  float m_colorSpaceGamma;
+
 public:
   ExrReader();
   ~ExrReader();
@@ -64,10 +77,19 @@ public:
   ;
   void readLine(char* buffer, int x0, int x1, int shrink) override;
   void readLine(short* buffer, int x0, int x1, int shrink) override;
+  void readLine(float* buffer, int x0, int x1, int shrink) override;
   void loadImage();
+  void setColorSpaceGamma(const double gamma) override {
+    assert(gamma > 0);
+    m_colorSpaceGamma = static_cast<float>(gamma);
+  }
 };
 
-ExrReader::ExrReader() : m_rgbaBuf(nullptr), m_row(0), m_exr_header(nullptr) {}
+ExrReader::ExrReader()
+    : m_rgbaBuf(nullptr)
+    , m_row(0)
+    , m_exr_header(nullptr)
+    , m_colorSpaceGamma(2.2f) {}
 
 ExrReader::~ExrReader() {
   if (m_rgbaBuf) free(m_rgbaBuf);
@@ -99,7 +121,8 @@ void ExrReader::open(FILE* file) {
     bps = 32;
     break;
   case TINYEXR_PIXELTYPE_HALF:
-    bps = 16;
+    // bps = 16;
+    bps = 32;  // set 32bps in order to return float raster
     break;
   }
   m_info.m_bitsPerSample = bps;
@@ -149,10 +172,10 @@ void ExrReader::readLine(char* buffer, int x0, int x1, int shrink) {
       (x1 < x0) ? (m_info.m_lx - 1) / shrink + 1 : (x1 - x0) / shrink + 1;
 
   for (int i = 0; i < width; i++) {
-    pix->r = ftouc(v[0]);
-    pix->g = ftouc(v[1]);
-    pix->b = ftouc(v[2]);
-    pix->m = ftouc(v[3]);
+    pix->r = ftouc(v[0], m_colorSpaceGamma);
+    pix->g = ftouc(v[1], m_colorSpaceGamma);
+    pix->b = ftouc(v[2], m_colorSpaceGamma);
+    pix->m = ftouc(v[3], 1.0f);
 
     v += shrink * 4;
     pix += shrink;
@@ -181,10 +204,42 @@ void ExrReader::readLine(short* buffer, int x0, int x1, int shrink) {
       (x1 < x0) ? (m_info.m_lx - 1) / shrink + 1 : (x1 - x0) / shrink + 1;
 
   for (int i = 0; i < width; i++) {
-    pix->r = ftous(v[0]);
-    pix->g = ftous(v[1]);
-    pix->b = ftous(v[2]);
+    pix->r = ftous(v[0], m_colorSpaceGamma);
+    pix->g = ftous(v[1], m_colorSpaceGamma);
+    pix->b = ftous(v[2], m_colorSpaceGamma);
     pix->m = ftous(v[3], 1.0f);
+
+    v += shrink * 4;
+    pix += shrink;
+  }
+
+  m_row++;
+}
+
+void ExrReader::readLine(float* buffer, int x0, int x1, int shrink) {
+  const int pixelSize = 16;
+  if (m_row < 0 || m_row >= m_info.m_ly) {
+    memset(buffer, 0, (x1 - x0 + 1) * pixelSize);
+    m_row++;
+    return;
+  }
+
+  if (!m_rgbaBuf) loadImage();
+
+  TPixelF* pix = (TPixelF*)buffer;
+  float* v     = m_rgbaBuf + m_row * m_info.m_lx * 4;
+
+  pix += x0;
+  v += x0 * 4;
+
+  int width =
+      (x1 < x0) ? (m_info.m_lx - 1) / shrink + 1 : (x1 - x0) / shrink + 1;
+  // いったんノンリニアで読み込む。リニア計算のときはあとでリニアに戻す
+  for (int i = 0; i < width; i++) {
+    pix->r = toNonlinear(v[0], m_colorSpaceGamma);
+    pix->g = toNonlinear(v[1], m_colorSpaceGamma);
+    pix->b = toNonlinear(v[2], m_colorSpaceGamma);
+    pix->m = toNonlinear(v[3], 1.0f);
 
     v += shrink * 4;
     pix += shrink;
@@ -198,10 +253,17 @@ void ExrReader::readLine(short* buffer, int x0, int x1, int shrink) {
 Tiio::ExrWriterProperties::ExrWriterProperties()
     : m_compressionType("Compression Type")
     , m_storageType("Storage Type")
-    , m_bitsPerPixel("Bits Per Pixel") {
-  m_bitsPerPixel.addValue(L"48(RGB)");
-  m_bitsPerPixel.addValue(L"64(RGBA)");
-  m_bitsPerPixel.setValue(L"64(RGBA)");
+    , m_bitsPerPixel("Bits Per Pixel")
+    , m_colorSpaceGamma("Color Space Gamma", 0.1, 10.0, 2.2) {
+  // internally handles float raster
+  m_bitsPerPixel.addValue(L"96(RGB)_HF");
+  m_bitsPerPixel.addValue(L"128(RGBA)_HF");
+  m_bitsPerPixel.addValue(L"96(RGB)_F");
+  m_bitsPerPixel.addValue(L"128(RGBA)_F");
+  m_bitsPerPixel.setValue(L"128(RGBA)_HF");
+  // m_bitsPerPixel.addValue(L"48(RGB)");
+  // m_bitsPerPixel.addValue(L"64(RGBA)");
+  // m_bitsPerPixel.setValue(L"64(RGBA)");
 
   m_compressionType.addValue(
       ExrCompTypeStr.value(TINYEXR_COMPRESSIONTYPE_NONE));
@@ -221,12 +283,18 @@ Tiio::ExrWriterProperties::ExrWriterProperties()
   bind(m_bitsPerPixel);
   bind(m_compressionType);
   bind(m_storageType);
+  bind(m_colorSpaceGamma);
 }
 
 void Tiio::ExrWriterProperties::updateTranslation() {
   m_bitsPerPixel.setQStringName(tr("Bits Per Pixel"));
-  m_bitsPerPixel.setItemUIName(L"48(RGB)", tr("48(RGB Half Float)"));
-  m_bitsPerPixel.setItemUIName(L"64(RGBA)", tr("64(RGBA Half Float)"));
+  // internally handles float raster
+  m_bitsPerPixel.setItemUIName(L"96(RGB)_HF", tr("48(RGB Half Float)"));
+  m_bitsPerPixel.setItemUIName(L"128(RGBA)_HF", tr("64(RGBA Half Float)"));
+  m_bitsPerPixel.setItemUIName(L"96(RGB)_F", tr("96(RGB Float)"));
+  m_bitsPerPixel.setItemUIName(L"128(RGBA)_F", tr("128(RGBA Float)"));
+  // m_bitsPerPixel.setItemUIName(L"48(RGB)", tr("48(RGB Half Float)"));
+  // m_bitsPerPixel.setItemUIName(L"64(RGBA)", tr("64(RGBA Half Float)"));
 
   m_compressionType.setQStringName(tr("Compression Type"));
   m_compressionType.setItemUIName(
@@ -247,6 +315,8 @@ void Tiio::ExrWriterProperties::updateTranslation() {
   m_storageType.setQStringName(tr("Storage Type"));
   m_storageType.setItemUIName(EXR_STORAGETYPE_SCANLINE, tr("Scan-line based"));
   m_storageType.setItemUIName(EXR_STORAGETYPE_TILE, tr("Tile based"));
+
+  m_colorSpaceGamma.setQStringName(tr("Color Space Gamma"));
 }
 
 //============================================================
@@ -266,16 +336,18 @@ public:
   void open(FILE* file, const TImageInfo& info) override;
   void writeLine(char* buffer) override;
   void writeLine(short* buffer) override;
+  void writeLine(float* buffer) override;
 
   void flush() override;
 
   Tiio::RowOrder getRowOrder() const override { return Tiio::TOP2BOTTOM; }
 
   // m_bpp is set to "Bits Per Pixel" property value in the function open()
-  bool writeAlphaSupported() const override { return m_bpp == 64; }
+  bool writeAlphaSupported() const override { return m_bpp == 128; }
+  bool writeInLinearColorSpace() const override { return true; }
 };
 
-ExrWriter::ExrWriter() : m_row(0), m_bpp(64) {}
+ExrWriter::ExrWriter() : m_row(0), m_bpp(96) {}
 
 ExrWriter::~ExrWriter() {
   free(m_header.channels);
@@ -293,8 +365,8 @@ void ExrWriter::open(FILE* file, const TImageInfo& info) {
 
   TEnumProperty* bitsPerPixel =
       (TEnumProperty*)(m_properties->getProperty("Bits Per Pixel"));
-  m_bpp = bitsPerPixel ? std::stoi(bitsPerPixel->getValue()) : 64;
-  assert(m_bpp == 48 || m_bpp == 64);
+  m_bpp = bitsPerPixel ? std::stoi(bitsPerPixel->getValue()) : 128;
+  assert(m_bpp == 96 || m_bpp == 128);
 
   std::wstring compressionType =
       ((TEnumProperty*)(m_properties->getProperty("Compression Type")))
@@ -311,7 +383,7 @@ void ExrWriter::open(FILE* file, const TImageInfo& info) {
   } else
     m_header.tiled = 0;
 
-  m_image.num_channels = (m_bpp == 64) ? 4 : 3;
+  m_image.num_channels = (m_bpp == 128) ? 4 : 3;
 
   for (int c = 0; c < m_image.num_channels; c++)
     m_imageBuf[c].resize(m_info.m_lx * m_info.m_ly);
@@ -323,15 +395,15 @@ void ExrWriter::open(FILE* file, const TImageInfo& info) {
   m_header.channels =
       (EXRChannelInfo*)malloc(sizeof(EXRChannelInfo) * m_header.num_channels);
   // Must be BGR(A) order, since most of EXR viewers expect this channel order.
-  if (m_bpp == 64) {
-    strncpy(m_header.channels[0].name, "A", 255);
-    m_header.channels[0].name[strlen("A")] = '\0';
-    strncpy(m_header.channels[1].name, "B", 255);
-    m_header.channels[1].name[strlen("B")] = '\0';
-    strncpy(m_header.channels[2].name, "G", 255);
-    m_header.channels[2].name[strlen("G")] = '\0';
-    strncpy(m_header.channels[3].name, "R", 255);
-    m_header.channels[3].name[strlen("R")] = '\0';
+  if (m_bpp == 128) {
+    strncpy(m_header.channels[0].name, "B", 255);
+    m_header.channels[0].name[strlen("B")] = '\0';
+    strncpy(m_header.channels[1].name, "G", 255);
+    m_header.channels[1].name[strlen("G")] = '\0';
+    strncpy(m_header.channels[2].name, "R", 255);
+    m_header.channels[2].name[strlen("R")] = '\0';
+    strncpy(m_header.channels[3].name, "A", 255);
+    m_header.channels[3].name[strlen("A")] = '\0';
   } else {
     strncpy(m_header.channels[0].name, "B", 255);
     m_header.channels[0].name[strlen("B")] = '\0';
@@ -341,6 +413,11 @@ void ExrWriter::open(FILE* file, const TImageInfo& info) {
     m_header.channels[2].name[strlen("R")] = '\0';
   }
 
+  int requested_pixel_type =
+      (QString::fromStdWString(bitsPerPixel->getValue()).endsWith("_HF"))
+          ? TINYEXR_PIXELTYPE_HALF
+          : TINYEXR_PIXELTYPE_FLOAT;
+
   m_header.pixel_types = (int*)malloc(sizeof(int) * m_header.num_channels);
   m_header.requested_pixel_types =
       (int*)malloc(sizeof(int) * m_header.num_channels);
@@ -348,11 +425,12 @@ void ExrWriter::open(FILE* file, const TImageInfo& info) {
     m_header.pixel_types[i] =
         TINYEXR_PIXELTYPE_FLOAT;  // pixel type of input image
     m_header.requested_pixel_types[i] =
-        TINYEXR_PIXELTYPE_HALF;  // pixel type of output image to be stored in
-                                 // .EXR
+        requested_pixel_type;  // pixel type of output image to be stored in
+                               // .EXR
   }
 }
 
+// unused
 void ExrWriter::writeLine(char* buffer) {
   TPixel32* pix    = (TPixel32*)buffer;
   TPixel32* endPix = pix + m_info.m_lx;
@@ -361,16 +439,17 @@ void ExrWriter::writeLine(char* buffer) {
   float* g_p = &m_imageBuf[1][m_row * m_info.m_lx];
   float* b_p = &m_imageBuf[2][m_row * m_info.m_lx];
   float* a_p;
-  if (m_bpp == 64) a_p = &m_imageBuf[3][m_row * m_info.m_lx];
+  if (m_bpp == 128) a_p = &m_imageBuf[3][m_row * m_info.m_lx];
   while (pix < endPix) {
     *r_p++ = uctof(pix->r);
     *g_p++ = uctof(pix->g);
     *b_p++ = uctof(pix->b);
-    if (m_bpp == 64) *a_p++ = uctof(pix->m, 1.0f);
+    if (m_bpp == 128) *a_p++ = uctof(pix->m, 1.0f);
     pix++;
   }
   m_row++;
 }
+// unused
 void ExrWriter::writeLine(short* buffer) {
   TPixel64* pix    = (TPixel64*)buffer;
   TPixel64* endPix = pix + m_info.m_lx;
@@ -379,24 +458,49 @@ void ExrWriter::writeLine(short* buffer) {
   float* g_p = &m_imageBuf[1][m_row * m_info.m_lx];
   float* b_p = &m_imageBuf[2][m_row * m_info.m_lx];
   float* a_p;
-  if (m_bpp == 64) a_p = &m_imageBuf[3][m_row * m_info.m_lx];
+  if (m_bpp == 128) a_p = &m_imageBuf[3][m_row * m_info.m_lx];
   while (pix < endPix) {
     *r_p++ = ustof(pix->r);
     *g_p++ = ustof(pix->g);
     *b_p++ = ustof(pix->b);
-    if (m_bpp == 64) *a_p++ = ustof(pix->m, 1.0f);
+    if (m_bpp == 128) *a_p++ = ustof(pix->m, 1.0f);
+    pix++;
+  }
+  m_row++;
+}
+
+void ExrWriter::writeLine(float* buffer) {
+  TPixelF* pix    = (TPixelF*)buffer;
+  TPixelF* endPix = pix + m_info.m_lx;
+
+  float* r_p = &m_imageBuf[0][m_row * m_info.m_lx];
+  float* g_p = &m_imageBuf[1][m_row * m_info.m_lx];
+  float* b_p = &m_imageBuf[2][m_row * m_info.m_lx];
+  float* a_p;
+  if (m_bpp == 128) a_p = &m_imageBuf[3][m_row * m_info.m_lx];
+  while (pix < endPix) {
+    // raster is already linearized (see  MovieRenderer::Imp::postProcessImage()
+    // in movierenderer.cpp)
+    *r_p++ = pix->r;
+    *g_p++ = pix->g;
+    *b_p++ = pix->b;
+    if (m_bpp == 128) *a_p++ = pix->m;
+    //*r_p++ = toLinear(pix->r);
+    //*g_p++ = toLinear(pix->g);
+    //*b_p++ = toLinear(pix->b);
+    // if (m_bpp == 128) *a_p++ = toLinear(pix->m, 1.0f);
     pix++;
   }
   m_row++;
 }
 
 void ExrWriter::flush() {
-  if (m_bpp == 64) {
+  if (m_bpp == 128) {
     float* image_ptr[4];
-    image_ptr[0]   = &(m_imageBuf[3].at(0));  // B
-    image_ptr[1]   = &(m_imageBuf[2].at(0));  // G
-    image_ptr[2]   = &(m_imageBuf[1].at(0));  // R
-    image_ptr[3]   = &(m_imageBuf[0].at(0));  // A
+    image_ptr[0]   = &(m_imageBuf[2].at(0));  // B
+    image_ptr[1]   = &(m_imageBuf[1].at(0));  // G
+    image_ptr[2]   = &(m_imageBuf[0].at(0));  // R
+    image_ptr[3]   = &(m_imageBuf[3].at(0));  // A
     m_image.images = (unsigned char**)image_ptr;
     const char* err;
     int ret = SaveEXRImageToFileHandle(&m_image, &m_header, m_fp, &err);

--- a/toonz/sources/image/exr/tiio_exr.h
+++ b/toonz/sources/image/exr/tiio_exr.h
@@ -17,6 +17,7 @@ public:
   TEnumProperty m_compressionType;
   TEnumProperty m_storageType;
   TEnumProperty m_bitsPerPixel;
+  TDoubleProperty m_colorSpaceGamma;
 
   ExrWriterProperties();
 

--- a/toonz/sources/include/tcacheresource.h
+++ b/toonz/sources/include/tcacheresource.h
@@ -138,7 +138,7 @@ public:
 
   QMutex *getMutex() { return &m_mutex; }
 
-  enum Type { NONE, RGBM32, RGBM64, CM32 };
+  enum Type { NONE, RGBM32, RGBM64, RGBMFloat, CM32 };
   int getRasterType() const { return m_tileType; }
   TRasterP buildCompatibleRaster(const TDimension &size);
 

--- a/toonz/sources/include/tcommon.h
+++ b/toonz/sources/include/tcommon.h
@@ -62,6 +62,7 @@ int nanosleep(struct timespec *, int);
 #include <list>
 #include <vector>
 #include <map>
+#include <cmath>
 // .. and so on
 
 namespace TConsts {
@@ -118,6 +119,11 @@ inline int troundp(double x) { return ((int)((x) + 0.5F)); }
 /*! byteFromUshort(u) converts integer from [0..65535] to [0..255] */
 inline UCHAR byteFromUshort(USHORT u) {
   return ((256U * 255U + 1U) * u + (1 << 23)) >> 24;
+}
+
+/*! from[0. .. 1.] to [0..255] */
+inline UCHAR byteFromFloat(float f) {
+  return (f >= 1.f) ? 0xFF : (f <= 0.f) ? 0 : (UCHAR)(std::floor(f * 256.f));
 }
 
 /*! ditheredByteFromUshort(u) is like byteFromUshort().

--- a/toonz/sources/include/tgl.h
+++ b/toonz/sources/include/tgl.h
@@ -3,7 +3,7 @@
 #ifndef TGL_INCLUDED
 #define TGL_INCLUDED
 
-//#include "tgeometry.h"
+// #include "tgeometry.h"
 #include "tmachine.h"
 
 #ifdef _WIN32
@@ -27,9 +27,9 @@
 #include <GL/glut.h>
 #endif
 
-//#include "tcurves.h"
+// #include "tcurves.h"
 #include "traster.h"
-//#include "tfilepath.h"
+// #include "tfilepath.h"
 
 class TFilePath;
 class TCubic;
@@ -73,6 +73,7 @@ class TCubic;
 
 #define TGL_TexFmt10 GL_RGB10_A2
 #define TGL_TYPE16 GL_UNSIGNED_SHORT
+#define TGL_TYPE32F GL_FLOAT
 
 //=============================================================================
 

--- a/toonz/sources/include/tiio.h
+++ b/toonz/sources/include/tiio.h
@@ -52,8 +52,10 @@ public:
 
   void readLine(char *buffer) { readLine(buffer, 0, m_info.m_lx - 1, 1); }
   void readLine(short *buffer) { readLine(buffer, 0, m_info.m_lx - 1, 1); }
+  void readLine(float *buffer) { readLine(buffer, 0, m_info.m_lx - 1, 1); }
   virtual void readLine(char *buffer, int x0, int x1, int shrink) = 0;
   virtual void readLine(short *, int, int, int) { assert(false); }
+  virtual void readLine(float *, int, int, int) { assert(false); }
   // Returns skipped lines number.
   // If not implemented returns 0;
   virtual int skipLines(int lineCount) = 0;
@@ -71,6 +73,10 @@ public:
       std::map<int, std::pair<std::string, std::string>> &pltColorNames) const {
     assert(false);
   }
+
+  // gamma value to be used for converting linear-based image file to nonlinear
+  // raster. Curretly only used in EXR images.
+  virtual void setColorSpaceGamma(const double) {}
 
 private:
   // not implemented
@@ -101,12 +107,15 @@ public:
 
   virtual void writeLine(char *buffer) = 0;
   virtual void writeLine(short *) { assert(false); }
+  virtual void writeLine(float *) { assert(false); }
 
   virtual void flush() {}
 
   virtual RowOrder getRowOrder() const { return BOTTOM2TOP; }
   virtual bool write64bitSupported() const { return false; }
   virtual bool writeAlphaSupported() const { return true; }
+  // only true in EXR format
+  virtual bool writeInLinearColorSpace() const { return false; }
 
   void setProperties(TPropertyGroup *properties);
 
@@ -178,6 +187,6 @@ DVAPI void updateFileWritersPropertiesTranslation();
 
 //-------------------------------------------------------------------
 
-}  // namespace
+}  // namespace Tiio
 
 #endif

--- a/toonz/sources/include/timage_io.h
+++ b/toonz/sources/include/timage_io.h
@@ -3,9 +3,9 @@
 #ifndef TIMAGE_IO_INCLUDED
 #define TIMAGE_IO_INCLUDED
 
-//#include "trasterimage.h"
-//#include "texception.h"
-//#include "tfilepath.h"
+// #include "trasterimage.h"
+// #include "texception.h"
+// #include "tfilepath.h"
 #include <QStringList>
 
 #include "tfilepath_io.h"
@@ -28,7 +28,7 @@ class Reader;
 class Writer;
 class VectorReader;
 class VectorWriter;
-}
+}  // namespace Tiio
 class TPropertyGroup;
 class TImageInfo;
 
@@ -93,9 +93,11 @@ protected:
   bool isOpen() const;
   bool m_readGreytones;
   bool m_is64BitEnabled;
+  bool m_isFloatEnabled;
   int m_shrink;
   TRect m_region;
   static bool m_safeMode;
+  double m_colorSpaceGamma;
 
 public:
   static void setSafeModeReadingForTzl(bool activated) {
@@ -148,6 +150,9 @@ Note: if the region, or part of it, is not contained in the image
   void enable16BitRead(bool is64bitEnabled) {
     m_is64BitEnabled = is64bitEnabled;
   }
+  void enableFloatRead(bool isFloatEnabled) {
+    m_isFloatEnabled = isFloatEnabled;
+  }
 
   int getShrink() const { return m_shrink; }
   /*!
@@ -174,6 +179,10 @@ Region dimension doesn't consider shrink
   void getTzpPaletteColorNames(
       std::map<int, std::pair<std::string, std::string>>
           &pltColorNames);  // colorindex(<256: paint), pagename, colorname
+
+  void setColorSpaceGamma(const double colorSpaceGamma) {
+    m_colorSpaceGamma = colorSpaceGamma;
+  }
 };
 
 //-----------------------------------------------------------

--- a/toonz/sources/include/tools/stylepicker.h
+++ b/toonz/sources/include/tools/stylepicker.h
@@ -3,7 +3,7 @@
 #ifndef STYLE_PICKER_H
 #define STYLE_PICKER_H
 
-//#include "timage.h"
+// #include "timage.h"
 #include "tcommon.h"
 #include "tpalette.h"
 
@@ -71,8 +71,11 @@ public:
   TPixel32 pickColor(const TPointD &point, double radius, double scale2) const;
   TPixel64 pickColor16(const TPointD &point, double radius,
                        double scale2) const;
+  TPixelF pickColor32F(const TPointD &point, double radius,
+                       double scale2) const;
   TPixel32 pickAverageColor(const TRectD &rect) const;
   TPixel64 pickAverageColor16(const TRectD &rect) const;
+  TPixelF pickAverageColor32F(const TRectD &rect) const;
 
   // ritorna il colore medio presente nell'area della finestra corrente openGL
   TPixel32 pickColor(const TRectD &area) const;

--- a/toonz/sources/include/toonz/imagemanager.h
+++ b/toonz/sources/include/toonz/imagemanager.h
@@ -112,6 +112,10 @@ public:
     toBeSaved = 0x8,  // User will save the image, reverts toBeModified
 
     is64bitEnabled = 0x10,  // Whether 64-bit rasters are allowed to return
+    isFloatEnabled = 0x20,  // Whether 128-bit float rasters are allowed to
+                            // return (for EXR format)
+    // isLinearEnabled = 0x40,  // Whether linear color space rasters are
+    // allowed to return (for EXR format)
 
     controlFlags = 0xF,  // Flags dealing with management control
     imageFlags =

--- a/toonz/sources/include/toonz/imagepainter.h
+++ b/toonz/sources/include/toonz/imagepainter.h
@@ -67,6 +67,9 @@ public:
   bool m_drawBlankFrame;
   bool m_useChecks;  //!< whether to consider  paint check and ink check
   bool m_forSceneIcon = false;  // whether it is rendered for the scene icons
+
+  int m_gainStep;
+
 public:
   VisualSettings();
 
@@ -108,6 +111,6 @@ DVAPI void paintImage(const TImageP &image, const TDimension &imageSize,
                       const VisualSettings &visualSettings,
                       const CompareSettings &compareSettings,
                       const TRect &loadbox);
-}
+}  // namespace ImagePainter
 
 #endif  // IMAGEPAINTER_H

--- a/toonz/sources/include/toonz/levelproperties.h
+++ b/toonz/sources/include/toonz/levelproperties.h
@@ -32,8 +32,9 @@
 
 class DVAPI LevelOptions {
 public:
-  enum DpiPolicy       //!  Describes the dpi policy used for a level.
-  { DP_ImageDpi  = 0,  //!< Level uses the natural dpi embedded in its images.
+  enum DpiPolicy  //!  Describes the dpi policy used for a level.
+  {
+    DP_ImageDpi  = 0,  //!< Level uses the natural dpi embedded in its images.
     DP_CustomDpi = 2   //!< Level uses a custom dpi set by the user.
   };
 
@@ -54,6 +55,12 @@ public:
       //!  premultiplied by Toonz for alpha compositing (because they
       //!  are not).
       m_isStopMotionLevel;
+
+  double m_colorSpaceGamma;  // gamma value to be used for converting
+                             // linear-based image file to nonlinear raster.
+                             // Curretly only used in EXR image levels.
+
+  static const double DefaultColorSpaceGamma;
 
 public:
   LevelOptions();  //!< Constructs with default values.
@@ -228,6 +235,11 @@ ie
     m_options.m_isStopMotionLevel = isStopMotion;
   }
   bool isStopMotionLevel() const { return m_options.m_isStopMotionLevel; }
+
+  // gamma value to be used for converting linear-based image file (EXR) to
+  // nonlinear raster.
+  void setColorSpaceGamma(double gamma) { m_options.m_colorSpaceGamma = gamma; }
+  double colorSpaceGamma() const { return m_options.m_colorSpaceGamma; }
 
 private:
   TPointD m_imageDpi;

--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -70,8 +70,9 @@ public:
 \sa       \p TXshSimpleLevel::getFrameStatus() and
           \p setFrameStatus() for further details.                  */
 
-  enum FrameStatusBit      //!  Describes a level's frame status.
-  { Normal         = 0x0,  //!< Frame has no special status.
+  enum FrameStatusBit  //!  Describes a level's frame status.
+  {
+    Normal         = 0x0,  //!< Frame has no special status.
     Scanned        = 0x1,  //!< A fullcolor frame (only tlv levels).
     Cleanupped     = 0x2,  //!< A cleanupped frame (only tlv levels).
     CleanupPreview = 0x4   //!< A cleanup preview (only fullcolor levels).
@@ -100,6 +101,12 @@ public:
   }
   void set16BitChannelLevel(bool value) {
     m_16BitChannelLevel = (value && getType() == OVL_XSHLEVEL);
+  }
+  bool isFloatChannelLevel() const {
+    return getType() == OVL_XSHLEVEL && m_floatChannelLevel;
+  }
+  void setFloatChannelLevel(bool value) {
+    m_floatChannelLevel = (value && getType() == OVL_XSHLEVEL);
   }
 
   bool isReadOnly() const { return m_isReadOnly; }
@@ -385,7 +392,7 @@ private:
   std::string m_idBase;
   std::wstring m_editableRangeUserInfo;
 
-  bool m_isSubsequence, m_16BitChannelLevel, m_isReadOnly,
+  bool m_isSubsequence, m_16BitChannelLevel, m_floatChannelLevel, m_isReadOnly,
       m_temporaryHookMerged;  //!< Used only during hook merge (and hence during
                               //! saving)
 

--- a/toonz/sources/include/toonzqt/combohistogram.h
+++ b/toonz/sources/include/toonzqt/combohistogram.h
@@ -32,6 +32,7 @@ class QColor;
 
 class RGBLabel;
 class QLabel;
+class QPushButton;
 
 #define COMBOHIST_RESOLUTION_W 256
 #define COMBOHIST_RESOLUTION_H 100
@@ -76,6 +77,7 @@ class DVAPI ChannelHistoGraph : public QWidget {
 
   int m_pickedValue;
   int m_channelIndex;
+  float m_range;
 
 public:
   bool *m_showComparePtr;
@@ -87,6 +89,7 @@ public:
   virtual void setValues(int *buf, bool isComp);
 
   void showCurrentChannelValue(int val);
+  void setRange(float range) { m_range = range; }
 
 protected:
   void paintEvent(QPaintEvent *event) override;
@@ -115,10 +118,12 @@ protected:
 class DVAPI ChannelColorBar final : public QWidget {
   Q_OBJECT
   QColor m_color;
+  float m_range;
 
 public:
   ChannelColorBar(QWidget *parent = 0, QColor m_color = QColor());
   ~ChannelColorBar() {}
+  void setRange(float range) { m_range = range; }
 
 protected:
   void paintEvent(QPaintEvent *event) override;
@@ -141,6 +146,11 @@ public:
   }
 
   void showCurrentChannelValue(int val);
+
+  void setRange(float range) {
+    m_histogramGraph->setRange(range);
+    m_colorBar->setRange(range);
+  }
 
 protected slots:
   void onShowAlphaButtonToggled(bool visible);
@@ -170,6 +180,12 @@ class DVAPI ComboHistogram final : public QWidget {
   QLabel *m_xPosLabel;
   QLabel *m_yPosLabel;
 
+  // graph range control (available only with TRasterF)
+  QWidget *m_rangeControlContainer;
+  QPushButton *m_rangeUpBtn, *m_rangeDwnBtn;
+  QLabel *m_rangeLabel;
+  int m_rangeStep;  // 0 = 1.0, 1 = 2.0, 2 = 4.0, 3 = 8.0...
+
   QComboBox *m_displayModeCombo;
 
   bool m_showCompare;
@@ -184,8 +200,10 @@ public:
   void setRaster(const TRasterP &raster, const TPaletteP &palette = 0);
   void updateInfo(const TPixel32 &pix, const TPointD &imagePos);
   void updateInfo(const TPixel64 &pix, const TPointD &imagePos);
+  void updateInfo(const TPixelF &pix, const TPointD &imagePos);
   void updateAverageColor(const TPixel32 &pix);
   void updateAverageColor(const TPixel64 &pix);
+  void updateAverageColor(const TPixelF &pix);
   void updateCompHistogram();
 
   void setShowCompare(bool on) {
@@ -197,6 +215,8 @@ public:
     if (isVisible() && m_showCompare) updateCompHistogram();
   }
 
+  void refreshHistogram();
+
 protected:
   void computeChannelsValue(int *buf, size_t size, TRasterP ras,
                             TPalette *extPlt = nullptr);
@@ -205,6 +225,8 @@ protected:
 protected slots:
   void onDisplayModeChanged();
   void onShowAlphaButtonToggled(bool);
+  void onRangeUp();
+  void onRangeDown();
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -225,6 +225,9 @@ public:
     eFlipVertical,
     eResetView,
     eBlankFrames,
+    eDecreaseGain,
+    eResetGain,
+    eIncreaseGain,
     // following values are hard-coded in ImagePainter
     eBlackBg = 0x40000,
     eWhiteBg = 0x80000,
@@ -316,6 +319,7 @@ public:
   void setFpsFieldColor(const QColor &color) { m_fpsFieldColor = color; }
   QColor getFpsFieldColor() const { return m_fpsFieldColor; }
 
+  void resetGain(bool forceInit = false);
 signals:
 
   void buttonPressed(FlipConsole::EGadget button);
@@ -331,7 +335,7 @@ private:
 
   QAction *m_customSep, *m_rateSep, *m_histoSep, *m_bgSep, *m_vcrSep,
       *m_compareSep, *m_saveSep, *m_colorFilterSep, *m_soundSep, *m_subcamSep,
-      *m_filledRasterSep, *m_viewerSep;
+      *m_filledRasterSep, *m_viewerSep, *m_gainSep;
 
   QToolBar *m_playToolBar;
   QActionGroup *m_colorFilterGroup;
@@ -347,6 +351,7 @@ private:
   QFrame *createFpsSlider();
   QAction *m_doubleRedAction, *m_doubleGreenAction, *m_doubleBlueAction;
   DoubleButton *m_doubleRed, *m_doubleGreen, *m_doubleBlue;
+
   std::vector<int> m_gadgetsMask;
   int m_from, m_to, m_step;
   int m_currentFrame, m_framesCount;
@@ -362,6 +367,9 @@ private:
   TPixel m_blankColor;
   int m_blanksToDraw;
   bool m_isLinkable;
+
+  QToolButton *m_resetGainBtn;
+  int m_prevGainStep;
 
   QMap<EGadget, QAbstractButton *> m_buttons;
   QMap<EGadget, QAction *> m_actions;
@@ -394,6 +402,8 @@ private:
 
   FlipConsoleOwner *m_consoleOwner;
   TFrameHandle *m_frameHandle;
+
+  void adjustGain(bool increase);
 
 protected slots:
 

--- a/toonz/sources/include/toonzqt/fxsettings.h
+++ b/toonz/sources/include/toonzqt/fxsettings.h
@@ -39,6 +39,7 @@ class QToolBar;
 class QStackedWidget;
 class QVBoxLayout;
 class QGridLayout;
+class QLabel;
 class QPushButton;
 class FxKeyframeNavigator;
 class ParamViewer;
@@ -153,6 +154,9 @@ class DVAPI ParamsPageSet final : public QWidget {
   /*-- ヘルプボタンで開くURL --*/
   std::string m_helpUrl;
   QPushButton *m_helpButton;
+  // waring mark appears when the current fx does not support
+  // float / linear render settings
+  QLabel *m_warningMark;
 
 public:
 #if QT_VERSION >= 0x050500
@@ -178,6 +182,8 @@ public:
   void addParamsPage(ParamsPage *page, const char *name);
 
   QSize getPreferredSize() { return m_preferredSize; }
+
+  void updateWarnings(const TFxP &currentFx, bool isFloat);
 
 protected:
   void createPage(TIStream &is, const TFxP &fx, int index);
@@ -223,6 +229,9 @@ public:
   void notifyPreferredSizeChanged(QSize size) {
     emit preferredSizeChanged(size);
   }
+
+  // show warning if the current Fx does not support float rendering
+  void updateWarnings(const TFxP &currentFx, bool isFloat);
 
 protected:
   ParamsPageSet *getCurrentPageSet() const;

--- a/toonz/sources/include/toutputproperties.h
+++ b/toonz/sources/include/toutputproperties.h
@@ -98,11 +98,18 @@ private:
   // such as new raster level, captured images by camera capture feature, etc.
   TFrameId m_formatTemplateFId;
 
+  // if true, channel width, linear color space and color space gamma will be
+  // shared between output and preview settings.
+  bool m_syncColorSettings;
+  // for restoring bpp when setting the color space back to nonlinear
+  int m_nonlinearBpp;
+
 public:
   /*!
 Constructs TOutputProperties with default value.
 */
   TOutputProperties();
+
   /*!
 Destroys the TOutputProperties object.
 */
@@ -227,6 +234,11 @@ machine's CPU).
   BoardSettings *getBoardSettings() const { return m_boardSettings; }
 
   TFrameId &formatTemplateFId() { return m_formatTemplateFId; }
+
+  bool isColorSettingsSynced() { return m_syncColorSettings; }
+  void syncColorSettings(bool sync) { m_syncColorSettings = sync; }
+  int getNonlinearBpp() { return m_nonlinearBpp; }
+  void setNonlinearBpp(int bpp) { m_nonlinearBpp = bpp; }
 };
 
 //--------------------------------------------

--- a/toonz/sources/include/tparamcontainer.h
+++ b/toonz/sources/include/tparamcontainer.h
@@ -6,7 +6,7 @@
 #include <memory>
 
 #include "tparam.h"
-//#include "tfx.h"
+// #include "tfx.h"
 #include "tcommon.h"
 
 #undef DVAPI
@@ -26,6 +26,7 @@ class TParam;
 
 class DVAPI TParamVar {
   std::string m_name;
+  // hidden parameter will be hidden from the fx settings or the function editor
   bool m_isHidden;
   // Flag for an obsolete parameter used for maintaining backward-compatiblity.
   // - The obsolete parameter will call a special function

--- a/toonz/sources/include/tparamset.h
+++ b/toonz/sources/include/tparamset.h
@@ -199,6 +199,7 @@ public:
   TPixel32 getDefaultValue() const;
   TPixelD getValueD(double frame) const;
   TPixel32 getValue(double frame) const;
+  TPixel32 getValue(double frame, bool linear, double colorSpaceGamma) const;
   TPixel64 getValue64(double frame) const;
   TPixel32 getPremultipliedValue(double frame) const;
 

--- a/toonz/sources/include/tpixel.h
+++ b/toonz/sources/include/tpixel.h
@@ -258,7 +258,6 @@ typedef TPixelRGBM64 TPixel64;
 class DVAPI TPixelD {
 public:
   typedef double Channel;
-
   Channel r, g, b, m;
 
   TPixelD() : r(0), g(0), b(0), m(1){};
@@ -316,6 +315,68 @@ static inline TPixelD from(const TPixelD &pix) {return pix;};
   static const TPixelD White;
   static const TPixelD Black;
   static const TPixelD Transparent;
+};
+
+//-----------------------------------------------------------------------------
+// TPixelF is used in floating-point rendering
+
+class DVAPI TPixelF {
+public:
+  typedef float Channel;
+  static const float maxChannelValue;
+
+#ifdef TNZ_MACHINE_CHANNEL_ORDER_BGRM
+  Channel b, g, r, m;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_MRGB)
+  Channel m, r, g, b;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_RGBM)
+  Channel r, g, b, m;
+#else
+  undefined machine order !!!!
+#endif
+
+  TPixelF() : r(0.f), g(0.f), b(0.f), m(1.f){};
+  TPixelF(const TPixelF &pix) : r(pix.r), g(pix.g), b(pix.b), m(pix.m){};
+  TPixelF(float rr, float gg, float bb, float mm = 1.f)
+      : r(rr), g(gg), b(bb), m(mm){};
+
+  inline bool operator==(const TPixelF &p) const {
+    return r == p.r && g == p.g && b == p.b && m == p.m;
+  };
+  inline bool operator<(const TPixelF &p) const {
+    return r < p.r ||
+           (r == p.r &&
+            (g < p.g || (g == p.g && (b < p.b || (b == p.b && (m < p.m))))));
+  };
+
+  inline bool operator>=(const TPixelF &p) const { return !operator<(p); };
+  inline bool operator!=(const TPixelF &p) const { return !operator==(p); };
+  inline bool operator>(const TPixelF &p) const {
+    return !operator<(p) && !operator==(p);
+  };
+  inline bool operator<=(const TPixelF &p) const { return !operator>(p); };
+
+  inline TPixelF operator*=(const TPixelF &p) {
+    r *= p.r;
+    g *= p.g;
+    b *= p.b;
+    m *= p.m;
+    return *this;
+  }
+  inline TPixelF operator*(const TPixelF &p) const {
+    TPixelF ret(*this);
+    return ret *= p;
+  }
+
+  static const TPixelF Red;
+  static const TPixelF Green;
+  static const TPixelF Blue;
+  static const TPixelF Yellow;
+  static const TPixelF Cyan;
+  static const TPixelF Magenta;
+  static const TPixelF White;
+  static const TPixelF Black;
+  static const TPixelF Transparent;
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/tpixelgr.h
+++ b/toonz/sources/include/tpixelgr.h
@@ -28,6 +28,8 @@ class TPixelGR8;
 //! Gray Scale 2 byte/pixel
 class TPixelGR16;
 
+class TPixelF;
+
 //-----------------------------------------------------------------------------
 /*! grey tones, 8 bits
    A set of predefined colors are included as well.
@@ -106,6 +108,22 @@ public:
 
   static const TPixelGR16 White;
   static const TPixelGR16 Black;
+};
+
+//-----------------------------------------------------------------------------
+
+class DVAPI TPixelGRF {
+public:
+  typedef float Channel;
+
+  float value;
+  TPixelGRF(float v = 0.f) : value(v){};
+  TPixelGRF(const TPixelGRF &pix) : value(pix.value){};
+  inline bool operator==(const TPixelGRF &p) const { return value == p.value; };
+  inline bool operator<(const TPixelGRF &p) const { return value < p.value; };
+
+  inline void setValue(float _value) { value = (float)_value; }
+  static TPixelGRF from(const TPixelF &pix);
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/traster.h
+++ b/toonz/sources/include/traster.h
@@ -88,6 +88,7 @@ protected:
   // i costruttori sono qui per centralizzare la gestione della memoria
   // e' comunque impossibile fare new TRaster perche' e' una classe astratta
   // (clone, extract)
+  bool m_isLinear;  // linear color space
 
   // crea il buffer associato (NON fa addRef())
   TRaster(int lx, int ly, int pixelSize);
@@ -172,11 +173,18 @@ public:
   TRasterP getParent() { return m_parent; }
   // creazione di TRaster derivati
 
+  bool isLinear() const { return m_isLinear; }
+  void setLinear(const bool linear) {
+    if (m_isLinear == linear) return;
+    m_isLinear = linear;
+    if (m_parent) m_parent->setLinear(linear);
+  }
+
   // devono essere virtuali puri perche' il nuovo raster creato deve essere del
   // tipo giusto
-  virtual TRasterP clone() const        = 0;
-  virtual TRasterP extract(TRect &rect) = 0;
-  virtual TRasterP create() const       = 0;
+  virtual TRasterP clone() const                = 0;
+  virtual TRasterP extract(TRect &rect)         = 0;
+  virtual TRasterP create() const               = 0;
   virtual TRasterP create(int lx, int ly) const = 0;
 
   // definita in termini di extract(rect); non lo posso fare subito perche'
@@ -192,7 +200,7 @@ public:
   // getBounds()
   // e i due raster sono allineati in basso a sinistra (src[0,0] -> dst[offset])
   /*!Copies the content of the source raster in the current raster.
-*/
+   */
   void copy(const TRasterP &src, const TPoint &offset = TPoint());
 
   void xMirror();
@@ -328,6 +336,8 @@ public:
     if (isEmpty() || getBounds().overlaps(rect) == false) return TRasterP();
     rect = getBounds() * rect;
     // addRef();
+    // return TRasterP(new TRasterT<T>(rect.getLx(), rect.getLy(), m_wrap,
+    //  pixels(rect.y0) + rect.x0, this));
     return TRasterP(new TRasterT<T>(rect.getLx(), rect.getLy(), m_wrap,
                                     pixels(rect.y0) + rect.x0, this));
   };
@@ -429,6 +439,9 @@ template class DVAPI TRasterPT<TPixel32>;
 template class DVAPI TSmartPointerT<TRasterT<TPixel64>>;
 template class DVAPI TRasterPT<TPixel64>;
 
+template class DVAPI TSmartPointerT<TRasterT<TPixelF>>;
+template class DVAPI TRasterPT<TPixelF>;
+
 template class DVAPI TSmartPointerT<TRasterT<TPixelGR8>>;
 template class DVAPI TRasterPT<TPixelGR8>;
 
@@ -445,6 +458,7 @@ template class DVAPI TRasterPT<TPixelCY>;
 
 typedef TRasterPT<TPixel32> TRaster32P;
 typedef TRasterPT<TPixel64> TRaster64P;
+typedef TRasterPT<TPixelF> TRasterFP;
 typedef TRasterPT<TPixelGR8> TRasterGR8P;
 typedef TRasterPT<TPixelGR16> TRasterGR16P;
 typedef TRasterPT<TPixelGRD> TRasterGRDP;

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -117,6 +117,9 @@ public:
               //! data
   //!  must be accompanied by a tile of the suitable type. \sa
   //!  TRasterFx::compute().
+
+  bool m_linearColorSpace;  // compute in linear color space (gamma 2.2)
+
   int m_maxTileSize;  //!< Maximum size (in MegaBytes) of a tile cachable during
                       //! a render process.
   //!  Used by the predictive cache manager to subdivide an fx calculation into
@@ -161,6 +164,8 @@ public:
   // for offscreen rendering to be done in non-GUI thread.
   // For now it is used only in the plasticDeformerFx.
   std::shared_ptr<QOffscreenSurface> m_offScreenSurface;
+
+  double m_colorSpaceGamma;
 
 public:
   TRenderSettings();
@@ -273,6 +278,13 @@ public:
   void enableCache(bool on);
   bool isCacheEnabled() const;
 
+  void enableComputeInFloat(bool on);
+  bool canComputeInFloat() const;
+  virtual bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                              bool tileIsLinear) const {
+    return false;
+  }
+
   // resituisce una stringa che identifica univocamente il sottoalbero
   // avente come radice l'effetto
   std::string getAlias(double frame,
@@ -355,6 +367,9 @@ public:
   void transform(double frame, int port, const TRectD &rectOnOutput,
                  const TRenderSettings &infoOnOutput, TRectD &rectOnInput,
                  TRenderSettings &infoOnInput) override;
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override;
 };
 
 //-------------------------------------------------------------------

--- a/toonz/sources/include/trop.h
+++ b/toonz/sources/include/trop.h
@@ -286,10 +286,10 @@ DVAPI void ropmin(const TRasterP &rup, const TRasterP &rdown,
 
 DVAPI void ropmax(const TRasterP &rup, const TRasterP &rdown,
                   const TRasterP &rout);
-DVAPI void linearburn(const TRasterP &rup, const TRasterP &rdown,
-                      const TRasterP &rout);
-DVAPI void overlay(const TRasterP &rup, const TRasterP &rdown,
-                   const TRasterP &rout);
+// DVAPI void linearburn(const TRasterP &rup, const TRasterP &rdown,
+//                       const TRasterP &rout);
+// DVAPI void overlay(const TRasterP &rup, const TRasterP &rdown,
+//                    const TRasterP &rout);
 
 //! Make a premultiply of all raster pixels
 DVAPI void premultiply(const TRasterP &ras);
@@ -411,5 +411,13 @@ DVAPI void lockRaster(_RASTER *raster);
 //! Surrenders the input raster's buffer to the cache. Should be called before
 //! inactivity periods.
 DVAPI void unlockRaster(_RASTER *raster);
+
+// conversion between sRGB <--> Linear RGB
+DVAPI void toLinearRGB(TRasterP raster, double gamma,
+                       bool sourceIsPremultiplied = true);
+DVAPI void tosRGB(TRasterP raster, double gamma,
+                  bool sourceIsPremultiplied = true);
+
+DVAPI void adjustGain(TRasterP raster, int gainStep, double gamma);
 
 }  // namespace TRop

--- a/toonz/sources/include/tspectrum.h
+++ b/toonz/sources/include/tspectrum.h
@@ -181,10 +181,12 @@ DVAPI TSpectrumT<TPixel64> convert(const TSpectrumT<TPixel32> &s);
 #ifdef _WIN32
 template class DVAPI TSpectrumT<TPixel32>;
 template class DVAPI TSpectrumT<TPixel64>;
+template class DVAPI TSpectrumT<TPixelF>;
 #endif
 
 typedef TSpectrumT<TPixel32> TSpectrum;
 typedef TSpectrumT<TPixel64> TSpectrum64;
+typedef TSpectrumT<TPixelF> TSpectrumF;
 
 #ifdef _MSC_VER
 #pragma warning(default : 4251)

--- a/toonz/sources/include/tspectrumparam.h
+++ b/toonz/sources/include/tspectrumparam.h
@@ -54,6 +54,7 @@ public:
 
   TSpectrum getValue(double frame) const;
   TSpectrum64 getValue64(double frame) const;
+  TSpectrumF getValueF(double frame) const;
   void setValue(double frame, const TSpectrum &value, bool undoing = false);
   void setDefaultValue(const TSpectrum &value);
 

--- a/toonz/sources/stdfx/adjustlevelsfx.cpp
+++ b/toonz/sources/stdfx/adjustlevelsfx.cpp
@@ -1,7 +1,7 @@
 
 
 #include "stdfx.h"
-//#include "tsystem.h"
+// #include "tsystem.h"
 #include "tfxparam.h"
 #include "tpixelutils.h"
 #include "tparamset.h"
@@ -64,7 +64,11 @@ public:
     bindParam(this, "gamma_b", m_gamma_b);
     bindParam(this, "gamma_m", m_gamma_m);
     addInputPort("Source", m_input);
-
+    // TODO: Floatでの計算が可能になるにあたって、
+    // 値の範囲を0-255で制限したくない
+    // →
+    // スライダは0-255のまま、入力フィールドは好きな数字を入れられるようにするか？
+    //   (Nuke の Histogramエフェクトのように)
     m_in_rgb->getMin()->setValueRange(0, 255);
     m_in_rgb->getMax()->setValueRange(0, 255);
     m_in_r->getMin()->setValueRange(0, 255);
@@ -90,6 +94,8 @@ public:
     m_gamma_g->setValueRange(0.0, 200.0);
     m_gamma_b->setValueRange(0.0, 200.0);
     m_gamma_m->setValueRange(0.0, 200.0);
+
+    enableComputeInFloat(true);
   }
 
   ~AdjustLevelsFx(){};

--- a/toonz/sources/stdfx/blurfx.cpp
+++ b/toonz/sources/stdfx/blurfx.cpp
@@ -21,6 +21,8 @@ public:
 
     addInputPort("Source", m_input);
     m_value->setValueRange(0, std::numeric_limits<double>::max());
+
+    enableComputeInFloat(true);
   }
 
   ~BlurFx(){};

--- a/toonz/sources/stdfx/gammafx.cpp
+++ b/toonz/sources/stdfx/gammafx.cpp
@@ -16,6 +16,8 @@ public:
     addInputPort("Source", m_input);
     // m_gamma->setValueRange(0, std::numeric_limits<double>::max());
     m_gamma->setValueRange(0.0, 200.0);
+
+    enableComputeInFloat(true);
   }
 
   ~GammaFx(){};

--- a/toonz/sources/stdfx/gradients.cpp
+++ b/toonz/sources/stdfx/gradients.cpp
@@ -76,6 +76,9 @@ void multiRadial(const TRasterP &ras, TPointD posTrasf,
   else if ((TRaster64P)ras)
     doComputeRadialT<TPixel64>(ras, posTrasf, colors->getValue64(frame), period,
                                count, cycle, aff, inner, type);
+  else if ((TRasterFP)ras)
+    doComputeRadialT<TPixelF>(ras, posTrasf, colors->getValueF(frame), period,
+                              count, cycle, aff, inner, type);
   else
     throw TException("MultiRadialGradientFx: unsupported Pixel Type");
 }
@@ -150,6 +153,9 @@ void multiLinear(const TRasterP &ras, TPointD posTrasf,
   else if ((TRaster64P)ras)
     doComputeLinearT<TPixel64>(ras, posTrasf, colors->getValue64(frame), period,
                                count, amplitude, freq, phase, cycle, aff, type);
+  else if ((TRasterFP)ras)
+    doComputeLinearT<TPixelF>(ras, posTrasf, colors->getValueF(frame), period,
+                              count, amplitude, freq, phase, cycle, aff, type);
   else
     throw TException("MultiLinearGradientFx: unsupported Pixel Type");
 }

--- a/toonz/sources/stdfx/hsvkeyfx.cpp
+++ b/toonz/sources/stdfx/hsvkeyfx.cpp
@@ -1,6 +1,6 @@
 
 
-//#include "trop.h"
+// #include "trop.h"
 #include "tfxparam.h"
 #include <math.h>
 #include "stdfx.h"
@@ -42,6 +42,7 @@ public:
     m_srange->setValueRange(0.0, 1.0);
     m_vrange->setValueRange(0.0, 1.0);
     addInputPort("Source", m_input);
+    enableComputeInFloat(true);
   }
 
   ~HSVKeyFx(){};
@@ -110,17 +111,17 @@ void HSVKeyFx::doCompute(TTile &tile, double frame, const TRenderSettings &ri) {
   double highV = std::min(1.0, v_ref + v_range);
 
   TRaster32P raster32 = tile.getRaster();
+  TRaster64P raster64 = tile.getRaster();
+  TRasterFP rasterF   = tile.getRaster();
 
   if (raster32)
     doHSVKey<TPixel32>(raster32, lowH, highH, lowS, highS, lowV, highV, gender);
-  else {
-    TRaster64P raster64 = tile.getRaster();
-    if (raster64)
-      doHSVKey<TPixel64>(raster64, lowH, highH, lowS, highS, lowV, highV,
-                         gender);
-    else
-      throw TException("HSVKey: unsupported Pixel Type");
-  }
+  else if (raster64)
+    doHSVKey<TPixel64>(raster64, lowH, highH, lowS, highS, lowV, highV, gender);
+  else if (rasterF)
+    doHSVKey<TPixelF>(rasterF, lowH, highH, lowS, highS, lowV, highV, gender);
+  else
+    throw TException("HSVKey: unsupported Pixel Type");
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/stdfx/igs_color_blend.cpp
+++ b/toonz/sources/stdfx/igs_color_blend.cpp
@@ -156,7 +156,9 @@ double lighten_ch_(const double dn, const double dn_a, const double up,
                                  : dn_add_up_ch_(dn, dn_a, up, up_opacity);
 }
 double screen_(const double dn, const double up) {
-  return 1.0 - (1.0 - dn) * (1.0 - up);
+  return (dn <= 1.0 && up <= 1.0) ? 1.0 - (1.0 - dn) * (1.0 - up)
+         : (up > dn)              ? up
+                                  : dn;
 }
 double color_dodge_(const double dn, const double up) {
   return (1.0 <= up) ? 1.0 : clamp_min1_ch_(dn / (1.0 - up));

--- a/toonz/sources/stdfx/igs_color_rgb_hls.cpp
+++ b/toonz/sources/stdfx/igs_color_rgb_hls.cpp
@@ -4,8 +4,9 @@ void igs::color::rgb_to_hls(const double red,  // 0.0...1.0
                             const double blu,  // 0.0...1.0
                             double &hue,       /* 0.0...360.0	hue(色相) */
                             double &lig,       /* 0.0...1.0	lightness(明度) */
-                            double &sat /* 0.0...1.0	saturation(彩度) */
-                            ) {
+                            double &sat,      /* 0.0...1.0	saturation(彩度) */
+                            bool cylindrical  // either cylindrical or conical
+) {
   const double maxi =
       (red < gre) ? ((gre < blu) ? blu : gre) : ((red < blu) ? blu : red);
   const double mini =
@@ -17,11 +18,14 @@ void igs::color::rgb_to_hls(const double red,  // 0.0...1.0
     sat = 0.0;        /* saturation(彩度)はゼロ */
     hue = 0.0;        /* hue(色相)は意味を持たない */
   } else {            /* 色のあるとき */
-    if (lig <= 0.5) {
-      sat = (maxi - mini) / (maxi + mini);
-    } else {
-      sat = (maxi - mini) / (2.0 - (maxi + mini));
-    }
+    if (cylindrical) {
+      if (lig <= 0.5) {
+        sat = (maxi - mini) / (maxi + mini);
+      } else {
+        sat = (maxi - mini) / (2.0 - (maxi + mini));
+      }
+    } else
+      sat = maxi - mini;
 
     /* 色相(Hue) */
     const double rmid = (maxi - red) / (maxi - mini);
@@ -70,23 +74,28 @@ double hls2rgb_calc(const double m1, const double m2, const double hue) {
   }
   return m1; /* 240 ... 360 */
 }
-}
-void igs::color::hls_to_rgb(
-    const double hue, /* 0.0...360.0	hue(色相) */
-    const double lig, /* 0.0...1.0	lightness(明度) */
-    const double sat, /* 0.0...1.0	saturation(彩度) */
-    double &red,      /* 0.0...1.0 */
-    double &gre,      /* 0.0...1.0 */
-    double &blu       /* 0.0...1.0 */
-    ) {
+}  // namespace
+void igs::color::hls_to_rgb(const double hue, /* 0.0...360.0	hue(色相) */
+                            const double lig, /* 0.0...1.0 lightness(明度) */
+                            const double sat, /* 0.0...1.0 saturation(彩度) */
+                            double &red,      /* 0.0...1.0 */
+                            double &gre,      /* 0.0...1.0 */
+                            double &blu,      /* 0.0...1.0 */
+                            bool cylindrical  // either cylindrical or conical
+) {
   if (0.0 == sat) { /* 白黒で色がない */
     red = gre = blu = lig;
   } else { /* 色のあるとき */
-    const double m2 =
-        (lig <= 0.5) ? (lig * (1.0 + sat)) : (lig + sat - lig * sat);
-    const double m1 = 2.0 * lig - m2;
-    red             = hls2rgb_calc(m1, m2, hue + 120.0);
-    gre             = hls2rgb_calc(m1, m2, hue);
-    blu             = hls2rgb_calc(m1, m2, hue - 120.0);
+    double m2, m1;
+    if (cylindrical) {
+      m2 = (lig <= 0.5) ? (lig * (1.0 + sat)) : (lig + sat - lig * sat);
+      m1 = 2.0 * lig - m2;
+    } else {
+      m2 = lig + sat * 0.5;
+      m1 = lig - sat * 0.5;
+    }
+    red = hls2rgb_calc(m1, m2, hue + 120.0);
+    gre = hls2rgb_calc(m1, m2, hue);
+    blu = hls2rgb_calc(m1, m2, hue - 120.0);
   }
 }

--- a/toonz/sources/stdfx/igs_color_rgb_hls.h
+++ b/toonz/sources/stdfx/igs_color_rgb_hls.h
@@ -7,10 +7,10 @@ namespace igs {
 namespace color {
 // Use add_hls & noise_hlsa
 void rgb_to_hls(const double red, const double gre, const double blu,
-                double &hue, double &lig, double &sat);
+                double &hue, double &lig, double &sat, bool cylindrical = true);
 void hls_to_rgb(const double hue, const double lig, const double sat,
-                double &red, double &gre, double &blu);
-}
-}
+                double &red, double &gre, double &blu, bool cylindrical = true);
+}  // namespace color
+}  // namespace igs
 
 #endif /* !igs_color_rgb_hls_h */

--- a/toonz/sources/stdfx/igs_color_rgb_hsv.cpp
+++ b/toonz/sources/stdfx/igs_color_rgb_hsv.cpp
@@ -1,23 +1,26 @@
 #include "igs_color_rgb_hsv.h"
+#include <cmath>
 void igs::color::rgb_to_hsv(const double red,  // 0.0...1.0
                             const double gre,  // 0.0...1.0
                             const double blu,  // 0.0...1.0
                             double &hue,       /* 0.0...360.0	hue(色相) */
                             double &sat, /* 0.0...1.0	saturation(彩度) */
                             double &val  /* 0.0...1.0	value(明度) */
-                            ) {
+) {
   const double maxi =
       (red < gre) ? ((gre < blu) ? blu : gre) : ((red < blu) ? blu : red);
   const double mini =
       (gre < red) ? ((blu < gre) ? blu : gre) : ((blu < red) ? blu : red);
 
-  val = maxi; /* value(明度) */
+  bool invertValue = std::abs(mini) > std::abs(maxi);
+
+  val = (invertValue) ? mini : maxi; /* value(明度) */
 
   if (maxi == mini) { /* RGB各色に差がない(白黒の)とき */
     sat = 0.0;        /* saturation(彩度)はゼロ */
     hue = 0.0;        /* hue(色相)は意味を持たない */
   } else {            /* 色のあるとき */
-    sat = (maxi - mini) / maxi;
+    sat = (invertValue) ? (mini - maxi) / mini : (maxi - mini) / maxi;
 
     const double maxmin = maxi - mini;
 
@@ -40,20 +43,20 @@ void igs::color::rgb_to_hsv(const double red,  // 0.0...1.0
            -1 0 1 2 3 4 5
     */
     hue *= 60.0; /* -60 ... 300 */
+    if (invertValue) hue -= 180.0;
     if (hue < 0.0) {
       hue += 360.0;
     }
   }
 }
-#include <cmath> /* floor() */
-void igs::color::hsv_to_rgb(
-    const double hue, /* 0.0...360.0	hue(色相) */
-    const double sat, /* 0.0...1.0	saturation(彩度) */
-    const double val, /* 0.0...1.0	value(明度) */
-    double &red,      /* 0.0...1.0 */
-    double &gre,      /* 0.0...1.0 */
-    double &blu       /* 0.0...1.0 */
-    ) {
+#include <cmath>                              /* floor() */
+void igs::color::hsv_to_rgb(const double hue, /* 0.0...360.0	hue(色相) */
+                            const double sat, /* 0.0...1.0 saturation(彩度) */
+                            const double val, /* 0.0...1.0	value(明度) */
+                            double &red,      /* 0.0...1.0 */
+                            double &gre,      /* 0.0...1.0 */
+                            double &blu       /* 0.0...1.0 */
+) {
   if (0.0 == sat) { /* 白黒で色がない */
     red = gre = blu = val;
   } else { /* 色のあるとき */

--- a/toonz/sources/stdfx/igs_density.cpp
+++ b/toonz/sources/stdfx/igs_density.cpp
@@ -1,131 +1,79 @@
 #include "igs_density.h"
-
+#include <iostream>
 namespace {
-double accum_by_trans_(
-    const double src_value /* 元値(R,G,B) */
-    ,
-    const double transparent /* src_valueの透明度(0...1) */
-    ,
-    const int integer_part /* 濃度値の整数部分(0...) */
-    ,
-    const double fractional_part /* 濃度値の少数部分(0...1) */
-    ) {
-  double accumulation = src_value;
+float accum_by_trans_(const float src_value /* 元値(R,G,B) */
+                      ,
+                      const float transparent /* src_valueの透明度(0...1) */
+                      ,
+                      const int integer_part /* 濃度値の整数部分(0...) */
+                      ,
+                      const double fractional_part /* 濃度値の少数部分(0...1) */
+) {
+  float accumulation = src_value;
   if (1 <= integer_part) {
     for (int ii = 1; ii < integer_part; ++ii) {
       accumulation = accumulation * transparent + src_value;
     }
-    if (0.0 < fractional_part) {
+    if (0.f < fractional_part) {
       accumulation +=
           ((accumulation * transparent + src_value) - accumulation) *
           fractional_part;
     }
   } else { /* 整数部分がゼロ以下のとき */
-    if (0.0 < fractional_part) {
+    if (0.f < fractional_part) {
       accumulation *= fractional_part;
     } else { /* 少数部分もゼロ以下のとき */
-      accumulation = 0.0;
+      accumulation = 0.f;
     }
   }
-  return (1.0 < accumulation) ? 1.0
-                              : ((accumulation < 0.0) ? 0.0 : accumulation);
+  return (1.f < accumulation) ? 1.f
+                              : ((accumulation < 0.f) ? 0.f : accumulation);
 }
-}
+}  // namespace
 #include <limits>           /* std::numeric_limits */
 #include "igs_ifx_common.h" /* igs::image::rgba */
 namespace {
-template <class IT, class RT>
-void change_template_(
-    IT *image_array, const int height, const int width, const int channels
-
-    ,
-    const RT *ref /* 求める画像と同じ高、幅、ch数 */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double density) {
+void change_(float *image_array, const int height, const int width,
+             const int channels, const float *ref, const double density) {
   const int integer_part       = (int)density;
   const double fractional_part = density - (int)density;
-  const double maxi            = std::numeric_limits<IT>::max();
 
   using namespace igs::image::rgba;
   const int pixsize = height * width;
-  const int r_max   = std::numeric_limits<RT>::max();
   for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
-    const double rr1 = (double)(image_array[red]) / maxi;
-    const double gg1 = (double)(image_array[gre]) / maxi;
-    const double bb1 = (double)(image_array[blu]) / maxi;
-    const double aa1 = (double)(image_array[alp]) / maxi;
+    const float rr1 = image_array[red];
+    const float gg1 = image_array[gre];
+    const float bb1 = image_array[blu];
+    const float aa1 = image_array[alp];
 
-    double rr2 = accum_by_trans_(rr1, 1.0 - aa1, integer_part, fractional_part);
-    double gg2 = accum_by_trans_(gg1, 1.0 - aa1, integer_part, fractional_part);
-    double bb2 = accum_by_trans_(bb1, 1.0 - aa1, integer_part, fractional_part);
-    double aa2 = accum_by_trans_(aa1, 1.0 - aa1, integer_part, fractional_part);
+    float rr2 = accum_by_trans_(rr1, 1.0 - aa1, integer_part, fractional_part);
+    float gg2 = accum_by_trans_(gg1, 1.0 - aa1, integer_part, fractional_part);
+    float bb2 = accum_by_trans_(bb1, 1.0 - aa1, integer_part, fractional_part);
+    float aa2 = accum_by_trans_(aa1, 1.0 - aa1, integer_part, fractional_part);
 
     /* 参照画像あればピクセル単位の画像変化 */
-    if (ref != 0) {
-      const double refv = igs::color::ref_value(ref, channels, r_max, ref_mode);
-
-      ref += channels; /* continue;の前に行うこと */
-
-      rr2 = (rr2 - rr1) * refv + rr1;
-      gg2 = (gg2 - gg1) * refv + gg1;
-      bb2 = (bb2 - bb1) * refv + bb1;
-      aa2 = (aa2 - aa1) * refv + aa1;
+    if (ref != nullptr) {
+      rr2 = (rr2 - rr1) * (*ref) + rr1;
+      gg2 = (gg2 - gg1) * (*ref) + gg1;
+      bb2 = (bb2 - bb1) * (*ref) + bb1;
+      aa2 = (aa2 - aa1) * (*ref) + aa1;
+      ref++;
     }
 
-    image_array[red] = static_cast<IT>(rr2 * (maxi + 0.999999));
-    image_array[gre] = static_cast<IT>(gg2 * (maxi + 0.999999));
-    image_array[blu] = static_cast<IT>(bb2 * (maxi + 0.999999));
-    image_array[alp] = static_cast<IT>(aa2 * (maxi + 0.999999));
+    image_array[red] = rr2;
+    image_array[gre] = gg2;
+    image_array[blu] = bb2;
+    image_array[alp] = aa2;
   }
 }
-}
+}  // namespace
 #include <stdexcept> /* std::domain_error(-) */
-void igs::density::change(
-    unsigned char *image_array /* RGBAでなければならない */
-    ,
-    const int height, const int width,
-    const int channels /* 4(=RGBAでなければならない) */
-    ,
-    const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、ch数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double density) {
+void igs::density::change(float *image_array, const int height, const int width,
+                          const int channels, /* 4(=RGBAでなければならない) */
+                          const float *ref, const double density) {
   if (igs::image::rgba::siz != channels) {
     throw std::domain_error("Bad channels,Not rgba");
   }
 
-  if ((std::numeric_limits<unsigned char>::digits == bits) &&
-      ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-       (0 == ref_bits))) {
-    change_template_(image_array, height, width, channels, ref, ref_mode,
-                     density);
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-              (0 == ref_bits))) {
-    change_template_(reinterpret_cast<unsigned short *>(image_array), height,
-                     width, channels, ref, ref_mode, density);
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(reinterpret_cast<unsigned short *>(image_array), height,
-                     width, channels,
-                     reinterpret_cast<const unsigned short *>(ref), ref_mode,
-                     density);
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(image_array, height, width, channels,
-                     reinterpret_cast<const unsigned short *>(ref), ref_mode,
-                     density);
-  } else {
-    throw std::domain_error("Bad bits,Not uchar/ushort");
-  }
+  change_(image_array, height, width, channels, ref, density);
 }

--- a/toonz/sources/stdfx/igs_density.h
+++ b/toonz/sources/stdfx/igs_density.h
@@ -10,23 +10,10 @@
 namespace igs {
 namespace density {
 IGS_DENSITY_EXPORT void change(
-    unsigned char *image_array /* RGBAでなければならない */
-    ,
-    const int height, const int width,
-    const int channels /* 4(=RGBAでなければならない) */
-    ,
-    const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、ch数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double density = 1.0);
+    float *image_array, const int height, const int width,
+    const int channels, /* 4(=RGBAでなければならない) */
+    const float *ref, const double density = 1.0);
 }
-}
+}  // namespace igs
 
 #endif /* !igs_density_h */

--- a/toonz/sources/stdfx/igs_gaussian_blur.cpp
+++ b/toonz/sources/stdfx/igs_gaussian_blur.cpp
@@ -13,6 +13,7 @@ const int diameter_from_radius_(const int radius) {
   /* テーブルの半径サイズ(=中心位置)からテーブルの大きさを決める */
   return radius * 2 + 1;
 }
+#if 0
 template <class RT>
 void blur_1st_hori_(
     const double **in_plane_with_margin  // &(std::vector<double *>).at(0)
@@ -78,6 +79,66 @@ accum += in_plane_with_margin[yo][xi] * brush_sequence[xb];
     }
   }
 }
+#endif
+
+void blur_1st_hori_(
+    const double** in_plane_with_margin  // &(std::vector<double *>).at(0)
+    ,
+    const int height_with_margin, const int width_with_margin,
+    double* brush_sequence  // &(std::vector<double *>).at(0)
+    ,
+    const int int_radius,
+    double** out_plane_with_margin  // &(std::vector<double *>).at(0)
+
+    /* 参照画像用情報(no margin) */
+    ,
+    const float* ref /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+    ,
+    const double real_radius, const double sigma) {
+  const int brush_diameter  = diameter_from_radius_(int_radius);
+  const int width_no_margin = width_with_margin - int_radius * 2;
+  // const int r_max = std::numeric_limits<RT>::max();
+  const float* ref_vert     = ref;
+  const float* ref_hori     = ref;
+  double before_real_radius = -1.0;
+
+  /* 縦方向 */
+  for (int yo = 0; yo < height_with_margin; ++yo) {
+    if (ref != nullptr) {
+      if (int_radius < yo && yo < (height_with_margin - int_radius)) {
+        ref_vert += width_no_margin;
+      }
+      ref_hori = ref_vert;
+    }
+
+    /* 横方向 */
+    for (int xx = 0, xo = int_radius; xx < width_no_margin; ++xx, ++xo) {
+      if (ref != 0) {
+        const double read_r = real_radius * (*ref_hori);
+        ref_hori++;
+
+        if (read_r != before_real_radius) {
+          gauss_distribution_1d_(brush_sequence, brush_diameter,
+                                 igs::gaussian_blur_hv::int_radius(read_r),
+                                 read_r, sigma);
+          before_real_radius = read_r;
+        }
+      }
+      /* ガウス分布で横blur */
+      double accum = 0;
+
+      const double* bru_seq = brush_sequence;
+      int bru_dia           = brush_diameter;
+      const double* inn_pla = &in_plane_with_margin[yo][xx];
+      while (0 < bru_dia--) {
+        accum += (*inn_pla++) * (*bru_seq++);
+      }
+      out_plane_with_margin[yo][xo] = accum;
+    }
+  }
+}
+
+#if 0
 template <class RT>
 void blur_2nd_vert_(
     const double **in_plane_with_margin  // &(std::vector<double *>).at(0)
@@ -145,6 +206,67 @@ accum += in_plane_with_margin[yi][xo] * brush_sequence[yb];
     }
   }
 }
+#endif
+
+void blur_2nd_vert_(
+    const double** in_plane_with_margin  // &(std::vector<double *>).at(0)
+    ,
+    const int height_with_margin, const int width_with_margin,
+    double* brush_sequence  // &(std::vector<double *>).at(0)
+    ,
+    const int int_radius,
+    double** out_plane_with_margin  // &(std::vector<double *>).at(0)
+
+    /* 参照画像用情報(no margin) */
+    ,
+    const float* ref /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+    ,
+    const double real_radius, const double sigma) {
+  const int brush_diameter   = diameter_from_radius_(int_radius);
+  const int height_no_margin = height_with_margin - int_radius * 2;
+  const int width_no_margin  = width_with_margin - int_radius * 2;
+  // const int r_max = std::numeric_limits<RT>::max();
+  const float* ref_vert     = ref;
+  const float* ref_hori     = ref;
+  double before_real_radius = -1.0;
+
+  /* 左右マージン部分はもう処理しなくていい */
+
+  /* 横方向 */
+  for (int xx = 0, xo = int_radius; xx < width_no_margin; ++xx, ++xo) {
+    if (ref != nullptr) {
+      ref_hori++;
+      ref_vert = ref_hori;
+    }
+
+    /* 縦方向 */
+    for (int yy = 0, yo = int_radius; yy < height_no_margin; ++yy, ++yo) {
+      if (ref != 0) {
+        const double read_r = real_radius * (*ref_vert);
+        ref_vert += width_no_margin;
+
+        if (read_r != before_real_radius) {
+          gauss_distribution_1d_(brush_sequence, brush_diameter,
+                                 igs::gaussian_blur_hv::int_radius(read_r),
+                                 read_r, sigma);
+          before_real_radius = read_r;
+        }
+      }
+      /* ガウス分布で横blur */
+      double accum          = 0;
+      const double* bru_seq = brush_sequence;
+      int bru_dia           = brush_diameter;
+      const double* inn_pla = &in_plane_with_margin[yy][xo];
+      while (0 < bru_dia--) {
+        accum += (*inn_pla) * (*bru_seq++);
+        inn_pla += width_with_margin;
+      }
+      out_plane_with_margin[yo][xo] = accum;
+    }
+  }
+}
+
+#if 0
 template <class T>
 void get_(const T *in, const int height, const int width, const int channels,
           const int current_ch, double **out  // &(std::vector<double *>).at(0)
@@ -158,6 +280,22 @@ void get_(const T *in, const int height, const int width, const int channels,
     }
   }
 }
+#endif
+
+void get_(const float* in, const int height, const int width,
+          const int channels, const int current_ch,
+          double** out  // &(std::vector<double *>).at(0)
+) {
+  in += current_ch;
+  for (int yy = 0; yy < height; ++yy) {
+    for (int xx = 0; xx < width; ++xx) {
+      out[yy][xx] = static_cast<double>(*in);
+      in += channels;
+    }
+  }
+}
+
+#if 0
 template <class T>
 void put_margin_(
     const double **in_with_margin  // &(std::vector<double *>).at(0)
@@ -175,6 +313,23 @@ void put_margin_(
     }
   }
 }
+#endif
+
+void put_margin_(
+    const double** in_with_margin,  // &(std::vector<double *>).at(0)
+    const int height_with_margin, const int width_with_margin,
+    const int channels, const int current_ch, const int margin,
+    float* out_no_margin) {
+  out_no_margin += current_ch;
+  for (int yy = margin; yy < (height_with_margin - margin); ++yy) {
+    for (int xx = margin; xx < (width_with_margin - margin); ++xx) {
+      *out_no_margin = in_with_margin[yy][xx];
+      out_no_margin += channels;
+    }
+  }
+}
+
+#if 0
 template <class T>
 bool diff_between_channel_(const T *in, const int height, const int width,
                            const int channels, const int ch1, const int ch2) {
@@ -191,6 +346,21 @@ bool diff_between_channel_(const T *in, const int height, const int width,
   }
   return false;
 }
+#endif
+bool diff_between_channel_(const float* in, const int height, const int width,
+                           const int channels, const int ch1, const int ch2) {
+  for (int yy = 0; yy < height; ++yy) {
+    for (int xx = 0; xx < width; ++xx) {
+      if (in[ch1] != in[ch2]) {
+        return true;
+      }
+      in += channels;
+    }
+  }
+  return false;
+}
+
+#if 0
 template <class IT, class RT>
 void convert_hv_(const IT *in_with_margin, IT *out_no_margin,
                  const int height_with_margin, const int width_with_margin,
@@ -238,7 +408,44 @@ void convert_hv_(const IT *in_with_margin, IT *out_no_margin,
                 width_with_margin, channels, cc, int_radius, out_no_margin);
   }
 }
+#endif
+
+void convert_hv_(
+    const float* in_with_margin, float* out_no_margin,
+    const int height_with_margin, const int width_with_margin,
+    const int channels,
+    double* filter,  // (double *)(&filter_buf.at(0))
+    const int int_radius,
+    double** buffer_inn,  // &(std::vector<double *>).at(0)
+    double** buffer_out,  // &(std::vector<double *>).at(0)
+    /* 参照画像用情報(no margin) */
+    const float* ref, /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+    const double real_radius, const double sigma) {
+  bool diff_sw = true; /* 1番目の画像は処理する */
+  for (int cc = 0; cc < channels; ++cc) {
+    if (0 < cc) { /* 2番目のチャンネル以後 */
+      /* 1つ前のチャンネルと違いを調べる */
+      diff_sw = diff_between_channel_(in_with_margin, height_with_margin,
+                                      width_with_margin, channels, cc - 1, cc);
+    }
+    /* 一つ前と同じ画像なら処理せず使い回して高速化する */
+    if (diff_sw) {
+      get_(in_with_margin, height_with_margin, width_with_margin, channels, cc,
+           buffer_inn);
+      blur_1st_hori_((const double**)(buffer_inn), height_with_margin,
+                     width_with_margin, filter, int_radius, buffer_out, ref,
+                     real_radius, sigma);
+      blur_2nd_vert_((const double**)(buffer_out), height_with_margin,
+                     width_with_margin, filter, int_radius, buffer_inn, ref,
+                     real_radius, sigma);
+    }
+
+    put_margin_((const double**)(buffer_inn), height_with_margin,
+                width_with_margin, channels, cc, int_radius, out_no_margin);
+  }
 }
+
+}  // namespace
 const int igs::gaussian_blur_hv::int_radius(const double real_radius) {
   /* ぼかしの半径から、pixelサイズ半径(=中心位置=margin)を決める */
   return static_cast<int>(ceil(real_radius));
@@ -253,31 +460,18 @@ const int igs::gaussian_blur_hv::buffer_bytes(const int height_with_margin,
 }
 void igs::gaussian_blur_hv::convert(
     /* 入出力画像 */
-    const void *in_with_margin, void *out_no_margin
-
-    ,
+    const float* in_with_margin, float* out_no_margin,
     const int height_with_margin, const int width_with_margin,
-    const int channels, const int bits
-
+    const int channels,
     /* Pixel毎に効果の強弱 */
-    ,
-    const unsigned char *ref /* 求める画像(out)と同じ高、幅、ch数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
+    const float* ref, /* 求める画像(out)と同じ高、幅、ch数 */
     /* 計算バッファ */
-    ,
-    void *buffer,
-    int buffer_bytes  // Must be igs::gaussian_blur_hv::buffer_bytes(-)
-
+    void* buffer,
+    int buffer_bytes,  // Must be igs::gaussian_blur_hv::buffer_bytes(-)
     /* Action Geometry */
-    ,
-    const int int_radius  // =margin
-    ,
+    const int int_radius,                         // =margin
     const double real_radius, const double sigma  //= 0.25
-    ) {
+) {
   /* 引数チェック */
   if (real_radius <= 0.0) {
     return;
@@ -285,18 +479,18 @@ void igs::gaussian_blur_hv::convert(
 
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
   /* 変数の設定 */
   const int int_diameter = diameter_from_radius_(int_radius);
-  double *double_buffer  = static_cast<double *>(buffer);
+  double* double_buffer  = static_cast<double*>(buffer);
 
   /* メモリバッファの設定 */
   std::vector<double> filter_buf(int_diameter);
 
-  std::vector<double *> in_plane_with_margin_dp(height_with_margin);
+  std::vector<double*> in_plane_with_margin_dp(height_with_margin);
   for (int yy = 0; yy < height_with_margin; ++yy) {
     in_plane_with_margin_dp.at(yy) = double_buffer;
     double_buffer += width_with_margin;
@@ -307,7 +501,7 @@ void igs::gaussian_blur_hv::convert(
     }
   }
 
-  std::vector<double *> out_plane_with_margin_dp(height_with_margin);
+  std::vector<double*> out_plane_with_margin_dp(height_with_margin);
   for (int yy = 0; yy < height_with_margin; ++yy) {
     out_plane_with_margin_dp.at(yy) = double_buffer;
     double_buffer += width_with_margin;
@@ -322,7 +516,11 @@ void igs::gaussian_blur_hv::convert(
   gauss_distribution_1d_(&filter_buf.at(0), int_diameter, int_radius,
                          real_radius, sigma);
 
-  /* 処理 */
+  convert_hv_(in_with_margin, out_no_margin, height_with_margin,
+              width_with_margin, channels, &filter_buf.at(0), int_radius,
+              &in_plane_with_margin_dp.at(0), &out_plane_with_margin_dp.at(0),
+              ref, real_radius, sigma);
+  /*
   if ((std::numeric_limits<unsigned char>::digits == bits) &&
       ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
        (0 == ref_bits))) {
@@ -369,4 +567,5 @@ void igs::gaussian_blur_hv::convert(
   } else {
     throw std::domain_error("Bad bits,Not uchar/ushort");
   }
+  */
 }

--- a/toonz/sources/stdfx/igs_gaussian_blur.h
+++ b/toonz/sources/stdfx/igs_gaussian_blur.h
@@ -15,33 +15,18 @@ IGS_GAUSSIAN_BLUR_HV_EXPORT const int buffer_bytes(const int height_with_margin,
                                                    const int int_radius);
 IGS_GAUSSIAN_BLUR_HV_EXPORT void convert(
     /* 入出力画像 */
-    const void *in_with_margin, void *out_no_margin
-
-    ,
+    const float* in_with_margin, float* out_no_margin,
     const int height_with_margin, const int width_with_margin,
-    const int channels, const int bits
-
+    const int channels,
     /* Pixel毎に効果の強弱 */
-    ,
-    const unsigned char *ref /* 求める画像(out)と同じ高、幅、ch数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
+    const float* ref, /* 求める画像(out)と同じ高、幅、ch数 */
     /* 計算バッファ */
-    ,
-    void *buffer, int buffer_bytes
-    // Must be igs::gaussian_blur_hv::buffer_bytes(-)
-
+    void* buffer,
+    int buffer_bytes,  // Must be igs::gaussian_blur_hv::buffer_bytes(-)
     /* Action Geometry */
-    ,
-    const int int_radius  // margin
-    // Must be igs::gaussian_blur_hv::int_radius(real_radius)
-
-    ,
+    const int int_radius,  // =margin
     const double real_radius, const double sigma = 0.25);
-}
-}
+}  // namespace gaussian_blur_hv
+}  // namespace igs
 
 #endif /* !igs_gaussian_blur_hv_h */

--- a/toonz/sources/stdfx/igs_hls_add.cpp
+++ b/toonz/sources/stdfx/igs_hls_add.cpp
@@ -9,9 +9,9 @@ void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
                  ,
                  const double sat_noise, const double alp_noise,
                  double &red_out, double &gre_out, double &blu_out,
-                 double &alp_out) {
+                 double &alp_out, const bool cylindrical = true) {
   double hue, lig, sat, alp;
-  igs::color::rgb_to_hls(red_in, gre_in, blu_in, hue, lig, sat);
+  igs::color::rgb_to_hls(red_in, gre_in, blu_in, hue, lig, sat, cylindrical);
   alp = alp_in;
 
   if (0.0 != hue_noise) {
@@ -25,40 +25,37 @@ void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
   }
   if (0.0 != lig_noise) {
     lig += lig_noise;
-    lig = (lig < 0.0) ? 0.0 : ((1.0 < lig) ? 1.0 : lig);
+    // lig = (lig < 0.0) ? 0.0 : ((1.0 < lig) ? 1.0 : lig);
   }
   if (0.0 != sat_noise) {
     sat += sat_noise;
-    sat = (sat < 0.0) ? 0.0 : ((1.0 < sat) ? 1.0 : sat);
+    sat = (sat < 0.0) ? 0.0 : sat;
+    // sat = (sat < 0.0) ? 0.0 : ((1.0 < sat) ? 1.0 : sat);
   }
   if (0.0 != alp_noise) {
     alp += alp_noise;
     alp = (alp < 0.0) ? 0.0 : ((1.0 < alp) ? 1.0 : alp);
   }
 
-  igs::color::hls_to_rgb(hue, lig, sat, red_out, gre_out, blu_out);
+  igs::color::hls_to_rgb(hue, lig, sat, red_out, gre_out, blu_out, cylindrical);
   alp_out = alp;
 }
-}
+}  // namespace
 //------------------------------------------------------------
 namespace {
 class noise_ref_ {
 public:
-  noise_ref_(const unsigned char *array, const int height, const int width,
-             const int channels, const int bits, const int xoffset,
-             const int yoffset, const int zz);
-  double noise(int xx  // 0...width-1...
-               ,
-               int yy    // 0...height-1...
-               ) const;  // return range is 0...1
+  noise_ref_(const float *array, const int height, const int width,
+             const int xoffset, const int yoffset, const int zz);
+  float noise(int xx  // 0...width-1...
+              ,
+              int yy  // 0...height-1...
+  ) const;            // return range is 0...1
 
 private:
-  const unsigned char *array_;
+  const float *array_;
   const int height_;
   const int width_;
-  const int channels_;
-  const int bits_;
-  const double bmax_;
   const int xoffset_;
   const int yoffset_;
   const int zz_;
@@ -69,30 +66,22 @@ private:
   /* 代入演算子を無効化 */
   noise_ref_ &operator=(const noise_ref_ &);
 };
-noise_ref_::noise_ref_(const unsigned char *array, const int height,
-                       const int width, const int channels, const int bits,
+noise_ref_::noise_ref_(const float *array, const int height, const int width,
                        const int xoffset, const int yoffset, const int zz)
     : array_(array)
     , height_(height)
     , width_(width)
-    , channels_(channels)
-    , bits_(bits)
-    , bmax_(static_cast<double>((1 << bits) - 1))
     , xoffset_(xoffset)
     , yoffset_(yoffset)
     , zz_(zz) {
   if (0 == array) {
     throw std::domain_error("noise_ref_  no data");
   }
-  if ((zz < 0) || (channels <= zz)) {
+  if ((zz < 0) || (4 <= zz)) {
     throw std::domain_error("noise_ref_  bad zz");
   }
-  if ((std::numeric_limits<unsigned char>::digits != this->bits_) &&
-      (std::numeric_limits<unsigned short>::digits != this->bits_)) {
-    throw std::domain_error("noise_ref_  bad bits");
-  }
 }
-double noise_ref_::noise(int xx, int yy) const {
+float noise_ref_::noise(int xx, int yy) const {
   xx -= this->xoffset_;
   yy -= this->yoffset_;
   while (xx < 0) {
@@ -108,59 +97,36 @@ double noise_ref_::noise(int xx, int yy) const {
     yy -= this->height_;
   }
 
-  if (std::numeric_limits<unsigned char>::digits == this->bits_) {
-    return (*(this->array_ + this->channels_ * this->width_ * yy +
-              this->channels_ * xx + this->zz_)) /
-           this->bmax_;
-  }
-  return (*(reinterpret_cast<const unsigned short *>(this->array_) +
-            this->channels_ * this->width_ * yy + this->channels_ * xx +
-            this->zz_)) /
-         this->bmax_;
+  return (*(this->array_ + 4 * this->width_ * yy + 4 * xx + this->zz_));
 }
-}
+}  // namespace
 //------------------------------------------------------------
 #include "igs_ifx_common.h" /* igs::image::rgba */
 #include "igs_hls_add.h"
 namespace {
-/* raster画像にノイズをのせるtemplate */
-template <class IT, class RT>
-void change_template_(
-    IT *image_array, const int height, const int width, const int channels
-
-    ,
-    const noise_ref_ &noi
-
-    ,
-    const RT *ref /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double offset, const double hue_scale, const double lig_scale,
-    const double sat_scale, const double alp_scale
-
-    ,
-    const bool add_blend_sw) {
-  const int t_max      = std::numeric_limits<IT>::max();
-  const double div_val = static_cast<double>(t_max);
-  const double mul_val = static_cast<double>(t_max) + 0.999999;
-  const int r_max      = std::numeric_limits<RT>::max();
+/* raster画像にノイズをのせる*/
+void change_(float *image_array, const int height, const int width,
+             const int channels, const noise_ref_ &noi,
+             const float *ref, /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+             const double offset, const double hue_scale,
+             const double lig_scale, const double sat_scale,
+             const double alp_scale, const bool add_blend_sw,
+             const bool cylindrical = true) {
   if (igs::image::rgba::siz == channels) {
     using namespace igs::image::rgba;
     for (int yy = 0; yy < height; ++yy) {
       for (int xx = 0; xx < width; ++xx, image_array += channels) {
         /* 変化量初期値 */
-        double refv = 1.0;
+        float refv = 1.f;
 
         /* 参照画像あればピクセル単位の画像変化量を得る */
-        if (ref != 0) {
-          refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-          ref += channels; /* continue;の前に行うこと */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
         }
 
         /* 加算合成で、Alpha値ゼロならRGB値を計算する必要はない */
-        if (add_blend_sw && (0 == image_array[alp])) {
+        if (add_blend_sw && (0.f == image_array[alp])) {
           continue;
         }
         /* 加算合成でなくAlpha合成の時は、
@@ -170,24 +136,22 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
         refv *= (noi.noise(xx, yy) - offset);
 
         /* マスクSWがON、なら変化をMask */
-        if (add_blend_sw && (image_array[alp] < t_max)) {
-          refv *= static_cast<double>(image_array[alp]) / div_val;
+        if (add_blend_sw && (image_array[alp] < 1.f)) {
+          refv *= image_array[alp];
         }
 
         /* RGBAにHLSAノイズを加える */
         double rr, gg, bb, aa;
-        pixel_rgba_(static_cast<double>(image_array[red]) / div_val,
-                    static_cast<double>(image_array[gre]) / div_val,
-                    static_cast<double>(image_array[blu]) / div_val,
-                    static_cast<double>(image_array[alp]) / div_val,
-                    refv * hue_scale, refv * lig_scale, refv * sat_scale,
-                    refv * alp_scale, rr, gg, bb, aa);
+        pixel_rgba_(image_array[red], image_array[gre], image_array[blu],
+                    image_array[alp], refv * hue_scale, refv * lig_scale,
+                    refv * sat_scale, refv * alp_scale, rr, gg, bb, aa,
+                    cylindrical);
 
         /* 変化後の値を戻す */
-        image_array[red] = static_cast<IT>(rr * mul_val);
-        image_array[gre] = static_cast<IT>(gg * mul_val);
-        image_array[blu] = static_cast<IT>(bb * mul_val);
-        image_array[alp] = static_cast<IT>(aa * mul_val);
+        image_array[red] = (float)rr;
+        image_array[gre] = (float)gg;
+        image_array[blu] = (float)bb;
+        image_array[alp] = (float)aa;
       }
     }
   } else if (igs::image::rgb::siz == channels) {
@@ -195,12 +159,12 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
     for (int yy = 0; yy < height; ++yy) {
       for (int xx = 0; xx < width; ++xx, image_array += channels) {
         /* 変化量初期値 */
-        double refv = 1.0;
+        float refv = 1.f;
 
         /* 参照画像あればピクセル単位の画像変化量を得る */
-        if (ref != 0) {
-          refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-          ref += channels; /* continue;の前に行うこと */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
         }
 
         /* HLSそれぞれに対するオフセット済ノイズ値 */
@@ -208,28 +172,26 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
 
         /* RGBにHLSノイズを加える */
         double rr, gg, bb, aa;
-        pixel_rgba_(static_cast<double>(image_array[red]) / div_val,
-                    static_cast<double>(image_array[gre]) / div_val,
-                    static_cast<double>(image_array[blu]) / div_val, 1.0,
+        pixel_rgba_(image_array[red], image_array[gre], image_array[blu], 1.0,
                     refv * hue_scale, refv * lig_scale, refv * sat_scale, 0.0,
-                    rr, gg, bb, aa);
+                    rr, gg, bb, aa, cylindrical);
 
         /* 変化後の値を戻す */
-        image_array[red] = static_cast<IT>(rr * mul_val);
-        image_array[gre] = static_cast<IT>(gg * mul_val);
-        image_array[blu] = static_cast<IT>(bb * mul_val);
+        image_array[red] = (float)rr;
+        image_array[gre] = (float)gg;
+        image_array[blu] = (float)bb;
       }
     }
   } else if (1 == channels) { /* grayscale */
     for (int yy = 0; yy < height; ++yy) {
       for (int xx = 0; xx < width; ++xx, ++image_array) {
         /* 変化量初期値 */
-        double refv = 1.0;
+        float refv = 1.f;
 
         /* 参照画像あればピクセル単位の画像変化量を得る */
-        if (ref != 0) {
-          refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-          ref += channels; /* continue;の前に行うこと */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
         }
 
         /* Lに対するオフセット済ノイズ値 */
@@ -241,40 +203,25 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
         }
 
         /* GrayscaleにLノイズを加える */
-        double lig =
-            static_cast<double>(image_array[0]) / div_val + refv * lig_scale;
-        lig = (lig < 0.0) ? 0.0 : ((1.0 < lig) ? 1.0 : lig);
+        float lig = image_array[0] + refv * lig_scale;
+        // lig = (lig < 0.f) ? 0.f : ((1.f < lig) ? 1.f : lig);
 
         /* 変化後の値を戻す */
-        image_array[0] = static_cast<IT>(lig * mul_val);
+        image_array[0] = lig;
       }
     }
   }
 }
-}
+}  // namespace
 
 void igs::hls_add::change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *noi_image_array, const int noi_height,
-    const int noi_width, const int noi_channels, const int noi_bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
+    float *image_array, const int height, const int width, const int channels,
+    const float *noi_image_array,
+    const float *ref, /* 求める画像と同じ高、幅、channels数 */
     const int xoffset, const int yoffset, const int from_rgba,
     const double offset, const double hue_scale, const double lig_scale,
-    const double sat_scale, const double alp_scale
-
-    ,
-    const bool add_blend_sw) {
+    const double sat_scale, const double alp_scale, const bool add_blend_sw,
+    const bool cylindrical) {
   if ((0.0 == hue_scale) && (0.0 == lig_scale) && (0.0 == sat_scale) &&
       (0.0 == alp_scale)) {
     return;
@@ -282,45 +229,43 @@ void igs::hls_add::change(
 
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
   /* ノイズ参照画像を作成する */
-  noise_ref_ noi(noi_image_array
+  noise_ref_ noi(noi_image_array, height, width, xoffset, yoffset, from_rgba);
 
-                 ,
-                 noi_height, noi_width, noi_channels, noi_bits
-
-                 ,
-                 xoffset, yoffset, from_rgba);
+  change_(image_array, height, width, channels, noi, ref, offset, hue_scale,
+          lig_scale, sat_scale, alp_scale, add_blend_sw, cylindrical);
 
   /* rgb(a)画像にhls(a)でドットノイズを加える */
-  if ((std::numeric_limits<unsigned char>::digits == bits) &&
-      ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-       (0 == ref_bits))) {
-    change_template_(image_array, height, width, channels, noi, ref, ref_mode,
-                     offset, hue_scale, lig_scale, sat_scale, alp_scale,
-                     add_blend_sw);
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-              (0 == ref_bits))) {
-    change_template_(reinterpret_cast<unsigned short *>(image_array), height,
-                     width, channels, noi, ref, ref_mode, offset, hue_scale,
-                     lig_scale, sat_scale, alp_scale, add_blend_sw);
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(
-        reinterpret_cast<unsigned short *>(image_array), height, width,
-        channels, noi, reinterpret_cast<const unsigned short *>(ref), ref_mode,
-        offset, hue_scale, lig_scale, sat_scale, alp_scale, add_blend_sw);
-  } else if ((std::numeric_limits<unsigned char>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(image_array, height, width, channels, noi,
-                     reinterpret_cast<const unsigned short *>(ref), ref_mode,
-                     offset, hue_scale, lig_scale, sat_scale, alp_scale,
-                     add_blend_sw);
-  } else {
-    throw std::domain_error("Bad bits,Not uchar/ushort");
-  }
+  /* if ((std::numeric_limits<unsigned char>::digits == bits) &&
+        ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
+         (0 == ref_bits))) {
+      change_template_(image_array, height, width, channels, noi, ref, ref_mode,
+                       offset, hue_scale, lig_scale, sat_scale, alp_scale,
+                       add_blend_sw);
+    } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
+               ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
+                (0 == ref_bits))) {
+      change_template_(reinterpret_cast<unsigned short *>(image_array), height,
+                       width, channels, noi, ref, ref_mode, offset, hue_scale,
+                       lig_scale, sat_scale, alp_scale, add_blend_sw);
+    } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
+               (std::numeric_limits<unsigned short>::digits == ref_bits)) {
+      change_template_(
+          reinterpret_cast<unsigned short *>(image_array), height, width,
+          channels, noi, reinterpret_cast<const unsigned short *>(ref),
+    ref_mode, offset, hue_scale, lig_scale, sat_scale, alp_scale, add_blend_sw);
+    } else if ((std::numeric_limits<unsigned char>::digits == bits) &&
+               (std::numeric_limits<unsigned short>::digits == ref_bits)) {
+      change_template_(image_array, height, width, channels, noi,
+                       reinterpret_cast<const unsigned short *>(ref), ref_mode,
+                       offset, hue_scale, lig_scale, sat_scale, alp_scale,
+                       add_blend_sw);
+    } else {
+      throw std::domain_error("Bad bits,Not uchar/ushort");
+    }
+    */
 }

--- a/toonz/sources/stdfx/igs_hls_add.h
+++ b/toonz/sources/stdfx/igs_hls_add.h
@@ -10,39 +10,18 @@
 namespace igs {
 namespace hls_add {
 IGS_HLS_ADD_EXPORT void change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *noi_image_array, const int noi_height,
-    const int noi_width, const int noi_channels, const int noi_bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const int xoffset /* 0	INT_MIN ... INT_MAX	*/
-    ,
-    const int yoffset /* 0	INT_MIN ... INT_MAX	*/
-    ,
-    const int from_rgba /* 0	0(R),1(G),2(B),3(A)	*/
-    ,
-    const double offset /* 0.5	-1.0 ... 1.0	*/
-    ,
-    const double hue_scale /* 0.0	-1.0 ... 1.0	*/
-    ,
-    const double lig_scale /* 0.5	-1.0 ... 1.0	*/
-    ,
-    const double sat_scale /* 0.0	-1.0 ... 1.0	*/
-    ,
-    const double alp_scale /* 0.0	-1.0 ... 1.0	*/
-
-    ,
-    const bool add_blend_sw
+    float *image_array, const int height, const int width, const int channels,
+    const float *noi_image_array,
+    const float *ref,    /* 求める画像と同じ高、幅、channels数 */
+    const int xoffset,   /* 0	INT_MIN ... INT_MAX	*/
+    const int yoffset,   /* 0	INT_MIN ... INT_MAX	*/
+    const int from_rgba, /* 0	0(R),1(G),2(B),3(A)	*/
+    const double offset, /* 0.5	-1.0 ... 1.0	*/
+    const double hue_scale, /* 0.0	-1.0 ... 1.0	*/
+    const double lig_scale, /* 0.5	-1.0 ... 1.0	*/
+    const double sat_scale, /* 0.0	-1.0 ... 1.0	*/
+    const double alp_scale, /* 0.0	-1.0 ... 1.0	*/
+    const bool add_blend_sw,
     /* 効果(変化量)をアルファブレンドするか否かのスイッチ
                 add_blend_sw == true
                     アルファ値によりRGBの変化量を調整する
@@ -55,7 +34,8 @@ IGS_HLS_ADD_EXPORT void change(
                             合成画 = 下絵 * (1 - alpha) + 上絵 * alpha
                     の場合こちらを使う
             */
-    );
+    const bool cylindrical = true  // colorspace shape: cylindrical or bicone
+);
 }
-}
+}  // namespace igs
 #endif /* !igs_add_hls_h */

--- a/toonz/sources/stdfx/igs_hls_adjust.cpp
+++ b/toonz/sources/stdfx/igs_hls_adjust.cpp
@@ -2,26 +2,18 @@
 namespace {
 void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
                  double &red_out, double &gre_out, double &blu_out,
-                 const double hue_pivot  // 0.0  ...0...360...
-                 ,
-                 const double hue_scale  // 1.0  ...1...
-                 ,
-                 const double hue_shift  // 0.0  ...0...360...
-                 ,
-                 const double lig_pivot  // 0.0  ...0...1...
-                 ,
-                 const double lig_scale  // 1.0  ...1...
-                 ,
-                 const double lig_shift  // 0.0  ...0...1...
-                 ,
-                 const double sat_pivot  // 0.0  ...0...1...
-                 ,
-                 const double sat_scale  // 1.0  ...1...
-                 ,
-                 const double sat_shift  // 0.0  ...0...1...
-                 ) {
+                 const double hue_pivot,  // 0.0  ...0...360...
+                 const double hue_scale,  // 1.0  ...1...
+                 const double hue_shift,  // 0.0  ...0...360...
+                 const double lig_pivot,  // 0.0  ...0...1...
+                 const double lig_scale,  // 1.0  ...1...
+                 const double lig_shift,  // 0.0  ...0...1...
+                 const double sat_pivot,  // 0.0  ...0...1...
+                 const double sat_scale,  // 1.0  ...1...
+                 const double sat_shift,  // 0.0  ...0...1...
+                 const bool cylindrical = true) {
   double hue, lig, sat;
-  igs::color::rgb_to_hls(red_in, gre_in, blu_in, hue, lig, sat);
+  igs::color::rgb_to_hls(red_in, gre_in, blu_in, hue, lig, sat, cylindrical);
   if ((1.0 != hue_scale) || (0.0 != hue_shift)) {
     hue -= hue_pivot;
     while (hue < -180.0) {
@@ -45,162 +37,139 @@ void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
     lig *= lig_scale;
     lig += lig_pivot;
     lig += lig_shift;
-    lig = (lig < 0.0) ? 0.0 : ((1.0 < lig) ? 1.0 : lig);
+    // lig = (lig < 0.0) ? 0.0 : ((1.0 < lig) ? 1.0 : lig);
   }
   if ((1.0 != sat_scale) || (0.0 != sat_shift)) {
     sat -= sat_pivot;
     sat *= sat_scale;
     sat += sat_pivot;
     sat += sat_shift;
-    sat = (sat < 0.0) ? 0.0 : ((1.0 < sat) ? 1.0 : sat);
+    sat = (sat < 0.0) ? 0.0 : sat;
+    // sat = (sat < 0.0) ? 0.0 : ((1.0 < sat) ? 1.0 : sat);
   }
-  igs::color::hls_to_rgb(hue, lig, sat, red_out, gre_out, blu_out);
+  igs::color::hls_to_rgb(hue, lig, sat, red_out, gre_out, blu_out, cylindrical);
 }
-}
+}  // namespace
 //------------------------------------------------------------
 #include <limits>           /* std::numeric_limits */
 #include "igs_ifx_common.h" /* igs::image::rgba */
 #include "igs_hls_adjust.h"
 namespace {
-/* raster画像にノイズをのせるtemplate */
-template <class IT, class RT>
-void change_template_(
-    IT *image_array, const int height, const int width, const int channels
-
-    ,
-    const RT *ref /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double hue_pivot, const double hue_scale, const double hue_shift,
-    const double lig_pivot, const double lig_scale, const double lig_shift,
-    const double sat_pivot, const double sat_scale, const double sat_shift
-
-    ,
-    const bool add_blend_sw) {
-  const int t_max      = std::numeric_limits<IT>::max();
-  const double div_val = static_cast<double>(t_max);
-  const double mul_val = static_cast<double>(t_max) + 0.999999;
-  const int pixsize    = height * width;
-  const int r_max      = std::numeric_limits<RT>::max();
+/* raster画像にノイズをのせる*/
+void change_(float *image_array, const int height, const int width,
+             const int channels,
+             const float *ref, /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+             const double hue_pivot, const double hue_scale,
+             const double hue_shift, const double lig_pivot,
+             const double lig_scale, const double lig_shift,
+             const double sat_pivot, const double sat_scale,
+             const double sat_shift, const bool add_blend_sw,
+             const bool cylindrical = true) {
+  // const int t_max      = std::numeric_limits<IT>::max();
+  // const double div_val = static_cast<double>(t_max);
+  // const double mul_val = static_cast<double>(t_max) + 0.999999;
+  const int pixsize = height * width;
+  // const int r_max      = std::numeric_limits<RT>::max();
   if (igs::image::rgba::siz == channels) {
     using namespace igs::image::rgba;
     for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
       /* 変化量初期値 */
-      double refv = 1.0;
+      float refv = 1.f;
 
       /* 参照画像あればピクセル単位の画像変化量を得る */
-      if (ref != 0) {
-        refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-        ref += channels; /* continue;の前に行うこと */
+      if (ref != nullptr) {
+        refv *= (*ref);
+        ref++; /* continue;の前に行うこと */
       }
 
       /* 加算合成で、Alpha値ゼロならRGB値を計算する必要はない */
-      if (add_blend_sw && (0 == image_array[alp])) {
+      if (add_blend_sw && (0.f == image_array[alp])) {
         continue;
       }
       /* 加算合成でなくAlpha合成の時は、
       Alpha値がゼロでもRGB値は存在する(してもよい) */
 
-      /* RGB値を正規化 */
-      const IT *const ia = image_array;
-      const double rr1   = static_cast<double>(ia[red]) / div_val;
-      const double gg1   = static_cast<double>(ia[gre]) / div_val;
-      const double bb1   = static_cast<double>(ia[blu]) / div_val;
-
       /* pivot,scale,shiftによってRGB値を変化する */
-      double rr2, gg2, bb2;
-      pixel_rgba_(rr1, gg1, bb1, rr2, gg2, bb2, hue_pivot, hue_scale, hue_shift,
-                  lig_pivot, lig_scale, lig_shift, sat_pivot, sat_scale,
-                  sat_shift);
+      double rr, gg, bb;
+      pixel_rgba_(image_array[red], image_array[gre], image_array[blu], rr, gg,
+                  bb, hue_pivot, hue_scale, hue_shift, lig_pivot, lig_scale,
+                  lig_shift, sat_pivot, sat_scale, sat_shift, cylindrical);
 
       /* 加算合成で、その値がMaxでなければ変化量に乗算 */
-      if (add_blend_sw && (ia[alp] < t_max)) {
-        refv *= static_cast<double>(ia[alp]) / div_val;
+      if (add_blend_sw && (image_array[alp] < 1.f)) {
+        refv *= image_array[alp];
       }
 
       /* ピクセル単位の変化量があれば、RGBを調整する */
-      if ((ref != 0) || (add_blend_sw && (ia[alp] < t_max))) {
-        rr2 = rr1 + (rr2 - rr1) * refv;
-        gg2 = gg1 + (gg2 - gg1) * refv;
-        bb2 = bb1 + (bb2 - bb1) * refv;
+      if ((ref != nullptr) || (add_blend_sw && (image_array[alp] < 1.f))) {
+        rr = image_array[red] + (rr - image_array[red]) * refv;
+        gg = image_array[gre] + (gg - image_array[gre]) * refv;
+        bb = image_array[blu] + (bb - image_array[blu]) * refv;
       }
 
       /* 結果をRGBに戻す */
-      image_array[red] = static_cast<IT>(rr2 * mul_val);
-      image_array[gre] = static_cast<IT>(gg2 * mul_val);
-      image_array[blu] = static_cast<IT>(bb2 * mul_val);
+      image_array[red] = rr;
+      image_array[gre] = gg;
+      image_array[blu] = bb;
     }
   } else if (igs::image::rgb::siz == channels) {
     using namespace igs::image::rgb;
     for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
-      double refv = 1.0;
-      if (ref != 0) {
-        refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-        ref += channels;
+      float refv = 1.f;
+      if (ref != nullptr) {
+        refv *= (*ref);
+        ref++;
       }
 
-      const IT *const ia = image_array;
-      const double rr1   = static_cast<double>(ia[red]) / div_val;
-      const double gg1   = static_cast<double>(ia[gre]) / div_val;
-      const double bb1   = static_cast<double>(ia[blu]) / div_val;
-      double rr2, gg2, bb2;
-      pixel_rgba_(rr1, gg1, bb1, rr2, gg2, bb2, hue_pivot, hue_scale, hue_shift,
-                  lig_pivot, lig_scale, lig_shift, sat_pivot, sat_scale,
-                  sat_shift);
+      // const IT *const ia = image_array;
+      // const double rr1   = static_cast<double>(ia[red]) / div_val;
+      // const double gg1   = static_cast<double>(ia[gre]) / div_val;
+      // const double bb1   = static_cast<double>(ia[blu]) / div_val;
+      double rr, gg, bb;
+      pixel_rgba_(image_array[red], image_array[gre], image_array[blu], rr, gg,
+                  bb, hue_pivot, hue_scale, hue_shift, lig_pivot, lig_scale,
+                  lig_shift, sat_pivot, sat_scale, sat_shift, cylindrical);
 
-      if (ref != 0) {
-        rr2 = rr1 + (rr2 - rr1) * refv;
-        gg2 = gg1 + (gg2 - gg1) * refv;
-        bb2 = bb1 + (bb2 - bb1) * refv;
+      if (ref != nullptr) {
+        rr = image_array[red] + (rr - image_array[red]) * refv;
+        gg = image_array[gre] + (gg - image_array[gre]) * refv;
+        bb = image_array[blu] + (bb - image_array[blu]) * refv;
       }
 
-      image_array[red] = static_cast<IT>(rr2 * mul_val);
-      image_array[gre] = static_cast<IT>(gg2 * mul_val);
-      image_array[blu] = static_cast<IT>(bb2 * mul_val);
+      image_array[red] = rr;
+      image_array[gre] = gg;
+      image_array[blu] = bb;
     }
   } else if (1 == channels) { /* grayscale */
     for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
-      double refv = 1.0;
-      if (ref != 0) {
-        refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-        ref += channels;
+      double refv = 1.f;
+      if (ref != nullptr) {
+        refv *= (*ref);
+        ref++;
       }
 
-      double li1 = static_cast<double>(image_array[0]) / div_val,
-             li2 = (li1 - lig_pivot) * lig_scale + lig_pivot + lig_shift;
-      li2        = (li2 < 0.0) ? 0.0 : ((1.0 < li2) ? 1.0 : li2);
+      double li =
+          (*image_array - lig_pivot) * lig_scale + lig_pivot + lig_shift;
+      // li        = (li < 0.0) ? 0.0 : ((1.0 < li) ? 1.0 : li);
 
-      if (ref != 0) {
-        li2 = li1 + (li2 - li1) * refv;
+      if (ref != nullptr) {
+        li = *image_array + (li - *image_array) * refv;
       }
 
-      image_array[0] = static_cast<IT>(li2 * mul_val);
+      *image_array = li;
     }
   }
 }
-}
+}  // namespace
 
 #include <stdexcept> /* std::domain_error  */
 void igs::hls_adjust::change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅、channels数 */
     const double hue_pivot, const double hue_scale, const double hue_shift,
     const double lig_pivot, const double lig_scale, const double lig_shift,
-    const double sat_pivot, const double sat_scale, const double sat_shift
-
-    ,
-    const bool add_blend_sw) {
+    const double sat_pivot, const double sat_scale, const double sat_shift,
+    const bool add_blend_sw, const bool cylindrical) {
   if ((1.0 == hue_scale) && (0.0 == hue_shift) && (1.0 == lig_scale) &&
       (0.0 == lig_shift) && (1.0 == sat_scale) && (0.0 == sat_shift)) {
     return;
@@ -208,11 +177,15 @@ void igs::hls_adjust::change(
 
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
+  change_(image_array, height, width, channels, ref, hue_pivot, hue_scale,
+          hue_shift, lig_pivot, lig_scale, lig_shift, sat_pivot, sat_scale,
+          sat_shift, add_blend_sw, cylindrical);
 
   /* rgb(a)画像にhls(a)でドットノイズを加える */
+  /*
   if ((std::numeric_limits<unsigned char>::digits == bits) &&
       ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
        (0 == ref_bits))) {
@@ -242,4 +215,5 @@ void igs::hls_adjust::change(
   } else {
     throw std::domain_error("Bad bits,Not uchar/ushort");
   }
+  */
 }

--- a/toonz/sources/stdfx/igs_hls_adjust.h
+++ b/toonz/sources/stdfx/igs_hls_adjust.h
@@ -10,37 +10,18 @@
 namespace igs {
 namespace hls_adjust {
 IGS_HLS_ADJUST_EXPORT void change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double hue_pivot /* 0.0  ...0...360... */
-    ,
-    const double hue_scale /* 1.0  ...1...       */
-    ,
-    const double hue_shift /* 0.0  ...0...360... */
-    ,
-    const double lig_pivot /* 0.0  ...0...1...   */
-    ,
-    const double lig_scale /* 1.0  ...1...       */
-    ,
-    const double lig_shift /* 0.0  ...0...1...   */
-    ,
-    const double sat_pivot /* 0.0  ...0...1...   */
-    ,
-    const double sat_scale /* 1.0  ...1...       */
-    ,
-    const double sat_shift /* 0.0  ...0...1...   */
-
-    ,
-    const bool add_blend_sw
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅、channels数 */
+    const double hue_pivot, /* 0.0  ...0...360... */
+    const double hue_scale, /* 1.0  ...1...       */
+    const double hue_shift, /* 0.0  ...0...360... */
+    const double lig_pivot, /* 0.0  ...0...1...   */
+    const double lig_scale, /* 1.0  ...1...       */
+    const double lig_shift, /* 0.0  ...0...1...   */
+    const double sat_pivot, /* 0.0  ...0...1...   */
+    const double sat_scale, /* 1.0  ...1...       */
+    const double sat_shift, /* 0.0  ...0...1...   */
+    const bool add_blend_sw,
     /* 効果(変化量)をアルファブレンドするか否かのスイッチ
                 add_blend_sw == true
                     アルファ値によりRGBの変化量を調整する
@@ -53,8 +34,9 @@ IGS_HLS_ADJUST_EXPORT void change(
                             合成画 = 下絵 * (1 - alpha) + 上絵 * alpha
                     の場合こちらを使う
             */
-    );
+    const bool cylindrical = true  // colorspace shape: cylindrical or bicone
+);
 }
-}
+}  // namespace igs
 
 #endif /* !igs_hls_adjust_h */

--- a/toonz/sources/stdfx/igs_hls_noise.cpp
+++ b/toonz/sources/stdfx/igs_hls_noise.cpp
@@ -368,7 +368,8 @@ void pixel_rgb_(const double red_in, const double gre_in, const double blu_in,
                 const double lig_noise, const double sat_noise,
                 control_term_within_limits_ &lig_term,
                 control_term_within_limits_ &sat_term, double &red_out,
-                double &gre_out, double &blu_out) {
+                double &gre_out, double &blu_out,
+                const bool cylindrical = true) {
   if (0.0 == alp_in) {
     red_out = red_in;
     gre_out = gre_in;
@@ -376,7 +377,7 @@ void pixel_rgb_(const double red_in, const double gre_in, const double blu_in,
     return;
   }
   double hue, lig, sat;
-  igs::color::rgb_to_hls(red_in, gre_in, blu_in, hue, lig, sat);
+  igs::color::rgb_to_hls(red_in, gre_in, blu_in, hue, lig, sat, cylindrical);
   if (0.0 != hue_noise) {
     hue += 360.0 * hue_noise * alp_in;
     while (hue < 0.0) {
@@ -392,11 +393,11 @@ void pixel_rgb_(const double red_in, const double gre_in, const double blu_in,
     lig_term.exec(lig, lignoise, shift_value);
     lig += shift_value * alp_in;
     lig += lignoise * alp_in;
-    if (lig < 0.0) {
-      lig = 0.0;
-    } else if (1.0 < lig) {
-      lig = 1.0;
-    }
+    // if (lig < 0.0) {
+    //   lig = 0.0;
+    // } else if (1.0 < lig) {
+    //   lig = 1.0;
+    // }
   }
   if (0.0 != sat_term.noise_range()) {
     double shift_value = 0;
@@ -404,15 +405,17 @@ void pixel_rgb_(const double red_in, const double gre_in, const double blu_in,
     sat_term.exec(sat, satnoise, shift_value);
     sat += shift_value * alp_in;
     sat += satnoise * alp_in;
-    if (sat < 0.0) {
-      sat = 0.0;
-    } else if (1.0 < sat) {
-      sat = 1.0;
-    }
-    // if( 0.0 == sat ) hue = -1.0; // hls_to_rgb(-)
+    sat = (sat < 0.0) ? 0.0 : sat;
+    // if (sat < 0.0) {
+    //   sat = 0.0;
+    // } else if (1.0 < sat) {
+    //   sat = 1.0;
+    // }
+    //  if( 0.0 == sat ) hue = -1.0; // hls_to_rgb(-)
   }
-  igs::color::hls_to_rgb(hue, lig, sat, red_out, gre_out, blu_out);
+  igs::color::hls_to_rgb(hue, lig, sat, red_out, gre_out, blu_out, cylindrical);
 }
+
 /*------ Alpha値にノイズをのせる ------*/
 void pixel_a_(const double alp_in, const double alp_noise,
               control_term_within_limits_ &alp_term, double &alp_out) {
@@ -433,38 +436,26 @@ void pixel_a_(const double alp_in, const double alp_noise,
   }
   alp_out = alpin;
 }
-/*------ raster画像にノイズをのせるtemplate ------*/
-template <class IT, class RT>
-void change_template_(
-    IT *image_array, const int width, const int height, const int channels
-
-    ,
-    const RT *ref /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    noise_reference_ &noise, const double hue_range,
-    control_term_within_limits_ &lig_term,
-    control_term_within_limits_ &sat_term, control_term_within_limits_ &alp_term
-
-    ,
-    const bool add_blend_sw) {
-  const int t_max      = std::numeric_limits<IT>::max();
-  const double div_val = static_cast<double>(t_max);
-  const double mul_val = static_cast<double>(t_max) + 0.999999;
-  const int r_max      = std::numeric_limits<RT>::max();
+/*------ raster画像にノイズをのせる ------*/
+void change_(float *image_array, const int width, const int height,
+             const int channels,
+             const float *ref, /* 求める画像(out)と同じ高さ、幅 */
+             noise_reference_ &noise, const double hue_range,
+             control_term_within_limits_ &lig_term,
+             control_term_within_limits_ &sat_term,
+             control_term_within_limits_ &alp_term, const bool add_blend_sw,
+             const bool cylindrical = true) {
   if (igs::image::rgba::siz == channels) {
     using namespace igs::image::rgba;
     for (int yy = 0; yy < height; ++yy) {
       for (int xx = 0; xx < width; ++xx, image_array += channels) {
         /* 変化量初期値 */
-        double refv = 1.0;
+        float refv = 1.f;
 
         /* 参照画像あればピクセル単位の画像変化量を得る */
-        if (ref != 0) {
-          refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-          ref += channels; /* continue;の前に行うこと */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
         }
         /* 加算合成で、Alpha値ゼロならRGB値を計算する必要はない */
         if (add_blend_sw && (0 == image_array[alp])) {
@@ -474,39 +465,37 @@ void change_template_(
 Alpha値がゼロでもRGB値は存在する(してもよい) */
 
         /* マスクSWがON、なら変化をMask */
-        if (add_blend_sw && (image_array[alp] < t_max)) {
-          refv *= static_cast<double>(image_array[alp]) / div_val;
+        if (add_blend_sw && (image_array[alp] < 1.f)) {
+          refv *= image_array[alp];
         }
 
         if (((0.0 != hue_range) || (0.0 != lig_term.noise_range()) ||
              (0.0 !=
               sat_term.noise_range())) /* ノイズがhlsのどれか一つはある */
-            ) {
-          double rr1 = static_cast<double>(image_array[red]) / div_val,
-                 gg1 = static_cast<double>(image_array[gre]) / div_val,
-                 bb1 = static_cast<double>(image_array[blu]) / div_val,
-                 aa1 = static_cast<double>(image_array[alp]) / div_val;
-          double rr2 = 0, gg2 = 0, bb2 = 0;
+        ) {
+          float rr1 = image_array[red], gg1 = image_array[gre],
+                bb1 = image_array[blu], aa1 = image_array[alp];
+          double rr2 = 0., gg2 = 0., bb2 = 0.;
           pixel_rgb_(rr1, gg1, bb1, aa1, noise.hue_value(xx, yy),
                      noise.lig_value(xx, yy), noise.sat_value(xx, yy), lig_term,
-                     sat_term, rr2, gg2, bb2);
-          if (refv != 1.0) {
+                     sat_term, rr2, gg2, bb2, cylindrical);
+          if (refv != 1.f) {
             rr2 = (rr2 - rr1) * refv + rr1;
             gg2 = (gg2 - gg1) * refv + gg1;
             bb2 = (bb2 - bb1) * refv + bb1;
           }
-          image_array[red] = static_cast<IT>(rr2 * mul_val);
-          image_array[gre] = static_cast<IT>(gg2 * mul_val);
-          image_array[blu] = static_cast<IT>(bb2 * mul_val);
+          image_array[red] = static_cast<float>(rr2);
+          image_array[gre] = static_cast<float>(gg2);
+          image_array[blu] = static_cast<float>(bb2);
         }
         if (0.0 != alp_term.noise_range()) {
-          double aa1 = static_cast<double>(image_array[alp]) / div_val;
-          double aa2 = 0;
+          double aa1 = static_cast<double>(image_array[alp]);
+          double aa2 = 0.;
           pixel_a_(aa1, noise.alp_value(xx, yy), alp_term, aa2);
-          if (refv != 1.0) {
+          if (refv != 1.f) {
             aa2 = (aa2 - aa1) * refv + aa1;
           }
-          image_array[alp] = static_cast<IT>(aa2 * mul_val);
+          image_array[alp] = static_cast<float>(aa2);
         }
       }
     }
@@ -514,33 +503,32 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
     using namespace igs::image::rgb;
     if (((0.0 != hue_range) || (0.0 != lig_term.noise_range()) ||
          (0.0 != sat_term.noise_range())) /* ノイズがhlsのどれか一つはある */
-        ) {
+    ) {
       for (int yy = 0; yy < height; ++yy) {
         for (int xx = 0; xx < width; ++xx, image_array += channels) {
           /* 変化量初期値 */
-          double refv = 1.0;
+          float refv = 1.f;
 
           /* 参照画像あればピクセル単位の画像変化量を得る */
-          if (ref != 0) {
-            refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-            ref += channels; /* continue;の前に行うこと */
+          if (ref != nullptr) {
+            refv *= (*ref);
+            ref++; /* continue;の前に行うこと */
           }
 
-          double rr1 = static_cast<double>(image_array[red]) / div_val,
-                 gg1 = static_cast<double>(image_array[gre]) / div_val,
-                 bb1 = static_cast<double>(image_array[blu]) / div_val;
-          double rr2 = 0, gg2 = 0, bb2 = 0;
+          float rr1 = image_array[red], gg1 = image_array[gre],
+                bb1  = image_array[blu];
+          double rr2 = 0., gg2 = 0., bb2 = 0.;
           pixel_rgb_(rr1, gg1, bb1, 1.0, noise.hue_value(xx, yy),
                      noise.lig_value(xx, yy), noise.sat_value(xx, yy), lig_term,
-                     sat_term, rr2, gg2, bb2);
-          if (refv != 1.0) {
+                     sat_term, rr2, gg2, bb2, cylindrical);
+          if (refv != 1.f) {
             rr2 = (rr2 - rr1) * refv + rr1;
             gg2 = (gg2 - gg1) * refv + gg1;
             bb2 = (bb2 - bb1) * refv + bb1;
           }
-          image_array[red] = static_cast<IT>(rr2 * mul_val);
-          image_array[gre] = static_cast<IT>(gg2 * mul_val);
-          image_array[blu] = static_cast<IT>(bb2 * mul_val);
+          image_array[red] = static_cast<float>(rr2);
+          image_array[gre] = static_cast<float>(gg2);
+          image_array[blu] = static_cast<float>(bb2);
         }
       }
     }
@@ -549,15 +537,15 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
       for (int yy = 0; yy < height; ++yy) {
         for (int xx = 0; xx < width; ++xx, ++image_array) {
           /* 変化量初期値 */
-          double refv = 1.0;
+          float refv = 1.f;
 
           /* 参照画像あればピクセル単位の画像変化量を得る */
-          if (ref != 0) {
-            refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-            ref += channels; /* continue;の前に行うこと */
+          if (ref != nullptr) {
+            refv *= (*ref);
+            ref++; /* continue;の前に行うこと */
           }
 
-          double li1         = static_cast<double>(image_array[0]) / div_val;
+          double li1         = static_cast<double>(image_array[0]);
           double shift_value = 0;
           double lig_noise   = noise.lig_value(xx, yy);
           lig_term.exec(li1, lig_noise, shift_value);
@@ -565,53 +553,36 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
           double li2 = li1;
           li2 += shift_value;
           li2 += lig_noise;
-          li2 = (li2 < 0.0) ? 0.0 : ((1.0 < li2) ? 1.0 : li2);
+          li2 = (li2 < 0.0) ? 0.0 : li2;
 
-          if (refv != 1.0) {
+          if (refv != 1.f) {
             li2 = li1 + (li2 - li1) * refv;
           }
 
-          image_array[0] = static_cast<IT>(li2 * mul_val);
+          image_array[0] = static_cast<float>(li2);
         }
       }
     }
   }
 }
-}
+
+}  // namespace
 //--------------------------------------------------------------------
 #include <stdexcept>  // std::domain_error
 #include "igs_hls_noise.h"
 void igs::hls_noise::change(
-    unsigned char *image_array
-
-    ,
-    const int height, const int width, const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅 */
     /* image_arrayに余白が変化してもノイズパターンが変わらない
-            ようにするためにカメラエリアを指定する */
-    ,
+              ようにするためにカメラエリアを指定する */
     const int camera_x, const int camera_y, const int camera_w,
-    const int camera_h
-
-    ,
-    const double hue_range, const double lig_range, const double sat_range,
-    const double alp_range, const unsigned long random_seed,
-    const double near_blur
-
-    ,
+    const int camera_h, const double hue_range, const double lig_range,
+    const double sat_range, const double alp_range,
+    const unsigned long random_seed, const double near_blur,
     const double lig_effective, const double lig_center, const int lig_type,
     const double sat_effective, const double sat_center, const int sat_type,
-    const double alp_effective, const double alp_center, const int alp_type
-
-    ,
-    const bool add_blend_sw) {
+    const double alp_effective, const double alp_center, const int alp_type,
+    const bool add_blend_sw, const bool cylindrical) {
   if ((0.0 == hue_range) && (0.0 == lig_range) && (0.0 == sat_range) &&
       (0.0 == alp_range)) {
     return;
@@ -619,7 +590,7 @@ void igs::hls_noise::change(
 
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
@@ -636,35 +607,7 @@ void igs::hls_noise::change(
   control_term_within_limits_ alp_term(alp_effective, alp_effective, alp_center,
                                        alp_type, alp_range);
 
-  /* rgb(a)画像にhls(a)でドットノイズを加える */
-  if ((std::numeric_limits<unsigned char>::digits == bits) &&
-      ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-       (0 == ref_bits))) {
-    change_template_(image_array, width, height, channels, ref, ref_mode, noise,
-                     hue_range, lig_term, sat_term, alp_term, add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-              (0 == ref_bits))) {
-    change_template_(reinterpret_cast<unsigned short *>(image_array), width,
-                     height, channels, ref, ref_mode, noise, hue_range,
-                     lig_term, sat_term, alp_term, add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(
-        reinterpret_cast<unsigned short *>(image_array), width, height,
-        channels, reinterpret_cast<const unsigned short *>(ref), ref_mode,
-        noise, hue_range, lig_term, sat_term, alp_term, add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else if ((std::numeric_limits<unsigned char>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(image_array, width, height, channels,
-                     reinterpret_cast<const unsigned short *>(ref), ref_mode,
-                     noise, hue_range, lig_term, sat_term, alp_term,
-                     add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else {
-    throw std::domain_error("Bad bits,Not uchar/ushort");
-  }
+  change_(image_array, width, height, channels, ref, noise, hue_range, lig_term,
+          sat_term, alp_term, add_blend_sw, cylindrical);
+  noise.clear(); /* ノイズ画像メモリ解放 */
 }

--- a/toonz/sources/stdfx/igs_hls_noise.h
+++ b/toonz/sources/stdfx/igs_hls_noise.h
@@ -10,61 +10,30 @@
 namespace igs {
 namespace hls_noise {
 IGS_HLS_NOISE_EXPORT void change(
-    unsigned char *image_array
-
-    ,
-    const int height, const int width, const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅*/
     /* image_arrayに余白が変化してもノイズパターンが変わらない
             ようにするためにカメラエリアを指定する */
-    ,
     const int camera_x, const int camera_y, const int camera_w,
-    const int camera_h
-
-    ,
-    const double hue_range /* =0.025  0 ... 1.0 */
-    ,
-    const double lig_range /* =0.035  0 ... 1.0 */
-    ,
-    const double sat_range /* =0.0	   0 ... 1.0 */
-    ,
-    const double alp_range /* =0.0	   0 ... 1.0 */
-    ,
-    const unsigned long random_seed /* =1      0 ... ULONG_MAX */
-    ,
-    const double near_blur /* =0.500  0 ... 0.5 */
-
-    ,
-    const double lig_effective /* =0.0	   0 ... 1.0 */
-    ,
-    const double lig_center /* =0.5    0 ... 1.0 */
-    ,
-    const int lig_type /* =0
-     0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
-    ,
-    const double sat_effective /* =0.0	   0 ... 1.0 */
-    ,
-    const double sat_center /* =0.5	   0 ... 1.0 */
-    ,
-    const int sat_type /* =0
-     0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
-    ,
-    const double alp_effective /* =0.0	   0 ... 1.0 */
-    ,
-    const double alp_center /* =0.5	   0 ... 1.0 */
-    ,
-    const int alp_type /* =0
-     0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
-
-    ,
-    const bool add_blend_sw
+    const int camera_h, const double hue_range, /* =0.025  0 ... 1.0 */
+    const double lig_range,                     /* =0.035  0 ... 1.0 */
+    const double sat_range,                     /* =0.0	   0 ... 1.0 */
+    const double alp_range,                     /* =0.0	   0 ... 1.0 */
+    const unsigned long random_seed,            /* =1      0 ... ULONG_MAX */
+    const double near_blur,                     /* =0.500  0 ... 0.5 */
+    const double lig_effective,                 /* =0.0	   0 ... 1.0 */
+    const double lig_center,                    /* =0.5    0 ... 1.0 */
+    const int lig_type,                         /* =0
+                             0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
+    const double sat_effective,                 /* =0.0	   0 ... 1.0 */
+    const double sat_center,                    /* =0.5	   0 ... 1.0 */
+    const int sat_type,                         /* =0
+                             0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
+    const double alp_effective,                 /* =0.0	   0 ... 1.0 */
+    const double alp_center,                    /* =0.5	   0 ... 1.0 */
+    const int alp_type,                         /* =0
+                             0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
+    const bool add_blend_sw,
     /* 効果(変化量)をアルファブレンドするか否かのスイッチ
                 add_blend_sw == true
                     アルファ値によりRGBの変化量を調整する
@@ -77,8 +46,9 @@ IGS_HLS_NOISE_EXPORT void change(
                             合成画 = 下絵 * (1 - alpha) + 上絵 * alpha
                     の場合こちらを使う
             */
-    );
+    const bool cylindrical = true  // colorspace shape: cylindrical or bicone
+);
 }
-}
+}  // namespace igs
 
 #endif /* !igs_hls_noise_h */

--- a/toonz/sources/stdfx/igs_hsv_add.cpp
+++ b/toonz/sources/stdfx/igs_hsv_add.cpp
@@ -26,17 +26,18 @@ void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
     sat += sat_noise;
     if (sat < 0.0) {
       sat = 0.0;
-    } else if (1.0 < sat) {
-      sat = 1.0;
     }
+    // else if (1.0 < sat) {
+    //   sat = 1.0;
+    // }
   }
   if (0.0 != val_noise) {
     val += val_noise;
-    if (val < 0.0) {
-      val = 0.0;
-    } else if (1.0 < val) {
-      val = 1.0;
-    }
+    // if (val < 0.0) {
+    //   val = 0.0;
+    // } else if (1.0 < val) {
+    //   val = 1.0;
+    // }
   }
   if (0.0 != alp_noise) {
     alp += alp_noise;
@@ -46,26 +47,22 @@ void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
   igs::color::hsv_to_rgb(hue, sat, val, red_out, gre_out, blu_out);
   alp_out = alp;
 }
-}
+}  // namespace
 //------------------------------------------------------------
 namespace {
 class noise_ref_ {
 public:
-  noise_ref_(const unsigned char *array, const int height, const int width,
-             const int channels, const int bits, const int xoffset,
-             const int yoffset, const int zz);
+  noise_ref_(const float *array, const int height, const int width,
+             const int xoffset, const int yoffset, const int zz);
   double noise(int xx  // 0...width-1...
                ,
-               int yy    // 0...height-1...
-               ) const;  // return range is 0...1
+               int yy  // 0...height-1...
+  ) const;             // return range is 0...1
 
 private:
-  const unsigned char *array_;
+  const float *array_;
   const int height_;
   const int width_;
-  const int channels_;
-  const int bits_;
-  const double bmax_;
   const int xoffset_;
   const int yoffset_;
   const int zz_;
@@ -76,27 +73,19 @@ private:
   /* 代入演算子を無効化 */
   noise_ref_ &operator=(const noise_ref_ &);
 };
-noise_ref_::noise_ref_(const unsigned char *array, const int height,
-                       const int width, const int channels, const int bits,
+noise_ref_::noise_ref_(const float *array, const int height, const int width,
                        const int xoffset, const int yoffset, const int zz)
     : array_(array)
     , height_(height)
     , width_(width)
-    , channels_(channels)
-    , bits_(bits)
-    , bmax_(static_cast<double>((1 << bits) - 1))
     , xoffset_(xoffset)
     , yoffset_(yoffset)
     , zz_(zz) {
   if (0 == array) {
     throw std::domain_error("noise_ref_  no data");
   }
-  if ((zz < 0) || (channels <= zz)) {
+  if ((zz < 0) || (4 <= zz)) {
     throw std::domain_error("noise_ref_  bad zz");
-  }
-  if ((std::numeric_limits<unsigned char>::digits != this->bits_) &&
-      (std::numeric_limits<unsigned short>::digits != this->bits_)) {
-    throw std::domain_error("noise_ref_  bad bits");
   }
 }
 double noise_ref_::noise(int xx, int yy) const {
@@ -115,59 +104,35 @@ double noise_ref_::noise(int xx, int yy) const {
     yy -= this->height_;
   }
 
-  if (std::numeric_limits<unsigned char>::digits == this->bits_) {
-    return (*(this->array_ + this->channels_ * this->width_ * yy +
-              this->channels_ * xx + this->zz_)) /
-           this->bmax_;
-  }
-  return (*(reinterpret_cast<const unsigned short *>(this->array_) +
-            this->channels_ * this->width_ * yy + this->channels_ * xx +
-            this->zz_)) /
-         this->bmax_;
+  return (*(this->array_ + 4 * this->width_ * yy + 4 * xx + this->zz_));
 }
-}
+}  // namespace
 //------------------------------------------------------------
 #include "igs_ifx_common.h" /* igs::image::rgba */
 #include "igs_hsv_add.h"
 namespace {
-/* raster画像にノイズをのせるtemplate */
-template <class IT, class RT>
-void change_template_(
-    IT *image_array, const int height, const int width, const int channels
-
-    ,
-    const noise_ref_ &noi
-
-    ,
-    const RT *ref /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double offset, const double hue_scale, const double sat_scale,
-    const double val_scale, const double alp_scale
-
-    ,
-    const bool add_blend_sw) {
-  const int t_max      = std::numeric_limits<IT>::max();
-  const double div_val = static_cast<double>(t_max);
-  const double mul_val = static_cast<double>(t_max) + 0.999999;
-  const int r_max      = std::numeric_limits<RT>::max();
+/* raster画像にノイズをのせる */
+void change_(float *image_array, const int height, const int width,
+             const int channels, const noise_ref_ &noi,
+             const float *ref, /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+             const double offset, const double hue_scale,
+             const double sat_scale, const double val_scale,
+             const double alp_scale, const bool add_blend_sw) {
   if (igs::image::rgba::siz == channels) {
     using namespace igs::image::rgba;
     for (int yy = 0; yy < height; ++yy) {
       for (int xx = 0; xx < width; ++xx, image_array += channels) {
         /* 変化量初期値 */
-        double refv = 1.0;
+        float refv = 1.f;
 
         /* 参照画像あればピクセル単位の画像変化量を得る */
-        if (ref != 0) {
-          refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-          ref += channels; /* continue;の前に行うこと */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
         }
 
         /* 加算合成で、Alpha値ゼロならRGB値を計算する必要はない */
-        if (add_blend_sw && (0 == image_array[alp])) {
+        if (add_blend_sw && (0.f == image_array[alp])) {
           continue;
         }
         /* 加算合成でなくAlpha合成の時は、
@@ -177,24 +142,21 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
         refv *= (noi.noise(xx, yy) - offset);
 
         /* マスクSWがON、なら変化をMask */
-        if (add_blend_sw && (image_array[alp] < t_max)) {
-          refv *= static_cast<double>(image_array[alp]) / div_val;
+        if (add_blend_sw && (image_array[alp] < 1.f)) {
+          refv *= image_array[alp];
         }
 
         /* RGBAにHSVAノイズを加える */
         double rr, gg, bb, aa;
-        pixel_rgba_(static_cast<double>(image_array[red]) / div_val,
-                    static_cast<double>(image_array[gre]) / div_val,
-                    static_cast<double>(image_array[blu]) / div_val,
-                    static_cast<double>(image_array[alp]) / div_val,
-                    refv * hue_scale, refv * sat_scale, refv * val_scale,
-                    refv * alp_scale, rr, gg, bb, aa);
+        pixel_rgba_(image_array[red], image_array[gre], image_array[blu],
+                    image_array[alp], refv * hue_scale, refv * sat_scale,
+                    refv * val_scale, refv * alp_scale, rr, gg, bb, aa);
 
         /* 変化後の値を戻す */
-        image_array[red] = static_cast<IT>(rr * mul_val);
-        image_array[gre] = static_cast<IT>(gg * mul_val);
-        image_array[blu] = static_cast<IT>(bb * mul_val);
-        image_array[alp] = static_cast<IT>(aa * mul_val);
+        image_array[red] = (float)rr;
+        image_array[gre] = (float)gg;
+        image_array[blu] = (float)bb;
+        image_array[alp] = (float)aa;
       }
     }
   } else if (igs::image::rgb::siz == channels) {
@@ -202,12 +164,12 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
     for (int yy = 0; yy < height; ++yy) {
       for (int xx = 0; xx < width; ++xx, image_array += channels) {
         /* 変化量初期値 */
-        double refv = 1.0;
+        float refv = 1.f;
 
         /* 参照画像あればピクセル単位の画像変化量を得る */
-        if (ref != 0) {
-          refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-          ref += channels; /* continue;の前に行うこと */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
         }
 
         /* HSVそれぞれに対するオフセット済ノイズ値 */
@@ -215,28 +177,26 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
 
         /* RGBにHSVノイズを加える */
         double rr, gg, bb, aa;
-        pixel_rgba_(static_cast<double>(image_array[red]) / div_val,
-                    static_cast<double>(image_array[gre]) / div_val,
-                    static_cast<double>(image_array[blu]) / div_val, 1.0,
+        pixel_rgba_(image_array[red], image_array[gre], image_array[blu], 1.0,
                     refv * hue_scale, refv * sat_scale, refv * val_scale, 0.0,
                     rr, gg, bb, aa);
 
         /* 変化後の値を戻す */
-        image_array[red] = static_cast<IT>(rr * mul_val);
-        image_array[gre] = static_cast<IT>(gg * mul_val);
-        image_array[blu] = static_cast<IT>(bb * mul_val);
+        image_array[red] = (float)rr;
+        image_array[gre] = (float)gg;
+        image_array[blu] = (float)bb;
       }
     }
   } else if (1 == channels) { /* grayscale */
     for (int yy = 0; yy < height; ++yy) {
       for (int xx = 0; xx < width; ++xx, ++image_array) {
         /* 変化量初期値 */
-        double refv = 1.0;
+        float refv = 1.f;
 
         /* 参照画像あればピクセル単位の画像変化量を得る */
-        if (ref != 0) {
-          refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-          ref += channels; /* continue;の前に行うこと */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
         }
 
         /* Lに対するオフセット済ノイズ値 */
@@ -248,40 +208,24 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
         }
 
         /* GrayscaleにLノイズを加える */
-        double val =
-            static_cast<double>(image_array[0]) / div_val + refv * val_scale;
-        val = (val < 0.0) ? 0.0 : ((1.0 < val) ? 1.0 : val);
+        float val = image_array[0] + refv * val_scale;
+        // val = (val < 0.0) ? 0.0 : ((1.0 < val) ? 1.0 : val);
 
         /* 変化後の値を戻す */
-        image_array[0] = static_cast<IT>(val * mul_val);
+        image_array[0] = val;
       }
     }
   }
 }
-}
+}  // namespace
 
 void igs::hsv_add::change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *noi_image_array, const int noi_height,
-    const int noi_width, const int noi_channels, const int noi_bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
+    float *image_array, const int height, const int width, const int channels,
+    const float *noi_image_array,
+    const float *ref, /* 求める画像と同じ高、幅、channels数 */
     const int xoffset, const int yoffset, const int from_rgba,
     const double offset, const double hue_scale, const double sat_scale,
-    const double val_scale, const double alp_scale
-
-    ,
-    const bool add_blend_sw) {
+    const double val_scale, const double alp_scale, const bool add_blend_sw) {
   if ((0.0 == hue_scale) && (0.0 == sat_scale) && (0.0 == val_scale) &&
       (0.0 == alp_scale)) {
     return;
@@ -289,20 +233,18 @@ void igs::hsv_add::change(
 
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
   /* ノイズ参照画像を作成する */
-  noise_ref_ noi(noi_image_array
+  noise_ref_ noi(noi_image_array, height, width, xoffset, yoffset, from_rgba);
 
-                 ,
-                 noi_height, noi_width, noi_channels, noi_bits
-
-                 ,
-                 xoffset, yoffset, from_rgba);
+  change_(image_array, height, width, channels, noi, ref, offset, hue_scale,
+          sat_scale, val_scale, alp_scale, add_blend_sw);
 
   /* rgb(a)画像にhsv(a)でドットノイズを加える */
+  /*
   if ((std::numeric_limits<unsigned char>::digits == bits) &&
       ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
        (0 == ref_bits))) {
@@ -330,4 +272,5 @@ void igs::hsv_add::change(
   } else {
     throw std::domain_error("Bad bits,Not uchar/ushort");
   }
+  */
 }

--- a/toonz/sources/stdfx/igs_hsv_add.h
+++ b/toonz/sources/stdfx/igs_hsv_add.h
@@ -10,38 +10,17 @@
 namespace igs {
 namespace hsv_add {
 IGS_HSV_ADD_EXPORT void change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *noi_image_array, const int noi_height,
-    const int noi_width, const int noi_channels, const int noi_bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const int xoffset /* 0	INT_MIN ... INT_MAX	*/
-    ,
-    const int yoffset /* 0	INT_MIN ... INT_MAX	*/
-    ,
-    const int from_rgba /* 0	0(R),1(G),2(B),3(A)	*/
-    ,
-    const double offset /* 0.5	-1.0 ... 1.0	*/
-    ,
-    const double hue_scale /* 0.0	-1.0 ... 1.0	*/
-    ,
-    const double sat_scale /* 0.0	-1.0 ... 1.0	*/
-    ,
-    const double val_scale /* 1.0	-1.0 ... 1.0	*/
-    ,
-    const double alp_scale /* 0.0	-1.0 ... 1.0	*/
-
-    ,
+    float *image_array, const int height, const int width, const int channels,
+    const float *noi_image_array,
+    const float *ref,    /* 求める画像と同じ高、幅、channels数 */
+    const int xoffset,   /* 0	INT_MIN ... INT_MAX	*/
+    const int yoffset,   /* 0	INT_MIN ... INT_MAX	*/
+    const int from_rgba, /* 0	0(R),1(G),2(B),3(A)	*/
+    const double offset, /* 0.5	-1.0 ... 1.0	*/
+    const double hue_scale, /* 0.0	-1.0 ... 1.0	*/
+    const double sat_scale, /* 0.0	-1.0 ... 1.0	*/
+    const double val_scale, /* 1.0	-1.0 ... 1.0	*/
+    const double alp_scale, /* 0.0	-1.0 ... 1.0	*/
     const bool add_blend_sw
     /* 効果(変化量)をアルファブレンドするか否かのスイッチ
                 add_blend_sw == true
@@ -55,7 +34,7 @@ IGS_HSV_ADD_EXPORT void change(
                             合成画 = 下絵 * (1 - alpha) + 上絵 * alpha
                     の場合こちらを使う
             */
-    );
+);
 }
-}
+}  // namespace igs
 #endif /* !igs_hsv_add_h */

--- a/toonz/sources/stdfx/igs_hsv_adjust.cpp
+++ b/toonz/sources/stdfx/igs_hsv_adjust.cpp
@@ -19,7 +19,7 @@ void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
                  const double val_scale  // 1.0  ...1...
                  ,
                  const double val_shift  // 0.0  ...0...1...
-                 ) {
+) {
   double hue, sat, val;
   igs::color::rgb_to_hsv(red_in, gre_in, blu_in, hue, sat, val);
   if ((1.0 != hue_scale) || (0.0 != hue_shift)) {
@@ -45,161 +45,136 @@ void pixel_rgba_(const double red_in, const double gre_in, const double blu_in,
     sat *= sat_scale;
     sat += sat_pivot;
     sat += sat_shift;
-    sat = (sat < 0.0) ? 0.0 : ((1.0 < sat) ? 1.0 : sat);
+    sat = (sat < 0.0) ? 0.0 : sat;
+    // sat = (sat < 0.0) ? 0.0 : ((1.0 < sat) ? 1.0 : sat);
   }
   if ((1.0 != val_scale) || (0.0 != val_shift)) {
     val -= val_pivot;
     val *= val_scale;
     val += val_pivot;
     val += val_shift;
-    val = (val < 0.0) ? 0.0 : ((1.0 < val) ? 1.0 : val);
+    // val = (val < 0.0) ? 0.0 : ((1.0 < val) ? 1.0 : val);
   }
   igs::color::hsv_to_rgb(hue, sat, val, red_out, gre_out, blu_out);
 }
-}
+}  // namespace
 //------------------------------------------------------------
 #include <limits>           /* std::numeric_limits */
 #include "igs_ifx_common.h" /* igs::image::rgba */
 #include "igs_hsv_adjust.h"
 namespace {
-/* raster画像にノイズをのせるtemplate */
-template <class IT, class RT>
-void change_template_(
-    IT *image_array, const int height, const int width, const int channels
-
-    ,
-    const RT *ref /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
-    ,
-    const int ref_mode  // R,G,B,A,luminance
-
-    ,
-    const double hue_pivot, const double hue_scale, const double hue_shift,
-    const double sat_pivot, const double sat_scale, const double sat_shift,
-    const double val_pivot, const double val_scale, const double val_shift
-
-    ,
-    const bool add_blend_sw) {
-  const int t_max      = std::numeric_limits<IT>::max();
-  const double div_val = static_cast<double>(t_max);
-  const double mul_val = static_cast<double>(t_max) + 0.999999;
-  const int pixsize    = height * width;
-  const int r_max      = std::numeric_limits<RT>::max();
+/* raster画像にノイズをのせる */
+void change_(float *image_array, const int height, const int width,
+             const int channels,
+             const float *ref, /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+             const double hue_pivot, const double hue_scale,
+             const double hue_shift, const double sat_pivot,
+             const double sat_scale, const double sat_shift,
+             const double val_pivot, const double val_scale,
+             const double val_shift, const bool add_blend_sw) {
+  // const int t_max      = std::numeric_limits<IT>::max();
+  // const double div_val = static_cast<double>(t_max);
+  // const double mul_val = static_cast<double>(t_max) + 0.999999;
+  const int pixsize = height * width;
+  // const int r_max      = std::numeric_limits<RT>::max();
   if (igs::image::rgba::siz == channels) {
     using namespace igs::image::rgba;
     for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
       /* 変化量初期値 */
-      double refv = 1.0;
+      float refv = 1.f;
 
       /* 参照画像によるピクセル単位の画像変化量を得る */
-      if (ref != 0) {
-        refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-        ref += channels; /* continue;の前に行うこと */
+      if (ref != nullptr) {
+        refv *= (*ref);
+        ref++; /* continue;の前に行うこと */
       }
 
       /* 加算合成で、Alpha値ゼロならRGB値を計算する必要はない */
-      if (add_blend_sw && (0 == image_array[alp])) {
+      if (add_blend_sw && (0.f == image_array[alp])) {
         continue;
       }
       /* 加算合成でなくAlpha合成の時は、
       Alpha値がゼロでもRGB値は存在する(してもよい) */
 
-      /* RGB値を正規化 */
-      const IT *const ia = image_array;
-      const double rr1   = static_cast<double>(ia[red]) / div_val;
-      const double gg1   = static_cast<double>(ia[gre]) / div_val;
-      const double bb1   = static_cast<double>(ia[blu]) / div_val;
-
       /* pivot,scale,shiftによってRGB値を変化する */
-      double rr2, gg2, bb2;
-      pixel_rgba_(rr1, gg1, bb1, rr2, gg2, bb2, hue_pivot, hue_scale, hue_shift,
-                  sat_pivot, sat_scale, sat_shift, val_pivot, val_scale,
-                  val_shift);
+      double rr, gg, bb;
+      pixel_rgba_(image_array[red], image_array[gre], image_array[blu], rr, gg,
+                  bb, hue_pivot, hue_scale, hue_shift, sat_pivot, sat_scale,
+                  sat_shift, val_pivot, val_scale, val_shift);
 
       /* 加算合成で、その値がMaxでなければ変化量に乗算 */
-      if (add_blend_sw && (ia[alp] < t_max)) {
-        refv *= static_cast<double>(ia[alp]) / div_val;
+      if (add_blend_sw && (image_array[alp] < 1.f)) {
+        refv *= image_array[alp];
       }
 
       /* ピクセル単位の変化量があれば、RGBを調整する */
-      if ((ref != 0) || (add_blend_sw && (ia[alp] < t_max))) {
-        rr2 = rr1 + (rr2 - rr1) * refv;
-        gg2 = gg1 + (gg2 - gg1) * refv;
-        bb2 = bb1 + (bb2 - bb1) * refv;
+      if ((ref != 0) || (add_blend_sw && (image_array[alp] < 1.f))) {
+        rr = image_array[red] + (rr - image_array[red]) * refv;
+        gg = image_array[gre] + (gg - image_array[gre]) * refv;
+        bb = image_array[blu] + (bb - image_array[blu]) * refv;
       }
 
       /* 結果をRGBに戻す */
-      image_array[red] = static_cast<IT>(rr2 * mul_val);
-      image_array[gre] = static_cast<IT>(gg2 * mul_val);
-      image_array[blu] = static_cast<IT>(bb2 * mul_val);
+      image_array[red] = rr;
+      image_array[gre] = gg;
+      image_array[blu] = bb;
     }
   } else if (igs::image::rgb::siz == channels) {
     using namespace igs::image::rgb;
     for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
-      double refv = 1.0;
+      float refv = 1.f;
       if (ref != 0) {
-        refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-        ref += channels;
+        refv *= (*ref);
+        ref++;
       }
 
-      const IT *const ia = image_array;
-      const double rr1   = static_cast<double>(ia[red]) / div_val;
-      const double gg1   = static_cast<double>(ia[gre]) / div_val;
-      const double bb1   = static_cast<double>(ia[blu]) / div_val;
-      double rr2, gg2, bb2;
-      pixel_rgba_(rr1, gg1, bb1, rr2, gg2, bb2, hue_pivot, hue_scale, hue_shift,
-                  sat_pivot, sat_scale, sat_shift, val_pivot, val_scale,
-                  val_shift);
+      // const IT *const ia = image_array;
+      // const double rr1   = static_cast<double>(ia[red]) / div_val;
+      // const double gg1   = static_cast<double>(ia[gre]) / div_val;
+      // const double bb1   = static_cast<double>(ia[blu]) / div_val;
+      double rr, gg, bb;
+      pixel_rgba_(image_array[red], image_array[gre], image_array[blu], rr, gg,
+                  bb, hue_pivot, hue_scale, hue_shift, sat_pivot, sat_scale,
+                  sat_shift, val_pivot, val_scale, val_shift);
 
-      if (ref != 0) {
-        rr2 = rr1 + (rr2 - rr1) * refv;
-        gg2 = gg1 + (gg2 - gg1) * refv;
-        bb2 = bb1 + (bb2 - bb1) * refv;
+      if (ref != nullptr) {
+        rr = image_array[red] + (rr - image_array[red]) * refv;
+        gg = image_array[gre] + (gg - image_array[gre]) * refv;
+        bb = image_array[blu] + (bb - image_array[blu]) * refv;
       }
 
-      image_array[red] = static_cast<IT>(rr2 * mul_val);
-      image_array[gre] = static_cast<IT>(gg2 * mul_val);
-      image_array[blu] = static_cast<IT>(bb2 * mul_val);
+      image_array[red] = rr;
+      image_array[gre] = gg;
+      image_array[blu] = bb;
     }
   } else if (1 == channels) { /* grayscale */
     for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
-      double refv = 1.0;
-      if (ref != 0) {
-        refv *= igs::color::ref_value(ref, channels, r_max, ref_mode);
-        ref += channels;
+      float refv = 1.f;
+      if (ref != nullptr) {
+        refv *= (*ref);
+        ref++;
       }
 
-      double li1 = static_cast<double>(image_array[0]) / div_val,
-             li2 = (li1 - val_pivot) * val_scale + val_pivot + val_shift;
-      li2        = (li2 < 0.0) ? 0.0 : ((1.0 < li2) ? 1.0 : li2);
+      double li =
+          (*image_array - val_pivot) * val_scale + val_pivot + val_shift;
 
-      if (ref != 0) {
-        li2 = li1 + (li2 - li1) * refv;
+      if (ref != nullptr) {
+        li = *image_array + (li - *image_array) * refv;
       }
 
-      image_array[0] = static_cast<IT>(li2 * mul_val);
+      *image_array = li;
     }
   }
 }
-}
+}  // namespace
 
 #include <stdexcept> /* std::domain_error  */
 void igs::hsv_adjust::change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅、channels数 */
     const double hue_pivot, const double hue_scale, const double hue_shift,
     const double sat_pivot, const double sat_scale, const double sat_shift,
-    const double val_pivot, const double val_scale, const double val_shift
-
-    ,
+    const double val_pivot, const double val_scale, const double val_shift,
     const bool add_blend_sw) {
   if ((1.0 == hue_scale) && (0.0 == hue_shift) && (1.0 == sat_scale) &&
       (0.0 == sat_shift) && (1.0 == val_scale) && (0.0 == val_shift)) {
@@ -208,11 +183,15 @@ void igs::hsv_adjust::change(
 
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
+  change_(image_array, height, width, channels, ref, hue_pivot, hue_scale,
+          hue_shift, sat_pivot, sat_scale, sat_shift, val_pivot, val_scale,
+          val_shift, add_blend_sw);
 
   /* rgb(a)画像にhsv(a)でドットノイズを加える */
+  /*
   if ((std::numeric_limits<unsigned char>::digits == bits) &&
       ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
        (0 == ref_bits))) {
@@ -242,4 +221,5 @@ void igs::hsv_adjust::change(
   } else {
     throw std::domain_error("Bad bits,Not uchar/ushort");
   }
+  */
 }

--- a/toonz/sources/stdfx/igs_hsv_adjust.h
+++ b/toonz/sources/stdfx/igs_hsv_adjust.h
@@ -10,36 +10,17 @@
 namespace igs {
 namespace hsv_adjust {
 IGS_HSV_ADJUST_EXPORT void change(
-    unsigned char *image_array, const int height, const int width,
-    const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
-    ,
-    const double hue_pivot /* 0.0  ...0...360... */
-    ,
-    const double hue_scale /* 1.0  ...1...       */
-    ,
-    const double hue_shift /* 0.0  ...0...360... */
-    ,
-    const double sat_pivot /* 0.0  ...0...1...   */
-    ,
-    const double sat_scale /* 1.0  ...1...       */
-    ,
-    const double sat_shift /* 0.0  ...0...1...   */
-    ,
-    const double val_pivot /* 0.0  ...0...1...   */
-    ,
-    const double val_scale /* 1.0  ...1...       */
-    ,
-    const double val_shift /* 0.0  ...0...1...   */
-
-    ,
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅、channels数 */
+    const double hue_pivot, /* 0.0  ...0...360... */
+    const double hue_scale, /* 1.0  ...1...       */
+    const double hue_shift, /* 0.0  ...0...360... */
+    const double sat_pivot, /* 0.0  ...0...1...   */
+    const double sat_scale, /* 1.0  ...1...       */
+    const double sat_shift, /* 0.0  ...0...1...   */
+    const double val_pivot, /* 0.0  ...0...1...   */
+    const double val_scale, /* 1.0  ...1...       */
+    const double val_shift, /* 0.0  ...0...1...   */
     const bool add_blend_sw
     /* 効果(変化量)をアルファブレンドするか否かのスイッチ
                 add_blend_sw == true
@@ -53,8 +34,8 @@ IGS_HSV_ADJUST_EXPORT void change(
                             合成画 = 下絵 * (1 - alpha) + 上絵 * alpha
                     の場合こちらを使う
             */
-    );
+);
 }
-}
+}  // namespace igs
 
 #endif /* !igs_hsv_adjust_h */

--- a/toonz/sources/stdfx/igs_hsv_noise.cpp
+++ b/toonz/sources/stdfx/igs_hsv_noise.cpp
@@ -395,10 +395,11 @@ void pixel_rgb_(const double red_in, const double gre_in, const double blu_in,
     sat += satnoise * alp_in;
     if (sat < 0.0) {
       sat = 0.0;
-    } else if (1.0 < sat) {
-      sat = 1.0;
     }
-    // if( 0.0 == sat ) hue = -1.0; // hsv_to_rgb(-)
+    // else if (1.0 < sat) {
+    //   sat = 1.0;
+    // }
+    //  if( 0.0 == sat ) hue = -1.0; // hsv_to_rgb(-)
   }
   if (0.0 != val_term.noise_range()) {
     double shift_value = 0;
@@ -406,11 +407,11 @@ void pixel_rgb_(const double red_in, const double gre_in, const double blu_in,
     val_term.exec(val, valnoise, shift_value);
     val += shift_value * alp_in;
     val += valnoise * alp_in;
-    if (val < 0.0) {
-      val = 0.0;
-    } else if (1.0 < val) {
-      val = 1.0;
-    }
+    // if (val < 0.0) {
+    //   val = 0.0;
+    // } else if (1.0 < val) {
+    //   val = 1.0;
+    // }
   }
   igs::color::hsv_to_rgb(hue, sat, val, red_out, gre_out, blu_out);
 }
@@ -482,7 +483,7 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
         if (((0.0 != hue_range) || (0.0 != val_term.noise_range()) ||
              (0.0 !=
               sat_term.noise_range())) /* ノイズがhsvのどれか一つはある */
-            ) {
+        ) {
           double rr1 = static_cast<double>(image_array[red]) / div_val,
                  gg1 = static_cast<double>(image_array[gre]) / div_val,
                  bb1 = static_cast<double>(image_array[blu]) / div_val,
@@ -496,6 +497,10 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
             gg2 = (gg2 - gg1) * refv + gg1;
             bb2 = (bb2 - bb1) * refv + bb1;
           }
+          rr2 = (rr2 < 0.) ? 0. : (rr2 > 1.) ? 1. : rr2;
+          gg2 = (gg2 < 0.) ? 0. : (gg2 > 1.) ? 1. : gg2;
+          bb2 = (bb2 < 0.) ? 0. : (bb2 > 1.) ? 1. : bb2;
+
           image_array[red] = static_cast<IT>(rr2 * mul_val);
           image_array[gre] = static_cast<IT>(gg2 * mul_val);
           image_array[blu] = static_cast<IT>(bb2 * mul_val);
@@ -515,7 +520,7 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
     using namespace igs::image::rgb;
     if (((0.0 != hue_range) || (0.0 != sat_term.noise_range()) ||
          (0.0 != val_term.noise_range())) /* ノイズがhsvのどれか一つはある */
-        ) {
+    ) {
       for (int yy = 0; yy < height; ++yy) {
         for (int xx = 0; xx < width; ++xx, image_array += channels) {
           /* 変化量初期値 */
@@ -539,6 +544,10 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
             gg2 = (gg2 - gg1) * refv + gg1;
             bb2 = (bb2 - bb1) * refv + bb1;
           }
+          rr2 = (rr2 < 0.) ? 0. : (rr2 > 1.) ? 1. : rr2;
+          gg2 = (gg2 < 0.) ? 0. : (gg2 > 1.) ? 1. : gg2;
+          bb2 = (bb2 < 0.) ? 0. : (bb2 > 1.) ? 1. : bb2;
+
           image_array[red] = static_cast<IT>(rr2 * mul_val);
           image_array[gre] = static_cast<IT>(gg2 * mul_val);
           image_array[blu] = static_cast<IT>(bb2 * mul_val);
@@ -578,41 +587,154 @@ Alpha値がゼロでもRGB値は存在する(してもよい) */
     }
   }
 }
+
+/*------ raster画像にノイズをのせる ------*/
+
+void change_(float *image_array, const int width, const int height,
+             const int channels,
+             const float *ref, /* 求める画像(out)と同じ高さ*/
+             noise_reference_ &noise, const double hue_range,
+             control_term_within_limits_ &sat_term,
+             control_term_within_limits_ &val_term,
+             control_term_within_limits_ &alp_term, const bool add_blend_sw) {
+  if (igs::image::rgba::siz == channels) {
+    using namespace igs::image::rgba;
+    for (int yy = 0; yy < height; ++yy) {
+      for (int xx = 0; xx < width; ++xx, image_array += channels) {
+        /* 変化量初期値 */
+        float refv = 1.f;
+
+        /* 参照画像あればピクセル単位の画像変化量を得る */
+        if (ref != nullptr) {
+          refv *= (*ref);
+          ref++; /* continue;の前に行うこと */
+        }
+        /* 加算合成で、Alpha値ゼロならRGB値を計算する必要はない */
+        if (add_blend_sw && (0 == image_array[alp])) {
+          continue;
+        }
+        /* 加算合成でなくAlpha合成の時は、
+Alpha値がゼロでもRGB値は存在する(してもよい) */
+
+        /* マスクSWがON、なら変化をMask */
+        if (add_blend_sw && (image_array[alp] < 1.f)) {
+          refv *= image_array[alp];
+        }
+
+        if (((0.0 != hue_range) || (0.0 != val_term.noise_range()) ||
+             (0.0 !=
+              sat_term.noise_range())) /* ノイズがhsvのどれか一つはある */
+        ) {
+          float rr1 = image_array[red], gg1 = image_array[gre],
+                bb1 = image_array[blu], aa1 = image_array[alp];
+          double rr2 = 0., gg2 = 0., bb2 = 0.;
+          pixel_rgb_(rr1, gg1, bb1, aa1, noise.hue_value(xx, yy),
+                     noise.sat_value(xx, yy), noise.val_value(xx, yy), sat_term,
+                     val_term, rr2, gg2, bb2);
+          if (refv != 1.f) {
+            rr2 = (rr2 - rr1) * refv + rr1;
+            gg2 = (gg2 - gg1) * refv + gg1;
+            bb2 = (bb2 - bb1) * refv + bb1;
+          }
+          image_array[red] = static_cast<float>(rr2);
+          image_array[gre] = static_cast<float>(gg2);
+          image_array[blu] = static_cast<float>(bb2);
+        }
+        if (0.0 != alp_term.noise_range()) {
+          double aa1 = static_cast<double>(image_array[alp]);
+          double aa2 = 0.;
+          pixel_a_(aa1, noise.alp_value(xx, yy), alp_term, aa2);
+          if (refv != 1.f) {
+            aa2 = (aa2 - aa1) * refv + aa1;
+          }
+          image_array[alp] = static_cast<float>(aa2);
+        }
+      }
+    }
+  } else if (igs::image::rgb::siz == channels) {
+    using namespace igs::image::rgb;
+    if (((0.0 != hue_range) || (0.0 != sat_term.noise_range()) ||
+         (0.0 != val_term.noise_range())) /* ノイズがhsvのどれか一つはある */
+    ) {
+      for (int yy = 0; yy < height; ++yy) {
+        for (int xx = 0; xx < width; ++xx, image_array += channels) {
+          /* 変化量初期値 */
+          float refv = 1.f;
+
+          /* 参照画像あればピクセル単位の画像変化量を得る */
+          if (ref != nullptr) {
+            refv *= (*ref);
+            ref++; /* continue;の前に行うこと */
+          }
+
+          float rr1 = image_array[red], gg1 = image_array[gre],
+                bb1  = image_array[blu];
+          double rr2 = 0., gg2 = 0., bb2 = 0.;
+          pixel_rgb_(rr1, gg1, bb1, 1.0, noise.hue_value(xx, yy),
+                     noise.sat_value(xx, yy), noise.val_value(xx, yy), sat_term,
+                     val_term, rr2, gg2, bb2);
+          if (refv != 1.f) {
+            rr2 = (rr2 - rr1) * refv + rr1;
+            gg2 = (gg2 - gg1) * refv + gg1;
+            bb2 = (bb2 - bb1) * refv + bb1;
+          }
+          image_array[red] = static_cast<float>(rr2);
+          image_array[gre] = static_cast<float>(gg2);
+          image_array[blu] = static_cast<float>(bb2);
+        }
+      }
+    }
+  } else if (1 == channels) { /* grayscale */
+    if (0.0 != val_term.noise_range()) {
+      for (int yy = 0; yy < height; ++yy) {
+        for (int xx = 0; xx < width; ++xx, ++image_array) {
+          /* 変化量初期値 */
+          float refv = 1.f;
+
+          /* 参照画像あればピクセル単位の画像変化量を得る */
+          if (ref != 0) {
+            refv *= (*ref);
+            ref++; /* continue;の前に行うこと */
+          }
+
+          double va1         = static_cast<double>(image_array[0]);
+          double shift_value = 0;
+          double val_noise   = noise.val_value(xx, yy);
+          val_term.exec(va1, val_noise, shift_value);
+
+          double va2 = va1;
+          va2 += shift_value;
+          va2 += val_noise;
+          va2 = (va2 < 0.0) ? 0.0 : ((1.0 < va2) ? 1.0 : va2);
+
+          if (refv != 1.f) {
+            va2 = va1 + (va2 - va1) * refv;
+          }
+
+          image_array[0] = static_cast<float>(va2);
+        }
+      }
+    }
+  }
 }
+
+}  // namespace
 //--------------------------------------------------------------------
 
 #include <stdexcept>  // std::domain_error
 #include "igs_hsv_noise.h"
 void igs::hsv_noise::change(
-    unsigned char *image_array
-
-    ,
-    const int height, const int width, const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅 */
     /* image_arrayに余白が変化してもノイズパターンが変わらない
             ようにするためにカメラエリアを指定する */
-    ,
     const int camera_x, const int camera_y, const int camera_w,
-    const int camera_h
-
-    ,
-    const double hue_range, const double sat_range, const double val_range,
-    const double alp_range, const unsigned long random_seed,
-    const double near_blur
-
-    ,
+    const int camera_h, const double hue_range, const double sat_range,
+    const double val_range, const double alp_range,
+    const unsigned long random_seed, const double near_blur,
     const double sat_effective, const double sat_center, const int sat_type,
     const double val_effective, const double val_center, const int val_type,
-    const double alp_effective, const double alp_center, const int alp_type
-
-    ,
+    const double alp_effective, const double alp_center, const int alp_type,
     const bool add_blend_sw) {
   if ((0.0 == hue_range) && (0.0 == sat_range) && (0.0 == val_range) &&
       (0.0 == alp_range)) {
@@ -621,7 +743,7 @@ void igs::hsv_noise::change(
 
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
@@ -638,35 +760,40 @@ void igs::hsv_noise::change(
   control_term_within_limits_ alp_term(alp_effective, alp_effective, alp_center,
                                        alp_type, alp_range);
 
-  /* rgb(a)画像にhsv(a)でドットノイズを加える */
-  if ((std::numeric_limits<unsigned char>::digits == bits) &&
-      ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-       (0 == ref_bits))) {
-    change_template_(image_array, width, height, channels, ref, ref_mode, noise,
-                     hue_range, sat_term, val_term, alp_term, add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
-              (0 == ref_bits))) {
-    change_template_(reinterpret_cast<unsigned short *>(image_array), width,
-                     height, channels, ref, ref_mode, noise, hue_range,
-                     sat_term, val_term, alp_term, add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(
-        reinterpret_cast<unsigned short *>(image_array), width, height,
-        channels, reinterpret_cast<const unsigned short *>(ref), ref_mode,
-        noise, hue_range, sat_term, val_term, alp_term, add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else if ((std::numeric_limits<unsigned char>::digits == bits) &&
-             (std::numeric_limits<unsigned short>::digits == ref_bits)) {
-    change_template_(image_array, width, height, channels,
-                     reinterpret_cast<const unsigned short *>(ref), ref_mode,
-                     noise, hue_range, sat_term, val_term, alp_term,
-                     add_blend_sw);
-    noise.clear(); /* ノイズ画像メモリ解放 */
-  } else {
-    throw std::domain_error("Bad bits,Not uchar/ushort");
-  }
+  change_(image_array, width, height, channels, ref, noise, hue_range, sat_term,
+          val_term, alp_term, add_blend_sw);
+  noise.clear(); /* ノイズ画像メモリ解放 */
+
+  ///* rgb(a)画像にhsv(a)でドットノイズを加える */
+  // if ((std::numeric_limits<unsigned char>::digits == bits) &&
+  //     ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
+  //      (0 == ref_bits))) {
+  //   change_template_(image_array, width, height, channels, ref, ref_mode,
+  //   noise,
+  //                    hue_range, sat_term, val_term, alp_term, add_blend_sw);
+  //   noise.clear(); /* ノイズ画像メモリ解放 */
+  // } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
+  //            ((std::numeric_limits<unsigned char>::digits == ref_bits) ||
+  //             (0 == ref_bits))) {
+  //   change_template_(reinterpret_cast<unsigned short *>(image_array), width,
+  //                    height, channels, ref, ref_mode, noise, hue_range,
+  //                    sat_term, val_term, alp_term, add_blend_sw);
+  //   noise.clear(); /* ノイズ画像メモリ解放 */
+  // } else if ((std::numeric_limits<unsigned short>::digits == bits) &&
+  //            (std::numeric_limits<unsigned short>::digits == ref_bits)) {
+  //   change_template_(
+  //       reinterpret_cast<unsigned short *>(image_array), width, height,
+  //       channels, reinterpret_cast<const unsigned short *>(ref), ref_mode,
+  //       noise, hue_range, sat_term, val_term, alp_term, add_blend_sw);
+  //   noise.clear(); /* ノイズ画像メモリ解放 */
+  // } else if ((std::numeric_limits<unsigned char>::digits == bits) &&
+  //            (std::numeric_limits<unsigned short>::digits == ref_bits)) {
+  //   change_template_(image_array, width, height, channels,
+  //                    reinterpret_cast<const unsigned short *>(ref), ref_mode,
+  //                    noise, hue_range, sat_term, val_term, alp_term,
+  //                    add_blend_sw);
+  //   noise.clear(); /* ノイズ画像メモリ解放 */
+  // } else {
+  //   throw std::domain_error("Bad bits,Not uchar/ushort");
+  // }
 }

--- a/toonz/sources/stdfx/igs_hsv_noise.h
+++ b/toonz/sources/stdfx/igs_hsv_noise.h
@@ -10,60 +10,29 @@
 namespace igs {
 namespace hsv_noise {
 IGS_HSV_NOISE_EXPORT void change(
-    unsigned char *image_array
-
-    ,
-    const int height, const int width, const int channels, const int bits
-
-    ,
-    const unsigned char *ref /* 求める画像と同じ高、幅、channels数 */
-    ,
-    const int ref_bits /* refがゼロのときはここもゼロ */
-    ,
-    const int ref_mode /* 0=R,1=G,2=B,3=A,4=Luminance,5=Nothing */
-
+    float *image_array, const int height, const int width, const int channels,
+    const float *ref, /* 求める画像と同じ高、幅 */
     /* image_arrayに余白が変化してもノイズパターンが変わらない
             ようにするためにカメラエリアを指定する */
-    ,
     const int camera_x, const int camera_y, const int camera_w,
-    const int camera_h
-
-    ,
-    const double hue_range /* =0.025  0 ... 1.0 */
-    ,
-    const double sat_range /* =0.0	   0 ... 1.0 */
-    ,
-    const double val_range /* =0.035  0 ... 1.0 */
-    ,
-    const double alp_range /* =0.0    0 ... 1.0 */
-    ,
-    const unsigned long random_seed /* =1	   0 ... ULONG_MAX */
-    ,
-    const double near_blur /* =0.500  0 ... 0.5 */
-
-    ,
-    const double sat_effective /* =0.0	   0 ... 1.0 */
-    ,
-    const double sat_center /* =0.5	   0 ... 1.0 */
-    ,
-    const int sat_type /* =0
-     0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
-    ,
-    const double val_effective /* =0.0	   0 ... 1.0 */
-    ,
-    const double val_center /* =0.5	   0 ... 1.0 */
-    ,
-    const int val_type /* =0
-     0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
-    ,
-    const double alp_effective /* =0.0	   0 ... 1.0 */
-    ,
-    const double alp_center /* =0.5	   0 ... 1.0 */
-    ,
-    const int alp_type /* =0
-     0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
-
-    ,
+    const int camera_h, const double hue_range, /* =0.025  0 ... 1.0 */
+    const double sat_range,                     /* =0.0	   0 ... 1.0 */
+    const double val_range,                     /* =0.035  0 ... 1.0 */
+    const double alp_range,                     /* =0.0    0 ... 1.0 */
+    const unsigned long random_seed,            /* =1	   0 ... ULONG_MAX */
+    const double near_blur,                     /* =0.500  0 ... 0.5 */
+    const double sat_effective,                 /* =0.0	   0 ... 1.0 */
+    const double sat_center,                    /* =0.5	   0 ... 1.0 */
+    const int sat_type,                         /* =0
+                             0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
+    const double val_effective,                 /* =0.0	   0 ... 1.0 */
+    const double val_center,                    /* =0.5	   0 ... 1.0 */
+    const int val_type,                         /* =0
+                             0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
+    const double alp_effective,                 /* =0.0	   0 ... 1.0 */
+    const double alp_center,                    /* =0.5	   0 ... 1.0 */
+    const int alp_type,                         /* =0
+                             0(shift_whole),1(shift_term),2(decrease_whole),3(decrease_term) */
     const bool add_blend_sw
     /* 効果(変化量)をアルファブレンドするか否かのスイッチ
                 add_blend_sw == true
@@ -77,8 +46,8 @@ IGS_HSV_NOISE_EXPORT void change(
                             合成画 = 下絵 * (1 - alpha) + 上絵 * alpha
                     の場合こちらを使う
             */
-    );
+);
 }
-}
+}  // namespace igs
 
 #endif /* !igs_hsv_noise_h */

--- a/toonz/sources/stdfx/igs_level_auto_in_camera.cpp
+++ b/toonz/sources/stdfx/igs_level_auto_in_camera.cpp
@@ -47,6 +47,42 @@ double level_value_(double value, double mul_max, bool act_sw, double in_min,
   /* 0〜1.0 --> 0〜mul_maxスケール変換し、整数値化 */
   return floor(value * mul_max);
 }
+
+//------------------------------------------------------------
+
+struct LevelAutoValueF {
+  double in_min[4];
+  double out_min[4];
+  double gamma[4];
+  double in_max_minus_in_min[4];
+  double out_max_minus_out_min[4];
+  LevelAutoValueF(const int channels, const float *_in_min,
+                  const float *_in_max, const double *_in_min_shift,
+                  const double *_in_max_shift, const double *_out_min,
+                  const double *_out_max, const double *_gamma) {
+    for (int c = 0; c < channels; c++) {
+      in_min[c]                = _in_min[c] + _in_min_shift[c];
+      out_min[c]               = _out_min[c];
+      gamma[c]                 = _gamma[c];
+      in_max_minus_in_min[c]   = _in_max[c] + _in_max_shift[c] - in_min[c];
+      out_max_minus_out_min[c] = _out_max[c] - _out_min[c];
+    }
+  }
+
+  inline float convert(const int c, float value) {
+    if (in_max_minus_in_min[c] == 0.0) {
+      value = in_min[c];
+    } else  // normalize
+      value = (value - in_min[c]) / in_max_minus_in_min[c];
+    // gamma transform
+    if ((1.0 != gamma[c]) && (0.0 != gamma[c]) && value > 0.0)
+      value = std::pow(value, 1.0 / gamma[c]);
+    // normalize to the output range
+    value = out_min[c] + value * out_max_minus_out_min[c];
+    return value;
+  }
+};
+
 //------------------------------------------------------------
 void level_ctable_template_(const unsigned int channels,
                             const bool *act_sw,          // user setting
@@ -67,7 +103,7 @@ void level_ctable_template_(const unsigned int channels,
                      ならOK
                      2009-01-27
                     */
-                            ) {
+) {
   const double div_val = static_cast<double>(div_num);
   const double mul_val = div_val + 0.999999;
 #if defined _WIN32  // vc compile_type
@@ -163,33 +199,95 @@ void change_template_(T *image_array, const int height, const int width,
 
   table_array.clear();
 }
+
+//------------------------------------------------------------
+
+template <>
+void change_template_<float>(float *image_array, const int height,
+                             const int width, const int channels,
+                             const bool *act_sw, const double *in_min_shift,
+                             const double *in_max_shift, const double *out_min,
+                             const double *out_max, const double *gamma,
+                             const int camera_x, const int camera_y,
+                             const int camera_w, const int camera_h) {
+  /* 1.まずcameraエリア内の最大値、最小値を求める */
+#if defined _WIN32
+  float in_min[4], in_max[4];
+#else
+  float in_min[channels], in_max[channels];
+#endif
+  float *image_crnt =
+      image_array + camera_y * width * channels + camera_x * channels;
+  for (int zz = 0; zz < channels; ++zz) {
+    in_min[zz] = in_max[zz] = image_crnt[zz];
+  }
+  float *image_xx = nullptr;
+  for (int yy = 0; yy < camera_h; ++yy) {
+    image_xx = image_crnt;
+    image_crnt += width * channels;
+    for (int xx = 0; xx < camera_w; ++xx) {
+      for (int zz = 0; zz < channels; ++zz) {
+        if (image_xx[zz] < in_min[zz]) {
+          in_min[zz] = image_xx[zz];
+        } else if (in_max[zz] < image_xx[zz]) {
+          in_max[zz] = image_xx[zz];
+        }
+      }
+      image_xx += channels;
+    }
+  }
+
+  /* 2.最大値、最小値から変換テーブルを求める */
+  // std::vector<std::vector<unsigned int>> table_array;
+  //
+  // level_ctable_template_(channels, act_sw, in_min, in_max, in_min_shift,
+  //   in_max_shift, out_min, out_max, gamma,
+  //   std::numeric_limits<T>::max(), table_array);
+
+  LevelAutoValueF converter(channels, in_min, in_max, in_min_shift,
+                            in_max_shift, out_min, out_max, gamma);
+
+  /* 画像全体をlevel変換する */
+  image_crnt        = image_array;
+  const int pixsize = height * width;
+
+  if (igs::image::rgba::siz == channels) {
+    using namespace igs::image::rgba;
+    for (int ii = 0; ii < pixsize; ++ii, image_crnt += channels) {
+      image_crnt[red] = converter.convert(0, image_crnt[red]);
+      image_crnt[gre] = converter.convert(1, image_crnt[gre]);
+      image_crnt[blu] = converter.convert(2, image_crnt[blu]);
+      image_crnt[alp] = converter.convert(3, image_crnt[alp]);
+    }
+  } else if (igs::image::rgb::siz == channels) {
+    using namespace igs::image::rgb;
+    for (int ii = 0; ii < pixsize; ++ii, image_crnt += channels) {
+      image_crnt[red] = converter.convert(0, image_crnt[red]);
+      image_crnt[gre] = converter.convert(1, image_crnt[gre]);
+      image_crnt[blu] = converter.convert(2, image_crnt[blu]);
+    }
+  } else if (1 == channels) { /* grayscale */
+    for (int ii = 0; ii < pixsize; ++ii, ++image_crnt) {
+      image_crnt[0] = converter.convert(0, image_crnt[0]);
+    }
+  }
 }
+}  // namespace
 
 void igs::level_auto_in_camera::change(
-    void *image_array
-
-    ,
-    const int height, const int width, const int channels, const int bits
-
-    ,
-    const bool *act_sw  // channels array
-    ,
-    const double *in_min_shift  // channels array
-    ,
-    const double *in_max_shift  // channels array
-    ,
-    const double *out_min  // channels array
-    ,
-    const double *out_max  // channels array
-    ,
-    const double *gamma  // channels array
-
-    ,
+    void *image_array, const int height, const int width, const int channels,
+    const int bits,
+    const bool *act_sw,          // channels array
+    const double *in_min_shift,  // channels array
+    const double *in_max_shift,  // channels array
+    const double *out_min,       // channels array
+    const double *out_max,       // channels array
+    const double *gamma,         // channels array
     const int camera_x, const int camera_y, const int camera_w,
     const int camera_h) {
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
@@ -201,6 +299,10 @@ void igs::level_auto_in_camera::change(
     change_template_(static_cast<unsigned short *>(image_array), height, width,
                      channels, act_sw, in_min_shift, in_max_shift, out_min,
                      out_max, gamma, camera_x, camera_y, camera_w, camera_h);
+  } else if (std::numeric_limits<float>::digits == bits) {
+    change_template_(static_cast<float *>(image_array), height, width, channels,
+                     act_sw, in_min_shift, in_max_shift, out_min, out_max,
+                     gamma, camera_x, camera_y, camera_w, camera_h);
   } else {
     throw std::domain_error("Bad bits,Not uchar/ushort");
   }

--- a/toonz/sources/stdfx/igs_level_auto_in_camera.h
+++ b/toonz/sources/stdfx/igs_level_auto_in_camera.h
@@ -10,28 +10,17 @@
 namespace igs {
 namespace level_auto_in_camera {
 IGS_LEVEL_AUTO_IN_CAMERA_EXPORT void change(
-    void *image_array
-
-    ,
-    const int height, const int width, const int channels, const int bits
-
-    ,
-    const bool *act_sw  // true(false/true)
-    ,
-    const double *in_min_shift  // 0(-1...1)
-    ,
-    const double *in_max_shift  // 0(-1...1)
-    ,
-    const double *out_min  // 0(0...1)
-    ,
-    const double *out_max  // 1(0...1)
-    ,
-    const double *gamma  // 1(0.01...100)
-
-    ,
+    void *image_array, const int height, const int width, const int channels,
+    const int bits,
+    const bool *act_sw,          // true(false/true)
+    const double *in_min_shift,  // 0(-1...1)
+    const double *in_max_shift,  // 0(-1...1)
+    const double *out_min,       // 0(0...1)
+    const double *out_max,       // 1(0...1)
+    const double *gamma,         // 1(0.01...100)
     const int camera_x, const int camera_y, const int camera_w,
     const int camera_h);
 }
-}
+}  // namespace igs
 
 #endif /* !igs_level_auto_in_camera_h */

--- a/toonz/sources/stdfx/igs_levels.cpp
+++ b/toonz/sources/stdfx/igs_levels.cpp
@@ -2,8 +2,11 @@
 #include <stdexcept>  // std::domain_error(-)
 #include <limits>     // std::numeric_limits
 #include <vector>
+#include <cassert>
 #include "igs_ifx_common.h" /* igs::image::rgba */
 #include "igs_levels.h"
+
+#include "tutil.h"  // areAlmostEqual
 
 //------------------------------------------------------------
 namespace {
@@ -24,8 +27,10 @@ void levels_(double &val  // 0...1
   val = (in_max == in_min) ? in_max : (val - in_min) / (in_max - in_min);
 
   /* 2 (出力範囲に)clamp */
-  if (clamp_sw) {
+  if (clamp_sw || !areAlmostEqual(out_max, 1.)) {
     val = (val < 0.0) ? 0.0 : ((1.0 < val) ? 1.0 : val);
+  } else {
+    val = (val < 0.0) ? 0.0 : val;
   }
 
   /* 3 正規化の範囲でgamma変換 */
@@ -33,17 +38,27 @@ void levels_(double &val  // 0...1
     if ((0.0 < val) && (val < 1.0)) {
       val = pow(val, 1.0 / gamma);
     }
+    // ガンマ補正の線を直線で延長する
+    else if (val > 1.0) {
+      val = 1. + (val - 1.) / gamma;
+    }
   }
 
   /* 4 正規化範囲を出力範囲に */
   val = out_min + val * (out_max - out_min);
 
   /* 5 clamp */
-  val = (val < 0.0) ? 0.0 : ((1.0 < val) ? 1.0 : val);
+  if (clamp_sw)
+    val = (val < 0.0) ? 0.0 : ((1.0 < val) ? 1.0 : val);
+  else
+    val = (val < 0.0) ? 0.0 : val;
 }
 double refchk_(const int src, const int tgt, const double refv) {
   return (src < tgt) ? (tgt - src + 0.999999) * refv + src
                      : (src - tgt + 0.999999) * (1.0 - refv) + tgt;
+}
+float refchk_(const float src, const float tgt, const double refv) {
+  return tgt * refv + src * (1. - refv);
 }
 //------------------------------------------------------------
 /*
@@ -196,7 +211,152 @@ void change_(IT *image_array, const int height, const int width,
   /* 1 変換テーブルのメモリ解放 */
   tables.clear();
 }
+
+template <>
+void change_(float *image_array, const int height, const int width,
+             const int channels,
+             const float *ref, /* 求める画像(out)と同じ高さ、幅、チャンネル数 */
+             const int ref_mode,                            // R,G,B,A,luminance
+             const double r_in_min, const double r_in_max,  // 0...1
+             const double g_in_min, const double g_in_max,  // 0...1
+             const double b_in_min, const double b_in_max,  // 0...1
+             const double a_in_min, const double a_in_max,  // 0...1
+             const double r_gamma,                          // 0.1 ... 10.0
+             const double g_gamma,                          // 0.1 ... 10.0
+             const double b_gamma,                          // 0.1 ... 10.0
+             const double a_gamma,                          // 0.1 ... 10.0
+             const double r_out_min, const double r_out_max,  // 0...1
+             const double g_out_min, const double g_out_max,  // 0...1
+             const double b_out_min, const double b_out_max,  // 0...1
+             const double a_out_min, const double a_out_max,  // 0...1
+             const bool clamp_sw, const bool alpha_sw,
+             const bool add_blend_sw) {
+  /* 1 最大値、最小値から変換テーブルを求める */
+  std::vector<std::vector<float>> tables;
+  const unsigned int table_size =
+      std::numeric_limits<unsigned short>::max() + 1;
+  const double div_val = static_cast<double>(table_size - 1);
+  // const double mul_val = div_val + 0.999999;
+  {
+    using namespace igs::image::rgba;
+    tables.resize(siz);
+    tables[red].resize(table_size);
+    tables[gre].resize(table_size);
+    tables[blu].resize(table_size);
+    tables[alp].resize(table_size);
+    for (unsigned int yy = 0; yy < table_size; ++yy) {
+      double rr, gg, bb, aa;
+      rr = gg = bb = aa = yy / div_val;
+      levels_(rr, r_in_min, r_in_max, r_gamma, r_out_min, r_out_max,
+              false);  // クランプしない
+      levels_(gg, g_in_min, g_in_max, g_gamma, g_out_min, g_out_max,
+              false);  // クランプしない
+      levels_(bb, b_in_min, b_in_max, b_gamma, b_out_min, b_out_max,
+              false);  // クランプしない
+      levels_(aa, a_in_min, a_in_max, a_gamma, a_out_min, a_out_max, clamp_sw);
+      /* 0〜1.0 --> 0〜mul_maxスケール変換し、整数値化 */
+      tables[red][yy] = static_cast<float>(rr);
+      tables[gre][yy] = static_cast<float>(gg);
+      tables[blu][yy] = static_cast<float>(bb);
+      tables[alp][yy] = static_cast<float>(aa);
+    }
+  }
+
+  // テーブル値を返すラムダ式。Inが1より大きい場合はmaxの線を直線で延長
+  auto getTableVal = [&](int channel, float in) {
+    if (in <= 0.f) {  // 先頭の値を返す
+      return tables[channel][0];
+    } else if (in <=
+               1.f) {  // テーブル範囲に収まっている場合、前後の値で線形補間
+      int index   = static_cast<int>(std::floor(in * div_val));
+      float ratio = in * div_val - static_cast<float>(index);
+      if (areAlmostEqual(ratio, 0.)) return tables[channel][index];
+      return tables[channel][index] * (1.f - ratio) +
+             tables[channel][index + 1] * ratio;
+    }
+    // inが1より大きい場合
+    // 傾き
+    float dv =
+        (tables[channel][table_size - 1] - tables[channel][table_size - 2]) *
+        div_val;
+    return tables[channel][table_size - 1] + dv * (in - 1.f);
+  };
+
+  /* 2 変換テーブルを使ってlevel変換する */
+  const int pixsize = height * width;
+  if (igs::image::rgba::siz == channels) {
+    using namespace igs::image::rgba;
+    for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
+      /* 変化量初期値 */
+      double refv = 1.0;
+
+      /* 参照画像あればピクセル単位の画像変化量を得る */
+      if (ref != 0) {
+        refv *= igs::color::ref_value(ref, channels, 1.0, ref_mode);
+        // clamp 0. to 1. in case the reference is more than 1
+        refv = std::min(1., std::max(0., refv));
+        ref += channels; /* continue;の前に行うこと */
+      }
+
+      /* AlphaのLevel処理した値をrefvの変化量比で加える */
+      if (alpha_sw) {
+        image_array[alp] =
+            refchk_(image_array[alp], getTableVal(alp, image_array[alp]), refv);
+      }
+
+      /* 加算合成で、Alpha値ゼロならRGB値を計算する必要はない */
+      if (add_blend_sw && areAlmostEqual(image_array[alp], 0.)) {
+        continue;
+      }
+      /* 加算合成でなくAlpha合成の時は、Alpha値がゼロでも
+      RGB値は存在する(してもよい)の計算する */
+
+      /* 加算合成で、その値がMaxでなければ変化量に乗算 */
+      if (add_blend_sw && (image_array[alp] < 1.f)) {
+        refv *= static_cast<double>(image_array[alp]);
+      }
+
+      /* RGBのLevel処理した値をrefvの変化量比で加える */
+      image_array[red] =
+          refchk_(image_array[red], getTableVal(red, image_array[red]), refv);
+      image_array[gre] =
+          refchk_(image_array[gre], getTableVal(gre, image_array[gre]), refv);
+      image_array[blu] =
+          refchk_(image_array[blu], getTableVal(blu, image_array[blu]), refv);
+    }
+  } else if (igs::image::rgb::siz == channels) {
+    using namespace igs::image::rgb;
+    for (int ii = 0; ii < pixsize; ++ii, image_array += channels) {
+      double refv = 1.0;
+      if (ref != 0) {
+        refv *= igs::color::ref_value(ref, channels, 1.0, ref_mode);
+        ref += channels;
+      }
+      /* RGBのLevel処理した値をrefvの変化量比で加える */
+      image_array[red] =
+          refchk_(image_array[red], getTableVal(red, image_array[red]), refv);
+      image_array[gre] =
+          refchk_(image_array[gre], getTableVal(gre, image_array[gre]), refv);
+      image_array[blu] =
+          refchk_(image_array[blu], getTableVal(blu, image_array[blu]), refv);
+    }
+  } else if (1 == channels) { /* grayscale */
+    for (int ii = 0; ii < pixsize; ++ii, ++image_array) {
+      double refv = 1.0;
+      if (ref != 0) {
+        refv *= igs::color::ref_value(ref, channels, 1.0, ref_mode);
+        ref += channels;
+      }
+      image_array[0] =
+          refchk_(image_array[0], getTableVal(0, image_array[0]), refv);
+    }
+  }
+
+  /* 1 変換テーブルのメモリ解放 */
+  tables.clear();
 }
+
+}  // namespace
 //------------------------------------------------------------
 void igs::levels::change(
     unsigned char *image_array, const int height, const int width,
@@ -238,7 +398,7 @@ void igs::levels::change(
     const bool clamp_sw, const bool alpha_sw, const bool add_blend_sw) {
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
@@ -274,6 +434,14 @@ void igs::levels::change(
             a_in_max, r_gamma, g_gamma, b_gamma, a_gamma, r_out_min, r_out_max,
             g_out_min, g_out_max, b_out_min, b_out_max, a_out_min, a_out_max,
             clamp_sw, alpha_sw, add_blend_sw);
+  } else if (std::numeric_limits<float>::digits == bits) {
+    assert(std::numeric_limits<float>::digits == ref_bits || 0 == ref_bits);
+    change_(reinterpret_cast<float *>(image_array), height, width, channels,
+            reinterpret_cast<const float *>(ref), ref_mode, r_in_min, r_in_max,
+            g_in_min, g_in_max, b_in_min, b_in_max, a_in_min, a_in_max, r_gamma,
+            g_gamma, b_gamma, a_gamma, r_out_min, r_out_max, g_out_min,
+            g_out_max, b_out_min, b_out_max, a_out_min, a_out_max, clamp_sw,
+            alpha_sw, add_blend_sw);
   } else {
     throw std::domain_error("Bad bits,Not uchar/ushort");
   }

--- a/toonz/sources/stdfx/igs_maxmin.cpp
+++ b/toonz/sources/stdfx/igs_maxmin.cpp
@@ -10,7 +10,8 @@ void igs::maxmin::convert(
     const unsigned char *inn, unsigned char *out
 
     ,
-    const int height, const int width, const int channels, const int bits
+    const int height, const int width, const int channels,
+    const int bits
 
     /* Pixel毎に効果の強弱 */
     ,
@@ -41,10 +42,10 @@ void igs::maxmin::convert(
     /* Speed up */
     ,
     const int number_of_thread /* =1    1...24...INT_MAX */
-    ) {
+) {
   if ((igs::image::rgba::siz != channels) &&
       (igs::image::rgb::siz != channels) && (1 != channels) /* grayscale */
-      ) {
+  ) {
     throw std::domain_error("Bad channels,Not rgba/rgb/grayscale");
   }
 
@@ -104,7 +105,17 @@ void igs::maxmin::convert(
         alpha_rendering_sw, add_blend_sw, number_of_thread);
     mthread.run();
     mthread.clear();
+  } else if ((std::numeric_limits<float>::digits == bits) &&
+             ((std::numeric_limits<float>::digits == ref_bits) ||
+              (0 == ref_bits))) {
+    igs::maxmin::multithread<float, float> mthread(
+        reinterpret_cast<const float *>(inn), reinterpret_cast<float *>(out),
+        height, width, channels, reinterpret_cast<const float *>(ref), ref_mode,
+        radius, smooth_outer_range, polygon_number, roll_degree, min_sw,
+        alpha_rendering_sw, add_blend_sw, number_of_thread);
+    mthread.run();
+    mthread.clear();
   } else {
-    throw std::domain_error("Bad bits,Not uchar/ushort");
+    throw std::domain_error("Bad bits,Not uchar/ushort/float");
   }
 }

--- a/toonz/sources/stdfx/igs_warp.h
+++ b/toonz/sources/stdfx/igs_warp.h
@@ -10,34 +10,16 @@
 namespace igs {
 namespace warp {
 IGS_WARP_EXPORT void hori_change(
-    unsigned char *image, const int height, const int width, const int channels,
-    const int bits
-
-    ,
-    const unsigned char *refer  // by height,width,channels
-    ,
-    const int refchannels, const int refcc, const int refbit
-
-    ,
-    const double offset = 0.5  //(double)(1<<(bits-1))/((1<<bits)-1)
-    ,
-    const double maxlen = 1.0, const bool alpha_rendering_sw = true,
-    const bool anti_aliasing_sw = true);
+    float *image, const int height, const int width, const int channels,
+    const float *refer,  // by height,width,channels
+    const int refchannels, const int refcc, const double maxlen = 1.0,
+    const bool alpha_rendering_sw = true, const bool anti_aliasing_sw = true);
 IGS_WARP_EXPORT void vert_change(
-    unsigned char *image, const int height, const int width, const int channels,
-    const int bits
-
-    ,
-    const unsigned char *refer  // by height,width,channels
-    ,
-    const int refchannels, const int refcc, const int refbit
-
-    ,
-    const double offset = 0.5  //(double)(1<<(bits-1))/((1<<bits)-1)
-    ,
-    const double maxlen = 1.0, const bool alpha_rendering_sw = true,
-    const bool anti_aliasing_sw = true);
-}
-}
+    float *image, const int height, const int width, const int channels,
+    const float *refer,  // by height,width,channels
+    const int refchannels, const int refcc, const double maxlen = 1.0,
+    const bool alpha_rendering_sw = true, const bool anti_aliasing_sw = true);
+}  // namespace warp
+}  // namespace igs
 
 #endif /* !igs_warp_h */

--- a/toonz/sources/stdfx/igs_warp_hori.cpp
+++ b/toonz/sources/stdfx/igs_warp_hori.cpp
@@ -5,127 +5,91 @@
 #include "igs_warp.h"
 
 namespace {
-template <class ST, class RT>
-void hori_change_template_(ST *image, const int height, const int width,
-                           const int channels
-
-                           ,
-                           const RT *refer  // same as height,width,channels
-                           ,
-                           const int refchannels, const int refcc
-
-                           ,
-                           const double offset, const double maxlen,
-                           const bool alpha_rendering_sw,
-                           const bool anti_aliasing_sw) {
-  const double smax = std::numeric_limits<ST>::max();
-  const double rmax = std::numeric_limits<RT>::max();
-
-  std::vector<std::vector<double>> buf_s1(channels), buf_s2(channels);
+void hori_change_(float* image, const int height, const int width,
+                  const int channels,
+                  const float* refer,  // same as height,width,channels
+                  const int refchannels, const int refcc, const double maxlen,
+                  const bool alpha_rendering_sw, const bool anti_aliasing_sw) {
+  std::vector<std::vector<float>> buf_s(channels);
   for (int zz = 0; zz < channels; ++zz) {
-    buf_s1.at(zz).resize(width);
-    buf_s2.at(zz).resize(width);
+    buf_s.at(zz).resize(width);
   }
   std::vector<double> buf_r(width);
 
   refer += refcc; /* 参照画像の参照色チャンネル */
   for (int yy = 0; yy < height;
        ++yy, image += channels * width, refer += refchannels * width) {
+    // buf_sにSourceのスキャンラインのピクセル値をいれる
     for (int xx = 0; xx < width; ++xx) {
       for (int zz = 0; zz < channels; ++zz) {
-        buf_s1.at(zz).at(xx) = image[xx * channels + zz] / smax;
+        buf_s.at(zz).at(xx) = image[xx * channels + zz];
       }
     }
-
+    // buf_rに参照画像の指定チャンネルの値を入れる
     for (int xx = 0; xx < width; ++xx) {  // reference red of refer[]
-      double pos   = static_cast<double>(refer[xx * refchannels]);
-      buf_r.at(xx) = ((pos / rmax) - offset) * maxlen;
+      float pos = refer[xx * refchannels];
+      // clamp 0.f to 1.f in case using TPixelF
+      pos          = std::min(1.f, std::max(0.f, pos));
+      buf_r.at(xx) = (pos - 0.5f) * maxlen;
     }
 
     if (anti_aliasing_sw) {
       for (int xx = 0; xx < width; ++xx) {
-        double pos = buf_r.at(xx);
+        float pos  = buf_r.at(xx);
         int fl_pos = xx + static_cast<int>(std::floor(pos));
         int ce_pos = xx + static_cast<int>(std::ceil(pos));
-        double div = pos - floor(pos);
-        if (fl_pos < 0) {
+        float div  = pos - floor(pos);
+
+        // clamp
+        if (fl_pos < 0)
           fl_pos = 0;
-        } else if (width <= fl_pos) {
+        else if (width <= fl_pos)
           fl_pos = width - 1;
-        }
-        if (ce_pos < 0) {
+
+        if (ce_pos < 0)
           ce_pos = 0;
-        } else if (width <= ce_pos) {
+        else if (width <= ce_pos)
           ce_pos = width - 1;
-        }
+
         for (int zz = 0; zz < channels; ++zz) {
           if (!alpha_rendering_sw && (igs::image::rgba::alp == zz)) {
-            buf_s2.at(zz).at(xx) = buf_s1.at(zz).at(xx);
+            image[xx * channels + zz] = buf_s.at(zz).at(xx);
           } else {
-            buf_s2.at(zz).at(xx) = buf_s1.at(zz).at(fl_pos) * (1.0 - div) +
-                                   buf_s1.at(zz).at(ce_pos) * div;
+            image[xx * channels + zz] = buf_s.at(zz).at(fl_pos) * (1.0 - div) +
+                                        buf_s.at(zz).at(ce_pos) * div;
           }
         }
       }
     } else {
       for (int xx = 0; xx < width; ++xx) {
         int pos = xx + static_cast<int>(floor(buf_r.at(xx) + 0.5));
-        if (pos < 0) {
+        // clamp
+        if (pos < 0)
           pos = 0;
-        } else if (width <= pos) {
+        else if (width <= pos)
           pos = width - 1;
-        }
+
         for (int zz = 0; zz < channels; ++zz) {
           if (!alpha_rendering_sw && (igs::image::rgba::alp == zz)) {
-            buf_s2.at(zz).at(xx) = buf_s1.at(zz).at(xx);
+            image[xx * channels + zz] = buf_s.at(zz).at(xx);
           } else {
-            buf_s2.at(zz).at(xx) = buf_s1.at(zz).at(pos);
+            image[xx * channels + zz] = buf_s.at(zz).at(pos);
           }
         }
       }
     }
-
-    for (int xx = 0; xx < width; ++xx) {
-      for (int zz = 0; zz < channels; ++zz) {
-        image[xx * channels + zz] =
-            static_cast<ST>(buf_s2.at(zz).at(xx) * (smax + 0.999999));
-      }
-    }
   }
 }
-}
+
+}  // namespace
 //--------------------------------------------------------------------
-void igs::warp::hori_change(
-    unsigned char *image, const int height, const int width, const int channels,
-    const int bits
 
-    ,
-    const unsigned char *refer  // by height,width,channels
-    ,
-    const int refchannels, const int refcc, const int refbit
-
-    ,
-    const double offset, const double maxlen, const bool alpha_rendering_sw,
-    const bool anti_aliasing_sw) {
-  const int ucharb  = std::numeric_limits<unsigned char>::digits;
-  const int ushortb = std::numeric_limits<unsigned short>::digits;
-  if ((ushortb == bits) && (ushortb == refbit)) {
-    hori_change_template_(
-        reinterpret_cast<unsigned short *>(image), height, width, channels,
-        reinterpret_cast<const unsigned short *>(refer), refchannels, refcc,
-        offset, maxlen, alpha_rendering_sw, anti_aliasing_sw);
-  } else if ((ushortb == bits) && (ucharb == refbit)) {
-    hori_change_template_(reinterpret_cast<unsigned short *>(image), height,
-                          width, channels, refer, refchannels, refcc, offset,
-                          maxlen, alpha_rendering_sw, anti_aliasing_sw);
-  } else if ((ucharb == bits) && (ushortb == refbit)) {
-    hori_change_template_(image, height, width, channels,
-                          reinterpret_cast<const unsigned short *>(refer),
-                          refchannels, refcc, offset, maxlen,
-                          alpha_rendering_sw, anti_aliasing_sw);
-  } else if ((ucharb == bits) && (ucharb == refbit)) {
-    hori_change_template_(image, height, width, channels, refer, refchannels,
-                          refcc, offset, maxlen, alpha_rendering_sw,
-                          anti_aliasing_sw);
-  }
+void igs::warp::hori_change(float* image, const int height, const int width,
+                            const int channels,
+                            const float* refer,  // by height,width,channels
+                            const int refchannels, const int refcc,
+                            const double maxlen, const bool alpha_rendering_sw,
+                            const bool anti_aliasing_sw) {
+  hori_change_(image, height, width, channels, refer, refchannels, refcc,
+               maxlen, alpha_rendering_sw, anti_aliasing_sw);
 }

--- a/toonz/sources/stdfx/igs_warp_vert.cpp
+++ b/toonz/sources/stdfx/igs_warp_vert.cpp
@@ -5,40 +5,29 @@
 #include "igs_warp.h"
 
 namespace {
-template <class ST, class RT>
-void vert_change_template_(ST *image, const int height, const int width,
-                           const int channels
 
-                           ,
-                           const RT *refer  // same as height,width,channels
-                           ,
-                           const int refchannels, const int refcc
-
-                           ,
-                           const double offset, const double maxlen,
-                           const bool alpha_rendering_sw,
-                           const bool anti_aliasing_sw) {
-  const double smax = std::numeric_limits<ST>::max();
-  const double rmax = std::numeric_limits<RT>::max();
-
-  std::vector<std::vector<double>> buf_s1(channels), buf_s2(channels);
+void vert_change_(float* image, const int height, const int width,
+                  const int channels,
+                  const float* refer,  // same as height,width,channels
+                  const int refchannels, const int refcc, const double maxlen,
+                  const bool alpha_rendering_sw, const bool anti_aliasing_sw) {
+  std::vector<std::vector<float>> buf_s1(channels);
   for (int zz = 0; zz < channels; ++zz) {
     buf_s1.at(zz).resize(height);
-    buf_s2.at(zz).resize(height);
   }
-  std::vector<double> buf_r(height);
+  std::vector<float> buf_r(height);
 
   refer += refcc; /* 参照画像の参照色チャンネル */
   for (int xx = 0; xx < width; ++xx, image += channels, refer += refchannels) {
     for (int yy = 0; yy < height; ++yy) {
       for (int zz = 0; zz < channels; ++zz) {
-        buf_s1.at(zz).at(yy) = image[yy * width * channels + zz] / smax;
+        buf_s1.at(zz).at(yy) = image[yy * width * channels + zz];
       }
     }
 
     for (int yy = 0; yy < height; ++yy) {  // reference red of refer[]
-      double pos   = static_cast<double>(refer[yy * width * refchannels]);
-      buf_r.at(yy) = ((pos / rmax) - offset) * maxlen;
+      float pos    = refer[yy * width * refchannels];
+      buf_r.at(yy) = (pos - 0.5f) * maxlen;
     }
 
     if (anti_aliasing_sw) {
@@ -46,85 +35,57 @@ void vert_change_template_(ST *image, const int height, const int width,
         double pos = buf_r.at(yy);
         int fl_pos = yy + static_cast<int>(std::floor(pos));
         int ce_pos = yy + static_cast<int>(std::ceil(pos));
-        double div = pos - floor(pos);
-        if (fl_pos < 0) {
+        float div  = pos - floor(pos);
+        // clamp
+        if (fl_pos < 0)
           fl_pos = 0;
-        } else if (height <= fl_pos) {
+        else if (height <= fl_pos)
           fl_pos = height - 1;
-        }
-        if (ce_pos < 0) {
+        if (ce_pos < 0)
           ce_pos = 0;
-        } else if (height <= ce_pos) {
+        else if (height <= ce_pos)
           ce_pos = height - 1;
-        }
+
         for (int zz = 0; zz < channels; ++zz) {
           if (!alpha_rendering_sw && (igs::image::rgba::alp == zz)) {
-            buf_s2.at(zz).at(yy) = buf_s1.at(zz).at(yy);
+            image[yy * width * channels + zz] = buf_s1.at(zz).at(yy);
           } else {
-            buf_s2.at(zz).at(yy) = buf_s1.at(zz).at(fl_pos) * (1.0 - div) +
-                                   buf_s1.at(zz).at(ce_pos) * div;
+            image[yy * width * channels + zz] =
+                buf_s1.at(zz).at(fl_pos) * (1.0 - div) +
+                buf_s1.at(zz).at(ce_pos) * div;
           }
         }
       }
     } else {
       for (int yy = 0; yy < height; ++yy) {
         int pos = yy + static_cast<int>(floor(buf_r.at(yy) + 0.5));
-        if (pos < 0) {
+        // clamp
+        if (pos < 0)
           pos = 0;
-        } else if (height <= pos) {
+        else if (height <= pos)
           pos = height - 1;
-        }
+
         for (int zz = 0; zz < channels; ++zz) {
           if (!alpha_rendering_sw && (igs::image::rgba::alp == zz)) {
-            buf_s2.at(zz).at(yy) = buf_s1.at(zz).at(yy);
+            image[yy * width * channels + zz] = buf_s1.at(zz).at(yy);
           } else {
-            buf_s2.at(zz).at(yy) = buf_s1.at(zz).at(pos);
+            image[yy * width * channels + zz] = buf_s1.at(zz).at(pos);
           }
         }
       }
     }
-
-    for (int yy = 0; yy < height; ++yy) {
-      for (int zz = 0; zz < channels; ++zz) {
-        image[yy * width * channels + zz] =
-            static_cast<ST>(buf_s2.at(zz).at(yy) * (smax + 0.999999));
-      }
-    }
   }
 }
-}
+
+}  // namespace
 //--------------------------------------------------------------------
-void igs::warp::vert_change(
-    unsigned char *image, const int height, const int width, const int channels,
-    const int bits
 
-    ,
-    const unsigned char *refer  // by height,width,channels
-    ,
-    const int refchannels, const int refcc, const int refbit
-
-    ,
-    const double offset, const double maxlen, const bool alpha_rendering_sw,
-    const bool anti_aliasing_sw) {
-  const int ucharb  = std::numeric_limits<unsigned char>::digits;
-  const int ushortb = std::numeric_limits<unsigned short>::digits;
-  if ((ushortb == bits) && (ushortb == refbit)) {
-    vert_change_template_(
-        reinterpret_cast<unsigned short *>(image), height, width, channels,
-        reinterpret_cast<const unsigned short *>(refer), refchannels, refcc,
-        offset, maxlen, alpha_rendering_sw, anti_aliasing_sw);
-  } else if ((ushortb == bits) && (ucharb == refbit)) {
-    vert_change_template_(reinterpret_cast<unsigned short *>(image), height,
-                          width, channels, refer, refchannels, refcc, offset,
-                          maxlen, alpha_rendering_sw, anti_aliasing_sw);
-  } else if ((ucharb == bits) && (ushortb == refbit)) {
-    vert_change_template_(image, height, width, channels,
-                          reinterpret_cast<const unsigned short *>(refer),
-                          refchannels, refcc, offset, maxlen,
-                          alpha_rendering_sw, anti_aliasing_sw);
-  } else if ((ucharb == bits) && (ucharb == refbit)) {
-    vert_change_template_(image, height, width, channels, refer, refchannels,
-                          refcc, offset, maxlen, alpha_rendering_sw,
-                          anti_aliasing_sw);
-  }
+void igs::warp::vert_change(float* image, const int height, const int width,
+                            const int channels,
+                            const float* refer,  // by height,width,channels
+                            const int refchannels, const int refcc,
+                            const double maxlen, const bool alpha_rendering_sw,
+                            const bool anti_aliasing_sw) {
+  vert_change_(image, height, width, channels, refer, refchannels, refcc,
+               maxlen, alpha_rendering_sw, anti_aliasing_sw);
 }

--- a/toonz/sources/stdfx/ino_blend_add.cpp
+++ b/toonz/sources/stdfx/ino_blend_add.cpp
@@ -28,9 +28,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::add(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                    !is_xyz);
+                    do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_add, "inoAddFx");

--- a/toonz/sources/stdfx/ino_blend_color_burn.cpp
+++ b/toonz/sources/stdfx/ino_blend_color_burn.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::color_burn(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                           !is_xyz);
+                           do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_color_burn, "inoColorBurnFx");

--- a/toonz/sources/stdfx/ino_blend_color_dodge.cpp
+++ b/toonz/sources/stdfx/ino_blend_color_dodge.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::color_dodge(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                            !is_xyz);
+                            do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_color_dodge, "inoColorDodgeFx");

--- a/toonz/sources/stdfx/ino_blend_cross_dissolve.cpp
+++ b/toonz/sources/stdfx/ino_blend_cross_dissolve.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::cross_dissolve(dnr, dng, dnb, dna, upr, upg, upb, upa,
-                               up_opacity, !is_xyz);
+                               up_opacity, do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_cross_dissolve, "inoCrossDissolveFx");

--- a/toonz/sources/stdfx/ino_blend_darken.cpp
+++ b/toonz/sources/stdfx/ino_blend_darken.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::darken(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                       !is_xyz);
+                       do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_darken, "inoDarkenFx");

--- a/toonz/sources/stdfx/ino_blend_darker_color.cpp
+++ b/toonz/sources/stdfx/ino_blend_darker_color.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::darker_color(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                             !is_xyz);
+                             do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_darker_color, "inoDarkerColorFx");

--- a/toonz/sources/stdfx/ino_blend_divide.cpp
+++ b/toonz/sources/stdfx/ino_blend_divide.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::divide(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                       !is_xyz);
+                       do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_divide, "inoDivideFx");

--- a/toonz/sources/stdfx/ino_blend_hard_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_hard_light.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::hard_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                           !is_xyz);
+                           do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_hard_light, "inoHardLightFx");

--- a/toonz/sources/stdfx/ino_blend_hard_mix.cpp
+++ b/toonz/sources/stdfx/ino_blend_hard_mix.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::hard_mix(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                         !is_xyz);
+                         do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_hard_mix, "inoHardMixFx");

--- a/toonz/sources/stdfx/ino_blend_lighten.cpp
+++ b/toonz/sources/stdfx/ino_blend_lighten.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::lighten(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                        !is_xyz);
+                        do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_lighten, "inoLightenFx");

--- a/toonz/sources/stdfx/ino_blend_lighter_color.cpp
+++ b/toonz/sources/stdfx/ino_blend_lighter_color.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::lighter_color(dnr, dng, dnb, dna, upr, upg, upb, upa,
-                              up_opacity, !is_xyz);
+                              up_opacity, do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_lighter_color, "inoLighterColorFx");

--- a/toonz/sources/stdfx/ino_blend_linear_burn.cpp
+++ b/toonz/sources/stdfx/ino_blend_linear_burn.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::linear_burn(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                            !is_xyz);
+                            do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_linear_burn, "inoLinearBurnFx");

--- a/toonz/sources/stdfx/ino_blend_linear_dodge.cpp
+++ b/toonz/sources/stdfx/ino_blend_linear_dodge.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::linear_dodge(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                             !is_xyz);
+                             do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_linear_dodge, "inoLinearDodgeFx");

--- a/toonz/sources/stdfx/ino_blend_linear_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_linear_light.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::linear_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                             !is_xyz);
+                             do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_linear_light, "inoLinearLightFx");

--- a/toonz/sources/stdfx/ino_blend_multiply.cpp
+++ b/toonz/sources/stdfx/ino_blend_multiply.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::multiply(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                         !is_xyz);
+                         do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_multiply, "inoMultiplyFx");

--- a/toonz/sources/stdfx/ino_blend_over.cpp
+++ b/toonz/sources/stdfx/ino_blend_over.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::over(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                     !is_xyz);
+                     do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_over, "inoOverFx");

--- a/toonz/sources/stdfx/ino_blend_overlay.cpp
+++ b/toonz/sources/stdfx/ino_blend_overlay.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::overlay(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                        !is_xyz);
+                        do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_overlay, "inoOverlayFx");

--- a/toonz/sources/stdfx/ino_blend_pin_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_pin_light.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::pin_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                          !is_xyz);
+                          do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_pin_light, "inoPinLightFx");

--- a/toonz/sources/stdfx/ino_blend_screen.cpp
+++ b/toonz/sources/stdfx/ino_blend_screen.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::screen(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                       !is_xyz);
+                       do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_screen, "inoScreenFx");

--- a/toonz/sources/stdfx/ino_blend_soft_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_soft_light.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::soft_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                           !is_xyz);
+                           do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_soft_light, "inoSoftLightFx");

--- a/toonz/sources/stdfx/ino_blend_subtract.cpp
+++ b/toonz/sources/stdfx/ino_blend_subtract.cpp
@@ -16,9 +16,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::subtract(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                         alpha_rendering_sw, !is_xyz);
+                         alpha_rendering_sw, do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_subtract, "inoSubtractFx");

--- a/toonz/sources/stdfx/ino_blend_vivid_light.cpp
+++ b/toonz/sources/stdfx/ino_blend_vivid_light.cpp
@@ -15,9 +15,9 @@ public:
                    const double upr, double upg, double upb, double upa,
                    const double up_opacity,
                    const bool alpha_rendering_sw = true,
-                   const bool is_xyz             = false) override {
+                   const bool do_clamp           = true) override {
     igs::color::vivid_light(dnr, dng, dnb, dna, upr, upg, upb, upa, up_opacity,
-                            !is_xyz);
+                            do_clamp);
   }
 };
 FX_PLUGIN_IDENTIFIER(ino_blend_vivid_light, "inoVividLightFx");

--- a/toonz/sources/stdfx/ino_blur.cpp
+++ b/toonz/sources/stdfx/ino_blur.cpp
@@ -30,6 +30,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+
+    enableComputeInFloat(true);
   }
   //------------------------------------------------------------
   double get_render_real_radius(const double frame, const TAffine affine) {
@@ -102,54 +104,50 @@ void fx_(const TRasterP in_ras  // with margin
          ,
          const TRasterP refer_ras, const int refer_mode, const int int_radius,
          const double real_radius) {
-  TRasterGR8P out_buffer(out_ras->getLy(),
-                         out_ras->getLx() * ino::channels() *
-                             ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                                 : sizeof(unsigned char)));
+  TRasterGR8P ref_gr8;
+  if ((refer_ras != nullptr) && (0 <= refer_mode)) {
+    ref_gr8 = TRasterGR8P(in_ras->getLy(), in_ras->getLx() * sizeof(float));
+    ref_gr8->lock();
+    ino::ras_to_ref_float_arr(refer_ras,
+                              reinterpret_cast<float *>(ref_gr8->getRawData()),
+                              refer_mode);
+  }
+
   const int buffer_bytes = igs::gaussian_blur_hv::buffer_bytes(
       in_ras->getLy(), in_ras->getLx(), int_radius);
   TRasterGR8P cvt_buffer(buffer_bytes, 1);
-  out_buffer->lock();
   cvt_buffer->lock();
+
+  TRasterGR8P in_gr8(in_ras->getLy(),
+                     in_ras->getLx() * ino::channels() * sizeof(float));
+  in_gr8->lock();
+  ino::ras_to_float_arr(in_ras, ino::channels(),
+                        reinterpret_cast<float *>(in_gr8->getRawData()));
+
+  TRasterGR8P out_buffer(out_ras->getLy(),
+                         out_ras->getLx() * ino::channels() * sizeof(float));
+  out_buffer->lock();
   igs::gaussian_blur_hv::convert(
-      in_ras->getRawData()  // const void *in_with_margin (BGRA)
-      ,
-      out_buffer->getRawData()  // void *out_no_margin (BGRA)
-
-      ,
-      in_ras->getLy()  // const int height_with_margin
-      ,
-      in_ras->getLx()  // const int width_with_margin
-      ,
-      ino::channels()  // const int channels
-      ,
-      ino::bits(in_ras)  // const int bits
-
-      ,
-      (((refer_ras != nullptr) && (0 <= refer_mode))
-           ? refer_ras->getRawData()
-           : nullptr)  // BGRA // const unsigned char *ref
-      ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? ino::bits(refer_ras)
-                                                     : 0)  // const int ref_bits
-      ,
-      refer_mode  // const int refer_mode
-
-      ,
-      cvt_buffer->getRawData()  // void *buffer
-      ,
-      buffer_bytes  // int buffer_bytes
-
-      ,
-      int_radius  // const int int_radius
-      ,
-      real_radius  // const double real_radius // , 0.25
-      );
-  ino::arr_to_ras(out_buffer->getRawData(), ino::channels(), out_ras, 0);
-  cvt_buffer->unlock();
+      reinterpret_cast<float *>(
+          in_gr8->getRawData()),  // const void *in_with_margin (BGRA)
+      reinterpret_cast<float *>(
+          out_buffer->getRawData()),  // void *out_no_margin (BGRA)
+      in_ras->getLy(),                // const int height_with_margin
+      in_ras->getLx(),                // const int width_with_margin
+      ino::channels(),                // const int channels
+      (ref_gr8) ? reinterpret_cast<float *>(ref_gr8->getRawData()) : nullptr,
+      cvt_buffer->getRawData(),  // void *buffer
+      buffer_bytes,              // int buffer_bytes
+      int_radius,                // const int int_radius
+      real_radius                // const double real_radius // , 0.25
+  );
+  in_gr8->unlock();
+  ino::float_arr_to_ras(out_buffer->getRawData(), ino::channels(), out_ras, 0);
   out_buffer->unlock();
+  cvt_buffer->unlock();
+  if (ref_gr8) ref_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_blur::doCompute(TTile &tile, double frame,
                          const TRenderSettings &rend_sets) {
@@ -159,7 +157,8 @@ void ino_blur::doCompute(TTile &tile, double frame,
     return;
   }
   /*------ サポートしていないPixelタイプはエラーを投げる -----*/
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
   /*------ ボケ足長さの実際の長さをえる ----------------------*/

--- a/toonz/sources/stdfx/ino_hsv_add.cpp
+++ b/toonz/sources/stdfx/ino_hsv_add.cpp
@@ -66,6 +66,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -99,62 +101,44 @@ void fx_(TRasterP in_ras, const TRasterP noise_ras, const TRasterP refer_ras,
   std::vector<unsigned char> refer_vec;
   ino::ras_to_vec( noise_ras, ino::channels(), refer_vec );***/
 
+  TRasterGR8P ref_gr8;
+  if ((refer_ras != nullptr) && (0 <= refer_mode)) {
+    ref_gr8 = TRasterGR8P(in_ras->getLy(), in_ras->getLx() * sizeof(float));
+    ref_gr8->lock();
+    ino::ras_to_ref_float_arr(refer_ras,
+                              reinterpret_cast<float *>(ref_gr8->getRawData()),
+                              refer_mode);
+  }
+
   TRasterGR8P in_gr8(in_ras->getLy(),
-                     in_ras->getLx() * ino::channels() *
-                         ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                             : sizeof(unsigned char)));
+                     in_ras->getLx() * ino::channels() * sizeof(float));
   in_gr8->lock();
-  ino::ras_to_arr(in_ras, ino::channels(), in_gr8->getRawData());
+  ino::ras_to_float_arr(in_ras, ino::channels(),
+                        reinterpret_cast<float *>(in_gr8->getRawData()));
 
   TRasterGR8P noise_gr8(noise_ras->getLy(),
-                        noise_ras->getLx() * ino::channels() *
-                            ((TRaster64P)noise_ras ? sizeof(unsigned short)
-                                                   : sizeof(unsigned char)));
+                        noise_ras->getLx() * ino::channels() * sizeof(float));
   noise_gr8->lock();
-  ino::ras_to_arr(noise_ras, ino::channels(), noise_gr8->getRawData());
+  ino::ras_to_float_arr(noise_ras, ino::channels(),
+                        reinterpret_cast<float *>(noise_gr8->getRawData()));
 
   igs::hsv_add::change(
-      // in_ras->getRawData() // BGRA
-      //&in_vec.at(0) // RGBA
-      in_gr8->getRawData()
-
-          ,
-      in_ras->getLy(), in_ras->getLx()  // Not use in_ras->getWrap()
+      reinterpret_cast<float *>(in_gr8->getRawData()), in_ras->getLy(),
+      in_ras->getLx()  // Not use in_ras->getWrap()
       ,
-      ino::channels(),
-      ino::bits(in_ras)
-
-      //,noise_ras->getRawData() // BGRA
-      //,&refer_vec.at(0) // RGBA
-      ,
-      noise_gr8->getRawData()
-
-          ,
-      noise_ras->getLy(), noise_ras->getLx(), ino::channels(),
-      ino::bits(noise_ras)
-
-          ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? refer_ras->getRawData()
-                                                     : nullptr)  // BGRA
-      ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? ino::bits(refer_ras)
-                                                     : 0),
-      refer_mode
-
-      ,
+      ino::channels(), reinterpret_cast<float *>(noise_gr8->getRawData()),
+      (ref_gr8) ? reinterpret_cast<float *>(ref_gr8->getRawData()) : nullptr,
       xoffset, yoffset, from_rgba, offset, hue_scale, sat_scale, val_scale,
-      alp_scale
-
-      //,true	/* add_blend_sw */
-      ,
-      anti_alias_sw);
+      alp_scale, anti_alias_sw);
 
   /***ino::vec_to_ras( refer_vec, 0, 0 );
   ino::vec_to_ras( in_vec, ino::channels(), in_ras, 0 );***/
 
-  ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
+  ino::float_arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   noise_gr8->unlock();
   in_gr8->unlock();
+
+  if (ref_gr8) ref_gr8->unlock();
 }
 }  // namespace
 //------------------------------------------------------------
@@ -169,7 +153,8 @@ void ino_hsv_add::doCompute(TTile &tile, double frame,
   }
 
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 

--- a/toonz/sources/stdfx/ino_hsv_adjust.cpp
+++ b/toonz/sources/stdfx/ino_hsv_adjust.cpp
@@ -70,6 +70,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -98,32 +100,27 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
   /***std::vector<unsigned char> in_vec;
   ino::ras_to_vec( in_ras, ino::channels(), in_vec );***/
 
+  TRasterGR8P ref_gr8;
+  if ((refer_ras != nullptr) && (0 <= refer_mode)) {
+    ref_gr8 = TRasterGR8P(in_ras->getLy(), in_ras->getLx() * sizeof(float));
+    ref_gr8->lock();
+    ino::ras_to_ref_float_arr(refer_ras,
+                              reinterpret_cast<float *>(ref_gr8->getRawData()),
+                              refer_mode);
+  }
+
   TRasterGR8P in_gr8(in_ras->getLy(),
-                     in_ras->getLx() * ino::channels() *
-                         ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                             : sizeof(unsigned char)));
+                     in_ras->getLx() * ino::channels() * sizeof(float));
   in_gr8->lock();
-  ino::ras_to_arr(in_ras, ino::channels(), in_gr8->getRawData());
+  ino::ras_to_float_arr(in_ras, ino::channels(),
+                        reinterpret_cast<float *>(in_gr8->getRawData()));
 
   igs::hsv_adjust::change(
-      // in_ras->getRawData() // BGRA
-      //&in_vec.at(0) // RGBA
-      in_gr8->getRawData()
-
-          ,
-      in_ras->getLy(), in_ras->getLx()  // Not use in_ras->getWrap()
+      reinterpret_cast<float *>(in_gr8->getRawData()), in_ras->getLy(),
+      in_ras->getLx()  // Not use in_ras->getWrap()
       ,
-      ino::channels(), ino::bits(in_ras)
-
-                           ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? refer_ras->getRawData()
-                                                     : nullptr)  // BGRA
-      ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? ino::bits(refer_ras)
-                                                     : 0),
-      refer_mode
-
-      ,
+      ino::channels(),
+      (ref_gr8) ? reinterpret_cast<float *>(ref_gr8->getRawData()) : nullptr,
       hue_pivot, hue_scale, hue_shift, sat_pivot, sat_scale, sat_shift,
       val_pivot, val_scale,
       val_shift
@@ -134,8 +131,10 @@ void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
 
   /***ino::vec_to_ras( in_vec, ino::channels(), in_ras, 0 );***/
 
-  ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
+  ino::float_arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
+
+  if (ref_gr8) ref_gr8->unlock();
 }
 }  // namespace
 //------------------------------------------------------------
@@ -148,7 +147,8 @@ void ino_hsv_adjust::doCompute(TTile &tile, double frame,
   }
 
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 

--- a/toonz/sources/stdfx/ino_hsv_noise.cpp
+++ b/toonz/sources/stdfx/ino_hsv_noise.cpp
@@ -77,6 +77,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -110,48 +112,39 @@ FX_PLUGIN_IDENTIFIER(ino_hsv_noise, "inohsvNoiseFx");
 //------------------------------------------------------------
 #include "igs_hsv_noise.h"
 namespace {
-void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode
-
-         ,
+void fx_(TRasterP in_ras, const TRasterP refer_ras, const int refer_mode,
          double hue_range, double sat_range, double val_range, double alp_range,
          unsigned long random_seed, double near_blur, double effective,
          double center, int type, const int camera_x, const int camera_y,
          const int camera_w, const int camera_h, const bool anti_alias_sw) {
+  TRasterGR8P ref_gr8;
+  if ((refer_ras != nullptr) && (0 <= refer_mode)) {
+    ref_gr8 = TRasterGR8P(in_ras->getLy(), in_ras->getLx() * sizeof(float));
+    ref_gr8->lock();
+    ino::ras_to_ref_float_arr(refer_ras,
+                              reinterpret_cast<float *>(ref_gr8->getRawData()),
+                              refer_mode);
+  }
+
   TRasterGR8P in_gr8(in_ras->getLy(),
-                     in_ras->getLx() * ino::channels() *
-                         ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                             : sizeof(unsigned char)));
+                     in_ras->getLx() * ino::channels() * sizeof(float));
   in_gr8->lock();
-  ino::ras_to_arr(in_ras, ino::channels(), in_gr8->getRawData());
+  ino::ras_to_float_arr(in_ras, ino::channels(),
+                        reinterpret_cast<float *>(in_gr8->getRawData()));
 
-  /* igs::hsv_noise::change(-)は今後つかわない2011-07-15 */
   igs::hsv_noise::change(
-      // in_ras->getRawData() // BGRA
-      in_gr8->getRawData()
+      reinterpret_cast<float *>(in_gr8->getRawData()), in_ras->getLy(),
+      in_ras->getLx(),  // Must Not use in_ras->getWrap()
+      ino::channels(),
+      (ref_gr8) ? reinterpret_cast<float *>(ref_gr8->getRawData()) : nullptr,
+      camera_x, camera_y, camera_w, camera_h, hue_range, sat_range, val_range,
+      alp_range, random_seed, near_blur, effective, center, type, effective,
+      center, type, effective, center, type, anti_alias_sw);
 
-          ,
-      in_ras->getLy(), in_ras->getLx()  // Must Not use in_ras->getWrap()
-      ,
-      ino::channels(), ino::bits(in_ras)
-
-                           ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? refer_ras->getRawData()
-                                                     : nullptr)  // BGRA
-      ,
-      (((refer_ras != nullptr) && (0 <= refer_mode)) ? ino::bits(refer_ras)
-                                                     : 0),
-      refer_mode
-
-      ,
-      camera_x, camera_y, camera_w, camera_h
-
-      ,
-      hue_range, sat_range, val_range, alp_range, random_seed, near_blur,
-      effective, center, type, effective, center, type, effective, center, type,
-      anti_alias_sw);
-
-  ino::arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
+  ino::float_arr_to_ras(in_gr8->getRawData(), ino::channels(), in_ras, 0);
   in_gr8->unlock();
+
+  if (ref_gr8) ref_gr8->unlock();
 }
 }  // namespace
 //------------------------------------------------------------
@@ -164,7 +157,8 @@ void ino_hsv_noise::doCompute(TTile &tile, double frame,
   }
 
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 

--- a/toonz/sources/stdfx/ino_level_auto.cpp
+++ b/toonz/sources/stdfx/ino_level_auto.cpp
@@ -39,6 +39,7 @@ public:
                                    1.0 * ino::param_range());
     this->m_gamma->setValueRange(0.1 * ino::param_range(),
                                  10.0 * ino::param_range()); /* gamma値 */
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -65,8 +66,9 @@ void fx_(TRasterP in_ras, bool *act_sw, double *in_min_shift,
          const int camera_h) {
   TRasterGR8P in_gr8(in_ras->getLy(),
                      in_ras->getLx() * ino::channels() *
-                         ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                             : sizeof(unsigned char)));
+                         ((TRaster64P)in_ras   ? sizeof(unsigned short)
+                          : (TRaster32P)in_ras ? sizeof(unsigned char)
+                                               : sizeof(float)));
   in_gr8->lock();
   ino::ras_to_arr(in_ras, ino::channels(), in_gr8->getRawData());
 
@@ -98,7 +100,8 @@ void ino_level_auto::doCompute(TTile &tile, double frame,
   }
 
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 

--- a/toonz/sources/stdfx/ino_level_master.cpp
+++ b/toonz/sources/stdfx/ino_level_master.cpp
@@ -55,6 +55,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -83,7 +85,8 @@ void ino_level_master::doCompute(TTile &tile, double frame,
   }
 
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 
@@ -136,10 +139,12 @@ void ino_level_master::doCompute(TTile &tile, double frame,
   /* ------ fx処理 ------------------------------------------ */
   try {
     TRasterP in_ras = tile.getRaster();
-    TRasterGR8P in_gr8(in_ras->getLy(),
-                       in_ras->getLx() * ino::channels() *
-                           ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                               : sizeof(unsigned char)));
+    TRasterGR8P in_gr8(
+        in_ras->getLy(),
+        in_ras->getLx() * ino::channels() *
+            ((TRaster64P)in_ras   ? sizeof(unsigned short)
+             : (TRaster32P)in_ras ? sizeof(unsigned char)
+                                  : sizeof(float)));  // TRasterFP case
 
     in_ras->lock();
     if (refer_tile.getRaster() != nullptr) {

--- a/toonz/sources/stdfx/ino_level_rgba.cpp
+++ b/toonz/sources/stdfx/ino_level_rgba.cpp
@@ -113,6 +113,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -141,7 +143,8 @@ void ino_level_rgba::doCompute(TTile &tile, double frame,
   }
 
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 
@@ -228,10 +231,12 @@ void ino_level_rgba::doCompute(TTile &tile, double frame,
   try {
     TRasterP in_ras = tile.getRaster();
 
-    TRasterGR8P in_gr8(in_ras->getLy(),
-                       in_ras->getLx() * ino::channels() *
-                           ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                               : sizeof(unsigned char)));
+    TRasterGR8P in_gr8(
+        in_ras->getLy(),
+        in_ras->getLx() * ino::channels() *
+            ((TRaster64P)in_ras   ? sizeof(unsigned short)
+             : (TRaster32P)in_ras ? sizeof(unsigned char)
+                                  : sizeof(float)));  // TRasterFP case
 
     in_ras->lock();
     if (refer_tile.getRaster() != nullptr) {

--- a/toonz/sources/stdfx/ino_maxmin.cpp
+++ b/toonz/sources/stdfx/ino_maxmin.cpp
@@ -60,6 +60,8 @@ public:
     this->m_ref_mode->addItem(-1, "Nothing");
     this->m_ref_mode->setDefaultValue(0);
     this->m_ref_mode->setValue(0);
+
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -108,10 +110,12 @@ void fx_(const TRasterP in_ras  // with margin
 
          ,
          const int nthread) {
-  TRasterGR8P out_gr8(in_ras->getLy(),
-                      in_ras->getLx() * ino::channels() *
-                          ((TRaster64P)in_ras ? sizeof(unsigned short)
-                                              : sizeof(unsigned char)));
+  TRasterGR8P out_gr8(
+      in_ras->getLy(),
+      in_ras->getLx() * ino::channels() *
+          ((TRaster64P)in_ras   ? sizeof(unsigned short)
+           : (TRaster32P)in_ras ? sizeof(unsigned char)
+                                : sizeof(float)));  // TRasterFP case
   out_gr8->lock();
 
   igs::maxmin::convert(
@@ -142,7 +146,7 @@ void fx_(const TRasterP in_ras  // with margin
   ino::arr_to_ras(out_gr8->getRawData(), ino::channels(), out_ras, margin);
   out_gr8->unlock();
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_maxmin::doCompute(TTile &tile, double frame,
                            const TRenderSettings &rend_sets) {
@@ -153,7 +157,8 @@ void ino_maxmin::doCompute(TTile &tile, double frame,
   }
 
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 

--- a/toonz/sources/stdfx/ino_pn_clouds.cpp
+++ b/toonz/sources/stdfx/ino_pn_clouds.cpp
@@ -46,6 +46,8 @@ public:
     this->m_size->setValueRange(0.0, 1000.0);
     this->m_persistance->setValueRange(0.1 * ino::param_range(),
                                        2.0 * ino::param_range());
+
+    enableComputeInFloat(true);
   }
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override {
@@ -79,7 +81,8 @@ void fx_(TRasterP in_ras, const double zz, const int octaves,
 void ino_pn_clouds::doCompute(TTile &tile, double frame,
                               const TRenderSettings &rend_sets) {
   /* ------ サポートしていないPixelタイプはエラーを投げる --- */
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 

--- a/toonz/sources/stdfx/ino_radial_blur.cpp
+++ b/toonz/sources/stdfx/ino_radial_blur.cpp
@@ -79,6 +79,8 @@ public:
     this->m_ref_mode->addItem(-1, "Nothing");
     this->m_type->addItem(1, "Uniform Length");
     this->m_intensity_correlation_with_ellipse->setValueRange(-1.0, 1.0);
+
+    enableComputeInFloat(true);
   }
   //------------------------------------------------------------
   TPointD get_render_center(const double frame, const TPointD &pos,
@@ -230,6 +232,7 @@ void fx_(const TRasterP in_ras,  // with margin
   in_gr8->unlock();
   ino::float_arr_to_ras(out_buffer->getRawData(), ino::channels(), out_ras, 0);
   out_buffer->unlock();
+
   if (ref_gr8) ref_gr8->unlock();
 }
 }  // namespace
@@ -242,7 +245,8 @@ void ino_radial_blur::doCompute(TTile &tile, double frame,
     return;
   }
   /*------ サポートしていないPixelタイプはエラーを投げる -----*/
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
   /*------ パラメータを得る ----------------------------------*/

--- a/toonz/sources/stdfx/ino_spin_blur.cpp
+++ b/toonz/sources/stdfx/ino_spin_blur.cpp
@@ -64,6 +64,8 @@ public:
     this->m_ref_mode->addItem(3, "Alpha");
     this->m_ref_mode->addItem(4, "Luminance");
     this->m_ref_mode->addItem(-1, "Nothing");
+
+    enableComputeInFloat(true);
   }
   //------------------------------------------------------------
   TPointD get_render_center(const double frame, const TPointD &pos,
@@ -197,6 +199,7 @@ void fx_(const TRasterP in_ras,  // with margin
   in_gr8->unlock();
   ino::float_arr_to_ras(out_buffer->getRawData(), ino::channels(), out_ras, 0);
   out_buffer->unlock();
+
   if (ref_gr8) ref_gr8->unlock();
 }
 }  // namespace
@@ -209,7 +212,8 @@ void ino_spin_blur::doCompute(TTile &tile, double frame,
     return;
   }
   /*------ サポートしていないPixelタイプはエラーを投げる -----*/
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
   /*------ パラメータを得る ----------------------------------*/

--- a/toonz/sources/stdfx/ino_warp_hv.cpp
+++ b/toonz/sources/stdfx/ino_warp_hv.cpp
@@ -4,6 +4,7 @@
 
 #include "ino_common.h"
 #include "igs_warp.h"
+#include "trop.h"
 //------------------------------------------------------------
 class ino_warp_hv final : public TStandardRasterFx {
   FX_PLUGIN_DECLARATION(ino_warp_hv)
@@ -51,6 +52,8 @@ public:
     this->m_v_ref_mode->addItem(1, "Green");
     this->m_v_ref_mode->addItem(0, "Blue");
     this->m_v_ref_mode->addItem(3, "Alpha");
+
+    enableComputeInFloat(true);
   }
   void get_render_real_hv(const double frame, const TAffine affine,
                           double &h_maxlen, double &v_maxlen) {
@@ -114,7 +117,7 @@ template <class T>
 void data_set_template_(const TRasterPT<T> in_ras  // with margin
                         ,
                         const int margin, TRasterPT<T> out_ras  // no margin
-                        ) {
+) {
   for (int yy = 0; yy < out_ras->getLy(); ++yy) {
     const T *in_ras_sl = in_ras->pixels(yy + margin);
     T *out_ras_sl      = out_ras->pixels(yy);
@@ -138,60 +141,87 @@ void fx_(TRasterP in_ras  // with margin
          const double h_maxlen, const double v_maxlen, const int h_ref_mode,
          const int v_ref_mode, const bool alpha_rendering_sw,
          const bool anti_aliasing_sw) {
-  if (0 != hori_ras) {
-    const int bits = ino::bits(hori_ras);
-    igs::warp::hori_change(in_ras->getRawData()  // BGRA
-                           ,
-                           in_ras->getLy(), in_ras->getLx(), ino::channels(),
-                           ino::bits(in_ras)
+  if (in_ras->getPixelSize() == 4 || in_ras->getPixelSize() == 8) {
+    TRasterGR8P in_gr8(in_ras->getLy(),
+                       in_ras->getLx() * ino::channels() * sizeof(float));
+    in_gr8->lock();
+    ino::ras_to_float_arr(in_ras, ino::channels(),
+                          reinterpret_cast<float *>(in_gr8->getRawData()));
 
-                               ,
-                           hori_ras->getRawData()  // BGRA
-                           ,
-                           ino::channels()
-                           //, 2 // order is "bgra", then r is 2.
-                           ,
-                           h_ref_mode, bits
+    if (0 != hori_ras) {
+      TRasterGR8P hori_gr8(hori_ras->getLy(),
+                           hori_ras->getLx() * ino::channels() * sizeof(float));
+      hori_gr8->lock();
+      ino::ras_to_float_arr(hori_ras, ino::channels(),
+                            reinterpret_cast<float *>(hori_gr8->getRawData()));
 
-                           ,
-                           (double)(1 << (bits - 1)) / ((1 << bits) - 1)
-                           // , h_maxlen
-                           ,
-                           -h_maxlen /* 移動方向と参照方向は逆 */
-                               * (double)((1 << bits) - 1) / (1 << (bits - 1)),
-                           alpha_rendering_sw, anti_aliasing_sw);
+      igs::warp::hori_change(
+          reinterpret_cast<float *>(in_gr8->getRawData()),  // BGRA
+          in_ras->getLy(), in_ras->getLx(), ino::channels(),
+          reinterpret_cast<float *>(hori_gr8->getRawData()),  // BGRA
+          ino::channels(), h_ref_mode,
+          -h_maxlen /* 移動方向と参照方向は逆 */
+              * 2.0,
+          alpha_rendering_sw, anti_aliasing_sw);
+      hori_gr8->unlock();
+    }
+    if (0 != vert_ras) {
+      TRasterGR8P vert_gr8(vert_ras->getLy(),
+                           vert_ras->getLx() * ino::channels() * sizeof(float));
+      vert_gr8->lock();
+      ino::ras_to_float_arr(vert_ras, ino::channels(),
+                            reinterpret_cast<float *>(vert_gr8->getRawData()));
+
+      igs::warp::vert_change(
+          reinterpret_cast<float *>(in_gr8->getRawData()),  // BGRA
+          in_ras->getLy(), in_ras->getLx(), ino::channels(),
+          reinterpret_cast<float *>(vert_gr8->getRawData()),  // BGRA
+          ino::channels(), v_ref_mode,
+          -v_maxlen /* 移動方向と参照方向は逆 */
+              * 2.0,
+          alpha_rendering_sw, anti_aliasing_sw);
+      vert_gr8->unlock();
+    }
+
+    in_gr8->unlock();
+    ino::float_arr_to_ras(in_gr8->getRawData(), ino::channels(), out_ras,
+                          margin);
+  } else if (in_ras->getPixelSize() == 16) {
+    if (0 != hori_ras) {
+      igs::warp::hori_change(
+          reinterpret_cast<float *>(in_ras->getRawData()),  // BGRA
+          in_ras->getLy(), in_ras->getLx(), ino::channels(),
+          reinterpret_cast<float *>(hori_ras->getRawData()),  // BGRA
+          ino::channels(), h_ref_mode,
+          -h_maxlen /* 移動方向と参照方向は逆 */
+              * 2.0,
+          alpha_rendering_sw, anti_aliasing_sw);
+    }
+    if (0 != vert_ras) {
+      igs::warp::vert_change(
+          reinterpret_cast<float *>(in_ras->getRawData()),  // BGRA
+          in_ras->getLy(), in_ras->getLx(), ino::channels(),
+          reinterpret_cast<float *>(vert_ras->getRawData()),  // BGRA
+          ino::channels(), v_ref_mode,
+          -v_maxlen /* 移動方向と参照方向は逆 */
+              * 2.0,
+          alpha_rendering_sw, anti_aliasing_sw);
+    }
+    data_set_template_<TPixelF>(in_ras, margin, out_ras);
+  } else {
+    throw TRopException("unsupported input pixel type");
   }
-  if (0 != vert_ras) {
-    const int bits = ino::bits(vert_ras);
-    igs::warp::vert_change(in_ras->getRawData()  // BGRA
-                           ,
-                           in_ras->getLy(), in_ras->getLx(), ino::channels(),
-                           ino::bits(in_ras)
 
-                               ,
-                           vert_ras->getRawData()  // BGRA
-                           ,
-                           ino::channels()
-                           //, 2 // order is "bgra", then r is 2.
-                           ,
-                           v_ref_mode, bits
-
-                           ,
-                           (double)(1 << (bits - 1)) / ((1 << bits) - 1)
-                           // , v_maxlen
-                           ,
-                           -v_maxlen /* 移動方向と参照方向は逆 */
-                               * (double)((1 << bits) - 1) / (1 << (bits - 1)),
-                           alpha_rendering_sw, anti_aliasing_sw);
-  }
-
+  /*
   if ((TRaster32P)in_ras) {
     data_set_template_<TPixel32>(in_ras, margin, out_ras);
   } else if ((TRaster64P)in_ras) {
     data_set_template_<TPixel64>(in_ras, margin, out_ras);
-  }
+  } else if ((TRasterFP)in_ras) {
+    data_set_template_<TPixelF>(in_ras, margin, out_ras);
+  }*/
 }
-}
+}  // namespace
 //------------------------------------------------------------
 void ino_warp_hv::doCompute(TTile &tile, double frame,
                             const TRenderSettings &rend_sets) {
@@ -202,7 +232,8 @@ void ino_warp_hv::doCompute(TTile &tile, double frame,
   }
 
   /*------ サポートしていないPixelタイプはエラーを投げる -----*/
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 
@@ -237,6 +268,7 @@ void ino_warp_hv::doCompute(TTile &tile, double frame,
   TTile vert_tile;
   const bool hori_cn_is = this->m_hori.isConnected();
   const bool vert_cn_is = this->m_vert.isConnected();
+
   if (hori_cn_is) {
     this->m_hori->allocateAndCompute(
         hori_tile, bBox.getP00(),

--- a/toonz/sources/stdfx/iwa_adjustexposurefx.cpp
+++ b/toonz/sources/stdfx/iwa_adjustexposurefx.cpp
@@ -25,6 +25,23 @@ void Iwa_AdjustExposureFx::setSourceRaster(const RASTER srcRas, float4 *dstMem,
   }
 }
 
+void Iwa_AdjustExposureFx::setSourceRasterF(const TRasterFP srcRas,
+                                            float4 *dstMem, TDimensionI dim) {
+  float4 *chann_p = dstMem;
+
+  for (int j = 0; j < dim.ly; j++) {
+    TPixelF *pix = srcRas->pixels(j);
+    for (int i = 0; i < dim.lx; i++) {
+      (*chann_p).x = pix->r;
+      (*chann_p).y = pix->g;
+      (*chann_p).z = pix->b;
+      (*chann_p).w = pix->m;
+
+      pix++;
+      chann_p++;
+    }
+  }
+}
 /*------------------------------------------------------------
  出力結果をChannel値に変換してタイルに格納
 ------------------------------------------------------------*/
@@ -59,18 +76,77 @@ void Iwa_AdjustExposureFx::setOutputRaster(float4 *srcMem, const RASTER dstRas,
   }
 }
 
+void Iwa_AdjustExposureFx::setOutputRasterF(float4 *srcMem,
+                                            const TRasterFP dstRas,
+                                            TDimensionI dim) {
+  float4 *chan_p = srcMem;
+  for (int j = 0; j < dim.ly; j++) {
+    TPixelF *pix = dstRas->pixels(j);
+    for (int i = 0; i < dim.lx; i++) {
+      pix->r = (*chan_p).x;
+      pix->g = (*chan_p).y;
+      pix->b = (*chan_p).z;
+      pix->m = (*chan_p).w;
+      pix++;
+      chan_p++;
+    }
+  }
+}
+
 //------------------------------------------------
 
 Iwa_AdjustExposureFx::Iwa_AdjustExposureFx()
-    : m_hardness(3.3), m_scale(0.0), m_offset(0.0) {
+    : m_hardness(3.3)
+    , m_scale(0.0)
+    , m_offset(0.0)
+    , m_gamma(2.2)
+    , m_gammaAdjust(0.) {
   addInputPort("Source", m_source);
   bindParam(this, "hardness", m_hardness, false);
+  bindParam(this, "gamma", m_gamma);
+  bindParam(this, "gammaAdjust", m_gammaAdjust);
   bindParam(this, "scale", m_scale, false);
   bindParam(this, "offset", m_offset, false);
 
   m_hardness->setValueRange(0.05, 20.0);
+  m_gamma->setValueRange(1.0, 10.0);
+  m_gammaAdjust->setValueRange(-5., 5.);
   m_scale->setValueRange(-10.0, 10.0);
   m_offset->setValueRange(-0.5, 0.5);
+  enableComputeInFloat(true);
+
+  // Version 1: Exposure is computed by using Hardness
+  //            E = std::pow(10.0, (value - 0.5) / hardness)
+  // Version 2: Exposure is computed by using Gamma, for easier combination with
+  // the linear color space
+  //            E = std::pow(value, gamma)
+  // Version 3: Gamma is computed by rs.m_colorSpaceGamma + gammaAdjust
+  // this must be called after binding the parameters (see onFxVersionSet())
+  setFxVersion(3);
+}
+
+//--------------------------------------------
+
+void Iwa_AdjustExposureFx::onFxVersionSet() {
+  if (getFxVersion() == 1) {  // use hardness
+    getParams()->getParamVar("hardness")->setIsHidden(false);
+    getParams()->getParamVar("gamma")->setIsHidden(true);
+    getParams()->getParamVar("gammaAdjust")->setIsHidden(true);
+    return;
+  }
+  getParams()->getParamVar("hardness")->setIsHidden(true);
+
+  bool useGamma = getFxVersion() == 2;
+  if (useGamma) {
+    // Automatically update version
+    if (m_gamma->getKeyframeCount() == 0 &&
+        areAlmostEqual(m_gamma->getDefaultValue(), 2.2)) {
+      useGamma = false;
+      setFxVersion(3);
+    }
+  }
+  getParams()->getParamVar("gamma")->setIsHidden(!useGamma);
+  getParams()->getParamVar("gammaAdjust")->setIsHidden(useGamma);
 }
 
 //------------------------------------------------
@@ -83,10 +159,33 @@ void Iwa_AdjustExposureFx::doCompute(TTile &tile, double frame,
     return;
   }
 
+  double gamma;
+  if (getFxVersion() == 1)  // hardness
+    gamma = m_hardness->getValue(frame);
+  else {  // gamma
+    if (getFxVersion() == 2)
+      gamma = m_gamma->getValue(frame);
+    else
+      gamma = std::max(
+          1., settings.m_colorSpaceGamma + m_gammaAdjust->getValue(frame));
+    if (tile.getRaster()->isLinear()) gamma /= settings.m_colorSpaceGamma;
+  }
+
   m_source->compute(tile, frame, settings);
 
-  float4 *tile_host;
   TDimensionI dim(tile.getRaster()->getSize());
+
+  if (TRasterFP rasF = tile.getRaster()) {
+    if (getFxVersion() == 1)
+      doFloatCompute(rasF, frame, dim,
+                     HardnessBasedConverter(gamma, settings.m_colorSpaceGamma,
+                                            tile.getRaster()->isLinear()));
+    else
+      doFloatCompute(rasF, frame, dim, GammaBasedConverter(gamma));
+    return;
+  }
+
+  float4 *tile_host;
 
   /*- ホストメモリ確保 -*/
   TRasterGR8P tile_host_ras(sizeof(float4) * dim.lx, dim.ly);
@@ -95,12 +194,18 @@ void Iwa_AdjustExposureFx::doCompute(TTile &tile, double frame,
 
   TRaster32P ras32 = tile.getRaster();
   TRaster64P ras64 = tile.getRaster();
+
   if (ras32)
     setSourceRaster<TRaster32P, TPixel32>(ras32, tile_host, dim);
   else if (ras64)
     setSourceRaster<TRaster64P, TPixel64>(ras64, tile_host, dim);
 
-  doCompute_CPU(tile, frame, settings, dim, tile_host);
+  if (getFxVersion() == 1)
+    doCompute_CPU(frame, dim, tile_host,
+                  HardnessBasedConverter(gamma, settings.m_colorSpaceGamma,
+                                         tile.getRaster()->isLinear()));
+  else
+    doCompute_CPU(frame, dim, tile_host, GammaBasedConverter(gamma));
 
   /*-  出力結果をチャンネル値に変換 -*/
   tile.getRaster()->clear();
@@ -114,14 +219,14 @@ void Iwa_AdjustExposureFx::doCompute(TTile &tile, double frame,
 
 //------------------------------------------------
 
-void Iwa_AdjustExposureFx::doCompute_CPU(TTile &tile, double frame,
-                                         const TRenderSettings &settings,
-                                         TDimensionI &dim, float4 *tile_host) {
-  float hardness = (float)m_hardness->getValue(frame);
-  float scale    = (float)m_scale->getValue(frame);
-  float offset   = (float)m_offset->getValue(frame);
+void Iwa_AdjustExposureFx::doCompute_CPU(double frame, TDimensionI &dim,
+                                         float4 *tile_host,
+                                         const ExposureConverter &conv) {
+  float scale  = (float)m_scale->getValue(frame);
+  float offset = (float)m_offset->getValue(frame);
 
-  float exposureOffset = (powf(10.0f, (float)(std::abs(offset) / hardness)) - 1.0f) *
+  float exposureOffset = (conv.valueToExposure(std::abs(offset) + 0.5) -
+                          conv.valueToExposure(0.5)) *
                          ((offset < 0.0f) ? -1.0f : 1.0f);
 
   float4 *pix = tile_host;
@@ -129,9 +234,9 @@ void Iwa_AdjustExposureFx::doCompute_CPU(TTile &tile, double frame,
   int size = dim.lx * dim.ly;
   for (int i = 0; i < size; i++, pix++) {
     /*- RGB->Exposure -*/
-    pix->x = powf(10, (pix->x - 0.5f) * hardness);
-    pix->y = powf(10, (pix->y - 0.5f) * hardness);
-    pix->z = powf(10, (pix->z - 0.5f) * hardness);
+    pix->x = conv.valueToExposure(pix->x);
+    pix->y = conv.valueToExposure(pix->y);
+    pix->z = conv.valueToExposure(pix->z);
 
     /*- スケール -*/
     pix->x *= powf(10, scale);
@@ -144,14 +249,39 @@ void Iwa_AdjustExposureFx::doCompute_CPU(TTile &tile, double frame,
     pix->z += exposureOffset;
 
     /*- Exposure->RGB -*/
-    pix->x = log10f(pix->x) / hardness + 0.5f;
-    pix->y = log10f(pix->y) / hardness + 0.5f;
-    pix->z = log10f(pix->z) / hardness + 0.5f;
+    pix->x = (pix->x < 0.0f) ? 0.0f : conv.exposureToValue(pix->x);
+    pix->y = (pix->y < 0.0f) ? 0.0f : conv.exposureToValue(pix->y);
+    pix->z = (pix->z < 0.0f) ? 0.0f : conv.exposureToValue(pix->z);
+  }
+}
 
-    /*- クランプ -*/
-    pix->x = (pix->x > 1.0f) ? 1.0f : ((pix->x < 0.0f) ? 0.0f : pix->x);
-    pix->y = (pix->y > 1.0f) ? 1.0f : ((pix->y < 0.0f) ? 0.0f : pix->y);
-    pix->z = (pix->z > 1.0f) ? 1.0f : ((pix->z < 0.0f) ? 0.0f : pix->z);
+//------------------------------------------------
+
+void Iwa_AdjustExposureFx::doFloatCompute(const TRasterFP rasD, double frame,
+                                          TDimensionI &dim,
+                                          const ExposureConverter &conv) {
+  double scale          = m_scale->getValue(frame);
+  double offset         = m_offset->getValue(frame);
+  double exposureOffset = (conv.valueToExposure(std::abs(offset) + 0.5) -
+                           conv.valueToExposure(0.5)) *
+                          ((offset < 0.) ? -1. : 1.);
+
+  for (int j = 0; j < dim.ly; j++) {
+    TPixelF *pix = rasD->pixels(j);
+    for (int i = 0; i < dim.lx; i++) {
+      for (int c = 0; c < 3; c++) {
+        float *val = (c == 0) ? &pix->r : (c == 1) ? &pix->g : &pix->b;
+        /*- RGB->Exposure -*/
+        *val = conv.valueToExposure(*val);
+        /*- スケール -*/
+        *val *= pow(10.0, scale);
+        /*- オフセット -*/
+        *val += exposureOffset;
+        /*- Exposure->RGB -*/
+        *val = (*val < 0.f) ? 0.f : conv.exposureToValue(*val);
+      }
+      pix++;
+    }
   }
 }
 
@@ -173,6 +303,14 @@ bool Iwa_AdjustExposureFx::doGetBBox(double frame, TRectD &bBox,
 bool Iwa_AdjustExposureFx::canHandle(const TRenderSettings &info,
                                      double frame) {
   return true;
+}
+
+//------------------------------------------------
+
+bool Iwa_AdjustExposureFx::toBeComputedInLinearColorSpace(
+    bool settingsIsLinear, bool tileIsLinear) const {
+  // 下流がリニア計算するかどうかで判断。これで変換を最小限にできるか…？
+  return tileIsLinear;
 }
 
 FX_PLUGIN_IDENTIFIER(Iwa_AdjustExposureFx, "iwa_AdjustExposureFx")

--- a/toonz/sources/stdfx/iwa_adjustexposurefx.h
+++ b/toonz/sources/stdfx/iwa_adjustexposurefx.h
@@ -10,6 +10,7 @@
 
 #include "stdfx.h"
 #include "tfxparam.h"
+#include "iwa_bokeh_util.h"  // ExposureConverter
 
 struct float4 {
   float x, y, z, w;
@@ -20,16 +21,23 @@ class Iwa_AdjustExposureFx final : public TStandardRasterFx {
 
 protected:
   TRasterFxPort m_source;
-  TDoubleParamP m_hardness; /*- フィルムのガンマ値 -*/
-  TDoubleParamP m_scale;    /*- 明るさのスケール値 -*/
-  TDoubleParamP m_offset;   /*- 明るさのオフセット値 -*/
+  TDoubleParamP m_hardness;     // gamma (version 1)
+  TDoubleParamP m_gamma;        // gamma (version 2)
+  TDoubleParamP m_gammaAdjust;  // Gamma offset from the current color space
+                                // gamma (version 3)
+  TDoubleParamP m_scale;        /*- 明るさのスケール値 -*/
+  TDoubleParamP m_offset;       /*- 明るさのオフセット値 -*/
 
   /*- タイルの画像を０〜１に正規化してホストメモリに読み込む -*/
   template <typename RASTER, typename PIXEL>
   void setSourceRaster(const RASTER srcRas, float4 *dstMem, TDimensionI dim);
+  void setSourceRasterF(const TRasterFP srcRas, float4 *dstMem,
+                        TDimensionI dim);
   /*- 出力結果をChannel値に変換して格納 -*/
   template <typename RASTER, typename PIXEL>
   void setOutputRaster(float4 *srcMem, const RASTER dstRas, TDimensionI dim);
+  void setOutputRasterF(float4 *srcMem, const TRasterFP dstRas,
+                        TDimensionI dim);
 
 public:
   Iwa_AdjustExposureFx();
@@ -37,13 +45,21 @@ public:
   void doCompute(TTile &tile, double frame,
                  const TRenderSettings &settings) override;
 
-  void doCompute_CPU(TTile &tile, double frame, const TRenderSettings &settings,
-                     TDimensionI &dim, float4 *tile_host);
+  void doCompute_CPU(double frame, TDimensionI &dim, float4 *tile_host,
+                     const ExposureConverter &conv);
+
+  void doFloatCompute(const TRasterFP rasF, double frame, TDimensionI &dim,
+                      const ExposureConverter &conv);
 
   bool doGetBBox(double frame, TRectD &bBox,
                  const TRenderSettings &info) override;
 
   bool canHandle(const TRenderSettings &info, double frame) override;
+
+  void onFxVersionSet() final override;
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_bloomfx.h
+++ b/toonz/sources/stdfx/iwa_bloomfx.h
@@ -25,6 +25,8 @@ class Iwa_BloomFx : public TStandardRasterFx {
 protected:
   TRasterFxPort m_source;
   TDoubleParamP m_gamma;
+  TDoubleParamP m_gammaAdjust;  // Gamma offset from the current color space
+                                // gamma (Version 3)
   TBoolParamP m_auto_gain;
   TDoubleParamP m_gain_adjust;
   TDoubleParamP m_gain;
@@ -55,6 +57,9 @@ public:
   bool canHandle(const TRenderSettings &info, double frame) override;
   void getParamUIs(TParamUIConcept *&concepts, int &length) override;
   void onObsoleteParamLoaded(const std::string &paramName) override;
+  void onFxVersionSet() override;
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_bokeh_advancedfx.cpp
+++ b/toonz/sources/stdfx/iwa_bokeh_advancedfx.cpp
@@ -134,18 +134,23 @@ Iwa_BokehAdvancedFx::Iwa_BokehAdvancedFx()
   bindParam(this, "on_focus_distance", m_onFocusDistance, false);
   bindParam(this, "bokeh_amount", m_bokehAmount, false);
   bindParam(this, "masterHardness", m_hardness, false);
+  bindParam(this, "masterGamma", m_gamma, false);
+  bindParam(this, "masterGammaAdjust", m_gammaAdjust, false);
   bindParam(this, "hardnessPerSource", m_hardnessPerSource, false);
+  bindParam(this, "linearizeMode", m_linearizeMode, false);
 
   // Bind layer parameters
   for (int layer = 0; layer < LAYER_NUM; layer++) {
     m_layerParams[layer].m_distance        = TDoubleParamP(0.5);
     m_layerParams[layer].m_bokehAdjustment = TDoubleParamP(1);
 
-    m_layerParams[layer].m_hardness   = TDoubleParamP(0.3);
-    m_layerParams[layer].m_depth_ref  = TIntParamP(0);
-    m_layerParams[layer].m_depthRange = TDoubleParamP(1.0);
-    m_layerParams[layer].m_fillGap    = TBoolParamP(true);
-    m_layerParams[layer].m_doMedian   = TBoolParamP(false);
+    m_layerParams[layer].m_hardness    = TDoubleParamP(0.3);
+    m_layerParams[layer].m_gamma       = TDoubleParamP(2.2);
+    m_layerParams[layer].m_gammaAdjust = TDoubleParamP(0.);
+    m_layerParams[layer].m_depth_ref   = TIntParamP(0);
+    m_layerParams[layer].m_depthRange  = TDoubleParamP(1.0);
+    m_layerParams[layer].m_fillGap     = TBoolParamP(true);
+    m_layerParams[layer].m_doMedian    = TBoolParamP(false);
 
     std::string str = QString("Source%1").arg(layer + 1).toStdString();
     addInputPort(str, m_layerParams[layer].m_source);
@@ -154,6 +159,10 @@ Iwa_BokehAdvancedFx::Iwa_BokehAdvancedFx()
     bindParam(this, QString("bokeh_adjustment%1").arg(layer + 1).toStdString(),
               m_layerParams[layer].m_bokehAdjustment);
 
+    bindParam(this, QString("gamma%1").arg(layer + 1).toStdString(),
+              m_layerParams[layer].m_gamma);
+    bindParam(this, QString("gammaAdjust%1").arg(layer + 1).toStdString(),
+              m_layerParams[layer].m_gammaAdjust);
     bindParam(this, QString("hardness%1").arg(layer + 1).toStdString(),
               m_layerParams[layer].m_hardness);
     bindParam(this, QString("depth_ref%1").arg(layer + 1).toStdString(),
@@ -169,10 +178,48 @@ Iwa_BokehAdvancedFx::Iwa_BokehAdvancedFx()
     m_layerParams[layer].m_bokehAdjustment->setValueRange(0.0, 2.0);
 
     m_layerParams[layer].m_hardness->setValueRange(0.05, 3.0);
+    m_layerParams[layer].m_gamma->setValueRange(1.0, 10.0);
+    m_layerParams[layer].m_gammaAdjust->setValueRange(-5., 5.);
     m_layerParams[layer].m_depthRange->setValueRange(0.0, 1.0);
   }
 
   addInputPort("Depth1", new TRasterFxPort, 0);
+
+  enableComputeInFloat(true);
+
+  // Version 1: Exposure is computed by using Hardness
+  //            E = std::pow(10.0, (value - 0.5) / hardness)
+  // Version 2: Exposure can also be computed by using Gamma, for easier
+  // combination with the linear color space
+  //            E = std::pow(value, gamma)
+  // this must be called after binding the parameters (see onFxVersionSet())
+  // Version 3: Gamma is computed by rs.m_colorSpaceGamma + gammaAdjust
+  setFxVersion(3);
+}
+
+//--------------------------------------------
+
+void Iwa_BokehAdvancedFx::onFxVersionSet() {
+  bool useGamma = getFxVersion() == 2;
+  if (getFxVersion() == 1) {
+    m_linearizeMode->setValue(Hardness);
+    setFxVersion(3);
+  } else if (getFxVersion() == 2) {
+    if (m_linearizeMode->getValue() == Hardness) {
+      useGamma = false;
+      setFxVersion(3);
+    }
+  }
+  getParams()->getParamVar("masterGamma")->setIsHidden(!useGamma);
+  getParams()->getParamVar("masterGammaAdjust")->setIsHidden(useGamma);
+  for (int layer = 0; layer < LAYER_NUM; layer++) {
+    getParams()
+        ->getParamVar(QString("gamma%1").arg(layer + 1).toStdString())
+        ->setIsHidden(!useGamma);
+    getParams()
+        ->getParamVar(QString("gammaAdjust%1").arg(layer + 1).toStdString())
+        ->setIsHidden(useGamma);
+  }
 }
 
 //--------------------------------------------
@@ -238,12 +285,11 @@ void Iwa_BokehAdvancedFx::doCompute(TTile& tile, double frame,
 
   // compute the input tiles
   QMap<int, TTile*> sourceTiles;
-  TRenderSettings infoOnInput(settings);
-  infoOnInput.m_bpp = 64;
   for (auto index : sourceIndices) {
     TTile* layerTile = new TTile();
     m_layerParams[index].m_source->allocateAndCompute(
-        *layerTile, _rectOut.getP00(), dimOut, 0, frame, infoOnInput);
+        *layerTile, _rectOut.getP00(), dimOut, tile.getRaster(), frame,
+        settings);
     sourceTiles[index] = layerTile;
   }
 
@@ -276,6 +322,7 @@ void Iwa_BokehAdvancedFx::doCompute(TTile& tile, double frame,
         unsigned char* ctrl_mem = (unsigned char*)ctrlRas->getRawData();
         TRaster32P ras32        = (TRaster32P)tmpTile.getRaster();
         TRaster64P ras64        = (TRaster64P)tmpTile.getRaster();
+        TRasterFP rasF          = (TRasterFP)tmpTile.getRaster();
         lock.lockForRead();
         if (ras32)
           BokehUtils::setDepthRaster<TRaster32P, TPixel32>(ras32, ctrl_mem,
@@ -283,6 +330,9 @@ void Iwa_BokehAdvancedFx::doCompute(TTile& tile, double frame,
         else if (ras64)
           BokehUtils::setDepthRaster<TRaster64P, TPixel64>(ras64, ctrl_mem,
                                                            dimOut);
+        else if (rasF)
+          BokehUtils::setDepthRaster<TRasterFP, TPixelF>(rasF, ctrl_mem,
+                                                         dimOut);
         lock.unlock();
         ctrl_rasters.push_back(ctrlRas);
         ctrls[portIndex] = ctrl_mem;
@@ -290,7 +340,17 @@ void Iwa_BokehAdvancedFx::doCompute(TTile& tile, double frame,
     }
   }
 
-  double masterHardness = m_hardness->getValue(frame);
+  double masterGamma;
+  if (m_linearizeMode->getValue() == Hardness)
+    masterGamma = m_hardness->getValue(frame);
+  else {  // Gamma
+    if (getFxVersion() == 2)
+      masterGamma = m_gamma->getValue(frame);
+    else
+      masterGamma = std::max(
+          1., settings.m_colorSpaceGamma + m_gammaAdjust->getValue(frame));
+    if (tile.getRaster()->isLinear()) masterGamma /= settings.m_colorSpaceGamma;
+  }
 
   QList<LayerValue> layerValues;
   for (auto index : sourceIndices) {
@@ -298,10 +358,24 @@ void Iwa_BokehAdvancedFx::doCompute(TTile& tile, double frame,
     layerValue.sourceTile = sourceTiles[index];
     layerValue.premultiply =
         false;  // assuming input images are always premultiplied
-    layerValue.layerHardness =
-        (m_hardnessPerSource->getValue())
-            ? m_layerParams[index].m_hardness->getValue(frame)
-            : masterHardness;
+
+    if (m_hardnessPerSource->getValue()) {
+      if (m_linearizeMode->getValue() == Hardness)
+        layerValue.layerGamma =
+            m_layerParams[index].m_hardness->getValue(frame);
+      else {  // Gamma
+        if (getFxVersion() == 2)
+          layerValue.layerGamma = m_layerParams[index].m_gamma->getValue(frame);
+        else
+          layerValue.layerGamma = std::max(
+              1., settings.m_colorSpaceGamma +
+                      m_layerParams[index].m_gammaAdjust->getValue(frame));
+        if (tile.getRaster()->isLinear())
+          layerValue.layerGamma /= settings.m_colorSpaceGamma;
+      }
+    } else
+      layerValue.layerGamma = masterGamma;
+
     layerValue.depth_ref = m_layerParams[index].m_depth_ref->getValue();
     layerValue.irisSize  = irisSizes.value(index);
     layerValue.distance  = m_layerParams[index].m_distance->getValue(frame);

--- a/toonz/sources/stdfx/iwa_bokeh_advancedfx.h
+++ b/toonz/sources/stdfx/iwa_bokeh_advancedfx.h
@@ -13,8 +13,6 @@
 #include "tfxparam.h"
 #include "traster.h"
 
-#include "kiss_fft.h"
-#include "tools/kiss_fftnd.h"
 #include "iwa_bokeh_util.h"
 
 #include <array>
@@ -37,10 +35,14 @@ protected:
     TDoubleParamP m_distance;  // The layer distance from the camera (0-1)
     TDoubleParamP m_bokehAdjustment;  // Factor for adjusting distance (= focal
                                       // distance - layer distance) (0-2.0)
-    TDoubleParamP m_hardness;         // film gamma for each layer
-    TIntParamP m_depth_ref;           // port index of depth reference image
-    TDoubleParamP m_depthRange;       // distance range varies depends on the
-                                      // brightness of the reference image (0-1)
+    TDoubleParamP m_hardness;         // film gamma for each layer (Version1)
+    TDoubleParamP m_gamma;            // film gamma for each layer (Version2)
+    TDoubleParamP m_gammaAdjust;  // Gamma offset from the current color space
+                                  // gamma (Version 3)
+
+    TIntParamP m_depth_ref;      // port index of depth reference image
+    TDoubleParamP m_depthRange;  // distance range varies depends on the
+                                 // brightness of the reference image (0-1)
     TBoolParamP m_fillGap;
     TBoolParamP m_doMedian;
   };
@@ -67,6 +69,7 @@ public:
   const TFxPortDG* dynamicPortGroup(int g) const override {
     return (g == 0) ? &m_control : 0;
   }
+  void onFxVersionSet() final override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_bokeh_util.cpp
+++ b/toonz/sources/stdfx/iwa_bokeh_util.cpp
@@ -2,6 +2,8 @@
 #include "iwa_bokeh_util.h"
 
 #include "trop.h"
+#include "tparamcontainer.h"
+
 #include <array>
 
 #include <QSet>
@@ -62,21 +64,19 @@ void releaseAllRastersAndPlans(QList<TRasterGR8P>& rasterList,
 BokehUtils::MyThread::MyThread(Channel channel, TRasterP layerTileRas,
                                double4* result, double* alpha_bokeh,
                                kiss_fft_cpx* kissfft_comp_iris,
-                               double layerHardness, double masterHardness,
-                               bool doLightenComp)
+                               double layerGamma, double masterGamma)
     : m_channel(channel)
     , m_layerTileRas(layerTileRas)
     , m_result(result)
     , m_alpha_bokeh(alpha_bokeh)
     , m_kissfft_comp_iris(kissfft_comp_iris)
-    , m_layerHardness(layerHardness)
-    , m_masterHardness(masterHardness)
+    , m_layerGamma(layerGamma)
+    , m_masterGamma(masterGamma)
     , m_finished(false)
     , m_kissfft_comp_in(0)
     , m_kissfft_comp_out(0)
-    , m_isTerminated(false)
-    , m_doLightenComp(doLightenComp) {
-  if (m_masterHardness == 0.0) m_masterHardness = m_layerHardness;
+    , m_isTerminated(false) {
+  if (m_masterGamma == 0.0) m_masterGamma = m_layerGamma;
 }
 
 bool BokehUtils::MyThread::init() {
@@ -168,8 +168,7 @@ void BokehUtils::MyThread::setLayerRaster(const RASTER srcRas,
                                             : (double)pix->b;
         // multiply the exposure by alpha channel value
         dstMem[j * dim.lx + i].r =
-            valueToExposure(val / (double)PIXEL::maxChannelValue,
-                            m_layerHardness) *
+            m_conv->valueToExposure(val / (double)PIXEL::maxChannelValue) *
             ((double)pix->m / (double)PIXEL::maxChannelValue);
       }
     }
@@ -193,6 +192,7 @@ void BokehUtils::MyThread::run() {
 
   TRaster32P ras32 = (TRaster32P)m_layerTileRas;
   TRaster64P ras64 = (TRaster64P)m_layerTileRas;
+  TRasterFP rasF   = (TRasterFP)m_layerTileRas;
   // Prepare data for FFT.
   // Convert the RGB values to the exposure, then multiply it by the alpha
   // channel value
@@ -202,6 +202,8 @@ void BokehUtils::MyThread::run() {
       setLayerRaster<TRaster32P, TPixel32>(ras32, m_kissfft_comp_in, dim);
     else if (ras64)
       setLayerRaster<TRaster64P, TPixel64>(ras64, m_kissfft_comp_in, dim);
+    else if (rasF)
+      setLayerRaster<TRasterFP, TPixelF>(rasF, m_kissfft_comp_in, dim);
     else {
       lock.unlock();
       return;
@@ -221,7 +223,7 @@ void BokehUtils::MyThread::run() {
   // Filtering. Multiply by the iris FFT data
   {
     for (int i = 0; i < lx * ly; i++) {
-      float re, im;
+      kiss_fft_scalar re, im;
       re = m_kissfft_comp_out[i].r * m_kissfft_comp_iris[i].r -
            m_kissfft_comp_out[i].i * m_kissfft_comp_iris[i].i;
       im = m_kissfft_comp_out[i].r * m_kissfft_comp_iris[i].i +
@@ -251,6 +253,7 @@ void BokehUtils::MyThread::run() {
 
     double* alp_p  = m_alpha_bokeh;
     double4* res_p = m_result;
+
     for (int i = 0; i < dim.lx * dim.ly; i++, alp_p++, res_p++) {
       if ((*alp_p) < 0.00001) continue;
 
@@ -259,10 +262,16 @@ void BokehUtils::MyThread::run() {
           (double)(dim.lx * dim.ly);
 
       // convert to layer hardness
-      if (m_masterHardness != m_layerHardness)
-        exposure =
-            std::pow(exposure / (*alp_p), m_layerHardness / m_masterHardness) *
-            (*alp_p);
+      if (m_masterGamma != m_layerGamma) {
+        if (isGammaBased())
+          exposure =
+              std::pow(exposure / (*alp_p), m_masterGamma / m_layerGamma) *
+              (*alp_p);
+        else  // hardness based
+          exposure =
+              std::pow(exposure / (*alp_p), m_layerGamma / m_masterGamma) *
+              (*alp_p);
+      }
 
       double* res = (m_channel == Red)     ? (&((*res_p).x))
                     : (m_channel == Green) ? (&((*res_p).y))
@@ -343,7 +352,7 @@ void BokehUtils::BokehRefThread::run() {
 
   // multiply filter
   for (int i = 0; i < size; i++) {
-    float re, im;
+    kiss_fft_scalar re, im;
     re = m_fftcpx_channel[i].r * m_fftcpx_iris[i].r -
          m_fftcpx_channel[i].i * m_fftcpx_iris[i].i;
     im = m_fftcpx_channel[i].r * m_fftcpx_iris[i].i +
@@ -415,6 +424,8 @@ template void BokehUtils::setSourceRaster<TRaster32P, TPixel32>(
     const TRaster32P srcRas, double4* dstMem, TDimensionI dim);
 template void BokehUtils::setSourceRaster<TRaster64P, TPixel64>(
     const TRaster64P srcRas, double4* dstMem, TDimensionI dim);
+template void BokehUtils::setSourceRaster<TRasterFP, TPixelF>(
+    const TRasterFP srcRas, double4* dstMem, TDimensionI dim);
 
 template <typename RASTER, typename PIXEL>
 void BokehUtils::setSourceRaster(const RASTER srcRas, double4* dstMem,
@@ -439,6 +450,8 @@ template void BokehUtils::setDepthRaster<TRaster32P, TPixel32>(
     const TRaster32P srcRas, unsigned char* dstMem, TDimensionI dim);
 template void BokehUtils::setDepthRaster<TRaster64P, TPixel64>(
     const TRaster64P srcRas, unsigned char* dstMem, TDimensionI dim);
+template void BokehUtils::setDepthRaster<TRasterFP, TPixelF>(
+    const TRasterFP srcRas, unsigned char* dstMem, TDimensionI dim);
 
 template <typename RASTER, typename PIXEL>
 void BokehUtils::setDepthRaster(const RASTER srcRas, unsigned char* dstMem,
@@ -451,6 +464,9 @@ void BokehUtils::setDepthRaster(const RASTER srcRas, unsigned char* dstMem,
       double val = ((double)pix->r * 0.3 + (double)pix->g * 0.59 +
                     (double)pix->b * 0.11) /
                    (double)PIXEL::maxChannelValue;
+      // clamp
+      val = std::min(1., std::max(0., val));
+
       // convert to unsigned char
       (*depth_p) = (unsigned char)(val * (double)UCHAR_MAX + 0.5);
     }
@@ -641,7 +657,7 @@ void BokehUtils::defineSegemntDepth(
 // convert source image value rgb -> exposure
 //--------------------------------------------
 void BokehUtils::convertRGBToExposure(const double4* source_buff, int size,
-                                      double filmGamma) {
+                                      const ExposureConverter& conv) {
   double4* source_p = (double4*)source_buff;
   for (int i = 0; i < size; i++, source_p++) {
     // continue if alpha channel is 0
@@ -653,9 +669,9 @@ void BokehUtils::convertRGBToExposure(const double4* source_buff, int size,
     }
 
     // RGB value -> exposure
-    (*source_p).x = valueToExposure((*source_p).x, filmGamma);
-    (*source_p).y = valueToExposure((*source_p).y, filmGamma);
-    (*source_p).z = valueToExposure((*source_p).z, filmGamma);
+    (*source_p).x = conv.valueToExposure((*source_p).x);
+    (*source_p).y = conv.valueToExposure((*source_p).y);
+    (*source_p).z = conv.valueToExposure((*source_p).z);
 
     // multiply with alpha channel
     (*source_p).x *= (*source_p).w;
@@ -668,12 +684,12 @@ void BokehUtils::convertRGBToExposure(const double4* source_buff, int size,
 // convert result image value exposure -> rgb
 //--------------------------------------------
 void BokehUtils::convertExposureToRGB(const double4* result_buff, int size,
-                                      double filmGamma) {
+                                      const ExposureConverter& conv) {
   double4* res_p = (double4*)result_buff;
   for (int i = 0; i < size; i++, res_p++) {
-    (*res_p).x = clamp01(exposureToValue((*res_p).x, filmGamma));
-    (*res_p).y = clamp01(exposureToValue((*res_p).y, filmGamma));
-    (*res_p).z = clamp01(exposureToValue((*res_p).z, filmGamma));
+    (*res_p).x = conv.exposureToValue((*res_p).x);
+    (*res_p).y = conv.exposureToValue((*res_p).y);
+    (*res_p).z = conv.exposureToValue((*res_p).z);
   }
 }
 
@@ -1040,7 +1056,7 @@ void BokehUtils::multiplyFilter(kiss_fft_cpx* fftcpx_channel,  // dst
                                 kiss_fft_cpx* fftcpx_iris,     // filter
                                 int size) {
   for (int i = 0; i < size; i++) {
-    float re, im;
+    kiss_fft_scalar re, im;
     re = fftcpx_channel[i].r * fftcpx_iris[i].r -
          fftcpx_channel[i].i * fftcpx_iris[i].i;
     im = fftcpx_channel[i].r * fftcpx_iris[i].i +
@@ -1127,7 +1143,8 @@ void BokehUtils::interpolateExposureAndConvertToRGB(
 //--------------------------------------------
 //"Over" composite the layer to the output exposure.
 void BokehUtils::compositLayerAsIs(TTile& layerTile, double4* result,
-                                   TDimensionI& dimOut, double filmGamma) {
+                                   TDimensionI& dimOut,
+                                   const ExposureConverter& conv) {
   double4* layer_buff;
   TRasterGR8P layer_buff_ras(dimOut.lx * sizeof(double4), dimOut.ly);
   layer_buff_ras->lock();
@@ -1135,6 +1152,7 @@ void BokehUtils::compositLayerAsIs(TTile& layerTile, double4* result,
 
   TRaster32P ras32 = (TRaster32P)layerTile.getRaster();
   TRaster64P ras64 = (TRaster64P)layerTile.getRaster();
+  TRasterFP rasF   = (TRasterFP)layerTile.getRaster();
   lock.lockForRead();
   if (ras32)
     BokehUtils::setSourceRaster<TRaster32P, TPixel32>(ras32, layer_buff,
@@ -1142,6 +1160,8 @@ void BokehUtils::compositLayerAsIs(TTile& layerTile, double4* result,
   else if (ras64)
     BokehUtils::setSourceRaster<TRaster64P, TPixel64>(ras64, layer_buff,
                                                       dimOut);
+  else if (rasF)
+    BokehUtils::setSourceRaster<TRasterFP, TPixelF>(rasF, layer_buff, dimOut);
   lock.unlock();
 
   double4* lay_p = layer_buff;
@@ -1151,20 +1171,20 @@ void BokehUtils::compositLayerAsIs(TTile& layerTile, double4* result,
       continue;
     else if ((*lay_p).w < 1.0) {
       // composite exposure
-      (*res_p).x = valueToExposure((*lay_p).x, filmGamma) * (*lay_p).w +
+      (*res_p).x = conv.valueToExposure((*lay_p).x) * (*lay_p).w +
                    (*res_p).x * (1.0 - (*lay_p).w);
-      (*res_p).y = valueToExposure((*lay_p).y, filmGamma) * (*lay_p).w +
+      (*res_p).y = conv.valueToExposure((*lay_p).y) * (*lay_p).w +
                    (*res_p).y * (1.0 - (*lay_p).w);
-      (*res_p).z = valueToExposure((*lay_p).z, filmGamma) * (*lay_p).w +
+      (*res_p).z = conv.valueToExposure((*lay_p).z) * (*lay_p).w +
                    (*res_p).z * (1.0 - (*lay_p).w);
       // over composite alpha
       (*res_p).w = (*lay_p).w + ((*res_p).w * (1.0 - (*lay_p).w));
       (*res_p).w = clamp01((*res_p).w);
     } else  // replace by upper layer
     {
-      (*res_p).x = valueToExposure((*lay_p).x, filmGamma);
-      (*res_p).y = valueToExposure((*lay_p).y, filmGamma);
-      (*res_p).z = valueToExposure((*lay_p).z, filmGamma);
+      (*res_p).x = conv.valueToExposure((*lay_p).x);
+      (*res_p).y = conv.valueToExposure((*lay_p).y);
+      (*res_p).z = conv.valueToExposure((*lay_p).z);
       (*res_p).w = 1.0;
     }
   }
@@ -1200,6 +1220,7 @@ void BokehUtils::calcAlfaChannelBokeh(kiss_fft_cpx* kissfft_comp_iris,
 
   TRaster32P ras32 = (TRaster32P)layerTile.getRaster();
   TRaster64P ras64 = (TRaster64P)layerTile.getRaster();
+  TRasterFP rasF   = (TRasterFP)layerTile.getRaster();
   if (ras32) {
     for (int j = 0; j < ly; j++) {
       TPixel32* pix = ras32->pixels(j);
@@ -1216,6 +1237,14 @@ void BokehUtils::calcAlfaChannelBokeh(kiss_fft_cpx* kissfft_comp_iris,
         pix++;
       }
     }
+  } else if (rasF) {
+    for (int j = 0; j < ly; j++) {
+      TPixelF* pix = rasF->pixels(j);
+      for (int i = 0; i < lx; i++) {
+        kissfft_comp_in[j * lx + i].r = (double)pix->m;
+        pix++;
+      }
+    }
   } else
     return;
 
@@ -1227,7 +1256,7 @@ void BokehUtils::calcAlfaChannelBokeh(kiss_fft_cpx* kissfft_comp_iris,
 
   // Filtering. Multiply by the iris FFT data
   for (int i = 0; i < lx * ly; i++) {
-    float re, im;
+    kiss_fft_scalar re, im;
     re = kissfft_comp_out[i].r * kissfft_comp_iris[i].r -
          kissfft_comp_out[i].i * kissfft_comp_iris[i].i;
     im = kissfft_comp_out[i].r * kissfft_comp_iris[i].i +
@@ -1305,6 +1334,32 @@ void BokehUtils::setOutputRaster(double4* src, const RASTER dstRas,
   }
 }
 
+template <>
+void BokehUtils::setOutputRaster<TRasterFP, TPixelF>(double4* src,
+                                                     const TRasterFP dstRas,
+                                                     TDimensionI& dim,
+                                                     int2 margin) {
+  double4* src_p = src + (margin.y * dim.lx);
+
+  for (int j = 0; j < dstRas->getLy(); j++) {
+    TPixelF* outPix = dstRas->pixels(j);
+    src_p += margin.x;
+    for (int i = 0; i < dstRas->getLx(); i++, outPix++, src_p++) {
+      outPix->r = (typename TPixelF::Channel)(
+          (std::isfinite((*src_p).x) && (*src_p).x > 0.) ? (*src_p).x : 0.);
+      outPix->g = (typename TPixelF::Channel)(
+          (std::isfinite((*src_p).y) && (*src_p).y > 0.) ? (*src_p).y : 0.);
+      outPix->b = (typename TPixelF::Channel)(
+          (std::isfinite((*src_p).z) && (*src_p).z > 0.) ? (*src_p).z : 0.);
+
+      outPix->m =
+          (typename TPixelF::Channel)(((*src_p).w > 1.) ? 1. : (*src_p).w);
+      assert(outPix->m >= 0.0);
+    }
+    src_p += margin.x;
+  }
+}
+
 //-----------------------------------------------------
 // Get the pixel size of bokehAmount ( referenced ino_blur.cpp )
 double BokehUtils::getBokehPixelAmount(const double bokehAmount,
@@ -1324,7 +1379,12 @@ double BokehUtils::getBokehPixelAmount(const double bokehAmount,
 //-----------------------------------------------------
 
 Iwa_BokehCommonFx::Iwa_BokehCommonFx()
-    : m_onFocusDistance(0.5), m_bokehAmount(30.0), m_hardness(0.3) {
+    : m_onFocusDistance(0.5)
+    , m_bokehAmount(30.0)
+    , m_hardness(0.3)
+    , m_gamma(2.2)
+    , m_gammaAdjust(0.)
+    , m_linearizeMode(new TIntEnumParam(Gamma, "Gamma")) {
   addInputPort("Iris", m_iris);
 
   // Set the ranges of common parameters
@@ -1332,6 +1392,9 @@ Iwa_BokehCommonFx::Iwa_BokehCommonFx()
   m_bokehAmount->setValueRange(0.0, 300.0);
   m_bokehAmount->setMeasureName("fxLength");
   m_hardness->setValueRange(0.05, 3.0);
+  m_gamma->setValueRange(1.0, 10.0);
+  m_gammaAdjust->setValueRange(-5., 5.);
+  m_linearizeMode->addItem(Hardness, "Hardness");
 }
 
 //--------------------------------------------
@@ -1373,7 +1436,13 @@ void Iwa_BokehCommonFx::doFx(TTile& tile, double frame,
   // initialize
   std::fill_n(result, dimOut.lx * dimOut.ly, zero);
 
-  double masterHardness = m_hardness->getValue(frame);
+  double masterGamma;
+  if (m_linearizeMode->getValue() == Hardness)
+    masterGamma = m_hardness->getValue(frame);
+  else {  // gamma
+    masterGamma = m_gamma->getValue(frame);
+    if (tile.getRaster()->isLinear()) masterGamma /= settings.m_colorSpaceGamma;
+  }
 
   // cancel check
   if (settings.m_isCanceled && *settings.m_isCanceled) {
@@ -1400,15 +1469,15 @@ void Iwa_BokehCommonFx::doFx(TTile& tile, double frame,
       if (!layer.premultiply) TRop::depremultiply(layerTile->getRaster());
 
       doBokehRef(result, frame, settings, bokehPixelAmount, margin, dimOut,
-                 irisBBox, irisTile, kissfft_comp_iris, layer,
-                 ctrls[ctrlIndex]);
+                 irisBBox, irisTile, kissfft_comp_iris, layer, ctrls[ctrlIndex],
+                 tile.getRaster()->isLinear());
 
       continue;
     }
 
     //-------------------
 
-    double layerHardness = layer.layerHardness;
+    double layerGamma = layer.layerGamma;
     // The iris size of the current layer
     double irisSize = layer.irisSize;
 
@@ -1416,7 +1485,16 @@ void Iwa_BokehCommonFx::doFx(TTile& tile, double frame,
     if (-1.0 <= irisSize && 1.0 >= irisSize) {
       TTile* layerTile = layer.sourceTile;
       if (!layer.premultiply) TRop::depremultiply(layerTile->getRaster());
-      BokehUtils::compositLayerAsIs(*layerTile, result, dimOut, masterHardness);
+
+      if (m_linearizeMode->getValue() == Hardness)
+        BokehUtils::compositLayerAsIs(
+            *layerTile, result, dimOut,
+            HardnessBasedConverter(masterGamma, settings.m_colorSpaceGamma,
+                                   layerTile->getRaster()->isLinear()));
+      else
+        BokehUtils::compositLayerAsIs(*layerTile, result, dimOut,
+                                      GammaBasedConverter(masterGamma));
+
       // Continue to the next layer
       continue;
     }
@@ -1480,15 +1558,26 @@ void Iwa_BokehCommonFx::doFx(TTile& tile, double frame,
       return;
     }
 
-    BokehUtils::MyThread threadR(
-        BokehUtils::MyThread::Red, layerTile->getRaster(), result, alpha_bokeh,
-        kissfft_comp_iris, layerHardness, masterHardness);
-    BokehUtils::MyThread threadG(
-        BokehUtils::MyThread::Green, layerTile->getRaster(), result,
-        alpha_bokeh, kissfft_comp_iris, layerHardness, masterHardness);
-    BokehUtils::MyThread threadB(
-        BokehUtils::MyThread::Blue, layerTile->getRaster(), result, alpha_bokeh,
-        kissfft_comp_iris, layerHardness, masterHardness);
+    BokehUtils::MyThread threadR(BokehUtils::MyThread::Red,
+                                 layerTile->getRaster(), result, alpha_bokeh,
+                                 kissfft_comp_iris, layerGamma, masterGamma);
+    BokehUtils::MyThread threadG(BokehUtils::MyThread::Green,
+                                 layerTile->getRaster(), result, alpha_bokeh,
+                                 kissfft_comp_iris, layerGamma, masterGamma);
+    BokehUtils::MyThread threadB(BokehUtils::MyThread::Blue,
+                                 layerTile->getRaster(), result, alpha_bokeh,
+                                 kissfft_comp_iris, layerGamma, masterGamma);
+
+    std::shared_ptr<ExposureConverter> conv;
+    if (m_linearizeMode->getValue() == Hardness)
+      conv.reset(
+          new HardnessBasedConverter(layerGamma, settings.m_colorSpaceGamma,
+                                     layerTile->getRaster()->isLinear()));
+    else
+      conv.reset(new GammaBasedConverter(layerGamma));
+    threadR.setConverter(conv);
+    threadG.setConverter(conv);
+    threadB.setConverter(conv);
 
     // If you set this flag to true, the fx will be forced to compute in single
     // thread.
@@ -1596,13 +1685,20 @@ void Iwa_BokehCommonFx::doFx(TTile& tile, double frame,
   }
 
   // convert result image value exposure -> rgb
-  BokehUtils::convertExposureToRGB(result, dimOut.lx * dimOut.ly,
-                                   masterHardness);
+  if (m_linearizeMode->getValue() == Hardness)
+    BokehUtils::convertExposureToRGB(
+        result, dimOut.lx * dimOut.ly,
+        HardnessBasedConverter(masterGamma, settings.m_colorSpaceGamma,
+                               tile.getRaster()->isLinear()));
+  else
+    BokehUtils::convertExposureToRGB(result, dimOut.lx * dimOut.ly,
+                                     GammaBasedConverter(masterGamma));
 
   // clear result raster
   tile.getRaster()->clear();
   TRaster32P outRas32 = (TRaster32P)tile.getRaster();
   TRaster64P outRas64 = (TRaster64P)tile.getRaster();
+  TRasterFP outRasF   = (TRasterFP)tile.getRaster();
 
   int2 outMargin = {(dimOut.lx - tile.getRaster()->getSize().lx) / 2,
                     (dimOut.ly - tile.getRaster()->getSize().ly) / 2};
@@ -1614,18 +1710,19 @@ void Iwa_BokehCommonFx::doFx(TTile& tile, double frame,
   else if (outRas64)
     BokehUtils::setOutputRaster<TRaster64P, TPixel64>(result, outRas64, dimOut,
                                                       outMargin);
+  else if (outRasF)
+    BokehUtils::setOutputRaster<TRasterFP, TPixelF>(result, outRasF, dimOut,
+                                                    outMargin);
   lock.unlock();
 
   releaseAllRastersAndPlans(rasterList, planList);
 }
 
-void Iwa_BokehCommonFx::doBokehRef(double4* result, double frame,
-                                   const TRenderSettings& settings,
-                                   double bokehPixelAmount, int margin,
-                                   TDimensionI& dimOut, TRectD& irisBBox,
-                                   TTile& irisTile,
-                                   kiss_fft_cpx* kissfft_comp_iris,
-                                   LayerValue layer, unsigned char* ctrl) {
+void Iwa_BokehCommonFx::doBokehRef(
+    double4* result, double frame, const TRenderSettings& settings,
+    double bokehPixelAmount, int margin, TDimensionI& dimOut, TRectD& irisBBox,
+    TTile& irisTile, kiss_fft_cpx* kissfft_comp_iris, LayerValue layer,
+    unsigned char* ctrl, const bool isLinear) {
   QList<TRasterGR8P> rasterList;
   QList<kiss_fftnd_cfg> planList;
   // source image
@@ -1634,6 +1731,7 @@ void Iwa_BokehCommonFx::doBokehRef(double4* result, double frame,
 
   TRaster32P ras32 = (TRaster32P)layer.sourceTile->getRaster();
   TRaster64P ras64 = (TRaster64P)layer.sourceTile->getRaster();
+  TRasterFP rasF   = (TRasterFP)layer.sourceTile->getRaster();
   lock.lockForRead();
   if (ras32)
     BokehUtils::setSourceRaster<TRaster32P, TPixel32>(ras32, source_buff,
@@ -1641,6 +1739,8 @@ void Iwa_BokehCommonFx::doBokehRef(double4* result, double frame,
   else if (ras64)
     BokehUtils::setSourceRaster<TRaster64P, TPixel64>(ras64, source_buff,
                                                       dimOut);
+  else if (rasF)
+    BokehUtils::setSourceRaster<TRasterFP, TPixelF>(rasF, source_buff, dimOut);
   lock.unlock();
 
   // create the index map, which indicates which layer each pixel belongs to
@@ -1740,13 +1840,26 @@ void Iwa_BokehCommonFx::doBokehRef(double4* result, double frame,
   memset(result_main_buff, 0, sizeof(double4) * size);
   memset(result_sub_buff, 0, sizeof(double4) * size);
 
-  double masterHardness = (double)m_hardness->getValue(frame);
-  double layerHardness  = layer.layerHardness;
+  double masterGamma;
+  if (m_linearizeMode->getValue() == Hardness)
+    masterGamma = m_hardness->getValue(frame);
+  else {  // gamma
+    masterGamma = m_gamma->getValue(frame);
+    if (isLinear) masterGamma /= settings.m_colorSpaceGamma;
+  }
+  double layerGamma = layer.layerGamma;
 
   // convert source image value rgb -> exposure
   // note that premultiplied source image is already unpremultiplied before this
   // function
-  BokehUtils::convertRGBToExposure(source_buff, size, layerHardness);
+  if (m_linearizeMode->getValue() == Hardness)
+    BokehUtils::convertRGBToExposure(
+        source_buff, size,
+        HardnessBasedConverter(layerGamma, settings.m_colorSpaceGamma,
+                               layer.sourceTile->getRaster()->isLinear()));
+  else
+    BokehUtils::convertRGBToExposure(source_buff, size,
+                                     GammaBasedConverter(layerGamma));
 
   double focus  = m_onFocusDistance->getValue(frame);
   double adjust = layer.bokehAdjustment;
@@ -1894,12 +2007,15 @@ void Iwa_BokehCommonFx::doBokehRef(double4* result, double frame,
     return;
   }
 
-  BokehUtils::interpolateExposureAndConvertToRGB(
-      result_main_buff,    // result1
-      result_sub_buff,     // result2
-      mainSub_ratio_buff,  // ratio
-      result,              // dst
-      size, layerHardness / masterHardness);
+  double adjustFactor = (m_linearizeMode->getValue() == Hardness)
+                            ? layerGamma / masterGamma
+                            : masterGamma / layerGamma;
+
+  BokehUtils::interpolateExposureAndConvertToRGB(result_main_buff,    // result1
+                                                 result_sub_buff,     // result2
+                                                 mainSub_ratio_buff,  // ratio
+                                                 result,              // dst
+                                                 size, adjustFactor);
 
   // release rasters and plans
   releaseAllRastersAndPlans(rasterList, planList);

--- a/toonz/sources/stdfx/iwa_bokeh_util.h
+++ b/toonz/sources/stdfx/iwa_bokeh_util.h
@@ -26,6 +26,56 @@ struct int2 {
   int x, y;
 };
 
+class ExposureConverter {
+protected:
+  double m_gamma;  // used as hardness in HardnessBasedConverter
+
+public:
+  ExposureConverter(double gamma) : m_gamma(gamma) {}
+  virtual double valueToExposure(double value) const    = 0;
+  virtual double exposureToValue(double exposure) const = 0;
+  virtual bool isGammaBased() { return true; }
+};
+
+class HardnessBasedConverter : public ExposureConverter {
+  bool m_fromLinear;
+  double m_colorSpaceGamma;
+
+public:
+  HardnessBasedConverter(double gamma, double colorSpaceGamma,
+                         bool fromLinear = false)
+      : ExposureConverter(gamma)
+      , m_fromLinear(fromLinear)
+      , m_colorSpaceGamma(colorSpaceGamma) {}
+  double valueToExposure(double value) const final override {
+    // conversion is assumed to be applied to non-linear value
+    if (m_fromLinear && value > 0.)
+      value = std::pow(value, 1. / m_colorSpaceGamma);
+    double logVal = (value - 0.5) / m_gamma;
+    return std::pow(10.0, logVal);
+  }
+  double exposureToValue(double exposure) const final override {
+    double ret = std::log10(exposure) * m_gamma + 0.5;
+    if (m_fromLinear && ret > 0.) ret = std::pow(ret, m_colorSpaceGamma);
+    return ret;
+  }
+  bool isGammaBased() final override { return false; }
+};
+
+class GammaBasedConverter : public ExposureConverter {
+public:
+  GammaBasedConverter(double gamma) : ExposureConverter(gamma) {}
+  double valueToExposure(double value) const final override {
+    if (value < 0. || m_gamma == 1.) return value;
+    return std::pow(value, m_gamma);
+  }
+  double exposureToValue(double exposure) const final override {
+    assert(m_gamma > 0.);
+    if (exposure < 0. || m_gamma == 1.) return exposure;
+    return std::pow(exposure, 1. / m_gamma);
+  }
+};
+
 namespace BokehUtils {
 
 //------------------------------------
@@ -45,8 +95,8 @@ private:
 
   kiss_fft_cpx* m_kissfft_comp_iris;
 
-  double m_layerHardness;
-  double m_masterHardness;
+  double m_layerGamma;
+  double m_masterGamma;
 
   TRasterGR8P m_kissfft_comp_in_ras, m_kissfft_comp_out_ras;
   kiss_fft_cpx *m_kissfft_comp_in, *m_kissfft_comp_out;
@@ -54,14 +104,12 @@ private:
 
   bool m_isTerminated;
 
-  // not used for now
-  bool m_doLightenComp;
+  std::shared_ptr<ExposureConverter> m_conv;
 
 public:
   MyThread(Channel channel, TRasterP layerTileRas, double4* result,
            double* alpha_bokeh, kiss_fft_cpx* kissfft_comp_iris,
-           double layerHardness, double masterHardness = 0.0,
-           bool doLightenComp = false);  // not used for now
+           double layerGamma, double masterGamma = 0.0);
 
   // Convert the pixels from RGB values to exposures and multiply it by alpha
   // channel value.
@@ -74,12 +122,15 @@ public:
 
   bool isFinished() { return m_finished; }
 
-  //ÉÅÉÇÉäämï€
+  // ÉÅÉÇÉäämï€
   bool init();
 
   void terminateThread() { m_isTerminated = true; }
 
   bool checkTerminationAndCleanupThread();
+
+  void setConverter(std::shared_ptr<ExposureConverter> conv) { m_conv = conv; }
+  bool isGammaBased() { return m_conv->isGammaBased(); }
 };
 
 //------------------------------------
@@ -135,11 +186,11 @@ void defineSegemntDepth(
 
 // convert source image value rgb -> exposure
 void convertRGBToExposure(const double4* source_buff, int size,
-                          double filmGamma);
+                          const ExposureConverter& conv);
 
 // convert result image value exposure -> rgb
 void convertExposureToRGB(const double4* result_buff, int size,
-                          double filmGamma);
+                          const ExposureConverter& conv);
 
 // obtain iris size from the depth value
 double calcIrisSize(const double depth, const double bokehPixelAmount,
@@ -195,7 +246,7 @@ void interpolateExposureAndConvertToRGB(
 
 //"Over" composite the layer to the output exposure.
 void compositLayerAsIs(TTile& layerTile, double4* result, TDimensionI& dimOut,
-                       double filmGamma);
+                       const ExposureConverter& conv);
 
 // Do FFT the alpha channel.
 // Forward FFT -> Multiply by the iris data -> Backward FFT
@@ -214,13 +265,20 @@ double getBokehPixelAmount(const double bokehAmount, const TAffine affine);
 //-----------------------------------------------------
 
 class Iwa_BokehCommonFx : public TStandardRasterFx {
+public:
+  enum LinearizeMode { Gamma, Hardness };
+
 protected:
   TRasterFxPort m_iris;
   TDoubleParamP m_onFocusDistance;  // Focus Distance (0-1)
   TDoubleParamP m_bokehAmount;  // The maximum bokeh size. The size of bokeh at
                                 // the layer separated by 1.0 from the focal
                                 // position
-  TDoubleParamP m_hardness;     // Film gamma
+  TDoubleParamP m_hardness;     // Film gamma (Version 1)
+  TDoubleParamP m_gamma;        // Film gamma (Version 2)
+  TDoubleParamP m_gammaAdjust;  // Gamma offset from the current color space
+                                // gamma (Version 3)
+  TIntEnumParamP m_linearizeMode;
 
   struct LayerValue {
     TTile* sourceTile;
@@ -228,7 +286,8 @@ protected:
     // this parameter is now always false (assuming input images are always
     // premultiplied). the value is left to keep backward compatibility
     bool premultiply;
-    double layerHardness;
+    double layerGamma;  // hardness based in fx version 1, gamma based in fx
+                        // version
     int depth_ref;
 
     double irisSize;
@@ -250,7 +309,7 @@ protected:
                   const TRenderSettings& settings, double bokehPixelAmount,
                   int margin, TDimensionI& dimOut, TRectD& irisBBox,
                   TTile& irisTile, kiss_fft_cpx* kissfft_comp_iris,
-                  LayerValue layer, unsigned char* ctrl);
+                  LayerValue layer, unsigned char* ctrl, const bool isLinear);
 
 public:
   Iwa_BokehCommonFx();

--- a/toonz/sources/stdfx/iwa_bokehfx.h
+++ b/toonz/sources/stdfx/iwa_bokehfx.h
@@ -20,7 +20,6 @@ distributed with a 3-clause BSD-style license.
 #include <QList>
 #include <QThread>
 
-#include "tools/kiss_fftnd.h"
 #include "iwa_bokeh_util.h"
 
 const int LAYER_NUM = 5;
@@ -50,6 +49,8 @@ public:
 
   void doCompute(TTile &tile, double frame,
                  const TRenderSettings &settings) override;
+
+  void onFxVersionSet() final override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_bokehreffx.cpp
+++ b/toonz/sources/stdfx/iwa_bokehreffx.cpp
@@ -82,11 +82,45 @@ Iwa_BokehRefFx::Iwa_BokehRefFx()
   bindParam(this, "on_focus_distance", m_onFocusDistance, false);
   bindParam(this, "bokeh_amount", m_bokehAmount, false);
   bindParam(this, "hardness", m_hardness, false);
+  bindParam(this, "gamma", m_gamma, false);
+  bindParam(this, "gammaAdjust", m_gammaAdjust, false);
   bindParam(this, "distance_precision", m_distancePrecision, false);
   bindParam(this, "fill_gap", m_fillGap, false);
   bindParam(this, "fill_gap_with_median_filter", m_doMedian, false);
+  bindParam(this, "linearizeMode", m_linearizeMode, false);
 
   m_distancePrecision->setValueRange(3, 128);
+
+  enableComputeInFloat(true);
+
+  // Version 1: Exposure is computed by using Hardness
+  //            E = std::pow(10.0, (value - 0.5) / hardness)
+  // Version 2: Exposure can also be computed by using Gamma, for easier
+  // combination with the linear color space
+  //            E = std::pow(value, gamma)
+  // this must be called after binding the parameters (see onFxVersionSet())
+  // Version 3: Gamma is computed by rs.m_colorSpaceGamma + gammaAdjust
+  setFxVersion(3);
+}
+
+//--------------------------------------------
+
+void Iwa_BokehRefFx::onFxVersionSet() {
+  bool useGamma = getFxVersion() == 2;
+  if (getFxVersion() == 1) {
+    m_linearizeMode->setValue(Hardness);
+    setFxVersion(3);
+  } else if (getFxVersion() == 2) {
+    // Automatically update version
+    if (m_linearizeMode->getValue() == Hardness ||
+        (m_gamma->getKeyframeCount() == 0 &&
+         areAlmostEqual(m_gamma->getDefaultValue(), 2.2))) {
+      useGamma = false;
+      setFxVersion(3);
+    }
+  }
+  getParams()->getParamVar("gamma")->setIsHidden(!useGamma);
+  getParams()->getParamVar("gammaAdjust")->setIsHidden(useGamma);
 }
 
 //--------------------------------------------
@@ -148,13 +182,12 @@ void Iwa_BokehRefFx::doCompute(TTile& tile, double frame,
   // rasterList.append(allocateRasterAndLock<double4>(&source_buff, dimOut));
 
   LayerValue layerValue;
-  TRenderSettings infoOnInput(settings);
-  infoOnInput.m_bpp = 64;
+  ;
   // source tile is used only in this focus.
   // normalized source image data is stored in source_buff.
   layerValue.sourceTile = new TTile();
   m_source->allocateAndCompute(*layerValue.sourceTile, rectOut.getP00(), dimOut,
-                               0, frame, infoOnInput);
+                               tile.getRaster(), frame, settings);
 
   // - - - iris image - - -
   // Get the original size of Iris image
@@ -173,6 +206,18 @@ void Iwa_BokehRefFx::doCompute(TTile& tile, double frame,
     releaseAllRasters(rasterList);
     tile.getRaster()->clear();
     return;
+  }
+
+  double masterGamma;
+  if (m_linearizeMode->getValue() == Hardness)
+    masterGamma = m_hardness->getValue(frame);
+  else {  // Gamma
+    if (getFxVersion() == 2)
+      masterGamma = m_gamma->getValue(frame);
+    else
+      masterGamma = std::max(
+          1., settings.m_colorSpaceGamma + m_gammaAdjust->getValue(frame));
+    if (tile.getRaster()->isLinear()) masterGamma /= settings.m_colorSpaceGamma;
   }
 
   // compute the reference image
@@ -199,6 +244,7 @@ void Iwa_BokehRefFx::doCompute(TTile& tile, double frame,
     TRasterGR16P rasGR16 = (TRasterGR16P)depthTile.getRaster();
     TRaster32P ras32     = (TRaster32P)depthTile.getRaster();
     TRaster64P ras64     = (TRaster64P)depthTile.getRaster();
+    TRasterFP rasF       = (TRasterFP)depthTile.getRaster();
     lock.lockForRead();
     if (rasGR8)
       setDepthRasterGray<TRasterGR8P, TPixelGR8>(rasGR8, depth_buff, dimOut);
@@ -210,12 +256,14 @@ void Iwa_BokehRefFx::doCompute(TTile& tile, double frame,
     else if (ras64)
       BokehUtils::setDepthRaster<TRaster64P, TPixel64>(ras64, depth_buff,
                                                        dimOut);
+    else if (rasF)
+      BokehUtils::setDepthRaster<TRasterFP, TPixelF>(rasF, depth_buff, dimOut);
     lock.unlock();
   }
   ctrls[1] = depth_buff;
 
   layerValue.premultiply       = false;
-  layerValue.layerHardness     = m_hardness->getValue(frame);
+  layerValue.layerGamma        = masterGamma;
   layerValue.depth_ref         = 1;
   layerValue.distance          = 0.5;
   layerValue.bokehAdjustment   = 1.0;

--- a/toonz/sources/stdfx/iwa_bokehreffx.h
+++ b/toonz/sources/stdfx/iwa_bokehreffx.h
@@ -20,7 +20,6 @@ distributed with a 3-clause BSD-style license.
 #include <QVector>
 #include <QThread>
 
-#include "tools/kiss_fftnd.h"
 #include "iwa_bokeh_util.h"
 
 //------------------------------------
@@ -56,6 +55,8 @@ public:
 
   void doCompute(TTile& tile, double frame,
                  const TRenderSettings& settings) override;
+
+  void onFxVersionSet() final override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_corridorgradientfx.cpp
+++ b/toonz/sources/stdfx/iwa_corridorgradientfx.cpp
@@ -60,6 +60,8 @@ Iwa_CorridorGradientFx::Iwa_CorridorGradientFx()
 
   bindParam(this, "inner_color", m_innerColor);
   bindParam(this, "outer_color", m_outerColor);
+
+  enableComputeInFloat(true);
 }
 
 //------------------------------------------------------------
@@ -295,7 +297,8 @@ void doCircleT(RASTER ras, TDimensionI dim, TPointD pos[2][4],
 
 void Iwa_CorridorGradientFx::doCompute(TTile &tile, double frame,
                                        const TRenderSettings &ri) {
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 
@@ -320,6 +323,7 @@ void Iwa_CorridorGradientFx::doCompute(TTile &tile, double frame,
   tile.getRaster()->clear();
   TRaster32P outRas32 = (TRaster32P)tile.getRaster();
   TRaster64P outRas64 = (TRaster64P)tile.getRaster();
+  TRasterFP outRasF   = (TRasterFP)tile.getRaster();
   if (m_shape->getValue() == 0) {  // Quadrangle
     if (outRas32)
       doQuadrangleT<TRaster32P, TPixel32>(
@@ -328,6 +332,10 @@ void Iwa_CorridorGradientFx::doCompute(TTile &tile, double frame,
     else if (outRas64)
       doQuadrangleT<TRaster64P, TPixel64>(
           outRas64, dimOut, pos, m_colors->getValue64(frame),
+          (GradientCurveType)m_curveType->getValue());
+    else if (outRasF)
+      doQuadrangleT<TRasterFP, TPixelF>(
+          outRasF, dimOut, pos, m_colors->getValueF(frame),
           (GradientCurveType)m_curveType->getValue());
   } else {  // m_shape == 1 : Circle
     if (outRas32)
@@ -338,6 +346,10 @@ void Iwa_CorridorGradientFx::doCompute(TTile &tile, double frame,
       doCircleT<TRaster64P, TPixel64>(
           outRas64, dimOut, pos, m_colors->getValue64(frame),
           (GradientCurveType)m_curveType->getValue());
+    else if (outRasF)
+      doCircleT<TRasterFP, TPixelF>(outRasF, dimOut, pos,
+                                    m_colors->getValueF(frame),
+                                    (GradientCurveType)m_curveType->getValue());
   }
 }
 

--- a/toonz/sources/stdfx/iwa_flowblurfx.cpp
+++ b/toonz/sources/stdfx/iwa_flowblurfx.cpp
@@ -49,11 +49,13 @@ inline double clamp01(double val) {
 // convert sRGB color space to power space
 template <typename T = double>
 inline T to_linear_color_space(T nonlinear_color, T exposure, T gamma) {
+  if (nonlinear_color <= T(0)) return T(0);
   return std::pow(nonlinear_color, gamma) / exposure;
 }
 // convert power space to sRGB color space
 template <typename T = double>
 inline T to_nonlinear_color_space(T linear_color, T exposure, T gamma) {
+  if (linear_color <= T(0)) return T(0);
   return std::pow(linear_color * exposure, T(1) / gamma);
 }
 

--- a/toonz/sources/stdfx/iwa_fractalnoisefx.cpp
+++ b/toonz/sources/stdfx/iwa_fractalnoisefx.cpp
@@ -9,12 +9,14 @@ namespace {
 template <typename T = double>
 inline T to_linear_color_space(T nonlinear_color, T exposure, T gamma) {
   // return -std::log(T(1) - std::pow(nonlinear_color, gamma)) / exposure;
+  if (nonlinear_color <= T(0)) return T(0);
   return std::pow(nonlinear_color, gamma) / exposure;
 }
 // convert power space to sRGB color space
 template <typename T = double>
 inline T to_nonlinear_color_space(T linear_color, T exposure, T gamma) {
   // return std::pow(T(1) - std::exp(-exposure * linear_color), T(1) / gamma);
+  if (linear_color <= T(0)) return T(0);
   return std::pow(exposure * linear_color, T(1) / gamma);
 }
 
@@ -134,6 +136,8 @@ Iwa_FractalNoiseFx::Iwa_FractalNoiseFx()
   bindParam(this, "zScale", m_zScale);
 
   bindParam(this, "alphaRendering", m_alphaRendering);
+
+  enableComputeInFloat(true);
 }
 
 //------------------------------------------------------------------
@@ -457,10 +461,13 @@ void Iwa_FractalNoiseFx::doCompute(TTile &tile, double frame,
   // convert to RGB channel values
   TRaster32P ras32 = (TRaster32P)tile.getRaster();
   TRaster64P ras64 = (TRaster64P)tile.getRaster();
+  TRasterFP rasF   = (TRasterFP)tile.getRaster();
   if (ras32)
     outputRaster<TRaster32P, TPixel32>(ras32, out_buf, param);
   else if (ras64)
     outputRaster<TRaster64P, TPixel64>(ras64, out_buf, param);
+  else if (rasF)
+    outputRaster<TRasterFP, TPixelF>(rasF, out_buf, param);
 
   out_buf_ras->unlock();
 }
@@ -516,11 +523,12 @@ void Iwa_FractalNoiseFx::outputRaster(const RASTER outRas, double *out_buf,
                                       const FNParam &param) {
   TDimension dim = outRas->getSize();
   double *buf_p  = out_buf;
+  bool doClamp   = !(outRas->getPixelSize() == 16);
   for (int j = 0; j < dim.ly; j++) {
     PIXEL *pix = outRas->pixels(j);
     for (int i = 0; i < dim.lx; i++, pix++, buf_p++) {
-      double val                   = (param.invert) ? 1.0 - (*buf_p) : (*buf_p);
-      val                          = clamp(val, 0.0, 1.0);
+      double val = (param.invert) ? 1.0 - (*buf_p) : (*buf_p);
+      if (doClamp) val = clamp(val, 0.0, 1.0);
       typename PIXEL::Channel chan = static_cast<typename PIXEL::Channel>(
           val * (double)PIXEL::maxChannelValue);
       pix->r = chan;

--- a/toonz/sources/stdfx/iwa_glarefx.cpp
+++ b/toonz/sources/stdfx/iwa_glarefx.cpp
@@ -41,7 +41,8 @@ inline int getCoord(int i, int j, int lx, int ly) {
 //--------------------------------------------
 
 Iwa_GlareFx::Iwa_GlareFx()
-    : m_renderMode(new TIntEnumParam(RendeMode_FilterPreview, "Filter Preview"))
+    : m_renderMode(
+          new TIntEnumParam(RenderMode_FilterPreview, "Filter Preview"))
     , m_irisMode(new TIntEnumParam(Iris_InputImage, "Input Image"))
     , m_irisScale(0.2)
     , m_irisGearEdgeCount(10)
@@ -59,14 +60,17 @@ Iwa_GlareFx::Iwa_GlareFx()
     , m_noise_offset(TPointD(0, 0)) {
   // Version 1 : lights had been constantly summed in all wavelength
   // Version 2 : intensities are weighted proportional to 1/(rambda^2)
-  setFxVersion(2);
+  // Version 3 : * 1/2.2 gamma to intensity when non-linear rendering
+  //             Source image is separated in each RGB channels
+  //             Filter is normalized with sum of green channel values
+  setFxVersion(3);
 
   // Bind the common parameters
   addInputPort("Source", m_source);
   addInputPort("Iris", m_iris);
 
   bindParam(this, "renderMode", m_renderMode);
-  m_renderMode->addItem(RendeMode_Render, "Render");
+  m_renderMode->addItem(RenderMode_Render, "Render");
   m_renderMode->addItem(RenderMode_Iris, "Iris");
 
   bindParam(this, "irisMode", m_irisMode);
@@ -114,6 +118,8 @@ Iwa_GlareFx::Iwa_GlareFx()
   m_aberration->setValueRange(-2.0, 2.0);
   m_noise_factor->setValueRange(0.0, 1.0);
   m_noise_size->setValueRange(0.01, 3.0);
+
+  enableComputeInFloat(true);
 }
 
 //--------------------------------------------------------------
@@ -280,7 +286,7 @@ void Iwa_GlareFx::doCompute(TTile& tile, double frame,
 
   int renderMode = m_renderMode->getValue();
   // If the source is not connected & it is render mode, then do nothing.
-  if (!m_source.isConnected() && renderMode == RendeMode_Render) {
+  if (!m_source.isConnected() && renderMode == RenderMode_Render) {
     tile.getRaster()->clear();
     return;
   }
@@ -321,6 +327,8 @@ void Iwa_GlareFx::doCompute(TTile& tile, double frame,
   while ((tile.getRaster()->getSize().lx - dimIris) % 2 != 0)
     dimIris = kiss_fft_next_fast_size(dimIris + 1);
   double irisResizeFactor = double(dimIris) * 0.5 / size;
+
+  bool isLinear = tile.getRaster()->isLinear();
 
   kiss_fft_cpx* kissfft_comp_iris;
   // create the iris data for FFT (in the same size as the source tile)
@@ -370,13 +378,16 @@ void Iwa_GlareFx::doCompute(TTile& tile, double frame,
   tile.getRaster()->clear();
   TRaster32P ras32 = tile.getRaster();
   TRaster64P ras64 = tile.getRaster();
-  if (ras32)
-    ras32->fill(TPixel32::Transparent);
-  else if (ras64)
-    ras64->fill(TPixel64::Transparent);
+  TRasterFP rasF   = tile.getRaster();
+  // if (ras32)
+  //   ras32->fill(TPixel32::Transparent);
+  // else if (ras64)
+  //   ras64->fill(TPixel64::Transparent);
+  // else if (rasF)
+  //   rasF->fill(TPixelF::Transparent);
 
   // filter preview mode
-  if (renderMode == RendeMode_FilterPreview) {
+  if (renderMode == RenderMode_FilterPreview) {
     int2 margin = {(dimIris - tile.getRaster()->getSize().lx) / 2,
                    (dimIris - tile.getRaster()->getSize().ly) / 2};
 
@@ -386,7 +397,14 @@ void Iwa_GlareFx::doCompute(TTile& tile, double frame,
     else if (ras64)
       setFilterPreviewToResult<TRaster64P, TPixel64>(ras64, glare_pattern,
                                                      dimIris, margin);
+    else if (rasF)
+      setFilterPreviewToResult<TRasterFP, TPixelF>(rasF, glare_pattern, dimIris,
+                                                   margin);
 
+    if (getFxVersion() >= 3 && !isLinear) {
+      tile.getRaster()->setLinear(true);
+      TRop::tosRGB(tile.getRaster(), settings.m_colorSpaceGamma);
+    }
     return;
   }
 
@@ -438,25 +456,46 @@ void Iwa_GlareFx::doCompute(TTile& tile, double frame,
   kiss_fftnd_cfg plan_fwd  = kiss_fftnd_alloc(dims, ndims, false, 0, 0);
   kiss_fftnd_cfg plan_bkwd = kiss_fftnd_alloc(dims, ndims, true, 0, 0);
 
-  // store the source image to tmp
-  {
-    // obtain the source tile
-    TTile sourceTile;
-    m_source->allocateAndCompute(sourceTile, _rectOut.getP00(), dimOut,
-                                 tile.getRaster(), frame, settings);
+  // obtain the source tile
+  TTile sourceTile;
+  m_source->allocateAndCompute(sourceTile, _rectOut.getP00(), dimOut,
+                               tile.getRaster(), frame, settings);
 
+  if (getFxVersion() >= 3 && !isLinear)
+    TRop::toLinearRGB(sourceTile.getRaster(), settings.m_colorSpaceGamma);
+
+  // store the source image to tmp
+  if (getFxVersion() < 3) {
     if (ras32)
       setSourceTileToBuffer<TRaster32P, TPixel32>(sourceTile.getRaster(),
                                                   kissfft_comp_tmp);
     else if (ras64)
       setSourceTileToBuffer<TRaster64P, TPixel64>(sourceTile.getRaster(),
                                                   kissfft_comp_tmp);
+    else if (rasF)
+      setSourceTileToBuffer<TRasterFP, TPixelF>(sourceTile.getRaster(),
+                                                kissfft_comp_tmp);
+    // FFT the source
+    kiss_fftnd(plan_fwd, kissfft_comp_tmp, kissfft_comp_source);
   }
-  // FFT the source
-  kiss_fftnd(plan_fwd, kissfft_comp_tmp, kissfft_comp_source);
 
   // compute for each rgb channels
   for (int ch = 0; ch < 3; ch++) {
+    // store the source image to tmp for each channel
+    if (getFxVersion() >= 3) {
+      if (ras32)
+        setSourceTileToBuffer<TRaster32P, TPixel32>(sourceTile.getRaster(),
+                                                    kissfft_comp_tmp, ch);
+      else if (ras64)
+        setSourceTileToBuffer<TRaster64P, TPixel64>(sourceTile.getRaster(),
+                                                    kissfft_comp_tmp, ch);
+      else if (rasF)
+        setSourceTileToBuffer<TRasterFP, TPixelF>(sourceTile.getRaster(),
+                                                  kissfft_comp_tmp, ch);
+      // FFT the source
+      kiss_fftnd(plan_fwd, kissfft_comp_tmp, kissfft_comp_source);
+    }
+
     kissfft_comp_tmp_ras->clear();
     // store the glare pattern to tmp
     setGlarePatternToBuffer(glare_pattern, kissfft_comp_tmp, ch, dimIris,
@@ -480,6 +519,14 @@ void Iwa_GlareFx::doCompute(TTile& tile, double frame,
     else if (ras64)
       setChannelToResult<TRaster64P, TPixel64>(ras64, kissfft_comp_tmp, ch,
                                                dimOut);
+    else if (rasF)
+      setChannelToResult<TRasterFP, TPixelF>(rasF, kissfft_comp_tmp, ch,
+                                             dimOut);
+  }
+
+  if (getFxVersion() >= 3 && !isLinear) {
+    tile.getRaster()->setLinear(true);
+    TRop::tosRGB(tile.getRaster(), settings.m_colorSpaceGamma);
   }
 
   kiss_fft_free(plan_fwd);
@@ -517,18 +564,19 @@ void Iwa_GlareFx::powerSpectrum2GlarePattern(
   };
 
   double factor =
-      (m_renderMode->getValue() == RendeMode_FilterPreview) ? -5 : -11;
+      (m_renderMode->getValue() == RenderMode_FilterPreview) ? -5 : -11;
 
   double* glarePattern_p;
   TRasterGR8P glarePattern_ras(dimIris * sizeof(double), dimIris);
   glarePattern_p = (double*)glarePattern_ras->getRawData();
   glarePattern_ras->lock();
   double* g_p = glarePattern_p;
+  double intensityFactor =
+      (getFxVersion() < 3) ? std::exp(intensity + factor) : 1.0;
   for (int j = 0; j < dimIris; j++) {
     for (int i = 0; i < dimIris; i++, g_p++) {
       kiss_fft_cpx sp_p = spectrum[getCoord(i, j, dimIris, dimIris)];
-      (*g_p)            = sqrt(sp_p.r * sp_p.r + sp_p.i * sp_p.i) *
-               std::exp(intensity + factor);
+      (*g_p) = sqrt(sp_p.r * sp_p.r + sp_p.i * sp_p.i) * intensityFactor;
     }
   }
 
@@ -551,7 +599,7 @@ void Iwa_GlareFx::powerSpectrum2GlarePattern(
   // old version had summed each wavelength constantly.
   // it was not physically-collect but keep it in order to maintain backward
   // compatibility.
-  bool isOldVersion = getFxVersion() < 2;
+  bool isVersion1 = getFxVersion() < 2;
 
   // accumurate xyz values for each optical wavelength
   for (int ram = 0; ram < 34; ram++) {
@@ -559,7 +607,7 @@ void Iwa_GlareFx::powerSpectrum2GlarePattern(
     // double scale = 0.55 / rambda;
     double scale = std::pow(0.55 / rambda, aberration);
     double intensity_scale =
-        (isOldVersion) ? 1.0 : std::pow(0.55 / rambda, 2.0 * aberration);
+        (isVersion1) ? 1.0 : std::pow(0.55 / rambda, 2.0 * aberration);
     scale *= irisResizeFactor;
     for (int j = 0; j < dimIris; j++) {
       double j_scaled = (double(j) - irisRadius) * scale + irisRadius;
@@ -578,9 +626,9 @@ void Iwa_GlareFx::powerSpectrum2GlarePattern(
 
         double gl =
             lerpGlarePtn(i_scaled, j_scaled, glarePattern_p) * intensity_scale;
-        g_xyz_p->x += gl * cie_d65[ram] * xyz[ram * 3 + 0];
-        g_xyz_p->y += gl * cie_d65[ram] * xyz[ram * 3 + 1];
-        g_xyz_p->z += gl * cie_d65[ram] * xyz[ram * 3 + 2];
+        g_xyz_p->x += gl * (double)cie_d65[ram] * (double)xyz[ram * 3 + 0];
+        g_xyz_p->y += gl * (double)cie_d65[ram] * (double)xyz[ram * 3 + 1];
+        g_xyz_p->z += gl * (double)cie_d65[ram] * (double)xyz[ram * 3 + 2];
       }
     }
   }
@@ -589,13 +637,36 @@ void Iwa_GlareFx::powerSpectrum2GlarePattern(
   // convert to rgb
   double3* g_xyz_p = glare_xyz;
   double3* g_out_p = glare;
+  double max_g     = 0.;
+  double sum_g     = 0.;
   for (int i = 0; i < dimIris * dimIris; i++, g_xyz_p++, g_out_p++) {
-    (*g_out_p).x = 3.240479f * (*g_xyz_p).x - 1.537150f * (*g_xyz_p).y -
-                   0.498535f * (*g_xyz_p).z;
-    (*g_out_p).y = -0.969256f * (*g_xyz_p).x + 1.875992f * (*g_xyz_p).y +
-                   0.041556f * (*g_xyz_p).z;
-    (*g_out_p).z = 0.055648f * (*g_xyz_p).x - 0.204043f * (*g_xyz_p).y +
-                   1.057311f * (*g_xyz_p).z;
+    (*g_out_p).x = 3.240479 * (*g_xyz_p).x - 1.537150 * (*g_xyz_p).y -
+                   0.498535 * (*g_xyz_p).z;
+    (*g_out_p).y = -0.969256 * (*g_xyz_p).x + 1.875992 * (*g_xyz_p).y +
+                   0.041556 * (*g_xyz_p).z;
+    (*g_out_p).z = 0.055648 * (*g_xyz_p).x - 0.204043 * (*g_xyz_p).y +
+                   1.057311 * (*g_xyz_p).z;
+
+    // get the maximum and sum the green channel
+    if ((*g_out_p).y > max_g) max_g = (*g_out_p).y;
+    sum_g += (*g_out_p).y;
+  }
+
+  if (getFxVersion() >= 3) {
+    double intensityFactor = std::exp(intensity);
+    // normalize with the brightest green channel
+    if (m_renderMode->getValue() == RenderMode_FilterPreview)
+      intensityFactor /= max_g;
+    // normalize with the sum of the intensity
+    else
+      intensityFactor /= sum_g;
+
+    g_out_p = glare;
+    for (int i = 0; i < dimIris * dimIris; i++, g_out_p++) {
+      (*g_out_p).x *= intensityFactor;
+      (*g_out_p).y *= intensityFactor;
+      (*g_out_p).z *= intensityFactor;
+    }
   }
 
   glare_xyz_ras->unlock();
@@ -713,7 +784,8 @@ void Iwa_GlareFx::setFilterPreviewToResult(const RASTER ras, double3* glare,
     if (chan > 1.0) return 1.0;
     return chan;
   };
-  int j = margin.y;
+  bool doClamp = (ras->getPixelSize() != 16);
+  int j        = margin.y;
   for (int out_j = 0; out_j < ras->getLy(); j++, out_j++) {
     if (j < 0)
       continue;
@@ -727,13 +799,19 @@ void Iwa_GlareFx::setFilterPreviewToResult(const RASTER ras, double3* glare,
       else if (i >= dimIris)
         break;
       double3 gl_p = glare[j * dimIris + i];
-      pix->r       = (typename PIXEL::Channel)(clamp01(gl_p.x) *
-                                         double(PIXEL::maxChannelValue));
-      pix->g       = (typename PIXEL::Channel)(clamp01(gl_p.y) *
-                                         double(PIXEL::maxChannelValue));
-      pix->b       = (typename PIXEL::Channel)(clamp01(gl_p.z) *
-                                         double(PIXEL::maxChannelValue));
-      pix->m       = PIXEL::maxChannelValue;
+      if (doClamp) {
+        pix->r = (typename PIXEL::Channel)(clamp01(gl_p.x) *
+                                           double(PIXEL::maxChannelValue));
+        pix->g = (typename PIXEL::Channel)(clamp01(gl_p.y) *
+                                           double(PIXEL::maxChannelValue));
+        pix->b = (typename PIXEL::Channel)(clamp01(gl_p.z) *
+                                           double(PIXEL::maxChannelValue));
+      } else {  // floating point case
+        pix->r = (typename PIXEL::Channel)gl_p.x;
+        pix->g = (typename PIXEL::Channel)gl_p.y;
+        pix->b = (typename PIXEL::Channel)gl_p.z;
+      }
+      pix->m = PIXEL::maxChannelValue;
     }
   }
 }
@@ -755,6 +833,26 @@ void Iwa_GlareFx::setSourceTileToBuffer(const RASTER ras, kiss_fft_cpx* buf) {
   }
 }
 
+// put the source tile's brightness to fft buffer
+template <typename RASTER, typename PIXEL>
+void Iwa_GlareFx::setSourceTileToBuffer(const RASTER ras, kiss_fft_cpx* buf,
+                                        int channel) {
+  kiss_fft_cpx* buf_p = buf;
+  for (int j = 0; j < ras->getLy(); j++) {
+    PIXEL* pix = ras->pixels(j);
+    for (int i = 0; i < ras->getLx(); i++, pix++, buf_p++) {
+      if (channel == 0)
+        (*buf_p).r = float(pix->r) / float(PIXEL::maxChannelValue);
+      else if (channel == 1)
+        (*buf_p).r = float(pix->g) / float(PIXEL::maxChannelValue);
+      else {  // if (channel == 2)
+        (*buf_p).r = float(pix->b) / float(PIXEL::maxChannelValue);
+      }
+      (*buf_p).i = 0.f;
+    }
+  }
+}
+
 //------------------------------------------------
 
 void Iwa_GlareFx::setGlarePatternToBuffer(const double3* glare,
@@ -767,9 +865,9 @@ void Iwa_GlareFx::setGlarePatternToBuffer(const double3* glare,
     const double3* glare_p = &glare[(j - margin_y) * dimIris];
     kiss_fft_cpx* buf_p    = &buf[j * dimOut.lx + margin_x];
     for (int i = margin_x; i < margin_x + dimIris; i++, buf_p++, glare_p++) {
-      (*buf_p).r = (channel == 0)
-                       ? (*glare_p).x
-                       : (channel == 1) ? (*glare_p).y : (*glare_p).z;
+      (*buf_p).r = (channel == 0)   ? (*glare_p).x
+                   : (channel == 1) ? (*glare_p).y
+                                    : (*glare_p).z;
     }
   }
 }
@@ -801,6 +899,8 @@ void Iwa_GlareFx::setChannelToResult(const RASTER ras, kiss_fft_cpx* buf,
   int margin_x = (dimOut.lx - ras->getSize().lx) / 2;
   int margin_y = (dimOut.ly - ras->getSize().ly) / 2;
 
+  bool doClamp = (ras->getPixelSize() != 16);
+
   for (int j = 0; j < ras->getLy(); j++) {
     // kiss_fft_cpx* buf_p = &buf[(j + margin_y)*dimOut.lx + margin_x];
     PIXEL* pix = ras->pixels(j);
@@ -808,16 +908,27 @@ void Iwa_GlareFx::setChannelToResult(const RASTER ras, kiss_fft_cpx* buf,
       kiss_fft_cpx fft_val =
           buf[getCoord(i + margin_x, j + margin_y, dimOut.lx, dimOut.ly)];
       double val = fft_val.r / (dimOut.lx * dimOut.ly);
-      if (channel == 0)
-        pix->r = (typename PIXEL::Channel)(clamp01(val) *
-                                           double(PIXEL::maxChannelValue));
-      else if (channel == 1)
-        pix->g = (typename PIXEL::Channel)(clamp01(val) *
-                                           double(PIXEL::maxChannelValue));
-      else if (channel == 2) {
-        pix->b = (typename PIXEL::Channel)(clamp01(val) *
-                                           double(PIXEL::maxChannelValue));
-        pix->m = PIXEL::maxChannelValue;
+      if (doClamp) {
+        if (channel == 0)
+          pix->r = (typename PIXEL::Channel)(clamp01(val) *
+                                             double(PIXEL::maxChannelValue));
+        else if (channel == 1)
+          pix->g = (typename PIXEL::Channel)(clamp01(val) *
+                                             double(PIXEL::maxChannelValue));
+        else if (channel == 2) {
+          pix->b = (typename PIXEL::Channel)(clamp01(val) *
+                                             double(PIXEL::maxChannelValue));
+          pix->m = PIXEL::maxChannelValue;
+        }
+      } else {  // floating point case
+        if (channel == 0)
+          pix->r = (typename PIXEL::Channel)val;
+        else if (channel == 1)
+          pix->g = (typename PIXEL::Channel)val;
+        else if (channel == 2) {
+          pix->b = (typename PIXEL::Channel)val;
+          pix->m = PIXEL::maxChannelValue;
+        }
       }
     }
   }
@@ -903,6 +1014,8 @@ void Iwa_GlareFx::convertIris(kiss_fft_cpx* kissfft_comp_iris_before,
   }
 }
 
+//------------------------------------------------
+
 void Iwa_GlareFx::getParamUIs(TParamUIConcept*& concepts, int& length) {
   concepts = new TParamUIConcept[length = 2];
 
@@ -913,6 +1026,13 @@ void Iwa_GlareFx::getParamUIs(TParamUIConcept*& concepts, int& length) {
   concepts[1].m_type  = TParamUIConcept::POINT;
   concepts[1].m_label = "Noise Offset";
   concepts[1].m_params.push_back(m_noise_offset);
+}
+
+//------------------------------------------------
+
+bool Iwa_GlareFx::toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                                 bool tileIsLinear) const {
+  return settingsIsLinear;
 }
 
 FX_PLUGIN_IDENTIFIER(Iwa_GlareFx, "iwa_GlareFx")

--- a/toonz/sources/stdfx/iwa_glarefx.h
+++ b/toonz/sources/stdfx/iwa_glarefx.h
@@ -57,7 +57,7 @@ protected:
   TDoubleParamP m_noise_evolution;
   TPointParamP m_noise_offset;
 
-  enum { RendeMode_FilterPreview = 0, RendeMode_Render, RenderMode_Iris };
+  enum { RenderMode_FilterPreview = 0, RenderMode_Render, RenderMode_Iris };
 
   enum {
     Iris_InputImage = 0,
@@ -100,6 +100,8 @@ protected:
   // put the source tile's brightness to fft buffer
   template <typename RASTER, typename PIXEL>
   void setSourceTileToBuffer(const RASTER ras, kiss_fft_cpx *buf);
+  template <typename RASTER, typename PIXEL>
+  void setSourceTileToBuffer(const RASTER ras, kiss_fft_cpx *buf, int channel);
 
   void setGlarePatternToBuffer(const double3 *glare, kiss_fft_cpx *buf,
                                const int channel, const int dimIris,
@@ -124,6 +126,9 @@ public:
   bool canHandle(const TRenderSettings &info, double frame) override;
 
   void getParamUIs(TParamUIConcept *&concepts, int &length) override;
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_gradientwarpfx.cpp
+++ b/toonz/sources/stdfx/iwa_gradientwarpfx.cpp
@@ -4,6 +4,7 @@
 ------------------------------------*/
 
 #include "iwa_gradientwarpfx.h"
+#include "trop.h"
 
 /*------------------------------------------------------------
  ソース画像を０〜１に正規化してホストメモリに読み込む
@@ -31,6 +32,8 @@ void Iwa_GradientWarpFx::setSourceRaster(const RASTER srcRas, float4 *dstMem,
 template <typename RASTER, typename PIXEL>
 void Iwa_GradientWarpFx::setWarperRaster(const RASTER warperRas, float *dstMem,
                                          TDimensionI dim) {
+  auto clamp01 = [](float val) { return std::min(1.f, std::max(0.f, val)); };
+
   float *chann_p = dstMem;
   for (int j = 0; j < dim.ly; j++) {
     PIXEL *pix = warperRas->pixels(j);
@@ -39,7 +42,7 @@ void Iwa_GradientWarpFx::setWarperRaster(const RASTER warperRas, float *dstMem,
       float g = (float)pix->g / (float)PIXEL::maxChannelValue;
       float b = (float)pix->b / (float)PIXEL::maxChannelValue;
 
-      (*chann_p) = 0.298912f * r + 0.586611f * g + 0.114478f * b;
+      (*chann_p) = clamp01(0.298912f * r + 0.586611f * g + 0.114478f * b);
     }
   }
 }
@@ -77,6 +80,22 @@ void Iwa_GradientWarpFx::setOutputRaster(float4 *srcMem, const RASTER dstRas,
   }
 }
 
+template <>
+void Iwa_GradientWarpFx::setOutputRaster<TRasterFP, TPixelF>(
+    float4 *srcMem, const TRasterFP dstRas, TDimensionI dim, int2 margin) {
+  int out_j = 0;
+  for (int j = margin.y; j < dstRas->getLy() + margin.y; j++, out_j++) {
+    TPixelF *pix   = dstRas->pixels(out_j);
+    float4 *chan_p = srcMem;
+    chan_p += j * dim.lx + margin.x;
+    for (int i = 0; i < dstRas->getLx(); i++, pix++, chan_p++) {
+      pix->r = (*chan_p).x;
+      pix->g = (*chan_p).y;
+      pix->b = (*chan_p).z;
+      pix->m = (*chan_p).w;
+    }
+  }
+}
 //------------------------------------
 
 Iwa_GradientWarpFx::Iwa_GradientWarpFx()
@@ -97,6 +116,7 @@ Iwa_GradientWarpFx::Iwa_GradientWarpFx()
   m_sampling_size->setMeasureName("fxLength");
   m_sampling_size->setValueRange(0.1, 20.0);
 
+  enableComputeInFloat(true);
   // Version 1: sampling distance had been always 1 pixel.
   // Version 2: sampling distance can be specified with the parameter.
   // this must be called after binding the parameters (see onFxVersionSet())
@@ -146,7 +166,8 @@ void Iwa_GradientWarpFx::doCompute(TTile &tile, double frame,
   int margin = static_cast<int>(ceil((std::abs(hLength) < std::abs(vLength))
                                          ? std::abs(vLength)
                                          : std::abs(hLength)));
-  margin     = std::max(margin, static_cast<int>(std::ceil(sampling_size)) + 1);
+
+  margin = std::max(margin, static_cast<int>(std::ceil(sampling_size)) + 1);
 
   /*- 素材計算範囲を計算 -*/
   /*- 出力範囲 -*/
@@ -156,24 +177,30 @@ void Iwa_GradientWarpFx::doCompute(TTile &tile, double frame,
   TDimensionI enlargedDim((int)enlargedRect.getLx(), (int)enlargedRect.getLy());
 
   /*- ソース画像を正規化して格納 -*/
+  TTile sourceTile;
+  m_source->allocateAndCompute(sourceTile, enlargedRect.getP00(), enlargedDim,
+                               tile.getRaster(), frame, settings);
+
   float4 *source_host;
-  TRasterGR8P source_host_ras(enlargedDim.lx * sizeof(float4), enlargedDim.ly);
-  source_host_ras->lock();
-  source_host = (float4 *)source_host_ras->getRawData();
-  {
-    /*-
-     * タイルはこのフォーカス内だけ使用。正規化してsource_hostに取り込んだらもう使わない。
-     * -*/
-    TTile sourceTile;
-    m_source->allocateAndCompute(sourceTile, enlargedRect.getP00(), enlargedDim,
-                                 tile.getRaster(), frame, settings);
-    /*- タイルの画像を０〜１に正規化してホストメモリに読み込む -*/
-    TRaster32P ras32 = (TRaster32P)sourceTile.getRaster();
-    TRaster64P ras64 = (TRaster64P)sourceTile.getRaster();
-    if (ras32)
-      setSourceRaster<TRaster32P, TPixel32>(ras32, source_host, enlargedDim);
-    else if (ras64)
-      setSourceRaster<TRaster64P, TPixel64>(ras64, source_host, enlargedDim);
+  TRasterGR8P source_host_ras;
+  if (tile.getRaster()->getPixelSize() == 4 ||
+      tile.getRaster()->getPixelSize() == 8) {
+    source_host_ras =
+        TRasterGR8P(enlargedDim.lx * sizeof(float4), enlargedDim.ly);
+    source_host_ras->lock();
+    source_host = (float4 *)source_host_ras->getRawData();
+    {
+      /*- タイルの画像を０〜１に正規化してホストメモリに読み込む -*/
+      TRaster32P ras32 = (TRaster32P)sourceTile.getRaster();
+      TRaster64P ras64 = (TRaster64P)sourceTile.getRaster();
+      if (ras32)
+        setSourceRaster<TRaster32P, TPixel32>(ras32, source_host, enlargedDim);
+      else if (ras64)
+        setSourceRaster<TRaster64P, TPixel64>(ras64, source_host, enlargedDim);
+    }
+  } else if (tile.getRaster()->getPixelSize() == 16) {
+    source_host =
+        reinterpret_cast<float4 *>(sourceTile.getRaster()->getRawData());
   }
 
   /*- 参照画像を正規化して格納 -*/
@@ -188,13 +215,19 @@ void Iwa_GradientWarpFx::doCompute(TTile &tile, double frame,
     TTile warperTile;
     m_warper->allocateAndCompute(warperTile, enlargedRect.getP00(), enlargedDim,
                                  tile.getRaster(), frame, settings);
+    // nonlinearのはず
+    assert(!warperTile.getRaster()->isLinear());
+
     /*- タイルの画像の輝度値を０〜１に正規化してホストメモリに読み込む -*/
     TRaster32P ras32 = (TRaster32P)warperTile.getRaster();
     TRaster64P ras64 = (TRaster64P)warperTile.getRaster();
+    TRasterFP rasF   = (TRasterFP)warperTile.getRaster();
     if (ras32)
       setWarperRaster<TRaster32P, TPixel32>(ras32, warper_host, enlargedDim);
     else if (ras64)
       setWarperRaster<TRaster64P, TPixel64>(ras64, warper_host, enlargedDim);
+    else if (rasF)
+      setWarperRaster<TRasterFP, TPixelF>(rasF, warper_host, enlargedDim);
   }
 
   /*- 変位値をScale倍して増やす -*/
@@ -221,15 +254,19 @@ void Iwa_GradientWarpFx::doCompute(TTile &tile, double frame,
   tile.getRaster()->clear();
   TRaster32P outRas32 = (TRaster32P)tile.getRaster();
   TRaster64P outRas64 = (TRaster64P)tile.getRaster();
+  TRasterFP outRasF   = (TRasterFP)tile.getRaster();
   if (outRas32)
     setOutputRaster<TRaster32P, TPixel32>(source_host, outRas32, enlargedDim,
                                           yohaku);
   else if (outRas64)
     setOutputRaster<TRaster64P, TPixel64>(source_host, outRas64, enlargedDim,
                                           yohaku);
+  else if (outRasF)
+    setOutputRaster<TRasterFP, TPixelF>(source_host, outRasF, enlargedDim,
+                                        yohaku);
 
   /*- ソース画像のメモリ解放 -*/
-  source_host_ras->unlock();
+  if (source_host_ras) source_host_ras->unlock();
   /*- 参照画像のメモリ解放 -*/
   warper_host_ras->unlock();
   result_host_ras->unlock();

--- a/toonz/sources/stdfx/iwa_gradientwarpfx.h
+++ b/toonz/sources/stdfx/iwa_gradientwarpfx.h
@@ -15,7 +15,15 @@ struct float2 {
   float x, y;
 };
 struct float4 {
-  float x, y, z, w;
+#if defined(TNZ_MACHINE_CHANNEL_ORDER_BGRM)
+  float z, y, x, w;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_MBGR)
+  float w, x, y, x;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_RGBM)
+  float x, y, x, w;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_MRGB)
+  float w, x, y, z;
+#endif
 };
 struct int2 {
   int x, y;

--- a/toonz/sources/stdfx/iwa_lineargradientfx.cpp
+++ b/toonz/sources/stdfx/iwa_lineargradientfx.cpp
@@ -36,6 +36,8 @@ Iwa_LinearGradientFx::Iwa_LinearGradientFx()
 
   bindParam(this, "startColor", m_startColor);
   bindParam(this, "endColor", m_endColor);
+
+  enableComputeInFloat(true);
 }
 
 //------------------------------------------------------------
@@ -123,7 +125,8 @@ void doLinearGradientT(RASTER ras, TDimensionI dim, TPointD startPos,
 
 void Iwa_LinearGradientFx::doCompute(TTile &tile, double frame,
                                      const TRenderSettings &ri) {
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 
@@ -144,11 +147,13 @@ void Iwa_LinearGradientFx::doCompute(TTile &tile, double frame,
   std::vector<TSpectrum::ColorKey> colors = {
       TSpectrum::ColorKey(0, m_startColor->getValue(frame)),
       TSpectrum::ColorKey(1, m_endColor->getValue(frame))};
+
   TSpectrumParamP m_colors = TSpectrumParamP(colors);
 
   tile.getRaster()->clear();
   TRaster32P outRas32 = (TRaster32P)tile.getRaster();
   TRaster64P outRas64 = (TRaster64P)tile.getRaster();
+  TRasterFP outRasF   = (TRasterFP)tile.getRaster();
   if (outRas32)
     doLinearGradientT<TRaster32P, TPixel32>(
         outRas32, dimOut, startPos, endPos, m_colors->getValue(frame),
@@ -157,6 +162,11 @@ void Iwa_LinearGradientFx::doCompute(TTile &tile, double frame,
   else if (outRas64)
     doLinearGradientT<TRaster64P, TPixel64>(
         outRas64, dimOut, startPos, endPos, m_colors->getValue64(frame),
+        (GradientCurveType)m_curveType->getValue(), w_amplitude, w_freq,
+        w_phase, aff.inv());
+  else if (outRasF)
+    doLinearGradientT<TRasterFP, TPixelF>(
+        outRasF, dimOut, startPos, endPos, m_colors->getValueF(frame),
         (GradientCurveType)m_curveType->getValue(), w_amplitude, w_freq,
         w_phase, aff.inv());
 }

--- a/toonz/sources/stdfx/iwa_perspectivedistortfx.h
+++ b/toonz/sources/stdfx/iwa_perspectivedistortfx.h
@@ -14,7 +14,15 @@
 #include "tparamset.h"
 
 struct float4 {
-  float x, y, z, w;
+#if defined(TNZ_MACHINE_CHANNEL_ORDER_BGRM)
+  float z, y, x, w;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_MBGR)
+  float w, x, y, x;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_RGBM)
+  float x, y, x, w;
+#elif defined(TNZ_MACHINE_CHANNEL_ORDER_MRGB)
+  float w, x, y, z;
+#endif
 };
 
 class Iwa_PerspectiveDistortFx final : public TStandardRasterFx {
@@ -55,6 +63,9 @@ public:
                      const double offs);
 
   void getParamUIs(TParamUIConcept *&concepts, int &length) override;
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_pnperspectivefx.h
+++ b/toonz/sources/stdfx/iwa_pnperspectivefx.h
@@ -103,7 +103,7 @@ public:
   void doCompute(TTile &tile, double frame,
                  const TRenderSettings &rend_sets) override;
 
-  void doCompute_CPU(TTile &tile, double frame, const TRenderSettings &settings,
+  void doCompute_CPU(double frame, const TRenderSettings &settings,
                      double4 *out_host, TDimensionI &dimOut,
                      PN_Params &pnParams);
 

--- a/toonz/sources/stdfx/iwa_rainbowfx.h
+++ b/toonz/sources/stdfx/iwa_rainbowfx.h
@@ -23,8 +23,8 @@ class Iwa_RainbowFx final : public TStandardZeraryFx {
   TBoolParamP m_alpha_rendering;
 
   double getSizePixelAmount(const double val, const TAffine affine);
-  void buildRanbowColorMap(double3 *core, double3 *wide, double intensity,
-                           double inside, double secondary);
+  void buildRainbowColorMap(double3 *core, double3 *wide, double intensity,
+                            double inside, double secondary, bool doClamp);
   inline double3 angleToColor(double angle, double3 *core, double3 *wide);
 
   template <typename RASTER, typename PIXEL>
@@ -40,6 +40,9 @@ public:
                  const TRenderSettings &ri) override;
   void doCompute(TTile &tile, double frame, const TRenderSettings &ri) override;
   void getParamUIs(TParamUIConcept *&concepts, int &length) override;
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_spectrumfx.cpp
+++ b/toonz/sources/stdfx/iwa_spectrumfx.cpp
@@ -16,6 +16,7 @@ const float PI = 3.14159265f;
  Calculate soap bubble color map
 ------------------------------------*/
 void Iwa_SpectrumFx::calcBubbleMap(float3 *bubbleColor, double frame,
+                                   bool isLinear, double colorSpaceGamma,
                                    bool computeAngularAxis) {
   int i, j, k;  /* bubbleColor[j][k] = [256][3] */
   float d;      /* Thickness of the film (μm) */
@@ -36,9 +37,18 @@ void Iwa_SpectrumFx::calcBubbleMap(float3 *bubbleColor, double frame,
   float refractiveIndex = (float)m_refractiveIndex->getValue(frame);
   float thickMax        = (float)m_thickMax->getValue(frame);
   float thickMin        = (float)m_thickMin->getValue(frame);
-  float rgbGamma[3]     = {(float)m_RGamma->getValue(frame),
-                       (float)m_GGamma->getValue(frame),
-                       (float)m_BGamma->getValue(frame)};
+
+  // Currently isLinear should be always false
+  assert(!isLinear);
+  float gammaAdjust = (getFxVersion() == 1 && isLinear) ? (float)colorSpaceGamma
+                      : (getFxVersion() >= 2 && !isLinear)
+                          ? 1.f / (float)colorSpaceGamma
+                          : 1.f;
+
+  float rgbGamma[3] = {(float)m_RGamma->getValue(frame) * gammaAdjust,
+                       (float)m_GGamma->getValue(frame) * gammaAdjust,
+                       (float)m_BGamma->getValue(frame) * gammaAdjust};
+
   float lensFactor = (float)m_lensFactor->getValue(frame);
   float shift      = (float)m_spectrumShift->getValue(frame);
   float fadeWidth  = (float)m_loopSpectrumFadeWidth->getValue(frame) / 2.0f;
@@ -182,7 +192,8 @@ void Iwa_SpectrumFx::calcBubbleMap(float3 *bubbleColor, double frame,
           /* gamma adjustment */
           tmp_rgb[fadeId][k] = powf((tmp_rgb[fadeId][k] / 255.0f), rgbGamma[k]);
 
-          if (tmp_rgb[fadeId][k] >= 1.0f) tmp_rgb[fadeId][k] = 1.0f;
+          // clamp will be done when storing the result raster
+          // if (tmp_rgb[fadeId][k] >= 1.0f) tmp_rgb[fadeId][k] = 1.0f;
         }
       }
       bubble_p->x = tmp_rgb[0][0] * tmp_ratio[0] + tmp_rgb[1][0] * tmp_ratio[1];
@@ -208,6 +219,11 @@ Iwa_SpectrumFx::Iwa_SpectrumFx()
     , m_lightIntensity(1.0)
     , m_loopSpectrumFadeWidth(0.0)
     , m_spectrumShift(0.0) {
+  // Fx Version 1: *2.2 Gamma when linear rendering (it duplicately applies
+  // gamma and is not correct) Fx Version 2: *1/2.2 Gamma when non-linear
+  // rendering
+  setFxVersion(2);
+
   addInputPort("Source", m_input);
   addInputPort("Light", m_light);
   bindParam(this, "intensity", m_intensity);
@@ -227,14 +243,16 @@ Iwa_SpectrumFx::Iwa_SpectrumFx()
   m_refractiveIndex->setValueRange(1.0, 3.0);
   m_thickMax->setValueRange(-1.5, 2.0);
   m_thickMin->setValueRange(-1.5, 2.0);
-  m_RGamma->setValueRange(0.001, 1.0);
-  m_GGamma->setValueRange(0.001, 1.0);
-  m_BGamma->setValueRange(0.001, 1.0);
+  m_RGamma->setValueRange(0.001, 5.0);
+  m_GGamma->setValueRange(0.001, 5.0);
+  m_BGamma->setValueRange(0.001, 5.0);
   m_lensFactor->setValueRange(0.01, 10.0);
   m_lightThres->setValueRange(-5.0, 1.0);
   m_lightIntensity->setValueRange(0.0, 1.0);
   m_loopSpectrumFadeWidth->setValueRange(0.0, 1.0);
   m_spectrumShift->setValueRange(-10.0, 10.0);
+
+  enableComputeInFloat(true);
 }
 
 //------------------------------------
@@ -253,7 +271,8 @@ void Iwa_SpectrumFx::doCompute(TTile &tile, double frame,
   bubbleColor = (float3 *)bubbleColor_ras->getRawData();
 
   /*- シャボン色マップの生成 -*/
-  calcBubbleMap(bubbleColor, frame);
+  calcBubbleMap(bubbleColor, frame, tile.getRaster()->isLinear(),
+                settings.m_colorSpaceGamma);
 
   /*- いったん素材をTileに収める -*/
   m_input->compute(tile, frame, settings);
@@ -273,6 +292,7 @@ void Iwa_SpectrumFx::doCompute(TTile &tile, double frame,
 
   TRaster32P ras32 = (TRaster32P)tile.getRaster();
   TRaster64P ras64 = (TRaster64P)tile.getRaster();
+  TRasterFP rasF   = (TRasterFP)tile.getRaster();
   {
     if (ras32) {
       if (lightRas)
@@ -290,11 +310,19 @@ void Iwa_SpectrumFx::doCompute(TTile &tile, double frame,
             (float)m_lightIntensity->getValue(frame));
       else
         convertRaster<TRaster64P, TPixel64>(ras64, dim, bubbleColor);
+    } else if (rasF) {
+      if (lightRas)
+        convertRasterWithLight<TRasterFP, TPixelF>(
+            rasF, dim, bubbleColor, (TRasterFP)lightRas,
+            (float)m_lightThres->getValue(frame),
+            (float)m_lightIntensity->getValue(frame));
+      else
+        convertRaster<TRasterFP, TPixelF>(rasF, dim, bubbleColor);
     }
   }
 
-  //メモリ解放
-  // brightness_ras->unlock();
+  // メモリ解放
+  //  brightness_ras->unlock();
   bubbleColor_ras->unlock();
   if (lightRas) lightRas->unlock();
 }
@@ -306,6 +334,9 @@ void Iwa_SpectrumFx::convertRaster(const RASTER ras, TDimensionI dim,
   float rr, gg, bb, aa;
   float spec_r, spec_g, spec_b;
   float brightness;
+
+  bool doClamp = (ras->getPixelSize() != 16);
+
   for (int j = 0; j < dim.ly; j++) {
     PIXEL *pix = ras->pixels(j);
     for (int i = 0; i < dim.lx; i++) {
@@ -344,20 +375,26 @@ void Iwa_SpectrumFx::convertRaster(const RASTER ras, TDimensionI dim,
         spec_b *= aa;
       }
       /*- 元のピクセルに書き戻す -*/
-      float val;
-      /*- チャンネル範囲にクランプ -*/
-      val    = spec_r * (float)PIXEL::maxChannelValue + 0.5f;
-      pix->r = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
-                                             ? (float)PIXEL::maxChannelValue
-                                             : val);
-      val    = spec_g * (float)PIXEL::maxChannelValue + 0.5f;
-      pix->g = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
-                                             ? (float)PIXEL::maxChannelValue
-                                             : val);
-      val    = spec_b * (float)PIXEL::maxChannelValue + 0.5f;
-      pix->b = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
-                                             ? (float)PIXEL::maxChannelValue
-                                             : val);
+      if (doClamp) {
+        float val;
+        /*- チャンネル範囲にクランプ -*/
+        val    = spec_r * (float)PIXEL::maxChannelValue + 0.5f;
+        pix->r = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
+                                               ? (float)PIXEL::maxChannelValue
+                                               : val);
+        val    = spec_g * (float)PIXEL::maxChannelValue + 0.5f;
+        pix->g = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
+                                               ? (float)PIXEL::maxChannelValue
+                                               : val);
+        val    = spec_b * (float)PIXEL::maxChannelValue + 0.5f;
+        pix->b = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
+                                               ? (float)PIXEL::maxChannelValue
+                                               : val);
+      } else {  // floating point case
+        pix->r = spec_r;
+        pix->g = spec_g;
+        pix->b = spec_b;
+      }
 
       pix++;
     }
@@ -374,6 +411,9 @@ void Iwa_SpectrumFx::convertRasterWithLight(const RASTER ras, TDimensionI dim,
   float rr, gg, bb, aa;
   float spec_r, spec_g, spec_b;
   float brightness;
+
+  bool doClamp = (ras->getPixelSize() != 16);
+
   for (int j = 0; j < dim.ly; j++) {
     PIXEL *light_pix = lightRas->pixels(j);
     PIXEL *pix       = ras->pixels(j);
@@ -435,21 +475,26 @@ void Iwa_SpectrumFx::convertRasterWithLight(const RASTER ras, TDimensionI dim,
       spec_b *= aa;
 
       /*- 元のピクセルに書き戻す -*/
-      float val;
-      /*- チャンネル範囲にクランプ -*/
-      val    = spec_r * (float)PIXEL::maxChannelValue + 0.5f;
-      pix->r = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
-                                             ? (float)PIXEL::maxChannelValue
-                                             : val);
-      val    = spec_g * (float)PIXEL::maxChannelValue + 0.5f;
-      pix->g = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
-                                             ? (float)PIXEL::maxChannelValue
-                                             : val);
-      val    = spec_b * (float)PIXEL::maxChannelValue + 0.5f;
-      pix->b = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
-                                             ? (float)PIXEL::maxChannelValue
-                                             : val);
-
+      if (doClamp) {
+        float val;
+        /*- チャンネル範囲にクランプ -*/
+        val    = spec_r * (float)PIXEL::maxChannelValue + 0.5f;
+        pix->r = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
+                                               ? (float)PIXEL::maxChannelValue
+                                               : val);
+        val    = spec_g * (float)PIXEL::maxChannelValue + 0.5f;
+        pix->g = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
+                                               ? (float)PIXEL::maxChannelValue
+                                               : val);
+        val    = spec_b * (float)PIXEL::maxChannelValue + 0.5f;
+        pix->b = (typename PIXEL::Channel)((val > (float)PIXEL::maxChannelValue)
+                                               ? (float)PIXEL::maxChannelValue
+                                               : val);
+      } else {  // floating point case
+        pix->r = spec_r;
+        pix->g = spec_g;
+        pix->b = spec_b;
+      }
       pix->m = light_pix->m;
 
       pix++;

--- a/toonz/sources/stdfx/iwa_spectrumfx.h
+++ b/toonz/sources/stdfx/iwa_spectrumfx.h
@@ -43,8 +43,8 @@ protected:
   TDoubleParamP m_lightIntensity;
 
   /*- シャボン色マップの生成 -*/
-  void calcBubbleMap(float3 *bubbleColor, double frame,
-                     bool computeAngularAxis = false);
+  void calcBubbleMap(float3 *bubbleColor, double frame, bool isLinear,
+                     double colorSpaceGamma, bool computeAngularAxis = false);
 
   template <typename RASTER, typename PIXEL>
   void convertRaster(const RASTER ras, TDimensionI dim, float3 *bubbleColor);

--- a/toonz/sources/stdfx/iwa_spingradientfx.cpp
+++ b/toonz/sources/stdfx/iwa_spingradientfx.cpp
@@ -38,6 +38,8 @@ Iwa_SpinGradientFx::Iwa_SpinGradientFx()
 
   bindParam(this, "startColor", m_startColor);
   bindParam(this, "endColor", m_endColor);
+
+  enableComputeInFloat(true);
 }
 
 //------------------------------------------------------------
@@ -109,7 +111,8 @@ void doSpinGradientT(RASTER ras, TDimensionI dim, TPointD centerPos,
 
 void Iwa_SpinGradientFx::doCompute(TTile &tile, double frame,
                                    const TRenderSettings &ri) {
-  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster())) {
+  if (!((TRaster32P)tile.getRaster()) && !((TRaster64P)tile.getRaster()) &&
+      !((TRasterFP)tile.getRaster())) {
     throw TRopException("unsupported input pixel type");
   }
 
@@ -142,6 +145,7 @@ void Iwa_SpinGradientFx::doCompute(TTile &tile, double frame,
   tile.getRaster()->clear();
   TRaster32P outRas32 = (TRaster32P)tile.getRaster();
   TRaster64P outRas64 = (TRaster64P)tile.getRaster();
+  TRasterFP outRasF   = (TRasterFP)tile.getRaster();
   if (outRas32)
     doSpinGradientT<TRaster32P, TPixel32>(
         outRas32, dimOut, centerPos, startAngle, endAngle,
@@ -151,6 +155,10 @@ void Iwa_SpinGradientFx::doCompute(TTile &tile, double frame,
         outRas64, dimOut, centerPos, startAngle, endAngle,
         m_colors->getValue64(frame),
         (GradientCurveType)m_curveType->getValue());
+  else if (outRasF)
+    doSpinGradientT<TRasterFP, TPixelF>(
+        outRasF, dimOut, centerPos, startAngle, endAngle,
+        m_colors->getValueF(frame), (GradientCurveType)m_curveType->getValue());
 }
 
 //------------------------------------------------------------

--- a/toonz/sources/stdfx/iwa_tilefx.cpp
+++ b/toonz/sources/stdfx/iwa_tilefx.cpp
@@ -48,6 +48,11 @@ public:
   bool checkIfThisTileShouldBeComptedOrNot(int horizIndex, int vertIndex);
   bool isInRange(int quantityMode, int index);
 
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override {
+    return tileIsLinear;
+  }
+
 private:
   void makeTile(const TTile &inputTile, const TTile &tile);
 };
@@ -97,6 +102,8 @@ Iwa_TileFx::Iwa_TileFx()
 
   bindParam(this, "vMargin", m_vmargin);
   m_vmargin->setMeasureName("fxLength");
+
+  enableComputeInFloat(true);
 }
 
 //------------------------------------------------------------------------------

--- a/toonz/sources/stdfx/kaleido.cpp
+++ b/toonz/sources/stdfx/kaleido.cpp
@@ -84,6 +84,7 @@ public:
     addInputPort("Source", m_input);
 
     m_count->setValueRange(1, 100);
+    enableComputeInFloat(true);
   }
 
   ~KaleidoFx(){};
@@ -99,6 +100,11 @@ public:
 
   bool canHandle(const TRenderSettings &info, double frame) override {
     return isAlmostIsotropic(info.m_affine);
+  }
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override {
+    return tileIsLinear;
   }
 
 private:

--- a/toonz/sources/stdfx/nothingfx.cpp
+++ b/toonz/sources/stdfx/nothingfx.cpp
@@ -14,6 +14,7 @@ class NothingFx final : public TStandardRasterFx {
 public:
   NothingFx() {
     addInputPort("Source", m_input);
+    enableComputeInFloat(true);
   }
 
   ~NothingFx(){};
@@ -39,7 +40,12 @@ public:
                            const TRenderSettings &info) override;
 
   bool canHandle(const TRenderSettings &info, double frame) override {
-	  return true;
+    return true;
+  }
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override {
+    return tileIsLinear;
   }
 };
 
@@ -48,8 +54,8 @@ FX_PLUGIN_IDENTIFIER(NothingFx, "nothingFx")
 //-------------------------------------------------------------------
 
 void NothingFx::transform(double frame, int port, const TRectD &rectOnOutput,
-                       const TRenderSettings &infoOnOutput, TRectD &rectOnInput,
-                       TRenderSettings &infoOnInput) {
+                          const TRenderSettings &infoOnOutput,
+                          TRectD &rectOnInput, TRenderSettings &infoOnInput) {
   infoOnInput = infoOnOutput;
   rectOnInput = rectOnOutput;
   return;
@@ -58,14 +64,14 @@ void NothingFx::transform(double frame, int port, const TRectD &rectOnOutput,
 //-------------------------------------------------------------------
 
 int NothingFx::getMemoryRequirement(const TRectD &rect, double frame,
-                                 const TRenderSettings &info) {
-	return 0;
+                                    const TRenderSettings &info) {
+  return 0;
 }
 
 //-------------------------------------------------------------------
 
 void NothingFx::doCompute(TTile &tile, double frame,
-                       const TRenderSettings &renderSettings) {
+                          const TRenderSettings &renderSettings) {
   if (!m_input.isConnected()) return;
   m_input->compute(tile, frame, renderSettings);
 }

--- a/toonz/sources/stdfx/particles.h
+++ b/toonz/sources/stdfx/particles.h
@@ -93,7 +93,7 @@ struct particles_values {
   bool pick_color_for_every_frame_val;
   bool perspective_distribution_val;
   bool motion_blur_val;
-  double motion_blur_gamma_val;
+  double motion_blur_gamma_adjust_val;
 };
 
 //------------------------------------------------------------------------------

--- a/toonz/sources/stdfx/particlesengine.cpp
+++ b/toonz/sources/stdfx/particlesengine.cpp
@@ -3,11 +3,11 @@
 #include "trop.h"
 #include "tfxparam.h"
 #include "tofflinegl.h"
-//#include "tstroke.h"
-//#include "drawutil.h"
+// #include "tstroke.h"
+// #include "drawutil.h"
 #include "tstopwatch.h"
-//#include "tpalette.h"
-//#include "tvectorrenderdata.h"
+// #include "tpalette.h"
+// #include "tvectorrenderdata.h"
 #include "tsystem.h"
 #include "timagecache.h"
 #include "tconvert.h"
@@ -139,8 +139,8 @@ void Particles_Engine::fill_value_struct(struct particles_values &myvalues,
   myvalues.perspective_distribution_val =
       m_parent->perspective_distribution_val->getValue();
   myvalues.motion_blur_val = m_parent->motion_blur_val->getValue();
-  myvalues.motion_blur_gamma_val =
-      m_parent->motion_blur_gamma_val->getValue(frame);
+  myvalues.motion_blur_gamma_adjust_val =
+      m_parent->motion_blur_gamma_adjust_val->getValue(frame);
 }
 
 /*-----------------------------------------------------------------*/
@@ -511,8 +511,9 @@ void Particles_Engine::render_particles(
     // Perform the roll
     /*- RenderSettingsを複製して現在のフレームの計算用にする -*/
     TRenderSettings riAux(ri);
-    riAux.m_affine = TAffine();
-    riAux.m_bpp    = 32;
+    riAux.m_affine           = TAffine();
+    riAux.m_bpp              = 32;
+    riAux.m_linearColorSpace = false;
     // control image using its gradient is computed in 64bpp
     TRenderSettings riAux64(riAux);
     riAux64.m_bpp = 64;
@@ -772,10 +773,11 @@ void Particles_Engine::do_render(
   }
 
   // Now, these are the particle rendering specifications
-  bbox            = bbox.enlarge(3);
-  standardRefBBox = bbox;
-  riNew.m_affine  = TScale(partScale);
-  bbox            = riNew.m_affine * bbox;
+  bbox                     = bbox.enlarge(3);
+  standardRefBBox          = bbox;
+  riNew.m_affine           = TScale(partScale);
+  bbox                     = riNew.m_affine * bbox;
+  riNew.m_linearColorSpace = false;
   /*- 縮小済みのParticleのサイズ -*/
   partResolution = TDimensionD(tceil(bbox.getLx()), tceil(bbox.getLy()));
 
@@ -864,7 +866,7 @@ void Particles_Engine::do_render(
   if (values.motion_blur_val) {
     if (do_render_motion_blur(part, tile, tileRas, rfinalpart, M, bbox,
                               values.trailopacity_val,
-                              values.motion_blur_gamma_val, ri))
+                              values.motion_blur_gamma_adjust_val, ri))
       return;
   }
 
@@ -890,12 +892,14 @@ void Particles_Engine::do_render(
 bool Particles_Engine::do_render_motion_blur(
     Particle *part, TTile *tile, TRasterP tileRas, TRaster32P rfinalpart,
     TAffine &M, const TRectD &bbox, const DoublePair &trailOpacity,
-    const double gamma, const TRenderSettings &ri) {
+    const double gamma_adjust, const TRenderSettings &ri) {
   QList<TPointD> points;
   QList<double> lengths;
 
   // do not render new-born particles as it has no trace
   if (part->genlifetime - part->lifetime == 0) return true;
+
+  double gamma = gamma_adjust + ri.m_colorSpaceGamma;
 
   TRectD partBBoxD =
       M * TTranslation(bbox.getP00()) * convert(rfinalpart->getBounds());

--- a/toonz/sources/stdfx/particlesengine.h
+++ b/toonz/sources/stdfx/particlesengine.h
@@ -57,7 +57,8 @@ public:
   bool do_render_motion_blur(Particle *part, TTile *tile, TRasterP tileRas,
                              TRaster32P rfinalpart, TAffine &M,
                              const TRectD &bbox, const DoublePair &trailOpacity,
-                             const double gamma, const TRenderSettings &ri);
+                             const double gamma_adjust,
+                             const TRenderSettings &ri);
 
   bool port_is_used(int i, struct particles_values &values);
   bool port_is_used_for_value(int i, struct particles_values &values);

--- a/toonz/sources/stdfx/particlesfx.cpp
+++ b/toonz/sources/stdfx/particlesfx.cpp
@@ -100,7 +100,7 @@ ParticlesFx::ParticlesFx()
     , pick_color_for_every_frame_val(false)
     , perspective_distribution_val(false)
     , motion_blur_val(false)
-    , motion_blur_gamma_val(2.2) {
+    , motion_blur_gamma_adjust_val(0.) {
   addInputPort("Texture1", new TRasterFxPort, 0);
   addInputPort("Control1", new TRasterFxPort, 1);
 
@@ -267,8 +267,8 @@ ParticlesFx::ParticlesFx()
   bindParam(this, "pick_color_for_every_frame", pick_color_for_every_frame_val);
   bindParam(this, "perspective_distribution", perspective_distribution_val);
   bindParam(this, "motion_blur", motion_blur_val);
-  bindParam(this, "motion_blur_gamma", motion_blur_gamma_val);
-  motion_blur_gamma_val->setValueRange(1.0, 5.0);
+  bindParam(this, "motion_blur_gamma_adjust", motion_blur_gamma_adjust_val);
+  motion_blur_gamma_adjust_val->setValueRange(-5., 5.);
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/stdfx/particlesfx.h
+++ b/toonz/sources/stdfx/particlesfx.h
@@ -91,7 +91,7 @@ public:
   TBoolParamP pick_color_for_every_frame_val;
   TBoolParamP perspective_distribution_val;
   TBoolParamP motion_blur_val;
-  TDoubleParamP motion_blur_gamma_val;
+  TDoubleParamP motion_blur_gamma_adjust_val;
 
 public:
   enum { UNIT_SMALL_INCH, UNIT_INCH };

--- a/toonz/sources/stdfx/premultiplyfx.cpp
+++ b/toonz/sources/stdfx/premultiplyfx.cpp
@@ -1,7 +1,7 @@
 
 
 #include "stdfx.h"
-//#include "tfxparam.h"
+// #include "tfxparam.h"
 #include "trop.h"
 //===================================================================
 
@@ -10,7 +10,10 @@ class PremultiplyFx final : public TStandardRasterFx {
   TRasterFxPort m_input;
 
 public:
-  PremultiplyFx() { addInputPort("Source", m_input); }
+  PremultiplyFx() {
+    addInputPort("Source", m_input);
+    enableComputeInFloat(true);
+  }
   ~PremultiplyFx(){};
 
   bool doGetBBox(double frame, TRectD &bBox,

--- a/toonz/sources/stdfx/raylitfx.cpp
+++ b/toonz/sources/stdfx/raylitfx.cpp
@@ -44,6 +44,8 @@ public:
 
     addInputPort("Source", m_input);
     m_radius->setValueRange(0.0, std::numeric_limits<double>::max());
+
+    enableComputeInFloat(true);
   }
 
   ~BaseRaylitFx() {}
@@ -174,7 +176,10 @@ void RaylitFx::doCompute(TTile &tileOut, double frame,
     params.m_lightOriginSrc.y = params.m_lightOriginDst.y = p.y;
     params.m_lightOriginSrc.z = params.m_lightOriginDst.z =
         (int)m_z->getValue(frame);
-    params.m_color        = m_color->getValue(frame);
+    // currently tile should be nonlinear
+    assert(!tileOut.getRaster()->isLinear());
+    params.m_color = m_color->getValue(frame, tileOut.getRaster()->isLinear(),
+                                       ri.m_colorSpaceGamma);
     params.m_intensity    = m_intensity->getValue(frame);
     params.m_decay        = m_decay->getValue(frame);
     params.m_smoothness   = m_smoothness->getValue(frame);

--- a/toonz/sources/stdfx/ripplefx.cpp
+++ b/toonz/sources/stdfx/ripplefx.cpp
@@ -60,6 +60,8 @@ public:
     m_cycle->setValueRange(0, (std::numeric_limits<double>::max)());
     m_count->setValueRange(0, (std::numeric_limits<double>::max)());
     m_angle->setMeasureName("angle");
+
+    enableComputeInFloat(true);
   }
   virtual ~RippleFx() {}
 

--- a/toonz/sources/stdfx/stdfx.cpp
+++ b/toonz/sources/stdfx/stdfx.cpp
@@ -34,6 +34,7 @@ public:
     bindParam(this, "value", m_value);
 
     addInputPort("Source", m_input);
+    enableComputeInFloat(true);
   };
 
   ~FadeFx(){};
@@ -221,6 +222,7 @@ public:
     m_count->setValueRange(0, (std::numeric_limits<double>::max)());
     m_period->setMeasureName("fxLength");
     m_wave_amplitude->setMeasureName("fxLength");
+    enableComputeInFloat(true);
   }
   ~MultiLinearGradientFx(){};
 
@@ -288,6 +290,7 @@ public:
     m_wave_amplitude->setValueRange(0, std::numeric_limits<double>::max());
     m_period->setMeasureName("fxLength");
     m_wave_amplitude->setMeasureName("fxLength");
+    enableComputeInFloat(true);
   }
   ~LinearGradientFx(){};
 
@@ -358,7 +361,8 @@ void doComputeT(TRasterPT<T> ras, TPointD posTrasf,
 
 void LinearGradientFx::doCompute(TTile &tile, double frame,
                                  const TRenderSettings &ri) {
-  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster());
+  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster() ||
+         (TRasterFP)tile.getRaster());
 
   double period      = m_period->getValue(frame) / ri.m_shrinkX;
   double count       = 1.0;
@@ -398,7 +402,8 @@ throw TException("MultiLinearGradientFx: unsupported Pixel Type");
 
 void MultiLinearGradientFx::doCompute(TTile &tile, double frame,
                                       const TRenderSettings &ri) {
-  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster());
+  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster() ||
+         (TRasterFP)tile.getRaster());
 
   double period      = m_period->getValue(frame) / ri.m_shrinkX;
   double count       = m_count->getValue(frame);
@@ -464,6 +469,8 @@ public:
     bindParam(this, "curveType", m_curveType);
     m_period->setValueRange(0.0, std::numeric_limits<double>::max());
     m_innerperiod->setValueRange(0.0, std::numeric_limits<double>::max());
+
+    enableComputeInFloat(true);
   }
   ~RadialGradientFx(){};
 
@@ -532,6 +539,8 @@ public:
     m_period->setValueRange(0, (std::numeric_limits<double>::max)());
     m_cycle->setValueRange(0, (std::numeric_limits<double>::max)());
     m_count->setValueRange(0, (std::numeric_limits<double>::max)());
+
+    enableComputeInFloat(true);
   }
   ~MultiRadialGradientFx(){};
 
@@ -561,7 +570,8 @@ public:
 
 void MultiRadialGradientFx::doCompute(TTile &tile, double frame,
                                       const TRenderSettings &ri) {
-  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster());
+  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster() ||
+         (TRasterFP)tile.getRaster());
   double period = m_period->getValue(frame) / ri.m_shrinkX;
   double count  = m_count->getValue(frame);
   double cycle  = m_cycle->getValue(frame) / ri.m_shrinkX;
@@ -576,7 +586,8 @@ void MultiRadialGradientFx::doCompute(TTile &tile, double frame,
 
 void RadialGradientFx::doCompute(TTile &tile, double frame,
                                  const TRenderSettings &ri) {
-  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster());
+  assert((TRaster32P)tile.getRaster() || (TRaster64P)tile.getRaster() ||
+         (TRasterFP)tile.getRaster());
   double period      = m_period->getValue(frame) / ri.m_shrinkX;
   double innerperiod = m_innerperiod->getValue(frame) / ri.m_shrinkX;
   double count       = 1.0;

--- a/toonz/sources/stdfx/tilefx.cpp
+++ b/toonz/sources/stdfx/tilefx.cpp
@@ -34,6 +34,11 @@ public:
                  const TRenderSettings &infoOnOutput, TRectD &rectOnInput,
                  TRenderSettings &infoOnInput) override;
 
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override {
+    return tileIsLinear;
+  }
+
 private:
   void makeTile(const TTile &inputTile, const TTile &tile) const;
 };
@@ -53,6 +58,8 @@ TileFx::TileFx()
   bindParam(this, "margin", m_margin);
   m_mode->addItem(eTileHorizontally, "Tile Horizontally");
   m_mode->addItem(eTileVertically, "Tile Vertically");
+
+  enableComputeInFloat(true);
 }
 
 //------------------------------------------------------------------------------

--- a/toonz/sources/stdfx/warp.cpp
+++ b/toonz/sources/stdfx/warp.cpp
@@ -22,7 +22,13 @@ template <>
 inline double convert<TPixel64>(const TPixel64 &pixel) {
   return TPixelGR16::from(pixel).value;
 }
+
+template <>
+inline double convert<TPixelF>(const TPixelF &pixel) {
+  // clamp between 0 and 1
+  return std::min(1.f, std::max(0.f, TPixelGRF::from(pixel).value));
 }
+}  // namespace
 
 /*-----------------------------------------------------------------*/
 
@@ -297,6 +303,9 @@ void warp(TRasterP &tileRas, const TRasterP &rasIn, TRasterP &warper,
   TRaster64P rasIn64   = rasIn;
   TRaster64P tileRas64 = tileRas;
   TRaster64P warper64  = warper;
+  TRasterFP rasInF     = rasIn;
+  TRasterFP tileRasF   = tileRas;
+  TRasterFP warperF    = warper;
 
   if (rasIn32 && tileRas32 && warper32) {
     Warper<TPixel32> warper(rasInPos, warperPos, rasIn32, warper32, tileRas32,
@@ -306,6 +315,11 @@ void warp(TRasterP &tileRas, const TRasterP &rasIn, TRasterP &warper,
   } else if (rasIn64 && tileRas64 && warper64) {
     Warper<TPixel64> warper(rasInPos, warperPos, rasIn64, warper64, tileRas64,
                             params);
+    warper.createLattice();
+    warper.shepardWarp();
+  } else if (rasInF && tileRasF && warperF) {
+    Warper<TPixelF> warper(rasInPos, warperPos, rasInF, warperF, tileRasF,
+                           params);
     warper.createLattice();
     warper.shepardWarp();
   } else

--- a/toonz/sources/stdfx/warpfx.cpp
+++ b/toonz/sources/stdfx/warpfx.cpp
@@ -5,7 +5,7 @@
 #include "trop.h"
 #include "warp.h"
 #include "trasterfx.h"
-//#include "timage_io.h"
+// #include "timage_io.h"
 
 //-------------------------------------------------------------------
 
@@ -28,6 +28,8 @@ public:
 
     m_intensity->setValueRange(-1000, 1000);
     m_gridStep->setValueRange(2, 20);
+
+    enableComputeInFloat(true);
   }
   virtual ~WarpFx() {}
 

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -22,7 +22,7 @@
 #include "trenderer.h"
 
 // Diagnostics
-//#define DIAGNOSTICS
+// #define DIAGNOSTICS
 #ifdef DIAGNOSTICS
 #include "diagnostics.h"
 
@@ -218,7 +218,7 @@ class TrFx final : public TBaseRasterFx {
   TRasterFx *m_fx;
 
 public:
-  TrFx() {}
+  TrFx() { enableComputeInFloat(true); }
   ~TrFx() {}
 
   //-----------------------------------------------------------
@@ -307,6 +307,13 @@ public:
     if (!buildInput(rect, frame, info, rectIn, infoIn, appliedAff)) return 0;
 
     return TRasterFx::memorySize(rectIn, info.m_bpp);
+  }
+
+  //-----------------------------------------------------------
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override {
+    return tileIsLinear;
   }
 
 private:
@@ -430,8 +437,10 @@ void FxResourceBuilder::buildTileToCalculate(const TRectD &tileGeom) {
     TRect rect(0, 0, requiredSize.lx - 1, requiredSize.ly - 1);
     ras = outRas->extract(rect);
     ras->clear();
-  } else
+  } else {
     ras = outRas->create(requiredSize.lx, requiredSize.ly);
+    ras->setLinear(outRas->isLinear());
+  }
 
   m_newTile.setRaster(ras);
 
@@ -489,7 +498,14 @@ public:
   std::string m_interactiveCacheId;
   mutable TThread::Mutex m_mutex;  // brutto
 
-  TRasterFxImp() : m_cacheEnabled(false), m_isEnabled(true), m_cachedTile(0) {}
+  bool m_canComputeInFloat;
+  bool m_canComputeInLinearColorSpace;
+
+  TRasterFxImp()
+      : m_cacheEnabled(false)
+      , m_isEnabled(true)
+      , m_cachedTile(0)
+      , m_canComputeInFloat(false) {}
 
   ~TRasterFxImp() {}
 
@@ -516,6 +532,9 @@ public:
     QMutexLocker sl(&m_mutex);  // a che serve
     m_isEnabled = on;
   }
+
+  void enableComputeInFloat(bool on) { m_canComputeInFloat = on; }
+  bool canComputeInFloat() { return m_canComputeInFloat; }
 };
 
 //--------------------------------------------------
@@ -680,7 +699,9 @@ void TRasterFx::dryCompute(TRectD &rect, double frame,
   }
 
   std::string alias = getAlias(frame, info) + "[" + ::traduce(info.m_affine) +
-                      "][" + std::to_string(info.m_bpp) + "]";
+                      "][" + std::to_string(info.m_bpp) + "][" +
+                      std::to_string(info.m_linearColorSpace) + "][" +
+                      std::to_string(info.m_colorSpaceGamma) + "]";
 
   int renderStatus =
       TRenderer::instance().getRenderStatus(TRenderer::renderId());
@@ -766,6 +787,8 @@ void TRasterFx::allocateAndCompute(TTile &tile, const TPointD &pos,
   if (templateRas) {
     TRaster32P ras32(templateRas);
     TRaster64P ras64(templateRas);
+    TRasterFP rasF(templateRas);
+    bool isLinear = templateRas->isLinear();
     templateRas = 0;  // Release the reference to templateRas before allocation
 
     TRasterP tileRas;
@@ -773,11 +796,13 @@ void TRasterFx::allocateAndCompute(TTile &tile, const TPointD &pos,
       tileRas = TRaster32P(size.lx, size.ly);
     else if (ras64)
       tileRas = TRaster64P(size.lx, size.ly);
+    else if (rasF)
+      tileRas = TRasterFP(size.lx, size.ly);
     else {
       assert(false);
       return;
     }
-
+    tileRas->setLinear(isLinear);
     tile.setRaster(tileRas);
   } else {
     if (info.m_bpp == 32) {
@@ -786,8 +811,12 @@ void TRasterFx::allocateAndCompute(TTile &tile, const TPointD &pos,
     } else if (info.m_bpp == 64) {
       TRaster64P tileRas(size.lx, size.ly);
       tile.setRaster(tileRas);
+    } else if (info.m_bpp == 128) {
+      TRasterFP tileRas(size.lx, size.ly);
+      tile.setRaster(tileRas);
     } else
       assert(false);
+    tile.getRaster()->setLinear(info.m_linearColorSpace);
   }
 
   tile.m_pos = pos;
@@ -862,17 +891,45 @@ void TRasterFx::compute(TTile &tile, double frame,
   // Retrieve tile's geometry
   TRectD tilePlacement = myConvert(tile.getRaster()->getBounds()) + tile.m_pos;
 
-  // Build the fx result alias (in other words, its name)
-  std::string alias = getAlias(frame, info) + "[" + ::traduce(info.m_affine) +
-                      "][" + std::to_string(info.m_bpp) +
-                      "]";  // To be moved below
-
   TRectD bbox;
   getBBox(frame, bbox, info);
   enlargeToI(bbox);
 
   TRectD interestingRect(tilePlacement * bbox);
   if (myIsEmpty(interestingRect)) return;
+
+  TDimension tileSize = tile.getRaster()->getSize();
+  // ひとつ前のノードが小数点対応しているかどうかによって、入ってくるラスタの形式が異なる
+  TRaster32P ras32 = tile.getRaster();
+  TRaster64P ras64 = tile.getRaster();
+  TRasterFP rasF   = tile.getRaster();
+  if (info.m_bpp == 128) {
+    if (rasF && !canComputeInFloat()) {
+      TRasterP rasAux = TRaster64P(tileSize);
+      TRop::convert(rasAux, tile.getRaster());
+      tile.setRaster(rasAux);
+    } else if ((ras32 || ras64) && canComputeInFloat()) {
+      TRasterFP rasAuxF = TRasterFP(tileSize);
+      TRop::convert(rasAuxF, tile.getRaster());
+      tile.setRaster(rasAuxF);
+    }
+  }
+  // linear化
+  bool isLinear = tile.getRaster()->isLinear();
+  bool computeInLinear =
+      toBeComputedInLinearColorSpace(info.m_linearColorSpace, isLinear);
+  if (isLinear != computeInLinear) {
+    if (isLinear) {  //  && !computeInLinear
+      TRop::tosRGB(tile.getRaster(), info.m_colorSpaceGamma);
+    } else  // !isLinear && computeInLinear
+      TRop::toLinearRGB(tile.getRaster(), info.m_colorSpaceGamma);
+  }
+
+  // Build the fx result alias (in other words, its name)
+  std::string alias = getAlias(frame, info) + "[" + ::traduce(info.m_affine) +
+                      "][" + std::to_string(info.m_bpp) + "][" +
+                      std::to_string(computeInLinear) + "][" +
+                      std::to_string(info.m_colorSpaceGamma) + "]";
 
   // Extract the interesting tile from requested one
   TTile interestingTile;
@@ -896,6 +953,29 @@ void TRasterFx::compute(TTile &tile, double frame,
   // Invoke the fx-specific computation process
   FxResourceBuilder rBuilder(alias, this, info, frame);
   rBuilder.build(interestingTile);
+
+  // linear化
+  if (isLinear != computeInLinear) {
+    if (isLinear)  //  && !computeInLinear
+      TRop::toLinearRGB(tile.getRaster(), info.m_colorSpaceGamma);
+    else  // !isLinear && computeInLinear
+      TRop::tosRGB(tile.getRaster(), info.m_colorSpaceGamma);
+  }
+
+  if (info.m_bpp == 128) {
+    if (rasF && !canComputeInFloat()) {
+      TRop::convert(rasF, tile.getRaster());
+      tile.setRaster(rasF);
+    } else if ((ras32 || ras64) && canComputeInFloat()) {
+      if (ras64) {
+        TRop::convert(ras64, tile.getRaster());
+        tile.setRaster(ras64);
+      } else {
+        TRop::convert(ras32, tile.getRaster());
+        tile.setRaster(ras32);
+      }
+    }
+  }
 
 #ifdef DIAGNOSTICS
   sw.stop();
@@ -982,7 +1062,7 @@ TRasterP TRasterFx::applyAffine(TTile &tileOut, const TTile &tileIn,
 
   TRectD rectInAfter = aff * myConvert(src_ras->getBounds());
   TAffine rasterAff  = TTranslation((aff * rectIn).getP00() - rectOut.getP00() -
-                                   rectInAfter.getP00()) *
+                                    rectInAfter.getP00()) *
                       aff;
 
   TRop::ResampleFilterType qual;
@@ -1055,6 +1135,18 @@ bool TRasterFx::isCacheEnabled() const { return m_rasFxImp->m_cacheEnabled; }
 
 void TRasterFx::enableCache(bool on) { m_rasFxImp->enableCache(on); }
 
+//--------------------------------------------------
+
+bool TRasterFx::canComputeInFloat() const {
+  return m_rasFxImp->canComputeInFloat();
+}
+
+//--------------------------------------------------
+
+void TRasterFx::enableComputeInFloat(bool on) {
+  m_rasFxImp->enableComputeInFloat(on);
+}
+
 //==============================================================================
 //
 // TRenderSettings
@@ -1077,7 +1169,9 @@ TRenderSettings::TRenderSettings()
     , m_applyShrinkToViewer(false)
     , m_userCachable(true)
     , m_isCanceled(NULL)
-    , m_getFullSizeBBox(false) {}
+    , m_getFullSizeBBox(false)
+    , m_linearColorSpace(false)
+    , m_colorSpaceGamma(2.2) {}
 
 //------------------------------------------------------------------------------
 
@@ -1096,7 +1190,8 @@ std::string TRenderSettings::toString() const {
       "," + std::to_string(m_affine.a21) + "," + std::to_string(m_affine.a22) +
       "," + std::to_string(m_affine.a23) + ";" + std::to_string(m_maxTileSize) +
       ";" + std::to_string(m_isSwatch) + ";" + std::to_string(m_userCachable) +
-      ";{";
+      ";" + std::to_string(m_linearColorSpace) + ";" +
+      std::to_string(m_colorSpaceGamma) + ";{";
   if (!m_data.empty()) {
     ss += m_data[0]->toString();
     for (int i = 1; i < (int)m_data.size(); i++)
@@ -1119,7 +1214,9 @@ bool TRenderSettings::operator==(const TRenderSettings &rhs) const {
       m_applyShrinkToViewer != rhs.m_applyShrinkToViewer ||
       m_maxTileSize != rhs.m_maxTileSize || m_affine != rhs.m_affine ||
       m_mark != rhs.m_mark || m_isSwatch != rhs.m_isSwatch ||
-      m_userCachable != rhs.m_userCachable)
+      m_userCachable != rhs.m_userCachable ||
+      m_linearColorSpace != rhs.m_linearColorSpace ||
+      m_colorSpaceGamma != rhs.m_colorSpaceGamma)
     return false;
 
   return std::equal(m_data.begin(), m_data.end(), rhs.m_data.begin(), areEqual);

--- a/toonz/sources/toonz/flipbook.h
+++ b/toonz/sources/toonz/flipbook.h
@@ -135,7 +135,8 @@ protected:
         , m_step(step)
         , m_randomAccessRead(false)
         , m_incrementalIndexing(false)
-        , m_premultiply(false) {}
+        , m_premultiply(false)
+        , m_colorSpaceGamma(LevelOptions::DefaultColorSpaceGamma) {}
     TLevelP m_level;
     int m_fromIndex, m_toIndex, m_step;
     bool m_incrementalIndexing;
@@ -147,6 +148,11 @@ protected:
     // By default, PNG will be loaded with being premultiplied so that it will
     // be displayed properly.
     bool m_premultiply;
+
+    // Gamma value to be used when converting EXR files to nonlinear.
+    // It may be set to some value in the Preferences > Loading > "Level
+    // Settings by File Format".
+    double m_colorSpaceGamma;
 
     TFilePath m_fp;
 

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -87,6 +87,9 @@ void HistogramPopup::updateInfo(const TPixel64 &pix, const TPointD &imagePos) {
   m_histogram->updateInfo(pix, imagePos);
 }
 
+void HistogramPopup::updateInfo(const TPixelF &pix, const TPointD &imagePos) {
+  m_histogram->updateInfo(pix, imagePos);
+}
 //-----------------------------------------------------------------------------
 /*! show the average-picked color
  */
@@ -95,6 +98,10 @@ void HistogramPopup::updateAverageColor(const TPixel32 &pix) {
 }
 
 void HistogramPopup::updateAverageColor(const TPixel64 &pix) {
+  m_histogram->updateAverageColor(pix);
+}
+
+void HistogramPopup::updateAverageColor(const TPixelF &pix) {
   m_histogram->updateAverageColor(pix);
 }
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/histogrampopup.h
+++ b/toonz/sources/toonz/histogrampopup.h
@@ -28,8 +28,10 @@ public:
 
   void updateInfo(const TPixel32 &pix, const TPointD &imagePos);
   void updateInfo(const TPixel64 &pix, const TPointD &imagePos);
+  void updateInfo(const TPixelF &pix, const TPointD &imagePos);
   void updateAverageColor(const TPixel32 &pix);
   void updateAverageColor(const TPixel64 &pix);
+  void updateAverageColor(const TPixelF &pix);
   void setShowCompare(bool on);
   void invalidateCompHisto();
   void moveNextToWidget(QWidget *widget);

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -214,6 +214,7 @@ ImageViewer::ImageViewer(QWidget *parent, FlipBook *flipbook,
     , m_mouseButton(Qt::NoButton)
     , m_draggingZoomSelection(false)
     , m_image()
+    , m_orgImage()
     , m_FPS(0)
     , m_viewAff()
     , m_pos(0, 0)
@@ -402,8 +403,9 @@ ImageViewer::~ImageViewer() {
 /*! Set current image to \b image and update. If Histogram is visible set its
  * image.
  */
-void ImageViewer::setImage(TImageP image) {
-  m_image = image;
+void ImageViewer::setImage(TImageP image, TImageP orgImage) {
+  m_image    = image;
+  m_orgImage = orgImage;
 
   if (m_image && m_firstImage) {
     m_firstImage = false;
@@ -415,7 +417,7 @@ void ImageViewer::setImage(TImageP image) {
   }
 
   if (m_isHistogramEnable && m_histogramPopup->isVisible())
-    m_histogramPopup->setImage(image);
+    m_histogramPopup->setImage((orgImage) ? orgImage : image);
 
   // make sure to redraw the frame here.
   // repaint() does NOT immediately redraw the frame for QOpenGLWidget
@@ -945,6 +947,8 @@ TImageP ImageViewer::getPickedImage(QPointF mousePos) {
   }
   if (cursorIsInSnapShot)
     return TImageCache::instance()->get(QString("TnzCompareImg"), false);
+  else if (m_orgImage)
+    return m_orgImage;
   else
     return m_image;
 }
@@ -977,8 +981,8 @@ void ImageViewer::pickColor(QMouseEvent *event, bool putValueToStyleEditor) {
       getViewAff().inv() * TPointD(curPos.x() - (qreal)(width()) / 2,
                                    -curPos.y() + (qreal)(height()) / 2);
 
-  TRectD imgRect = (img->raster()) ? convert(TRect(img->raster()->getSize()))
-                                   : img->getBBox();
+  TRectD imgRect   = (img->raster()) ? convert(TRect(img->raster()->getSize()))
+                                     : img->getBBox();
   TPointD imagePos = (img->raster()) ? TPointD(0.5 * imgRect.getLx() + pos.x,
                                                0.5 * imgRect.getLy() + pos.y)
                                      : pos;
@@ -996,25 +1000,35 @@ void ImageViewer::pickColor(QMouseEvent *event, bool putValueToStyleEditor) {
     TPixel32 pix = picker.pickColor(area);
     m_histogramPopup->updateInfo(pix, imagePos);
     if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
-  } else if (img->raster()->getPixelSize() == 8)  // 16bpc raster
-  {
+  } else {
     // for specifying pixel range on picking vector
     double scale2 = getViewAff().det();
-    TPixel64 pix  = picker.pickColor16(pos + TPointD(-0.5, -0.5), 10.0, scale2);
+    TPixel32 pixForStyleEditor;
 
-    // throw the picked color to the histogram
-    m_histogramPopup->updateInfo(pix, imagePos);
-    // throw it to the style editor as well
-    if (putValueToStyleEditor) setPickedColorToStyleEditor(toPixel32(pix));
-  } else {  // 8bpc raster
-    // for specifying pixel range on picking vector
-    double scale2 = getViewAff().det();
-    TPixel32 pix  = picker.pickColor(pos + TPointD(-0.5, -0.5), 10.0, scale2);
+    if (img->raster()->getPixelSize() == 8)  // 16bpc raster
+    {
+      TPixel64 pix =
+          picker.pickColor16(pos + TPointD(-0.5, -0.5), 10.0, scale2);
+      // throw the picked color to the histogram
+      m_histogramPopup->updateInfo(pix, imagePos);
+      pixForStyleEditor = toPixel32(pix);
+    } else if (img->raster()->getPixelSize() ==
+               16)  // 32bpc floating point raster
+    {
+      TPixelF pix =
+          picker.pickColor32F(pos + TPointD(-0.5, -0.5), 10.0, scale2);
+      // throw the picked color to the histogram
+      m_histogramPopup->updateInfo(pix, imagePos);
+      pixForStyleEditor = toPixel32(pix);
+    } else {  // 8bpc raster
+      TPixel32 pix = picker.pickColor(pos + TPointD(-0.5, -0.5), 10.0, scale2);
+      // throw the picked color to the histogram
+      m_histogramPopup->updateInfo(pix, imagePos);
+      pixForStyleEditor = pix;
+    }
 
-    // throw the picked color to the histogram
-    m_histogramPopup->updateInfo(pix, imagePos);
     // throw it to the style editor as well
-    if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
+    if (putValueToStyleEditor) setPickedColorToStyleEditor(pixForStyleEditor);
   }
 }
 
@@ -1045,7 +1059,7 @@ void ImageViewer::rectPickColor(bool putValueToStyleEditor) {
   if (!img->raster()) {  // vector image
     TPointD pressedWinPos = convert(m_pressedMousePos) + m_winPosMousePosOffset;
     TPointD startPos      = TPointD(pressedWinPos.x,
-                               (double)(window()->height()) - pressedWinPos.y);
+                                    (double)(window()->height()) - pressedWinPos.y);
     TPointD currentWinPos =
         TPointD(m_pos.x(), m_pos.y()) + m_winPosMousePosOffset;
     TPointD endPos = TPointD(currentWinPos.x,
@@ -1078,20 +1092,28 @@ void ImageViewer::rectPickColor(bool putValueToStyleEditor) {
   TPointD end = getViewAff().inv() *
                 TPointD(endPos.x - width() / 2, endPos.y - height() / 2);
 
+  TPixel32 pixForStyleEditor;
   if (img->raster()->getPixelSize() == 8)  // 16bpc raster
   {
     TPixel64 pix = picker.pickAverageColor16(TRectD(start, end));
     // throw the picked color to the histogram
     m_histogramPopup->updateAverageColor(pix);
-    // throw it to the style editor as well
-    if (putValueToStyleEditor) setPickedColorToStyleEditor(toPixel32(pix));
+    pixForStyleEditor = toPixel32(pix);
+  } else if (img->raster()->getPixelSize() ==
+             16)  // 32bpc floating point raster
+  {
+    TPixelF pix = picker.pickAverageColor32F(TRectD(start, end));
+    // throw the picked color to the histogram
+    m_histogramPopup->updateAverageColor(pix);
+    pixForStyleEditor = toPixel32(pix);
   } else {  // 8bpc raster
     TPixel32 pix = picker.pickAverageColor(TRectD(start, end));
     // throw the picked color to the histogram
     m_histogramPopup->updateAverageColor(pix);
-    // throw it to the style editor as well
-    if (putValueToStyleEditor) setPickedColorToStyleEditor(pix);
+    pixForStyleEditor = pix;
   }
+  // throw it to the style editor as well
+  if (putValueToStyleEditor) setPickedColorToStyleEditor(pixForStyleEditor);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -54,7 +54,8 @@ class ImageViewer final : public GLWidgetForHighDpi {
   ImagePainter::VisualSettings m_visualSettings;
   ImagePainter::CompareSettings m_compareSettings;
 
-  TImageP m_image;
+  TImageP m_image;     // displayed image
+  TImageP m_orgImage;  // image without gain adjustment
   TAffine m_viewAff;
   QPoint m_pos;
   bool m_isHistogramEnable;
@@ -104,7 +105,7 @@ public:
 
   void setVisual(const ImagePainter::VisualSettings &settings);
 
-  void setImage(TImageP image);
+  void setImage(TImageP image, TImageP orgImage = TImageP());
   TImageP getImage() { return m_image; }
 
   TAffine getViewAff() { return m_viewAff; }

--- a/toonz/sources/toonz/levelsettingspopup.h
+++ b/toonz/sources/toonz/levelsettingspopup.h
@@ -30,20 +30,22 @@ class CheckBox;
 }  // namespace DVGui
 
 enum SelectedLevelType {
-  None        = 0x0,
-  ToonzRaster = 0x1,
-  Raster      = 0x2,
-  Mesh        = 0x4,
-  ToonzVector = 0x8,
-  Palette     = 0x10,
-  SubXsheet   = 0x20,
-  Sound       = 0x40,
-  Others      = 0x80,
+  None            = 0x0,
+  ToonzRaster     = 0x1,
+  NonLinearRaster = 0x2,
+  Mesh            = 0x4,
+  ToonzVector     = 0x8,
+  Palette         = 0x10,
+  SubXsheet       = 0x20,
+  Sound           = 0x40,
+  LinearRaster = 0x80,  // EXR files only enables the "Color Space Gamma" field
+  Others       = 0x100,
 
-  MultiSelection  = 0x100,
-  HideOnPixelMode = 0x200,
-  NoSelection     = 0x400,
+  MultiSelection  = 0x1000,
+  HideOnPixelMode = 0x2000,
+  NoSelection     = 0x4000,
 
+  Raster      = NonLinearRaster | LinearRaster,
   SimpleLevel = ToonzRaster | Raster | Mesh | ToonzVector,
   HasDPILevel = ToonzRaster | Raster | Mesh,
   AllTypes    = SimpleLevel | Palette | SubXsheet | Sound
@@ -55,7 +57,7 @@ struct LevelSettingsValues {
   TPointD dpi               = TPointD(0, 0);
   Qt::CheckState doPremulti = Qt::Unchecked, whiteTransp = Qt::Unchecked,
                  doAntialias = Qt::Unchecked, isDirty = Qt::Unchecked;
-  double width = 0.0, height = 0.0;
+  double width = 0.0, height = 0.0, colorSpaceGamma = -1.0;
 };
 
 //=============================================================================
@@ -90,6 +92,9 @@ class LevelSettingsPopup final : public DVGui::Dialog {
   QLabel *m_subsamplingLabel;
   DVGui::IntLineEdit *m_subsamplingFld;
 
+  QLabel *m_colorSpaceGammaLabel;
+  DVGui::DoubleLineEdit *m_colorSpaceGammaFld;
+
   SelectedLevelType getType(TXshLevelP);
   LevelSettingsValues getValues(TXshLevelP);
 
@@ -119,6 +124,7 @@ protected slots:
   void onDoAntialiasClicked();
   void onAntialiasSoftnessChanged();
   void onWhiteTranspClicked();
+  void onColorSpaceGammaFieldChanged();
   void onSceneChanged();
   void onPreferenceChanged(const QString &);
 };

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -58,6 +58,8 @@ class OutputSettingsPopup : public DVGui::Dialog {
   QComboBox *m_multimediaOm;
   QComboBox *m_resampleBalanceOm;
   QComboBox *m_channelWidthOm;
+  DVGui::CheckBox *m_linearColorSpaceChk;
+  DVGui::DoubleLineEdit *m_colorSpaceGammaFld;
   DVGui::DoubleLineEdit *m_gammaFld;
   QComboBox *m_dominantFieldOm;
   DVGui::CheckBox *m_applyShrinkChk;
@@ -79,8 +81,10 @@ class OutputSettingsPopup : public DVGui::Dialog {
   QPushButton *m_boardSettingsBtn;
 
   QScrollArea *m_scrollArea;
-  AnimatedLabel *m_cameraLabel, *m_fileLabel, *m_moreLabel;
-  QFrame *m_cameraBox, *m_fileBox, *m_moreBox;
+  AnimatedLabel *m_cameraLabel, *m_colorLabel, *m_fileLabel, *m_moreLabel;
+  QFrame *m_cameraBox, *m_colorBox, *m_fileBox, *m_moreBox;
+
+  DVGui::CheckBox *m_syncColorSettingsButton;
 
   bool m_isPreviewSettings;
 
@@ -89,6 +93,7 @@ class OutputSettingsPopup : public DVGui::Dialog {
 
   QFrame *createPanel(bool isPreview);
   QFrame *createCameraSettingsBox(bool isPreview);
+  QFrame *createColorSettingsBox(bool isPreview);
   QFrame *createFileSettingsBox(bool isPreview);
   QFrame *createMoreSettingsBox();
 
@@ -113,6 +118,8 @@ protected slots:
   void onFrameFldEditFinished();
   void onResampleChanged(int type);
   void onChannelWidthChanged(int type);
+  void onLinearColorSpaceChecked(int state);
+  void onColorSpaceGammaEdited();
   void onGammaFldEditFinished();
   void onDominantFieldChanged(int type);
   void onStretchFldEditFinished();
@@ -123,6 +130,7 @@ protected slots:
   void onRasterGranularityChanged(int type);
   void onStereoChecked(int);
   void onStereoChanged();
+  void onSyncColorSettingsChecked(int state);
   void onRenderClicked();
 
   /*-- OutputSettingsのPreset登録/削除/選択 --*/

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -194,7 +194,7 @@ private:
 
   DVGui::LineEdit *m_name, *m_regExp;
 
-  DVGui::DoubleLineEdit* m_dpi;
+  DVGui::DoubleLineEdit *m_dpi, *m_colorSpaceGamma;
 
   DVGui::IntLineEdit *m_priority, *m_subsampling, *m_antialias;
 

--- a/toonz/sources/toonz/previewer.cpp
+++ b/toonz/sources/toonz/previewer.cpp
@@ -393,13 +393,11 @@ void Previewer::Imp::updateProgressBarStatus() {
   unsigned int i, pbSize = m_pbStatus.size();
   std::map<int, FrameInfo>::iterator it;
   for (i = 0; i < pbSize; ++i) {
-    it = m_frames.find(i);
-    m_pbStatus[i] =
-        (it == m_frames.end())
-            ? FlipSlider::PBFrameNotStarted
-            : ::contains(it->second.m_renderedRegion, m_previewRect)
-                  ? FlipSlider::PBFrameFinished
-                  : it->second.m_rectUnderRender.contains(m_previewRect)
+    it            = m_frames.find(i);
+    m_pbStatus[i] = (it == m_frames.end()) ? FlipSlider::PBFrameNotStarted
+                    : ::contains(it->second.m_renderedRegion, m_previewRect)
+                        ? FlipSlider::PBFrameFinished
+                    : it->second.m_rectUnderRender.contains(m_previewRect)
                         ? FlipSlider::PBFrameStarted
                         : FlipSlider::PBFrameNotStarted;
   }
@@ -674,6 +672,11 @@ void Previewer::Imp::doOnRenderRasterCompleted(const RenderData &renderData) {
   }
 
   TRasterP ras(renderData.m_rasA);
+
+  // Linear Color Space -> sRGB
+  if (ras->isLinear()) {
+    TRop::tosRGB(ras, m_renderSettings.m_colorSpaceGamma);
+  }
 
   m_computingFrameCount--;
 
@@ -1152,7 +1155,7 @@ TRasterP Previewer::getRaster(int frame, bool renderIfNeeded) const {
             (TRasterImageP)TImageCache::instance()->get(str, false);
         if (rimg) {
           TRasterP ras = rimg->getRaster();
-          assert((TRaster32P)ras || (TRaster64P)ras);
+          assert((TRaster32P)ras || (TRaster64P)ras || (TRasterFP)ras);
           return ras;
         } else
           // Weird case - the frame was declared rendered, but no raster is
@@ -1171,7 +1174,7 @@ TRasterP Previewer::getRaster(int frame, bool renderIfNeeded) const {
         (TRasterImageP)TImageCache::instance()->get(str, false);
     if (rimg) {
       TRasterP ras = rimg->getRaster();
-      assert((TRaster32P)ras || (TRaster64P)ras);
+      assert((TRaster32P)ras || (TRaster64P)ras || (TRasterFP)ras);
       return ras;
     } else
       return TRasterP();

--- a/toonz/sources/toonz/previewfxmanager.cpp
+++ b/toonz/sources/toonz/previewfxmanager.cpp
@@ -713,7 +713,7 @@ void PreviewFxInstance::updateRenderSettings() {
 
   m_subcamera = properties->isSubcameraPreview();
 
-  const TRenderSettings &renderSettings = properties->getRenderSettings();
+  TRenderSettings renderSettings = properties->getRenderSettings();
 
   if (m_renderSettings != renderSettings) {
     m_renderSettings = renderSettings;
@@ -1067,11 +1067,19 @@ void PreviewFxInstance::doOnRenderRasterCompleted(
   else
     ras = 0;
 
-  /*-- 16bpcで計算された場合、結果をDitheringする --*/
   TRasterP rasA = renderData.m_rasA;
   TRasterP rasB = renderData.m_rasB;
+
+  // Linear Color Space -> sRGB
+  if (rasA->isLinear()) {
+    TRop::tosRGB(rasA, m_renderSettings.m_colorSpaceGamma);
+    if (m_renderSettings.m_stereoscopic)
+      TRop::tosRGB(rasB, m_renderSettings.m_colorSpaceGamma);
+  }
+
+  /*-- 16bpcで計算された場合、結果をDitheringする --*/
   // dither the 16bpc image IF the "30bit display" preference option is OFF
-  if (rasA->getPixelSize() == 8 &&
+  if ((rasA->getPixelSize() == 8 || rasA->getPixelSize() == 16) &&
       !Preferences::instance()->is30bitDisplayEnabled())  // render in 64 bits
   {
     TRaster32P auxA(rasA->getLx(), rasA->getLy());

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -339,7 +339,7 @@ SceneSettingsPopup::SceneSettingsPopup()
   mainLayout->setColumnStretch(2, 0);
   mainLayout->setColumnStretch(3, 0);
   mainLayout->setColumnStretch(4, 1);
-  mainLayout->setRowStretch(7, 1);
+  mainLayout->setRowStretch(9, 1);
   setLayout(mainLayout);
 
   // signal-slot connections

--- a/toonz/sources/toonz/scenesettingspopup.h
+++ b/toonz/sources/toonz/scenesettingspopup.h
@@ -58,6 +58,8 @@ class SceneSettingsPopup final : public QDialog {
 
   CellMarksPopup *m_cellMarksPopup;
 
+  DVGui::DoubleLineEdit *m_colorSpaceGammaFld;
+
 public:
   SceneSettingsPopup();
   void configureNotify();

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -92,9 +92,10 @@ BaseViewerPanel::BaseViewerPanel(QWidget *parent, Qt::WindowFlags flags)
   m_keyFrameButton->setObjectHandle(app->getCurrentObject());
   m_keyFrameButton->setXsheetHandle(app->getCurrentXsheet());
 
-  std::vector<int> buttonMask = {FlipConsole::eFilledRaster,
-                                 FlipConsole::eDefineLoadBox,
-                                 FlipConsole::eUseLoadBox};
+  std::vector<int> buttonMask = {
+      FlipConsole::eFilledRaster, FlipConsole::eDefineLoadBox,
+      FlipConsole::eUseLoadBox,   FlipConsole::eDecreaseGain,
+      FlipConsole::eIncreaseGain, FlipConsole::eResetGain};
 
   m_flipConsole =
       new FlipConsole(m_mainLayout, buttonMask, false, m_keyFrameButton,

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -76,8 +76,11 @@ private:
   TFrameId m_fid;    //!< Frame of the level to load
 
   bool m_64bitCompatible;  //!< Whether current image is 64-bit compatible
+  bool m_floatCompatible;  //!< Whether current image is float compatible
   int m_subsampling;       //!< Current image subsampling
   //!< NOTE: Should this be replaced by requests to the TImageCache?
+
+  double m_colorSpaceGamma;  // current gamma. only used in EXR levels
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/imagepainter.cpp
+++ b/toonz/sources/toonzlib/imagepainter.cpp
@@ -28,23 +28,38 @@ namespace {
 
 //-----------------------------------------------------------------------------
 
-TRaster32P keepChannels(const TRasterP &rin, TPalette *palette, UCHAR channel) {
-  TRaster32P rout(rin->getSize());
+TRasterP keepChannels(const TRasterP &rin, TPalette *palette, UCHAR channel) {
+  TRasterP rout;
+  if ((TRasterFP)rin) {
+    rout = rin->clone();
 
-  if ((TRasterCM32P)rin)
-    TRop::convert(rout, (TRasterCM32P)rin, TPaletteP(palette));
-  else
-    TRop::copy(rout, rin);
+    TPixelF *pix = (TPixelF *)rout->getRawData();
 
-  TPixel32 *pix = (TPixel32 *)rout->getRawData();
+    assert(channel & TRop::MChan);
+    int i;
+    for (i = 0; i < rout->getLx() * rout->getLy(); i++, pix++) {
+      if (!(channel & TRop::RChan)) pix->r = 0.f;
+      if (!(channel & TRop::GChan)) pix->g = 0.f;
+      if (!(channel & TRop::BChan)) pix->b = 0.f;
+    }
+  } else {
+    rout = TRaster32P(rin->getSize());
 
-  assert(channel & TRop::MChan);
-  int i;
+    if ((TRasterCM32P)rin)
+      TRop::convert(rout, (TRasterCM32P)rin, TPaletteP(palette));
+    else
+      TRop::copy(rout, rin);
 
-  for (i = 0; i < rout->getLx() * rout->getLy(); i++, pix++) {
-    if (!(channel & TRop::RChan)) pix->r = 0;
-    if (!(channel & TRop::GChan)) pix->g = 0;
-    if (!(channel & TRop::BChan)) pix->b = 0;
+    TPixel32 *pix = (TPixel32 *)rout->getRawData();
+
+    assert(channel & TRop::MChan);
+    int i;
+
+    for (i = 0; i < rout->getLx() * rout->getLy(); i++, pix++) {
+      if (!(channel & TRop::RChan)) pix->r = 0;
+      if (!(channel & TRop::GChan)) pix->g = 0;
+      if (!(channel & TRop::BChan)) pix->b = 0;
+    }
   }
   return rout;
 }
@@ -172,7 +187,8 @@ public:
   void onRasterImage(TRasterImage *ri);
   void onToonzImage(TToonzImage *ti);
   void drawBlank();
-  TRaster32P buildCheckboard(int bg, const TDimension &dim);
+  TRasterP buildCheckboard(int bg, const TDimension &dim,
+                           TRasterP templateRas = TRaster32P());
 };
 
 //-----------------------------------------------------------------------------
@@ -303,35 +319,43 @@ void Painter::flushRasterImages(const TRect &loadbox, double compareX,
 
 //-----------------------------------------------------------------------------
 
-TRaster32P Painter::buildCheckboard(int bg, const TDimension &dim) {
-  TRaster32P checkBoard = TRaster32P(100, 100);
-  if (bg == 0x100000) {
-    TPixel col1, col2;
-    Preferences::instance()->getChessboardColors(col1, col2);
-    TPointD p = TPointD(0, 0);
-    if (m_vSettings.m_useTexture)
-      p = TPointD(m_bbox.x0 > 0 ? 0 : -m_bbox.x0,
-                  m_bbox.y0 > 0 ? 0 : -m_bbox.y0);
+TRasterP Painter::buildCheckboard(int bg, const TDimension &dim,
+                                  TRasterP templateRas) {
+  TRaster32P ras32(templateRas);
+  TRaster64P ras64(templateRas);
+  TRasterFP rasF(templateRas);
+  templateRas = 0;
+  TRasterP checkBoard;
+  if (ras32)
+    checkBoard = TRaster32P(100, 100);
+  else if (ras64)
+    checkBoard = TRaster64P(100, 100);
+  else if (rasF)
+    checkBoard = TRasterFP(100, 100);
 
-    assert(checkBoard.getPointer());
-    TRop::checkBoard(checkBoard, col1, col2, TDimensionD(50, 50), p);
-  } else {
-    TPixel pix = bg == 0x40000 ? TPixel::Black : TPixel::White;
-    assert(checkBoard.getPointer());
-    checkBoard->fill(pix);
-  }
+  TPixel col1, col2;
+  Preferences::instance()->getChessboardColors(col1, col2);
+  TPointD p = TPointD(0, 0);
+  if (m_vSettings.m_useTexture)
+    p = TPointD(m_bbox.x0 > 0 ? 0 : -m_bbox.x0, m_bbox.y0 > 0 ? 0 : -m_bbox.y0);
 
-  // TRaster32P textureBackGround;
-
-  // if(m_vSettings.m_useTexture)
-  //  textureBackGround = TRaster32P(dim.lx,dim.ly);
+  assert(checkBoard.getPointer());
+  TRop::checkBoard(checkBoard, col1, col2, TDimensionD(50, 50), p);
 
   assert(checkBoard.getPointer());
   int lx = (m_imageSize.lx == 0 ? dim.lx : m_imageSize.lx);
   int ly = (m_imageSize.ly == 0 ? dim.ly : m_imageSize.ly);
   int x, y;
 
-  TRaster32P checkBoardRas(lx, ly);
+  TRasterP checkBoardRas;
+
+  if (ras32)
+    checkBoardRas = TRaster32P(lx, ly);
+  else if (ras64)
+    checkBoardRas = TRaster64P(lx, ly);
+  else if (rasF)
+    checkBoardRas = TRasterFP(lx, ly);
+
   for (y = 0; y < ly; y += 100) {
     for (x = 0; x < lx; x += 100) {
       // TAffine checkTrans = TTranslation(x,y);
@@ -368,7 +392,8 @@ void Painter::doFlushRasterImages(const TRasterP &rin, int bg,
   // TRaster32P ras;
   TRasterP _rin = rin;
   TAffine aff;
-  bool is16bpc = false;
+  GLenum bpcType = TGL_TYPE;
+  // is16bpc = false;
   if (m_vSettings.m_useTexture) {
     ras = _rin;
     aff = m_aff;
@@ -380,7 +405,10 @@ void Painter::doFlushRasterImages(const TRasterP &rin, int bg,
     // but is kept the channel depth as 16bpc.
     if (_rin->getPixelSize() == 8) {
       ras     = TRaster64P(lx, ly);
-      is16bpc = true;
+      bpcType = TGL_TYPE16;
+    } else if (_rin->getPixelSize() == 16) {
+      ras     = TRasterFP(lx, ly);
+      bpcType = TGL_TYPE32F;
     } else
       ras = TRaster32P(lx, ly);
 
@@ -409,12 +437,14 @@ void Painter::doFlushRasterImages(const TRasterP &rin, int bg,
                                              // shifted of an half pixel...it's
                                              // a quickput approximation?
     if (bg == 0x100000)
-      quickput(ras, buildCheckboard(bg, _rin->getSize()), m_palette, aff,
+      quickput(ras, buildCheckboard(bg, _rin->getSize(), ras), m_palette, aff,
                false);
     else {
-      if (is16bpc)
+      if (bpcType == TGL_TYPE16)
         ((TRaster64P)ras)
             ->fill(bg == 0x40000 ? TPixel64::Black : TPixel64::White);
+      else if (bpcType == TGL_TYPE32F)
+        ((TRasterFP)ras)->fill(bg == 0x40000 ? TPixelF::Black : TPixelF::White);
       else
         ((TRaster32P)ras)->fill(bg == 0x40000 ? TPixel::Black : TPixel::White);
     }
@@ -470,8 +500,7 @@ void Painter::doFlushRasterImages(const TRasterP &rin, int bg,
     glRasterPos2d(rect.x0, rect.y0);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
-    glDrawPixels(ras->getWrap(), ras->getLy(), TGL_FMT,
-                 (is16bpc) ? TGL_TYPE16 : TGL_TYPE,
+    glDrawPixels(ras->getWrap(), ras->getLy(), TGL_FMT, bpcType,
                  (GLvoid *)ras->getRawData());
 
     CHECK_ERRORS_BY_GL
@@ -593,7 +622,8 @@ ImagePainter::VisualSettings::VisualSettings()
     , m_sceneProperties(0)
     , m_recomputeIfNeeded(true)
     , m_drawBlankFrame(false)
-    , m_useChecks(false) {
+    , m_useChecks(false)
+    , m_gainStep(0) {
   if (FlipBookBlackBgToggle) m_bg = 0x40000;
   if (FlipBookWhiteBgToggle) m_bg = 0x80000;
   if (FlipBookCheckBgToggle) m_bg = 0x100000;
@@ -606,7 +636,8 @@ bool ImagePainter::VisualSettings::needRepaint(const VisualSettings &vs) const {
            m_bg == vs.m_bg && m_doCompare == vs.m_doCompare &&
            m_defineLoadbox == vs.m_defineLoadbox &&
            m_useLoadbox == vs.m_useLoadbox && m_useTexture == vs.m_useTexture &&
-           m_drawExternalBG == vs.m_drawExternalBG);
+           m_drawExternalBG == vs.m_drawExternalBG &&
+           m_gainStep == vs.m_gainStep);
 }
 
 //=============================================================================

--- a/toonz/sources/toonzlib/levelproperties.cpp
+++ b/toonz/sources/toonzlib/levelproperties.cpp
@@ -5,6 +5,8 @@
 // TnzLib includes
 #include "toonz/stage.h"
 
+const double LevelOptions::DefaultColorSpaceGamma = 2.2;
+
 //**********************************************************************************
 //    LevelProperties::Options  implementation
 //**********************************************************************************
@@ -16,7 +18,8 @@ LevelOptions::LevelOptions()
     , m_dpiPolicy(DP_ImageDpi)
     , m_whiteTransp(false)
     , m_premultiply(false)
-    , m_isStopMotionLevel(false) {}
+    , m_isStopMotionLevel(false)
+    , m_colorSpaceGamma(DefaultColorSpaceGamma) {}
 
 //-----------------------------------------------------------------------------
 
@@ -26,7 +29,8 @@ bool LevelOptions::operator==(const LevelOptions &other) const {
           m_dpiPolicy == other.m_dpiPolicy &&
           m_antialias == other.m_antialias &&
           m_isStopMotionLevel == other.m_isStopMotionLevel &&
-          (m_dpiPolicy == LevelOptions::DP_ImageDpi || m_dpi == other.m_dpi));
+          (m_dpiPolicy == LevelOptions::DP_ImageDpi || m_dpi == other.m_dpi)) &&
+         areAlmostEqual(m_colorSpaceGamma, other.m_colorSpaceGamma);
 }
 
 //**********************************************************************************

--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -11,6 +11,8 @@
 #include "trop.h"
 #include "tsop.h"
 
+#include "tiio.h"
+
 // TnzLib includes
 #include "toonz/toonzscene.h"
 #include "toonz/sceneproperties.h"
@@ -81,10 +83,10 @@ void getRange(ToonzScene *scene, bool isPreview, int &from, int &to) {
       int r0, r1;
       xs->getCellRange(k, r0, r1);
 
-       TXshColumn *col         = xs->getColumn(k);
+      TXshColumn *col         = xs->getColumn(k);
       TXshSoundColumn *sndCol = col ? col->getSoundColumn() : 0;
 
-      if (sndCol) r0  = 0;
+      if (sndCol) r0 = 0;
       from = std::min(from, r0), to = std::max(to, r1);
     }
   }
@@ -159,7 +161,15 @@ public:
 
   void prepareForStart();
   void addSoundtrack(int r0, int r1, double fps, int boardDuration = 0);
+
+  // writeInLinearColorSpace : Whether the format will save image in linear
+  // color space. (true only in EXR fromat) writingGamma : Color space gamma to
+  // be used for saving in the file ("Color Space Gamma" property in EXR format)
+  // renderingGamma : Color space gamma used on rendering ( "Color Space Gamma"
+  // value in the Render Settings )
   void postProcessImage(const TRasterImageP &img, bool has64bitOutputSupport,
+                        bool writeInLinearColorSpace, bool isFirstTime,
+                        double writingGamma, double renderingGamma,
                         const TRasterP &mark, int frame);
 
   //! Saves the specified rasters at the specified time; returns whether the
@@ -318,7 +328,7 @@ void MovieRenderer::Imp::prepareForStart() {
 
 void MovieRenderer::Imp::addSoundtrack(int r0, int r1, double fps,
                                        int boardDuration) {
-  TCG_ASSERT(r0 <= r1, return );
+  TCG_ASSERT(r0 <= r1, return);
 
   TXsheet::SoundProperties *prop =
       new TXsheet::SoundProperties();  // Ownership will be surrendered ...
@@ -372,6 +382,9 @@ void MovieRenderer::Imp::onRenderRasterCompleted(const RenderData &renderData) {
 
 void MovieRenderer::Imp::postProcessImage(const TRasterImageP &img,
                                           bool has64bitOutputSupport,
+                                          bool writeInLinearColorSpace,
+                                          bool isFirstTime, double writingGamma,
+                                          double renderingGamma,
                                           const TRasterP &mark, int frame) {
   img->setDpi(m_xDpi, m_yDpi);
 
@@ -379,6 +392,23 @@ void MovieRenderer::Imp::postProcessImage(const TRasterImageP &img,
     TRaster32P aux(img->getRaster()->getLx(), img->getRaster()->getLy());
     TRop::convert(aux, img->getRaster());
     img->setRaster(aux);
+  }
+
+  // raster will be converted to linear before saving in exr format
+  if (isFirstTime) {
+    if (img->getRaster()->isLinear()) {
+      if (!writeInLinearColorSpace)
+        TRop::tosRGB(img->getRaster(), renderingGamma);
+      // write in linear color space, but with different gamma
+      else if (!areAlmostEqual(renderingGamma, writingGamma)) {
+        double gammaAdjust = writingGamma / renderingGamma;
+        // temporarily release the linear flag in order to use toLinearRGB
+        img->getRaster()->setLinear(false);
+        TRop::toLinearRGB(img->getRaster(), gammaAdjust);
+      }
+    } else if (!img->getRaster()->isLinear() && writeInLinearColorSpace) {
+      TRop::toLinearRGB(img->getRaster(), writingGamma);
+    }
   }
 
   if (mark) addMark(mark, img);
@@ -412,11 +442,25 @@ std::pair<bool, int> MovieRenderer::Imp::saveFrame(
     assert(m_levelUpdaterB.get() || !rasters.second);
 
     // Analyze writer
-    bool has64bitOutputSupport = false;
+    bool has64bitOutputSupport   = false;
+    bool writeInLinearColorSpace = false;
+    double writingGamma          = 2.2;
     {
       if (TImageWriterP writerA =
-              m_levelUpdaterA->getLevelWriter()->getFrameWriter(fid))
+              m_levelUpdaterA->getLevelWriter()->getFrameWriter(fid)) {
         has64bitOutputSupport = writerA->is64bitOutputSupported();
+
+        const std::string &type = toLower(m_fp.getType());
+        Tiio::Writer *writer    = Tiio::makeWriter(type);
+        writeInLinearColorSpace = writer && writer->writeInLinearColorSpace();
+        if (writeInLinearColorSpace) {
+          TDoubleProperty *gammaProp =
+              (TDoubleProperty *)(m_levelUpdaterA->getLevelWriter()
+                                      ->getProperties()
+                                      ->getProperty("Color Space Gamma"));
+          if (gammaProp) writingGamma = gammaProp->getValue();
+        }
+      }
 
       // NOTE: If the writer could not be retrieved, the updater will throw.
       // Failure will be caught then.
@@ -437,15 +481,19 @@ std::pair<bool, int> MovieRenderer::Imp::saveFrame(
     // Flush images
     try {
       TRasterImageP imgA(rasterA);
-      postProcessImage(imgA, has64bitOutputSupport, m_renderSettings.m_mark,
-                       fid.getNumber());
+      postProcessImage(imgA, has64bitOutputSupport, writeInLinearColorSpace,
+                       m_toBeAppliedGamma[frame], writingGamma,
+                       m_renderSettings.m_colorSpaceGamma,
+                       m_renderSettings.m_mark, fid.getNumber());
 
       m_levelUpdaterA->update(fid, imgA);
 
       if (rasterB) {
         TRasterImageP imgB(rasterB);
-        postProcessImage(imgB, has64bitOutputSupport, m_renderSettings.m_mark,
-                         fid.getNumber());
+        postProcessImage(imgB, has64bitOutputSupport, writeInLinearColorSpace,
+                         m_toBeAppliedGamma[frame], writingGamma,
+                         m_renderSettings.m_colorSpaceGamma,
+                         m_renderSettings.m_mark, fid.getNumber());
 
         m_levelUpdaterB->update(fid, imgB);
       }
@@ -453,9 +501,10 @@ std::pair<bool, int> MovieRenderer::Imp::saveFrame(
       // Should no more throw from here on
 
       if (m_cacheResults) {
-        if (imgA->getRaster()->getPixelSize() == 8) {
-          // Convert 64-bit images to 32 - cached images are supposed to be
-          // 32-bit
+        if (imgA->getRaster()->getPixelSize() == 8 ||
+            imgA->getRaster()->getPixelSize() == 16) {
+          // Convert 64-bit / float images to 32 - cached images are supposed to
+          // be 32-bit
           TRaster32P aux(imgA->getRaster()->getLx(),
                          imgA->getRaster()->getLy());
 

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -42,8 +42,10 @@ TOutputProperties::TOutputProperties()
     , m_threadIndex(2)
     , m_subcameraPreview(false)
     , m_boardSettings(new BoardSettings())
-    , m_formatTemplateFId() {
+    , m_formatTemplateFId()
+    , m_syncColorSettings(true) {
   m_renderSettings = new TRenderSettings();
+  m_nonlinearBpp   = m_renderSettings->m_bpp;
 }
 
 //-------------------------------------------------------------------
@@ -63,7 +65,9 @@ TOutputProperties::TOutputProperties(const TOutputProperties &src)
     , m_threadIndex(src.m_threadIndex)
     , m_subcameraPreview(src.m_subcameraPreview)
     , m_boardSettings(new BoardSettings(*src.m_boardSettings))
-    , m_formatTemplateFId(src.m_formatTemplateFId) {
+    , m_formatTemplateFId(src.m_formatTemplateFId)
+    , m_syncColorSettings(src.m_syncColorSettings)
+    , m_nonlinearBpp(src.m_nonlinearBpp) {
   std::map<std::string, TPropertyGroup *>::iterator ft,
       fEnd = m_formatProperties.end();
   for (ft = m_formatProperties.begin(); ft != fEnd; ++ft) {
@@ -189,7 +193,8 @@ void TOutputProperties::getFileFormatPropertiesExtensions(
 
 void TOutputProperties::setRenderSettings(
     const TRenderSettings &renderSettings) {
-  assert(renderSettings.m_bpp == 32 || renderSettings.m_bpp == 64);
+  assert(renderSettings.m_bpp == 32 || renderSettings.m_bpp == 64 ||
+         renderSettings.m_bpp == 128);
   assert(renderSettings.m_gamma > 0);
   assert(renderSettings.m_quality == TRenderSettings::StandardResampleQuality ||
          renderSettings.m_quality == TRenderSettings::ImprovedResampleQuality ||

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -47,7 +47,8 @@ const char *s_name = "name", *s_regexp = "regexp", *s_priority = "priority";
 
 const char *s_dpiPolicy = "dpiPolicy", *s_dpi = "dpi",
            *s_subsampling = "subsampling", *s_antialias = "antialias",
-           *s_premultiply = "premultiply", *s_whiteTransp = "whiteTransp";
+           *s_premultiply = "premultiply", *s_whiteTransp = "whiteTransp",
+           *s_colorSpaceGamma = "colorSpaceGamma";
 
 //=================================================================
 
@@ -124,6 +125,7 @@ void setValue(QSettings &settings, const LevelOptions &lo) {
   settings.setValue(s_antialias, lo.m_antialias);
   settings.setValue(s_premultiply, int(lo.m_premultiply));
   settings.setValue(s_whiteTransp, int(lo.m_whiteTransp));
+  settings.setValue(s_colorSpaceGamma, lo.m_colorSpaceGamma);
 }
 
 //-----------------------------------------------------------------
@@ -138,6 +140,8 @@ void getValue(const QSettings &settings, LevelOptions &lo) {
       (settings.value(s_premultiply, lo.m_premultiply).toInt() != 0);
   lo.m_whiteTransp =
       (settings.value(s_whiteTransp, lo.m_whiteTransp).toInt() != 0);
+  lo.m_colorSpaceGamma =
+      settings.value(s_colorSpaceGamma, lo.m_colorSpaceGamma).toDouble();
 }
 
 //-----------------------------------------------------------------

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -77,6 +77,8 @@ public:
   TimeShuffleFx()
       : TRasterFx(), m_frame(0), m_timeRegion(), m_cellColumn(nullptr) {
     addInputPort("source", m_port);
+
+    enableComputeInFloat(true);
   }
   ~TimeShuffleFx() {}
 
@@ -141,6 +143,11 @@ public:
                     const TRenderSettings &info) override {
     if (m_port.isConnected())
       TRasterFxP(m_port.getFx())->dryCompute(rect, getLevelFrame(frame), info);
+  }
+
+  bool toBeComputedInLinearColorSpace(bool settingsIsLinear,
+                                      bool tileIsLinear) const override {
+    return tileIsLinear;
   }
 
 private:

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -233,6 +233,16 @@ void TSceneProperties::saveData(TOStream &os) const {
     os.child("fps") << out.getFrameRate();
     os.child("path") << outPath;
     os.child("bpp") << rs.m_bpp;
+    if (rs.m_linearColorSpace) {
+      os.child("linearColorSpace") << (rs.m_linearColorSpace ? 1 : 0);
+      os.child("nonlinearBpp") << out.getNonlinearBpp();
+    }
+    if (rs.m_colorSpaceGamma >= 1. &&
+        !areAlmostEqual(rs.m_colorSpaceGamma, 2.2))
+      os.child("colorSpaceGamma") << rs.m_colorSpaceGamma;
+    if (i == 1)  // preview
+      os.child("syncColorSettings") << (out.isColorSettingsSynced() ? 1 : 0);
+
     os.child("multimedia") << out.getMultimediaRendering();
     os.child("threadsIndex") << out.getThreadIndex();
     os.child("maxTileSizeIndex") << out.getMaxTileSizeIndex();
@@ -387,7 +397,9 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
   int globFrom = -1, globTo = 0, globStep = 1;
   double globFrameRate = -1;
   std::string tagName;
-  *m_outputProp = *m_previewProp = TOutputProperties();
+  *m_outputProp  = TOutputProperties();
+  *m_previewProp = TOutputProperties();
+
   while (is.matchTag(tagName)) {
     if (tagName == "projectPath") {
       TFilePath projectPath;
@@ -538,7 +550,24 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
             } else if (tagName == "bpp") {
               int j;
               is >> j;
-              if (j == 32 || j == 64) renderSettings.m_bpp = j;
+              if (j == 32 || j == 64 || j == 128) renderSettings.m_bpp = j;
+            } else if (tagName == "linearColorSpace") {
+              int linearColorSpace;
+              is >> linearColorSpace;
+              renderSettings.m_linearColorSpace = (linearColorSpace != 0);
+            } else if (tagName == "nonlinearBpp") {
+              int j;
+              is >> j;
+              if (j == 32 || j == 64 || j == 128) out.setNonlinearBpp(j);
+            } else if (tagName == "colorSpaceGamma") {
+              double colorSpaceGamma;
+              is >> colorSpaceGamma;
+              renderSettings.m_colorSpaceGamma = colorSpaceGamma;
+            } else if (tagName == "syncColorSettings") {
+              assert(name == "preview");
+              int syncColorSettings;
+              is >> syncColorSettings;
+              out.syncColorSettings(syncColorSettings != 0);
             } else if (tagName == "multimedia") {
               int j;
               is >> j;
@@ -784,6 +813,13 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
       throw TException("unexpected property tag: " + tagName);
     }
     is.closeChild();
+  }
+
+  // in order to support scenes made in previous development version
+  if (m_previewProp->getRenderSettings().m_colorSpaceGamma < 0.) {
+    TRenderSettings rs(m_previewProp->getRenderSettings());
+    rs.m_colorSpaceGamma = m_outputProp->getRenderSettings().m_colorSpaceGamma;
+    m_previewProp->setRenderSettings(rs);
   }
 }
 

--- a/toonz/sources/toonzlib/tcolumnfx.cpp
+++ b/toonz/sources/toonzlib/tcolumnfx.cpp
@@ -87,8 +87,8 @@ namespace {
 
 void setMaxMatte(TRasterP r) {
   TRaster32P r32 = (TRaster32P)r;
-
   TRaster64P r64 = (TRaster64P)r;
+  TRasterFP rF   = (TRasterFP)r;
 
   if (r32)
     for (int i = 0; i < r32->getLy(); i++) {
@@ -99,6 +99,12 @@ void setMaxMatte(TRasterP r) {
     for (int i = 0; i < r64->getLy(); i++) {
       TPixel64 *pix = r64->pixels(i);
       for (int j = 0; j < r64->getLx(); j++, pix++) pix->m = 65535;
+    }
+  else if (rF)
+    for (int i = 0; i < rF->getLy(); i++) {
+      TPixelF *pix = rF->pixels(i);
+      for (int j = 0; j < rF->getLx(); j++, pix++)
+        pix->m = TPixelF::maxChannelValue;
     }
 }
 
@@ -332,12 +338,12 @@ inline bool fxLess(TRasterFxRenderDataP a, TRasterFxRenderDataP b) {
       dynamic_cast<SandorFxRenderData *>(b.getPointer());
   if (!sandorDataB) return true;
 
-  int aIndex = sandorDataA->m_type == OutBorder
-                   ? 2
-                   : sandorDataA->m_type == BlendTz ? 1 : 0;
-  int bIndex = sandorDataB->m_type == OutBorder
-                   ? 2
-                   : sandorDataB->m_type == BlendTz ? 1 : 0;
+  int aIndex = sandorDataA->m_type == OutBorder ? 2
+               : sandorDataA->m_type == BlendTz ? 1
+                                                : 0;
+  int bIndex = sandorDataB->m_type == OutBorder ? 2
+               : sandorDataB->m_type == BlendTz ? 1
+                                                : 0;
 
   return aIndex < bIndex;
 }
@@ -725,7 +731,9 @@ class LevelFxBuilder final : public ResourceBuilder {
   TXshSimpleLevel *m_sl;
   TFrameId m_fid;
   TRectD m_tileGeom;
-  bool m_64bit;
+  int m_bpp;
+  // bool m_linear;
+  // bool m_64bit;
 
   TRect m_rasBounds;
 
@@ -737,23 +745,29 @@ public:
       , m_palette()
       , m_sl(sl)
       , m_fid(fid)
-      , m_64bit(rs.m_bpp == 64) {}
+      , m_bpp(rs.m_bpp) {}
+  //, m_linear(rs.m_linearColorSpace){}
 
   void setRasBounds(const TRect &rasBounds) { m_rasBounds = rasBounds; }
 
   void compute(const TRectD &tileRect) override {
+    UCHAR flag = ImageManager::dontPutInCache;
+    if (m_bpp == 64 || m_bpp == 128) flag = flag | ImageManager::is64bitEnabled;
+    if (m_bpp == 128) flag = flag | ImageManager::isFloatEnabled;
+    // if (m_linear)
+    //   flag = flag | ImageManager::isLinearEnabled;
+
     // Load the image
-    TImageP img(m_sl->getFullsampledFrame(
-        m_fid, (m_64bit ? ImageManager::is64bitEnabled : 0) |
-                   ImageManager::dontPutInCache));
+    TImageP img(m_sl->getFullsampledFrame(m_fid, flag));
 
     if (!img) return;
 
     TRasterImageP rimg(img);
     TToonzImageP timg(img);
 
-    m_loadedRas = rimg ? (TRasterP)rimg->getRaster()
-                       : timg ? (TRasterP)timg->getRaster() : TRasterP();
+    m_loadedRas = rimg   ? (TRasterP)rimg->getRaster()
+                  : timg ? (TRasterP)timg->getRaster()
+                         : TRasterP();
     assert(m_loadedRas);
 
     if (timg) m_palette = timg->getPalette();
@@ -804,6 +818,7 @@ public:
 TLevelColumnFx::TLevelColumnFx()
     : m_levelColumn(0), m_isCachable(true), m_mutex(), m_offlineContext(0) {
   setName(L"LevelColumn");
+  enableComputeInFloat(true);
 }
 
 //--------------------------------------------------
@@ -1087,13 +1102,15 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
       ri  = 0;
       TRaster32P ras32(ras);
       TRaster64P ras64(ras);
+      TRasterFP rasF(ras);
 
       // Ensure that ras is either a 32 or 64 fullcolor.
       // Otherwise, we have to convert it.
-      if (!ras32 && !ras64) {
+      if (!ras32 && !ras64 && !rasF) {
         TRasterP tileRas(tile.getRaster());
         TRaster32P tileRas32(tileRas);
         TRaster64P tileRas64(tileRas);
+        TRasterFP tileRasF(tileRas);
 
         if (tileRas32) {
           ras32 = TRaster32P(ras->getLx(), ras->getLy());
@@ -1103,6 +1120,10 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
           ras64 = TRaster64P(ras->getLx(), ras->getLy());
           TRop::convert(ras64, ras);
           ras = ras64;
+        } else if (tileRasF) {
+          rasF = TRasterFP(ras->getLx(), ras->getLy());
+          TRop::convert(rasF, ras);
+          ras = rasF;
         } else
           assert(0);
       }
@@ -1127,7 +1148,8 @@ void TLevelColumnFx::doCompute(TTile &tile, double frame,
         TRop::whiteTransp(appRas);
         ras = appRas;
       }
-      if (levelProp->antialiasSoftness() > 0) {
+      if (levelProp->antialiasSoftness() > 0 &&
+          !rasF) {  // temporarily disabled with float raster
         TRasterP appRas = ras->create(ras->getLx(), ras->getLy());
         TRop::antialias(ras, appRas, 10, levelProp->antialiasSoftness());
         ras = appRas;

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1181,6 +1181,8 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     LevelProperties *lp = xl->getProperties();
     assert(lp);
 
+    bool formatSpecified = false;
+
     if (levelOptions)
       lp->options() = *levelOptions;
     else {
@@ -1188,9 +1190,10 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
       int formatIdx            = prefs.matchLevelFormat(
           levelPath);  // Should I use actualPath here? It's mostly
                                   // irrelevant anyway, it's for old tzp/tzu...
-      if (formatIdx >= 0)
-        lp->options() = prefs.levelFormat(formatIdx).m_options;
-      else {
+      if (formatIdx >= 0) {
+        lp->options()   = prefs.levelFormat(formatIdx).m_options;
+        formatSpecified = true;
+      } else {
         // Default subsampling values are assigned from scene properties
         if (xl->getType() == OVL_XSHLEVEL)
           lp->setSubsampling(getProperties()->getFullcolorSubsampling());
@@ -1216,6 +1219,17 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
         // Has dpi alright - assign it to custom dpi, too
         lp->setDpi(imageDpi);
       }
+    }
+
+    // for EXR level, set the color space gamma to the same value as the output
+    // settings. skip if the loading gamma is specified in the preferences.
+    if (xl->getType() == OVL_XSHLEVEL && levelPath.getType() == "exr" &&
+        !formatSpecified) {
+      double gamma = getProperties()
+                         ->getOutputProperties()
+                         ->getRenderSettings()
+                         .m_colorSpaceGamma;
+      lp->setColorSpaceGamma(gamma);
     }
 
     m_levelSet->insertLevel(xl);

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -272,7 +272,7 @@ QVariant StageObjectChannelGroup::data(int role) const {
     std::string name = (m_stageObject->getId().isTable())
                            ? FunctionTreeView::tr("Table").toStdString()
                            : m_stageObject->getName();
-    std::string id = m_stageObject->getId().toString();
+    std::string id   = m_stageObject->getId().toString();
 
     return (name == id) ? QString::fromStdString(name)
                         : QString::fromStdString(id + " (" + name + ")");
@@ -604,7 +604,8 @@ QVariant FunctionTreeModel::Channel::data(int role) const {
     if (isIgnored()) return isActive() ? paramIgnoredOn : paramIgnoredOff;
 
     return m_param->hasKeyframes() ? isActive() ? paramAnimOn : paramAnimOff
-                                   : isActive() ? paramOn : paramOff;
+           : isActive()            ? paramOn
+                                   : paramOff;
   } else if (role == Qt::DisplayRole) {
     if (m_param->hasUILabel()) {
       return QString::fromStdString(m_param->getUILabel());
@@ -1144,8 +1145,11 @@ void FunctionTreeModel::addChannels(TFx *fx, ChannelGroup *groupItem,
   const std::string &paramNamePref = fx->getFxType() + ".";
 
   int p, pCount = params->getParamCount();
-  for (p = 0; p != pCount; ++p)
+  for (p = 0; p != pCount; ++p) {
+    // hidden parameter are not displayed in the tree
+    if (params->isParamHidden(p)) continue;
     addParameter(fxItem, paramNamePref, fxId, params->getParam(p));
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/fxhistogramrender.cpp
+++ b/toonz/sources/toonzqt/fxhistogramrender.cpp
@@ -90,7 +90,8 @@ void FxHistogramRender::computeHistogram(TFxP fx, int frame) {
   if (!sceneProperties) return;
   TOutputProperties *outputProperties = sceneProperties->getPreviewProperties();
   if (!outputProperties) return;
-  const TRenderSettings rs = outputProperties->getRenderSettings();
+  TRenderSettings rs = outputProperties->getRenderSettings();
+
   TFxP buildedFx;
   if (m_isCameraViewMode)
     buildedFx =
@@ -167,8 +168,9 @@ void FxHistogramRender::remakeRender() {
   TRectD area(TPointD(-0.5 * size.lx, -0.5 * size.ly),
               TDimensionD(size.lx, size.ly));
   m_renderPort->setRenderArea(area);
-  const TRenderSettings rs =
+  TRenderSettings rs =
       m_scene->getProperties()->getPreviewProperties()->getRenderSettings();
+
   TFxP buildedFx =
       buildPartialSceneFx(m_scene, (double)m_lastFrameInfo.m_frame,
                           m_lastFrameInfo.m_fx, rs.m_shrinkX, true);

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -65,43 +65,6 @@ bool hasEmptyInputPort(const TFxP &currentFx) {
   if (currentFx->getInputPortCount() == 0) return false;
   return hasEmptyInputPort(currentFx->getInputPort(0)->getFx());
 }
-/*
-TFxP cloneInputPort(const TFxP &currentFx)
-{
-        int i;
-  for (i=0; i<getInputPortCount(); ++i)
-  {
-                TFx *inputFx = sceneFx->getInputPort(i)->getFx();
-                if(inputFx)
-                {
-                        if(TLevelColumnFx* affFx = dynamic_cast<TLevelColumnFx*
->(inputFx))
-                                currentFx->getInputPort(i)->setFx(inputFx);
-                        else
-                                currentFx->getInputPort(i)->setFx(cloneInputPort());
-                }
-                TFxPort *port = getInputPort(i);
-                if (port->getFx())
-                        fx->connect(getInputPortName(i),
-cloneInputPort(port->getFx()));
-}
-void setLevelFxInputPort(const TFxP &currentFx, const TFxP &sceneFx)
-{
-        for (int i=0; i<sceneFx->getInputPortCount(); ++i)
-        {
-                TFx *inputFx = sceneFx->getInputPort(i)->getFx();
-                if(inputFx)
-                {
-                        if(TLevelColumnFx* affFx = dynamic_cast<TLevelColumnFx*
->(inputFx))
-                                currentFx->getInputPort(i)->setFx(inputFx);
-                        else
-                                setLevelFxInputPort(currentFx->getInputPort(i)->getFx(),
-inputFx);
-                }
-        }
-}
-*/
 
 // find the field by parameter name and register the field and its label widget
 bool findItemByParamName(QLayout *layout, std::string name,
@@ -131,7 +94,6 @@ bool findItemByParamName(QLayout *layout, std::string name,
   }
   return false;
 };
-
 }  // namespace
 
 //=============================================================================
@@ -192,6 +154,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
       std::string name;
       is >> name;
       is.matchEndTag();
+
       /*-- Layout設定名とFxParameterの名前が一致するものを取得 --*/
       TParamP param = fx->getParams()->getParam(name);
       bool isHidden =
@@ -760,6 +723,13 @@ ParamsPageSet::ParamsPageSet(QWidget *parent, Qt::WFlags flags)
   m_helpButton->setObjectName("FxSettingsHelpButton");
   m_helpButton->setFocusPolicy(Qt::NoFocus);
 
+  m_warningMark = new QLabel(this);
+  static QIcon warningIcon(":Resources/paramignored_on.svg");
+  m_warningMark->setPixmap(warningIcon.pixmap(QSize(22, 22)));
+  m_warningMark->setFixedSize(22, 22);
+  m_warningMark->setStyleSheet(
+      "margin: 0px; padding: 0px; background-color: rgba(0,0,0,0);");
+
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setMargin(0);
@@ -770,6 +740,7 @@ ParamsPageSet::ParamsPageSet(QWidget *parent, Qt::WFlags flags)
     hLayout->addSpacing(0);
     {
       hLayout->addWidget(m_tabBar);
+      hLayout->addWidget(m_warningMark);
       hLayout->addStretch(1);
       hLayout->addWidget(m_helpButton);
     }
@@ -1047,6 +1018,49 @@ void ParamsPageSet::openHelpUrl() {
   QDesktopServices::openUrl(QUrl(QString(m_helpUrl.c_str())));
 }
 
+void ParamsPageSet::updateWarnings(const TFxP &currentFx, bool isFloat) {
+  if (!isFloat) {
+    m_warningMark->hide();
+    return;
+  }
+
+  bool isFloatSupported = true;
+
+  TMacroFx *currentFxMacro = dynamic_cast<TMacroFx *>(currentFx.getPointer());
+  if (currentFxMacro) {
+    const std::vector<TFxP> &currentFxMacroFxs = currentFxMacro->getFxs();
+    for (auto fxP : currentFxMacroFxs) {
+      TRasterFx *rasFx = dynamic_cast<TRasterFx *>(fxP.getPointer());
+      if (rasFx) {
+        isFloatSupported = isFloatSupported & rasFx->canComputeInFloat();
+      }
+      if (!isFloatSupported) break;
+    }
+  } else {
+    TRasterFx *rasFx = dynamic_cast<TRasterFx *>(currentFx.getPointer());
+    if (rasFx) {
+      isFloatSupported = rasFx->canComputeInFloat();
+    }
+  }
+
+  bool showFloatWarning = isFloat && !isFloatSupported;
+  if (!showFloatWarning) {
+    m_warningMark->hide();
+    return;
+  }
+
+  QString warningTxt;
+  if (showFloatWarning) {
+    warningTxt +=
+        tr("This Fx does not support rendering in floating point channel width "
+           "(32bit).\n"
+           "The output pixel values from this fx will be clamped to 0.0 - 1.0\n"
+           "and tone may be slightly discretized.");
+  }
+  m_warningMark->setToolTip(warningTxt);
+  m_warningMark->show();
+}
+
 //=============================================================================
 // ParamViewer
 //-----------------------------------------------------------------------------
@@ -1189,6 +1203,13 @@ void ParamViewer::setPointValue(int index, const TPointD &p) {
 
 ParamsPageSet *ParamViewer::getCurrentPageSet() const {
   return dynamic_cast<ParamsPageSet *>(m_tablePageSet->currentWidget());
+}
+
+//-----------------------------------------------------------------------------
+// show warning if the current Fx does not support float / linear rendering
+void ParamViewer::updateWarnings(const TFxP &currentFx, bool isFloat) {
+  if (getCurrentPageSet())
+    getCurrentPageSet()->updateWarnings(currentFx, isFloat);
 }
 
 //=============================================================================
@@ -1396,11 +1417,24 @@ void FxSettings::setFx(const TFxP &currentFx, const TFxP &actualFx) {
   ToonzScene *scene = 0;
   if (m_sceneHandle) scene = m_sceneHandle->getScene();
 
+  // check if the current render settings are float
+  bool isFloat = false;
+  if (scene) {
+    const TRenderSettings ps =
+        scene->getProperties()->getPreviewProperties()->getRenderSettings();
+    const TRenderSettings os =
+        scene->getProperties()->getOutputProperties()->getRenderSettings();
+    isFloat = (ps.m_bpp == 128) || (os.m_bpp == 128);
+  }
+
   int frameIndex = 0;
   if (m_frameHandle) frameIndex = m_frameHandle->getFrameIndex();
 
   m_paramViewer->setFx(currentFxWithoutCamera, actualFx, frameIndex, scene);
   m_paramViewer->setIsCameraViewMode(m_isCameraModeView);
+  // show warning if the current Fx does not support float / linear rendering
+  m_paramViewer->updateWarnings(currentFxWithoutCamera, isFloat);
+
   m_viewer->setCameraMode(m_isCameraModeView);
 
   TDimension cameraSize = TDimension(-1, -1);

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -566,8 +566,11 @@ void LutManager::convert(float& r, float& g, float& b) {
   float ratio[3];   // RGB軸
   int index[3][2];  // rgb インデックス
   float rawVal[3] = {r, g, b};
+  // clamp values (for HDR image)
+  for (int c = 0; c < 3; c++)
+    rawVal[c] = (rawVal[c] < 0.f) ? 0.f : (rawVal[c] > 1.f) ? 1.f : rawVal[c];
 
-  float vertex_color[2][2][2][3];  //補間用の１ボクセルの頂点色
+  float vertex_color[2][2][2][3];  // 補間用の１ボクセルの頂点色
 
   for (int c = 0; c < 3; c++) {
     float val   = rawVal[c] * (float)(m_lut.meshSize - 1);
@@ -615,9 +618,7 @@ void LutManager::convert(QColor& col) {
   float g = col.greenF();
   float b = col.blueF();
   convert(r, g, b);
-  // 0.5 offset is necessary for converting to 255 grading
-  col = QColor((int)(r * 255.0 + 0.5), (int)(g * 255.0 + 0.5),
-               (int)(b * 255.0 + 0.5), col.alpha());
+  col = QColor::fromRgbF(r, g, b, col.alphaF());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/pluginhost.cpp
+++ b/toonz/sources/toonzqt/pluginhost.cpp
@@ -36,7 +36,7 @@
 #include <QLabel>
 #include <QHBoxLayout>
 #include <QFormLayout>
-//#include <QtConcurrent>
+// #include <QtConcurrent>
 
 #include "plugin_param_traits.h"
 #include "../include/toonzqt/pluginloader.h"
@@ -451,7 +451,7 @@ RasterFxPluginHost *RasterFxPluginHost::newInstance(
 }
 
 const TPersistDeclaration *RasterFxPluginHost::getDeclaration() const {
-  printf("RasterFxPluginHost::getDeclaration()\n");
+  // printf("RasterFxPluginHost::getDeclaration()\n");
   return pi_->decl_;
 }
 
@@ -1560,11 +1560,10 @@ PluginLoadController::PluginLoadController(const std::string &basedir,
   connect(&work_entity, &QThread::finished, ld, &QObject::deleteLater);
   /* AddFxContextMenu から呼ばれていたが、プラグインの検索が load_entries()
      を通じて起動時に呼ばれるようにした関係で,
-     (あまりよくはないが)listener の有無によって receiver を分けるようにしている.
-     listener がいる場合は従来通り context menu の構築のために
-     AddFxContextMenu::fixup() に接続するが
-     それ以外では plugin_dict_ への追加のため PluginLoadController::finished
-     に接続する.
+     (あまりよくはないが)listener の有無によって receiver
+     を分けるようにしている. listener がいる場合は従来通り context menu
+     の構築のために AddFxContextMenu::fixup() に接続するが それ以外では
+     plugin_dict_ への追加のため PluginLoadController::finished に接続する.
   */
   if (listener) {
     AddFxContextMenu *a = qobject_cast<AddFxContextMenu *>(listener);
@@ -1619,4 +1618,4 @@ static bool copy_rendering_setting(toonz_rendering_setting_t *dst,
   return true;
 }
 
-//#include "pluginhost.moc"
+// #include "pluginhost.moc"


### PR DESCRIPTION
This PR will enable OT to render in floating point pixel, i.e. each channel in pixel has 32bit float value.
Using this feature you can compute the scene in high-dynamic range (HDR), which is necessary to meet some premium cinema requirements such as [Dolby Cinema](https://en.wikipedia.org/wiki/Dolby_Cinema).

### Changes

#### Output / Preview Settings
- Added a new option `32bit Floating point` to `Channel Width`.
    - HDR images can be rendered with this option. 
    - Note that some Fxs (as listed below) does not support floating point rendering.  When an unsupported Fx is used, the output from that Fx node will be clamped to 0-1.
- Added `Linear Color Space` check box.
    - This option is referenced when the `Color Space` combo box (see below) in Layer Blending **Ino** Fxs is set to `Auto`.
    - From Layer Blending Fxs, this option is always referenced.
- Added `Color Space Gamma` parameter, which is used to convert images between linear and nonlinear color spaces.

#### Layer Blending Ino Fxs
- Replaced the `Linear Color Space` check box by a `Color Space` combo box with options as follows:
    - **Auto** (default) : Same as the `Linear Color Space` option in Output/Preview settings.
    - **Linear** : Always compute in the linear color space. Color space gamma can be adjustable with the `Gamma Adjust` parameter.
    - **Nonlinear** : Always compute in the nonlinear color space. 

#### Layer Blending Ino Fxs, Adjust Exposure Iwa, Motion Blur Iwa, all Bokeh Fxs, and Bloom Iwa
- Replaced the `Gamma` parameter by `Gamma Adjust`. Which is an offset value from `Color Space Gamma` specified in Output/Preview settings.

#### All Bokeh Fxs
- Added `Linearize Mode` combo box which enables to choose how to convert color spaces, from Hardness-based (conventional way) and Gamma-based (newly added way).

#### EXR format I/O
- HDR is now supported.
- Added `Float` to the `Bit Per Pixel` output property, in addition to `Half Float`.
- Added `Color Space Gamma` to the output property to specify gamma value when saving.
- Enabled to specify loading gamma value in the Level Settings.

#### Flipbook
- Gain can now be changed when displaying a raster image in Floating Point format.
    ![image](https://user-images.githubusercontent.com/17974955/211521413-a476cd14-1235-42ed-b5a9-cd1c3743d2a7.png)
    ![image](https://user-images.githubusercontent.com/17974955/211522497-924e15f1-8176-4b7f-aca9-bad9d112ecac.png)

#### Histogram
- When displaying a raster in floating point format, the upper range of the histogram can now be expanded.
    <img src="https://user-images.githubusercontent.com/17974955/211523027-c57c4ba3-9e50-419e-b74b-f4634f47d1c7.png" height=400>

-----
### Effects that do NOT support Floating Point calculations
- Blur
    - Line Blur Ino
    - Local Blur
    - Motion Blur
    - Motion Blur Ino
    - Radial Blur
    - Spin Blur
    - Flow Blur Iwa
- Distort
    - Free Distort
    - Linear Wave
    - Random Wave
    - Floor Bump Iwa
- Gradient
    - Diamond Gradient
    - Four Points
    - Spiral
    - Square Gradient
- Image Adjust
    - Despeckle
    - HSV Scale
    - Multitone
    - Negate Ino
    - RGBA Cut
    - RGBA Scale
    - Sharpen
- Light
    - Backlit
    - Body Highlight
    - Cast Shadow
    - Fog Ino
    - Glow
    - Light Spot
    - Target Spot
- Matte
    - Erode/Dilate
- Noise
    - Dissolve
    - Median Ino
    - Median Filter Ino
    - Noise
    - Salt Pepper Noise
- Render
    - Clouds
    - Particles
    - Tiled Particles
    - TimeCode Iwa
    - Text Iwa
    - Flow Paint Brush Iwa
- Stylize
    - All Fxs other than Max Min Ino
- Toonz Level
    - All Fxs
- Shaders
    - All Fxs