### PR TITLE
fix: unreachable code in tscannerepson.cpp and Naa2TlvConverter.cpp

### DIFF
--- a/toonz/sources/tnzbase/tscanner/tscannerepson.cpp
+++ b/toonz/sources/tnzbase/tscanner/tscannerepson.cpp
@@ -254,7 +254,6 @@ throw TException("Scan area too large, select a correct paper size");
       rasBuffer = TRasterGR8P(dimlx, dimly);
       buffer    = rasBuffer->getRawData();
       break;
-      break;
 #else
       ras       = TRasterGR8P(dimlx, dimly);
       bytes     = tceil(dimlx / 8) * dimly;
@@ -868,7 +867,6 @@ bool TScannerEpson::ESCI_doADF(bool on) {
   bool status1        = expectACK();
   return status1;
 
-  return 1;
   if (!ESCI_command_1b('e', 0x01, true)) {
     if (on)
       throw TException("Scanner error loading paper");

--- a/toonz/sources/toonzlib/Naa2TlvConverter.cpp
+++ b/toonz/sources/toonzlib/Naa2TlvConverter.cpp
@@ -547,24 +547,31 @@ void Naa2TlvConverter::findThinInks() {
   if (!m_regionRas || !m_borderRas || m_regions.empty()) return;
   for (int i = 0; i < m_regions.count(); i++) {
     RegionInfo &region = m_regions[i];
-    if (region.type != RegionInfo::Unknown) continue;
+    if (region.type != RegionInfo::Unknown) continue; // Skip already classified regions
+
     QList<int> &bs = region.boundaries;
-    if (bs.count() == 2)
+
+    if (bs.count() == 2) {
+      // If there are exactly 2 boundaries, classify as ThinInk
       region.type = RegionInfo::ThinInk;
-    else if (bs.count() == 3) {
-      continue;
-      if (bs[2] * 5 < bs[1]) region.type = RegionInfo::ThinInk;
+    } else if (bs.count() == 3) {
+      // If there are exactly 3 boundaries, classify as ThinInk if bs[2] is small compared to bs[1]
+      if (bs[2] * 5 < bs[1]) {
+        region.type = RegionInfo::ThinInk;
+      }
     } else {
-      continue;
+      // For other cases, calculate a threshold and classify as ThinInk if conditions are met
       int k = 1;
       int s = 0;
-      while (k < bs.count() && s * 100 < region.pixelCount * 90) s += bs[k++];
-      if (region.pixelCount > 100 && k <= 3)
-        region.type = RegionInfo::ThinInk;  // era Ink per qualche ragione
+      while (k < bs.count() && s * 100 < region.pixelCount * 90) {
+        s += bs[k++];
+      }
+      if (region.pixelCount > 100 && k <= 3) {
+        region.type = RegionInfo::ThinInk; // was Ink for some reason
+      }
     }
   }
 }
-
 //-----------------------------------------------------------------------------
 
 void Naa2TlvConverter::findPaints() {


### PR DESCRIPTION
-  Removed second break at L257 and unreachable return 1; at L871 in tscannerepson.cpp.
This PR fixes: #5495

- Fixed unreachable code due to `continue` statement in `Naa2TlvConverter.cpp`.
This PR fixes: #4386

In Naa2TlvConverter.cpp, the `continue` statements may have been left unintentionally. Since the code is used to convert raster images to (TLV) format, it’s crucial to test the entire conversion pipeline to ensure that changes do not negatively affect the process **before merging**. If the `continue` statements were intentional, the code should be restructured to better clarify the intent.