### PR TITLE
fix: resolve C4018 signed/unsigned mismatch warnings

### DIFF
--- a/toonz/sources/tnztools/cuttertool.cpp
+++ b/toonz/sources/tnztools/cuttertool.cpp
@@ -461,8 +461,8 @@ public:
     TVectorImageP vi = TImageP(getImage(false));
     if (!vi) return false;
 
-    if (m_lockedStrokeIndex >= vi->getStrokeCount()) {
-      m_lockedStrokeIndex = -1;
+    if (m_lockedStrokeIndex >= static_cast<int>(vi->getStrokeCount())) {
+        m_lockedStrokeIndex = -1;
     }
 
     if (lock && m_lockedStrokeIndex >= 0) {

--- a/toonz/sources/tnztools/pumptool.cpp
+++ b/toonz/sources/tnztools/pumptool.cpp
@@ -775,7 +775,7 @@ bool PumpTool::getNearestStrokeWithLock(const TPointD &p, double &outW,
   TVectorImageP vi = TImageP(getImage(false));
   if (!vi) return false;
 
-  if (m_lockedStrokeIndex >= vi->getStrokeCount()) {
+  if (m_lockedStrokeIndex >= static_cast<int>(vi->getStrokeCount())) {
     m_lockedStrokeIndex = -1;
   }
 

--- a/toonz/sources/toonz/svnlockframerangedialog.cpp
+++ b/toonz/sources/toonz/svnlockframerangedialog.cpp
@@ -260,44 +260,31 @@ void SVNLockFrameRangeDialog::onCancelButtonClicked() {
 //-----------------------------------------------------------------------------
 
 void SVNLockFrameRangeDialog::onFromLineEditTextChanged() {
-  int value = m_fromLineEdit->getValue();
-
-  // Check if from is inside one range
-  int count = m_lockInfos.size();
-
-  m_fromIsValid = true;
-  for (int i = 0; i < count; i++) {
-    SVNPartialLockInfo lockInfo = m_lockInfos.at(i);
-    if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
-      m_fromIsValid = false;
-      break;
+    unsigned int value = static_cast<unsigned int>(m_fromLineEdit->getValue());
+    m_fromIsValid = true;
+    for (const SVNPartialLockInfo& lockInfo : m_lockInfos) {
+        if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
+            m_fromIsValid = false;
+            break;
+        }
     }
-  }
-
-  m_fromLineEdit->setStyleSheet(
-      m_fromIsValid ? "" : "color: red; background-color: red;");
-  m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
+    m_fromLineEdit->setStyleSheet(m_fromIsValid ? "" : "color: red; background-color: red;");
+    m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
 }
 
 //-----------------------------------------------------------------------------
 
 void SVNLockFrameRangeDialog::onToLineEditTextChanged() {
-  int value = m_toLineEdit->getValue();
-
-  // Check if from is inside one range
-  int count   = m_lockInfos.size();
-  m_toIsValid = true;
-  for (int i = 0; i < count; i++) {
-    SVNPartialLockInfo lockInfo = m_lockInfos.at(i);
-    if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
-      m_toIsValid = false;
-      break;
+    unsigned int value = static_cast<unsigned int>(m_toLineEdit->getValue());
+    m_toIsValid = true;
+    for (const SVNPartialLockInfo& lockInfo : m_lockInfos) {
+        if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
+            m_toIsValid = false;
+            break;
+        }
     }
-  }
-
-  m_toLineEdit->setStyleSheet(
-      m_toIsValid ? "" : "color: red; background-color: red;");
-  m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
+    m_toLineEdit->setStyleSheet(m_toIsValid ? "" : "color: red; background-color: red;");
+    m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
 }
 
 //-----------------------------------------------------------------------------
@@ -560,44 +547,31 @@ void SVNLockMultiFrameRangeDialog::onStatusRetrieved(
 //-----------------------------------------------------------------------------
 
 void SVNLockMultiFrameRangeDialog::onFromLineEditTextChanged() {
-  int value = m_fromLineEdit->getValue();
-
-  // Check if from is inside one range
-  int count = m_lockInfos.size();
-
-  m_fromIsValid = true;
-  for (int i = 0; i < count; i++) {
-    SVNPartialLockInfo lockInfo = m_lockInfos.at(i);
-    if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
-      m_fromIsValid = false;
-      break;
+    unsigned int value = static_cast<unsigned int>(m_fromLineEdit->getValue());
+    m_fromIsValid = true;
+    for (const SVNPartialLockInfo& lockInfo : m_lockInfos) {
+        if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
+            m_fromIsValid = false;
+            break;
+        }
     }
-  }
-
-  m_fromLineEdit->setStyleSheet(
-      m_fromIsValid ? "" : "color: red; background-color: red;");
-  m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
+    m_fromLineEdit->setStyleSheet(m_fromIsValid ? "" : "color: red; background-color: red;");
+    m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
 }
 
 //-----------------------------------------------------------------------------
 
 void SVNLockMultiFrameRangeDialog::onToLineEditTextChanged() {
-  int value = m_toLineEdit->getValue();
-
-  // Check if from is inside one range
-  int count   = m_lockInfos.size();
-  m_toIsValid = true;
-  for (int i = 0; i < count; i++) {
-    SVNPartialLockInfo lockInfo = m_lockInfos.at(i);
-    if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
-      m_toIsValid = false;
-      break;
+    unsigned int value = static_cast<unsigned int>(m_toLineEdit->getValue());
+    m_toIsValid = true;
+    for (const SVNPartialLockInfo& lockInfo : m_lockInfos) {
+        if (value >= lockInfo.m_from && value <= lockInfo.m_to) {
+            m_toIsValid = false;
+            break;
+        }
     }
-  }
-
-  m_toLineEdit->setStyleSheet(
-      m_toIsValid ? "" : "color: red; background-color: red;");
-  m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
+    m_toLineEdit->setStyleSheet(m_toIsValid ? "" : "color: red; background-color: red;");
+    m_lockButton->setEnabled(m_fromIsValid && m_toIsValid);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses and resolves the C4018 signed/unsigned mismatch warnings encountered during the build process. 

- Fixed signed/unsigned mismatch warnings (C4018) in the following files:
  - `svnlockframerangedialog.cpp` (lines 271, 292, 571, 592)
  - `pumptool.cpp` (line 778)
  - `cuttertool.cpp` (line 464)

