### PR TITLE
Change empty shared_ptr ctor to make_shared

### DIFF
--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -715,7 +715,7 @@ void ProjectCreatePopup::createProject() {
 
   TFilePath projectFolder = currentProjectRoot + projectName;
   TFilePath projectPath   = pm->projectFolderToProjectPath(projectFolder);
-  auto project            = std::shared_ptr<TProject>();
+  auto project            = std::make_shared<TProject>();
   updateProjectFromFields(project);
   auto currentProject = pm->getCurrentProject();
   project->setSceneProperties(currentProject->getSceneProperties());


### PR DESCRIPTION
Fix for https://github.com/opentoonz/opentoonz/issues/5598. 

Currently, it's creating a shared_ptr calling a constructor without arguments. This will result in a shared_ptr with no managed object, causing a nullpointer, as it tries to use the pointer in updateProjectFromFields right away.
Check https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr to see how shared_ptr() is equivalent to shared_ptr(nullptr) (methods (1) and (2) have the same behaviour).

Simply changing it to `auto project = std::make_shared<TProject>();` should be enough.