### PR TITLE
Include functional in place of removed xstddef

### DIFF
--- a/toonz/sources/tnzext/NotSymmetricBezierPotential.cpp
+++ b/toonz/sources/tnzext/NotSymmetricBezierPotential.cpp
@@ -5,6 +5,7 @@
 #include <tcurves.h>
 
 #include <algorithm>
+#include <functional>
 
 using namespace std;
 

--- a/toonz/sources/tnzext/NotSymmetricExpPotential.cpp
+++ b/toonz/sources/tnzext/NotSymmetricExpPotential.cpp
@@ -4,6 +4,7 @@
 
 #include <tmathutil.h>
 #include <algorithm>
+#include <functional>
 
 using namespace std;
 


### PR DESCRIPTION
I am now migrating my development environment to Win11+Visual Studio 2022.
In VS2022 `unary_function` and other components have moved from `<xstddef>` to other headers.
This PR includes the proper header `<functional>` to avoid build errors.

A personal note to add..
After a one-year parental leave following the birth of my third son, I returned to my regular work this week. :-)