### PR TITLE
Fix rendering loud output + additional changes (Part 2)

### DIFF
--- a/toonz/sources/common/tsound/tsound_qt.cpp
+++ b/toonz/sources/common/tsound/tsound_qt.cpp
@@ -160,10 +160,13 @@ public:
     switch (st->getSampleType()) {
     case TSound::INT:
       format.setSampleType(QAudioFormat::SignedInt);
+      break;
     case TSound::UINT:
       format.setSampleType(QAudioFormat::UnSignedInt);
+      break;
     case TSound::FLOAT:
       format.setSampleType(QAudioFormat::Float);
+      break;
     }
     format.setSampleRate(st->getSampleRate());
 


### PR DESCRIPTION
There were additional missing `breaks` not caught in #4785

Hopefully this should fix the Linux audio shenanigans in #4779 for good.