### PR TITLE
Fix MacOS color model picking with stylus

### DIFF
--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -1496,8 +1496,6 @@ void ImageViewer::tabletEvent(QTabletEvent *e) {
   } else if (e->type() == QTabletEvent::TabletRelease) {
     m_stylusUsed = false;
   }
-
-  e->accept();
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes #4819 

Accepting the tablet event in `ImageViewer::tabletEvent` prevents to propagate the event to the parent widget `ColorModelViewer` and it seemed to be a probable cause of the problem.
Thank you @Kumotate for reporting the issue!