### PR TITLE
Unify preview and camstand visibility toggles option by Contrail Co., Ltd.

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2368,6 +2368,7 @@ XsheetViewer {
   qproperty-XsheetPreviewButtonOnImage: url('../Default/imgs/white/x_prev_eye_on.svg');
   qproperty-XsheetPreviewButtonBgOffColor: transparent;
   qproperty-XsheetPreviewButtonOffImage: url('../Default/imgs/white/x_prev_eye_off.svg');
+  qproperty-XsheetUnifiedButtonTranspImage: url('../Default/imgs/white/x_prev_eye_transp.svg');
   qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
   qproperty-XsheetCamstandButtonOnImage: url('../Default/imgs/white/x_table_view_on.svg');
   qproperty-XsheetCamstandButtonTranspImage: url('../Default/imgs/white/x_table_view_transp.svg');
@@ -2385,6 +2386,7 @@ XsheetViewer {
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/white/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #414345;
   qproperty-TimelinePreviewButtonOffImage: url('none');
+  qproperty-TimelineUnifiedButtonTranspImage: url('../Default/imgs/white/preview_trans_small.svg');
   qproperty-TimelineCamstandButtonBgOnColor: #414345;
   qproperty-TimelineCamstandButtonOnImage: url('../Default/imgs/white/table_small.svg');
   qproperty-TimelineCamstandButtonTranspImage: url('../Default/imgs/white/trans_small.svg');

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2368,6 +2368,7 @@ XsheetViewer {
   qproperty-XsheetPreviewButtonOnImage: url('../Default/imgs/white/x_prev_eye_on.svg');
   qproperty-XsheetPreviewButtonBgOffColor: transparent;
   qproperty-XsheetPreviewButtonOffImage: url('../Default/imgs/white/x_prev_eye_off.svg');
+  qproperty-XsheetUnifiedButtonTranspImage: url('../Default/imgs/white/x_prev_eye_transp.svg');
   qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
   qproperty-XsheetCamstandButtonOnImage: url('../Default/imgs/white/x_table_view_on.svg');
   qproperty-XsheetCamstandButtonTranspImage: url('../Default/imgs/white/x_table_view_transp.svg');
@@ -2385,6 +2386,7 @@ XsheetViewer {
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/white/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #303030;
   qproperty-TimelinePreviewButtonOffImage: url('none');
+  qproperty-TimelineUnifiedButtonTranspImage: url('../Default/imgs/white/preview_trans_small.svg');
   qproperty-TimelineCamstandButtonBgOnColor: #303030;
   qproperty-TimelineCamstandButtonOnImage: url('../Default/imgs/white/table_small.svg');
   qproperty-TimelineCamstandButtonTranspImage: url('../Default/imgs/white/trans_small.svg');

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2368,6 +2368,7 @@ XsheetViewer {
   qproperty-XsheetPreviewButtonOnImage: url('imgs/white/x_prev_eye_on.svg');
   qproperty-XsheetPreviewButtonBgOffColor: transparent;
   qproperty-XsheetPreviewButtonOffImage: url('imgs/white/x_prev_eye_off.svg');
+  qproperty-XsheetUnifiedButtonTranspImage: url('imgs/white/x_prev_eye_transp.svg');
   qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
   qproperty-XsheetCamstandButtonOnImage: url('imgs/white/x_table_view_on.svg');
   qproperty-XsheetCamstandButtonTranspImage: url('imgs/white/x_table_view_transp.svg');
@@ -2385,6 +2386,7 @@ XsheetViewer {
   qproperty-TimelinePreviewButtonOnImage: url('imgs/white/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #484848;
   qproperty-TimelinePreviewButtonOffImage: url('none');
+  qproperty-TimelineUnifiedButtonTranspImage: url('imgs/white/preview_trans_small.svg');
   qproperty-TimelineCamstandButtonBgOnColor: #484848;
   qproperty-TimelineCamstandButtonOnImage: url('imgs/white/table_small.svg');
   qproperty-TimelineCamstandButtonTranspImage: url('imgs/white/trans_small.svg');

--- a/stuff/config/qss/Default/imgs/black/preview_trans_small.svg
+++ b/stuff/config/qss/Default/imgs/black/preview_trans_small.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="18px"
+   height="18px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg10"
+   sodipodi:docname="preview_trans_small.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs14" /><sodipodi:namedview
+   id="namedview12"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="true"
+   inkscape:zoom="40.34437"
+   inkscape:cx="14.314265"
+   inkscape:cy="11.178759"
+   inkscape:window-width="2560"
+   inkscape:window-height="1377"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg10" />
+    <rect
+   x="0"
+   y="0"
+   width="18"
+   height="18"
+   style="fill-opacity:0;"
+   id="rect2" />
+    <path
+   d="M3,8.991C3,8.991 5.248,5 9,5C12.752,5 15,8.991 15,8.991C15,8.991 12.761,13 9,13C5.239,13 3,8.991 3,8.991ZM9,6C10.656,6 12,7.344 12,9C12,10.656 10.656,12 9,12C7.344,12 6,10.656 6,9C6,7.344 7.344,6 9,6Z"
+   style="fill-opacity:0.8;stroke:#000000;stroke-opacity:0.7962963;fill:none;stroke-linejoin:miter"
+   id="path4" />
+    
+</svg>

--- a/stuff/config/qss/Default/imgs/black/x_prev_eye_transp.svg
+++ b/stuff/config/qss/Default/imgs/black/x_prev_eye_transp.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="18px"
+   height="17px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg1414"
+   sodipodi:docname="x_prev_eye_transp.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1418"><linearGradient
+     inkscape:collect="always"
+     id="linearGradient3559"><stop
+       style="stop-color:#000000;stop-opacity:1;"
+       offset="0"
+       id="stop3555" /><stop
+       style="stop-color:#000000;stop-opacity:0;"
+       offset="1"
+       id="stop3557" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#linearGradient3559"
+     id="linearGradient3561"
+     x1="9.0022936"
+     y1="13.096883"
+     x2="9.0022936"
+     y2="4.9616437"
+     gradientUnits="userSpaceOnUse"
+     spreadMethod="pad" /></defs><sodipodi:namedview
+   id="namedview1416"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="true"
+   inkscape:zoom="60.411765"
+   inkscape:cx="9.013145"
+   inkscape:cy="8.5082765"
+   inkscape:window-width="2560"
+   inkscape:window-height="1377"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g1412"><inkscape:grid
+     type="xygrid"
+     id="grid1900" /></sodipodi:namedview>
+    <rect
+   x="0"
+   y="0"
+   width="18"
+   height="17"
+   style="fill:white;fill-opacity:0;"
+   id="rect1408" />
+    <g
+   transform="matrix(0.848485,0,0,0.848485,1.36364,1.36364)"
+   id="g1412">
+        <path
+   d="M 9,3.375 C 5.25,3.375 2.047,5.708 0.75,9 2.047,12.293 5.25,14.625 9,14.625 12.75,14.625 15.953,12.293 17.25,9 15.953,5.708 12.75,3.375 9,3.375 Z m 0,9.75 C 6.723,13.125 4.875,11.277 4.875,9 c 1.7618094,0 6.517777,0 8.25,0 0,2.277 -1.848,4.125 -4.125,4.125 z M 6.643,9 c 0,1.304 1.053,2.357 2.357,2.357 1.304,0 2.357,-1.053 2.357,-2.357 -1.155448,0 -3.5107138,0 -4.714,0 z"
+   style="fill-opacity:1;fill-rule:nonzero;fill:url(#linearGradient3561)"
+   id="path1410"
+   sodipodi:nodetypes="scscssccscscc" />
+    </g>
+</svg>

--- a/stuff/config/qss/Default/imgs/white/preview_trans_small.svg
+++ b/stuff/config/qss/Default/imgs/white/preview_trans_small.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="18px"
+   height="18px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg10"
+   sodipodi:docname="preview_trans_small.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs14" /><sodipodi:namedview
+   id="namedview12"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="true"
+   inkscape:zoom="40.34437"
+   inkscape:cx="14.339052"
+   inkscape:cy="11.178759"
+   inkscape:window-width="2560"
+   inkscape:window-height="1377"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg10" />
+    <rect
+   x="0"
+   y="0"
+   width="18"
+   height="18"
+   style="fill-opacity:0;"
+   id="rect2" />
+    <path
+   d="M3,8.991C3,8.991 5.248,5 9,5C12.752,5 15,8.991 15,8.991C15,8.991 12.761,13 9,13C5.239,13 3,8.991 3,8.991ZM9,6C10.656,6 12,7.344 12,9C12,10.656 10.656,12 9,12C7.344,12 6,10.656 6,9C6,7.344 7.344,6 9,6Z"
+   style="fill-opacity:0.80000001;fill:none;stroke:#ffffff;stroke-opacity:0.80000001"
+   id="path4" />
+    
+</svg>

--- a/stuff/config/qss/Default/imgs/white/x_prev_eye_transp.svg
+++ b/stuff/config/qss/Default/imgs/white/x_prev_eye_transp.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="18px"
+   height="17px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg1414"
+   sodipodi:docname="x_prev_eye_transp.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1418"><linearGradient
+     inkscape:collect="always"
+     id="linearGradient3559"><stop
+       style="stop-color:#000000;stop-opacity:1;"
+       offset="0"
+       id="stop3555" /><stop
+       style="stop-color:#000000;stop-opacity:0;"
+       offset="1"
+       id="stop3557" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#linearGradient3559"
+     id="linearGradient3561"
+     x1="9.0022936"
+     y1="13.096883"
+     x2="9.0022936"
+     y2="4.9616437"
+     gradientUnits="userSpaceOnUse"
+     spreadMethod="pad" /></defs><sodipodi:namedview
+   id="namedview1416"
+   pagecolor="#ffffff"
+   bordercolor="#000000"
+   borderopacity="0.25"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="true"
+   inkscape:zoom="60.411765"
+   inkscape:cx="9.013145"
+   inkscape:cy="8.5082765"
+   inkscape:window-width="2560"
+   inkscape:window-height="1377"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g1412"><inkscape:grid
+     type="xygrid"
+     id="grid1900" /></sodipodi:namedview>
+    <rect
+   x="0"
+   y="0"
+   width="18"
+   height="17"
+   style="fill:white;fill-opacity:0;"
+   id="rect1408" />
+    <g
+   transform="matrix(0.848485,0,0,0.848485,1.36364,1.36364)"
+   id="g1412">
+        <path
+   d="M 9,3.375 C 5.25,3.375 2.047,5.708 0.75,9 2.047,12.293 5.25,14.625 9,14.625 12.75,14.625 15.953,12.293 17.25,9 15.953,5.708 12.75,3.375 9,3.375 Z m 0,9.75 C 6.723,13.125 4.875,11.277 4.875,9 c 1.7618094,0 6.517777,0 8.25,0 0,2.277 -1.848,4.125 -4.125,4.125 z M 6.643,9 c 0,1.304 1.053,2.357 2.357,2.357 1.304,0 2.357,-1.053 2.357,-2.357 -1.155448,0 -3.5107138,0 -4.714,0 z"
+   style="fill-opacity:1;fill-rule:nonzero;fill:url(#linearGradient3561)"
+   id="path1410"
+   sodipodi:nodetypes="scscssccscscc" />
+    </g>
+</svg>

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -166,6 +166,8 @@ XsheetViewer {
   qproperty-XsheetPreviewButtonBgOffColor: transparent;
   qproperty-XsheetPreviewButtonOffImage: url('@{img-url}/x_prev_eye_off.svg');
 
+  qproperty-XsheetUnifiedButtonTranspImage: url('@{img-url}/x_prev_eye_transp.svg');
+
   qproperty-XsheetCamstandButtonBgOnColor: @xsheet-CamstandButtonBgOn-color;
   qproperty-XsheetCamstandButtonOnImage: url('@{img-url}/x_table_view_on.svg');
   qproperty-XsheetCamstandButtonTranspImage: url('@{img-url}/x_table_view_transp.svg');
@@ -188,6 +190,8 @@ XsheetViewer {
   qproperty-TimelinePreviewButtonOnImage: url('@{img-url}/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: @bg;
   qproperty-TimelinePreviewButtonOffImage: url('none');
+  
+  qproperty-TimelineUnifiedButtonTranspImage: url('@{img-url}/preview_trans_small.svg');
 
   qproperty-TimelineCamstandButtonBgOnColor: @bg;
   qproperty-TimelineCamstandButtonOnImage: url('@{img-url}/table_small.svg');

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2368,6 +2368,7 @@ XsheetViewer {
   qproperty-XsheetPreviewButtonOnImage: url('../Default/imgs/black/x_prev_eye_on.svg');
   qproperty-XsheetPreviewButtonBgOffColor: transparent;
   qproperty-XsheetPreviewButtonOffImage: url('../Default/imgs/black/x_prev_eye_off.svg');
+  qproperty-XsheetUnifiedButtonTranspImage: url('../Default/imgs/black/x_prev_eye_transp.svg');
   qproperty-XsheetCamstandButtonBgOnColor: #ffa683;
   qproperty-XsheetCamstandButtonOnImage: url('../Default/imgs/black/x_table_view_on.svg');
   qproperty-XsheetCamstandButtonTranspImage: url('../Default/imgs/black/x_table_view_transp.svg');
@@ -2385,6 +2386,7 @@ XsheetViewer {
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/black/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #DBDBDB;
   qproperty-TimelinePreviewButtonOffImage: url('none');
+  qproperty-TimelineUnifiedButtonTranspImage: url('../Default/imgs/black/preview_trans_small.svg');
   qproperty-TimelineCamstandButtonBgOnColor: #DBDBDB;
   qproperty-TimelineCamstandButtonOnImage: url('../Default/imgs/black/table_small.svg');
   qproperty-TimelineCamstandButtonTranspImage: url('../Default/imgs/black/trans_small.svg');

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2368,6 +2368,7 @@ XsheetViewer {
   qproperty-XsheetPreviewButtonOnImage: url('../Default/imgs/black/x_prev_eye_on.svg');
   qproperty-XsheetPreviewButtonBgOffColor: transparent;
   qproperty-XsheetPreviewButtonOffImage: url('../Default/imgs/black/x_prev_eye_off.svg');
+  qproperty-XsheetUnifiedButtonTranspImage: url('../Default/imgs/black/x_prev_eye_transp.svg');
   qproperty-XsheetCamstandButtonBgOnColor: #eb906b;
   qproperty-XsheetCamstandButtonOnImage: url('../Default/imgs/black/x_table_view_on.svg');
   qproperty-XsheetCamstandButtonTranspImage: url('../Default/imgs/black/x_table_view_transp.svg');
@@ -2385,6 +2386,7 @@ XsheetViewer {
   qproperty-TimelinePreviewButtonOnImage: url('../Default/imgs/black/preview_small.svg');
   qproperty-TimelinePreviewButtonBgOffColor: #808080;
   qproperty-TimelinePreviewButtonOffImage: url('none');
+  qproperty-TimelineUnifiedButtonTranspImage: url('../Default/imgs/black/preview_trans_small.svg');
   qproperty-TimelineCamstandButtonBgOnColor: #808080;
   qproperty-TimelineCamstandButtonOnImage: url('../Default/imgs/black/table_small.svg');
   qproperty-TimelineCamstandButtonTranspImage: url('../Default/imgs/black/trans_small.svg');

--- a/toonz/sources/include/orientation.h
+++ b/toonz/sources/include/orientation.h
@@ -93,6 +93,9 @@ enum class PredefinedRect {
   PREVIEW_LAYER_AREA,  //! clickable area larger than preview icon, containing
                        //! it
   PREVIEW_LAYER,
+  UNIFIEDVIEW_LAYER_AREA,  //! used when unifying the preview and the camstand
+                           //! toggles
+  UNIFIEDVIEW_LAYER,
   LOCK_AREA,          //! clickable area larger than lock icon, containing it
   LOCK,               //! the lock icon itself
   CAMERA_LOCK_AREA,   //! lock area for the camera column

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -396,6 +396,9 @@ public:
   bool isShowColumnNumbersEnabled() const {
     return getBoolValue(showColumnNumbers);
   }
+  bool isUnifyColumnVisibilityTogglesEnabled() const {
+    return getBoolValue(unifyColumnVisibilityToggles);
+  }
   bool isParentColorsInXsheetColumnEnabled() const {
     return getBoolValue(parentColorsInXsheetColumn);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -132,6 +132,7 @@ enum PreferencesItemId {
   showXSheetToolbar,
   expandFunctionHeader,
   showColumnNumbers,
+  unifyColumnVisibilityToggles,
   parentColorsInXsheetColumn,
   highlightLineEverySecond,
   syncLevelRenumberWithXsheet,

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -658,6 +658,48 @@ public:
   int getHistoryType() override { return HistoryType::Xsheet; }
 };
 
+//---------------------------------------------------------------------------
+
+void doUnifyColumnVisibilityToggles_Recursive(const TXsheet *xsh,
+                                              QStringList &modifiedColumnNames,
+                                              QList<TXsheet *> doneList,
+                                              QStringList &parentXshStack) {
+  for (int c = 0; c < xsh->getColumnCount(); c++) {
+    TXshColumn *column = xsh->getColumn(c);
+    if (!column || column->isEmpty()) continue;
+    int colType = column->getColumnType();
+    if (colType == TXshColumn::ePaletteType ||
+        colType == TXshColumn::eSoundType ||
+        colType == TXshColumn::eSoundTextType)
+      continue;
+    // visibility check
+    if (column->isPreviewVisible() != column->isCamstandVisible()) {
+      column->setCamstandVisible(column->isPreviewVisible());
+      QString colName = QString::fromStdString(
+          xsh->getStageObject(TStageObjectId::ColumnId(c))->getName());
+      modifiedColumnNames.append(parentXshStack.join(" > ") + colName);
+    }
+
+    // check subxsheet recursively
+    TXshCellColumn *cellCol = column->getCellColumn();
+    if (!cellCol) continue;
+    int r0, r1;
+    column->getRange(r0, r1);
+    TXshCell cell              = cellCol->getCell(r0);
+    TXshChildLevel *childLevel = cell.m_level->getChildLevel();
+    if (childLevel) {
+      TXsheet *subSheet = childLevel->getXsheet();
+      if (!doneList.contains(subSheet)) {
+        doneList.append(subSheet);
+        parentXshStack.append(QString::fromStdWString(childLevel->getName()));
+        doUnifyColumnVisibilityToggles_Recursive(xsh, modifiedColumnNames,
+                                                 doneList, parentXshStack);
+        parentXshStack.pop_back();
+      }
+    }
+  }
+}
+
 }  // namespace
 
 //*************************************************************************
@@ -1394,6 +1436,28 @@ bool ColumnCmd::checkExpressionReferences(
       colIdsToBeDeleted, fxsToBeDeleted, objIdsToBeDuplicated, true);
 }
 
+//---------------------------------------------------------------------------
+// Check if any column has visibility toggles with different states and the
+// "unify visibility toggles" option is enabled
+void ColumnCmd::unifyColumnVisibilityToggles() {
+  TApp *app         = TApp::instance();
+  ToonzScene *scene = app->getCurrentScene()->getScene();
+  QStringList modifiedColumnNames;
+  QList<TXsheet *> doneList;
+  QStringList parentStack;
+  doUnifyColumnVisibilityToggles_Recursive(
+      scene->getTopXsheet(), modifiedColumnNames, doneList, parentStack);
+  if (!modifiedColumnNames.isEmpty()) {
+    DVGui::warning(
+        QObject::tr(
+            "The visibility toggles of following columns are modified \n"
+            "due to \"Unify Preview and Camstand Visibility Toggles\" "
+            "preference option : \n  %1")
+            .arg(modifiedColumnNames.join("\n  ")));
+    app->getCurrentScene()->setDirtyFlag(true);
+  }
+}
+
 //=============================================================================
 
 namespace {
@@ -1482,6 +1546,10 @@ public:
           column->setPreviewVisible(negate);
         else
           column->setPreviewVisible(!column->isPreviewVisible());
+
+        // sync camstand visibility
+        if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+          column->setCamstandVisible(column->isPreviewVisible());
       }
       if (cmd &
           (CMD_ENABLE_CAMSTAND | CMD_DISABLE_CAMSTAND | CMD_TOGGLE_CAMSTAND)) {

--- a/toonz/sources/toonz/columncommand.h
+++ b/toonz/sources/toonz/columncommand.h
@@ -54,6 +54,10 @@ bool checkExpressionReferences(const std::set<int> &indices,
 // checkInvert is always true for collapsing in stage schematic
 bool checkExpressionReferences(const QList<TStageObjectId> &objects);
 
+// Check if any column has visibility toggles with different states and the
+// "unify visibility toggles" option is enabled
+void unifyColumnVisibilityToggles();
+
 }  // namespace ColumnCmd
 
 #endif

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -22,6 +22,7 @@
 #include "xdtsio.h"
 #include "expressionreferencemanager.h"
 #include "levelcommand.h"
+#include "columncommand.h"
 
 // TnzTools includes
 #include "tools/toolhandle.h"
@@ -1200,7 +1201,6 @@ inline TPaletteP dirtyWhite(const TPaletteP &plt) {
   return out;
 }
 
-//---------------------------------------------------------------------------
 }  // namespace
 //---------------------------------------------------------------------------
 
@@ -2087,6 +2087,11 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
       app->getCurrentScene()->setDirtyFlag(true);
     }
   }
+
+  // Check if any column has visibility toggles with different states and the
+  // "unify visibility toggles" option is enabled
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    ColumnCmd::unifyColumnVisibilityToggles();
 
   // caching raster levels
   int cacheRasterBehavior =

--- a/toonz/sources/toonz/layerheaderpanel.cpp
+++ b/toonz/sources/toonz/layerheaderpanel.cpp
@@ -66,7 +66,8 @@ void LayerHeaderPanel::paintEvent(QPaintEvent *event) {
                          : m_viewer->getLayerHeaderLockImage());
 
   drawIcon(p, PredefinedRect::PANEL_EYE, boost::none, preview);
-  drawIcon(p, PredefinedRect::PANEL_PREVIEW_LAYER, boost::none, camstand);
+  if (!Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    drawIcon(p, PredefinedRect::PANEL_PREVIEW_LAYER, boost::none, camstand);
   drawIcon(p, PredefinedRect::PANEL_LOCK, boost::none, lock);
 }
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -9,6 +9,7 @@
 #include "tapp.h"
 #include "cleanupsettingsmodel.h"
 #include "formatsettingspopups.h"
+#include "columncommand.h"
 
 // TnzQt includes
 #include "toonzqt/tabbar.h"
@@ -679,6 +680,18 @@ void PreferencesPopup::onShowXSheetToolbarClicked() {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onUnifyColumnVisibilityTogglesChanged() {
+  // Check if any column has visibility toggles with different states and the
+  // "unify visibility toggles" option is enabled
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    ColumnCmd::unifyColumnVisibilityToggles();
+
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
+      "unifyColumnVisibilityToggles");
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onModifyExpressionOnMovingReferencesChanged() {
   TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
       "modifyExpressionOnMovingReferences");
@@ -1279,6 +1292,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {expandFunctionHeader,
        tr("Expand Function Editor Header to Match Xsheet Toolbar Height*")},
       {showColumnNumbers, tr("Show Column Numbers in Column Headers")},
+      {unifyColumnVisibilityToggles,
+       tr("Unify Preview and Camstand Visibility Toggles")},
       {parentColorsInXsheetColumn,
        tr("Show Column Parent's Color in the Xsheet")},
       {highlightLineEverySecond, tr("Highlight Line Every Second")},
@@ -2013,6 +2028,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   QGridLayout* xshToolbarLay = insertGroupBoxUI(showXSheetToolbar, lay);
   { insertUI(expandFunctionHeader, xshToolbarLay); }
   insertUI(showColumnNumbers, lay);
+  insertUI(unifyColumnVisibilityToggles, lay);
   insertUI(parentColorsInXsheetColumn, lay);
   insertUI(highlightLineEverySecond, lay);
   insertUI(syncLevelRenumberWithXsheet, lay);
@@ -2028,6 +2044,9 @@ QWidget* PreferencesPopup::createXsheetPage() {
                            &PreferencesPopup::onShowKeyframesOnCellAreaChanged);
   m_onEditedFuncMap.insert(showXsheetCameraColumn,
                            &PreferencesPopup::onShowKeyframesOnCellAreaChanged);
+  m_onEditedFuncMap.insert(
+      unifyColumnVisibilityToggles,
+      &PreferencesPopup::onUnifyColumnVisibilityTogglesChanged);
 
   return widget;
 }

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -139,6 +139,7 @@ private:
   // Xsheet
   void onShowKeyframesOnCellAreaChanged();
   void onShowXSheetToolbarClicked();
+  void onUnifyColumnVisibilityTogglesChanged();
   // Animation
   void onModifyExpressionOnMovingReferencesChanged();
   // Preview

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -266,6 +266,13 @@ void SchematicScenePanel::onColumnPaste(const QList<TXshColumnP> &columns) {
 
 //-----------------------------------------------------------------------------
 
+void SchematicScenePanel::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "unifyColumnVisibilityToggles")
+    m_schematicViewer->updateSchematic();
+}
+
+//-----------------------------------------------------------------------------
+
 void SchematicScenePanel::showEvent(QShowEvent *e) {
   if (m_schematicViewer->isStageSchematicViewed())
     setWindowTitle(QObject::tr("Stage Schematic"));
@@ -299,6 +306,8 @@ void SchematicScenePanel::showEvent(QShowEvent *e) {
           SLOT(updateSchematic()));
   connect(app->getCurrentScene(), SIGNAL(sceneSwitched()), m_schematicViewer,
           SLOT(onSceneSwitched()));
+  connect(app->getCurrentScene(), SIGNAL(preferenceChanged(const QString &)),
+          this, SLOT(onPreferenceChanged(const QString &)));
   connect(m_schematicViewer, SIGNAL(columnPasted(const QList<TXshColumnP> &)),
           this, SLOT(onColumnPaste(const QList<TXshColumnP> &)));
   m_schematicViewer->updateSchematic();
@@ -330,6 +339,8 @@ void SchematicScenePanel::hideEvent(QHideEvent *e) {
              m_schematicViewer, SLOT(updateSchematic()));
   disconnect(app->getCurrentScene(), SIGNAL(sceneSwitched()), m_schematicViewer,
              SLOT(onSceneSwitched()));
+  disconnect(app->getCurrentScene(), SIGNAL(preferenceChanged(const QString &)),
+             this, SLOT(onPreferenceChanged(const QString &)));
   disconnect(m_schematicViewer,
              SIGNAL(columnPasted(const QList<TXshColumnP> &)), this,
              SLOT(onColumnPaste(const QList<TXshColumnP> &)));

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -193,6 +193,7 @@ protected slots:
   void onDeleteFxs(const FxSelection *);
   void onDeleteStageObjects(const StageObjectSelection *);
   void onColumnPaste(const QList<TXshColumnP> &);
+  void onPreferenceChanged(const QString &);
 };
 
 //=========================================================

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -334,6 +334,7 @@ class ColumnArea final : public QWidget {
     void drawBaseFill(const QColor &columnColor, const QColor &dragColor) const;
     void drawEye() const;
     void drawPreviewToggle(int opacity) const;
+    void drawUnifiedViewToggle(int opacity) const;
     void drawLock() const;
     void drawConfig() const;
     void drawColumnNumber() const;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -203,6 +203,12 @@ void XsheetViewer::getButton(const int &btype, QColor &bgColor,
     iconImage = (isTimeline) ? getTimelineConfigButtonImage()
                              : getXsheetConfigButtonImage();
     break;
+  case UNIFIED_TRANSP_XSHBUTTON:
+    bgColor   = (isTimeline) ? getTimelinePreviewButtonBgOnColor()
+                             : getXsheetPreviewButtonBgOnColor();
+    iconImage = (isTimeline) ? getTimelineUnifiedButtonTranspImage()
+                             : getXsheetUnifiedButtonTranspImage();
+    break;
   default:
     bgColor = grey210;
     static QImage iconignored;

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -40,7 +40,8 @@ enum TXshButtonType {
   CAMSTAND_TRANSP_XSHBUTTON,
   LOCK_ON_XSHBUTTON,
   LOCK_OFF_XSHBUTTON,
-  CONFIG_XSHBUTTON
+  CONFIG_XSHBUTTON,
+  UNIFIED_TRANSP_XSHBUTTON
 };
 
 namespace XsheetGUI {
@@ -435,6 +436,7 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   QImage m_xsheetPreviewButtonOnImage;
   QColor m_xsheetPreviewButtonBgOffColor;
   QImage m_xsheetPreviewButtonOffImage;
+  QImage m_xsheetUnifiedButtonTranspImage;
   Q_PROPERTY(
       QColor XsheetPreviewButtonBgOnColor READ getXsheetPreviewButtonBgOnColor
           WRITE setXsheetPreviewButtonBgOnColor)
@@ -447,6 +449,9 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   Q_PROPERTY(
       QImage XsheetPreviewButtonOffImage READ getXsheetPreviewButtonOffImage
           WRITE setXsheetPreviewButtonOffImage)
+  Q_PROPERTY(QImage XsheetUnifiedButtonTranspImage READ
+                 getXsheetUnifiedButtonTranspImage WRITE
+                     setXsheetUnifiedButtonTranspImage)
   // Xsheet Camstand Button
   QColor m_xsheetCamstandButtonBgOnColor;
   QImage m_xsheetCamstandButtonOnImage;
@@ -494,6 +499,7 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   QImage m_timelinePreviewButtonOnImage;
   QColor m_timelinePreviewButtonBgOffColor;
   QImage m_timelinePreviewButtonOffImage;
+  QImage m_timelineUnifiedButtonTranspImage;
   Q_PROPERTY(QColor TimelinePreviewButtonBgOnColor READ
                  getTimelinePreviewButtonBgOnColor WRITE
                      setTimelinePreviewButtonBgOnColor)
@@ -506,6 +512,9 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   Q_PROPERTY(
       QImage TimelinePreviewButtonOffImage READ getTimelinePreviewButtonOffImage
           WRITE setTimelinePreviewButtonOffImage)
+  Q_PROPERTY(QImage TimelineUnifiedButtonTranspImage READ
+                 getTimelineUnifiedButtonTranspImage WRITE
+                     setTimelineUnifiedButtonTranspImage)
   // Timeline Camstand Button
   QColor m_timelineCamstandButtonBgOnColor;
   QImage m_timelineCamstandButtonOnImage;
@@ -1071,6 +1080,9 @@ public:
   void setXsheetPreviewButtonOffImage(const QImage &image) {
     m_xsheetPreviewButtonOffImage = image;
   }
+  void setXsheetUnifiedButtonTranspImage(const QImage &image) {
+    m_xsheetUnifiedButtonTranspImage = image;
+  }
   QColor getXsheetPreviewButtonBgOnColor() const {
     return m_xsheetPreviewButtonBgOnColor;
   }
@@ -1082,6 +1094,9 @@ public:
   }
   QImage getXsheetPreviewButtonOffImage() const {
     return m_xsheetPreviewButtonOffImage;
+  }
+  QImage getXsheetUnifiedButtonTranspImage() const {
+    return m_xsheetUnifiedButtonTranspImage;
   }
   // Xsheet Camstand Button
   void setXsheetCamstandButtonBgOnColor(const QColor &color) {
@@ -1165,6 +1180,9 @@ public:
   void setTimelinePreviewButtonOffImage(const QImage &image) {
     m_timelinePreviewButtonOffImage = image;
   }
+  void setTimelineUnifiedButtonTranspImage(const QImage &image) {
+    m_timelineUnifiedButtonTranspImage = image;
+  }
   QColor getTimelinePreviewButtonBgOnColor() const {
     return m_timelinePreviewButtonBgOnColor;
   }
@@ -1176,6 +1194,9 @@ public:
   }
   QImage getTimelinePreviewButtonOffImage() const {
     return m_timelinePreviewButtonOffImage;
+  }
+  QImage getTimelineUnifiedButtonTranspImage() const {
+    return m_timelineUnifiedButtonTranspImage;
   }
   // Timeline Camstand Button
   void setTimelineCamstandButtonBgOnColor(const QColor &color) {

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -438,9 +438,9 @@ TopToBottomOrientation::TopToBottomOrientation() {
   static int HDRROW3;
   static int HDRROW4;
   static int HDRROW5;
-  QRect layername, eyeArea, previewArea, lockArea, cameraLockArea, configArea,
-      cameraConfigArea, thumbnailArea, thumbnail, cameraIconArea, pegbarname,
-      volumeArea;
+  QRect layername, eyeArea, previewArea, unifiedViewArea, lockArea,
+      cameraLockArea, configArea, cameraConfigArea, thumbnailArea, thumbnail,
+      cameraIconArea, pegbarname, volumeArea;
   QPoint soundTopLeft;
 
   if (layout == QString("Minimum")) {
@@ -472,6 +472,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::PREVIEW_LAYER_AREA, previewArea);
     addRect(PredefinedRect::PREVIEW_LAYER,
             iconRect(previewArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
+
+    unifiedViewArea = QRect(
+        INDENT, HDRROW2, eyeArea.width() + previewArea.width(), HDRROW_HEIGHT);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER_AREA, unifiedViewArea);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER,
+            iconRect(unifiedViewArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
 
     addRect(PredefinedRect::LOCK_AREA, QRect(0, 0, -1, -1));
     addRect(PredefinedRect::LOCK, QRect(0, 0, -1, -1));
@@ -558,6 +564,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::PREVIEW_LAYER_AREA, previewArea);
     addRect(PredefinedRect::PREVIEW_LAYER,
             iconRect(previewArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
+
+    unifiedViewArea = QRect(
+        INDENT, HDRROW2, eyeArea.width() + previewArea.width(), HDRROW_HEIGHT);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER_AREA, unifiedViewArea);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER,
+            iconRect(unifiedViewArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
 
     lockArea = QRect(INDENT + eyeArea.width() + previewArea.width(), HDRROW2,
                      ICON_WIDTH, HDRROW_HEIGHT);
@@ -670,6 +682,12 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::PREVIEW_LAYER,
             iconRect(previewArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
 
+    unifiedViewArea =
+        QRect(INDENT, HDRROW2, CELL_WIDTH - ICON_WIDTH, HDRROW_HEIGHT * 2);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER_AREA, unifiedViewArea);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER,
+            iconRect(unifiedViewArea, ICON_WIDTH, ICON_HEIGHT - 1, 1));
+
     lockArea =
         QRect(INDENT + eyeArea.width(), HDRROW2, ICON_WIDTH, HDRROW_HEIGHT);
     addRect(PredefinedRect::LOCK_AREA, lockArea);
@@ -780,6 +798,13 @@ TopToBottomOrientation::TopToBottomOrientation() {
     addRect(PredefinedRect::PREVIEW_LAYER_AREA, previewArea);
     addRect(PredefinedRect::PREVIEW_LAYER,
             previewArea.adjusted(previewArea.width() - ICON_WIDTH, 0, 0, 0));
+
+    unifiedViewArea =
+        QRect(INDENT, HDRROW2, CELL_WIDTH - INDENT - 2, HDRROW_HEIGHT - 1);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER_AREA, unifiedViewArea);
+    addRect(PredefinedRect::UNIFIEDVIEW_LAYER,
+            unifiedViewArea.adjusted(unifiedViewArea.width() - ICON_WIDTH, 0, 0,
+                                     0));
 
     lockArea = QRect(INDENT, HDRROW2, ICON_WIDTH - 1, HDRROW_HEIGHT - 1);
     addRect(PredefinedRect::LOCK_AREA, lockArea);
@@ -1216,7 +1241,6 @@ LeftToRightOrientation::LeftToRightOrientation() {
                 (FRAME_HEADER_HEIGHT - NAV_TAG_HEIGHT) / 2, NAV_TAG_WIDTH,
                 NAV_TAG_HEIGHT));
 
-
   // Column viewer
   addRect(PredefinedRect::LAYER_HEADER,
           QRect(1, 0, LAYER_HEADER_WIDTH - 2, CELL_HEIGHT));
@@ -1238,6 +1262,10 @@ LeftToRightOrientation::LeftToRightOrientation() {
           eyeArea.translated(ICON_OFFSET, 0));
   addRect(PredefinedRect::PREVIEW_LAYER,
           eye.translated(ICON_OFFSET, 0).adjusted(1, 1, -1, -1));
+
+  addRect(PredefinedRect::UNIFIEDVIEW_LAYER_AREA, eyeArea);
+  addRect(PredefinedRect::UNIFIEDVIEW_LAYER, eye.adjusted(1, 1, -1, -1));
+
   addRect(PredefinedRect::LOCK_AREA, eyeArea.translated(2 * ICON_OFFSET, 0));
   addRect(PredefinedRect::LOCK,
           eye.translated(2 * ICON_OFFSET, 0).adjusted(1, 1, -1, -1));

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -586,6 +586,8 @@ void Preferences::definePreferenceItems() {
   define(showXSheetToolbar, "showXSheetToolbar", QMetaType::Bool, true);
   define(expandFunctionHeader, "expandFunctionHeader", QMetaType::Bool, false);
   define(showColumnNumbers, "showColumnNumbers", QMetaType::Bool, false);
+  define(unifyColumnVisibilityToggles, "unifyColumnVisibilityToggles",
+         QMetaType::Bool, false);
   define(parentColorsInXsheetColumn, "parentColorsInXsheetColumn",
          QMetaType::Bool, false);
   define(highlightLineEverySecond, "highlightLineEverySecond", QMetaType::Bool,

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -2821,8 +2821,11 @@ FxSchematicZeraryNode::FxSchematicZeraryNode(FxSchematicScene *scene,
   connect(m_nameItem, SIGNAL(focusOut()), this, SLOT(onNameChanged()));
   connect(m_renderToggle, SIGNAL(toggled(bool)), this,
           SLOT(onRenderToggleClicked(bool)));
-  connect(m_cameraStandToggle, SIGNAL(stateChanged(int)), this,
-          SLOT(onCameraStandToggleClicked(int)));
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    m_cameraStandToggle->hide();
+  else
+    connect(m_cameraStandToggle, SIGNAL(stateChanged(int)), this,
+            SLOT(onCameraStandToggleClicked(int)));
 
   if (zeraryFx) {
     int i, inputPorts = zeraryFx->getInputPortCount();
@@ -3085,8 +3088,11 @@ FxSchematicColumnNode::FxSchematicColumnNode(FxSchematicScene *scene,
         connect(m_nameItem, SIGNAL(focusOut()), this, SLOT(onNameChanged()));
   ret = ret && connect(m_renderToggle, SIGNAL(toggled(bool)), this,
                        SLOT(onRenderToggleClicked(bool)));
-  ret = ret && connect(m_cameraStandToggle, SIGNAL(stateChanged(int)), this,
-                       SLOT(onCameraStandToggleClicked(int)));
+  if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    m_cameraStandToggle->hide();
+  else
+    ret = ret && connect(m_cameraStandToggle, SIGNAL(stateChanged(int)), this,
+                         SLOT(onCameraStandToggleClicked(int)));
 
   assert(ret);
 
@@ -3122,6 +3128,8 @@ void FxSchematicColumnNode::onRenderToggleClicked(bool toggled) {
   TXshColumn *column = fxScene->getXsheet()->getColumn(m_columnIndex);
   if (column) {
     column->setPreviewVisible(toggled);
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      column->setCamstandVisible(toggled);
     emit sceneChanged();
     emit xsheetChanged();
   }

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -1753,7 +1753,8 @@ StageSchematicColumnNode::StageSchematicColumnNode(StageSchematicScene *scene,
   if (levelType == PLT_XSHLEVEL) {
     m_resizeItem->hide();
     m_cameraStandToggle->hide();
-  }
+  } else if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+    m_cameraStandToggle->hide();
 }
 
 //--------------------------------------------------------
@@ -1961,6 +1962,8 @@ void StageSchematicColumnNode::onRenderToggleClicked(bool isActive) {
       stageScene->getXsheet()->getColumn(m_stageObject->getId().getIndex());
   if (column) {
     column->setPreviewVisible(isActive);
+    if (Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled())
+      column->setCamstandVisible(isActive);
     emit sceneChanged();
     emit xsheetChanged();
   }


### PR DESCRIPTION
**This is to be merged after releasing the next version.**

This PR will add a preferences option `Unify Preview and Camstand Visibility Toggles` which will unify the camstand and the preview visibility to get a simple UI.

![image](https://user-images.githubusercontent.com/17974955/233532841-9bcb5389-c774-40d7-9c1e-202df1b3f06d.png)

When this option is turned on, the camera stand and the preview visibility toggles in all columns will be automatically adjusted to the same states.
This improvement was developed on consignment and is copyrighted by [Contrail Co., Ltd.](https://contrail.tokyo/)