### PR TITLE
CI - Windows: Update GHA Workflow

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -16,12 +16,12 @@ on:
 
 jobs:
   Windows:
-    runs-on: windows-2019
+    runs-on: windows-2025
     env:
       QT_PATH: ${{ github.workspace }}\thirdparty\qt\5.15.2_wintab\msvc2019_64  # Path to custom Qt.
-      VCINSTALLDIR: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC'  # Path to MSVC.
-      MSVCVERSION: "Visual Studio 16 2019"  # Visual Studio version.
-      BOOST_ROOT: C:\local\boost_1_74_0  # Boost library root.
+      VCINSTALLDIR: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC'  # Path to MSVC.
+      MSVCVERSION: "Visual Studio 17 2022"  # Visual Studio version.
+      BOOST_ROOT: C:\local\boost_1_87_0  # Boost library root.
       OpenCV_DIR: C:\tools\opencv\build  # Path to OpenCV.
 
     steps:
@@ -47,7 +47,7 @@ jobs:
         run: |
           @echo on
           choco install opencv --version=4.11.0 -y
-          choco install boost-msvc-14.2 --version=1.74.0 -y
+          choco install boost-msvc-14.3 --version=1.87.0 -y
         shell: cmd
 
       - name: Install custom Qt 5.15.2 with WinTab support


### PR DESCRIPTION
* Bumped Runner Image to 2025
* Bumped Boost to 1.87.0
* Bumped Visual Studio to 2022