### PR TITLE
Update macOS workflow

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -93,10 +93,26 @@ jobs:
             done
           done
 
+      - name: Unmount Existing Disk Images
+        run: |
+          if mount | grep "/Volumes/OpenToonz"; then
+            echo "Unmounting existing volume..."
+            hdiutil detach /Volumes/OpenToonz || true
+            echo "Volume unmounted."
+          else
+            echo "No volume to unmount."
+          fi
+
       - name: Create Artifact
         run: |
           cd toonz/build/toonz
-          /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=1
+          echo "Creating DMG..."
+          if /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=1; then
+            echo "DMG created successfully."
+          else
+            echo "Failed to create DMG."
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -6,93 +6,99 @@ jobs:
   macOS:
     # runs-on: macos-latest
     # avoid the headache of arm64 builds?
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Remove symlinks
-      run: |
-        # remove existing symlinks before installing Python
-        for symlink in 2to3 idle3 pydoc3 python3 python3-config 2to3-3.11 idle3.11 pydoc3.11 python3.11 python3.11-config 2to3-3.12 idle3.12 pydoc3.12 python3.12 python3.12-config; do
-          rm -f /usr/local/bin/$symlink
-        done
-
-    - name: Install libraries
-      run: |
-        checkPkgAndInstall() {
-          for pkg in "$@"; do
-            if brew ls --versions $pkg; then
-              brew upgrade $pkg
-            else
-              brew install $pkg
-            fi
+      - name: Remove symlinks
+        run: |
+          # Remove existing symlinks before installing Python
+          for symlink in 2to3 idle3 pydoc3 python3 python3-config \
+                         2to3-3.11 idle3.11 pydoc3.11 python3.11 python3.11-config \
+                         2to3-3.12 idle3.12 pydoc3.12 python3.12 python3.12-config; do
+            rm -f /usr/local/bin/$symlink
           done
-        }
-        brew update
-        brew cleanup
-        checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv qt@5
-        brew unlink qt
 
-    - name: Set up cache
-      run: |
-        export PATH="/usr/local/opt/ccache/libexec:$PATH"
-        mkdir -p /Users/runner/.ccache
+      - name: Install libraries
+        run: |
+          checkPkgAndInstall() {
+            for pkg in "$@"; do
+              if brew ls --versions $pkg; then
+                brew upgrade $pkg
+              else
+                brew install $pkg
+              fi
+            done
+          }
+          
+          brew update
+          brew cleanup
 
-    - uses: actions/cache@v4
-      with:
-        path: /Users/runner/.ccache
-        key: ${{ runner.os }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-
+          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv qt@5
+          brew unlink qt
 
-    - name: Build libtiff
-      run: |
-        cd thirdparty/tiff-4.0.3
-        CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./configure --disable-lzma
-        make -j $(sysctl -n hw.ncpu)
+      - name: Set up cache
+        run: |
+          export PATH="/usr/local/opt/ccache/libexec:$PATH"
+          mkdir -p /Users/runner/.ccache
 
-    - name: Build
-      run: |
-        export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
-        cd toonz
-        mkdir -p build
-        cd build
-        cmake ../sources -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQT_PATH=$(brew --prefix qt@5)/lib -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 -DWITH_TRANSLATION=OFF
-        ninja
+      - uses: actions/cache@v4
+        with:
+          path: /Users/runner/.ccache
+          key: ${{ runner.os }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-
 
-    - name: Introduce Libraries and Stuff
-      run: |
-        cd toonz/build/toonz
-        cp -pr ../../../stuff OpenToonz.app/portablestuff
-        /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -verbose=1 -always-overwrite \
-          -executable=OpenToonz.app/Contents/MacOS/lzocompress \
-          -executable=OpenToonz.app/Contents/MacOS/lzodecompress \
-          -executable=OpenToonz.app/Contents/MacOS/tcleanup \
-          -executable=OpenToonz.app/Contents/MacOS/tcomposer \
-          -executable=OpenToonz.app/Contents/MacOS/tconverter \
-          -executable=OpenToonz.app/Contents/MacOS/tfarmcontroller \
-          -executable=OpenToonz.app/Contents/MacOS/tfarmserver
+      - name: Build libtiff
+        run: |
+          cd thirdparty/tiff-4.0.3
+          CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./configure --disable-lzma
+          make -j $(sysctl -n hw.ncpu)
 
-    - name: Modify Library Paths
-      run: |
-        cd toonz/build/toonz/OpenToonz.app/Contents/Frameworks
-        for TARGETLIB in *.dylib; do
-          echo $TARGETLIB
-          otool -L "$TARGETLIB" | grep ".dylib" | grep -v "$TARGETLIB" | grep -v "@executable_path/../Frameworks" | awk '{print $1}' | while read -r FROMPATH; do
-            echo "  $FROMPATH"
-            LIBNAME=$(basename "$FROMPATH")
-            if [[ -e ./$LIBNAME ]]; then
-              echo "updating library path of $LIBNAME in $TARGETLIB"
-              install_name_tool -change "$FROMPATH" "@executable_path/../Frameworks/$LIBNAME" "$TARGETLIB"
-            fi
+      - name: Build
+        run: |
+          export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
+          cd toonz
+          mkdir -p build
+          cd build
+          cmake ../sources -G Ninja \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DQT_PATH=$(brew --prefix qt@5)/lib \
+            -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
+            -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 \
+            -DWITH_TRANSLATION=OFF
+          ninja -j $(sysctl -n hw.ncpu)
+
+      - name: Introduce Libraries and Stuff
+        run: |
+          cd toonz/build/toonz
+          cp -pr ../../../stuff OpenToonz.app/portablestuff
+          /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -verbose=1 -always-overwrite \
+            -executable=OpenToonz.app/Contents/MacOS/lzocompress \
+            -executable=OpenToonz.app/Contents/MacOS/lzodecompress \
+            -executable=OpenToonz.app/Contents/MacOS/tcleanup \
+            -executable=OpenToonz.app/Contents/MacOS/tcomposer \
+            -executable=OpenToonz.app/Contents/MacOS/tconverter \
+            -executable=OpenToonz.app/Contents/MacOS/tfarmcontroller \
+            -executable=OpenToonz.app/Contents/MacOS/tfarmserver
+
+      - name: Modify Library Paths
+        run: |
+          cd toonz/build/toonz/OpenToonz.app/Contents/Frameworks
+          for TARGETLIB in *.dylib; do
+            otool -L "$TARGETLIB" | grep ".dylib" | grep -v "$TARGETLIB" | grep -v "@executable_path/../Frameworks" | awk '{print $1}' | while read -r FROMPATH; do
+              LIBNAME=$(basename "$FROMPATH")
+              if [[ -e ./$LIBNAME ]]; then
+                install_name_tool -change "$FROMPATH" "@executable_path/../Frameworks/$LIBNAME" "$TARGETLIB"
+              fi
+            done
           done
-        done
 
-    - name: Create Artifact
-      run: |
-        cd toonz/build/toonz
-        /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=1
+      - name: Create Artifact
+        run: |
+          cd toonz/build/toonz
+          /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=1
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Opentoonz-${{ runner.os }}-${{ github.sha }}
-        path: toonz/build/toonz/OpenToonz.dmg
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Opentoonz-${{ runner.os }}-${{ github.sha }}
+          path: toonz/build/toonz/OpenToonz.dmg

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -97,42 +97,22 @@ jobs:
       - name: Create Artifact
         run: |
           cd toonz/build/toonz
-          echo "Creating DMG..."
-          ATTEMPT=1
-          MAX_ATTEMPTS=3
-          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-            echo "Building the OpenToonz application into a DMG (Attempt $ATTEMPT of $MAX_ATTEMPTS)..."
-            DMG_OUTPUT=$(/usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0 2>&1)
-
-            # Check if the DMG file was actually created
+          echo "Creating DMG..."    
+          for ATTEMPT in {1..10}; do
+            echo "Attempt $ATTEMPT to build DMG..."
+            /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0
+            
             if [ -f OpenToonz.dmg ]; then
               echo "DMG created successfully."
-              break
-            else
-              echo "DMG creation failed or file not found. Checking for 'Resource busy' error..."
-
-              # Check if "Resource busy" error occurred
-              if echo "$DMG_OUTPUT" | grep -q "Resource busy"; then
-                echo "'Resource busy' error detected, attempting to kill XProtectBehaviorService..."
-                sudo pkill -9 XProtectBehaviorService >/dev/null || true
-                echo "Waiting for XProtectBehaviorService to terminate..."
-                while pgrep XProtectBehaviorService; do
-                  sleep 3
-                done
-              else
-                echo "No 'Resource busy' error detected. DMG creation failed for another reason."
-              fi
-
-              ATTEMPT=$((ATTEMPT + 1))
-              sleep 10  # Give some time before retrying
+              exit 0  # Exit if successful
             fi
+            
+            echo "DMG creation failed. Retrying in 10 seconds..."  
+            sleep 10  
           done
 
-          # Check if all attempts have been used up
-          if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
-            echo "Failed to create DMG after $MAX_ATTEMPTS attempts."
-            exit 1
-          fi
+          echo ">>> DMG file creation failed after 10 attempts. Aborting!"
+          exit 1  # Exit with failure status
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           cd toonz/build/toonz
           cp -pr ../../../stuff OpenToonz.app/portablestuff
-          /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -verbose=1 -always-overwrite \
+          /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -verbose=0 -always-overwrite \
             -executable=OpenToonz.app/Contents/MacOS/lzocompress \
             -executable=OpenToonz.app/Contents/MacOS/lzodecompress \
             -executable=OpenToonz.app/Contents/MacOS/tcleanup \
@@ -107,7 +107,7 @@ jobs:
         run: |
           cd toonz/build/toonz
           echo "Creating DMG..."
-          if /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=1; then
+          if /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0; then
             echo "DMG created successfully."
           else
             echo "Failed to create DMG."

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   macOS:
+    timeout-minutes: 90
     # runs-on: macos-latest
     # avoid the headache of arm64 builds?
     runs-on: macos-13
@@ -93,24 +94,43 @@ jobs:
             done
           done
 
-      - name: Unmount Existing Disk Images
-        run: |
-          if mount | grep "/Volumes/OpenToonz"; then
-            echo "Unmounting existing volume..."
-            hdiutil detach /Volumes/OpenToonz || true
-            echo "Volume unmounted."
-          else
-            echo "No volume to unmount."
-          fi
-
       - name: Create Artifact
         run: |
           cd toonz/build/toonz
           echo "Creating DMG..."
-          if /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0; then
-            echo "DMG created successfully."
-          else
-            echo "Failed to create DMG."
+          ATTEMPT=1
+          MAX_ATTEMPTS=3
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Building the OpenToonz application into a DMG (Attempt $ATTEMPT of $MAX_ATTEMPTS)..."
+            DMG_OUTPUT=$(/usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0 2>&1)
+
+            # Check if the DMG file was actually created
+            if [ -f OpenToonz.dmg ]; then
+              echo "DMG created successfully."
+              break
+            else
+              echo "DMG creation failed or file not found. Checking for 'Resource busy' error..."
+
+              # Check if "Resource busy" error occurred
+              if echo "$DMG_OUTPUT" | grep -q "Resource busy"; then
+                echo "'Resource busy' error detected, attempting to kill XProtectBehaviorService..."
+                sudo pkill -9 XProtectBehaviorService >/dev/null || true
+                echo "Waiting for XProtectBehaviorService to terminate..."
+                while pgrep XProtectBehaviorService; do
+                  sleep 3
+                done
+              else
+                echo "No 'Resource busy' error detected. DMG creation failed for another reason."
+              fi
+
+              ATTEMPT=$((ATTEMPT + 1))
+              sleep 10  # Give some time before retrying
+            fi
+          done
+
+          # Check if all attempts have been used up
+          if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
+            echo "Failed to create DMG after $MAX_ATTEMPTS attempts."
             exit 1
           fi
 


### PR DESCRIPTION
Update the GitHub Actions workflow to operate on macOS 13 (Ventura) due to the discontinuation of macOS 12, which caused build times of several hours and job interruptions when building from source code and other libraries.

see: https://github.com/actions/runner-images/issues/10721
