### PR TITLE
Update xsheetviewer.cpp

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1899,9 +1899,6 @@ void XsheetViewer::zoomToFramesPerPage(int frames) {
 
 //----------------------------------------------------------------
 int XsheetViewer::getFrameZoomFactor() const {
-  if (orientation()->isVerticalTimeline())
-    return 50 + (m_frameZoomFactor - 20) * 5 / 8;
-
   return m_frameZoomFactor;
 }
 


### PR DESCRIPTION
A strange calculation for scroll zooming that locks vertical xsheet zooming minimum 50% of the GUI zoom slider, would removing it break anything?