### PR TITLE
Fix unreachable code and duplicate VEC array initialization

### DIFF
--- a/toonz/sources/stdfx/shaderinterface.cpp
+++ b/toonz/sources/stdfx/shaderinterface.cpp
@@ -602,15 +602,14 @@ void ShaderInterface::Parameter::loadData(TIStream &is) {
         (std::numeric_limits<GLfloat>::max)();
     break;
   case VEC3:
-    m_default.m_vec3[0] = m_default.m_vec3[1] = m_default.m_vec3[1] = 0.0;
+    m_default.m_vec3[0] = m_default.m_vec3[1] = m_default.m_vec3[2] = 0.0;
     m_range[0].m_vec3[0] = m_range[0].m_vec3[1] = m_range[0].m_vec3[2] =
         -(std::numeric_limits<GLfloat>::max)();
     m_range[1].m_vec3[0] = m_range[1].m_vec3[1] = m_range[1].m_vec3[2] =
         (std::numeric_limits<GLfloat>::max)();
     break;
   case VEC4:
-    m_default.m_vec4[0] = m_default.m_vec4[1] = m_default.m_vec4[1] =
-        m_default.m_vec4[1]                   = 0.0;
+    m_default.m_vec4[0] = m_default.m_vec4[1] = m_default.m_vec4[2] = m_default.m_vec4[3] = 0.0;
     m_range[0].m_vec4[0] = m_range[0].m_vec4[1] = m_range[0].m_vec4[2] =
         m_range[0].m_vec4[3] = -(std::numeric_limits<GLfloat>::max)();
     m_range[1].m_vec4[0] = m_range[1].m_vec4[1] = m_range[1].m_vec4[2] =
@@ -629,15 +628,14 @@ void ShaderInterface::Parameter::loadData(TIStream &is) {
         (std::numeric_limits<GLint>::max)();
     break;
   case IVEC3:
-    m_default.m_ivec3[0] = m_default.m_ivec3[1] = m_default.m_ivec3[1] = 0;
+    m_default.m_ivec3[0] = m_default.m_ivec3[1] = m_default.m_ivec3[2] = 0;
     m_range[0].m_ivec3[0] = m_range[0].m_ivec3[1] = m_range[0].m_ivec3[2] =
         -(std::numeric_limits<GLint>::max)();
     m_range[1].m_ivec3[0] = m_range[1].m_ivec3[1] = m_range[1].m_ivec3[2] =
         (std::numeric_limits<GLint>::max)();
     break;
   case IVEC4:
-    m_default.m_ivec4[0] = m_default.m_ivec4[1] = m_default.m_ivec4[1] =
-        m_default.m_ivec4[1]                    = 0;
+    m_default.m_ivec4[0] = m_default.m_ivec4[1] = m_default.m_ivec4[2] = m_default.m_ivec4[3] = 0;
     m_range[0].m_ivec4[0] = m_range[0].m_ivec4[1] = m_range[0].m_ivec4[2] =
         m_range[0].m_ivec4[3] = -(std::numeric_limits<GLint>::max)();
     m_range[1].m_ivec4[0] = m_range[1].m_ivec4[1] = m_range[1].m_ivec4[2] =

--- a/toonz/sources/toonzqt/plugin_param_traits.h
+++ b/toonz/sources/toonzqt/plugin_param_traits.h
@@ -617,14 +617,15 @@ inline bool param_read_value_(TParam *p, const toonz_param_desc_t *desc,
                               size_t &osize) {
   /* isize は iovaluetype の size でなく count になったのでサイズチェックは無効
    */
-  // if (isize == sizeof(typename T::traittype::iovaluetype)) {
+  // TODO: Consider reintroducing input validation for safety.
+  // if (isize == sizeof(tpbind_dbl_t::traittype::iovaluetype)) {
   auto r = reinterpret_cast<typename T::realtype *>(p);
   auto v = r->getValue();
   *reinterpret_cast<typename T::traittype::iovaluetype *>(ptr) = v;
   osize                                                        = 1;
   return true;
-  //}
-  return false;
+  // }
+  // return false; // Unreachable code, removed for clarity.
 }
 
 template <>
@@ -632,14 +633,15 @@ inline bool param_read_value_<tpbind_dbl_t>(TParam *p,
                                             const toonz_param_desc_t *desc,
                                             void *ptr, double frame,
                                             size_t isize, size_t &osize) {
+  // TODO: Consider reintroducing input validation for safety.
   // if (isize == sizeof(tpbind_dbl_t::traittype::iovaluetype)) {
   auto r = reinterpret_cast<tpbind_dbl_t::realtype *>(p);
   auto v = r->getValue(frame);
   *reinterpret_cast<tpbind_dbl_t::traittype::iovaluetype *>(ptr) = v;
   osize                                                          = 1;
   return true;
-  //}
-  return false;
+  // }
+  // return false; // Unreachable code, removed for clarity.
 }
 
 template <>


### PR DESCRIPTION
- Commented out the `if` condition for input validation with a `TODO` for future consideration and removed unreachable `return false;` statements for clarity.
This PR fixes: #5252

- Fixed incorrect initialization of `m_default.m_vec3`, `m_default.m_vec4`, `m_default.m_ivec3`, and `m_default.m_ivec4` arrays.
This PR fixes:
 #5081
 #5251 