### PR TITLE
Fix tablet tools

### DIFF
--- a/toonz/sources/tnztools/vectortapetool.cpp
+++ b/toonz/sources/tnztools/vectortapetool.cpp
@@ -327,7 +327,7 @@ public:
     if (!vi) return;
 
     // BUTTA e rimetti (Dava problemi con la penna)
-    if (!m_draw) return;  // Questa riga potrebbe non essere messa
+    //if (!m_draw) return;  // Questa riga potrebbe non essere messa
     // m_draw=true;   //Perche'??? Non basta dargli true in onEnter??
 
     if (m_type.getValue() == RECT) return;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -408,7 +408,6 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
   default:
     break;
   }
-  e->accept();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
(again on linux, maybe macos also?) 

This just removes two lines that blocked tablet input, so assuming they where there for some reason something "should" break, but seems to fix thing like: 
- setting the right cursor when re-entering the canvas
- allow editing with tape tool
- allow drawing arcs