### PR TITLE
[Fix]Refactor camera DPI handling in image processing

### DIFF
--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -283,7 +283,8 @@ bool ImageRasterizer::getInfo(TImageInfo &info, int imFlags, void *extData) {
 
 bool ImageRasterizer::isImageCompatible(int imFlags, void* extData) { 
   ImageLoader::BuildExtData *data = (ImageLoader::BuildExtData *)extData;
-  if (m_cameraDPI == data->currentCamera->getDpi())
+  
+  if (m_cameraDPI == data->m_cameraDPI)
     if (m_antiAliasing == Preferences::instance()->getRasterizeAntialias())
         return true;
   return false;
@@ -306,7 +307,7 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
     TVectorImageP vi = img;
     if (vi) {
       TRectD bbox = vi->getBBox();
-      m_cameraDPI       = data->currentCamera->getDpi();
+      m_cameraDPI       = data->m_cameraDPI;
 
       double sx, sy;
       sx           = m_cameraDPI.x / Stage::inch;

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -8,6 +8,9 @@
 #include "toonz/imagemanager.h"
 #include "toonz/tcamera.h"
 
+// ToonzLib includes
+#include "toonz/stage.h"
+
 //======================================================
 
 //  Forward declarations
@@ -41,12 +44,16 @@ public:
     //!< m_sl's subsampling property otherwise)
     bool m_icon;  //!< Whether the icon (if any) should be loaded instead
     
-    TCamera *currentCamera;//for Rasterizer
+    TPointD m_cameraDPI;  // for Rasterizer
 
   public:
     BuildExtData(const TXshSimpleLevel *sl, const TFrameId &fid, int subs = 0,
                  bool icon = false)
-        : m_sl(sl), m_fid(fid), m_subs(subs), m_icon(icon), currentCamera(nullptr) {}
+        : m_sl(sl)
+        , m_fid(fid)
+        , m_subs(subs)
+        , m_icon(icon)
+        , m_cameraDPI(Stage::inch, Stage::inch) {}
   };
 
 public:

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -59,7 +59,7 @@ TImageP Stage::Player::image() const {
   if (slType == PLI_XSHLEVEL && TXshSimpleLevel::m_rasterizePli) {
     if (!(m_isCurrentColumn && m_isCurrentXsheetLevel)) id = id + "_rasterized";
     if(m_xsh)
-      extData.currentCamera = m_xsh->getStageObjectTree()->getCurrentCamera();
+      extData.m_cameraDPI = m_xsh->getStageObjectTree()->getCurrentCamera()->getDpi();
   }  // use cameraDpi to rasterize vector
         
 


### PR DESCRIPTION
fixes #5885
This PR resolve the crash when animating a mesh level when rasterize vector is on.
Related to #5793 