### PR TITLE
Update workflow_macos.yml

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -16,7 +16,8 @@ jobs:
           # Remove existing symlinks before installing Python
           for symlink in 2to3 idle3 pydoc3 python3 python3-config \
                          2to3-3.11 idle3.11 pydoc3.11 python3.11 python3.11-config \
-                         2to3-3.12 idle3.12 pydoc3.12 python3.12 python3.12-config; do
+                         2to3-3.12 idle3.12 pydoc3.12 python3.12 python3.12-config \
+                         idle3.13 pydoc3.13 python3.13 python3.13-config; do
             rm -f /usr/local/bin/$symlink
           done
 


### PR DESCRIPTION
Removes old or conflicting symlinks for Python 3.13, allowing Homebrew to link the correct version of Python 3.13 without issues.

With these symlinks removed, the macOS build should now work correctly again.