### PR TITLE
Update deprecated github artifact actions to version 4

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -13,17 +13,17 @@ jobs:
       QT_URL: https://github.com/shun-iwasawa/qt5/releases/download/v5.15.2_wintab/Qt5.15.2_wintab.zip
       LTIFF: ${{github.workspace}}/thirdparty/tiff-4.0.3/lib/LibTIFF-4.0.3_2015_64.lib
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Checkout mypaint/libmypaint
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'mypaint/libmypaint'
         ref: '70f7686db792fa4953dc60f28a322bf2cd388ed7'
         path: 'libmypaint'
 
     - name: Checkout xiaoyeli/superlu
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: 'xiaoyeli/superlu'
         ref: 'a3d5233770f0caad4bc4578b46d3b26af99e9c19'
@@ -38,7 +38,7 @@ jobs:
         git checkout "$env:vcpkg_ref"
         ./bootstrap-vcpkg.bat
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
        path: C:/vcpkg/installed
        key: ${{ runner.os }}-vcpkg-${{ env.vcpkg_ref }}-${{ github.sha }}
@@ -70,7 +70,7 @@ jobs:
       shell: bash
 
     - name: Restore Boost cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
@@ -90,7 +90,7 @@ jobs:
       shell: bash
       
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.9.1'
 
@@ -178,7 +178,7 @@ jobs:
         cp C:/vcpkg/installed/x64-windows/bin/libprotobuf.dll .
         cp C:/vcpkg/installed/x64-windows/bin/libwebpdecoder.dll .
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: Opentoonz-${{ runner.os }}-${{ github.sha }}
         path: artifact


### PR DESCRIPTION
Version 1, 2 and 3 of github artifact actions are being deprecated.

Please see action error logs and:  https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

