### PR TITLE
Add View Check indicators to Viewer

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -235,6 +235,11 @@ public:
   void setColorCalibrationLutPath(QString monitorName, QString path);
   QString getColorCalibrationLutPath(QString &monitorName) const;
   bool is30bitDisplayEnabled() const { return getBoolValue(displayIn30bit); }
+
+  bool isViewerIndicatorEnabled() const {
+    return getBoolValue(viewerIndicatorEnabled);
+  }
+
   // Visualization  tab
   bool getShow0ThickLines() const { return getBoolValue(show0ThickLines); }
   bool getRegionAntialias() const { return getBoolValue(regionAntialias); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -40,6 +40,7 @@ enum PreferencesItemId {
   colorCalibrationLutPaths,
   showIconsInMenu,
   displayIn30bit,
+  viewerIndicatorEnabled,
 
   //----------
   // Visualization

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2487,6 +2487,9 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_SeparateColors,
                              QT_TR_NOOP("Separate Colors..."), "",
                              "separate_colors");
+  createToggle(MI_ViewerIndicator, QT_TR_NOOP("Toggle Viewer Indicators"), "",
+               Preferences::instance()->isViewerIndicatorEnabled(),
+               RightClickMenuCommandType);
 
   // Tools
 

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -243,6 +243,7 @@
 #define MI_OnionSkin "MI_OnionSkin"
 #define MI_ZeroThick "MI_ZeroThick"
 #define MI_CursorOutline "MI_CursorOutline"
+#define MI_ViewerIndicator "MI_ViewerIndicator"
 
 // #define MI_LoadResourceFile       "MI_LoadResourceFile"
 #define MI_DuplicateFile "MI_DuplicateFile"

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1244,6 +1244,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
            .arg(LutManager::instance()->getMonitorName())},
       {displayIn30bit, tr("30bit Display*")},
       {showIconsInMenu, tr("Show Icons In Menu*")},
+      {viewerIndicatorEnabled, tr("Show Viewer Indicators")},
 
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
@@ -1738,6 +1739,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   insertUI(functionEditorToggle, lay, getComboItemList(functionEditorToggle));
   insertUI(moveCurrentFrameByClickCellArea, lay);
   insertUI(actualPixelViewOnSceneEditingMode, lay);
+  insertUI(viewerIndicatorEnabled, lay);
   insertUI(showRasterImagesDarkenBlendedInViewer, lay);
   insertUI(iconSize, lay);
   insertDualUIs(viewShrink, viewStep, lay);

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1754,10 +1754,6 @@ void SceneViewer::drawOverlay() {
     else
       m_FPS = 0;
 
-    if (m_freezedStatus != NO_FREEZED) {
-      tglColor(TPixel32::Red);
-      tglDrawText(TPointD(0, 0), "FROZEN");
-    }
     assert(glGetError() == GL_NO_ERROR);
 
   }  //! cameraTest
@@ -1898,6 +1894,57 @@ void SceneViewer::drawOverlay() {
 
 //-----------------------------------------------------------------------------
 
+void SceneViewer::drawViewerIndicators() {
+  if (!Preferences::instance()->isViewerIndicatorEnabled()) return;
+
+  QStringList checkTexts;
+
+  // Frozen Viewer Indicator
+  if (m_freezedStatus) checkTexts.append(tr("FROZEN"));
+
+  // Motion Path Indicator
+  TApp *app            = TApp::instance();
+  TStageObjectId objId = app->getCurrentObject()->getObjectId();
+  TXsheet *xsh         = app->getCurrentXsheet()->getXsheet();
+  if (app->getCurrentObject()->isSpline())
+    checkTexts.append(tr("Motion Path Selected"));
+
+  // Check Indicators (disabled in Preview mode)
+  ToonzCheck *tc = ToonzCheck::instance();
+  int mask       = tc->getChecks();
+  if (!m_previewMode && mask) {
+    if (mask & ToonzCheck::eTransparency)
+      checkTexts.append(tr("Transparency Check"));
+    if (mask & ToonzCheck::eInk) checkTexts.append(tr("Ink Check"));
+    if (mask & ToonzCheck::eInk1) checkTexts.append(tr("Ink#1 Check"));
+    if (mask & ToonzCheck::ePaint) checkTexts.append(tr("Paint Check"));
+    if (mask & ToonzCheck::eInksOnly) checkTexts.append(tr("Inks Only Check"));
+    if (mask & ToonzCheck::eBlackBg) checkTexts.append(tr("Black BG Check"));
+    if (mask & ToonzCheck::eGap) checkTexts.append(tr("Fill Check"));
+    if (mask & ToonzCheck::eAutoclose) checkTexts.append(tr("Gap Check"));
+  }
+
+  if (!checkTexts.size()) return;
+
+  int devPixRatio = getDevPixRatio();
+
+  int x0, x1, y0, y1;
+  rect().getCoords(&x0, &y0, &x1, &y1);
+  x0 = (-(x1 / (2 * devPixRatio))) + 15;
+  y0 = ((y1 / (2 * devPixRatio))) - 25;
+
+  glPushMatrix();
+  glScaled(2 * devPixRatio, 2 * devPixRatio, 2 * devPixRatio);
+  glColor3d(1.0, 0.0, 0.0);
+  for (int i = 0; i < checkTexts.size(); i++) {
+    int y = (y0 / 2) - (i * 10);
+    tglDrawText(TPointD((x0 / 2), y), checkTexts[i].toStdString());
+  }
+  glPopMatrix();
+}
+
+//-----------------------------------------------------------------------------
+
 static void drawFpsGraph(int t0, int t1) {
   glDisable(GL_BLEND);
   static std::deque<std::pair<int, int>> times;
@@ -2001,6 +2048,8 @@ void SceneViewer::paintGL() {
     if (!m_isPicking && m_lutCalibrator && m_lutCalibrator->isValid())
       m_lutCalibrator->onEndDraw(m_fbo);
 
+    drawViewerIndicators();
+
     return;
   }
 
@@ -2021,6 +2070,8 @@ void SceneViewer::paintGL() {
   drawOverlay();
 
   drawDisableScissor();
+
+  drawViewerIndicators();
 
   // Il freezed e' attivo ed e' in stato "update": faccio il grab del viewer.
   if (m_freezedStatus == UPDATE_FREEZED) {

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -145,6 +145,7 @@ class SceneViewer final : public GLWidgetForHighDpi,
   TRectD m_clipRect;
 
   bool m_isPicking;
+  bool m_showViewerIndicators = true;
 
   TRaster32P m_3DSideL;
   TRaster32P m_3DSideR;
@@ -321,6 +322,7 @@ protected:
   void drawCameraStand();
   void drawPreview();
   void drawOverlay();
+  void drawViewerIndicators();
 
   void drawScene();
   void drawToolGadgets();

--- a/toonz/sources/toonz/sceneviewercontextmenu.cpp
+++ b/toonz/sources/toonz/sceneviewercontextmenu.cpp
@@ -222,6 +222,8 @@ SceneViewerContextMenu::SceneViewerContextMenu(SceneViewer *parent)
   // Brush size outline
   CursorOutlineToggleGui::addCursorOutlineCommand(this);
 
+  ViewerIndicatorToggleGui::addViewerIndicatorCommand(this);
+
   // preview
   if (parent->isPreviewEnabled()) {
     addSeparator();
@@ -538,4 +540,42 @@ void CursorOutlineToggleGui::CursorOutlineToggleHandler::activate() {
 
 void CursorOutlineToggleGui::CursorOutlineToggleHandler::deactivate() {
   CursorOutlineToggle::enableCursorOutline(false);
+}
+
+class ViewerIndicatorToggle : public MenuItemHandler {
+public:
+  ViewerIndicatorToggle() : MenuItemHandler(MI_ViewerIndicator) {}
+  void execute() {
+    QAction *action = CommandManager::instance()->getAction(MI_ViewerIndicator);
+    if (!action) return;
+    bool checked = action->isChecked();
+    enableViewerIndicator(checked);
+  }
+
+  static void enableViewerIndicator(bool enable = true) {
+    Preferences::instance()->setValue(viewerIndicatorEnabled, enable);
+  }
+} ViewerIndicatorToggle;
+
+void ViewerIndicatorToggleGui::addViewerIndicatorCommand(QMenu *menu) {
+  static ViewerIndicatorToggleHandler switcher;
+  if (Preferences::instance()->isViewerIndicatorEnabled()) {
+    QAction *hideViewerIndicator =
+        menu->addAction(QString(QObject::tr("Hide Viewer Indicators")));
+    menu->connect(hideViewerIndicator, SIGNAL(triggered()), &switcher,
+                  SLOT(deactivate()));
+  } else {
+    QAction *showViewerIndicator =
+        menu->addAction(QString(QObject::tr("Show Viewer Indicators")));
+    menu->connect(showViewerIndicator, SIGNAL(triggered()), &switcher,
+                  SLOT(activate()));
+  }
+}
+
+void ViewerIndicatorToggleGui::ViewerIndicatorToggleHandler::activate() {
+  ViewerIndicatorToggle::enableViewerIndicator(true);
+}
+
+void ViewerIndicatorToggleGui::ViewerIndicatorToggleHandler::deactivate() {
+  ViewerIndicatorToggle::enableViewerIndicator(false);
 }

--- a/toonz/sources/toonz/sceneviewercontextmenu.h
+++ b/toonz/sources/toonz/sceneviewercontextmenu.h
@@ -65,4 +65,17 @@ public slots:
 
 }  // Namespace CursorOutlineToggleGui
 
+namespace ViewerIndicatorToggleGui {
+void addViewerIndicatorCommand(QMenu *menu);
+
+class ViewerIndicatorToggleHandler : public QObject {
+  Q_OBJECT
+
+public slots:
+  void activate();
+  void deactivate();
+};
+
+}  // Namespace ViewerIndicatorToggleGui
+
 #endif

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -448,6 +448,9 @@ void Preferences::definePreferenceItems() {
   setCallBack(linearUnits, &Preferences::setUnits);
   setCallBack(cameraUnits, &Preferences::setCameraUnits);
 
+  define(viewerIndicatorEnabled, "viewerIndicatorEnabled", QMetaType::Bool,
+         true);
+
   // Visualization
   define(show0ThickLines, "show0ThickLines", QMetaType::Bool, true);
   define(regionAntialias, "regionAntialias", QMetaType::Bool, false);


### PR DESCRIPTION
This PR is a requested straight port from T2D which makes it obvious that 1 or more `View` -> check menu options are enabled, the canvas is Frozen or you are working on a Motion Path by putting indicators (text) in the upper left corner of the viewer when selected:

![image](https://github.com/user-attachments/assets/01b19755-7c3b-4301-bde1-7048fb4ed19f)

Updates:
Added Viewer right-click menu option to Hide/Show Check Indicators

![image](https://github.com/user-attachments/assets/56086876-ab9e-40b7-aef4-ae2b1aec9e03)

Option controls Preference setting: `Interface` -> `Show Check Indicators` (Default is ON):

Command button/Shortcut is available for this setting as `Toggle Check Indicators`.

NOTE: Much like most of the GL-drawn On-Screen widgets, the indicators can be hard to read due to contrast issues with the colors behind it and/or the line weight being drawn on High DPI monitors.  This is true even in T2D currently.  That is a general issue that needs to be address separately.