### PR TITLE
qol: Prevent CTRL activating draw straight line angle snap

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -318,7 +318,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   if (!ri) return;
 
   // Modifier to do straight line
-  if (e.isShiftPressed() || e.isCtrlPressed()) {
+  if (e.isShiftPressed()) {
     m_isStraight = true;
     m_firstPoint = pos;
     m_lastPoint  = pos;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1288,7 +1288,7 @@ void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
   }
 
   // Modifier to do straight line
-  if (e.isShiftPressed() || e.isCtrlPressed()) {
+  if (e.isShiftPressed()) {
     m_isStraight = true;
     m_firstPoint = pos;
     m_lastPoint  = pos;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -786,7 +786,7 @@ void ToonzVectorBrushTool::leftButtonDrag(const TPointD &pos,
     invalidateRect +=
         TRectD(m_lastSnapPoint - snapThick, m_lastSnapPoint + snapThick);
 
-  if (e.isCtrlPressed()) {
+  if (e.isShiftPressed() && e.isCtrlPressed()) {
     TPointD m_firstPoint = m_track.getFirstPoint();
 
     double denominator = m_lastSnapPoint.x - m_firstPoint.x;


### PR DESCRIPTION
A QoL change, CTRL seems to fire or become sticky enough that it's causing issues with shortcuts, I think it's good to instead only activate angle snap when holding Shift & CTRL (before, it was just either), which this change does.