### PR TITLE
Fix Text Iwa Fx input field (again)

### DIFF
--- a/toonz/sources/include/toonzqt/paramfield.h
+++ b/toonz/sources/include/toonzqt/paramfield.h
@@ -618,7 +618,6 @@ public:
 protected:
   void keyPressEvent(QKeyEvent *event) override;
   void focusOutEvent(QFocusEvent *e) override;
-  bool eventFilter(QObject *, QEvent *) override;
 
 signals:
   void edited();

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -34,6 +34,7 @@
 #include <QDesktopWidget>
 #include <QDialog>
 #include <QLineEdit>
+#include <QTextEdit>
 #include <QScreen>
 
 extern TEnv::StringVar EnvSafeAreaName;
@@ -123,7 +124,8 @@ void TPanel::enterEvent(QEvent *event) {
   if (w) {
     // grab the focus, unless a line-edit is focused currently
     QWidget *focusWidget = qApp->focusWidget();
-    if (focusWidget && dynamic_cast<QLineEdit *>(focusWidget)) {
+    if (focusWidget && (dynamic_cast<QLineEdit *>(focusWidget) ||
+                        dynamic_cast<QTextEdit *>(focusWidget))) {
       event->accept();
       return;
     }

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -1565,9 +1565,7 @@ void IntParamField::update(int frame) {
 namespace component {
 
 MyTextEdit::MyTextEdit(const QString &text, QWidget *parent)
-    : QTextEdit(text, parent) {
-  installEventFilter(this);
-}
+    : QTextEdit(text, parent) {}
 
 void MyTextEdit::keyPressEvent(QKeyEvent *event) {
   QTextEdit::keyPressEvent(event);
@@ -1577,25 +1575,6 @@ void MyTextEdit::keyPressEvent(QKeyEvent *event) {
 void MyTextEdit::focusOutEvent(QFocusEvent *event) {
   QTextEdit::focusOutEvent(event);
   emit edited();
-}
-
-bool MyTextEdit::eventFilter(QObject *obj, QEvent *e) {
-  if (e->type() != QEvent::ShortcutOverride)
-    return QTextEdit::eventFilter(obj, e);
-
-  QKeyEvent *ke = (QKeyEvent *)e;
-  std::string keyStr =
-      QKeySequence(ke->key() + ke->modifiers()).toString().toStdString();
-  QAction *action = CommandManager::instance()->getActionFromShortcut(keyStr);
-  if (!action) return QTextEdit::eventFilter(obj, e);
-
-  std::string actionId = CommandManager::instance()->getIdFromAction(action);
-  if (actionId == "MI_Undo" || actionId == "MI_Redo" ||
-      actionId == "MI_Clear" || actionId == "MI_Copy" ||
-      actionId == "MI_Paste" || actionId == "MI_Cut")
-    return QTextEdit::eventFilter(obj, e);
-
-  return true;
 }
 
 };  // namespace component


### PR DESCRIPTION
This will partially fix #4922 
The previous fix #4923 seems to be wrong. (So sorry for the trouble!)
I found one of the cause is the panel taking the focus while typing in the field.

Unfortunately, I found that this PR does not fix the problem completely. (It still sometimes input `sあ` instead of `さ`)
But the problems occur less frequently.