### PR TITLE
Fix deleting output node

### DIFF
--- a/toonz/sources/include/tundo.h
+++ b/toonz/sources/include/tundo.h
@@ -29,9 +29,9 @@
 class DVAPI TUndo {
 public:
   // To be called in the last of the block when undo
-  bool m_isLastInBlock;
+  bool m_isLastInBlock = true;
   // To be called in the last of the block when redo
-  bool m_isLastInRedoBlock;
+  bool m_isLastInRedoBlock = true;
 
 public:
   TUndo() {}


### PR DESCRIPTION
This PR will fix #4822 

- Deleting output node is done in `DeleteFxOrColumnUndo::redo()` .
- Updating schematic UI after delete is done only when `m_isLastInRedoBlock==true` .
- `m_isLastInRedoBlock` will be properly set when registering the undo. However, since the initialization was missing, calling `redo()` before registering the undo had been unpredictable.

I set the initial value to `m_isLastInRedoBlock` to fix the problem.