### PR TITLE
Stretch function curve keys with Alt+drag

### DIFF
--- a/toonz/sources/include/toonzqt/functionselection.h
+++ b/toonz/sources/include/toonzqt/functionselection.h
@@ -131,6 +131,7 @@ public:
   // overlapping the selection
   int getCommonSegmentType(bool inclusive = true);
 
+  QList<int> getSelectedKeyIndices(TDoubleParam *curve);
 signals:
   void selectionChanged();
 };

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -1274,16 +1274,39 @@ void FunctionPanel::mousePressEvent(QMouseEvent *e) {
               getSelection()->deselectAllKeyframes();
             getSelection()->select(currentCurve, kIndex);
           }
-          // move selected point(s)
-          MovePointDragTool *dragTool =
-              new MovePointDragTool(this, currentCurve);
-          if (getSelection()->getSelectedSegment().first != 0) {
-            // if a segment is selected then move only the clicked point
-            dragTool->addKeyframe2(kIndex);
-          } else {
-            dragTool->setSelection(getSelection());
+
+          // stretch the selected keys IF;
+          // 1) alt key is pressed, and
+          // 2) more than two keys are selected, and
+          // 3) clicked key is one of the end of the selection, and
+          // 4) all keys between the both end of the selection are selected
+          if (e->modifiers() & Qt::AltModifier) {
+            QList<int> selectedIndices =
+                getSelection()->getSelectedKeyIndices(currentCurve);
+            if (selectedIndices.count() >= 3 &&
+                (selectedIndices.first() == kIndex ||
+                 selectedIndices.last() == kIndex) &&
+                (selectedIndices.last() - selectedIndices.first()) ==
+                    selectedIndices.count() - 1) {
+              bool moveLeft = selectedIndices.first() == kIndex;
+              m_dragTool    = new StretchPointDragTool(
+                  this, currentCurve, selectedIndices.first(),
+                  selectedIndices.last(), moveLeft);
+            }
           }
-          m_dragTool = dragTool;
+
+          if (!m_dragTool) {
+            // move selected point(s)
+            MovePointDragTool *dragTool =
+                new MovePointDragTool(this, currentCurve);
+            if (getSelection()->getSelectedSegment().first != 0) {
+              // if a segment is selected then move only the clicked point
+              dragTool->addKeyframe2(kIndex);
+            } else {
+              dragTool->setSelection(getSelection());
+            }
+            m_dragTool = dragTool;
+          }
         } else {
           m_dragTool =
               new MoveHandleDragTool(this, currentCurve, kIndex, handle);

--- a/toonz/sources/toonzqt/functionpaneltools.h
+++ b/toonz/sources/toonzqt/functionpaneltools.h
@@ -7,6 +7,7 @@
 #include "tdoublekeyframe.h"
 #include "toonz/doubleparamcmd.h"
 
+#include <QList>
 // class QMouseEvent;
 class KeyframeSetter;
 class TDoubleParam;
@@ -151,4 +152,31 @@ public:
   void release(QMouseEvent *e) override;
 };
 
+class StretchPointDragTool final : public FunctionPanel::DragTool {
+private:
+  FunctionPanel *m_panel;
+  TDoubleParam *m_curve;
+  double m_clickedFrame;
+
+  struct keyInfo {
+    int kIndex;
+    double orgFramePos;
+    TPointD orgSpeedIn;
+    TPointD orgSpeedOut;
+    KeyframeSetter *setter;
+  };
+
+  QList<keyInfo> m_keys;
+  bool m_moveLeft;
+  double m_previousRange;
+
+public:
+  StretchPointDragTool(FunctionPanel *panel, TDoubleParam *curve, int leftId,
+                       int rightId, bool moveLeft);
+  ~StretchPointDragTool();
+
+  void click(QMouseEvent *e) override;
+  void drag(QMouseEvent *e) override;
+  void release(QMouseEvent *e) override;
+};
 #endif

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -709,6 +709,17 @@ int FunctionSelection::getCommonSegmentType(bool inclusive) {
   return type;
 }
 
+QList<int> FunctionSelection::getSelectedKeyIndices(TDoubleParam *curve) {
+  for (auto selectedParam : m_selectedKeyframes) {
+    if (curve == selectedParam.first) {
+      QList<int> ret = selectedParam.second.toList();
+      std::sort(ret.begin(), ret.end());
+      return ret;
+    }
+  }
+  return QList<int>();
+}
+
 //=============================================================================
 //
 // FunctionKeyframesData


### PR DESCRIPTION
![stretch_curve](https://user-images.githubusercontent.com/17974955/219566136-c802ee94-cf08-4980-889b-76d7bddbe4ec.gif)
This PR enables stretching timings of the selected keys with Alt + dragging in the function curve panel.