### PR TITLE
Refactor palette(Cleanup&Level) handling in scene management

### DIFF
--- a/toonz/sources/toonz/cleanupsettingsmodel.cpp
+++ b/toonz/sources/toonz/cleanupsettingsmodel.cpp
@@ -458,7 +458,21 @@ void CleanupSettingsModel::onSceneSwitched() {
   TCleanupper::instance()->setParameters(params);
 
   // Finally, send notifications, deal with backups, etc.
-  restoreGlobalSettings();
+
+  // Make sure that the current cleanup palette is set to currentParams' palette
+  // This might refresh the StyleEditor
+  TApp::instance()
+      ->getPaletteController()
+      ->getCurrentCleanupPalette()
+      ->setPalette(params->m_cleanupPalette.getPointer());
+
+  m_clnPath = TFilePath();  // This Path won't be stored in scene or project
+  m_backupParams.assign(params, false);
+
+  if (m_previewersCount > 0 || m_cameraTestsCount > 0) rebuildPreview();
+
+  emit modelChanged(false);
+  emit clnLoaded();
 }
 
 //-----------------------------------------------------------------------

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1365,7 +1365,6 @@ void IoCmd::newScene() {
                           ->m_cleanupPalette.getPointer();
   PaletteController *paletteController = app->getPaletteController();
   paletteController->getCurrentCleanupPalette()->setPalette(palette, -1);
-  paletteController->editLevelPalette();
 
   TFilePath scenePath = scene->getScenePath();
   DvDirModel::instance()->refreshFolder(scenePath.getParentDir());
@@ -2028,10 +2027,7 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   app->getCurrentScene()->notifyNameSceneChange();
   app->getCurrentFrame()->setFrame(0);
   app->getCurrentColumn()->setColumnIndex(0);
-  TPalette *palette = 0;
-  if (app->getCurrentLevel() && app->getCurrentLevel()->getSimpleLevel())
-    palette = app->getCurrentLevel()->getSimpleLevel()->getPalette();
-  app->getCurrentPalette()->setPalette(palette);
+  
   app->getCurrentXsheet()->notifyXsheetSoundChanged();
   app->getCurrentObject()->setIsSpline(false);
 
@@ -2153,7 +2149,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
 
   printf("%s:%s loadScene() completed :\n", __FILE__, __FUNCTION__);
   
-  TApp::instance()->getPaletteController()->editLevelPalette();
+  // Load current Level's palette
+  app->getPaletteController()->editLevelPalette();
   return true;
 }
 

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -434,13 +434,6 @@ void TApp::onSceneSwitched() {
   // update XSheet
   m_currentXsheet->setXsheet(m_currentScene->getScene()->getXsheet());
 
-  TPalette *palette = m_currentScene->getScene()
-                          ->getProperties()
-                          ->getCleanupParameters()
-                          ->m_cleanupPalette.getPointer();
-  m_paletteController->getCurrentCleanupPalette()->setPalette(palette, -1);
-  m_paletteController->editLevelPalette();
-
   // reset current frame
   m_currentFrame->setFrame(0);
 

--- a/toonz/sources/toonzlib/palettecontroller.cpp
+++ b/toonz/sources/toonzlib/palettecontroller.cpp
@@ -27,6 +27,7 @@ PaletteController::PaletteController()
   m_currentCleanupPalette = new TPaletteHandle;
   m_currentPalette        = new TPaletteHandle;
 
+  // Would be called twice when setting current CleanUpPalette
   QObject::connect(m_currentCleanupPalette, SIGNAL(paletteSwitched()), this,
                    SLOT(editCleanupPalette()));
   QObject::connect(m_currentCleanupPalette, SIGNAL(colorStyleSwitched()), this,
@@ -89,7 +90,7 @@ void PaletteController::setCurrentPalette(TPaletteHandle *paletteHandle) {
 //-----------------------------------------------------------------------------
 
 void PaletteController::editLevelPalette() {
-  setCurrentPalette(m_currentLevelPalette);
+    setCurrentPalette(m_currentLevelPalette);
   emit(checkPaletteLock());
 }
 


### PR DESCRIPTION
I think this PR would resolve most crashes related to a dangling pointer of the palette (ACCESS VIOLATION of palette or style).
Here I list some of them out:
#5728 #5892 #5514
But I get the crash when I click on xsheet while OT loading a scene, which is different.