### PR TITLE
[ui] Extra x-sheet colors

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -1762,6 +1762,7 @@ ProjectPopup QLabel {
 ----------------------------------------------------------------------------- */
 SchematicViewer {
   qproperty-TextColor: #d6d8dd;
+  qproperty-PassThroughTextColor: #d6d8dd;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-LevelColumnColor: #4C6E4C;
   qproperty-VectorColumnColor: #7B7B4C;

--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -583,8 +583,6 @@ DvScrollWidget {
   image: url('../Default/imgs/white/scroll-down.svg');
 }
 /* -------------------------------------------------------------------------- */
-/* For the buttons to display a BG color we need to set a blank image, setting
-   an empty URL solves this. */
 #keyFrameNavigator {
   background: transparent;
   margin: 0;
@@ -595,20 +593,12 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #PreviousKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #NextKey {
   margin: 0 2;
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #NextKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo,
 #keyFrameNavigator #KeyPartial,
@@ -617,20 +607,10 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled,
-#keyFrameNavigator #KeyPartial:disabled,
-#keyFrameNavigator #KeyTotal:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo {
   background-color: rgba(0, 0, 0, 0);
   border: 1 solid rgba(0, 0, 0, 0);
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo:hover {
   background-color: #696c6f;
@@ -639,7 +619,6 @@ DvScrollWidget {
 #keyFrameNavigator #KeyPartial {
   background-color: #be7323;
   border: 1 solid #be7323;
-  image: url('');
 }
 #keyFrameNavigator #KeyPartial:hover {
   background-color: #db8d39;
@@ -2305,7 +2284,6 @@ XsheetViewer {
   qproperty-SelectedTextColor: #d6d8dd;
   qproperty-FrameTextColor: #d6d8dd;
   qproperty-CurrentFrameTextColor: #d6d8dd;
-  qproperty-CycleColor: #d6d8dd;
   qproperty-BGColor: #3a3b3d;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
@@ -2324,6 +2302,8 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(221, 231, 237, 0.3);
   qproperty-PlayRangeColor: #414345;
+  qproperty-KeyframeLineColor: #d6d8dd;
+  qproperty-LevelEndColor: #d6d8dd;
   qproperty-FoldedColumnBGColor: #5a5d5f;
   qproperty-FoldedColumnLineColor: #353638;
   qproperty-EmptyCellColor: #323435;
@@ -2479,7 +2459,7 @@ SpreadsheetViewer {
   qproperty-FrameTextColor: #d6d8dd;
   qproperty-GroupNameTextColor: #d6d8dd;
   qproperty-ChannelNameTextColor: #d6d8dd;
-  qproperty-CycleColor: #d6d8dd;
+  qproperty-KeyframeLineColor: #d6d8dd;
   qproperty-ColumnHeaderBorderColor: #212223;
 }
 #ExpressionField {

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -583,8 +583,6 @@ DvScrollWidget {
   image: url('../Default/imgs/white/scroll-down.svg');
 }
 /* -------------------------------------------------------------------------- */
-/* For the buttons to display a BG color we need to set a blank image, setting
-   an empty URL solves this. */
 #keyFrameNavigator {
   background: transparent;
   margin: 0;
@@ -595,20 +593,12 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #PreviousKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #NextKey {
   margin: 0 2;
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #NextKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo,
 #keyFrameNavigator #KeyPartial,
@@ -617,20 +607,10 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled,
-#keyFrameNavigator #KeyPartial:disabled,
-#keyFrameNavigator #KeyTotal:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo {
   background-color: rgba(0, 0, 0, 0);
   border: 1 solid rgba(0, 0, 0, 0);
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo:hover {
   background-color: #595959;
@@ -639,7 +619,6 @@ DvScrollWidget {
 #keyFrameNavigator #KeyPartial {
   background-color: #be7323;
   border: 1 solid #be7323;
-  image: url('');
 }
 #keyFrameNavigator #KeyPartial:hover {
   background-color: #db8d39;
@@ -2305,7 +2284,6 @@ XsheetViewer {
   qproperty-SelectedTextColor: #e6e6e6;
   qproperty-FrameTextColor: #e6e6e6;
   qproperty-CurrentFrameTextColor: #e6e6e6;
-  qproperty-CycleColor: #e6e6e6;
   qproperty-BGColor: #303030;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.3);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
@@ -2324,6 +2302,8 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(221, 231, 237, 0.3);
   qproperty-PlayRangeColor: #383838;
+  qproperty-KeyframeLineColor: #e6e6e6;
+  qproperty-LevelEndColor: #e6e6e6;
   qproperty-FoldedColumnBGColor: #4a4a4a;
   qproperty-FoldedColumnLineColor: #232323;
   qproperty-EmptyCellColor: #282828;
@@ -2479,7 +2459,7 @@ SpreadsheetViewer {
   qproperty-FrameTextColor: #e6e6e6;
   qproperty-GroupNameTextColor: #e6e6e6;
   qproperty-ChannelNameTextColor: #e6e6e6;
-  qproperty-CycleColor: #e6e6e6;
+  qproperty-KeyframeLineColor: #e6e6e6;
   qproperty-ColumnHeaderBorderColor: #4a4a4a;
 }
 #ExpressionField {

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -1762,6 +1762,7 @@ ProjectPopup QLabel {
 ----------------------------------------------------------------------------- */
 SchematicViewer {
   qproperty-TextColor: #e6e6e6;
+  qproperty-PassThroughTextColor: #e6e6e6;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.4);
   qproperty-LevelColumnColor: #4C6E4C;
   qproperty-VectorColumnColor: #7B7B4C;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -1762,6 +1762,7 @@ ProjectPopup QLabel {
 ----------------------------------------------------------------------------- */
 SchematicViewer {
   qproperty-TextColor: #e6e6e6;
+  qproperty-PassThroughTextColor: #e6e6e6;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-LevelColumnColor: #4C6E4C;
   qproperty-VectorColumnColor: #7B7B4C;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -583,8 +583,6 @@ DvScrollWidget {
   image: url('imgs/white/scroll-down.svg');
 }
 /* -------------------------------------------------------------------------- */
-/* For the buttons to display a BG color we need to set a blank image, setting
-   an empty URL solves this. */
 #keyFrameNavigator {
   background: transparent;
   margin: 0;
@@ -595,20 +593,12 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #PreviousKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #NextKey {
   margin: 0 2;
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #NextKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo,
 #keyFrameNavigator #KeyPartial,
@@ -617,20 +607,10 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled,
-#keyFrameNavigator #KeyPartial:disabled,
-#keyFrameNavigator #KeyTotal:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo {
   background-color: rgba(0, 0, 0, 0);
   border: 1 solid rgba(0, 0, 0, 0);
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo:hover {
   background-color: #717171;
@@ -639,7 +619,6 @@ DvScrollWidget {
 #keyFrameNavigator #KeyPartial {
   background-color: #be7323;
   border: 1 solid #be7323;
-  image: url('');
 }
 #keyFrameNavigator #KeyPartial:hover {
   background-color: #db8d39;
@@ -2305,7 +2284,6 @@ XsheetViewer {
   qproperty-SelectedTextColor: #e6e6e6;
   qproperty-FrameTextColor: #e6e6e6;
   qproperty-CurrentFrameTextColor: #e6e6e6;
-  qproperty-CycleColor: #e6e6e6;
   qproperty-BGColor: #404040;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.2);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.15);
@@ -2324,6 +2302,8 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(221, 231, 237, 0.3);
   qproperty-PlayRangeColor: #484848;
+  qproperty-KeyframeLineColor: #e6e6e6;
+  qproperty-LevelEndColor: #e6e6e6;
   qproperty-FoldedColumnBGColor: #626262;
   qproperty-FoldedColumnLineColor: #3b3b3b;
   qproperty-EmptyCellColor: #393939;
@@ -2479,7 +2459,7 @@ SpreadsheetViewer {
   qproperty-FrameTextColor: #e6e6e6;
   qproperty-GroupNameTextColor: #e6e6e6;
   qproperty-ChannelNameTextColor: #e6e6e6;
-  qproperty-CycleColor: #e6e6e6;
+  qproperty-KeyframeLineColor: #e6e6e6;
   qproperty-ColumnHeaderBorderColor: #272727;
 }
 #ExpressionField {

--- a/stuff/config/qss/Default/less/Default.less
+++ b/stuff/config/qss/Default/less/Default.less
@@ -429,6 +429,8 @@
 @xsheet-DarkBG-color:                       lighten(@bg, 60.0000);
 @xsheet-DarkLine-color:                     lighten(@bg, 30.5882);
 @xsheet-ColumnIconLine-color:               @accent;
+@xsheet-KeyframeLine-color:                 @xsheet-text-color;
+@xsheet-LevelEnd-color:                     @xsheet-text-color;
 
 @xsheet-CellArea-bg-color-focus:            rgb(0, 0, 0);
 @xsheet-CellFocus-color:                    #000;

--- a/stuff/config/qss/Default/less/layouts/mainwindow.less
+++ b/stuff/config/qss/Default/less/layouts/mainwindow.less
@@ -430,8 +430,6 @@ DvScrollWidget {
 
 /* -------------------------------------------------------------------------- */
 
-/* For the buttons to display a BG color we need to set a blank image, setting
-   an empty URL solves this. */
 #keyFrameNavigator {
   background: transparent;
   margin: 0;
@@ -441,20 +439,12 @@ DvScrollWidget {
     padding-right: -1;
     width: 20px;
     height: 20px;
-    image: url('');
-	  &:disabled {
-		  image: url('');
-	  }
   }
   #NextKey {
     margin: 0 2;
     padding-right: -1;
     width: 20px;
     height: 20px;
-    image: url('');
-	  &:disabled {
-		  image: url('');
-	  }
   }
   #KeyNo,
   #KeyPartial,
@@ -463,18 +453,10 @@ DvScrollWidget {
     padding-right: -1;
     width: 20px;
     height: 20px;
-    image: url('');
-    &:disabled {
-      image: url('');
-    }
   }
   #KeyNo {
     background-color: @keyframe-off-color;
     border: 1 solid @keyframe-off-border-color;
-    image: url('');
-    &:disabled {
-      image: url('');
-    }
     &:hover {
       background-color: @keyframe-off-color-hover;
       border-color: @keyframe-off-border-color-hover;
@@ -483,7 +465,6 @@ DvScrollWidget {
   #KeyPartial {
     background-color: @keyframe-partial-color;
     border: 1 solid @keyframe-partial-border-color;
-    image: url('');
     &:hover {
       background-color: @keyframe-partial-color-hover;
       border-color: @keyframe-partial-border-color-hover;

--- a/stuff/config/qss/Default/less/layouts/schematic.less
+++ b/stuff/config/qss/Default/less/layouts/schematic.less
@@ -4,6 +4,7 @@
 
 SchematicViewer {
   qproperty-TextColor: @schematic-text-color;
+  qproperty-PassThroughTextColor: @schematic-text-color;
   qproperty-VerticalLineColor: @schematic-VerticalLine-color;
 
   qproperty-LevelColumnColor: @xsheet-LevelColumn-color;

--- a/stuff/config/qss/Default/less/layouts/xsheet.less
+++ b/stuff/config/qss/Default/less/layouts/xsheet.less
@@ -87,7 +87,6 @@ XsheetViewer {
   qproperty-SelectedTextColor: @xsheet-selected-text-color;
   qproperty-FrameTextColor: @xsheet-text-color;
   qproperty-CurrentFrameTextColor: @xsheet-currentFrame-text-color;
-  qproperty-CycleColor: @xsheet-text-color;
   qproperty-BGColor: @xsheet-bg-color;
   qproperty-LightLineColor: @xsheet-LightLine-color;
   qproperty-MarkerLineColor: @xsheet-MarkerLine-color;
@@ -106,6 +105,8 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: @xsheet-ColumnHeadPastelizer-color;
   qproperty-SelectedColumnHead: @xsheet-SelectedColumnHead-color;
   qproperty-PlayRangeColor: @xsheet-PlayRange-Color;
+  qproperty-KeyframeLineColor: @xsheet-KeyframeLine-color;
+  qproperty-LevelEndColor: @xsheet-LevelEnd-color;
 
   qproperty-FoldedColumnBGColor: @xsheet-FoldedColumnBG-color;
   qproperty-FoldedColumnLineColor: @xsheet-FoldedColumnLine-color;
@@ -312,7 +313,7 @@ SpreadsheetViewer {
   qproperty-FrameTextColor: @xsheet-text-color;
   qproperty-GroupNameTextColor: @xsheet-text-color;
   qproperty-ChannelNameTextColor: @xsheet-text-color;
-  qproperty-CycleColor: @xsheet-text-color;
+  qproperty-KeyframeLineColor: @xsheet-KeyframeLine-color;
   qproperty-ColumnHeaderBorderColor: @function-ColumnHeaderBorder-color; // paired
 }
 

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -583,8 +583,6 @@ DvScrollWidget {
   image: url('../Default/imgs/black/scroll-down.svg');
 }
 /* -------------------------------------------------------------------------- */
-/* For the buttons to display a BG color we need to set a blank image, setting
-   an empty URL solves this. */
 #keyFrameNavigator {
   background: transparent;
   margin: 0;
@@ -595,20 +593,12 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #PreviousKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #NextKey {
   margin: 0 2;
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #NextKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo,
 #keyFrameNavigator #KeyPartial,
@@ -617,20 +607,10 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled,
-#keyFrameNavigator #KeyPartial:disabled,
-#keyFrameNavigator #KeyTotal:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo {
   background-color: rgba(0, 0, 0, 0);
   border: 1 solid rgba(0, 0, 0, 0);
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo:hover {
   background-color: #b5b5b5;
@@ -639,7 +619,6 @@ DvScrollWidget {
 #keyFrameNavigator #KeyPartial {
   background-color: #f8a145;
   border: 1 solid #cf6e08;
-  image: url('');
 }
 #keyFrameNavigator #KeyPartial:hover {
   background-color: #faba76;
@@ -2305,7 +2284,6 @@ XsheetViewer {
   qproperty-SelectedTextColor: #000;
   qproperty-FrameTextColor: #000;
   qproperty-CurrentFrameTextColor: #000;
-  qproperty-CycleColor: #000;
   qproperty-BGColor: #cecece;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(0, 0, 0, 0.3);
@@ -2324,6 +2302,8 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(0, 0, 0, 0.15);
   qproperty-PlayRangeColor: #DBDBDB;
+  qproperty-KeyframeLineColor: #000;
+  qproperty-LevelEndColor: #000;
   qproperty-FoldedColumnBGColor: #a8a8a8;
   qproperty-FoldedColumnLineColor: #757575;
   qproperty-EmptyCellColor: #c2c2c2;
@@ -2479,7 +2459,7 @@ SpreadsheetViewer {
   qproperty-FrameTextColor: #000;
   qproperty-GroupNameTextColor: #000;
   qproperty-ChannelNameTextColor: #000;
-  qproperty-CycleColor: #000;
+  qproperty-KeyframeLineColor: #000;
   qproperty-ColumnHeaderBorderColor: #5b5b5b;
 }
 #ExpressionField {

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -1762,6 +1762,7 @@ ProjectPopup QLabel {
 ----------------------------------------------------------------------------- */
 SchematicViewer {
   qproperty-TextColor: #000;
+  qproperty-PassThroughTextColor: #000;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.15);
   qproperty-LevelColumnColor: #a1cea1;
   qproperty-VectorColumnColor: #d3cf9a;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -583,8 +583,6 @@ DvScrollWidget {
   image: url('../Default/imgs/black/scroll-down.svg');
 }
 /* -------------------------------------------------------------------------- */
-/* For the buttons to display a BG color we need to set a blank image, setting
-   an empty URL solves this. */
 #keyFrameNavigator {
   background: transparent;
   margin: 0;
@@ -595,20 +593,12 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #PreviousKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #NextKey {
   margin: 0 2;
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #NextKey:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo,
 #keyFrameNavigator #KeyPartial,
@@ -617,20 +607,10 @@ DvScrollWidget {
   padding-right: -1;
   width: 20px;
   height: 20px;
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled,
-#keyFrameNavigator #KeyPartial:disabled,
-#keyFrameNavigator #KeyTotal:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo {
   background-color: rgba(0, 0, 0, 0);
   border: 1 solid rgba(0, 0, 0, 0);
-  image: url('');
-}
-#keyFrameNavigator #KeyNo:disabled {
-  image: url('');
 }
 #keyFrameNavigator #KeyNo:hover {
   background-color: #b3b3b3;
@@ -639,7 +619,6 @@ DvScrollWidget {
 #keyFrameNavigator #KeyPartial {
   background-color: #c77a27;
   border: 1 solid #724616;
-  image: url('');
 }
 #keyFrameNavigator #KeyPartial:hover {
   background-color: #db9346;
@@ -2305,7 +2284,6 @@ XsheetViewer {
   qproperty-SelectedTextColor: #000;
   qproperty-FrameTextColor: #000;
   qproperty-CurrentFrameTextColor: #000;
-  qproperty-CycleColor: #000;
   qproperty-BGColor: #767676;
   qproperty-LightLineColor: rgba(0, 0, 0, 0.15);
   qproperty-MarkerLineColor: rgba(255, 255, 255, 0.2);
@@ -2324,6 +2302,8 @@ XsheetViewer {
   qproperty-ColumnHeadPastelizer: rgba(0, 0, 0, 0);
   qproperty-SelectedColumnHead: rgba(233, 236, 240, 0.3);
   qproperty-PlayRangeColor: #808080;
+  qproperty-KeyframeLineColor: #000;
+  qproperty-LevelEndColor: #000;
   qproperty-FoldedColumnBGColor: #9a9a9a;
   qproperty-FoldedColumnLineColor: #737373;
   qproperty-EmptyCellColor: #6c6c6c;
@@ -2479,7 +2459,7 @@ SpreadsheetViewer {
   qproperty-FrameTextColor: #000;
   qproperty-GroupNameTextColor: #000;
   qproperty-ChannelNameTextColor: #000;
-  qproperty-CycleColor: #000;
+  qproperty-KeyframeLineColor: #000;
   qproperty-ColumnHeaderBorderColor: #343434;
 }
 #ExpressionField {

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -1762,6 +1762,7 @@ ProjectPopup QLabel {
 ----------------------------------------------------------------------------- */
 SchematicViewer {
   qproperty-TextColor: #000;
+  qproperty-PassThroughTextColor: #000;
   qproperty-VerticalLineColor: rgba(0, 0, 0, 0.3);
   qproperty-LevelColumnColor: #78a578;
   qproperty-VectorColumnColor: #a7a163;

--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -212,6 +212,10 @@ class DVAPI SchematicViewer final : public QWidget {
   QColor m_textColor;  // text color (black)
   Q_PROPERTY(QColor TextColor READ getTextColor WRITE setTextColor)
 
+  QColor m_passThroughTextColor;  // text outside of the node rect
+  Q_PROPERTY(QColor PassThroughTextColor READ getPassThroughTextColor WRITE
+                 setPassThroughTextColor)
+
   QColor m_verticalLineColor;
   Q_PROPERTY(QColor VerticalLineColor READ getVerticalLineColor WRITE
                  setVerticalLineColor)
@@ -390,6 +394,11 @@ public:
 
   void setTextColor(const QColor &color) { m_textColor = color; }
   QColor getTextColor() const { return m_textColor; }
+
+  void setPassThroughTextColor(const QColor &color) {
+    m_passThroughTextColor = color;
+  }
+  QColor getPassThroughTextColor() const { return m_passThroughTextColor; }
 
   void setVerticalLineColor(const QColor &color) {
     m_verticalLineColor = color;

--- a/toonz/sources/include/toonzqt/spreadsheetviewer.h
+++ b/toonz/sources/include/toonzqt/spreadsheetviewer.h
@@ -242,7 +242,7 @@ class DVAPI SpreadsheetViewer : public QDialog {
   QColor m_frameTextColor;       // text color for frame numbers
   QColor m_groupNameTextColor;   // text color for group name
   QColor m_channelNameTextColor; // text color for channel name
-  QColor m_cycleColor;           // color of zig zag line
+  QColor m_keyframeLineColor;    // color of keyframe lines
   QColor m_verticalLineColor;    // vertical line (black)
 
   Q_PROPERTY(QColor CurrentRowBgColor READ getCurrentRowBgColor WRITE
@@ -259,7 +259,8 @@ class DVAPI SpreadsheetViewer : public QDialog {
                  setGroupNameTextColor)
   Q_PROPERTY(QColor ChannelNameTextColor READ getChannelNameTextColor WRITE
                  setChannelNameTextColor)
-  Q_PROPERTY(QColor CycleColor READ getCycleColor WRITE setCycleColor)
+  Q_PROPERTY(QColor KeyframeLineColor READ getKeyframeLineColor WRITE
+                 setKeyframeLineColor)
   Q_PROPERTY(QColor VerticalLineColor READ getVerticalLineColor WRITE
                  setVerticalLineColor)
 
@@ -387,8 +388,8 @@ public:
     m_channelNameTextColor = color;
   }
   QColor getChannelNameTextColor() const { return m_channelNameTextColor; }
-  void setCycleColor(const QColor &color) { m_cycleColor = color; }
-  QColor getCycleColor() const { return m_cycleColor; }
+  void setKeyframeLineColor(const QColor &color) { m_keyframeLineColor = color; }
+  QColor getKeyframeLineColor() const { return m_keyframeLineColor; }
   void setVerticalLineColor(const QColor &color) {
     m_verticalLineColor = color;
   }

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1967,7 +1967,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
       p.drawEllipse(markRect);
     }
 
-    QColor levelEndColor = m_viewer->getTextColor();
+    QColor levelEndColor = m_viewer->getLevelEndColor();
     levelEndColor.setAlphaF(0.3);
     p.setPen(levelEndColor);
     p.drawLine(rect.topLeft(), rect.bottomRight());
@@ -2250,7 +2250,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
 
     drawFrameSeparator(p, row, col, false, heldFrame);
 
-    QColor levelEndColor = m_viewer->getTextColor();
+    QColor levelEndColor = m_viewer->getLevelEndColor();
     levelEndColor.setAlphaF(0.3);
     p.setPen(levelEndColor);
     p.drawLine(rect.topLeft(), rect.bottomRight());
@@ -2455,7 +2455,7 @@ void CellArea::drawSoundTextColumn(QPainter &p, int r0, int r1, int col) {
       TXshCell prevCell;
       if (row > 0) prevCell = xsh->getCell(row - 1, col);
       if (!prevCell.isEmpty()) {
-        QColor levelEndColor = m_viewer->getTextColor();
+        QColor levelEndColor = m_viewer->getLevelEndColor();
         levelEndColor.setAlphaF(0.3);
         p.setPen(levelEndColor);
         p.drawLine(info.rect.topLeft(), info.rect.bottomRight());
@@ -2710,7 +2710,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
 
     drawFrameSeparator(p, row, col, false, heldFrame);
 
-    QColor levelEndColor = m_viewer->getTextColor();
+    QColor levelEndColor = m_viewer->getLevelEndColor();
     levelEndColor.setAlphaF(0.3);
     p.setPen(levelEndColor);
     p.drawLine(rect.topLeft(), rect.bottomRight());

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3006,7 +3006,7 @@ void CellArea::drawKeyframe(QPainter &p, const QRect toBeUpdated) {
       int qy   = icon_frameAxis + 12;
       int zig  = 2;
       int qx   = icon_layerAxis + 5;
-      p.setPen(m_viewer->getCycleColor());
+      p.setPen(m_viewer->getKeyframeLineColor());
       p.drawLine(o->frameLayerToXY(qy, qx),
                  o->frameLayerToXY(qy + zig, qx - zig));
       while (qy < ymax) {
@@ -3031,7 +3031,7 @@ void CellArea::drawKeyframeLine(QPainter &p, int col,
       keyRect.center() + m_viewer->positionToXY(CellPosition(rows.from(), col));
   QPoint end =
       keyRect.center() + m_viewer->positionToXY(CellPosition(rows.to(), col));
-  p.setPen(m_viewer->getTextColor());
+  p.setPen(m_viewer->getKeyframeLineColor());
   p.drawLine(QLine(begin, end));
 }
 

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -277,12 +277,14 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   QColor m_emptyCellColor;          // empty cell (124,124,124)
   QColor m_notEmptyColumnColor;     // occupied column (164,164,164)
   QColor m_selectedEmptyCellColor;  // selected empty cell (210,210,210)
+  QColor m_levelEndColor;           // end level cross
   Q_PROPERTY(
       QColor EmptyCellColor READ getEmptyCellColor WRITE setEmptyCellColor)
   Q_PROPERTY(QColor NotEmptyColumnColor READ getNotEmptyColumnColor WRITE
                  setNotEmptyColumnColor)
   Q_PROPERTY(QColor SelectedEmptyCellColor READ getSelectedEmptyCellColor WRITE
                  setSelectedEmptyCellColor)
+  Q_PROPERTY(QColor LevelEndColor READ getLevelEndColor WRITE setLevelEndColor)
 
   // Cell focus
   QColor m_cellFocusColor;
@@ -906,6 +908,8 @@ public:
     m_selectedEmptyCellColor = color;
   }
   QColor getSelectedEmptyCellColor() const { return m_selectedEmptyCellColor; }
+  void setLevelEndColor(const QColor &color) { m_levelEndColor = color; }
+  QColor getLevelEndColor() const { return m_levelEndColor; }
 
   // Cell focus
   void setCellFocusColor(const QColor &color) { m_cellFocusColor = color; }

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -224,7 +224,7 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
   QColor m_errorTextColor;           // error text color (red, probably)
   QColor m_selectedTextColor;        // text color for the selected cells
   QColor m_frameTextColor;           // text color for frame numbers
-  QColor m_cycleColor;               // color of the zig zag line
+  QColor m_keyframeLineColor;        // color of keyframe lines
   QColor m_currentFrameTextColor;    // text color for the current frame row
   QColor m_previewFrameTextColor;    // frame number in preview range (blue)
   QColor m_onionSkinAreaBgColor;
@@ -251,7 +251,8 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
                  setSelectedTextColor)
   Q_PROPERTY(QColor FrameTextColor READ getFrameTextColor WRITE
                  setFrameTextColor)
-  Q_PROPERTY(QColor CycleColor READ getCycleColor WRITE setCycleColor)
+  Q_PROPERTY(QColor KeyframeLineColor READ getKeyframeLineColor WRITE
+                 setKeyframeLineColor)
   Q_PROPERTY(QColor PreviewFrameTextColor READ getPreviewFrameTextColor WRITE
                  setPreviewFrameTextColor)
   Q_PROPERTY(QColor OnionSkinAreaBgColor READ getOnionSkinAreaBgColor WRITE
@@ -859,9 +860,9 @@ public:
   void setCurrentFrameTextColor(const QColor &color) {
     m_currentFrameTextColor = color;
   }
-  QColor getCycleColor() const { return m_cycleColor; }
-  void setCycleColor(const QColor &color) {
-    m_cycleColor = color;
+  QColor getKeyframeLineColor() const { return m_keyframeLineColor; }
+  void setKeyframeLineColor(const QColor &color) {
+    m_keyframeLineColor = color;
   }
   QColor getCurrentFrameTextColor() const { return m_currentFrameTextColor; }
   void setPreviewFrameTextColor(const QColor &color) {

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -832,7 +832,7 @@ void FunctionSheetCellViewer::drawCells(QPainter &painter, int r0, int c0,
         if (drawValue == Key || drawValue == Inbetween)
           painter.setPen(getViewer()->getTextColor());
         else {
-          QColor semiTranspTextColor = getViewer()->getCycleColor();
+          QColor semiTranspTextColor = getViewer()->getKeyframeLineColor();
           semiTranspTextColor.setAlpha(128);
           painter.setPen(semiTranspTextColor);
         }
@@ -880,8 +880,9 @@ void FunctionSheetCellViewer::drawCells(QPainter &painter, int r0, int c0,
       int qx             = x0 + 4;
       int qy             = m_sheet->rowToY(kr1 + 1);
       int zig            = 2;
-      QColor zigzagColor = (isStageObjectCycled) ? getViewer()->getCycleColor()
-                                                 : KeyFrameBorderColor;
+      QColor zigzagColor = (isStageObjectCycled)
+                               ? getViewer()->getKeyframeLineColor()
+                               : KeyFrameBorderColor;
       painter.setPen(zigzagColor);
       painter.drawLine(QPoint(qx, qy), QPoint(qx - zig, qy + zig));
       qy += zig;

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -832,7 +832,7 @@ void FunctionSheetCellViewer::drawCells(QPainter &painter, int r0, int c0,
         if (drawValue == Key || drawValue == Inbetween)
           painter.setPen(getViewer()->getTextColor());
         else {
-          QColor semiTranspTextColor = getViewer()->getTextColor();
+          QColor semiTranspTextColor = getViewer()->getCycleColor();
           semiTranspTextColor.setAlpha(128);
           painter.setPen(semiTranspTextColor);
         }

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -3815,7 +3815,7 @@ void FxPassThroughPainter::paint(QPainter *painter,
     painter->setFont(fnt);
   }
 
-  painter->setPen(viewer->getTextColor());
+  painter->setPen(viewer->getPassThroughTextColor());
 
   if (!m_parent->isNameEditing()) {
     // if this is a current object


### PR DESCRIPTION
No front-end change, just adds a couple extra x-sheet QColors for stylesheets.

This also I believe fixes #5318, by removing calls to load blank images in KeyFrameNavigator, but hard to say so soon, which was only affecting Windows it seems, and also gets rid of all the load errors in terminal at startup.