### PR TITLE
Increase build timeout to 120 minutes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
   parallel: true
   verbosity: minimal
+  timeout: 120 # increase to maximum allowed timeout
 after_build:
 - cmd: >-
     


### PR DESCRIPTION
This will increase the build timeout to the maximum allowed by AppVeyor, which is 120 minutes, and should help avoid timeouts for longer builds.

ps. I'm not sure about the permissions; maybe need to adjust the timeout in the AppVeyor Web UI. Log in to AppVeyor and set it there.
