### PR TITLE
Update workflow_linux.yml

### DIFF
--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -33,7 +33,6 @@ jobs:
         restore-keys: | 
           ${{ runner.os }}-${{ matrix.compiler }}-
           ${{ runner.os }}-
-          ${{ runner.os }}
 
     - name: Build libtiff
       run: |

--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -17,16 +17,23 @@ jobs:
             cxx: clang++
     steps:
     - uses: actions/checkout@v4
+
     - name: Install libraries
       run: |
         sudo apt-get update
-        sudo apt-get install build-essential cmake pkg-config ninja-build ccache libboost-all-dev qtbase5-dev qt5-qmake qtscript5-dev qttools5-dev qttools5-dev-tools qtmultimedia5-dev qtwebengine5-dev qtwayland5 libqt5svg5-dev libqt5websockets5-dev libqt5opengl5-dev libqt5multimedia5-plugins libqt5serialport5-dev libsuperlu-dev liblz4-dev libusb-1.0-0-dev liblzo2-dev libpng-dev libjpeg-dev libglew-dev freeglut3-dev libfreetype6-dev libjson-c-dev libmypaint-dev libopencv-dev libturbojpeg-dev libomp-dev libfuse2
+        sudo apt-get install -y build-essential cmake pkg-config ninja-build ccache libboost-all-dev qtbase5-dev qt5-qmake qtscript5-dev qttools5-dev qttools5-dev-tools qtmultimedia5-dev qtwayland5 libqt5svg5-dev libqt5opengl5-dev libqt5multimedia5-plugins libqt5serialport5-dev libsuperlu-dev liblz4-dev libusb-1.0-0-dev liblzo2-dev libpng-dev libjpeg-dev libglew-dev freeglut3-dev libfreetype6-dev libjson-c-dev libmypaint-dev libopencv-dev libturbojpeg-dev libomp-dev libfuse2
+
+    - name: Set up cache
+      run: mkdir -p /home/runner/.ccache
 
     - uses: actions/cache@v4
       with:
         path: /home/runner/.ccache
         key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
+        restore-keys: | 
+          ${{ runner.os }}-${{ matrix.compiler }}-
+          ${{ runner.os }}-
+          ${{ runner.os }}
 
     - name: Build libtiff
       run: |
@@ -36,6 +43,9 @@ jobs:
 
     - name: Build
       run: |
+        export CCACHE_DIR=/home/runner/.ccache
+        export CC="ccache ${{ matrix.cc }}"
+        export CXX="ccache ${{ matrix.cxx }}"
         cd toonz
         mkdir build
         cd build


### PR DESCRIPTION
Update workflow to generate cache correctly

I'm checking **Post Run actions/cache@v4** in workflow runs and it showed this:


> 
> Post job cleanup.
> Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.


Apparently actions/v4 requires explicit directory creation to ensure the path is available.

So I set the path:

```
 - name: Set up cache
 run: mkdir -p /home/runner/.ccache
```
I changed 'restore keys' to provides a more comprehensive set of restore keys to maximize the chances of finding a hit in the cache. These keys progressively fall back to broader matches if a specific cache key is not found.

```
 ${{ runner.os }}-${{ matrix.compiler }}-
 ${{runner.os}}-
```
and I configured 'ccache' to intercept compiler calls and cache the results, ensuring that builds benefit from caching, reducing build time by avoiding redundant builds.

```
 export CCACHE_DIR=/home/runner/.ccache
 export CC="ccache ${{ matrix.cc }}"
 export CXX="ccache ${{ matrix.cxx }}"
```

It will now store the cache properly and speed up the process of upcoming Linux builds artifacts.