### PR TITLE
Fix Use default constructor instead

### DIFF
--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -923,8 +923,8 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
       }
       m_tabBarContainer->setLayout(hLayout);
 
-      mainLayout->addWidget(m_tabBarContainer, 0, 0);
-      mainLayout->addWidget(m_stackedChooser, 1, 0);
+      mainLayout->addWidget(m_tabBarContainer, 0);
+      mainLayout->addWidget(m_stackedChooser, 1);
       mainLayout->addWidget(opacityFrame, 0);
       mainLayout->addWidget(controlButtonFrame, 0);
       setLayout(mainLayout);

--- a/toonz/sources/toonz/batchserversviewer.h
+++ b/toonz/sources/toonz/batchserversviewer.h
@@ -44,7 +44,7 @@ class BatchServersViewer final : public QFrame {
   Q_OBJECT
 
 public:
-  BatchServersViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  BatchServersViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~BatchServersViewer();
 
   void updateSelected();

--- a/toonz/sources/toonz/castviewer.h
+++ b/toonz/sources/toonz/castviewer.h
@@ -78,7 +78,7 @@ class CastBrowser final : public QSplitter, public DvItemListModel {
   std::unique_ptr<CastItems> m_castItems;
 
 public:
-  CastBrowser(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  CastBrowser(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~CastBrowser();
 
   CastItems const &getCastItems() const { return *m_castItems; }

--- a/toonz/sources/toonz/comboviewerpane.h
+++ b/toonz/sources/toonz/comboviewerpane.h
@@ -21,7 +21,7 @@ class ComboViewerPanel final : public BaseViewerPanel {
   Ruler *m_hRuler;
 
 public:
-  ComboViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  ComboViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ComboViewerPanel() {}
 
   ToolOptions *getToolOptions() { return m_toolOptions; }

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -25,7 +25,7 @@ protected:
   bool m_isCollapsible;
 
 public:
-  CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = 0,
+  CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
              bool isCollapsible = false, bool isXsheetToolbar = false);
 
 signals:

--- a/toonz/sources/toonz/exportpanel.h
+++ b/toonz/sources/toonz/exportpanel.h
@@ -90,7 +90,7 @@ class ExportPanel final : public TPanel {
   QCheckBox *m_useMarker;
 
 public:
-  ExportPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  ExportPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~ExportPanel();
   void loadExportSettings();
   void saveExportSettings();

--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -60,7 +60,7 @@ class FileBrowser final : public QFrame, public DvItemListModel {
   Q_OBJECT
 
 public:
-  FileBrowser(QWidget *parent, Qt::WindowFlags flags = 0,
+  FileBrowser(QWidget *parent, Qt::WindowFlags flags = Qt::WindowFlags(),
               bool noContextMenu = false, bool multiSelectionEnabled = false);
   ~FileBrowser();
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -86,7 +86,7 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
   setWindowTitle(title);
   setModal(false);
 
-  m_browser        = new FileBrowser(this, 0, false, m_multiSelectionEnabled);
+  m_browser        = new FileBrowser(this, Qt::WindowFlags(), false, m_multiSelectionEnabled);
   m_nameFieldLabel = new QLabel(tr("File name:"));
   m_nameField      = new DVGui::LineEdit(this);
   m_okButton       = new QPushButton(tr("OK"), this);

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -236,7 +236,7 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
   bool m_showComboBox  = true;
 
 public:
-  Filmstrip(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  Filmstrip(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~Filmstrip();
 
   // SaveLoadQSettings

--- a/toonz/sources/toonz/historypane.h
+++ b/toonz/sources/toonz/historypane.h
@@ -33,7 +33,7 @@ class HistoryPane final : public QWidget {
   QScrollArea *m_frameArea;
 
 public:
-  HistoryPane(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  HistoryPane(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~HistoryPane(){};
 
 protected:

--- a/toonz/sources/toonz/layerfooterpanel.h
+++ b/toonz/sources/toonz/layerfooterpanel.h
@@ -32,7 +32,7 @@ private:
 
 public:
   LayerFooterPanel(XsheetViewer *viewer, QWidget *parent = 0,
-                   Qt::WindowFlags flags = 0);
+                   Qt::WindowFlags flags = Qt::WindowFlags());
   ~LayerFooterPanel();
 
   void showOrHide(const Orientation *o);

--- a/toonz/sources/toonz/messagepanel.h
+++ b/toonz/sources/toonz/messagepanel.h
@@ -54,7 +54,7 @@ class LogPanel final : public TPanel, public TLogger::Listener {
   int m_poolIndex;
 
 public:
-  LogPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  LogPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~LogPanel();
 
   void onLogChanged() override;

--- a/toonz/sources/toonz/scenebrowser.h
+++ b/toonz/sources/toonz/scenebrowser.h
@@ -43,7 +43,7 @@ class SceneBrowser final : public QFrame, public DvItemListModel {
   Q_OBJECT
 
 public:
-  SceneBrowser(QWidget *parent, Qt::WindowFlags flags = 0,
+  SceneBrowser(QWidget *parent, Qt::WindowFlags flags = Qt::WindowFlags(),
                bool noContextMenu = false, bool multiSelectionEnabled = false);
   ~SceneBrowser();
 

--- a/toonz/sources/toonz/tasksviewer.h
+++ b/toonz/sources/toonz/tasksviewer.h
@@ -169,7 +169,7 @@ public:
   TaskTreeView *m_treeView;
   QTimer *m_timer;
 
-  TasksViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  TasksViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~TasksViewer();
 
   void update() override;

--- a/toonz/sources/toonz/testpanel.h
+++ b/toonz/sources/toonz/testpanel.h
@@ -13,7 +13,7 @@ class TestPanel final : public TPanel {
   Q_OBJECT
 
 public:
-  TestPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  TestPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~TestPanel();
 
 public slots:

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -990,7 +990,7 @@ public:
 
 //-----------------------------------------------------------------------------
 CommandBarPanel::CommandBarPanel(QWidget *parent)
-    : TPanel(parent, 0, TDockWidget::horizontal) {
+    : TPanel(parent, Qt::WindowFlags(), TDockWidget::horizontal) {
   CommandBar *xsheetToolbar = new CommandBar();
   setWidget(xsheetToolbar);
   setIsMaximizable(false);
@@ -1018,7 +1018,7 @@ OpenFloatingPanel openCommandBarCommand(MI_OpenCommandToolbar, "CommandBar",
 //---------------------------------------------------------
 
 ToolOptionPanel::ToolOptionPanel(QWidget *parent)
-    : TPanel(parent, 0, TDockWidget::horizontal) {
+    : TPanel(parent, Qt::WindowFlags(), TDockWidget::horizontal) {
   TApp *app    = TApp::instance();
   m_toolOption = new ToolOptions;
 
@@ -1212,7 +1212,7 @@ class BrowserFactory final : public TPanelFactory {
 public:
   BrowserFactory() : TPanelFactory("Browser") {}
   void initialize(TPanel *panel) override {
-    FileBrowser *browser = new FileBrowser(panel, 0, false, true);
+    FileBrowser *browser = new FileBrowser(panel, Qt::WindowFlags(), false, true);
     panel->setWidget(browser);
     panel->setWindowTitle(QObject::tr("File Browser"));
     TFilePath currentProjectFolder =
@@ -1229,7 +1229,7 @@ class PreproductionBoardFactory final : public TPanelFactory {
 public:
   PreproductionBoardFactory() : TPanelFactory("PreproductionBoard") {}
   void initialize(TPanel *panel) override {
-    SceneBrowser *browser = new SceneBrowser(panel, 0, false, true);
+    SceneBrowser *browser = new SceneBrowser(panel, Qt::WindowFlags(), false, true);
     panel->setWidget(browser);
     panel->setWindowTitle(QObject::tr("Preproduction Board"));
     TFilePath scenesFolder =

--- a/toonz/sources/toonz/vectorguideddrawingpane.h
+++ b/toonz/sources/toonz/vectorguideddrawingpane.h
@@ -26,7 +26,7 @@ class VectorGuidedDrawingPane final : public QFrame {
       *m_FlipNextDirectionBtn, *m_FlipPrevDirectionBtn;
 
 public:
-  VectorGuidedDrawingPane(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  VectorGuidedDrawingPane(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~VectorGuidedDrawingPane(){};
 
   void updateStatus();

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -68,7 +68,7 @@ protected:
   bool m_isActive = false;
 
 public:
-  BaseViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  BaseViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~BaseViewerPanel() {}
 
   virtual void updateShowHide();

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3522,7 +3522,7 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
 //-----------------------------------------------------------------------------
 
 void CellArea::mouseReleaseEvent(QMouseEvent *event) {
-  m_viewer->setQtModifiers(0);
+  m_viewer->setQtModifiers(Qt::KeyboardModifiers());
   m_isMousePressed = false;
   m_viewer->stopAutoPan();
   m_isPanning = false;

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2810,7 +2810,7 @@ void ColumnArea::mouseReleaseEvent(QMouseEvent *event) {
 
   if (m_transparencyPopupTimer) m_transparencyPopupTimer->stop();
 
-  m_viewer->setQtModifiers(0);
+  m_viewer->setQtModifiers(Qt::KeyboardModifiers());
   m_viewer->dragToolRelease(event);
   m_isPanning = false;
   m_viewer->stopAutoPan();

--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -50,7 +50,7 @@ class MotionPathMenu final : public QWidget {
   QPoint m_pos;
 
 public:
-  MotionPathMenu(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  MotionPathMenu(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~MotionPathMenu();
 
 protected:

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -238,7 +238,7 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WindowFlags flags)
     , m_isCurrentColumnSwitched(false)
     , m_isComputingSize(false)
     , m_currentNoteIndex(0)
-    , m_qtModifiers(0)
+    , m_qtModifiers(Qt::KeyboardModifiers())
     , m_frameDisplayStyle(to_enum(FrameDisplayStyleInXsheetRowArea))
     , m_orientation(nullptr)
     , m_xsheetLayout("Classic")
@@ -258,7 +258,7 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WindowFlags flags)
   m_toolbarScrollArea = new XsheetScrollArea(this);
   m_toolbarScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_toolbarScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-  m_toolbar = new XsheetGUI::XSheetToolbar(this, 0, true);
+  m_toolbar = new XsheetGUI::XSheetToolbar(this, Qt::WindowFlags(), true);
   m_toolbarScrollArea->setWidget(m_toolbar);
 
   m_noteArea       = new XsheetGUI::NoteArea(this);
@@ -702,7 +702,7 @@ void XsheetViewer::timerEvent(QTimerEvent *) {
   scroll(m_autoPanSpeed);
   if (!m_dragTool) return;
   QMouseEvent mouseEvent(QEvent::MouseMove, m_lastAutoPanPos - m_autoPanSpeed,
-                         Qt::NoButton, 0, m_qtModifiers);
+                         Qt::NoButton, Qt::MouseButtons(), m_qtModifiers);
   m_dragTool->onDrag(&mouseEvent);
   m_lastAutoPanPos += m_autoPanSpeed;
 }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -168,7 +168,7 @@ class XsheetScrollArea final : public QScrollArea {
   Q_OBJECT
 
 public:
-  XsheetScrollArea(QWidget *parent = 0, Qt::WindowFlags flags = 0)
+  XsheetScrollArea(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags())
       : QScrollArea(parent) {
     setObjectName("xsheetScrollArea");
     setFrameStyle(QFrame::StyledPanel);
@@ -658,7 +658,7 @@ private:
   }
 
 public:
-  XsheetViewer(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  XsheetViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~XsheetViewer();
 
   TColumnSelection *getColumnSelection() const { return m_columnSelection; }

--- a/toonz/sources/toonz/xshnoteviewer.h
+++ b/toonz/sources/toonz/xshnoteviewer.h
@@ -135,7 +135,7 @@ class NoteArea final : public QFrame {
   QLayout *m_currentLayout;
 
 public:
-  NoteArea(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0);
+  NoteArea(XsheetViewer *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
 
   void updatePopup() { m_newNotePopup->update(); }
   void updateButtons();

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1331,7 +1331,7 @@ void RowArea::mouseMoveEvent(QMouseEvent *event) {
 //-----------------------------------------------------------------------------
 
 void RowArea::mouseReleaseEvent(QMouseEvent *event) {
-  m_viewer->setQtModifiers(0);
+  m_viewer->setQtModifiers(Qt::KeyboardModifiers());
   m_viewer->stopAutoPan();
   m_isPanning = false;
   m_viewer->dragToolRelease(event);

--- a/toonz/sources/toonz/xshtoolbar.h
+++ b/toonz/sources/toonz/xshtoolbar.h
@@ -31,7 +31,7 @@ class XSheetToolbar final : public CommandBar {
   XsheetViewer *m_viewer;
 
 public:
-  XSheetToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = 0,
+  XSheetToolbar(XsheetViewer *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
                 bool isCollapsible = false);
   static void toggleXSheetToolbar();
   void showToolbar(bool show);

--- a/toonz/sources/toonzqt/tdockwindows.h
+++ b/toonz/sources/toonzqt/tdockwindows.h
@@ -43,7 +43,7 @@ class DVAPI TMainWindow : public QWidget {
   QWidget *m_menu;
 
 public:
-  TMainWindow(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  TMainWindow(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   virtual ~TMainWindow();
 
   void addDockWidget(TDockWidget *item);
@@ -85,8 +85,8 @@ class DVAPI TDockWidget : public DockWidget {
 
 public:
   TDockWidget(const QString &title, QWidget *parent = 0,
-              Qt::WindowFlags flags = 0);
-  TDockWidget(QWidget *parent = 0, Qt::WindowFlags flags = 0);
+              Qt::WindowFlags flags = Qt::WindowFlags());
+  TDockWidget(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
   ~TDockWidget() {}
 
   void setTitleBarWidget(QWidget *titlebar);


### PR DESCRIPTION
Fix this warning.
```
/usr/include/x86_64-linux-gnu/qt5/QtCore/qflags.h:123:80: note: declared here
  123 |     QT_DEPRECATED_X("Use default constructor instead") Q_DECL_CONSTEXPR inline QFlags(Zero) noexcept : i(0) {}
      |                                                                                ^~~~~~
```