### PR TITLE
[VectorSelectionTool] Fix Rasterized Vector Image update failure

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -476,8 +476,9 @@ return true if the method execution can have changed the current tool
   TStageObjectId getObjectId()
       const;  //!< Returns a pointer to the actual stage object.
 
-  void notifyImageChanged();  //!< Notifies changes on the actual image; used to
+  virtual void notifyImageChanged();  //!< Notifies changes on the actual image; used to
                               //! update
+                              //! override by vector selection tool
   //!  images on the level view.
   void notifyImageChanged(const TFrameId &fid);  //!< Notifies changes on the
   //! frame \p fid; used to update

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -757,6 +757,9 @@ void TTool::notifyImageChanged(const TFrameId &fid) {
     if (sl) {
       IconGenerator::instance()->invalidate(sl, fid);
       IconGenerator::instance()->invalidateSceneIcon();
+      //In case of Rasterize Vector is on
+      if (sl->m_rasterizePli)
+        sl->touchFrame(fid);
       sl->setDirtyFlag(true);
     }
   }

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -1495,7 +1495,7 @@ void ThickChangeField::onChange(TMeasuredValue *fld, bool addToUndo) {
   }
   m_tool->computeBBox();
   m_tool->invalidate();
-  m_tool->notifyImageChanged(m_tool->getCurrentFid());
+  m_tool->notifyImageChanged();//overided version of VectorSelectionTool
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/vectorselectiontool.cpp
+++ b/toonz/sources/tnztools/vectorselectiontool.cpp
@@ -390,7 +390,7 @@ void DragSelectionTool::UndoChangeStrokes::transform(
   } else
     m_tool->computeBBox();
 
-  m_tool->notifyImageChanged(m_frameId);
+  m_tool->notifyImageChanged();
   m_tool->m_deformValues = deformValues;
   TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
   TTool::getApplication()->getCurrentTool()->notifyToolChanged();
@@ -510,7 +510,7 @@ void UndoChangeOutlineStyle::transform(
     m_tool->setBBox(bbox);
   else
     m_tool->computeBBox();
-  m_tool->notifyImageChanged(m_frameId);
+  m_tool->notifyImageChanged();
   TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
   TTool::getApplication()->getCurrentTool()->notifyToolChanged();
 }
@@ -1017,7 +1017,7 @@ void DragSelectionTool::VectorChangeThicknessTool::changeImageThickness(
 
   VectorSelectionTool *vsTool = static_cast<VectorSelectionTool *>(getTool());
   const LevelSelection &levelSelection = vsTool->levelSelection();
-
+  
   if (levelSelection.isEmpty()) {
     StrokeSelection *strokeSelection =
         static_cast<StrokeSelection *>(m_tool->getSelection());
@@ -1881,6 +1881,31 @@ void VectorSelectionTool::computeBBox() {
   }
 
   ++m_selectionCount;
+}
+
+void VectorSelectionTool::notifyImageChanged() {
+  TXshSimpleLevel* level;
+  std::set<TFrameId> frames;
+
+  switch (m_levelSelection.framesMode()) {
+  case LevelSelection::FramesMode::FRAMES_NONE:
+  case LevelSelection::FramesMode::FRAMES_CURRENT:
+    TTool::notifyImageChanged(getCurrentFid());
+    break;
+  case LevelSelection::FramesMode::FRAMES_SELECTED:
+    frames = getSelectedFrames();
+    for (TFrameId fid : frames) {
+      TTool::notifyImageChanged(fid);
+    }
+    break;
+  case LevelSelection::FramesMode::FRAMES_ALL:
+    level     = TTool::getApplication()->getCurrentLevel()->getSimpleLevel();
+    int count = level->getFrameCount();
+    for (int i=0; i < count;i++) {
+      TTool::notifyImageChanged(level->getFrameId(i));
+    }
+    break;
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -304,6 +304,7 @@ public:
   bool isSelectionEmpty() override;
 
   void computeBBox() override;
+  void notifyImageChanged() override;
 
   TPropertyGroup *getProperties(int targetType) override;
 


### PR DESCRIPTION
# Issue Description
If View->Visualize Vector as Raster is on, and we adjust line's thickness through selection tool, the rasterized Image won't update.
![图片](https://github.com/user-attachments/assets/05a90e97-084f-40e2-832e-9dd7d36ae27a)
