### PR TITLE
Sub-Xsheet Navigation Bar

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2268,7 +2268,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #262728;
 }

--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2267,6 +2267,14 @@ Ruler {
 #RenameCellField {
   padding-right: 3;
 }
+#XsheetBreadcrumbs {
+  padding: 0;
+  margin: 0;
+  border-bottom: 1 solid #262728;
+}
+#XsheetBreadcrumbs::separator:horizontal {
+  margin: 0 0 0 2;
+}
 /* xsheetColumnHeader (Context Menus)
 ----------------------------------------------------------------------------- */
 #xsheetColumnAreaMenu_Preview {

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2268,7 +2268,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #111111;
 }

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2267,6 +2267,14 @@ Ruler {
 #RenameCellField {
   padding-right: 3;
 }
+#XsheetBreadcrumbs {
+  padding: 0;
+  margin: 0;
+  border-bottom: 1 solid #111111;
+}
+#XsheetBreadcrumbs::separator:horizontal {
+  margin: 0 0 0 2;
+}
 /* xsheetColumnHeader (Context Menus)
 ----------------------------------------------------------------------------- */
 #xsheetColumnAreaMenu_Preview {

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2267,6 +2267,14 @@ Ruler {
 #RenameCellField {
   padding-right: 3;
 }
+#XsheetBreadcrumbs {
+  padding: 0;
+  margin: 0;
+  border-bottom: 1 solid #2c2c2c;
+}
+#XsheetBreadcrumbs::separator:horizontal {
+  margin: 0 0 0 2;
+}
 /* xsheetColumnHeader (Context Menus)
 ----------------------------------------------------------------------------- */
 #xsheetColumnAreaMenu_Preview {

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2268,7 +2268,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #2c2c2c;
 }

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -40,6 +40,15 @@
   padding-right: 3;
 }
 
+#XsheetBreadcrumbs {
+  padding: 0;
+  margin: 0;
+  border-bottom: 1 solid @accent;
+  &::separator:horizontal {
+    margin: 0 0 0 2;
+  }
+}
+
 /* xsheetColumnHeader (Context Menus)
 ----------------------------------------------------------------------------- */
 

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -41,7 +41,7 @@
 }
 
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid @accent;
   &::separator:horizontal {

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2267,6 +2267,14 @@ Ruler {
 #RenameCellField {
   padding-right: 3;
 }
+#XsheetBreadcrumbs {
+  padding: 0;
+  margin: 0;
+  border-bottom: 1 solid #a8a8a8;
+}
+#XsheetBreadcrumbs::separator:horizontal {
+  margin: 0 0 0 2;
+}
 /* xsheetColumnHeader (Context Menus)
 ----------------------------------------------------------------------------- */
 #xsheetColumnAreaMenu_Preview {

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2268,7 +2268,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #a8a8a8;
 }

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2267,6 +2267,14 @@ Ruler {
 #RenameCellField {
   padding-right: 3;
 }
+#XsheetBreadcrumbs {
+  padding: 0;
+  margin: 0;
+  border-bottom: 1 solid #5a5a5a;
+}
+#XsheetBreadcrumbs::separator:horizontal {
+  margin: 0 0 0 2;
+}
 /* xsheetColumnHeader (Context Menus)
 ----------------------------------------------------------------------------- */
 #xsheetColumnAreaMenu_Preview {

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2268,7 +2268,7 @@ Ruler {
   padding-right: 3;
 }
 #XsheetBreadcrumbs {
-  padding: 0;
+  padding: 0 5px 0 5px;
   margin: 0;
   border-bottom: 1 solid #5a5a5a;
 }

--- a/toonz/sources/include/toonz/childstack.h
+++ b/toonz/sources/include/toonz/childstack.h
@@ -5,6 +5,8 @@
 
 #include "tcommon.h"
 
+#include "toonz/txshchildlevel.h"
+
 #undef DVAPI
 #undef DVVAR
 #ifdef TOONZLIB_EXPORTS
@@ -36,11 +38,29 @@ class TXshChildLevel;
    properties, getAncestor(), getAncestorCount(), getAncestorAffine(),
    getTopXsheet().
 */
+
 //=============================================================================
+//! The Node class is a container of element necessary to define a sub-xsheet.
+/*!
+   The class contain a pointer to \b TXsheet \b m_xsheet, two integer to
+   identify column
+   \b m_col and row \b m_row, a \b TXshChildLevelP \b m_cl and a bool \b
+   m_justCreated.
+*/
+
+class AncestorNode {
+public:
+  TXsheet *m_xsheet;
+  int m_row, m_col;
+  std::map<int, int> m_rowTable;
+  TXshChildLevelP m_cl;
+  bool m_justCreated;
+  AncestorNode()
+      : m_xsheet(0), m_row(0), m_col(0), m_rowTable(), m_justCreated(false) {}
+};
 
 class DVAPI ChildStack {
-  class Node;
-  std::vector<Node *> m_stack;
+  std::vector<AncestorNode *> m_stack;
   TXsheet *m_xsheet;
   ToonzScene *m_scene;
 
@@ -113,6 +133,8 @@ Set aff to ancestor affine in \b row. Return true if all ancestors are
 visible in \b row.
 */
   bool getAncestorAffine(TAffine &aff, int row) const;
+
+  AncestorNode *getAncestorInfo(int ancestorDepth);
 
 private:
   // not implemented

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -390,6 +390,9 @@ public:
   bool isShowXSheetToolbarEnabled() const {
     return getBoolValue(showXSheetToolbar);
   }
+  bool isShowXsheetBreadcrumbsEnabled() const {
+    return getBoolValue(showXsheetBreadcrumbs);
+  }
   bool isExpandFunctionHeaderEnabled() const {
     return getBoolValue(expandFunctionHeader);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -130,6 +130,7 @@ enum PreferencesItemId {
   inputCellsWithoutDoubleClickingEnabled,
   shortcutCommandsWhileRenamingCellEnabled,
   showXSheetToolbar,
+  showXsheetBreadcrumbs,
   expandFunctionHeader,
   showColumnNumbers,
   unifyColumnVisibilityToggles,

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -146,6 +146,7 @@ if(PLATFORM EQUAL 64)
         cameracapturelevelcontrol.h
         penciltestpopup.h
         navtageditorpopup.h
+        xshbreadcrumbs.h
     )
 else()
     set(MOC_HEADERS
@@ -153,6 +154,7 @@ else()
         cameracapturelevelcontrol_qt.h
         penciltestpopup_qt.h
         navtageditorpopup.h
+        xshbreadcrumbs.h
     )
 endif()
 
@@ -404,6 +406,7 @@ if(PLATFORM EQUAL 64)
         cameracapturelevelcontrol.cpp
         penciltestpopup.cpp
         navtageditorpopup.cpp
+        xshbreadcrumbs.cpp
     )
 else()
     set(SOURCES
@@ -411,6 +414,7 @@ else()
         cameracapturelevelcontrol_qt.cpp
         penciltestpopup_qt.cpp
         navtageditorpopup.cpp
+        xshbreadcrumbs.cpp
     )
 endif()
 

--- a/toonz/sources/toonz/icons/dark/actions/16/toggle_sub_nav.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16/toggle_sub_nav.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="100%"
+   height="100%"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg9"
+   sodipodi:docname="toggle_sub_nav.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs13">
+        
+        
+        
+        
+    </defs><sodipodi:namedview
+   id="namedview11"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="31.775611"
+   inkscape:cx="11.596945"
+   inkscape:cy="9.1264964"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg9" />
+    
+<g
+   id="g8948"><rect
+     id="bg"
+     x="0"
+     y="0"
+     width="16"
+     height="16"
+     style="fill:#878787;fill-opacity:0" /><path
+     d="m 11,9 h 4 V 7 H 12 V 4 H 8 V 1 H 0 V 9 H 1 V 8 2 H 7 V 9 H 8 V 5 h 3 z m 1,0 V 8 h 2 v 1 z"
+     id="path3"
+     sodipodi:nodetypes="cccccccccccccccccccccccc" /><path
+     d="M 4.499,8 H 11 V 7 H 0 V 8 Z M 1,10 c 0.0027,0.526025 -0.257,0.696 0,1 H 14 V 10 Z M 0,4 V 5 H 7 V 4 Z"
+     style="fill-opacity:0.5"
+     id="path5"
+     sodipodi:nodetypes="cccccccccccccccc" /><path
+     id="rect4189"
+     style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:2;stroke-dasharray:none"
+     d="m 0,10 v 6 h 16 v -6 z m 1,1 h 4 l 3,2 -3,2 H 1 l 3,-2 z m 7,0 h 4 l 3,2 -3,2 H 8 l 3,-2 z"
+     sodipodi:nodetypes="ccccccccccccccccccc" /></g></svg>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2309,6 +2309,8 @@ void MainWindow::defineActions() {
                              "view_file");
   createRightClickMenuAction(MI_ToggleXSheetToolbar,
                              QT_TR_NOOP("Toggle XSheet Toolbar"), "");
+  createRightClickMenuAction(MI_ToggleXsheetBreadcrumbs,
+                             QT_TR_NOOP("Toggle Sub-Xsheet Navigation Bar"), "");
   createRightClickMenuAction(MI_ToggleXsheetCameraColumn,
                              QT_TR_NOOP("Show/Hide Xsheet Camera Column"), "");
   createRightClickMenuAction(MI_SetKeyframes, QT_TR_NOOP("&Set Key"), "Z",

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2310,7 +2310,8 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_ToggleXSheetToolbar,
                              QT_TR_NOOP("Toggle XSheet Toolbar"), "");
   createRightClickMenuAction(MI_ToggleXsheetBreadcrumbs,
-                             QT_TR_NOOP("Toggle Sub-Xsheet Navigation Bar"), "");
+                             QT_TR_NOOP("Toggle Sub-Xsheet Navigation Bar"), "",
+                             "toggle_sub_nav");
   createRightClickMenuAction(MI_ToggleXsheetCameraColumn,
                              QT_TR_NOOP("Show/Hide Xsheet Camera Column"), "");
   createRightClickMenuAction(MI_SetKeyframes, QT_TR_NOOP("&Set Key"), "Z",

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -313,6 +313,7 @@
 #define MI_UnlockAllColumns "MI_UnlockAllColumns"
 #define MI_ToggleColumnLocks "MI_ToggleColumnLocks"
 #define MI_ToggleXSheetToolbar "MI_ToggleXSheetToolbar"
+#define MI_ToggleXsheetBreadcrumbs "MI_ToggleXsheetBreadcrumbs"
 #define MI_FoldColumns "MI_FoldColumns"
 #define MI_ToggleXsheetCameraColumn "MI_ToggleXsheetCameraColumn"
 #define MI_ToggleCurrentTimeIndicator "MI_ToggleCurrentTimeIndicator"

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -687,6 +687,13 @@ void PreferencesPopup::onUnifyColumnVisibilityTogglesChanged() {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onShowXsheetBreadcrumbsClicked() {
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
+      "XsheetBreadcrumbs");
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onModifyExpressionOnMovingReferencesChanged() {
   TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
       "modifyExpressionOnMovingReferences");
@@ -1284,8 +1291,9 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {shortcutCommandsWhileRenamingCellEnabled,
        tr("Enable OpenToonz Commands' Shortcut Keys While Renaming Cell")},
       {showXSheetToolbar, tr("Show Toolbar in the Xsheet")},
+      {showXsheetBreadcrumbs, tr("Show Sub-Xsheet Navigation Bar")},
       {expandFunctionHeader,
-       tr("Expand Function Editor Header to Match Xsheet Toolbar Height*")},
+       tr("Expand Function Editor Header to Match Xsheet Header Height*")},
       {showColumnNumbers, tr("Show Column Numbers in Column Headers")},
       {unifyColumnVisibilityToggles,
        tr("Unify Preview and Camstand Visibility Toggles")},
@@ -2024,8 +2032,12 @@ QWidget* PreferencesPopup::createXsheetPage() {
   insertUI(useArrowKeyToShiftCellSelection, lay);
   insertUI(inputCellsWithoutDoubleClickingEnabled, lay);
   insertUI(shortcutCommandsWhileRenamingCellEnabled, lay);
-  QGridLayout* xshToolbarLay = insertGroupBoxUI(showXSheetToolbar, lay);
-  { insertUI(expandFunctionHeader, xshToolbarLay); }
+  QGridLayout* xshToolbarLay = insertGroupBox(tr("Xsheet Tools"), lay);
+  {
+    insertUI(showXSheetToolbar, xshToolbarLay);
+    insertUI(showXsheetBreadcrumbs, xshToolbarLay);
+    insertUI(expandFunctionHeader, xshToolbarLay);
+  }
   insertUI(showColumnNumbers, lay);
   insertUI(unifyColumnVisibilityToggles, lay);
   insertUI(parentColorsInXsheetColumn, lay);
@@ -2046,6 +2058,8 @@ QWidget* PreferencesPopup::createXsheetPage() {
   m_onEditedFuncMap.insert(
       unifyColumnVisibilityToggles,
       &PreferencesPopup::onUnifyColumnVisibilityTogglesChanged);
+  m_onEditedFuncMap.insert(showXsheetBreadcrumbs,
+                           &PreferencesPopup::onShowXsheetBreadcrumbsClicked);
 
   QCheckBox* linkColumnNameWithLevelCheck =
       getUI<QCheckBox*>(linkColumnNameWithLevel);

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -140,6 +140,7 @@ private:
   void onShowKeyframesOnCellAreaChanged();
   void onShowXSheetToolbarClicked();
   void onUnifyColumnVisibilityTogglesChanged();
+  void onShowXsheetBreadcrumbsClicked();
   // Animation
   void onModifyExpressionOnMovingReferencesChanged();
   // Preview

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -382,6 +382,8 @@
     <file>icons/dark/actions/16/next_nav_tag.svg</file>
     <file>icons/dark/actions/16/prev_nav_tag.svg</file>
 
+    <file>icons/dark/actions/16/toggle_sub_nav.svg</file>
+
     <!-- Modes, Types, Options -->
 		<file>icons/dark/actions/16/ink_check.svg</file>
 		<file>icons/dark/actions/16/inks_only.svg</file>

--- a/toonz/sources/toonz/xshbreadcrumbs.cpp
+++ b/toonz/sources/toonz/xshbreadcrumbs.cpp
@@ -1,0 +1,345 @@
+#include "xshbreadcrumbs.h"
+
+// Tnz6 includes
+#include "xsheetviewer.h"
+#include "tapp.h"
+#include "menubarcommandids.h"
+
+// TnzLib includes
+#include "toonz/preferences.h"
+#include "toonz/toonzscene.h"
+#include "toonz/tscenehandle.h"
+#include "toonz/childstack.h"
+
+#include "toonzqt/menubarcommand.h"
+#include "toonzqt/tselectionhandle.h"
+#include "toonzqt/dvscrollwidget.h"
+
+// Qt includes
+#include <QWidgetAction>
+#include <QLabel>
+#include <QComboBox>
+
+//=============================================================================
+
+BreadcrumbClickableLabel::BreadcrumbClickableLabel(QString labelName,
+                                                   QWidget *parent,
+                                                   Qt::WindowFlags f)
+    : QLabel(labelName, parent) {
+  setStyleSheet("text-decoration: underline;");
+}
+
+BreadcrumbClickableLabel::~BreadcrumbClickableLabel() {}
+
+void BreadcrumbClickableLabel::mousePressEvent(QMouseEvent *event) {
+  emit clicked();
+}
+
+namespace XsheetGUI {
+//=============================================================================
+
+Breadcrumb::Breadcrumb(CrumbType crumbType, QString crumbName,
+                       CrumbWidgetType crumbWidgetType, QWidget *parent)
+    : QWidget(parent)
+    , m_crumbType(crumbType)
+    , m_col(-1)
+    , m_colList(0)
+    , m_distanceFromCurrent(0) {
+  if (crumbWidgetType == CrumbWidgetType::LABEL)
+    m_crumbWidget = new QLabel(crumbName, parent);
+  else if (crumbWidgetType == CrumbWidgetType::BUTTON) {
+    BreadcrumbClickableLabel *crumbButton =
+        new BreadcrumbClickableLabel(crumbName, parent);
+    m_crumbWidget = crumbButton;
+    connect(crumbButton, SIGNAL(clicked()), this, SLOT(onButtonClicked()));
+  } else if (crumbWidgetType == CrumbWidgetType::COMBOBOX) {
+    QComboBox *crumbCB = new QComboBox(parent);
+    m_crumbWidget      = crumbCB;
+    connect(crumbCB, SIGNAL(currentIndexChanged(int)), this,
+            SLOT(onComboBoxIndexChanged(int)));
+  }
+}
+
+void Breadcrumb::onButtonClicked() {
+  TApp *app              = TApp::instance();
+  ToonzScene *scene      = app->getCurrentScene()->getScene();
+  ChildStack *childStack = scene->getChildStack();
+
+  if (m_crumbType == CrumbType::CHILD) {
+    TXsheet *xsh = childStack->getXsheet();
+
+    int r = app->getCurrentFrame()->getFrameIndex();
+    int r0, r1;
+    xsh->getCellRange(m_col, r0, r1);
+    if (r1 < r0) r1 = r0;
+    if (r < r0)
+      r = r0;
+    else if (r > r1)
+      r = r1;
+    else {
+      TXshCell cell               = xsh->getCell(r, m_col);
+      while (cell.isEmpty()) cell = xsh->getCell(++r, m_col);
+    }
+
+    app->getCurrentColumn()->setColumnIndex(m_col);
+    app->getCurrentFrame()->setFrameIndex(r);
+    app->getCurrentSelection()->getSelection()->selectNone();
+
+    QAction *openChildAction =
+        CommandManager::instance()->getAction(MI_OpenChild);
+    if (!openChildAction) return;
+    openChildAction->trigger();
+  } else if (m_crumbType == CrumbType::ANCESTOR) {
+    QAction *closeChildAction =
+        CommandManager::instance()->getAction(MI_CloseChild);
+    if (!closeChildAction) return;
+    TUndoManager::manager()->beginBlock();
+    for (int i = 0; i > m_distanceFromCurrent; i--) closeChildAction->trigger();
+    TUndoManager::manager()->endBlock();
+  }
+}
+
+void Breadcrumb::onComboBoxIndexChanged(int index) {
+  if (m_crumbType != CrumbType::CHILD || !index) return;
+
+  TApp *app              = TApp::instance();
+  ToonzScene *scene      = app->getCurrentScene()->getScene();
+  ChildStack *childStack = scene->getChildStack();
+  TXsheet *xsh           = childStack->getXsheet();
+
+  int col = m_colList[index - 1];
+  int r   = app->getCurrentFrame()->getFrameIndex();
+  int r0, r1;
+  xsh->getCellRange(col, r0, r1);
+  if (r1 < r0) r1 = r0;
+  if (r < r0)
+    r = r0;
+  else if (r > r1)
+    r = r1;
+  else {
+    TXshCell cell               = xsh->getCell(r, col);
+    while (cell.isEmpty()) cell = xsh->getCell(++r, col);
+  }
+
+  app->getCurrentColumn()->setColumnIndex(col);
+  app->getCurrentFrame()->setFrameIndex(r);
+  app->getCurrentSelection()->getSelection()->selectNone();
+
+  QAction *openChildAction =
+      CommandManager::instance()->getAction(MI_OpenChild);
+  if (!openChildAction) return;
+  openChildAction->trigger();
+}
+
+//=============================================================================
+// BreadcrumbArea
+//-----------------------------------------------------------------------------
+
+BreadcrumbArea::BreadcrumbArea(XsheetViewer *parent, Qt::WindowFlags flags)
+    : m_viewer(parent) {
+  setObjectName("cornerWidget");
+  setFixedHeight(29);
+  setObjectName("XsheetBreadcrumbs");
+
+  m_breadcrumbWidgets.clear();
+  updateBreadcrumbs();
+}
+
+//-----------------------------------------------------------------------------
+
+void BreadcrumbArea::showBreadcrumbs(bool show) {
+  show ? this->show() : this->hide();
+}
+
+//-----------------------------------------------------------------------------
+
+void BreadcrumbArea::toggleBreadcrumbArea() {
+  bool breadcrumbsEnabled =
+      Preferences::instance()->isShowXsheetBreadcrumbsEnabled();
+  Preferences::instance()->setValue(showXsheetBreadcrumbs, !breadcrumbsEnabled);
+  TApp::instance()->getCurrentScene()->notifyPreferenceChanged(
+      "XsheetBreadcrumbs");
+}
+
+//-----------------------------------------------------------------------------
+
+void BreadcrumbArea::showEvent(QShowEvent *e) {
+  TApp *app = TApp::instance();
+  connect(app->getCurrentXsheet(), SIGNAL(xsheetSwitched()), this,
+          SLOT(updateBreadcrumbs()));
+  connect(app->getCurrentXsheet(), SIGNAL(xsheetChanged()), this,
+          SLOT(updateBreadcrumbs()));
+
+  updateBreadcrumbs();
+}
+
+//-----------------------------------------------------------------------------
+
+void BreadcrumbArea::hideEvent(QHideEvent *e) {
+  TApp *app = TApp::instance();
+  disconnect(app->getCurrentXsheet(), SIGNAL(xsheetSwitched()), this,
+             SLOT(updateBreadcrumbs()));
+  disconnect(app->getCurrentXsheet(), SIGNAL(xsheetChanged()), this,
+             SLOT(updateBreadcrumbs()));
+}
+
+//-----------------------------------------------------------------------------
+
+void BreadcrumbArea::updateBreadcrumbs() {
+  if (isHidden()) return;
+
+  // Remove the current layout
+  QLayout *currentLayout = layout();
+
+  if (currentLayout) {
+    QLayoutItem *item;
+    while ((item = currentLayout->takeAt(0)) != nullptr) {
+      currentLayout->removeWidget(item->widget());
+      item->widget()->deleteLater();
+    }
+    delete currentLayout;
+  }
+
+  m_breadcrumbWidgets.clear();
+
+  // Rebuild the breadcrumb widget list
+  TApp *app = TApp::instance();
+
+  ToonzScene *scene      = app->getCurrentScene()->getScene();
+  ChildStack *childStack = scene->getChildStack();
+  TXsheet *xsh           = childStack->getXsheet();
+  int ancestorCount      = childStack->getAncestorCount();
+
+  // Look for any sub-xsheets in current xsheet
+  std::vector<int> childCol;
+  for (int col = 0; col < xsh->getColumnCount(); col++) {
+    if (xsh->isColumnEmpty(col)) continue;
+
+    int r0, r1;
+    xsh->getCellRange(col, r0, r1);
+    TXshCell cell = xsh->getCell(r0, col);
+    TXshLevel *xl = cell.m_level.getPointer();
+    if (!xl) continue;
+    TXshChildLevel *cl = xl->getChildLevel();
+    if (!cl) continue;
+    childCol.push_back(col);
+  }
+
+  QString separator  = tr("  >  ");
+  QString separator2 = tr("  |  ");
+
+  Breadcrumb *crumb;
+
+  QString childName;
+  if (childCol.size() == 1) {
+    TStageObjectId columnId    = TStageObjectId::ColumnId(childCol[0]);
+    TStageObject *columnObject = xsh->getStageObject(columnId);
+    childName = QString::fromStdString(columnObject->getName());
+
+    crumb = new Breadcrumb(CrumbType::CHILD, childName, CrumbWidgetType::BUTTON,
+                           this);
+    crumb->setColumnNumber(childCol[0]);
+    m_breadcrumbWidgets.push_back(crumb);
+  } else if (childCol.size() > 1) {
+    crumb =
+        new Breadcrumb(CrumbType::CHILD, 0, CrumbWidgetType::COMBOBOX, this);
+    crumb->setColumnNumberList(childCol);
+    QComboBox *childCB = dynamic_cast<QComboBox *>(crumb->getCrumbWidget());
+    childCB->blockSignals(true);
+    childCB->addItem(tr("---"));
+    for (int i = 0; i < childCol.size(); i++) {
+      TStageObjectId columnId    = TStageObjectId::ColumnId(childCol[i]);
+      TStageObject *columnObject = xsh->getStageObject(columnId);
+      childName = QString::fromStdString(columnObject->getName());
+      childCB->addItem(childName);
+    }
+    childCB->blockSignals(false);
+    m_breadcrumbWidgets.push_back(crumb);
+  }
+
+  if (m_breadcrumbWidgets.size())
+    m_breadcrumbWidgets.push_back(new Breadcrumb(
+        CrumbType::SEPARATOR, separator2, CrumbWidgetType::LABEL, this));
+
+  QString ancestorName;
+  for (int i = ancestorCount; i > 0; i--) {
+    AncestorNode *ancestor = childStack->getAncestorInfo(i - 1);
+    if (!ancestor || !ancestor->m_cl || !ancestor->m_xsheet) break;
+
+    TStageObjectId columnId    = TStageObjectId::ColumnId(ancestor->m_col);
+    TStageObject *columnObject = ancestor->m_xsheet->getStageObject(columnId);
+    ancestorName = QString::fromStdString(columnObject->getName());
+
+    // Add label for current xsheet, button for everything else
+    if (i == ancestorCount)
+      crumb = new Breadcrumb(CrumbType::ANCESTOR, ancestorName,
+                             CrumbWidgetType::LABEL, this);
+    else {
+      crumb = new Breadcrumb(CrumbType::ANCESTOR, ancestorName,
+                             CrumbWidgetType::BUTTON, this);
+      crumb->setDistanceFromCurrent(i - ancestorCount);
+    }
+    m_breadcrumbWidgets.push_back(crumb);
+
+    m_breadcrumbWidgets.push_back(new Breadcrumb(
+        CrumbType::SEPARATOR, separator, CrumbWidgetType::LABEL, this));
+  }
+
+  ancestorName = tr("Main");
+  if (!ancestorCount)
+    crumb = new Breadcrumb(CrumbType::ANCESTOR, ancestorName,
+                           CrumbWidgetType::LABEL, this);
+  else {
+    crumb = new Breadcrumb(CrumbType::ANCESTOR, ancestorName,
+                           CrumbWidgetType::BUTTON, this);
+    crumb->setDistanceFromCurrent(-ancestorCount);
+  }
+  m_breadcrumbWidgets.push_back(crumb);
+
+  // Now let's put everything in a layout
+  m_breadcrumbLayout = new QHBoxLayout();
+  m_breadcrumbLayout->setMargin(0);
+  m_breadcrumbLayout->setSpacing(0);
+  {
+    if (!m_viewer->orientation()->isVerticalTimeline())
+      m_breadcrumbLayout->addSpacing(220);
+    m_breadcrumbLayout->addWidget(new QLabel(tr("Xsheet Depth:"), this), 0,
+                                  Qt::AlignCenter);
+    m_breadcrumbLayout->addSpacing(5);
+
+    std::vector<Breadcrumb *>::reverse_iterator rit;
+    for (rit = m_breadcrumbWidgets.rbegin(); rit != m_breadcrumbWidgets.rend();
+         ++rit) {
+      m_breadcrumbLayout->addWidget((*rit)->getCrumbWidget(), 0,
+                                    Qt::AlignCenter);
+    }
+  }
+  m_breadcrumbLayout->addStretch(1);
+
+  QHBoxLayout *hLayout = new QHBoxLayout;
+  hLayout->setMargin(0);
+  hLayout->setSpacing(0);
+  setLayout(hLayout);
+
+  DvScrollWidget *scrollWidget = new DvScrollWidget;
+  hLayout->addWidget(scrollWidget);
+
+  QWidget *crumbContainer = new QWidget;
+  scrollWidget->setWidget(crumbContainer);
+
+  crumbContainer->setSizePolicy(QSizePolicy::MinimumExpanding,
+                                QSizePolicy::Fixed);
+  crumbContainer->setFixedHeight(24);
+  crumbContainer->setLayout(m_breadcrumbLayout);
+}
+
+//============================================================
+
+class ToggleXsheetBreadcrumbsCommand final : public MenuItemHandler {
+public:
+  ToggleXsheetBreadcrumbsCommand()
+      : MenuItemHandler(MI_ToggleXsheetBreadcrumbs) {}
+  void execute() override { BreadcrumbArea::toggleBreadcrumbArea(); }
+} ToggleXsheetBreadcrumbsCommand;
+
+}  // namespace XsheetGUI

--- a/toonz/sources/toonz/xshbreadcrumbs.cpp
+++ b/toonz/sources/toonz/xshbreadcrumbs.cpp
@@ -83,7 +83,8 @@ void Breadcrumb::onButtonClicked() {
 
     app->getCurrentColumn()->setColumnIndex(m_col);
     app->getCurrentFrame()->setFrameIndex(r);
-    app->getCurrentSelection()->getSelection()->selectNone();
+    if (app->getCurrentSelection()->getSelection())
+      app->getCurrentSelection()->getSelection()->selectNone();
 
     QAction *openChildAction =
         CommandManager::instance()->getAction(MI_OpenChild);
@@ -123,7 +124,8 @@ void Breadcrumb::onComboBoxIndexChanged(int index) {
 
   app->getCurrentColumn()->setColumnIndex(col);
   app->getCurrentFrame()->setFrameIndex(r);
-  app->getCurrentSelection()->getSelection()->selectNone();
+  if (app->getCurrentSelection()->getSelection())
+    app->getCurrentSelection()->getSelection()->selectNone();
 
   QAction *openChildAction =
       CommandManager::instance()->getAction(MI_OpenChild);

--- a/toonz/sources/toonz/xshbreadcrumbs.cpp
+++ b/toonz/sources/toonz/xshbreadcrumbs.cpp
@@ -304,7 +304,7 @@ void BreadcrumbArea::updateBreadcrumbs() {
   m_breadcrumbLayout->setSpacing(0);
   {
     if (!m_viewer->orientation()->isVerticalTimeline())
-      m_breadcrumbLayout->addSpacing(220);
+      m_breadcrumbLayout->addSpacing(215);
     m_breadcrumbLayout->addWidget(new QLabel(tr("Xsheet Depth:"), this), 0,
                                   Qt::AlignCenter);
     m_breadcrumbLayout->addSpacing(5);

--- a/toonz/sources/toonz/xshbreadcrumbs.h
+++ b/toonz/sources/toonz/xshbreadcrumbs.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#ifndef XSHBREADCRUMBS_H
+#define XSHBREADCRUMBS_H
+
+#include <QWidget>
+#include <QLabel>
+#include <QHBoxLayout>
+
+#include "toonz/txsheet.h"
+
+//-----------------------------------------------------------------------------
+
+// forward declaration
+class XsheetViewer;
+class QAction;
+
+//-----------------------------------------------------------------------------
+
+class BreadcrumbClickableLabel : public QLabel {
+  Q_OBJECT
+
+public:
+  BreadcrumbClickableLabel(QString labelName, QWidget *parent = Q_NULLPTR,
+                           Qt::WindowFlags f = Qt::WindowFlags());
+  ~BreadcrumbClickableLabel();
+
+signals:
+  void clicked();
+
+protected:
+  void mousePressEvent(QMouseEvent *event);
+};
+
+//-----------------------------------------------------------------------------
+
+namespace XsheetGUI {
+
+enum CrumbType { SEPARATOR = 0, CURRENT, ANCESTOR, CHILD };
+enum CrumbWidgetType { LABEL = 0, BUTTON, COMBOBOX };
+
+class Breadcrumb : public QWidget {
+  Q_OBJECT
+
+  QWidget *m_crumbWidget;
+  CrumbType m_crumbType;
+  int m_col;
+  std::vector<int> m_colList;
+  int m_distanceFromCurrent;
+
+public:
+  Breadcrumb(CrumbType crumbType, QString crumbName,
+             CrumbWidgetType crumbWidgetType, QWidget *parent);
+  ~Breadcrumb() {}
+
+  void setColumnNumber(int col) { m_col = col; }
+  void setColumnNumberList(std::vector<int> colList) { m_colList = colList; }
+  void setDistanceFromCurrent(int distance) {
+    m_distanceFromCurrent = distance;
+  }
+
+  QWidget *getCrumbWidget() { return m_crumbWidget; }
+
+public slots:
+  void onButtonClicked();
+  void onComboBoxIndexChanged(int);
+};
+
+//=============================================================================
+// BreadcrumbArea
+//-----------------------------------------------------------------------------
+
+class BreadcrumbArea final : public QFrame {
+  Q_OBJECT
+
+  XsheetViewer *m_viewer;
+  std::vector<Breadcrumb *> m_breadcrumbWidgets;
+
+  QHBoxLayout *m_breadcrumbLayout;
+
+public:
+  BreadcrumbArea(XsheetViewer *parent  = 0,
+                 Qt::WindowFlags flags = Qt::WindowFlags());
+  static void toggleBreadcrumbArea();
+  void showBreadcrumbs(bool show);
+
+protected:
+  void showEvent(QShowEvent *e) override;
+  void hideEvent(QHideEvent *e) override;
+
+public slots:
+  void updateBreadcrumbs();
+};
+
+}  // namespace XsheetGUI
+
+#endif  // XSHBREADCRUMBS_H

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2993,6 +2993,7 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
     }
     menu.addSeparator();
     menu.addAction(cmdManager->getAction(MI_ToggleXSheetToolbar));
+    menu.addAction(cmdManager->getAction(MI_ToggleXsheetBreadcrumbs));
 
     if (isCamera) {
       menu.exec(event->globalPos());

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -451,6 +451,7 @@ void XsheetViewer::positionSections() {
                                          XsheetGUI::BREADCRUMB_HEIGHT);
       bodyLayer = bodyLayer.adjusted(XsheetGUI::BREADCRUMB_HEIGHT, 0);
     }
+    m_breadcrumbArea->updateBreadcrumbs();
   } else {
     m_breadcrumbArea->showBreadcrumbs(false);
     m_breadcrumbScrollArea->setGeometry(0, 0, 0, 0);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -53,12 +53,13 @@ TEnv::IntVar FrameDisplayStyleInXsheetRowArea(
 namespace XsheetGUI {
 //-----------------------------------------------------------------------------
 
-const int ColumnWidth     = 74;
-const int RowHeight       = 20;
-const int SCROLLBAR_WIDTH = 16;
-const int TOOLBAR_HEIGHT  = 29;
-const int ZOOM_FACTOR_MAX = 100;
-const int ZOOM_FACTOR_MIN = 20;
+const int ColumnWidth       = 74;
+const int RowHeight         = 20;
+const int SCROLLBAR_WIDTH   = 16;
+const int TOOLBAR_HEIGHT    = 29;
+const int BREADCRUMB_HEIGHT = 29;
+const int ZOOM_FACTOR_MAX   = 100;
+const int ZOOM_FACTOR_MIN   = 20;
 }  // namespace XsheetGUI
 
 //=============================================================================
@@ -261,6 +262,12 @@ XsheetViewer::XsheetViewer(QWidget *parent, Qt::WindowFlags flags)
   m_toolbar = new XsheetGUI::XSheetToolbar(this, Qt::WindowFlags(), true);
   m_toolbarScrollArea->setWidget(m_toolbar);
 
+  m_breadcrumbArea = new XsheetGUI::BreadcrumbArea(this, Qt::WindowFlags());
+  m_breadcrumbScrollArea = new XsheetScrollArea(this);
+  m_breadcrumbScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  m_breadcrumbScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  m_breadcrumbScrollArea->setWidget(m_breadcrumbArea);
+
   m_noteArea       = new XsheetGUI::NoteArea(this);
   m_noteScrollArea = new XsheetScrollArea(this);
   m_noteScrollArea->setObjectName("xsheetArea");
@@ -422,6 +429,31 @@ void XsheetViewer::positionSections() {
     }
   } else {
     m_toolbar->showToolbar(false);
+    m_toolbarScrollArea->setGeometry(0, 0, 0, 0);
+  }
+
+  if (Preferences::instance()->isShowXsheetBreadcrumbsEnabled()) {
+    m_breadcrumbArea->showBreadcrumbs(true);
+    int w = visibleRegion().boundingRect().width();
+    if (o->isVerticalTimeline())
+      m_breadcrumbScrollArea->setGeometry(0, headerFrame.from(), w,
+                                          XsheetGUI::BREADCRUMB_HEIGHT);
+    else
+      m_breadcrumbScrollArea->setGeometry(0, headerLayer.from(), w,
+                                          XsheetGUI::BREADCRUMB_HEIGHT);
+    m_breadcrumbArea->setFixedWidth(w);
+    if (o->isVerticalTimeline()) {
+      headerFrame = headerFrame.adjusted(XsheetGUI::BREADCRUMB_HEIGHT,
+                                         XsheetGUI::BREADCRUMB_HEIGHT);
+      bodyFrame = bodyFrame.adjusted(XsheetGUI::BREADCRUMB_HEIGHT, 0);
+    } else {
+      headerLayer = headerLayer.adjusted(XsheetGUI::BREADCRUMB_HEIGHT,
+                                         XsheetGUI::BREADCRUMB_HEIGHT);
+      bodyLayer = bodyLayer.adjusted(XsheetGUI::BREADCRUMB_HEIGHT, 0);
+    }
+  } else {
+    m_breadcrumbArea->showBreadcrumbs(false);
+    m_breadcrumbScrollArea->setGeometry(0, 0, 0, 0);
   }
 
   m_noteScrollArea->setGeometry(o->frameLayerRect(headerFrame, headerLayer));
@@ -1446,7 +1478,7 @@ void XsheetViewer::onXsheetChanged() {
 //-----------------------------------------------------------------------------
 
 void XsheetViewer::onPreferenceChanged(const QString &prefName) {
-  if (prefName == "XSheetToolbar") {
+  if (prefName == "XSheetToolbar" || prefName == "XsheetBreadcrumbs") {
     positionSections();
     refreshContentSize(0, 0);
   } else if (prefName == "XsheetCamera") {

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -16,6 +16,7 @@
 #include "saveloadqsettings.h"
 #include "toonzqt/spreadsheetviewer.h"
 #include "orientation.h"
+#include "xshbreadcrumbs.h"
 #include <boost/optional.hpp>
 
 using boost::optional;
@@ -601,12 +602,15 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   XsheetScrollArea *m_rowScrollArea;
   XsheetScrollArea *m_noteScrollArea;
   XsheetScrollArea *m_toolbarScrollArea;
+  XsheetScrollArea *m_breadcrumbScrollArea;
 
   XsheetGUI::ColumnArea *m_columnArea;
   XsheetGUI::RowArea *m_rowArea;
   XsheetGUI::CellArea *m_cellArea;
   XsheetGUI::NoteArea *m_noteArea;
   XsheetGUI::XSheetToolbar *m_toolbar;
+  XsheetGUI::BreadcrumbArea *m_breadcrumbArea;
+  
   LayerFooterPanel *m_layerFooterPanel;
 
   Spreadsheet::FrameScroller m_frameScroller;

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -581,6 +581,8 @@ void Preferences::definePreferenceItems() {
   define(shortcutCommandsWhileRenamingCellEnabled,
          "shortcutCommandsWhileRenamingCellEnabled", QMetaType::Bool, false);
   define(showXSheetToolbar, "showXSheetToolbar", QMetaType::Bool, true);
+  define(showXsheetBreadcrumbs, "showXsheetBreadcrumbs", QMetaType::Bool,
+         false);
   define(expandFunctionHeader, "expandFunctionHeader", QMetaType::Bool, false);
   define(showColumnNumbers, "showColumnNumbers", QMetaType::Bool, false);
   define(unifyColumnVisibilityToggles, "unifyColumnVisibilityToggles",

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -220,12 +220,17 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
     bool toolBarVisible =
         Preferences::instance()->isShowXSheetToolbarEnabled() &&
         Preferences::instance()->isExpandFunctionHeaderEnabled();
+    bool breadcrumbsVisible =
+        Preferences::instance()->isShowXsheetBreadcrumbsEnabled() &&
+        Preferences::instance()->isExpandFunctionHeaderEnabled();
     if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
-      spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0),
+      spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0) +
+                                ((breadcrumbsVisible) ? 10 : 0),
                          QSizePolicy::Fixed, QSizePolicy::Fixed);
       spacer->invalidate();
     } else
-      m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0));
+      m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0) +
+                               ((breadcrumbsVisible) ? 10 : 0));
     if (m_toggleStart ==
         Preferences::FunctionEditorToggle::ShowGraphEditorInPopup) {
       m_functionGraph->hide();
@@ -508,14 +513,19 @@ void FunctionViewer::toggleMode() {
       bool toolBarVisible =
           Preferences::instance()->isShowXSheetToolbarEnabled() &&
           Preferences::instance()->isExpandFunctionHeaderEnabled();
+      bool breadcrumbsVisible =
+          Preferences::instance()->isShowXsheetBreadcrumbsEnabled() &&
+          Preferences::instance()->isExpandFunctionHeaderEnabled();
       if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
-        spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0),
+        spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0) +
+                                  ((breadcrumbsVisible) ? 10 : 0),
                            QSizePolicy::Fixed, QSizePolicy::Fixed);
         spacer->invalidate();
         m_numericalColumns->updateHeaderHeight();
         m_leftLayout->setSpacing(0);
       } else
-        m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0));
+        m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0) +
+                                 ((breadcrumbsVisible) ? 10 : 0));
       updateGeometry();
       m_toggleStatus = 0;
     } else {
@@ -660,7 +670,9 @@ void FunctionViewer::doSwitchCurrentObject(TStageObject *obj) {
 //-----------------------------------------------------------------------------
 
 void FunctionViewer::onPreferenceChanged(const QString &prefName) {
-  if (prefName != "XSheetToolbar" && !prefName.isEmpty()) return;
+  if (prefName != "XSheetToolbar" && prefName != "XsheetBreadcrumbs" &&
+      !prefName.isEmpty())
+    return;
   if (!Preferences::instance()->isExpandFunctionHeaderEnabled()) return;
   if (m_toggleStart ==
       Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup)
@@ -683,16 +695,21 @@ void FunctionViewer::onPreferenceChanged(const QString &prefName) {
   bool toolBarVisible =
       Preferences::instance()->isShowXSheetToolbarEnabled() &&
       Preferences::instance()->isExpandFunctionHeaderEnabled();
+  bool breadcrumbsVisible =
+      Preferences::instance()->isShowXsheetBreadcrumbsEnabled() &&
+      Preferences::instance()->isExpandFunctionHeaderEnabled();
   m_functionGraph->hide();
   m_numericalColumns->show();
   if (QSpacerItem *spacer = m_leftLayout->itemAt(0)->spacerItem()) {
-    spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0),
+    spacer->changeSize(1, m_spacing + ((toolBarVisible) ? 10 : 0) +
+                              ((breadcrumbsVisible) ? 10 : 0),
                        QSizePolicy::Fixed, QSizePolicy::Fixed);
     spacer->invalidate();
     m_numericalColumns->updateHeaderHeight();
     m_leftLayout->setSpacing(0);
   } else
-    m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0));
+    m_leftLayout->setSpacing(m_spacing + ((toolBarVisible) ? 30 : 0) +
+                             ((breadcrumbsVisible) ? 30 : 0));
   updateGeometry();
 }
 


### PR DESCRIPTION
This was a requested T2D port to add the following feature:

This new feature will make it easier to visualize and navigate multiple nested sub-xsheets.

![image](https://github.com/opentoonz/opentoonz/assets/19245851/3ba9d58c-aaea-467c-8bd3-83c433adeded)

The panel in the timeline/xsheet shows you where you are in nested sub-xsheets (Xsheet Depth), relative to the main. You can click on any prior sub-xsheet breadcrumb to return to it quickly. Breadcrumbs will also show what sub-xsheets are in the current timeline/xsheet you can open. Click on the breadcrumb to enter it. In cases of multiple sub-xsheets in the current timeline/xsheet, a dropdown will be shown. Select the one you want to enter.

This new panel can be toggled on from column header's context menu, a defined shortcut or in Preferences -> Xsheet

![image](https://github.com/opentoonz/opentoonz/assets/19245851/d926c18c-cf01-4e94-91f3-09cde2db6a23)

![image](https://github.com/opentoonz/opentoonz/assets/19245851/1fd11841-fc67-4983-877f-8ef6f86ce924)
