### PR TITLE
Extend the coverage of the "Default TLV Caching Behavior" option to all raster levels on any loading

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -250,8 +250,8 @@ public:
     return getBoolValue(removeSceneNumberFromLoadedLevelName);
   }
   bool isIgnoreImageDpiEnabled() const { return getBoolValue(IgnoreImageDpi); }
-  int getInitialLoadTlvCachingBehavior() const {
-    return getIntValue(initialLoadTlvCachingBehavior);
+  int getRasterLevelCachingBehavior() const {
+    return getIntValue(rasterLevelCachingBehavior);
   }
   ColumnIconLoadingPolicy getColumnIconLoadingPolicy() const {
     return ColumnIconLoadingPolicy(getIntValue(columnIconLoadingPolicy));

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -53,7 +53,8 @@ enum PreferencesItemId {
   subsceneFolderEnabled,
   removeSceneNumberFromLoadedLevelName,
   IgnoreImageDpi,
-  initialLoadTlvCachingBehavior,
+  rasterLevelCachingBehavior,
+  // initialLoadTlvCachingBehavior, // deprecated
   columnIconLoadingPolicy,
   levelFormats,  // need to be handle separately
   autoRemoveUnusedLevels,

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -682,8 +682,9 @@ LoadLevelPopup::LoadLevelPopup()
   QWidget *optionWidget = (QWidget *)m_customWidget;
 
   // choose tlv caching behavior
-  QLabel *cacheBehaviorLabel = new QLabel(tr("TLV Caching Behavior"), this);
-  m_loadTlvBehaviorComboBox  = new QComboBox(this);
+  QLabel *cacheBehaviorLabel =
+      new QLabel(tr("Raster Level Caching Behavior"), this);
+  m_rasterCacheBehaviorComboBox = new QComboBox(this);
 
   //----Load Subsequence Level
   QPushButton *showSubsequenceButton = createShowButton(this);
@@ -719,17 +720,17 @@ LoadLevelPopup::LoadLevelPopup()
   m_notExistLabel = new QLabel(tr("(FILE DOES NOT EXIST)"));
 
   //----
-  m_loadTlvBehaviorComboBox->addItem(tr("On Demand"),
-                                     IoCmd::LoadResourceArguments::ON_DEMAND);
-  m_loadTlvBehaviorComboBox->addItem(tr("All Icons"),
-                                     IoCmd::LoadResourceArguments::ALL_ICONS);
-  m_loadTlvBehaviorComboBox->addItem(
+  m_rasterCacheBehaviorComboBox->addItem(
+      tr("On Demand"), IoCmd::LoadResourceArguments::ON_DEMAND);
+  m_rasterCacheBehaviorComboBox->addItem(
+      tr("All Icons"), IoCmd::LoadResourceArguments::ALL_ICONS);
+  m_rasterCacheBehaviorComboBox->addItem(
       tr("All Icons & Images"),
       IoCmd::LoadResourceArguments::ALL_ICONS_AND_IMAGES);
   // use the default value set in the preference
-  m_loadTlvBehaviorComboBox->setCurrentIndex(
-      m_loadTlvBehaviorComboBox->findData(
-          Preferences::instance()->getInitialLoadTlvCachingBehavior()));
+  m_rasterCacheBehaviorComboBox->setCurrentIndex(
+      m_rasterCacheBehaviorComboBox->findData(
+          Preferences::instance()->getRasterLevelCachingBehavior()));
   cacheBehaviorLabel->setObjectName("TitleTxtLabel");
 
   //----Load Subsequence Level
@@ -786,7 +787,7 @@ LoadLevelPopup::LoadLevelPopup()
     {
       cacheLay->addStretch(1);
       cacheLay->addWidget(cacheBehaviorLabel, 0);
-      cacheLay->addWidget(m_loadTlvBehaviorComboBox, 0);
+      cacheLay->addWidget(m_rasterCacheBehaviorComboBox, 0);
     }
     mainLayout->addLayout(cacheLay, 0);
 
@@ -1239,8 +1240,8 @@ bool LoadLevelPopup::execute() {
     args.step                  = m_stepCombo->currentIndex();
     args.inc                   = m_incCombo->currentIndex();
     args.doesFileActuallyExist = !m_notExistLabel->isVisible();
-    args.cachingBehavior       = IoCmd::LoadResourceArguments::CacheTlvBehavior(
-        m_loadTlvBehaviorComboBox->currentData().toInt());
+    args.cachingBehavior = IoCmd::LoadResourceArguments::CacheRasterBehavior(
+        m_rasterCacheBehaviorComboBox->currentData().toInt());
 
     if (m_arrLvlPropWidget->isVisible() &&
         m_levelPropertiesFrame->isEnabled()) {
@@ -1269,8 +1270,8 @@ bool LoadLevelPopup::execute() {
         args.frameIdsSet.insert(args.frameIdsSet.begin(), *fIdIt);
     }
 
-    args.cachingBehavior = IoCmd::LoadResourceArguments::CacheTlvBehavior(
-        m_loadTlvBehaviorComboBox->currentData().toInt());
+    args.cachingBehavior = IoCmd::LoadResourceArguments::CacheRasterBehavior(
+        m_rasterCacheBehaviorComboBox->currentData().toInt());
 
     if (m_arrLvlPropWidget->isVisible() &&
         m_levelPropertiesFrame->isEnabled()) {

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -49,7 +49,8 @@ class FileBrowserPopup : public QDialog {
 
 public:
   enum Options  //! Various options used to customize the popup's behavior.
-  { STANDARD      = 0x0,  //!< Standard options.
+  {
+    STANDARD      = 0x0,  //!< Standard options.
     CUSTOM_LAYOUT = 0x1,  //!< Prevents standard layout organization at
                           //! construction, surrendering it
     //!  to the user. Observe that sub-widgets creation is still enforced.
@@ -284,7 +285,7 @@ class LoadLevelPopup final : public FileBrowserPopup {
   DVGui::CheckBox *m_premultiply, *m_whiteTransp;  // , *m_doAntialias;
 
   QLabel *m_notExistLabel;
-  QComboBox *m_loadTlvBehaviorComboBox;
+  QComboBox *m_rasterCacheBehaviorComboBox;
 
 public:
   LoadLevelPopup();

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -95,9 +95,10 @@ struct LoadResourceArguments {
 
   enum ImportPolicy  //!  Policy adopted for resources external to current
                      //!  scene.
-  { ASK_USER,        //!< User is prompted for a resolution.
-    IMPORT,          //!< Resources are copied to scene folders (\a overwrites).
-    LOAD,            //!< Resources are loaded from their original paths.
+  {
+    ASK_USER,  //!< User is prompted for a resolution.
+    IMPORT,    //!< Resources are copied to scene folders (\a overwrites).
+    LOAD,      //!< Resources are loaded from their original paths.
   };
 
 public:
@@ -132,7 +133,7 @@ public:
   int step, inc, frameCount;
   bool doesFileActuallyExist;
 
-  enum CacheTlvBehavior {
+  enum CacheRasterBehavior {
     ON_DEMAND = 0,  // image data will be loaded when needed
     ALL_ICONS,      // icon data of all frames will be cached at the begininng
     ALL_ICONS_AND_IMAGES  // both icon and image data of all frames will be

--- a/toonz/sources/toonz/levelcommand.cpp
+++ b/toonz/sources/toonz/levelcommand.cpp
@@ -33,6 +33,10 @@
 #include "toonzqt/gutil.h"
 #include "toonz/namebuilder.h"
 
+#include <QProgressDialog>
+#include <QMainWindow>
+#include <QApplication>
+
 namespace {
 
 class DeleteLevelUndo final : public TUndo {
@@ -115,6 +119,58 @@ bool LevelCmd::removeLevelFromCast(TXshLevel *level, ToonzScene *scene,
     scene->getLevelSet()->removeLevel(level);
   }
   return true;
+}
+
+void LevelCmd::loadAllUsedRasterLevelsAndPutInCache(bool cacheImagesAsWell) {
+  TApp *app         = TApp::instance();
+  ToonzScene *scene = app->getCurrentScene()->getScene();
+
+  TLevelSet *levelSet = scene->getLevelSet();
+
+  std::set<TXshLevel *> usedLevels;
+  scene->getTopXsheet()->getUsedLevels(usedLevels);
+
+  std::map<TXshSimpleLevel *, int>
+      targetLevels;  // level pointer and its frame amount
+  int totalFrames = 0;
+  // estimate the amount
+  for (auto xl : usedLevels) {
+    TXshSimpleLevel *simpleLevel = xl->getSimpleLevel();
+    if (simpleLevel && (simpleLevel->getType() == TZP_XSHLEVEL ||
+                        simpleLevel->getType() == OVL_XSHLEVEL)) {
+      targetLevels[simpleLevel] = simpleLevel->getFrameCount();
+      totalFrames += simpleLevel->getFrameCount();
+    }
+  }
+
+  // if the amount of frames is more than 10, open a progress dialog and
+  // shows WaitCursor
+  QProgressDialog *pd = nullptr;
+  if (totalFrames > 10) {
+    pd = new QProgressDialog(QObject::tr("Loading Raster Images To Cache..."),
+                             QObject::tr("Cancel"), 0, totalFrames,
+                             app->getMainWindow());
+    pd->setAttribute(Qt::WA_DeleteOnClose, true);
+    pd->setWindowModality(Qt::WindowModal);
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    pd->show();
+  }
+  std::map<TXshSimpleLevel *, int>::iterator i = targetLevels.begin();
+  while (i != targetLevels.end()) {
+    if (pd && pd->wasCanceled()) break;
+    i->first->loadAllIconsAndPutInCache(cacheImagesAsWell);
+    if (pd) {
+      pd->setValue(pd->value() + i->second);
+      QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+    }
+    ++i;
+  }
+
+  if (pd) {
+    QApplication::restoreOverrideCursor();
+    pd->close();
+  }
+  return;
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/levelcommand.h
+++ b/toonz/sources/toonz/levelcommand.h
@@ -26,6 +26,8 @@ bool removeUnusedLevelsFromCast(bool showMessage = true);
 // returns false.
 bool removeLevelFromCast(TXshLevel* level, ToonzScene* scene = nullptr,
                          bool showMessage = true);
+
+void loadAllUsedRasterLevelsAndPutInCache(bool cacheImagesAsWell);
 }  // namespace LevelCmd
 
 #endif

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1197,7 +1197,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {removeSceneNumberFromLoadedLevelName,
        tr("Automatically Remove Scene Number from Loaded Level Name")},
       {IgnoreImageDpi, tr("Use Camera DPI for All Imported Images")},
-      {initialLoadTlvCachingBehavior, tr("Default TLV Caching Behavior:")},
+      {rasterLevelCachingBehavior, tr("Raster Level Caching Behavior:")},
       {columnIconLoadingPolicy, tr("Column Icon:")},
       //{ levelFormats,                           tr("") },
 
@@ -1375,7 +1375,7 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
        {{tr("Always ask before loading or importing"), 0},
         {tr("Always import the file to the current project"), 1},
         {tr("Always load the file from the current location"), 2}}},
-      {initialLoadTlvCachingBehavior,
+      {rasterLevelCachingBehavior,
        {{tr("On Demand"), 0},
         {tr("All Icons"), 1},
         {tr("All Icons & Images"), 2}}},
@@ -1745,8 +1745,8 @@ QWidget* PreferencesPopup::createLoadingPage() {
   insertUI(subsceneFolderEnabled, lay);
   insertUI(removeSceneNumberFromLoadedLevelName, lay);
   insertUI(IgnoreImageDpi, lay);
-  insertUI(initialLoadTlvCachingBehavior, lay,
-           getComboItemList(initialLoadTlvCachingBehavior));
+  insertUI(rasterLevelCachingBehavior, lay,
+           getComboItemList(rasterLevelCachingBehavior));
   insertUI(columnIconLoadingPolicy, lay,
            getComboItemList(columnIconLoadingPolicy));
 

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -220,7 +220,10 @@ void ImageLoader::buildAllIconsAndPutInCache(TXshSimpleLevel *level,
                                              std::vector<TFrameId> fids,
                                              std::vector<std::string> iconIds,
                                              bool cacheImagesAsWell) {
-  if (m_path.getType() != "tlv") return;
+  // if (m_path.getType() != "tlv") return;
+  if (level->getType() != TZP_XSHLEVEL && level->getType() != OVL_XSHLEVEL)
+    return;
+
   if (fids.empty() || iconIds.empty()) return;
   /*- The number of fid and icon id should be the same -*/
   if ((int)fids.size() != (int)iconIds.size()) return;

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -467,7 +467,7 @@ void Preferences::definePreferenceItems() {
   define(removeSceneNumberFromLoadedLevelName,
          "removeSceneNumberFromLoadedLevelName", QMetaType::Bool, false);
   define(IgnoreImageDpi, "IgnoreImageDpi", QMetaType::Bool, false);
-  define(initialLoadTlvCachingBehavior, "initialLoadTlvCachingBehavior",
+  define(rasterLevelCachingBehavior, "rasterLevelCachingBehavior",
          QMetaType::Int, 0);  // On Demand
   define(columnIconLoadingPolicy, "columnIconLoadingPolicy", QMetaType::Int,
          (int)LoadAtOnce);
@@ -797,6 +797,16 @@ void Preferences::resolveCompatibility() {
   if (m_settings->contains("scanLevelType") &&
       !m_settings->contains("DefRasterFormat")) {
     setValue(DefRasterFormat, m_settings->value("scanLevelType").toString());
+  }
+  // "initialLoadTlvCachingBehavior" is changed to "rasterLevelCachingBehavior"
+  // , Now this setting also applies to raster levels (previously only Toonz
+  // raster levels). It also applies to any operation that loads a level, such
+  // as loading scene or loading a recent level. (Previously, this was only
+  // available from the Load Level popup.)
+  if (m_settings->contains("initialLoadTlvCachingBehavior") &&
+      !m_settings->contains("rasterLevelCachingBehavior")) {
+    setValue(rasterLevelCachingBehavior,
+             m_settings->value("initialLoadTlvCachingBehavior").toInt());
   }
 }
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -625,7 +625,7 @@ TImageP TXshSimpleLevel::getFrameIcon(const TFrameId &fid) const {
 //-----------------------------------------------------------------------------
 // load icon (and image) data of all frames into cache
 void TXshSimpleLevel::loadAllIconsAndPutInCache(bool cacheImagesAsWell) {
-  if (m_type != TZP_XSHLEVEL) return;
+  if (m_type != TZP_XSHLEVEL && m_type != OVL_XSHLEVEL) return;
 
   std::vector<TFrameId> fids;
   getFids(fids);


### PR DESCRIPTION
This PR alters name and behavior of `Default TLV Caching Behavior` preference option as follows:

#### Before this PR
- Name : Default TLV Caching Behavior
- Specifies the default value of `TLV Caching Behavior` option in the load level popup. i.e. This option only works when loading toonz raster level via `Load Level` command.

#### After this PR
- Name: Raster Level Caching Behavior
- Now this option works for all raster levels.
- Now this option works when any loading commands such as `Load Scene`, `Load Recent Levels`, etc.

The pencil test process tends to place a lot of raster levels on the xsheet.
If this option is set to `All Icons & Images`, all raster level images will be cached when the scene is loaded, so there will be no lag when switching frames afterwards compared to the `On Demand` option. 