### PR TITLE
Refactoring: Replace obsolete Qt functions

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -555,6 +555,9 @@ if(BUILD_ENV_MSVC)
     # place Toonz.exe and dlls in the same directory
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+    # use secure functions by defaualt
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT=1")
 elseif(BUILD_ENV_APPLE)
     # pass
 elseif(BUILD_ENV_UNIXLIKE)

--- a/toonz/sources/common/psdlib/psdutils.cpp
+++ b/toonz/sources/common/psdlib/psdutils.cpp
@@ -19,16 +19,17 @@ void readrow(FILE *psd, TPSDChannelInfo *chan,
 
   switch (chan->comptype) {
   case RAWDATA: /* uncompressed */
-    pos                  = chan->filepos + chan->rowbytes * row;
-    seekres              = fseek(psd, pos, SEEK_SET);
-    if (seekres != -1) n = fread(inbuffer, 1, chan->rowbytes, psd);
+    pos     = chan->filepos + chan->rowbytes * row;
+    seekres = fseek(psd, pos, SEEK_SET);
+    if (seekres != -1) n = (psdPixel)fread(inbuffer, 1, chan->rowbytes, psd);
     break;
   case RLECOMP:
     pos     = chan->rowpos[row];
     seekres = fseek(psd, pos, SEEK_SET);
     if (seekres != -1) {
-      rlebytes = fread(tmpbuffer, 1, chan->rowpos[row + 1] - pos, psd);
-      n        = unpackrow(inbuffer, tmpbuffer, chan->rowbytes, rlebytes);
+      rlebytes =
+          (psdPixel)fread(tmpbuffer, 1, chan->rowpos[row + 1] - pos, psd);
+      n = unpackrow(inbuffer, tmpbuffer, chan->rowbytes, rlebytes);
     }
     break;
   case ZIPWITHPREDICTION:

--- a/toonz/sources/common/tapptools/tcolorutils.cpp
+++ b/toonz/sources/common/tapptools/tcolorutils.cpp
@@ -1,6 +1,6 @@
 
 
-//#include "traster.h"
+// #include "traster.h"
 #include "tcolorutils.h"
 #include "tmathutil.h"
 
@@ -12,8 +12,8 @@ typedef float KEYER_FLOAT;
 
 //------------------------------------------------------------------------------
 
-//#define CLUSTER_ELEM_CONTAINER_IS_A_SET
-//#define WITH_ALPHA_IN_STATISTICS
+// #define CLUSTER_ELEM_CONTAINER_IS_A_SET
+// #define WITH_ALPHA_IN_STATISTICS
 
 //------------------------------------------------------------------------------
 
@@ -214,7 +214,7 @@ void chooseLeafToClusterize(ClusterContainer::iterator &itRet,
 
     const KEYER_FLOAT *clusterCovariance = clusterFound->statistic.covariance;
     int i                                = 0;
-    for (; i < 9; ++i) tmpMatrixM[i]     = clusterCovariance[i];
+    for (; i < 9; ++i) tmpMatrixM[i] = clusterCovariance[i];
 
     tmpMatrixM[0] -= maxEigenValue;
     tmpMatrixM[4] -= maxEigenValue;
@@ -412,7 +412,7 @@ void SolveCubic(KEYER_FLOAT a,  /* coefficient of x^3 */
     x[0]       = (KEYER_FLOAT)(-2.0 * sqrt(Q) * cos(theta / 3.0) - a1 / 3.0);
     x[1]       = (KEYER_FLOAT)(-2.0 * sqrt(Q) * cos((theta + 2.0 * PI) / 3.0) -
                          a1 / 3.0);
-    x[2] = (KEYER_FLOAT)(-2.0 * sqrt(Q) * cos((theta + 4.0 * PI) / 3.0) -
+    x[2]       = (KEYER_FLOAT)(-2.0 * sqrt(Q) * cos((theta + 4.0 * PI) / 3.0) -
                          a1 / 3.0);
 
     assert(!std::isnan(x[0]));
@@ -530,7 +530,7 @@ static void clusterize(ClusterContainer &clusters, int clustersCount) {
 
 #endif
 
-    for (j                              = 0; j < 9; ++j)
+    for (j = 0; j < 9; ++j)
       subcluster2->statistic.matrixR[j] = choosedCluster->statistic.matrixR[j] -
                                           subcluster1->statistic.matrixR[j];
 
@@ -624,7 +624,7 @@ void Cluster::computeStatistics() {
 
   statistic.sumCoords = TPoint(0, 0);
 
-  int i                                         = 0;
+  int i = 0;
   for (; i < 3; ++i) statistic.sumComponents[i] = 0.0;
 
   for (i = 0; i < 9; ++i) statistic.matrixR[i] = 0.0;
@@ -729,7 +729,7 @@ void Cluster::getMeanAxis(KEYER_FLOAT axis[3]) {
 
 //------------------------------------------------------------------------------
 
-//#define METODO_USATO_SU_TOONZ46
+// #define METODO_USATO_SU_TOONZ46
 
 static void buildPaletteForBlendedImages(std::set<TPixel32> &palette,
                                          const TRaster32P &raster,
@@ -850,11 +850,11 @@ struct EdgePoint {
     // identify available corners
     if (info & UpperEdge) {
       if (info & RightEdge) info = info | RightUpper;
-      if (info & LeftEdge) info  = info | LeftUpper;
+      if (info & LeftEdge) info = info | LeftUpper;
     }
     if (info & LowerEdge) {
       if (info & RightEdge) info = info | RightLower;
-      if (info & LeftEdge) info  = info | LeftLower;
+      if (info & LeftEdge) info = info | LeftLower;
     }
   }
 
@@ -932,7 +932,7 @@ bool colorChipLeftUpperThan(const ColorChip &chip1, const ColorChip &chip2) {
 
 }  // namespace
 
-/*-- 似ている色をまとめて1つのStyleにする --*/
+/*-- Combine similar colors into one style. --*/
 void TColorUtils::buildPalette(std::set<TPixel32> &palette,
                                const TRaster32P &raster, int maxColorCount) {
   int lx   = raster->getLx();
@@ -973,7 +973,7 @@ void TColorUtils::buildPalette(std::set<TPixel32> &palette,
 }
 //------------------------------------------------------------------------------
 
-/*-- 全ての異なるピクセルの色を別のStyleにする --*/
+/*-- Make each different pixel color a separate style --*/
 void TColorUtils::buildPrecisePalette(std::set<TPixel32> &palette,
                                       const TRaster32P &raster,
                                       int maxColorCount) {
@@ -997,7 +997,8 @@ void TColorUtils::buildPrecisePalette(std::set<TPixel32> &palette,
 
   raster->unlock();
 
-  /*-- 色数が最大値を超えたら、似ている色をまとめて1つのStyleにする手法を行う
+  /*-- If the maximum number of colors is exceeded, perform the method of
+   * combining similar colors into a single style.
    * --*/
   if (count == 0) {
     palette.clear();

--- a/toonz/sources/common/tcolor/tcolorfunctions.cpp
+++ b/toonz/sources/common/tcolor/tcolorfunctions.cpp
@@ -28,10 +28,10 @@ TGenericColorFunction::TGenericColorFunction(const double m[4],
 //---------------------------------------
 
 TPixel32 TGenericColorFunction::operator()(const TPixel32 &color) const {
-  return TPixel32(tcrop(m_m[0] * color.r + m_c[0], 0.0, 255.0),
-                  tcrop(m_m[1] * color.g + m_c[1], 0.0, 255.0),
-                  tcrop(m_m[2] * color.b + m_c[2], 0.0, 255.0),
-                  tcrop(m_m[3] * color.m + m_c[3], 0.0, 255.0));
+  return TPixel32((int)tcrop(m_m[0] * color.r + m_c[0], 0.0, 255.0),
+                  (int)tcrop(m_m[1] * color.g + m_c[1], 0.0, 255.0),
+                  (int)tcrop(m_m[2] * color.b + m_c[2], 0.0, 255.0),
+                  (int)tcrop(m_m[3] * color.m + m_c[3], 0.0, 255.0));
 }
 
 //---------------------------------------
@@ -46,7 +46,7 @@ bool TGenericColorFunction::getParameters(Parameters &p) const {
 //---------------------------------------
 
 TPixel32 TTranspFader::operator()(const TPixel32 &color) const {
-  return TPixel32(color.r, color.g, color.b, m_transp * color.m);
+  return TPixel32(color.r, color.g, color.b, (int)(m_transp * (double)color.m));
 }
 
 //---------------------------------------

--- a/toonz/sources/common/tcolor/tpixelutils.cpp
+++ b/toonz/sources/common/tcolor/tpixelutils.cpp
@@ -172,7 +172,7 @@ void rgb2hsv(int dstHsv[3], const TPixel32 &srcRgb, int maxHsv) {
   double max, min;
   double delta;
   double r, g, b;
-  double v, s, h;
+  double v, s, h = 0.;
   r = srcRgb.r / 255.;
   g = srcRgb.g / 255.;
   b = srcRgb.b / 255.;
@@ -337,10 +337,11 @@ TPixel64 toPixel64(const TPixelGR8 &src) {
 //-----------------------------------------------------------------------------
 
 TPixel64 toPixel64(const TPixelF &src) {
-  const float factor = 65535.0f;
-  return TPixel64(
-      wordCrop(tround(src.r * factor)), wordCrop(tround(src.g * factor)),
-      wordCrop(tround(src.b * factor)), wordCrop(tround(src.m * factor)));
+  const double factor = 65535.0;
+  return TPixel64(wordCrop(tround((double)src.r * factor)),
+                  wordCrop(tround((double)src.g * factor)),
+                  wordCrop(tround((double)src.b * factor)),
+                  wordCrop(tround((double)src.m * factor)));
 }
 
 //-----------------------------------------------------------------------------
@@ -383,7 +384,7 @@ TPixelF toPixelF(const TPixel32 &src) {
 //-----------------------------------------------------------------------------
 
 TPixelF toPixelF(const TPixelD &src) {
-  return TPixelF(src.r, src.g, src.b, src.m);
+  return TPixelF((float)src.r, (float)src.g, (float)src.b, (float)src.m);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/common/tfx/trenderer.cpp
+++ b/toonz/sources/common/tfx/trenderer.cpp
@@ -989,7 +989,7 @@ void RenderTask::run() {
     if (!m_fieldRender && !m_stereoscopic) {
       // Common case - just build the first tile
       buildTile(m_tileA);
-      /*-- 通常はここがFxのレンダリング処理 --*/
+      /*-- Normally, Fx rendering process is performed here --*/
       m_fx.m_frameA->compute(m_tileA, t, m_info);
     } else {
       assert(!(m_stereoscopic && m_fieldRender));
@@ -1131,7 +1131,7 @@ void RenderTask::onFinished(TThread::RunnableP) {
 
   // If the render instance has just expired
   if (instanceExpires) {
-    /*-- キャンセルされた場合はm_overallRenderedRegionの更新をしない --*/
+    /*-- Do not update m_overallRenderedRegion if canceled --*/
 
     // Inform the render ports
     rendererImp->notifyRenderFinished(isCanceled);
@@ -1184,8 +1184,8 @@ void TRendererStartInvoker::doStartRender(TRendererImp *renderer,
 }
 
 std::vector<const TFx *> calculateSortedFxs(TRasterFxP rootFx) {
-  std::map<const TFx *, std::set<const TFx *>> E; /* 辺の情報 */
-  std::set<const TFx *> Sources; /* 入次数0のノード群 */
+  std::map<const TFx *, std::set<const TFx *>> E; /* information on the edges */
+  std::set<const TFx *> Sources;                  /* Node group with no input */
 
   std::queue<const TFx *> Q;
   Q.push(rootFx.getPointer());
@@ -1199,8 +1199,7 @@ std::vector<const TFx *> calculateSortedFxs(TRasterFxP rootFx) {
       continue;
     }
 
-    /* 繋がっている入力ポートの先の Fx を訪問する
-入力ポートが無ければ終了 */
+    /* If there is no input port to visit Fx connected to input port, exit */
     int portCount = vptr->getInputPortCount();
     if (portCount < 1) {
       Sources.insert(vptr);
@@ -1223,7 +1222,7 @@ std::vector<const TFx *> calculateSortedFxs(TRasterFxP rootFx) {
     }
   }
 
-  /* トポロジカルソート */
+  /* topological sorting */
   std::set<const TFx *> visited;
   std::vector<const TFx *> L;
   std::function<void(const TFx *)> visit = [&visit, &visited, &E,
@@ -1402,10 +1401,10 @@ void TRendererImp::startRendering(
     // Build the frame's description alias
     const TRenderer::RenderData &renderData = *it;
 
-    /*--- カメラサイズ (LevelAutoやノイズで使用する) ---*/
+    /*--- Camera size (used for LevelAuto and noise) ---*/
     TRenderSettings rs = renderData.m_info;
     rs.m_cameraBox     = camBox;
-    /*--- 途中でPreview計算がキャンセルされたときのフラグ ---*/
+    /*--- Flag when Preview calculation is canceled during the process ---*/
     rs.m_isCanceled = &renderInfos->m_canceled;
 
     TRasterFxP fx = renderData.m_fxRoot.m_frameA;

--- a/toonz/sources/common/tiio/movsettings.cpp
+++ b/toonz/sources/common/tiio/movsettings.cpp
@@ -2,12 +2,14 @@
 
 #include "texception.h"
 #include "tpropertytype.h"
-//#include "timageinfo.h"
-//#include "tlevel_io.h"
+// #include "timageinfo.h"
+// #include "tlevel_io.h"
 #include "tproperty.h"
 #include "tiio.h"
 
-#if !defined(x64) && !defined(__LP64__) && !(defined(LINUX) || defined(FREEBSD)) && !(defined(__GNUC__) && defined(_WIN32))
+#if !defined(x64) && !defined(__LP64__) &&                                     \
+    !(defined(LINUX) || defined(FREEBSD)) &&                                   \
+    !(defined(__GNUC__) && defined(_WIN32))
 
 //*******************************************************************************
 //    32-bit version
@@ -112,8 +114,8 @@ void visitAtoms(const QTAtomContainer &atoms, const QTAtom &parent,
     int sonCount = QTCountChildrenOfType(atoms, curr, 0);
 
     char buffer[1024];
-    snprintf(buffer, sizeof(buffer), "%d %d %d",
-      (int)atomType, (int)id, sonCount);
+    snprintf(buffer, sizeof(buffer), "%d %d %d", (int)atomType, (int)id,
+             sonCount);
     string str(buffer);
 
     if (sonCount > 0) {
@@ -201,7 +203,7 @@ void compareAtoms(const QTAtomContainer &atoms1, QTAtom parent1,
     }
   } while (curr1 != 0 && curr2 != 0);
 }
-}
+}  // namespace
 
 //------------------------------------------------
 
@@ -370,7 +372,7 @@ bool Tiio::isQuicktimeInstalled() {
   return true;
 #else
 
-  static int ret     = -1;
+  static int ret = -1;
   if (ret == -1) ret = (InitializeQTML(0) == noErr) ? 1 : 0;
 
   return (ret == 1);
@@ -405,7 +407,8 @@ bool Tiio::isQuicktimeInstalled() {
 void openMovSettingsPopup(TPropertyGroup *props, bool unused) {
   QLocalSocket socket;
   if (!tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), 3000,
-                                  t32bitsrv::srvCmdline(), "_main"))
+                                  t32bitsrv::srvCmdlinePrg(),
+                                  t32bitsrv::srvCmdlineArgs(), "_main"))
     return;
 
   // Send the appropriate commands to the server

--- a/toonz/sources/common/tiio/tiio_jpg_exif.cpp
+++ b/toonz/sources/common/tiio/tiio_jpg_exif.cpp
@@ -504,7 +504,9 @@ void JpgExifReader::ProcessExifDir(unsigned char *DirStart,
                                    unsigned char *OffsetBase,
                                    unsigned ExifLength, int NestingLevel) {
   int de;
+#ifdef ReadAllTags
   int a;
+#endif
   int NumDirEntries;
   unsigned ThumbnailOffset = 0;
   unsigned ThumbnailSize   = 0;
@@ -524,7 +526,7 @@ void JpgExifReader::ProcessExifDir(unsigned char *DirStart,
 
   {
     unsigned char *DirEnd;
-    DirEnd = DIR_ENTRY_ADDR(DirStart, NumDirEntries);
+    DirEnd = DIR_ENTRY_ADDR(DirStart, static_cast<int64_t>(NumDirEntries));
     if (DirEnd + 4 > (OffsetBase + ExifLength)) {
       if (DirEnd + 2 == OffsetBase + ExifLength ||
           DirEnd == OffsetBase + ExifLength) {
@@ -551,7 +553,7 @@ void JpgExifReader::ProcessExifDir(unsigned char *DirStart,
     unsigned char *ValuePtr;
     int ByteCount;
     unsigned char *DirEntry;
-    DirEntry = DIR_ENTRY_ADDR(DirStart, de);
+    DirEntry = DIR_ENTRY_ADDR(DirStart, static_cast<int64_t>(de));
 
     Tag        = Get16u(DirEntry);
     Format     = Get16u(DirEntry + 2);

--- a/toonz/sources/common/tmsgcore.cpp
+++ b/toonz/sources/common/tmsgcore.cpp
@@ -10,7 +10,7 @@
 #include <QTcpSocket>
 
 TMsgCore *TMsgCore::instance() {
-  static TMsgCore *theInstance  = 0;
+  static TMsgCore *theInstance = 0;
   if (!theInstance) theInstance = new TMsgCore();
   return theInstance;
 }
@@ -133,7 +133,11 @@ void TMsgCore::readFromSocket(QTcpSocket *socket)  // server side
     message.chop(lastbegin);
   }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QStringList messages = message.split("#TMSG", Qt::SkipEmptyParts);
+#else
   QStringList messages = message.split("#TMSG", QString::SkipEmptyParts);
+#endif
 
   for (int i = 0; i < messages.size(); i++) {
     QString str = messages.at(i).simplified();
@@ -177,11 +181,7 @@ bool TMsgCore::send(DVGui::MsgType type, const QString &message)  // client side
              : (type == DVGui::WARNING ? "#TMSG WARNING " : "#TMSG INFO ")) +
         message + " #END\n";
 
-#if QT_VERSION >= 0x050000
     m_clientSocket->write(socketMessage.toLatin1());
-#else
-    m_clientSocket->write(socketMessage.toAscii());
-#endif
     m_clientSocket->flush();
     // m_clientSocket->waitForBytesWritten (1000);
   } else

--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -40,7 +40,7 @@ public:
   }
   TActualDoubleKeyframe &operator=(const TDoubleKeyframe &src) {
     TDoubleKeyframe::operator=(src);
-    m_unit                   = 0;
+    m_unit = 0;
     if (m_type == Expression || m_type == SimilarShape) {
       m_expression.setText(m_expressionText);
     } else if (m_type == File) {
@@ -96,16 +96,15 @@ inline double getConstantValue(const TActualDoubleKeyframe &k0,
 
 inline double getLinearValue(const TActualDoubleKeyframe &k0,
                              const TActualDoubleKeyframe &k1, double f) {
-  return k0.m_value +
-         (f - k0.m_frame) * (k1.m_value - k0.m_value) /
-             (k1.m_frame - k0.m_frame);
+  return k0.m_value + (f - k0.m_frame) * (k1.m_value - k0.m_value) /
+                          (k1.m_frame - k0.m_frame);
 }
 
 //---------------------------------------------------------
 
 static void truncateSpeeds(double aFrame, double bFrame, TPointD &aSpeedTrunc,
                            TPointD &bSpeedTrunc) {
-  double deltaX                        = bFrame - aFrame;
+  double deltaX = bFrame - aFrame;
   if (aSpeedTrunc.x < 0) aSpeedTrunc.x = 0;
   if (bSpeedTrunc.x > 0) bSpeedTrunc.x = 0;
 
@@ -262,7 +261,7 @@ inline double getExpressionValue(const TActualDoubleKeyframe &k0,
                                  const TActualDoubleKeyframe &k1, double frame,
                                  const TMeasure *measure) {
   double t = 0, rframe = frame - k0.m_frame;
-  if (k1.m_frame > k0.m_frame) t  = rframe / (k1.m_frame - k0.m_frame);
+  if (k1.m_frame > k0.m_frame) t = rframe / (k1.m_frame - k0.m_frame);
   TSyntax::Calculator *calculator = k0.m_expression.getCalculator();
   if (calculator) {
     calculator->setUnit(
@@ -543,7 +542,7 @@ double TDoubleParam::getValue(double frame, bool leftmost) const {
     if (frame < f0)
       frame = f0;
     else if (frame > f1 && !m_imp->m_cycleEnabled)
-      frame            = f1;
+      frame = f1;
     double valueOffset = 0;
 
     if (m_imp->m_cycleEnabled) {
@@ -598,7 +597,7 @@ double TDoubleParam::getValue(double frame, bool leftmost) const {
         if (b->m_type != TDoubleKeyframe::Expression ||
             !b->m_expression.isCycling())
           tmpKeyframe[0].m_value = getValue(b->m_frame);
-        b                        = tmpKeyframe.begin();
+        b = tmpKeyframe.begin();
       }
       // .. and/or if prev segment is not then update the a value
       if (a != keyframes.begin() &&
@@ -616,7 +615,7 @@ double TDoubleParam::getValue(double frame, bool leftmost) const {
       int relPos = tfloor(b->m_frame - a->m_frame),
           step   = std::min(a->m_step, relPos);
 
-      tmpKeyframe[2].m_frame        = a->m_frame + tfloor(relPos, step);
+      tmpKeyframe[2].m_frame = a->m_frame + tfloor(relPos, step);
       if (frame > b->m_frame) frame = b->m_frame;
 
       frame = a->m_frame + tfloor(tfloor(frame - a->m_frame), step);
@@ -680,7 +679,7 @@ bool TDoubleParam::setValue(double frame, double value) {
   it           = std::lower_bound(keyframes.begin(), keyframes.end(), k);
   int index    = 0;
   bool created = false;
-  /*-- キーフレームが見つかった場合 --*/
+  /*-- If a keyframe is found --*/
   if (it != keyframes.end() && it->m_frame == frame) {
     // changing a keyframe value
     index                             = std::distance(keyframes.begin(), it);
@@ -693,7 +692,7 @@ bool TDoubleParam::setValue(double frame, double value) {
 
     m_imp->notify(TParamChange(this, 0, 0, true, false, false));
   }
-  /*-- セグメントの部分なので、新たにキーフレームを作る --*/
+  /*-- It is a segment, so create a new keyframe. --*/
   else {
     assert(it == keyframes.end() || it->m_frame > frame);
 
@@ -713,7 +712,8 @@ bool TDoubleParam::setValue(double frame, double value) {
       it->m_prevType = TDoubleKeyframe::None;
     else {
       it->m_prevType = it[-1].m_type;
-      /*-- FxGuiでSegment内にKeyを打った場合は、Step値も引き継ぐ --*/
+      /*-- If you create Key in Segment in FxGui, the Step value is also
+       * inherited. --*/
       it->m_step = it[-1].m_step;
     }
     if (it + 1 != keyframes.end()) it[1].m_prevType = it->m_type;
@@ -758,7 +758,7 @@ void TDoubleParam::setKeyframe(int index, const TDoubleKeyframe &k) {
   else
     dst.m_prevType = keyframes[index - 1].m_type;
 
- if (getKeyframeCount() - 1 != index)
+  if (getKeyframeCount() - 1 != index)
     keyframes[index + 1].m_prevType = dst.m_type;
 }
 
@@ -786,7 +786,7 @@ void TDoubleParam::setKeyframes(const std::map<int, TDoubleKeyframe> &ks) {
   }
   if (!keyframes.empty()) {
     keyframes[0].m_prevType = TDoubleKeyframe::None;
-    for (int i                = 1; i < (int)keyframes.size(); i++)
+    for (int i = 1; i < (int)keyframes.size(); i++)
       keyframes[i].m_prevType = keyframes[i - 1].m_type;
   }
 
@@ -919,8 +919,8 @@ void TDoubleParam::deleteKeyframe(double frame) {
                         TDoubleKeyframe(frame));
   if (it == keyframes.end() || it->m_frame != frame) return;
 
-  TDoubleKeyframe::Type type                = it->m_prevType;
-  it                                        = m_imp->m_keyframes.erase(it);
+  TDoubleKeyframe::Type type = it->m_prevType;
+  it                         = m_imp->m_keyframes.erase(it);
   if (it != keyframes.end()) it->m_prevType = type;
 
   m_imp->notify(TParamChange(this, 0, 0, true, false, false));
@@ -1153,7 +1153,7 @@ is >> m_imp->m_defaultValue;
       while (!is.eos()) {
         TDoubleKeyframe kk;
         kk.loadData(is);
-         // Throw out invalid interpolation types
+        // Throw out invalid interpolation types
         if (kk.m_type == TDoubleKeyframe::None) continue;
         TActualDoubleKeyframe k(kk);
         k.m_expression.setGrammar(m_imp->m_grammar);

--- a/toonz/sources/common/trop/quickput.cpp
+++ b/toonz/sources/common/trop/quickput.cpp
@@ -40,11 +40,13 @@ inline TPixel32 applyColorScale(const TPixel32 &color,
                                 const TPixel32 &colorScale,
                                 bool toBePremultiplied = false) {
   /*--
-   * 半透明のラスタをViewer上で半透明にquickputするとき、色が暗くなってしまうのを防ぐ
+   * Prevent colors from being darkened when quickputting a semi-transparent
+   * raster on the Viewer
    * --*/
   if (colorScale.r == 0 && colorScale.g == 0 && colorScale.b == 0) {
     /*--
-     * toBePremultipliedがONのときは、後でPremultiplyをするので、ここでは行わない
+     * When toBePremultiplied is ON, Premultiply is done later, so it is not
+     * done here.
      * --*/
     if (toBePremultiplied)
       return TPixel32(color.r, color.g, color.b, color.m * colorScale.m / 255);
@@ -2328,7 +2330,7 @@ void doQuickPutNoFilter(const TRaster32P &dn, const TRaster32P &up, double sx,
 
       TPixel32 upPix = *(upBasePix + (yI * upWrap + xI));
 
-      if (firstColumn) upPix.m = 65535;
+      if (firstColumn) upPix.m = 255;
 
       if (upPix.m == 0 || (whiteTransp && upPix == TPixel::White)) continue;
 

--- a/toonz/sources/common/trop/traylit.cpp
+++ b/toonz/sources/common/trop/traylit.cpp
@@ -40,11 +40,11 @@ of the ray we're tracing
 
   // Build colors-related variables
   int max = T::maxChannelValue;
-  /*-- 透明部分の色 --*/
+  /*-- Color of transparent part --*/
   int transp_val = (params.m_invert) ? max : 0, opaque_val = max - transp_val;
   int value, val_r, val_g, val_b, val_m;
   double lightness, r_fac, g_fac, b_fac, m_fac;
-  /*-- 8bit/16bitの違いを吸収する係数 --*/
+  /*--  Coefficients to absorb 8bit/16bit difference --*/
   double factor = max / 255.0;
 
   // NOTE: These variable initializations are, well,
@@ -60,13 +60,16 @@ of the ray we're tracing
   double smoothness = log(params.m_smoothness * 5.0 / 100.0 + 1.0);
   double radius     = params.m_radius;
 
-  /*-- 1ステップ進んだ時、次のピクセルで光源が無かったときの光の弱まる割合 --*/
+  /*-- The rate at which light diminishes when there is no light source at the
+   * next pixel when advancing one step. --*/
   double neg_delta_p = smoothness * intensity;
-  /*-- 1ステップ進んだ時、次のピクセルで光源が有ったときの光の強まる割合 --*/
+  /*-- The rate at which light intensifies when there is a light source at the
+   * next pixel when advancing one step. --*/
   double quot_delta_p = intensity / max;  //
 
   /*--
-   * m_colorはRaylitFxのColor値。r_fac、g_fac、b_facは各チャンネルをPremultiplyした値
+   * m_color is the Color value of RaylitFx. r_fac, g_fac, b_fac are the
+   * premultiplied values of each channel
    * --*/
   m_fac = (params.m_color.m / 255.0);
   r_fac = m_fac * (params.m_color.r / 255.0);
@@ -210,12 +213,12 @@ of the ray we're tracing
 
   // Build colors-related variables
   float max = TPixelF::maxChannelValue;
-  /*-- 透明部分の色 --*/
+  /*-- Color of transparent part --*/
   float transp_val = (params.m_invert) ? max : 0.f,
         opaque_val = max - transp_val;
   float value, val_r, val_g, val_b, val_m;
   double lightness, r_fac, g_fac, b_fac, m_fac;
-  /*-- 8bit/ 32bit-Float の違いを吸収する係数 --*/
+  /*-- Coefficients to absorb 8bit/16bit difference --*/
   double factor = max / 255.0;
 
   // NOTE: These variable initializations are, well,
@@ -231,13 +234,16 @@ of the ray we're tracing
   double smoothness = log(params.m_smoothness * 5.0 / 100.0 + 1.0);
   double radius     = params.m_radius;
 
-  /*-- 1ステップ進んだ時、次のピクセルで光源が無かったときの光の弱まる割合 --*/
+  /*-- The rate at which light diminishes when there is no light source at the
+   * next pixel when advancing one step. --*/
   double neg_delta_p = smoothness * intensity;
-  /*-- 1ステップ進んだ時、次のピクセルで光源が有ったときの光の強まる割合 --*/
+  /*-- The rate at which light intensifies when there is a light source at the
+   * next pixel when advancing one step. --*/
   double quot_delta_p = intensity / max;  //
 
   /*--
-   * m_colorはRaylitFxのColor値。r_fac、g_fac、b_facは各チャンネルをPremultiplyした値
+   * m_color is the Color value of RaylitFx. r_fac, g_fac, b_fac are the
+   * premultiplied values of each channel
    * --*/
   TPixelF colorF = toPixelF(params.m_color);
   m_fac          = colorF.m;
@@ -628,7 +634,7 @@ void performColorRaylit<TPixelF>(TPixelF *bufIn, TPixelF *bufOut, int dxIn,
   }
 }
 //--------------------------------------------------------------------------------------------
-/*-- ピザ状に8分割された領域の1つを計算する --*/
+/*-- Calculate one of the 8 pizza-shaped regions --*/
 template <typename T>
 void computeOctant(const TRasterPT<T> &src, const TRasterPT<T> &dst, int octant,
                    const TRop::RaylitParams &params,
@@ -651,7 +657,7 @@ void computeOctant(const TRasterPT<T> &src, const TRasterPT<T> &dst, int octant,
   lxIn = src->getLx(), lxOut = dst->getLx();
   lyIn = src->getLy(), lyOut = dst->getLy();
 
-  /*-- 1ピクセルずつ進むときの移動値 --*/
+  /*-- Movement value when moving forward by 1 pixel --*/
   // Vertical octant pairs
   if (octant == 1 || octant == 8)
     dxIn = 1, dxOut = 1, x0 = tfloor(pOut.x), x1 = lxOut;
@@ -680,7 +686,8 @@ void computeOctant(const TRasterPT<T> &src, const TRasterPT<T> &dst, int octant,
     x1         = lyOut, std::swap(srcRect.y0, srcRect.y1),
     srcRect.y0 = lyOut - srcRect.y0, srcRect.y1 = lyOut - srcRect.y1;
 
-  /*-- 縦向きのピザ領域を計算する場合は、90度回転してから --*/
+  /*-- To calculate the pizza area in vertical orientation, rotate 90 degrees in
+   * advance --*/
   // Swap x and y axis where necessary
   if (octant == 2 || octant == 3 || octant == 6 || octant == 7) {
     std::swap(lxIn, lyIn), std::swap(lxOut, lyOut);

--- a/toonz/sources/common/trop/trgbmscale.cpp
+++ b/toonz/sources/common/trop/trgbmscale.cpp
@@ -208,9 +208,6 @@ void do_rgbmScale<TPixelF>(TRasterFP rout, TRasterFP rin, const double *a,
   float out0M = std::max(fac * (float)out0[3], 0.f);
   float out1M = std::min(fac * (float)out1[3], 1.f);
 
-  // Retrieve de/premultiplication luts
-  double premFac, depremFac;
-
   float aFac[4];
   for (int i = 0; i < 4; i++) aFac[i] = a[i] * (float)fac;
 

--- a/toonz/sources/common/tsound/tsound_nt.cpp
+++ b/toonz/sources/common/tsound/tsound_nt.cpp
@@ -20,8 +20,8 @@ class TSoundInputDeviceImp;
 //=========================================================
 
 namespace {
-void CALLBACK recordCB(HWAVEIN hwi, UINT uMsg, DWORD dwInstance, DWORD dwParam1,
-                       DWORD dwParam2);
+void CALLBACK recordCB(HWAVEIN hwi, UINT uMsg, DWORD_PTR dwInstance,
+                       DWORD_PTR dwParam1, DWORD dwParam2);
 
 bool setRecordLine(TSoundInputDevice::Source typeInput);
 
@@ -43,7 +43,7 @@ MMRESULT isaFormatSupported(int sampleRate, int channelCount, int bitPerSample,
 
 DWORD WINAPI MyWaveOutCallbackThread(LPVOID lpParameter);
 void getAmplitude(int &amplitude, const TSoundTrackP st, TINT32 sample);
-}
+}  // namespace
 
 //==============================================================================
 //     Class to send the message that a playback is completed
@@ -503,8 +503,9 @@ bool TSoundOutputDeviceImp::doOpenDevice(const TSoundTrackFormat &format) {
                            &m_notifyThreadId));
 
   MMRESULT ret;
-  if ((ret = waveOutOpen(&m_wout, WAVE_MAPPER, &wf, (DWORD)m_notifyThreadId,
-                         (DWORD)this, CALLBACK_THREAD)) != MMSYSERR_NOERROR) {
+  if ((ret = waveOutOpen(&m_wout, WAVE_MAPPER, &wf, (DWORD_PTR)m_notifyThreadId,
+                         (DWORD_PTR)this, CALLBACK_THREAD)) !=
+      MMSYSERR_NOERROR) {
     while (!PostThreadMessage(m_notifyThreadId, WM_QUIT, 0, 0))
       ;
   }
@@ -688,7 +689,7 @@ void getAmplitude(int &amplitude, const TSoundTrackP st, TINT32 sample) {
     amplitude += (int)snd->getPressure(sample, k);
   amplitude /= k;
 }
-}
+}  // namespace
 
 //------------------------------------------------------------------------------
 
@@ -821,16 +822,16 @@ TSoundTrackFormat TSoundOutputDevice::getPreferredFormat(TUINT32 sampleRate,
 
   // Normalize bit sample and set preferred sample type
   if (bitPerSample <= 8) {
-    bitPerSample = 8;
+    bitPerSample     = 8;
     fmt.m_sampleType = TSound::UINT;
   } else if (bitPerSample <= 16) {
-    bitPerSample = 16;
+    bitPerSample     = 16;
     fmt.m_sampleType = TSound::INT;
   } else if (bitPerSample <= 24) {
-    bitPerSample = 24;
+    bitPerSample     = 24;
     fmt.m_sampleType = TSound::INT;
   } else if (bitPerSample <= 32) {
-    bitPerSample = 32;
+    bitPerSample     = 32;
     fmt.m_sampleType = TSound::FLOAT;
   }
 
@@ -934,8 +935,8 @@ WinSoundInputDevice::~WinSoundInputDevice() { CloseHandle(m_hBlockDone); }
 void WinSoundInputDevice::open(const WaveFormat &wf) {
   if (m_hWaveIn) close();
 
-  MMRESULT ret = waveInOpen(&m_hWaveIn, WAVE_MAPPER, &wf, (DWORD)recordCB,
-                            (DWORD)m_hBlockDone, CALLBACK_FUNCTION);
+  MMRESULT ret = waveInOpen(&m_hWaveIn, WAVE_MAPPER, &wf, (DWORD_PTR)recordCB,
+                            (DWORD_PTR)m_hBlockDone, CALLBACK_FUNCTION);
 
   if (ret != MMSYSERR_NOERROR) {
     throw TException("Error to open the input device");
@@ -1148,15 +1149,15 @@ bool TSoundInputDeviceImp::verifyRate() {
 
 //====================================================================
 namespace {
-void CALLBACK recordCB(HWAVEIN hwi, UINT uMsg, DWORD dwInstance, DWORD dwParam1,
-                       DWORD dwParam2) {
+void CALLBACK recordCB(HWAVEIN hwi, UINT uMsg, DWORD_PTR dwInstance,
+                       DWORD_PTR dwParam1, DWORD dwParam2) {
   WAVEHDR *whdr     = (WAVEHDR *)dwParam1;
   HANDLE *blockDone = (HANDLE *)dwInstance;
 
   if (uMsg != MM_WIM_DATA) return;
   SetEvent(blockDone);
 }
-}
+}  // namespace
 
 //==============================================================================
 
@@ -1549,7 +1550,7 @@ bool TSoundInputDevice::setVolume(double value) {
   double delta    = (double)(dwMaximum / (mxc.Metrics.cSteps - 1));
   newValue        = (int)(tround(fattProp) * delta);
 
-  MIXERCONTROLDETAILS_UNSIGNED mxcdVolume = {newValue};
+  MIXERCONTROLDETAILS_UNSIGNED mxcdVolume = {(DWORD)newValue};
   ret = setControlDetails((HMIXEROBJ)0, dwVolumeControlID, mxc.cMultipleItems,
                           &mxcdVolume);
   if (ret != MMSYSERR_NOERROR)
@@ -1801,7 +1802,7 @@ MMRESULT getLineInfo(HMIXEROBJ hMixer, MIXERLINE &mxl, DWORD destination,
   mxl.dwDestination = destination;
   mxl.dwSource      = source;
   ret               = mixerGetLineInfo(0, &mxl,
-                         MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_SOURCE);
+                                       MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_SOURCE);
   return ret;
 }
 
@@ -1815,7 +1816,7 @@ MMRESULT getLineInfo(HMIXEROBJ hMixer, MIXERLINE &mxl, DWORD dwLineID) {
   mxl.cbStruct = sizeof(mxl);
   mxl.dwLineID = dwLineID;
   ret          = mixerGetLineInfo((HMIXEROBJ)hMixer, &mxl,
-                         MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_LINEID);
+                                  MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_LINEID);
   return ret;
 }
 
@@ -1913,7 +1914,7 @@ MMRESULT getControlDetails(HMIXEROBJ hMixer, DWORD dwSelectControlID,
   mxcd.cbDetails      = sizeof(MIXERCONTROLDETAILS_LISTTEXT);
   mxcd.paDetails      = pmxcdSelectText;
   ret                 = mixerGetControlDetails((HMIXEROBJ)0, &mxcd,
-                               MIXER_GETCONTROLDETAILSF_LISTTEXT);
+                                               MIXER_GETCONTROLDETAILSF_LISTTEXT);
   return ret;
 }
 
@@ -2119,7 +2120,8 @@ bool setRecordLine(TSoundInputDevice::Source typeInput) {
   case TSoundInputDevice::LineIn:
     dwComponentTypeSrc = MIXERLINE_COMPONENTTYPE_SRC_LINE /*|
                              MIXERLINE_COMPONENTTYPE_SRC_AUXILIARY |
-                             MIXERLINE_COMPONENTTYPE_SRC_ANALOG*/;
+                             MIXERLINE_COMPONENTTYPE_SRC_ANALOG*/
+        ;
     break;
   case TSoundInputDevice::DigitalIn:
     dwComponentTypeSrc = MIXERLINE_COMPONENTTYPE_SRC_DIGITAL;
@@ -2188,4 +2190,4 @@ MMRESULT isaFormatSupported(int sampleRate, int channelCount, int bitPerSample,
     ret = waveOutOpen(NULL, WAVE_MAPPER, &wf, NULL, NULL, WAVE_FORMAT_QUERY);
   return ret;
 }
-}
+}  // namespace

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -39,9 +39,8 @@ int TFilePath::m_letterCountForSuffix     = 1;
 
 namespace {
 
-/*-- fromSeg位置 と
- * toSeg位置は含まず、それらの間に挟まれている文字列が「数字4ケタ」ならtrueを返す
- * --*/
+// Returns true if the string between the fromSeg position and the toSeg
+// position is "4 digits".
 bool isNumbers(std::wstring str, int fromSeg, int toSeg) {
   /*
     if (toSeg - fromSeg != 5) return false;
@@ -766,7 +765,8 @@ TFrameId TFilePath::getFrame() const {
   if (j == (int)std::wstring::npos) return TFrameId(TFrameId::NO_FRAME);
   if (i == j + 1) return TFrameId(TFrameId::EMPTY_FRAME);
 
-  // 間が数字でない場合（ファイル名にまぎれた"_" や "."がある場合）を除外する
+  // Exclude cases with non-numeric characters inbetween. (In case the file name
+  // contains "_" or ".")
   if (!checkForSeqNum(type) || !isNumbers(str, j, i))
     return TFrameId(TFrameId::NO_FRAME);
 
@@ -968,7 +968,7 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
         (k == j - 1 ||
          (checkForSeqNum(type) &&
           isNumbers(str, k,
-                    j))))  //-- "_." の並びか、"_[数字]."の並びのとき --
+                    j))))  // -- In case of "_." or "_[numbers]." --
       return TFilePath(m_path.substr(0, k + i + 1) +
                        ((frame.isNoFrame())
                             ? L""
@@ -1087,7 +1087,7 @@ TFilePath::TFilePathInfo TFilePath::analyzePath() const {
   // Frame Number and Suffix
   QString fIdRegExp = TFilePath::fidRegExpStr();
 
-  // Extension：letters other than "._" or  \/:,;*?"<>|  or " "(space)
+  // Extension: letters other than "._" or  \/:,;*?"<>|  or " "(space)
   const QString extensionRegExp("([^\\._ \\\\/:,;*?\"<>|]+)");
 
   // ignore frame numbers on non-sequential (i.e. movie) extension case :
@@ -1098,7 +1098,7 @@ TFilePath::TFilePathInfo TFilePath::analyzePath() const {
   //  if (!checkForSeqNum(ext)) {
   //    info.levelName = rx_mf.cap(1);
   //    info.sepChar = QChar();
-  //    info.fId = TFrameId(TFrameId::NO_FRAME, 0, 0); //NO_PADで初期化する
+  //    info.fId = TFrameId(TFrameId::NO_FRAME, 0, 0); // initialize with NO_PAD
   //    info.extension = ext;
   //    return info;
   //  }

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -87,13 +87,13 @@ QDateTime TFileStatus::getLastModificationTime() const {
 
 QDateTime TFileStatus::getCreationTime() const {
   if (!m_exist) return QDateTime();
-  return m_fileInfo.created();
+  return m_fileInfo.birthTime();
 }
 
 //-----------------------------------------------------------------------------------
 
 QFile::Permissions TFileStatus::getPermissions() const {
-  if (!m_exist) return 0;
+  if (!m_exist) return QFileDevice::Permissions();
   return m_fileInfo.permissions();
 }
 
@@ -160,7 +160,11 @@ TFilePath TSystem::getTestDir(string name) {
 //------------------------------------------------------------
 
 QString TSystem::getSystemValue(const TFilePath &name) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QStringList strlist = toQString(name).split("\\", Qt::SkipEmptyParts);
+#else
   QStringList strlist = toQString(name).split("\\", QString::SkipEmptyParts);
+#endif
 
   assert(strlist.size() > 3);
   assert(strlist.at(0) == "SOFTWARE");
@@ -1004,8 +1008,8 @@ bool TSystem::touchParentDir(const TFilePath &fp) {
 
 bool TSystem::showDocument(const TFilePath &path) {
 #ifdef _WIN32
-  int ret = (int)ShellExecuteW(0, L"open", path.getWideString().c_str(), 0, 0,
-                               SW_SHOWNORMAL);
+  unsigned long long ret = (unsigned long long)ShellExecuteW(
+      0, L"open", path.getWideString().c_str(), 0, 0, SW_SHOWNORMAL);
   if (ret <= 32) {
     return false;
     throw TSystemException(path, "Can't open");

--- a/toonz/sources/common/tsystem/uncpath.cpp
+++ b/toonz/sources/common/tsystem/uncpath.cpp
@@ -4,7 +4,9 @@
 #include "tconvert.h"
 
 #ifdef _WIN32
+#ifndef UNICODE
 #define UNICODE  // per le funzioni di conversione da/a UNC
+#endif
 #include <windows.h>
 #include <lm.h>
 #endif
@@ -82,14 +84,14 @@ TFilePath TSystem::toUNC(const TFilePath &fp) {
           // Loop through the entries;
           for (i = 1; i <= er; i++) {
             if (p->shi502_type == STYPE_DISKTREE) {
-              //#ifdef IS_DOTNET
-              // shi502_path e' una wstring, aanche se la dichiarazione di
-              // PSHARE_INFO_502 non lo sa!
+              // #ifdef IS_DOTNET
+              //  shi502_path e' una wstring, aanche se la dichiarazione di
+              //  PSHARE_INFO_502 non lo sa!
               std::wstring shareLocalPathW = (LPWSTR)(p->shi502_path);
               std::string shareLocalPath   = ::to_string(shareLocalPathW);
-              //#else
-              // string shareLocalPath = toString(p->shi502_path);
-              //#endif
+              // #else
+              //  string shareLocalPath = toString(p->shi502_path);
+              // #endif
 
               if (toLower(fpStr).find(toLower(shareLocalPath)) == 0) {
                 std::string hostName = TSystem::getHostName().toStdString();
@@ -100,7 +102,7 @@ TFilePath TSystem::toUNC(const TFilePath &fp) {
                 std::string shareNetName   = ::to_string(shareNetNameW);
                 //	 #else
                 // string shareNetName = toString(p->shi502_netname);
-                //#endif
+                // #endif
                 shareNetName.append("\\");
 
                 std::string fp(fpStr);
@@ -176,19 +178,19 @@ TFilePath TSystem::toLocalPath(const TFilePath &fp) {
       // Loop through the entries;
       for (int i = 1; i <= (int)er; i++) {
         if (p->shi502_type == STYPE_DISKTREE) {
-          //#ifdef IS_DOTNET
-          // shi502_netname e' una wstring, anche se la dichiarazione di
-          // PSHARE_INFO_502 non lo sa!
+          // #ifdef IS_DOTNET
+          //  shi502_netname e' una wstring, anche se la dichiarazione di
+          //  PSHARE_INFO_502 non lo sa!
           std::wstring shareNetNameW = (LPWSTR)(p->shi502_netname);
           std::string shareNetName   = ::to_string(shareNetNameW);
           //	#else
           // string shareNetName = toString(p->shi502_netname);
-          //#endif
+          // #endif
 
           if (toLower(fpShareName) == toLower(shareNetName)) {
-            //#ifdef IS_DOTNET
-            // shi502_path e' una wstring, anche se la dichiarazione di
-            // PSHARE_INFO_502 non lo sa!
+            // #ifdef IS_DOTNET
+            //  shi502_path e' una wstring, anche se la dichiarazione di
+            //  PSHARE_INFO_502 non lo sa!
             std::wstring shareLocalPathW = (LPWSTR)(p->shi502_path);
             return TFilePath(shareLocalPathW) + TFilePath(path);
           }

--- a/toonz/sources/common/tunit/tunit.cpp
+++ b/toonz/sources/common/tunit/tunit.cpp
@@ -31,7 +31,7 @@ static std::pair<double, double> dummyCurrentDpiGetter() {
 CurrentDpiGetter currentDpiGetter = &dummyCurrentDpiGetter;
 
 void setCurrentDpiGetter(CurrentDpiGetter f) { currentDpiGetter = f; }
-}
+}  // namespace UnitParameters
 
 //-------------------------------------------------------------------
 
@@ -66,7 +66,7 @@ void setFieldGuideAspectRatio(double ar) {
 double getFieldGuideAspectRatio() {
   return VerticalFldUnitConverter::m_fieldGuideAspectRatio;
 }
-}
+}  // namespace UnitParameters
 
 //===================================================================
 
@@ -148,9 +148,8 @@ bool TUnit::isExtension(std::wstring ext) const {
 //-------------------------------------------------------------------
 
 void TUnit::setDefaultExtension(std::wstring ext) {
-  if (!ext.empty() &&
-      std::find(m_extensions.begin(), m_extensions.end(), ext) ==
-          m_extensions.end())
+  if (!ext.empty() && std::find(m_extensions.begin(), m_extensions.end(),
+                                ext) == m_extensions.end())
     m_extensions.push_back(ext);
   m_defaultExtension = ext;
 }
@@ -278,13 +277,13 @@ TMeasureManager::TMeasureManager() {
   length = m = new TMeasure("length", inch.clone());
   m->add(cm.clone());
   /*---
-  Fxの寸法パラメータは単位なし（実際にはStageInch（1 StageInch = 1/53.33333
-  inch）という値）
-  Fxの寸法パラメータからExpressionで単位のあるパラメータを参照すると、
-  カレントUnitによってFxの計算結果が変わってしまう。
-  tcomposerで用いられるカレントUnitはデフォルト値なので、
-  ここでデフォルトのカレントUnitをmmにしておくことで、
-  Unit = mm でシーンを作っておけば、作業時と同じRender結果が得られるようにする。
+  The dimensional parameters of Fx are unitless (actually it uses the unit of
+  StageInch (1 StageInch = 1/53.33333 inch)). If you refer to a parameter with a
+  unit in Expression from the Fx dimension parameter, the Fx calculation results
+  will vary depending on the current Unit. Since the current Unit used in
+  tcomposer is the default value, we can set the default current Unit to mm here
+  so that if we create a scene with Unit = mm, we will get the same Render
+  results as when we work.
   ---*/
   TUnit *mmUnit = mm.clone();
   m->add(mmUnit);
@@ -486,9 +485,9 @@ bool TMeasuredValue::setValue(std::wstring s, int *pErr) {
       value = std::stod(s.substr(j, i - j));
     }
     // handle exceptions
-    catch (const std::invalid_argument &e) {
+    catch (const std::invalid_argument &) {
       return false;
-    } catch (const std::out_of_range &e) {
+    } catch (const std::out_of_range &) {
       return false;
     }
 
@@ -599,7 +598,7 @@ public:
 };
 
 //===================================================================
-/*-- Zのカーブのハンドルの長さは0=0となるようにしなければならない --*/
+/*-- The length of the Z curve handle must be 0=0 --*/
 class ZDepthHandleUnitConverter final : public TUnitConverter {
   TMeasureManager::CameraSizeProvider *m_cameraSizeProvider;
 

--- a/toonz/sources/common/tvrender/qtofflinegl.cpp
+++ b/toonz/sources/common/tvrender/qtofflinegl.cpp
@@ -140,7 +140,7 @@ void QtOfflineGL::createContext(TDimension rasterSize,
 #elif defined(MACOSX)
   fmt = QGLFormat::defaultFormat();
   // printf("GL Version: %s\n",glGetString(GL_VERSION));
-  fmt.setVersion(2, 1); /* OSX10.8 では 3.2 だめかも */
+  fmt.setVersion(2, 1); /* 3.2 might not work on OSX10.8 */
 #if 0
   fmt.setAlphaBufferSize(8);
   fmt.setAlpha(true);

--- a/toonz/sources/common/tvrender/tfont_qt.cpp
+++ b/toonz/sources/common/tvrender/tfont_qt.cpp
@@ -237,7 +237,7 @@ TPoint TFont::drawChar(TRasterCM32P &outImage, TPoint &unused, int inkId,
 
 TPoint TFont::getDistance(wchar_t firstChar, wchar_t secondChar) const {
   QFontMetrics metrics(m_pimpl->m_font);
-  return TPoint(metrics.width(QChar(firstChar)), 0);
+  return TPoint(metrics.horizontalAdvance(QChar(firstChar)), 0);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/common/tvrender/tofflinegl.cpp
+++ b/toonz/sources/common/tvrender/tofflinegl.cpp
@@ -65,7 +65,7 @@ namespace {
 // on particular configurations (notably, Windows 7). So we mutex them as
 // a temporary workaround.
 static QMutex win32ImpMutex;
-}
+}  // namespace
 
 //-------------------------------
 
@@ -183,23 +183,33 @@ public:
     static PIXELFORMATDESCRIPTOR pfd = {
         sizeof(PIXELFORMATDESCRIPTOR),  // size of this pfd
         1,                              // version number
-        0 | (false ? (PFD_DRAW_TO_WINDOW | PFD_DOUBLEBUFFER)
+        0 |
+            (false ? (PFD_DRAW_TO_WINDOW | PFD_DOUBLEBUFFER)
                    : (PFD_DRAW_TO_BITMAP | PFD_SUPPORT_GDI)) |
             PFD_SUPPORT_OPENGL,  // support OpenGL
         PFD_TYPE_RGBA,           // RGBA type
         32,                      // 32-bit color depth
         0,
-        0, 0, 0, 0, 0,   // color bits ignored
-        8,               // no alpha buffer /*===*/
-        0,               // shift bit ignored
-        0,               // no accumulation buffer
-        0, 0, 0, 0,      // accum bits ignored
+        0,
+        0,
+        0,
+        0,
+        0,  // color bits ignored
+        8,  // no alpha buffer /*===*/
+        0,  // shift bit ignored
+        0,  // no accumulation buffer
+        0,
+        0,
+        0,
+        0,               // accum bits ignored
         32,              // 32-bit z-buffer
         32,              // max stencil buffer
         0,               // no auxiliary buffer
         PFD_MAIN_PLANE,  // main layer
         0,               // reserved
-        0, 0, 0          // layer masks ignored
+        0,
+        0,
+        0  // layer masks ignored
     };
 
     // get the best available match of pixel format for the device context
@@ -241,7 +251,7 @@ public:
     void *b = buffer;  // Pointer To The Buffer
 
 #if !defined(x64) && defined(_MSC_VER)
-    __asm        // Assembler Code To Follow
+    __asm            // Assembler Code To Follow
     {
         mov ecx, bufferSize  // Counter Set To Dimensions Of Our Memory Block
         mov ebx, b  // Points ebx To Our Data (b)
@@ -312,7 +322,7 @@ namespace {
 // The XScopedLock stuff doesn't seem finished,
 // why not just do the same as with win32 and use a Qt lock??
 static QMutex linuxImpMutex;
-}
+}  // namespace
 
 class XImplementation final : public TOfflineGL::Imp {
 public:
@@ -348,14 +358,14 @@ public:
     static TThread::Mutex mutex;
 
     QMutexLocker sl(&mutex);
-    pthread_t self = pthread_self();
+    pthread_t self                               = pthread_self();
     std::map<pthread_t, GLXContext>::iterator it = m_glxContext.find(self);
     if (((it != m_glxContext.end()) && (it->second != m_context)) ||
         (it == m_glxContext.end())) {
       //	cout << "calling GLXMakeCurrent " << self << " " << m_context <<
       // endl;
       Bool ret;
-      if (!isDtor) ret   = glXMakeCurrent(m_dpy, m_pixmap, m_context);
+      if (!isDtor) ret = glXMakeCurrent(m_dpy, m_pixmap, m_context);
       m_glxContext[self] = m_context;
       return ret;
     }
@@ -432,7 +442,7 @@ Bool ret = glXMakeCurrent(m_dpy,
     m_raster = raster;
   }
 
-//-----------------------------------------------------------------------------
+  //-----------------------------------------------------------------------------
 
 #if defined(MACOSX)
 #if defined(powerpc)
@@ -545,10 +555,10 @@ TOfflineGL::TOfflineGL(TDimension dim, const TOfflineGL *shared) : m_imp(0) {
 #endif
 
   /*
-  元のコードは(別スレッドから呼び出すための) offline renderer を作って main
-  thread に dispatch するという訳のわからないことをしていたが Q*GLContext は
-  thread context を超えられないので直接生成してこのコンテキストで閉じる.
-  別スレッドには dispatch しない.
+ The original code did some incomprehensible things like creating an offline
+ renderer (to be called from another thread) and dispatching it to the main
+ thread, but Q*GLContext can't go beyond the  thread context, so it is created
+ directly and closed in this context. It does not dispatch to another thread.
 */
   m_imp = currentImpGenerator(dim, shared ? shared->m_imp : 0);
 
@@ -594,7 +604,7 @@ TOfflineGL::ImpGenerator *TOfflineGL::defineImpGenerator(
 
 void TOfflineGL::makeCurrent() {
   if (currentContextManager) currentContextManager->store();
-  // Tutto il codice è stato spostato dentro Imp
+  // All the code was moved inside Imp
   m_imp->makeCurrent();
   assert(glGetError() == GL_NO_ERROR);
 }

--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -90,10 +90,18 @@ std::string fidsToString(const std::vector<TFrameId> &fids) {
 // convert loaded string to refLevelFids
 std::vector<TFrameId> strToFids(std::string fidsStr) {
   std::vector<TFrameId> ret;
-  QString str        = QString::fromStdString(fidsStr);
+  QString str = QString::fromStdString(fidsStr);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QStringList chunks = str.split(',', Qt::SkipEmptyParts);
+#else
   QStringList chunks = str.split(',', QString::SkipEmptyParts);
+#endif
   for (const auto &chunk : chunks) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList nums = chunk.split('-', Qt::SkipEmptyParts);
+#else
     QStringList nums = chunk.split('-', QString::SkipEmptyParts);
+#endif
     assert(nums.count() > 0 && nums.count() <= 2);
     if (nums.count() == 1)
       ret.push_back(TFrameId(nums[0].toInt()));

--- a/toonz/sources/common/tvrender/tstrokeutil.cpp
+++ b/toonz/sources/common/tvrender/tstrokeutil.cpp
@@ -73,45 +73,37 @@ double findMinimum(const TStrokeDeformation &def, const TStroke &stroke,
 //---------------------------------------------------------------------------
 
 /**
-  * Rationale:
-  *  Supponiamo di voler modellare un segmento (rappresentato da una stroke)
-  *  in modo che assuma la forma di una parabola (caso abituale offerto dal
- * modificatore).
-  *  Poniamo il che:
-  *   (o) i punti della stroke si trovino lungo l'asse y=-100;
-  *   (o) le x che corrisponderanno siano x1=-10 e x2=+10 (ovvio
- * dall'equazione).
-  *
-  *  La parabola potrà essere rappresentata sul lato sx da una quadratica con
-  *  punti di controllo:
-  *    P0=(-10,-100),
-  *    P1=(-5,    0),
-  *    P2=( 0,    0).
-  *  Se conosciamo il numero di tratti lineari che rappresentano questa
- * parabola,
-  *  sappiamo anche quanti "campioni" sono richiesti per la sua linearizzazione.
-  *  Questo parametro può essere utilizzato per stabilire in modo qualitativo
-  *  il valore con cui campionare la stroke da testare; ci dovranno essere tanti
-  *  punti da spostare per quanti campioni sono presenti nel riferimento.
-  */
+ * Rationale:
+ *  Suppose we want to model a segment (represented by a stroke)  so that it
+ * takes the shape of a parabola (the usual case offered by the modifier). We
+ * assume that: (o) stroke points lie along the y=-100 axis; (o) the x's that
+ * will correspond are x1=-10 and x2=+10 (obvious from the equation).
+ *
+ *  The parabola may be represented on the left side by a quadratic with control
+ * points: P0=(-10,-100), P1=(-5,    0), P2=( 0,    0). If we know the number of
+ * linear strokes representing this parabola, we also know how many "samples"
+ * are required for its linearization. This parameter can be used to
+ * qualitatively determine the value with which to sample the stroke to be
+ * tested; there will need to be as many points to move as there are samples in
+ * the reference.
+ */
 double computeIncrement(double strokeLength, double pixelSize) {
   assert(pixelSize > 0 && "Pixel size is negative!!!");
   assert(strokeLength > 0 && "Stroke Length size is negative!!!");
 
-  // altezza della parabola (va verso il basso)
+  // height of the parabola (goes downward)
   double height = 100;
 
-  // suppongo di fare almeno un drag di 100 pixel
+  // I suppose I'm doing at least a 100-pixel drag
   assert(height >= 100.0);
 
   double x = sqrt(height);
 
-  // il punto p1 dovra' essere all'intersezione
-  //  tra le tangenti ai due estremi.
-  //  La tangente del punto p2 e l'asse x,
-  //  l'altra avra' versore dato dal gradiente in p0,
-  //  cioe': grad(x,-2 x)
-  //  e se y = m x + q
+  // the point p1 will have to be at the intersection of the tangents to the two
+  // extremes. The tangent of the point p2 and the x-axis, the other will have
+  // versor given by the gradient at p0,
+  //  ie: grad(x,-2 x)
+  //  and if y = m x + q
   //  m =
   double m = 2.0 * x;
 
@@ -131,7 +123,7 @@ double computeIncrement(double strokeLength, double pixelSize) {
 
   double step = computeStep(quadratic, pixelSize);
 
-  //  giusto per aggiungere punti anche nel caso peggiore.
+  //  just to add points even in the worst case.
   if (step >= 1.0) step = 0.1;
 
   return step;
@@ -141,39 +133,35 @@ double computeIncrement(double strokeLength, double pixelSize) {
 
 void detectEdges(const std::vector<TPointD> &pointArray,
                  std::vector<UINT> &edgeIndexArray) {
-  // ASSUNZIONE: sharpPointArray non contiene punti coincidenti adiacenti
+  // ASSUMPTION: sharpPointArray does not contain adjacent coincident points
 
   int size = pointArray.size();
-  // controllo che ci siano piu' di tre elementi
+  // I check that there are more than three elements
   if (size < 3) return;
-  //  scorre pointArray e per ogni suo punto cerca di inscrivere triangoli
-  //  (utilizzando i
-  //  punti a sinistra e a destra) considerando potenziali corner quelli con
-  //  lati l tale
-  //  che dMin <= l <= dMax (in realta' alla prima volta che l > dMax: breack) e
-  //  con apertura
-  //  angolare alpha <= alphaMax. Poi cerca i max locali tra i potenziali corner
-  //  in una
-  //  finestra di semiampiezza dMax (al solito alla prima volta che si supera
-  //  dMax: breack)
-
-  //  valori di default: dMin = 7; dMax = dMin + 2; alphaMax = 2.6 (150°)
+  //  runs pointArray and for each of its points tries to inscribe triangles
+  //  (using left and right points) considering potential corners those with
+  //  sides l such that dMin <= l <= dMax (actually at the first time that l >
+  //  dMax: breack) and with angular aperture alpha <= alphaMax.
+  // Then it looks for local maxes among the potential corners in a window of
+  // semiamplitude dMax(actually at the first time dMax : breack is exceeded)
+  //  default values: dMin = 7; dMax = dMin + 2; alphaMax = 2.6 (150 degrees)
 
   const double dMin     = 4;
   const double dMax     = dMin + 3;
-  const double alphaMax = 2.4;  // ( 137.5°)
+  const double alphaMax = 2.4;  // ( 137.5 degrees)
   const double dMin2    = dMin * dMin;
   const double dMax2    = dMax * dMax;
   std::vector<double> sharpnessArray;
-  sharpnessArray.push_back(M_PI);  //  il primo punto e' un corner
+  sharpnessArray.push_back(M_PI);  //  the first point is a corner
   int nodeCount;
   for (nodeCount = 1; nodeCount < size - 1;
-       ++nodeCount) {  //  scorre la sharpPointArray escludendo gli estremi
+       ++nodeCount) {  //  scrolls the sharpPointArray excluding the extremes
     sharpnessArray.push_back(0);
     TPointD point(pointArray[nodeCount]);
     int leftCount;
     for (leftCount = nodeCount - 1; leftCount >= 0;
-         --leftCount) {  //  calcola i lati "left" dei triangoli inscritti...
+         --leftCount) {  //  Calculates the "left" sides of the inscribed
+                         //  triangles...
       TPointD left  = pointArray[leftCount];
       double dLeft2 = norm2(left - point);
       if (dLeft2 < dMin2)
@@ -182,8 +170,8 @@ void detectEdges(const std::vector<TPointD> &pointArray,
         break;
       int rightCount;
       for (rightCount = nodeCount + 1; rightCount < size;
-           ++rightCount) {  //  calcola i lati "right" dei triangoli
-                            //  inscritti...
+           ++rightCount) {  // Calculates the "right" sides of the inscribed
+                            // triangles...
         TPointD right  = pointArray[rightCount];
         double dRight2 = norm2(right - point);
         if (dRight2 < dMin2)
@@ -191,7 +179,7 @@ void detectEdges(const std::vector<TPointD> &pointArray,
         else if (dMax2 < dRight2)
           break;
 
-        //  calcola i lati "center" dei triangoli inscritti
+        //  Calculates the "center" sides of the inscribed triangles
         double dCenter2 = norm2(left - right);
         assert(dLeft2 != 0.0 && dRight2 != 0.0);
 
@@ -208,16 +196,17 @@ void detectEdges(const std::vector<TPointD> &pointArray,
     }
   }
 
-  edgeIndexArray.push_back(0);  //  il primo punto e' un corner
+  edgeIndexArray.push_back(0);  // the first point is a corner
 
-  // trovo i massimi locali escludendo gli estremi
+  // I find local maxima by excluding extremes
   for (nodeCount = 1; nodeCount < size - 1;
-       ++nodeCount) {  //  scorre la lista escludendo gli estremi
+       ++nodeCount) {  // scroll through the list excluding the extremes
     bool isCorner = true;
     TPointD point(pointArray[nodeCount]);
     int leftCount;
     for (leftCount = nodeCount - 1; leftCount >= 0;
-         --leftCount) {  //  scorre la lista di sharpPoint a sinistra di node...
+         --leftCount) {  //  scrolls down the list of sharpPoints to the left of
+                         //  node...
       TPointD left  = pointArray[leftCount];
       double dLeft2 = norm2(left - point);
       if (dLeft2 > dMax2) break;
@@ -229,7 +218,8 @@ void detectEdges(const std::vector<TPointD> &pointArray,
     if (isCorner) continue;
     int rightCount;
     for (rightCount = nodeCount + 1; rightCount < size;
-         ++rightCount) {  //  scorre la lista di sharpPoint a destra di node..
+         ++rightCount) {  // scrolls the list of sharpPoints to the right of
+                          // node..
       TPointD right  = pointArray[rightCount];
       double dRight2 = norm2(right - point);
       if (dRight2 > dMax2) break;
@@ -240,9 +230,8 @@ void detectEdges(const std::vector<TPointD> &pointArray,
     }
     if (isCorner) edgeIndexArray.push_back(nodeCount);
   }
-  edgeIndexArray.push_back(size - 1);  //  l'ultimo punto e' un corner
+  edgeIndexArray.push_back(size - 1);  //  the last point is a corner
 }
-
 }  // namespace
 
 //*******************************************************************************
@@ -271,8 +260,7 @@ bool increaseControlPoints(TStroke &stroke, const TStrokeDeformation &deformer,
   // step 2:
   //  increase control point checking delta of deformer
   double maxDifference =
-      deformer
-          .getMaxDiff();  // sopra questo valore di delta, si aggiungono punti
+      deformer.getMaxDiff();  // above this delta value, points are added
 
   int strokeControlPoint = stroke.getControlPointCount();
 
@@ -313,8 +301,9 @@ bool increaseControlPoints(TStroke &stroke, const TStrokeDeformation &deformer,
       // find the position of step
       minimum = findMinimum(
           deformer, stroke, x1, x2, TConsts::epsilon, offset,
-          20);  // tra x1 e x2 va messo un nuovo punto di controllo. dove?
-      // questa funzione trova il punto in cui si supera il valore maxdifference
+          20);  // A new control point should be put between x1 and x2. where?
+      // this function finds the point at which the maxdifference value is
+      // exceeded
 
       // if minimum is not found or is equal to previous value
       //  use an heuristic...
@@ -324,8 +313,9 @@ bool increaseControlPoints(TStroke &stroke, const TStrokeDeformation &deformer,
       }
 
       //... else insert a control point in minimum
-      w = minimum;  // la scansione riprende dal nuovo punto, in questo modo si
-                    // infittisce...
+      w = minimum;  // scanning resumes from the new point, in this way it
+                    // thickens ...
+
       stroke.insertControlPoints(minimum);
 
       // update of step

--- a/toonz/sources/common/twain/ttwain_capability.c
+++ b/toonz/sources/common/twain/ttwain_capability.c
@@ -228,8 +228,8 @@ static int ConvertOneValue2Enum(TW_ONEVALUE one_value,
 static int ConvertEnum2OneValue(TW_ENUMERATION tw_enum,
                                 TW_ONEVALUE *one_value) {
   unsigned char *base;
-  TW_UINT32 ofs;
-  TW_UINT32 itemSize;
+  size_t ofs;
+  size_t itemSize;
 
   itemSize = DCItemSize[tw_enum.ItemType];
   base     = tw_enum.ItemList;
@@ -242,8 +242,8 @@ static int ConvertEnum2OneValue(TW_ENUMERATION tw_enum,
 }
 /*---------------------------------------------------------------------------*/
 static int ConvertEnum2Array(TW_ENUMERATION tw_enum, TW_ARRAY *array) {
-  TW_UINT32 itemSize;
-  TW_UINT32 listSize;
+  size_t itemSize;
+  size_t listSize;
 
   itemSize        = DCItemSize[tw_enum.ItemType];
   listSize        = itemSize * tw_enum.NumItems;
@@ -270,7 +270,7 @@ int TTWAIN_SetCap(TW_UINT16 cap_id, TW_UINT16 conType, TW_UINT16 itemType,
   containerH = GLOBAL_ALLOC(GMEM_FIXED, size);
   if (!containerH) goto done;
   container = (TW_ONEVALUE *)GLOBAL_LOCK(containerH);
-
+  if (!container) goto done;
   container->ItemType = itemType;
   container->Item     = *value;
   capabilityH         = GLOBAL_ALLOC(GMEM_FIXED, sizeof(TW_CAPABILITY));
@@ -281,7 +281,8 @@ int TTWAIN_SetCap(TW_UINT16 cap_id, TW_UINT16 conType, TW_UINT16 itemType,
     goto done;
   }
 
-  capability             = (TW_CAPABILITY *)GLOBAL_LOCK(capabilityH);
+  capability = (TW_CAPABILITY *)GLOBAL_LOCK(capabilityH);
+  if (!capability) goto done;
   capability->ConType    = conType;
   capability->hContainer = containerH;
 
@@ -310,7 +311,7 @@ done:
 }
 /*---------------------------------------------------------------------------*/
 static TUINT32 GetContainerSize(int nFormat, unsigned twty, TW_UINT32 nItems) {
-  TUINT32 size;
+  size_t size;
   switch (nFormat) {
   case TWON_ONEVALUE:
     size = sizeof(TW_ONEVALUE);
@@ -332,7 +333,7 @@ static TUINT32 GetContainerSize(int nFormat, unsigned twty, TW_UINT32 nItems) {
     size = 0;
     break;
   } /* switch */
-  return size;
+  return (TUINT32)size;
 }
 /*---------------------------------------------------------------------------*/
 

--- a/toonz/sources/common/twain/ttwain_util.c
+++ b/toonz/sources/common/twain/ttwain_util.c
@@ -216,7 +216,7 @@ l'immagine)
     if (TTWAIN_SupportsFeeder()) {
       feeder_status = TTWAIN_GetFeeder();
       rc            = TTWAIN_SetFeeder(TRUE);
-      if (rc) rc    = TTWAIN_GetPhysicalWidth(width);
+      if (rc) rc = TTWAIN_GetPhysicalWidth(width);
       TTWAIN_SetFeeder(feeder_status);
     }
     return rc;
@@ -229,7 +229,7 @@ l'immagine)
     if (TTWAIN_SupportsFeeder()) {
       feeder_status = TTWAIN_GetFeeder();
       rc            = TTWAIN_SetFeeder(TRUE);
-      if (rc) rc    = TTWAIN_GetPhysicalHeight(height);
+      if (rc) rc = TTWAIN_GetPhysicalHeight(height);
       TTWAIN_SetFeeder(feeder_status);
     }
     return rc;
@@ -242,7 +242,7 @@ l'immagine)
     if (TTWAIN_SupportsFeeder()) {
       feeder_status = TTWAIN_GetFeeder();
       rc            = TTWAIN_SetFeeder(TRUE);
-      if (rc) rc    = TTWAIN_GetMinimumWidth(width);
+      if (rc) rc = TTWAIN_GetMinimumWidth(width);
       TTWAIN_SetFeeder(feeder_status);
     }
     return rc;
@@ -255,7 +255,7 @@ l'immagine)
     if (TTWAIN_SupportsFeeder()) {
       feeder_status = TTWAIN_GetFeeder();
       rc            = TTWAIN_SetFeeder(TRUE);
-      if (rc) rc    = TTWAIN_GetMinimumHeight(height);
+      if (rc) rc = TTWAIN_GetMinimumHeight(height);
       TTWAIN_SetFeeder(feeder_status);
     }
     return rc;
@@ -330,7 +330,7 @@ l'immagine)
     container = (TW_ENUMERATION *)GLOBAL_LOCK(handle);
     rc = TTWAIN_GetCap(ICAP_PIXELTYPE, TWON_ENUMERATION, (void *)container, 0);
 
-    if (!rc) goto done;
+    if (!rc || !container) goto done;
     found =
         TTWAIN_IsItemInList(container->ItemList, &twPix, container->NumItems,
                             DCItemSize[container->ItemType]);
@@ -360,7 +360,7 @@ l'immagine)
     rc =
         TTWAIN_GetCap(ICAP_COMPRESSION, TWON_ENUMERATION, (void *)container, 0);
 
-    if (!rc) goto done;
+    if (!rc || !container) goto done;
     found = TTWAIN_IsItemInList(container->ItemList, &comprType,
                                 container->NumItems,
                                 DCItemSize[container->ItemType]);
@@ -443,8 +443,8 @@ l'immagine)
     static char version[5 + 1 + 5 + 1 + 32 + 1];
     snprintf(version, sizeof(version), "%d.%d %s",
              TTwainData.sourceId.Version.MajorNum,
-	     TTwainData.sourceId.Version.MinorNum,
-	     (char *)TTwainData.sourceId.Version.Info);
+             TTwainData.sourceId.Version.MinorNum,
+             (char *)TTwainData.sourceId.Version.Info);
     return version;
   }
   /*---------------------------------------------------------------------------*/
@@ -656,9 +656,9 @@ GLOBAL_FREE(TTwainData.supportedCaps);
     int rc1, rc2;
     TW_FIX32 twfix = TTWAIN_FloatToFix32(resolution);
     rc1            = TTWAIN_SetCap(ICAP_XRESOLUTION, TWON_ONEVALUE, TWTY_FIX32,
-                        (TW_UINT32 *)&twfix);
-    rc2 = TTWAIN_SetCap(ICAP_YRESOLUTION, TWON_ONEVALUE, TWTY_FIX32,
-                        (TW_UINT32 *)&twfix);
+                                   (TW_UINT32 *)&twfix);
+    rc2            = TTWAIN_SetCap(ICAP_YRESOLUTION, TWON_ONEVALUE, TWTY_FIX32,
+                                   (TW_UINT32 *)&twfix);
     return (rc1 & rc2);
   }
   /*---------------------------------------------------------------------------*/
@@ -666,7 +666,7 @@ GLOBAL_FREE(TTwainData.supportedCaps);
     int rc;
     TW_FIX32 twfix = TTWAIN_FloatToFix32(scale);
     rc             = TTWAIN_SetCap(ICAP_XSCALING, TWON_ONEVALUE, TWTY_FIX32,
-                       (TW_UINT32 *)&twfix);
+                                   (TW_UINT32 *)&twfix);
     return rc;
   }
   /*---------------------------------------------------------------------------*/
@@ -674,7 +674,7 @@ GLOBAL_FREE(TTwainData.supportedCaps);
     int rc;
     TW_FIX32 twfix = TTWAIN_FloatToFix32(scale);
     rc             = TTWAIN_SetCap(ICAP_YSCALING, TWON_ONEVALUE, TWTY_FIX32,
-                       (TW_UINT32 *)&twfix);
+                                   (TW_UINT32 *)&twfix);
     return rc;
   }
   /*---------------------------------------------------------------------------*/
@@ -792,7 +792,7 @@ return FALSE;
     layout.DocumentNumber = TWON_DONTCARE32;
     layout.PageNumber     = TWON_DONTCARE32;
     layout.FrameNumber    = TWON_DONTCARE32;
-    rc = (TTWAIN_DS(DG_IMAGE, DAT_IMAGELAYOUT, MSG_SET, &layout) ==
+    rc  = (TTWAIN_DS(DG_IMAGE, DAT_IMAGELAYOUT, MSG_SET, &layout) ==
           TWRC_SUCCESS);
     rc2 = (TTWAIN_DS(DG_IMAGE, DAT_IMAGELAYOUT, MSG_GET, &layout2) ==
            TWRC_SUCCESS);
@@ -1295,7 +1295,7 @@ TTwainData.transferInfo.multiTransfer = status;
     TTwainData.callback.onErrorCb  = proc;
     TTwainData.callback.onErrorArg = arg;
   }
-/*---------------------------------------------------------------------------*/
+  /*---------------------------------------------------------------------------*/
 
 #ifdef __cplusplus
 }

--- a/toonz/sources/image/3gp/tiio_3gp_proxy.cpp
+++ b/toonz/sources/image/3gp/tiio_3gp_proxy.cpp
@@ -88,7 +88,8 @@ TLevelWriter3gp::TLevelWriter3gp(const TFilePath &path, TPropertyGroup *winfo)
 
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -133,7 +134,8 @@ err:
 TLevelWriter3gp::~TLevelWriter3gp() {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -151,7 +153,8 @@ void TLevelWriter3gp::setFrameRate(double fps) {
 
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -188,7 +191,8 @@ void TLevelWriter3gp::save(const TImageP &img, int frameIndex) {
   // Send messages
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -215,7 +219,8 @@ void TLevelWriter3gp::saveSoundTrack(TSoundTrack *st) {
   // Prepare connection
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   unsigned int size = st->getSampleSize() * st->getSampleCount();
 
@@ -304,7 +309,8 @@ TLevelReader3gp::TLevelReader3gp(const TFilePath &path) : TLevelReader(path) {
 
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -328,7 +334,8 @@ TLevelReader3gp::TLevelReader3gp(const TFilePath &path) : TLevelReader(path) {
 TLevelReader3gp::~TLevelReader3gp() {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -352,7 +359,8 @@ TImageReaderP TLevelReader3gp::getFrameReader(TFrameId fid) {
 TLevelP TLevelReader3gp::loadInfo() {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -400,7 +408,8 @@ err:
 void TLevelReader3gp::enableRandomAccessRead(bool enable) {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -417,7 +426,8 @@ void TLevelReader3gp::load(const TRasterP &ras, int frameIndex,
                            const TPoint &pos, int shrinkX, int shrinkY) {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;

--- a/toonz/sources/image/mov/tiio_mov_proxy.cpp
+++ b/toonz/sources/image/mov/tiio_mov_proxy.cpp
@@ -41,7 +41,8 @@ bool IsQuickTimeInstalled() {
   // throughout Toonz, even if it's EXPORT-defined.
   QLocalSocket socket;
   if (!tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), 3000,
-                                  t32bitsrv::srvCmdline()))
+                                  t32bitsrv::srvCmdlinePrg(),
+                                  t32bitsrv::srvCmdlineArgs()))
     return false;
 
   tipc::Stream stream(&socket);
@@ -61,7 +62,8 @@ bool IsQuickTimeInstalled() {
 Tiio::MovWriterProperties::MovWriterProperties() {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -156,7 +158,8 @@ TLevelWriterMov::TLevelWriterMov(const TFilePath &path, TPropertyGroup *winfo)
 
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -201,7 +204,8 @@ err:
 TLevelWriterMov::~TLevelWriterMov() {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -219,7 +223,8 @@ void TLevelWriterMov::setFrameRate(double fps) {
 
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -256,7 +261,8 @@ void TLevelWriterMov::save(const TImageP &img, int frameIndex) {
   // Send messages
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -283,7 +289,8 @@ void TLevelWriterMov::saveSoundTrack(TSoundTrack *st) {
   // Prepare connection
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   unsigned int size = st->getSampleSize() * st->getSampleCount();
 
@@ -372,7 +379,8 @@ TLevelReaderMov::TLevelReaderMov(const TFilePath &path) : TLevelReader(path) {
 
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -396,7 +404,8 @@ TLevelReaderMov::TLevelReaderMov(const TFilePath &path) : TLevelReader(path) {
 TLevelReaderMov::~TLevelReaderMov() {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -420,7 +429,8 @@ TImageReaderP TLevelReaderMov::getFrameReader(TFrameId fid) {
 TLevelP TLevelReaderMov::loadInfo() {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -468,7 +478,8 @@ err:
 void TLevelReaderMov::enableRandomAccessRead(bool enable) {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;
@@ -485,7 +496,8 @@ void TLevelReaderMov::load(const TRasterP &ras, int frameIndex,
                            const TPoint &pos, int shrinkX, int shrinkY) {
   QLocalSocket socket;
   tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), -1,
-                             t32bitsrv::srvCmdline());
+                             t32bitsrv::srvCmdlinePrg(),
+                             t32bitsrv::srvCmdlineArgs());
 
   tipc::Stream stream(&socket);
   tipc::Message msg;

--- a/toonz/sources/image/tzl/tiio_tzl.cpp
+++ b/toonz/sources/image/tzl/tiio_tzl.cpp
@@ -114,17 +114,9 @@ bool writeVersionAndCreator(FILE *chan, const char *version, QString creator) {
   if (creator.length() == 0) creator = "UNKNOWN";
   memset(s, 0, sizeof s);
   if (creator.length() > CREATOR_LENGTH - 1)
-#if QT_VERSION >= 0x050000
     memcpy(s, creator.toLatin1(), CREATOR_LENGTH - 1);
-#else
-    memcpy(s, creator.toAscii(), CREATOR_LENGTH - 1);
-#endif
   else
-#if QT_VERSION >= 0x050000
     memcpy(s, creator.toLatin1(), creator.length());
-#else
-    memcpy(s, creator.toAscii(), creator.length());
-#endif
   tfwrite(s, CREATOR_LENGTH, chan);
 
   return true;
@@ -1076,9 +1068,9 @@ void TLevelWriterTzl::saveImage(const TImageP &img, const TFrameId &_fid,
   }
   rCompressed->unlock();
 
-  //#if !TNZ_LITTLE_ENDIAN
-  // delete [] buff;
-  //#endif
+  // #if !TNZ_LITTLE_ENDIAN
+  //  delete [] buff;
+  // #endif
 }
 
 //-------------------------------------------------------------------
@@ -2194,7 +2186,7 @@ TImageP TImageReaderTzl::load14() {
       TINT32 iconsbx0 = tfloor((double)iconLx * sbx0 / m_lrp->m_res.lx);
       TINT32 iconsby0 = tfloor((double)iconLy * sby0 / m_lrp->m_res.ly);
       savebox         = TRect(TPoint(iconsbx0, iconsby0),
-                      TDimension(tmp_savebox.getLx(), tmp_savebox.getLy()));
+                              TDimension(tmp_savebox.getLx(), tmp_savebox.getLy()));
     }
 
     // int ly = tround((double)m_lrp->m_res.ly*iconLx/m_lrp->m_res.lx);

--- a/toonz/sources/include/t32bitsrv_wrap.h
+++ b/toonz/sources/include/t32bitsrv_wrap.h
@@ -43,16 +43,20 @@ static QString srvName() {
 }
 
 #ifdef _WIN32
-static QString srvCmdline() {
-  static QString cmd("srv/t32bitsrv.exe " + srvName());
+static QString srvCmdlinePrg() {
+  static QString cmd("srv/t32bitsrv.exe");
   return cmd;
 }
 #else
-static QString srvCmdline() {
-  return "\"" + QCoreApplication::applicationDirPath() + "/t32bitsrv\" " +
-         srvName();
+static QString srvCmdlinePrg() {
+  return "\"" + QCoreApplication::applicationDirPath() + "/t32bitsrv";
 }
 #endif
+
+static QStringList srvCmdlineArgs() {
+  static QStringList args = {srvName()};
+  return args;
+}
 
 //*************************************************************************************
 //  Buffer data exchanger

--- a/toonz/sources/include/tcg/hpp/mesh.hpp
+++ b/toonz/sources/include/tcg/hpp/mesh.hpp
@@ -337,9 +337,9 @@ int TriMesh<V, E, F>::collapseEdge(int e) {
     {
       F &fc = this->face(*ft);
 
-      (fc.edge(0) == srcE)
-          ? fc.setEdge(0, dstE)
-          : (fc.edge(1) == srcE) ? fc.setEdge(1, dstE) : fc.setEdge(2, dstE);
+      (fc.edge(0) == srcE)   ? fc.setEdge(0, dstE)
+      : (fc.edge(1) == srcE) ? fc.setEdge(1, dstE)
+                             : fc.setEdge(2, dstE);
 
       dstEd.addFace(*ft);
       ft = srcEd.eraseFace(ft);  // here
@@ -356,7 +356,7 @@ int TriMesh<V, E, F>::collapseEdge(int e) {
 
 // Ensure that there is no remaining edge which would be duplicated
 // after vDelete and vKeep merge
-/* FIXME: edgeInciding がないと言われるのでとりあえず省略 */
+/* FIXME: Omitted for now because it is warned that there is no edgeInciding */
 #if 0
     assert("Detected vertex adjacent to collapsed edge's endpoints, but not to its faces." &&
            edgeInciding(ed.otherVertex(vDelete), vKeep) < 0);
@@ -394,7 +394,7 @@ int TriMesh<V, E, F>::splitEdge(int e) {
       fCount =
           ed.facesCount();  //       MORE than 2 adjacent faces, the new faces
   //       should be inserted BEFORE removing the split
-  for (f      = 0; f != fCount; ++f)  //       edge.
+  for (f = 0; f != fCount; ++f)  //       edge.
     otherV[f] = otherFaceVertex(ed.face(f), e);
 
   // Remove e

--- a/toonz/sources/include/tcolorutils.h
+++ b/toonz/sources/include/tcolorutils.h
@@ -5,7 +5,7 @@
 
 //------------------------------------------------------------------------------
 #include <set>
-//#include "tpixel.h"
+// #include "tpixel.h"
 #include "traster.h"
 
 #include <QList>
@@ -22,10 +22,10 @@
 
 namespace TColorUtils {
 
-/*-- 似ている色をまとめて1つのStyleにする --*/
+/*-- Combine similar colors into one style --*/
 DVAPI void buildPalette(std::set<TPixel32> &palette, const TRaster32P &raster,
                         int maxColorCount);
-/*-- 全ての異なるピクセルの色を別のStyleにする --*/
+/*-- Make each different pixel color a separate style --*/
 DVAPI void buildPrecisePalette(std::set<TPixel32> &palette,
                                const TRaster32P &raster, int maxColorCount);
 //  pick up color chip sorrounded by frames with specified color
@@ -34,7 +34,7 @@ DVAPI void buildColorChipPalette(QList<QPair<TPixel32, TPoint>> &palette,
                                  const TPixel32 &gridColor,
                                  const int gridLineWidth,
                                  const int colorChipOrder);
-}
+}  // namespace TColorUtils
 
 //------------------------------------------------------------------------------
 

--- a/toonz/sources/include/tfarmtask.h
+++ b/toonz/sources/include/tfarmtask.h
@@ -133,6 +133,8 @@ public:
   virtual int getTaskCount() const { return 1; }
   virtual TFarmTask *getTask(int index) { return this; }
 
+  QString getCommandLinePrgName() const;
+  QString getCommandLineArguments() const;
   QString getCommandLine(bool isFarmTask = false) const;
   void parseCommandLine(QString commandLine);
 

--- a/toonz/sources/include/tfx.h
+++ b/toonz/sources/include/tfx.h
@@ -488,10 +488,10 @@ public:
   virtual void compatibilityTranslatePort(int majorVersion, int minorVersion,
                                           std::string &portName) {}
 
-  /*-- Rendering（目玉）ボタンがOFFのときに使用されるInputPort --*/
+  /*-- InputPort used when the Rendering (eye) button is OFF --*/
   virtual int getPreferredInputPort() { return 0; }
 
-  /* RasterFxPluginHost 用の仮想関数 */
+  /* Virtual function for RasterFxPluginHost */
   virtual void callStartRenderHandler() {}
   virtual void callEndRenderHandler() {}
   virtual void callStartRenderFrameHandler(const TRenderSettings *rs,

--- a/toonz/sources/include/tfxattributes.h
+++ b/toonz/sources/include/tfxattributes.h
@@ -31,7 +31,7 @@ class DVAPI TFxAttributes {
 
   int m_groupSelector;
 
-  /*-- MotionBlurなどのFxのために、オブジェクトの軌跡のデータを取得する --*/
+  /*-- Get object trajectory data for MotionBlur and other Fxs --*/
   QList<TPointD> m_motionPoints;
   TAffine m_motionAffine[2];
   // to maintain backward compatibility in the fx

--- a/toonz/sources/include/tfxutil.h
+++ b/toonz/sources/include/tfxutil.h
@@ -18,7 +18,8 @@ DVAPI TFxP makeCheckboard();
 DVAPI TFxP makeCheckboard(TPixel32 c0, TPixel32 c1, double squareSize);
 
 /*--
- * Preferenceオプションにより、Xsheetノードに繋がった素材を「比較暗」合成して表示する
+ * Darken composite display of nodes connected to the Xsheet node according to
+ * the Preference option
  * --*/
 DVAPI TFxP makeDarken(const TFxP &dn, const TFxP &up);
 
@@ -38,6 +39,6 @@ DVAPI void deleteKeyframes(const TFxP &fx, int frame);
 
 DVAPI void setKeyframe(const TFxP &dstFx, int dstFrame, const TFxP &srcFx,
                        int srcFrame, bool changedOnly = false);
-}
+}  // namespace TFxUtil
 
 #endif

--- a/toonz/sources/include/tipc.h
+++ b/toonz/sources/include/tipc.h
@@ -192,13 +192,17 @@ namespace tipc {
 
 //---------------------- Connection-message utilities ----------------------
 
-DVAPI bool startBackgroundProcess(QString cmdline);
+DVAPI bool startBackgroundProcess(QString cmdlineProgram,
+                                  QStringList cmdlineArguments);
 
 DVAPI QString applicationSpecificServerName(QString srvName);
 DVAPI bool startSlaveConnection(QLocalSocket *socket, QString srvName,
-                                int msecs = -1, QString cmdline = QString(),
-                                QString threadName = QString());
-DVAPI bool startSlaveServer(QString srvName, QString cmdline);
+                                int msecs                    = -1,
+                                QString cmdlineProgram       = QString(),
+                                QStringList cmdlineArguments = QStringList(),
+                                QString threadName           = QString());
+DVAPI bool startSlaveServer(QString srvName, QString cmdlineProgram,
+                            QStringList cmdlineArguments);
 
 DVAPI QString readMessage(Stream &stream, Message &msg, int msecs = -1);
 DVAPI QString

--- a/toonz/sources/include/tools/toolhandle.h
+++ b/toonz/sources/include/tools/toolhandle.h
@@ -7,7 +7,7 @@
 #include "timage.h"
 #include <QObject>
 #include <QMap>
-#include <QTime>
+#include <QElapsedTimer>
 
 // forward declaration
 class TTool;
@@ -35,7 +35,7 @@ class DVAPI ToolHandle final : public QObject {
   QString m_toolName;
   int m_toolTargetType;
   QString m_storedToolName;
-  QTime m_storedToolTime;
+  QElapsedTimer m_storedToolTime;
   QString m_oldToolName;
   bool m_toolIsBusy;
 

--- a/toonz/sources/include/toonz/cleanupparameters.h
+++ b/toonz/sources/include/toonz/cleanupparameters.h
@@ -157,7 +157,7 @@ public:
   TPaletteP m_cleanupPalette;
   TFilePath m_path;
 
-  /*--- オフセットを軸ごとにロックする ---*/
+  /*--- Lock offsets by axis ---*/
   bool m_offx_lock, m_offy_lock;
 
   // hold brightness and contrast values for each line processing modes (grey

--- a/toonz/sources/include/toonz/hook.h
+++ b/toonz/sources/include/toonz/hook.h
@@ -97,7 +97,7 @@ private:
   TPointD m_delta;
   int m_id;
 
-  // Proprietà relative alla trackerRegion
+  // Properties related to trackerRegion
   //! If Hook is also a Trackeregion then m_trackerObjectId>=0, else is -1
   int m_trackerObjectId;
   double m_width;   // trackerRegion width

--- a/toonz/sources/include/toonz4.6/tcm.h
+++ b/toonz/sources/include/toonz4.6/tcm.h
@@ -66,6 +66,6 @@ static const TCM_INFO Tcm_32_default_info = {
 #define TCM_CMAP_COLBUFFER_SIZE(TCM) (1 << ((TCM).color_bits + (TCM).tone_bits))
 
 #define TCM_CMAP_PENBUFFER_SIZE(TCM)                                           \
-  (1 << ((TCM).pencil_bits + (TCM).tone_bits))
+  (uint64_t(1) << ((TCM).pencil_bits + (TCM).tone_bits))
 
 #endif

--- a/toonz/sources/include/toonzqt/dvdialog.h
+++ b/toonz/sources/include/toonzqt/dvdialog.h
@@ -278,7 +278,7 @@ class DVAPI RadioButtonDialog final : public DVGui::Dialog {
 public:
   RadioButtonDialog(const QString &labelText,
                     const QList<QString> &radioButtonList, QWidget *parent = 0,
-                    Qt::WindowFlags f = 0);
+                    Qt::WindowFlags f = Qt::WindowFlags());
 
 public Q_SLOTS:
   void onButtonClicked(int id);
@@ -306,7 +306,7 @@ protected:
 public:
   ProgressDialog(const QString &labelText, const QString &cancelButtonText,
                  int minimum, int maximum, QWidget *parent = 0,
-                 Qt::WindowFlags f = 0);
+                 Qt::WindowFlags f = Qt::WindowFlags());
 
   void setLabelText(const QString &text);
   void setCancelButton(QPushButton *cancelButton);

--- a/toonz/sources/include/toonzqt/functionviewer.h
+++ b/toonz/sources/include/toonzqt/functionviewer.h
@@ -74,11 +74,8 @@ public:
   enum IoType { eSaveCurve, eLoadCurve, eExportCurve };
 
 public:
-#if QT_VERSION >= 0x050500
-  FunctionViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  FunctionViewer(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  FunctionViewer(QWidget *parent       = 0,
+                 Qt::WindowFlags flags = Qt::WindowFlags());
   ~FunctionViewer();
 
   void setXsheetHandle(TXsheetHandle *xshHandle);  //!< Associates an xsheet to

--- a/toonz/sources/include/toonzqt/fxschematicnode.h
+++ b/toonz/sources/include/toonzqt/fxschematicnode.h
@@ -72,6 +72,8 @@ protected:
 
 class FxPalettePainter final : public QObject, public QGraphicsItem {
   Q_OBJECT
+  Q_INTERFACES(QGraphicsItem)
+
   FxSchematicPaletteNode *m_parent;
   double m_width, m_height;
   QString m_name;

--- a/toonz/sources/include/toonzqt/fxsettings.h
+++ b/toonz/sources/include/toonzqt/fxsettings.h
@@ -159,11 +159,7 @@ class DVAPI ParamsPageSet final : public QWidget {
   QLabel *m_warningMark;
 
 public:
-#if QT_VERSION >= 0x050500
-  ParamsPageSet(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ParamsPageSet(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  ParamsPageSet(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ParamsPageSet();
 
   void setFx(const TFxP &currentFx, const TFxP &actualFx, int frame);
@@ -210,11 +206,7 @@ class DVAPI ParamViewer final : public QFrame {
   QMap<std::string, int> m_tableFxIndex;
 
 public:
-#if QT_VERSION >= 0x050500
-  ParamViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ParamViewer(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  ParamViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ParamViewer();
 
   void setFx(const TFxP &currentFx, const TFxP &actualFx, int frame,

--- a/toonz/sources/include/toonzqt/lutcalibrator.h
+++ b/toonz/sources/include/toonzqt/lutcalibrator.h
@@ -89,7 +89,7 @@ public:
 
   bool isValid() { return m_isValid; }
   int meshSize() const { return m_lut.meshSize; }
-  float* data() const { return m_lut.data; }
+  const float* data() const { return m_lut.data; }
 
   bool loadLutFile(const QString& fp);
 

--- a/toonz/sources/include/toonzqt/paletteviewergui.h
+++ b/toonz/sources/include/toonzqt/paletteviewergui.h
@@ -51,9 +51,10 @@ class StyleNameEditor;
 namespace PaletteViewerGUI {
 
 enum PaletteViewType  //! Possible palette contents of a Palette Viewer.
-{ LEVEL_PALETTE,      //!< Content palette is from a level.
-  CLEANUP_PALETTE,    //!< Content palette is from cleanup settings.
-  STUDIO_PALETTE      //!< Content palette is from a Studio Palette panel.
+{
+  LEVEL_PALETTE,    //!< Content palette is from a level.
+  CLEANUP_PALETTE,  //!< Content palette is from cleanup settings.
+  STUDIO_PALETTE    //!< Content palette is from a Studio Palette panel.
 };
 
 //****************************************************************************
@@ -102,8 +103,9 @@ class DVAPI PageViewer final : public QFrame, public TSelection::View {
           WRITE setListNumpadShortcutBorderColor)
 
 public:
-  enum ViewMode         //! Possible view modes for a Palette Viewer.
-  { SmallChips,         //!< Small icons.
+  enum ViewMode  //! Possible view modes for a Palette Viewer.
+  {
+    SmallChips,         //!< Small icons.
     MediumChips,        //!< Medium icons.
     LargeChips,         //!< Large icons with style names.
     List,               //!< Top-down list of all icons.
@@ -345,11 +347,8 @@ class DVAPI PaletteIconWidget final : public QWidget {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
-  PaletteIconWidget(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  PaletteIconWidget(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  PaletteIconWidget(QWidget *parent       = 0,
+                    Qt::WindowFlags flags = Qt::WindowFlags());
   ~PaletteIconWidget();
 
 signals:

--- a/toonz/sources/include/toonzqt/schematicgroupeditor.h
+++ b/toonz/sources/include/toonzqt/schematicgroupeditor.h
@@ -34,6 +34,7 @@ class SchematicName;
 
 class DVAPI SchematicWindowEditor : public QObject, public QGraphicsItem {
   Q_OBJECT
+  Q_INTERFACES(QGraphicsItem)
 
   QPointF m_lastPos;
 
@@ -52,7 +53,7 @@ public:
 
   QRectF boundingRect() const override;
   void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-             QWidget *widget                    = 0) override;
+             QWidget *widget = 0) override;
   virtual QRectF boundingSceneRect() const      = 0;
   virtual void setGroupedNodeZValue(int zValue) = 0;
   bool contains(SchematicNode *node) const {

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -232,6 +232,8 @@ protected:
 */
 class SchematicLink : public QObject, public QGraphicsItem {
   Q_OBJECT
+  Q_INTERFACES(QGraphicsItem)
+
   SchematicPort *m_startPort, *m_endPort;
   QPainterPath m_path, m_hitPath;
   bool m_lineShaped;

--- a/toonz/sources/include/toonzqt/spreadsheetviewer.h
+++ b/toonz/sources/include/toonzqt/spreadsheetviewer.h
@@ -144,11 +144,7 @@ class DVAPI ScrollArea final : public QScrollArea {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
-  ScrollArea(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ScrollArea(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  ScrollArea(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   virtual ~ScrollArea();
 
 protected:

--- a/toonz/sources/include/toonzqt/swatchviewer.h
+++ b/toonz/sources/include/toonzqt/swatchviewer.h
@@ -175,11 +175,7 @@ public:
     void onCanceled(TThread::RunnableP task) override;
   };
 
-#if QT_VERSION >= 0x050500
-  SwatchViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  SwatchViewer(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  SwatchViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~SwatchViewer();
 
   static void suspendRendering(bool suspend, bool blocking = true);

--- a/toonz/sources/include/tpixel.h
+++ b/toonz/sources/include/tpixel.h
@@ -41,7 +41,7 @@ class TPixelGR16;
     Note that channel ordering is platform depending. */
 
 class DVAPI DV_ALIGNED(4) TPixelRGBM32 {
-  TPixelRGBM32(TUINT32 mask) { *(TUINT32 *)this = mask; };
+  TPixelRGBM32(TUINT32 mask) : TPixelRGBM32() { *(TUINT32 *)this = mask; };
 
 public:
   static const int maxChannelValue;
@@ -82,7 +82,7 @@ public:
       : r(rr), g(gg), b(bb), m(mm){};
 
   // Copy constructor and operator=
-  TPixelRGBM32(const TPixelRGBM32 &pix) {
+  TPixelRGBM32(const TPixelRGBM32 &pix) : TPixelRGBM32() {
     *(TUINT32 *)this = *(const TUINT32 *)&pix;
   }
 
@@ -195,7 +195,7 @@ undefined machine order !!!!
 #endif
 
   // Copy constructor and operator=
-  TPixelRGBM64(const TPixelRGBM64 &pix) {
+  TPixelRGBM64(const TPixelRGBM64 &pix) : TPixelRGBM64() {
     *(TUINT64 *)this = *(const TUINT64 *)&pix;
   }
 

--- a/toonz/sources/include/tpixelutils.h
+++ b/toonz/sources/include/tpixelutils.h
@@ -31,8 +31,10 @@ inline T blend(const T &a, const T &b, double t) {
 
 template <>
 inline TPixelF blend(const TPixelF &a, const TPixelF &b, double t) {
-  return TPixelF((1 - t) * a.r + t * b.r, (1 - t) * a.g + t * b.g,
-                 (1 - t) * a.b + t * b.b, (1 - t) * a.m + t * b.m);
+  return TPixelF((float)(1. - t) * a.r + (float)t * b.r,
+                 (float)(1. - t) * a.g + (float)t * b.g,
+                 (float)(1. - t) * a.b + (float)t * b.b,
+                 (float)(1. - t) * a.m + (float)t * b.m);
 }
 
 //-----------------------------------------------------------------------------
@@ -419,9 +421,9 @@ inline void premult(TPixel32 &pix) {
 }
 
 inline void premult(TPixel64 &pix) {
-  pix.r = pix.r * pix.m / 65535.0;
-  pix.g = pix.g * pix.m / 65535.0;
-  pix.b = pix.b * pix.m / 65535.0;
+  pix.r = (typename TPixel64::Channel)((double)pix.r * (double)pix.m / 65535.0);
+  pix.g = (typename TPixel64::Channel)((double)pix.g * (double)pix.m / 65535.0);
+  pix.b = (typename TPixel64::Channel)((double)pix.b * (double)pix.m / 65535.0);
 }
 
 inline void premult(TPixelF &pix) {
@@ -431,17 +433,17 @@ inline void premult(TPixelF &pix) {
 }
 
 inline void depremult(TPixel32 &pix) {
-  float fac = 255.0f / pix.m;
-  pix.r     = std::min(pix.r * fac, 255.0f);
-  pix.g     = std::min(pix.g * fac, 255.0f);
-  pix.b     = std::min(pix.b * fac, 255.0f);
+  float fac = 255.f / (float)pix.m;
+  pix.r     = (typename TPixel32::Channel)(std::min((float)pix.r * fac, 255.f));
+  pix.g     = (typename TPixel32::Channel)(std::min((float)pix.g * fac, 255.f));
+  pix.b     = (typename TPixel32::Channel)(std::min((float)pix.b * fac, 255.f));
 }
 
 inline void depremult(TPixel64 &pix) {
-  double fac = 65535.0 / pix.m;
-  pix.r      = std::min(pix.r * fac, 65535.0);
-  pix.g      = std::min(pix.g * fac, 65535.0);
-  pix.b      = std::min(pix.b * fac, 65535.0);
+  double fac = 65535. / (double)pix.m;
+  pix.r = (typename TPixel64::Channel)(std::min((double)pix.r * fac, 65535.));
+  pix.g = (typename TPixel64::Channel)(std::min((double)pix.g * fac, 65535.));
+  pix.b = (typename TPixel64::Channel)(std::min((double)pix.b * fac, 65535.));
 }
 
 inline void depremult(TPixelF &pix) {
@@ -469,8 +471,9 @@ inline TPixel32 premultiply(const TPixel32 &pix) {
 }
 
 inline TPixel64 premultiply(const TPixel64 &pix) {
-  return TPixel64(pix.r * pix.m / 65535.0, pix.g * pix.m / 65535.0,
-                  pix.b * pix.m / 65535.0, pix.m);
+  return TPixel64((int)((double)pix.r * (double)pix.m / 65535.),
+                  (int)((double)pix.g * (double)pix.m / 65535.),
+                  (int)((double)pix.b * (double)pix.m / 65535.), pix.m);
 }
 
 inline TPixelF premultiply(const TPixelF &pix) {
@@ -479,13 +482,15 @@ inline TPixelF premultiply(const TPixelF &pix) {
 }
 
 inline TPixel32 depremultiply(const TPixel32 &pix) {
-  return TPixel32(pix.r * 255.0 / pix.m, pix.g * 255.0 / pix.m,
-                  pix.b * 255.0 / pix.m, pix.m);
+  return TPixel32((int)((double)pix.r * 255. / (double)pix.m),
+                  (int)((double)pix.g * 255. / (double)pix.m),
+                  (int)((double)pix.b * 255. / (double)pix.m), pix.m);
 }
 
 inline TPixel64 depremultiply(const TPixel64 &pix) {
-  return TPixel64(pix.r * 65535.0 / pix.m, pix.g * 65535.0 / pix.m,
-                  pix.b * 65535.0 / pix.m, pix.m);
+  return TPixel64((int)((double)pix.r * 65535. / (double)pix.m),
+                  (int)((double)pix.g * 65535. / (double)pix.m),
+                  (int)((double)pix.b * 65535. / (double)pix.m), pix.m);
 }
 
 inline TPixelF depremultiply(const TPixelF &pix) {

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -154,9 +154,9 @@ public:
   // Raster levels. Currently used only in Tile Fx Iwa. (see iwa_tilefx.cpp)
   bool m_getFullSizeBBox;
 
-  /*-- カメラサイズ --*/
+  /*-- camera size --*/
   TRectD m_cameraBox;
-  /*-- 途中でPreview計算がキャンセルされたときのフラグ --*/
+  /*-- Flag when Preview calculation is canceled during the process --*/
   int *m_isCanceled;
 
   // pointer to QOffscreenSurface which is created on

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -18,7 +18,7 @@ public:
 
 private:
   const char *applicationName     = "OpenToonz";
-  const float applicationVersion  = 1.6;
+  const float applicationVersion  = 1.6f;
   const float applicationRevision = 0;
   const char *applicationNote     = "";
 };

--- a/toonz/sources/stdfx/igs_ifx_common.h
+++ b/toonz/sources/stdfx/igs_ifx_common.h
@@ -55,7 +55,7 @@ void copy_except_margin(const T *in, const int margin, T *out, const int hh,
     }
   }
 }
-}
+}  // namespace image
 namespace color {
 template <class T>
 double ref_value(const T *ref, const int cc, const int ref_max,
@@ -64,49 +64,55 @@ double ref_value(const T *ref, const int cc, const int ref_max,
     using namespace igs::image::rgba;
     switch (ref_mode) {
     case 0:
-      return static_cast<double>(ref[red]) / ref_max;
+      return static_cast<double>(ref[red]) / static_cast<double>(ref_max);
       break;
     case 1:
-      return static_cast<double>(ref[gre]) / ref_max;
+      return static_cast<double>(ref[gre]) / static_cast<double>(ref_max);
       break;
     case 2:
-      return static_cast<double>(ref[blu]) / ref_max;
+      return static_cast<double>(ref[blu]) / static_cast<double>(ref_max);
       break;
     case 3:
-      return static_cast<double>(ref[alp]) / ref_max;
+      return static_cast<double>(ref[alp]) / static_cast<double>(ref_max);
       break;
     case 4:
       return /* 輝度(Luminance)(CCIR Rec.601) */
-          0.298912 * static_cast<double>(ref[red]) / ref_max +
-          0.586611 * static_cast<double>(ref[gre]) / ref_max +
-          0.114478 * static_cast<double>(ref[blu]) / ref_max;
+          0.298912 * static_cast<double>(ref[red]) /
+              static_cast<double>(ref_max) +
+          0.586611 * static_cast<double>(ref[gre]) /
+              static_cast<double>(ref_max) +
+          0.114478 * static_cast<double>(ref[blu]) /
+              static_cast<double>(ref_max);
       break;
     }
   } else if (igs::image::rgb::siz == cc) {
     using namespace igs::image::rgb;
     switch (ref_mode) {
     case 0:
-      return static_cast<double>(ref[red]) / ref_max;
+      return static_cast<double>(ref[red]) / static_cast<double>(ref_max);
       break;
     case 1:
-      return static_cast<double>(ref[gre]) / ref_max;
+      return static_cast<double>(ref[gre]) / static_cast<double>(ref_max);
       break;
     case 2:
-      return static_cast<double>(ref[blu]) / ref_max;
+      return static_cast<double>(ref[blu]) / static_cast<double>(ref_max);
       break;
     case 3:
       return /* 輝度(Luminance)(CCIR Rec.601) */
-          0.298912 * static_cast<double>(ref[red]) / ref_max +
-          0.586611 * static_cast<double>(ref[gre]) / ref_max +
-          0.114478 * static_cast<double>(ref[blu]) / ref_max;
+          0.298912 * static_cast<double>(ref[red]) /
+              static_cast<double>(ref_max) +
+          0.586611 * static_cast<double>(ref[gre]) /
+              static_cast<double>(ref_max) +
+          0.114478 * static_cast<double>(ref[blu]) /
+              static_cast<double>(ref_max);
       break;
     }
   } else if (1 == cc) {
-    return static_cast<double>(ref[0]) / ref_max;
+    return static_cast<double>(ref[0]) / static_cast<double>(ref_max);
   }
   return 1.0;
 }
-}
-}
+}  // namespace color
+}  // namespace igs
 
 #endif /* !igs_ifx_common_h */

--- a/toonz/sources/stdfx/igs_line_blur.cpp
+++ b/toonz/sources/stdfx/igs_line_blur.cpp
@@ -88,7 +88,7 @@ void pri_funct_cv_end(void) {
 
 /* Windowsではvsnprintf()の頭にアンダーバーが付く!!! */
 #if defined _WIN32
-#define vsnprintf(buf, len, fmt, ap) _vsnprintf(buf, len, fmt, ap)
+#define vsnprintf(buf, len, fmt, ap) _vsnprintf_s(buf, len, fmt, ap)
 #endif
 
 static const char *pri_param_cp_com_name = "#";
@@ -1660,9 +1660,9 @@ void pixel_line_node::_get_link_line_selecter_vector(pixel_point_node *clp_crnt,
 
 pixel_point_node *pixel_line_node::_get_link_line_selecter(
     double d_xv, double d_yv, pixel_point_node *clp_crnt, int32_t i32_count) {
-  int32_t ii, i32_pos;
-  double da_xv[LINK_NEAR_COUNT], da_yv[LINK_NEAR_COUNT],
-      da_radian[LINK_NEAR_COUNT], d_radian;
+  int32_t ii, i32_pos = 0;
+  double da_xv[LINK_NEAR_COUNT] = {0.}, da_yv[LINK_NEAR_COUNT] = {0.},
+         da_radian[LINK_NEAR_COUNT] = {0.}, d_radian;
 
   /* あってはならないプログラムバグのチェック */
   assert((0.0 != d_xv) || (0.0 != d_yv));

--- a/toonz/sources/stdfx/iwa_bokeh_util.cpp
+++ b/toonz/sources/stdfx/iwa_bokeh_util.cpp
@@ -818,8 +818,7 @@ void doSingleExtend(const double4* source_buff,
       // continue if the current pixel is already extended
       if ((*gen_p) > 0) continue;
 
-      // check out the neighbor pixels. store brightness in neighbor[x].w
-      double4 neighbor[8];
+      // check out the neighbor pixels.
       bool neighbor_found = false;
       for (int ky = posY - 1; ky <= posY + 1; ky++) {
         for (int kx = posX - 1; kx <= posX + 1; kx++) {

--- a/toonz/sources/stdfx/iwa_floorbumpfx.cpp
+++ b/toonz/sources/stdfx/iwa_floorbumpfx.cpp
@@ -286,6 +286,7 @@ inline float4 getColor(QVector3D pre_n, QVector3D cur_n, QVector3D pre_p,
   else if (vars.renderMode == Iwa_FloorBumpFx::ReflectionMode)
     return getReflectionColor(lerpNormal(pre_n, cur_n, ratio),
                               lerpPos(pre_p, cur_p, ratio), source_host, vars);
+  return float4();
 };
 
 QList<QPointF> getSubPointsList(int subAmount,

--- a/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
+++ b/toonz/sources/stdfx/iwa_flowpaintbrushfx.cpp
@@ -748,7 +748,7 @@ void Iwa_FlowPaintBrushFx::computeBrushVertices(
         break;
       }
     }
-    qSort(brushStrokes.begin(), brushStrokes.end(), strokeStackGraterThan);
+    std::sort(brushStrokes.begin(), brushStrokes.end(), strokeStackGraterThan);
   }
 
   // ƒ^ƒbƒ`‚ğ‚¹‚ñ’f‚É‘Î‚µ‚Ä‚±‚Á‚¿Œü‚¯‚Ä‘¾‚­‚·‚éŠ„‡

--- a/toonz/sources/stdfx/iwa_timecodefx.cpp
+++ b/toonz/sources/stdfx/iwa_timecodefx.cpp
@@ -60,7 +60,7 @@ void Iwa_TimeCodeFx::doCompute(TTile &tile, double frame,
   font.setWeight(QFont::Normal);
   QFontMetrics fm(font);
   QString timeCodeStr = getTimeCodeStr(frame, ri);
-  int width           = fm.width(timeCodeStr);
+  int width           = fm.horizontalAdvance(timeCodeStr);
   int height          = fm.height();
 
   QImage img(width, height, QImage::Format_ARGB32);

--- a/toonz/sources/stdfx/shaderfx.cpp
+++ b/toonz/sources/stdfx/shaderfx.cpp
@@ -35,7 +35,7 @@
 #include <boost/ptr_container/ptr_vector.hpp>
 
 // Diagnostics include
-//#define DIAGNOSTICS
+// #define DIAGNOSTICS
 #ifdef DIAGNOSTICS
 #include "diagnostics.h"
 #endif
@@ -799,8 +799,7 @@ void ShaderFx::bindParameters(QOpenGLShaderProgram *program, double frame) {
 
 void ShaderFx::bindWorldTransform(QOpenGLShaderProgram *program,
                                   const TAffine &worldToDst) {
-// Bind transformation affine
-#if QT_VERSION >= 0x050500
+  // Bind transformation affine
   float qwToD[9] = {static_cast<float>(worldToDst.a11),
                     static_cast<float>(worldToDst.a12),
                     static_cast<float>(worldToDst.a13),
@@ -810,34 +809,18 @@ void ShaderFx::bindWorldTransform(QOpenGLShaderProgram *program,
                     0.0f,
                     0.0f,
                     1.0f};
-#else
-  qreal qwToD[9] = {worldToDst.a11,
-                    worldToDst.a12,
-                    worldToDst.a13,
-                    worldToDst.a21,
-                    worldToDst.a22,
-                    worldToDst.a23,
-                    0.0,
-                    0.0,
-                    1.0};
-#endif
   program->setUniformValue("worldToOutput", QMatrix3x3(qwToD));
 
   const TAffine &dToW = worldToDst.inv();
-#if QT_VERSION >= 0x050500
-  float qdToW[9] = {static_cast<float>(dToW.a11),
-                    static_cast<float>(dToW.a12),
-                    static_cast<float>(dToW.a13),
-                    static_cast<float>(dToW.a21),
-                    static_cast<float>(dToW.a22),
-                    static_cast<float>(dToW.a23),
-                    0.0f,
-                    0.0f,
-                    1.0f};
-#else
-  qreal qdToW[9] = {dToW.a11, dToW.a12, dToW.a13, dToW.a21, dToW.a22,
-                    dToW.a23, 0.0,      0.0,      1.0};
-#endif
+  float qdToW[9]      = {static_cast<float>(dToW.a11),
+                         static_cast<float>(dToW.a12),
+                         static_cast<float>(dToW.a13),
+                         static_cast<float>(dToW.a21),
+                         static_cast<float>(dToW.a22),
+                         static_cast<float>(dToW.a23),
+                         0.0f,
+                         0.0f,
+                         1.0f};
   program->setUniformValue("outputToWorld", QMatrix3x3(qdToW));
 }
 
@@ -1095,7 +1078,6 @@ void ShaderFx::doCompute(TTile &tile, double frame,
 
           TAffine sToI(iToS.inv());
 
-#if QT_VERSION >= 0x050500
           float qiToS[9] = {static_cast<float>(iToS.a11),
                             static_cast<float>(iToS.a12),
                             static_cast<float>(iToS.a13),
@@ -1114,13 +1096,6 @@ void ShaderFx::doCompute(TTile &tile, double frame,
                             0.0f,
                             0.0f,
                             1.0f};
-#else
-          qreal qiToS[9] = {iToS.a11, iToS.a12, iToS.a13, iToS.a21, iToS.a22,
-                            iToS.a23, 0.0,      0.0,      1.0};
-
-          qreal qsToI[9] = {sToI.a11, sToI.a12, sToI.a13, sToI.a21, sToI.a22,
-                            sToI.a23, 0.0,      0.0,      1.0};
-#endif
           inputs[p] = p, screenToInput[p] = QMatrix3x3(qsToI),
           inputToScreen[p] = QMatrix3x3(qiToS);
         }

--- a/toonz/sources/tnzbase/tfxutil.cpp
+++ b/toonz/sources/tnzbase/tfxutil.cpp
@@ -2,7 +2,7 @@
 
 #include "tfxutil.h"
 #include "tbasefx.h"
-//#include "timage_io.h"
+// #include "timage_io.h"
 #include "trasterimage.h"
 #include "tdoubleparam.h"
 #include "tparamset.h"
@@ -82,8 +82,8 @@ TFxP TFxUtil::makeDarken(const TFxP &dn, const TFxP &up) {
   assert(dn);
   assert(up);
 
-  /*-- TODO: FxId名変更となる可能性が高い。DarkenFx実装後に修正のこと。2016/2/3
-   * shun_iwasawa --*/
+  /*-- TODO: FxId name will likely be changed; correct after DarkenFx
+   * implementation. 2016/2/3 shun_iwasawa --*/
   TFxP darkenFx = TFx::create("STD_inoDarkenFx");
   assert(darkenFx);
   if (!darkenFx) return 0;

--- a/toonz/sources/tnzbase/trasterfx.cpp
+++ b/toonz/sources/tnzbase/trasterfx.cpp
@@ -862,13 +862,13 @@ void TRasterFx::compute(TTile &tile, double frame,
                             tfloor(fracInfoTranslation.y));
   TPointD newTilePos(intTilePos.x - intInfoTranslation.x,
                      intTilePos.y - intInfoTranslation.y);
-  /*-- 入力タイルの位置が、小数値を持っていた場合 --*/
+  /*-- If the position of the input tile had a fractional value --*/
   if (tile.m_pos != newTilePos) {
-    /*-- RenderSettingsのaffine行列に位置ずれを足しこむ --*/
+    /*-- Add the offset to the affine matrix in RenderSettings --*/
     TRenderSettings newInfo(info);
     newInfo.m_affine.a13 = fracInfoTranslation.x - intInfoTranslation.x;
     newInfo.m_affine.a23 = fracInfoTranslation.y - intInfoTranslation.y;
-    /*-- タイルの位置は整数値にする --*/
+    /*-- Tile position should be an integer value --*/
     TPointD oldPos(tile.m_pos);
     tile.m_pos = newTilePos;
 
@@ -899,7 +899,8 @@ void TRasterFx::compute(TTile &tile, double frame,
   if (myIsEmpty(interestingRect)) return;
 
   TDimension tileSize = tile.getRaster()->getSize();
-  // ひとつ前のノードが小数点対応しているかどうかによって、入ってくるラスタの形式が異なる
+  // The format of the incoming raster depends on whether the previous node
+  // supports floating point rendering or not.
   TRaster32P ras32 = tile.getRaster();
   TRaster64P ras64 = tile.getRaster();
   TRasterFP rasF   = tile.getRaster();
@@ -914,7 +915,7 @@ void TRasterFx::compute(TTile &tile, double frame,
       tile.setRaster(rasAuxF);
     }
   }
-  // linear化
+  // convert to linear
   bool isLinear = tile.getRaster()->isLinear();
   bool computeInLinear =
       toBeComputedInLinearColorSpace(info.m_linearColorSpace, isLinear);
@@ -954,7 +955,7 @@ void TRasterFx::compute(TTile &tile, double frame,
   FxResourceBuilder rBuilder(alias, this, info, frame);
   rBuilder.build(interestingTile);
 
-  // linear化
+  // convert to linear
   if (isLinear != computeInLinear) {
     if (isLinear)  //  && !computeInLinear
       TRop::toLinearRGB(tile.getRaster(), info.m_colorSpaceGamma);

--- a/toonz/sources/tnztools/bluredbrush.cpp
+++ b/toonz/sources/tnztools/bluredbrush.cpp
@@ -50,15 +50,15 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
                                outPix->getTone());
           continue;
         }
-        bool sameStyleId   = styleId == outPix->getInk();
+        bool sameStyleId = styleId == outPix->getInk();
         // line with the same style : multiply tones
         // line with different style : pick darker tone
         int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
                                : std::min(255 - inPix->m, outPix->getTone());
-        int ink = !sameStyleId && outPix->getTone() < 255 - inPix->m
-                      ? outPix->getInk()
-                      : styleId;
-        *outPix = TPixelCM32(ink, outPix->getPaint(), tone);
+        int ink  = !sameStyleId && outPix->getTone() < 255 - inPix->m
+                       ? outPix->getInk()
+                       : styleId;
+        *outPix  = TPixelCM32(ink, outPix->getPaint(), tone);
       }
     }
   } else if (drawOrderMode == 1) {  // UnderAll
@@ -79,15 +79,15 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
                                outPix->getTone());
           continue;
         }
-        bool sameStyleId   = styleId == outPix->getInk();
+        bool sameStyleId = styleId == outPix->getInk();
         // line with the same style : multiply tones
         // line with different style : pick darker tone
         int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
                                : std::min(255 - inPix->m, outPix->getTone());
-        int ink = !sameStyleId && outPix->getTone() <= 255 - inPix->m
-                      ? outPix->getInk()
-                      : styleId;
-        *outPix = TPixelCM32(ink, outPix->getPaint(), tone);
+        int ink  = !sameStyleId && outPix->getTone() <= 255 - inPix->m
+                       ? outPix->getInk()
+                       : styleId;
+        *outPix  = TPixelCM32(ink, outPix->getPaint(), tone);
       }
     }
   } else {  // PaletteOrder
@@ -102,7 +102,7 @@ void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
                                outPix->getTone());
           continue;
         }
-        bool sameStyleId   = styleId == outPix->getInk();
+        bool sameStyleId = styleId == outPix->getInk();
         // line with the same style : multiply tones
         // line with different style : pick darker tone
         int tone = sameStyleId ? outPix->getTone() * (255 - inPix->m) / 255
@@ -143,9 +143,9 @@ void eraseFromRasterCM(const TRasterCM32P &out, const TRaster32P &in,
           !selective || (selective && selectedStyleId == outPix->getPaint());
       int paint = eraseAreas && erasePaint ? 0 : outPix->getPaint();
       int tone  = inPix->m > 0 && eraseLine && eraseInk
-                     ? std::max(outPix->getTone(), (int)inPix->m)
-                     : outPix->getTone();
-      *outPix = TPixelCM32(outPix->getInk(), paint, tone);
+                      ? std::max(outPix->getTone(), (int)inPix->m)
+                      : outPix->getTone();
+      *outPix   = TPixelCM32(outPix->getInk(), paint, tone);
     }
   }
 }
@@ -165,7 +165,7 @@ TRasterP rasterFromQImage(
                        (TPixelGR8 *)image.bits(), false);
   return TRasterP();
 }
-}
+}  // namespace
 
 //=======================================================
 //
@@ -204,9 +204,9 @@ void BluredBrush::addPoint(const TThickPoint &p, double opacity) {
   painter.setRenderHint(QPainter::Antialiasing);
   painter.setPen(Qt::NoPen);
   painter.setBrush(m_gradient);
-  painter.setMatrix(
-      QMatrix(scaleFactor, 0.0, 0.0, scaleFactor, p.x - radius, p.y - radius),
-      false);
+  painter.setTransform(QTransform(scaleFactor, 0.0, 0.0, scaleFactor,
+                                  p.x - radius, p.y - radius),
+                       false);
   if (m_enableDynamicOpacity) painter.setOpacity(opacity);
   painter.drawEllipse(0, 0, m_size, m_size);
   painter.end();
@@ -235,9 +235,9 @@ void BluredBrush::addArc(const TThickPoint &pa, const TThickPoint &pb,
     double radius      = point.thick * 0.5;
     double scaleFactor = radius / brushRadius;
 
-    painter.setMatrix(QMatrix(scaleFactor, 0.0, 0.0, scaleFactor,
-                              point.x - radius, point.y - radius),
-                      false);
+    painter.setTransform(QTransform(scaleFactor, 0.0, 0.0, scaleFactor,
+                                    point.x - radius, point.y - radius),
+                         false);
     if (m_enableDynamicOpacity) {
       double opacity = opacityA + ((opacityC - opacityA) * t);
       if (fabs(opacity - m_oldOpacity) > 0.01)

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -403,7 +403,7 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
                  TPointD(m_brushPos.x + distance, m_brushPos.y + distance));
       invalidateRect += (brushRect);
       double denominator = m_lastPoint.x - m_firstPoint.x;
-      if (denominator == 0) denominator == 0.001;
+      if (denominator == 0) denominator = 0.001;
       double slope = ((m_lastPoint.y - m_firstPoint.y) / denominator);
       double angle = std::atan(slope) * (180 / 3.14159);
       if (abs(angle) > 67.5)

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -790,7 +790,7 @@ void ToonzVectorBrushTool::leftButtonDrag(const TPointD &pos,
     TPointD m_firstPoint = m_track.getFirstPoint();
 
     double denominator = m_lastSnapPoint.x - m_firstPoint.x;
-    if (denominator == 0) denominator == 0.001;
+    if (denominator == 0) denominator = 0.001;
     double slope = ((m_brushPos.y - m_firstPoint.y) / denominator);
     double angle = std::atan(slope) * (180 / 3.14159);
     if (abs(angle) > 67.5)
@@ -1097,9 +1097,9 @@ bool ToonzVectorBrushTool::doFrameRangeStrokes(
   assert(m > 0);
 
   if (withUndo) TUndoManager::manager()->beginBlock();
-  int row = getApplication()->getCurrentFrame()->isEditingScene()
-                ? getApplication()->getCurrentFrame()->getFrameIndex()
-                : -1;
+  int row       = getApplication()->getCurrentFrame()->isEditingScene()
+                      ? getApplication()->getCurrentFrame()->getFrameIndex()
+                      : -1;
   TFrameId cFid = getApplication()->getCurrentFrame()->getFid();
   for (int i = 0; i < m; ++i) {
     TFrameId fid = fids[i];
@@ -1207,7 +1207,7 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
       bool frameCreated = m_isFrameCreated;
       m_isFrameCreated  = false;
       touchImage();
-      resultBack        = doFrameRangeStrokes(
+      resultBack = doFrameRangeStrokes(
           oFid, fStroke, cFid, cStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,
           autoGroup, autoFill, false, drawStroke, false);
@@ -1242,7 +1242,7 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
       bool frameCreated = m_isFrameCreated;
       m_isFrameCreated  = false;
       touchImage();
-      resultFront       = doFrameRangeStrokes(
+      resultFront = doFrameRangeStrokes(
           cFid, cStroke, oFid, fStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,
           autoGroup, autoFill, drawFirstStroke, false, false);
@@ -1395,7 +1395,7 @@ void ToonzVectorBrushTool::checkStrokeSnapping(bool beforeMousePress,
       stroke = vi->getStroke(i);
       if (stroke->getNearestW(m_mousePos, outW, distance2) &&
           distance2 < minDistance2) {
-        minDistance2                      = distance2;
+        minDistance2 = distance2;
         beforeMousePress ? m_strokeIndex1 = i : m_strokeIndex2 = i;
         if (areAlmostEqual(outW, 0.0, 1e-3))
           beforeMousePress ? m_w1 = 0.0 : m_w2 = 0.0;
@@ -1406,7 +1406,7 @@ void ToonzVectorBrushTool::checkStrokeSnapping(bool beforeMousePress,
 
         beforeMousePress ? point1 = stroke->getPoint(m_w1)
                          : point1 = stroke->getPoint(m_w2);
-        snapFound                 = true;
+        snapFound = true;
       }
     }
     // compare to first point of current stroke
@@ -1507,8 +1507,8 @@ void ToonzVectorBrushTool::checkGuideSnapping(bool beforeMousePress,
         snapPoint.x = hGuide;
       }
       beforeMousePress ? m_foundFirstSnap = true : m_foundLastSnap = true;
-      beforeMousePress ? m_firstSnapPoint                          = snapPoint
-                       : m_lastSnapPoint                           = snapPoint;
+      beforeMousePress ? m_firstSnapPoint = snapPoint
+                       : m_lastSnapPoint  = snapPoint;
     }
   }
 }

--- a/toonz/sources/toonz/batches.cpp
+++ b/toonz/sources/toonz/batches.cpp
@@ -243,7 +243,19 @@ commandline += " -id " + task->m_id;*/
     RunningTasks[task->m_id] = process;
   }
 
-  process->start(task->getCommandLine());
+  process->setProgram(task->getCommandLinePrgName());
+#if defined(_WIN32)
+  process->setNativeArguments(task->getCommandLineArguments());
+#else
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  process->setArguments(
+      task->getCommandLineArguments().split(" ", Qt::SkipEmptyParts));
+#else
+  process->setArguments(
+      task->getCommandLineArguments().split(" ", QString::SkipEmptyParts));
+#endif
+#endif
+  process->start();
   process->waitForFinished(-1);
 
   {
@@ -347,7 +359,7 @@ void BatchesController::addComposerTask(const TFilePath &_taskFilePath) {
   out.getRange(r0, r1, step);
 
   int sceneFrameCount = scene.getFrameCount();
-  if (r0 < 0) r0      = 0;
+  if (r0 < 0) r0 = 0;
   if (r1 >= sceneFrameCount)
     r1 = sceneFrameCount - 1;
   else if (r1 < r0)
@@ -478,7 +490,7 @@ namespace {
 void DeleteTask(const std::pair<QString, TFarmTask *> &mapItem) {
   if (mapItem.second->m_parentId.isEmpty()) delete mapItem.second;
 }
-}
+}  // namespace
 
 void BatchesController::removeAllTasks() {
   std::map<QString, TFarmTask *>::iterator tt, tEnd(m_tasks.end());
@@ -557,7 +569,7 @@ void BatchesController::setDirtyFlag(bool state) {
   if (FirstTime) {
     FirstTime = false;
     bool ret  = connect(TApp::instance()->getMainWindow(), SIGNAL(exit(bool &)),
-                       SLOT(onExit(bool &)));
+                        SLOT(onExit(bool &)));
     assert(ret);
   }
 
@@ -709,7 +721,7 @@ void BatchesController::stop(const QString &taskId) {
     int count = task->getTaskCount();
     if (count > 1) {
       for (int i = 0; i < count; ++i) {
-        TFarmTask *subtask                                  = task->getTask(i);
+        TFarmTask *subtask = task->getTask(i);
         if (subtask->m_status == Waiting) subtask->m_status = Suspended;
         if ((it = RunningTasks.find(subtask->m_id)) != RunningTasks.end()) {
           it->second->kill();
@@ -872,7 +884,7 @@ void BatchesController::saveas() {
   }
 
   static SaveTaskListPopup *popup = 0;
-  if (!popup) popup               = new SaveTaskListPopup();
+  if (!popup) popup = new SaveTaskListPopup();
 
   popup->exec();
 }
@@ -931,7 +943,7 @@ void BatchesController::detach(BatchesController::Observer *obs) {
 namespace {
 
 void notifyObserver(BatchesController::Observer *obs) { obs->update(); }
-}
+}  // namespace
 
 void BatchesController::notify() {
   std::for_each(m_observers.begin(), m_observers.end(), notifyObserver);

--- a/toonz/sources/toonz/batchserversviewer.cpp
+++ b/toonz/sources/toonz/batchserversviewer.cpp
@@ -255,11 +255,7 @@ static LineEdit *create(QGridLayout *layout, const QString &name, int &row,
   return ret;
 }
 
-#if QT_VERSION >= 0x050500
 BatchServersViewer::BatchServersViewer(QWidget *parent, Qt::WindowFlags flags)
-#else
-BatchServersViewer::BatchServersViewer(QWidget *parent, Qt::WFlags flags)
-#endif
     : QFrame(parent) {
   int row = 0;
 

--- a/toonz/sources/toonz/batchserversviewer.h
+++ b/toonz/sources/toonz/batchserversviewer.h
@@ -44,11 +44,7 @@ class BatchServersViewer final : public QFrame {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
   BatchServersViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  BatchServersViewer(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~BatchServersViewer();
 
   void updateSelected();

--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -91,7 +91,7 @@ public:
     return QObject::tr("Move Level to Cast Folder");
   }
 };
-}
+}  // namespace
 
 //=============================================================================
 //
@@ -452,11 +452,7 @@ void CastTreeViewer::deleteFolder() {
 //
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 CastBrowser::CastBrowser(QWidget *parent, Qt::WindowFlags flags)
-#else
-CastBrowser::CastBrowser(QWidget *parent, Qt::WFlags flags)
-#endif
     : QSplitter(parent)
     , m_treeViewer(0)
     , m_folderName(0)

--- a/toonz/sources/toonz/castviewer.h
+++ b/toonz/sources/toonz/castviewer.h
@@ -78,11 +78,7 @@ class CastBrowser final : public QSplitter, public DvItemListModel {
   std::unique_ptr<CastItems> m_castItems;
 
 public:
-#if QT_VERSION >= 0x050500
   CastBrowser(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  CastBrowser(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~CastBrowser();
 
   CastItems const &getCastItems() const { return *m_castItems; }

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1686,15 +1686,14 @@ static void pasteRasterImageInCell(int row, int col,
     } else {
       TXshSimpleLevel *sl = cell.getSimpleLevel();
       // don't do anything to ffmpeg level types
-      if (sl->getType() == OVL_XSHLEVEL && sl->getPath().isUneditable())
-        return;
+      if (sl->getType() == OVL_XSHLEVEL && sl->getPath().isUneditable()) return;
       oldPalette = sl->getPalette();
     }
   }
   if (oldPalette) oldPalette = oldPalette->clone();
   TTileSet *tiles = 0;
   bool isPaste    = pasteRasterImageInCellWithoutUndo(row, col, rasterImageData,
-                                                   &tiles, isLevelCreated);
+                                                      &tiles, isLevelCreated);
   if (isLevelCreated && oldPalette.getPointer()) oldPalette = 0;
   if (!isPaste) return;
   cell = xsh->getCell(row, col);
@@ -1969,7 +1968,8 @@ void TCellSelection::pasteCells() {
           }
         } else {
           QString question = QObject::tr(
-              "Pasting external image from clipboard.\n\nWhat do you want to do?");
+              "Pasting external image from clipboard.\n\nWhat do you want to "
+              "do?");
           int ret = DVGui::MsgBox(question, QObject::tr("New raster level"),
                                   QObject::tr("Cancel"), 0);
           if (ret == 1) {  // New level chosen
@@ -3584,7 +3584,7 @@ void TCellSelection::convertToToonzRaster() {
   TApp *app = TApp::instance();
   int row   = app->getCurrentFrame()->getFrame();
   int col   = app->getCurrentColumn()->getColumnIndex();
-  int i, j;
+  int i;
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXsheet *xsh      = scene->getXsheet();
@@ -3699,7 +3699,7 @@ void TCellSelection::convertVectortoVector() {
   TApp *app = TApp::instance();
   int row   = app->getCurrentFrame()->getFrame();
   int col   = app->getCurrentColumn()->getColumnIndex();
-  int i, j;
+  int i;
 
   ToonzScene *scene = app->getCurrentScene()->getScene();
   TXsheet *xsh      = scene->getXsheet();

--- a/toonz/sources/toonz/cleanupswatch.cpp
+++ b/toonz/sources/toonz/cleanupswatch.cpp
@@ -83,7 +83,7 @@ void CleanupSwatch::CleanupSwatchArea::mousePressEvent(QMouseEvent *event) {
   //   TRop::addBackground(m_sw->m_lastRasCleanupped, TPixel::White);
   m_pos = event->pos();
 
-  if (event->button() != Qt::MidButton || !m_sw->m_resampledRaster) {
+  if (event->button() != Qt::MiddleButton || !m_sw->m_resampledRaster) {
     event->ignore();
     return;
     m_panning = false;
@@ -189,7 +189,7 @@ void CleanupSwatch::CleanupSwatchArea::mouseMoveEvent(QMouseEvent *event) {
 void CleanupSwatch::CleanupSwatchArea::wheelEvent(QWheelEvent *event) {
   if (!m_sw->m_resampledRaster || m_sw->m_lx == 0 || m_sw->m_ly == 0) return;
 
-  int step      = event->delta() > 0 ? 120 : -120;
+  int step      = event->angleDelta().y() > 0 ? 120 : -120;
   double factor = exp(0.001 * step);
   if (factor == 1.0) return;
   double scale = m_sw->m_viewAff.det();
@@ -199,7 +199,11 @@ void CleanupSwatch::CleanupSwatchArea::wheelEvent(QWheelEvent *event) {
   if ((factor < 1 && sqrt(scale) < minZoom) || (factor > 1 && scale > 1200.0))
     return;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  TPointD delta(event->position().x(), height() - event->position().y());
+#else
   TPointD delta(event->pos().x(), height() - event->pos().y());
+#endif
   m_sw->m_viewAff =
       (TTranslation(delta) * TScale(factor) * TTranslation(-delta)) *
       m_sw->m_viewAff;

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -28,12 +28,8 @@
 // Toolbar
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 CommandBar::CommandBar(QWidget *parent, Qt::WindowFlags flags,
                        bool isCollapsible, bool isXsheetToolbar)
-#else
-CommandBar::CommandBar(QWidget *parent, Qt::WFlags flags)
-#endif
     : QToolBar(parent), m_isCollapsible(isCollapsible) {
   setObjectName("cornerWidget");
   setObjectName("CommandBar");

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -25,12 +25,8 @@ protected:
   bool m_isCollapsible;
 
 public:
-#if QT_VERSION >= 0x050500
   CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = 0,
              bool isCollapsible = false, bool isXsheetToolbar = false);
-#else
-  CommandBar(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
 
 signals:
   void updateVisibility();

--- a/toonz/sources/toonz/convertfolderpopup.cpp
+++ b/toonz/sources/toonz/convertfolderpopup.cpp
@@ -240,7 +240,8 @@ ConvertFolderPopup::ConvertFolderPopup()
 
   m_srcFileList = new QListWidget(this);
 
-  m_convertFolderFld->setFileMode(QFileDialog::DirectoryOnly);
+  m_convertFolderFld->setFileMode(
+      QFileDialog::Directory);  // implies ShowDirsOnly
   //-----------------------
 
   m_progressDialog->setWindowTitle(tr("Convert TZP in Folder"));

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -588,7 +588,8 @@ QFrame *ConvertPopup::createTlvSettings() {
   m_dpiMode = new QComboBox();
   m_dpiFld  = new DVGui::DoubleLineEdit();
 
-  m_unpaintedFolder->setFileMode(QFileDialog::DirectoryOnly);
+  m_unpaintedFolder->setFileMode(
+      QFileDialog::Directory);  // implies ShowDirsOnly
   m_unpaintedSuffix->setMaximumWidth(40);
   QStringList items1;
   items1 << tr("Keep Original Antialiasing")
@@ -667,11 +668,11 @@ QFrame *ConvertPopup::createTlvSettings() {
 
   bool ret = true;
   ret      = ret && connect(m_antialias, SIGNAL(currentIndexChanged(int)), this,
-                       SLOT(onAntialiasSelected(int)));
+                            SLOT(onAntialiasSelected(int)));
   ret      = ret && connect(m_palettePath, SIGNAL(pathChanged()), this,
-                       SLOT(onPalettePathChanged()));
+                            SLOT(onPalettePathChanged()));
   ret      = ret && connect(m_dpiMode, SIGNAL(currentIndexChanged(int)), this,
-                       SLOT(onDpiModeSelected(int)));
+                            SLOT(onDpiModeSelected(int)));
 
   assert(ret);
 
@@ -1193,13 +1194,8 @@ void ConvertPopup::apply() {
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
   m_converter = new Converter(this);
-#if QT_VERSION >= 0x050000
   bool ret =
       connect(m_converter, SIGNAL(finished()), this, SLOT(onConvertFinished()));
-#else
-  int ret =
-      connect(m_converter, SIGNAL(finished()), this, SLOT(onConvertFinished()));
-#endif
   Q_ASSERT(ret);
 
   // TODO: salvare il vecchio stato

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -117,11 +117,7 @@ QWidget *DvDirTreeViewDelegate::createEditor(QWidget *parent,
   if (!fnode || fnode->isProjectFolder()) return 0;
   QPixmap px = node->getPixmap(m_treeView->isExpanded(index));
   QRect rect = option.rect;
-#if QT_VERSION >= 0x050000
   if (index.data().canConvert(QMetaType::QString)) {
-#else
-  if (qVariantCanConvert<QString>(index.data())) {
-#endif
     NodeEditor *editor = new NodeEditor(parent, rect, px.width());
     editor->setText(index.data().toString());
     connect(editor, SIGNAL(editingFinished()), this,
@@ -265,11 +261,7 @@ void DvDirTreeViewDelegate::paint(QPainter *painter,
 
 void DvDirTreeViewDelegate::setEditorData(QWidget *editor,
                                           const QModelIndex &index) const {
-#if QT_VERSION >= 0x050000
   if (index.data().canConvert(QMetaType::QString))
-#else
-  if (qVariantCanConvert<QString>(index.data()))
-#endif
     NodeEditor *nodeEditor = qobject_cast<NodeEditor *>(editor);
   else
     QAbstractItemDelegate::setEditorData(editor, index);
@@ -280,12 +272,7 @@ void DvDirTreeViewDelegate::setEditorData(QWidget *editor,
 void DvDirTreeViewDelegate::setModelData(QWidget *editor,
                                          QAbstractItemModel *model,
                                          const QModelIndex &index) const {
-#if QT_VERSION >= 0x050000
-  if (index.data().canConvert(QMetaType::QString))
-#else
-  if (qVariantCanConvert<QString>(index.data()))
-#endif
-  {
+  if (index.data().canConvert(QMetaType::QString)) {
     NodeEditor *nodeEditor = qobject_cast<NodeEditor *>(editor);
     model->setData(index, qVariantFromValue(
                               nodeEditor->getText()));  // starEditor->text()));
@@ -340,7 +327,7 @@ DvDirTreeView::DvDirTreeView(QWidget *parent)
   // bottom horizontal scrollbar to resize contents...
   bool ret = true;
   ret      = ret && connect(this, SIGNAL(expanded(const QModelIndex &)), this,
-                       SLOT(resizeToConts()));
+                            SLOT(resizeToConts()));
 
   ret = ret && connect(this, SIGNAL(collapsed(const QModelIndex &)), this,
                        SLOT(resizeToConts()));
@@ -439,8 +426,7 @@ void DvDirTreeView::dropEvent(QDropEvent *e) {
     NameBuilder *nameBuilder =
         NameBuilder::getBuilder(::to_wstring(path.getName()));
     std::wstring levelNameOut;
-    do
-      levelNameOut = nameBuilder->getNext();
+    do levelNameOut = nameBuilder->getNext();
     while (TSystem::doesExistFileOrLevel(path.withName(levelNameOut)));
     dstFp = path.withName(levelNameOut);
 

--- a/toonz/sources/toonz/dvitemview.cpp
+++ b/toonz/sources/toonz/dvitemview.cpp
@@ -98,7 +98,7 @@ void getFileFids(TFilePath path, std::vector<TFrameId> &fids) {
 
 QString hyphenText(const QString &srcText, const QFont &font, int width) {
   QFontMetrics metrics(font);
-  int srcWidth = metrics.width(srcText);
+  int srcWidth = metrics.horizontalAdvance(srcText);
   if (srcWidth < width) return srcText;
 
   int count = double(srcWidth) / double(width);
@@ -110,8 +110,8 @@ QString hyphenText(const QString &srcText, const QFont &font, int width) {
   int hyphenCount = 1;
   for (i = 0; i < srcText.size(); i++) {
     QChar c       = srcText.at(i);
-    int cWidth    = metrics.width(c);
-    int textWidth = metrics.width(text) + cWidth;
+    int cWidth    = metrics.horizontalAdvance(c);
+    int textWidth = metrics.horizontalAdvance(text) + cWidth;
     if ((c.isSpace() && textWidth > (hyphenCount - 1) * width + diff) ||
         (textWidth > hyphenCount * width)) {
       ++hyphenCount;
@@ -177,10 +177,10 @@ QString DvItemListModel::getItemDataAsString(int index, DataType dataType) {
   case Icon:
     return "";
   case CreationDate:
-    return value.toDateTime().toString(Qt::SystemLocaleShortDate);
+    return QLocale::system().toString(value.toDateTime());
     break;
   case ModifiedDate:
-    return value.toDateTime().toString(Qt::SystemLocaleShortDate);
+    return QLocale::system().toString(value.toDateTime());
     break;
   case FileSize: {
     if (getItemData(index, IsFolder).toBool()) return QString("");
@@ -412,7 +412,7 @@ void ItemViewPlayWidget::PlayManager::setInfo(DvItemListModel *model,
   m_pixmap =
       model->getItemData(index, DvItemListModel::Thumbnail).value<QPixmap>();
   if (!m_pixmap.isNull()) m_iconSize = m_pixmap.size();
-  m_path                             = path;
+  m_path = path;
   getFileFids(m_path, m_fids);
 }
 
@@ -1142,8 +1142,9 @@ void DvItemViewerPanel::paintTableItem(QPainter &p, int index) {
   // Version Control status pixmap
   QPixmap statusPixmap = getStatusPixmap(status);
   if (!statusPixmap.isNull()) {
-    p.drawPixmap(x + 1, y + 1, statusPixmap.scaled(15, 15, Qt::KeepAspectRatio,
-                                                   Qt::SmoothTransformation));
+    p.drawPixmap(x + 1, y + 1,
+                 statusPixmap.scaled(15, 15, Qt::KeepAspectRatio,
+                                     Qt::SmoothTransformation));
     x += 15;
   }
 
@@ -1194,7 +1195,7 @@ void DvItemViewerPanel::mousePressEvent(QMouseEvent *event) {
       update();
     }
     return;
-  } else if (event->button() == Qt::MidButton) {
+  } else if (event->button() == Qt::MiddleButton) {
     m_lastMousePos = event->globalPos();
     event->accept();
     return;
@@ -1233,7 +1234,7 @@ void DvItemViewerPanel::mousePressEvent(QMouseEvent *event) {
         int a = index, b = index;
         while (a > 0 && !m_selection->isSelected(a - 1)) a--;
         if (a == 0) a = index;
-        int k         = getItemCount();
+        int k = getItemCount();
         while (b < k && !m_selection->isSelected(b + 1)) b++;
         if (b == k) b = index;
         int i;
@@ -1258,7 +1259,7 @@ void DvItemViewerPanel::mousePressEvent(QMouseEvent *event) {
 //-----------------------------------------------------------------------------
 
 void DvItemViewerPanel::mouseMoveEvent(QMouseEvent *event) {
-  if (event->buttons() == Qt::MidButton) {
+  if (event->buttons() == Qt::MiddleButton) {
     QPoint d       = event->globalPos() - m_lastMousePos;
     m_lastMousePos = event->globalPos();
     if (m_viewer) {
@@ -1380,7 +1381,7 @@ bool DvItemViewerPanel::event(QEvent *event) {
 //-----------------------------------------------------------------------------
 
 void DvItemViewerPanel::setListView() {
-  m_viewType                                                 = ListView;
+  m_viewType = ListView;
   m_viewer->m_windowType == DvItemViewer::Cast ? CastView    = ListView
                                                : BrowserView = ListView;
   emit viewTypeChange(m_viewType);
@@ -1391,7 +1392,7 @@ void DvItemViewerPanel::setListView() {
 //-----------------------------------------------------------------------------
 
 void DvItemViewerPanel::setTableView() {
-  m_viewType                                                 = TableView;
+  m_viewType = TableView;
   m_viewer->m_windowType == DvItemViewer::Cast ? CastView    = TableView
                                                : BrowserView = TableView;
   emit viewTypeChange(m_viewType);
@@ -1402,7 +1403,7 @@ void DvItemViewerPanel::setTableView() {
 //-----------------------------------------------------------------------------
 
 void DvItemViewerPanel::setThumbnailsView() {
-  m_viewType                                                 = ThumbnailView;
+  m_viewType = ThumbnailView;
   m_viewer->m_windowType == DvItemViewer::Cast ? CastView    = ThumbnailView
                                                : BrowserView = ThumbnailView;
   emit viewTypeChange(m_viewType);
@@ -1490,9 +1491,9 @@ void DvItemViewer::setModel(DvItemListModel *model) {
 //-----------------------------------------------------------------------------
 
 void DvItemViewer::updateContentSize() {
-  int w              = m_panel->getContentMinimumWidth();
+  int w = m_panel->getContentMinimumWidth();
   if (w < width()) w = width();
-  int h              = m_panel->getContentHeight(w) +
+  int h = m_panel->getContentHeight(w) +
           20;  // 20 is margin for showing the empty area
   if (h < height()) h = height();
   m_panel->resize(w, h);

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -94,9 +94,8 @@ bool checkForMeshColumns(TXsheet *xsh,
             cells[i].m_level->getType() == CHILD_XSHLEVEL) {
           TXshChildLevel *level = cells[i].m_level->getChildLevel();
           // make sure we haven't already checked the level
-          if (level &&
-              std::find(childLevels.begin(), childLevels.end(), level) ==
-                  childLevels.end()) {
+          if (level && std::find(childLevels.begin(), childLevels.end(),
+                                 level) == childLevels.end()) {
             childLevels.push_back(level);
             TXsheet *subXsh = level->getXsheet();
             foundMesh       = checkForMeshColumns(subXsh, childLevels);
@@ -692,7 +691,7 @@ void ClipListViewer::dragMoveEvent(QDragMoveEvent *event) {
 
 void ClipListViewer::dropEvent(QDropEvent *event) {
   if (event->mimeData()->hasUrls()) {
-    int j        = m_dropInsertionPoint;
+    int j = m_dropInsertionPoint;
     if (j < 0) j = getItemCount();
     for (const QUrl &url : event->mimeData()->urls()) {
       TFilePath fp(url.toLocalFile().toStdString());
@@ -772,11 +771,7 @@ void ClipListViewer::loadScene() {
 //
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
-#else
-ExportPanel::ExportPanel(QWidget *parent, Qt::WFlags flags)
-#endif
     : TPanel(parent)
     , m_clipListViewer(0)
     , m_saveInFileFld(0)

--- a/toonz/sources/toonz/exportpanel.h
+++ b/toonz/sources/toonz/exportpanel.h
@@ -31,7 +31,7 @@ namespace DVGui {
 class ProgressDialog;
 class FileField;
 class LineEdit;
-}
+}  // namespace DVGui
 
 //-----------------------------------------------------------------------------
 
@@ -90,11 +90,7 @@ class ExportPanel final : public TPanel {
   QCheckBox *m_useMarker;
 
 public:
-#if QT_VERSION >= 0x050500
   ExportPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ExportPanel(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~ExportPanel();
   void loadExportSettings();
   void saveExportSettings();

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -59,6 +59,7 @@
 #include <QDesktopServices>
 #include <QGroupBox>
 #include <QSettings>
+#include <QLocale>
 
 // Template
 TEnv::StringVar XShPdfExportTemplate("XShPdfExportTemplate", "B4_6sec");
@@ -1311,9 +1312,9 @@ XSheetPDFTemplate::XSheetPDFTemplate(
 void XSheetPDFTemplate::setInfo(const XSheetPDFFormatInfo& info) {
   m_info         = info;
   thinPen        = QPen(info.lineColor, param(ThinLineWidth, mm2px(0.25)),
-                 Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
+                        Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
   thickPen       = QPen(info.lineColor, param(ThickLineWidth, mm2px(0.5)),
-                  Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
+                        Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
   bodyOutlinePen = QPen(info.lineColor, param(BodyOutlineWidth, mm2px(0.5)),
                         Qt::SolidLine, Qt::FlatCap, Qt::MiterJoin);
   blockBorderPen = (param(IsBlockBorderThick, 0) > 0) ? thickPen : thinPen;
@@ -1582,8 +1583,8 @@ QPixmap XSheetPDFTemplate::initializePreview() {
 }
 
 int XSheetPDFTemplate::framePageCount() {
-  int ret = m_duration / param(FrameLength);
-  if (m_duration % param(FrameLength) != 0 || m_duration == 0) ret += 1;
+  int ret = m_duration / param(FrameLength, 1);
+  if (m_duration % param(FrameLength, 1) != 0 || m_duration == 0) ret += 1;
   return ret;
 }
 
@@ -1931,7 +1932,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
   //------
   QStringList pdfFileTypes = {"pdf"};
   m_pathFld->setFilters(pdfFileTypes);
-  m_pathFld->setFileMode(QFileDialog::DirectoryOnly);
+  m_pathFld->setFileMode(QFileDialog::Directory);  // implies ShowDirOnly
   m_fileNameFld->setFixedWidth(100);
   m_previewArea->setWidget(m_previewPane);
   m_previewArea->setAlignment(Qt::AlignCenter);
@@ -2366,8 +2367,9 @@ void ExportXsheetPdfPopup::saveSettings() {
 
   ContinuousLineMode clMode =
       (ContinuousLineMode)(m_continuousLineCombo->currentData().toInt());
-  XShPdfExportContinuousLineThres =
-      (clMode == Line_Always) ? 0 : (clMode == Line_None) ? -1 : 3;
+  XShPdfExportContinuousLineThres = (clMode == Line_Always) ? 0
+                                    : (clMode == Line_None) ? -1
+                                                            : 3;
 
   XShPdfExportTick1Id   = m_tick1IdCombo->currentData().toInt();
   XShPdfExportTick2Id   = m_tick2IdCombo->currentData().toInt();
@@ -2404,11 +2406,10 @@ void ExportXsheetPdfPopup::loadSettings() {
   m_logoTextEdit->setText(QString::fromStdString(XShPdfExportLogoText));
   m_logoImgPathField->setPath(QString::fromStdString(XShPdfExportImgPath));
 
-  ContinuousLineMode clMode = (XShPdfExportContinuousLineThres == 0)
-                                  ? Line_Always
-                                  : (XShPdfExportContinuousLineThres == -1)
-                                        ? Line_None
-                                        : Line_MoreThan3s;
+  ContinuousLineMode clMode =
+      (XShPdfExportContinuousLineThres == 0)    ? Line_Always
+      : (XShPdfExportContinuousLineThres == -1) ? Line_None
+                                                : Line_MoreThan3s;
   m_continuousLineCombo->setCurrentIndex(
       m_continuousLineCombo->findData(clMode));
 
@@ -2468,7 +2469,7 @@ void ExportXsheetPdfPopup::setInfo() {
   info.lineColor = QColor(col.r, col.g, col.b);
   info.dateTimeText =
       (m_addDateTimeCB->isChecked())
-          ? QDateTime::currentDateTime().toString(Qt::DefaultLocaleLongDate)
+          ? QLocale::system().toString(QDateTime::currentDateTime())
           : "";
   ToonzScene* scene = TApp::instance()->getCurrentScene()->getScene();
   info.scenePathText =

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -148,13 +148,8 @@ QMutex levelFileMutex;
 // FileBrowser
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 FileBrowser::FileBrowser(QWidget *parent, Qt::WindowFlags flags,
                          bool noContextMenu, bool multiSelectionEnabled)
-#else
-FileBrowser::FileBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu,
-                         bool multiSelectionEnabled)
-#endif
     : QFrame(parent), m_folderName(0), m_itemViewer(0) {
   // style sheet
   setObjectName("FileBrowser");
@@ -1230,13 +1225,13 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
        files[1].getType() == "TIFF" || files[1].getType() == "PNG")) {
     QAction *action = new QAction(tr("Convert to Painted TLV"), menu);
     ret             = ret && connect(action, SIGNAL(triggered()), this,
-                         SLOT(convertToPaintedTlv()));
+                                     SLOT(convertToPaintedTlv()));
     menu->addAction(action);
   }
   if (areFullcolor) {
     QAction *action = new QAction(tr("Convert to Unpainted TLV"), menu);
     ret             = ret && connect(action, SIGNAL(triggered()), this,
-                         SLOT(convertToUnpaintedTlv()));
+                                     SLOT(convertToUnpaintedTlv()));
     menu->addAction(action);
     menu->addSeparator();
   }
@@ -1269,42 +1264,42 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
       if (status == DvItemListModel::VC_ReadOnly) {
         action = vcMenu->addAction(tr("Edit"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(editVersionControl()));
+                                SLOT(editVersionControl()));
 
         TFilePath path       = files.at(0);
         std::string fileType = path.getType();
         if (fileType == "tlv" || fileType == "pli" || path.getDots() == "..") {
           action = vcMenu->addAction(tr("Edit Frame Range..."));
           ret    = ret && connect(action, SIGNAL(triggered()), this,
-                               SLOT(editFrameRangeVersionControl()));
+                                  SLOT(editFrameRangeVersionControl()));
         }
       } else {
         action = vcMenu->addAction(tr("Edit"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(updateAndEditVersionControl()));
+                                SLOT(updateAndEditVersionControl()));
       }
     }
 
     if (status == DvItemListModel::VC_Modified) {
       action = vcMenu->addAction(tr("Put..."));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(putVersionControl()));
+                              SLOT(putVersionControl()));
 
       action = vcMenu->addAction(tr("Revert"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(revertVersionControl()));
+                              SLOT(revertVersionControl()));
     }
 
     if (status == DvItemListModel::VC_ReadOnly ||
         status == DvItemListModel::VC_ToUpdate) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (status == DvItemListModel::VC_ReadOnly) {
         action = vcMenu->addAction(tr("Delete"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(deleteVersionControl()));
+                                SLOT(deleteVersionControl()));
       }
 
       vcMenu->addSeparator();
@@ -1321,36 +1316,36 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
       } else if (files.size() > 1) {
         action = vcMenu->addAction("Get Revision...");
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(getRevisionVersionControl()));
+                                SLOT(getRevisionVersionControl()));
       }
     }
 
     if (status == DvItemListModel::VC_Edited) {
       action = vcMenu->addAction(tr("Unlock"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(unlockVersionControl()));
+                              SLOT(unlockVersionControl()));
     }
 
     if (status == DvItemListModel::VC_Unversioned) {
       action = vcMenu->addAction(tr("Put..."));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(putVersionControl()));
+                              SLOT(putVersionControl()));
     }
 
     if (status == DvItemListModel::VC_Locked && files.size() == 1) {
       action = vcMenu->addAction(tr("Unlock"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(unlockVersionControl()));
+                              SLOT(unlockVersionControl()));
 
       action = vcMenu->addAction(tr("Edit Info"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(showLockInformation()));
+                              SLOT(showLockInformation()));
     }
 
     if (status == DvItemListModel::VC_Missing) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (files.size() == 1) {
         vcMenu->addSeparator();
@@ -1368,44 +1363,44 @@ QMenu *FileBrowser::getContextMenu(QWidget *parent, int index) {
     if (status == DvItemListModel::VC_PartialLocked) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
       if (files.size() == 1) {
         action = vcMenu->addAction(tr("Edit Frame Range..."));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(editFrameRangeVersionControl()));
+                                SLOT(editFrameRangeVersionControl()));
 
         action = vcMenu->addAction(tr("Edit Info"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(showFrameRangeLockInfo()));
+                                SLOT(showFrameRangeLockInfo()));
       }
 
     } else if (status == DvItemListModel::VC_PartialEdited) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (files.size() == 1) {
         action = vcMenu->addAction(tr("Unlock Frame Range"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(unlockFrameRangeVersionControl()));
+                                SLOT(unlockFrameRangeVersionControl()));
 
         action = vcMenu->addAction(tr("Edit Info"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(showFrameRangeLockInfo()));
+                                SLOT(showFrameRangeLockInfo()));
       }
     } else if (status == DvItemListModel::VC_PartialModified) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (files.size() == 1) {
         action = vcMenu->addAction(tr("Put..."));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(putFrameRangeVersionControl()));
+                                SLOT(putFrameRangeVersionControl()));
 
         action = vcMenu->addAction(tr("Revert"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(revertFrameRangeVersionControl()));
+                                SLOT(revertFrameRangeVersionControl()));
       }
     }
 
@@ -1568,8 +1563,7 @@ bool FileBrowser::drop(const QMimeData *mimeData) {
       TFilePath path = folderPath;
       NameBuilder *nameBuilder =
           NameBuilder::getBuilder(::to_wstring(path.getName()));
-      do
-        levelName = nameBuilder->getNext();
+      do levelName = nameBuilder->getNext();
       while (TSystem::doesExistFileOrLevel(path.withName(levelName)));
       folderPath = path.withName(levelName);
     }
@@ -1763,11 +1757,7 @@ QString getFrame(const QString &filename) {
   QString number = filename.mid(from + 1, to - from);
   for (i = 0; i < 4 - number.size(); i++) padStr[i] = '0';
   for (i = 0; i < number.size(); i++)
-#if QT_VERSION >= 0x050500
     padStr[4 - number.size() + i] = number.at(i).toLatin1();
-#else
-    padStr[4 - number.size() + i] = number.at(i).toAscii();
-#endif
   return QString(padStr);
 }
 

--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -60,13 +60,8 @@ class FileBrowser final : public QFrame, public DvItemListModel {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
   FileBrowser(QWidget *parent, Qt::WindowFlags flags = 0,
               bool noContextMenu = false, bool multiSelectionEnabled = false);
-#else
-  FileBrowser(QWidget *parent, Qt::WFlags flags = 0, bool noContextMenu = false,
-              bool multiSelectionEnabled = false);
-#endif
   ~FileBrowser();
 
   void sortByDataModel(DataType dataType, bool isDiscendent) override;
@@ -100,8 +95,8 @@ types to be displayed in the file browser.
 
   void setFolder(const TFilePath &fp, bool expandNode = false,
                  bool forceUpdate = false);
-  // process when inputting the folder which is not registered in the folder tree
-  // (e.g. UNC path in Windows)
+  // process when inputting the folder which is not registered in the folder
+  // tree (e.g. UNC path in Windows)
   void setUnregisteredFolder(const TFilePath &fp);
 
   void setHistoryDay(std::string dayDateString);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -94,11 +94,7 @@ QString fidToFrameNumberWithLetter(int f) {
 // Filmstrip
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 FilmstripFrames::FilmstripFrames(QScrollArea *parent, Qt::WindowFlags flags)
-#else
-FilmstripFrames::FilmstripFrames(QScrollArea *parent, Qt::WFlags flags)
-#endif
     : QFrame(parent, flags)
     , m_scrollArea(parent)
     , m_selection(new TFilmstripSelection())
@@ -1267,9 +1263,8 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
     if (sl && sl->getType() == TZP_XSHLEVEL)
       menu->addAction(cm->getAction(MI_RevertToCleanedUp));
   }
-  if (sl &&
-      (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL ||
-       (sl->getType() == OVL_XSHLEVEL && !sl->getPath().isUneditable())))
+  if (sl && (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL ||
+             (sl->getType() == OVL_XSHLEVEL && !sl->getPath().isUneditable())))
     menu->addAction(cm->getAction(MI_RevertToLastSaved));
   menu->addSeparator();
   createSelectLevelMenu(menu);
@@ -1508,12 +1503,7 @@ void FilmstripFrames::onViewerAboutToBeDestroyed() {
 // Filmstrip
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
-Filmstrip::Filmstrip(QWidget *parent, Qt::WindowFlags flags)
-#else
-Filmstrip::Filmstrip(QWidget *parent, Qt::WFlags flags)
-#endif
-    : QWidget(parent) {
+Filmstrip::Filmstrip(QWidget *parent, Qt::WindowFlags flags) : QWidget(parent) {
   setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
   m_frameArea        = new QScrollArea(this);

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -42,11 +42,8 @@ class FilmstripFrames final : public QFrame, public TSelection::View {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
-  FilmstripFrames(QScrollArea *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  FilmstripFrames(QScrollArea *parent = 0, Qt::WFlags flags = 0);
-#endif
+  FilmstripFrames(QScrollArea *parent   = 0,
+                  Qt::WindowFlags flags = Qt::WindowFlags());
   ~FilmstripFrames();
 
   bool m_isVertical    = true;
@@ -239,11 +236,7 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
   bool m_showComboBox  = true;
 
 public:
-#if QT_VERSION >= 0x050500
   Filmstrip(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  Filmstrip(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~Filmstrip();
 
   // SaveLoadQSettings

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -25,6 +25,7 @@
 #include <QMainWindow>
 #include <QDesktopWidget>
 #include <QFocusEvent>
+#include <QScreen>
 
 using namespace DVGui;
 
@@ -125,9 +126,13 @@ void HistogramPopup::moveNextToWidget(QWidget *widget) {
   if (minimumSize().isEmpty()) grab();
   QSize popupSize = frameSize();
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QRect screenRect = widget->screen()->availableGeometry();
+#else
   int currentScreen = QApplication::desktop()->screenNumber(widget);
   QRect screenRect  = QApplication::desktop()->availableGeometry(currentScreen);
-  QRect viewerRect  = widget->rect();
+#endif
+  QRect viewerRect = widget->rect();
   viewerRect.moveTo(widget->mapToGlobal(QPoint(0, 0)));
   // decide which side to open the popup
   QPoint popupPos = widget->mapToGlobal(QPoint(0, 0));

--- a/toonz/sources/toonz/history.cpp
+++ b/toonz/sources/toonz/history.cpp
@@ -3,11 +3,13 @@
 #include "history.h"
 #include "tsystem.h"
 #include "tenv.h"
-//#include "tutil.h"
+// #include "tutil.h"
 #include "tfilepath_io.h"
 #include "toonz/toonzfolders.h"
 
-//#include <fstream.h>
+#include <QLocale>
+
+// #include <fstream.h>
 
 inline TFilePath getHistoryFile() {
   return TEnv::getConfigDir() +
@@ -22,7 +24,8 @@ std::string History::Day::getDate() const {
   else if (m_timeStamp == yesterday)
     return "yesterday";
   else
-    return m_timeStamp.toString(Qt::SystemLocaleDate)
+    return QLocale::system()
+        .toString(m_timeStamp)
         .toStdString();  // "%d %b %A %x");
 }
 

--- a/toonz/sources/toonz/historypane.cpp
+++ b/toonz/sources/toonz/historypane.cpp
@@ -38,7 +38,7 @@ const struct {
     {HistoryType::FilmStrip, "history_filmstrip"},
 
     {0, 0}};
-};
+};  // namespace
 
 class HistoryPixmapManager {  // singleton
 
@@ -72,11 +72,7 @@ public:
   }
 };
 //-----------------------------------------------------------------------------
-#if QT_VERSION >= 0x050500
 HistoryField::HistoryField(QScrollArea *parent, Qt::WindowFlags flags)
-#else
-HistoryField::HistoryField(QScrollArea *parent, Qt::WFlags flags)
-#endif
     : QFrame(parent, flags), m_scrollArea(parent) {
   setObjectName("filmStripFrames");
   setFrameStyle(QFrame::StyledPanel);
@@ -94,8 +90,8 @@ void HistoryField::updateContentHeight(int minimumHeight) {
   int contentHeight =
       TUndoManager::manager()->getHistoryCount() * HISTORY_ITEM_HEIGHT;
   if (contentHeight < minimumHeight) contentHeight = minimumHeight;
-  int parentHeight                                 = parentWidget()->height();
-  if (contentHeight < parentHeight) contentHeight  = parentHeight;
+  int parentHeight = parentWidget()->height();
+  if (contentHeight < parentHeight) contentHeight = parentHeight;
   if (contentHeight != height()) setFixedHeight(contentHeight);
 }
 
@@ -191,11 +187,7 @@ void HistoryField::exposeCurrent() {
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-#if QT_VERSION >= 0x050500
 HistoryPane::HistoryPane(QWidget *parent, Qt::WindowFlags flags)
-#else
-HistoryPane::HistoryPane(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent) {
   m_frameArea = new QScrollArea(this);
   m_field     = new HistoryField(m_frameArea);

--- a/toonz/sources/toonz/historypane.h
+++ b/toonz/sources/toonz/historypane.h
@@ -11,11 +11,8 @@ class HistoryField final : public QFrame {
   QScrollArea *m_scrollArea;
 
 public:
-#if QT_VERSION >= 0x050500
-  HistoryField(QScrollArea *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  HistoryField(QScrollArea *parent = 0, Qt::WFlags flags = 0);
-#endif
+  HistoryField(QScrollArea *parent   = 0,
+               Qt::WindowFlags flags = Qt::WindowFlags());
   ~HistoryField(){};
 
   void updateContentHeight(int minimumHeight = -1);
@@ -36,11 +33,7 @@ class HistoryPane final : public QWidget {
   QScrollArea *m_frameArea;
 
 public:
-#if QT_VERSION >= 0x050500
   HistoryPane(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  HistoryPane(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~HistoryPane(){};
 
 protected:

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -839,7 +839,7 @@ void ImageViewer::mouseMoveEvent(QMouseEvent *event) {
   if (m_visualSettings.m_defineLoadbox && m_flipbook) {
     if (m_mouseButton == Qt::LeftButton)
       updateLoadbox(curPos);
-    else if (m_mouseButton == Qt::MidButton)
+    else if (m_mouseButton == Qt::MiddleButton)
       panQt(curQPos - m_pos);
     else
       updateCursor(curPos);
@@ -868,7 +868,7 @@ void ImageViewer::mouseMoveEvent(QMouseEvent *event) {
 
   if (m_compareSettings.m_dragCompareX || m_compareSettings.m_dragCompareY)
     dragCompare(curQPos - m_pos);
-  else if (m_mouseButton == Qt::MidButton)
+  else if (m_mouseButton == Qt::MiddleButton)
     panQt(curQPos - m_pos);
 
   m_pos = curQPos;
@@ -1268,7 +1268,6 @@ void ImageViewer::mouseReleaseEvent(QMouseEvent *event) {
  */
 void ImageViewer::wheelEvent(QWheelEvent *event) {
   if (!m_image) return;
-  if (event->orientation() == Qt::Horizontal) return;
   int delta = 0;
   switch (event->source()) {
   case Qt::MouseEventNotSynthesized: {
@@ -1302,14 +1301,19 @@ void ImageViewer::wheelEvent(QWheelEvent *event) {
 
   }  // end switch
 
-  if (abs(delta) > 0) {
+  if (delta != 0) {
     if ((m_gestureActive == true &&
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
-      int delta = event->delta() > 0 ? 120 : -120;
+      int d = delta > 0 ? 120 : -120;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+      QPoint center(event->position().x() * getDevPixRatio() - width() / 2,
+                    -event->position().y() * getDevPixRatio() + height() / 2);
+#else
       QPoint center(event->pos().x() * getDevPixRatio() - width() / 2,
                     -event->pos().y() * getDevPixRatio() + height() / 2);
-      zoomQt(center, exp(0.001 * delta));
+#endif
+      zoomQt(center, exp(0.001 * d));
     }
   }
   event->accept();

--- a/toonz/sources/toonz/kis_tablet_support_win8.cpp
+++ b/toonz/sources/toonz/kis_tablet_support_win8.cpp
@@ -95,13 +95,13 @@ class Win8PointerInputApi {
 
 public:
 #define DEFINE_FP_FROM_WINAPI(func)                                            \
-  \
+                                                                               \
 public:                                                                        \
   using p##func##_t = std::add_pointer<decltype(func)>::type;                  \
-  \
+                                                                               \
 private:                                                                       \
   p##func##_t m_p##func = nullptr;                                             \
-  \
+                                                                               \
 public:                                                                        \
   const p##func##_t &func = m_p##func;  // const fp ref to member
 
@@ -523,8 +523,8 @@ QTabletEvent makeProximityTabletEvent(const QEvent::Type eventType,
       Qt::NoModifier,        // keyState
       reinterpret_cast<qint64>(penInfo.pointerInfo.sourceDevice),  // uniqueID
       Qt::NoButton,                                                // button
-      (Qt::MouseButtons)0                                          // buttons
-      );
+      Qt::MouseButtons()                                           // buttons
+  );
 }
 
 // void rotateTiltAngles(int &tiltX, int &tiltY, const DISPLAYCONFIG_ROTATION
@@ -660,7 +660,7 @@ QTabletEvent makePositionalTabletEvent(const QWidget *targetWidget,
       reinterpret_cast<qint64>(penInfo.pointerInfo.sourceDevice),  // uniqueID
       mouseButton,                                                 // button
       mouseButtons                                                 // buttons
-      );
+  );
 }
 
 bool sendProximityTabletEvent(const QEvent::Type eventType,

--- a/toonz/sources/toonz/layerfooterpanel.cpp
+++ b/toonz/sources/toonz/layerfooterpanel.cpp
@@ -18,13 +18,8 @@
 
 using XsheetGUI::ColumnArea;
 
-#if QT_VERSION >= 0x050500
 LayerFooterPanel::LayerFooterPanel(XsheetViewer *viewer, QWidget *parent,
                                    Qt::WindowFlags flags)
-#else
-LayerFooterPanel::LayerFooterPanel(XsheetViewer *viewer, QWidget *parent,
-                                   Qt::WFlags flags)
-#endif
     : QWidget(parent, flags), m_viewer(viewer) {
   const Orientation *o = viewer->orientation();
 

--- a/toonz/sources/toonz/layerfooterpanel.h
+++ b/toonz/sources/toonz/layerfooterpanel.h
@@ -31,13 +31,8 @@ private:
   XsheetViewer *m_viewer;
 
 public:
-#if QT_VERSION >= 0x050500
   LayerFooterPanel(XsheetViewer *viewer, QWidget *parent = 0,
                    Qt::WindowFlags flags = 0);
-#else
-  LayerFooterPanel(XsheetViewer *viewer, QWidget *parent = 0,
-                   Qt::WFlags flags = 0);
-#endif
   ~LayerFooterPanel();
 
   void showOrHide(const Orientation *o);

--- a/toonz/sources/toonz/layerheaderpanel.cpp
+++ b/toonz/sources/toonz/layerheaderpanel.cpp
@@ -15,13 +15,8 @@
 
 using XsheetGUI::ColumnArea;
 
-#if QT_VERSION >= 0x050500
 LayerHeaderPanel::LayerHeaderPanel(XsheetViewer *viewer, QWidget *parent,
                                    Qt::WindowFlags flags)
-#else
-LayerHeaderPanel::LayerHeaderPanel(XsheetViewer *viewer, QWidget *parent,
-                                   Qt::WFlags flags)
-#endif
     : QWidget(parent, flags), m_viewer(viewer) {
   const Orientation *o = Orientations::leftToRight();
   QRect rect           = o->rect(PredefinedRect::LAYER_HEADER_PANEL);
@@ -52,7 +47,7 @@ QRect shorter(const QRect original) { return original.adjusted(0, 2, 0, -2); }
 QLine leftSide(const QRect &r) { return QLine(r.topLeft(), r.bottomLeft()); }
 
 QLine rightSide(const QRect &r) { return QLine(r.topRight(), r.bottomRight()); }
-}
+}  // namespace
 
 void LayerHeaderPanel::paintEvent(QPaintEvent *event) {
   QPainter p(this);
@@ -60,15 +55,15 @@ void LayerHeaderPanel::paintEvent(QPaintEvent *event) {
 
   const Orientation *o = Orientations::leftToRight();
 
-  QImage preview = (m_buttonHighlighted == PreviewButton
-                        ? m_viewer->getLayerHeaderPreviewOverImage()
-                        : m_viewer->getLayerHeaderPreviewImage());
+  QImage preview  = (m_buttonHighlighted == PreviewButton
+                         ? m_viewer->getLayerHeaderPreviewOverImage()
+                         : m_viewer->getLayerHeaderPreviewImage());
   QImage camstand = (m_buttonHighlighted == CamstandButton
                          ? m_viewer->getLayerHeaderCamstandOverImage()
                          : m_viewer->getLayerHeaderCamstandImage());
-  QImage lock = (m_buttonHighlighted == LockButton
-                     ? m_viewer->getLayerHeaderLockOverImage()
-                     : m_viewer->getLayerHeaderLockImage());
+  QImage lock     = (m_buttonHighlighted == LockButton
+                         ? m_viewer->getLayerHeaderLockOverImage()
+                         : m_viewer->getLayerHeaderLockImage());
 
   drawIcon(p, PredefinedRect::PANEL_EYE, boost::none, preview);
   drawIcon(p, PredefinedRect::PANEL_PREVIEW_LAYER, boost::none, camstand);

--- a/toonz/sources/toonz/layerheaderpanel.h
+++ b/toonz/sources/toonz/layerheaderpanel.h
@@ -29,13 +29,8 @@ private:
   XsheetViewer *m_viewer;
 
 public:
-#if QT_VERSION >= 0x050500
   LayerHeaderPanel(XsheetViewer *viewer, QWidget *parent = 0,
                    Qt::WindowFlags flags = 0);
-#else
-  LayerHeaderPanel(XsheetViewer *viewer, QWidget *parent = 0,
-                   Qt::WFlags flags = 0);
-#endif
   ~LayerHeaderPanel();
 
   void showOrHide(const Orientation *o);

--- a/toonz/sources/toonz/lipsyncpopup.cpp
+++ b/toonz/sources/toonz/lipsyncpopup.cpp
@@ -431,7 +431,7 @@ void LipSyncPopup::onApplyButton() {
   int lastFrame = m_textLines.at(m_textLines.size() - 2).toInt() + startFrame;
 
   if (m_restToEnd->isChecked()) {
-    int r0, r1, step;
+    int r0, r1;
     TApp::instance()->getCurrentXsheet()->getXsheet()->getCellRange(m_col, r0,
                                                                     r1);
     if (lastFrame < r1 + 1) lastFrame = r1 + 1;
@@ -470,7 +470,7 @@ void LipSyncPopup::imageNavClicked(int id) {
   else if (frameIndex == 0 && direction == -1)
     newIndex = m_levelFrameIds.size() - 1;
   else
-    newIndex                    = frameIndex + direction;
+    newIndex = frameIndex + direction;
   m_activeFrameIds[frameNumber] = m_levelFrameIds.at(newIndex);
   TXshCell newCell =
       TApp::instance()->getCurrentScene()->getScene()->getXsheet()->getCell(

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -252,9 +252,7 @@ int main(int argc, char *argv[]) {
     freopen("CON", "r", stdin);
     freopen("CON", "w", stdout);
     freopen("CON", "w", stderr);
-    atexit([]() {
-      ::FreeConsole();
-    });
+    atexit([]() { ::FreeConsole(); });
   }
 #endif
 
@@ -321,11 +319,9 @@ int main(int argc, char *argv[]) {
     argc = 1;
   }
 
-// Enables high-DPI scaling. This attribute must be set before QApplication is
-// constructed. Available from Qt 5.6.
-#if QT_VERSION >= 0x050600
+  // Enables high-DPI scaling. This attribute must be set before QApplication is
+  // constructed. Available from Qt 5.6.
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
 
   QApplication a(argc, argv);
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -362,13 +362,8 @@ void Room::load(const TFilePath &fp) {
 // MainWindow
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 MainWindow::MainWindow(const QString &argumentLayoutFileName, QWidget *parent,
                        Qt::WindowFlags flags)
-#else
-MainWindow::MainWindow(const QString &argumentLayoutFileName, QWidget *parent,
-                       Qt::WFlags flags)
-#endif
     : QMainWindow(parent, flags)
     , m_saveSettingsOnQuit(true)
     , m_oldRoomIndex(0)

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -6,11 +6,7 @@
 #include "tfilepath.h"
 #include "toonzqt/menubarcommand.h"
 
-#if QT_VERSION >= 0x050000
 #include <QtWidgets/QMainWindow>
-#else
-#include <QtGui/QMainWindow>
-#endif
 #include <map>
 #include <QAction>
 #include <QString>
@@ -31,13 +27,8 @@ class Room final : public TMainWindow {
   QString m_name;
 
 public:
-#if QT_VERSION >= 0x050500
-  Room(QWidget *parent = 0, Qt::WindowFlags flags = 0)
-#else
-  Room(QWidget *parent = 0, Qt::WFlags flags = 0)
-#endif
-      : TMainWindow(parent, flags) {
-  }
+  Room(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags())
+      : TMainWindow(parent, flags) {}
 
   ~Room() {}
 
@@ -73,13 +64,8 @@ class MainWindow final : public QMainWindow {
   QString m_layoutName;
 
 public:
-#if QT_VERSION >= 0x050500
   MainWindow(const QString &argumentLayoutFileName, QWidget *parent = 0,
-             Qt::WindowFlags flags = 0);
-#else
-  MainWindow(const QString &argumentLayoutFileName, QWidget *parent = 0,
-             Qt::WFlags flags = 0);
-#endif
+             Qt::WindowFlags flags = Qt::WindowFlags());
   ~MainWindow();
 
   void startupFloatingPanels();

--- a/toonz/sources/toonz/mergecmapped.cpp
+++ b/toonz/sources/toonz/mergecmapped.cpp
@@ -6,7 +6,7 @@
 #include "toonz/txshsimplelevel.h"
 #include "toonz/txshlevelcolumn.h"
 #include "toonz/txshcell.h"
-//#include "tw/action.h"
+// #include "tw/action.h"
 #include "tropcm.h"
 #include "ttoonzimage.h"
 #include "matchline.h"
@@ -61,8 +61,6 @@ void mergeCmapped(const std::vector<MergeCmappedPair> &matchingLevels) {
   TPalette *palette = matchingLevels[0].m_cell->getImage(false)->getPalette();
   TPalette *matchPalette =
       matchingLevels[0].m_mcell->getImage(false)->getPalette();
-
-  TPalette::Page *page;
 
   // upInkId -> downInkId
   std::map<int, int> usedColors;
@@ -239,17 +237,17 @@ public:
   DeleteMatchlineUndo(
       TXshLevel *xl, TXshSimpleLevel *sl, const std::vector<TFrameId> &fids,
       const std::vector<int> &indexes)  //, TPalette*matchPalette)
-      : TUndo(),
-        m_xl(xl),
-        m_sl(sl),
-        m_fids(fids),
-        m_indexes(indexes)
+      : TUndo()
+      , m_xl(xl)
+      , m_sl(sl)
+      , m_fids(fids)
+      , m_indexes(indexes)
   //, m_matchlinePalette(matchPalette->clone())
   {
     // assert(matchPalette);
     int i;
     for (i = 0; i < fids.size(); i++) {
-      QString id = "DeleteMatchlineUndo" + QString::number((uintptr_t) this) +
+      QString id = "DeleteMatchlineUndo" + QString::number((uintptr_t)this) +
                    "-" + QString::number(i);
       TToonzImageP image = sl->getFrame(fids[i], false);
       assert(image);
@@ -262,7 +260,7 @@ public:
     // TPalette *palette = m_matchlinePalette->clone();
     // m_sl->setPalette(palette);
     for (i = 0; i < m_fids.size(); i++) {
-      QString id = "DeleteMatchlineUndo" + QString::number((uintptr_t) this) +
+      QString id = "DeleteMatchlineUndo" + QString::number((uintptr_t)this) +
                    "-" + QString::number(i);
       TImageP img = TImageCache::instance()->get(id, false)->cloneImage();
 
@@ -297,7 +295,7 @@ public:
     int i;
     for (i = 0; i < m_fids.size(); i++)
       TImageCache::instance()->remove("DeleteMatchlineUndo" +
-                                      QString::number((uintptr_t) this) + "-" +
+                                      QString::number((uintptr_t)this) + "-" +
                                       QString::number(i));
   }
 };
@@ -378,7 +376,7 @@ public:
 
   void undo() const override {
     std::map<TFrameId, QString>::const_iterator it = m_images.begin();
-    TPalette *palette = m_palette->clone();
+    TPalette *palette                              = m_palette->clone();
     m_level->setPalette(palette);
     std::vector<TFrameId> fids;
     for (; it != m_images.end(); ++it)  //, ++mit)
@@ -413,8 +411,8 @@ public:
     std::map<TFrameId, QString>::const_iterator it = m_images.begin();
     for (; it != m_images.end(); ++it)  //, ++mit)
     {
-      QString id = "MergeCmappedUndo" + QString::number((uintptr_t) this) +
-                   "-" + QString::number(it->first.getNumber());
+      QString id = "MergeCmappedUndo" + QString::number((uintptr_t)this) + "-" +
+                   QString::number(it->first.getNumber());
       TImageCache::instance()->remove(id);
     }
     delete m_palette;

--- a/toonz/sources/toonz/messagepanel.cpp
+++ b/toonz/sources/toonz/messagepanel.cpp
@@ -30,7 +30,7 @@ protected:
 
     QFontMetrics fm    = p.fontMetrics();
     QString elidedText = fm.elidedText(m_text, Qt::ElideRight, width());
-    qreal textWidth    = fm.width(elidedText);
+    qreal textWidth    = fm.horizontalAdvance(elidedText);
     p.drawText((width() - textWidth) * 0.5, (height() - fm.height()) * 0.5,
                elidedText);
   }
@@ -86,11 +86,7 @@ void MessagePanel::setMessage(QString text) { m_messageBox->setText(text); }
 
                 Inherits \b TPanel.
 */
-#if QT_VERSION >= 0x050500
 LogPanel::LogPanel(QWidget *parent, Qt::WindowFlags flags)
-#else
-LogPanel::LogPanel(QWidget *parent, Qt::WFlags flags)
-#endif
     : TPanel(parent), TLogger::Listener() {
   TLogger::instance()->addListener(this);
   TLogger::instance()->clearMessages();
@@ -149,7 +145,7 @@ void LogPanel::onLogChanged() {
 
 //-----------------------------------------------------------------------------
 /*! Clear panel text box from all messages.
-*/
+ */
 void LogPanel::clear() {
   TLogger::instance()->clearMessages();
   m_messageBox->clear();

--- a/toonz/sources/toonz/messagepanel.h
+++ b/toonz/sources/toonz/messagepanel.h
@@ -54,11 +54,7 @@ class LogPanel final : public TPanel, public TLogger::Listener {
   int m_poolIndex;
 
 public:
-#if QT_VERSION >= 0x050500
   LogPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  LogPanel(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~LogPanel();
 
   void onLogChanged() override;

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -217,7 +217,7 @@ class TPanel : public TDockWidget {
   QByteArray m_currentRoomOldState;
 
 public:
-  TPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0,
+  TPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
          TDockWidget::Orientation orientation = TDockWidget::vertical);
   ~TPanel();
 

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1423,7 +1423,7 @@ void SubCameraButton::onSubCameraAct() {
 }
 
 void SubCameraButton::onSaveSubCamera() {
-  auto initDialog = [](QLineEdit** lineEdit) {
+  auto initDialog = [&](QLineEdit** lineEdit) {
     QDialog* ret = new QDialog();
     *lineEdit    = new QLineEdit(ret);
     QDialogButtonBox* buttonBox =

--- a/toonz/sources/toonz/pltgizmopopup.cpp
+++ b/toonz/sources/toonz/pltgizmopopup.cpp
@@ -448,11 +448,7 @@ void modifyColor(const T &modifier) {
 // ValueAdjuster
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 ValueAdjuster::ValueAdjuster(QWidget *parent, Qt::WindowFlags flags)
-#else
-ValueAdjuster::ValueAdjuster(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent) {
   QPushButton *plusBut  = new QPushButton(QString("+"), this);
   QPushButton *minusBut = new QPushButton(QString("-"), this);
@@ -501,11 +497,7 @@ void ValueAdjuster::onClickedMinus() {
 // ValueShifter
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 ValueShifter::ValueShifter(bool isHue, QWidget *parent, Qt::WindowFlags flags)
-#else
-ValueShifter::ValueShifter(bool isHue, QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent) {
   QPushButton *plusBut  = new QPushButton(QString("+"), this);
   QPushButton *minusBut = new QPushButton(QString("-"), this);
@@ -553,11 +545,7 @@ void ValueShifter::onClickedMinus() {
 // ColorFader
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 ColorFader::ColorFader(QString name, QWidget *parent, Qt::WindowFlags flags)
-#else
-ColorFader::ColorFader(QString name, QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent) {
   QHBoxLayout *layout = new QHBoxLayout(this);
   layout->setMargin(0);

--- a/toonz/sources/toonz/pltgizmopopup.h
+++ b/toonz/sources/toonz/pltgizmopopup.h
@@ -18,11 +18,7 @@ class ValueAdjuster final : public QWidget {
   DVGui::DoubleLineEdit *m_valueLineEdit;
 
 public:
-#if QT_VERSION >= 0x050500
-  ValueAdjuster(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ValueAdjuster(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  ValueAdjuster(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ValueAdjuster();
 
 protected slots:
@@ -43,11 +39,8 @@ class ValueShifter final : public QWidget {
   DVGui::DoubleLineEdit *m_valueLineEdit;
 
 public:
-#if QT_VERSION >= 0x050500
-  ValueShifter(bool isHue, QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ValueShifter(bool isHue, QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  ValueShifter(bool isHue, QWidget *parent = 0,
+               Qt::WindowFlags flags = Qt::WindowFlags());
   ~ValueShifter();
 
 protected slots:
@@ -70,11 +63,8 @@ class ColorFader final : public QWidget {
   DVGui::DoubleLineEdit *m_valueLineEdit;
 
 public:
-#if QT_VERSION >= 0x050500
-  ColorFader(QString name = "", QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ColorFader(QString name = "", QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  ColorFader(QString name = "", QWidget *parent = 0,
+             Qt::WindowFlags flags = Qt::WindowFlags());
   ~ColorFader();
 
 protected slots:

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -90,15 +90,14 @@ namespace ba = boost::adaptors;
 
 using namespace DVGui;
 
-
 //=============================================================================
 //      Local namespace
 //=============================================================================
 
 namespace {
 std::set<SceneBrowser *> activePreproductionBoards;
-//std::map<TFilePath, FCData> frameCountMap;
-//QMutex frameCountMapMutex;
+// std::map<TFilePath, FCData> frameCountMap;
+// QMutex frameCountMapMutex;
 QMutex levelFileMutex;
 
 }  // namespace
@@ -118,10 +117,10 @@ SceneBrowserButtonBar::SceneBrowserButtonBar(DvItemViewer *itemViewer,
   // buttonBar->setIconSize(QSize(10,10));
 
   QIcon newFolderIcon = createQIcon("newfolder");
-  QAction *newScene  = new QAction(newFolderIcon, tr("Create new scene"), this);
+  QAction *newScene = new QAction(newFolderIcon, tr("Create new scene"), this);
   newScene->setIconText(tr("Create scene"));
   addAction(newScene);
-  //addSeparator();
+  // addSeparator();
 
   connect(newScene, SIGNAL(triggered()), SIGNAL(newScene()));
 }
@@ -130,19 +129,14 @@ SceneBrowserButtonBar::SceneBrowserButtonBar(DvItemViewer *itemViewer,
 // SceneBrowser
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 SceneBrowser::SceneBrowser(QWidget *parent, Qt::WindowFlags flags,
-                         bool noContextMenu, bool multiSelectionEnabled)
-#else
-SceneBrowser::SceneBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu,
-                         bool multiSelectionEnabled)
-#endif
+                           bool noContextMenu, bool multiSelectionEnabled)
     : QFrame(parent), m_folderName(0), m_itemViewer(0) {
   // style sheet
   setObjectName("SceneBrowser");
   setFrameStyle(QFrame::StyledPanel);
 
-  //m_mainSplitter      = new QSplitter(this);
+  // m_mainSplitter      = new QSplitter(this);
   m_folderTreeView    = new DvDirTreeView(this);
   QFrame *box         = new QFrame(this);
   QLabel *folderLabel = new QLabel(tr("Folder: "), this);
@@ -154,7 +148,7 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu
       new SceneBrowserButtonBar(m_itemViewer, box);
   DvItemViewerPanel *viewerPanel = m_itemViewer->getPanel();
   viewerPanel->setThumbnailsView();
-  viewerPanel->setIconSize(QSize(192,108)); //default 80, 60
+  viewerPanel->setIconSize(QSize(192, 108));  // default 80, 60
   viewerPanel->addColumn(DvItemListModel::FileType, 50);
   viewerPanel->addColumn(DvItemListModel::FrameCount, 50);
   viewerPanel->addColumn(DvItemListModel::FileSize, 50);
@@ -168,7 +162,7 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu
       new DVItemViewPlayDelegate(viewerPanel);
   viewerPanel->setItemViewPlayDelegate(itemViewPlayDelegate);
 
-  //m_mainSplitter->setObjectName("SceneBrowserSplitter");
+  // m_mainSplitter->setObjectName("SceneBrowserSplitter");
   m_folderTreeView->hide();
   m_folderTreeView->setObjectName("DirTreeView");
   box->setObjectName("castFrame");
@@ -192,7 +186,7 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu
     }
     mainLayout->addLayout(folderLay, 0);
 
-    //m_mainSplitter->addWidget(m_folderTreeView);
+    // m_mainSplitter->addWidget(m_folderTreeView);
     QVBoxLayout *boxLayout = new QVBoxLayout(box);
     boxLayout->setMargin(0);
     boxLayout->setSpacing(0);
@@ -200,12 +194,12 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu
       boxLayout->addWidget(titleBar, 0);
       boxLayout->addWidget(m_itemViewer, 1);
     }
-    //m_mainSplitter->addWidget(box);
+    // m_mainSplitter->addWidget(box);
     mainLayout->addWidget(box, 1);
   }
   setLayout(mainLayout);
 
-  //m_mainSplitter->setSizes(QList<int>() << 270 << 500);
+  // m_mainSplitter->setSizes(QList<int>() << 270 << 500);
 
   // signal-slot connections
   bool ret = connect(m_folderTreeView, SIGNAL(currentNodeChanged()),
@@ -252,15 +246,15 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WFlags flags, bool noContextMenu
   ret = ret && connect(MyFileSystemWatcher::instance(),
                        SIGNAL(directoryChanged(const QString &)), this,
                        SLOT(onFileSystemChanged(const QString &)));
-  
+
   // when the scene switched, update the path of the scene location node
   TSceneHandle *sceneHandle = TApp::instance()->getCurrentScene();
-  //ret = ret && connect(sceneHandle, SIGNAL(sceneSwitched()), this,
-  //                     SLOT(onSceneSwitched()));
+  // ret = ret && connect(sceneHandle, SIGNAL(sceneSwitched()), this,
+  //                      SLOT(onSceneSwitched()));
   ret = ret && connect(sceneHandle, SIGNAL(nameSceneChanged()), this,
                        SLOT(onSceneSwitched()));
 
-  //onSceneSwitched();
+  // onSceneSwitched();
 
   // store the first item("Root") in the history
   m_indexHistoryList.append(m_folderTreeView->currentIndex());
@@ -491,7 +485,9 @@ void SceneBrowser::sortByDataModel(DataType dataType, bool isDiscendent) {
 
 //-----------------------------------------------------------------------------
 
-void SceneBrowser::setFilterTypes(const QStringList &types) { m_filter = types; }
+void SceneBrowser::setFilterTypes(const QStringList &types) {
+  m_filter = types;
+}
 
 //-----------------------------------------------------------------------------
 
@@ -511,8 +507,8 @@ void SceneBrowser::refreshCurrentFolderItems() {
   m_items.clear();
 
   // put the parent directory item
-  //TFilePath parentFp = m_folder.getParentDir();
-  //if (parentFp != TFilePath("") && parentFp != m_folder)
+  // TFilePath parentFp = m_folder.getParentDir();
+  // if (parentFp != TFilePath("") && parentFp != m_folder)
   //  m_items.push_back(Item(parentFp, true, false));
 
   // register the file items
@@ -621,7 +617,7 @@ void SceneBrowser::refreshCurrentFolderItems() {
 //-----------------------------------------------------------------------------
 
 void SceneBrowser::setFolder(const TFilePath &fp, bool expandNode,
-                            bool forceUpdate) {
+                             bool forceUpdate) {
   if (fp == m_folder && !forceUpdate) return;
 
   // set the current folder path
@@ -829,7 +825,7 @@ void SceneBrowser::readFrameCount(Item &item) {
 //-----------------------------------------------------------------------------
 
 QVariant SceneBrowser::getItemData(int index, DataType dataType,
-                                  bool isSelected) {
+                                   bool isSelected) {
   if (index < 0 || index >= (int)m_items.size()) return QVariant();
   Item &item = m_items[index];
   if (dataType == Name) {
@@ -1140,7 +1136,7 @@ QMenu *SceneBrowser::getContextMenu(QWidget *parent, int index) {
   if (files.size() == 1 && files[0].getType() != "tnz") {
     QAction *action = new QAction(tr("Rename"), menu);
     ret             = ret && connect(action, SIGNAL(triggered()), this,
-                         SLOT(renameAsToonzLevel()));
+                                     SLOT(renameAsToonzLevel()));
     menu->addAction(action);
   }
 #ifdef LEVO
@@ -1154,13 +1150,13 @@ QMenu *SceneBrowser::getContextMenu(QWidget *parent, int index) {
        files[1].getType() == "TIFF" || files[1].getType() == "PNG")) {
     QAction *action = new QAction(tr("Convert to Painted TLV"), menu);
     ret             = ret && connect(action, SIGNAL(triggered()), this,
-                         SLOT(convertToPaintedTlv()));
+                                     SLOT(convertToPaintedTlv()));
     menu->addAction(action);
   }
   if (areFullcolor) {
     QAction *action = new QAction(tr("Convert to Unpainted TLV"), menu);
     ret             = ret && connect(action, SIGNAL(triggered()), this,
-                         SLOT(convertToUnpaintedTlv()));
+                                     SLOT(convertToUnpaintedTlv()));
     menu->addAction(action);
     menu->addSeparator();
   }
@@ -1193,42 +1189,42 @@ QMenu *SceneBrowser::getContextMenu(QWidget *parent, int index) {
       if (status == DvItemListModel::VC_ReadOnly) {
         action = vcMenu->addAction(tr("Edit"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(editVersionControl()));
+                                SLOT(editVersionControl()));
 
         TFilePath path       = files.at(0);
         std::string fileType = path.getType();
         if (fileType == "tlv" || fileType == "pli" || path.getDots() == "..") {
           action = vcMenu->addAction(tr("Edit Frame Range..."));
           ret    = ret && connect(action, SIGNAL(triggered()), this,
-                               SLOT(editFrameRangeVersionControl()));
+                                  SLOT(editFrameRangeVersionControl()));
         }
       } else {
         action = vcMenu->addAction(tr("Edit"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(updateAndEditVersionControl()));
+                                SLOT(updateAndEditVersionControl()));
       }
     }
 
     if (status == DvItemListModel::VC_Modified) {
       action = vcMenu->addAction(tr("Put..."));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(putVersionControl()));
+                              SLOT(putVersionControl()));
 
       action = vcMenu->addAction(tr("Revert"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(revertVersionControl()));
+                              SLOT(revertVersionControl()));
     }
 
     if (status == DvItemListModel::VC_ReadOnly ||
         status == DvItemListModel::VC_ToUpdate) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (status == DvItemListModel::VC_ReadOnly) {
         action = vcMenu->addAction(tr("Delete"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(deleteVersionControl()));
+                                SLOT(deleteVersionControl()));
       }
 
       vcMenu->addSeparator();
@@ -1245,36 +1241,36 @@ QMenu *SceneBrowser::getContextMenu(QWidget *parent, int index) {
       } else if (files.size() > 1) {
         action = vcMenu->addAction("Get Revision...");
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(getRevisionVersionControl()));
+                                SLOT(getRevisionVersionControl()));
       }
     }
 
     if (status == DvItemListModel::VC_Edited) {
       action = vcMenu->addAction(tr("Unlock"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(unlockVersionControl()));
+                              SLOT(unlockVersionControl()));
     }
 
     if (status == DvItemListModel::VC_Unversioned) {
       action = vcMenu->addAction(tr("Put..."));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(putVersionControl()));
+                              SLOT(putVersionControl()));
     }
 
     if (status == DvItemListModel::VC_Locked && files.size() == 1) {
       action = vcMenu->addAction(tr("Unlock"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(unlockVersionControl()));
+                              SLOT(unlockVersionControl()));
 
       action = vcMenu->addAction(tr("Edit Info"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(showLockInformation()));
+                              SLOT(showLockInformation()));
     }
 
     if (status == DvItemListModel::VC_Missing) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (files.size() == 1) {
         vcMenu->addSeparator();
@@ -1292,44 +1288,44 @@ QMenu *SceneBrowser::getContextMenu(QWidget *parent, int index) {
     if (status == DvItemListModel::VC_PartialLocked) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
       if (files.size() == 1) {
         action = vcMenu->addAction(tr("Edit Frame Range..."));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(editFrameRangeVersionControl()));
+                                SLOT(editFrameRangeVersionControl()));
 
         action = vcMenu->addAction(tr("Edit Info"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(showFrameRangeLockInfo()));
+                                SLOT(showFrameRangeLockInfo()));
       }
 
     } else if (status == DvItemListModel::VC_PartialEdited) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (files.size() == 1) {
         action = vcMenu->addAction(tr("Unlock Frame Range"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(unlockFrameRangeVersionControl()));
+                                SLOT(unlockFrameRangeVersionControl()));
 
         action = vcMenu->addAction(tr("Edit Info"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(showFrameRangeLockInfo()));
+                                SLOT(showFrameRangeLockInfo()));
       }
     } else if (status == DvItemListModel::VC_PartialModified) {
       action = vcMenu->addAction(tr("Get"));
       ret    = ret && connect(action, SIGNAL(triggered()), this,
-                           SLOT(getVersionControl()));
+                              SLOT(getVersionControl()));
 
       if (files.size() == 1) {
         action = vcMenu->addAction(tr("Put..."));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(putFrameRangeVersionControl()));
+                                SLOT(putFrameRangeVersionControl()));
 
         action = vcMenu->addAction(tr("Revert"));
         ret    = ret && connect(action, SIGNAL(triggered()), this,
-                             SLOT(revertFrameRangeVersionControl()));
+                                SLOT(revertFrameRangeVersionControl()));
       }
     }
 
@@ -1385,7 +1381,7 @@ void SceneBrowser::startDragDrop() {
 //-----------------------------------------------------------------------------
 
 bool SceneBrowser::dropMimeData(QTreeWidgetItem *parent, int index,
-                               const QMimeData *data, Qt::DropAction action) {
+                                const QMimeData *data, Qt::DropAction action) {
   return false;
 }
 
@@ -1394,10 +1390,10 @@ bool SceneBrowser::dropMimeData(QTreeWidgetItem *parent, int index,
 void SceneBrowser::onTreeFolderChanged() {
   // Commented by KD
   DvDirModelNode *node = m_folderTreeView->getCurrentNode();
-  //if (node)
-  //  node->visualizeContent(this);
-  //else
-  //  setFolder(TFilePath());
+  // if (node)
+  //   node->visualizeContent(this);
+  // else
+  //   setFolder(TFilePath());
   m_itemViewer->resetVerticalScrollBar();
   m_itemViewer->updateContentSize();
   m_itemViewer->getPanel()->update();
@@ -1410,7 +1406,6 @@ void SceneBrowser::onTreeFolderChanged() {
 
   // Restore scroll position
   m_itemViewer->verticalScrollBar()->setValue(m_currentScroll);
-
 }
 
 //-----------------------------------------------------------------------------
@@ -1420,7 +1415,7 @@ void SceneBrowser::changeFolder(const QModelIndex &index) {}
 //-----------------------------------------------------------------------------
 
 void SceneBrowser::onDataChanged(const QModelIndex &topLeft,
-                                const QModelIndex &bottomRight) {
+                                 const QModelIndex &bottomRight) {
   onTreeFolderChanged();
 }
 
@@ -1497,8 +1492,7 @@ bool SceneBrowser::drop(const QMimeData *mimeData) {
       TFilePath path = folderPath;
       NameBuilder *nameBuilder =
           NameBuilder::getBuilder(::to_wstring(path.getName()));
-      do
-        levelName = nameBuilder->getNext();
+      do levelName = nameBuilder->getNext();
       while (TSystem::doesExistFileOrLevel(path.withName(levelName)));
       folderPath = path.withName(levelName);
     }
@@ -1634,11 +1628,7 @@ QString getFrame(const QString &filename) {
   QString number = filename.mid(from + 1, to - from);
   for (i = 0; i < 4 - number.size(); i++) padStr[i] = '0';
   for (i = 0; i < number.size(); i++)
-#if QT_VERSION >= 0x050500
     padStr[4 - number.size() + i] = number.at(i).toLatin1();
-#else
-    padStr[4 - number.size() + i] = number.at(i).toAscii();
-#endif
   return QString(padStr);
 }
 
@@ -1926,9 +1916,10 @@ void SceneBrowser::convertToPaintedTlv() {
 //-----------------------------------------------------------------------------
 
 void SceneBrowser::onSceneSwitched() {
-  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+  ToonzScene *scene      = TApp::instance()->getCurrentScene()->getScene();
   TFilePath scenesFolder = scene->getScenePath().getParentDir();
-  //TFilePath scenesFolder = TProjectManager::instance()->getCurrentProject()->getScenesPath();
+  // TFilePath scenesFolder =
+  // TProjectManager::instance()->getCurrentProject()->getScenesPath();
   setFolder(scenesFolder, true);
 }
 
@@ -1991,7 +1982,8 @@ void SceneBrowser::onDoubleClickedItem(int index) {
 
 void SceneBrowser::refreshFolder(const TFilePath &folderPath) {
   std::set<SceneBrowser *>::iterator it;
-  for (it = activePreproductionBoards.begin(); it != activePreproductionBoards.end(); ++it) {
+  for (it = activePreproductionBoards.begin();
+       it != activePreproductionBoards.end(); ++it) {
     SceneBrowser *browser = *it;
     DvDirModel::instance()->refreshFolder(folderPath);
     if (browser->getFolder() == folderPath) {
@@ -2004,7 +1996,8 @@ void SceneBrowser::refreshFolder(const TFilePath &folderPath) {
 
 void SceneBrowser::updateItemViewerPanel() {
   std::set<SceneBrowser *>::iterator it;
-  for (it = activePreproductionBoards.begin(); it != activePreproductionBoards.end(); ++it) {
+  for (it = activePreproductionBoards.begin();
+       it != activePreproductionBoards.end(); ++it) {
     SceneBrowser *browser = *it;
     browser->m_itemViewer->getPanel()->update();
   }
@@ -2013,7 +2006,7 @@ void SceneBrowser::updateItemViewerPanel() {
 //-----------------------------------------------------------------------------
 
 void SceneBrowser::getExpandedFolders(DvDirModelNode *node,
-                                     QList<DvDirModelNode *> &expandedNodes) {
+                                      QList<DvDirModelNode *> &expandedNodes) {
   if (!node) return;
   QModelIndex newIndex = DvDirModel::instance()->getIndexByNode(node);
   if (!m_folderTreeView->isExpanded(newIndex)) return;
@@ -2061,7 +2054,6 @@ void SceneBrowser::refresh() {
 //-----------------------------------------------------------------------------
 
 void SceneBrowser::newScene() {
-
   m_currentScroll = m_itemViewer->verticalScrollBar()->value();
 
   TFilePath parentFolder = getFolder();
@@ -2069,37 +2061,38 @@ void SceneBrowser::newScene() {
   TFilePath scenePath;
   ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
   if (scene->isUntitled()) {
-      bool ok;
-      sceneName =
-          QInputDialog::getText(this, tr("Save Scene"), tr("Scene name:"),
-                                QLineEdit::Normal, QString(), &ok);
-      if (!ok || sceneName == "") return;
-    } else {
-      sceneName = QString::fromWCharArray( scene->getSceneName().c_str() );
+    bool ok;
+    sceneName = QInputDialog::getText(this, tr("Save Scene"), tr("Scene name:"),
+                                      QLineEdit::Normal, QString(), &ok);
+    if (!ok || sceneName == "") return;
+  } else {
+    sceneName = QString::fromWCharArray(scene->getSceneName().c_str());
   }
   QString prefix;
   QString number;
-  for(int j = 0; j<sceneName.length(); j++) {
+  for (int j = 0; j < sceneName.length(); j++) {
     QChar c;
-    c = sceneName.at(sceneName.length()-1-j);
+    c = sceneName.at(sceneName.length() - 1 - j);
     if (c.isDigit()) {
       number = QString(c) + number;
     } else {
       prefix = sceneName;
-      prefix.truncate(sceneName.length()-j);
+      prefix.truncate(sceneName.length() - j);
       break;
     }
   }
-  if (number.length()==0) {
-    //prefix+="-";
-    number="000";
+  if (number.length() == 0) {
+    // prefix+="-";
+    number = "000";
   }
   int i = number.toInt();
   do {
-    QString number_ext = QStringLiteral("%1").arg(++i, number.length(), 10, QLatin1Char('0'));
-    scenePath = parentFolder + (prefix.toStdWString()+number_ext.toStdWString()+L".tnz");
+    QString number_ext =
+        QStringLiteral("%1").arg(++i, number.length(), 10, QLatin1Char('0'));
+    scenePath = parentFolder +
+                (prefix.toStdWString() + number_ext.toStdWString() + L".tnz");
   } while (TFileStatus(scenePath).doesExist());
-  
+
   if (!IoCmd::saveSceneIfNeeded(QObject::tr("Change project"))) return;
   IoCmd::newScene();
   IoCmd::saveScene(scenePath, false);
@@ -2110,7 +2103,7 @@ void SceneBrowser::newScene() {
   QString tempName(tr("New Folder"));
   std::wstring folderName = tempName.toStdWString();
   TFilePath folderPath    = parentFolder + folderName;
-  //int i                   = 1;
+  // int i                   = 1;
   while (TFileStatus(folderPath).doesExist())
     folderPath = parentFolder + (folderName + L" " + std::to_wstring(++i));
 
@@ -2202,5 +2195,6 @@ void SceneBrowser::tryToOpenScene(const TFilePath &filePath) {
 
 //=============================================================================
 
-OpenFloatingPanel openPreproductionBoardPane(MI_OpenPreproductionBoard, "PreproductionBoard",
-                                  QObject::tr("Preproduction Board"));
+OpenFloatingPanel openPreproductionBoardPane(
+    MI_OpenPreproductionBoard, "PreproductionBoard",
+    QObject::tr("Preproduction Board"));

--- a/toonz/sources/toonz/scenebrowser.h
+++ b/toonz/sources/toonz/scenebrowser.h
@@ -43,13 +43,8 @@ class SceneBrowser final : public QFrame, public DvItemListModel {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
   SceneBrowser(QWidget *parent, Qt::WindowFlags flags = 0,
-              bool noContextMenu = false, bool multiSelectionEnabled = false);
-#else
-  SceneBrowser(QWidget *parent, Qt::WFlags flags = 0, bool noContextMenu = false,
-              bool multiSelectionEnabled = false);
-#endif
+               bool noContextMenu = false, bool multiSelectionEnabled = false);
   ~SceneBrowser();
 
   void sortByDataModel(DataType dataType, bool isDiscendent) override;

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -82,11 +82,7 @@
 #include <QMenu>
 #include <QApplication>
 #include <QDesktopWidget>
-#if QT_VERSION >= 0x050000
 #include <QInputMethod>
-#else
-#include <QInputContext>
-#endif
 #include <QGLContext>
 #include <QOpenGLFramebufferObject>
 #include <QMainWindow>
@@ -812,10 +808,8 @@ SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
   setFocusPolicy(Qt::StrongFocus);
   setAcceptDrops(true);
   this->setMouseTracking(true);
-// introduced from Qt 5.9
-#if QT_VERSION >= 0x050900
+  // introduced from Qt 5.9
   this->setTabletTracking(true);
-#endif
 
   for (int i = 0; i < m_viewAff.size(); ++i) {
     setViewMatrix(getNormalZoomScale(), i);
@@ -3238,11 +3232,7 @@ void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
 //-----------------------------------------------------------------------------
 
 void SceneViewer::resetInputMethod() {
-#if QT_VERSION >= 0x050000
   QGuiApplication::inputMethod()->reset();
-#else
-  qApp->inputContext()->reset();
-#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/scriptconsolepanel.cpp
+++ b/toonz/sources/toonz/scriptconsolepanel.cpp
@@ -123,13 +123,8 @@ static void def(ScriptEngine *teng, const QString &name,
   eng->globalObject().setProperty(name, evalFun);
 }
 
-#if QT_VERSION >= 0x050500
 ScriptConsolePanel::ScriptConsolePanel(QWidget *parent, Qt::WindowFlags flags)
-#else
-ScriptConsolePanel::ScriptConsolePanel(QWidget *parent, Qt::WFlags flags)
-#endif
     : TPanel(parent) {
-
   setPanelType("ScriptConsole");
   setIsMaximizable(false);
   setWindowTitle(QObject::tr("Script Console"));

--- a/toonz/sources/toonz/scriptconsolepanel.h
+++ b/toonz/sources/toonz/scriptconsolepanel.h
@@ -12,11 +12,8 @@ class ScriptConsolePanel final : public TPanel {
   ScriptConsole *m_scriptConsole;
 
 public:
-#if QT_VERSION >= 0x050500
-  ScriptConsolePanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  ScriptConsolePanel(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
+  ScriptConsolePanel(QWidget *parent       = 0,
+                     Qt::WindowFlags flags = Qt::WindowFlags());
   ~ScriptConsolePanel();
 
   void executeCommand(const QString &cmd);

--- a/toonz/sources/toonz/separatecolorsswatch.cpp
+++ b/toonz/sources/toonz/separatecolorsswatch.cpp
@@ -240,7 +240,7 @@ void SeparateSwatchArea::paintEvent(QPaintEvent *event) {
 void SeparateSwatchArea::wheelEvent(QWheelEvent *event) {
   if (!m_sw->m_mainSwatch || m_sw->m_lx == 0 || m_sw->m_ly == 0) return;
 
-  int step      = event->delta() > 0 ? 120 : -120;
+  int step      = event->angleDelta().y() > 0 ? 120 : -120;
   double factor = exp(0.001 * step);
   if (factor == 1.0) return;
   double scale   = m_sw->m_viewAff.det();
@@ -249,7 +249,11 @@ void SeparateSwatchArea::wheelEvent(QWheelEvent *event) {
   if ((factor < 1 && sqrt(scale) < minZoom) || (factor > 1 && scale > 1200.0))
     return;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  TPointD delta(event->position().x(), height() - event->position().y());
+#else
   TPointD delta(event->pos().x(), height() - event->pos().y());
+#endif
   m_sw->m_viewAff =
       (TTranslation(delta) * TScale(factor) * TTranslation(-delta)) *
       m_sw->m_viewAff;
@@ -411,7 +415,7 @@ void SeparateSwatch::setRaster(TRasterP orgRas, TRasterP mainRas,
 void SeparateSwatch::setRaster(TRasterP orgRas, TRasterP mainRas,
                                TRasterP sub1Ras, TRasterP sub2Ras,
                                TRasterP sub3Ras) {
-  //o‚·
+  // o‚·
   m_sub3Swatch->setVisible(true);
   m_sub3Label->setVisible(true);
 

--- a/toonz/sources/toonz/styleshortcutswitchablepanel.h
+++ b/toonz/sources/toonz/styleshortcutswitchablepanel.h
@@ -22,7 +22,7 @@ class StyleShortcutSwitchablePanel : public TPanel {
 
 public:
   StyleShortcutSwitchablePanel(
-      QWidget *parent = 0, Qt::WindowFlags flags = 0,
+      QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
       TDockWidget::Orientation orientation = TDockWidget::vertical)
       : TPanel(parent, flags, orientation) {}
 

--- a/toonz/sources/toonz/subcameramanager.cpp
+++ b/toonz/sources/toonz/subcameramanager.cpp
@@ -259,7 +259,7 @@ bool PreviewSubCameraManager::mouseMoveEvent(SceneViewer *viewer,
   }
 
   // In case, perform the pan
-  return event.buttons() == Qt::MidButton;
+  return event.buttons() == Qt::MiddleButton;
 }
 
 //----------------------------------------------------------------------

--- a/toonz/sources/toonz/subscenecommand.cpp
+++ b/toonz/sources/toonz/subscenecommand.cpp
@@ -1408,8 +1408,8 @@ void collapseColumns(std::set<int> indices,
   }
 
   StageObjectsData *data = new StageObjectsData();
-  data->storeObjects(objIds.toVector().toStdVector(), xsh,
-                     StageObjectsData::eDoClone);
+  data->storeObjects(std::vector<TStageObjectId>(objIds.begin(), objIds.end()),
+                     xsh, StageObjectsData::eDoClone);
   data->storeColumnFxs(indices, xsh, StageObjectsData::eDoClone);
 
   // ExpressionReferenceMonitor *monitor = xsh->getExpRefMonitor()->clone();

--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -43,13 +43,8 @@ const std::vector<QAction *> &TasksViewer::getActions() const {
 
 void TasksViewer::add(const QString &iconName, QString text, QToolBar *toolBar,
                       const char *slot, QString iconText) {
-#if QT_VERSION >= 0x050500
   QAction *action = new QAction(
       createQIcon(iconName.toLatin1().constData(), false), text, this);
-#else
-  QAction *action = new QAction(
-      createQIcon(iconName.toAscii().constData(), false), text, this);
-#endif
   action->setIconText(iconText);
   bool ret = connect(action, SIGNAL(triggered(bool)),
                      (TaskTreeModel *)m_treeView->model(), slot);
@@ -110,11 +105,7 @@ QWidget *TasksViewer::createToolBar() {
 /*! \class TasksViewer
                 Inherits \b QSplitter.
 */
-#if QT_VERSION >= 0x050500
 TasksViewer::TasksViewer(QWidget *parent, Qt::WindowFlags flags)
-#else
-TasksViewer::TasksViewer(QWidget *parent, Qt::WFlags flags)
-#endif
     : QSplitter(parent) {
   QFrame *box;
 
@@ -607,7 +598,7 @@ void TaskSheet::setShrink() {
     // Update children tasks, if present.
     TFarmTaskGroup *taskGroup = dynamic_cast<TFarmTaskGroup *>(m_task);
     if (taskGroup) {
-      for (int i                        = 0; i < taskGroup->getTaskCount(); ++i)
+      for (int i = 0; i < taskGroup->getTaskCount(); ++i)
         taskGroup->getTask(i)->m_shrink = taskGroup->m_shrink;
     }
   }
@@ -635,7 +626,7 @@ void TaskSheet::setStep() {
     // Update children tasks, if present.
     TFarmTaskGroup *taskGroup = dynamic_cast<TFarmTaskGroup *>(m_task);
     if (taskGroup) {
-      for (int i                      = 0; i < taskGroup->getTaskCount(); ++i)
+      for (int i = 0; i < taskGroup->getTaskCount(); ++i)
         taskGroup->getTask(i)->m_step = taskGroup->m_step;
     }
   }

--- a/toonz/sources/toonz/tasksviewer.h
+++ b/toonz/sources/toonz/tasksviewer.h
@@ -169,11 +169,7 @@ public:
   TaskTreeView *m_treeView;
   QTimer *m_timer;
 
-#if QT_VERSION >= 0x050500
   TasksViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  TasksViewer(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~TasksViewer();
 
   void update() override;

--- a/toonz/sources/toonz/testpanel.cpp
+++ b/toonz/sources/toonz/testpanel.cpp
@@ -31,12 +31,7 @@ using namespace DVGui;
                         margin: 1px;
                 }
 */
-#if QT_VERSION >= 0x050500
-TestPanel::TestPanel(QWidget *parent, Qt::WindowFlags flags)
-#else
-TestPanel::TestPanel(QWidget *parent, Qt::WFlags flags)
-#endif
-    : TPanel(parent) {
+TestPanel::TestPanel(QWidget *parent, Qt::WindowFlags flags) : TPanel(parent) {
   setPanelType("Test");
   setIsMaximizable(false);
   setWindowTitle("Test");

--- a/toonz/sources/toonz/testpanel.h
+++ b/toonz/sources/toonz/testpanel.h
@@ -13,11 +13,7 @@ class TestPanel final : public TPanel {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
   TestPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  TestPanel(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~TestPanel();
 
 public slots:

--- a/toonz/sources/toonz/trackerpopup.cpp
+++ b/toonz/sources/toonz/trackerpopup.cpp
@@ -147,11 +147,7 @@ TRaster32P loadFrame(int frame, const TAffine &affine) {
 // TrackerPopup
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 TrackerPopup::TrackerPopup(QWidget *parent, Qt::WindowFlags flags)
-#else
-TrackerPopup::TrackerPopup(QWidget *parent, Qt::WFlags flags)
-#endif
     : Dialog(TApp::instance()->getMainWindow(), true, true, "Tracker") {
   // Su MAC i dialog modali non hanno bottoni di chiusura nella titleBar
   setModal(false);
@@ -423,7 +419,7 @@ bool Tracker::setup() {
     return false;
   }
 
-  //# start frame
+  // # start frame
   std::unique_ptr<int[]> m_numstart(new int[m_trackerCount]);
   if (!m_numstart) {
     m_lastErrorCode = 1;

--- a/toonz/sources/toonz/trackerpopup.h
+++ b/toonz/sources/toonz/trackerpopup.h
@@ -32,7 +32,7 @@ class DoubleField;
 class IntField;
 // class LineEdit;
 class CheckBox;
-}
+}  // namespace DVGui
 
 //=============================================================================
 // TrackerPopup
@@ -56,11 +56,7 @@ class TrackerPopup final : public DVGui::Dialog {
   DVGui::IntField *m_to;
 
 public:
-#if QT_VERSION >= 0x050500
   TrackerPopup(QWidget *parent = 0, Qt::WindowFlags flags = Qt::Tool);
-#else
-  TrackerPopup(QWidget *parent = 0, Qt::WFlags flags = Qt::Tool);
-#endif
 
   bool apply();
 

--- a/toonz/sources/toonz/vectorguideddrawingpane.cpp
+++ b/toonz/sources/toonz/vectorguideddrawingpane.cpp
@@ -18,15 +18,9 @@ using namespace DVGui;
 
 //=============================================================================
 
-#if QT_VERSION >= 0x050500
 VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
                                                  Qt::WindowFlags flags)
-#else
-VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
-                                                 Qt::WindowFlags flags)
-#endif
     : QFrame(parent) {
-
   setObjectName("cornerWidget");
   setObjectName("VectorGuidedDrawingToolbar");
 

--- a/toonz/sources/toonz/vectorguideddrawingpane.h
+++ b/toonz/sources/toonz/vectorguideddrawingpane.h
@@ -26,11 +26,7 @@ class VectorGuidedDrawingPane final : public QFrame {
       *m_FlipNextDirectionBtn, *m_FlipPrevDirectionBtn;
 
 public:
-#if QT_VERSION >= 0x050500
   VectorGuidedDrawingPane(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  VectorGuidedDrawingPane(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#endif
   ~VectorGuidedDrawingPane(){};
 
   void updateStatus();

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -419,11 +419,7 @@ void Vectorizer::run() { doVectorize(); }
 //    VectorizerPopup implementation
 //*****************************************************************************
 
-#if QT_VERSION >= 0x050500
 VectorizerPopup::VectorizerPopup(QWidget *parent, Qt::WindowFlags flags)
-#else
-VectorizerPopup::VectorizerPopup(QWidget *parent, Qt::WFlags flags)
-#endif
     : Dialog(TApp::instance()->getMainWindow(), true, false, "Vectorizer")
     , m_sceneHandle(TApp::instance()->getCurrentScene()) {
   struct Locals {

--- a/toonz/sources/toonz/vectorizerpopup.h
+++ b/toonz/sources/toonz/vectorizerpopup.h
@@ -88,11 +88,7 @@ class VectorizerPopup final : public DVGui::Dialog {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
   VectorizerPopup(QWidget *parent = 0, Qt::WindowFlags flags = Qt::Tool);
-#else
-  VectorizerPopup(QWidget *parent = 0, Qt::WFlags flags = Qt::Tool);
-#endif
 
   bool apply();  //!< The main vectorization method - prepares input
                  //!  configuration and runs the vectorization thread.

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -133,7 +133,8 @@ protected slots:
 class SceneViewerPanel final : public BaseViewerPanel {
   Q_OBJECT
 public:
-  SceneViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  SceneViewerPanel(QWidget *parent       = 0,
+                   Qt::WindowFlags flags = Qt::WindowFlags());
   ~SceneViewerPanel() {}
 
 protected:

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -676,13 +676,12 @@ void RenameCellField::showInRowCol(int row, int col, bool multiColumnSelected) {
     // Ex.  12 -> 1B    21 -> 2A   30 -> 3
     if (Preferences::instance()->isShowFrameNumberWithLettersEnabled() &&
         cell.m_level->getType() != TXshLevelType::SND_TXT_XSHLEVEL)
-      setText(
-          (fid.isEmptyFrame() || fid.isNoFrame())
-              ? QString::fromStdWString(levelName)
+      setText((fid.isEmptyFrame() || fid.isNoFrame())
+                  ? QString::fromStdWString(levelName)
               : (multiColumnSelected)
-                    ? m_viewer->getFrameNumberWithLetters(fid.getNumber())
-                    : QString::fromStdWString(levelName) + QString(" ") +
-                          m_viewer->getFrameNumberWithLetters(fid.getNumber()));
+                  ? m_viewer->getFrameNumberWithLetters(fid.getNumber())
+                  : QString::fromStdWString(levelName) + QString(" ") +
+                        m_viewer->getFrameNumberWithLetters(fid.getNumber()));
     else {
       QString frameNumber("");
       if (fid.getNumber() > 0) frameNumber = QString::number(fid.getNumber());
@@ -699,12 +698,10 @@ void RenameCellField::showInRowCol(int row, int col, bool multiColumnSelected) {
       }
       // other level types
       else {
-        setText((frameNumber.isEmpty())
-                    ? QString::fromStdWString(levelName)
-                    : (multiColumnSelected)
-                          ? frameNumber
-                          : QString::fromStdWString(levelName) + QString(" ") +
-                                frameNumber);
+        setText((frameNumber.isEmpty()) ? QString::fromStdWString(levelName)
+                : (multiColumnSelected) ? frameNumber
+                                        : QString::fromStdWString(levelName) +
+                                              QString(" ") + frameNumber);
       }
     }
     selectAll();
@@ -839,28 +836,6 @@ void RenameCellField::renameCell() {
   bool animationSheetEnabled =
       Preferences::instance()->isAnimationSheetEnabled();
 
-  /*bool levelDefined =
-      xsheet->getCell(m_row, m_col).getSimpleLevel() != 0 ||
-      m_row > 0 && xsheet->getCell(m_row - 1, m_col).getSimpleLevel() != 0;
-
-  if (animationSheetEnabled && levelDefined) {
-    TXshCell cell       = xsheet->getCell(m_row, m_col);
-    TXshSimpleLevel *sl = cell.getSimpleLevel();
-    if (sl) {
-      QRegExp fidRe("([0-9]+)([a-z]?)");
-      if (fidRe.exactMatch(s)) {
-#if QT_VERSION >= 0x050500
-        fid = TFrameId(fidRe.cap(1).toInt(),
-                       fidRe.cap(2) == "" ? 0 : fidRe.cap(2).toLatin1()[0]);
-#else
-        fid  = TFrameId(fidRe.cap(1).toInt(),
-                       fidRe.cap(2) == "" ? 0 : fidRe.cap(2).toAscii()[0]);
-#endif
-        FilmstripCmd::renumberDrawing(sl, cell.m_frameId, fid);
-      }
-    }
-    return;
-  }*/
   TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
       TApp::instance()->getCurrentSelection()->getSelection());
   if (!cellSelection) return;
@@ -1131,11 +1106,7 @@ void RenameCellField::onXsheetChanged() {
 // CellArea
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 CellArea::CellArea(XsheetViewer *parent, Qt::WindowFlags flags)
-#else
-CellArea::CellArea(XsheetViewer *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent, flags)
     , m_viewer(parent)
     , m_levelExtenderRect()
@@ -1190,24 +1161,23 @@ void CellArea::drawFrameSeparator(QPainter &p, int row, int col,
   TCellSelection *cellSelection = m_viewer->getCellSelection();
   bool isSelected               = cellSelection->isCellSelected(row, col);
 
-  QColor color = (isAfterMarkers || isAfterSecMarkers)
-                     ? (isSelected) ? m_viewer->getSelectedMarkerLineColor()
-                                    : (isAfterSecMarkers)
-                                          ? m_viewer->getSecMarkerLineColor()
-                                          : m_viewer->getMarkerLineColor()
-                     : m_viewer->getLightLineColor();
-  double lineWidth =
-      (isAfterSecMarkers) ? 3. : (secDistance > 0 && isAfterMarkers) ? 2. : 1.;
+  QColor color     = (isAfterMarkers || isAfterSecMarkers)
+                         ? (isSelected) ? m_viewer->getSelectedMarkerLineColor()
+                           : (isAfterSecMarkers) ? m_viewer->getSecMarkerLineColor()
+                                                 : m_viewer->getMarkerLineColor()
+                         : m_viewer->getLightLineColor();
+  double lineWidth = (isAfterSecMarkers)                   ? 3.
+                     : (secDistance > 0 && isAfterMarkers) ? 2.
+                                                           : 1.;
 
   int frameAxis = m_viewer->rowToFrameAxis(row);
   int handleSize =
-      (emptyFrame)
-          ? 0
-          : (o->isVerticalTimeline())
-                ? (isAfterMarkers || isAfterSecMarkers)
-                      ? 0
-                      : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).width()
-                : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).height();
+      (emptyFrame) ? 0
+      : (o->isVerticalTimeline())
+          ? (isAfterMarkers || isAfterSecMarkers)
+                ? 0
+                : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).width()
+          : o->rect(PredefinedRect::DRAG_HANDLE_CORNER).height();
 
   QLine horizontalLine = m_viewer->orientation()->horizontalLine(
       frameAxis, layerAxisRange.adjusted(handleSize - 1, 1));
@@ -1426,7 +1396,7 @@ void CellArea::drawSelectionBackground(QPainter &p) const {
     int newSelCol1 = std::min(selCol0, selCol1);
     selectionRect  = m_viewer->rangeToXYRect(
         CellRange(CellPosition(selRow0, newSelCol0),
-                  CellPosition(selRow1 + 1, newSelCol1 - 1)));
+                   CellPosition(selRow1 + 1, newSelCol1 - 1)));
   }
 
   p.fillRect(selectionRect, QBrush(m_viewer->getSelectedEmptyCellColor()));
@@ -1792,11 +1762,11 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
   QColor outlineColor = Qt::black;
   QPoint frameAdj     = m_viewer->getFrameZoomAdjustment();
   QRect dotRect       = (isCamera)
-                      ? m_viewer->orientation()
+                            ? m_viewer->orientation()
                             ->rect(PredefinedRect::CAMERA_FRAME_MARKER_AREA)
                             .translated(xy)
                             .translated(-frameAdj / 2)
-                      : m_viewer->orientation()
+                            : m_viewer->orientation()
                             ->rect(PredefinedRect::FRAME_MARKER_AREA)
                             .translated(xy)
                             .translated(-frameAdj / 2);
@@ -2052,9 +2022,9 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
   TXshChildLevel *cl = cell.getChildLevel();
   if (cl && cell.getFrameId().getNumber() - 1 >= cl->getFrameCount())
     isRed = true;
-  QColor penColor = isRed ? QColor(m_viewer->getErrorTextColor())
-                          : isSelected ? m_viewer->getSelectedTextColor()
-                                       : m_viewer->getTextColor();
+  QColor penColor = isRed        ? QColor(m_viewer->getErrorTextColor())
+                    : isSelected ? m_viewer->getSelectedTextColor()
+                                 : m_viewer->getTextColor();
   p.setPen(penColor);
 
   /*
@@ -2161,14 +2131,8 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     std::wstring levelName = cell.m_level->getName();
     QString text           = QString::fromStdWString(levelName);
     QFontMetrics fm(font);
-#if QT_VERSION >= 0x050500
-    //    QFontMetrics fm(font);
     QString elidaName =
         elideText(text, fm, nameRect.width() - fm.width(fnum), QString("~"));
-#else
-    QString elidaName =
-        elideText(text, font, nameRect.width() - fm.width(fnum));
-#endif
     p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
   }
 }
@@ -2352,11 +2316,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
   int charWidth = metric.width(text, 1);
   if ((charWidth * 2) > nameRect.width()) nameRect.adjust(-2, 0, 4, 0);
 
-#if QT_VERSION >= 0x050500
   QString elidaName = elideText(text, metric, nameRect.width(), "~");
-#else
-  QString elidaName = elideText(text, font, nameRect.width(), "~");
-#endif
 
   if (!sameLevel || prevCell.m_frameId != cell.m_frameId)
     p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
@@ -2856,14 +2816,9 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
       }
     }
 
-    QString text = QString::fromStdWString(levelName);
-#if QT_VERSION >= 0x050500
+    QString text      = QString::fromStdWString(levelName);
     QString elidaName = elideText(
         text, fm, nameRect.width() - fm.width(numberStr) - 2, QString("~"));
-#else
-    QString elidaName = elideText(
-        text, font, nameRect.width() - fm.width(numberStr) - 2, QString("~"));
-#endif
 
     if (!sameLevel || isAfterMarkers)
       p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -136,11 +136,7 @@ class CellArea final : public QWidget {
   void setDragTool(DragTool *dragTool);
 
 public:
-#if QT_VERSION >= 0x050500
-  CellArea(XsheetViewer *parent, Qt::WindowFlags flags = 0);
-#else
-  CellArea(XsheetViewer *parent, Qt::WFlags flags = 0);
-#endif
+  CellArea(XsheetViewer *parent, Qt::WindowFlags flags = Qt::WindowFlags());
   ~CellArea();
 
   void mouseMoveEvent(QMouseEvent *event) override;

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -232,11 +232,7 @@ static void getVolumeCursorRect(QRect &out, double volume,
 // MotionPathMenu
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 MotionPathMenu::MotionPathMenu(QWidget *parent, Qt::WindowFlags flags)
-#else
-MotionPathMenu::MotionPathMenu(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent, flags)
     , m_mDeleteRect(QRect(0, 0, ColumnWidth - 13, RowHeight))
     , m_mNormalRect(QRect(0, RowHeight, ColumnWidth - 13, RowHeight))
@@ -1257,8 +1253,7 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   p.setPen(m_viewer->getVerticalLineColor());
   if (o->flag(PredefinedFlag::PEGBAR_NAME_BORDER)) p.drawRect(pegbarnamerect);
 
-  if (column->getSoundColumn() || column->getSoundTextColumn())
-    return;
+  if (column->getSoundColumn() || column->getSoundTextColumn()) return;
 
   if (Preferences::instance()->isParentColorsInXsheetColumnEnabled() &&
       column->isPreviewVisible()) {
@@ -1419,11 +1414,7 @@ void ColumnArea::DrawHeader::drawVolumeControl(double volume) const {
 //=============================================================================
 // ColumnArea
 //-----------------------------------------------------------------------------
-#if QT_VERSION >= 0x050500
 ColumnArea::ColumnArea(XsheetViewer *parent, Qt::WindowFlags flags)
-#else
-ColumnArea::ColumnArea(XsheetViewer *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent, flags)
     , m_viewer(parent)
     , m_pos(-1, -1)
@@ -2002,11 +1993,11 @@ m_value->setFont(font);*/
   bool ret = connect(m_slider, SIGNAL(sliderReleased()), this,
                      SLOT(onSliderReleased()));
   ret      = ret && connect(m_slider, SIGNAL(sliderMoved(int)), this,
-                       SLOT(onSliderChange(int)));
+                            SLOT(onSliderChange(int)));
   ret      = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
-                       SLOT(onSliderValueChanged(int)));
+                            SLOT(onSliderValueChanged(int)));
   ret      = ret && connect(m_value, SIGNAL(textChanged(const QString &)), this,
-                       SLOT(onValueChanged(const QString &)));
+                            SLOT(onValueChanged(const QString &)));
 
   ret = ret && connect(m_filterColorCombo, SIGNAL(activated(int)), this,
                        SLOT(onFilterColorChanged(int)));
@@ -2136,11 +2127,11 @@ SoundColumnPopup::SoundColumnPopup(QWidget *parent)
   bool ret = connect(m_slider, SIGNAL(sliderReleased()), this,
                      SLOT(onSliderReleased()));
   ret      = ret && connect(m_slider, SIGNAL(sliderMoved(int)), this,
-                       SLOT(onSliderChange(int)));
+                            SLOT(onSliderChange(int)));
   ret      = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
-                       SLOT(onSliderValueChanged(int)));
+                            SLOT(onSliderValueChanged(int)));
   ret      = ret && connect(m_value, SIGNAL(textChanged(const QString &)), this,
-                       SLOT(onValueChanged(const QString &)));
+                            SLOT(onValueChanged(const QString &)));
   assert(ret);
 }
 

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -50,12 +50,7 @@ class MotionPathMenu final : public QWidget {
   QPoint m_pos;
 
 public:
-#if QT_VERSION >= 0x050500
   MotionPathMenu(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  MotionPathMenu(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
-
   ~MotionPathMenu();
 
 protected:
@@ -353,11 +348,7 @@ class ColumnArea final : public QWidget {
   };
 
 public:
-#if QT_VERSION >= 0x050500
-  ColumnArea(XsheetViewer *parent, Qt::WindowFlags flags = 0);
-#else
-  ColumnArea(XsheetViewer *parent, Qt::WFlags flags = 0);
-#endif
+  ColumnArea(XsheetViewer *parent, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ColumnArea();
 
   void onControlPressed(bool pressed);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -210,11 +210,7 @@ void XsheetViewer::getButton(const int &btype, QColor &bgColor,
 
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 XsheetViewer::XsheetViewer(QWidget *parent, Qt::WindowFlags flags)
-#else
-XsheetViewer::XsheetViewer(QWidget *parent, Qt::WFlags flags)
-#endif
     : QFrame(parent)
     , m_timerId(0)
     , m_autoPanSpeed(0, 0)
@@ -234,7 +230,6 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WFlags flags)
     , m_orientation(nullptr)
     , m_xsheetLayout("Classic")
     , m_frameZoomFactor(100) {
-
   m_xsheetLayout = Preferences::instance()->getLoadedXsheetLayout();
 
   setFocusPolicy(Qt::StrongFocus);
@@ -693,7 +688,7 @@ bool XsheetViewer::refreshContentSize(int dx, int dy) {
   QSize viewportSize = m_cellScrollArea->viewport()->size();
   QPoint offset      = m_cellArea->pos();
   offset             = QPoint(std::min(0, offset.x() - dx),
-                  std::min(0, offset.y() - dy));  // what?
+                              std::min(0, offset.y() - dy));  // what?
 
   TXsheet *xsh    = getXsheet();
   int frameCount  = xsh ? xsh->getFrameCount() : 0;
@@ -1428,7 +1423,7 @@ void XsheetViewer::onCurrentFrameSwitched() {
   m_isCurrentFrameSwitched = false;
   scrollToRow(row);
 
-  TXsheet *xsh = getXsheet();
+  TXsheet *xsh            = getXsheet();
   NavigationTags *navTags = xsh->getNavigationTags();
   int lastTag             = navTags->getPrevTag(INT_MAX);
   int firstTag            = navTags->getNextTag(-1);

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -163,11 +163,7 @@ class XsheetScrollArea final : public QScrollArea {
   Q_OBJECT
 
 public:
-#if QT_VERSION >= 0x050500
   XsheetScrollArea(QWidget *parent = 0, Qt::WindowFlags flags = 0)
-#else
-  XsheetScrollArea(QWidget *parent = 0, Qt::WFlags flags = 0)
-#endif
       : QScrollArea(parent) {
     setObjectName("xsheetScrollArea");
     setFrameStyle(QFrame::StyledPanel);
@@ -639,11 +635,7 @@ private:
   }
 
 public:
-#if QT_VERSION >= 0x050500
   XsheetViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  XsheetViewer(QWidget *parent = 0, Qt::WFlags flags = 0);
-#endif
   ~XsheetViewer();
 
   TColumnSelection *getColumnSelection() const { return m_columnSelection; }

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -448,11 +448,7 @@ void NoteWidget::paintEvent(QPaintEvent *event) {
 // NoteArea
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 NoteArea::NoteArea(XsheetViewer *parent, Qt::WindowFlags flags)
-#else
-NoteArea::NoteArea(XsheetViewer *parent, Qt::WFlags flags)
-#endif
     : QFrame(parent)
     , m_viewer(parent)
     , m_flipOrientationButton(nullptr)
@@ -464,7 +460,6 @@ NoteArea::NoteArea(XsheetViewer *parent, Qt::WFlags flags)
     , m_hamburgerButton(nullptr)
     , m_popup(nullptr)
     , m_currentLayout(nullptr) {
-
   setFrameStyle(QFrame::StyledPanel);
   setObjectName("cornerWidget");
 
@@ -514,7 +509,7 @@ NoteArea::NoteArea(XsheetViewer *parent, Qt::WFlags flags)
   // signal-slot connections
   bool ret = true;
   ret      = ret && connect(m_flipOrientationButton, SIGNAL(clicked()),
-                       SLOT(flipOrientation()));
+                            SLOT(flipOrientation()));
 
   ret = ret && connect(m_noteButton, SIGNAL(clicked()), SLOT(toggleNewNote()));
   ret = ret &&

--- a/toonz/sources/toonz/xshnoteviewer.h
+++ b/toonz/sources/toonz/xshnoteviewer.h
@@ -135,11 +135,7 @@ class NoteArea final : public QFrame {
   QLayout *m_currentLayout;
 
 public:
-#if QT_VERSION >= 0x050500
   NoteArea(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0);
-#else
-  NoteArea(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
-#endif
 
   void updatePopup() { m_newNotePopup->update(); }
   void updateButtons();

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -43,11 +43,7 @@ namespace XsheetGUI {
 // RowArea
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 RowArea::RowArea(XsheetViewer *parent, Qt::WindowFlags flags)
-#else
-RowArea::RowArea(XsheetViewer *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent, flags)
     , m_viewer(parent)
     , m_row(-1)
@@ -147,13 +143,12 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
     bool isAfterSecMarkers =
         secDistance > 0 && ((r - offset) % secDistance) == 0 && r != 0;
 
-    QColor color = (isAfterSecMarkers)
-                       ? m_viewer->getSecMarkerLineColor()
-                       : (isAfterMarkers) ? m_viewer->getMarkerLineColor()
-                                          : m_viewer->getLightLineColor();
-    double lineWidth = (isAfterSecMarkers)
-                           ? 3.
-                           : (secDistance > 0 && isAfterMarkers) ? 2. : 1.;
+    QColor color     = (isAfterSecMarkers) ? m_viewer->getSecMarkerLineColor()
+                       : (isAfterMarkers)  ? m_viewer->getMarkerLineColor()
+                                           : m_viewer->getLightLineColor();
+    double lineWidth = (isAfterSecMarkers)                   ? 3.
+                       : (secDistance > 0 && isAfterMarkers) ? 2.
+                                                             : 1.;
 
     p.setPen(QPen(color, lineWidth, Qt::SolidLine, Qt::FlatCap));
     // p.setPen(color);
@@ -774,8 +769,8 @@ void RowArea::drawShiftTraceMarker(QPainter &p) {
 
   QPoint frameAdj = m_viewer->getFrameZoomAdjustment();
   int frameAdj_i  = (m_viewer->orientation()->isVerticalTimeline())
-                       ? frameAdj.y()
-                       : frameAdj.x();
+                        ? frameAdj.y()
+                        : frameAdj.x();
 
   // get onion colors
   TPixel frontPixel, backPixel;
@@ -1315,7 +1310,7 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
   else if (o->rect(PredefinedRect::NAVIGATION_TAG_AREA)
                .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
                .contains(mouseInCell)) {
-    TXsheet *xsh = m_viewer->getXsheet();
+    TXsheet *xsh  = m_viewer->getXsheet();
     QString label = xsh->getNavigationTags()->getTagLabel(m_row);
     if (label.isEmpty()) label = "-";
     if (xsh->isFrameTagged(m_row)) m_tooltip = tr("Tag: %1").arg(label);

--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -73,11 +73,7 @@ class RowArea final : public QWidget {
   int getNonEmptyCell(int row, int column, Direction);
 
 public:
-#if QT_VERSION >= 0x050500
-  RowArea(XsheetViewer *parent, Qt::WindowFlags flags = 0);
-#else
-  RowArea(XsheetViewer *parent, Qt::WFlags flags = 0);
-#endif
+  RowArea(XsheetViewer *parent, Qt::WindowFlags flags = Qt::WindowFlags());
   ~RowArea();
 
 protected:

--- a/toonz/sources/toonz/xshtoolbar.cpp
+++ b/toonz/sources/toonz/xshtoolbar.cpp
@@ -23,12 +23,8 @@ namespace XsheetGUI {
 // Toolbar
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WindowFlags flags,
                              bool isCollapsible)
-#else
-XSheetToolbar::XSheetToolbar(XsheetViewer *parent, Qt::WFlags flags)
-#endif
     : CommandBar(parent, flags, isCollapsible, true), m_viewer(parent) {
   setObjectName("cornerWidget");
   setFixedHeight(29);

--- a/toonz/sources/toonz/xshtoolbar.h
+++ b/toonz/sources/toonz/xshtoolbar.h
@@ -31,12 +31,8 @@ class XSheetToolbar final : public CommandBar {
   XsheetViewer *m_viewer;
 
 public:
-#if QT_VERSION >= 0x050500
   XSheetToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0,
                 bool isCollapsible = false);
-#else
-  XSheetToolbar(XsheetViewer *parent = 0, Qt::WFlags flags = 0);
-#endif
   static void toggleXSheetToolbar();
   void showToolbar(bool show);
 
@@ -48,6 +44,6 @@ protected slots:
   void doCustomizeCommandBar();
 };
 
-}  // namespace XsheetGUI;
+}  // namespace XsheetGUI
 
 #endif  // XSHTOOLBAR_H

--- a/toonz/sources/toonzfarm/tfarm/ttcpipclient.cpp
+++ b/toonz/sources/toonzfarm/tfarm/ttcpipclient.cpp
@@ -43,17 +43,13 @@ TTcpIpClient::~TTcpIpClient() {
 
 int TTcpIpClient::connect(const QString &hostName, const QString &addrStr,
                           int port, int &sock) {
-/*
-  if (!addrStr.empty())
-  {
-    unsigned long ipAddr = inet_addr(addrStr.c_str());
-  }
-*/
-#if QT_VERSION >= 0x050500
+  /*
+    if (!addrStr.empty())
+    {
+      unsigned long ipAddr = inet_addr(addrStr.c_str());
+    }
+  */
   struct hostent *he = gethostbyname(hostName.toUtf8());
-#else
-  struct hostent *he = gethostbyname(hostName.toAscii());
-#endif
   if (!he) {
 #ifdef _WIN32
     int err = WSAGetLastError();
@@ -309,7 +305,7 @@ int readData(int sock, string &data)
 
 #endif
 
-//#define PRIMA
+// #define PRIMA
 
 #ifdef PRIMA
 
@@ -353,7 +349,7 @@ int readData(int sock, string &data) {
 
 int TTcpIpClient::send(int sock, const QString &data, QString &reply) {
   if (data.size() > 0) {
-    int ret           = send(sock, data);
+    int ret = send(sock, data);
     if (ret == 0) ret = readData(sock, reply);
     return ret;
   }

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -31,7 +31,7 @@ using namespace TVER;
 #include <unistd.h>
 #endif
 
-//#define REDIRECT_OUTPUT
+// #define REDIRECT_OUTPUT
 
 #ifdef _WIN32
 #define QUOTE_STR "\""
@@ -67,8 +67,8 @@ TFilePath getGlobalRoot() {
 // Leggo la localRoot da File txt
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
-  std::string unixpath = "./" + tver.getAppName() +
-                         ".app/Contents/Resources/configfarmroot.txt";
+  std::string unixpath =
+      "./" + tver.getAppName() + ".app/Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
   std::string unixpath = "/etc/" + tver.getAppName() + "/opentoonz.conf";
@@ -111,12 +111,13 @@ TFilePath getLocalRoot() {
 #else
 #ifdef MACOSX
   // If MACOSX, change to MACOSX path
-  std::string unixpath = "./" + tver.getAppName() + 
-                         ".app/Contents/Resources/configfarmroot.txt";
+  std::string unixpath =
+      "./" + tver.getAppName() + ".app/Contents/Resources/configfarmroot.txt";
 #else
   // set path to something suitable for most linux (Unix?) systems
 #ifdef FREEBSD
-  std::string unixpath = "/usr/local/etc/" + tver.getAppName() + "/opentoonz.conf";
+  std::string unixpath =
+      "/usr/local/etc/" + tver.getAppName() + "/opentoonz.conf";
 #else
   std::string unixpath = "/etc/" + tver.getAppName() + "/opentoonz.conf";
 #endif
@@ -460,9 +461,30 @@ void Task::run() {
   // cout << exename << endl;
   // cout << cmdline << endl;
 
-  QProcess process;
+  // parse command line
+  QString prgName;
+  QString argsStr = "";
+  int sepPos      = cmdline.indexOf(" ");
 
-  process.start(cmdline);
+  if (sepPos == -1) {
+    prgName = cmdline;
+  } else {
+    prgName = cmdline.left(sepPos);
+    argsStr = cmdline.right(cmdline.size() - sepPos - 1);
+  }
+
+  QProcess process;
+  process.setProgram(prgName);
+#if defined(_WIN32)
+  process.setNativeArguments(argsStr);
+#else
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  process.setArguments(argsStr.split(" ", Qt::SkipEmptyParts));
+#else
+  process.setArguments(argsStr.split(" ", QString::SkipEmptyParts));
+#endif
+#endif
+  process.start();
   process.waitForFinished(-1);
 
   int exitCode  = process.exitCode();
@@ -612,13 +634,9 @@ int FarmServer::addTask(const QString &id, const QString &cmdline) {
 
 int FarmServer::terminateTask(const QString &taskid) {
 #ifdef _WIN32
-  HANDLE hJob = OpenJobObject(MAXIMUM_ALLOWED,  // access right
-                              TRUE,             // inheritance state
-#if QT_VERSION >= 0x050500
+  HANDLE hJob = OpenJobObject(MAXIMUM_ALLOWED,   // access right
+                              TRUE,              // inheritance state
                               taskid.toUtf8());  // job name
-#else
-                              taskid.toAscii());              // job name
-#endif
 
   if (hJob != NULL) {
     BOOL res = TerminateJobObject(hJob,  // handle to job
@@ -661,7 +679,7 @@ void FarmServer::queryHwInfo(HwInfo &hwInfo) {
 #ifdef __sgi
   hwInfo.m_type         = Irix;
 #else
-  hwInfo.m_type         = Linux;
+  hwInfo.m_type = Linux;
 #endif
 #endif
 }
@@ -705,7 +723,7 @@ std::string getLine(std::istream &is) {
           out.append(1, c);
         } else {
           break;
-	}
+        }
       } else {
         break;
       }
@@ -746,12 +764,7 @@ static bool loadServerData(const QString &hostname, QString &addr, int &port) {
 
     iss >> name >> ipAddress >> port;
     if (name[0] == '#') continue;
-#if QT_VERSION >= 0x050500
-    if (STRICMP(hostname.toUtf8(), name.c_str()) == 0)
-#else
-    if (STRICMP(hostname.toAscii(), name.c_str()) == 0)
-#endif
-    {
+    if (STRICMP(hostname.toUtf8(), name.c_str()) == 0) {
       addr = QString(ipAddress.c_str());
       return true;
     }
@@ -1033,11 +1046,7 @@ void FarmServerService::mountDisks() {
     DWORD res =
         WNetAddConnection2(&NetResource,  // connection details
                            0,             // password
-#if QT_VERSION >= 0x050500
                            TSystem::getUserName().toUtf8(),  // user name
-#else
-                           TSystem::getUserName().toAscii(),  // user name
-#endif
                            0);  // connection options
 
     if (res == NO_ERROR) m_disksMounted.push_back(drive);

--- a/toonz/sources/toonzlib/Naa2TlvConverter.cpp
+++ b/toonz/sources/toonzlib/Naa2TlvConverter.cpp
@@ -8,7 +8,7 @@
 #include "tpalette.h"
 
 #include <QSet>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QDebug>
 #include <QMultiMap>
 
@@ -130,7 +130,7 @@ void Naa2TlvConverter::setSourceImage(const TRaster32P &srcRas) {
     TPixel32 *srcScanLine          = srcRas->pixels(y);
     unsigned short *regionScanLine = m_regionRas->pixels(y);
     for (int x = 0; x < lx; x++) {
-      TPixel32 srcPix = overPixOnWhite(srcScanLine[x]);
+      TPixel32 srcPix                       = overPixOnWhite(srcScanLine[x]);
       QMap<TPixel32, int>::ConstIterator it = colorTable.find(srcPix);
       if (it == colorTable.end()) {
         // found new color (and therefore new region)
@@ -357,7 +357,7 @@ void Naa2TlvConverter::findBackgroundRegions() {
   }
 
   for (int i = 0; i < m_regions.count(); i++) {
-    RegionInfo &region                                 = m_regions[i];
+    RegionInfo &region = m_regions[i];
     if (region.colorIndex == bgColorIndex) region.type = RegionInfo::Background;
   }
 }
@@ -407,8 +407,10 @@ void Naa2TlvConverter::findRegionBorders() {
 // pixels belonging to that region with m_border[pix] == k)
 
 void Naa2TlvConverter::erodeRegions() {
-  QTime clock;
+#ifdef _DEBUG
+  QElapsedTimer clock;
   clock.start();
+#endif
   if (!m_regionRas || !m_borderRas) return;
   int lx = m_regionRas->getLx();
   int ly = m_regionRas->getLy();
@@ -461,7 +463,9 @@ void Naa2TlvConverter::erodeRegions() {
       }
     }
   }
+#ifdef _DEBUG
   qDebug() << "Erode regions. time = " << clock.elapsed();
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -630,8 +634,7 @@ void Naa2TlvConverter::findThinPaints() {
     if (inkBoundary * 100 > region.perimeter * 80) regions.append(i);
   }
 
-  for (int c : regions)
-    m_regions[c].type = RegionInfo::SmallPaint;
+  for (int c : regions) m_regions[c].type = RegionInfo::SmallPaint;
 }
 
 //-----------------------------------------------------------------------------
@@ -683,7 +686,8 @@ void Naa2TlvConverter::findSuspectInks() {
       int lx = region.x1 - region.x0 + 1;
       int ly = region.y1 - region.y0 + 1;
       int d  = std::max(lx, ly);
-      if (std::min(lx, ly) * 2 > std::max(lx, ly) && region.pixelCount > d * d / 2) {
+      if (std::min(lx, ly) * 2 > std::max(lx, ly) &&
+          region.pixelCount > d * d / 2) {
         region.type = RegionInfo::Paint;
       }
     }
@@ -695,8 +699,8 @@ void Naa2TlvConverter::findSuspectInks() {
         if (region.boundaries.count() == 2)
           isInk = true;
         else if (region.boundaries.count() == 3) {
-          int b1                 = region.boundaries.at(1);
-          int b2                 = region.boundaries.at(2);
+          int b1 = region.boundaries.at(1);
+          int b2 = region.boundaries.at(2);
           if (b1 * 2 < b2) isInk = true;
         }
       }
@@ -806,8 +810,10 @@ void Naa2TlvConverter::addBorderInks()  // add synthetic inks: lines between two
 //-----------------------------------------------------------------------------
 
 void Naa2TlvConverter::measureThickness() {
-  QTime timer;
+#ifdef _DEBUG
+  QElapsedTimer timer;
   timer.start();
+#endif
   if (!m_regionRas || !m_borderRas) return;
   unsigned short *regionBuffer = m_regionRas->pixels();
   unsigned char *borderBuffer  = m_borderRas->pixels();
@@ -862,7 +868,9 @@ void Naa2TlvConverter::measureThickness() {
       region.thickness = thickness;
     }
   }
+#ifdef _DEBUG
   qDebug() << "measure thickness. time=" << timer.elapsed();
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -893,9 +901,8 @@ int Naa2TlvConverter::measureThickness(int x0, int y0) {
 
   // a is a direction index; a : inside; a+1 : outside
   int a = 0;
-  while (a < 8 &&
-         !(regionBuffer[k0 + dd[a]] == regionId &&
-           regionBuffer[k0 + dd[(a + 1) % 8]] != regionId))
+  while (a < 8 && !(regionBuffer[k0 + dd[a]] == regionId &&
+                    regionBuffer[k0 + dd[(a + 1) % 8]] != regionId))
     a++;
   if (a == 8) {
     // k0 is an isolated point or (strange!) an intern point
@@ -904,7 +911,7 @@ int Naa2TlvConverter::measureThickness(int x0, int y0) {
   }
   int ka = k0 + dd[a];
 
-  int b                                          = (a + 2) % 8;
+  int b = (a + 2) % 8;
   while (regionBuffer[k0 + dd[b]] != regionId) b = (b + 1) % 8;
   // a..b = boundaries
   int kb = k0 + dd[b];
@@ -941,9 +948,9 @@ int Naa2TlvConverter::measureThickness(int x0, int y0) {
       break;  // just to be sure
     int d2 = (x - x0) * (x - x0) + (y - y0) * (y - y0);
     if (d2 <= lastd2) break;
-    lastd2                                          = d2;
-    int d1                                          = (d + 4) % 8;
-    d1                                              = (d1 + 1) % 8;
+    lastd2 = d2;
+    int d1 = (d + 4) % 8;
+    d1     = (d1 + 1) % 8;
     while (regionBuffer[k + dd[d1]] != regionId) d1 = (d1 + 1) % 8;
     Q_ASSERT(regionBuffer[k + dd[d1]] == regionId);
     oldk         = k;
@@ -967,9 +974,9 @@ int Naa2TlvConverter::measureThickness(int x0, int y0) {
       break;  // just to be sure
     int d2 = (x - x0) * (x - x0) + (y - y0) * (y - y0);
     if (d2 <= lastd2) break;
-    lastd2                                          = d2;
-    int d1                                          = (d + 4) % 8;
-    d1                                              = (d1 + 7) % 8;
+    lastd2 = d2;
+    int d1 = (d + 4) % 8;
+    d1     = (d1 + 7) % 8;
     while (regionBuffer[k + dd[d1]] != regionId) d1 = (d1 + 7) % 8;
     Q_ASSERT(regionBuffer[k + dd[d1]] == regionId);
     oldk         = k;
@@ -1015,9 +1022,9 @@ TToonzImageP Naa2TlvConverter::makeTlv(bool transparentSyntheticInks,
                                        QList<int> &usedStyleIds, double dpi) {
   if (!m_valid || m_colors.empty() || m_regions.empty() || !m_regionRas)
     return TToonzImageP();
-  int lx                = m_regionRas->getLx();
-  int ly                = m_regionRas->getLy();
-  TPalette *palette     = m_palette;
+  int lx            = m_regionRas->getLx();
+  int ly            = m_regionRas->getLy();
+  TPalette *palette = m_palette;
   if (!palette) palette = new TPalette();
 
   TRasterCM32P ras(lx, ly);
@@ -1145,7 +1152,7 @@ TVectorImageP Naa2TlvConverter::vectorize(const TToonzImageP &ti) {
   TPointD center = ti->getRaster()->getCenterD();
 
   if (dpix != 0.0 && dpiy != 0.0) dpiAff = TScale(factor / dpix, factor / dpiy);
-  factor                                 = norm(dpiAff * TPointD(1, 0));
+  factor = norm(dpiAff * TPointD(1, 0));
 
   conf.m_affine         = dpiAff * TTranslation(-center);
   conf.m_thickScale     = factor;

--- a/toonz/sources/toonzlib/boardsettings.cpp
+++ b/toonz/sources/toonzlib/boardsettings.cpp
@@ -13,6 +13,7 @@
 #include <QDateTime>
 #include <QFontMetricsF>
 #include <QMap>
+#include <QLocale>
 
 namespace {
 QMap<BoardItem::Type, std::wstring> strs = {
@@ -91,10 +92,10 @@ QString BoardItem::getContentText(ToonzScene *scene) {
            QString::number(ff).rightJustified(2, '0');
   } break;
   case CurrentDate:
-    return QDate::currentDate().toString(Qt::DefaultLocaleLongDate);
+    return QLocale::system().toString(QDate::currentDate());
     break;
   case CurrentDateTime:
-    return QDateTime::currentDateTime().toString(Qt::DefaultLocaleLongDate);
+    return QLocale::system().toString(QDateTime::currentDateTime());
     break;
   case UserName:
     return TSystem::getUserName();
@@ -332,7 +333,11 @@ void BoardSettings::removeItem(int index) {
   m_items.removeAt(index);
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+void BoardSettings::swapItems(int i, int j) { m_items.swapItemsAt(i, j); }
+#else
 void BoardSettings::swapItems(int i, int j) { m_items.swap(i, j); }
+#endif
 
 void BoardSettings::saveData(TOStream &os, bool forPreset) {
   if (!forPreset) os.child("active") << (int)((m_active) ? 1 : 0);

--- a/toonz/sources/toonzlib/convert2tlv.cpp
+++ b/toonz/sources/toonzlib/convert2tlv.cpp
@@ -563,7 +563,7 @@ TPalette *Convert2Tlv::buildPalette() {
       stylesToBeAddedToPage.push_back(it->second);
   }
 
-  /*- インデックス順にページに格納する -*/
+  /*- Store on page in index order -*/
   if (!stylesToBeAddedToPage.isEmpty()) {
     std::sort(stylesToBeAddedToPage.begin(), stylesToBeAddedToPage.end());
     for (int s = 0; s < stylesToBeAddedToPage.size(); s++)
@@ -628,7 +628,7 @@ TPalette *Convert2Tlv::buildPalette() {
       int addedId =
           m_palette->addStyle(srcPage->getStyle(srcIndexInPage)->clone());
       dstPage->addStyle(addedId);
-      /*-- StudioPalette由来のDefaultPaletteの場合、GrobalNameを消去する --*/
+      /*--  For StudioPalette-derived DefaultPalettes, clear the GrobalName --*/
       m_palette->getStyle(addedId)->setGlobalName(L"");
       m_palette->getStyle(addedId)->setOriginalName(L"");
     }

--- a/toonz/sources/toonzlib/doubleparamcmd.cpp
+++ b/toonz/sources/toonzlib/doubleparamcmd.cpp
@@ -120,7 +120,7 @@ void KeyframeSetter::selectKeyframe(int kIndex) {
 
 // set key frame at frame and returns its index
 int KeyframeSetter::createKeyframe(double frame) {
-  /*--- すでにそこにキーフレームがある場合はそのIndexを返すだけ ---*/
+  /*--- If there is already a keyframe there, just return its Index ---*/
   int kIndex = m_param->getClosestKeyframe(frame);
   if (kIndex >= 0 && m_param->getKeyframe(kIndex).m_frame == frame) {
     selectKeyframe(kIndex);
@@ -161,7 +161,8 @@ int KeyframeSetter::createKeyframe(double frame) {
       m_keyframe.m_step = ka.m_step;  // An existing segment step should prevail
                                       // over the preference
 
-      /*---Segment内にKeyを打った場合は、Step値も元のSegmentの値を引き継ぐようにする---*/
+      /*---When a Key is entered in a Segment, the Step value should also
+       * inherit the value of the original Segment.---*/
       m_param->setKeyframe(m_kIndex, m_keyframe);
 
       if (segmentType == TDoubleKeyframe::SpeedInOut ||
@@ -765,7 +766,7 @@ void KeyframeSetter::setAllParams(
     break;
   }
 
-  /*--- リンクされたカーブの処理 ---*/
+  /*--- Processing Linked Curves ---*/
   const double eps = 0.00001;
   if (m_kIndex != 0 && keyframe.m_linkedHandles &&
       keyframe.m_prevType == TDoubleKeyframe::SpeedInOut) {

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -135,7 +135,7 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
     oldtone = tone;
   }
   if (tone == 0) {
-    tmp_limit                    = pix - 10;
+    tmp_limit = pix - 10;
     if (limit < tmp_limit) limit = tmp_limit;
     for (; pix >= limit; pix--) {
       if (pix->getPaint() == paint) break;
@@ -210,7 +210,7 @@ void findSegment(const TRaster32P &r, const TPoint &p, int &xa, int &xb,
     oldmatte = matte;
   }
   if (matte == 0) {
-    tmp_limit                    = pix - 10;
+    tmp_limit = pix - 10;
     if (limit < tmp_limit) limit = tmp_limit;
     for (; pix >= limit; pix--) {
       if (*pix == color) break;
@@ -362,7 +362,7 @@ bool floodCheck(const TPixel32 &clickColor, const TPixel32 *targetPix,
 //-----------------------------------------------------------------------------
 }  // namespace
 //-----------------------------------------------------------------------------
-/*-- 戻り値はsaveBoxが更新されたかどうか --*/
+/*-- The return value is whether the saveBox has been updated or not. --*/
 bool fill(const TRasterCM32P &r, const FillParameters &params,
           TTileSaverCM32 *saver) {
   TPixelCM32 *pix, *limit, *pix0, *oldpix;
@@ -375,15 +375,16 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
   int fillDepth =
       params.m_shiftFill ? params.m_maxFillDepth : params.m_minFillDepth;
 
-  /*-- getBoundsは画像全面 --*/
+  /*-- getBounds returns the entire image --*/
   TRect bbbox = r->getBounds();
 
-  /*- 画面外のクリックの場合はreturn -*/
+  /*- Return if clicked outside the screen -*/
   if (!bbbox.contains(p)) return false;
-  /*- 既に同じ色が塗られている場合はreturn -*/
+  /*- If the same color has already been painted, return -*/
   int paintAtClickedPos = (r->pixels(p.y) + p.x)->getPaint();
   if (paintAtClickedPos == paint) return false;
-  /*- 「透明部分だけを塗る」オプションが有効で、既に色が付いている場合はreturn
+  /*- If the "paint only transparent areas" option is enabled and the area is
+   * already colored, return
    * -*/
   if (params.m_emptyOnly && (r->pixels(p.y) + p.x)->getPaint() != 0)
     return false;
@@ -400,7 +401,8 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
   default:
     assert(false);
   }
-  /*-- 四隅の色を見て、一つでも変わったらsaveBoxを更新する --*/
+  /*--Look at the colors in the four corners and update the saveBox if any of
+   * the colors change. --*/
   TPixelCM32 borderIndex[4];
   TPixelCM32 *borderPix[4];
   pix            = r->pixels(0);
@@ -591,7 +593,7 @@ void fill(const TRaster32P &ras, const TRaster32P &ref,
     for (int i = 0; i < (int)segmentVector.size(); i++) {
       std::pair<int, int> segment = segmentVector[i];
       if (segment.second >= segment.first) {
-        pix             = line + segment.first;
+        pix = line + segment.first;
         if (ref) refPix = refLine + segment.first;
         int n;
         for (n = 0; n < segment.second - segment.first + 1; n++, pix++) {
@@ -778,8 +780,8 @@ void fullColorFill(const TRaster32P &ras, const FillParameters &params,
 
   std::map<int, std::vector<std::pair<int, int>>>::iterator it;
   for (it = segments.begin(); it != segments.end(); it++) {
-    TPixel32 *line    = ras->pixels(it->first);
-    TPixel32 *refLine = 0;
+    TPixel32 *line                                 = ras->pixels(it->first);
+    TPixel32 *refLine                              = 0;
     std::vector<std::pair<int, int>> segmentVector = it->second;
     for (int i = 0; i < (int)segmentVector.size(); i++) {
       std::pair<int, int> segment = segmentVector[i];

--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -161,7 +161,7 @@ void fillautoInks(TRasterCM32P &rin, TRect &rect, const TRasterCM32P &rbefore,
 bool AreaFiller::rectFill(const TRect &rect, int color, bool onlyUnfilled,
                           bool fillPaints, bool fillInks) {
   // Viene trattato il caso fillInks
-  /*- FillInkのみの場合 -*/
+  /*- In case of FillInk only -*/
   if (!fillPaints) {
     assert(fillInks);
     assert(m_ras->getBounds().contains(rect));
@@ -182,7 +182,7 @@ bool AreaFiller::rectFill(const TRect &rect, int color, bool onlyUnfilled,
   std::vector<int> frameSeed(2 * (r.getLx() + r.getLy() - 2));
 
   int x, y, count1, count2;
-  /*- ptrをRect範囲のスタート地点に移動 -*/
+  /*- Move ptr to the start of the Rectangular range -*/
   Pixel *ptr = m_pixels + r.y0 * m_wrap + r.x0;
   count1     = 0;
   count2     = r.y1 - r.y0 + 1;
@@ -195,7 +195,7 @@ bool AreaFiller::rectFill(const TRect &rect, int color, bool onlyUnfilled,
   // Viene riempito frameSeed con tutti i paint delle varie aree del rettangolo
   // di contorno.
   // Viene verificato se i pixels del rettangolo sono tutti pure paint.
-  /*- 輪郭のPaintのIDをframeseed内に格納 -*/
+  /*- Store the Paint ID of the contour in the frameseed -*/
   for (y = r.y0; y <= r.y1; y++, ptr += m_wrap, count1++, count2++) {
     if (r.x0 > 0) frameSeed[count1] = ptr->getPaint();
     if (r.x1 < m_ras->getLx() - 1) frameSeed[count2] = (ptr + dx)->getPaint();
@@ -430,7 +430,7 @@ public:
 
     pix = m_buf + p.y * m_wrap + p.x;
 
-    /*-- 同じインクの場合はreturn --*/
+    /*-- If the same ink is used, RETURN --*/
     if (pix->getInk() == ink) return false;
 
     if (!ConnectionTable[neighboursCode(pix, p)]) {

--- a/toonz/sources/toonzlib/ikjacobian.cpp
+++ b/toonz/sources/toonzlib/ikjacobian.cpp
@@ -844,9 +844,9 @@ void MatrixRmn::ConvertBidiagToDiagonal(MatrixRmn &U, MatrixRmn &V, VectorRn &w,
     // This gives a lambda value which will shift the Givens rotations
     // Last four entries of M^T * M are  ( ( A, B ), ( B, C ) ).
     double A;
-    A = (firstBidiagIdx < lastBidiagIdx - 1)
-            ? Square(superDiag[lastBidiagIdx - 2])
-            : 0.0;
+    A          = (firstBidiagIdx < lastBidiagIdx - 1)
+                     ? Square(superDiag[lastBidiagIdx - 2])
+                     : 0.0;
     double BSq = Square(w[lastBidiagIdx - 1]);
     A += BSq;  // The "A" entry of M^T * M
     double C = Square(superDiag[lastBidiagIdx - 1]);
@@ -1106,9 +1106,9 @@ void Jacobian::Reset() {
   // Usato nel Damped Least Squares Method
   DampingLambda   = DefaultDampingLambda;
   DampingLambdaSq = Square(DampingLambda);
-  for (int i            = 0; i < DampingLambdaSqV.GetLength(); i++)
+  for (int i = 0; i < DampingLambdaSqV.GetLength(); i++)
     DampingLambdaSqV[i] = DampingLambdaSq;
-  for (int i           = 0; i < diagMatIdentity.GetLength(); i++)
+  for (int i = 0; i < diagMatIdentity.GetLength(); i++)
     diagMatIdentity[i] = 1.0;
   // DampingLambdaSDLS = 1.5*DefaultDampingLambda;
 
@@ -1358,7 +1358,7 @@ void Jacobian::CalcDeltaThetasPseudoinverse() {
     Jcurrent.Multiply(dTheta, dTemp);
 
     VectorRn dTemp2(dScurrent.GetLength());
-    for (int k  = 0; k < dScurrent.GetLength(); k++)
+    for (int k = 0; k < dScurrent.GetLength(); k++)
       dTemp2[k] = dScurrent[k] - dTemp[k];
 
     // Moltiplico JdstPinv per dTemp2
@@ -1366,8 +1366,8 @@ void Jacobian::CalcDeltaThetasPseudoinverse() {
     JdstPinv.Multiply(dTemp2, dThetaCurrent);
     for (int k = 0; k < dTheta.GetLength(); k++) dTheta[k] += dThetaCurrent[k];
 
-    // Infine mi calcolo la pseudoinversa di Jcurrent e quindi la sua proiezione
-    // che servirà al passo successivo
+    // Finally, I calculate the pseudoinverse of Jcurrent and thus its
+    // projection, which will be used in the next step
 
     // calcolo la pseudoinversa di Jcurrent
     Jcurrent.ComputeSVD(U, w, V);

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -212,7 +212,8 @@ void ImageLoader::invalidate() {
 
 //-------------------------------------------------------------------------
 /*--
- * ImageBuilder仮想関数の実装。アイコン、画像をLoad時に全てキャッシュに格納する
+ * Implement ImageBuilder virtual functions. All icons and images are stored in
+ * the cache on Loading.
  * --*/
 
 void ImageLoader::buildAllIconsAndPutInCache(TXshSimpleLevel *level,
@@ -221,7 +222,7 @@ void ImageLoader::buildAllIconsAndPutInCache(TXshSimpleLevel *level,
                                              bool cacheImagesAsWell) {
   if (m_path.getType() != "tlv") return;
   if (fids.empty() || iconIds.empty()) return;
-  /*- fidとアイコンidの数は同じはず -*/
+  /*- The number of fid and icon id should be the same -*/
   if ((int)fids.size() != (int)iconIds.size()) return;
 
   try {
@@ -237,7 +238,7 @@ void ImageLoader::buildAllIconsAndPutInCache(TXshSimpleLevel *level,
       TPalette *palette     = level->getPalette();
       std::string fullImgId = level->getImageId(fids[i]);
 
-      /*- 画像データも一緒にキャッシュする場合 -*/
+      /*- When image data is also cached together -*/
       if (cacheImagesAsWell) {
         ir->enable16BitRead(m_64bitCompatible);
         ir->setShrink(1);
@@ -249,7 +250,7 @@ void ImageLoader::buildAllIconsAndPutInCache(TXshSimpleLevel *level,
         }
       }
 
-      /*- アイコンのロード -*/
+      /*- load icons -*/
       TImageP img = ir->loadIcon();
       ir->enable16BitRead(false);
       if (img) {

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -52,7 +52,8 @@ public:
   bool isImageCompatible(int imFlags, void *extData) override;
 
   /*--
-   * ImageBuilder仮想関数の実装。アイコン、画像をLoad時に全てキャッシュに格納する
+   * Implement ImageBuilder virtual functions. All icons and images are stored
+   * in the cache on loading
    * --*/
   void buildAllIconsAndPutInCache(TXshSimpleLevel *level,
                                   std::vector<TFrameId> fids,

--- a/toonz/sources/toonzlib/movierenderer.cpp
+++ b/toonz/sources/toonzlib/movierenderer.cpp
@@ -121,8 +121,8 @@ public:
   std::map<double, std::pair<TRasterP, TRasterP>> m_toBeSaved;
   std::vector<std::pair<double, TFxPair>> m_framesToBeRendered;
   std::string m_renderCacheId;
-  /*--- 同じラスタのキャッシュを使いまわすとき、
-          最初のものだけガンマをかけ、以降はそれを使いまわすようにする。
+  /*--- When caching the same raster, gamma only the first one and use the
+  result in subsequent frames
   ---*/
   std::map<double, bool> m_toBeAppliedGamma;
 
@@ -151,7 +151,7 @@ public:
   void onRenderRasterCompleted(const RenderData &renderData) override;
   void onRenderFailure(const RenderData &renderData, TException &e) override;
 
-  /*-- キャンセル時にはm_overallRenderedRegionを更新しない --*/
+  /*-- Do not update m_overallRenderedRegion on cancel --*/
   void onRenderFinished(bool isCanceled = false) override;
 
   void doRenderRasterCompleted(const RenderData &renderData);
@@ -262,7 +262,7 @@ void MovieRenderer::Imp::prepareForStart() {
   TOutputProperties *oprop = m_scene->getProperties()->getOutputProperties();
   double frameRate         = (double)oprop->getFrameRate();
 
-  /*-- Frame rate の stretch --*/
+  /*-- stretch of the Frame rate --*/
   double stretchFactor = oprop->getRenderSettings().m_timeStretchTo /
                          oprop->getRenderSettings().m_timeStretchFrom;
   frameRate *= stretchFactor;
@@ -470,8 +470,8 @@ std::pair<bool, int> MovieRenderer::Imp::saveFrame(
     TRasterP rasterA = rasters.first, rasterB = rasters.second;
     assert(rasterA);
 
-    /*--- 同じラスタのキャッシュを使いまわすとき、
-    最初のものだけガンマをかけ、以降はそれを使いまわすようにする。
+    /*--- When caching the same raster, gamma only the first one and use the
+result in subsequent frames
 ---*/
     if (m_renderSettings.m_gamma != 1.0 && m_toBeAppliedGamma[frame]) {
       TRop::gammaCorrect(rasterA, m_renderSettings.m_gamma);

--- a/toonz/sources/toonzlib/rasterbrush.cpp
+++ b/toonz/sources/toonzlib/rasterbrush.cpp
@@ -381,13 +381,13 @@ double findChordalDeviation(const TQuadratic &quadratic, double t,
 }
 
 // Accende un pixel calcolandone l'intensita'
-/*-- 筆先のアンチエイリアス部分の描画 --*/
+/*-- Drawing the anti-aliased portion of the brush tip --*/
 void lightPixel(const TRasterCM32P &ras, const TPoint &pix, double distance,
                 int styleId, bool checkAntialiasedPixel) {
   TPixelCM32 pixel      = ras->pixels(pix.y)[pix.x];
   double volumeParziale = ConeSubVolume::compute(distance);
 
-  /*- 現在のToneに乗算していく -*/
+  /*- Multiply to current Tone. -*/
   int newTone = tround((double)pixel.getTone() * (1.0 - volumeParziale));
   assert(newTone >= 0 && newTone <= 255);
   ras->pixels(pix.y)[pix.x] = TPixelCM32(styleId, pixel.getPaint(), newTone);

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -73,7 +73,7 @@ void RasterStrokeGenerator::generateStroke(bool isPencil,
     }
     rasterBrush(rasBuffer, partialPoints, m_styleId, !isPencil);
     placeOver(m_raster, rasBuffer, newOrigin);
-  } else if (size % 2 == 1) /*-- 奇数の場合 --*/
+  } else if (size % 2 == 1) /*-- In the case of odd numbers --*/
   {
     int strokeCount = (size - 1) / 2 - 1;
     std::vector<TThickPoint> partialPoints;
@@ -156,7 +156,7 @@ TRect RasterStrokeGenerator::getBBox(
          x1 = -(std::numeric_limits<double>::max)(),
          y1 = -(std::numeric_limits<double>::max)();
   for (int i = 0; i < (int)points.size(); i++) {
-    double radius                     = points[i].thick * 0.5;
+    double radius = points[i].thick * 0.5;
     if (points[i].x - radius < x0) x0 = points[i].x - radius;
     if (points[i].x + radius > x1) x1 = points[i].x + radius;
     if (points[i].y - radius < y0) y0 = points[i].y - radius;
@@ -189,7 +189,7 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
   TRect box2        = box - p;
   TRasterCM32P rIn  = in->extract(box2);
   for (int y = 0; y < rOut->getLy(); y++) {
-    /*-- Finger Toolの境界条件 --*/
+    /*--Finger Tool Boundary Conditions --*/
     if (m_task == FINGER && (y == 0 || y == rOut->getLy() - 1)) continue;
 
     TPixelCM32 *inPix  = rIn->pixels(y);
@@ -279,26 +279,27 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
 
       /*-- Finger tool --*/
       else if (m_task == FINGER) {
-        /*-- 境界条件 --*/
+        /*-- Boundary Conditions --*/
         if (outPix == rOut->pixels(y) || outPix == outEnd - 1) continue;
 
         int inkId = inPix->getInk();
         if (inkId == 0) continue;
 
         TPixelCM32 *neighbourPixels[4];
-        neighbourPixels[0] = outPix - 1;               /* 左 */
-        neighbourPixels[1] = outPix + 1;               /* 右 */
-        neighbourPixels[2] = outPix - rOut->getWrap(); /* 上 */
-        neighbourPixels[3] = outPix + rOut->getWrap(); /* 下 */
+        neighbourPixels[0] = outPix - 1;               /* left */
+        neighbourPixels[1] = outPix + 1;               /* right */
+        neighbourPixels[2] = outPix - rOut->getWrap(); /* top */
+        neighbourPixels[3] = outPix + rOut->getWrap(); /* bottom */
         int count          = 0;
         int tone           = outPix->getTone();
 
-        /*--- Invertがオフのとき：穴を埋める操作 ---*/
+        /*--- When Invert is off: Fill hole operation ---*/
         if (!m_selective) {
-          /*-- 4近傍のピクセルについて --*/
+          /*-- For 4 neighborhood pixels --*/
           int minTone = tone;
           for (int p = 0; p < 4; p++) {
-            /*-- 自分Pixelより線が濃い（Toneが低い）ものを集計する --*/
+            /*-- Count up the items that have darker lines (lower Tone) than the
+             * current pixel. --*/
             if (neighbourPixels[p]->getTone() < tone) {
               count++;
               if (neighbourPixels[p]->getTone() < minTone)
@@ -306,19 +307,21 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
             }
           }
 
-          /*--- 周りの３つ以上のピクセルが濃ければ、最小Toneと置き換える ---*/
+          /*--- If 3 or more surrounding pixels are darker, replace with the
+           * minimum Tone ---*/
           if (count <= 2) continue;
           *outPix = TPixelCM32(inkId, outPix->getPaint(), minTone);
         }
-        /*--- InvertがONのとき：出っ張りを削る操作 ---*/
+        /*--- When Invert is ON: Operation to trim protrusion ---*/
         else {
           if (outPix->isPurePaint() || outPix->getInk() != inkId) continue;
 
-          /*-- 4近傍のピクセルについて --*/
+          /*-- For 4 neighborhood pixels --*/
           int maxTone = tone;
           for (int p = 0; p < 4; p++) {
             /*--
-             * Ink＃がCurrentでない、または、自分Pixelより線が薄い（Toneが高い）ものを集計する
+             * Count up items whose Ink# is not Current or whose line is thinner
+             * than your Pixel (Tone is higher).
              * --*/
             if (neighbourPixels[p]->getInk() != inkId) {
               count++;
@@ -330,7 +333,8 @@ void RasterStrokeGenerator::placeOver(const TRasterCM32P &out,
             }
           }
 
-          /*--- 周りの３つ以上のピクセルが薄ければ、最大Toneと置き換える ---*/
+          /*---  If 3 or more surrounding pixels are thinner, replace with the
+           * maximum Tone ---*/
           if (count <= 2) continue;
           *outPix = TPixelCM32((maxTone == 255) ? 0 : inkId, outPix->getPaint(),
                                maxTone);

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -363,7 +363,7 @@ static bool getColumnPlacement(PlacedFx &pf, TXsheet *xsh, double row, int col,
 }
 
 //-------------------------------------------------------------------
-/*-- Objectの位置を得る --*/
+/*-- Obtain the position of the Object --*/
 static bool getStageObjectPlacement(TAffine &aff, TXsheet *xsh, double row,
                                     TStageObjectId &id, bool isPreview) {
   TStageObject *pegbar = xsh->getStageObjectTree()->getStageObject(id, false);
@@ -388,7 +388,7 @@ static bool getStageObjectPlacement(TAffine &aff, TXsheet *xsh, double row,
   return isVisible;
 }
 
-/*-- typeとindexからStageObjectIdを得る --*/
+/*-- Get StageObjectId from type and index --*/
 namespace {
 TStageObjectId getMotionObjectId(MotionObjectType type, int index) {
   switch (type) {
@@ -425,7 +425,7 @@ static TPointD getColumnSpeed(TXsheet *xsh, double row, int col,
   const double h = 0.001;
   getColumnPlacement(aff, xsh, row + h, col, isPreview);
 
-  /*-- カラムと、カメラの動きに反応 --*/
+  /*-- Reacts to columns and camera movement --*/
   TStageObjectId cameraId;
   if (isPreview)
     cameraId = xsh->getStageObjectTree()->getCurrentPreviewCameraId();
@@ -445,15 +445,15 @@ static TPointD getColumnSpeed(TXsheet *xsh, double row, int col,
 }
 
 //-------------------------------------------------------------------
-/*-- オブジェクトの軌跡を、基準点との差分で得る
-        objectId: 移動の参考にするオブジェクト。自分自身の場合はNoneId
+/*-- Obtain the trajectory of an object by the difference from the reference
+point objectId: The reference object for the move. NoneId for itself.
 --*/
 static QList<TPointD> getColumnMotionPoints(TXsheet *xsh, double row, int col,
                                             TStageObjectId &objectId,
                                             bool isPreview, double shutterStart,
                                             double shutterEnd,
                                             int traceResolution) {
-  /*-- 前後フレームが共に０なら空のリストを返す --*/
+  /*-- Returns an empty list if the previous and next frames are both zero. --*/
   if (shutterStart == 0.0 && shutterEnd == 0.0) return QList<TPointD>();
 
   /*-- 現在のカメラを得る --*/

--- a/toonz/sources/toonzlib/scriptbinding_level.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_level.cpp
@@ -221,14 +221,10 @@ TFrameId Level::getFid(const QScriptValue &arg, QString &err) {
       QString c = re.cap(2);
       TFrameId fid;
       if (c.length() == 1)
-#if QT_VERSION >= 0x050500
         fid = TFrameId(d, c[0].unicode());
-#else
-        fid = TFrameId(d, c[0].toAscii());
-#endif
       else
         fid = TFrameId(d);
-      err   = "";
+      err = "";
       return fid;
     }
   }

--- a/toonz/sources/toonzlib/stylemanager.cpp
+++ b/toonz/sources/toonzlib/stylemanager.cpp
@@ -328,8 +328,8 @@ void CustomStyleManager::loadItems() {
   for (i = 0; i < m_chips.size(); i++) {
     ChipData data = m_chips.at(i);
     for (it = fps.begin(); it != fps.end(); ++it) {
-      int isVector = (it->getType() == "pli") ? 1 : 0;
-      QString name = QString::fromStdWString(it->getWideName());
+      bool isVector = (it->getType() == "pli");
+      QString name  = QString::fromStdWString(it->getWideName());
       if (data.name == name && data.isVector == isVector) break;
     }
 

--- a/toonz/sources/toonzlib/trasterimageutils.cpp
+++ b/toonz/sources/toonzlib/trasterimageutils.cpp
@@ -122,7 +122,7 @@ TRect fastAddInkStroke(const TRasterImageP &ri, TStroke *stroke, TRectD clip,
 
 TRect rasterizeRegion(TOfflineGL *&gl, TRect rasBounds, TRegion *region,
                       TPalette *palette, TRectD clip) {
-  TRectD regionBBox               = region->getBBox();
+  TRectD regionBBox = region->getBBox();
   if (!clip.isEmpty()) regionBBox = regionBBox * clip;
 
   TRect rect = convert(regionBBox) * rasBounds;
@@ -172,7 +172,7 @@ void fastAddPaintRegion(const TRasterImageP &ri, TRegion *region,
                        std::min(maxStyleId, subregion->getStyle()), maxStyleId);
   }
 }
-}
+}  // namespace
 
 //==========================================================================
 
@@ -295,7 +295,7 @@ TRasterImageP TRasterImageUtils::vectorToFullColorImage(
     else {
       visible = false;
       for (int j = 0; j < style->getColorParamCount() && !visible; j++) {
-        TPixel32 color            = style->getColorParamValue(j);
+        TPixel32 color = style->getColorParamValue(j);
         if (color.m != 0) visible = true;
       }
     }
@@ -355,8 +355,8 @@ void TRasterImageUtils::addSceneNumbering(const TRasterImageP &ri,
   numberingFont.setPixelSize(ly * 0.04);
   numberingFont.setBold(true);
   p.setFont(numberingFont);
-  QMatrix matrix;
-  p.setMatrix(matrix.translate(0, ly).scale(1, -1), true);
+  QTransform transform;
+  p.setTransform(transform.translate(0, ly).scale(1, -1), true);
   QFontMetrics fm = p.fontMetrics();
   int fontHeight  = fm.height();
   int offset      = fontHeight * 0.2;
@@ -367,7 +367,7 @@ void TRasterImageUtils::addSceneNumbering(const TRasterImageP &ri,
   QString sceneNumberingString =
       QString::fromStdWString(sceneName) + ": " + sceneFrame;
 
-  int sceneNumberingWidth = fm.width(sceneNumberingString);
+  int sceneNumberingWidth = fm.horizontalAdvance(sceneNumberingString);
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(255, 255, 255, 255));
   p.drawRect(offset, ly - offset - fontHeight, sceneNumberingWidth + offset * 2,
@@ -382,7 +382,7 @@ void TRasterImageUtils::addSceneNumbering(const TRasterImageP &ri,
   QString globalFrame = QString::number(globalIndex);
   while (globalFrame.size() < 4) globalFrame.push_front("0");
 
-  int gloablNumberingWidth = fm.width(globalFrame);
+  int gloablNumberingWidth = fm.horizontalAdvance(globalFrame);
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(255, 255, 255, 255));
   p.drawRect(lx - 3 * offset - gloablNumberingWidth, ly - offset - fontHeight,
@@ -411,8 +411,8 @@ void TRasterImageUtils::addGlobalNumbering(const TRasterImageP &ri,
   numberingFont.setPixelSize(ly * 0.04);
   numberingFont.setBold(true);
   p.setFont(numberingFont);
-  QMatrix matrix;
-  p.setMatrix(matrix.translate(0, ly).scale(1, -1), true);
+  QTransform transform;
+  p.setTransform(transform.translate(0, ly).scale(1, -1), true);
   QFontMetrics fm     = p.fontMetrics();
   int fontHeight      = fm.height();
   int offset          = fontHeight * 0.2;
@@ -421,7 +421,7 @@ void TRasterImageUtils::addGlobalNumbering(const TRasterImageP &ri,
   QString globalNumberingString =
       QString::fromStdWString(sceneName) + ": " + globalFrame;
 
-  int globalNumberingWidth = fm.width(globalNumberingString);
+  int globalNumberingWidth = fm.horizontalAdvance(globalNumberingString);
   p.setPen(Qt::NoPen);
   p.setBrush(QColor(255, 255, 255, 255));
   p.drawRect(offset, ly - offset - fontHeight,

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -554,6 +554,7 @@ bool TXshColumn::canBeParent() const {
     return false;
   default:
     assert(!"Unknown level type!");
+    return false;
   }
 }
 

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -958,9 +958,9 @@ static void calculateNearest(std::vector<double> target,
 
   for (i = 0; i < target.size(); ++i) {
     if (nearest[i] < intervals[i].first || nearest[i] > intervals[i].second) {
-      distance = nearest[i] < intervals[i].first
-                     ? intervals[i].first - nearest[i]
-                     : nearest[i] - intervals[i].second;
+      distance   = nearest[i] < intervals[i].first
+                       ? intervals[i].first - nearest[i]
+                       : nearest[i] - intervals[i].second;
       nearest[i] = nearest[i] < intervals[i].first ? intervals[i].first
                                                    : intervals[i].second;
       if (maxDistance < distance) {
@@ -1448,7 +1448,11 @@ void DockLayout::writeRegion(Region *r, QString &hierarchy) {
 //! widget has ever been left unchanged or completely restored
 //! as it were when saved. In particular, their ordering must be preserved.
 bool DockLayout::restoreState(const State &state) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QStringList vars = state.second.split(" ", Qt::SkipEmptyParts);
+#else
   QStringList vars = state.second.split(" ", QString::SkipEmptyParts);
+#endif
   if (vars.size() < 1) return 0;
 
   // Check number of items

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -9,6 +9,7 @@
 #include <QMouseEvent>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QScreen>
 
 // STD includes
 #include <assert.h>
@@ -82,7 +83,7 @@ inline QRect toRect(const QRectF &rect) {
 namespace {
 QDesktopWidget *desktop;
 void getClosestAvailableMousePosition(QPoint &globalPos);
-}
+}  // namespace
 
 //========================================================
 
@@ -396,12 +397,19 @@ void DockWidget::maximizeDock() {
 void DockWidget::wheelEvent(QWheelEvent *we) {
   if (m_dragging) {
     if (m_selectedPlace) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       DockPlaceholder *newSelected =
-          (we->delta() > 0)
+          (we->angleDelta().y() > 0)
+              ? m_selectedPlace->parentPlaceholder()
+              : m_selectedPlace->childPlaceholder(parentWidget()->mapFromGlobal(
+                    we->globalPosition().toPoint()));
+#else
+      DockPlaceholder *newSelected =
+          (we->angleDelta().y() > 0)
               ? m_selectedPlace->parentPlaceholder()
               : m_selectedPlace->childPlaceholder(
                     parentWidget()->mapFromGlobal(we->globalPos()));
-
+#endif
       if (newSelected != m_selectedPlace) {
         m_selectedPlace->hide();
         newSelected->show();
@@ -712,10 +720,9 @@ DockPlaceholder *DockPlaceholder::childPlaceholder(QPoint p) {
   r = r->childRegion(i);
 
   // Finally, return child placeholder found.
-  return r->placeholders().size()
-             ? lastExtremity ? r->placeholders().back()
-                             : r->placeholders().front()
-             : this;
+  return r->placeholders().size() ? lastExtremity ? r->placeholders().back()
+                                                  : r->placeholders().front()
+                                  : this;
 }
 
 //------------------------------------------------------
@@ -960,25 +967,25 @@ namespace {
 // Finds the closest mouse point belonging to some available geometry.
 void getClosestAvailableMousePosition(QPoint &globalPos) {
   // Search the screen rect containing the mouse position
-  int i, screens = desktop->numScreens();
-  for (i = 0; i < screens; ++i)
-    if (desktop->screenGeometry(i).contains(globalPos)) break;
+  for (auto screen : QGuiApplication::screens()) {
+    if (screen->geometry().contains(globalPos)) {
+      // Find the closest point to the corresponding available region
+      QRect rect(screen->availableGeometry());
+      if (rect.contains(globalPos)) return;
 
-  // Find the closest point to the corresponding available region
-  QRect rect(desktop->availableGeometry(i));
-  if (rect.contains(globalPos)) return;
+      // Return the closest point to the available geometry
+      QPoint result;
+      if (globalPos.x() < rect.left())
+        globalPos.setX(rect.left());
+      else if (globalPos.x() > rect.right())
+        globalPos.setX(rect.right());
 
-  // Return the closest point to the available geometry
-  QPoint result;
-  if (globalPos.x() < rect.left())
-    globalPos.setX(rect.left());
-  else if (globalPos.x() > rect.right())
-    globalPos.setX(rect.right());
-
-  if (globalPos.y() < rect.top())
-    globalPos.setY(rect.top());
-  else if (globalPos.y() > rect.bottom())
-    globalPos.setY(rect.bottom());
+      if (globalPos.y() < rect.top())
+        globalPos.setY(rect.top());
+      else if (globalPos.y() > rect.bottom())
+        globalPos.setY(rect.bottom());
+    }
+  }
 }
 
-}  // Local namespace
+}  // namespace

--- a/toonz/sources/toonzqt/doublepairfield.cpp
+++ b/toonz/sources/toonzqt/doublepairfield.cpp
@@ -70,7 +70,7 @@ DoubleValuePairField::DoubleValuePairField(QWidget *parent,
   bool ret = connect(m_leftLineEdit, SIGNAL(editingFinished()),
                      SLOT(onLeftEditingFinished()));
   ret      = ret && connect(m_rightLineEdit, SIGNAL(editingFinished()),
-                       SLOT(onRightEditingFinished()));
+                            SLOT(onRightEditingFinished()));
   assert(ret);
 }
 
@@ -157,8 +157,8 @@ void DoubleValuePairField::paintEvent(QPaintEvent *) {
 void DoubleValuePairField::setLeftText(const QString &text) {
   QString oldText = m_leftLabel->text();
 
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
+  int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
+  int newLabelSize = fontMetrics().horizontalAdvance(text);
   int labelSize    = newLabelSize - oldLabelSize;
   m_leftMargin += labelSize + MARGIN_OFFSET;
 
@@ -171,8 +171,8 @@ void DoubleValuePairField::setLeftText(const QString &text) {
 void DoubleValuePairField::setRightText(const QString &text) {
   QString oldText = m_rightLabel->text();
 
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
+  int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
+  int newLabelSize = fontMetrics().horizontalAdvance(text);
   int labelSize    = newLabelSize - oldLabelSize;
   m_rightMargin += labelSize + MARGIN_OFFSET;
 

--- a/toonz/sources/toonzqt/expressionfield.cpp
+++ b/toonz/sources/toonzqt/expressionfield.cpp
@@ -219,7 +219,7 @@ void ExpressionField::keyPressEvent(QKeyEvent *e) {
     setAutoFillBackground(true);
     QPalette p = palette();
     p.setColor(QPalette::Base, Qt::cyan);
-    p.setColor(QPalette::Background, Qt::cyan);
+    p.setColor(QPalette::Window, Qt::cyan);
     setPalette(p);
     update();
     setStyleSheet("#ExpressionField {background-color:cyan;}");
@@ -351,7 +351,8 @@ bool ExpressionField::updateCompleterPopup() {
   int w = m_completerPopup->sizeHintForColumn(0) +
           m_completerPopup->verticalScrollBar()->sizeHint().width() + 5;
   int h =
-      (m_completerPopup->sizeHintForRow(0) * std::min(7, model->rowCount()) + 3) +
+      (m_completerPopup->sizeHintForRow(0) * std::min(7, model->rowCount()) +
+       3) +
       3;
 
   QSize size(w, h);
@@ -372,8 +373,8 @@ int ExpressionField::computeSuggestions() {
     while (start > 0) {
       char c = text[start - 1];
       if ((isascii(c) && isalpha(c)) || c == '_' ||
-          (c == '.' && (start - 2 < 0 ||
-                        (isascii(text[start - 2]) && isalpha(text[start - 2]))))) {
+          (c == '.' && (start - 2 < 0 || (isascii(text[start - 2]) &&
+                                          isalpha(text[start - 2]))))) {
       } else
         break;
       start--;

--- a/toonz/sources/toonzqt/filefield.cpp
+++ b/toonz/sources/toonzqt/filefield.cpp
@@ -22,7 +22,7 @@ FileField::FileField(QWidget *parent, QString path, bool readOnly,
                      bool doNotBrowseInitialPath, bool codePath)
     : QWidget(parent)
     , m_filters(QStringList())
-    , m_fileMode(QFileDialog::DirectoryOnly)
+    , m_fileMode(QFileDialog::Directory)  // implies ShowDirsOnly
     , m_lastSelectedPath(path)
     , m_codePath(codePath) {
   setMaximumHeight(WidgetHeight);
@@ -96,7 +96,7 @@ void FileField::browseDirectory() {
 
   if (!m_browserPopupController) return;
   m_browserPopupController->openPopup(
-      m_filters, (m_fileMode == QFileDialog::DirectoryOnly),
+      m_filters, (m_fileMode == QFileDialog::Directory),
       (m_lastSelectedPath == m_descriptionText) ? "" : m_lastSelectedPath,
       this);
   if (m_browserPopupController->isExecute())

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -392,7 +392,7 @@ void FlipSlider::mousePressEvent(QMouseEvent *me) {
   emit flipSliderPressed();
   int cursorValue = sliderValueFromPosition(minimum(), maximum(), singleStep(),
                                             me->pos().x(), width());
-  if (me->button() == Qt::MidButton)
+  if (me->button() == Qt::MiddleButton)
     if (cursorValue == value())
       setSliderDown(true);
     else {
@@ -1878,7 +1878,8 @@ QFrame *FlipConsole::createFpsSlider() {
   m_fpsField  = new DVGui::IntLineEdit(fpsSliderFrame, m_fps, -60, 60);
   m_fpsField->setFixedWidth(40);
 
-  m_fpsLabel->setMinimumWidth(m_fpsLabel->fontMetrics().width("_FPS_24___"));
+  m_fpsLabel->setMinimumWidth(
+      m_fpsLabel->fontMetrics().horizontalAdvance("_FPS_24___"));
   m_fpsLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
   m_fpsSlider->setObjectName("ViewerFpsSlider");
   m_fpsSlider->setRange(-60, 60);

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -394,7 +394,7 @@ QPair<TDoubleParam *, int> FunctionSelection::getSelectedKeyframe(
     if (index < count) {
       TDoubleParam *curve          = m_selectedKeyframes[i].first;
       QSet<int>::const_iterator it = m_selectedKeyframes[i].second.begin();
-      it += index;
+      std::advance(it, index);
       return QPair<TDoubleParam *, int>(curve, *it);
     }
     index -= count;

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -430,7 +430,7 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
 /*! update tooltips
  */
 void FunctionSheetColumnHeadViewer::mouseMoveEvent(QMouseEvent *e) {
-  if ((e->buttons() & Qt::MidButton) && m_draggingChannel &&
+  if ((e->buttons() & Qt::MiddleButton) && m_draggingChannel &&
       (e->pos() - m_dragStartPosition).manhattanLength() >=
           QApplication::startDragDistance()) {
     QDrag *drag         = new QDrag(this);
@@ -490,7 +490,7 @@ void FunctionSheetColumnHeadViewer::mousePressEvent(QMouseEvent *e) {
     return;
   }
 
-  if (e->button() == Qt::MidButton) {
+  if (e->button() == Qt::MiddleButton) {
     m_draggingChannel   = channel;
     m_dragStartPosition = e->pos();
     return;
@@ -636,7 +636,7 @@ FunctionSheetCellViewer::FunctionSheetCellViewer(FunctionSheet *parent)
   bool ret = connect(m_lineEdit, SIGNAL(editingFinished()), this,
                      SLOT(onCellEditorEditingFinished()));
   ret      = ret && connect(m_lineEdit, SIGNAL(mouseMoved(QMouseEvent *)), this,
-                       SLOT(onMouseMovedInLineEdit(QMouseEvent *)));
+                            SLOT(onMouseMovedInLineEdit(QMouseEvent *)));
   assert(ret);
   setMouseTracking(true);
 
@@ -799,8 +799,9 @@ void FunctionSheetCellViewer::drawCells(QPainter &painter, int r0, int c0,
           }
         }
 
-        drawValue =
-            (curve->isKeyframe(row)) ? Key : (showIbtwn) ? Inbetween : None;
+        drawValue = (curve->isKeyframe(row)) ? Key
+                    : (showIbtwn)            ? Inbetween
+                                             : None;
 
       }
       // empty cells
@@ -987,7 +988,7 @@ void FunctionSheetCellViewer::mousePressEvent(QMouseEvent *e) {
     if (curve) {
       KeyframeSetter::removeKeyframeAt(curve, row);
     }
-  } else if (e->button() == Qt::LeftButton || e->button() == Qt::MidButton)
+  } else if (e->button() == Qt::LeftButton || e->button() == Qt::MiddleButton)
     Spreadsheet::CellPanel::mousePressEvent(e);
   else if (e->button() == Qt::RightButton) {
     update();

--- a/toonz/sources/toonzqt/functiontreeviewer.cpp
+++ b/toonz/sources/toonzqt/functiontreeviewer.cpp
@@ -279,19 +279,9 @@ QVariant StageObjectChannelGroup::data(int role) const {
 
   } else if (role == Qt::ForegroundRole) {
     FunctionTreeModel *model = dynamic_cast<FunctionTreeModel *>(getModel());
-    if (!model)
-#if QT_VERSION >= 0x050000
-      return QColor(Qt::black);
-#else
-      return Qt::black;
-#endif
+    if (!model) return QColor(Qt::black);
     FunctionTreeView *view = dynamic_cast<FunctionTreeView *>(model->getView());
-    if (!view || !model->getCurrentStageObject())
-#if QT_VERSION >= 0x050000
-      return QColor(Qt::black);
-#else
-      return Qt::black;
-#endif
+    if (!view || !model->getCurrentStageObject()) return QColor(Qt::black);
     TStageObjectId currentId = model->getCurrentStageObject()->getId();
     return m_stageObject->getId() == currentId
                ? view->getViewer()->getCurrentTextColor()
@@ -398,19 +388,9 @@ QVariant FxChannelGroup::data(int role) const {
       return QString::fromStdWString(id + L" (" + name + L")");
   } else if (role == Qt::ForegroundRole) {
     FunctionTreeModel *model = dynamic_cast<FunctionTreeModel *>(getModel());
-    if (!model)
-#if QT_VERSION >= 0x050000
-      return QColor(Qt::black);
-#else
-      return Qt::black;
-#endif
+    if (!model) return QColor(Qt::black);
     FunctionTreeView *view = dynamic_cast<FunctionTreeView *>(model->getView());
-    if (!view)
-#if QT_VERSION >= 0x050000
-      return QColor(Qt::black);
-#else
-      return Qt::black;
-#endif
+    if (!view) return QColor(Qt::black);
     TFx *currentFx = model->getCurrentFx();
     return m_fx == currentFx ? view->getViewer()->getCurrentTextColor()
                              : view->getTextColor();
@@ -513,19 +493,9 @@ QVariant SkVDChannelGroup::data(int role) const {
     // it selection color
     // if this group refers to current vertex
     FunctionTreeModel *model = dynamic_cast<FunctionTreeModel *>(getModel());
-    if (!model)
-#if QT_VERSION >= 0x050000
-      return QColor(Qt::black);
-#else
-      return Qt::black;
-#endif
+    if (!model) return QColor(Qt::black);
     FunctionTreeView *view = dynamic_cast<FunctionTreeView *>(model->getView());
-    if (!view || !model->getCurrentStageObject())
-#if QT_VERSION >= 0x050000
-      return QColor(Qt::black);
-#else
-      return Qt::black;
-#endif
+    if (!view || !model->getCurrentStageObject()) return QColor(Qt::black);
 
     if (PlasticVertexSelection *vxSel =
             dynamic_cast<PlasticVertexSelection *>(TSelection::getCurrent()))
@@ -618,12 +588,7 @@ QVariant FunctionTreeModel::Channel::data(int role) const {
   } else if (role == Qt::ForegroundRole) {
     // 130221 iwasawa
     FunctionTreeView *view = dynamic_cast<FunctionTreeView *>(m_model->m_view);
-    if (!view)
-#if QT_VERSION >= 0x050000
-      return QColor(Qt::black);
-#else
-      return Qt::black;
-#endif
+    if (!view) return QColor(Qt::black);
     return (isCurrent()) ? view->getViewer()->getCurrentTextColor()
                          : view->getTextColor();
   } else if (role == Qt::ToolTipRole) {
@@ -1256,9 +1221,7 @@ void FunctionTreeModel::onParamChange(bool isDragging) {
 //-----------------------------------------------------------------------------
 
 void FunctionTreeModel::resetAll() {
-#if QT_VERSION >= 0x050000
   beginResetModel();
-#endif
   m_activeChannels.clear();
 
   TreeModel::Item *root_item = getRootItem();
@@ -1266,9 +1229,6 @@ void FunctionTreeModel::resetAll() {
 
   m_stageObjects = 0;
   m_fxs          = 0;
-#if QT_VERSION < 0x050000
-  reset();
-#endif
 
   beginRefresh();
   refreshActiveChannels();
@@ -1280,9 +1240,7 @@ void FunctionTreeModel::resetAll() {
 
   m_currentChannel = 0;
 
-#if QT_VERSION >= 0x050000
   endResetModel();
-#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -1528,7 +1486,7 @@ void FunctionTreeView::onMidClick(TreeModel::Item *item, const QPoint &itemPos,
                                   QMouseEvent *e) {
   FunctionTreeModel::Channel *channel =
       dynamic_cast<FunctionTreeModel::Channel *>(item);
-  if (channel && e->button() == Qt::MidButton) {
+  if (channel && e->button() == Qt::MiddleButton) {
     m_draggingChannel   = channel;
     m_dragStartPosition = e->pos();
   } else
@@ -1540,7 +1498,7 @@ void FunctionTreeView::onMidClick(TreeModel::Item *item, const QPoint &itemPos,
 void FunctionTreeView::onDrag(TreeModel::Item *item, const QPoint &itemPos,
                               QMouseEvent *e) {
   // middle drag of the channel item can retrieve expression name
-  if ((e->buttons() & Qt::MidButton) && m_draggingChannel &&
+  if ((e->buttons() & Qt::MiddleButton) && m_draggingChannel &&
       (e->pos() - m_dragStartPosition).manhattanLength() >=
           QApplication::startDragDistance()) {
     QDrag *drag         = new QDrag(this);

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -56,11 +56,7 @@ TEnv::IntVar FunctionEditorToggleStatus("FunctionEditorToggleStatus", 0);
 //
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
-#else
-FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
-#endif
     : QSplitter(parent)
     , m_xshHandle(0)
     , m_frameHandle(0)
@@ -179,13 +175,13 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WFlags flags)
   //---- signal-slot connections
   bool ret = true;
   ret      = ret && connect(m_toolbar, SIGNAL(numericalColumnToggled()), this,
-                       SLOT(toggleMode()));
+                            SLOT(toggleMode()));
   ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
-                       m_functionGraph, SLOT(update()));
+                            m_functionGraph, SLOT(update()));
   ret      = ret && connect(ftModel, SIGNAL(activeChannelsChanged()),
-                       m_numericalColumns, SLOT(updateAll()));
+                            m_numericalColumns, SLOT(updateAll()));
   ret      = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_treeView,
-                       SLOT(update()));
+                            SLOT(update()));
   ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_functionGraph,
                        SLOT(update()));
   ret = ret && connect(ftModel, SIGNAL(curveChanged(bool)), m_numericalColumns,
@@ -432,7 +428,7 @@ void FunctionViewer::setObjectHandle(TObjectHandle *objectHandle) {
 
     bool ret = true;
     ret      = connect(m_objectHandle, SIGNAL(objectSwitched()), this,
-                  SLOT(onStageObjectSwitched())) &&
+                       SLOT(onStageObjectSwitched())) &&
           ret;
     ret = connect(m_objectHandle, SIGNAL(objectChanged(bool)), this,
                   SLOT(onStageObjectChanged(bool))) &&
@@ -548,7 +544,7 @@ void FunctionViewer::onCurveChanged(bool isDragging) {
     if (ftModel) {
       FunctionTreeModel::Channel *currChan = ftModel->getCurrentChannel();
       if (currChan) {
-        //カレントチャンネルがFxChannelGroupに含まれていたらEmit
+        // カレントチャンネルがFxChannelGroupに含まれていたらEmit
         FxChannelGroup *fxChanGroup =
             dynamic_cast<FxChannelGroup *>(currChan->getChannelGroup());
         if (fxChanGroup) m_fxHandle->notifyFxChanged();
@@ -590,8 +586,8 @@ void FunctionViewer::onStageObjectSwitched() {
 
   const TStageObjectId &objId = m_objectHandle->getObjectId();
   TStageObject *obj           = (objId == TStageObjectId::NoneId)
-                          ? (TStageObject *)0
-                          : xsh->getStageObject(objId);
+                                    ? (TStageObject *)0
+                                    : xsh->getStageObject(objId);
 
   static_cast<FunctionTreeModel *>(m_treeView->model())
       ->setCurrentStageObject(obj);
@@ -607,8 +603,8 @@ void FunctionViewer::onStageObjectChanged(bool isDragging) {
 
   const TStageObjectId &objId = m_objectHandle->getObjectId();
   TStageObject *obj           = (objId == TStageObjectId::NoneId)
-                          ? (TStageObject *)0
-                          : xsh->getStageObject(objId);
+                                    ? (TStageObject *)0
+                                    : xsh->getStageObject(objId);
 
   static_cast<FunctionTreeModel *>(m_treeView->model())
       ->setCurrentStageObject(obj);

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -462,7 +462,7 @@ void FxSchematicScene::updateScene() {
   }
 
   // sorting fxs so that fxs with specified positions are placed first
-  qSort(fxsToBePlaced.begin(), fxsToBePlaced.end(), nodePosDefined);
+  std::sort(fxsToBePlaced.begin(), fxsToBePlaced.end(), nodePosDefined);
 
   for (auto fx : fxsToBePlaced) {
     SchematicNode *node = addFxSchematicNode(fx);
@@ -1034,7 +1034,6 @@ QPointF FxSchematicScene::nearestPoint(const QPointF &point) {
     rect.adjust(-0.1, -0.1, 0.1, 0.1);
     itemList = items(rect);
   }
-#if QT_VERSION >= 0x050000
   /*
   FIXME: QTransform() のデフォルトは Qt4.8 の itemAt() と比べて equivant
   だろうか？
@@ -1046,15 +1045,6 @@ QPointF FxSchematicScene::nearestPoint(const QPointF &point) {
   item = itemAt(rect.topLeft(), QTransform());
   if (item) return rect.topLeft();
   item = itemAt(rect.topRight(), QTransform());
-#else
-  QGraphicsItem *item = itemAt(rect.bottomLeft());
-  if (item) return rect.bottomLeft();
-  item = itemAt(rect.bottomRight());
-  if (item) return rect.bottomRight();
-  item = itemAt(rect.topLeft());
-  if (item) return rect.topLeft();
-  item                = itemAt(rect.topRight());
-#endif
   if (item) return rect.topRight();
   return QPointF();
 }
@@ -1384,26 +1374,28 @@ void FxSchematicScene::placeNodeAndParents(TFx *fx, double x, double &maxX,
 //------------------------------------------------------------------
 
 void FxSchematicScene::onDisconnectFromXSheet() {
-  std::list<TFxP, std::allocator<TFxP>> list =
-      m_selection->getFxs().toStdList();
+  std::list<TFxP, std::allocator<TFxP>> list(m_selection->getFxs().begin(),
+                                             m_selection->getFxs().end());
   TFxCommand::disconnectNodesFromXsheet(list, m_xshHandle);
 }
 
 //------------------------------------------------------------------
 
 void FxSchematicScene::onConnectToXSheet() {
-  std::list<TFxP, std::allocator<TFxP>> list =
-      m_selection->getFxs().toStdList();
+  std::list<TFxP, std::allocator<TFxP>> list(m_selection->getFxs().begin(),
+                                             m_selection->getFxs().end());
   TFxCommand::connectNodesToXsheet(list, m_xshHandle);
 }
 
 //------------------------------------------------------------------
 
 void FxSchematicScene::onDeleteFx() {
-  std::list<TFxP, std::allocator<TFxP>> fxList =
-      m_selection->getFxs().toStdList();
-  std::list<TFxCommand::Link> linkList = m_selection->getLinks().toStdList();
-  std::list<int> columnIndexList = m_selection->getColumnIndexes().toStdList();
+  std::list<TFxP, std::allocator<TFxP>> fxList(m_selection->getFxs().begin(),
+                                               m_selection->getFxs().end());
+  std::list<TFxCommand::Link> linkList(m_selection->getLinks().begin(),
+                                       m_selection->getLinks().end());
+  std::list<int> columnIndexList(m_selection->getColumnIndexes().begin(),
+                                 m_selection->getColumnIndexes().end());
   TFxCommand::deleteSelection(fxList, linkList, columnIndexList, m_xshHandle,
                               m_fxHandle);
 }
@@ -1441,7 +1433,8 @@ void FxSchematicScene::onUnlinkFx() {
 //------------------------------------------------------------------
 
 void FxSchematicScene::onMacroFx() {
-  TFxCommand::makeMacroFx(m_selection->getFxs().toVector().toStdVector(),
+  TFxCommand::makeMacroFx(std::vector<TFxP>(m_selection->getFxs().begin(),
+                                            m_selection->getFxs().end()),
                           m_app);
 }
 
@@ -1613,16 +1606,12 @@ TFx *FxSchematicScene::getCurrentFx() { return m_fxHandle->getFx(); }
 
 void FxSchematicScene::mousePressEvent(QGraphicsSceneMouseEvent *me) {
   QList<QGraphicsItem *> items = selectedItems();
-#if QT_VERSION >= 0x050000
-  QGraphicsItem *item = itemAt(me->scenePos(), QTransform());
-#else
-  QGraphicsItem *item = itemAt(me->scenePos());
-#endif
-  FxSchematicPort *port = dynamic_cast<FxSchematicPort *>(item);
-  FxSchematicLink *link = dynamic_cast<FxSchematicLink *>(item);
+  QGraphicsItem *item          = itemAt(me->scenePos(), QTransform());
+  FxSchematicPort *port        = dynamic_cast<FxSchematicPort *>(item);
+  FxSchematicLink *link        = dynamic_cast<FxSchematicLink *>(item);
   SchematicScene::mousePressEvent(me);
   onSelectionChanged();
-  if (me->button() == Qt::MidButton) {
+  if (me->button() == Qt::MiddleButton) {
     int i;
     for (i = 0; i < items.size(); i++) items[i]->setSelected(true);
   }
@@ -1632,7 +1621,7 @@ void FxSchematicScene::mousePressEvent(QGraphicsSceneMouseEvent *me) {
   not.
   */
   if (selectedItems().isEmpty()) {
-    if (me->button() != Qt::MidButton && !item) m_fxHandle->setFx(0, false);
+    if (me->button() != Qt::MiddleButton && !item) m_fxHandle->setFx(0, false);
     return;
   }
   m_isConnected = false;
@@ -1669,12 +1658,8 @@ void FxSchematicScene::mouseMoveEvent(QGraphicsSceneMouseEvent *me) {
     simulateDisconnectSelection(true);
     m_connectionLinks.showBridgeLinks();
 
-#if QT_VERSION >= 0x050000
     SchematicLink *link =
         dynamic_cast<SchematicLink *>(itemAt(m_lastPos, QTransform()));
-#else
-    SchematicLink *link = dynamic_cast<SchematicLink *>(itemAt(m_lastPos));
-#endif
     if (link && (link->getEndPort() && link->getStartPort())) {
       TFxCommand::Link fxLink = m_selection->getBoundingFxs(link);
       if (fxLink == TFxCommand::Link()) return;
@@ -1741,14 +1726,16 @@ void FxSchematicScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *me) {
           fxLink.m_inputFx  = inputNode->getFx();
           if (!outputNode->isA(eXSheetFx)) fxLink.m_index = i;
 
-          TFxCommand::connectFxs(fxLink, m_selection->getFxs().toStdList(),
+          TFxCommand::connectFxs(fxLink,
+                                 std::list<TFxP>(m_selection->getFxs().begin(),
+                                                 m_selection->getFxs().end()),
                                  m_xshHandle, m_selectionOldPos);
         }
       }
     } else if (m_disconnectionLinks.size() > 0) {
-      QList<TFxP> fxs = m_selection->getFxs();
-      TFxCommand::disconnectFxs(fxs.toStdList(), m_xshHandle,
-                                m_selectionOldPos);
+      TFxCommand::disconnectFxs(std::list<TFxP>(m_selection->getFxs().begin(),
+                                                m_selection->getFxs().end()),
+                                m_xshHandle, m_selectionOldPos);
       m_selectionOldPos.clear();
     }
   }
@@ -1816,12 +1803,8 @@ void FxSchematicScene::onAltModifierChanged(bool altPressed) {
     if (m_disconnectionLinks.size() == 0 && m_linkUnlinkSimulation)
       simulateDisconnectSelection(altPressed);
     if (m_connectionLinks.size() == 0 && m_linkUnlinkSimulation) {
-#if QT_VERSION >= 0x050000
       SchematicLink *link =
           dynamic_cast<SchematicLink *>(itemAt(m_lastPos, QTransform()));
-#else
-      SchematicLink *link = dynamic_cast<SchematicLink *>(itemAt(m_lastPos));
-#endif
       if (link && (!link->getEndPort() || !link->getStartPort())) return;
       simulateInsertSelection(link, altPressed && !!link);
     }
@@ -2065,11 +2048,7 @@ void FxSchematicScene::updateNestedGroupEditors(FxSchematicNode *node,
       if (rect.isEmpty())
         rect = app;
       else
-#if QT_VERSION >= 0x050000
         rect = rect.united(app);
-#else
-        rect = rect.unite(app);
-#endif
     }
   }
   QMap<TMacroFx *, FxSchematicMacroEditor *>::iterator it;
@@ -2079,22 +2058,14 @@ void FxSchematicScene::updateNestedGroupEditors(FxSchematicNode *node,
       if (rect.isEmpty())
         rect = app;
       else
-#if QT_VERSION >= 0x050000
         rect = rect.united(app);
-#else
-        rect = rect.unite(app);
-#endif
     }
   }
   node->setPos(newPos);
   for (i = 0; i < groupIdStack.size(); i++) {
     if (!m_groupEditorTable.contains(groupIdStack[i])) continue;
-#if QT_VERSION >= 0x050000
     rect =
         rect.united(m_groupEditorTable[groupIdStack[i]]->sceneBoundingRect());
-#else
-    rect = rect.unite(m_groupEditorTable[groupIdStack[i]]->sceneBoundingRect());
-#endif
     QRectF app = m_groupEditorTable[groupIdStack[i]]->boundingSceneRect();
     if (m_groupEditorTable[groupIdStack[i]]->scenePos() != app.topLeft())
       m_groupEditorTable[groupIdStack[i]]->setPos(app.topLeft());
@@ -2103,12 +2074,8 @@ void FxSchematicScene::updateNestedGroupEditors(FxSchematicNode *node,
     FxSchematicMacroEditor *editor = it.value();
     if (editor->contains(node)) {
       QRectF app = editor->sceneBoundingRect();
-#if QT_VERSION >= 0x050000
-      rect = rect.united(app);
-#else
-      rect = rect.unite(app);
-#endif
-      app = editor->boundingSceneRect();
+      rect       = rect.united(app);
+      app        = editor->boundingSceneRect();
       if (editor->scenePos() != app.topLeft()) editor->setPos(app.topLeft());
     }
   }

--- a/toonz/sources/toonzqt/fxselection.cpp
+++ b/toonz/sources/toonzqt/fxselection.cpp
@@ -219,9 +219,10 @@ void FxSelection::pasteSelection() {
       emit columnPasted(columns);
     }
 
-    TFxCommand::pasteFxs(fxs.toStdList(), zeraryFxColumnSize.toStdMap(),
-                         columns.toStdList(), m_pastePosition, m_xshHandle,
-                         m_fxHandle);
+    TFxCommand::pasteFxs(std::list<TFxP>(fxs.begin(), fxs.end()),
+                         zeraryFxColumnSize.toStdMap(),
+                         std::list<TXshColumnP>(columns.begin(), columns.end()),
+                         m_pastePosition, m_xshHandle, m_fxHandle);
 
     if (!columns.isEmpty()) {
       TUndoManager::manager()->endBlock();
@@ -281,9 +282,11 @@ bool FxSelection::insertPasteSelection() {
       emit columnPasted(columns);
     }
 
-    TFxCommand::insertPasteFxs(selectedLinks[i], fxs.toStdList(),
-                               zeraryFxColumnSize.toStdMap(),
-                               columns.toStdList(), m_xshHandle, m_fxHandle);
+    TFxCommand::insertPasteFxs(
+        selectedLinks[i], std::list<TFxP>(fxs.begin(), fxs.end()),
+        zeraryFxColumnSize.toStdMap(),
+        std::list<TXshColumnP>(columns.begin(), columns.end()), m_xshHandle,
+        m_fxHandle);
   }
 
   return true;
@@ -325,9 +328,11 @@ bool FxSelection::addPasteSelection() {
       auto_.m_destruct = true, TUndoManager::manager()->beginBlock();
 
     TFx *inFx = selectedFxs[i].getPointer();
-    TFxCommand::addPasteFxs(inFx, fxs.toStdList(),
-                            zeraryFxColumnSize.toStdMap(), columns.toStdList(),
-                            m_xshHandle, m_fxHandle);
+    TFxCommand::addPasteFxs(
+        inFx, std::list<TFxP>(fxs.begin(), fxs.end()),
+        zeraryFxColumnSize.toStdMap(),
+        std::list<TXshColumnP>(columns.begin(), columns.end()), m_xshHandle,
+        m_fxHandle);
   }
 
   return true;
@@ -374,9 +379,11 @@ bool FxSelection::replacePasteSelection() {
     }
 
     TFx *inFx = m_selectedFxs[i].getPointer();
-    TFxCommand::replacePasteFxs(inFx, fxs.toStdList(),
-                                zeraryFxColumnSize.toStdMap(),
-                                columns.toStdList(), m_xshHandle, m_fxHandle);
+    TFxCommand::replacePasteFxs(
+        inFx, std::list<TFxP>(fxs.begin(), fxs.end()),
+        zeraryFxColumnSize.toStdMap(),
+        std::list<TXshColumnP>(columns.begin(), columns.end()), m_xshHandle,
+        m_fxHandle);
   }
 
   return true;
@@ -386,7 +393,8 @@ bool FxSelection::replacePasteSelection() {
 
 void FxSelection::groupSelection() {
   if (m_selectedFxs.size() <= 1) return;
-  TFxCommand::groupFxs(m_selectedFxs.toStdList(), m_xshHandle);
+  TFxCommand::groupFxs(
+      std::list<TFxP>(m_selectedFxs.begin(), m_selectedFxs.end()), m_xshHandle);
   selectNone();
   m_xshHandle->notifyXsheetChanged();
 }

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -264,9 +264,15 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
           tmpWidget->setVisible(shrink == 1);
         } else {  // modeSensitiveStr != ""
           QList<int> modes;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+          QStringList modeListStr =
+              QString::fromStdString(is.getTagAttribute("mode"))
+                  .split(',', Qt::SkipEmptyParts);
+#else
           QStringList modeListStr =
               QString::fromStdString(is.getTagAttribute("mode"))
                   .split(',', QString::SkipEmptyParts);
+#endif
           for (QString modeNum : modeListStr) modes.push_back(modeNum.toInt());
           // find the mode combobox
           ModeChangerParamField *modeChanger = nullptr;
@@ -624,7 +630,7 @@ void updateMaximumPageSize(QGridLayout *layout, int &maxLabelWidth,
     QGroupBox *gBox =
         dynamic_cast<QGroupBox *>(layout->itemAtPosition(r, 0)->widget());
     if (label) {
-      int tmpWidth = label->fontMetrics().width(label->text());
+      int tmpWidth = label->fontMetrics().horizontalAdvance(label->text());
       if (maxLabelWidth < tmpWidth) maxLabelWidth = tmpWidth;
     }
     /*-- PlugInFxのGroupパラメータのサイズ --*/
@@ -693,11 +699,7 @@ QSize ParamsPage::getPreferredSize() {
 // ParamsPageSet
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 ParamsPageSet::ParamsPageSet(QWidget *parent, Qt::WindowFlags flags)
-#else
-ParamsPageSet::ParamsPageSet(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent, flags)
     , m_preferredSize(0, 0)
     , m_helpFilePath("")
@@ -1065,11 +1067,7 @@ void ParamsPageSet::updateWarnings(const TFxP &currentFx, bool isFloat) {
 // ParamViewer
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 ParamViewer::ParamViewer(QWidget *parent, Qt::WindowFlags flags)
-#else
-ParamViewer::ParamViewer(QWidget *parent, Qt::WFlags flags)
-#endif
     : QFrame(parent, flags), m_fx(0) {
   m_tablePageSet = new QStackedWidget(this);
   m_tablePageSet->addWidget(new QWidget());

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -698,21 +698,21 @@ bool isReservedFileName_message(const QString &fileName) {
 
 QString elideText(const QString &srcText, const QFont &font, int width) {
   QFontMetrics metrix(font);
-  int srcWidth = metrix.width(srcText);
+  int srcWidth = metrix.horizontalAdvance(srcText);
   if (srcWidth < width) return srcText;
-  int tilde = metrix.width("~");
+  int tilde = metrix.horizontalAdvance("~");
   int block = (width - tilde) / 2;
   QString text("");
   int i;
   for (i = 0; i < srcText.size(); i++) {
     text += srcText.at(i);
-    if (metrix.width(text) > block) break;
+    if (metrix.horizontalAdvance(text) > block) break;
   }
   text[i] = '~';
   QString endText("");
   for (i = srcText.size() - 1; i >= 0; i--) {
     endText.push_front(srcText.at(i));
-    if (metrix.width(endText) > block) break;
+    if (metrix.horizontalAdvance(endText) > block) break;
   }
   endText.remove(0, 1);
   text += endText;
@@ -725,7 +725,7 @@ QString elideText(const QString &srcText, const QFontMetrics &fm, int width,
                   const QString &elideSymbol) {
   QString text(srcText);
 
-  for (int i = text.size(); i > 1 && fm.width(text) > width;)
+  for (int i = text.size(); i > 1 && fm.horizontalAdvance(text) > width;)
     text = srcText.left(--i).append(elideSymbol);
 
   return text;

--- a/toonz/sources/toonzqt/infoviewer.cpp
+++ b/toonz/sources/toonzqt/infoviewer.cpp
@@ -302,7 +302,7 @@ void InfoViewerImp::setGeneralFileInfo(const TFilePath &path) {
   setVal(eFileType, getTypeString());
   if (fi.owner() != "") setVal(eOwner, fi.owner());
   setVal(eSize, fileSizeString(fi.size()));
-  setVal(eCreated, fi.created().toString());
+  setVal(eCreated, fi.birthTime().toString());
   setVal(eModified, fi.lastModified().toString());
   setVal(eLastAccess, fi.lastRead().toString());
   m_separator1.show();

--- a/toonz/sources/toonzqt/intpairfield.cpp
+++ b/toonz/sources/toonzqt/intpairfield.cpp
@@ -65,7 +65,7 @@ IntPairField::IntPairField(QWidget *parent, bool isMaxRangeLimited)
   bool ret = connect(m_leftLineEdit, SIGNAL(editingFinished()),
                      SLOT(onLeftEditingFinished()));
   ret      = ret && connect(m_rightLineEdit, SIGNAL(editingFinished()),
-                       SLOT(onRightEditingFinished()));
+                            SLOT(onRightEditingFinished()));
 
   assert(ret);
 }
@@ -153,8 +153,8 @@ void IntPairField::paintEvent(QPaintEvent *) {
 void IntPairField::setLeftText(const QString &text) {
   QPoint pos       = m_leftLabel->pos();
   QString oldText  = m_leftLabel->text();
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
+  int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
+  int newLabelSize = fontMetrics().horizontalAdvance(text);
   int labelSize    = newLabelSize - oldLabelSize;
   m_leftMargin += labelSize + MARGIN_OFFSET;
   m_leftLabel->setText(text);
@@ -165,8 +165,8 @@ void IntPairField::setLeftText(const QString &text) {
 
 void IntPairField::setRightText(const QString &text) {
   QString oldText  = m_rightLabel->text();
-  int oldLabelSize = fontMetrics().width(oldText);
-  int newLabelSize = fontMetrics().width(text);
+  int oldLabelSize = fontMetrics().horizontalAdvance(oldText);
+  int newLabelSize = fontMetrics().horizontalAdvance(text);
   int labelSize    = newLabelSize - oldLabelSize;
   m_rightMargin += labelSize + MARGIN_OFFSET;
   m_rightLabel->setText(text);

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -513,7 +513,11 @@ bool LutManager::loadLutFile(const QString& fp) {
 
   // The third line is corrections of values at each LUT grid
   line = locals::readDataLine(stream);
-  list = line.split(" ", QString::SkipEmptyParts);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  list = line.split(" ", Qt::SkipEmptyParts);
+#else
+  list        = line.split(" ", QString::SkipEmptyParts);
+#endif
   if (list.size() != m_lut.meshSize) {
     file.close();
     return execWarning(QObject::tr("Failed to Load 3DLUT File."));
@@ -529,7 +533,11 @@ bool LutManager::loadLutFile(const QString& fp) {
       for (int i = 0; i < m_lut.meshSize; ++i)  // b
       {
         line = locals::readDataLine(stream);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        list = line.split(" ", Qt::SkipEmptyParts);
+#else
         list = line.split(" ", QString::SkipEmptyParts);
+#endif
         if (list.size() != 3) {
           file.close();
           delete[] m_lut.data;

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -327,7 +327,7 @@ void PageViewer::drop(int dstIndexInPage, const QMimeData *mimeData) {
   int dstPageIndex = m_page->getIndex();
   if ((m_page->getStyleId(0) == 0 || m_page->getStyleId(1) == 1) &&
       dstIndexInPage < 2)
-    dstIndexInPage                       = 2;
+    dstIndexInPage = 2;
   if (dstIndexInPage < 0) dstIndexInPage = m_page->getStyleCount();
 
   const PaletteData *paletteData = dynamic_cast<const PaletteData *>(mimeData);
@@ -478,7 +478,7 @@ void PageViewer::drawColorName(QPainter &p, QRect &nameRect, TColorStyle *style,
     TPixel32 color = style->getMainColor();
     int v          = (int)(0.299 * color.r + 0.587 * color.g + 0.114 * color.b);
     p.setPen(v > 127 ? Qt::black : Qt::white);
-    int textWidth = QFontMetrics(p.font()).width(name);
+    int textWidth = QFontMetrics(p.font()).horizontalAdvance(name);
     if (textWidth < rect.width() - 2)
       p.drawText(rect, Qt::AlignCenter, name);
     else
@@ -488,15 +488,15 @@ void PageViewer::drawColorName(QPainter &p, QRect &nameRect, TColorStyle *style,
   }
 
   if (m_viewMode == LargeChips) {
-    QString index                = QString::number(styleIndex);
-    QFont font                   = p.font();
-    int fontSize                 = font.pointSize();
+    QString index = QString::number(styleIndex);
+    QFont font    = p.font();
+    int fontSize  = font.pointSize();
     if (fontSize == -1) fontSize = font.pixelSize();
-    int length                   = index.length() * fontSize;
-    int w                        = (length > 11) ? (length) : 11;
-    int h                        = 11;
-    int x0                       = nameRect.right() - w + 1;
-    int y0                       = nameRect.top() - h - 1;
+    int length = index.length() * fontSize;
+    int w      = (length > 11) ? (length) : 11;
+    int h      = 11;
+    int x0     = nameRect.right() - w + 1;
+    int y0     = nameRect.top() - h - 1;
     p.drawText(nameRect.adjusted(6, 1, -6, -1), name);
     QRect indexRect(x0, y0, w, h);
     p.fillRect(indexRect, QBrush(Qt::white));
@@ -590,10 +590,10 @@ void PageViewer::paintEvent(QPaintEvent *e) {
   if (!palette) return;
 
   // [i0,i1] = visible cell range
-  QRect visibleRect            = e->rect();
-  int i0                       = posToIndex(visibleRect.topLeft());
-  if (i0 < 0) i0               = 0;
-  int i1                       = posToIndex(visibleRect.bottomRight());
+  QRect visibleRect = e->rect();
+  int i0            = posToIndex(visibleRect.topLeft());
+  if (i0 < 0) i0 = 0;
+  int i1 = posToIndex(visibleRect.bottomRight());
   if (i1 >= getChipCount()) i1 = getChipCount() - 1;
 
   QFont preFont = p.font();
@@ -707,12 +707,12 @@ void PageViewer::paintEvent(QPaintEvent *e) {
         QRect itemRect = getItemRect(i).adjusted(0, -1, 0, 1);
         p.setPen(Qt::NoPen);
         p.setBrush(getSelectedBorderColor());
-        p.drawRoundRect(itemRect, 7, 25);
+        p.drawRoundedRect(itemRect, 7, 25, Qt::RelativeSize);
       } else if (currentStyleIndex == styleIndex) {
         QRect itemRect = getItemRect(i).adjusted(1, 0, -1, 0);
         p.setPen(Qt::NoPen);
         p.setBrush(getSelectedBorderColor());
-        p.drawRoundRect(itemRect, 7, 25);
+        p.drawRoundedRect(itemRect, 7, 25, Qt::RelativeSize);
       }
       // paint style
       QRect chipRect = getItemRect(i).adjusted(4, 4, -5, -5);
@@ -843,7 +843,8 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       tmpFont.setPointSize(9);
       tmpFont.setItalic(false);
       p.setFont(tmpFont);
-      int indexWidth = fontMetrics().width(QString().setNum(styleIndex)) + 4;
+      int indexWidth =
+          fontMetrics().horizontalAdvance(QString().setNum(styleIndex)) + 4;
       QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
                       chipRect.bottomRight());
       p.setPen(Qt::black);
@@ -1241,7 +1242,7 @@ void PageViewer::dragEnterEvent(QDragEnterEvent *event) {
     if (index < 0)
       index = 0;
     else if (index > m_page->getStyleCount())
-      index             = m_page->getStyleCount();
+      index = m_page->getStyleCount();
     m_dropPositionIndex = index;
     update();
     event->acceptProposedAction();
@@ -1261,7 +1262,7 @@ void PageViewer::dragMoveEvent(QDragMoveEvent *event) {
     if (index < 0)
       index = 0;
     else if (index > m_page->getStyleCount())
-      index             = m_page->getStyleCount();
+      index = m_page->getStyleCount();
     m_dropPositionIndex = index;
     update();
     event->acceptProposedAction();
@@ -1337,9 +1338,8 @@ void PageViewer::keyPressEvent(QKeyEvent *e) {
     if (key ==
         cManager->getKeyFromShortcut(cManager->getShortcutFromId(V_ZoomIn)))
       zoomInChip();
-    else if (key ==
-             cManager->getKeyFromShortcut(
-                 cManager->getShortcutFromId(V_ZoomOut)))
+    else if (key == cManager->getKeyFromShortcut(
+                        cManager->getShortcutFromId(V_ZoomOut)))
       zoomOutChip();
     else
       e->ignore();
@@ -1451,8 +1451,8 @@ void PageViewer::select(int indexInPage, QMouseEvent *event) {
   }
 
   bool isStyleChanged = false;
-  if (on) selected    = true;
-  int styleIndex      = m_page->getStyleId(indexInPage);
+  if (on) selected = true;
+  int styleIndex = m_page->getStyleId(indexInPage);
   if (selected) {
     setCurrentStyleIndex(styleIndex);
 
@@ -1669,11 +1669,7 @@ void PaletteTabBar::updateTabName() {
   \brief  PaletteIconWidget class provides a widget to show a palette icon.
   */
 
-#if QT_VERSION >= 0x050500
 PaletteIconWidget::PaletteIconWidget(QWidget *parent, Qt::WindowFlags flags)
-#else
-PaletteIconWidget::PaletteIconWidget(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent, flags), m_isOver(false) {
   setFixedSize(30, 20);
   setToolTip(QObject::tr("Click & Drag Palette into Studio Palette"));

--- a/toonz/sources/toonzqt/pickrgbutils.cpp
+++ b/toonz/sources/toonzqt/pickrgbutils.cpp
@@ -8,6 +8,7 @@
 #include <QOpenGLWidget>
 #include <QDesktopWidget>
 #include <QApplication>
+#include <QScreen>
 
 #include "toonzqt/pickrgbutils.h"
 
@@ -43,14 +44,12 @@ QRgb meanColor(const QImage &img, const QRect &rect) {
 
   return r | (g << 8) | (b << 16) | (m << 24);
 }
-}
+}  // namespace
 
 //==============================================================================
 
 QRgb pickRGB(QWidget *widget, const QRect &rect) {
-  QImage img(QPixmap::grabWidget(widget, rect.x(), rect.y(), rect.width(),
-                                 rect.height())
-                 .toImage());
+  QImage img(widget->grab(rect).toImage());
   return meanColor(img, img.rect());
 }
 
@@ -84,9 +83,16 @@ QRgb pickScreenRGB(const QRect &rect) {
 
 #endif
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+  QImage img(widget->screen()
+                 ->grabWindow(widget->winId(), theRect.x(), theRect.y(),
+                              theRect.width(), theRect.height())
+                 .toImage());
+#else
   QImage img(QPixmap::grabWindow(widget->winId(), theRect.x(), theRect.y(),
                                  theRect.width(), theRect.height())
                  .toImage());
+#endif
   return meanColor(
       img, QRect(rect.left() - theRect.left(), rect.top() - theRect.top(),
                  rect.width(), rect.height()));

--- a/toonz/sources/toonzqt/planeviewer.cpp
+++ b/toonz/sources/toonzqt/planeviewer.cpp
@@ -29,7 +29,7 @@
 #include <QHideEvent>
 #include <QGestureEvent>
 
-//#define PRINT_AFF
+// #define PRINT_AFF
 
 //**********************************************************************************
 //    Local namespace  stuff
@@ -50,8 +50,9 @@ private:
 bool PlaneViewerZoomer::zoom(bool zoomin, bool resetZoom) {
   PlaneViewer &planeViewer = static_cast<PlaneViewer &>(*getWidget());
 
-  resetZoom ? planeViewer.resetView() : zoomin ? planeViewer.zoomIn()
-                                               : planeViewer.zoomOut();
+  resetZoom ? planeViewer.resetView()
+  : zoomin  ? planeViewer.zoomIn()
+            : planeViewer.zoomOut();
 
   return true;
 }
@@ -189,7 +190,7 @@ void PlaneViewer::mouseMoveEvent(QMouseEvent *event) {
   }
 
   QPoint curPos = event->pos() * getDevPixRatio();
-  if (event->buttons() & Qt::MidButton)
+  if (event->buttons() & Qt::MiddleButton)
     moveView(curPos.x() - m_xpos, height() - curPos.y() - m_ypos);
 
   m_xpos = curPos.x(), m_ypos = height() - curPos.y();
@@ -255,12 +256,12 @@ void PlaneViewer::wheelEvent(QWheelEvent *event) {
 
   default:  // Qt::MouseEventSynthesizedByQt,
             // Qt::MouseEventSynthesizedByApplication
-    {
-      std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
-                   "Qt::MouseEventSynthesizedByApplication"
-                << std::endl;
-      break;
-    }
+  {
+    std::cout << "not supported event: Qt::MouseEventSynthesizedByQt, "
+                 "Qt::MouseEventSynthesizedByApplication"
+              << std::endl;
+    break;
+  }
 
   }  // end switch
 
@@ -268,9 +269,14 @@ void PlaneViewer::wheelEvent(QWheelEvent *event) {
     if ((m_gestureActive == true &&
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
-      TPointD pos(event->x() * getDevPixRatio(),
-                  height() - event->y() * getDevPixRatio());
-      double zoom_par = 1 + event->delta() * 0.001;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+      TPointD pos(event->position().x() * getDevPixRatio(),
+                  height() - event->position().y() * getDevPixRatio());
+#else
+      TPointD pos(event->pos().x() * getDevPixRatio(),
+                  height() - event->pos().y() * getDevPixRatio());
+#endif
+      double zoom_par = 1 + event->angleDelta().y() * 0.001;
 
       zoomView(pos.x, pos.y, zoom_par);
     }
@@ -469,10 +475,9 @@ bool PlaneViewer::event(QEvent *e) {
   }
   */
 
-  if (e->type() == QEvent::Gesture &&
-      CommandManager::instance()
-          ->getAction(MI_TouchGestureControl)
-          ->isChecked()) {
+  if (e->type() == QEvent::Gesture && CommandManager::instance()
+                                          ->getAction(MI_TouchGestureControl)
+                                          ->isChecked()) {
     gestureEvent(static_cast<QGestureEvent *>(e));
     return true;
   }

--- a/toonz/sources/toonzqt/schematicgroupeditor.cpp
+++ b/toonz/sources/toonzqt/schematicgroupeditor.cpp
@@ -24,19 +24,13 @@
 
 SchematicWindowEditor::SchematicWindowEditor(
     const QList<SchematicNode *> &groupedNode, SchematicScene *scene)
-#if QT_VERSION >= 0x050000
     : QGraphicsItem()
-#else
-    : QGraphicsItem(0, scene)
-#endif
     , m_groupedNode(groupedNode)
     , m_scene(scene)
     , m_lastPos()
     , m_button(Qt::NoButton)
     , m_isMacroEditor(false) {
-#if QT_VERSION >= 0x050000
   scene->addItem(this);
-#endif
   m_nameItem = new SchematicName(this, 67, 14);
   m_nameItem->setPos(-2, -2);
   m_nameItem->setZValue(1);
@@ -266,7 +260,8 @@ void FxSchematicGroupEditor::onNameChanged() {
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TFxCommand::renameGroup(fxs.toStdList(), m_groupName.toStdWString(), true,
+  TFxCommand::renameGroup(std::list<TFxP>(fxs.begin(), fxs.end()),
+                          m_groupName.toStdWString(), true,
                           fxScene->getXsheetHandle());
   update();
 }
@@ -297,11 +292,7 @@ QRectF FxSchematicGroupEditor::boundingSceneRect() const {
       int factor = k * 30;
       app.adjust(-factor, -factor, factor, factor);
     }
-#if QT_VERSION >= 0x050000
     rect = rect.united(app);
-#else
-    rect = rect.unite(app);
-#endif
   }
   rect.adjust(-20, -35, 0, 20);
   return rect;
@@ -387,11 +378,7 @@ QRectF FxSchematicMacroEditor::boundingSceneRect() const {
     QPointF shiftAppPos(node->scenePos().x() - app.left(),
                         node->scenePos().y() + app.top() + 10);
     app.moveTopLeft(shiftAppPos);
-#if QT_VERSION >= 0x050000
     rect = rect.united(app);
-#else
-    rect = rect.unite(app);
-#endif
   }
   rect.adjust(-20, -35, 0, 20);
   return rect;
@@ -467,11 +454,7 @@ QRectF StageSchematicGroupEditor::boundingSceneRect() const {
     app.moveTopLeft(shiftAppPos);
     bool isASubgroupedNode = obj->getEditingGroupId() != m_groupId;
     if (isASubgroupedNode) app.adjust(-30, -30, 30, 30);
-#if QT_VERSION >= 0x050000
     rect = rect.united(app);
-#else
-    rect = rect.unite(app);
-#endif
   }
   rect.adjust(-20, -35, 0, 0);
   return rect;

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -296,7 +296,7 @@ void SchematicThumbnailToggle::paint(QPainter *painter,
                                      const QStyleOptionGraphicsItem *option,
                                      QWidget *widget) {
   QRect rect(3, 3, 8, 8);
-  QRect sourceRect = scene()->views()[0]->matrix().mapRect(rect);
+  QRect sourceRect = scene()->views()[0]->transform().mapRect(rect);
   static QIcon onIcon(":Resources/schematic_thumbtoggle_on.svg");
   static QIcon offIcon(":Resources/schematic_thumbtoggle_off.svg");
   QPixmap pixmap;
@@ -420,7 +420,7 @@ void SchematicToggle::paint(QPainter *painter,
         (m_state == 2 && !m_imageOn2.isNull()) ? m_imageOn2 : m_imageOn;
     painter->fillRect(boundingRect().toRect(), m_colorOn);
     QRect sourceRect =
-        scene()->views()[0]->matrix().mapRect(QRect(0, 0, 18, 17));
+        scene()->views()[0]->transform().mapRect(QRect(0, 0, 18, 17));
     QPixmap redPm = pix.pixmap(sourceRect.size());
     painter->drawPixmap(rect, redPm);
   } else if (!m_imageOff.isNull()) {
@@ -431,7 +431,7 @@ void SchematicToggle::paint(QPainter *painter,
     double d = pen.widthF() / 2.0;
     painter->drawRect(boundingRect().adjusted(d, d, -d, -d));
     QRect sourceRect =
-        scene()->views()[0]->matrix().mapRect(QRect(0, 0, 18, 17));
+        scene()->views()[0]->transform().mapRect(QRect(0, 0, 18, 17));
     QPixmap redPm = m_imageOff.pixmap(sourceRect.size());
     painter->drawPixmap(rect, redPm);
   }
@@ -496,7 +496,7 @@ void SchematicToggle_SplineOptions::paint(
   if (m_state != 0) {
     QIcon &pix =
         (m_state == 2 && !m_imageOn2.isNull()) ? m_imageOn2 : m_imageOn;
-    QRect sourceRect = scene()->views()[0]->matrix().mapRect(rect.toRect());
+    QRect sourceRect = scene()->views()[0]->transform().mapRect(rect.toRect());
     QPixmap redPm    = pix.pixmap(sourceRect.size());
     painter->drawPixmap(rect.toRect(), redPm);
   }
@@ -591,20 +591,14 @@ void SchematicHandleSpinBox::mouseReleaseEvent(QGraphicsSceneMouseEvent *me) {
 //========================================================
 
 SchematicLink::SchematicLink(QGraphicsItem *parent, QGraphicsScene *scene)
-#if QT_VERSION >= 0x050000
     : QGraphicsItem(parent)
-#else
-    : QGraphicsItem(parent, scene)
-#endif
     , m_startPort(0)
     , m_endPort(0)
     , m_path()
     , m_hitPath()
     , m_lineShaped(false)
     , m_highlighted(false) {
-#if QT_VERSION >= 0x050000
   scene->addItem(this);
-#endif
   setFlag(QGraphicsItem::ItemIsMovable, false);
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   setFlag(QGraphicsItem::ItemIsFocusable, false);
@@ -752,12 +746,8 @@ void SchematicLink::mousePressEvent(QGraphicsSceneMouseEvent *me) {
     }
   }
 
-  QMatrix matrix = scene()->views()[0]->matrix();
-#if QT_VERSION >= 0x050000
-  double scaleFactor = sqrt(matrix.determinant());
-#else
-  double scaleFactor = sqrt(matrix.det());
-#endif
+  QTransform transform = scene()->views()[0]->transform();
+  double scaleFactor   = sqrt(transform.determinant());
 
   QPointF startPos = getStartPort()->getLinkEndPoint();
   QPointF endPos   = getEndPort()->getLinkEndPoint();
@@ -815,11 +805,7 @@ SchematicPort::SchematicPort(QGraphicsItem *parent, SchematicNode *node,
     , m_linkingTo(0)
     , m_hook(0, 0)
     , m_type(type) {
-#if QT_VERSION >= 0x050000
   setAcceptHoverEvents(false);
-#else
-  setAcceptsHoverEvents(false);
-#endif
   setFlag(QGraphicsItem::ItemIsSelectable, false);
   setFlag(QGraphicsItem::ItemIsFocusable, false);
 }
@@ -1055,18 +1041,12 @@ QPointF SchematicPort::getLinkEndPoint() const { return scenePos() + m_hook; }
 */
 
 SchematicNode::SchematicNode(SchematicScene *scene)
-#if QT_VERSION >= 0x050000
     : QGraphicsItem(0)
-#else
-    : QGraphicsItem(0, scene)
-#endif
     , m_scene(scene)
     , m_width(0)
     , m_height(0)
     , m_buttonState(Qt::NoButton) {
-#if QT_VERSION >= 0x050000
   scene->addItem(this);
-#endif
   setFlag(QGraphicsItem::ItemIsMovable, false);
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   setFlag(QGraphicsItem::ItemIsFocusable, false);

--- a/toonz/sources/toonzqt/screenboard.cpp
+++ b/toonz/sources/toonzqt/screenboard.cpp
@@ -12,6 +12,7 @@
 using namespace DVGui;
 
 #include <QPalette>
+#include <QScreen>
 
 //***********************************************************************************
 //    Local namespace
@@ -25,13 +26,13 @@ public:
     return rect.contains(QCursor::pos());
   }
   void paintEvent(QWidget *widget, QPaintEvent *pe) override {
-// Seems that mouse masking is on by default on the drawn regions, when using
-// WA_TranslucentBackground (which is weird). I think it's the Qt 2 autoMask
-// feature
-// that disappeared from Qt 3 on - now it must be managed internally.
+    // Seems that mouse masking is on by default on the drawn regions, when
+    // using WA_TranslucentBackground (which is weird). I think it's the Qt 2
+    // autoMask feature that disappeared from Qt 3 on - now it must be managed
+    // internally.
 
-// So, we have to fill the entire screen region with the most invisible color
-// possible...
+    // So, we have to fill the entire screen region with the most invisible
+    // color possible...
 
 #ifdef MACOSX
 #define MIN_ALPHA                                                              \
@@ -179,7 +180,8 @@ void ScreenBoard::releaseMouse() {
 void ScreenBoard::reallocScreenWidgets() {
   QDesktopWidget *desktop = QApplication::desktop();
 
-  int i, screensCount = desktop->numScreens();
+  int i;
+  int screensCount = QGuiApplication::screens().count();
 
   // Delete exceeding screens and resize to screensCount
   for (i = screensCount; i < m_screenWidgets.size(); ++i) {
@@ -188,7 +190,7 @@ void ScreenBoard::reallocScreenWidgets() {
     // Note that updates may be invoked in event handlers.
   }
 
-  m_screenWidgets.resize(desktop->numScreens());
+  m_screenWidgets.resize(screensCount);
 
   // Re-initialize the screen widgets list
   for (i = 0; i < screensCount; ++i) {
@@ -200,7 +202,7 @@ void ScreenBoard::reallocScreenWidgets() {
   int j, drawingsCount = m_drawings.size();
   for (i = 0; i < screensCount; ++i) {
     ScreenWidget *screenWidget = m_screenWidgets[i];
-    const QRect &screenGeom    = desktop->screenGeometry(i);
+    const QRect &screenGeom    = QGuiApplication::screens().at(i)->geometry();
 
     for (j = 0; j < drawingsCount; ++j) {
       Drawing *drawing = m_drawings[j];

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -249,11 +249,7 @@ void PanTool::release(int row, int col, QMouseEvent *e) {
 
 //=============================================================================
 
-#if QT_VERSION >= 0x050500
 ScrollArea::ScrollArea(QWidget *parent, Qt::WindowFlags flags)
-#else
-ScrollArea::ScrollArea(QWidget *parent, Qt::WFlags flags)
-#endif
     : QScrollArea(parent) {
   setFrameStyle(QFrame::Panel | QFrame::Raised);
   setLineWidth(6);
@@ -294,7 +290,7 @@ void GenericPanel::paintEvent(QPaintEvent *e) {
 
 void GenericPanel::mousePressEvent(QMouseEvent *e) {
   assert(!m_dragTool);
-  if (e->button() == Qt::MidButton)
+  if (e->button() == Qt::MiddleButton)
     m_dragTool = new PanTool(this);
   else
     m_dragTool = createDragTool(e);
@@ -379,16 +375,14 @@ void RowPanel::drawRows(QPainter &p, int r0, int r1) {
     // draw horizontal line
     bool isMarkSecRow = getViewer()->isMarkSecRow(r);
     bool isMarkRow    = getViewer()->isMarkRow(r);
-    QColor color      = (isMarkSecRow)
-                       ? getViewer()->getSecMarkerLineColor()
-                       : (isMarkRow) ? getViewer()->getMarkerLineColor()
-                                     : getViewer()->getLightLineColor();
-    p.setPen(
-        QPen(color,
-             (isMarkSecRow)
-                 ? 3.
-                 : (getViewer()->isSecMarkerActive() && isMarkRow) ? 2. : 1.,
-             Qt::SolidLine, Qt::FlatCap));
+    QColor color      = (isMarkSecRow) ? getViewer()->getSecMarkerLineColor()
+                        : (isMarkRow)  ? getViewer()->getMarkerLineColor()
+                                       : getViewer()->getLightLineColor();
+    p.setPen(QPen(color,
+                  (isMarkSecRow)                                    ? 3.
+                  : (getViewer()->isSecMarkerActive() && isMarkRow) ? 2.
+                                                                    : 1.,
+                  Qt::SolidLine, Qt::FlatCap));
     p.drawLine(x0, y, x1, y);
 
     if (simpleView && r > 0 && !getViewer()->isMarkRow(r + 1)) {
@@ -501,16 +495,14 @@ void CellPanel::paintEvent(QPaintEvent *e) {
     int y             = getViewer()->rowToY(r);
     bool isMarkSecRow = getViewer()->isMarkSecRow(r);
     bool isMarkRow    = getViewer()->isMarkRow(r);
-    QColor color      = (isMarkSecRow)
-                       ? getViewer()->getSecMarkerLineColor()
-                       : (isMarkRow) ? getViewer()->getMarkerLineColor()
-                                     : getViewer()->getLightLineColor();
-    painter.setPen(
-        QPen(color,
-             (isMarkSecRow)
-                 ? 3.
-                 : (getViewer()->isSecMarkerActive() && isMarkRow) ? 2. : 1.,
-             Qt::SolidLine, Qt::FlatCap));
+    QColor color      = (isMarkSecRow) ? getViewer()->getSecMarkerLineColor()
+                        : (isMarkRow)  ? getViewer()->getMarkerLineColor()
+                                       : getViewer()->getLightLineColor();
+    painter.setPen(QPen(color,
+                        (isMarkSecRow)                                    ? 3.
+                        : (getViewer()->isSecMarkerActive() && isMarkRow) ? 2.
+                                                                          : 1.,
+                        Qt::SolidLine, Qt::FlatCap));
     painter.drawLine(x0, y, x1, y);
   }
 }
@@ -816,7 +808,7 @@ bool SpreadsheetViewer::refreshContentSize(int scrollDx, int scrollDy) {
   QSize viewportSize = m_cellScrollArea->viewport()->size();
   QPoint offset      = m_cellScrollArea->widget()->pos();
   offset             = QPoint(std::min(0, offset.x() - scrollDx),
-                  std::min(0, offset.y() - scrollDy));
+                              std::min(0, offset.y() - scrollDy));
 
   QSize contentSize(columnToX(m_columnCount + 1), rowToY(m_rowCount + 1));
 

--- a/toonz/sources/toonzqt/stageobjectselection.cpp
+++ b/toonz/sources/toonzqt/stageobjectselection.cpp
@@ -331,7 +331,9 @@ void StageObjectSelection::copySelection() {
   StageObjectsData *data = new StageObjectsData();
   bool pegSelected       = false;
   data->storeObjects(
-      m_selectedObjects.toVector().toStdVector(), m_xshHandle->getXsheet(),
+      std::vector<TStageObjectId>(m_selectedObjects.begin(),
+                                  m_selectedObjects.end()),
+      m_xshHandle->getXsheet(),
       StageObjectsData::eDoClone | StageObjectsData::eResetFxDagPositions);
   std::set<int> columnIndexes;
   int i;
@@ -342,7 +344,8 @@ void StageObjectSelection::copySelection() {
       columnIndexes, m_xshHandle->getXsheet(),
       StageObjectsData::eDoClone | StageObjectsData::eResetFxDagPositions);
   data->storeSplines(
-      m_selectedSplines.toStdList(), m_xshHandle->getXsheet(),
+      std::list<int>(m_selectedSplines.begin(), m_selectedSplines.end()),
+      m_xshHandle->getXsheet(),
       StageObjectsData::eDoClone | StageObjectsData::eResetFxDagPositions);
 
   if (!data->isEmpty())

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -475,7 +475,7 @@ void CameraPainter::paint(QPainter *painter,
 
   SchematicViewer *viewer = stageScene->getSchematicViewer();
   QColor cameraColor      = m_isActive ? viewer->getActiveCameraColor()
-                                  : viewer->getOtherCameraColor();
+                                       : viewer->getOtherCameraColor();
 
   painter->setBrush(cameraColor);
   painter->setPen(Qt::NoPen);
@@ -1083,11 +1083,7 @@ StageSchematicNodeDock::StageSchematicNodeDock(StageSchematicNode *parent,
   connect(m_port, SIGNAL(xsheetChanged()), parent, SIGNAL(xsheetChanged()));
 
   setZValue(1.5);
-#if QT_VERSION >= 0x050000
   setAcceptHoverEvents(true);
-#else
-  setAcceptsHoverEvents(true);
-#endif
 }
 
 //--------------------------------------------------------
@@ -1104,11 +1100,7 @@ QRectF StageSchematicNodeDock::boundingRect() const {
   if (stageScene && stageScene->isShowLetterOnPortFlagEnabled()) {
     QRectF handleRect = m_handleSpinBox->boundingRect();
     handleRect.moveTopLeft(QPointF(portRect.width(), handleRect.topLeft().y()));
-#if QT_VERSION >= 0x050000
     portRect = portRect.united(handleRect);
-#else
-    portRect = portRect.unite(handleRect);
-#endif
   }
   return portRect;
 }
@@ -1136,7 +1128,7 @@ void StageSchematicNodeDock::onModifyHandle(int increase) {
   int min = (getNode()->getStageObject()->getId().isColumn())
                 ? -HookSet::maxHooksCount
                 : 0;
-  index = tcrop(index, min, 25);
+  index   = tcrop(index, min, 25);
 
   if (index >= 0)
     handle = std::string(1, (char)('A' + index));
@@ -1262,11 +1254,7 @@ StageSchematicSplineDock::StageSchematicSplineDock(SchematicNode *parent,
   setFlag(QGraphicsItem::ItemIsSelectable, false);
   setFlag(QGraphicsItem::ItemIsFocusable, false);
   m_port = new StageSchematicSplinePort(this, type);
-#if QT_VERSION >= 0x050000
   setAcceptHoverEvents(true);
-#else
-  setAcceptsHoverEvents(true);
-#endif
 
   connect(m_port, SIGNAL(sceneChanged()), parent, SIGNAL(sceneChanged()));
   connect(m_port, SIGNAL(xsheetChanged()), parent, SIGNAL(xsheetChanged()));
@@ -1622,8 +1610,8 @@ void StageSchematicPegbarNode::onNameChanged() {
   std::string strId = id.toString();
   std::string name  = m_name.toStdString();
   QString toolTip   = name == strId
-                        ? m_name
-                        : m_name + " (" + QString::fromStdString(strId) + ")";
+                          ? m_name
+                          : m_name + " (" + QString::fromStdString(strId) + ")";
   setToolTip(toolTip);
   if (id.isPegbar())
     TStageObjectCmd::rename(id, m_name.toStdString(),

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -519,22 +519,14 @@ void StageSchematicScene::updateNestedGroupEditors(StageSchematicNode *node,
       if (rect.isEmpty())
         rect = app;
       else
-#if QT_VERSION >= 0x050000
         rect = rect.united(app);
-#else
-        rect = rect.unite(app);
-#endif
     }
   }
   node->setPos(newPos);
   for (i = 0; i < groupIdStack.size(); i++) {
     if (!m_groupEditorTable.contains(groupIdStack[i])) continue;
-#if QT_VERSION >= 0x050000
     rect =
         rect.united(m_groupEditorTable[groupIdStack[i]]->sceneBoundingRect());
-#else
-    rect = rect.unite(m_groupEditorTable[groupIdStack[i]]->sceneBoundingRect());
-#endif
     QRectF app = m_groupEditorTable[groupIdStack[i]]->boundingSceneRect();
     if (m_groupEditorTable[groupIdStack[i]]->scenePos() != app.topLeft())
       m_groupEditorTable[groupIdStack[i]]->setPos(app.topLeft());
@@ -1173,7 +1165,7 @@ void StageSchematicScene::contextMenuEvent(
 void StageSchematicScene::mousePressEvent(QGraphicsSceneMouseEvent *me) {
   QList<QGraphicsItem *> items = selectedItems();
   SchematicScene::mousePressEvent(me);
-  if (me->button() == Qt::MidButton) {
+  if (me->button() == Qt::MiddleButton) {
     int i;
     for (i = 0; i < items.size(); i++) items[i]->setSelected(true);
   }

--- a/toonz/sources/toonzqt/styleindexlineedit.cpp
+++ b/toonz/sources/toonzqt/styleindexlineedit.cpp
@@ -15,8 +15,8 @@ using namespace DVGui;
 StyleIndexLineEdit::StyleIndexLineEdit() : m_pltHandle(0) {
   // style index will not be more than 4096, but a longer text
   // "current" may be input instead of style id + chip width + margin
-  int currentWidth = std::max(fontMetrics().width("current"),
-                              fontMetrics().width(tr("current")));
+  int currentWidth = std::max(fontMetrics().horizontalAdvance("current"),
+                              fontMetrics().horizontalAdvance(tr("current")));
   setMaximumWidth(currentWidth + 30);
   setFixedHeight(20);
 }

--- a/toonz/sources/toonzqt/swatchviewer.cpp
+++ b/toonz/sources/toonzqt/swatchviewer.cpp
@@ -30,7 +30,7 @@
 
 using namespace TFxUtil;
 
-//#define USE_SQLITE_HDPOOL
+// #define USE_SQLITE_HDPOOL
 
 //*************************************************************************************
 //    Swatch cache delegate
@@ -242,11 +242,7 @@ int submittedTasks      = 0;
 // SwatchViewer
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 SwatchViewer::SwatchViewer(QWidget *parent, Qt::WindowFlags flags)
-#else
-SwatchViewer::SwatchViewer(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent, flags)
     , m_fx(0)
     , m_actualFxClone(0)
@@ -394,7 +390,7 @@ void SwatchViewer::updateSize(const QSize &size) {
   double ratio = m_cameraRect.getLy() > 0
                      ? m_cameraRect.getLx() / (double)m_cameraRect.getLy()
                      : 1.0;
-  int w = std::min((int)(h * ratio), parentWidget()->width());
+  int w        = std::min((int)(h * ratio), parentWidget()->width());
   setFixedWidth(w);
   if (w > 2 && h > 2)
     m_raster = TRaster32P(TDimension(w, h));
@@ -686,7 +682,7 @@ void SwatchViewer::mousePressEvent(QMouseEvent *event) {
       }
     }
     update();
-  } else if (m_mouseButton == Qt::MidButton) {
+  } else if (m_mouseButton == Qt::MiddleButton) {
     m_pos        = pos;
     m_firstPos   = pos;
     m_oldContent = getContent();
@@ -724,7 +720,7 @@ void SwatchViewer::mouseMoveEvent(QMouseEvent *event) {
     // to avoid unnecessary recursions.
 
     QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-  } else if (m_mouseButton == Qt::MidButton) {
+  } else if (m_mouseButton == Qt::MiddleButton) {
     pan(pos - m_pos);
     m_pos = pos;
   }
@@ -736,7 +732,7 @@ void SwatchViewer::mouseReleaseEvent(QMouseEvent *event) {
   m_mouseButton   = Qt::NoButton;
   m_selectedPoint = -1;
   TPoint pos      = TPoint(event->pos().x(), event->pos().y());
-  if (event->button() == Qt::MidButton) {
+  if (event->button() == Qt::MiddleButton) {
     if (!m_oldContent || !m_curContent) return;
     TPointD p = convert(pos - m_pos);
     setAff(TTranslation(p.x, -p.y) * m_aff);
@@ -788,9 +784,14 @@ void SwatchViewer::wheelEvent(QWheelEvent *event) {
     if ((m_gestureActive == true &&
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+      TPoint center(event->position().x() - width() / 2,
+                    -event->position().y() + height() / 2);
+#else
       TPoint center(event->pos().x() - width() / 2,
                     -event->pos().y() + height() / 2);
-      zoom(center, exp(0.001 * event->delta()));
+#endif
+      zoom(center, exp(0.001 * event->angleDelta().y()));
     }
   }
   event->accept();

--- a/toonz/sources/toonzqt/treemodel.cpp
+++ b/toonz/sources/toonzqt/treemodel.cpp
@@ -230,7 +230,7 @@ int TreeModel::columnCount(const QModelIndex &parent) const { return 1; }
 //------------------------------------------------------------------------------------------------------------------
 
 Qt::ItemFlags TreeModel::flags(const QModelIndex &index) const {
-  if (!index.isValid()) return 0;
+  if (!index.isValid()) return Qt::ItemFlags();
   return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 }
 
@@ -398,7 +398,7 @@ void TreeView::mousePressEvent(QMouseEvent *e) {
       onClick(item, itemPos, e);
     }
     // for drag & drop
-    else if (e->button() == Qt::MidButton) {
+    else if (e->button() == Qt::MiddleButton) {
       m_dragging = true;
       setMouseTracking(true);
       onMidClick(item, itemPos, e);


### PR DESCRIPTION
This PR resolves build warnings, including all `C4996` warnings for using obsolete Qt functions.
Also I removed some conditions to separate the process for compatibility with Qt versions older than 5.9.
