### PR TITLE
build: Update Boost to v1.86.0 in AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 
     mkdir %PLATFORM% && cd %PLATFORM%
 
-    cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_85_0" -DOpenCV_DIR="C:\Tools\opencv\build"
+    cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_86_0" -DOpenCV_DIR="C:\Tools\opencv\build"
 build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
   parallel: true


### PR DESCRIPTION
This experimental PR tests whether upgrading Boost from 1.85.0 to 1.86.0 can reduce build times in AppVeyor.

Version 1.86.0 is [the latest supported version](https://www.appveyor.com/docs/windows-images-software/#boost)) in AppVeyor's environment.

In the last PR, even with optimizations, we only gained about 30 to 60 seconds.

Ref: #5857
