### PR TITLE
[WIP] Text Shadow for X-Sheet/Schematic/Function Editor

### DIFF
--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -82,6 +82,11 @@ TRaster32P DVAPI rasterFromQPixmap(QPixmap pixmap, bool premultiply = true,
 
 //-----------------------------------------------------------------------------
 
+void DVAPI drawTextAndDropShadow(QPainter &p, const QRect &r, int flags,
+                                 const QString &text, QRect *br = nullptr);
+
+//-----------------------------------------------------------------------------
+
 void DVAPI drawPolygon(QPainter &p, const std::vector<QPointF> &points,
                        bool fill = false, const QColor colorFill = Qt::white,
                        const QColor colorLine = Qt::black);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -2841,14 +2841,16 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
       // Ex.  12 -> 1B    21 -> 2A   30 -> 3
       if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
         numberStr = m_viewer->getFrameNumberWithLetters(fid.getNumber());
-        p.drawText(nameRect, Qt::AlignRight | Qt::AlignBottom, numberStr);
+        drawTextAndDropShadow(p, nameRect, Qt::AlignRight | Qt::AlignBottom,
+                              numberStr);
       } else {
         QString frameNumber("");
         // set number
         if (fid.getNumber() > 0) frameNumber = QString::number(fid.getNumber());
         // add letter
         if (!fid.getLetter().isEmpty()) frameNumber += fid.getLetter();
-        p.drawText(nameRect, Qt::AlignRight | Qt::AlignBottom, frameNumber);
+        drawTextAndDropShadow(p, nameRect, Qt::AlignRight | Qt::AlignBottom,
+                              frameNumber);
       }
     }
 
@@ -2858,7 +2860,8 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
         QString("~"));
 
     if (!sameLevel || isAfterMarkers)
-      p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
+      drawTextAndDropShadow(p, nameRect, Qt::AlignLeft | Qt::AlignBottom,
+                            elidaName);
   }
 
   // cell mark

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1486,7 +1486,8 @@ void CellArea::drawExtenderHandles(QPainter &p) {
           .translated(selected.bottomRight() + smartTabPosOffset);
   p.setPen(Qt::black);
   p.setBrush(SmartTabColor);
-  p.drawRoundRect(m_levelExtenderRect, xyRadius.x(), xyRadius.y());
+  p.drawRoundedRect(m_levelExtenderRect, xyRadius.x(), xyRadius.y(),
+                    Qt::RelativeSize);
   QColor color = (distance > 0 && ((selRow1 + 1 - offset) % distance) != 0)
                      ? m_viewer->getLightLineColor()
                      : m_viewer->getMarkerLineColor();
@@ -1502,7 +1503,8 @@ void CellArea::drawExtenderHandles(QPainter &p) {
                                    .translated(properPoint + smartTabPosOffset);
     p.setPen(Qt::black);
     p.setBrush(SmartTabColor);
-    p.drawRoundRect(m_upperLevelExtenderRect, xyRadius.x(), xyRadius.y());
+    p.drawRoundedRect(m_upperLevelExtenderRect, xyRadius.x(), xyRadius.y(),
+                      Qt::RelativeSize);
     QColor color = (distance > 0 && ((selRow0 - offset) % distance) != 0)
                        ? m_viewer->getLightLineColor()
                        : m_viewer->getMarkerLineColor();
@@ -2137,9 +2139,9 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
       fnum = frameNumber;
     }
 
-    int alignFlag =
-        ((showLevelName) ? Qt::AlignRight | Qt::AlignBottom : Qt::AlignCenter);
-    p.drawText(nameRect, alignFlag, fnum);
+    int alignmentFlags =
+        showLevelName ? Qt::AlignRight | Qt::AlignBottom : Qt::AlignCenter;
+    drawTextAndDropShadow(p, nameRect, alignmentFlags, fnum);
   }
 
   // cell mark
@@ -2164,9 +2166,10 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     std::wstring levelName = cell.m_level->getName();
     QString text           = QString::fromStdWString(levelName);
     QFontMetrics fm(font);
-    QString elidaName =
-        elideText(text, fm, nameRect.width() - fm.width(fnum), QString("~"));
-    p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
+    QString elidaName = elideText(
+        text, fm, nameRect.width() - fm.horizontalAdvance(fnum), QString("~"));
+    drawTextAndDropShadow(p, nameRect, Qt::AlignLeft | Qt::AlignBottom,
+                          elidaName);
   }
 }
 
@@ -2346,7 +2349,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
 
   QFontMetrics metric(font);
 
-  int charWidth = metric.width(text, 1);
+  int charWidth = metric.horizontalAdvance(text, 1);
   if ((charWidth * 2) > nameRect.width()) nameRect.adjust(-2, 0, 4, 0);
 
   QString elidaName = elideText(text, metric, nameRect.width(), "~");
@@ -2851,7 +2854,8 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
 
     QString text      = QString::fromStdWString(levelName);
     QString elidaName = elideText(
-        text, fm, nameRect.width() - fm.width(numberStr) - 2, QString("~"));
+        text, fm, nameRect.width() - fm.horizontalAdvance(numberStr) - 2,
+        QString("~"));
 
     if (!sameLevel || isAfterMarkers)
       p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -512,7 +512,7 @@ void ChangeObjectParent::refresh() {
   for (i = 0; i < pegbarListID.size(); i++)
     addText(pegbarListID.at(i), pegbarListTr.at(i), pegbarListColor.at(i));
 
-  m_width = fontMetrics().width(theLongestTxt) + 32;
+  m_width = fontMetrics().horizontalAdvance(theLongestTxt) + 32;
   selectCurrent(currentId);
 }
 
@@ -1144,8 +1144,8 @@ void ColumnArea::DrawHeader::drawColumnNumber() const {
 
   int valign = o->isVerticalTimeline() ? Qt::AlignVCenter : Qt::AlignBottom;
 
-  p.drawText(pos, Qt::AlignHCenter | valign | Qt::TextSingleLine,
-             QString::number(col + 1));
+  drawTextAndDropShadow(p, pos, Qt::AlignHCenter | valign | Qt::TextSingleLine,
+                        QString::number(col + 1));
 }
 
 void ColumnArea::DrawHeader::drawColumnName() const {
@@ -1222,17 +1222,18 @@ void ColumnArea::DrawHeader::drawColumnName() const {
     p.save();
     p.translate(columnName.topRight());
     p.rotate(90);
-    p.drawText(columnName.translated(-columnName.topLeft())
-                   .transposed()
-                   .adjusted(5, 0, 0, 0),
-               Qt::AlignLeft | valign, cameraName);
+    drawTextAndDropShadow(p,
+                          columnName.translated(-columnName.topLeft())
+                              .transposed()
+                              .adjusted(5, 0, 0, 0),
+                          Qt::AlignLeft | valign, cameraName);
     p.restore();
     return;
   }
 
-  p.drawText(columnName.adjusted(leftadj, 0, rightadj, 0),
-             Qt::AlignLeft | valign | Qt::TextSingleLine,
-             QString(name.c_str()));
+  drawTextAndDropShadow(p, columnName.adjusted(leftadj, 0, rightadj, 0),
+                        Qt::AlignLeft | valign | Qt::TextSingleLine,
+                        QString(name.c_str()));
 }
 
 void ColumnArea::DrawHeader::drawThumbnail(QPixmap &iconPixmap) const {
@@ -1338,11 +1339,11 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   std::string handle = xsh->getStageObject(columnId)->getParentHandle();
   if (handle == "B") handleWidth = 0;  // Default handle
 
-  int width = QFontMetrics(font).width(name);
+  int width = QFontMetrics(font).horizontalAdvance(name);
 
   while (width > o->rect(PredefinedRect::PEGBAR_NAME).width() - handleWidth) {
     name.remove(-1, 1000);
-    width = QFontMetrics(font).width(name);
+    width = QFontMetrics(font).horizontalAdvance(name);
   }
 
   // pegbar name
@@ -1378,8 +1379,9 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
 
   p.setPen(m_viewer->getTextColor());
 
-  p.drawText(pegbarnamerect.adjusted(3, 0, 0, 0),
-             Qt::AlignLeft | Qt::AlignVCenter | Qt::TextSingleLine, name);
+  drawTextAndDropShadow(p, pegbarnamerect.adjusted(3, 0, 0, 0),
+                        Qt::AlignLeft | Qt::AlignVCenter | Qt::TextSingleLine,
+                        name);
 }
 
 void ColumnArea::DrawHeader::drawParentHandleName() const {
@@ -1412,9 +1414,10 @@ void ColumnArea::DrawHeader::drawParentHandleName() const {
   p.drawRect(parenthandleRect.adjusted(2, 0, 0, 0));
 
   p.setPen(m_viewer->getTextColor());
-  p.drawText(parenthandleRect,
-             Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextSingleLine,
-             QString::fromStdString(handle));
+  drawTextAndDropShadow(
+      p, parenthandleRect,
+      Qt::AlignHCenter | Qt::AlignVCenter | Qt::TextSingleLine,
+      QString::fromStdString(handle));
 }
 
 void ColumnArea::DrawHeader::drawFilterColor() const {
@@ -2343,7 +2346,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
       return;
     }
-    
+
     TXshColumn *column = xsh->getColumn(m_col);
     bool isEmpty       = !column || column->isEmpty();
     TApp::instance()->getCurrentObject()->setIsSpline(false);
@@ -2355,7 +2358,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     // int y = event->pos().y();
     // QPoint mouseInCell(x, y);
     int x = mouseInCell.x(), y = mouseInCell.y();
-    
+
     // don't make column current when click on some of its toggle buttons
     bool needMakeColumnCurrent = true;
     if ( o->rect(PredefinedRect::LOCK_AREA).contains(mouseInCell)

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -222,7 +222,7 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
         str = QString("%1\"").arg(QString::number(koma).rightJustified(2, '0'));
       }
 
-      p.drawText(labelRect, align, str);
+      drawTextAndDropShadow(p, labelRect, align, str);
 
       break;
     }
@@ -230,7 +230,7 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
     case XsheetViewer::Frame: {
       if (simpleView && r > 0 && (r + 1) % (distance > 0 ? distance : 5)) break;
       QString number = QString::number(r + 1);
-      p.drawText(labelRect, align, number);
+      drawTextAndDropShadow(p, labelRect, align, number);
       break;
     }
 
@@ -261,7 +261,7 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
         if (koma == 0) koma = frameRate * 6;
         str = QString("%1").arg(QString::number(koma).rightJustified(3, '0'));
       }
-      p.drawText(labelRect, align, str);
+      drawTextAndDropShadow(p, labelRect, align, str);
       break;
     }
     // 3 second sheet (72frames per page)
@@ -291,7 +291,7 @@ void RowArea::drawRows(QPainter &p, int r0, int r1) {
         if (koma == 0) koma = frameRate * 3;
         str = QString("%1").arg(QString::number(koma).rightJustified(2, '0'));
       }
-      p.drawText(labelRect, align, str);
+      drawTextAndDropShadow(p, labelRect, align, str);
       break;
     }
     }

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -402,7 +402,8 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
     int d        = 8;
     int flags    = Qt::AlignLeft | Qt::AlignVCenter;
     if (!m_sheet->isSmallHeader()) flags |= Qt::TextWrapAnywhere;
-    painter.drawText(x0 + d, y1, width - d, y3 - y1 + 1, flags, text);
+    drawTextAndDropShadow(painter, QRect(x0 + d, y1, width - d, y3 - y1 + 1),
+                          flags, text);
 
     // warning of losing expression reference
     TXsheet *xsh = m_sheet->getViewer()->getXsheetHandle()->getXsheet();
@@ -419,8 +420,9 @@ void FunctionSheetColumnHeadViewer::paintEvent(QPaintEvent *e) {
       if (group == currentGroup)
         painter.setPen(m_sheet->getViewer()->getCurrentTextColor());
       text = group->getShortName();
-      painter.drawText(x0 + d, y0, tmpwidth - d, y1 - y0 + 1,
-                       Qt::AlignLeft | Qt::AlignVCenter, text);
+      drawTextAndDropShadow(painter,
+                            QRect(x0 + d, y0, tmpwidth - d, y1 - y0 + 1),
+                            Qt::AlignLeft | Qt::AlignVCenter, text);
     }
   }
 }
@@ -869,8 +871,7 @@ void FunctionSheetCellViewer::drawCells(QPainter &painter, int r0, int c0,
         font.setBold(drawValue == Key);
         font.setPixelSize(12);
         painter.setFont(font);
-        painter.drawText(cellRect.adjusted(10, 0, 0, 0),
-                         Qt::AlignVCenter | Qt::AlignLeft, text);
+        drawTextAndDropShadow(painter, cellRect.adjusted(10, 0, 0, 0), Qt::AlignVCenter | Qt::AlignLeft, text);
       }
     }
 

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -866,11 +866,11 @@ void FxPainter::paint_small(QPainter *painter) {
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
     painter->setFont(fnt);
-    painter->setPen(viewer->getTextColor()); //#todo
+    painter->setPen(viewer->getTextColor());
     FxSchematicScene *sceneFx = dynamic_cast<FxSchematicScene *>(scene());
     if (!sceneFx) return;
     if (sceneFx->getCurrentFx() == m_parent->getFx())
-      painter->setPen(viewer->getSelectedNodeTextColor()); //#todo
+      painter->setPen(viewer->getSelectedNodeTextColor());
   }
 
   if (m_type == eGroupedFx) {

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -204,14 +204,14 @@ void FxColumnPainter::paint(QPainter *painter,
   painter->setPen(viewer->getTextColor());
   painter->setBrush(Qt::NoBrush);
 
-  QRectF columnNameRect;
-  QRectF levelNameRect;
+  QRect columnNameRect;
+  QRect levelNameRect;
   if (m_parent->isNormalIconView()) {
     columnNameRect = QRect(18, 2, 54, 14);
-    levelNameRect  = QRectF(18, 16, 54, 14);
+    levelNameRect  = QRect(18, 16, 54, 14);
   } else {
     columnNameRect = QRect(4, 2, 78, 22);
-    levelNameRect  = QRectF(4, 26, 78, 22);
+    levelNameRect  = QRect(4, 26, 78, 22);
 
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
@@ -225,15 +225,15 @@ void FxColumnPainter::paint(QPainter *painter,
       painter->setPen(viewer->getSelectedNodeTextColor());
     QString elidedName =
         elideText(m_name, painter->font(), columnNameRect.width());
-    painter->drawText(columnNameRect, Qt::AlignLeft | Qt::AlignVCenter,
-                      elidedName);
+    drawTextAndDropShadow(*painter, columnNameRect,
+                          Qt::AlignLeft | Qt::AlignVCenter, elidedName);
   }
 
   // level name
   QString elidedName =
       elideText(levelName, painter->font(), levelNameRect.width());
-  painter->drawText(levelNameRect, Qt::AlignLeft | Qt::AlignVCenter,
-                    elidedName);
+  drawTextAndDropShadow(*painter, levelNameRect,
+                        Qt::AlignLeft | Qt::AlignVCenter, elidedName);
 }
 
 //-----------------------------------------------------
@@ -432,16 +432,16 @@ void FxPalettePainter::paint(QPainter *painter,
 
   // draw icon
   QRect paletteRect;
-  QRectF idRect;
-  QRectF palNameRect;
+  QRect idRect;
+  QRect palNameRect;
   if (m_parent->isNormalIconView()) {
     paletteRect = QRect(-3, -1, 20, 16);
-    idRect      = QRectF(18, 2, 54, 14);
-    palNameRect = QRectF(18, 16, 54, 14);
+    idRect      = QRect(18, 2, 54, 14);
+    palNameRect = QRect(18, 16, 54, 14);
   } else {
     paletteRect = QRect(4, -6, 35, 28);
-    idRect      = QRectF(25, 2, 49, 22);
-    palNameRect = QRectF(4, 26, 78, 22);
+    idRect      = QRect(25, 2, 49, 22);
+    palNameRect = QRect(4, 26, 78, 22);
 
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
@@ -461,17 +461,19 @@ void FxPalettePainter::paint(QPainter *painter,
 
     if (m_parent->isNormalIconView()) {
       QString elidedName = elideText(m_name, painter->font(), w);
-      painter->drawText(idRect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+      drawTextAndDropShadow(*painter, idRect, Qt::AlignLeft | Qt::AlignVCenter,
+                            elidedName);
     } else
-      painter->drawText(idRect, Qt::AlignRight | Qt::AlignVCenter,
-                        QString::number(m_parent->getColumnIndex() + 1));
+      drawTextAndDropShadow(*painter, idRect, Qt::AlignRight | Qt::AlignVCenter,
+                            QString::number(m_parent->getColumnIndex() + 1));
   }
 
   // level name
   QString paletteName = m_parent->getPaletteName();
   QString elidedName =
       elideText(paletteName, painter->font(), palNameRect.width());
-  painter->drawText(palNameRect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+  drawTextAndDropShadow(*painter, palNameRect, Qt::AlignLeft | Qt::AlignVCenter,
+                        elidedName);
 }
 
 //-----------------------------------------------------
@@ -638,8 +640,8 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
 
   if (label != m_name) {
     label = elideText(label, painter->font(), m_width - 21);
-    painter->drawText(QRectF(3, 16, m_width - 21, 14),
-                      Qt::AlignLeft | Qt::AlignVCenter, label);
+    drawTextAndDropShadow(*painter, QRect(3, 15, m_width - 21, 14),
+                          Qt::AlignLeft | Qt::AlignVCenter, label);
   }
 
   // draw user-defined fx name in the upper part
@@ -649,14 +651,14 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
     if (!sceneFx) return;
     if (sceneFx->getCurrentFx() == m_parent->getFx())
       painter->setPen(viewer->getSelectedNodeTextColor());
-    QRectF rect(3, 2, m_width - 21, 14);
+    QRect rect(3, 2, m_width - 21, 14);
     int w = rect.width();
     if (label == m_name) {
       rect.adjust(0, 0, 0, 14);
       w *= 2;
     }
     QString elidedName = elideText(m_name, painter->font(), w);
-    painter->drawText(rect, Qt::TextWrapAnywhere, elidedName);
+    drawTextAndDropShadow(*painter, rect, Qt::TextWrapAnywhere, elidedName);
   }
 }
 
@@ -864,19 +866,20 @@ void FxPainter::paint_small(QPainter *painter) {
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
     painter->setFont(fnt);
-    painter->setPen(viewer->getTextColor());
+    painter->setPen(viewer->getTextColor()); //#todo
     FxSchematicScene *sceneFx = dynamic_cast<FxSchematicScene *>(scene());
     if (!sceneFx) return;
     if (sceneFx->getCurrentFx() == m_parent->getFx())
-      painter->setPen(viewer->getSelectedNodeTextColor());
+      painter->setPen(viewer->getSelectedNodeTextColor()); //#todo
   }
 
   if (m_type == eGroupedFx) {
     if (!m_parent->isNameEditing()) {
-      QRectF rect(14, 2, 68, 22);
+      QRect rect(14, 2, 68, 22);
       int w              = rect.width();
       QString elidedName = elideText(m_name, painter->font(), w);
-      painter->drawText(rect, elidedName);
+      drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                            elidedName);
     }
   } else {
     painter->drawPixmap(16, 6, 38, 38,
@@ -889,8 +892,8 @@ void FxPainter::paint_small(QPainter *painter) {
         dynamic_cast<FxSchematicZeraryNode *>(m_parent);
     if (zeraryNode) {
       QRect idRect(30, 10, 46, 38);
-      painter->drawText(idRect, Qt::AlignRight | Qt::AlignBottom,
-                        QString::number(zeraryNode->getColumnIndex() + 1));
+      drawTextAndDropShadow(*painter, idRect, Qt::AlignRight | Qt::AlignBottom,
+                            QString::number(zeraryNode->getColumnIndex() + 1));
     }
   }
 
@@ -957,17 +960,18 @@ void FxXSheetPainter::paint(QPainter *painter,
     painter->setPen(viewer->getTextColor());
   if (m_parent->isNormalIconView()) {
     // Draw the name
-    QRectF rect(18, 0, 54, 18);
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter,
-                      QString(tr("XSheet")));
+    QRect rect(18, 0, 54, 18);
+    drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          QString(tr("XSheet")));
   }
   // small scaled
   else {
-    QRectF rect(28, 4, 32, 32);
+    QRect rect(28, 4, 32, 32);
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
     painter->setFont(fnt);
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, QString("X"));
+    drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          QString("X"));
   }
 }
 
@@ -1061,17 +1065,18 @@ void FxOutputPainter::paint(QPainter *painter,
     painter->setPen(viewer->getTextColor());
   if (m_parent->isNormalIconView()) {
     // Draw the name
-    QRectF rect(18, 0, 72, 18);
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter,
-                      QString(tr("Output")));
+    QRect rect(18, 0, 72, 18);
+        drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          QString(tr("Output")));
   }
   // small view
   else {
-    QRectF rect(16, 0, 50, 36);
+    QRect rect(16, 0, 50, 36);
     QFont fnt = painter->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
     painter->setFont(fnt);
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, QString("Out"));
+        drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          QString(tr("Out")));
   }
 }
 
@@ -3804,7 +3809,7 @@ void FxPassThroughPainter::paint(QPainter *painter,
 
   QFont fnt = painter->font();
   int width = QFontMetrics(fnt).width(m_name) + 1;
-  QRectF nameArea(0, 0, width, 14);
+  QRect nameArea(0, 0, width, 14);
 
   if (m_parent->isNormalIconView()) {
     nameArea.adjust(-(width / 2) + 6, -51, 0, 0);
@@ -3821,7 +3826,8 @@ void FxPassThroughPainter::paint(QPainter *painter,
     // if this is a current object
     if (sceneFx->getCurrentFx() == m_parent->getFx())
       painter->setPen(viewer->getSelectedNodeTextColor());
-    painter->drawText(nameArea, Qt::AlignLeft | Qt::AlignVCenter, m_name);
+    drawTextAndDropShadow(*painter, nameArea, Qt::AlignLeft | Qt::AlignVCenter,
+                          m_name);
   }
 }
 

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -144,8 +144,13 @@ void drawTextAndDropShadow(QPainter &p, const QRect &r, int flags,
   static const QColor shadowColor(0, 0, 0, 128);
   QColor textColor = p.pen().color();
 
-  // draw shadow, but only if textColor is bright enough
-  if (textColor.value() > 128) {
+  // Calculate luminance of the text color
+  double luminance = 0.299 * textColor.redF() +
+                     0.587 * textColor.greenF() +
+                     0.114 * textColor.blueF();
+
+  // Draw shadow if the text color is bright enough
+  if (luminance > 0.5) {
     p.setPen(shadowColor);
     QRect shadowRect = r.translated(1, 1);
     p.drawText(shadowRect, flags, text, br);

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -139,6 +139,25 @@ TRaster32P rasterFromQPixmap(
 
 //-----------------------------------------------------------------------------
 
+void drawTextAndDropShadow(QPainter &p, const QRect &r, int flags,
+                           const QString &text, QRect *br) {
+  static const QColor shadowColor(0, 0, 0, 128);
+  QColor textColor = p.pen().color();
+
+  // draw shadow, but only if textColor is bright enough
+  if (textColor.value() > 128) {
+    p.setPen(shadowColor);
+    QRect shadowRect = r.translated(1, 1);
+    p.drawText(shadowRect, flags, text, br);
+  }
+
+  // draw main text
+  p.setPen(textColor);
+  p.drawText(r, flags, text, br);
+}
+
+//-----------------------------------------------------------------------------
+
 void drawPolygon(QPainter &p, const std::vector<QPointF> &points, bool fill,
                  const QColor colorFill, const QColor colorLine) {
   if (points.size() == 0) return;

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -151,13 +151,14 @@ void drawTextAndDropShadow(QPainter &p, const QRect &r, int flags,
 
   // Draw shadow if the text color is bright enough
   if (luminance > 0.5) {
+    p.save();
     p.setPen(shadowColor);
     QRect shadowRect = r.translated(1, 1);
     p.drawText(shadowRect, flags, text, br);
+    p.restore();
   }
 
-  // draw main text
-  p.setPen(textColor);
+  // Draw main text
   p.drawText(r, flags, text, br);
 }
 

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -395,8 +395,8 @@ void RowPanel::drawRows(QPainter &p, int r0, int r1) {
                                : getViewer()->getFrameTextColor());
 
     QString number = QString::number(r + 1);
-    p.drawText(QRect(x0, y + 1, width() - 4, next_y - y - 1),
-               Qt::AlignVCenter | Qt::AlignRight, number);
+    drawTextAndDropShadow(p, QRect(x0, y + 1, width() - 4, next_y - y - 1),
+                          Qt::AlignVCenter | Qt::AlignRight, number);
     y = next_y;
   }
 }

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -183,19 +183,19 @@ void ColumnPainter::paint(QPainter *painter,
     // if this is current object
     if (stageScene->getCurrentObject() == m_parent->getStageObject()->getId())
       painter->setPen(viewer->getSelectedNodeTextColor());
-    QRectF columnNameRect(18, 2, 54, 14);
+    QRect columnNameRect(18, 2, 54, 14);
     QString elidedName =
         elideText(m_name, painter->font(), columnNameRect.width());
-    painter->drawText(columnNameRect, Qt::AlignLeft | Qt::AlignVCenter,
-                      elidedName);
+    drawTextAndDropShadow(*painter, columnNameRect,
+                          Qt::AlignLeft | Qt::AlignVCenter, elidedName);
   }
 
   // level names
-  QRectF levelNameRect(18, 16, 54, 14);
+  QRect levelNameRect(18, 16, 54, 14);
   QString elidedName =
       elideText(levelName, painter->font(), levelNameRect.width());
-  painter->drawText(levelNameRect, Qt::AlignLeft | Qt::AlignVCenter,
-                    elidedName);
+  drawTextAndDropShadow(*painter, levelNameRect,
+                        Qt::AlignLeft | Qt::AlignVCenter, elidedName);
 }
 
 //--------------------------------------------------------
@@ -330,9 +330,10 @@ void GroupPainter::paint(QPainter *painter,
     else
       painter->setPen(viewer->getTextColor());
 
-    QRectF rect(18, 0, 54, 18);
+    QRect rect(18, 0, 54, 18);
     QString elidedName = elideText(m_name, painter->font(), rect.width());
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+    drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          elidedName);
   }
 }
 
@@ -400,9 +401,10 @@ void PegbarPainter::paint(QPainter *painter,
     else
       painter->setPen(viewer->getTextColor());
     // Draw the name
-    QRectF rect(18, 0, 54, 18);
+    QRect rect(18, 0, 54, 18);
     QString elidedName = elideText(m_name, painter->font(), rect.width());
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+    drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          elidedName);
   }
 }
 
@@ -487,9 +489,10 @@ void CameraPainter::paint(QPainter *painter,
     else
       painter->setPen(viewer->getTextColor());
     // Draw the name
-    QRectF rect(18, 0, 54, 18);
+    QRect rect(18, 0, 54, 18);
     QString elidedName = elideText(m_name, painter->font(), rect.width());
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+    drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          elidedName);
   }
 }
 
@@ -581,9 +584,9 @@ void TablePainter::paint(QPainter *painter,
     painter->setPen(viewer->getTextColor());
 
   // Draw the name
-  QRectF rect(30, 0, 42, 18);
-  painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter,
-                    QString(tr("Table")));
+  QRect rect(30, 0, 42, 18);
+  drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                        QString(tr("Table")));
 }
 
 //--------------------------------------------------------
@@ -664,9 +667,10 @@ void SplinePainter::paint(QPainter *painter,
         else
     */
     painter->setPen(viewer->getTextColor());
-    QRectF rect(18, 0, 72, 18);
+    QRect rect(18, 0, 72, 18);
     QString elidedName = elideText(m_name, painter->font(), rect.width());
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+    drawTextAndDropShadow(*painter, rect, Qt::AlignLeft | Qt::AlignVCenter,
+                          elidedName);
   }
 }
 


### PR DESCRIPTION
This puts a shadow under text in the X-Sheet (columns, frame numbers) and Schematic nodes similar to the Blender interface to improve the readability for light text colors. If the text is dark color there is no shadow.

<img width="200" alt="txtsh_xsh" src="https://github.com/user-attachments/assets/e5d8037e-463d-4d0a-81e7-807cfa8156ec">
<img width="124" alt="txtsh_fe" src="https://github.com/user-attachments/assets/d75c3d71-5e21-42e2-92b1-eb0b6064b486">
<img width="267" alt="txtsh_node" src="https://github.com/user-attachments/assets/9eb61722-cabf-45cd-b387-8d042d7a73cb">
