### PR TITLE
ci: Remove Debug build configuration from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,7 @@ pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
 image: Visual Studio 2022
-configuration:
-- Debug
-- Release
+configuration: Release
 platform: x64
 clone_depth: 1
 


### PR DESCRIPTION
Removed Debug from configuration based on discussion to streamline CI, prevent dual builds, and reduce LFS usage. 

The LFS quota should reset next month in about 3 days, so things should normalize a bit more after that

Ref: https://github.com/opentoonz/opentoonz/issues/5914