### PR TITLE
Fix cell selection resizing with arrow keys not to refer to the current frame

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1502,7 +1502,8 @@ int TCellSelection::Range::getColCount() const { return m_c1 - m_c0 + 1; }
 // TCellSelection
 //-----------------------------------------------------------------------------
 
-TCellSelection::TCellSelection() : m_timeStretchPopup(0), m_reframePopup(0) {
+TCellSelection::TCellSelection()
+    : m_timeStretchPopup(0), m_reframePopup(0), m_resizePivotRow(-1) {
   setAlternativeCommandNames();
 }
 
@@ -1650,6 +1651,10 @@ void TCellSelection::selectCells(int r0, int c0, int r1, int c1) {
   m_range.m_r1            = r1;
   m_range.m_c1            = c1;
   bool onlyOneRasterLevel = containsOnlyOneRasterLevel(r0, c0, r1, c1);
+  // set the nearest row
+  m_resizePivotRow =
+      (std::abs(r0 - m_resizePivotRow) < std::abs(r1 - m_resizePivotRow)) ? r0
+                                                                          : r1;
   CommandManager::instance()->enable(MI_CanvasSize, onlyOneRasterLevel);
 }
 
@@ -1661,13 +1666,15 @@ void TCellSelection::selectCell(int row, int col) {
   m_range.m_r1            = row;
   m_range.m_c1            = col;
   bool onlyOneRasterLevel = containsOnlyOneRasterLevel(row, col, row, col);
+  m_resizePivotRow        = row;
   CommandManager::instance()->enable(MI_CanvasSize, onlyOneRasterLevel);
 }
 
 //-----------------------------------------------------------------------------
 
 void TCellSelection::selectNone() {
-  m_range = Range();
+  m_range          = Range();
+  m_resizePivotRow = -1;
   CommandManager::instance()->enable(MI_CanvasSize, false);
 }
 

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -33,6 +33,8 @@ public:
 
 private:
   Range m_range;
+  int m_resizePivotRow;  // pivot frame when resizing the selection with
+                         // ctrl+arrow keys
 
 public:
   TCellSelection();
@@ -129,6 +131,7 @@ public:
   void createBlankDrawing(int row, int col, bool inRange);
   void createBlankDrawings();
   void fillEmptyCell();
+  int getResizePivotRow() const { return m_resizePivotRow; }
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1268,7 +1268,8 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
     if (m_cellArea->isControlPressed()) {  // resize
 
       // resize selection of frames/rows forward or backwards
-      if (rowA < getCurrentRow())
+      assert(cellSel->getResizePivotRow() >= 0);
+      if (rowA < cellSel->getResizePivotRow())
         rowA += shift.frame();
       else
         rowB += shift.frame();
@@ -1290,10 +1291,10 @@ void XsheetViewer::keyPressEvent(QKeyEvent *event) {
 
     } else {  // shift
       CellPosition offset(shift * stride);
-      int movedRow0   = std::max(0, rowA + offset.frame());
-      int movedCol0   = std::max(firstCol, colA + offset.layer());
-      int diffRow = movedRow0 - rowA;
-      int diffCol = movedCol0 - colA;
+      int movedRow0 = std::max(0, rowA + offset.frame());
+      int movedCol0 = std::max(firstCol, colA + offset.layer());
+      int diffRow   = movedRow0 - rowA;
+      int diffCol   = movedCol0 - colA;
       cellSel->selectCells(rowA + diffRow, colA + diffCol, rowB + diffRow,
                            colB + diffCol);
       TApp::instance()->getCurrentSelection()->notifySelectionChanged();


### PR DESCRIPTION
This PR is a  small modification to #4592 by @flurick.
Instead of using the current frame, in this PR I introduced a variable `TCellSelection::m_resizePivotRow` and use it as an pivot frame when resizing the selected cells with arrow keys.