### PR TITLE
Add search command list for customize popups by manongjohn

### DIFF
--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -427,6 +427,10 @@ void CommandBarListTree::searchItems(const QString& searchWord) {
     for (int i = 0; i < itemCount; ++i) {
       displayAll(topLevelItem(i));
     }
+
+    // revert to the initial state - expanding "Menu Commands" tree
+    findItems(ShortcutTree::tr("Menu Commands"), Qt::MatchExactly)[0]
+        ->setExpanded(true);
     update();
     return;
   }

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -396,6 +396,66 @@ void CommandBarListTree::mousePressEvent(QMouseEvent* event) {
   QTreeWidget::mousePressEvent(event);
 }
 
+//-----------------------------------------------------------------------------
+
+void CommandBarListTree::displayAll(QTreeWidgetItem* item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    displayAll(item->child(i));
+  }
+  item->setHidden(false);
+  item->setExpanded(false);
+}
+
+//-------------------------------------------------------------------
+
+void CommandBarListTree::hideAll(QTreeWidgetItem* item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    hideAll(item->child(i));
+  }
+  item->setHidden(true);
+  item->setExpanded(false);
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBarListTree::searchItems(const QString& searchWord) {
+  // if search word is empty, show all items
+  if (searchWord.isEmpty()) {
+    int itemCount = topLevelItemCount();
+    for (int i = 0; i < itemCount; ++i) {
+      displayAll(topLevelItem(i));
+    }
+    update();
+    return;
+  }
+
+  // hide all items first
+  int itemCount = topLevelItemCount();
+  for (int i = 0; i < itemCount; ++i) {
+    hideAll(topLevelItem(i));
+  }
+
+  QList<QTreeWidgetItem*> foundItems =
+      findItems(searchWord, Qt::MatchContains | Qt::MatchRecursive, 0);
+  if (foundItems.isEmpty()) {  // if nothing is found, do nothing but update
+    update();
+    return;
+  }
+
+  // for each item found, show it and show its parent
+  for (auto item : foundItems) {
+    while (item) {
+      item->setHidden(false);
+      item->setExpanded(true);
+      item = item->parent();
+    }
+  }
+
+  update();
+}
+
 //=============================================================================
 // CommandBarPopup
 //-----------------------------------------------------------------------------
@@ -437,6 +497,8 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
   nf.setItalic(true);
   noticeLabel->setFont(nf);
 
+  QLineEdit* searchEdit = new QLineEdit(this);
+
   //--- layout
   m_topLayout->setMargin(0);
   m_topLayout->setSpacing(0);
@@ -448,10 +510,20 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
     {
       mainUILay->addWidget(commandBarLabel, 0, 0);
       mainUILay->addWidget(commandItemListLabel, 0, 1);
-      mainUILay->addWidget(m_menuBarTree, 1, 0);
-      mainUILay->addWidget(m_commandListTree, 1, 1);
 
-      mainUILay->addWidget(noticeLabel, 2, 0, 1, 2);
+      mainUILay->addWidget(m_menuBarTree, 1, 0, 2, 1);
+
+      QHBoxLayout* searchLay = new QHBoxLayout();
+      searchLay->setMargin(0);
+      searchLay->setSpacing(5);
+      {
+        searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
+        searchLay->addWidget(searchEdit);
+      }
+      mainUILay->addLayout(searchLay, 1, 1);
+      mainUILay->addWidget(m_commandListTree, 2, 1);
+
+      mainUILay->addWidget(noticeLabel, 3, 0, 1, 2);
     }
     mainUILay->setRowStretch(0, 0);
     mainUILay->setRowStretch(1, 1);
@@ -475,6 +547,9 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
 
   bool ret = connect(okBtn, SIGNAL(clicked()), this, SLOT(onOkPressed()));
   ret      = ret && connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
+  ret = ret && connect(searchEdit, SIGNAL(textChanged(const QString&)), this,
+                       SLOT(onSearchTextChanged(const QString&)));
+
   assert(ret);
 }
 
@@ -484,4 +559,12 @@ void CommandBarPopup::onOkPressed() {
   m_menuBarTree->saveMenuTree(m_path);
 
   accept();
+}
+
+void CommandBarPopup::onSearchTextChanged(const QString& text) {
+  static bool busy = false;
+  if (busy) return;
+  busy = true;
+  m_commandListTree->searchItems(text);
+  busy = false;
 }

--- a/toonz/sources/toonz/commandbarpopup.h
+++ b/toonz/sources/toonz/commandbarpopup.h
@@ -50,6 +50,12 @@ class CommandBarListTree final : public QTreeWidget {
 public:
   CommandBarListTree(QWidget* parent = 0);
 
+  void searchItems(const QString& searchWord = QString());
+
+private:
+  void displayAll(QTreeWidgetItem* item);
+  void hideAll(QTreeWidgetItem* item);
+
 protected:
   void mousePressEvent(QMouseEvent*) override;
 };
@@ -68,6 +74,7 @@ public:
   CommandBarPopup(bool isXsheetToolbar = false);
 protected slots:
   void onOkPressed();
+  void onSearchTextChanged(const QString& text);
 };
 
 #endif

--- a/toonz/sources/toonz/custompaneleditorpopup.cpp
+++ b/toonz/sources/toonz/custompaneleditorpopup.cpp
@@ -390,6 +390,69 @@ void CustomPanelCommandListTree::mousePressEvent(QMouseEvent* event) {
   QTreeWidget::mousePressEvent(event);
 }
 
+//-----------------------------------------------------------------------------
+
+void CustomPanelCommandListTree::displayAll(QTreeWidgetItem* item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    displayAll(item->child(i));
+  }
+  item->setHidden(false);
+  item->setExpanded(false);
+}
+
+//-------------------------------------------------------------------
+
+void CustomPanelCommandListTree::hideAll(QTreeWidgetItem* item) {
+  int childCount = item->childCount();
+  for (int i = 0; i < childCount; ++i) {
+    hideAll(item->child(i));
+  }
+  item->setHidden(true);
+  item->setExpanded(false);
+}
+
+//-----------------------------------------------------------------------------
+
+void CustomPanelCommandListTree::searchItems(const QString& searchWord) {
+  // if search word is empty, show all items
+  if (searchWord.isEmpty()) {
+    int itemCount = topLevelItemCount();
+    for (int i = 0; i < itemCount; ++i) {
+      displayAll(topLevelItem(i));
+    }
+    // revert to the initial state - expanding "Menu Commands" tree
+    findItems(ShortcutTree::tr("Menu Commands"), Qt::MatchExactly)[0]
+        ->setExpanded(true);
+    update();
+    return;
+  }
+
+  // hide all items first
+  int itemCount = topLevelItemCount();
+  for (int i = 0; i < itemCount; ++i) {
+    hideAll(topLevelItem(i));
+  }
+
+  QList<QTreeWidgetItem*> foundItems =
+      findItems(searchWord, Qt::MatchContains | Qt::MatchRecursive, 0);
+  if (foundItems.isEmpty()) {  // if nothing is found, do nothing but update
+    update();
+    return;
+  }
+
+  // for each item found, show it and show its parent
+  for (auto item : foundItems) {
+    while (item) {
+      item->setHidden(false);
+      item->setExpanded(true);
+      item = item->parent();
+    }
+  }
+
+  update();
+}
+
 //=============================================================================
 // CustomPanelEditorPopup
 //-----------------------------------------------------------------------------
@@ -558,7 +621,7 @@ void CustomPanelEditorPopup::updateControls(QWidget* customWidget) {
     if (entry.type == Button) {
       QString commandId = entry.field->commandId();
       QAction* action   = CommandManager::instance()->getAction(
-            commandId.toStdString().c_str());
+          commandId.toStdString().c_str());
       if (!action) continue;
       QAbstractButton* button = dynamic_cast<QAbstractButton*>(widget);
       QToolButton* tb         = dynamic_cast<QToolButton*>(widget);
@@ -717,7 +780,7 @@ void CustomPanelEditorPopup::replaceObjectNames(QDomElement& element) {
   while (!n.isNull()) {
     if (n.isElement()) {
       QDomElement e = n.toElement();
-      //自分自身をチェック
+      // 自分自身をチェック
       if (e.tagName() == "widget" && e.hasAttribute("name")) {
         QString objName     = e.attribute("name");
         QList<int> entryIds = entryIdByObjName(objName);
@@ -814,6 +877,8 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
   QFont f("Arial", 15, QFont::Bold);
   commandItemListLabel->setFont(f);
 
+  QLineEdit* searchEdit = new QLineEdit(this);
+
   m_previewArea       = new UiPreviewArea(this);
   m_UiFieldsContainer = new QWidget(this);
   m_templateCombo     = new QComboBox(this);
@@ -848,6 +913,14 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
   rightLay->setSpacing(10);
   {
     rightLay->addWidget(commandItemListLabel, 0);
+    QHBoxLayout* searchLay = new QHBoxLayout();
+    searchLay->setMargin(0);
+    searchLay->setSpacing(5);
+    {
+      searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
+      searchLay->addWidget(searchEdit);
+    }
+    rightLay->addLayout(searchLay, 0);
     rightLay->addWidget(m_commandListTree, 1);
   }
   addLayout(rightLay);
@@ -873,6 +946,8 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
                        SLOT(onTemplateSwitched()));
   ret = ret &&
         connect(registerButton, SIGNAL(clicked()), this, SLOT(onRegister()));
+  ret = ret && connect(searchEdit, SIGNAL(textChanged(const QString&)), this,
+                       SLOT(onSearchTextChanged(const QString&)));
   assert(ret);
 
   // load template
@@ -880,6 +955,16 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
   if (!ok) {
     // show some warning?
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void CustomPanelEditorPopup::onSearchTextChanged(const QString& text) {
+  static bool busy = false;
+  if (busy) return;
+  busy = true;
+  m_commandListTree->searchItems(text);
+  busy = false;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/custompaneleditorpopup.h
+++ b/toonz/sources/toonz/custompaneleditorpopup.h
@@ -115,6 +115,12 @@ class CustomPanelCommandListTree final : public QTreeWidget {
 public:
   CustomPanelCommandListTree(QWidget* parent = 0);
 
+  void searchItems(const QString& searchWord = QString());
+
+private:
+  void displayAll(QTreeWidgetItem* item);
+  void hideAll(QTreeWidgetItem* item);
+
 protected:
   void mousePressEvent(QMouseEvent*) override;
 };
@@ -155,6 +161,7 @@ protected slots:
   void onPreviewClicked(int id);
   void onPreviewDropped(int id, QString cmdId, bool fromTree);
   void onRegister();
+  void onSearchTextChanged(const QString& text);
 };
 
 #endif

--- a/toonz/sources/toonz/menubarpopup.h
+++ b/toonz/sources/toonz/menubarpopup.h
@@ -55,6 +55,12 @@ class CommandListTree final : public QTreeWidget {
 public:
   CommandListTree(QWidget* parent = 0);
 
+  void searchItems(const QString& searchWord = QString());
+
+private:
+  void displayAll(QTreeWidgetItem* item);
+  void hideAll(QTreeWidgetItem* item);
+
 protected:
   void mousePressEvent(QMouseEvent*) override;
 };
@@ -72,6 +78,7 @@ public:
   MenuBarPopup(Room* room);
 protected slots:
   void onOkPressed();
+  void onSearchTextChanged(const QString& text);
 };
 
 #endif


### PR DESCRIPTION
This PR will add a search box above the Toolbar Items list in Customize Command Bar and Customize XSheet Toolbar popups, authored by @manongjohn . ( tahoma2d/tahoma2d#101 )

Also introduced the same fields to the Menubar popup and the Custom Panel editor as well (in the second commit).

Thank you @manongjohn for the very nice feature !