### PR TITLE
Refactor: Drop support for Qt versions before 5.15

### DIFF
--- a/toonz/sources/common/tmsgcore.cpp
+++ b/toonz/sources/common/tmsgcore.cpp
@@ -133,11 +133,7 @@ void TMsgCore::readFromSocket(QTcpSocket *socket)  // server side
     message.chop(lastbegin);
   }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList messages = message.split("#TMSG", Qt::SkipEmptyParts);
-#else
-  QStringList messages = message.split("#TMSG", QString::SkipEmptyParts);
-#endif
 
   for (int i = 0; i < messages.size(); i++) {
     QString str = messages.at(i).simplified();

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -160,11 +160,7 @@ TFilePath TSystem::getTestDir(string name) {
 //------------------------------------------------------------
 
 QString TSystem::getSystemValue(const TFilePath &name) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList strlist = toQString(name).split("\\", Qt::SkipEmptyParts);
-#else
-  QStringList strlist = toQString(name).split("\\", QString::SkipEmptyParts);
-#endif
 
   assert(strlist.size() > 3);
   assert(strlist.at(0) == "SOFTWARE");

--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -91,17 +91,9 @@ std::string fidsToString(const std::vector<TFrameId> &fids) {
 std::vector<TFrameId> strToFids(std::string fidsStr) {
   std::vector<TFrameId> ret;
   QString str = QString::fromStdString(fidsStr);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList chunks = str.split(',', Qt::SkipEmptyParts);
-#else
-  QStringList chunks = str.split(',', QString::SkipEmptyParts);
-#endif
   for (const auto &chunk : chunks) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QStringList nums = chunk.split('-', Qt::SkipEmptyParts);
-#else
-    QStringList nums = chunk.split('-', QString::SkipEmptyParts);
-#endif
     assert(nums.count() > 0 && nums.count() <= 2);
     if (nums.count() == 1)
       ret.push_back(TFrameId(nums[0].toInt()));

--- a/toonz/sources/image/mov/tiio_movM.cpp
+++ b/toonz/sources/image/mov/tiio_movM.cpp
@@ -602,11 +602,7 @@ void TLevelWriterMov::save(const TImageP &img, int frameIndex) {
     frame.right  = lx;
     frame.bottom = ly;
 
-#if QT_VERSION >= 0x050000
     if ((err = QTNewGWorld(&(m_gworld), pixSize * 8, &frame, 0, 0, 0)) != noErr)
-#else
-    if ((err = NewGWorld(&(m_gworld), pixSize * 8, &frame, 0, 0, 0)) != noErr)
-#endif
       throw TImageException(getFilePath(), "can't create movie buffer");
 
     //#ifdef WIN32

--- a/toonz/sources/toonz/cleanupswatch.cpp
+++ b/toonz/sources/toonz/cleanupswatch.cpp
@@ -199,11 +199,7 @@ void CleanupSwatch::CleanupSwatchArea::wheelEvent(QWheelEvent *event) {
   if ((factor < 1 && sqrt(scale) < minZoom) || (factor > 1 && scale > 1200.0))
     return;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   TPointD delta(event->position().x(), height() - event->position().y());
-#else
-  TPointD delta(event->pos().x(), height() - event->pos().y());
-#endif
   m_sw->m_viewAff =
       (TTranslation(delta) * TScale(factor) * TTranslation(-delta)) *
       m_sw->m_viewAff;

--- a/toonz/sources/toonz/exportcameratrackpopup.cpp
+++ b/toonz/sources/toonz/exportcameratrackpopup.cpp
@@ -893,13 +893,8 @@ void ExportCameraTrackPopup::getInfoFromUI(ExportCameraTrackInfo& info) {
   // camera rect settings
   info.cameraRectOnKeys = m_cameraRectOnKeysCB->isChecked();
   info.cameraRectOnTags = m_cameraRectOnTagsCB->isChecked();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
   QStringList framesStrList =
       m_cameraRectFramesEdit->text().split(",", Qt::SkipEmptyParts);
-#else
-  QStringList framesStrList =
-      m_cameraRectFramesEdit->text().split(",", QString::SkipEmptyParts);
-#endif
   for (auto fStr : framesStrList) {
     bool ok;
     int f = fStr.toInt(&ok);

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -1552,8 +1552,8 @@ void XSheetPDFTemplate::initializePage(QPdfWriter& writer) {
   QPageLayout pageLayout;
   pageLayout.setUnits(QPageLayout::Millimeter);
   pageLayout.setPageSize(
-      QPageSize(m_p.documentPageSize));  // ���ʂ�B4��ISO B4(250x353mm)
-                                         // ���{��B4��JIS B4(257x364mm)
+      QPageSize(m_p.documentPageSize));  // ISO B4(250x353mm)
+                                         // JIS B4(257x364mm)
   pageLayout.setOrientation(QPageLayout::Portrait);
   pageLayout.setMargins(m_p.documentMargin);
   writer.setPageLayout(pageLayout);
@@ -2785,7 +2785,7 @@ void ExportXsheetPdfPopup::onExportCSV() {
       //add cell number
       if (cell.m_level)
           csvCol.append(QString::number(cell.m_frameId.getNumber()));
-      else//    add ��
+      else// TODO: Fix corrupted encoding (unknown characters)
           csvCol.append(QString::fromUtf8("\u00D7"));
       
       prevCell = cell;

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -1552,8 +1552,8 @@ void XSheetPDFTemplate::initializePage(QPdfWriter& writer) {
   QPageLayout pageLayout;
   pageLayout.setUnits(QPageLayout::Millimeter);
   pageLayout.setPageSize(
-      QPageSize(m_p.documentPageSize));  // •’Ê‚ÌB4‚ÍISO B4(250x353mm)
-                                         // “ú–{‚ÌB4‚ÍJIS B4(257x364mm)
+      QPageSize(m_p.documentPageSize));  // ï¿½ï¿½ï¿½Ê‚ï¿½B4ï¿½ï¿½ISO B4(250x353mm)
+                                         // ï¿½ï¿½ï¿½{ï¿½ï¿½B4ï¿½ï¿½JIS B4(257x364mm)
   pageLayout.setOrientation(QPageLayout::Portrait);
   pageLayout.setMargins(m_p.documentMargin);
   writer.setPageLayout(pageLayout);
@@ -1688,11 +1688,9 @@ XSheetPDFTemplate_Custom::XSheetPDFTemplate_Custom(
     m_p.documentPageSize = str2PageSizeId(pageStr);
 
     QString marginStr = s.value("Margin").toString();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+
     QStringList m = marginStr.split(QLatin1Char(','), Qt::SkipEmptyParts);
-#else
-    QStringList m = marginStr.split(QLatin1Char(','), QString::SkipEmptyParts);
-#endif
+
     assert(m.size() == 4);
     if (m.size() == 4)
       m_p.documentMargin = QMarginsF(m[0].toDouble(), m[1].toDouble(),
@@ -1734,12 +1732,7 @@ XSheetPDFTemplate_Custom::XSheetPDFTemplate_Custom(
     {
       for (auto key : s.childKeys()) {
         QString rectStr = s.value(key).toString();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
         QStringList r = rectStr.split(QLatin1Char(','), Qt::SkipEmptyParts);
-#else
-        QStringList r =
-            rectStr.split(QLatin1Char(','), QString::SkipEmptyParts);
-#endif
         assert(r.size() == 4);
         if (r.size() == 4)
           m_dataRects[dataStr2Type(key)] =
@@ -2792,7 +2785,7 @@ void ExportXsheetPdfPopup::onExportCSV() {
       //add cell number
       if (cell.m_level)
           csvCol.append(QString::number(cell.m_frameId.getNumber()));
-      else//    add ¡Á
+      else//    add ï¿½ï¿½
           csvCol.append(QString::fromUtf8("\u00D7"));
       
       prevCell = cell;

--- a/toonz/sources/toonz/fileviewerpopup.cpp
+++ b/toonz/sources/toonz/fileviewerpopup.cpp
@@ -33,11 +33,7 @@ using namespace TwConsts;*/
 // FileViewer
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 FileViewer::FileViewer(QWidget *parent, Qt::WindowFlags flags)
-#else
-FileViewer::FileViewer(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent), m_fileSize(0), m_player(0), m_snd(0), m_soundOn(false) {
   setAcceptDrops(true);
 }
@@ -689,11 +685,7 @@ public:
 // FileViewerPopup
 //-----------------------------------------------------------------------------
 
-#if QT_VERSION >= 0x050500
 FileViewerPopup::FileViewerPopup(QWidget *parent, Qt::WindowFlags flags)
-#else
-FileViewerPopup::FileViewerPopup(QWidget *parent, Qt::WFlags flags)
-#endif
     : QWidget(parent) {
   setWindowTitle(tr("Viewer"));
   QHBoxLayout *layout    = new QHBoxLayout(this);

--- a/toonz/sources/toonz/fileviewerpopup.h
+++ b/toonz/sources/toonz/fileviewerpopup.h
@@ -35,11 +35,7 @@ class FileViewer : public QWidget {
   bool m_soundOn;
 
 public:
-#if QT_VERSION >= 0x050500
   FileViewer(QWidget *parent = 0, Qt::WindowFlags flags = Qt::Tool);
-#else
-  FileViewer(QWidget *parent = 0, Qt::WFlags flags = Qt::Tool);
-#endif
 
   void setPath(const TFilePath &fp, int from = 0, int to = 0, int step = 0,
                TSoundTrack *snd = 0);
@@ -154,11 +150,7 @@ class FileViewerPopup : public QWidget {
   FileViewer *m_viewer;
 
 public:
-#if QT_VERSION >= 0x050500
   FileViewerPopup(QWidget *parent = 0, Qt::WindowFlags flags = Qt::Tool);
-#else
-  FileViewerPopup(QWidget *parent = 0, Qt::WFlags flags = Qt::Tool);
-#endif
 };
 
 /*

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -126,12 +126,7 @@ void HistogramPopup::moveNextToWidget(QWidget *widget) {
   if (minimumSize().isEmpty()) grab();
   QSize popupSize = frameSize();
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QRect screenRect = widget->screen()->availableGeometry();
-#else
-  int currentScreen = QApplication::desktop()->screenNumber(widget);
-  QRect screenRect  = QApplication::desktop()->availableGeometry(currentScreen);
-#endif
   QRect viewerRect = widget->rect();
   viewerRect.moveTo(widget->mapToGlobal(QPoint(0, 0)));
   // decide which side to open the popup

--- a/toonz/sources/toonz/imageviewer.cpp
+++ b/toonz/sources/toonz/imageviewer.cpp
@@ -1306,13 +1306,8 @@ void ImageViewer::wheelEvent(QWheelEvent *event) {
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
       int d = delta > 0 ? 120 : -120;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       QPoint center(event->position().x() * getDevPixRatio() - width() / 2,
                     -event->position().y() * getDevPixRatio() + height() / 2);
-#else
-      QPoint center(event->pos().x() * getDevPixRatio() - width() / 2,
-                    -event->pos().y() * getDevPixRatio() + height() / 2);
-#endif
       zoomQt(center, exp(0.001 * d));
     }
   }

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -405,7 +405,7 @@ int main(int argc, char *argv[]) {
 
   // Enable to render smooth icons on high dpi monitors
   a.setAttribute(Qt::AA_UseHighDpiPixmaps);
-#if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+#if defined(_WIN32)
   // Compress tablet events with application attributes instead of implementing
   // the delay-timer by ourselves
   a.setAttribute(Qt::AA_CompressHighFrequencyEvents);

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1338,11 +1338,9 @@ void PencilTestSaveInFolderPopup::updateParentFolder() {
 namespace {
 
 bool strToSubCamera(const QString& str, QRect& subCamera, double& dpi) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+
   QStringList values = str.split(',', Qt::SkipEmptyParts);
-#else
-  QStringList values         = str.split(',', QString::SkipEmptyParts);
-#endif
+
   if (values.count() != 4 && values.count() != 5) return false;
   subCamera = QRect(values[0].toInt(), values[1].toInt(), values[2].toInt(),
                     values[3].toInt());

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -359,7 +359,7 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 #endif
 
     QPointF curPos = e->posF() * getDevPixRatio();
-#if defined(_WIN32) && QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+#if defined(_WIN32)
     // Use the application attribute Qt::AA_CompressTabletEvents instead of the
     // delay timer
     // 21/4/2021 High frequent tablet event caused slowness when deforming with

--- a/toonz/sources/toonz/separatecolorsswatch.cpp
+++ b/toonz/sources/toonz/separatecolorsswatch.cpp
@@ -249,11 +249,7 @@ void SeparateSwatchArea::wheelEvent(QWheelEvent *event) {
   if ((factor < 1 && sqrt(scale) < minZoom) || (factor > 1 && scale > 1200.0))
     return;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   TPointD delta(event->position().x(), height() - event->position().y());
-#else
-  TPointD delta(event->pos().x(), height() - event->pos().y());
-#endif
   m_sw->m_viewAff =
       (TTranslation(delta) * TScale(factor) * TTranslation(-delta)) *
       m_sw->m_viewAff;
@@ -415,7 +411,7 @@ void SeparateSwatch::setRaster(TRasterP orgRas, TRasterP mainRas,
 void SeparateSwatch::setRaster(TRasterP orgRas, TRasterP mainRas,
                                TRasterP sub1Ras, TRasterP sub2Ras,
                                TRasterP sub3Ras) {
-  // o‚·
+  // ï¿½oï¿½ï¿½
   m_sub3Swatch->setVisible(true);
   m_sub3Label->setVisible(true);
 

--- a/toonz/sources/toonz/separatecolorsswatch.cpp
+++ b/toonz/sources/toonz/separatecolorsswatch.cpp
@@ -411,7 +411,7 @@ void SeparateSwatch::setRaster(TRasterP orgRas, TRasterP mainRas,
 void SeparateSwatch::setRaster(TRasterP orgRas, TRasterP mainRas,
                                TRasterP sub1Ras, TRasterP sub2Ras,
                                TRasterP sub3Ras) {
-  // �o��
+  // TODO: Fix corrupted encoding (unknown characters)
   m_sub3Swatch->setVisible(true);
   m_sub3Label->setVisible(true);
 

--- a/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
+++ b/toonz/sources/toonzfarm/tfarm/tfarmtask.cpp
@@ -404,11 +404,7 @@ static TFilePath getFilePath(const QStringList &l, int &i) {
 //------------------------------------------------------------------------------
 
 void TFarmTask::parseCommandLine(QString commandLine) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList l = commandLine.split(" ", Qt::SkipEmptyParts);
-#else
-  QStringList l = commandLine.split(" ", QString::SkipEmptyParts);
-#endif
   assert(l.size() >= 2);
 
   // serve per skippare il path dell'eseguibile su mac che contiene spazi

--- a/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
+++ b/toonz/sources/toonzfarm/tfarmserver/tfarmserver.cpp
@@ -478,11 +478,7 @@ void Task::run() {
 #if defined(_WIN32)
   process.setNativeArguments(argsStr);
 #else
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   process.setArguments(argsStr.split(" ", Qt::SkipEmptyParts));
-#else
-  process.setArguments(argsStr.split(" ", QString::SkipEmptyParts));
-#endif
 #endif
   process.start();
   process.waitForFinished(-1);

--- a/toonz/sources/toonzlib/boardsettings.cpp
+++ b/toonz/sources/toonzlib/boardsettings.cpp
@@ -334,11 +334,7 @@ void BoardSettings::removeItem(int index) {
   m_items.removeAt(index);
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
 void BoardSettings::swapItems(int i, int j) { m_items.swapItemsAt(i, j); }
-#else
-void BoardSettings::swapItems(int i, int j) { m_items.swap(i, j); }
-#endif
 
 void BoardSettings::saveData(TOStream &os, bool forPreset) {
   if (!forPreset) os.child("active") << (int)((m_active) ? 1 : 0);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -389,15 +389,11 @@ void Preferences::definePreferenceItems() {
   define(CurrentStyleSheetName, "CurrentStyleSheetName", QMetaType::QString,
          "Default");
 
-  // Qt has a bug in recent versions that Menu item Does not show correctly
-  // (QTBUG-90242) Since the current OT is made to handle such issue, so we need
-  // to apply an extra adjustment when it is run on the older versions (5.9.x)
-  // of Qt
-  // Update: confirmed that the bug does not appear at least in Qt 5.12.8
+// Qt has a bug in recent versions that Menu item does not show correctly
+// (QTBUG-90242). The current OT handles this issue by applying an extra adjustment
+// for Qt versions 5.9.x.
+// Update: Issue confirmed fixed in Qt 5.12.8 and above, no longer affecting Qt 5.15 and later.
   QString defaultAditionalSheet = "";
-#if QT_VERSION < QT_VERSION_CHECK(5, 12, 9)
-  defaultAditionalSheet = "QMenu::Item{ padding: 3 28 3 28; }";
-#endif
 
   define(additionalStyleSheet, "additionalStyleSheet", QMetaType::QString,
          defaultAditionalSheet);

--- a/toonz/sources/toonzlib/txshcolumn.cpp
+++ b/toonz/sources/toonzlib/txshcolumn.cpp
@@ -464,11 +464,7 @@ bool TXshCellColumn::loadCellMarks(std::string tagName, TIStream &is) {
       QString frameStr;
       if (is.getTagParam("id", id)) {
         is >> frameStr;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         QStringList frameStrList = frameStr.split(" ", Qt::SkipEmptyParts);
-#else
-        QStringList frameStrList = frameStr.split(" ", QString::SkipEmptyParts);
-#endif
         for (auto fStr : frameStrList) m_cellMarkIds.insert(fStr.toInt(), id);
       }
     }

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -1471,11 +1471,7 @@ void DockLayout::writeRegion(Region *r, QString &hierarchy) {
 //! widget has ever been left unchanged or completely restored
 //! as it were when saved. In particular, their ordering must be preserved.
 bool DockLayout::restoreState(const State &state) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QStringList vars = state.second.split(" ", Qt::SkipEmptyParts);
-#else
-  QStringList vars = state.second.split(" ", QString::SkipEmptyParts);
-#endif
   if (vars.size() < 1) return 0;
 
   // Check number of items

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -398,19 +398,11 @@ void DockWidget::maximizeDock() {
 void DockWidget::wheelEvent(QWheelEvent *we) {
   if (m_dragging) {
     if (m_selectedPlace) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       DockPlaceholder *newSelected =
           (we->angleDelta().y() > 0)
               ? m_selectedPlace->parentPlaceholder()
               : m_selectedPlace->childPlaceholder(parentWidget()->mapFromGlobal(
                     we->globalPosition().toPoint()));
-#else
-      DockPlaceholder *newSelected =
-          (we->angleDelta().y() > 0)
-              ? m_selectedPlace->parentPlaceholder()
-              : m_selectedPlace->childPlaceholder(
-                    parentWidget()->mapFromGlobal(we->globalPos()));
-#endif
       if (newSelected != m_selectedPlace) {
         m_selectedPlace->hide();
         newSelected->show();

--- a/toonz/sources/toonzqt/functionpanel.cpp
+++ b/toonz/sources/toonzqt/functionpanel.cpp
@@ -1467,11 +1467,7 @@ void FunctionPanel::leaveEvent(QEvent *) {
 
 void FunctionPanel::wheelEvent(QWheelEvent *e) {
   double factor = exp(0.002 * (double)e->angleDelta().y());
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   zoom(factor, factor, e->position().toPoint());
-#else
-  zoom(factor, factor, e->pos());
-#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -264,15 +264,9 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
           tmpWidget->setVisible(shrink == 1);
         } else {  // modeSensitiveStr != ""
           QList<int> modes;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
           QStringList modeListStr =
               QString::fromStdString(is.getTagAttribute("mode"))
                   .split(',', Qt::SkipEmptyParts);
-#else
-          QStringList modeListStr =
-              QString::fromStdString(is.getTagAttribute("mode"))
-                  .split(',', QString::SkipEmptyParts);
-#endif
           for (QString modeNum : modeListStr) modes.push_back(modeNum.toInt());
           // find the mode combobox
           ModeChangerParamField *modeChanger = nullptr;

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -189,13 +189,7 @@ QPixmap scalePixmapKeepingAspectRatio(QPixmap pixmap, QSize size,
 
 int getDevicePixelRatio(const QWidget *widget) {
   if (hasScreensWithDifferentDevPixRatio() && widget) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     return widget->screen()->devicePixelRatio();
-#else
-    if (!widget->windowHandle()) widget->winId();
-    if (widget->windowHandle())
-      return widget->windowHandle()->devicePixelRatio();
-#endif
   }
   static int devPixRatio = QApplication::desktop()->devicePixelRatio();
   return devPixRatio;

--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -513,11 +513,7 @@ bool LutManager::loadLutFile(const QString& fp) {
 
   // The third line is corrections of values at each LUT grid
   line = locals::readDataLine(stream);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   list = line.split(" ", Qt::SkipEmptyParts);
-#else
-  list        = line.split(" ", QString::SkipEmptyParts);
-#endif
   if (list.size() != m_lut.meshSize) {
     file.close();
     return execWarning(QObject::tr("Failed to Load 3DLUT File."));
@@ -533,11 +529,7 @@ bool LutManager::loadLutFile(const QString& fp) {
       for (int i = 0; i < m_lut.meshSize; ++i)  // b
       {
         line = locals::readDataLine(stream);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
         list = line.split(" ", Qt::SkipEmptyParts);
-#else
-        list = line.split(" ", QString::SkipEmptyParts);
-#endif
         if (list.size() != 3) {
           file.close();
           delete[] m_lut.data;

--- a/toonz/sources/toonzqt/pickrgbutils.cpp
+++ b/toonz/sources/toonzqt/pickrgbutils.cpp
@@ -83,16 +83,10 @@ QRgb pickScreenRGB(const QRect &rect) {
 
 #endif
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QImage img(widget->screen()
                  ->grabWindow(widget->winId(), theRect.x(), theRect.y(),
                               theRect.width(), theRect.height())
                  .toImage());
-#else
-  QImage img(QPixmap::grabWindow(widget->winId(), theRect.x(), theRect.y(),
-                                 theRect.width(), theRect.height())
-                 .toImage());
-#endif
   return meanColor(
       img, QRect(rect.left() - theRect.left(), rect.top() - theRect.top(),
                  rect.width(), rect.height()));

--- a/toonz/sources/toonzqt/planeviewer.cpp
+++ b/toonz/sources/toonzqt/planeviewer.cpp
@@ -269,13 +269,8 @@ void PlaneViewer::wheelEvent(QWheelEvent *event) {
     if ((m_gestureActive == true &&
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       TPointD pos(event->position().x() * getDevPixRatio(),
                   height() - event->position().y() * getDevPixRatio());
-#else
-      TPointD pos(event->pos().x() * getDevPixRatio(),
-                  height() - event->pos().y() * getDevPixRatio());
-#endif
       double zoom_par = 1 + event->angleDelta().y() * 0.001;
 
       zoomView(pos.x, pos.y, zoom_par);

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -495,11 +495,7 @@ void SchematicSceneViewer::wheelEvent(QWheelEvent *me) {
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
       double factor = exp(delta * 0.001);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       changeScale(me->position().toPoint(), factor);
-#else
-      changeScale(me->pos(), factor);
-#endif
       m_panning = false;
     }
   }

--- a/toonz/sources/toonzqt/swatchviewer.cpp
+++ b/toonz/sources/toonzqt/swatchviewer.cpp
@@ -784,13 +784,8 @@ void SwatchViewer::wheelEvent(QWheelEvent *event) {
     if ((m_gestureActive == true &&
          m_touchDevice == QTouchDevice::TouchScreen) ||
         m_gestureActive == false) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
       TPoint center(event->position().x() - width() / 2,
                     -event->position().y() + height() / 2);
-#else
-      TPoint center(event->pos().x() - width() / 2,
-                    -event->pos().y() + height() / 2);
-#endif
       zoom(center, exp(0.001 * event->angleDelta().y()));
     }
   }


### PR DESCRIPTION
This change simplifies the code by removing obsolete compatibility checks, aiming to support Qt 5.15 and above.

Some people building locally may encounter issues, especially if they don't keep up with changes in the code, as the documentation wasn't always up to date. Now, it's important to keep everything in sync, as many reported issues were caused by building with older versions of Qt, especially on Linux.