### PR TITLE
fix column right-click action

### DIFF
--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -1514,7 +1514,9 @@ public:
       TXshColumn *column = xsh->getColumn(i);
       if (!column) continue;
       /*- Skip if target is in selected column mode and not selected -*/
-      bool isSelected = selection && selection->isColumnSelected(i);
+      bool isSelected = selection && !selection->isEmpty()
+                      ? selection->isColumnSelected(i)
+                      : cc == i;
       if (m_target == TARGET_SELECTED && !isSelected) continue;
 
       /*-


### PR DESCRIPTION
This fix make it possible to toggle visibility of a current column by a keyboard shortcut (by the action)

This PR has touched following column actions:
- ON selected;
- OFF selected;
- Show selected;
- Hide selected;
- Lock selected;
- Unlock selected.

Now when we have no columns selected, then the current column is being assume as selected.

By my sight this change has no side effects. But if we have any "scripts" that uses this action... and these scripts uses such actions without column selected... and a script author expects that such actions must do nothing in this case...

I don't know about existence of such scripts. Actually i'm not sure that we have ability to use these actions in any scripts.

See the explanation of the problem here: https://github.com/opentoonz/opentoonz/pull/5108#issuecomment-1733489022