### PR TITLE
Improve assistant tool selection

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -288,7 +288,7 @@ public:
 
     EmptyTarget = 0x80,  //!< Will work on empty cells/columns
 
-    MetaImage   = 0x100, //!< Will work on mets images
+    MetaImage   = 0x100, //!< Will work on meta images
 
     CommonImages = VectorImage | ToonzImage | RasterImage,
     AllImages    = CommonImages | MeshImage | MetaImage,
@@ -572,8 +572,16 @@ protected:
 
   static std::set<TFrameId> m_selectedFrames;
 
-protected:
-  void bind(int targetType);
+private:
+  void bind(const std::string &name, int targetType);
+
+public:
+  inline void bind(int targetType)
+    { bind(getName(), targetType); }
+  void bind( int targetType,
+             const std::string &alias1,
+             const std::string &alias2 = std::string(),
+             const std::string &alias3 = std::string() );
 
   virtual void onSelectedFramesChanged() {}
 

--- a/toonz/sources/include/tools/toolhandle.h
+++ b/toonz/sources/include/tools/toolhandle.h
@@ -44,11 +44,12 @@ public:
   ~ToolHandle();
 
   TTool *getTool() const;
-  void setTool(TTool *tool);
-
   void setTool(QString name);
   void setTargetType(int targetType);
 
+  const QString& getRequestedToolName() const
+    { return m_toolName; }
+  
   // used to change tool for a short while (e.g. while keeping pressed a
   // short-key)
   void storeTool();

--- a/toonz/sources/toonz/toolbar.cpp
+++ b/toonz/sources/toonz/toolbar.cpp
@@ -287,8 +287,7 @@ void Toolbar::hideEvent(QHideEvent *e) {
 
 void Toolbar::onToolChanged() {
   ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
-  TTool *tool            = toolHandle->getTool();
-  std::string toolName   = tool->getName();
+  std::string toolName   = toolHandle->getRequestedToolName().toStdString();
   QAction *act = CommandManager::instance()->getAction(toolName.c_str());
   if (!act || act->isChecked()) return;
   act->setChecked(true);


### PR DESCRIPTION
I've changed behavior of tool selection to allow to make aliases for tools (via TTool::bind)

Now tool can be assigned to multiple toolbar buttons (actions)
We already had ability to assign different tools to a single tool button (for example, three different brush tools share the same button)

I've assigned the EditAssistantsTool to the "brush" button.
And now for editing of assistants you do not need to switch the tool  (while drawing). You just need to choose a cell in Xsheet/timeline.

Also i've made more detailed message about level/tool imcompatibility.

![msg](https://github.com/opentoonz/opentoonz/assets/5143743/03485fbf-4a87-4e7e-86a9-8a936b62cc75)