### PR TITLE
Fix SVG sequence file loading

### DIFF
--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -81,7 +81,8 @@
 #include "./mov/tiio_movM.h"
 #include "./3gp/tiio_3gpM.h"
 
-#elif defined(LINUX) || defined(FREEBSD) || defined(HAIKU)  // No more supported by the way...
+#elif defined(LINUX) || defined(FREEBSD) ||                                    \
+    defined(HAIKU)  // No more supported by the way...
 // #include "./mov/tiio_movL.h"
 #include "./mov/tiio_mov_proxy.h"
 #include "./3gp/tiio_3gp_proxy.h"
@@ -99,7 +100,7 @@ void initImageIo(bool lightVersion) {
     TFileType::declare("pli", TFileType::VECTOR_LEVEL);
 
     TLevelReader::define("svg", 0, TLevelReaderSvg::create);
-    TFileType::declare("svg", TFileType::VECTOR_LEVEL);
+    TFileType::declare("svg", TFileType::VECTOR_IMAGE);
     TLevelWriter::define("svg", TLevelWriterSvg::create, false);
     Tiio::defineWriterProperties("svg", new Tiio::SvgWriterProperties());
 

--- a/toonz/sources/include/tlevel_io.h
+++ b/toonz/sources/include/tlevel_io.h
@@ -288,6 +288,9 @@ inline bool isMultipleFrameType(const TFilePath &fp) {
 
 inline bool doesSupportRandomAccess(const TFilePath &fp,
                                     bool isToonzOutput = false) {
+  const std::string &type = fp.getType();
+  if (type == "pli") return false;
+
   return (fp.getDots() == "..") || (isToonzOutput && fp.getType() == "mov");
 }
 

--- a/toonz/sources/toonzlib/levelupdater.cpp
+++ b/toonz/sources/toonzlib/levelupdater.cpp
@@ -25,6 +25,9 @@ namespace {
 
 inline bool supportsRandomAccess(const TFilePath &fp) {
   const std::string &type = fp.getType();
+
+  if (type == "pli") return false;
+
   return type == "tlv" ||  // TLVs do support random access
                            // type == "pli" || // PLIs... I thought they would -
                            // but no :( type == "mov" || // MOVs are 'on the

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -999,6 +999,7 @@ static LevelType getLevelType(const TFilePath &fp) {
       ret.m_ltype = OVL_XSHLEVEL;
     break;
 
+  case TFileType::VECTOR_IMAGE:
   case TFileType::VECTOR_LEVEL:
     if (format == "svg") {
       ret.m_vectorNotPli = true;
@@ -1194,7 +1195,7 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     else {
       const Preferences &prefs = *Preferences::instance();
       int formatIdx            = prefs.matchLevelFormat(
-          levelPath);  // Should I use actualPath here? It's mostly
+                     levelPath);  // Should I use actualPath here? It's mostly
                                   // irrelevant anyway, it's for old tzp/tzu...
       if (formatIdx >= 0) {
         lp->options()   = prefs.levelFormat(formatIdx).m_options;


### PR DESCRIPTION
This PR fixes an issue when trying to load an SVG file sequence.

Modified it so SVG files are treated as Vector Images instead of Vector Levels, which allows the SVG files to be detected as a single image file or a series of files (filename.####.svg or filename_####.svg format).

Ported from https://github.com/tahoma2d/tahoma2d/pull/1212

Co-authored-by  @manongjohn .