### PR TITLE
Update workflow_macos.yml

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -8,50 +8,37 @@ jobs:
     # avoid the headache of arm64 builds?
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Remove symlinks
       run: |
-        # remove existing symlinks before installing python@3.10, 3.11, and 3.12
-        rm -f /usr/local/bin/2to3
-        rm -f /usr/local/bin/idle3
-        rm -f /usr/local/bin/pydoc3
-        rm -f /usr/local/bin/python3
-        rm -f /usr/local/bin/python3-config
-        rm -f /usr/local/bin/2to3-3.11
-        rm -f /usr/local/bin/idle3.11
-        rm -f /usr/local/bin/pydoc3.11
-        rm -f /usr/local/bin/python3.11
-        rm -f /usr/local/bin/python3.11-config
-        rm -f /usr/local/bin/2to3-3.12
-        rm -f /usr/local/bin/idle3.12
-        rm -f /usr/local/bin/pydoc3.12
-        rm -f /usr/local/bin/python3.12
-        rm -f /usr/local/bin/python3.12-config
+        # remove existing symlinks before installing Python
+        for symlink in 2to3 idle3 pydoc3 python3 python3-config 2to3-3.11 idle3.11 pydoc3.11 python3.11 python3.11-config 2to3-3.12 idle3.12 pydoc3.12 python3.12 python3.12-config; do
+          rm -f /usr/local/bin/$symlink
+        done
 
     - name: Install libraries
       run: |
-        checkPkgAndInstall()
-        {
-          while [ $# -ne 0 ]
-          do
-            if brew ls --versions $1 ; then
-              brew upgrade $1
+        checkPkgAndInstall() {
+          for pkg in "$@"; do
+            if brew ls --versions $pkg; then
+              brew upgrade $pkg
             else
-              brew install $1
+              brew install $pkg
             fi
-            shift
           done
-        }        
+        }
         brew update
         brew cleanup
-        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja
-        checkPkgAndInstall opencv
-        # opencv depends on vtk and vtk depends on qt6
+        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv qt@5
         brew unlink qt
-        checkPkgAndInstall qt@5
-        
-    - uses: actions/cache@v1
+
+    - name: Set up cache
+      run: |
+        export PATH="/usr/local/opt/ccache/libexec:$PATH"
+        mkdir -p /Users/runner/.ccache
+
+    - uses: actions/cache@v4
       with:
         path: /Users/runner/.ccache
         key: ${{ runner.os }}-${{ github.sha }}
@@ -59,48 +46,43 @@ jobs:
 
     - name: Build libtiff
       run: |
-        export PATH="/usr/local/opt/ccache/libexec:$PATH"
         cd thirdparty/tiff-4.0.3
         CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./configure --disable-lzma
-        make -j $(nproc)
+        make -j $(sysctl -n hw.ncpu)
 
     - name: Build
       run: |
         export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
         cd toonz
-        mkdir build
+        mkdir -p build
         cd build
-        # cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH='/usr/local/opt/qt@5/lib' -DWITH_TRANSLATION=OFF
-        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH=$(brew --prefix qt@5)/lib -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5  -DWITH_TRANSLATION=OFF
-        # ninja -w dupbuild=warn
+        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH=$(brew --prefix qt@5)/lib -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 -DWITH_TRANSLATION=OFF
         ninja
-    
+
     - name: Introduce Libraries and Stuff
       run: |
         cd toonz/build/toonz
         cp -pr ../../../stuff OpenToonz.app/portablestuff
         /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -verbose=1 -always-overwrite \
-        -executable=OpenToonz.app/Contents/MacOS/lzocompress \
-        -executable=OpenToonz.app/Contents/MacOS/lzodecompress \
-        -executable=OpenToonz.app/Contents/MacOS/tcleanup \
-        -executable=OpenToonz.app/Contents/MacOS/tcomposer \
-        -executable=OpenToonz.app/Contents/MacOS/tconverter \
-        -executable=OpenToonz.app/Contents/MacOS/tfarmcontroller \
-        -executable=OpenToonz.app/Contents/MacOS/tfarmserver
-    
+          -executable=OpenToonz.app/Contents/MacOS/lzocompress \
+          -executable=OpenToonz.app/Contents/MacOS/lzodecompress \
+          -executable=OpenToonz.app/Contents/MacOS/tcleanup \
+          -executable=OpenToonz.app/Contents/MacOS/tcomposer \
+          -executable=OpenToonz.app/Contents/MacOS/tconverter \
+          -executable=OpenToonz.app/Contents/MacOS/tfarmcontroller \
+          -executable=OpenToonz.app/Contents/MacOS/tfarmserver
+
     - name: Modify Library Paths
       run: |
         cd toonz/build/toonz/OpenToonz.app/Contents/Frameworks
-        for TARGETLIB in `ls ./ | grep dylib`
-        do
+        for TARGETLIB in *.dylib; do
           echo $TARGETLIB
-          for FROMPATH in `otool -L "$TARGETLIB" | grep ".dylib" | grep -v "$TARGETLIB" | grep -v "@executable_path/../Frameworks" | sed -e"s/ (.*$//"`
-          do
+          otool -L "$TARGETLIB" | grep ".dylib" | grep -v "$TARGETLIB" | grep -v "@executable_path/../Frameworks" | awk '{print $1}' | while read -r FROMPATH; do
             echo "  $FROMPATH"
-            LIBNAME=`basename $FROMPATH`
+            LIBNAME=$(basename "$FROMPATH")
             if [[ -e ./$LIBNAME ]]; then
               echo "updating library path of $LIBNAME in $TARGETLIB"
-              install_name_tool -change "$FROMPATH" "@executable_path/../Frameworks/$LIBNAME" $TARGETLIB
+              install_name_tool -change "$FROMPATH" "@executable_path/../Frameworks/$LIBNAME" "$TARGETLIB"
             fi
           done
         done
@@ -109,8 +91,8 @@ jobs:
       run: |
         cd toonz/build/toonz
         /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=1
-    
-    - uses: actions/upload-artifact@v1
+
+    - uses: actions/upload-artifact@v4
       with:
         name: Opentoonz-${{ runner.os }}-${{ github.sha }}
         path: toonz/build/toonz/OpenToonz.dmg


### PR DESCRIPTION
Updated actions/checkout and actions/cache to v4

Created a loop to remove symlinks more efficiently. The _checkPkgAndInstall_ function has been simplified for better readability.

Changed `make -j $(nproc)` to `make -j $(sysctl -n hw.ncpu)` this command is specific to macOS.

This workflow must work with ccache support and create the required artifact correctly. I'd appreciate it if MacOs users could test the artifact.