### PR TITLE
Update license copyright year to 2023

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -7,11 +7,11 @@ For files in the "stuff/library/mypaint brushes" directory: Please see the licen
 OpenToonz
 
 All contributions by DWANGO:
-Copyright (c) 2016 - 2018, DWANGO Co., Ltd.
+Copyright (c) 2016 - 2023, DWANGO Co., Ltd.
 All rights reserved.
 
 All other contributions:
-Copyright (c) 2016 - 2018, the respective contributors.
+Copyright (c) 2016 - 2023, the respective contributors.
 All rights reserved.
 
 Each contributor holds copyright over their respective contributions.

--- a/stuff/doc/LICENSE/LICENSE.txt
+++ b/stuff/doc/LICENSE/LICENSE.txt
@@ -5,11 +5,11 @@ For licenses of third party libraries exploited in this software, please see the
 OpenToonz
 
 All contributions by DWANGO:
-Copyright (c) 2016 - 2021, DWANGO Co., Ltd.
+Copyright (c) 2016 - 2023, DWANGO Co., Ltd.
 All rights reserved.
 
 All other contributions:
-Copyright (c) 2016 - 2021, the respective contributors.
+Copyright (c) 2016 - 2023, the respective contributors.
 All rights reserved.
 
 Each contributor holds copyright over their respective contributions.


### PR DESCRIPTION
This PR updates the copyright year written in the license files to 2023.

Also this is to see if the GitHub Actions MacOS build failure that is happening in #5039 is happening in any PR.