### PR TITLE
ci: Add pre-build check to avoid unnecessary builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,44 +8,53 @@ configuration:
 - Release
 platform: x64
 clone_depth: 1
+
+before_build:
+- ps: |
+    $skipPattern = '^(doc(/|\\).*|\.github(/|\\).*|README\.md)$'
+    git fetch origin +refs/heads/$env:APPVEYOR_REPO_BRANCH --quiet
+    $changedFiles = git diff --name-only HEAD~1 HEAD
+    $hasRelevantChanges = $false
+    foreach ($file in $changedFiles) {
+      if ($file -notmatch $skipPattern) {
+        $hasRelevantChanges = $true
+        Write-Host "Relevant file detected: $file"
+        break
+      }
+    }
+    if (-not $hasRelevantChanges -and $changedFiles.Count -gt 0) {
+      Write-Host "Build skipped: Only changes in .github/, doc/, or README.md."
+      Exit 0
+    }
+    Write-Host "Build required: Relevant changes detected."
+
 cache:
-  - C:\Tools\opencv
+- C:\Tools\opencv
+
 install:
 - cmd: >-
     if exist "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" (echo OpenCV cached, skipping install) else (choco install opencv --version=4.11.0 --no-progress --yes --force)
-
     cd thirdparty
-
     copy /Y tiff-4.0.3\libtiff\tif_config.vc.h tiff-4.0.3\libtiff\tif_config.h
-
     copy /Y tiff-4.0.3\libtiff\tiffconf.vc.h tiff-4.0.3\libtiff\tiffconf.h
-
     copy /Y libpng-1.6.21\scripts\pnglibconf.h.prebuilt libpng-1.6.21\pnglibconf.h
-
     cd ../toonz
-
     mkdir %PLATFORM% && cd %PLATFORM%
-
     cmake ..\sources -G "Visual Studio 17 2022" -Ax64 -DQT_PATH="C:\Qt\5.15.2\msvc2019_64" -DBOOST_ROOT="C:\Libraries\boost_1_86_0" -DOpenCV_DIR="C:\Tools\opencv\build"
+
 build:
   project: $(APPVEYOR_BUILD_FOLDER)\toonz\$(PLATFORM)\ALL_BUILD.vcxproj
   parallel: true
   verbosity: minimal
+
 after_build:
 - cmd: >-
-
     C:\Qt\5.15.2\msvc2019_64\bin\windeployqt.exe %CONFIGURATION%\OpenToonz.exe
-
     copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION%
-
     copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION%
-
     copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" %CONFIGURATION%
-
     xcopy /Y /E ..\..\thirdparty\libmypaint\dist\64\*.dll %CONFIGURATION%
-
     mkdir "%CONFIGURATION%\portablestuff"
-
     xcopy /Y /E ..\..\stuff "%CONFIGURATION%\portablestuff"
 
 artifacts:


### PR DESCRIPTION
This PR adds a pre-build check in appveyor.yml to skip CI runs when only non-code files are changed (e.g. doc/, .github/, or README.md).

This is a complement to PR: #5915, I don't think it affects release and nightly trigger, but if it does, we can adapt.

**References:** 

PR: #5915 
Issue: [opentoonz/opentoonz#5914](https://github.com/opentoonz/opentoonz/issues/5914)
