### PR TITLE
Export Scene enhancements

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -26,6 +26,7 @@
             <command>MI_ImportMagpieFile</command>
         </menu>
         <menu title="Export">
+            <command>MI_ExportCurrentScene</command>		
             <command>MI_SoundTrack</command>
             <command>MI_ExportXDTS</command>
             <command>MI_ExportOCA</command>

--- a/toonz/sources/include/toonzqt/filefield.h
+++ b/toonz/sources/include/toonzqt/filefield.h
@@ -92,6 +92,7 @@ public:
   void setValidator(const QValidator *v) { m_field->setValidator(v); }
   QString getPath();
   void setPath(const QString &path);
+  LineEdit *getField() { return m_field; }
 
   static void setBrowserPopupController(BrowserPopupController *controller);
   static BrowserPopupController *getBrowserPopupController();

--- a/toonz/sources/toonz/exportscenepopup.h
+++ b/toonz/sources/toonz/exportscenepopup.h
@@ -5,6 +5,7 @@
 
 #include "toonzqt/dvdialog.h"
 #include "toonzqt/lineedit.h"
+#include "toonzqt/filefield.h"
 #include "tfilepath.h"
 #include "filebrowsermodel.h"
 #include "dvdirtreeview.h"
@@ -162,6 +163,9 @@ class ExportScenePopup final : public DVGui::Dialog {
   ExportSceneTreeView *m_projectTreeView;
   QRadioButton *m_newProjectButton;
   QRadioButton *m_chooseProjectButton;
+
+  QLabel *m_pathFieldLabel;
+  DVGui::FileField *m_projectLocationFld;
 
   bool m_createNewProject;
 

--- a/toonz/sources/toonz/fileselection.cpp
+++ b/toonz/sources/toonz/fileselection.cpp
@@ -33,6 +33,7 @@
 #include "toonz/studiopalette.h"
 #include "toonz/palettecontroller.h"
 #include "toonz/tpalettehandle.h"
+#include "toonz/tscenehandle.h"
 
 // TnzCore includes
 #include "tfiletype.h"
@@ -609,6 +610,20 @@ void FileSelection::exportScenes() {
 
 //------------------------------------------------------------------------
 
+void FileSelection::exportScene(TFilePath scenePath) {
+  if (scenePath.isEmpty()) return;
+
+  std::vector<TFilePath> files;
+  files.push_back(scenePath);
+  if (!m_exportScenePopup)
+    m_exportScenePopup = new ExportScenePopup(files);
+  else
+    m_exportScenePopup->setScenes(files);
+  m_exportScenePopup->show();
+}
+
+//------------------------------------------------------------------------
+
 void FileSelection::selectAll() {
   DvItemSelection::selectAll();
   const std::set<int> &indices = getSelectedIndices();
@@ -621,3 +636,27 @@ void FileSelection::selectAll() {
     FileBrowser::updateItemViewerPanel();
   }
 }
+
+//-----------------------------------------------------------------------------
+
+class ExportCurrentSceneCommandHandler final : public MenuItemHandler {
+public:
+  ExportCurrentSceneCommandHandler() : MenuItemHandler(MI_ExportCurrentScene) {}
+  void execute() override {
+    TApp *app                 = TApp::instance();
+    TSceneHandle *sceneHandle = app->getCurrentScene();
+    if (!sceneHandle) return;
+    ToonzScene *scene = sceneHandle->getScene();
+    if (!scene) return;
+    TFilePath fp = scene->getScenePath();
+
+    if (sceneHandle->getDirtyFlag() || scene->isUntitled() ||
+        !TSystem::doesExistFileOrLevel(fp)) {
+      DVGui::warning(tr("You must save the current scene first."));
+      return;
+    }
+
+    FileSelection *fs = new FileSelection();
+    fs->exportScene(fp);
+  }
+} ExportCurrentSceneCommandHandler;

--- a/toonz/sources/toonz/fileselection.h
+++ b/toonz/sources/toonz/fileselection.h
@@ -43,6 +43,7 @@ public:
   void collectAssets();
   void importScenes();
   void exportScenes();
+  void exportScene(TFilePath scenePath);
   void selectAll();
   void separateFilesByColors();
 };

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1731,6 +1731,8 @@ void MainWindow::defineActions() {
                        QT_TR_NOOP("&Clear Recent Flipbook Image List"), "");
   createMenuFileAction(MI_ClearCacheFolder, QT_TR_NOOP("&Clear Cache Folder"),
                        "", "clear_cache");
+  createMenuFileAction(MI_ExportCurrentScene,
+                       QT_TR_NOOP("&Export Current Scene"), "");
 
   // Menu - Edit
 

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1108,6 +1108,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   { addMenuItem(importMenu, MI_ImportMagpieFile); }
   QMenu *exportMenu = fileMenu->addMenu(tr("Export"));
   {
+    addMenuItem(exportMenu, MI_ExportCurrentScene);
     addMenuItem(exportMenu, MI_SoundTrack);
     addMenuItem(exportMenu, MI_ExportXDTS);
     addMenuItem(exportMenu, MI_ExportOCA);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -261,6 +261,7 @@
 #define MI_CollectAssets "MI_CollectAssets"
 #define MI_ImportScenes "MI_ImportScenes"
 #define MI_ExportScenes "MI_ExportScenes"
+#define MI_ExportCurrentScene "MI_ExportCurrentScene"
 
 #define MI_SelectRowKeyframes "MI_SelectRowKeyframes"
 #define MI_SelectColumnKeyframes "MI_SelectColumnKeyframes"


### PR DESCRIPTION
A requested port from T2D which will enhance Export scene as follows:

1. Adds a `Create In` option for new Project creation

![image](https://user-images.githubusercontent.com/19245851/212147372-fe3681d1-d251-48e3-bdac-2828376bf119.png)

3. Adds an `Export Current Scene` command*

![image](https://user-images.githubusercontent.com/19245851/212147540-adb43b9a-4720-4fec-a0d8-c512455a8776.png)

*Due to OT's customizable menus `Export Current Scene` will only be visible on clean installations or by resetting rooms after an in place upgrade
