### PR TITLE
Fix Assistant Tool Slowness

### DIFF
--- a/toonz/sources/include/tools/modifiers/modifiertest.h
+++ b/toonz/sources/include/tools/modifiers/modifiertest.h
@@ -1,3 +1,5 @@
+
+#ifndef NDEBUG
 #pragma once
 
 #ifndef MODIFIERTEST_INCLUDED
@@ -5,7 +7,6 @@
 
 // TnzTools includes
 #include <tools/inputmanager.h>
-
 
 #undef DVAPI
 #undef DVVAR
@@ -17,28 +18,28 @@
 #define DVVAR DV_IMPORT_VAR
 #endif
 
-
 //===================================================================
 
 //*****************************************************************************************
 //    TModifierTest definition
 //*****************************************************************************************
 
-class DVAPI TModifierTest: public TInputModifier {
+class DVAPI TModifierTest : public TInputModifier {
 public:
-  class DVAPI Handler: public TTrackHandler {
+  class DVAPI Handler : public TTrackHandler {
   public:
     std::vector<double> angles;
-    Handler(const TTrack &original): TTrackHandler(original) { }
+    Handler(const TTrack &original) : TTrackHandler(original) {}
   };
 
-  class DVAPI Modifier: public TTrackModifier {
+  class DVAPI Modifier : public TTrackModifier {
   public:
     double angle;
     double radius;
     double speed;
 
-    Modifier(TTrackHandler &handler, double angle, double radius, double speed = 0.25);
+    Modifier(TTrackHandler &handler, double angle, double radius,
+             double speed = 0.25);
     TTrackPoint calcPoint(double originalIndex) override;
   };
 
@@ -48,11 +49,10 @@ public:
 
   TModifierTest(int count, double radius);
 
-  void modifyTrack(
-    const TTrack &track,
-    const TInputSavePoint::Holder &savePoint,
-    TTrackList &outTracks ) override;
+  void modifyTrack(const TTrack &track,
+                   const TInputSavePoint::Holder &savePoint,
+                   TTrackList &outTracks) override;
 };
 
-
+#endif
 #endif

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -557,6 +557,7 @@ class BrushToolOptionsBox final : public ToolOptionsBox {
 private:
   class PresetNamePopup;
   PresetNamePopup *m_presetNamePopup;
+  void filterControls();
 
 public:
   BrushToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -6,7 +6,9 @@
 #include <ctime>
 
 #include <tools/inputmanager.h>
+#ifndef NDEBUG
 #include <tools/modifiers/modifiertest.h>
+#endif
 #include <tools/modifiers/modifierline.h>
 #include <tools/modifiers/modifiertangents.h>
 #include <tools/modifiers/modifierassistants.h>
@@ -35,19 +37,18 @@ class Brush;
 //    FullColor Brush Tool declaration
 //************************************************************************
 
-class FullColorBrushTool final : public TTool, public RasterController, public TInputHandler {
+class FullColorBrushTool final : public TTool,
+                                 public RasterController,
+                                 public TInputHandler {
   Q_DECLARE_TR_FUNCTIONS(FullColorBrushTool)
 public:
-  class TrackHandler: public TTrackToolHandler {
+  class TrackHandler : public TTrackToolHandler {
   public:
     MyPaintToonzBrush brush;
 
-    TrackHandler(
-      const TRaster32P &ras,
-      RasterController &controller,
-      const mypaint::Brush &brush
-    ):
-      brush(ras, controller, brush) { }
+    TrackHandler(const TRaster32P &ras, RasterController &controller,
+                 const mypaint::Brush &brush)
+        : brush(ras, controller, brush) {}
   };
 
 private:
@@ -76,11 +77,13 @@ public:
   void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override;
   void mouseMove(const TPointD &pos, const TMouseEvent &e) override;
 
-  void inputMouseMove(const TPointD &position, const TInputState &state) override;
+  void inputMouseMove(const TPointD &position,
+                      const TInputState &state) override;
   void inputSetBusy(bool busy) override;
-  void inputPaintTrackPoint(const TTrackPoint &point, const TTrack &track, bool firstTrack) override;
+  void inputPaintTrackPoint(const TTrackPoint &point, const TTrack &track,
+                            bool firstTrack) override;
   void inputInvalidateRect(const TRectD &bounds) override;
-  TTool* inputGetTool() override { return this; };
+  TTool *inputGetTool() override { return this; };
 
   void draw() override;
 
@@ -110,28 +113,31 @@ public:
 
 private:
   enum MouseEventType { ME_DOWN, ME_DRAG, ME_UP, ME_MOVE };
-  void handleMouseEvent(MouseEventType type, const TPointD &pos, const TMouseEvent &e);
-  
+  void handleMouseEvent(MouseEventType type, const TPointD &pos,
+                        const TMouseEvent &e);
+
 protected:
   TInputManager m_inputmanager;
+#ifndef NDEBUG
   TSmartPointerT<TModifierTest> m_modifierTest;
+#endif
   TSmartPointerT<TModifierLine> m_modifierLine;
   TSmartPointerT<TModifierTangents> m_modifierTangents;
   TSmartPointerT<TModifierAssistants> m_modifierAssistants;
   TSmartPointerT<TModifierSegmentation> m_modifierSegmentation;
-  
+
   TPropertyGroup m_prop;
 
-  TIntPairProperty    m_thickness;
-  TBoolProperty       m_pressure;
+  TIntPairProperty m_thickness;
+  TBoolProperty m_pressure;
   TDoublePairProperty m_opacity;
-  TDoubleProperty     m_hardness;
-  TDoubleProperty     m_modifierSize;
-  TDoubleProperty     m_modifierOpacity;
-  TBoolProperty       m_modifierEraser;
-  TBoolProperty       m_modifierLockAlpha;
-  TBoolProperty       m_assistants;
-  TEnumProperty       m_preset;
+  TDoubleProperty m_hardness;
+  TDoubleProperty m_modifierSize;
+  TDoubleProperty m_modifierOpacity;
+  TBoolProperty m_modifierEraser;
+  TBoolProperty m_modifierLockAlpha;
+  TBoolProperty m_assistants;
+  TEnumProperty m_preset;
 
   TPixel32 m_currentColor;
   bool m_enabledPressure;
@@ -169,6 +175,8 @@ class FullColorBrushToolNotifier final : public QObject {
 
 public:
   FullColorBrushToolNotifier(FullColorBrushTool *tool);
+  void onActivate();
+  void onDeactivate();
 
 protected slots:
   void onCanvasSizeChanged() { m_tool->onCanvasSizeChanged(); }

--- a/toonz/sources/tnztools/modifiers/modifiertest.cpp
+++ b/toonz/sources/tnztools/modifiers/modifiertest.cpp
@@ -1,4 +1,5 @@
 
+#ifndef NDEBUG
 
 #include <tools/modifiers/modifiertest.h>
 
@@ -9,22 +10,11 @@
 //    TModifierTest::Modifier implementation
 //*****************************************************************************************
 
+TModifierTest::Modifier::Modifier(TTrackHandler &handler, double angle,
+                                  double radius, double speed)
+    : TTrackModifier(handler), angle(angle), radius(radius), speed(speed) {}
 
-TModifierTest::Modifier::Modifier(
-  TTrackHandler &handler,
-  double angle,
-  double radius,
-  double speed
-):
-  TTrackModifier(handler),
-  angle(angle),
-  radius(radius),
-  speed(speed)
-{ }
-
-
-TTrackPoint
-TModifierTest::Modifier::calcPoint(double originalIndex) {
+TTrackPoint TModifierTest::Modifier::calcPoint(double originalIndex) {
   TTrackPoint p = TTrackModifier::calcPoint(originalIndex);
 
   if (p.length > TConsts::epsilon) {
@@ -33,17 +23,19 @@ TModifierTest::Modifier::calcPoint(double originalIndex) {
     int i1 = original.ceilIndex(originalIndex);
     if (i0 < 0) return p;
 
-    if (Handler *handler = dynamic_cast<Handler*>(&this->handler)) {
-      double angle = this->angle + speed*TTrack::interpolationLinear(
-        handler->angles[i0], handler->angles[i1], frac);
-      double radius = 2.0*this->radius*p.pressure;
-      double s = sin(angle);
-      double c = cos(angle);
+    if (Handler *handler = dynamic_cast<Handler *>(&this->handler)) {
+      double angle = this->angle + speed * TTrack::interpolationLinear(
+                                               handler->angles[i0],
+                                               handler->angles[i1], frac);
+      double radius = 2.0 * this->radius * p.pressure;
+      double s      = sin(angle);
+      double c      = cos(angle);
 
-      TPointD tangent = original.calcTangent(originalIndex, fabs(2.0*this->radius/speed));
-      p.position.x -= tangent.y*s*radius;
-      p.position.y += tangent.x*s*radius;
-      p.pressure   *= 1.0 - 0.5*c;
+      TPointD tangent =
+          original.calcTangent(originalIndex, fabs(2.0 * this->radius / speed));
+      p.position.x -= tangent.y * s * radius;
+      p.position.y += tangent.x * s * radius;
+      p.pressure *= 1.0 - 0.5 * c;
     }
   } else {
     p.pressure = 0.0;
@@ -52,103 +44,94 @@ TModifierTest::Modifier::calcPoint(double originalIndex) {
   return p;
 }
 
-
 //*****************************************************************************************
 //    TModifierTest implementation
 //*****************************************************************************************
 
+TModifierTest::TModifierTest(int count, double radius)
+    : count(count), radius(radius) {}
 
-TModifierTest::TModifierTest(int count, double radius):
-  count(count),
-  radius(radius)
-{ }
-
-
-void
-TModifierTest::modifyTrack(
-  const TTrack &track,
-  const TInputSavePoint::Holder &savePoint,
-  TTrackList &outTracks )
-{
-  const double segmentSize = 2.0*M_PI/10.0;
+void TModifierTest::modifyTrack(const TTrack &track,
+                                const TInputSavePoint::Holder &savePoint,
+                                TTrackList &outTracks) {
+  const double segmentSize = 2.0 * M_PI / 10.0;
 
   if (!track.handler) {
     if (track.getKeyState(track.front().time).isPressed(TKey(Qt::Key_Alt))) {
       // TModifierTest::Handler for spiro
       track.handler = new Handler(track);
-      for(int i = 0; i < count; ++i)
-        track.handler->tracks.push_back(
-          new TTrack(
-            new Modifier(
-              *track.handler,
-              i*2.0*M_PI/(double)count,
-              radius,
-              0.25 )));
+      for (int i = 0; i < count; ++i)
+        track.handler->tracks.push_back(new TTrack(new Modifier(
+            *track.handler, i * 2.0 * M_PI / (double)count, radius, 0.25)));
     }
   }
 
-  Handler *handler = dynamic_cast<Handler*>(track.handler.getPointer());
+  Handler *handler = dynamic_cast<Handler *>(track.handler.getPointer());
   if (!handler) {
     TInputModifier::modifyTrack(track, savePoint, outTracks);
     return;
   }
 
-  outTracks.insert(
-    outTracks.end(),
-    track.handler->tracks.begin(),
-    track.handler->tracks.end() );
-  if (!track.changed())
-    return;
+  outTracks.insert(outTracks.end(), track.handler->tracks.begin(),
+                   track.handler->tracks.end());
+  if (!track.changed()) return;
 
   int start = track.size() - track.pointsAdded;
   if (start < 0) start = 0;
 
   // remove angles
-  double lastAngle = start < (int)handler->angles.size() ? handler->angles[start]
-                   : handler->angles.empty() ? 0.0
-                   : handler->angles.back();
+  double lastAngle = start < (int)handler->angles.size()
+                         ? handler->angles[start]
+                     : handler->angles.empty() ? 0.0
+                                               : handler->angles.back();
   handler->angles.resize(start, lastAngle);
 
   // add angles
-  for(int i = start; i < track.size(); ++i) {
+  for (int i = start; i < track.size(); ++i) {
     if (i > 0) {
-      double dl = track[i].length - track[i-1].length;
+      double dl = track[i].length - track[i - 1].length;
       double da = track[i].pressure > TConsts::epsilon
-                ? dl/(radius*track[i].pressure) : 0.0;
-      handler->angles.push_back(handler->angles[i-1] + da);
+                      ? dl / (radius * track[i].pressure)
+                      : 0.0;
+      handler->angles.push_back(handler->angles[i - 1] + da);
     } else {
       handler->angles.push_back(0.0);
     }
   }
 
   // process sub-tracks
-  for(TTrackList::const_iterator ti = handler->tracks.begin(); ti != handler->tracks.end(); ++ti) {
-    TTrack &subTrack = **ti;
+  for (TTrackList::const_iterator ti = handler->tracks.begin();
+       ti != handler->tracks.end(); ++ti) {
+    TTrack &subTrack          = **ti;
     double currentSegmentSize = segmentSize;
-    if (const Modifier *modifier = dynamic_cast<const Modifier*>(subTrack.modifier.getPointer()))
+    if (const Modifier *modifier =
+            dynamic_cast<const Modifier *>(subTrack.modifier.getPointer()))
       if (fabs(modifier->speed) > TConsts::epsilon)
-        currentSegmentSize = segmentSize/fabs(modifier->speed);
+        currentSegmentSize = segmentSize / fabs(modifier->speed);
 
     // remove points
-    int subStart = subTrack.floorIndex(subTrack.indexByOriginalIndex(start-1)) + 1;
+    int subStart =
+        subTrack.floorIndex(subTrack.indexByOriginalIndex(start - 1)) + 1;
     subTrack.truncate(subStart);
 
     // add points
-    for(int i = start; i < track.size(); ++i) {
+    for (int i = start; i < track.size(); ++i) {
       if (i > 0) {
-        double prevAngle = handler->angles[i-1];
+        double prevAngle = handler->angles[i - 1];
         double nextAngle = handler->angles[i];
-        if (fabs(nextAngle - prevAngle) > 1.5*currentSegmentSize) {
-          double step = currentSegmentSize/fabs(nextAngle - prevAngle);
-          double end = 1.0 - 0.5*step;
-          for(double frac = step; frac < end; frac += step)
-            subTrack.push_back( subTrack.modifier->calcPoint((double)i - 1.0 + frac) );
+        if (fabs(nextAngle - prevAngle) > 1.5 * currentSegmentSize) {
+          double step = currentSegmentSize / fabs(nextAngle - prevAngle);
+          double end  = 1.0 - 0.5 * step;
+          for (double frac = step; frac < end; frac += step)
+            subTrack.push_back(
+                subTrack.modifier->calcPoint((double)i - 1.0 + frac));
         }
       }
-      subTrack.push_back( subTrack.modifier->calcPoint(i) );
+      subTrack.push_back(subTrack.modifier->calcPoint(i));
     }
   }
 
   track.resetChanges();
 }
 
+#endif

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1953,11 +1953,53 @@ BrushToolOptionsBox::BrushToolOptionsBox(QWidget *parent, TTool *tool,
                              TStroke::OutlineOptions::MITER_JOIN);
   }
   hLayout()->addStretch(1);
+  filterControls();
+}
+
+//-----------------------------------------------------------------------------
+
+void BrushToolOptionsBox::filterControls() {
+  // show or hide widgets which modify imported brush (mypaint)
+
+  bool showModifiers = false;
+  if (m_tool->getTargetType() & TTool::RasterImage) {
+    FullColorBrushTool *fullColorBrushTool =
+        dynamic_cast<FullColorBrushTool *>(m_tool);
+    showModifiers = fullColorBrushTool->getBrushStyle();
+  } else if (m_tool->getTargetType() & TTool::ToonzImage) {
+    ToonzRasterBrushTool *toonzRasterBrushTool =
+        dynamic_cast<ToonzRasterBrushTool *>(m_tool);
+    showModifiers = toonzRasterBrushTool->isMyPaintStyleSelected();
+  } else {  // (m_tool->getTargetType() & TTool::Vectors)
+    m_snapSensitivityCombo->setHidden(!m_snapCheckbox->isChecked());
+    return;
+  }
+
+  for (QMap<std::string, QLabel *>::iterator it = m_labels.begin();
+       it != m_labels.end(); it++) {
+    bool isModifier = (it.key().substr(0, 8) == "Modifier");
+    bool isCommon   = (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
+                     it.key() == "Assistants" || it.key() == "Preset:");
+    bool visible    = isCommon || (isModifier == showModifiers);
+    it.value()->setVisible(visible);
+  }
+
+  for (QMap<std::string, ToolOptionControl *>::iterator it = m_controls.begin();
+       it != m_controls.end(); it++) {
+    bool isModifier = (it.key().substr(0, 8) == "Modifier");
+    bool isCommon   = (it.key() == "Lock Alpha" || it.key() == "Pressure" ||
+                     it.key() == "Assistants" || it.key() == "Preset:");
+    bool visible    = isCommon || (isModifier == showModifiers);
+    if (QWidget *widget = dynamic_cast<QWidget *>(it.value()))
+      widget->setVisible(visible);
+  }
 }
 
 //-----------------------------------------------------------------------------
 
 void BrushToolOptionsBox::updateStatus() {
+  filterControls();
+
   QMap<std::string, ToolOptionControl *>::iterator it;
   for (it = m_controls.begin(); it != m_controls.end(); it++)
     it.value()->updateStatus();
@@ -2804,23 +2846,16 @@ ToolOptions::~ToolOptions() {}
 void ToolOptions::showEvent(QShowEvent *) {
   TTool::Application *app = TTool::getApplication();
 
-  if (ToolHandle *currTool = app->getCurrentTool())
-    currTool->disconnect(this);
-  if (TObjectHandle *currObject = app->getCurrentObject())
-    currObject->disconnect(this);
-  if (TXshLevelHandle *currLevel = app->getCurrentLevel())
-    currLevel->disconnect(this);
-  
   if (ToolHandle *currTool = app->getCurrentTool()) {
     currTool->disconnect(this);
     onToolSwitched();
     connect(currTool, SIGNAL(toolSwitched()), SLOT(onToolSwitched()));
-    connect(currTool, SIGNAL(toolOptionsBoxChanged()), SLOT(onToolOptionsBoxChanged()));
+    connect(currTool, SIGNAL(toolOptionsBoxChanged()),
+            SLOT(onToolOptionsBoxChanged()));
     connect(currTool, SIGNAL(toolChanged()), SLOT(onToolChanged()));
   }
 
   if (TObjectHandle *currObject = app->getCurrentObject()) {
-    currObject->disconnect(this);
     onStageObjectChange();
     connect(currObject, SIGNAL(objectSwitched()), SLOT(onStageObjectChange()));
     connect(currObject, SIGNAL(objectChanged(bool)),
@@ -2848,7 +2883,7 @@ void ToolOptions::hideEvent(QShowEvent *) {
 }
 
 //-----------------------------------------------------------------------------
-
+// used for altering assistant tool options
 void ToolOptions::onToolOptionsBoxChanged() {
   TTool *tool = TTool::getApplication()->getCurrentTool()->getTool();
   std::map<TTool *, ToolOptionsBox *>::iterator it = m_panels.find(tool);

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -344,10 +344,20 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 #endif
   } break;
   case QEvent::TabletMove: {
+#ifdef MACOSX
+    // for now OSX seems to fail to call enter/leaveEvent properly while
+    // the tablet is floating
     bool isHoveringInsideViewer =
         !rect().marginsRemoved(QMargins(5, 5, 5, 5)).contains(e->pos());
     // call the fake enter event
     if (isHoveringInsideViewer) onEnter();
+#else
+    // for Windowsm, use tabletEvent only for the left Button
+    if (m_tabletState != StartStroke && m_tabletState != OnStroke) {
+      m_tabletEvent = false;
+      break;
+    }
+#endif
 
     QPointF curPos = e->posF() * getDevPixRatio();
 #if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)


### PR DESCRIPTION
This PR will partially fix the slowness mentioned in #4852 and #4957 .

- Reverted the update method of tool options bar, from re-building whole options from scratch to show/hiding the relevant fields. Which will
  - remove unwanted "Size" field in the tool option of Toonz Raster Brush, and
  - will resolve the slowness when dragging on the color wheel in the style editor.
- Made the twizzler shape to be available only in the debug builds.
- Reverted the `SceneViewer::tabletEvent` to modify the slowness when using tablet