### PR TITLE
Fix OCA import/export frame range

### DIFF
--- a/toonz/sources/toonz/ocaio.cpp
+++ b/toonz/sources/toonz/ocaio.cpp
@@ -180,12 +180,9 @@ bool OCAData::buildGroup(QJsonObject &json, const QList<int> &rows,
 
   // Build a list of child rows
   QList<int> crows;
-  for (int i = m_startTime; i <= m_endTime; i++) {
-    TXshCell cell = column->getCell(i);
-    if (cell.isEmpty())
-      crows.append(-1);
-    else
-      crows.append(cell.getFrameId().getNumber() - 1);
+  int crow = xsheet->getFrameCount() - 1;
+  for (int i = 0; i <= crow; i++) {
+      crows.append(i);
   }
 
   // Build all columns from sub-xsheet
@@ -331,20 +328,9 @@ void OCAData::build(ToonzScene *scene, TXsheet *xsheet, QString name,
   m_raEXR = useEXR;
   m_veSVG = vectorAsSVG;
 
-  // if the current xsheet is top xsheet in the scene and the output
-  // frame range is specified, set the "to" frame value as duration
   TOutputProperties *oprop = scene->getProperties()->getOutputProperties();
-  int from, to, step;
-  if (scene->getTopXsheet() == xsheet && oprop->getRange(from, to, step)) {
-    m_startTime = from;
-    m_endTime   = to;
-    // m_stepTime  = step;
-  } else {
-    m_startTime = 0;
-    m_endTime   = xsheet->getFrameCount() - 1;
-    // m_stepTime  = 1;
-  }
-  if (m_endTime < 0) m_endTime = 0;
+  m_startTime = 0;
+  m_endTime   = xsheet->getFrameCount() - 1;
 
   // Build a list of rows
   QList<int> rows;
@@ -632,16 +618,6 @@ bool OCAIo::OCAInputData::read(QString path, QJsonObject &json) {
 
 void OCAIo::OCAInputData::getSceneData() {
   m_framerate = m_oprop->getFrameRate();
-  int from, to, step;
-  if (m_scene->getTopXsheet() == m_xsheet &&
-      m_oprop->getRange(from, to, step)) {
-    m_startTime = from;
-    m_endTime   = to;
-  } else {
-    m_startTime = 0;
-    m_endTime   = m_xsheet->getFrameCount() - 1;
-  }
-  if (m_endTime < 0) m_endTime = 0;
 
   m_width  = m_scene->getCurrentCamera()->getRes().lx;
   m_height = m_scene->getCurrentCamera()->getRes().ly;
@@ -686,7 +662,6 @@ void OCAIo::OCAInputData::setSceneData() {
   m_scene->getCurrentCamera()->setRes(resolution);
 
   m_xsheet->updateFrameCount();
-  m_oprop->setRange(m_startTime, m_endTime, 1);
 
   // If background is all 0s, use our default Bg color
   if (m_bgRed || m_bgGreen || m_bgBlue || m_bgAlpha) {


### PR DESCRIPTION
This changes OCA Import/Export's frame range as follows:

Export frames based on timeline/xsheet frame count instead of using Output Setting's frame range so the entirety of the scene is always exported.
This also applies to sub-scenes which can have more or less frames than the main.
Fixed an issue with using the wrong frame range for folders within sub-scenes.

Do not update scene's Output Settings frame range using Import's startTime and endtime.
This will allow the scene's Output Setting frame range to remain dynamic, changing as frames are added to extend the scene after import.