### PR TITLE
Chore: Improve AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,35 +12,49 @@ cache:
   - c:\Tools\vcpkg\installed
   - c:\Libraries\boost_1_85_0
   - c:\Tools\opencv\build
-
 install:
-  - cmd: >-
+  - cmd: |
       choco install opencv --version=4.10.0
+
       cd thirdparty
+
       copy /Y tiff-4.0.3\libtiff\tif_config.vc.h tiff-4.0.3\libtiff\tif_config.h
+
       copy /Y tiff-4.0.3\libtiff\tiffconf.vc.h tiff-4.0.3\libtiff\tiffconf.h
+
       copy /Y libpng-1.6.21\scripts\pnglibconf.h.prebuilt libpng-1.6.21\pnglibconf.h
+
       cd ../toonz
+
       mkdir %PLATFORM% && cd %PLATFORM%
+
       cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
-
 build_script:
-  - cmd: echo Building project at: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
-  - cmd: msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /m
-
+  - cmd: |
+      echo Building project at: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
+  - cmd: |
+      msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /m
 after_build:
-  - cmd: >-
+  - cmd: |
       C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz.exe
-      copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%
-      copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION%
-      copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll %CONFIGURATION%
-      copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll %CONFIGURATION%
-      copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll %CONFIGURATION%
-      copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%
-      copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4100.dll" %CONFIGURATION%
-      mkdir "%CONFIGURATION%\portablestuff"
-      xcopy /Y /E ..\..\stuff "%CONFIGURATION%\portablestuff"
 
+      copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%
+
+      copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION%
+
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll %CONFIGURATION%
+
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll %CONFIGURATION%
+
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll %CONFIGURATION%
+
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%
+
+      copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4100.dll" %CONFIGURATION%
+
+      mkdir "%CONFIGURATION%\portablestuff"
+
+      xcopy /Y /E ..\..\stuff "%CONFIGURATION%\portablestuff"
 artifacts:
   - path: toonz\$(PLATFORM)\$(CONFIGURATION)
     name: OpenToonz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
     cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
 build_script:
 - cmd: >-
-    msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /MP
+    msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /m
 after_build:
 - cmd: >-
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,10 @@ configuration:
 - Release
 platform: x64
 clone_depth: 1
-cache: c:\tools\vcpkg\installed
+cache:
+  - c:\Tools\vcpkg\installed
+  - c:\Libraries\boost_1_85_0
+  - c:\Tools\opencv\build
 install:
 - cmd: >-
     choco install opencv --version=4.10.0
@@ -28,7 +31,7 @@ install:
     cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
 build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
-  parallel: true
+  parallel: false
   verbosity: minimal
 after_build:
 - cmd: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,8 @@ build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
   parallel: false
   verbosity: minimal
+  cmd: >-
+    msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /MP
 after_build:
 - cmd: >-
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,11 +29,8 @@ install:
     mkdir %PLATFORM% && cd %PLATFORM%
 
     cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
-build:
-  project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
-  parallel: false
-  verbosity: minimal
-  cmd: >-
+build_script:
+- cmd: >-
     msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /MP
 after_build:
 - cmd: >-
@@ -61,4 +58,3 @@ after_build:
 artifacts:
 - path: toonz\$(PLATFORM)\$(CONFIGURATION)
   name: OpenToonz
-  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,8 @@ install:
 
     cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
 build_script:
-- cmd: >-
-    msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /m
+- cmd: echo Building project at: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
+- cmd: msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /m
 after_build:
 - cmd: >-
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,57 +4,43 @@ pull_requests:
 skip_tags: true
 image: Visual Studio 2019
 configuration:
-- Debug
-- Release
+  - Debug
+  - Release
 platform: x64
 clone_depth: 1
 cache:
   - c:\Tools\vcpkg\installed
   - c:\Libraries\boost_1_85_0
   - c:\Tools\opencv\build
+
 install:
-- cmd: >-
-    choco install opencv --version=4.10.0
+  - cmd: >-
+      choco install opencv --version=4.10.0
+      cd thirdparty
+      copy /Y tiff-4.0.3\libtiff\tif_config.vc.h tiff-4.0.3\libtiff\tif_config.h
+      copy /Y tiff-4.0.3\libtiff\tiffconf.vc.h tiff-4.0.3\libtiff\tiffconf.h
+      copy /Y libpng-1.6.21\scripts\pnglibconf.h.prebuilt libpng-1.6.21\pnglibconf.h
+      cd ../toonz
+      mkdir %PLATFORM% && cd %PLATFORM%
+      cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
 
-    cd thirdparty
-
-    copy /Y tiff-4.0.3\libtiff\tif_config.vc.h tiff-4.0.3\libtiff\tif_config.h
-
-    copy /Y tiff-4.0.3\libtiff\tiffconf.vc.h tiff-4.0.3\libtiff\tiffconf.h
-
-    copy /Y libpng-1.6.21\scripts\pnglibconf.h.prebuilt libpng-1.6.21\pnglibconf.h
-
-    cd ../toonz
-
-    mkdir %PLATFORM% && cd %PLATFORM%
-
-    cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
 build_script:
-- cmd: echo Building project at: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
-- cmd: msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /m
+  - cmd: echo Building project at: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
+  - cmd: msbuild $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=x64 /m
+
 after_build:
-- cmd: >-
-    
-    C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz.exe
-
-    copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%
-    
-    copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION%
-
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll %CONFIGURATION%
-
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll %CONFIGURATION%
-
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll %CONFIGURATION%
-    
-    copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%
-    
-    copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4100.dll" %CONFIGURATION%
-
-    mkdir "%CONFIGURATION%\portablestuff"
-
-    xcopy /Y /E ..\..\stuff "%CONFIGURATION%\portablestuff"
+  - cmd: >-
+      C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz.exe
+      copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%
+      copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION%
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll %CONFIGURATION%
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll %CONFIGURATION%
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll %CONFIGURATION%
+      copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll %CONFIGURATION%
+      copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4100.dll" %CONFIGURATION%
+      mkdir "%CONFIGURATION%\portablestuff"
+      xcopy /Y /E ..\..\stuff "%CONFIGURATION%\portablestuff"
 
 artifacts:
-- path: toonz\$(PLATFORM)\$(CONFIGURATION)
-  name: OpenToonz
+  - path: toonz\$(PLATFORM)\$(CONFIGURATION)
+    name: OpenToonz


### PR DESCRIPTION
Try adding caching and disabling parallel builds to resolve potential AppVeyor timeout issues.

- Added caching for Boost, and OpenCV to speed up builds.

- Disabled parallel builds for Release configuration to avoid potential issues.