### PR TITLE
Fix Navigation Mode States

### DIFF
--- a/toonz/sources/include/tools/toolhandle.h
+++ b/toonz/sources/include/tools/toolhandle.h
@@ -31,20 +31,24 @@ class QString;
 class DVAPI ToolHandle final : public QObject {
   Q_OBJECT
 
+  // Core tool state
   TTool *m_tool;
   QString m_toolName;
   int m_toolTargetType;
+
+  // Navigation state
+  struct NavigationState {
+    bool active = false;        // Whether navigation mode is active
+    QString originalTool;       // Tool to restore when exiting navigation
+    bool spacePressed = false;  // Space key state
+    bool shiftPressed = false;  // Shift key state
+    bool ctrlPressed  = false;  // Ctrl key state
+  } m_navState;
+
   QString m_storedToolName;
   QElapsedTimer m_storedToolTime;
   QString m_oldToolName;
   bool m_toolIsBusy;
-
-  // State tracking for intuitive viewer navigation
-  QString m_originalTool;  // Store tool before navigation mode
-  bool m_inNavigationMode = false;
-  bool m_spacePressed     = false;
-  bool m_shiftPressed     = false;
-  bool m_ctrlPressed      = false;
 
 public:
   ToolHandle();
@@ -56,13 +60,12 @@ public:
 
   const QString &getRequestedToolName() const { return m_toolName; }
 
-  // used to handle viewer navigation state
+  // Navigation methods
   void setSpacePressed(bool pressed);
   void setShiftPressed(bool pressed);
   void setCtrlPressed(bool pressed);
-  bool isSpacePressed() const { return m_spacePressed; }
-  bool isShiftPressed() const { return m_shiftPressed; }
-  bool isCtrlPressed() const { return m_ctrlPressed; }
+  bool isSpacePressed() const { return m_navState.spacePressed; }
+  bool isNavigating() const { return m_navState.active; }
 
   // used to change tool for a short while (e.g. while keeping pressed a
   // short-key)
@@ -86,7 +89,9 @@ public:
   }
 
 private:
-  void updateNavigationState();
+  // Navigation methods
+  void updateNavigationTool();  // Select appropriate navigation tool
+  void exitNavigation();        // Clean exit from navigation mode
 
 signals:
   void toolComboBoxListChanged(std::string);


### PR DESCRIPTION
Follow up on: https://github.com/opentoonz/opentoonz/pull/5761

Fixed issues:
- T_Hand was getting called and getting stuck, it has something to do with speed of user pressing key combination
- Key buffering: T_Hand was default even if user buffered (holding a modifier) before pressing space, now we buffer by checking the modifier key directly, so user goes straight to T_Rotate if they're holding Shift before hitting Space
- Better organization of the code, more self-contained