### PR TITLE
Fix Visualize Vector As Raster

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -239,6 +239,7 @@ public:
   // Visualization  tab
   bool getShow0ThickLines() const { return getBoolValue(show0ThickLines); }
   bool getRegionAntialias() const { return getBoolValue(regionAntialias); }
+  bool getRasterizeAntialias() const { return getBoolValue(rasterizeAntialias); }
 
   // Loading  tab
   int getDefaultImportPolicy() { return getIntValue(importPolicy); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -45,6 +45,7 @@ enum PreferencesItemId {
   // Visualization
   show0ThickLines,
   regionAntialias,
+  rasterizeAntialias,
 
   //----------
   // Loading

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1205,6 +1205,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
       {regionAntialias, tr("Antialiased Region Boundaries")},
+      {rasterizeAntialias, tr("Rasterize Vector with Anti Aliasing")},
 
       // Loading
       {importPolicy, tr("Default File Import Behavior:")},
@@ -1751,6 +1752,7 @@ QWidget* PreferencesPopup::createVisualizationPage() {
 
   insertUI(show0ThickLines, lay);
   insertUI(regionAntialias, lay);
+  insertUI(rasterizeAntialias, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -24,6 +24,8 @@
 #include "toonz/levelproperties.h"
 #include "toonz/txshsimplelevel.h"
 #include "toonz/fill.h"
+#include "toonz/dpiscale.h"
+#include "toonz/stage.h"
 
 // Qt includes
 #include <QImage>
@@ -289,7 +291,7 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
   // Fetch image
   assert(extData);
   ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
-
+  
   const std::string &srcImgId = data->m_sl->getImageId(data->m_fid);
 
   TImageP img = ImageManager::instance()->getImage(srcImgId, imFlags, extData);
@@ -297,14 +299,22 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
     TVectorImageP vi = img;
     if (vi) {
       TRectD bbox = vi->getBBox();
-
-      d   = TDimension(tceil(bbox.getLx()) + 1, tceil(bbox.getLy()) + 1);
-      off = TPoint((int)bbox.x0, (int)bbox.y0);
+      d = TDimension(tceil(bbox.getLx() * data->cameraDpi.x / Stage::inch+1),
+                     tceil(bbox.getLy() * data->cameraDpi.x / Stage::inch+1));
+      TScale scale = TScale(data->cameraDpi.x / Stage::inch,
+                            data->cameraDpi.y / Stage::inch);
+      off          = TPoint((int)bbox.x0, (int)bbox.y0);
 
       TPalette *vpalette = vi->getPalette();
-      TVectorRenderData rd(TTranslation(-off.x, -off.y), TRect(TPoint(0, 0), d),
-                           vpalette, 0, true, true);
 
+      //TVectorRenderData rd(scale * TTranslation(-off.x, -off.y),
+         //                  TRect(TPoint(0, 0), TDimension(d.lx, d.ly)),
+           //                vpalette, 0, false, true);
+      TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
+                           scale * TTranslation(-off.x, -off.y),
+                           TRect(TPoint(0, 0), TDimension(d.lx, d.ly)),
+                           vpalette);
+      
       // this is too slow.
       {
         QSurfaceFormat format;

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -294,7 +294,7 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
            ~(ImageManager::dontPutInCache | ImageManager::forceRebuild)));
 
   TDimension d(10, 10);
-  TPoint off(0, 0);
+  TPointD off(0, 0);
   
   // Fetch image
   assert(extData);
@@ -308,81 +308,83 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
     TVectorImageP vi = img;
     if (vi) {
       TRectD bbox = vi->getBBox();
-      double sx, sy;
-      sx = data->m_cameraDpi.x / Stage::inch;
-      sy = data->m_cameraDpi.x / Stage::inch;
-      d = TDimension(tceil(bbox.getLx() * sx)+1,
-                     tceil(bbox.getLy() * sy)+1);
-      TScale scale = TScale(sx,sy);
-      off          = TPoint((int)bbox.x0, (int)bbox.y0);
+      bbox        = TRectD(bbox.x0-5,bbox.y0-5,bbox.x1+5,bbox.y1+5);
+      if (!bbox.isEmpty()) {
+        double sx, sy;
+        sx = data->m_cameraDpi.x / Stage::inch;
+        sy = data->m_cameraDpi.x / Stage::inch;
+        d  = TDimension(tceil(bbox.getLx() * sx), tceil(bbox.getLy() * sy));
+        TScale scale = TScale(sx, sy);
 
-      TPalette *vpalette = vi->getPalette();
+        off          = TPointD(bbox.x0, bbox.y0);
 
-      TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
-                           scale * TTranslation(-off.x, -off.y),
-                           TRect(TPoint(0, 0), TDimension(d.lx, d.ly)),
-                           vpalette);
-      
-      // this is too slow.
-      {
-        QSurfaceFormat format;
-        format.setProfile(QSurfaceFormat::CompatibilityProfile);
+        TPalette *vpalette = vi->getPalette();
 
-        std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
-        surface->setFormat(format);
-        surface->create();
+        TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
+                             scale * TTranslation(-off.x, -off.y),
+                             TRect(TPoint(0, 0), TDimension(d.lx, d.ly)),
+                             vpalette);
 
-        TRaster32P ras(d);
-
-        glPushAttrib(GL_ALL_ATTRIB_BITS);
-        glMatrixMode(GL_MODELVIEW), glPushMatrix();
-        glMatrixMode(GL_PROJECTION), glPushMatrix();
+        // this is too slow.
         {
-          std::unique_ptr<QOpenGLFramebufferObject> fb(
-              new QOpenGLFramebufferObject(d.lx, d.ly));
+          QSurfaceFormat format;
+          format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
-          fb->bind();
+          std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
+          surface->setFormat(format);
+          surface->create();
 
-          glViewport(0, 0, d.lx, d.ly);
-          glClearColor(0, 0, 0, 0);
-          glClear(GL_COLOR_BUFFER_BIT);
+          TRaster32P ras(d);
 
-          glMatrixMode(GL_PROJECTION);
-          glLoadIdentity();
-          gluOrtho2D(0, d.lx, 0, d.ly);
+          glPushAttrib(GL_ALL_ATTRIB_BITS);
+          glMatrixMode(GL_MODELVIEW), glPushMatrix();
+          glMatrixMode(GL_PROJECTION), glPushMatrix();
+          {
+            std::unique_ptr<QOpenGLFramebufferObject> fb(
+                new QOpenGLFramebufferObject(d.lx, d.ly));
 
-          glMatrixMode(GL_MODELVIEW);
-          glLoadIdentity();
-          glTranslatef(0.375, 0.375, 0.0);
+            fb->bind();
 
-          tglDraw(rd, vi.getPointer());
+            glViewport(0, 0, d.lx, d.ly);
+            glClearColor(0, 0, 0, 0);
+            glClear(GL_COLOR_BUFFER_BIT);
 
-          glFlush();
+            glMatrixMode(GL_PROJECTION);
+            glLoadIdentity();
+            gluOrtho2D(0, d.lx, 0, d.ly);
 
-          QImage img =
-              fb->toImage().scaled(QSize(d.lx, d.ly), Qt::IgnoreAspectRatio,
-                                   Qt::SmoothTransformation);
+            glMatrixMode(GL_MODELVIEW);
+            glLoadIdentity();
+            glTranslatef(0.375, 0.375, 0.0);
 
-          int wrap      = ras->getLx() * sizeof(TPixel32);
-          uchar *srcPix = img.bits();
-          uchar *dstPix = ras->getRawData() + wrap * (d.ly - 1);
-          for (int y = 0; y < d.ly; y++) {
-            memcpy(dstPix, srcPix, wrap);
-            dstPix -= wrap;
-            srcPix += wrap;
+            tglDraw(rd, vi.getPointer());
+
+            glFlush();
+
+            QImage img = fb->toImage();
+
+            int wrap      = ras->getLx() * sizeof(TPixel32);
+            uchar *srcPix = img.bits();
+            uchar *dstPix = ras->getRawData() + wrap * (d.ly - 1);
+            for (int y = 0; y < d.ly; y++) {
+              memcpy(dstPix, srcPix, wrap);
+              dstPix -= wrap;
+              srcPix += wrap;
+            }
+            fb->release();
           }
-          fb->release();
+          glMatrixMode(GL_MODELVIEW), glPopMatrix();
+          glMatrixMode(GL_PROJECTION), glPopMatrix();
+
+          glPopAttrib();
+
+          TRasterImageP ri = TRasterImageP(ras);
+          ri->setOffset(TPoint(tceil(off.x * sx), tceil(off.y * sy)) +
+                        ras->getCenter());
+          assert(glGetError() == 0);
+
+          return ri;
         }
-        glMatrixMode(GL_MODELVIEW), glPopMatrix();
-        glMatrixMode(GL_PROJECTION), glPopMatrix();
-
-        glPopAttrib();
-
-        TRasterImageP ri = TRasterImageP(ras);
-        ri->setOffset(TPoint(off.x*sx,off.y*sy) + ras->getCenter());
-        assert(glGetError() == 0);
-
-        return ri;
       }
     }
   }

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -355,7 +355,7 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
 
             glMatrixMode(GL_MODELVIEW);
             glLoadIdentity();
-            glTranslatef(0.375, 0.375, 0.0);
+            glTranslatef(-0.66, -0.2, 0.0);//dirty...
 
             tglDraw(rd, vi.getPointer());
 

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -26,6 +26,7 @@
 #include "toonz/fill.h"
 #include "toonz/dpiscale.h"
 #include "toonz/stage.h"
+#include "toonz/tcamera.h"
 
 // Qt includes
 #include <QImage>
@@ -281,7 +282,9 @@ bool ImageRasterizer::getInfo(TImageInfo &info, int imFlags, void *extData) {
 
 bool ImageRasterizer::isImageCompatible(int imFlags, void* extData) { 
   ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
-  if (data->m_cameraDpi == oldCameraDpi) return true;
+
+  if (m_aff == data->currentCamera->getStageToCameraRef())
+    return true;
   else {
     return false;
   }
@@ -293,14 +296,10 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
   assert(!(imFlags &
            ~(ImageManager::dontPutInCache | ImageManager::forceRebuild)));
 
-  TDimension d(10, 10);
-  TPointD off(0, 0);
-  
   // Fetch image
   assert(extData);
   ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
-  oldCameraDpi                    = data->m_cameraDpi;
-  
+
   const std::string &srcImgId = data->m_sl->getImageId(data->m_fid);
 
   TImageP img = ImageManager::instance()->getImage(srcImgId, imFlags, extData);
@@ -308,90 +307,78 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
     TVectorImageP vi = img;
     if (vi) {
       TRectD bbox = vi->getBBox();
-      bbox        = TRectD(bbox.x0-5,bbox.y0-5,bbox.x1+5,bbox.y1+5);
       if (!bbox.isEmpty()) {
-        double sx, sy;
-        sx = data->m_cameraDpi.x / Stage::inch;
-        sy = data->m_cameraDpi.x / Stage::inch;
-        d  = TDimension(tceil(bbox.getLx() * sx), tceil(bbox.getLy() * sy));
-        TScale scale = TScale(sx, sy);
+          m_aff = data->currentCamera->getStageToCameraRef();
+          TDimension d = data->currentCamera->getRes();
+          TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
+              m_aff,
+              TRect(), vi->getPalette());
+          rd.m_antiAliasing = true;//TODO: get this value from Preference
 
-        off          = TPointD(bbox.x0, bbox.y0);
-
-        TPalette *vpalette = vi->getPalette();
-
-        TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
-                             scale * TTranslation(-off.x, -off.y),
-                             TRect(TPoint(0, 0), TDimension(d.lx, d.ly)),
-                             vpalette);
-
-        // this is too slow.
-        {
-          QSurfaceFormat format;
-          format.setProfile(QSurfaceFormat::CompatibilityProfile);
-
-          std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
-          surface->setFormat(format);
-          surface->create();
-
-          TRaster32P ras(d);
-
-          glPushAttrib(GL_ALL_ATTRIB_BITS);
-          glMatrixMode(GL_MODELVIEW), glPushMatrix();
-          glMatrixMode(GL_PROJECTION), glPushMatrix();
+          //Is this too slow?
           {
-            std::unique_ptr<QOpenGLFramebufferObject> fb(
-                new QOpenGLFramebufferObject(d.lx, d.ly));
+            QSurfaceFormat format;
+            format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
-            fb->bind();
+            std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
+            surface->setFormat(format);
+            surface->create();
 
-            glViewport(0, 0, d.lx, d.ly);
-            glClearColor(0, 0, 0, 0);
-            glClear(GL_COLOR_BUFFER_BIT);
+            TRaster32P ras(d);
 
-            glMatrixMode(GL_PROJECTION);
-            glLoadIdentity();
-            gluOrtho2D(0, d.lx, 0, d.ly);
+            glPushAttrib(GL_ALL_ATTRIB_BITS);
+            glMatrixMode(GL_MODELVIEW), glPushMatrix();
+            glMatrixMode(GL_PROJECTION), glPushMatrix();
+            {
+              std::unique_ptr<QOpenGLFramebufferObject> fb(
+                  new QOpenGLFramebufferObject(d.lx, d.ly));
 
-            glMatrixMode(GL_MODELVIEW);
-            glLoadIdentity();
-            glTranslatef(-0.66, -0.2, 0.0);//dirty...
+              fb->bind();
 
-            tglDraw(rd, vi.getPointer());
+              glViewport(0, 0, d.lx, d.ly);
+              glClearColor(0, 0, 0, 0);
+              glClear(GL_COLOR_BUFFER_BIT);
 
-            glFlush();
+              glMatrixMode(GL_PROJECTION);
+              glLoadIdentity();
+              gluOrtho2D(0, d.lx, 0, d.ly);
 
-            QImage img = fb->toImage();
+              glMatrixMode(GL_MODELVIEW);
+              glLoadIdentity();
 
-            int wrap      = ras->getLx() * sizeof(TPixel32);
-            uchar *srcPix = img.bits();
-            uchar *dstPix = ras->getRawData() + wrap * (d.ly - 1);
-            for (int y = 0; y < d.ly; y++) {
-              memcpy(dstPix, srcPix, wrap);
-              dstPix -= wrap;
-              srcPix += wrap;
+              tglDraw(rd, vi.getPointer());
+
+              glFlush();
+
+              QImage img = fb->toImage();
+
+              int wrap      = ras->getLx() * sizeof(TPixel32);
+              uchar *srcPix = img.bits();
+              uchar *dstPix = ras->getRawData() + wrap * (d.ly - 1);
+              for (int y = 0; y < d.ly; y++) {
+                memcpy(dstPix, srcPix, wrap);
+                dstPix -= wrap;
+                srcPix += wrap;
+              }
+              fb->release();
             }
-            fb->release();
+            glMatrixMode(GL_MODELVIEW), glPopMatrix();
+            glMatrixMode(GL_PROJECTION), glPopMatrix();
+
+            glPopAttrib();
+
+            TRasterImageP ri = TRasterImageP(ras);
+            assert(glGetError() == 0);
+
+            return ri;
           }
-          glMatrixMode(GL_MODELVIEW), glPopMatrix();
-          glMatrixMode(GL_PROJECTION), glPopMatrix();
-
-          glPopAttrib();
-
-          TRasterImageP ri = TRasterImageP(ras);
-          ri->setOffset(TPoint(tceil(off.x * sx), tceil(off.y * sy)) +
-                        ras->getCenter());
-          assert(glGetError() == 0);
-
-          return ri;
-        }
       }
     }
   }
-
+  
   // Error case: return a dummy image (is it really required?)
 
-  TRaster32P ras(d);
+  TRaster32P ras(10,10);
   ras->fill(TPixel32(127, 0, 127, 127));
 
   return TRasterImageP(ras);

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -283,7 +283,7 @@ bool ImageRasterizer::getInfo(TImageInfo &info, int imFlags, void *extData) {
 
 bool ImageRasterizer::isImageCompatible(int imFlags, void* extData) { 
   ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
-  if (m_aff == data->currentCamera->getStageToCameraRef())
+  if (m_cameraDPI == data->currentCamera->getDpi())
     if (m_antiAliasing == Preferences::instance()->getRasterizeAntialias())
         return true;
   return false;
@@ -306,12 +306,24 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
     TVectorImageP vi = img;
     if (vi) {
       TRectD bbox = vi->getBBox();
+      m_cameraDPI       = data->currentCamera->getDpi();
+
+      double sx, sy;
+      sx           = m_cameraDPI.x / Stage::inch;
+      sy           = m_cameraDPI.y / Stage::inch;
+      bbox.x0     = std::floor(bbox.x0 * sx);
+      bbox.y0     = std::floor(bbox.y0 * sy);
+      bbox.x1     = std::ceil(bbox.x1 * sx);
+      bbox.y1     = std::ceil(bbox.y1 * sy);
+
+      bbox.x1 += static_cast<int>(std::ceil(bbox.x1 - bbox.x0)) % 2;
+      bbox.y1 += static_cast<int>(std::ceil(bbox.y1 - bbox.y0)) % 2;
+
       if (!bbox.isEmpty()) {
-          m_aff = data->currentCamera->getStageToCameraRef();
           m_antiAliasing = Preferences::instance()->getRasterizeAntialias();
-          TDimension d = data->currentCamera->getRes();
+          TDimension d(bbox.getLx(),bbox.getLy());
           TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
-              m_aff,
+                               TScale(sx,sy),
               TRect(), vi->getPalette());
           rd.m_antiAliasing = m_antiAliasing;
 
@@ -320,9 +332,12 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
             QSurfaceFormat format;
             format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
-            std::unique_ptr<QOffscreenSurface> surface(new QOffscreenSurface());
-            surface->setFormat(format);
-            surface->create();
+            static QOffscreenSurface *surface = nullptr;
+            if (!surface) {
+              surface = new QOffscreenSurface();
+              surface->setFormat(format);
+              surface->create();
+            }
 
             TRaster32P ras(d);
 
@@ -330,36 +345,40 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
             glMatrixMode(GL_MODELVIEW), glPushMatrix();
             glMatrixMode(GL_PROJECTION), glPushMatrix();
             {
-              std::unique_ptr<QOpenGLFramebufferObject> fb(
-                  new QOpenGLFramebufferObject(d.lx, d.ly));
+              static std::unique_ptr<QOpenGLFramebufferObject> fb;
+              static int lastLx = 0, lastLy = 0;
+              static bool bboxChanged;
 
+              if (!fb || d.lx != lastLx || d.ly != lastLy) {
+                bboxChanged = true;
+              }
+              if (bboxChanged){
+                fb.reset(new QOpenGLFramebufferObject(d.lx, d.ly));
+                lastLx = d.lx;
+                lastLy = d.ly;
+              }
               fb->bind();
 
-              glViewport(0, 0, d.lx, d.ly);
-              glClearColor(0, 0, 0, 0);
-              glClear(GL_COLOR_BUFFER_BIT);
+              if (bboxChanged) {
+                glViewport(0, 0, d.lx, d.ly);
+                glClearColor(0, 0, 0, 0);
+                glClear(GL_COLOR_BUFFER_BIT);
 
-              glMatrixMode(GL_PROJECTION);
-              glLoadIdentity();
-              gluOrtho2D(0, d.lx, 0, d.ly);
+                glMatrixMode(GL_PROJECTION);
+                glLoadIdentity();
+                gluOrtho2D(bbox.x0, bbox.x1, bbox.y0, bbox.y1);
 
-              glMatrixMode(GL_MODELVIEW);
-              glLoadIdentity();
-
+                glMatrixMode(GL_MODELVIEW);
+                glLoadIdentity();
+              }
+              
               tglDraw(rd, vi.getPointer());
 
               glFlush();
 
-              QImage img = fb->toImage();
+              glReadPixels(0, 0, d.lx, d.ly, GL_BGRA, GL_UNSIGNED_BYTE,
+                           ras->getRawData());
 
-              int wrap      = ras->getLx() * sizeof(TPixel32);
-              uchar *srcPix = img.bits();
-              uchar *dstPix = ras->getRawData() + wrap * (d.ly - 1);
-              for (int y = 0; y < d.ly; y++) {
-                memcpy(dstPix, srcPix, wrap);
-                dstPix -= wrap;
-                srcPix += wrap;
-              }
               fb->release();
             }
             glMatrixMode(GL_MODELVIEW), glPopMatrix();
@@ -368,6 +387,11 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
             glPopAttrib();
 
             TRasterImageP ri = TRasterImageP(ras);
+
+            int offsetX      = bbox.x1 - (d.lx / 2);
+            int offsetY      = bbox.y1 - (d.ly / 2);
+            ri->setOffset(TPoint(offsetX, offsetY));
+
             assert(glGetError() == 0);
 
             return ri;

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -299,17 +299,16 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
     TVectorImageP vi = img;
     if (vi) {
       TRectD bbox = vi->getBBox();
-      d = TDimension(tceil(bbox.getLx() * data->cameraDpi.x / Stage::inch+1),
-                     tceil(bbox.getLy() * data->cameraDpi.x / Stage::inch+1));
-      TScale scale = TScale(data->cameraDpi.x / Stage::inch,
-                            data->cameraDpi.y / Stage::inch);
+      double sx, sy;
+      sx = data->cameraDpi.x / Stage::inch;
+      sy = data->cameraDpi.x / Stage::inch;
+      d = TDimension(tceil(bbox.getLx() * sx)+1,
+                     tceil(bbox.getLy() * sy)+1);
+      TScale scale = TScale(sx,sy);
       off          = TPoint((int)bbox.x0, (int)bbox.y0);
 
       TPalette *vpalette = vi->getPalette();
 
-      //TVectorRenderData rd(scale * TTranslation(-off.x, -off.y),
-         //                  TRect(TPoint(0, 0), TDimension(d.lx, d.ly)),
-           //                vpalette, 0, false, true);
       TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
                            scale * TTranslation(-off.x, -off.y),
                            TRect(TPoint(0, 0), TDimension(d.lx, d.ly)),
@@ -371,8 +370,7 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
         glPopAttrib();
 
         TRasterImageP ri = TRasterImageP(ras);
-        ri->setOffset(off + ras->getCenter());
-
+        ri->setOffset(TPoint(off.x*sx,off.y*sy) + ras->getCenter());
         assert(glGetError() == 0);
 
         return ri;

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -27,6 +27,7 @@
 #include "toonz/dpiscale.h"
 #include "toonz/stage.h"
 #include "toonz/tcamera.h"
+#include "toonz/preferences.h"
 
 // Qt includes
 #include <QImage>
@@ -282,12 +283,10 @@ bool ImageRasterizer::getInfo(TImageInfo &info, int imFlags, void *extData) {
 
 bool ImageRasterizer::isImageCompatible(int imFlags, void* extData) { 
   ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
-
   if (m_aff == data->currentCamera->getStageToCameraRef())
-    return true;
-  else {
-    return false;
-  }
+    if (m_antiAliasing == Preferences::instance()->getRasterizeAntialias())
+        return true;
+  return false;
 }
 
 //-------------------------------------------------------------------------
@@ -309,11 +308,12 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
       TRectD bbox = vi->getBBox();
       if (!bbox.isEmpty()) {
           m_aff = data->currentCamera->getStageToCameraRef();
+          m_antiAliasing = Preferences::instance()->getRasterizeAntialias();
           TDimension d = data->currentCamera->getRes();
           TVectorRenderData rd(TVectorRenderData::ProductionSettings(),
               m_aff,
               TRect(), vi->getPalette());
-          rd.m_antiAliasing = true;//TODO: get this value from Preference
+          rd.m_antiAliasing = m_antiAliasing;
 
           //Is this too slow?
           {

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -279,6 +279,14 @@ bool ImageRasterizer::getInfo(TImageInfo &info, int imFlags, void *extData) {
   return false;
 }
 
+bool ImageRasterizer::isImageCompatible(int imFlags, void* extData) { 
+  ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
+  if (data->m_cameraDpi == oldCameraDpi) return true;
+  else {
+    return false;
+  }
+}
+
 //-------------------------------------------------------------------------
 
 TImageP ImageRasterizer::build(int imFlags, void *extData) {
@@ -287,10 +295,11 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
 
   TDimension d(10, 10);
   TPoint off(0, 0);
-
+  
   // Fetch image
   assert(extData);
   ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
+  oldCameraDpi                    = data->m_cameraDpi;
   
   const std::string &srcImgId = data->m_sl->getImageId(data->m_fid);
 
@@ -300,8 +309,8 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
     if (vi) {
       TRectD bbox = vi->getBBox();
       double sx, sy;
-      sx = data->cameraDpi.x / Stage::inch;
-      sy = data->cameraDpi.x / Stage::inch;
+      sx = data->m_cameraDpi.x / Stage::inch;
+      sy = data->m_cameraDpi.x / Stage::inch;
       d = TDimension(tceil(bbox.getLx() * sx)+1,
                      tceil(bbox.getLy() * sy)+1);
       TScale scale = TScale(sx,sy);

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -94,8 +94,8 @@ public:
   ImageRasterizer() {}
   ~ImageRasterizer() {}
 
-  TAffine m_aff = TAffine();
-  bool m_antiAliasing = true;
+  TPointD m_cameraDPI;
+  bool m_antiAliasing;
 
   //Imagemaneget::getImage
   bool isImageCompatible(int imFlags, void *extData) override;

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -40,7 +40,7 @@ public:
     //!< m_sl's subsampling property otherwise)
     bool m_icon;  //!< Whether the icon (if any) should be loaded instead
     
-    TPointD cameraDpi;  //!< For Rasterizer scale, set to current camera dpi
+    TPointD m_cameraDpi;  //!< For Rasterizer scale, set to current camera dpi
 
   public:
     BuildExtData(const TXshSimpleLevel *sl, const TFrameId &fid, int subs = 0,
@@ -93,7 +93,9 @@ public:
   ImageRasterizer() {}
   ~ImageRasterizer() {}
 
-  bool isImageCompatible(int imFlags, void *extData) override { return true; }
+  TPointD oldCameraDpi;
+  //Imagemaneget::getImage
+  bool isImageCompatible(int imFlags, void *extData) override;
 
 protected:
   bool getInfo(TImageInfo &info, int imFlags, void *extData) override;

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -39,6 +39,8 @@ public:
     //!< 'the currently stored one' if an image is already cached, or
     //!< m_sl's subsampling property otherwise)
     bool m_icon;  //!< Whether the icon (if any) should be loaded instead
+    
+    TPointD cameraDpi;  //!< For Rasterizer scale, set to current camera dpi
 
   public:
     BuildExtData(const TXshSimpleLevel *sl, const TFrameId &fid, int subs = 0,

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -94,7 +94,9 @@ public:
   ImageRasterizer() {}
   ~ImageRasterizer() {}
 
-  TAffine m_aff;
+  TAffine m_aff = TAffine();
+  bool m_antiAliasing = true;
+
   //Imagemaneget::getImage
   bool isImageCompatible(int imFlags, void *extData) override;
 

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -6,6 +6,7 @@
 #include "tfilepath.h"
 
 #include "toonz/imagemanager.h"
+#include "toonz/tcamera.h"
 
 //======================================================
 
@@ -40,12 +41,12 @@ public:
     //!< m_sl's subsampling property otherwise)
     bool m_icon;  //!< Whether the icon (if any) should be loaded instead
     
-    TPointD m_cameraDpi;  //!< For Rasterizer scale, set to current camera dpi
+    TCamera *currentCamera;//for Rasterizer
 
   public:
     BuildExtData(const TXshSimpleLevel *sl, const TFrameId &fid, int subs = 0,
                  bool icon = false)
-        : m_sl(sl), m_fid(fid), m_subs(subs), m_icon(icon) {}
+        : m_sl(sl), m_fid(fid), m_subs(subs), m_icon(icon), currentCamera(nullptr) {}
   };
 
 public:
@@ -93,7 +94,7 @@ public:
   ImageRasterizer() {}
   ~ImageRasterizer() {}
 
-  TPointD oldCameraDpi;
+  TAffine m_aff;
   //Imagemaneget::getImage
   bool isImageCompatible(int imFlags, void *extData) override;
 

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -456,6 +456,7 @@ void Preferences::definePreferenceItems() {
   // Visualization
   define(show0ThickLines, "show0ThickLines", QMetaType::Bool, true);
   define(regionAntialias, "regionAntialias", QMetaType::Bool, false);
+  define(rasterizeAntialias, "rasterizeAntialias", QMetaType::Bool, true);
 
   // Loading
   define(importPolicy, "importPolicy", QMetaType::Int, 0);  // Always ask

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -426,7 +426,7 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     player.m_guidedFrontStroke      = m_guidedFrontStroke;
     player.m_guidedBackStroke       = m_guidedBackStroke;
     if (xsh) {
-      TPointD cameraDpi =
+      TPointD cameraDpi =//use cameraDpi for rasterized vector image
           xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
         player.m_dpiAff =
           sl ? ((sl->getType() == PLI_XSHLEVEL && sl->m_rasterizePli)

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -38,6 +38,7 @@
 #include "imagebuilders.h"
 #include "toonz/toonzscene.h"
 #include "toonz/sceneproperties.h"
+#include "toonz/tcamera.h"
 
 // Qt includes
 #include <QImage>
@@ -424,7 +425,18 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     player.m_isGuidedDrawingEnabled = m_isGuidedDrawingEnabled;
     player.m_guidedFrontStroke      = m_guidedFrontStroke;
     player.m_guidedBackStroke       = m_guidedBackStroke;
+    if (xsh) {
+      TPointD cameraDpi =
+          xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
+        player.m_dpiAff =
+          sl ? ((sl->getType() == PLI_XSHLEVEL && sl->m_rasterizePli)
+                    ? TScale(Stage::inch / cameraDpi.x,
+                             Stage::inch / cameraDpi.y)
+                    : getDpiAffine(sl, cell.m_frameId))
+             : TAffine();
+    } else  
     player.m_dpiAff = sl ? getDpiAffine(sl, cell.m_frameId) : TAffine();
+
     player.m_onionSkinDistance = m_onionSkinDistance;
     // when visiting the subxsheet, valuate the subxsheet column index
     bool isCurrent               = (subSheetColIndex >= 0)

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -12,6 +12,8 @@
 #include "imagebuilders.h"
 
 #include "toonz/stageplayer.h"
+#include "toonz/tstageobjecttree.h"
+#include "toonz/tcamera.h"
 
 using namespace Stage;
 
@@ -63,6 +65,8 @@ TImageP Stage::Player::image() const {
     id = id + "_filled";
 
   ImageLoader::BuildExtData extData(m_sl, m_fid);
+  extData.cameraDpi =
+      m_xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
   return ImageManager::instance()->getImage(id, ImageManager::none, &extData);
 }
 

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -55,18 +55,19 @@ TImageP Stage::Player::image() const {
 
   std::string id = m_sl->getImageId(m_fid);
   int slType     = m_sl->getType();
+  ImageLoader::BuildExtData extData(m_sl, m_fid);
 
   if (slType == PLI_XSHLEVEL && TXshSimpleLevel::m_rasterizePli) {
     if (!(m_isCurrentColumn && m_isCurrentXsheetLevel)) id = id + "_rasterized";
+    if(m_xsh)
+        extData.m_cameraDpi =//use cameraDpi to rasterize vector
+        m_xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
   }
 
   if (TXshSimpleLevel::m_fillFullColorRaster &&
       (slType == OVL_XSHLEVEL || slType == TZI_XSHLEVEL))
     id = id + "_filled";
 
-  ImageLoader::BuildExtData extData(m_sl, m_fid);
-  extData.cameraDpi =
-      m_xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
   return ImageManager::instance()->getImage(id, ImageManager::none, &extData);
 }
 

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -13,7 +13,6 @@
 
 #include "toonz/stageplayer.h"
 #include "toonz/tstageobjecttree.h"
-#include "toonz/tcamera.h"
 
 using namespace Stage;
 
@@ -60,9 +59,9 @@ TImageP Stage::Player::image() const {
   if (slType == PLI_XSHLEVEL && TXshSimpleLevel::m_rasterizePli) {
     if (!(m_isCurrentColumn && m_isCurrentXsheetLevel)) id = id + "_rasterized";
     if(m_xsh)
-        extData.m_cameraDpi =//use cameraDpi to rasterize vector
-        m_xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
-  }
+      extData.currentCamera = m_xsh->getStageObjectTree()->getCurrentCamera();
+  }  // use cameraDpi to rasterize vector
+        
 
   if (TXshSimpleLevel::m_fillFullColorRaster &&
       (slType == OVL_XSHLEVEL || slType == TZI_XSHLEVEL))

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -50,7 +50,6 @@
 #include "imagebuilders.h"
 #include "toonz/tframehandle.h"
 #include "toonz/preferences.h"
-#include "toonz/tcamera.h"
 
 // Qt includes
 #include <QImage>
@@ -999,14 +998,13 @@ void RasterPainter::onRasterImage(TRasterImage *ri,
 
   TAffine aff;
   aff = m_viewAff * player.m_placement * player.m_dpiAff;
+  
   aff = TTranslation(m_dim.lx * 0.5, m_dim.ly * 0.5) * aff *
         TTranslation(-r->getCenterD() +
                      convert(ri->getOffset()));  // this offset is !=0 only if
-                                                 // in cleanup camera test mode
-  if (player.m_sl->m_rasterizePli) {
-    TPointD dpi = player.m_xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
-    aff *= TScale(Stage::inch / dpi.x, Stage::inch / dpi.y);
-  }
+                                                 // in cleanup camera test mode 
+                                                 // and rasterizer 
+
   TRectD bbox = TRectD(0, 0, m_dim.lx, m_dim.ly);
   bbox *= convert(m_clipRect);
   if (bbox.isEmpty()) return;

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -1003,7 +1003,6 @@ void RasterPainter::onRasterImage(TRasterImage *ri,
         TTranslation(-r->getCenterD() +
                      convert(ri->getOffset()));  // this offset is !=0 only if
                                                  // in cleanup camera test mode 
-                                                 // and rasterizer 
 
   TRectD bbox = TRectD(0, 0, m_dim.lx, m_dim.ly);
   bbox *= convert(m_clipRect);

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -50,6 +50,7 @@
 #include "imagebuilders.h"
 #include "toonz/tframehandle.h"
 #include "toonz/preferences.h"
+#include "toonz/tcamera.h"
 
 // Qt includes
 #include <QImage>
@@ -1002,7 +1003,10 @@ void RasterPainter::onRasterImage(TRasterImage *ri,
         TTranslation(-r->getCenterD() +
                      convert(ri->getOffset()));  // this offset is !=0 only if
                                                  // in cleanup camera test mode
-
+  if (player.m_sl->m_rasterizePli) {
+    TPointD dpi = player.m_xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
+    aff *= TScale(Stage::inch / dpi.x, Stage::inch / dpi.y);
+  }
   TRectD bbox = TRectD(0, 0, m_dim.lx, m_dim.ly);
   bbox *= convert(m_clipRect);
   if (bbox.isEmpty()) return;


### PR DESCRIPTION
Resolves #4807 

- [x] Make rasterized result same as export and preview
![图片](https://github.com/user-attachments/assets/2aded7b1-5f9f-44ab-af7f-75e4a7fb0167)
- [x] Add preference of whether to enable Anti Aliasing (in the visualization page)
![图片](https://github.com/user-attachments/assets/cc370566-19dd-4f97-a7dd-07fb989a662d)
- [x] Enlarge the rasterized area(not only camera area)
![图片](https://github.com/user-attachments/assets/5c2f7a88-0f80-46f7-b53f-e67cd2d8775e)

# Issue Description
This [function](https://github.com/opentoonz/opentoonz/blob/9dffdf827c7281025fd605cc85f0536753da1d05/toonz/sources/toonzlib/imagebuilders.cpp#L282C1-L380C1)(_build(int imFlags, void *extData)_) is used to rasterize Vector and return a TRasterImageP.

This function would use to get BBox of the stroke, and make it the size of the Raster Image to return.
But the BBox is not always the actual size that match the canvas, the returned Rasterized Image would be scaled again to fit the actual size.
Here shows how to reproduce it.

**1.** If we set camera DPI > 53.34, the "Visualize Vector as Raster" would scale up, the pixel is bigger.
![图片](https://github.com/user-attachments/assets/593e787c-6a91-4090-846d-e6ae01ab4908)

**2.** If we set camera DPI < 53.34, the "Visualize Vector as Raster" would scale down, the pixel is smaller.
![图片](https://github.com/user-attachments/assets/f0fd22c1-e05a-4788-8df1-d24c5295895b)

**3.** If we set camera DPI = 53.34, the accurancy of "Visualize Vector as Raster" would recover.
![图片](https://github.com/user-attachments/assets/574e4d3c-e7b5-4e58-acb6-aebbb7022052)

I thought it might related to default *Stage::inch* that affect the way of writing or reading of vector layer.

[stage.cpp](https://github.com/opentoonz/opentoonz/blob/9dffdf827c7281025fd605cc85f0536753da1d05/toonz/sources/toonzlib/stage.cpp#L66C1-L75C39)
``` C++
/*! \var Stage::inch
                For historical reasons camera stand is defined in a coordinate
   system in which
                an inch is equal to 'Stage::inch' unit.
                Pay attention: modify this value condition apparent line
   thickness of
                images .pli.
*/
const double Stage::inch        = 53.33333;
const double Stage::standardDpi = 120;
```