### PR TITLE
Fix permanently disabled undo in MACOSX

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -343,11 +343,6 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 #endif
   } break;
   case QEvent::TabletMove: {
-    // for Windowsm, use tabletEvent only for the left Button
-    if (m_tabletState != StartStroke && m_tabletState != OnStroke) {
-      m_tabletEvent = false;
-      break;
-    }
 
 #ifdef MACOSX
     // for now OSX seems to fail to call enter/leaveEvent properly while
@@ -357,6 +352,18 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     // call the fake enter event
     if (isHoveringInsideViewer) onEnter();
 #endif
+
+    // for Windowsm, use tabletEvent only for the left Button
+    if (m_tabletState != StartStroke && m_tabletState != OnStroke) {
+      m_tabletEvent = false;
+
+#ifdef MACOSX
+      // leave the fake event after the stroke is finished
+      onLeave();
+#endif
+
+      break;
+    }
 
     QPointF curPos = e->posF() * getDevPixRatio();
 #if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -343,6 +343,12 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 #endif
   } break;
   case QEvent::TabletMove: {
+    // for Windowsm, use tabletEvent only for the left Button
+    if (m_tabletState != StartStroke && m_tabletState != OnStroke) {
+      m_tabletEvent = false;
+      break;
+    }
+
 #ifdef MACOSX
     // for now OSX seems to fail to call enter/leaveEvent properly while
     // the tablet is floating
@@ -350,12 +356,6 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
         !rect().marginsRemoved(QMargins(5, 5, 5, 5)).contains(e->pos());
     // call the fake enter event
     if (isHoveringInsideViewer) onEnter();
-#else
-    // for Windowsm, use tabletEvent only for the left Button
-    if (m_tabletState != StartStroke && m_tabletState != OnStroke) {
-      m_tabletEvent = false;
-      break;
-    }
 #endif
 
     QPointF curPos = e->posF() * getDevPixRatio();


### PR DESCRIPTION
This PR aims to fix the previous PR #5187 and issue #5288. 

It turns out the variable I used in the previous PR fix, m_toolIsBusy, is permanently true on macosx and linux. Since the software always believes a tool is busy it prevents itself from using undo to prevent other bugs. 

**The reason for the variable being permanently true is as follows:**

![image](https://github.com/opentoonz/opentoonz/assets/77250215/fb4cfeb1-69bc-48a8-9699-94546d9b9461)
This function keeps being called in the tablet move event, setting the value to be true for macosx without checking if a stroke is being created.

I'm not completely sure if I am correct about this fix because **I don't have a mac, so if someone with a mac could please check if they can undo a drawn line using my PR** that would be great. The variable is also used for the autosave feature and could potentially fix other long term bugs. Also, Tahoma2d has the same code structure for the tablet event, so if all goes well the fix could be imported into Tahoma2d.