### PR TITLE
refactor: Use strcmp and restore addSpecifiedSizedImageToIcon function

### DIFF
--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -161,6 +161,11 @@ void DVAPI addImagesToIcon(QIcon &icon, const QImage &baseImg,
 
 //-----------------------------------------------------------------------------
 
+void DVAPI addSpecifiedSizedImageToIcon(QIcon &icon, const char *iconSVGName,
+                                        QSize newSize = QSize());
+
+//-----------------------------------------------------------------------------
+
 void DVAPI addPixmapToAllModesAndStates(QIcon &icon, const QPixmap &pixmap);
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -453,6 +453,27 @@ void addImagesToIcon(QIcon &icon, const QImage &baseImg, const QImage &overImg,
 
 //-----------------------------------------------------------------------------
 
+void addSpecifiedSizedImageToIcon(QIcon &icon, const char *iconSVGName,
+                                  QSize newSize) {
+  static int devPixRatio = getHighestDevicePixelRatio();
+  newSize *= devPixRatio;
+
+  // Construct icon filenames
+  QString iconName     = QString::fromUtf8(iconSVGName);
+  QString overIconName = iconName + "_over";
+  QString onIconName   = iconName + "_on";
+
+  // Generate icon images
+  QImage baseImg = generateIconImage(iconName, 1.0, newSize);
+  QImage overImg = generateIconImage(overIconName, 1.0, newSize);
+  QImage onImg   = generateIconImage(onIconName, 1.0, newSize);
+
+  // Add newly sized images to the icon
+  addImagesToIcon(icon, baseImg, overImg, onImg);
+}
+
+//-----------------------------------------------------------------------------
+
 // Add the same pixmap to all modes and states of a QIcon
 void addPixmapToAllModesAndStates(QIcon &icon, const QPixmap &pixmap) {
   QIcon::Mode modes[]   = {QIcon::Normal, QIcon::Disabled, QIcon::Selected};

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -410,7 +410,7 @@ void CommandManager::enlargeIcon(CommandId id, const QSize dstSize) {
       return;
   }
 
-  icon = createQIcon(iconSVGName, false, false, dstSize);
+  addSpecifiedSizedImageToIcon(icon, iconSVGName, dstSize);
   
   action->setIcon(icon);
 }

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -399,7 +399,7 @@ void CommandManager::enlargeIcon(CommandId id, const QSize dstSize) {
   if (!action) return;
 
   const char *iconSVGName = getIconSVGName(id);
-  if (iconSVGName == "") return;
+  if (strcmp(iconSVGName, "") == 0) return;
 
   QIcon icon = action->icon();
 


### PR DESCRIPTION
Closes #5076, and restores the logic of `addSpecifiedSizedImageToIcon` function I removed earlier except now instead of scaling the pixmap it just grabs the image again and renders the SVG at the new size.