### PR TITLE
ci: fix macOS 15 build with SuperLU in GitHub Actions

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -20,9 +20,7 @@ on:
 
 jobs:
   macOS:
-    timeout-minutes: 90
-    # runs-on: macos-latest
-    # avoid the headache of arm64 builds?
+    timeout-minutes: 90 # Stop job if it exceeds expected build time
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -48,16 +46,14 @@ jobs:
               fi
             done
           }
-          
           brew update
           brew cleanup
-
-          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv qt@5
+          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv superlu qt@5
           brew unlink qt
 
       - name: Set up cache
         run: |
-          export PATH="/usr/local/opt/ccache/libexec:$PATH"
+          export PATH="/opt/homebrew/opt/ccache/libexec:$PATH"
           mkdir -p /Users/runner/.ccache
 
       - uses: actions/cache@v4
@@ -74,7 +70,7 @@ jobs:
 
       - name: Build
         run: |
-          export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export PKG_CONFIG_PATH="$(brew --prefix jpeg-turbo)/lib/pkgconfig:$PKG_CONFIG_PATH"
           cd toonz
           mkdir -p build
           cd build
@@ -83,6 +79,7 @@ jobs:
             -DQT_PATH=$(brew --prefix qt@5)/lib \
             -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
             -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 \
+            -DWITH_SYSTEM_SUPERLU=ON \
             -DWITH_TRANSLATION=OFF
           ninja -j $(sysctl -n hw.ncpu)
 
@@ -90,7 +87,9 @@ jobs:
         run: |
           cd toonz/build/toonz
           cp -pr ../../../stuff OpenToonz.app/portablestuff
-          /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -verbose=0 -always-overwrite \
+          QT_DEPLOY=$(brew --prefix qt@5)/bin/macdeployqt
+          echo "Using macdeployqt from: $QT_DEPLOY"
+          $QT_DEPLOY OpenToonz.app -verbose=0 -always-overwrite \
             -executable=OpenToonz.app/Contents/MacOS/lzocompress \
             -executable=OpenToonz.app/Contents/MacOS/lzodecompress \
             -executable=OpenToonz.app/Contents/MacOS/tcleanup \
@@ -116,20 +115,18 @@ jobs:
           cd toonz/build/toonz
           echo "Creating DMG..."
 
+          QT_DEPLOY=$(brew --prefix qt@5)/bin/macdeployqt
           ATTEMPT=1
-          until /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0 && [ -f OpenToonz.dmg ]; do
+          until $QT_DEPLOY OpenToonz.app -dmg -verbose=0 && [ -f OpenToonz.dmg ]; do
             echo "Attempt $ATTEMPT failed to build DMG."
-
             if [ $ATTEMPT -eq 10 ]; then
               echo ">>> DMG file creation failed after 10 attempts. Aborting!"
               exit 1
             fi
-
             ATTEMPT=$((ATTEMPT + 1))
-            echo "Retrying in 5 seconds..."
-            sleep 5
+            echo "Retrying in 10 seconds..."
+            sleep 10
           done
-
           echo "DMG created successfully."
 
       - uses: actions/upload-artifact@v4

--- a/toonz/cmake/FindSuperLU.cmake
+++ b/toonz/cmake/FindSuperLU.cmake
@@ -1,6 +1,5 @@
-
 if(WITH_SYSTEM_SUPERLU)
-    # depend on CMake's defaults
+    # Depend on CMake's default settings
     set(_header_hints)
     set(_header_suffixes
         superlu
@@ -8,7 +7,7 @@ if(WITH_SYSTEM_SUPERLU)
     )
     set(_lib_suffixes)
 else()
-    # preferred homebrew's directories.
+    # Preferred directories for Homebrew installation
     set(_header_hints
         ${THIRDPARTY_LIBS_HINTS}
     )
@@ -24,6 +23,41 @@ else()
     )
 endif()
 
+# Check for macOS with Homebrew
+if(APPLE)
+    # Detect Homebrew installation (different paths for Intel and ARM systems)
+    if(EXISTS "/opt/homebrew")
+        # For Apple Silicon systems (M1/M2)
+        set(_header_hints
+            /opt/homebrew/include
+            /usr/local/include
+            ${THIRDPARTY_LIBS_HINTS}
+        )
+        set(_lib_hints
+            /opt/homebrew/lib
+            /usr/local/lib
+            ${THIRDPARTY_LIBS_HINTS}
+        )
+        message("***** Using Homebrew for Apple Silicon (M1/M2)")
+    elseif(EXISTS "/usr/local")
+        # For Intel systems
+        set(_header_hints
+            /opt/homebrew/include
+            /usr/local/include
+            ${THIRDPARTY_LIBS_HINTS}
+        )
+        set(_lib_hints
+            /opt/homebrew/lib
+            /usr/local/lib
+            ${THIRDPARTY_LIBS_HINTS}
+        )
+        message("***** Using Homebrew for Intel")
+    else()
+        message(FATAL_ERROR "Homebrew not installed or path not found")
+    endif()
+endif()
+
+# Find the path to the SuperLU header files
 find_path(
     SUPERLU_INCLUDE_DIR
     NAMES
@@ -34,10 +68,12 @@ find_path(
         ${_header_suffixes}
 )
 
+# Find the path to the SuperLU library
 find_library(
     SUPERLU_LIBRARY
     NAMES
         libsuperlu.so
+        libsuperlu.dylib
         libsuperlu.a
         libsuperlu_4.1.a
     HINTS
@@ -46,24 +82,30 @@ find_library(
         ${_lib_suffixes}
 )
 
+# Output the paths for debugging purposes
 message("***** SuperLU Header path:" ${SUPERLU_INCLUDE_DIR})
 message("***** SuperLU Library path:" ${SUPERLU_LIBRARY})
 
+# Set the SuperLU names
 set(SUPERLU_NAMES ${SUPERLU_NAMES} SuperLU)
 
+# Handle standard package search arguments
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SuperLU
     DEFAULT_MSG SUPERLU_LIBRARY SUPERLU_INCLUDE_DIR)
 
+# If SuperLU is found, set the libraries
 if(SUPERLU_FOUND)
     set(SUPERLU_LIBRARIES ${SUPERLU_LIBRARY})
 endif()
 
+# Mark the library and include directories as advanced for the user
 mark_as_advanced(
     SUPERLU_LIBRARY
     SUPERLU_INCLUDE_DIR
 )
 
+# Unset temporary variables used during the configuration
 unset(_header_hints)
 unset(_header_suffixes)
 unset(_lib_hints)


### PR DESCRIPTION
This pull request fixes the macOS build had issues with handling SuperLU (the library was built for x86_64 only) and its dependencies on macOS 15. These changes ensure that the build now runs successfully.

- Updated CMake to support macOS 15 and correctly detect SuperLU
- Enable `-DWITH_SYSTEM_SUPERLU=ON` in GitHub Actions workflow to use system-installed SuperLU via Homebrew
- Adjusted paths for Homebrew libraries to ensure compatibility on macOS 15

I suggest not approving CI changes that are known to be broken, as this could disrupt the **few developers** who are actively writing code and can't be certain the code will run correctly in the target environment. These builds are essential for validating whether the code works properly across all platforms and also allow beta testers to download and test the latest versions.

Although the build completes successfully, I can't confirm that OpenToonz runs as expected, as I currently don't have access to a macOS system for testing. If it doesn't work for any reason, I recommend reverting the workflow again to macOS 13 until a developer with access to a macOS machine can properly address the issue.