### PR TITLE
Fix 32bit preview

### DIFF
--- a/toonz/sources/toonz/previewfxmanager.cpp
+++ b/toonz/sources/toonz/previewfxmanager.cpp
@@ -1079,7 +1079,7 @@ void PreviewFxInstance::doOnRenderRasterCompleted(
 
   /*-- 16bpcで計算された場合、結果をDitheringする --*/
   // dither the 16bpc image IF the "30bit display" preference option is OFF
-  if ((rasA->getPixelSize() == 8 || rasA->getPixelSize() == 16) &&
+  if (rasA->getPixelSize() == 8 &&
       !Preferences::instance()->is30bitDisplayEnabled())  // render in 64 bits
   {
     TRaster32P auxA(rasA->getLx(), rasA->getLy());


### PR DESCRIPTION
This PR fixes the following problem:
- Even if `Preview Settings > Channel Width` is set to `32bit Floating Point`, the preview result is not HDR. Only when `Preferences > Interface > 30bit display` is set to ON, the preview result becomes correctly HDR.

The dithering process was incorrectly applied to the 32bpc preview results.