### PR TITLE
feat: Add support for custom display labels in menu commands

### DIFF
--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -269,8 +269,8 @@ QMenuBar *StackedMenuBar::loadMenuBar(const TFilePath &fp) {
   }
 
   QXmlStreamReader reader(&file);
-
   QMenuBar *menuBar = new QMenuBar(this);
+
   if (reader.readNextStartElement()) {
     if (reader.name() == "menubar") {
       while (reader.readNextStartElement()) {
@@ -286,25 +286,34 @@ QMenuBar *StackedMenuBar::loadMenuBar(const TFilePath &fp) {
             reader.raiseError(tr("Failed to load menu %1").arg(title));
             delete menu;
           }
-
         } else if (reader.name() == "command") {
+          // Read the optional 'label' attribute for display
+          QString displayLabel = reader.attributes().value("label").toString();
           QString cmdName = reader.readElementText();
 
           QAction *action = CommandManager::instance()->getAction(
               cmdName.toStdString().c_str());
-          if (action)
+          if (action) {
+            // Override the QAction text if a custom 'label' attribute is provided
+            if (!displayLabel.isEmpty()) {
+              action->setText(tr(displayLabel.toStdString().c_str()));
+            }
             menuBar->addAction(action);
-          else
+          } else {
             reader.raiseError(tr("Failed to add command %1").arg(cmdName));
-        } else
+          }
+        } else {
           reader.skipCurrentElement();
+        }
       }
-    } else
+    } else {
       reader.raiseError(QObject::tr("Incorrect file"));
+    }
   }
 
   if (reader.hasError()) {
     delete menuBar;
+    qDebug() << "XML error:" << reader.errorString();
     return 0;
   }
   return menuBar;
@@ -315,7 +324,7 @@ QMenuBar *StackedMenuBar::loadMenuBar(const TFilePath &fp) {
 bool StackedMenuBar::readMenuRecursive(QXmlStreamReader &reader, QMenu *menu) {
   while (reader.readNextStartElement()) {
     if (reader.name() == "menu") {
-      QString title  = reader.attributes().value("title").toString();
+      QString title = reader.attributes().value("title").toString();
       QMenu *subMenu = new QMenu(tr(title.toStdString().c_str()));
 
       if (readMenuRecursive(reader, subMenu))
@@ -325,22 +334,38 @@ bool StackedMenuBar::readMenuRecursive(QXmlStreamReader &reader, QMenu *menu) {
         delete subMenu;
         return false;
       }
-
     } else if (reader.name() == "command") {
+      QString displayLabel = reader.attributes().value("label").toString();
       QString cmdName = reader.readElementText();
-      addMenuItem(menu, cmdName.toStdString().c_str());
+      QAction *action = CommandManager::instance()->getAction(
+          cmdName.toStdString().c_str());
+      if (action) {
+        if (!displayLabel.isEmpty()) {
+          action->setText(tr(displayLabel.toStdString().c_str()));
+        }
+        menu->addAction(action);
+      }
     } else if (reader.name() == "command_debug") {
 #ifndef NDEBUG
+      QString displayLabel = reader.attributes().value("label").toString();
       QString cmdName = reader.readElementText();
-      addMenuItem(menu, cmdName.toStdString().c_str());
+      QAction *action = CommandManager::instance()->getAction(
+          cmdName.toStdString().c_str());
+      if (action) {
+        if (!displayLabel.isEmpty()) {
+          action->setText(tr(displayLabel.toStdString().c_str()));
+        }
+        menu->addAction(action);
+      }
 #else
       reader.skipCurrentElement();
 #endif
     } else if (reader.name() == "separator") {
       menu->addSeparator();
       reader.skipCurrentElement();
-    } else
+    } else {
       reader.skipCurrentElement();
+    }
   }
 
   return !reader.hasError();


### PR DESCRIPTION
- Modified `loadMenuBar` and `readMenuRecursive` methods in `StackedMenuBar` to support an optional `label` attribute for menu commands in XML. When a `label` attribute is provided, it overrides the default text of the corresponding `QAction`.

This allows for more flexible and customizable menu bar configurations, with "user-friendly labels" for commands.

Here's a more practical and step-by-step example of how this works (Changing "Save All" to "Save").

1) Create a copy of the `Default` folder inside `stuff\profiles\layouts\rooms` and rename it (this may be Experimental).
menubar_template.xml

2) Open the **menubar_template.xml** file inside the 'Experimental' folder and edit the following.

`<command>MI_SaveAll</command>` to `<command label="Save">MI_SaveAll</command>`

3) Open OpenToonz, go to Preferences > Interface > *Rooms, and choose Experimental.

4) Close OpenToonz and reopen it to refresh the settings.

Now, instead of displaying "Save All", it will display "Save".

![example menu ](https://github.com/user-attachments/assets/81ec8489-4d2c-45c6-b77f-3161a90c3812)

This process allows the user to customize their menus with greater flexibility than before, by modifying labels directly through an XML file. With this approach, users can adapt the interface to their preferences. 


Ref: #5859, #5866


**PS**: Keep in mind that custom setups can limit access to future updates. You need to be cautious because if OpenToonz comes with new configurations, like the great work @konero did with the Update Rooms Layout, those updates might not apply to users who are using their custom profile room. If we look at Studio Ghibli's room setup, it's not viable for general users, but rather just for the studio.
