### PR TITLE
Macos undo freeze

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -585,7 +585,7 @@ protected:
   int m_targetType;  //!< The tool's image type target.
 
   bool m_enabled;  //!< Whether the tool allows user interaction.
-  bool m_canUndo; //!< Whether the tool allows the user to undo while the tool is selected
+  bool m_canUndo = true; //!< Whether the tool allows the user to undo while the tool is selected
   bool m_active;
   bool m_picking;
 

--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -550,6 +550,9 @@ transformation.
     return m_selectedFrames;
   }
 
+  void setCanUndo(bool on) { m_canUndo = on; }
+  bool isUndoable() const { return m_canUndo; }
+
   void tweenSelectedGuideStrokes();
   void tweenGuideStrokeToSelected();
   void flipGuideStrokeDirection(int mode);
@@ -582,6 +585,7 @@ protected:
   int m_targetType;  //!< The tool's image type target.
 
   bool m_enabled;  //!< Whether the tool allows user interaction.
+  bool m_canUndo; //!< Whether the tool allows the user to undo while the tool is selected
   bool m_active;
   bool m_picking;
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -941,7 +941,7 @@ void MainWindow::onUndo() {
   ToolHandle *toolH = TApp::instance()->getCurrentTool();
 
   // do not use undo if tool is currently in use
-  if (!toolH->getTool()->isUndoable()) {
+  if (toolH->getTool()->isUndoable()) {
     bool ret = TUndoManager::manager()->undo();
     if (!ret) DVGui::error(QObject::tr("No more Undo operations available."));
   }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -941,7 +941,7 @@ void MainWindow::onUndo() {
   ToolHandle *toolH = TApp::instance()->getCurrentTool();
 
   // do not use undo if tool is currently in use
-  if (!toolH->isToolBusy()) {
+  if (!toolH->getTool()->isUndoable()) {
     bool ret = TUndoManager::manager()->undo();
     if (!ret) DVGui::error(QObject::tr("No more Undo operations available."));
   }

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -827,13 +827,13 @@ void SceneViewer::onPress(const TMouseEvent &event) {
   // separate tablet and mouse events
   if (m_tabletEvent && m_tabletState == Touched) {
     TApp::instance()->getCurrentTool()->setToolBusy(true);
-    tool->setCanUndo(true);
+    tool->setCanUndo(false);
     m_tabletState = StartStroke;
     tool->leftButtonDown(pos, event);
   } else if (m_mouseButton == Qt::LeftButton) {
     m_mouseState = StartStroke;
     TApp::instance()->getCurrentTool()->setToolBusy(true);
-    tool->setCanUndo(true);
+    tool->setCanUndo(false);
     tool->leftButtonDown(pos, event);
   }
   if (m_mouseButton == Qt::RightButton) tool->rightButtonDown(pos, event);
@@ -926,7 +926,7 @@ void SceneViewer::onRelease(const TMouseEvent &event) {
     if (m_mouseButton == Qt::LeftButton || m_tabletState == Released) {
       if (!m_toolSwitched) tool->leftButtonUp(pos, event);
       TApp::instance()->getCurrentTool()->setToolBusy(false);
-      tool->setCanUndo(false);
+      tool->setCanUndo(true);
     }
   }
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -827,11 +827,13 @@ void SceneViewer::onPress(const TMouseEvent &event) {
   // separate tablet and mouse events
   if (m_tabletEvent && m_tabletState == Touched) {
     TApp::instance()->getCurrentTool()->setToolBusy(true);
+    tool->setCanUndo(true);
     m_tabletState = StartStroke;
     tool->leftButtonDown(pos, event);
   } else if (m_mouseButton == Qt::LeftButton) {
     m_mouseState = StartStroke;
     TApp::instance()->getCurrentTool()->setToolBusy(true);
+    tool->setCanUndo(true);
     tool->leftButtonDown(pos, event);
   }
   if (m_mouseButton == Qt::RightButton) tool->rightButtonDown(pos, event);
@@ -924,6 +926,7 @@ void SceneViewer::onRelease(const TMouseEvent &event) {
     if (m_mouseButton == Qt::LeftButton || m_tabletState == Released) {
       if (!m_toolSwitched) tool->leftButtonUp(pos, event);
       TApp::instance()->getCurrentTool()->setToolBusy(false);
+      tool->setCanUndo(false);
     }
   }
 


### PR DESCRIPTION
This PR is a continuation of PR #5301, attempting to fix PR #5187 and issue #5288.

The original issue, is that a mac user cannot use undo after drawing a line with their tablet. This is because sometimes, the busy tool flag is sometimes permanently true preventing the undo function from working.

The new implementation adds an undo flag on the tool class, thereby separating the need to check the busy tool flag used for the different implementations of macos and windows. Moreover, the extension attempts to get away from the event handling bugs that cause the variable to be permanent. Therefore, the user should be able to undo after using a tool with a tablet for any OS with this fix.

I already tested it on windows and it seems to be okay.

**I don't have a mac, so we need someone to test this PR on a mac to verify my implementation.**