### PR TITLE
Adjust Notice Label Size and Color after Text Changed

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1788,6 +1788,7 @@ bool IoCmd::saveAll(int flags) {
         "background-color: black; color: green; "
         "font-weight: bold; padding: 5px;");
   }
+  Label->adjustSize();
   
   QTimer::singleShot(2500, Label, &QLabel::deleteLater);
   return result;

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1785,7 +1785,7 @@ bool IoCmd::saveAll(int flags) {
     Label->setText("Save Failed");
     Label->setStyleSheet(
         "font-size: 20px;"
-        "background-color: black; color: green; "
+        "background-color: black; color: red; "
         "font-weight: bold; padding: 5px;");
   }
   Label->adjustSize();


### PR DESCRIPTION
1. Adapt to different Fonts.
2. Change font color to red if save failed.