### PR TITLE
Increase drag detection threshold of Arc

### DIFF
--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -2839,12 +2839,12 @@ void MultiArcPrimitive::leftButtonDrag(const TPointD &pos,
                                        const TMouseEvent &e) {
   switch (m_clickNumber) {
   case 0:
-    if ((tdistance2(m_startPoint, pos) < sq(7.0 * m_tool->getPixelSize())))
+    if ((tdistance2(m_startPoint, pos) < sq(10.0 * m_tool->getPixelSize())))
       return;
     break;
   case 1:
     if (m_undoCount != 1 &&
-        (tdistance2(m_endPoint, pos) < sq(7.0 * m_tool->getPixelSize())))
+        (tdistance2(m_endPoint, pos) < sq(10.0 * m_tool->getPixelSize())))
       return;
     break;
   }


### PR DESCRIPTION
This PR is related to #5823.
Adjust the threshold from 7.0 units to 10.0 units.
But also suggest user to avoid small dragging while clicking a point with a tablet.

CC: @Ahl76