### PR TITLE
Optimize Adjust Current Level to This Palette

### DIFF
--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -753,6 +753,11 @@ that the last operation is the icon refresh...
                                            m_currentLevelHandle,
                                            apd.getTolerance());
 
+  m_currentLevelHandle->getSimpleLevel()->setDirtyFlag(true);
+
+  //TApp::instance()->getCurrentLevel()->notifyLevelChange();
+  //No need to notice user
+
   TUndoManager::manager()->add(new InvalidateIconsUndo(m_currentLevelHandle));
 
   TUndoManager::manager()->endBlock();


### PR DESCRIPTION
This PR would Resolves #5676
Set current level to dirty so that line/area which have different style index but it's color is included in studio palette can be saved properly.