### PR TITLE
Actions: fix MacOS runner removing link to qt6

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -37,8 +37,11 @@ jobs:
           done
         }        
         brew update
-        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo qt@5 boost libusb libmypaint ccache jpeg-turbo ninja
+        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja
         checkPkgAndInstall opencv
+        # opencv depends on vtk and vtk depends on qt6
+        brew unlink qt
+        checkPkgAndInstall qt@5
         
     - uses: actions/cache@v1
       with:


### PR DESCRIPTION
This PR will resolve recent failure in GitHub Actions MacOS runner.
The error message was `"Qt requires a C++17 compiler"`. This occurs when Qt6 and Qt5 are installed at the same time and the two are mixed up.
After investigation, the vtk package in Homebrew was updated on August 1 so that it now depends on Qt6.
Since vtk is used by OpenCV, it is assumed that Qt6 is to be installed when installing OpenCV via Homebrew.
This PR removes the link to Qt6 when installing the library.