### PR TITLE
Add feature to rename image sequences with separator

### DIFF
--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -871,7 +871,7 @@ bool TSystem::renameImageSequence_throw(TFilePath &path) {
     ++padding;
   }
   levelBaseName         = levelBaseName.left(i);
-  QDir parentFolder    = QDir(path.getParentDir().getQString());  // No Slash
+  QDir parentFolder = QDir(path.getParentDir().getQString());  // No Slash
   QString suffix       = QString::fromStdString(path.getType());
 
   QStringList fileNames = parentFolder.entryList(QStringList(levelBaseName + "*." + suffix),
@@ -885,7 +885,6 @@ bool TSystem::renameImageSequence_throw(TFilePath &path) {
 
     }
   
-
   char separator  = '.';
   padding = 4;
   QString FrameID;
@@ -899,6 +898,7 @@ bool TSystem::renameImageSequence_throw(TFilePath &path) {
     if (FrameID.isEmpty()) continue;
       newFileName = levelBaseName + separator +
                           FrameID.rightJustified(padding, '0') + '.' + suffix;
+
 #ifdef __cpp_filesystem
     std::filesystem::path oldPath =
         parentFolder.absoluteFilePath(fileName).toStdString();
@@ -917,8 +917,7 @@ bool TSystem::renameImageSequence_throw(TFilePath &path) {
     }
 #endif
   }
-  path = TFilePath(
-      parentFolder.absoluteFilePath(levelBaseName + separator + '.' + suffix));
+  path = path.withName(levelBaseName.toStdWString()).withFrame();
   return true;
 }
 

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -859,7 +859,7 @@ void TSystem::copyFileOrLevel_throw(const TFilePath &dst,
 
 //--------------------------------------------------------------
 
-void TSystem::renameImageSequence(const TFilePathSet &files,
+bool TSystem::renameImageSequence(const TFilePathSet &files,
                                         const TFilePath &levelPath,
                                         int prefixLength) {
   std::string levelBaseName = levelPath.withoutParentDir().getName();
@@ -876,7 +876,11 @@ void TSystem::renameImageSequence(const TFilePathSet &files,
     else
       wstr.clear();
     dst = file.withName(levelBaseName).withFrame(TFrameId(TFrameId(wstr).expand()));
-    TSystem::renameFile(dst, file);
+    try {
+      TSystem::renameFile(dst, file);
+    } catch (...){
+      return false;
+    }
   }
 }
 

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -876,7 +876,6 @@ void TSystem::renameImageSequence(const TFilePathSet &files,
     else
       wstr.clear();
     dst = file.withName(levelBaseName).withFrame(TFrameId(TFrameId(wstr).expand()));
-    qDebug() << dst.getQString() << file.getQString();
     TSystem::renameFile(dst, file);
   }
 }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -49,6 +49,7 @@ enum PreferencesItemId {
   //----------
   // Loading
   importPolicy,
+  renamePolicy,
   autoExposeEnabled,
   subsceneFolderEnabled,
   removeSceneNumberFromLoadedLevelName,

--- a/toonz/sources/include/toonz/tscenehandle.h
+++ b/toonz/sources/include/toonz/tscenehandle.h
@@ -60,6 +60,9 @@ public:
   void notifyImportPolicyChanged(int policy) {
     emit importPolicyChanged(policy);
   }
+  void notifyRenamePolicyChanged(int policy) {
+    emit renamePolicyChanged(policy);
+  }
 
   void setDirtyFlag(bool dirtyFlag) {
     if (m_dirtyFlag == dirtyFlag) return;
@@ -84,6 +87,7 @@ signals:
   void preferenceChanged(const QString &prefName);
   void pixelUnitSelected(bool on);
   void importPolicyChanged(int policy);
+  void renamePolicyChanged(int policy);
 };
 
 #endif  // TSCENEHANDLE_H

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -166,7 +166,7 @@ DVAPI void hideFile(const TFilePath &dst);
 DVAPI void moveFileToRecycleBin(const TFilePath &fp);
 
 DVAPI void copyFileOrLevel_throw(const TFilePath &dst, const TFilePath &src);
-DVAPI void renameImageSequence(const TFilePathSet &files,
+DVAPI bool renameImageSequence(const TFilePathSet &files,
                                      const TFilePath &levelName,
                                      int prefixLength);
 DVAPI void renameFileOrLevel_throw(const TFilePath &dst, const TFilePath &src,

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -166,6 +166,7 @@ DVAPI void hideFile(const TFilePath &dst);
 DVAPI void moveFileToRecycleBin(const TFilePath &fp);
 
 DVAPI void copyFileOrLevel_throw(const TFilePath &dst, const TFilePath &src);
+DVAPI bool renameImageSequence_throw(TFilePath &path);
 DVAPI void renameFileOrLevel_throw(const TFilePath &dst, const TFilePath &src,
                                    bool renamePalette = false);
 DVAPI void removeFileOrLevel_throw(const TFilePath &fp);

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -166,7 +166,7 @@ DVAPI void hideFile(const TFilePath &dst);
 DVAPI void moveFileToRecycleBin(const TFilePath &fp);
 
 DVAPI void copyFileOrLevel_throw(const TFilePath &dst, const TFilePath &src);
-DVAPI bool renameImageSequence_throw(TFilePath &path);
+DVAPI void renameImageSequence_throw(TFilePath &path, bool overwrite = false);
 DVAPI void renameFileOrLevel_throw(const TFilePath &dst, const TFilePath &src,
                                    bool renamePalette = false);
 DVAPI void removeFileOrLevel_throw(const TFilePath &fp);

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -166,7 +166,9 @@ DVAPI void hideFile(const TFilePath &dst);
 DVAPI void moveFileToRecycleBin(const TFilePath &fp);
 
 DVAPI void copyFileOrLevel_throw(const TFilePath &dst, const TFilePath &src);
-DVAPI void renameImageSequence_throw(TFilePath &path, bool overwrite = false);
+DVAPI void renameImageSequence(const TFilePathSet &files,
+                                     const TFilePath &levelName,
+                                     int prefixLength);
 DVAPI void renameFileOrLevel_throw(const TFilePath &dst, const TFilePath &src,
                                    bool renamePalette = false);
 DVAPI void removeFileOrLevel_throw(const TFilePath &fp);

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2643,7 +2643,7 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
       else if (locals::matchSequencePattern(path) &&
                locals::checkRenamePolicy(path)) {
         TFilePathSet files;
-        TFilePath backup    = path;
+        TFilePath backup    = scene->codeFilePath(path);
         TFilePath levelPath = locals::getLevelPath(path);
         progressDialog->setLabelText(
             QString("Loading \"%1\"...")

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2691,13 +2691,19 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
           ++r;
         }
         if (importDialog.aborted()) break;
-        TSystem::renameImageSequence(
+        if(TSystem::renameImageSequence(
             files, levelPath,
             backup.getWideName().substr(0,
                 backup.getWideName().find_last_not_of(L"0123456789") + 1)
-                .size());
-        QCoreApplication::processEvents();
-        path = levelPath;
+                    .size())) {
+          QCoreApplication::processEvents();
+          path = levelPath;
+        } else {
+          // Failed to rename Files
+          DVGui::warning(QString("Failed to rename files!"));
+          break;
+        }
+        
       }
     }
     // for other level files

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -923,6 +923,13 @@ void PreferencesPopup::onImportPolicyExternallyChanged(int policy) {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onRenamePolicyExternallyChanged(int policy) {
+  QComboBox* renamePolicyCombo = getUI<QComboBox*>(renamePolicy);
+  // update preferences data accordingly
+  renamePolicyCombo->setCurrentIndex(policy);
+}
+//-----------------------------------------------------------------------------
+
 QWidget* PreferencesPopup::createUI(PreferencesItemId id,
                                     const QList<ComboBoxItem>& comboItems) {
   PreferencesItem item = m_pref->getItem(id);
@@ -1208,6 +1215,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
 
       // Loading
       {importPolicy, tr("Default File Import Behavior:")},
+      {renamePolicy, tr("Normalize Imported Image Sequences:")},
       {autoExposeEnabled, tr("Expose Loaded Levels in Xsheet")},
       {autoRemoveUnusedLevels,
        tr("Automatically Remove Unused Levels From Scene Cast")},
@@ -1400,6 +1408,10 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
        {{tr("Always ask before loading or importing"), 0},
         {tr("Always import the file to the current project"), 1},
         {tr("Always load the file from the current location"), 2}}},
+      {renamePolicy,
+       {{tr("Always ask before renaming"), 0},
+        {tr("Normalize sequence names automatically"), 1},
+        {tr("Keep original filenames"), 2}}},
       {rasterLevelCachingBehavior,
        {{tr("On Demand"), 0},
         {tr("All Icons"), 1},
@@ -1775,6 +1787,7 @@ QWidget* PreferencesPopup::createLoadingPage() {
   setupLayout(lay);
 
   insertUI(importPolicy, lay, getComboItemList(importPolicy));
+  insertUI(renamePolicy, lay, getComboItemList(renamePolicy));
   QGridLayout* autoExposeLay = insertGroupBoxUI(autoExposeEnabled, lay);
   { insertUI(autoRemoveUnusedLevels, autoExposeLay); }
   insertUI(subsceneFolderEnabled, lay);
@@ -1814,6 +1827,9 @@ QWidget* PreferencesPopup::createLoadingPage() {
   ret = ret && connect(TApp::instance()->getCurrentScene(),
                        SIGNAL(importPolicyChanged(int)), this,
                        SLOT(onImportPolicyExternallyChanged(int)));
+  ret = ret && connect(TApp::instance()->getCurrentScene(),
+                       SIGNAL(renamePolicyChanged(int)), this,
+                       SLOT(onRenamePolicyExternallyChanged(int)));
   assert(ret);
 
   return widget;

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -177,6 +177,7 @@ private slots:
   void onEditLevelFormat();
   void onLevelFormatEdited();
   void onImportPolicyExternallyChanged(int policy);
+  void onRenamePolicyExternallyChanged(int policy);
 };
 
 //**********************************************************************************

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -459,6 +459,7 @@ void Preferences::definePreferenceItems() {
 
   // Loading
   define(importPolicy, "importPolicy", QMetaType::Int, 0);  // Always ask
+  define(renamePolicy, "renamePolicy", QMetaType::Int, 0); // Always ask
   define(autoExposeEnabled, "autoExposeEnabled", QMetaType::Bool, true);
   define(subsceneFolderEnabled, "subsceneFolderEnabled", QMetaType::Bool, true);
   define(removeSceneNumberFromLoadedLevelName,


### PR DESCRIPTION
Consider these file name as part of potential sequence while loading resources.
- `1.imgext` or `2.imgext` and so on (no padding and no name)
- `name1.imgext` (no padding )
- `name01.imgext` (padding = 2)
- `name001.imgext` (padding = 3)
- `name0001.imgext` (padding = 4)

- [x] Ask the user whether to rename the files if a sequence is detected.
This will not be triggered when dragging in a single file.
![图片](https://github.com/user-attachments/assets/713b4fef-1844-4917-8716-61907e40e6c0)

- [x] Add Preference
![图片](https://github.com/user-attachments/assets/b465b8ea-4b38-4ac7-aad5-820420c46426)
