### PR TITLE
Fix File Browser Model Refreshing

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -271,39 +271,51 @@ void DvDirModelFileFolderNode::refreshChildren() {
   std::vector<std::wstring> names;
   getChildrenNames(names);
 
-  std::vector<DvDirModelNode *> oldChildren;
-  oldChildren.swap(m_children);
+  std::vector<DvDirModelNode *> oldChildren = m_children;
 
-  std::vector<DvDirModelNode *>::iterator j;
-  int i;
+  // synchronize nodes for each items in the current folder
+  QModelIndex index = DvDirModel::instance()->getIndexByNode(this);
+  int i, j;
   for (i = 0; i < (int)names.size(); i++) {
     std::wstring name = names[i];
-    for (j = oldChildren.begin();
-         j != oldChildren.end() && (*j)->getName() != name; ++j) {
+
+    // check if the item is already in the children nodes
+    for (j = i; j < m_children.size() && m_children[j]->getName() != name;
+         j++) {
     }
-    DvDirModelNode *child = 0;
-    if (j != oldChildren.end()) {
-      child = *j;
-      oldChildren.erase(j);
-    } else {
-      child = makeChild(name);
+    // if the child is already registered
+    if (j < m_children.size()) {
+      if (i != j) {
+        // swap node order
+        DvDirModel::instance()->notifyBeginMoveRows(index, j, j, index, i);
+        std::swap(m_children[i], m_children[j]);
+        DvDirModel::instance()->notifyEndMoveRows();
+      }
+    }
+    // if not, create a new child and insert
+    else {
+      DvDirModelNode *child = makeChild(name);
       if (DvDirModelFileFolderNode *folderNode =
               dynamic_cast<DvDirModelFileFolderNode *>(child))
         folderNode->setPeeking(m_peeks);
+      assert(child);
+      DvDirModel::instance()->notifyBeginInsertRows(index, i, i);
+      addChild(child);
+      DvDirModel::instance()->notifyEndInsertRows();
     }
-
-    if (!child) continue;
-
-    addChild(child);
   }
-  for (j = oldChildren.begin(); j != oldChildren.end(); ++j) {
-    DvDirModelNode *child = *j;
+  // delete rest of the children nodes
+  for (j = m_children.size() - 1; j >= i; j--) {
+    DvDirModelNode *child = m_children[j];
+    DvDirModel::instance()->notifyBeginRemoveRows(index, j, j);
+    m_children.erase(m_children.begin() + j);
+    DvDirModel::instance()->notifyEndRemoveRows();
+
     if (!!child && child->hasChildren())
       child->removeChildren(0, child->getChildCount());
 
-    delete *j;
+    delete child;
   }
-
   m_hasChildren = (m_children.size() > 0);
 }
 
@@ -706,7 +718,7 @@ void DvDirVersionControlProjectNode::refreshChildren() {
   DvDirModelFileFolderNode::refreshChildren();
   int i;
   TProjectManager *pm = TProjectManager::instance();
-  auto project = std::make_shared<TProject>();
+  auto project        = std::make_shared<TProject>();
   project->load(getProjectPath());
   for (i = 0; i < getChildCount(); i++) {
     DvDirModelFileFolderNode *node =
@@ -724,7 +736,7 @@ void DvDirVersionControlProjectNode::getChildrenNames(
     std::vector<std::wstring> &names) const {
   DvDirVersionControlNode::getChildrenNames(names);
   TProjectManager *pm = TProjectManager::instance();
-  auto project = std::make_shared<TProject>();
+  auto project        = std::make_shared<TProject>();
   project->load(getProjectPath());
   int i;
   for (i = 0; i < project->getFolderCount(); i++) {
@@ -787,7 +799,7 @@ void DvDirModelProjectNode::refreshChildren() {
   DvDirModelFileFolderNode::refreshChildren();
   int i;
   TProjectManager *pm = TProjectManager::instance();
-  auto project = std::make_shared<TProject>();
+  auto project        = std::make_shared<TProject>();
   project->load(getProjectPath());
   for (i = 0; i < getChildCount(); i++) {
     DvDirModelFileFolderNode *node =
@@ -805,7 +817,7 @@ void DvDirModelProjectNode::getChildrenNames(
     std::vector<std::wstring> &names) const {
   DvDirModelFileFolderNode::getChildrenNames(names);
   TProjectManager *pm = TProjectManager::instance();
-  auto project = std::make_shared<TProject>();
+  auto project        = std::make_shared<TProject>();
   project->load(getProjectPath());
   int i;
   for (i = 0; i < project->getFolderCount(); i++) {
@@ -823,7 +835,7 @@ void DvDirModelProjectNode::getChildrenNames(
 DvDirModelNode *DvDirModelProjectNode::makeChild(std::wstring name) {
   if (name != L"" && name[0] == L'+') {
     TProjectManager *pm = TProjectManager::instance();
-    auto project = std::make_shared<TProject>();
+    auto project        = std::make_shared<TProject>();
     project->load(getProjectPath());
     std::string folderName = ::to_string(name.substr(1));
     TFilePath folderPath   = project->getFolder(folderName);
@@ -874,14 +886,26 @@ DvDirModelHistoryNode::DvDirModelHistoryNode(DvDirModelNode *parent)
 //-----------------------------------------------------------------------------
 
 void DvDirModelHistoryNode::refreshChildren() {
-  m_children.clear();
-  m_childrenValid = true;
-  History *h      = History::instance();
-  for (int i = 0; i < h->getDayCount(); i++) {
-    const History::Day *day = h->getDay(i);
-    DvDirModelNode *child =
-        new DvDirModelDayNode(this, ::to_wstring(day->getDate()));
-    addChild(child);
+  QModelIndex index = DvDirModel::instance()->getIndexByNode(this);
+  m_childrenValid   = true;
+  if (!m_children.empty()) {
+    DvDirModel::instance()->notifyBeginRemoveRows(index, 0,
+                                                  m_children.size() - 1);
+    clearPointerContainer(m_children);
+    DvDirModel::instance()->notifyEndRemoveRows();
+  }
+
+  History *h   = History::instance();
+  int dayCount = h->getDayCount();
+  if (dayCount > 0) {
+    DvDirModel::instance()->notifyBeginInsertRows(index, 0, dayCount);
+    for (int i = 0; i < dayCount; i++) {
+      const History::Day *day = h->getDay(i);
+      DvDirModelNode *child =
+          new DvDirModelDayNode(this, ::to_wstring(day->getDate()));
+      addChild(child);
+    }
+    DvDirModel::instance()->notifyEndInsertRows();
   }
 }
 
@@ -908,8 +932,15 @@ DvDirModelMyComputerNode::DvDirModelMyComputerNode(DvDirModelNode *parent)
 //-----------------------------------------------------------------------------
 
 void DvDirModelMyComputerNode::refreshChildren() {
-  m_childrenValid = true;
-  if (!m_children.empty()) clearPointerContainer(m_children);
+  QModelIndex index = DvDirModel::instance()->getIndexByNode(this);
+  m_childrenValid   = true;
+
+  if (!m_children.empty()) {
+    DvDirModel::instance()->notifyBeginRemoveRows(index, 0,
+                                                  m_children.size() - 1);
+    clearPointerContainer(m_children);
+    DvDirModel::instance()->notifyEndRemoveRows();
+  }
 
   TFilePathSet fps = TSystem::getDisks();
 
@@ -917,12 +948,14 @@ void DvDirModelMyComputerNode::refreshChildren() {
   fps.push_back(TFilePath("/Volumes/"));
 #endif
 
+  DvDirModel::instance()->notifyBeginInsertRows(index, 0, fps.size() - 1);
   TFilePathSet::iterator it;
   for (it = fps.begin(); it != fps.end(); ++it) {
     DvDirModelNode *child =
         new DvDirModelFileFolderNode(this, it->getWideString(), *it);
     addChild(child);
   }
+  DvDirModel::instance()->notifyEndInsertRows();
 }
 
 //-----------------------------------------------------------------------------
@@ -947,9 +980,15 @@ DvDirModelNetworkNode::DvDirModelNetworkNode(DvDirModelNode *parent)
 //-----------------------------------------------------------------------------
 
 void DvDirModelNetworkNode::refreshChildren() {
-  m_childrenValid = true;
+  QModelIndex index = DvDirModel::instance()->getIndexByNode(this);
+  m_childrenValid   = true;
 
-  if (!m_children.empty()) clearPointerContainer(m_children);
+  if (!m_children.empty()) {
+    DvDirModel::instance()->notifyBeginRemoveRows(index, 0,
+                                                  m_children.size() - 1);
+    clearPointerContainer(m_children);
+    DvDirModel::instance()->notifyEndRemoveRows();
+  }
 
 #ifdef _WIN32
 
@@ -982,7 +1021,10 @@ void DvDirModelNetworkNode::refreshChildren() {
               new DvDirModelFileFolderNode(this, wstr, TFilePath(wstr));
           child->setPeeking(false);
 
+          DvDirModel::instance()->notifyBeginInsertRows(
+              index, m_children.size(), m_children.size());
           addChild(child);
+          DvDirModel::instance()->notifyEndInsertRows();
         }
       }
     } else if (err != ERROR_NO_MORE_ITEMS)
@@ -1084,12 +1126,12 @@ void DvDirModelRootNode::refreshChildren() {
     int i;
     for (i = 0; i < (int)projectRoots.size(); i++) {
       TFilePath projectRoot = projectRoots[i];
-      std::wstring rootDir = projectRoot.getWideString();
+      std::wstring rootDir  = projectRoot.getWideString();
       DvDirModelSpecialFileFolderNode *projectRootNode =
           new DvDirModelSpecialFileFolderNode(
               this,
-              L"*" + projectRoot.withoutParentDir().getWideString()
-              + L" (" +rootDir + L")",
+              L"*" + projectRoot.withoutParentDir().getWideString() + L" (" +
+                  rootDir + L")",
               projectRoot);
       projectRootNode->setPixmap(
           QPixmap(generateIconPixmap("folder_project_root")));
@@ -1214,7 +1256,6 @@ DvDirModelNode *DvDirModelRootNode::getNodeByPath(const TFilePath &path) {
   if (m_networkNode) {
     QString pathStr = path.getQString();
     if (pathStr.startsWith("\\\\") || pathStr.startsWith("//")) {
-
       for (i = 0; i < m_networkNode->getChildCount(); i++) {
         DvDirModelNode *node = m_networkNode->getChild(i)->getNodeByPath(path);
         if (node) return node;
@@ -1225,7 +1266,6 @@ DvDirModelNode *DvDirModelRootNode::getNodeByPath(const TFilePath &path) {
         DvDirModelNode *node = m_networkNode->createNetworkFolderNode(path);
         if (node) return node;
       }
-
     }
   }
 
@@ -1302,29 +1342,11 @@ void DvDirModel::refresh(const QModelIndex &index) {
   if (!index.isValid()) return;
   DvDirModelNode *node = getNode(index);
   if (!node) return;
-  
+
   emit layoutAboutToBeChanged();
 
-  int oldChildren = node->getChildCount();
-  if (oldChildren > 0) {
-    emit beginRemoveRows(index, 0, oldChildren - 1);
-    node->refreshChildren();
-    emit endRemoveRows();
-  }
-  else if (oldChildren == 0) {
-    node->refreshChildren();
-  }
-  else {
-    emit layoutChanged();
-    return;
-  }
+  node->refreshChildren();
 
-  int newChildren = node->getChildCount();
-  if(newChildren > 0){
-    emit beginInsertRows(index, 0, newChildren - 1);
-    emit endInsertRows();
-  }
-  
   emit layoutChanged();
 }
 

--- a/toonz/sources/toonz/filebrowsermodel.h
+++ b/toonz/sources/toonz/filebrowsermodel.h
@@ -383,6 +383,12 @@ public:
   }
   void notifyEndInsertRows() { emit endInsertRows(); }
 
+  void notifyBeginMoveRows(const QModelIndex &srcParent, int first, int last,
+                           const QModelIndex &dstParent, int dstChild) {
+    emit beginMoveRows(srcParent, first, last, dstParent, dstChild);
+  }
+  void notifyEndMoveRows() { emit endMoveRows(); }
+
 protected slots:
   // when the scene switched, update the path of the scene location node
   void onSceneSwitched();


### PR DESCRIPTION
This PR fixes the following problem in the File Browser, probably related to #5717 :
- Folder Tree and Item View do not update properly when using `New Folder` command on a folder with no subfolders. The problem does not occur on folders that already have subfolders.

As stated in the [documentation](https://qthub.com/static/doc/qt5/qtcore/qabstractitemmodel.html#beginInsertRows), I have changed `beginInsertRows / beginRemoveRows` to be emitted just before the actual insertion/deletion of data in each node's `refreshChildren()`.