### PR TITLE
Studio Palette Tweaks

### DIFF
--- a/toonz/sources/include/toonzqt/styleselection.h
+++ b/toonz/sources/include/toonzqt/styleselection.h
@@ -98,7 +98,9 @@ public:
   void removeLink();
   // get back the style from the studio palette (if linked)
   void getBackOriginalStyle();
-  // return true if there is at least one linked style in the selection
+
+  // return true if there is at least one linked style in the selection.
+  // link parent styles are not counted
   bool hasLinkedStyle();
 };
 

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -542,7 +542,10 @@ void PageViewer::drawToggleLink(QPainter &p, QRect &chipRect,
     p.setPen(Qt::black);
     p.drawRect(rect);
 
-    if (globalName[0] == L'+') {
+    if (style->getOriginalName().empty()) {
+      p.setBrush(Qt::black);
+      p.drawRect(rect.adjusted(2, 2, -2, -2));
+    } else if (globalName[0] == L'+') {
       QPointF a(x + 2, y + 2);
       QPointF b(x + 2, y + 5);
       QPointF c(x + 5, y + 2);
@@ -588,6 +591,8 @@ void PageViewer::paintEvent(QPaintEvent *e) {
   // currentStyle e palette
   TPalette *palette = (m_page) ? m_page->getPalette() : 0;
   if (!palette) return;
+
+  bool isStudioPalette = palette->getGlobalName() != L"";
 
   // [i0,i1] = visible cell range
   QRect visibleRect = e->rect();
@@ -648,7 +653,7 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       }
 
       // toggle link
-      drawToggleLink(p, chipRect, m_page->getStyle(i));
+      drawToggleLink(p, chipRect, style);
     }
     if (ShowNewStyleButton && !m_page->getPalette()->isLocked()) {
       int j      = getChipCount();
@@ -1173,18 +1178,18 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   bool isLocked = m_page ? m_page->getPalette()->isLocked() : false;
 
   // remove links from studio palette
-  if (m_viewType == LEVEL_PALETTE && m_styleSelection &&
-      !m_styleSelection->isEmpty() && !isLocked &&
+  if (m_styleSelection && !m_styleSelection->isEmpty() && !isLocked &&
       m_styleSelection->hasLinkedStyle()) {
-    menu.addSeparator();
-    QAction *toggleStyleLink = cmd->getAction("MI_ToggleLinkToStudioPalette");
-    menu.addAction(toggleStyleLink);
-    QAction *removeStyleLink =
-        cmd->getAction("MI_RemoveReferenceToStudioPalette");
-    menu.addAction(removeStyleLink);
-    QAction *getBackOriginalAct =
-        cmd->getAction("MI_GetColorFromStudioPalette");
-    menu.addAction(getBackOriginalAct);
+    if (m_viewType == LEVEL_PALETTE) {
+      menu.addSeparator();
+      menu.addAction(cmd->getAction("MI_ToggleLinkToStudioPalette"));
+      menu.addAction(cmd->getAction("MI_RemoveReferenceToStudioPalette"));
+      menu.addAction(cmd->getAction("MI_GetColorFromStudioPalette"));
+    } else if (m_viewType == STUDIO_PALETTE) {
+      menu.addSeparator();
+      menu.addAction(cmd->getAction("MI_RemoveReferenceToStudioPalette"));
+      menu.addAction(cmd->getAction("MI_GetColorFromStudioPalette"));
+    }
   }
 
   if (((indexPage == 0 && index > 0) || (indexPage > 0 && index >= 0)) &&


### PR DESCRIPTION
**This is to be merged after releasing the next version.**

![image](https://user-images.githubusercontent.com/17974955/235435964-dec64f5e-de5b-41e5-adba-dc52105ecef9.png)

This PR will modify Studio Palette as follows:
- Changed mark of studio palette's link parent styles. Before this change, parent and child of the link has the identical mark (white square). It was impossible to distinguish between the parent or the child styles in studio palettes. (Yes, styles in the studio palette can also be a child of the link!)  Now the parent style has small black square in its mark. 
- Enabled to use `Remove Reference to Studio Palette` command to the studio palette child styles. Using the command in the studio palette will convert the styles to parent.
- Enabled to use `Get Color from Studio Palette` command to the studio palette child styles.