### PR TITLE
Fix mac build v2 : staying on c++11, macos-12, x86-64...

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -4,7 +4,9 @@ on: [push, pull_request]
 
 jobs:
   macOS:
-    runs-on: macos-latest
+    # runs-on: macos-latest
+    # avoid the headache of arm64 builds?
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
 
@@ -43,9 +45,6 @@ jobs:
         }        
         brew update
         brew cleanup
-        # the thirdparty provided lib isn't arm64: warning: ignoring file 
-        # '/Users/runner/work/opentoonz/opentoonz/thirdparty/superlu/libsuperlu_4.1.a': fat file missing arch 'arm64', file has 'i386,x86_64'
-        checkPkgAndInstall superlu
         checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja
         checkPkgAndInstall opencv
         # opencv depends on vtk and vtk depends on qt6

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -69,7 +69,8 @@ jobs:
         mkdir build
         cd build
         cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH='/usr/local/opt/qt@5/lib' -DWITH_TRANSLATION=OFF
-        ninja -w dupbuild=warn
+        # ninja -w dupbuild=warn
+        ninja
     
     - name: Introduce Libraries and Stuff
       run: |

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -68,7 +68,8 @@ jobs:
         cd toonz
         mkdir build
         cd build
-        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH='/usr/local/opt/qt@5/lib' -DWITH_TRANSLATION=OFF
+        # cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH='/usr/local/opt/qt@5/lib' -DWITH_TRANSLATION=OFF
+        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH=$(brew --prefix qt@5)/lib -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5  -DWITH_TRANSLATION=OFF
         # ninja -w dupbuild=warn
         ninja
     

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -43,6 +43,9 @@ jobs:
         }        
         brew update
         brew cleanup
+        # the thirdparty provided lib isn't arm64: warning: ignoring file 
+        # '/Users/runner/work/opentoonz/opentoonz/thirdparty/superlu/libsuperlu_4.1.a': fat file missing arch 'arm64', file has 'i386,x86_64'
+        checkPkgAndInstall superlu
         checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja
         checkPkgAndInstall opencv
         # opencv depends on vtk and vtk depends on qt6

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,6 +1,4 @@
-# cmake_minimum_required(VERSION 2.8.11)
-#required by CMAKE_IGNORE_PATH
-cmake_minimum_required(VERSION 3.28.1)
+cmake_minimum_required(VERSION 2.8.11)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 
@@ -372,9 +370,6 @@ elseif(BUILD_ENV_APPLE)
     set(PNG_LIB ${PNG_LIBRARY})
     find_package(GLEW)
 
-    # force the github workflow to use the brew superlu instead to make it compatible with arm64
-    # (as the provided lib .a in ${SDKROOT}/superlu is x86_64...)
-    CMAKE_IGNORE_PATH(${SDKROOT}/superlu)
     find_package(SuperLU REQUIRED)
     set(SUPERLU_INCLUDE_DIR ${SUPERLU_INCLUDE_DIR}/superlu)
     set(SUPERLU_LIB ${SUPERLU_LIBRARY})

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,6 +1,6 @@
 # cmake_minimum_required(VERSION 2.8.11)
 #required by CMAKE_IGNORE_PATH
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.28.1)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 2.8.11)
+# cmake_minimum_required(VERSION 2.8.11)
+#required by CMAKE_IGNORE_PATH
+cmake_minimum_required(VERSION 3.0.2)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 
@@ -370,6 +372,9 @@ elseif(BUILD_ENV_APPLE)
     set(PNG_LIB ${PNG_LIBRARY})
     find_package(GLEW)
 
+    # force the github workflow to use the brew superlu instead to make it compatible with arm64
+    # (as the provided lib .a in ${SDKROOT}/superlu is x86_64...)
+    CMAKE_IGNORE_PATH(${SDKROOT}/superlu)
     find_package(SuperLU REQUIRED)
     set(SUPERLU_INCLUDE_DIR ${SUPERLU_INCLUDE_DIR}/superlu)
     set(SUPERLU_LIB ${SUPERLU_LIBRARY})


### PR DESCRIPTION
Minimal change to fix the macos build

* removed the obsolete ninja argument

* All the arm64 issues might be due to 
`runs-on: macos-latest` :
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

replacing with
`runs-on: macos-12`
fixes it...
That would explain inconsistancies while the workflow_macos.yml didn't change, since latest behavior change over the time...

* FindQt5 needs a minimal fix (I didn't retry without that change since i switched to macos-12) :
`        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH=$(brew --prefix qt@5)/lib -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5  -DWITH_TRANSLATION=OFF
`

For a deeper fix (wip) with mac arm64 & c++17 support see https://github.com/opentoonz/opentoonz/pull/5425