### PR TITLE
Fix selecting previous xsheet frames/layers with the arrow keys by flurick (modified)

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1502,7 +1502,8 @@ int TCellSelection::Range::getColCount() const { return m_c1 - m_c0 + 1; }
 // TCellSelection
 //-----------------------------------------------------------------------------
 
-TCellSelection::TCellSelection() : m_timeStretchPopup(0), m_reframePopup(0) {
+TCellSelection::TCellSelection()
+    : m_timeStretchPopup(0), m_reframePopup(0), m_resizePivotRow(-1) {
   setAlternativeCommandNames();
 }
 
@@ -1650,6 +1651,10 @@ void TCellSelection::selectCells(int r0, int c0, int r1, int c1) {
   m_range.m_r1            = r1;
   m_range.m_c1            = c1;
   bool onlyOneRasterLevel = containsOnlyOneRasterLevel(r0, c0, r1, c1);
+  // set the nearest row
+  m_resizePivotRow =
+      (std::abs(r0 - m_resizePivotRow) < std::abs(r1 - m_resizePivotRow)) ? r0
+                                                                          : r1;
   CommandManager::instance()->enable(MI_CanvasSize, onlyOneRasterLevel);
 }
 
@@ -1661,13 +1666,15 @@ void TCellSelection::selectCell(int row, int col) {
   m_range.m_r1            = row;
   m_range.m_c1            = col;
   bool onlyOneRasterLevel = containsOnlyOneRasterLevel(row, col, row, col);
+  m_resizePivotRow        = row;
   CommandManager::instance()->enable(MI_CanvasSize, onlyOneRasterLevel);
 }
 
 //-----------------------------------------------------------------------------
 
 void TCellSelection::selectNone() {
-  m_range = Range();
+  m_range          = Range();
+  m_resizePivotRow = -1;
   CommandManager::instance()->enable(MI_CanvasSize, false);
 }
 

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -33,6 +33,8 @@ public:
 
 private:
   Range m_range;
+  int m_resizePivotRow;  // pivot frame when resizing the selection with
+                         // ctrl+arrow keys
 
 public:
   TCellSelection();
@@ -129,6 +131,7 @@ public:
   void createBlankDrawing(int row, int col, bool inRange);
   void createBlankDrawings();
   void fillEmptyCell();
+  int getResizePivotRow() const { return m_resizePivotRow; }
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1268,7 +1268,8 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
     if (m_cellArea->isControlPressed()) {  // resize
 
       // resize selection of frames/rows forward or backwards
-      if (rowA < getCurrentRow())
+      assert(cellSel->getResizePivotRow() >= 0);
+      if (rowA < cellSel->getResizePivotRow())
         rowA += shift.frame();
       else
         rowB += shift.frame();
@@ -1290,10 +1291,10 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
 
     } else {  // shift
       CellPosition offset(shift * stride);
-      int movedRow0   = std::max(0, rowA + offset.frame());
-      int movedCol0   = std::max(firstCol, colA + offset.layer());
-      int diffRow = movedRow0 - rowA;
-      int diffCol = movedCol0 - colA;
+      int movedRow0 = std::max(0, rowA + offset.frame());
+      int movedCol0 = std::max(firstCol, colA + offset.layer());
+      int diffRow   = movedRow0 - rowA;
+      int diffCol   = movedCol0 - colA;
       cellSel->selectCells(rowA + diffRow, colA + diffCol, rowB + diffRow,
                            colB + diffCol);
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1267,16 +1267,23 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
 
     if (m_cellArea->isControlPressed()) {  // resize
 
-      if (c0 == c1 && shift.layer() < firstCol) return;
+      // resize selection of frames/rows forward or backwards
+      if (r0 < getCurrentRow())
+        r0 += shift.frame();
+      else
+        r1 += shift.frame();
 
-      bool prevRow = r0 < getCurrentRow();
-      bool prevCol = c0 < getCurrentColumn();
+      // resize selection of layers/columns "up" or "down"
+      if (c0 < getCurrentColumn())
+        c0 += shift.layer();
+      else
+        c1 += shift.layer();
 
-      if (!prevRow and !prevCol)  cellSel->selectCells(r0, c0, r1 + shift.frame(), c1 + shift.layer());
-      if ( prevRow and !prevCol)  cellSel->selectCells(r0 + shift.frame(), c0, r1, c1 + shift.layer());
-      if (!prevRow and  prevCol)  cellSel->selectCells(r0, c0 + shift.layer(), r1 + shift.frame(), c1);
-      if ( prevRow and  prevCol)  cellSel->selectCells(r0 + shift.frame(), c0 + shift.layer(), r1, c1);
+      // keep selection inside the xsheet/timeline
+      if (c0 < firstCol || c1 < firstCol || r0 < 0 || r1 < 0) return;
 
+      // apply new selection rectangle
+      cellSel->selectCells(r0, c0, r1, c1);
       updateCells();
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
       return;

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1261,41 +1261,41 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
   // selection range.
   if (Preferences::instance()->isUseArrowKeyToShiftCellSelectionEnabled() &&
       cellSel && !cellSel->isEmpty()) {
-    int r0, c0, r1, c1;
-    cellSel->getSelectedCells(r0, c0, r1, c1);
+    int rowA, colA, rowB, colB;
+    cellSel->getSelectedCells(rowA, colA, rowB, colB);
     stride.setFrame(cellSel->getSelectedCells().getRowCount());
 
     if (m_cellArea->isControlPressed()) {  // resize
 
       // resize selection of frames/rows forward or backwards
-      if (r0 < getCurrentRow())
-        r0 += shift.frame();
+      if (rowA < getCurrentRow())
+        rowA += shift.frame();
       else
-        r1 += shift.frame();
+        rowB += shift.frame();
 
       // resize selection of layers/columns "up" or "down"
-      if (c0 < getCurrentColumn())
-        c0 += shift.layer();
+      if (colA < getCurrentColumn())
+        colA += shift.layer();
       else
-        c1 += shift.layer();
+        colB += shift.layer();
 
       // keep selection inside the xsheet/timeline
-      if (c0 < firstCol || c1 < firstCol || r0 < 0 || r1 < 0) return;
+      if (colA < firstCol || colB < firstCol || rowA < 0 || rowB < 0) return;
 
       // apply new selection rectangle
-      cellSel->selectCells(r0, c0, r1, c1);
+      cellSel->selectCells(rowA, colA, rowB, colB);
       updateCells();
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
       return;
 
     } else {  // shift
       CellPosition offset(shift * stride);
-      int movedR0   = std::max(0, r0 + offset.frame());
-      int movedC0   = std::max(firstCol, c0 + offset.layer());
-      int diffFrame = movedR0 - r0;
-      int diffLayer = movedC0 - c0;
-      cellSel->selectCells(r0 + diffFrame, c0 + diffLayer, r1 + diffFrame,
-                           c1 + diffLayer);
+      int movedRow0   = std::max(0, rowA + offset.frame());
+      int movedCol0   = std::max(firstCol, colA + offset.layer());
+      int diffRow = movedRow0 - rowA;
+      int diffCol = movedCol0 - colA;
+      cellSel->selectCells(rowA + diffRow, colA + diffCol, rowB + diffRow,
+                           colB + diffCol);
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
     }
   }

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1266,12 +1266,21 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
     stride.setFrame(cellSel->getSelectedCells().getRowCount());
 
     if (m_cellArea->isControlPressed()) {  // resize
-      if (r0 == r1 && shift.frame() < 0) return;
+
       if (c0 == c1 && shift.layer() < firstCol) return;
-      cellSel->selectCells(r0, c0, r1 + shift.frame(), c1 + shift.layer());
+
+      bool prevRow = r0 < getCurrentRow();
+      bool prevCol = c0 < getCurrentColumn();
+
+      if (!prevRow and !prevCol)  cellSel->selectCells(r0, c0, r1 + shift.frame(), c1 + shift.layer());
+      if ( prevRow and !prevCol)  cellSel->selectCells(r0 + shift.frame(), c0, r1, c1 + shift.layer());
+      if (!prevRow and  prevCol)  cellSel->selectCells(r0, c0 + shift.layer(), r1 + shift.frame(), c1);
+      if ( prevRow and  prevCol)  cellSel->selectCells(r0 + shift.frame(), c0 + shift.layer(), r1, c1);
+
       updateCells();
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();
       return;
+
     } else {  // shift
       CellPosition offset(shift * stride);
       int movedR0   = std::max(0, r0 + offset.frame());


### PR DESCRIPTION
This PR is based on #4592 by @flurick , with small modification.
Instead of using the current frame, in this PR I introduced a variable `TCellSelection::m_resizePivotRow` and use it as an pivot frame when resizing the selected cells with arrow keys.