### PR TITLE
Fix Linux Desktop Path Detection Failure

### DIFF
--- a/toonz/sources/toonz/filebrowsermodel.cpp
+++ b/toonz/sources/toonz/filebrowsermodel.cpp
@@ -28,6 +28,9 @@
 #ifdef MACOSX
 #include <Cocoa/Cocoa.h>
 #endif
+#ifdef LINUX
+#include <QStandardPaths>
+#endif
 
 namespace {
 TFilePath getMyDocumentsPath() {
@@ -70,6 +73,15 @@ TFilePath getDesktopPath() {
   NSString *desktopDirectory = [foundref objectAtIndex:0];
   return TFilePath((const char *)[desktopDirectory
       cStringUsingEncoding:NSASCIIStringEncoding]);
+#elif defined LINUX
+  QString desktopPath =
+      QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+  if (desktopPath.isEmpty()) {
+    QDir dir = QDir::home();
+    if (!dir.cd("Desktop")) return TFilePath();
+    desktopPath = dir.absolutePath();
+  }
+  return TFilePath(desktopPath.toStdString());
 #else
   QDir dir = QDir::home();
   if (!dir.cd("Desktop")) return TFilePath();


### PR DESCRIPTION
I only tested on wsl.

It's related to tahoma2d/[#1776](https://github.com/tahoma2d/tahoma2d/issues/1776)
