### PR TITLE
Update how_to_build_linux.md

### DIFF
--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -6,7 +6,7 @@ Building OpenToonz from source requires the following dependencies:
 - Git
 - GCC or Clang
 - CMake (3.4.1 or newer).
-- Qt5 (5.9 or newer)
+- Qt5 (5.15 or newer)
 - Boost (1.55 or newer)
 - LibPNG
 - SuperLU


### PR DESCRIPTION
OpenToonz requires Qt 5.15 to support new code functions and ensure proper functionality.

This will avoid problems when the user build OpenToonz locally from source on Linux.

ref: https://github.com/opentoonz/opentoonz/issues/5508