### PR TITLE
Panel FixWidth mode + Level Palette option to not auto adjust width

### DIFF
--- a/toonz/sources/include/toonzqt/paletteviewer.h
+++ b/toonz/sources/include/toonzqt/paletteviewer.h
@@ -140,6 +140,9 @@ protected:
   QAction *m_visibleGizmoAction;
   QAction *m_visibleNameAction;
 
+  bool m_variableWidth;
+  QAction *m_variableWidthAct;
+
 protected:
   void createTabBar();
 
@@ -208,6 +211,8 @@ protected slots:
   void toggleNewStylePageVisibility(bool);
   void togglePaletteGizmoVisibility(bool);
   void toggleNameEditorVisibility(bool);
+
+  void toggleVariableWidth(bool);
 };
 
 #endif  // PALETTEVIEWER_H

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1930,7 +1930,8 @@ void Filmstrip::setOrientation(bool isVertical) {
     m_frameArea->horizontalScrollBar()->setObjectName("LevelStripScrollBar");
   }
   m_frames->setOrientation(m_isVertical);
-  dynamic_cast<TPanel *>(parentWidget())->setCanFixWidth(m_isVertical);
+  dynamic_cast<TPanel *>(parentWidget())
+      ->setFixWidthMode(m_isVertical ? TPanel::sizeable : TPanel::variable);
 }
 
 // SaveLoadQSettings

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -659,6 +659,7 @@ public:
 
   TPanel *createPanel(QWidget *parent) override {
     PaletteViewerPanel *panel = new PaletteViewerPanel(parent);
+    panel->setFixWidthMode(TPanel::sizeable);
     panel->setObjectName(getPanelType());
     panel->setWindowTitle(QObject::tr(("Level Palette")));
 
@@ -942,6 +943,7 @@ public:
 
   TPanel *createPanel(QWidget *parent) override {
     StyleEditorPanel *panel = new StyleEditorPanel(parent);
+    panel->setFixWidthMode(TPanel::sizeable);
     panel->setObjectName(getPanelType());
     panel->setWindowTitle(QObject::tr("Style Editor"));
     return panel;
@@ -961,6 +963,7 @@ public:
   ToolbarFactory() : TPanelFactory("ToolBar") {}
   void initialize(TPanel *panel) override {
     Toolbar *toolbar = new Toolbar(panel);
+    panel->setFixWidthMode(TPanel::fixed);
     panel->setWidget(toolbar);
     panel->setIsMaximizable(false);
     // panel->setAllowedAreas(Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea);

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -430,6 +430,7 @@ bool Region::checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
       m_item->clearWasFloating();
       return false;
     }
+    /*
     if ((m_item->objectName() == "FilmStrip" && m_item->getCanFixWidth()) ||
         m_item->objectName() == "StyleEditor") {
       widgets.push_back(m_item);
@@ -438,6 +439,16 @@ bool Region::checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
       return true;
     } else
       return false;
+    */
+    switch (m_item->getFixWidthMode()) {
+    case 2:
+      widgets.push_back(m_item);
+      // fallthrough
+    case 1:
+      return true;
+    default:
+      return false;
+    }
   }
   if (m_childList.empty()) return false;
   // for horizontal orientation, return true if all items are to be fixed
@@ -465,6 +476,8 @@ bool Region::checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
 void DockLayout::redistribute() {
   if (!m_regions.empty()) {
     std::vector<QWidget *> widgets;
+    std::vector<QSize> minSizes;
+    std::vector<QSize> maxSizes;
 
     // Recompute extremal region sizes
     // NOTA: Sarebbe da fare solo se un certo flag lo richiede; altrimenti tipo
@@ -478,7 +491,11 @@ void DockLayout::redistribute() {
     bool widgetsCanBeFixedWidth =
         !m_regions.front()->checkWidgetsToBeFixedWidth(widgets, fromDocking);
     if (!fromDocking && widgetsCanBeFixedWidth) {
-      for (QWidget *widget : widgets) widget->setFixedWidth(widget->width());
+      for (QWidget *widget : widgets) {
+        minSizes.push_back(widget->minimumSize());
+        maxSizes.push_back(widget->maximumSize());
+        widget->setFixedWidth(widget->width());
+      }
     }
 
     m_regions.front()->calculateExtremalSizes();
@@ -499,9 +516,15 @@ void DockLayout::redistribute() {
     m_regions.front()->redistribute();
 
     if (!fromDocking && widgetsCanBeFixedWidth) {
+      /*
       for (QWidget *widget : widgets) {
         widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
         widget->setMinimumSize(0, 0);
+      }
+      */
+      for (int i = 0; i < widgets.size(); ++i) {
+        widgets[i]->setMinimumSize(minSizes[i]);
+        widgets[i]->setMaximumSize(maxSizes[i]);
       }
     }
   }

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -171,8 +171,13 @@ class DVAPI DockWidget : public QFrame {
 public:
   void maximizeDock();
 
-  bool getCanFixWidth() { return m_canFixWidth; }
-  void setCanFixWidth(bool fixed) { m_canFixWidth = fixed; }
+  enum {
+      variable = 0,  // default, docked panel may auto resize with window
+      fixed = 1,     // to be used with setFixedWidth()
+      sizeable = 2   // allow panel to be sizeable but doesn't auto resize
+  };
+  int getFixWidthMode() { return m_modeFixWidth; }
+  void setFixWidthMode(int fixedmode) { m_modeFixWidth = fixedmode; }
 
 protected:
   // Private attributes for dragging purposes
@@ -194,7 +199,9 @@ protected:
   // window resize to minimize user frustration
   // This variable is only used by Level Strip right now.
   // This is only true if the level strip is vertical.
-  bool m_canFixWidth = false;
+  //
+  // Edit: Implementation changed to avoid hardcoded checks with panels names
+  int m_modeFixWidth = 0;
 
 private:
   QPoint m_dragInitialPos;

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -112,6 +112,7 @@ DockWidget::DockWidget(QWidget *parent, Qt::WindowFlags flags)
     , m_undocking(false)
     , m_parentLayout(0)
     , m_selectedPlace(0)
+    , m_modeFixWidth(0)
     , m_maximized(0) {
   // Don't let this widget inherit the parent's background color
   // setAutoFillBackground(true);


### PR DESCRIPTION
Both a bit of code refactoring and a new feature.

Level Palette panel now can have a fixed width while docked, if the panel is too narrow it will avoid mysterious stretching each time OT opens or main-window gets resized *(in one of my rooms i have a very narrow Level Palette for quick color select and the excessive stretching after reopening the program was driving me nuts, hence this PR)*.

This option can be found on Level Palette hamburger menu called "Auto Adjust Panel Width", it's checked by default and that's the original behavior *(Check state is opposite of this feature)*.

To use this new feature just uncheck this option and the main-window won't be able to auto resize the panel, note that manually resizing with the cursor still works.
Anyway having the panel width fixed has a side-effect! Shrinking the main-window will be limited by the width of the panel since... well... it won't be able to resize it automatically.

Lastly the refactoring did bring a few changes in behavior, panels now keep track of the minimum width properties of the widgets instead of overriding them to 0px, that means certain panels can't be resized to width of 0 anymore.
