### PR TITLE
Fix stylesheet variables

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -237,9 +237,9 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
   Q_PROPERTY(
       QColor ErrorTextColor READ getErrorTextColor WRITE setErrorTextColor)
-  Q_PROPERTY(QColor SelectedTextColor READ getCurrentFrameTextColor WRITE
+  Q_PROPERTY(QColor CurrentFrameTextColor READ getCurrentFrameTextColor WRITE
                  setCurrentFrameTextColor)
-  Q_PROPERTY(QColor CurrentFrameTextColor READ getSelectedTextColor WRITE
+  Q_PROPERTY(QColor SelectedTextColor READ getSelectedTextColor WRITE
                  setSelectedTextColor)
   Q_PROPERTY(QColor PreviewFrameTextColor READ getPreviewFrameTextColor WRITE
                  setPreviewFrameTextColor)


### PR DESCRIPTION
This PR fixes property variable names used in the style sheet.
As you can see, the two variable names were obviously reversed.