### PR TITLE
Simplify and organize Windows build workflow

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -9,6 +9,13 @@ on:
 jobs:
   Windows:
     runs-on: windows-2019
+    env:
+      QT_PATH: ${{ github.workspace }}\thirdparty\qt\5.15.2_wintab\msvc2019_64  # Path to custom Qt.
+      VCINSTALLDIR: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'  # Path to MSVC.
+      MSVCVERSION: "Visual Studio 16 2019"  # Visual Studio version.
+      BOOST_ROOT: C:\local\boost_1_74_0  # Boost library root.
+      OpenCV_DIR: C:\tools\opencv\build  # Path to OpenCV.
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,10 +38,8 @@ jobs:
       - name: Install OpenCV and Boost
         run: |
           @echo on
-          REM  install opencv
-          choco install opencv --version=4.10.0
-          REM install boost
-          choco install boost-msvc-14.2 --version=1.74.0
+          choco install opencv --version=4.10.0 -y
+          choco install boost-msvc-14.2 --version=1.74.0 -y
         shell: cmd
 
       - name: Install custom Qt 5.15.2 with WinTab support
@@ -53,86 +58,60 @@ jobs:
         run: |
           @echo on
           cd thirdparty
-          REM Copy headers
           copy /Y tiff-4.0.3\libtiff\tif_config.vc.h tiff-4.0.3\libtiff\tif_config.h
           copy /Y tiff-4.0.3\libtiff\tiffconf.vc.h tiff-4.0.3\libtiff\tiffconf.h
           copy /Y libpng-1.6.21\scripts\pnglibconf.h.prebuilt libpng-1.6.21\pnglibconf.h
 
           cd ../toonz
-
-          IF NOT EXIST build mkdir build
+          mkdir build
           cd build
-          
-          set MSVCVERSION="Visual Studio 16 2019"
-          IF EXIST C:\local\boost_1_74_0 set BOOST_ROOT=C:\local\boost_1_74_0
-          IF EXIST C:\tools\opencv set OPENCV_DIR=C:\tools\opencv\build
 
-          set WITH_WINTAB=Y
-          IF EXIST D:\a\opentoonz\opentoonz\thirdparty\qt\5.15.2_wintab\msvc2019_64 (
-              set QT_PATH=D:\a\opentoonz\opentoonz\thirdparty\qt\5.15.2_wintab\msvc2019_64
-          )
-
-          cmake ..\sources -G %MSVCVERSION% -Ax64 -DQT_PATH=%QT_PATH% -DBOOST_ROOT=%BOOST_ROOT% -DOpenCV_DIR=%OPENCV_DIR% -DWITH_WINTAB=%WITH_WINTAB%
+          cmake ..\sources -G "%MSVCVERSION%" -Ax64 -DQT_PATH="%QT_PATH%" -DBOOST_ROOT="%BOOST_ROOT%" -DOpenCV_DIR="%OpenCV_DIR%" -DWITH_WINTAB=Y
         shell: cmd
 
       - name: Build Opentoonz
         run: |
           @echo on
-          cd toonz/build/
-          IF EXIST C:\ProgramData\chocolatey\bin\cl.exe (
-              msbuild /p:CLToolPath=C:\ProgramData\chocolatey\bin /p:UseMultiToolTask=true /p:Configuration=RelWithDebInfo /m /verbosity:minimal ALL_BUILD.vcxproj
-          ) ELSE (
-              msbuild /p:Configuration=RelWithDebInfo /m /verbosity:minimal ALL_BUILD.vcxproj
-          )
+          cd toonz\build
+          msbuild /p:Configuration=RelWithDebInfo /m /verbosity:minimal ALL_BUILD.vcxproj
         shell: cmd
 
       - name: Create Package
         run: |
           @echo on
           cd toonz\build
-
-          IF EXIST Opentoonz rmdir /S /Q Opentoonz
-          mkdir Opentoonz
           
-          Rem Copy and configure Opentoonz installation
-          copy /y RelWithDebInfo\*.* Opentoonz
+          REM Create Opentoonz directory and copy files from RelWithDebInfo
+          mkdir Opentoonz
+          copy /Y RelWithDebInfo\*.* Opentoonz\
 
+          REM Copy required DLLs for proper functionality
           copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll Opentoonz
           copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll Opentoonz
           copy /Y ..\..\thirdparty\libmypaint\dist\64\libiconv-2.dll Opentoonz
           copy /Y ..\..\thirdparty\libmypaint\dist\64\libintl-8.dll Opentoonz
           copy /Y ..\..\thirdparty\libmypaint\dist\64\libjson-c-2.dll Opentoonz
           copy /Y ..\..\thirdparty\libmypaint\dist\64\libmypaint-1-4-0.dll Opentoonz
-
-          IF EXIST C:\tools\opencv (
-             copy /Y "C:\tools\opencv\build\x64\vc16\bin\opencv_world4100.dll" Opentoonz
-          )
-
-          REM Configuring Opentoonz.exe for deployment
-          set QT_PATH=C:\Qt\5.15.2_wintab\msvc2019_64
-          IF EXIST D:\a\opentoonz\opentoonz\thirdparty\qt\5.15.2_wintab\msvc2019_64 set QT_PATH=D:\a\opentoonz\opentoonz\thirdparty\qt\5.15.2_wintab\msvc2019_64
-
-          set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC"
-          IF EXIST "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC" set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"
-
-          REM Remove PDB files
-          del Opentoonz\*.pdb
           
-          %QT_PATH%\bin\windeployqt.exe Opentoonz\Opentoonz.exe --opengl
-
-          # REM Creating Opentoonz Windows Portable package
+          REM Copy OpenCV DLL (IMPORTANT: Update path/filename when upgrading OpenCV version)
+          copy /Y "C:\tools\opencv\build\x64\vc16\bin\opencv_world4100.dll" Opentoonz
           
-          REM Copy stuff files directly to OpenToonz stuff          
-          IF EXIST Opentoonz\"portablestuff" rmdir /S /Q Opentoonz\"portablestuff"
-          xcopy /Y /E /I ..\..\stuff .\Opentoonz\"portablestuff"
-
-          cd ..\..
+          REM Deploy Qt dependencies
+          "%QT_PATH%\bin\windeployqt.exe" Opentoonz\Opentoonz.exe --opengl
+          
+          del /Q Opentoonz\*.pdb  REM Remove .pdb files
+          del /Q Opentoonz\vc_redist.x64.exe REM Remove vc_redist.x64.exe file
+          
+          REM Create portablestuff directory and copy stuff folder
+          mkdir Opentoonz\portablestuff
+          xcopy /Y /E /I ..\..\stuff .\Opentoonz\portablestuff
         shell: cmd
 
       - name: Create Artifact
         run: |
           mkdir artifact
-          cp -r toonz\build\Opentoonz artifact
+          xcopy toonz\build\Opentoonz artifact\ /E /H /Y
+        shell: cmd
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Simplified the setup of environment variables for paths (QT_PATH, BOOST_ROOT, OpenCV_DIR, VCINSTALLDIR) to reduce redundancy.

Consolidated and cleaned up redundant steps related to file copying and environment configuration.

Set VCINSTALLDIR correctly, allowing windeployqt.exe to locate the required Visual Studio installation directory. The warning 'Cannot find Visual Studio installation directory, VCINSTALLDIR is not set' has been fixed, which automatically generates the vc_redist.x64.exe file. Since the portable version doesn't require it, vc_redist.x64.exe is manually excluded.

The warning appeared as follows: `Warning: Cannot find Visual Studio redist directory, "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC"\redist.`

 
