### PR TITLE
Show autopaint style color in Transparency Check

### DIFF
--- a/toonz/sources/common/trop/quickput.cpp
+++ b/toonz/sources/common/trop/quickput.cpp
@@ -4135,7 +4135,9 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
 
   if (s.m_transparencyCheck && !s.m_isOnionSkin) {
     for (int i = 0; i < palette->getStyleCount(); i++) {
-      if (i == s.m_gapCheckIndex) {
+      // if the style's autopaint flag is ON, show its original color
+      // so that users can easily find lines left unpainted.
+      if (i == s.m_gapCheckIndex || palette->getStyle(i)->getFlags() != 0) {
         paints[i] = inks[i] = applyColorScaleCMapped(
             palette->getStyle(i)->getAverageColor(), s.m_globalColorScale);
       } else {


### PR DESCRIPTION
This PR resolves #4760 .
Now the Transparency Check will show lines & areas painted with "Autopaint" styles in its original color, instead of replacing with the colors specified in the preferences.

At the end of Ink&Paint workflow, all "Autopaint" lines are expected to be painted with another style.
So highlighting them will be helpful for finding lines left unpainted.

This change will also enhance consistency with Retas PaintMan, in which pixels painted in red, green, or blue will appear in their respective colors, not black, when the color check mode is turned on.
