### PR TITLE
Fix deleting output node (part 2)

### DIFF
--- a/toonz/sources/include/toonz/fxcommand.h
+++ b/toonz/sources/include/toonz/fxcommand.h
@@ -72,8 +72,6 @@ DVAPI void unlinkFx(TFx *fx, TFxHandle *fxHandle, TXsheetHandle *xshHandle);
 DVAPI void makeMacroFx(const std::vector<TFxP> &fxs, TApplication *app);
 DVAPI void explodeMacroFx(TMacroFx *macroFx, TApplication *app);
 DVAPI void createOutputFx(TXsheetHandle *xshHandle, TFx *currentFx);
-DVAPI void removeOutputFx(TFx *fx, TXsheetHandle *xshHandle,
-                          TFxHandle *fxHandle);
 DVAPI void makeOutputFxCurrent(TFx *fx, TXsheetHandle *xshHandle);
 DVAPI void disconnectNodesFromXsheet(const std::list<TFxP> &fxs,
                                      TXsheetHandle *xshHandle);

--- a/toonz/sources/include/toonzqt/fxschematicscene.h
+++ b/toonz/sources/include/toonzqt/fxschematicscene.h
@@ -213,7 +213,6 @@ protected slots:
   void onExplodeMacroFx();
   void onOpenMacroFx();
   void onSavePresetFx();
-  void onRemoveOutput();
   void onActivateOutput();
   void onPreview();
   void onCacheFx();

--- a/toonz/sources/toonzlib/fxcommand.cpp
+++ b/toonz/sources/toonzlib/fxcommand.cpp
@@ -400,7 +400,7 @@ void FxCommandUndo::attach(TXsheet *xsh, const TFxCommand::Link &link,
 //------------------------------------------------------
 
 void FxCommandUndo::attachOutputs(TXsheet *xsh, TFx *insertedFx, TFx *inputFx) {
-  TCG_ASSERT(inputFx, return );
+  TCG_ASSERT(inputFx, return);
 
   FxDag *fxDag = xsh->getFxDag();
 
@@ -2350,23 +2350,6 @@ static void deleteFxs(const std::list<TFxP> &fxs, TXsheetHandle *xshHandle,
 }
 
 //**********************************************************************
-//    Remove Output Fx  command
-//**********************************************************************
-
-void TFxCommand::removeOutputFx(TFx *fx, TXsheetHandle *xshHandle,
-                                TFxHandle *fxHandle) {
-  TOutputFx *outputFx = dynamic_cast<TOutputFx *>(fx);
-  if (!outputFx) return;
-
-  std::unique_ptr<FxCommandUndo> undo(
-      new DeleteFxOrColumnUndo(fx, xshHandle, fxHandle));
-  if (undo->isConsistent()) {
-    undo->redo();
-    TUndoManager::manager()->add(undo.release());
-  }
-}
-
-//**********************************************************************
 //    Delete Columns  command
 //**********************************************************************
 
@@ -3302,7 +3285,7 @@ void UndoConnectFxs::GroupData::restore() const {
 void UndoConnectFxs::initialize() {
   if (!UndoDisconnectFxs::isConsistent()) return;
 
-  TCG_ASSERT(m_link.m_inputFx && m_link.m_outputFx, m_fxs.clear(); return );
+  TCG_ASSERT(m_link.m_inputFx && m_link.m_outputFx, m_fxs.clear(); return);
 
   // Store sensible original data for the undo
   m_undoGroupDatas.reserve(m_fxs.size());

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -1082,7 +1082,7 @@ void FxOutputPainter::contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) {
   QMenu menu(fxScene->views()[0]);
   if (fxScene->getXsheet()->getFxDag()->getOutputFxCount() > 1) {
     QAction *removeOutput = new QAction(tr("&Delete"), &menu);
-    connect(removeOutput, SIGNAL(triggered()), fxScene, SLOT(onRemoveOutput()));
+    connect(removeOutput, SIGNAL(triggered()), fxScene, SLOT(onDeleteFx()));
 
     QAction *activateOutput = new QAction(tr("&Activate"), &menu);
     connect(activateOutput, SIGNAL(triggered()), fxScene,
@@ -3080,7 +3080,7 @@ FxSchematicColumnNode::FxSchematicColumnNode(FxSchematicScene *scene,
 
   bool ret = true;
   ret      = ret && connect(m_resizeItem, SIGNAL(toggled(bool)), this,
-                       SLOT(onChangedSize(bool)));
+                            SLOT(onChangedSize(bool)));
   ret      = ret &&
         connect(m_nameItem, SIGNAL(focusOut()), this, SLOT(onNameChanged()));
   ret = ret && connect(m_renderToggle, SIGNAL(toggled(bool)), this,

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -1462,12 +1462,6 @@ void FxSchematicScene::onSavePresetFx() {
 
 //------------------------------------------------------------------
 
-void FxSchematicScene::onRemoveOutput() {
-  TFxCommand::removeOutputFx(m_fxHandle->getFx(), m_xshHandle, m_fxHandle);
-}
-
-//------------------------------------------------------------------
-
 void FxSchematicScene::onActivateOutput() {
   TFxCommand::makeOutputFxCurrent(m_fxHandle->getFx(), m_xshHandle);
 }


### PR DESCRIPTION
This PR modifies `Delete` command in the context menu of Output node in Fx Schematic, so that the command will delete all selected (highlighted) nodes instead of deleting only the clicked node.

This PR will resolve the problem mentioned in [this comment](https://github.com/opentoonz/opentoonz/pull/4824#issuecomment-1510337106). 