### PR TITLE
fix: ODR violations (#241) by adding flipbooksettings.h for toggle vars

### DIFF
--- a/toonz/sources/include/toonz/flipbooksettings.h
+++ b/toonz/sources/include/toonz/flipbooksettings.h
@@ -1,0 +1,10 @@
+#ifndef FLIPBOOKSETTINGS_H
+#define FLIPBOOKSETTINGS_H
+#include "tenv.h"
+
+// Shared flipbook background toggle settings for UI and rendering
+inline TEnv::IntVar FlipBookWhiteBgToggle("FlipBookWhiteBgToggle", 1);
+inline TEnv::IntVar FlipBookBlackBgToggle("FlipBookBlackBgToggle", 0);
+inline TEnv::IntVar FlipBookCheckBgToggle("FlipBookCheckBgToggle", 0);
+
+#endif

--- a/toonz/sources/toonzlib/imagepainter.cpp
+++ b/toonz/sources/toonzlib/imagepainter.cpp
@@ -2,6 +2,8 @@
 #include <GL/glew.h>
 
 #include "toonz/imagepainter.h"
+// Include shared flipbook background toggle settings (e.g., for m_bg) from toonz/
+#include "toonz/flipbooksettings.h"
 #include "toonz/glrasterpainter.h"
 #include "trastercm.h"
 #include "tropcm.h"
@@ -21,9 +23,6 @@
 
 using namespace ImagePainter;
 
-TEnv::IntVar FlipBookWhiteBgToggle("FlipBookWhiteBgToggle", 1);
-TEnv::IntVar FlipBookBlackBgToggle("FlipBookBlackBgToggle", 0);
-TEnv::IntVar FlipBookCheckBgToggle("FlipBookCheckBgToggle", 0);
 namespace {
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -1,6 +1,8 @@
 
 
 #include "toonzqt/flipconsole.h"
+// Include shared flipbook settings (e.g., FlipBookWhiteBgToggle) from toonz/
+#include "toonz/flipbooksettings.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -50,9 +52,6 @@ using namespace DVGui;
 //==========================================================================================
 //    Preliminary stuff - local namespace
 //==========================================================================================
-TEnv::IntVar FlipBookWhiteBgToggle("FlipBookWhiteBgToggle", 1);
-TEnv::IntVar FlipBookBlackBgToggle("FlipBookBlackBgToggle", 0);
-TEnv::IntVar FlipBookCheckBgToggle("FlipBookCheckBgToggle", 0);
 namespace {
 // Please refer to the "qss/standard/standard.qss" file for explanations of the
 // following properties.


### PR DESCRIPTION
This PR fixes **One Definition Rule (ODR) violations** caused by duplicate global `TEnv::IntVar` definitions in:  
- `toonzlib/imagepainter.cpp`  
- `toonzqt/flipconsole.cpp`  

**Why `inline`?** 

It takes advantage of C++17’s guaranteed single-definition rule, ensuring type-safe linkage without redundant `extern` declarations.

Fixes #241.  