### PR TITLE
Fix pasting raster drawing selection undo

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2172,6 +2172,8 @@ void TCellSelection::pasteCells() {
             toolHandle->getTool()->onDeactivate();
             toolHandle->getTool()->onActivate();
             rs->pasteSelection();
+            assert(initUndo);
+            TUndoManager::manager()->endBlock();
             return;
           }
         }


### PR DESCRIPTION
This PR fixes #4910 
Added missing `TUndoManager::manager()->endBlock()` to register the undo properly.

Thank you @RattusaurusRex for reporting the bug!