### PR TITLE
Fix Focus Lost when renaming new created folder

### DIFF
--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -2180,14 +2180,30 @@ void FileBrowser::newFolder() {
   int i                   = 1;
   while (TFileStatus(folderPath).doesExist())
     folderPath = parentFolder + (folderName + L" " + std::to_wstring(++i));
+  
+  if (Preferences::instance()->isWatchFileSystemEnabled()) {
+    MyFileSystemWatcher *watcher = MyFileSystemWatcher::instance();
+    // Remove parent folder from watcher
+    watcher->removePaths(QStringList() << parentFolder.getQString());
 
-  try {
-    TSystem::mkDir(folderPath);
-
-  } catch (...) {
-    DVGui::error(tr("It is not possible to create the %1 folder.")
-                     .arg(toQString(folderPath)));
-    return;
+    try {
+      TSystem::mkDir(folderPath);
+    } catch (...) {
+      DVGui::error(tr("It is not possible to create the %1 folder.")
+                       .arg(toQString(folderPath)));
+      watcher->addPaths(QStringList() << parentFolder.getQString());
+      return;
+    }
+    // Add the parent folder back
+    watcher->addPaths(QStringList() << parentFolder.getQString());
+  } else {
+    try {
+      TSystem::mkDir(folderPath);
+    } catch (...) {
+      DVGui::error(tr("It is not possible to create the %1 folder.")
+                       .arg(toQString(folderPath)));
+      return;
+    }
   }
 
   DvDirModel *model = DvDirModel::instance();


### PR DESCRIPTION
## Issue Description
When **Watch File System and Update File Browser Automatically** is enabled in Preference.
Open File Browser and click New Folder Button ,
would see LineEdit appears but remains no time for user to type.