### PR TITLE
Porting some fixes

### DIFF
--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -55,6 +55,10 @@ class DVAPI RasterSelection final : public TSelection {
   bool m_isPastedSelection;
   bool m_noAntialiasing;
 
+  bool m_createdFrame;
+  bool m_createdLevel;
+  bool m_renumberedLevel;
+
 private:
   bool pasteSelection(const RasterImageData *data);
 
@@ -100,6 +104,10 @@ public:
   void setNoAntialiasing(bool value) { m_noAntialiasing = value; }
 
   bool isPastedSelection() const { return m_isPastedSelection; }
+
+  bool wasFrameCreated() const { return m_createdFrame; }
+  bool wasLevelCreated() const { return m_createdLevel; }
+  bool wasLevelRenumbered() const { return m_renumberedLevel; }
 
   /*! Returns strokes bounding box.*/
   TRectD getStrokesBound(std::vector<TStroke> strokes) const;

--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -171,7 +171,8 @@ protected:
 public:
   TToolUndo(TXshSimpleLevel *level, const TFrameId &frameId,
             bool createdFrame = false, bool createdLevel = false,
-            const TPaletteP &oldPalette = 0);
+            const TPaletteP &oldPalette = 0,
+            bool renumberedLevel        = TTool::m_isLevelRenumbererd);
   ~TToolUndo();
 
   virtual QString getToolName() { return QString("Tool"); }

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -383,12 +383,16 @@ int UndoDeleteSelection::m_id = 0;
 // UndoPasteSelection
 //-----------------------------------------------------------------------------
 
-class UndoPasteSelection final : public TUndo {
+class UndoPasteSelection final : public ToolUtils::TToolUndo {
   RasterSelection *m_currentSelection, m_newSelection;
 
 public:
-  UndoPasteSelection(RasterSelection *currentSelection)
-      : TUndo()
+  UndoPasteSelection(RasterSelection *currentSelection, TXshSimpleLevel *sl,
+                     const TPaletteP &oldPalette)
+      : TToolUndo(sl, currentSelection->getFrameId(),
+                  currentSelection->wasFrameCreated(),
+                  currentSelection->wasLevelCreated(), oldPalette,
+                  currentSelection->wasLevelRenumbered())
       , m_currentSelection(currentSelection)
       , m_newSelection(*currentSelection) {}
 
@@ -398,9 +402,17 @@ public:
     m_currentSelection->setFloatingSeletion(TRasterP());
     m_currentSelection->selectNone();
     m_currentSelection->notify();
+    removeLevelAndFrameIfNeeded();
+    if (m_createdFrame)
+      TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
+    notifyImageChanged();
   }
 
   void redo() const override {
+    insertLevelAndFrameIfNeeded();
+    if (m_createdFrame)
+      TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
+    notifyImageChanged();
     *m_currentSelection = m_newSelection;
     m_currentSelection->notify();
   }
@@ -414,7 +426,7 @@ public:
 // UndoPasteFloatingSelection
 //-----------------------------------------------------------------------------
 
-class UndoPasteFloatingSelection final : public TUndo {
+class UndoPasteFloatingSelection final : public ToolUtils::TToolUndo {
   static int m_id;
 
   TXshCell m_imageCell;  //!< Level/frame pair to the pasted-to image
@@ -433,8 +445,12 @@ class UndoPasteFloatingSelection final : public TUndo {
 
 public:
   UndoPasteFloatingSelection(RasterSelection *currentSelection,
-                             TPalette *oldPalette, bool noAntialiasing)
-      : TUndo()
+                             TXshSimpleLevel *sl, TPalette *oldPalette,
+                             bool noAntialiasing)
+      : TToolUndo(sl, currentSelection->getFrameId(),
+                  currentSelection->wasFrameCreated(),
+                  currentSelection->wasLevelCreated(), oldPalette,
+                  currentSelection->wasLevelRenumbered())
       , m_imageCell(currentSelection->getCurrentImageCell())
       , m_oldPalette(oldPalette ? oldPalette->clone() : 0)
       , m_strokes(currentSelection->getOriginalStrokes())
@@ -537,6 +553,10 @@ public:
     app->getPaletteController()
         ->getCurrentLevelPalette()
         ->notifyPaletteChanged();
+
+    removeLevelAndFrameIfNeeded();
+    if (m_createdFrame) app->getCurrentXsheet()->notifyXsheetChanged();
+
     if (!m_tool) return;
     m_tool->notifyImageChanged(m_frameId);
     m_tool->invalidate();
@@ -547,6 +567,11 @@ public:
     TImageP floatingImage =
         TImageCache::instance()->get(m_floatingImageId, false);
     if (!floatingImage || !image) return;
+
+    TTool::Application *app = TTool::getApplication();
+    insertLevelAndFrameIfNeeded();
+    if (m_createdFrame) app->getCurrentXsheet()->notifyXsheetChanged();
+
     TRasterP floatingRas = getRaster(floatingImage);
 
     TXshSimpleLevelP sl(m_imageCell.getSimpleLevel());
@@ -561,7 +586,6 @@ public:
     ToolUtils::updateSaveBox(sl, fid);
 
     if (m_newPalette) image->getPalette()->assign(m_newPalette->clone());
-    TTool::Application *app = TTool::getApplication();
     app->getPaletteController()
         ->getCurrentLevelPalette()
         ->notifyPaletteChanged();
@@ -880,7 +904,10 @@ RasterSelection::RasterSelection()
     , m_fid()
     , m_transformationCount(0)
     , m_isPastedSelection(false)
-    , m_noAntialiasing(false) {
+    , m_noAntialiasing(false)
+    , m_createdFrame(false)
+    , m_createdLevel(false)
+    , m_renumberedLevel(false) {
   m_strokes.clear();
   m_originalStrokes.clear();
 }
@@ -900,6 +927,9 @@ RasterSelection::RasterSelection(const RasterSelection &src)
     , m_transformationCount(src.m_transformationCount)
     , m_isPastedSelection(src.m_isPastedSelection)
     , m_noAntialiasing(src.m_noAntialiasing)
+    , m_createdFrame(src.m_createdFrame)
+    , m_createdLevel(src.m_createdLevel)
+    , m_renumberedLevel(src.m_renumberedLevel)
 
 {
   setView(src.getView());
@@ -949,6 +979,9 @@ void RasterSelection::selectNone() {
   m_transformationCount       = 0;
   m_isPastedSelection         = false;
   m_oldPalette                = 0;
+  m_createdFrame              = false;
+  m_createdLevel              = false;
+  m_renumberedLevel           = false;
   notify();
 }
 
@@ -1047,7 +1080,8 @@ void RasterSelection::pasteFloatingSelection() {
 
   if (m_transformationCount > 0 || m_isPastedSelection)
     TUndoManager::manager()->add(new UndoPasteFloatingSelection(
-        this, m_oldPalette.getPointer(), m_noAntialiasing));
+        this, m_currentImageCell.getSimpleLevel(), m_oldPalette.getPointer(),
+        m_noAntialiasing));
   else if (m_transformationCount == 0)
     TUndoManager::manager()->popUndo(-1, true);
 
@@ -1214,6 +1248,10 @@ void RasterSelection::pasteSelection() {
   if (isFloating()) pasteFloatingSelection();
   selectNone();
   m_isPastedSelection = true;
+  m_createdFrame      = tool->m_isFrameCreated;
+  m_createdLevel      = tool->m_isLevelCreated;
+  m_renumberedLevel   = tool->m_isLevelRenumbererd;
+
   if (!m_currentImageCell.getSimpleLevel()) {
     const TXshCell &imageCell = TTool::getImageCell();
 
@@ -1293,7 +1331,8 @@ void RasterSelection::pasteSelection() {
 
   app->getPaletteController()->getCurrentLevelPalette()->notifyPaletteChanged();
   notify();
-  TUndoManager::manager()->add(new UndoPasteSelection(this));
+  if (m_createdFrame) tool->notifyImageChanged(m_fid);
+  TUndoManager::manager()->add(new UndoPasteSelection(this, sl, m_oldPalette));
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -451,7 +451,8 @@ TStroke *ToolUtils::merge(const ArrayOfStroke &a) {
 
 ToolUtils::TToolUndo::TToolUndo(TXshSimpleLevel *level, const TFrameId &frameId,
                                 bool createdFrame, bool createdLevel,
-                                const TPaletteP &oldPalette)
+                                const TPaletteP &oldPalette,
+                                bool renumberedLevel)
     : TUndo()
     , m_level(level)
     , m_frameId(frameId)
@@ -461,7 +462,7 @@ ToolUtils::TToolUndo::TToolUndo(TXshSimpleLevel *level, const TFrameId &frameId,
     , m_isEditingLevel(false)
     , m_createdFrame(createdFrame)
     , m_createdLevel(createdLevel)
-    , m_renumberedLevel(TTool::m_isLevelRenumbererd)
+    , m_renumberedLevel(renumberedLevel)
     , m_imageId("") {
   TTool::Application *app = TTool::getApplication();
   m_isEditingLevel        = app->getCurrentFrame()->isEditingLevel();
@@ -552,7 +553,6 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
         app->getCurrentScene()->notifyCastChange();
       }
     }
-    app->getCurrentLevel()->notifyLevelChange();
   }
   if (m_oldPalette.getPointer()) {
     m_level->getPalette()->assign(m_oldPalette->clone());
@@ -568,6 +568,8 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
     m_level->renumber(m_oldFids);
     app->getCurrentXsheet()->notifyXsheetChanged();
   }
+  if (m_createdFrame || m_createdLevel)
+    app->getCurrentLevel()->notifyLevelChange();
 }
 
 //------------------------------------------------------------------------------------------

--- a/toonz/sources/toonz/columncommand.cpp
+++ b/toonz/sources/toonz/columncommand.cpp
@@ -813,6 +813,7 @@ void InsertEmptyColumnsUndo::undo() const {
 
 void ColumnCmd::insertEmptyColumns(const std::set<int> &indices,
                                    bool insertAfter) {
+  if (indices.empty()) return;
   // Filter out all less than 0 indices (in particular, the 'camera' column
   // in the Toonz derivative product "Tab")
   std::vector<int> positiveIndices(indices.begin(), indices.end());

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -21,6 +21,7 @@
 #include "orientation.h"
 #include "toonz/preferences.h"
 #include "toonz/txshchildlevel.h"
+#include "toonz/tcolumnhandle.h"
 
 // TnzCore includes
 #include "tvectorimage.h"
@@ -189,12 +190,22 @@ void TColumnSelection::cutColumns() {
 //-----------------------------------------------------------------------------
 
 void TColumnSelection::insertColumns() {
+  if (m_indices.empty()) {
+    int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
+    if (col < 0) return;
+    selectColumn(col, true);
+  }
   ColumnCmd::insertEmptyColumns(m_indices);
 }
 
 //-----------------------------------------------------------------------------
 
 void TColumnSelection::insertColumnsAbove() {
+  if (m_indices.empty()) {
+    int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
+    if (col < 0) return;
+    selectColumn(col, true);
+  }
   ColumnCmd::insertEmptyColumns(m_indices, true);
 }
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1517,6 +1517,11 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   CleanupParameters oldCP(*cp);
   cp->assign(&CleanupParameters::GlobalParameters);
 
+  // Must wait for current save to finish, just in case
+  while (TApp::instance()->isSaveInProgress())
+    ;
+
+  TApp::instance()->setSaveInProgress(true);
   try {
     scene->save(scenePath, xsheet);
   } catch (const TSystemException &se) {
@@ -1524,6 +1529,7 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
   } catch (...) {
     DVGui::error(QObject::tr("Couldn't save %1").arg(toQString(scenePath)));
   }
+  TApp::instance()->setSaveInProgress(false);
 
   cp->assign(&oldCP);
 
@@ -1584,6 +1590,7 @@ bool IoCmd::saveScene(int flags) {
   } else {
     TFilePath fp = scene->getScenePath();
     // salva la scena con il nome fp. se fp esiste gia' lo sovrascrive
+    // NOTE: saveScene already check saveInProgress
     return saveScene(fp, SILENTLY_OVERWRITE | flags);
   }
 }
@@ -1732,13 +1739,20 @@ bool IoCmd::saveLevel(TXshSimpleLevel *sl) {
 bool IoCmd::saveAll(int flags) {
   // try to save as much as possible
   // if anything is wrong, return false
+  // NOTE: saveScene already check saveInProgress
   bool result = saveScene(flags);
 
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
   bool untitled     = scene->isUntitled();
   SceneResources resources(scene, 0);
+  // Must wait for current save to finish, just in case
+  while (TApp::instance()->isSaveInProgress())
+    ;
+
+  TApp::instance()->setSaveInProgress(true);
   resources.save(scene->getScenePath());
+  TApp::instance()->setSaveInProgress(false);
   resources.updatePaths();
 
   // for update title bar
@@ -1759,7 +1773,13 @@ void IoCmd::saveNonSceneFiles() {
   ToonzScene *scene = app->getCurrentScene()->getScene();
   bool untitled     = scene->isUntitled();
   SceneResources resources(scene, 0);
+  // Must wait for current save to finish, just in case
+  while (TApp::instance()->isSaveInProgress())
+    ;
+
+  TApp::instance()->setSaveInProgress(true);
   resources.save(scene->getScenePath());
+  TApp::instance()->setSaveInProgress(false);
   if (untitled) scene->setUntitled();
   resources.updatePaths();
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -934,6 +934,10 @@ Room *MainWindow::getCurrentRoom() const {
 //-----------------------------------------------------------------------------
 
 void MainWindow::onUndo() {
+  // Must wait for current save to finish, just in case
+  while (TApp::instance()->isSaveInProgress())
+    ;
+
   ToolHandle *toolH = TApp::instance()->getCurrentTool();
 
   // do not use undo if tool is currently in use
@@ -946,6 +950,10 @@ void MainWindow::onUndo() {
 //-----------------------------------------------------------------------------
 
 void MainWindow::onRedo() {
+  // Must wait for current save to finish, just in case
+  while (TApp::instance()->isSaveInProgress())
+    ;
+
   bool ret = TUndoManager::manager()->redo();
   if (!ret) DVGui::error(QObject::tr("No more Redo operations available."));
 }

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -103,6 +103,7 @@ TApp::TApp()
     , m_mainWindow(0)
     , m_autosaveTimer(0)
     , m_autosaveSuspended(false)
+    , m_saveInProgress(false)
     , m_isStarting(false)
     , m_isPenCloseToTablet(false) {
   m_currentScene         = new TSceneHandle();
@@ -706,6 +707,8 @@ void TApp::autosave() {
     return;
   } else
     m_autosaveSuspended = false;
+
+  if (m_saveInProgress) return;
 
   DVGui::ProgressDialog pb(
       "Autosaving scene..." + toQString(scene->getScenePath()), 0, 0, 1);

--- a/toonz/sources/toonz/tapp.h
+++ b/toonz/sources/toonz/tapp.h
@@ -86,6 +86,7 @@ class TApp final : public QObject,
 
   int m_autosavePeriod;  // minutes
   bool m_autosaveSuspended;
+  bool m_saveInProgress;
   QTimer *m_autosaveTimer;
 
   TApp();
@@ -204,6 +205,9 @@ public:
   void setCurrentXsheetViewer(XsheetViewer *viewer) { m_xsheetViewer = viewer; }
 
   XsheetViewer *getCurrentXsheetViewer() const { return m_xsheetViewer; }
+
+  bool isSaveInProgress() { return m_saveInProgress; }
+  void setSaveInProgress(bool inProgress) { m_saveInProgress = inProgress; }
 
 protected:
   bool eventFilter(QObject *obj, QEvent *event) override;


### PR DESCRIPTION
Here are 4 Tahoma2D fixes that were requested to be ported to OT:

-----
### 1. Fix undo selection paste into new frame + undo renumbering

While trying to reproduce the crash mentioned in a report, I found an issue with Undo when selecting part of a Raster/Smart Raster level and then pasting into a held frame w/ `Creation In Hold Cells` toggled `On`. A new blank frame is created with the paste, but an Undo doesn't remove the newly created frame. There after, the undo history becomes messed up.

Corrected the logic to record the creation of the blank frame as part of the paste so it is undone correctly.

Also fixed an issue with undo and cell renumbering. After removing the newly created frame as part of the undo, an update to the level was triggered. This reset the old frame ids list which can cause the renumber to crash if the list was empty. This may be why the crash occurred, but I could not duplicate the original issue to confirm. Modified the logic to update the level after the renumber is complete.

-----
### 2. Fix actions that shouldn't happen while autosaving

While reviewing a reported issue, I noticed there is a potential for overlapping save operations under certain scenarios which could potentially result in file corruption. Additionally, the report suggests an undo operation was performed while an autosave was in progress. This could cause a crash when it tries to access something that may no longer exist.

I've added logic to internally flag when a save is in progress so that any additional calls to save while actively saving will wait until the flag is cleared.

Scenarios that should be covered by this fix

Timed autosave + suspended autosave due to active drawing or something
Timed autosave + manual save by user
Timed autosave + Undo/Redo
NOTE: It's hard to duplicate overlapping saving issues naturally. I mostly regression tested for normal saving and autosaving operations as well as a simple saving error (file locked) and ensuring I didn't completely freeze up.

-----
### 3. Fix palette loss when caching images

Fixed a crash caused by the system running low on memory. When it detects the system is low in memory, it will compress and cache raster images in memory or onto disk in order to gain more space. When it does this, it loses palette information. Later, when the palette information is accessed, it may either do nothing or crash as was the case here.

Modified logic to store/restore palette information for compressed images.

-----
### 4. Fix insert column crash without a column selected

Some column operations like `Fold Column` and `Delete` cause the selected column list to be cleared. When you attempt an Insert column without a selected column, the logic didn't account for this and crashed.

Added logic to find the current column focus, outlined in cyan, and use that as the insert point. Still added logic to ignore the insert action if for some reason a current column still could not be found.