### PR TITLE
Fix pane buttons hit area on hdpi

### DIFF
--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -245,7 +245,7 @@ TPanelTitleBarButton::TPanelTitleBarButton(QWidget *parent,
     , m_buttonSet(0)
     , m_id(0) {
   updatePixmaps();
-  setFixedSize(m_onPixmap.size());
+  setFixedSize(m_onPixmap.size() / m_onPixmap.devicePixelRatio());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -187,8 +187,6 @@ protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseDoubleClickEvent(QMouseEvent *) override;
 
-  QPixmap getPixmap(const QString &iconSVGName, bool rollover);
-
   Q_PROPERTY(QColor TitleColor READ getTitleColor WRITE setTitleColor);
   Q_PROPERTY(QColor ActiveTitleColor READ getActiveTitleColor WRITE
                  setActiveTitleColor);


### PR DESCRIPTION
Caused by me in #4988, on display scales above 100% the pane buttons had an oversized hit area, this fixes it. Thanks @manongjohn for spotting the issue.