### PR TITLE
Fix rendering loud output + additional changes (Part 3) 

### DIFF
--- a/toonz/sources/common/tsound/tsound.cpp
+++ b/toonz/sources/common/tsound/tsound.cpp
@@ -37,7 +37,8 @@ TSoundTrack::TSoundTrack(TUINT32 sampleRate, int bitPerSample, int channelCount,
     , m_sampleCount(sampleCount)
     , m_channelCount(channelCount)
     , m_parent(0)
-    , m_bufferOwner(true) {
+    , m_bufferOwner(true)
+    , m_sampleType(sampleType) {
   m_buffer = (UCHAR *)malloc(sampleCount * m_sampleSize);
   if (!m_buffer) return;
 

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -191,7 +191,8 @@ void Ffmpeg::saveSoundTrack(TSoundTrack *st) {
 
   m_audioPath = getFfmpegCache().getQString() + "//" +
                 QString::fromStdString(m_path.getName()) + "tempOut.raw";
-  m_audioFormat = "s" + QString::number(m_bitsPerSample);
+  m_audioFormat = ((st->getSampleType() == TSound::FLOAT) ? "f" : "s") +
+                  QString::number(m_bitsPerSample);
   if (m_bitsPerSample > 8) m_audioFormat = m_audioFormat + "le";
   std::string strPath = m_audioPath.toStdString();
 

--- a/toonz/sources/toonzlib/txshsoundcolumn.cpp
+++ b/toonz/sources/toonzlib/txshsoundcolumn.cpp
@@ -1079,12 +1079,8 @@ TSoundTrackP TXshSoundColumn::getOverallSoundTrack(int fromFrame, int toFrame,
 
     if (s1 > 0 && s1 >= s0) {
       soundTrack = soundTrack->extract(s0, s1);
-      if (format.m_sampleType != TSound::FLOAT)							 
-        overallSoundTrack->copy(
-            soundTrack, int((levelStartFrame - fromFrame) * samplePerFrame));
-      else
-        overallSoundTrack->copy(
-            soundTrack, double((levelStartFrame - fromFrame) * samplePerFrame));
+      overallSoundTrack->copy(
+          soundTrack, int((levelStartFrame - fromFrame) * samplePerFrame));
     }
   }
   return overallSoundTrack;


### PR DESCRIPTION
I'm porting these additional changes I am making to T2D to fix 2 issues that also are in OT.

- Multiple audio levels not always mixing properly, caused by additional changes I added in #4785 that were actually unecessary. Sorry about that
- Rendered 32bit Fixed audio was garbled/noisy.  Corrected ffmpeg arguments to encode using `f32le` or `s32le` depending on the final audio format.