### PR TITLE
Link Column Name with Level option by Contrail Co., Ltd.

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -421,6 +421,9 @@ public:
   bool isShowFrameNumberWithLettersEnabled() const {
     return getBoolValue(showFrameNumberWithLetters);
   }
+  bool isLinkColumnNameWithLevelEnabled() const {
+    return getBoolValue(linkColumnNameWithLevel);
+  }
 
   // Animation  tab
   int getKeyframeType() const { return getIntValue(keyframeType); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -140,6 +140,7 @@ enum PreferencesItemId {
   currentColumnColor,
   levelNameDisplayType,
   showFrameNumberWithLetters,
+  linkColumnNameWithLevel,
 
   //----------
   // Animation

--- a/toonz/sources/include/toonz/txshlevelcolumn.h
+++ b/toonz/sources/include/toonz/txshlevelcolumn.h
@@ -19,6 +19,7 @@
 // forward declarations
 class TLevelColumnFx;
 class TXshCell;
+class TXshLevel;
 
 //=============================================================================
 //! The TXshLevelColumn class provides a column of levels in xsheet and allows
@@ -86,7 +87,8 @@ Return \b TFx.
   TFx *getFx() const override;
 
   // Used in TCellData::getNumbers
-  bool setNumbers(int row, int rowCount, const TXshCell cells[]);
+  bool setNumbers(int row, int rowCount, const TXshCell cells[],
+                  TXshLevel *reservedLevel);
 
 private:
   // not implemented

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -58,6 +58,7 @@
 #include "tools/strokeselection.h"
 #include "toonz/sceneproperties.h"
 #include "toutputproperties.h"
+#include "toonz/tstageobjectcmd.h"
 
 // TnzCore includes
 #include "timagecache.h"
@@ -217,13 +218,17 @@ class PasteCellsUndo final : public TUndo {
   TCellData *m_data;
   std::vector<bool> m_areOldColumnsEmpty;
   bool m_containsSoundColumn;
+  std::map<int, std::string> m_oldEmptyColumnNames;
 
 public:
   PasteCellsUndo(int r0, int c0, int r1, int c1, int oldR0, int oldC0,
                  int oldR1, int oldC1, const std::vector<bool> &areColumnsEmpty,
-                 bool containsSoundColumn)
+                 bool containsSoundColumn,
+                 const std::map<int, std::string> &oldEmptyColumnNames =
+                     std::map<int, std::string>())
       : m_areOldColumnsEmpty(areColumnsEmpty)
-      , m_containsSoundColumn(containsSoundColumn) {
+      , m_containsSoundColumn(containsSoundColumn)
+      , m_oldEmptyColumnNames(oldEmptyColumnNames) {
     m_data       = new TCellData();
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     m_data->setCells(xsh, r0, c0, r1, c1);
@@ -246,13 +251,18 @@ public:
     int oldR0, oldC0, oldR1, oldC1;
     m_oldSelection->getSelectedCells(oldR0, oldC0, oldR1, oldC1);
 
+    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (const auto &item : m_oldEmptyColumnNames) {
+      xsh->getStageObject(TStageObjectId::ColumnId(item.first))
+          ->setName(item.second);
+    }
+
     int c0BeforeCut = c0;
     int c1BeforeCut = c1;
     // Cut delle celle che sono in newSelection
     cutCellsWithoutUndo(r0, c0, r1, c1);
     // Se le colonne erano vuote le resetto (e' necessario farlo per le colonne
     // particolari, colonne sount o palette)
-    TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
     assert(c1BeforeCut - c0BeforeCut + 1 == (int)m_areOldColumnsEmpty.size());
     int c;
     for (c = c0BeforeCut; c <= c1BeforeCut; c++) {
@@ -1868,6 +1878,23 @@ void TCellSelection::pasteCells() {
       return;
     }
 
+    // pasting cells may change empty column names. So keep old column names for
+    // undo
+    std::map<int, std::string> emptyColumnNames;
+    if (Preferences::instance()->isLinkColumnNameWithLevelEnabled()) {
+      for (int c = c0; c < c0 + cellData->getColCount(); c++) {
+        TXshColumn *column = xsh->getColumn(c);
+        if (!column || column->isEmpty()) {
+          if (!xsh->getStageObject(TStageObjectId::ColumnId(c))
+                   ->hasSpecifiedName())
+            emptyColumnNames[c] = "";
+          else
+            emptyColumnNames[c] =
+                xsh->getStageObject(TStageObjectId::ColumnId(c))->getName();
+        }
+      }
+    }
+
     bool isPaste = pasteCellsWithoutUndo(cellData, r0, c0, r1, c1);
 
     // Se la selezione corrente e' TCellSelection selezione le celle copiate
@@ -1905,9 +1932,9 @@ void TCellSelection::pasteCells() {
     getLevelSetFromData(cellData, pastedLevels);
     LevelCmd::addMissingLevelsToCast(pastedLevels);
 
-    TUndoManager::manager()->add(
-        new PasteCellsUndo(r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1,
-                           areColumnsEmpty, containsSoundColumn));
+    TUndoManager::manager()->add(new PasteCellsUndo(
+        r0, c0, r1, c1, oldR0, oldC0, oldR1, oldC1, areColumnsEmpty,
+        containsSoundColumn, emptyColumnNames));
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);
     if (containsSoundColumn)
       TApp::instance()->getCurrentXsheet()->notifyXsheetSoundChanged();
@@ -2530,8 +2557,20 @@ void TCellSelection::deleteCells(bool withShift) {
     TUndoManager::manager()->beginBlock();
     // remove, then insert empty column
     for (auto colId : removedColIds) {
+      // keep column name if specified
+      std::string columnName = "";
+      if (Preferences::instance()->isLinkColumnNameWithLevelEnabled() &&
+          xsh->getStageObject(TStageObjectId::ColumnId(colId))
+              ->hasSpecifiedName())
+        columnName =
+            xsh->getStageObject(TStageObjectId::ColumnId(colId))->getName();
+
       ColumnCmd::deleteColumn(colId, true);
       ColumnCmd::insertEmptyColumn(colId);
+
+      if (!columnName.empty())
+        TStageObjectCmd::rename(TStageObjectId::ColumnId(colId), columnName,
+                                TApp::instance()->getCurrentXsheet());
     }
   }
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1306,6 +1306,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {levelNameDisplayType, tr("Level Name Display:")},
       {showFrameNumberWithLetters,
        tr("Show \"ABC\" Appendix to the Frame Number in Xsheet Cell")},
+      {linkColumnNameWithLevel, tr("Link Column Name with Level")},
 
       // Animation
       {keyframeType, tr("Default Interpolation:")},
@@ -2013,6 +2014,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   insertUI(xsheetLayoutPreference, lay,
            getComboItemList(xsheetLayoutPreference));
   insertUI(levelNameDisplayType, lay, getComboItemList(levelNameDisplayType));
+  insertUI(linkColumnNameWithLevel, lay);
   insertUI(xsheetStep, lay);
   insertUI(xsheetAutopanEnabled, lay);
   insertUI(DragCellsBehaviour, lay, getComboItemList(DragCellsBehaviour));
@@ -2048,6 +2050,15 @@ QWidget* PreferencesPopup::createXsheetPage() {
       unifyColumnVisibilityToggles,
       &PreferencesPopup::onUnifyColumnVisibilityTogglesChanged);
 
+  QCheckBox* linkColumnNameWithLevelCheck =
+      getUI<QCheckBox*>(linkColumnNameWithLevel);
+  linkColumnNameWithLevelCheck->setToolTip(
+      tr("This option will do the following:\n"
+         "- When setting a cell in the empty column, level name will be copied "
+         "to the column name\n"
+         "- Typing the cell without level name in the empty column will try to "
+         "use a level with the same name as the column\n"
+         "The behavior may be changed in the future development."));
   return widget;
 }
 

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -321,6 +321,7 @@ class ColumnArea final : public QWidget {
     bool isEmpty, isCurrent;
     TXshColumn *column;
     QPoint orig;
+    TXshLevel *reservedLevel;
 
   public:
     DrawHeader(ColumnArea *area, QPainter &p, int col);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -604,6 +604,14 @@ void Preferences::definePreferenceItems() {
          0);  // default
   define(showFrameNumberWithLetters, "showFrameNumberWithLetters",
          QMetaType::Bool, false);
+  // This option will do the following:
+  // - When setting a cell in the empty column, level name will be copied to the
+  // column name
+  // - Typing the cell without level name in the empty column will try to use a
+  // level with the same name as the column The behavior may be changed in the
+  // future development.
+  define(linkColumnNameWithLevel, "linkColumnNameWithLevel", QMetaType::Bool,
+         false);
 
   // Animation
   define(keyframeType, "keyframeType", QMetaType::Int, 2);  // Linear

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -302,6 +302,13 @@ bool TXsheet::setCell(int row, int col, const TXshCell &cell) {
   else if (row >= m_imp->m_frameCount)
     m_imp->m_frameCount = row + 1;
 
+  // set the level name to the column
+  if (wasColumnEmpty && cellColumn && !cell.isEmpty() &&
+      Preferences::instance()->isLinkColumnNameWithLevelEnabled()) {
+    getStageObject(TStageObjectId::ColumnId(col))
+        ->setName(to_string(cell.m_level->getName()));
+  }
+
   TNotifier::instance()->notify(TXsheetChange());
 
   return true;
@@ -385,6 +392,14 @@ bool TXsheet::setCells(int row, int col, int rowCount, const TXshCell cells[]) {
     if (oldColRowCount == m_imp->m_frameCount &&
         newColRowCount < m_imp->m_frameCount)
       updateFrameCount();
+  }
+  row + 1;
+
+  // set the level name to the column
+  if (wasColumnEmpty && i < rowCount &&
+      Preferences::instance()->isLinkColumnNameWithLevelEnabled()) {
+    getStageObject(TStageObjectId::ColumnId(col))
+        ->setName(to_string(cells[i].m_level->getName()));
   }
 
   return true;

--- a/toonz/sources/toonzlib/txshlevelcolumn.cpp
+++ b/toonz/sources/toonzlib/txshlevelcolumn.cpp
@@ -209,9 +209,12 @@ void TXshLevelColumn::saveData(TOStream &os) {
 
 //-----------------------------------------------------------------------------
 // Used in TCellData::getNumbers
-bool TXshLevelColumn::setNumbers(int row, int rowCount,
-                                 const TXshCell cells[]) {
-  if (m_cells.empty()) return false;
+// reservedLevel can be nonzero if the preferences option
+// "LinkColumnNameWithLevel" is ON and the column name is the same as some level
+// in the scene cast.
+bool TXshLevelColumn::setNumbers(int row, int rowCount, const TXshCell cells[],
+                                 TXshLevel *reservedLevel) {
+  if (m_cells.empty() && !reservedLevel) return false;
   // Check availability.
   // - if source cells are all empty, do nothing
   // - also, if source or target cells contain NO_FRAME, do nothing
@@ -236,16 +239,18 @@ bool TXshLevelColumn::setNumbers(int row, int rowCount,
   // Find a level to input.
   // If the first target cell is empty, search the upper cells, and lower cells
   // and use a level of firsty-found occupied neighbor cell.
-  TXshLevelP currentLevel;
-  int tmpIndex = std::min(row - m_first, (int)m_cells.size() - 1);
+  TXshLevelP currentLevel = reservedLevel;
+  int tmpIndex            = std::min(row - m_first, (int)m_cells.size() - 1);
   // search upper cells
-  while (tmpIndex >= 0) {
-    TXshCell tmpCell = m_cells[tmpIndex];
-    if (!tmpCell.isEmpty() && tmpCell.m_frameId != TFrameId::NO_FRAME) {
-      currentLevel = tmpCell.m_level;
-      break;
+  if (!currentLevel) {
+    while (tmpIndex >= 0) {
+      TXshCell tmpCell = m_cells[tmpIndex];
+      if (!tmpCell.isEmpty() && tmpCell.m_frameId != TFrameId::NO_FRAME) {
+        currentLevel = tmpCell.m_level;
+        break;
+      }
+      tmpIndex--;
     }
-    tmpIndex--;
   }
   // if not found any level in upper cells, then search the lower cells
   if (!currentLevel) {


### PR DESCRIPTION
This PR will add a new preference option `Link Column Name with Level` to `Preferences > Xsheet` category.

OpenToonz allows multiple levels in one column. This is a very flexible advantage, but in the Japanese animation industry, in most cases, only one level goes in one column.
This option "reserves" the levels that will be placed in a column by the name of the column, so that you can set cells in an empty column by simply entering a number.

![image](https://github.com/opentoonz/opentoonz/assets/17974955/1d08ea91-183e-4a33-9029-75fd1fb0e162)


This improvement was developed on consignment and is copyrighted by [Contrail Co., Ltd.](https://contrail.tokyo/)