### PR TITLE
Revert the Qt5::Widget change

### DIFF
--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -199,4 +199,4 @@ elseif(BUILD_ENV_UNIXLIKE)
     endif()
 endif()
 
-target_link_libraries(image Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Network ${Z_LIB} ${GLUT_LIB} ${GL_LIB} ${JPEG_LIB} ${TIFF_LIB} ${PNG_LIB} ${EXTRA_LIBS})
+target_link_libraries(image Qt5::Core Qt5::Gui Qt5::Network ${Z_LIB} ${GLUT_LIB} ${GL_LIB} ${JPEG_LIB} ${TIFF_LIB} ${PNG_LIB} ${EXTRA_LIBS})

--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -182,6 +182,7 @@ elseif(BUILD_ENV_APPLE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -F ${OSX_10_6_SDK_PATH}")
     endif()
     set(EXTRA_LIBS
+        Qt5::Widgets
         ${TNZLIBS}
         ${QT_LIB}
         ${CARBON_LIB}


### PR DESCRIPTION
Suspected to have caused OTZ to not launch with this change. Reverting.