### PR TITLE
fixing workflow_macos.yml

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -10,7 +10,7 @@ jobs:
 
     - name: Remove symlinks
       run: |
-        # remove existing symlinks before installing python@3.10 and 3.11
+        # remove existing symlinks before installing python@3.10, 3.11, and 3.12
         rm /usr/local/bin/2to3
         rm /usr/local/bin/idle3
         rm /usr/local/bin/pydoc3
@@ -21,6 +21,11 @@ jobs:
         rm /usr/local/bin/pydoc3.11
         rm /usr/local/bin/python3.11
         rm /usr/local/bin/python3.11-config
+        rm /usr/local/bin/2to3-3.12
+        rm /usr/local/bin/idle3.12
+        rm /usr/local/bin/pydoc3.12
+        rm /usr/local/bin/python3.12
+        rm /usr/local/bin/python3.12-config
 
     - name: Install libraries
       run: |


### PR DESCRIPTION
This PR fixes the brew installation of the macos test workflow file.

I believe that the GitHub macos workflow may have been updated to include python 3.12, which would break the brew installation if the python 3.12 symlinks are not removed. Therefore, I just added their removal in the symlink remove step in the macos workflow file to fix the build test.

Successful build after my fix: https://github.com/Funinja/opentoonz/actions/runs/7152992464 

