### PR TITLE
Remove boost::bind

### DIFF
--- a/toonz/sources/tnztools/levelselection.cpp
+++ b/toonz/sources/tnztools/levelselection.cpp
@@ -14,7 +14,6 @@
 
 // Boost includes
 #include <boost/iterator/counting_iterator.hpp>
-#include <boost/bind.hpp>
 
 //*******************************************************************************
 //    Local namespace  stuff
@@ -108,7 +107,7 @@ void getBoundaries(TVectorImage &vi, std::vector<int> &strokes) {
   std::copy_if(boost::make_counting_iterator(0u),
                boost::make_counting_iterator(vi.getStrokeCount()),
                std::back_inserter(strokes),
-               boost::bind(locals::isBoundary, sData, _1));
+               [&](UINT e) { return locals::isBoundary(sData, e); });
 }
 
 }  // namespace

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -24,9 +24,6 @@
 // TnzCore includes
 #include "drawutil.h"
 
-// boost includes
-#include <boost/bind.hpp>
-
 using namespace ToolUtils;
 using namespace DragSelectionTool;
 
@@ -652,7 +649,7 @@ void DragSelectionTool::VectorDeformTool::transformWholeLevel() {
   // Remove unwanted fids
   fids.erase(std::remove_if(
                  fids.begin(), fids.end(),
-                 boost::bind(::currentOrNotSelected, boost::cref(*tool), _1)),
+                 [tool](const TFrameId &fid) { return currentOrNotSelected(*tool, fid); }),
              fids.end());
 
   TUndoManager::manager()->beginBlock();
@@ -701,9 +698,9 @@ void DragSelectionTool::VectorDeformTool::transformWholeLevel() {
 
   // Finally, notify changed frames
   std::for_each(fids.begin(), fids.end(),
-                boost::bind(  // NOTE: current frame is not here - it should be,
-                    &TTool::notifyImageChanged, m_tool,
-                    _1));  //       but it's currently unnecessary, in fact...
+  // NOTE: current frame is not here - it should be,
+  // but it's currently unnecessary, in fact...
+  [this](const TFrameId &fid) { m_tool->notifyImageChanged(fid); });
 
   // notifyImageChanged(fid) must be invoked OUTSIDE of the loop - since it
   // seems to imply notifyImageChanged()
@@ -973,12 +970,12 @@ void DragSelectionTool::VectorChangeThicknessTool::setStrokesThickness(
     const std::set<int> &selectedStrokeIdxs = strokeSelection->getSelection();
 
     std::for_each(selectedStrokeIdxs.begin(), selectedStrokeIdxs.end(),
-                  boost::bind(locals::setThickness, boost::cref(data), _1));
+      [&data](int s) { locals::setThickness(data, s); });
   } else {
     std::vector<int> strokeIdxs = getSelectedStrokes(vi, levelSelection);
 
     std::for_each(strokeIdxs.begin(), strokeIdxs.end(),
-                  boost::bind(locals::setThickness, boost::cref(data), _1));
+      [&data](int s) { locals::setThickness(data, s); });
   }
 }
 
@@ -1027,12 +1024,12 @@ void DragSelectionTool::VectorChangeThicknessTool::changeImageThickness(
     const std::set<int> &selectedStrokeIdxs = strokeSelection->getSelection();
 
     std::for_each(selectedStrokeIdxs.begin(), selectedStrokeIdxs.end(),
-                  boost::bind(locals::changeThickness, boost::ref(data), _1));
+      [&data](int s) { locals::changeThickness(data, s); });
   } else {
     std::vector<int> strokeIdxs = getSelectedStrokes(vi, levelSelection);
 
     std::for_each(strokeIdxs.begin(), strokeIdxs.end(),
-                  boost::bind(locals::changeThickness, boost::ref(data), _1));
+      [&data](int s) { locals::changeThickness(data, s); });
   }
 }
 
@@ -1058,8 +1055,7 @@ void DragSelectionTool::VectorChangeThicknessTool::addUndo() {
 
     // Remove unwanted frames
     fids.erase(std::remove_if(fids.begin(), fids.end(),
-                              boost::bind(::currentOrNotSelected,
-                                          boost::cref(*vtool), _1)),
+      [vtool](const TFrameId &fid) { return currentOrNotSelected(*vtool, fid); }),
                fids.end());
 
     TUndoManager::manager()->beginBlock();
@@ -1095,9 +1091,7 @@ void DragSelectionTool::VectorChangeThicknessTool::addUndo() {
 
     // Finally, notify changed frames
     std::for_each(fids.begin(), fids.end(),
-                  boost::bind(  // NOTE: current frame is not here - it was
-                      &TTool::notifyImageChanged, m_tool,
-                      _1));  //       aldready notified
+      [this](const TFrameId &fid) { m_tool->notifyImageChanged(fid); });
   } else
     TUndoManager::manager()->add(m_undo.release());  // Outside any undo block
 }
@@ -1283,7 +1277,7 @@ void VectorSelectionTool::setNewFreeDeformer() {
 
     fids.erase(std::remove_if(
                    fids.begin(), fids.end(),
-                   boost::bind(::currentOrNotSelected, boost::cref(*this), _1)),
+                   [this](const TFrameId &fid) { return currentOrNotSelected(*this, fid); }),
                fids.end());
 
     std::vector<TFrameId>::iterator ft, fEnd = fids.end();

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -81,7 +81,6 @@
 #include "tcg/boost/permuted_range.h"
 
 // boost includes
-#include <boost/bind.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
@@ -419,7 +418,7 @@ void SceneBrowser::sortByDataModel(DataType dataType, bool isDiscendent) {
 
     std::stable_sort(
         new2OldIdx.begin(), new2OldIdx.end(),
-        boost::bind(locals::itemLess, _1, _2, boost::ref(*this), dataType));
+        [this, dataType](int x, int y){ return locals::itemLess(x, y, *this, dataType); });
 
     // Use the renumbering table to permutate elements
     std::vector<Item>(
@@ -437,15 +436,13 @@ void SceneBrowser::sortByDataModel(DataType dataType, bool isDiscendent) {
           boost::make_counting_iterator(int(m_items.size())));
 
       std::sort(old2NewIdx.begin(), old2NewIdx.end(),
-                boost::bind(locals::indexLess, _1, _2, boost::ref(new2OldIdx)));
+                [&new2OldIdx](int x, int y){ return locals::indexLess(x, y, new2OldIdx); });
 
       std::vector<int> newSelectedIndices;
       tcg::substitute(
           newSelectedIndices,
           tcg::permuted_range(old2NewIdx, fs->getSelectedIndices() |
-                                              ba::filtered(boost::bind(
-                                                  std::less<int>(), _1,
-                                                  int(old2NewIdx.size())))));
+              ba::filtered([&old2NewIdx](int x){ return x < old2NewIdx.size(); })));
 
       fs->select(!newSelectedIndices.empty() ? &newSelectedIndices.front() : 0,
                  int(newSelectedIndices.size()));
@@ -470,8 +467,8 @@ void SceneBrowser::sortByDataModel(DataType dataType, bool isDiscendent) {
       tcg::substitute(
           newSelectedIndices,
           fs->getSelectedIndices() |
-              ba::filtered(boost::bind(std::less<int>(), _1, iCount)) |
-              ba::transformed(boost::bind(locals::complement, _1, lastIdx)));
+              ba::filtered([iCount](int x){ return x < iCount; }) |
+              ba::transformed([lastIdx](int x){ return locals::complement(x, lastIdx); }));
 
       fs->select(!newSelectedIndices.empty() ? &newSelectedIndices.front() : 0,
                  int(newSelectedIndices.size()));

--- a/toonz/sources/toonz/selectionutils.cpp
+++ b/toonz/sources/toonz/selectionutils.cpp
@@ -24,7 +24,6 @@
 #include "tcg/boost/range_utility.h"
 
 // Boost includes
-#include <boost/bind.hpp>
 #include <boost/range/counting_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
@@ -63,8 +62,7 @@ void getSelectedFrames<TXshSimpleLevel>(
     if (!sl) continue;
 
     tcg::substitute(frames[sl], boost::counting_range(0, sl->getFrameCount()) |
-                                    boost::adaptors::transformed(boost::bind(
-                                        &TXshSimpleLevel::getFrameId, sl, _1)));
+      boost::adaptors::transformed([&sl](int index){ return sl->getFrameId(index); }));
   }
 }
 

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -71,8 +71,6 @@
 #include "tcg/boost/range_utility.h"
 
 // boost includes
-#include <boost/bind.hpp>
-#include <boost/bind/make_adaptable.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
@@ -431,8 +429,7 @@ public:
       : GlobalKeyframeUndo(frame) {
     tcg::substitute(
         m_columns,
-        columns | ba::filtered(std::not1(boost::make_adaptable<bool, int>(
-                      boost::bind(isKeyframe, frame, _1)))));
+        columns | ba::filtered([frame](int c){ return !isKeyframe(frame, c); }));
   }
 
   void redo() const override {
@@ -506,11 +503,10 @@ public:
     };  // locals
 
     tcg::substitute(m_columns,
-                    columns | ba::filtered(boost::bind(isKeyframe, frame, _1)));
+                    columns | ba::filtered([frame](int c){ return isKeyframe(frame, c); }));
 
     tcg::substitute(m_keyframes,
-                    m_columns | ba::transformed(boost::bind(locals::getKeyframe,
-                                                            frame, _1)));
+                    m_columns | ba::transformed([frame](int c){ return locals::getKeyframe(frame, c); }));
   }
 
   void redo() const override {

--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -39,7 +39,6 @@
 #include "tcg/boost/range_utility.h"
 
 // boost includes
-#include <boost/bind.hpp>
 #include <boost/range/counting_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/filtered.hpp>
@@ -583,8 +582,7 @@ void PaletteCmd::eraseStyles(const std::set<TXshSimpleLevel *> &levels,
       tcg::substitute(
           levelImages.second,
           boost::counting_range(0, levelImages.first->getFrameCount()) |
-              boost::adaptors::transformed(boost::bind(
-                  cloneImage, boost::cref(*levelImages.first), _1)));
+              boost::adaptors::transformed([&levelImages](int f){ return cloneImage(*levelImages.first, f); }));
     }
 
     static void restoreImage(const TXshSimpleLevelP &level, int f,

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -27,9 +27,6 @@
 #include <QColor>
 #include <QTextStream>
 
-// boost includes
-#include <boost/bind.hpp>
-
 //**********************************************************************************
 //    Local namespace  stuff
 //**********************************************************************************
@@ -1106,7 +1103,7 @@ int Preferences::levelFormatsCount() const {
 int Preferences::matchLevelFormat(const TFilePath &fp) const {
   LevelFormatVector::const_iterator lft =
       std::find_if(m_levelFormats.begin(), m_levelFormats.end(),
-                   boost::bind(&LevelFormat::matches, _1, boost::cref(fp)));
+                   [&fp](const LevelFormat &format) { return format.matches(fp); });
 
   return (lft != m_levelFormats.end()) ? lft - m_levelFormats.begin() : -1;
 }


### PR DESCRIPTION
Fix this warning.
```
warning:    36 | BOOST_PRAGMA_MESSAGE(
warning:       | ^~~~~~~~~~~~~~~~~~~~
warning: In file included from /usr/include/boost/bind.hpp:30,
warning:                  from toonz/sources/toonz/filebrowser.cpp:83:
warning: /usr/include/boost/bind.hpp:36:1: note: ‘#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’
```