### PR TITLE
Fix Camera Capture to flip image after BG reduction

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -2750,12 +2750,12 @@ void PencilTestPopup::processImage(cv::Mat& image) {
               cv::INTER_LINEAR);
   }
 
-  //  void PencilTestPopup::processImage(QImage& image) {
-  if (m_upsideDownCB->isChecked())
-    cv::flip(image, image, -1);  // flip in both directions
   // white bg reduction
   if (!m_whiteBGImg.empty() && m_bgReductionFld->getValue() != 0)
     bgReduction(image, m_whiteBGImg, m_bgReductionFld->getValue());
+  //  void PencilTestPopup::processImage(QImage& image) {
+  if (m_upsideDownCB->isChecked())
+    cv::flip(image, image, -1);  // flip in both directions
 
   // obtain histogram AFTER bg reduction
   m_camCapLevelControl->updateHistogram(image);


### PR DESCRIPTION
This PR fixes the problem regarding the Camera Capture as follows:

- When using the `Upside Down` option, BG reduction feature does not work properly as the white reference BG image is not flipped.