### PR TITLE
Add info how to install OpenToonz as portable and without admin rights required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Please download and install OpenToonz from the latest installer at <https://open
 
 Older versions and unstable nightly build are also available at <https://github.com/opentoonz/opentoonz/releases>.
 
+If you cannot install because you lack sufficent permissions, read [here](./doc/how_to_extract_opentoonz.md)
+
 ## How to Build Locally
 
 - [Windows](./doc/how_to_build_win.md)

--- a/doc/how_to_extract_opentoonz.md
+++ b/doc/how_to_extract_opentoonz.md
@@ -1,0 +1,12 @@
+This document is assuming you're on windows, but can be modified to work on other operating systems as well.
+
+First, download [innotextract](https://constexpr.org/innoextract/) from the website.
+
+Make a temporary folder where you downloaded it. Ensure the innoextract binary is in the same location as the OpenToonz installer.
+Type the following in your terminal or command prompt:
+.\innoextract.exe OpenToonzSetup.exe --output-dir <folder you made>
+
+cd to the extracted folder.
+
+You should see two directories, app and one (most likely) called code$GetGeneraldir. Rename that to portablestuff.
+Move portablestuff into the app folder. You can now rename app as OpenToonz or whatever you like and move it anywhere you desire.


### PR DESCRIPTION
It works so far, no issues loading OpenToonz. It just needs a (also portable) application called innoextract to fully extract the contents of the installer and then one directory has to be moved. That's all it is. I think this should be added so more people can use OpenToonz where they cannot because they don't have admin rights.