### PR TITLE
Paste cells command behavior option by Contrail Co.,Ltd.

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -368,7 +368,7 @@ public:
   int getDeleteCommandBehaviour() const {
     return getIntValue(deleteCommandBehavior);
   }
-
+  int getPasteCellsBehavior() const { return getIntValue(pasteCellsBehavior); }
   bool isIgnoreAlphaonColumn1Enabled() const {
     return getBoolValue(ignoreAlphaonColumn1Enabled);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -122,6 +122,7 @@ enum PreferencesItemId {
   xsheetAutopanEnabled,
   DragCellsBehaviour,
   deleteCommandBehavior,
+  pasteCellsBehavior,
   ignoreAlphaonColumn1Enabled,
   showKeyframesOnXsheetCellArea,
   showXsheetCameraColumn,

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -40,5 +40,6 @@
 #define MI_ExplodeChild "MI_ExplodeChild"
 #define MI_ToggleEditInPlace "MI_ToggleEditInPlace"
 #define MI_PasteNumbers "MI_PasteNumbers"
+#define MI_PasteWholeCellData "MI_PasteWholeCellData"
 
 #endif

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -40,6 +40,6 @@
 #define MI_ExplodeChild "MI_ExplodeChild"
 #define MI_ToggleEditInPlace "MI_ToggleEditInPlace"
 #define MI_PasteNumbers "MI_PasteNumbers"
-#define MI_PasteWholeCellData "MI_PasteWholeCellData"
+#define MI_PasteCellContent "MI_PasteCellContent"
 
 #endif

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1482,7 +1482,9 @@ void TCellSelection::enableCommands() {
   enableCommand(this, MI_ShiftKeyframesUp, &TCellSelection::shiftKeyframesUp);
 
   enableCommand(this, MI_Copy, &TCellSelection::copyCells);
-  enableCommand(this, MI_Paste, &TCellSelection::pasteCells);
+  enableCommand(this, MI_Paste,
+                &TCellSelection::doPaste);  // choose pasting behavior by
+                                            // preference option
 
   if (dynamic_cast<const TKeyframeData *>(
           QApplication::clipboard()->mimeData()))
@@ -1507,6 +1509,7 @@ void TCellSelection::enableCommands() {
                 &TCellSelection::reframeWithEmptyInbetweens);
 
   enableCommand(this, MI_PasteNumbers, &TCellSelection::overwritePasteNumbers);
+  enableCommand(this, MI_PasteWholeCellData, &TCellSelection::pasteCells);
   enableCommand(this, MI_CreateBlankDrawing,
                 &TCellSelection::createBlankDrawings);
   enableCommand(this, MI_Duplicate, &TCellSelection::duplicateFrames);
@@ -1552,6 +1555,7 @@ bool TCellSelection::isEnabledCommand(
                                         MI_Undo,
                                         MI_Redo,
                                         MI_PasteNumbers,
+                                        MI_PasteWholeCellData,
                                         MI_ConvertToToonzRaster,
                                         MI_ConvertVectorToVector,
                                         MI_CreateBlankDrawing,
@@ -1724,6 +1728,16 @@ static void pasteRasterImageInCell(int row, int col,
         rasterImageData, fullColorTiles, cell.getSimpleLevel(),
         cell.getFrameId(), oldPalette, createdFrame, isLevelCreated, col));
   }
+}
+
+//-----------------------------------------------------------------------------
+// choose pasting behavior by preference option
+void TCellSelection::doPaste() {
+  if (Preferences::instance()->getPasteCellsBehavior() ==
+      0)  // insert paste whole contents of copied cells
+    pasteCells();
+  else  // overwrite paste numbers, consistent with QuickChecker
+    overwritePasteNumbers();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1509,7 +1509,7 @@ void TCellSelection::enableCommands() {
                 &TCellSelection::reframeWithEmptyInbetweens);
 
   enableCommand(this, MI_PasteNumbers, &TCellSelection::overwritePasteNumbers);
-  enableCommand(this, MI_PasteWholeCellData, &TCellSelection::pasteCells);
+  enableCommand(this, MI_PasteCellContent, &TCellSelection::pasteCells);
   enableCommand(this, MI_CreateBlankDrawing,
                 &TCellSelection::createBlankDrawings);
   enableCommand(this, MI_Duplicate, &TCellSelection::duplicateFrames);
@@ -1555,7 +1555,7 @@ bool TCellSelection::isEnabledCommand(
                                         MI_Undo,
                                         MI_Redo,
                                         MI_PasteNumbers,
-                                        MI_PasteWholeCellData,
+                                        MI_PasteCellContent,
                                         MI_ConvertToToonzRaster,
                                         MI_ConvertVectorToVector,
                                         MI_CreateBlankDrawing,

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -45,6 +45,7 @@ public:
 
   void copyCells();
   void pasteCells();
+  void doPaste();  // choose pasting behavior by preference option
   void pasteDuplicateCells();
   void deleteCells();
   void deleteCells(bool withShift);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2299,8 +2299,8 @@ void MainWindow::defineActions() {
                              "", "shift_keys_up");
   createRightClickMenuAction(MI_PasteNumbers, QT_TR_NOOP("&Paste Numbers"), "",
                              "paste_numbers");
-  createRightClickMenuAction(MI_PasteWholeCellData,
-                             QT_TR_NOOP("&Paste Whole Cell Data"), "", "paste");
+  createRightClickMenuAction(MI_PasteCellContent,
+                             QT_TR_NOOP("&Paste Cell Content"), "", "paste");
 
   createRightClickMenuAction(MI_Histogram, QT_TR_NOOP("&Histogram"), "");
   // MI_ViewerHistogram command is used as a proxy. It will be called when

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2299,6 +2299,8 @@ void MainWindow::defineActions() {
                              "", "shift_keys_up");
   createRightClickMenuAction(MI_PasteNumbers, QT_TR_NOOP("&Paste Numbers"), "",
                              "paste_numbers");
+  createRightClickMenuAction(MI_PasteWholeCellData,
+                             QT_TR_NOOP("&Paste Whole Cell Data"), "", "paste");
 
   createRightClickMenuAction(MI_Histogram, QT_TR_NOOP("&Histogram"), "");
   // MI_ViewerHistogram command is used as a proxy. It will be called when

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1260,6 +1260,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {xsheetAutopanEnabled, tr("Xsheet Autopan during Playback")},
       {DragCellsBehaviour, tr("Cell-dragging Behaviour:")},
       {deleteCommandBehavior, tr("Delete Command Behaviour:")},
+      {pasteCellsBehavior, tr("Paste Cells Behaviour:")},
       {ignoreAlphaonColumn1Enabled,
        tr("Ignore Alpha Channel on Levels in Column 1")},
       {showKeyframesOnXsheetCellArea, tr("Show Keyframes on Cell Area")},
@@ -1431,6 +1432,9 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
       {deleteCommandBehavior,
        {{tr("Clear Cell / Frame"), 0},
         {tr("Remove and Shift Cells / Frames Up"), 1}}},
+      {pasteCellsBehavior,
+       {{tr("Insert Paste Whole Data"), 0},
+        {tr("Overwrite Paste Cell Numbers"), 1}}},
       {keyframeType,  // note that the value starts from 1, not 0
        {{tr("Constant"), 1},
         {tr("Linear"), 2},
@@ -1992,6 +1996,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   insertUI(xsheetAutopanEnabled, lay);
   insertUI(DragCellsBehaviour, lay, getComboItemList(DragCellsBehaviour));
   insertUI(deleteCommandBehavior, lay, getComboItemList(deleteCommandBehavior));
+  insertUI(pasteCellsBehavior, lay, getComboItemList(pasteCellsBehavior));
   insertUI(ignoreAlphaonColumn1Enabled, lay);
   QGridLayout* showKeyLay =
       insertGroupBoxUI(showKeyframesOnXsheetCellArea, lay);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3866,8 +3866,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
       if (Preferences::instance()->getPasteCellsBehavior() == 0)
         pasteSpecialMenu->addAction(cmdManager->getAction(MI_PasteNumbers));
       else
-        pasteSpecialMenu->addAction(
-            cmdManager->getAction(MI_PasteWholeCellData));
+        pasteSpecialMenu->addAction(cmdManager->getAction(MI_PasteCellContent));
       if (!soundTextCellsSelected) {
         pasteSpecialMenu->addAction(cmdManager->getAction(MI_PasteDuplicate));
       }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3861,7 +3861,13 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
     QMenu *pasteSpecialMenu = new QMenu(tr("Paste Special"), this);
     {
       pasteSpecialMenu->addAction(cmdManager->getAction(MI_PasteInto));
-      pasteSpecialMenu->addAction(cmdManager->getAction(MI_PasteNumbers));
+      // the "standard" paste behavior for MI_Paste is specified in the
+      // preferences. here we display the alternative behavior.
+      if (Preferences::instance()->getPasteCellsBehavior() == 0)
+        pasteSpecialMenu->addAction(cmdManager->getAction(MI_PasteNumbers));
+      else
+        pasteSpecialMenu->addAction(
+            cmdManager->getAction(MI_PasteWholeCellData));
       if (!soundTextCellsSelected) {
         pasteSpecialMenu->addAction(cmdManager->getAction(MI_PasteDuplicate));
       }

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -569,6 +569,8 @@ void Preferences::definePreferenceItems() {
          1);  // Cells and Column Data
   define(deleteCommandBehavior, "deleteCommandBehavior", QMetaType::Int,
          0);  // Clear Cell / Frame
+  define(pasteCellsBehavior, "pasteCellsBehavior", QMetaType::Int,
+         0);  // Insert paste whole cell data
   define(ignoreAlphaonColumn1Enabled, "ignoreAlphaonColumn1Enabled",
          QMetaType::Bool, false);
   define(showKeyframesOnXsheetCellArea, "showKeyframesOnXsheetCellArea",


### PR DESCRIPTION
In most cases in Japanese animation production, one xsheet column corresponds to one level. Therefore, there are few cases where the entire contents of a cell (i.e. level and drawing number) in one column are pasted into another column, and pasting of drawing numbers is more frequently required.

Therefore, this PR will add a preference item `Paste Cells Behaviour` to Xsheet category, with the options as follows;
- **Insert Paste Whole Data** (default option)  : The command will paste entire contents of copied cells.
- **Overwrite Paste Cell Numbers** : The command will execute `Paste Cell Numbers` instead.

When the latter option is selected, a command ~~`Paste Whole Cell Data`~~  `Paste Cell Content` will appear in the right click menu of xsheet, in `Paste Special` submenu. This will allow users to use the conventional paste behavior.

This improvement was developed on consignment and is copyrighted by [Contrail Co., Ltd.](https://contrail.tokyo/)