### PR TITLE
Make delete command behavior selectable by Contrail Co.,ltd.

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -365,6 +365,10 @@ public:
     return getBoolValue(xsheetAutopanEnabled);
   }  //!< Returns whether xsheet pans during playback.
   int getDragCellsBehaviour() const { return getIntValue(DragCellsBehaviour); }
+  int getDeleteCommandBehaviour() const {
+    return getIntValue(deleteCommandBehavior);
+  }
+
   bool isIgnoreAlphaonColumn1Enabled() const {
     return getBoolValue(ignoreAlphaonColumn1Enabled);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -121,6 +121,7 @@ enum PreferencesItemId {
   xsheetStep,
   xsheetAutopanEnabled,
   DragCellsBehaviour,
+  deleteCommandBehavior,
   ignoreAlphaonColumn1Enabled,
   showKeyframesOnXsheetCellArea,
   showXsheetCameraColumn,

--- a/toonz/sources/toonz/cellkeyframeselection.cpp
+++ b/toonz/sources/toonz/cellkeyframeselection.cpp
@@ -91,7 +91,10 @@ void TCellKeyframeSelection::pasteCellsKeyframes() {
 
 void TCellKeyframeSelection::deleteCellsKeyframes() {
   TUndoManager::manager()->beginBlock();
-  m_cellSelection->deleteCells();
+  // clear cells without shifting
+  // TODO: behavior of deleting cell+keyframe should also follow the preference
+  // option.
+  m_cellSelection->deleteCells(false);
   m_keyframeSelection->deleteKeyframes();
   TUndoManager::manager()->endBlock();
 }

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -47,6 +47,7 @@ public:
   void pasteCells();
   void pasteDuplicateCells();
   void deleteCells();
+  void deleteCells(bool withShift);
   void cutCells();
   void cutCells(bool withoutCopy);
 

--- a/toonz/sources/toonz/filmstripcommand.h
+++ b/toonz/sources/toonz/filmstripcommand.h
@@ -32,6 +32,7 @@ void merge(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void pasteInto(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void cut(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void clear(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
+void remove(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void insert(TXshSimpleLevel *sl, const std::set<TFrameId> &frames,
             bool withUndo);
 

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -237,7 +237,7 @@ void TFilmstripSelection::cutFrames() {
   TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
   if (sl) {
     int firstSelectedIndex = sl->fid2index(*m_selectedFrames.begin());
-    if(firstSelectedIndex < 0 || firstSelectedIndex > sl->getFrameCount()) {
+    if (firstSelectedIndex < 0 || firstSelectedIndex > sl->getFrameCount()) {
       selectNone();
       return;
     }
@@ -285,7 +285,12 @@ void TFilmstripSelection::pasteInto() {
 
 void TFilmstripSelection::deleteFrames() {
   TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
-  if (sl) FilmstripCmd::clear(sl, m_selectedFrames);
+  if (sl) {
+    if (Preferences::instance()->getDeleteCommandBehaviour() == 0)  // Clear
+      FilmstripCmd::clear(sl, m_selectedFrames);
+    else  // Remove and Shift
+      FilmstripCmd::remove(sl, m_selectedFrames);
+  }
   updateInbetweenRange();
 }
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1259,6 +1259,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {xsheetStep, tr("Next/Previous Step Frames:")},
       {xsheetAutopanEnabled, tr("Xsheet Autopan during Playback")},
       {DragCellsBehaviour, tr("Cell-dragging Behaviour:")},
+      {deleteCommandBehavior, tr("Delete Command Behaviour:")},
       {ignoreAlphaonColumn1Enabled,
        tr("Ignore Alpha Channel on Levels in Column 1")},
       {showKeyframesOnXsheetCellArea, tr("Show Keyframes on Cell Area")},
@@ -1427,6 +1428,9 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
          Preferences::ShowLevelNameOnColumnHeader}}},
       {DragCellsBehaviour,
        {{tr("Cells Only"), 0}, {tr("Cells and Column Data"), 1}}},
+      {deleteCommandBehavior,
+       {{tr("Clear Cell / Frame"), 0},
+        {tr("Remove and Shift Cells / Frames Up"), 1}}},
       {keyframeType,  // note that the value starts from 1, not 0
        {{tr("Constant"), 1},
         {tr("Linear"), 2},
@@ -1987,6 +1991,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   insertUI(xsheetStep, lay);
   insertUI(xsheetAutopanEnabled, lay);
   insertUI(DragCellsBehaviour, lay, getComboItemList(DragCellsBehaviour));
+  insertUI(deleteCommandBehavior, lay, getComboItemList(deleteCommandBehavior));
   insertUI(ignoreAlphaonColumn1Enabled, lay);
   QGridLayout* showKeyLay =
       insertGroupBoxUI(showKeyframesOnXsheetCellArea, lay);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -929,7 +929,8 @@ void RenameCellField::renameCell() {
 
   if (fid.getNumber() == 0 && !hasFrameZero) {
     TCellSelection::Range range = cellSelection->getSelectedCells();
-    cellSelection->deleteCells();
+    // clear cells without shifting
+    cellSelection->deleteCells(false);
     // revert cell selection
     cellSelection->selectCells(range.m_r0, range.m_c0, range.m_r1, range.m_c1);
   } else if (cells.size() == 1)

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -567,6 +567,8 @@ void Preferences::definePreferenceItems() {
   define(xsheetAutopanEnabled, "xsheetAutopanEnabled", QMetaType::Bool, true);
   define(DragCellsBehaviour, "DragCellsBehaviour", QMetaType::Int,
          1);  // Cells and Column Data
+  define(deleteCommandBehavior, "deleteCommandBehavior", QMetaType::Int,
+         0);  // Clear Cell / Frame
   define(ignoreAlphaonColumn1Enabled, "ignoreAlphaonColumn1Enabled",
          QMetaType::Bool, false);
   define(showKeyframesOnXsheetCellArea, "showKeyframesOnXsheetCellArea",


### PR DESCRIPTION
This PR will add a preferences option `Delete Command Behaviour` to the Xsheet category, with the following items:
- **Clear Cell / Frame** (default value) : The command with selecting Xsheet cells / Level Strip frames will clear the selection. (i.e. make the cells / frames empty.)
- **Remove and Shift Cells / Frames Up** (new option) : The command will remove the selection and shift the following cells / frames up. It is similar to the result using Cut command but no data will be stored in the clipboard.

This PR will resolve #3724 .
This improvement was developed on consignment and is copyrighted by [Contrail Co., Ltd.](https://contrail.tokyo/)