### PR TITLE
Antialias xsheet

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1430,6 +1430,8 @@ void CellArea::drawExtenderHandles(QPainter &p) {
     selected.adjust(0, topAdj, 0, bottomAdj);
   }
 
+  p.setRenderHint(QPainter::Antialiasing, true);
+
   int x0, y0, x1, y1;
   x0 = selected.left();
   x1 = selected.right();
@@ -2840,6 +2842,8 @@ void CellArea::drawKeyframe(QPainter &p, const QRect toBeUpdated) {
   int r0, r1, c0, c1;  // range of visible rows and columns
   CellRange visible    = m_viewer->xyRectToRange(toBeUpdated);
   QColor keyFrameColor = Qt::white, outline = Qt::black;
+  p.setRenderHint(QPainter::Antialiasing, true);
+
   r0 = visible.from().frame();
   r1 = visible.to().frame();
   c0 = visible.from().layer();

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -539,6 +539,8 @@ void RowArea::drawOnionSkinSelection(QPainter &p) {
   }
   QPen frontPen, backPen;
 
+  p.setRenderHint(QPainter::Antialiasing, true);
+
   // If the onion skin is disabled, draw dash line instead.
   if (osMask.isEnabled()) {
     frontPen.setColor(frontDotOutlineColor);


### PR DESCRIPTION
No aa:
![before](https://github.com/opentoonz/opentoonz/assets/3645797/d76d0a7d-fcca-4e52-88d8-86a20ddbf907)
With aa:
![after](https://github.com/opentoonz/opentoonz/assets/3645797/5084d635-303b-49e5-8866-b2df2b282aa3)

The loop arrow icon maybe looks a bit too blury? Other than that things are slightly more round