### PR TITLE
Fix notifyClick when mouse button is released rather than pressed

### DIFF
--- a/toonz/sources/toonz/dvitemview.cpp
+++ b/toonz/sources/toonz/dvitemview.cpp
@@ -1251,7 +1251,7 @@ void DvItemViewerPanel::mousePressEvent(QMouseEvent *event) {
   }
   if (m_globalSelectionEnabled) m_selection->makeCurrent();
   m_currentIndex = index;
-  if (m_viewer) m_viewer->notifyClick(index);
+  //if (m_viewer ) m_viewer->notifyClick(index);
   m_startDragPosition = event->pos();
   update();
 }
@@ -1301,7 +1301,9 @@ void DvItemViewerPanel::mouseMoveEvent(QMouseEvent *event) {
 
 //-----------------------------------------------------------------------------
 
-void DvItemViewerPanel::mouseReleaseEvent(QMouseEvent *) {}
+void DvItemViewerPanel::mouseReleaseEvent(QMouseEvent *) {
+  if (m_viewer ) m_viewer->notifyClick(m_currentIndex);
+}
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
To allow dragging scenes in browser views that are activated with a single click, previously this would cancel the drag action