### PR TITLE
Revert "Increase build timeout to 120 minutes"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,6 @@ build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
   parallel: true
   verbosity: minimal
-  timeout: 120 # increase to maximum allowed timeout
 after_build:
 - cmd: >-
     


### PR DESCRIPTION
Attempting to see if this will get Appveyor back online.

According to Appveyor documentation:  

> Time limitations
All plans have 60 minutes quota per build job.