### PR TITLE
Fix RGB picker notification

### DIFF
--- a/toonz/sources/tnztools/rgbpickertool.cpp
+++ b/toonz/sources/tnztools/rgbpickertool.cpp
@@ -147,7 +147,7 @@ void setCurrentColor(const TPixel32 &color) {
       cs->setMainColor(color);
 
     cs->invalidateIcon();
-    ph->notifyColorStyleChanged();
+    ph->notifyColorStyleChanged(false);
 
     // per le palette animate
     int styleIndex    = ph->getStyleIndex();


### PR DESCRIPTION
This PR fixes #4894 
Added `isDragging = false` flag so that the OT properly update the scene.