### PR TITLE
Refactor FFmpeg format check on launch

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -24,15 +24,18 @@ Ffmpeg::Ffmpeg() {
 Ffmpeg::~Ffmpeg() {}
 
 bool Ffmpeg::checkFormat(std::string format) {
-  QStringList args;
-  args << "-formats";
-  QProcess ffmpeg;
-  ThirdParty::runFFmpeg(ffmpeg, args);
-  ffmpeg.waitForFinished();
-  QString results = ffmpeg.readAllStandardError();
-  results += ffmpeg.readAllStandardOutput();
-  ffmpeg.close();
-  std::string strResults = results.toStdString();
+  static std::string strResults = "";
+  if (strResults.empty()) {
+    QStringList args;
+    args << "-formats";
+    QProcess ffmpeg;
+    ThirdParty::runFFmpeg(ffmpeg, args);
+    ffmpeg.waitForFinished();
+    QString results = ffmpeg.readAllStandardError();
+    results += ffmpeg.readAllStandardOutput();
+    ffmpeg.close();
+    strResults = results.toStdString();
+  }
   std::string::size_type n;
   n = strResults.find(format);
   if (n != std::string::npos)


### PR DESCRIPTION
This PR refactors the file i/o availability checking procedure on launch.
Before this PR, OT calls ffmpeg.exe for each format type. This PR makes OT to keep the first returned value (a text containing all available format extensions) and reuse it for the rest of the formats.
This modification shortens the launching time for about 10 seconds in our environment.