### PR TITLE
Appveyor fix: Update OpenCV version to 4.9.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ after_build:
     
     copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%\OpenToonz
 
-    copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world481.dll" %CONFIGURATION%\OpenToonz
+    copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world490.dll" %CONFIGURATION%\OpenToonz
 
     mkdir "%CONFIGURATION%\OpenToonz stuff"
 


### PR DESCRIPTION
This PR is to fix recent failures in Appveyor. 
Updated OpenCV version to 4.9.0 follow the package update of [Chocolatey](https://community.chocolatey.org/packages/OpenCV).