### PR TITLE
Modify Convert TZP in Folder and register TZP icon 

### DIFF
--- a/toonz/sources/toonz/convertfolderpopup.cpp
+++ b/toonz/sources/toonz/convertfolderpopup.cpp
@@ -62,9 +62,12 @@ void ConvertFolderPopup::Converter::run() {
   DVGui::ProgressDialog* progressDialog = m_parent->m_progressDialog;
   int levelCount                        = m_parent->m_srcFilePaths.size();
 
+  QDir targetDir(m_parent->m_convertFolderFld->getPath());
+
   for (int i = 0; !m_parent->m_notifier->abortTask() && i < levelCount; i++) {
     TFilePath sourceLevelPath = sc->decodeFilePath(m_parent->m_srcFilePaths[i]);
-    QString levelName = QString::fromStdString(sourceLevelPath.getLevelName());
+    QString levelName =
+        targetDir.relativeFilePath(sourceLevelPath.getQString());
 
     TFilePath dstFolder = sourceLevelPath.getParentDir();
     // check already existent levels

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -664,6 +664,8 @@
 		<file>Resources/tape.png</file>
 		<file>Resources/type_in.png</file>
 		<file>Resources/type_out.png</file>
+		<file>Resources/tzpicon.png</file>
+		<file>Resources/tzuicon.png</file>
 		<file>Resources/work.png</file>
 		<file>Resources/zoom.png</file>
 		<file>Resources/browser_scene_open.svg</file>


### PR DESCRIPTION
Modified the `Convert TZP in Folder` command so that the progress bar popup shows the relative path from the target folder instead of only showing the level name.
![image](https://user-images.githubusercontent.com/17974955/228768682-b3361fe9-9617-47e0-8815-5b47b6242736.png)

Also registered the icon files for TZP and TZU (both are level file formats used in old Toonz versions). Missing registration had caused the `Run out of contiguous memory` error popup in File Browser.