### PR TITLE
Update Webm Export

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -429,13 +429,29 @@ void Ffmpeg::getFramesFromMovie(int frame) {
     // frameArgs << "-accurate_seek";
     // frameArgs << "-ss";
     // frameArgs << "0" + QString::number(frameIndex / m_info->m_frameRate);
-    if (m_path.getType() == "webm") {
-      // To load in webm transparency
-      preIFrameArgs << "-vcodec";
-      preIFrameArgs << "libvpx";
+
+    // Detect codec from the input file
+    QStringList probeArgs;
+    probeArgs << "-v" << "error"
+              << "-select_streams" << "v:0"
+              << "-show_entries" << "stream=codec_name"
+              << "-of" << "default=noprint_wrappers=1:nokey=1"
+              << m_path.getQString();
+
+    QString codecName = runFfprobe(probeArgs).trimmed();
+
+    // Set decoder based on detected codec
+    if (codecName.contains("vp9", Qt::CaseInsensitive)) {
+      preIFrameArgs << "-vcodec" << "libvpx-vp9";
+    } else if (codecName.contains("vp8", Qt::CaseInsensitive)) {
+      preIFrameArgs << "-vcodec" << "libvpx";
+    } else if (codecName.contains("av1", Qt::CaseInsensitive)) {
+      preIFrameArgs << "-vcodec" << "libaom-av1";
     }
-    preIFrameArgs << "-i";
-    preIFrameArgs << m_path.getQString();
+
+    // Common args
+    preIFrameArgs << "-threads" << "auto";
+    preIFrameArgs << "-i" << m_path.getQString();
     postIFrameArgs << "-y";
     postIFrameArgs << "-f";
     postIFrameArgs << "image2";
@@ -444,10 +460,11 @@ void Ffmpeg::getFramesFromMovie(int frame) {
 
     runFfmpeg(preIFrameArgs, postIFrameArgs, true, true, true, false);
 
+    QString addToDelete;
+    QString tempBase = tempPath + "In";
     for (int i = 1; i <= m_frameCount; i++) {
-      QString number      = QString("%1").arg(i, 4, 10, QChar('0'));
-      addToDelete         = tempBase + number + "." + m_intermediateFormat;
-      std::string delPath = addToDelete.toStdString();
+      QString number = QString("%1").arg(i, 4, 10, QChar('0'));
+      addToDelete    = tempBase + number + "." + m_intermediateFormat;
       // addToCleanUp(addToDelete);
     }
   }

--- a/toonz/sources/image/ffmpeg/tiio_webm.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_webm.cpp
@@ -109,6 +109,7 @@ TLevelWriterWebm::~TLevelWriterWebm() {
     postIArgs << "-lossless" << "1";
     postIArgs << "-tune" << "ssim";
   } else {
+    postIArgs << "-b:v" << "0";
     postIArgs << "-crf" << QString::number(crf);
     postIArgs << "-tune" << "psnr";
   }

--- a/toonz/sources/image/ffmpeg/tiio_webm.h
+++ b/toonz/sources/image/ffmpeg/tiio_webm.h
@@ -18,26 +18,36 @@ class TLevelWriterWebm : public TLevelWriter {
 public:
   TLevelWriterWebm(const TFilePath &path, TPropertyGroup *winfo);
   ~TLevelWriterWebm();
+
+  // Framerate control
   void setFrameRate(double fps) override;
 
+  // Property parsing
+  void parseProperties();
+
+  // Image and frame handling
   TImageWriterP getFrameWriter(TFrameId fid) override;
   void save(const TImageP &image, int frameIndex);
 
+  // Soundtrack handling
   void saveSoundTrack(TSoundTrack *st) override;
 
+  // Factory method for creating instances
   static TLevelWriter *create(const TFilePath &path, TPropertyGroup *winfo) {
     return new TLevelWriterWebm(path, winfo);
   }
 
 private:
+  // FFmpeg writer instance
   Ffmpeg *ffmpegWriter;
-  int m_lx, m_ly;
-  int m_scale;
-  QString m_codec;
-  QString m_speed;
-  QString m_pixelFormat;
-  int m_crf;
-  // void *m_buffer;
+
+  // Video properties
+  int m_lx, m_ly;         // Frame width and height
+  int m_scale;            // Scaling factor
+  QString m_codec;        // Video codec
+  QString m_speed;        // Encoding speed preset
+  QString m_pixelFormat;  // Pixel format
+  int m_crf;              // Constant Rate Factor (CRF) for quality control
 };
 
 //===========================================================

--- a/toonz/sources/image/ffmpeg/tiio_webm.h
+++ b/toonz/sources/image/ffmpeg/tiio_webm.h
@@ -33,7 +33,10 @@ private:
   Ffmpeg *ffmpegWriter;
   int m_lx, m_ly;
   int m_scale;
-  int m_vidQuality;
+  QString m_codec;
+  QString m_speed;
+  QString m_pixelFormat;
+  int m_crf;
   // void *m_buffer;
 };
 
@@ -74,10 +77,12 @@ namespace Tiio {
 class WebmWriterProperties : public TPropertyGroup {
   Q_DECLARE_TR_FUNCTIONS(WebmWriterProperties)
 public:
-  // TEnumProperty m_pixelSize;
-  // TBoolProperty m_matte;
-  TIntProperty m_vidQuality;
   TIntProperty m_scale;
+  TEnumProperty m_codec;
+  TEnumProperty m_speed;
+  TEnumProperty m_pixelFormat;
+  TIntProperty m_crf;
+
   WebmWriterProperties();
   void updateTranslation() override;
 };

--- a/toonz/sources/image/ffmpeg/tiio_webm.h
+++ b/toonz/sources/image/ffmpeg/tiio_webm.h
@@ -22,9 +22,6 @@ public:
   // Framerate control
   void setFrameRate(double fps) override;
 
-  // Property parsing
-  void parseProperties();
-
   // Image and frame handling
   TImageWriterP getFrameWriter(TFrameId fid) override;
   void save(const TImageP &image, int frameIndex);
@@ -42,12 +39,12 @@ private:
   Ffmpeg *ffmpegWriter;
 
   // Video properties
-  int m_lx, m_ly;   // Frame width and height
-  int m_scale;      // Scaling factor
-  QString m_codec;  // Video codec
-  QString m_speed;  // Encoding speed preset
-  int m_crf;        // Constant Rate Factor (CRF) for quality control
-  int m_kf;         // Keyframes
+  int m_lx, m_ly;        // Frame width and height
+  int m_scale;           // Scaling factor
+  QString m_speed;       // Encoding speed preset
+  int m_kfSetting;       // Keyframe interval
+  bool m_preserveAlpha;  // Preserve alpha channel
+  bool m_lossless;       // Lossless quality
 };
 
 //===========================================================
@@ -88,10 +85,10 @@ class WebmWriterProperties : public TPropertyGroup {
   Q_DECLARE_TR_FUNCTIONS(WebmWriterProperties)
 public:
   TIntProperty m_scale;
-  TEnumProperty m_codec;
   TEnumProperty m_speed;
-  TIntProperty m_crf;
-  TIntProperty m_kf;
+  TEnumProperty m_kf;
+  TBoolProperty m_preserveAlpha;
+  TBoolProperty m_lossless;
 
   WebmWriterProperties();
   void updateTranslation() override;

--- a/toonz/sources/image/ffmpeg/tiio_webm.h
+++ b/toonz/sources/image/ffmpeg/tiio_webm.h
@@ -42,12 +42,12 @@ private:
   Ffmpeg *ffmpegWriter;
 
   // Video properties
-  int m_lx, m_ly;         // Frame width and height
-  int m_scale;            // Scaling factor
-  QString m_codec;        // Video codec
-  QString m_speed;        // Encoding speed preset
-  QString m_pixelFormat;  // Pixel format
-  int m_crf;              // Constant Rate Factor (CRF) for quality control
+  int m_lx, m_ly;   // Frame width and height
+  int m_scale;      // Scaling factor
+  QString m_codec;  // Video codec
+  QString m_speed;  // Encoding speed preset
+  int m_crf;        // Constant Rate Factor (CRF) for quality control
+  int m_kf;         // Keyframes
 };
 
 //===========================================================
@@ -90,8 +90,8 @@ public:
   TIntProperty m_scale;
   TEnumProperty m_codec;
   TEnumProperty m_speed;
-  TEnumProperty m_pixelFormat;
   TIntProperty m_crf;
+  TIntProperty m_kf;
 
   WebmWriterProperties();
   void updateTranslation() override;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bca391cc-715e-4575-b096-c51658ff7c2b)

**Updates FFmpeg Webm export options:**
- Upgrade codec from VP8 > VP9
- Quality handled by CRF dynamically based on resolution (no more quality slider)
- Added Encoding Speed presets (controls file compression)
- Keyframe interval option

**And import:**
- Can now import VP8/VP9 and AV1
- Changed threads to auto instead of 4 for decode to drastically speed it up for CPU's with more threads

The settings are optimized for animation as much as possible for smallest file size. Please test.