### PR TITLE
Update vcpkg libraries

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -6,11 +6,12 @@ jobs:
   Windows:
     runs-on: windows-2019
     env:
-      vcpkg_ref: 14e7bb4ae24616ec54ff6b2f6ef4e8659434ea44
+      vcpkg_ref: cd5e746ec203c8c3c61647e0886a8df8c1e78e41
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2/download
       QT_ROOT: ${{github.workspace}}/3rdparty/qt
       QT_URL: https://github.com/shun-iwasawa/qt5/releases/download/v5.15.2_wintab/Qt5.15.2_wintab.zip
+      LTIFF: ${{github.workspace}}/thirdparty/tiff-4.0.3/lib/LibTIFF-4.0.3_2015_64.lib
     steps:
     - uses: actions/checkout@v2
 
@@ -153,7 +154,7 @@ jobs:
         cd build
         $env:BOOST_ROOT = '${{ env.BOOST_ROOT }}'
         $env:QT_PATH = '${{ env.QT_ROOT }}/Qt5.15.2_wintab/5.15.2_wintab/msvc2019_64'
-        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DQT_PATH="$env:QT_PATH" -DOpenCV_DIR='C:/vcpkg/installed/x64-windows/share/opencv' -DBOOST_ROOT="$env:BOOST_ROOT" -DWITH_WINTAB=ON
+        cmake ../sources -G 'Visual Studio 16 2019' -Ax64 -DCMAKE_TOOLCHAIN_FILE='C:/vcpkg/scripts/buildsystems/vcpkg.cmake' -DProtobuf_DIR='C:/vcpkg/installed/x64-windows/share/protobuf/' -Dquirc_DIR='C:/vcpkg/installed/x64-windows/share/quirc/' -DTIFF_LIBRARY="$env:LTIFF"  -DQT_PATH="$env:QT_PATH" -DOpenCV_DIR='C:/vcpkg/installed/x64-windows/share/opencv' -DBOOST_ROOT="$env:BOOST_ROOT" -DWITH_WINTAB=ON 
         cmake --build . --config Release
 
     - name: Create Artifact
@@ -167,15 +168,15 @@ jobs:
         ${{ env.QT_ROOT }}/Qt5.15.2_wintab/5.15.2_wintab/msvc2019_64/bin/windeployqt.exe OpenToonz.exe
         cp C:/vcpkg/installed/x64-windows/bin/freeglut.dll .
         cp C:/vcpkg/installed/x64-windows/bin/glew32.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/opencv_world.dll .
+        cp C:/vcpkg/installed/x64-windows/bin/opencv_world4.dll .
         cp C:/vcpkg/installed/x64-windows/bin/zlib1.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/webp.dll .
+        cp C:/vcpkg/installed/x64-windows/bin/libwebp.dll .
         cp C:/vcpkg/installed/x64-windows/bin/libpng16.dll .
         cp C:/vcpkg/installed/x64-windows/bin/jpeg62.dll .
         cp C:/vcpkg/installed/x64-windows/bin/tiff.dll .
         cp C:/vcpkg/installed/x64-windows/bin/liblzma.dll .
         cp C:/vcpkg/installed/x64-windows/bin/libprotobuf.dll .
-        cp C:/vcpkg/installed/x64-windows/bin/webpdecoder.dll .
+        cp C:/vcpkg/installed/x64-windows/bin/libwebpdecoder.dll .
 
     - uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
The current version of opentoonz has an outdated windows workflow test:

![image](https://github.com/opentoonz/opentoonz/assets/77250215/85e97ad8-8e8c-417c-8da8-cc232073ee94)
Failed workflow link: https://github.com/Funinja/opentoonz/actions/runs/7109875503/job/19389469866 

Specifically, its vcpkg version is outdated.

This PR updates the vcpkg commit version and updates the names and imports of updated libraries in the windows workflow file.
Successful workflow after my update: https://github.com/Funinja/opentoonz/actions/runs/7120719117/job/19388561922 



