### PR TITLE
Tune column selection

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2343,10 +2343,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
       return;
     }
-    // set the clicked column to current
-    else
-      m_viewer->setCurrentColumn(m_col);
-
+    
     TXshColumn *column = xsh->getColumn(m_col);
     bool isEmpty       = !column || column->isEmpty();
     TApp::instance()->getCurrentObject()->setIsSpline(false);
@@ -2358,6 +2355,24 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     // int y = event->pos().y();
     // QPoint mouseInCell(x, y);
     int x = mouseInCell.x(), y = mouseInCell.y();
+    
+    // don't make column current when click on some of its toggle buttons
+    bool needMakeColumnCurrent = true;
+    if ( o->rect(PredefinedRect::LOCK_AREA).contains(mouseInCell)
+      || o->rect(PredefinedRect::CONFIG_AREA).contains(mouseInCell) )
+      needMakeColumnCurrent = false;
+    if ( Preferences::instance()->isUnifyColumnVisibilityTogglesEnabled() ) {
+      if ( o->rect(PredefinedRect::UNIFIEDVIEW_LAYER_AREA).contains(mouseInCell) )
+        needMakeColumnCurrent = false;
+    } else {
+      if ( o->rect(PredefinedRect::EYE_AREA).contains(mouseInCell)
+        || o->rect(PredefinedRect::PREVIEW_LAYER_AREA).contains(mouseInCell) )
+        needMakeColumnCurrent = false;
+    }
+      
+    // set the clicked column to current
+    if (needMakeColumnCurrent)
+      m_viewer->setCurrentColumn(m_col);
 
     // clicking on the camera column
     if (m_col < 0) {


### PR DESCRIPTION
This PR prevents selection of a column when clicking on the "eye", "camera stand", "lock" and "options" buttons of the column. 

See also discussion here https://github.com/opentoonz/opentoonz/pull/5100#issuecomment-1728063568