### PR TITLE
Fix update sound after editing cells

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -216,11 +216,14 @@ class PasteCellsUndo final : public TUndo {
   TCellSelection *m_newSelection;
   TCellData *m_data;
   std::vector<bool> m_areOldColumnsEmpty;
+  bool m_containsSoundColumn;
 
 public:
   PasteCellsUndo(int r0, int c0, int r1, int c1, int oldR0, int oldC0,
-                 int oldR1, int oldC1, const std::vector<bool> &areColumnsEmpty)
-      : m_areOldColumnsEmpty(areColumnsEmpty) {
+                 int oldR1, int oldC1, const std::vector<bool> &areColumnsEmpty,
+                 bool containsSoundColumn)
+      : m_areOldColumnsEmpty(areColumnsEmpty)
+      , m_containsSoundColumn(containsSoundColumn) {
     m_data       = new TCellData();
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     m_data->setCells(xsh, r0, c0, r1, c1);
@@ -258,6 +261,8 @@ public:
     }
 
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   void redo() const override {
@@ -266,6 +271,8 @@ public:
     // Cut delle celle che sono in newSelection
     pasteCellsWithoutUndo(m_data, r0, c0, c1, r1, true, false);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   int getSize() const override { return sizeof(*this); }
@@ -284,18 +291,28 @@ public:
 
 class DeleteCellsUndo final : public TUndo {
   TCellSelection *m_selection;
-  QMimeData *m_data;
+  TCellData *m_data;
 
   bool m_doShift;  // whether clear cell or remove and shift cells up
+  bool m_containsSoundColumn;
 
 public:
-  DeleteCellsUndo(TCellSelection *selection, QMimeData *data, bool doShift)
-      : m_data(data), m_doShift(doShift) {
+  DeleteCellsUndo(TCellSelection *selection, TCellData *data, bool doShift)
+      : m_data(data), m_doShift(doShift), m_containsSoundColumn(false) {
     int r0, c0, r1, c1;
     selection->getSelectedCells(r0, c0, r1, c1);
     if (c0 < 0) c0 = 0;  // Ignore camera column
     m_selection = new TCellSelection();
     m_selection->selectCells(r0, c0, r1, c1);
+
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (int c = c0; c <= c1; c++) {
+      TXshColumn *column = xsh->getColumn(c);
+      if (column && column->getSoundColumn()) {
+        m_containsSoundColumn = true;
+        break;
+      }
+    }
   }
 
   ~DeleteCellsUndo() { delete m_selection; }
@@ -306,10 +323,11 @@ public:
     int r0, c0, r1, c1;
     m_selection->getSelectedCells(r0, c0, r1, c1);
 
-    const TCellData *cellData = dynamic_cast<const TCellData *>(m_data);
     // insert cells if the delete operation had shifted cells up
-    pasteCellsWithoutUndo(cellData, r0, c0, r1, c1, m_doShift, false);
+    pasteCellsWithoutUndo(m_data, r0, c0, r1, c1, m_doShift, false);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   void redo() const override {
@@ -317,12 +335,15 @@ public:
     m_selection->getSelectedCells(r0, c0, r1, c1);
     deleteCellsWithoutUndo(r0, c0, r1, c1, m_doShift);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   int getSize() const override { return sizeof(*this); }
 
   QString getHistoryString() override { return QObject::tr("Delete Cells"); }
   int getHistoryType() override { return HistoryType::Xsheet; }
+  bool containsSoundColumn() { return m_containsSoundColumn; }
 };
 
 //=============================================================================
@@ -336,8 +357,11 @@ class CutCellsUndo final : public TUndo {
   TCellSelection *m_selection;
   TCellData *m_data;
 
+  bool m_containsSoundColumn;
+
 public:
-  CutCellsUndo(TCellSelection *selection) : m_data() {
+  CutCellsUndo(TCellSelection *selection)
+      : m_data(), m_containsSoundColumn(false) {
     int r0, c0, r1, c1;
     selection->getSelectedCells(r0, c0, r1, c1);
     if (c0 < 0) c0 = 0;  // Ignore camera column
@@ -349,6 +373,14 @@ public:
     m_data       = new TCellData();
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     m_data->setCells(xsh, r0, c0, r1, c1);
+
+    for (int c = c0; c <= c1; c++) {
+      TXshColumn *column = xsh->getColumn(c);
+      if (column && column->getSoundColumn()) {
+        m_containsSoundColumn = true;
+        break;
+      }
+    }
   }
 
   ~CutCellsUndo() {
@@ -362,6 +394,8 @@ public:
 
     pasteCellsWithoutUndo(m_data, r0, c0, r1, c1, true);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   void redo() const override {
@@ -374,12 +408,16 @@ public:
 
     clipboard->setMimeData(currentData, QClipboard::Clipboard);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   int getSize() const override { return sizeof(*this); }
 
   QString getHistoryString() override { return QObject::tr("Cut Cells"); }
   int getHistoryType() override { return HistoryType::Xsheet; }
+
+  bool containsSoundColumn() { return m_containsSoundColumn; }
 };
 
 //=============================================================================
@@ -388,9 +426,19 @@ public:
 
 class InsertUndo final : public TUndo {
   TCellSelection::Range m_range;
+  bool m_containsSoundColumn;
 
 public:
-  InsertUndo(const TCellSelection::Range &range) : m_range(range) {}
+  InsertUndo(const TCellSelection::Range &range) : m_range(range) {
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (int c = m_range.m_c0; c <= m_range.m_c1; c++) {
+      TXshColumn *column = xsh->getColumn(c);
+      if (column && column->getSoundColumn()) {
+        m_containsSoundColumn = true;
+        break;
+      }
+    }
+  }
 
   void undo() const override {
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
@@ -399,6 +447,8 @@ public:
     for (c = m_range.m_c0; c <= m_range.m_c1; c++)
       xsh->removeCells(m_range.m_r0, c, rowCount);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
   void redo() const override {
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
@@ -407,6 +457,8 @@ public:
     for (c = m_range.m_c0; c <= m_range.m_c1; c++)
       xsh->insertCells(m_range.m_r0, c, rowCount);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
   int getSize() const override { return sizeof(*this); }
   QString getHistoryString() override { return QObject::tr("Insert Cells"); }
@@ -926,13 +978,15 @@ class OverwritePasteCellsUndo final : public TUndo {
   std::vector<bool> m_areOldColumnsEmpty;
 
   QMimeData *m_beforeData;
+  bool m_containsSoundColumn;
 
 public:
   OverwritePasteCellsUndo(int r0, int c0, int r1, int c1, int oldR0, int oldC0,
                           int oldR1, int oldC1,
                           const std::vector<bool> &areColumnsEmpty,
-                          TCellData *beforeData)
-      : m_areOldColumnsEmpty(areColumnsEmpty) {
+                          TCellData *beforeData, bool containsSoundColumn)
+      : m_areOldColumnsEmpty(areColumnsEmpty)
+      , m_containsSoundColumn(containsSoundColumn) {
     QClipboard *clipboard = QApplication::clipboard();
     /*-- ペーストされたセルをdataに保持しておく --*/
     TCellData *data = new TCellData();
@@ -997,6 +1051,8 @@ public:
       cellSelection->selectCells(oldR0, oldC0, oldR1, oldC1);
 
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   void redo() const override {
@@ -1007,6 +1063,8 @@ public:
     // Cut delle celle che sono in newSelection
     pasteCellsWithoutUndo(r0, c0, c1, r1, false, false);
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+    if (m_containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   int getSize() const override { return sizeof(*this); }
@@ -1814,6 +1872,7 @@ void TCellSelection::pasteCells() {
     // n.b. devo farlo dopo il paste perche' prima non ho il range delle colonne
     // incollate corrette.
     std::vector<bool> areColumnsEmpty;
+    bool containsSoundColumn = false;
     int c;
     for (c = c0; c <= c1; c++) {
       TXshColumn *column = xsh->getColumn(c);
@@ -1821,6 +1880,8 @@ void TCellSelection::pasteCells() {
         areColumnsEmpty.push_back(false);
         continue;
       }
+      if (!containsSoundColumn && column->getSoundColumn())
+        containsSoundColumn = true;
       int newCr0, newCr1;
       column->getRange(newCr0, newCr1);
       areColumnsEmpty.push_back(!column || column->isEmpty() ||
@@ -1837,9 +1898,12 @@ void TCellSelection::pasteCells() {
     getLevelSetFromData(cellData, pastedLevels);
     LevelCmd::addMissingLevelsToCast(pastedLevels);
 
-    TUndoManager::manager()->add(new PasteCellsUndo(
-        r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1, areColumnsEmpty));
+    TUndoManager::manager()->add(
+        new PasteCellsUndo(r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1,
+                           areColumnsEmpty, containsSoundColumn));
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    if (containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
   }
 
   const TKeyframeData *keyframeData =
@@ -2327,6 +2391,7 @@ void TCellSelection::pasteDuplicateCells() {
     if (cellSelection) cellSelection->selectCells(r0, c0, r1, c1);
 
     std::vector<bool> areColumnsEmpty;
+    bool containsSoundColumn;
     int c;
     for (c = c0; c <= c1; c++) {
       TXshColumn *column = xsh->getColumn(c);
@@ -2334,6 +2399,8 @@ void TCellSelection::pasteDuplicateCells() {
         areColumnsEmpty.push_back(false);
         continue;
       }
+      if (!containsSoundColumn && column->getSoundColumn())
+        containsSoundColumn = true;
       int newCr0, newCr1;
       column->getRange(newCr0, newCr1);
       areColumnsEmpty.push_back(!column || column->isEmpty() ||
@@ -2355,8 +2422,9 @@ void TCellSelection::pasteDuplicateCells() {
     getLevelSetFromData(newCellData, pastedLevels);
     LevelCmd::addMissingLevelsToCast(pastedLevels);
 
-    TUndoManager::manager()->add(new PasteCellsUndo(
-        r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1, areColumnsEmpty));
+    TUndoManager::manager()->add(
+        new PasteCellsUndo(r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1,
+                           areColumnsEmpty, containsSoundColumn));
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
@@ -2480,6 +2548,8 @@ void TCellSelection::deleteCells(bool withShift) {
 
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  if (undo->containsSoundColumn())
+    TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
 }
 
 //-----------------------------------------------------------------------------
@@ -2500,7 +2570,10 @@ void TCellSelection::cutCells(bool withoutCopy) {
   std::set<int> removedColIds;
   // check if the operation may remove expression reference as column becomes
   // empty and deleted after the operation.
-  if (!checkColumnRemoval(r0, c0, r1, c1, removedColIds)) return;
+  if (!checkColumnRemoval(r0, c0, r1, c1, removedColIds)) {
+    delete undo;
+    return;
+  }
 
   undo->setCurrentData(r0, c0, r1, c1);
   if (!withoutCopy) copyCellsWithoutUndo(r0, c0, r1, c1);
@@ -2532,6 +2605,8 @@ void TCellSelection::cutCells(bool withoutCopy) {
 
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  if (undo->containsSoundColumn())
+    TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
 }
 
 //-----------------------------------------------------------------------------
@@ -3247,6 +3322,7 @@ void TCellSelection::overWritePasteCells() {
 
     /*-- 各カラムについて、ペースト前にカラムが空だったならtrue --*/
     std::vector<bool> areColumnsEmpty;
+    bool containsSoundColumn = false;
     int c;
     /*-- ペースト後の各カラムについて --*/
     for (c = c0; c <= c1; c++) {
@@ -3255,6 +3331,8 @@ void TCellSelection::overWritePasteCells() {
         areColumnsEmpty.push_back(false);
         continue;
       }
+      if (!containsSoundColumn && column->getSoundColumn())
+        containsSoundColumn = true;
       int newCr0, newCr1;
       /*-- 新たなカラムに何かペーストされているかどうか --*/
       column->getRange(newCr0, newCr1);
@@ -3270,11 +3348,13 @@ void TCellSelection::overWritePasteCells() {
     LevelCmd::addMissingLevelsToCast(pastedLevels);
 
     /*-- r0,c0,r1,c1はペーストされた範囲　old付きはペースト前の選択範囲 --*/
-    TUndoManager::manager()->add(
-        new OverwritePasteCellsUndo(r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1,
-                                    areColumnsEmpty, beforeData));
+    TUndoManager::manager()->add(new OverwritePasteCellsUndo(
+        r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1, areColumnsEmpty, beforeData,
+        containsSoundColumn));
     TUndoManager::manager()->endBlock();
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    if (containsSoundColumn)
+      TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
 
     delete beforeData;
   } else


### PR DESCRIPTION
This PR fixes #4846 
Added emitting signal for updating sounds when sound cells are cut.

The same modification was applied to other edit cells commands as well, such as pasting, deleting, and inserting cells.