### PR TITLE
Add better getters for icon properties

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -12,6 +12,8 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #43464d;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;
   -icon-active-color: white;
   -icon-selected-color: white;

--- a/stuff/config/qss/Clay/Clay.qss
+++ b/stuff/config/qss/Clay/Clay.qss
@@ -12,6 +12,8 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #514d4c;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;
   -icon-active-color: white;
   -icon-selected-color: white;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -12,6 +12,8 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #303030;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: #cecece;
   -icon-active-color: white;
   -icon-selected-color: white;

--- a/stuff/config/qss/Default-Green/Default-Green.qss
+++ b/stuff/config/qss/Default-Green/Default-Green.qss
@@ -12,6 +12,8 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #484848;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;
   -icon-active-color: white;
   -icon-selected-color: white;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -12,6 +12,8 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #484848;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;
   -icon-active-color: white;
   -icon-selected-color: white;

--- a/stuff/config/qss/Default/less/layouts/_mainwindow.less
+++ b/stuff/config/qss/Default/less/layouts/_mainwindow.less
@@ -16,10 +16,18 @@ QToolBar * {
 
 :TOONZCOLORS {
   -bg-color: @bg-color;
+
+  // Opacity
+  -icon-base-opacity: @icon-base-opacity;
+  -icon-disabled-opacity: @icon-disabled-opacity;
+
+  // General
   -icon-base-color: @icon-base-color;
   -icon-active-color: @icon-active-color;
   -icon-selected-color: @icon-selected-color;
   -icon-on-color: @icon-on-color;
+
+  // Individual on states
   -icon-close-color: @icon-close-color;
   -icon-preview-color: @icon-preview-color;
   -icon-vcheck-color: @icon-view-check-color;

--- a/stuff/config/qss/Default/less/themes/default/default-theme.less
+++ b/stuff/config/qss/Default/less/themes/default/default-theme.less
@@ -61,13 +61,15 @@
 @tooltip-padding: 2px;
 
 // Icon Theme Colors
+@icon-base-opacity: 0.8;
+@icon-disabled-opacity: 0.3;
 @icon-base-color: @text-color;
 @icon-active-color: white;
 @icon-selected-color: @icon-active-color;
 @icon-on-color: @icon-active-color;
 
 // Individual Icon Colors
-@icon-preview-color: black;
+@icon-preview-color: if(lightness(@preview-color) > 50%, black, white);
 @icon-view-check-color: @icon-on-color;
 @icon-lock-color: @icon-active-color;
 @icon-keyframe-color: @icon-active-color;

--- a/stuff/config/qss/Default/less/themes/others/light-theme.less
+++ b/stuff/config/qss/Default/less/themes/others/light-theme.less
@@ -50,7 +50,7 @@
 
 // Icon Theme Colors
 @icon-base-color: @text-color;
-@icon-active-color: rgb(0, 0, 0);
+@icon-active-color: black;
 
 // -----------------------------------------------------------------------------
 // Tabs

--- a/stuff/config/qss/Default/less/themes/others/neutral-theme.less
+++ b/stuff/config/qss/Default/less/themes/others/neutral-theme.less
@@ -48,17 +48,8 @@
 @fx-settings-label-color: rgb(0, 0, 0);
 
 // Icon Theme Colors
-@icon-active-color: rgb(0, 0, 0);
-@icon-selected-color: @icon-active-color;
-@icon-on-color: @icon-active-color;
-
-// Individual Icon Colors
-@icon-preview-color: black;
-@icon-view-check-color: @icon-on-color;
-@icon-lock-color: @icon-active-color;
-@icon-keyframe-color: @icon-active-color;
-@icon-keyframe-modified-color: @icon-active-color;
-@icon-close-color: @icon-active-color;
+@icon-base-color: @text-color;
+@icon-active-color: black;
 
 // -----------------------------------------------------------------------------
 // Tabs

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -12,16 +12,18 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #DBDBDB;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: black;
-  -icon-active-color: #000000;
-  -icon-selected-color: #000000;
-  -icon-on-color: #000000;
-  -icon-close-color: #000000;
+  -icon-active-color: black;
+  -icon-selected-color: black;
+  -icon-on-color: black;
+  -icon-close-color: black;
   -icon-preview-color: black;
-  -icon-vcheck-color: #000000;
-  -icon-lock-color: #000000;
-  -icon-keyframe-color: #000000;
-  -icon-keyframe-modified-color: #000000;
+  -icon-vcheck-color: black;
+  -icon-lock-color: black;
+  -icon-keyframe-color: black;
+  -icon-keyframe-modified-color: black;
 }
 QWidget {
   background-color: #DBDBDB;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -12,16 +12,18 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #808080;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: black;
-  -icon-active-color: #000000;
-  -icon-selected-color: #000000;
-  -icon-on-color: #000000;
-  -icon-close-color: #000000;
+  -icon-active-color: black;
+  -icon-selected-color: black;
+  -icon-on-color: black;
+  -icon-close-color: black;
   -icon-preview-color: black;
-  -icon-vcheck-color: #000000;
-  -icon-lock-color: #000000;
-  -icon-keyframe-color: #000000;
-  -icon-keyframe-modified-color: #000000;
+  -icon-vcheck-color: black;
+  -icon-lock-color: black;
+  -icon-keyframe-color: black;
+  -icon-keyframe-modified-color: black;
 }
 QWidget {
   background-color: #808080;

--- a/stuff/config/qss/Synthwave/Synthwave.qss
+++ b/stuff/config/qss/Synthwave/Synthwave.qss
@@ -12,6 +12,8 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #2b313a;
+  -icon-base-opacity: 0.8;
+  -icon-disabled-opacity: 0.3;
   -icon-base-color: #cecece;
   -icon-active-color: white;
   -icon-selected-color: white;

--- a/toonz/sources/include/toonzqt/gutil.h
+++ b/toonz/sources/include/toonzqt/gutil.h
@@ -249,7 +249,7 @@ public:
 
   // Icon Management
   void preloadIconMetadata(const QString &path);
-  void updateThemeColor();
+  void updateThemeProperties();
   QString getIconPath(const QString &iconName, QIcon::Mode mode = QIcon::Normal,
                       QIcon::State state = QIcon::Off) const;
   QSize getIconSize(const QString &iconName) const;
@@ -258,6 +258,16 @@ public:
   bool isColoredIcon(const QString &iconName) const;
 
   // Icon Color Management
+  void setIconBaseOpacity(const double &val) { m_iconBaseOpacity = val; }
+  double getIconBaseOpacity() const { return m_iconBaseOpacity; }
+  void setIconDisabledOpacity(const double &val) {
+    m_iconDisabledOpacity = val;
+  }
+  double getIconDisabledOpacity() const { return m_iconDisabledOpacity; }
+
+  void setInterfaceColor(const QColor &color) { m_interfaceColor = color; }
+  QColor getInterfaceColor() const { return m_interfaceColor; }
+
   void setIconBaseColor(const QColor &color) { m_iconBaseColor = color; }
   QColor getIconBaseColor() const { return m_iconBaseColor; }
 
@@ -299,7 +309,14 @@ public:
   // Stylesheet Parsing
   void parseCustomPropertiesFromStylesheet(const QString &styleSheet);
   void setCustomProperty(const QString &name, const QString &value);
-  QString getCustomProperty(const QString &name) const;
+  QString getCustomProperty(const QString &name,
+                            const QString &defaultValue = QString()) const;
+
+  double getCustomPropertyDouble(const QString &name,
+                                 double defaultValue = 1.0) const;
+
+  QColor getCustomPropertyColor(const QString &name,
+                                const QColor &defaultValue = QColor()) const;
 
 private:
   // Constructor & Restriction
@@ -318,6 +335,11 @@ private:
   QHash<QString, QString> m_customProperties;
 
   // Theme Colors
+  double m_iconBaseOpacity;
+  double m_iconDisabledOpacity;
+
+  QColor m_interfaceColor;
+
   QColor m_iconBaseColor;
   QColor m_iconActiveColor;
   QColor m_iconOnColor;

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -950,7 +950,6 @@ double ThemeManager::getCustomPropertyDouble(const QString &name,
   QString value = getCustomProperty(name);
   bool ok       = false;
   double result = value.toDouble(&ok);
-  qDebug() << "result" << value << result;
   return ok ? result : defaultValue;
 }
 

--- a/toonz/sources/toonzqt/gutil.cpp
+++ b/toonz/sources/toonzqt/gutil.cpp
@@ -760,25 +760,29 @@ void ThemeManager::initialize() { preloadIconMetadata(":/icons"); }
 
 //-----------------------------------------------------------------------------
 
-void ThemeManager::updateThemeColor() {
+void ThemeManager::updateThemeProperties() {
+  // Icon opacities
+  setIconBaseOpacity(getCustomPropertyDouble("icon-base-opacity", 0.8));
+  setIconDisabledOpacity(getCustomPropertyDouble("icon-disabled-opacity", 0.2));
+
   // Base icon colors
-  setIconBaseColor(QColor(getCustomProperty("icon-base-color")));
-  setIconActiveColor(QColor(getCustomProperty("icon-active-color")));
-  setIconOnColor(QColor(getCustomProperty("icon-on-color")));
-  setIconSelectedColor(QColor(getCustomProperty("icon-selected-color")));
+  setIconBaseColor(getCustomPropertyColor("icon-base-color"));
+  setIconActiveColor(getCustomPropertyColor("icon-active-color"));
+  setIconOnColor(getCustomPropertyColor("icon-on-color"));
+  setIconSelectedColor(getCustomPropertyColor("icon-selected-color"));
 
   // Individual icon colors
-  setIconCloseColor(QColor(getCustomProperty("icon-close-color")));
-  setIconPreviewColor(QColor(getCustomProperty("icon-preview-color")));
-  setIconLockColor(QColor(getCustomProperty("icon-lock-color")));
+  setIconCloseColor(getCustomPropertyColor("icon-close-color"));
+  setIconPreviewColor(getCustomPropertyColor("icon-preview-color"));
+  setIconLockColor(getCustomPropertyColor("icon-lock-color"));
 
   // Keyframe icon colors
-  setIconKeyframeColor(QColor(getCustomProperty("icon-keyframe-color")));
+  setIconKeyframeColor(getCustomPropertyColor("icon-keyframe-color"));
   setIconKeyframeModifiedColor(
-      QColor(getCustomProperty("icon-keyframe-modified-color")));
+      getCustomPropertyColor("icon-keyframe-modified-color"));
 
   // Viewer check icon colors
-  setIconVCheckColor(QColor(getCustomProperty("icon-vcheck-color")));
+  setIconVCheckColor(getCustomPropertyColor("icon-vcheck-color"));
 
   // Invalidate cache to force re-rendering of icons
   clearQPixmapCache();
@@ -922,7 +926,7 @@ void ThemeManager::parseCustomPropertiesFromStylesheet(
     }
   }
 
-  updateThemeColor();
+  updateThemeProperties();
 }
 
 //-----------------------------------------------------------------------------
@@ -934,8 +938,32 @@ void ThemeManager::setCustomProperty(const QString &name,
 
 //-----------------------------------------------------------------------------
 
-QString ThemeManager::getCustomProperty(const QString &name) const {
+QString ThemeManager::getCustomProperty(const QString &name,
+                                        const QString &defaultValue) const {
   return m_customProperties.value(name, QString());
+}
+
+//-----------------------------------------------------------------------------
+
+double ThemeManager::getCustomPropertyDouble(const QString &name,
+                                             double defaultValue) const {
+  QString value = getCustomProperty(name);
+  bool ok       = false;
+  double result = value.toDouble(&ok);
+  qDebug() << "result" << value << result;
+  return ok ? result : defaultValue;
+}
+
+//-----------------------------------------------------------------------------
+
+QColor ThemeManager::getCustomPropertyColor(const QString &name,
+                                            const QColor &defaultValue) const {
+  QString value = getCustomProperty(name);
+  if (value.isEmpty()) return defaultValue;
+
+  // Try to parse the color from the string
+  QColor color(value);
+  return color.isValid() ? color : defaultValue;
 }
 
 //-----------------------------------------------------------------------------
@@ -1094,13 +1122,19 @@ void SvgIconEngine::paint(QPainter *painter, const QRect &rect,
 
 qreal SvgIconEngine::getOpacityForModeState(QIcon::Mode mode,
                                             QIcon::State state) {
+  auto &tm = ThemeManager::getInstance();
+
+  const double baseOpacity     = tm.getIconBaseOpacity();
+  const double disabledOpacity = tm.getIconDisabledOpacity();
+  const double activeOpacity   = 1.0;
+
   qreal opacity;
   if (m_isColored) {
-    opacity = (mode == QIcon::Disabled) ? 0.4 : 1.0;
+    opacity = (mode == QIcon::Disabled) ? disabledOpacity : activeOpacity;
   } else {
-    opacity = (mode == QIcon::Disabled)                        ? 0.4
-              : (mode == QIcon::Normal && state == QIcon::Off) ? 0.8
-                                                               : 1.0;
+    opacity = (mode == QIcon::Disabled)                        ? disabledOpacity
+              : (mode == QIcon::Normal && state == QIcon::Off) ? baseOpacity
+                                                               : activeOpacity;
   }
 
   return opacity;


### PR DESCRIPTION
Slightly tweak #5845 by adding better property getters and slightly adjust disabled opacity to make it more feint. Opacity levels can now be controlled with stylesheets.