### PR TITLE
Improve mypaint chip icon

### DIFF
--- a/toonz/sources/toonzlib/mypaintbrushstyle.cpp
+++ b/toonz/sources/toonzlib/mypaintbrushstyle.cpp
@@ -289,11 +289,15 @@ void TMyPaintBrushStyle::makeIcon(const TDimension &d) {
     double sx    = (double)d.lx / (double)m_preview->getLx();
     double sy    = (double)d.ly / (double)m_preview->getLy();
     double scale = std::min(sx, sy);
-    TRop::quickPut(m_icon, m_preview, TScale(scale));
+    TRaster32P resamplePreview(m_preview->getLx(), m_preview->getLy());
+    TRop::resample(resamplePreview, m_preview, TScale(scale),
+                   TRop::ResampleFilterType::Hamming3);
+    TRop::over(m_icon, resamplePreview);
   }
 
   // paint color marker
-  if (d.lx > 0 && d.ly > 0) {
+  // Only show color marker when the icon size is 22x22
+  if (d.lx == d.ly && d.lx <= 22) {
     int size       = std::min(1 + std::min(d.lx, d.ly) * 2 / 3,
                         1 + std::max(d.lx, d.ly) / 2);
     TPixel32 color = getMainColor();


### PR DESCRIPTION
This was a requested T2D port to improve Mypaint chip icon in the Style Editor and Palette viewer.

Before:
<img src="https://user-images.githubusercontent.com/19245851/227752554-c1612869-e02c-46e3-8889-b1887618fa1d.png" width="40%" height="40%">

After:
<img src="https://user-images.githubusercontent.com/19245851/227752576-6a9326b9-2ea5-4a95-b10c-932c2c48996a.png" width="40%" height="40%">

Note: The color triangle in the upper left corner only shows up in List View since there is no other color indicator in that chip.
