### PR TITLE
(WIP) Port fix enabling tool options on Vector Select All

### DIFF
--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -495,6 +495,10 @@ void StrokeSelection::selectAll() {
   StrokeSelection *selection = dynamic_cast<StrokeSelection *>(
       TTool::getApplication()->getCurrentSelection()->getSelection());
   if (selection) selection->notifyView();
+
+  TTool::getApplication()
+      ->getCurrentTool()
+      ->notifyToolChanged();  // Refreshes toolbar values
 }
 
 //=============================================================================


### PR DESCRIPTION
A bug fix for Tahoma2D which also applies to Opentoonz to address issue using select all on a vector level not activating the attribute boxes in the tool option bar.

REF:  https://github.com/tahoma2d/tahoma2d/pull/1626

Note:  This is mostly a test to confirm that a direct transfer of that code in Tahoma2D works in Opentoonz.

I'm not seeing the co-author attributed here  so perhaps am pull requesting the wrong branch.