### PR TITLE
Fixed crash when holding Ctrl+Z while drawing.

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -936,13 +936,11 @@ Room *MainWindow::getCurrentRoom() const {
 void MainWindow::onUndo() {
   ToolHandle *toolH = TApp::instance()->getCurrentTool();
 
-  // end tool use to avoid applying tool on removed layer on undo
-  if (toolH->isToolBusy()) {
-    toolH->getTool()->onDeactivate();
+  // do not use undo if tool is currently in use
+  if (!toolH->isToolBusy()) {
+    bool ret = TUndoManager::manager()->undo();
+    if (!ret) DVGui::error(QObject::tr("No more Undo operations available."));
   }
-
-  bool ret = TUndoManager::manager()->undo();
-  if (!ret) DVGui::error(QObject::tr("No more Undo operations available."));
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -934,6 +934,13 @@ Room *MainWindow::getCurrentRoom() const {
 //-----------------------------------------------------------------------------
 
 void MainWindow::onUndo() {
+  ToolHandle *toolH = TApp::instance()->getCurrentTool();
+
+  // end tool use to avoid applying tool on removed layer on undo
+  if (toolH->isToolBusy()) {
+    toolH->getTool()->onDeactivate();
+  }
+
   bool ret = TUndoManager::manager()->undo();
   if (!ret) DVGui::error(QObject::tr("No more Undo operations available."));
 }


### PR DESCRIPTION
This PR fixes issue #4887, crashing after creating layer and holding Ctrl+Z while drawing.

To fix this, I just deactivated the tool before the undo of the Ctrl+Z. Maybe it's better to just disable Ctrl+Z while drawing, any thoughts??