### PR TITLE
Fix project reload fail

### DIFF
--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -973,7 +973,7 @@ void TProjectManager::getFolderNames(std::vector<std::string> &names) {
 void TProjectManager::setCurrentProjectPath(const TFilePath &fp) {
   assert(TProject::isAProjectPath(fp));
   currentProjectPath = ::to_string(fp.getWideString());
-  currentProject     = std::make_shared<TProject>();
+  currentProject     = nullptr;// init this pointer in getCurrentProject()
   notifyListeners();
 }
 


### PR DESCRIPTION
The project pointer reloading is by two methods called in StartupPopup::onProjectChanged(int index): 

1. TProjectManager::setCurrentProjectPath(const TFilePath &fp)
2. TProjectManager::getCurrentProject()

https://github.com/opentoonz/opentoonz/blob/dc40b92ba06fdb47824536f50d2f646c04a04125/toonz/sources/toonz/startuppopup.cpp#L659-L676

And here is their definition

https://github.com/opentoonz/opentoonz/blob/dc40b92ba06fdb47824536f50d2f646c04a04125/toonz/sources/toonzlib/tproject.cpp#L973-L978

https://github.com/opentoonz/opentoonz/blob/dc40b92ba06fdb47824536f50d2f646c04a04125/toonz/sources/toonzlib/tproject.cpp#L1008-L1022

The problem is that **!currentProject** is always false(currentProject always not empty,but ProjectPath is not loaded), so the pointer would never point to a TProject which ProjectPath is loaded.

Replace
` currentProject     = std::make_shared<TProject>(); ` in setCurrentProjectPath(const TFilePath &fp) 
with
` currentProject     = nullptr; `
would solve this problem.