### PR TITLE
Revert preprodcution board icon sizes to 80x60

### DIFF
--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -148,7 +148,7 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WindowFlags flags,
       new SceneBrowserButtonBar(m_itemViewer, box);
   DvItemViewerPanel *viewerPanel = m_itemViewer->getPanel();
   viewerPanel->setThumbnailsView();
-  viewerPanel->setIconSize(QSize(192, 108));  // default 80, 60
+  viewerPanel->setIconSize(QSize(80, 60));
   viewerPanel->addColumn(DvItemListModel::FileType, 50);
   viewerPanel->addColumn(DvItemListModel::FrameCount, 50);
   viewerPanel->addColumn(DvItemListModel::FileSize, 50);


### PR DESCRIPTION
For larger thumbnails the quality should to be improved with some kind of smoothing