### PR TITLE
Update how_to_build_linux.md

### DIFF
--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -38,7 +38,7 @@ Notes:
 (it may include some useless packages)
 
 ```
-$ sudo dnf install gcc gcc-c++ automake git cmake boost boost-devel SuperLU SuperLU-devel lz4-devel lzma libusb-devel lzo-devel libjpeg-turbo-devel libGLEW glew-devel freeglut-devel freeglut freetype-devel libpng-devel qt5-qtbase-devel qt5-qtsvg qt5-qtsvg-devel qt5-qtscript qt5-qtscript-devel qt5-qttools qt5-qttools-devel qt5-qtmultimedia-devel blas blas-devel json-c-devel libtool intltool make qt5-qtmultimedia
+$ sudo dnf install gcc gcc-c++ automake git cmake boost boost-devel SuperLU SuperLU-devel lz4-devel lzma libusb-devel lzo-devel libjpeg-turbo-devel libGLEW glew-devel freeglut-devel freeglut freetype-devel libpng-devel qt5-qtbase-devel qt5-qtsvg qt5-qtsvg-devel qt5-qtscript qt5-qtscript-devel qt5-qttools qt5-qttools-devel qt5-qtmultimedia-devel blas blas-devel json-c-devel libtool intltool make qt5-qtmultimedia turbojpeg-devel opencv-devel qt5-qttools-static qt5-qtserialport-devel
 ```
 
 For newest versions of OS you may install libmypaint from repository and don't need to build it from source:


### PR DESCRIPTION
It seems at least for Fedora 37 some extra packages are needed in order to compile Opentoonz so I decided to add those to the instalation guide for Linux:
- turbojpeg-devel
- opencv-devel
- qt5-qttools-static
- qt5-qtserialport-devel

I have never done a pull request before so if there is anything wrong you can tell me :)