### PR TITLE
Add Foreground Alpha Option for HSLBlend Shader

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -535,6 +535,7 @@
   <item>"SHADER_HSLBlendGPU.bhue"			"Hue"    </item>
   <item>"SHADER_HSLBlendGPU.bsat"			"Saturation"    </item>
   <item>"SHADER_HSLBlendGPU.blum"			"Luminosity"    </item>
+  <item>"SHADER_HSLBlendGPU.matte"			"Alpha"    </item>
   <item>"SHADER_HSLBlendGPU.balpha"			"Opacity"    </item>
   <item>"SHADER_HSLBlendGPU.bmask"			"Clipping Mask"    </item>
 

--- a/stuff/library/shaders/HSLBlendGPU.xml
+++ b/stuff/library/shaders/HSLBlendGPU.xml
@@ -48,6 +48,12 @@
       0
     </Default>
   </Parameter>
+    <Parameter>
+    bool matte
+    <Default>
+      0
+    </Default>
+  </Parameter>
   <Parameter>
     float balpha
     <Concept>

--- a/stuff/library/shaders/programs/HSLBlendGPU.frag
+++ b/stuff/library/shaders/programs/HSLBlendGPU.frag
@@ -11,6 +11,7 @@ uniform mat3      outputToInput[2];
 uniform bool bhue;    // Blend HUE?
 uniform bool bsat;    // Blend Saturation?
 uniform bool blum;    // Blend Luminosity?
+uniform bool matte;   // Use foreground alpha?
 uniform float balpha; // Blending Alpha
 uniform bool bmask;   // Base mask?
 
@@ -114,7 +115,11 @@ void main( void )
   // Perform blending
   if (fg_alpha > 0.0 && bg_alpha > 0.0) {
     vec3 o_pix = SetLumSat(bhue ? fg_pix : bg_pix, bsat ? fg_pix : bg_pix, blum ? fg_pix : bg_pix);
-    gl_FragColor.rgb = mix(bg_pix, o_pix, balpha);
+    if (matte) {
+      gl_FragColor.rgb = mix(bg_pix, o_pix, balpha * fg_frag.a);
+    } else {
+      gl_FragColor.rgb = mix(bg_pix, o_pix, balpha);
+    }
   } else if (fg_alpha > 0.0) {
     gl_FragColor.rgb = fg_pix;
   } else {
@@ -122,5 +127,9 @@ void main( void )
   }
 
   // Premultiplication
-  gl_FragColor.rgb *= gl_FragColor.a;
+  if (matte) {
+    gl_FragColor.rgb = gl_FragColor.rgb * gl_FragColor.a;
+  } else {
+    gl_FragColor.rgb *= gl_FragColor.a;
+  }
 }

--- a/stuff/profiles/layouts/fxs/SHADER_HSLBlendGPU.xml
+++ b/stuff/profiles/layouts/fxs/SHADER_HSLBlendGPU.xml
@@ -3,6 +3,7 @@
     <control>bhue</control>
     <control>bsat</control>
     <control>blum</control>
+    <control>matte</control>
     <control>balpha</control>
     <control>bmask</control>
   </page>


### PR DESCRIPTION
Adds an option to use the alpha of the foreground. For example, currently using a color card connected to the blend port changing the alpha produces a strange result, enabling the alpha option produces a result I would expect.

I'm an absolute beginner at GLSL (literally just going by the ReadMe) so please don't merge until:
1. Someone checks the code properly
2. That this doesn't modify the original intent of the shader
3. That the original implementation isn't actually a bug

Based from: #4146 