### PR TITLE
Fix SVG import from Browser

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -926,7 +926,8 @@ TXshLevel *loadLevel(ToonzScene *scene,
       std::string format = actualPath.getType();
       if (format == "tzp" || format == "tzu") convertingPopup->show();
 
-      if (fIds.size() != 0 && doesFileActuallyExist)
+      // SVGs are treated as PLI. Ignore the fIds lists
+      if (format != "svg" && fIds.size() != 0 && doesFileActuallyExist)
         xl = scene->loadLevel(actualPath, rd.m_options ? &*rd.m_options : 0,
                               levelName, fIds);
       else


### PR DESCRIPTION
SVGs are treated as PLI. Ignore the fIds lists.

Ported from https://github.com/tahoma2d/tahoma2d/pull/1230

Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>