### PR TITLE
Fix rendering loud output  + additional changes

### DIFF
--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -977,7 +977,7 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
   }
 
 #ifdef _WIN32
-  if (format.m_sampleRate > 44100) format.m_sampleRate = 44100;
+  if (format.m_sampleRate > 48000) format.m_sampleRate = 48000;
 #else
   QAudioDeviceInfo info(QAudioDeviceInfo::defaultOutputDevice());
   if (info.deviceName().length() == 0)
@@ -990,10 +990,15 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
   switch (format.m_sampleType) {
   case TSound::INT:
     qFormat.setSampleType(QAudioFormat::SignedInt);
+    break;
   case TSound::UINT:
     qFormat.setSampleType(QAudioFormat::UnSignedInt);
+    break;
   case TSound::FLOAT:
     qFormat.setSampleType(QAudioFormat::Float);
+    break;
+  default:
+    break;
   }
   qFormat.setSampleSize(format.m_bitPerSample);
   qFormat.setCodec("audio/pcm");
@@ -1007,10 +1012,15 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
     switch (qFormat.sampleType()) {
     case QAudioFormat::SignedInt:
       format.m_sampleType = TSound::INT;
+      break;
     case QAudioFormat::UnSignedInt:
       format.m_sampleType = TSound::UINT;
+      break;
     case QAudioFormat::Float:
       format.m_sampleType = TSound::FLOAT;
+      break;
+    default:
+      break;
     }
   }
 #endif
@@ -1069,15 +1079,14 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
 
     if (s1 > 0 && s1 >= s0) {
       soundTrack = soundTrack->extract(s0, s1);
-
-      // Copy the sound track
-      overallSoundTrack->copy(
-          soundTrack,
-          int((levelStartFrame - fromFrame) *
-              samplePerFrame));  // The int cast is IMPORTANT, since
-    }                            // there are 2 overloads (int & double)
-  }                              // with DIFFERENT SCALES. We mean the
-                                 // SAMPLES-BASED one.
+      if (format.m_sampleType != TSound::FLOAT)							 
+        overallSoundTrack->copy(
+            soundTrack, int((levelStartFrame - fromFrame) * samplePerFrame));
+      else
+        overallSoundTrack->copy(
+            soundTrack, double((levelStartFrame - fromFrame) * samplePerFrame));
+    }
+  }
   return overallSoundTrack;
 }
 


### PR DESCRIPTION
This PR contains 3 general changes ported over from T2D:

1. Add missing `break;` statements missing in logic executed only by Linux and macOS builds. Fixes #4779
2. Changed the max sample rate from 44100 to 48000 for Windows builds.
3. Use the appropriate copy overall sound functions based on sample type.

I forget why I did the last 2 changes in T2D's original 32bit implementation but figured it might be good for OT as well. 