### PR TITLE
Fix viewer preview fails to restart after canceling while rendering

### DIFF
--- a/toonz/sources/toonz/previewer.cpp
+++ b/toonz/sources/toonz/previewer.cpp
@@ -1281,6 +1281,17 @@ bool Previewer::isFrameReady(int frame) const {
 
 //-----------------------------------------------------------------------------
 
+void Previewer::clearAllUnfinishedFrames() {
+  for (int f = 0; f < m_imp->m_pbStatus.size(); f++) {
+    if (m_imp->m_pbStatus[f] == FlipSlider::PBFrameStarted) {
+      m_imp->remove(f);
+    }
+  }
+  m_imp->updateProgressBarStatus();
+}
+
+//-----------------------------------------------------------------------------
+
 bool Previewer::isActive() const { return !m_imp->m_listeners.empty(); }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/previewer.h
+++ b/toonz/sources/toonz/previewer.h
@@ -88,6 +88,8 @@ public:
 
   std::vector<UCHAR> &getProgressBarStatus() const;
 
+  void clearAllUnfinishedFrames();
+
 private:
   friend class Imp;
   void emitStartedFrame(const TRenderPort::RenderData &renderData);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -948,9 +948,12 @@ void SceneViewer::enablePreview(int previewMode) {
     emit freezeStateChanged(false);
   }
 
-  if (m_previewMode != NO_PREVIEW)
+  if (m_previewMode != NO_PREVIEW) {
     Previewer::instance(m_previewMode == SUBCAMERA_PREVIEW)
         ->removeListener(this);
+    Previewer::instance(m_previewMode == SUBCAMERA_PREVIEW)
+        ->clearAllUnfinishedFrames();
+  }
 
   m_previewMode = previewMode;
 


### PR DESCRIPTION
This PR fixes the problem as follows:

- Open relatively long and heavy scene
- Set the viewer preview option to `All preview range frames`
    ![image](https://user-images.githubusercontent.com/17974955/234480801-ab4a5524-8e08-44b4-9e9f-234abd57c1cf.png)
- Click the eye button and start preview
- Click the eye button again and release the preview before the rendering is finished
- Click the eye button again and start preview
- Rendering fails to finish. The frame slider remains green (=unfinished) in some frames even if you toggle preview.
    ![preview_bug](https://user-images.githubusercontent.com/17974955/234483253-4f8cbea6-65ef-4cba-acae-4c1d9f4f1f79.gif)

This PR adds clearance of unfinished frames when releasing viewer preview.