### PR TITLE
fix: remove std::iterator to resolve deprecation warning

### DIFF
--- a/toonz/sources/include/tcg/cyclic.h
+++ b/toonz/sources/include/tcg/cyclic.h
@@ -72,7 +72,6 @@ value_type increased(const value_type &val, const value_type &start,
                      diff_type length, diff_type add) {
   return start + numeric_ops::mod(val - start + add, length);
 }
-
 //-------------------------------------------------------------------------------------------
 
 template <typename value_type, typename diff_type>
@@ -102,17 +101,18 @@ class cyclic_iterator;
 //------------------------------------------------------------------------------------------
 
 template <typename It>
-class cyclic_iterator<It, std::forward_iterator_tag>
-    : public std::iterator<std::forward_iterator_tag,
-                           typename std::iterator_traits<It>::value_type,
-                           typename std::iterator_traits<It>::difference_type,
-                           typename std::iterator_traits<It>::pointer,
-                           typename std::iterator_traits<It>::reference> {
+class cyclic_iterator<It, std::forward_iterator_tag> {
 protected:
   It m_it, m_begin, m_end;
   int m_lap;
 
 public:
+  typedef std::forward_iterator_tag iterator_category;
+  typedef typename std::iterator_traits<It>::value_type value_type;
+  typedef typename std::iterator_traits<It>::difference_type difference_type;
+  typedef typename std::iterator_traits<It>::pointer pointer;
+  typedef typename std::iterator_traits<It>::reference reference;
+
   cyclic_iterator() : m_lap(0) {}
   cyclic_iterator(const It &it, const It &begin, const It &end, int lap = 0)
       : m_it(it), m_begin(begin), m_end(end), m_lap(lap) {}
@@ -128,29 +128,29 @@ public:
     return it;
   }
 
-  typename cyclic_iterator::reference operator*() { return *m_it; }
-  typename cyclic_iterator::pointer operator->() { return m_it.operator->(); }
+  reference operator*() { return *m_it; }
+  pointer operator->() { return m_it.operator->(); }
 
   bool operator==(const cyclic_iterator &it) const {
     return m_it == it.m_it && m_lap == it.m_lap;
   }
   bool operator!=(const cyclic_iterator &it) const { return !operator==(it); }
 };
-
 //------------------------------------------------------------------------------------------
 
 template <typename It>
-class cyclic_iterator<It, std::bidirectional_iterator_tag>
-    : public std::iterator<std::bidirectional_iterator_tag,
-                           typename std::iterator_traits<It>::value_type,
-                           typename std::iterator_traits<It>::difference_type,
-                           typename std::iterator_traits<It>::pointer,
-                           typename std::iterator_traits<It>::reference> {
+class cyclic_iterator<It, std::bidirectional_iterator_tag> {
 protected:
   It m_it, m_begin, m_end;
   int m_lap;
 
 public:
+  typedef std::bidirectional_iterator_tag iterator_category;
+  typedef typename std::iterator_traits<It>::value_type value_type;
+  typedef typename std::iterator_traits<It>::difference_type difference_type;
+  typedef typename std::iterator_traits<It>::pointer pointer;
+  typedef typename std::iterator_traits<It>::reference reference;
+
   cyclic_iterator() : m_lap(0) {}
   cyclic_iterator(const It &it, const It &begin, const It &end, int lap = 0)
       : m_it(it), m_begin(begin), m_end(end), m_lap(lap) {}
@@ -178,30 +178,30 @@ public:
     return it;
   }
 
-  typename cyclic_iterator::reference operator*() { return *m_it; }
-  typename cyclic_iterator::pointer operator->() { return m_it.operator->(); }
+  reference operator*() { return *m_it; }
+  pointer operator->() { return m_it.operator->(); }
 
   bool operator==(const cyclic_iterator &it) const {
     return m_it == it.m_it && m_lap == it.m_lap;
   }
   bool operator!=(const cyclic_iterator &it) const { return !operator==(it); }
 };
-
 //------------------------------------------------------------------------------------------
 
 template <typename It>
-class cyclic_iterator<It, std::random_access_iterator_tag>
-    : public std::iterator<std::random_access_iterator_tag,
-                           typename std::iterator_traits<It>::value_type,
-                           typename std::iterator_traits<It>::difference_type,
-                           typename std::iterator_traits<It>::pointer,
-                           typename std::iterator_traits<It>::reference> {
+class cyclic_iterator<It, std::random_access_iterator_tag> {
 protected:
   It m_it, m_begin, m_end;
   int m_lap;
-  typename cyclic_iterator::difference_type m_count;
+  typename std::iterator_traits<It>::difference_type m_count;
 
 public:
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef typename std::iterator_traits<It>::value_type value_type;
+  typedef typename std::iterator_traits<It>::difference_type difference_type;
+  typedef typename std::iterator_traits<It>::pointer pointer;
+  typedef typename std::iterator_traits<It>::reference reference;
+
   cyclic_iterator() : m_lap(0), m_count(0) {}
   cyclic_iterator(const It &it, const It &begin, const It &end, int lap = 0)
       : m_it(it)
@@ -233,45 +233,37 @@ public:
     return it;
   }
 
-  cyclic_iterator &operator+=(
-      const typename cyclic_iterator::difference_type &val) {
+  cyclic_iterator &operator+=(difference_type val) {
     m_lap += (val + (m_it - m_begin)) / m_count;
     m_it = cyclic_ops::increased(m_it, m_begin, m_count, val);
     return *this;
   }
 
-  cyclic_iterator &operator-=(
-      const typename cyclic_iterator::difference_type &val) {
+  cyclic_iterator &operator-=(difference_type val) {
     m_lap -= (val + (m_end - m_it)) / m_count;
     m_it = cyclic_ops::decreased(m_it, m_begin, m_count, val);
     return *this;
   }
 
-  typename cyclic_iterator::difference_type operator-(
-      const cyclic_iterator &it) const {
+  difference_type operator-(const cyclic_iterator &it) const {
     assert(m_begin == it.m_begin && m_end == it.m_end);
     return m_it - it.m_it + m_lap * m_count - it.m_lap * it.m_count;
   }
 
-  cyclic_iterator operator+(
-      const typename cyclic_iterator::difference_type &val) const {
+  cyclic_iterator operator+(difference_type val) const {
     cyclic_iterator it(*this);
     it += val;
     return it;
   }
 
-  cyclic_iterator operator-(
-      const typename cyclic_iterator::difference_type &val) const {
+  cyclic_iterator operator-(difference_type val) const {
     cyclic_iterator it(*this);
     it -= val;
     return it;
   }
 
-  typename cyclic_iterator::reference operator*() const { return *m_it; }
-  typename cyclic_iterator::pointer operator->() const {
-    return m_it.operator->();
-  }
-
+  reference operator*() const { return *m_it; }
+  pointer operator->() const { return m_it.operator->(); }
   bool operator==(const cyclic_iterator &it) const {
     return m_it == it.m_it && m_lap == it.m_lap;
   }

--- a/toonz/sources/include/tcg/iterator_ops.h
+++ b/toonz/sources/include/tcg/iterator_ops.h
@@ -39,18 +39,20 @@ struct iterator_traits<T *> : public std::iterator_traits<T *> {
 */
 
 template <typename RanIt>
-class step_iterator : public std::iterator<
-                          std::random_access_iterator_tag,
-                          typename std::iterator_traits<RanIt>::value_type,
-                          typename std::iterator_traits<RanIt>::difference_type,
-                          typename std::iterator_traits<RanIt>::pointer,
-                          typename std::iterator_traits<RanIt>::reference> {
+class step_iterator {
+protected:
   RanIt m_it;
-  typename step_iterator::difference_type m_step;
+  typename std::iterator_traits<RanIt>::difference_type m_step;
 
 public:
+  typedef std::random_access_iterator_tag iterator_category;
+  typedef typename std::iterator_traits<RanIt>::value_type value_type;
+  typedef typename std::iterator_traits<RanIt>::difference_type difference_type;
+  typedef typename std::iterator_traits<RanIt>::pointer pointer;
+  typedef typename std::iterator_traits<RanIt>::reference reference;
+
   step_iterator() {}
-  step_iterator(const RanIt &it, typename step_iterator::difference_type step)
+  step_iterator(const RanIt &it, difference_type step)
       : m_it(it), m_step(step) {}
 
   step_iterator &operator++() {
@@ -75,41 +77,34 @@ public:
     return it;
   }
 
-  step_iterator &operator+=(
-      const typename step_iterator::difference_type &val) {
+  step_iterator &operator+=(difference_type val) {
     m_it += val * m_step;
     return *this;
   }
 
-  step_iterator &operator-=(
-      const typename step_iterator::difference_type &val) {
+  step_iterator &operator-=(difference_type val) {
     m_it -= val * m_step;
     return *this;
   }
 
-  typename step_iterator::difference_type operator-(
-      const step_iterator &it) const {
+  difference_type operator-(const step_iterator &it) const {
     return (m_it - it.m_it) / m_step;
   }
 
-  step_iterator operator+(
-      const typename step_iterator::difference_type &val) const {
+  step_iterator operator+(difference_type val) const {
     step_iterator it(*this);
     it += val;
     return it;
   }
 
-  step_iterator operator-(
-      const typename step_iterator::difference_type &val) const {
+  step_iterator operator-(difference_type val) const {
     step_iterator it(*this);
     it -= val;
     return it;
   }
 
-  typename step_iterator::reference operator*() const { return *m_it; }
-  typename step_iterator::pointer operator->() const {
-    return m_it.operator->();
-  }
+  reference operator*() const { return *m_it; }
+  pointer operator->() const { return m_it.operator->(); }
 
   const RanIt &it() const { return m_it; }
   int step() const { return m_step; }

--- a/toonz/sources/include/tcg/mesh_bgl.h
+++ b/toonz/sources/include/tcg/mesh_bgl.h
@@ -6,6 +6,9 @@
 // TCG includes
 #include "mesh.h"
 
+// STD includes
+#include <utility>  // Added for std::make_pair
+
 // Boost includes
 #include <boost/graph/graph_traits.hpp>
 
@@ -116,11 +119,10 @@ template <typename Mesh>
 inline std::pair<typename boost::graph_traits<Mesh>::out_edge_iterator,
                  typename boost::graph_traits<Mesh>::out_edge_iterator>
 out_edges(int v, const Mesh &mesh) {
-  typedef
-      typename boost::graph_traits<Mesh>::out_edge_iterator out_edge_iterator;
+  typedef typename boost::graph_traits<Mesh>::out_edge_iterator out_edge_iterator;
 
-  return make_pair(out_edge_iterator(mesh.vertex(v).edgesBegin(), v),
-                   out_edge_iterator(mesh.vertex(v).edgesEnd(), v));
+  return std::make_pair(out_edge_iterator(mesh.vertex(v).edgesBegin(), v),
+                        out_edge_iterator(mesh.vertex(v).edgesEnd(), v));
 }
 
 //---------------------------------------------------------------------------------------
@@ -129,7 +131,8 @@ template <typename Mesh>
 inline int out_degree(int v, const Mesh &mesh) {
   return mesh.vertex(v).edgesCount();
 }
-}
-}  // namespace tcg::bgl
+
+}  // namespace bgl
+}  // namespace tcg
 
 #endif  // TCG_MESH_BGL_H


### PR DESCRIPTION
**Changes:**
1. Removed std::iterator inheritance to resolve C4996 warnings in:
   - tcg/list.h
   - tcg/cyclic.h
   - tcg/iterator_ops.h 
  
(Added explicit iterator traits to comply with C++17 standards)

2. Fixed mesh_bgl.h compilation:
   - Added missing `#include <utility>` to resolve `std::make_pair usage`.

While removing std::iterator inheritance in tcg/list.h to resolve C4996 warnings, a compilation issue was exposed in tcg/mesh_bgl.h due to a missing `#include <utility>`. It’s possible that the missing include may have caused silent issues or undefined behavior over time, potentially affecting the program, but this cannot be confirmed at this point.

---
 _This PR addresses a deprecation issue, but I'll use the original reference for future indexing in case any of the changes or explanations need to be consulted._ **Ref:** [#5834](https://github.com/opentoonz/opentoonz/issues/5834)

