### PR TITLE
Fix raster caching not to set the modified flag

### DIFF
--- a/toonz/sources/include/toonz/imagemanager.h
+++ b/toonz/sources/include/toonz/imagemanager.h
@@ -314,10 +314,7 @@ private:
   ImageBuilder(const ImageBuilder &);
   const ImageBuilder &operator=(const ImageBuilder &);
 
-  void setImageCachedAndModified() {
-    m_cached   = true;
-    m_modified = true;
-  }
+  void setImageCached() { m_cached = true; }
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/imagemanager.cpp
+++ b/toonz/sources/toonzlib/imagemanager.cpp
@@ -414,7 +414,7 @@ void ImageManager::loadAllTlvIconsAndPutInCache(
           m_imp->m_builders.find(level->getImageId(fids[f]));
       if (it != m_imp->m_builders.end()) {
         const ImageBuilderP &builder = it->second;
-        builder->setImageCachedAndModified();
+        builder->setImageCached();
         builder->m_info = info;
       }
     }


### PR DESCRIPTION
This PR will fix the following problem:

1. Do pencil testing. Capture many drawings (say, 50 frames) and save as frames in one raster level
3. Set the preference option `Loading > Raster Level Caching Behavior` to All Icons & Images
4. Save the scene & Revert the same scene 
5. Try to capture another drawing as a frame of the same level
6. OT freezes

This problem was caused by the `m_modified` flag being set on all frames when caching the raster level at load time.
As a result, when saving the additional frames captured, all other frames were being overwritten and saved.