### PR TITLE
Bug Fix #5207: fix typo in test condition to use atos on MACOSX

### DIFF
--- a/toonz/sources/toonz/crashhandler.cpp
+++ b/toonz/sources/toonz/crashhandler.cpp
@@ -288,7 +288,7 @@ static bool sh(std::string &out, const char *cmd) {
 
 static bool addr2line(std::string &out, const char *exepath, const char *addr) {
   char cmd[512];
-#ifdef OSX
+#ifdef MACOSX
   sprintf(cmd, "atos -o \"%.400s\" %s 2>&1", exepath, addr);
 #else
   sprintf(cmd, "addr2line -f -p -e \"%.400s\" %s 2>&1", exepath, addr);


### PR DESCRIPTION
Fix #5207 by changing test condition from `OSX` instead to `MACOSX` in [crashhandler.cpp](https://github.com/opentoonz/opentoonz/blob/b7470844aec8f730d1e4bc5a841d86bd53ddee6c/toonz/sources/toonz/crashhandler.cpp#L291)