### PR TITLE
Fixed deselect of hexlineedit after right click

### DIFF
--- a/toonz/sources/toonzqt/hexcolornames.cpp
+++ b/toonz/sources/toonzqt/hexcolornames.cpp
@@ -390,7 +390,10 @@ void HexLineEdit::mousePressEvent(QMouseEvent *event) {
 
 void HexLineEdit::focusOutEvent(QFocusEvent *event) {
   QLineEdit::focusOutEvent(event);
-  deselect();
+  if (!m_editing) {
+    deselect();
+  }
+
   m_editing = false;
 }
 


### PR DESCRIPTION
This PR attempts to fix issue #5002, loss of focus on right click of the hex code in the style menu. 

I believe its due to the shift of focus from the style editor to the right click menu. To fix this I just disabled deselect upon editing the hex code. 

