### PR TITLE
v1.7.0 RC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.6.0.{build}
+version: 1.7.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true

--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.7.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.6</string>
+	<string>1.7</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -18,9 +18,9 @@ public:
 
 private:
   const char *applicationName     = "OpenToonz";
-  const float applicationVersion  = 1.6f;
+  const float applicationVersion  = 1.7f;
   const float applicationRevision = 0;
-  const char *applicationNote     = "";
+  const char *applicationNote     = "RC";
 };
 
 std::string ToonzVersion::getAppName(void) {

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(VERSION 1.6)
+set(VERSION 1.7)
 
 set(MOC_HEADERS
     addfilmstripframespopup.h

--- a/toonz/sources/xdg-data/io.github.OpenToonz.appdata.xml
+++ b/toonz/sources/xdg-data/io.github.OpenToonz.appdata.xml
@@ -28,6 +28,6 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="1.6.0" date="2022-03-25"></release>
+    <release version="1.7.0" date="2023-05-01"></release>
   </releases>
 </component>


### PR DESCRIPTION
This PR changes the version number to v1.7 .
It will be merged just before releasing v1.7 RC.

**[Note to self]** When releasing V1.7, remember to remove `RC` note in the line 23 of `toonz/sources/include/tversion.h`