### PR TITLE
Optimize Background Process Startup

### DIFF
--- a/toonz/sources/common/tipc/tipc.cpp
+++ b/toonz/sources/common/tipc/tipc.cpp
@@ -263,18 +263,22 @@ QString tipc::applicationSpecificServerName(QString srvName) {
 bool tipc::startBackgroundProcess(QString cmdlineProgram,
                                   QStringList cmdlineArguments) {
 #ifdef _WIN32
+  SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+
   QProcess *proc = new QProcess;
 
   proc->start(cmdlineProgram, cmdlineArguments);
-  if (proc->state() == QProcess::NotRunning) {
-    delete proc;
-    return false;
-  }
-
+  
   QObject::connect(proc, SIGNAL(finished(int, QProcess::ExitStatus)), proc,
                    SLOT(deleteLater()));
   QObject::connect(proc, SIGNAL(error(QProcess::ProcessError)), proc,
                    SLOT(deleteLater()));
+
+if (proc->waitForFinished(150)) {
+    delete proc;
+    return false;
+  }
+  
   return true;
 #else
   return QProcess::startDetached(cmdlineProgram, cmdlineArguments);

--- a/toonz/sources/common/tipc/tipc.cpp
+++ b/toonz/sources/common/tipc/tipc.cpp
@@ -263,21 +263,18 @@ QString tipc::applicationSpecificServerName(QString srvName) {
 bool tipc::startBackgroundProcess(QString cmdlineProgram,
                                   QStringList cmdlineArguments) {
 #ifdef _WIN32
-  SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
 
   QProcess *proc = new QProcess;
 
   proc->start(cmdlineProgram, cmdlineArguments);
-  
+  if (proc->waitForStarted() && proc->error() != QProcess::FailedToStart) {
+    return false;
+  }
+
   QObject::connect(proc, SIGNAL(finished(int, QProcess::ExitStatus)), proc,
                    SLOT(deleteLater()));
   QObject::connect(proc, SIGNAL(error(QProcess::ProcessError)), proc,
                    SLOT(deleteLater()));
-
-if (proc->waitForFinished(150)) {
-    delete proc;
-    return false;
-  }
   
   return true;
 #else

--- a/toonz/sources/common/tipc/tipc.cpp
+++ b/toonz/sources/common/tipc/tipc.cpp
@@ -268,6 +268,7 @@ bool tipc::startBackgroundProcess(QString cmdlineProgram,
 
   proc->start(cmdlineProgram, cmdlineArguments);
   if (proc->waitForStarted() && proc->error() != QProcess::FailedToStart) {
+    delete proc;
     return false;
   }
 

--- a/toonz/sources/common/tipc/tipc.cpp
+++ b/toonz/sources/common/tipc/tipc.cpp
@@ -267,16 +267,17 @@ bool tipc::startBackgroundProcess(QString cmdlineProgram,
   QProcess *proc = new QProcess;
 
   proc->start(cmdlineProgram, cmdlineArguments);
-  if (proc->waitForStarted() && proc->error() != QProcess::FailedToStart) {
-    delete proc;
-    return false;
-  }
 
   QObject::connect(proc, SIGNAL(finished(int, QProcess::ExitStatus)), proc,
                    SLOT(deleteLater()));
   QObject::connect(proc, SIGNAL(error(QProcess::ProcessError)), proc,
                    SLOT(deleteLater()));
   
+  if (proc->waitForStarted() && proc->error() != QProcess::FailedToStart) {
+    delete proc;
+    return false;
+  }
+
   return true;
 #else
   return QProcess::startDetached(cmdlineProgram, cmdlineArguments);


### PR DESCRIPTION
If the background exe get error after started, we failed to start it.
Make sure process run without crash.

This PR would alsoo make OpenToonz to turn to use ffmpeg if t32bitsrv.exe is missing .dll.