### PR TITLE
Clarify size_t origin for `tgc::hash::BucketNode`

### DIFF
--- a/toonz/sources/include/tcg/hash.h
+++ b/toonz/sources/include/tcg/hash.h
@@ -21,6 +21,11 @@ public:
   typedef T value_type;
   typedef Hash_functor hash_type;
 
+  struct BucketNode;
+  typedef typename tcg::list<BucketNode>::size_t size_t;
+  typedef typename tcg::list<BucketNode>::iterator iterator;
+  typedef typename tcg::list<BucketNode>::const_iterator const_iterator;
+
   struct BucketNode {
     K m_key;
     T m_val;
@@ -33,11 +38,6 @@ public:
         : m_key(pair.first), m_val(pair.second), m_next(-1), m_prev(-1) {}
     ~BucketNode() {}
   };
-
-  typedef typename tcg::list<BucketNode>::size_t size_t;
-
-  typedef typename tcg::list<BucketNode>::iterator iterator;
-  typedef typename tcg::list<BucketNode>::const_iterator const_iterator;
 
 private:
   std::vector<size_t> m_bucketsIdx;


### PR DESCRIPTION
## The problem

The problem with #4738 is the following:

`toonz/sources/include/tcg/hash.h:37`:
```cpp
template <typename K, typename T, typename Hash_functor = size_t (*)(const K &)>
class hash {
public:
  typedef K key_type;
  typedef T value_type;
  typedef Hash_functor hash_type;

  struct BucketNode {
    K m_key;
    T m_val;
    size_t m_next;
    size_t m_prev;

    BucketNode(const K &key, const T &val)
        : m_key(key), m_val(val), m_next(-1), m_prev(-1) {}
    BucketNode(const std::pair<K, T> &pair)
        : m_key(pair.first), m_val(pair.second), m_next(-1), m_prev(-1) {}
    ~BucketNode() {}
  };

  typedef typename tcg::list<BucketNode>::size_t size_t;
  typedef typename tcg::list<BucketNode>::iterator iterator;
  typedef typename tcg::list<BucketNode>::const_iterator const_iterator;
  ...
  ```

In the line that says `typedef typename tcg::list<BucketNode>::size_t size_t;` it's declaring that in the scope of this class, the `size_t` keyword should be treated as the `tcg::list<BucketNode>::size_t` type. This line was declared after the `BucketNode` struct was declared, and since this struct uses `size_t` type parameters, the compiler doesn't know if the programmer's intention was to declare them as the global `::size_t` or `typename tcg::list<BucketNode>::size_t`, which is in the scope of the class but declared later in the code. [0]

The truth is that this is not actually a problem, since the `tcg::list<BucketNode>::size_t` is declared in the following block:

`toonz/sources/include/tcg/list.h:177`:
```cpp
template <typename T>
class list_base {
public:
  typedef T value_type;
  typedef ::size_t size_t;
```

So then we can conclude that `tcg::list<BucketNode>::size_t` is actually the same as `::size_t`. But since I have to implement this cos the compiler it's complaining anyway, I thought it would be a good idea to upstream this change :).

[0] https://stackoverflow.com/questions/12187549/typedef-changes-meaning

## The solution

There are several ways to fix this, the easiest one being the following

```cpp
template <typename K, typename T, typename Hash_functor = size_t (*)(const K &)>
class hash {
public:
  typedef K key_type;
  typedef T value_type;
  typedef Hash_functor hash_type;

  struct BucketNode {
    K m_key;
    T m_val;
>   ::size_t m_next;
>   ::size_t m_prev;

    BucketNode(const K &key, const T &val)
        : m_key(key), m_val(val), m_next(-1), m_prev(-1) {}
    BucketNode(const std::pair<K, T> &pair)
        : m_key(pair.first), m_val(pair.second), m_next(-1), m_prev(-1) {}
    ~BucketNode() {}
  };

  typedef typename tcg::list<BucketNode>::size_t size_t;
  typedef typename tcg::list<BucketNode>::iterator iterator;
  typedef typename tcg::list<BucketNode>::const_iterator const_iterator;
  ...
```

But I think that it might be a better Idea to use the `tcg::list<BucketNode>::size_t` as the type of those variables in case a refactor to this part is needed in the future. This is what I implemented in the end:

```cpp
template <typename K, typename T, typename Hash_functor = size_t (*)(const K &)>
class hash {
public:
  typedef K key_type;
  typedef T value_type;
  typedef Hash_functor hash_type;

> struct BucketNode;
> typedef typename tcg::list<BucketNode>::size_t size_t;
> typedef typename tcg::list<BucketNode>::iterator iterator;
> typedef typename tcg::list<BucketNode>::const_iterator const_iterator;
>
  struct BucketNode {
    K m_key;
    T m_val;
    size_t m_next;
    size_t m_prev;

    BucketNode(const K &key, const T &val)
        : m_key(key), m_val(val), m_next(-1), m_prev(-1) {}
    BucketNode(const std::pair<K, T> &pair)
        : m_key(pair.first), m_val(pair.second), m_next(-1), m_prev(-1) {}
    ~BucketNode() {}
  };
  ...
```

I know that this is not a problem in the current backend considering that it's being built on ubuntu with an older version of gcc that ignores this case, but I still think that it will be better to clarify this part and improve consistency 😄 

Let me know if this implementation is ok, if you don't like it or if there is another way it should get implemented 😉 