### PR TITLE
Fix File Browser to open network path

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -464,6 +464,13 @@ void TSystem::readDirectory_DirItems(QStringList &dst, const TFilePath &path) {
   QDir dir(toQString(path));
 
 #ifdef _WIN32
+  QString pathStr = toQString(path);
+  if (pathStr.startsWith("\\\\") || pathStr.startsWith("//")) {
+    dst = dir.entryList(QDir::AllDirs | QDir::NoDotAndDotDot | QDir::Readable,
+                        QDir::Name | QDir::LocaleAware);
+    return;
+  }
+
   // equivalent to sorting with QDir::LocaleAware
   auto const strCompare = [](const QString &s1, const QString &s2) {
     return QString::localeAwareCompare(s1, s2) < 0;

--- a/toonz/sources/toonz/filebrowsermodel.h
+++ b/toonz/sources/toonz/filebrowsermodel.h
@@ -300,6 +300,7 @@ public:
   void refreshChildren() override;
   QPixmap getPixmap(bool isOpen) const override;
   bool isFolder() const override { return true; }
+  DvDirModelNode *createNetworkFolderNode(const TFilePath &path);
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR will fix the following problem:

- When typing a network path in the `Folder` input field of the File Browser and the path is not a project folder, the error message `The input folder path was invalid.` appears and the folder cannot be displayed.

If there is no node in the file browser tree that matches the input path, now the file browser will search for network folders and will add a new node.