### PR TITLE
Enhance Assets Import

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -247,6 +247,8 @@ public:
 
   // Loading  tab
   int getDefaultImportPolicy() { return getIntValue(importPolicy); }
+  int getDefaultRenamePolicy() { return getIntValue(renamePolicy); }
+  int getDefaultConvertPolicy() { return getIntValue(convertPolicy); }
   bool isAutoExposeEnabled() const { return getBoolValue(autoExposeEnabled); }
   bool isSubsceneFolderEnabled() const {
     return getBoolValue(subsceneFolderEnabled);

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -52,6 +52,7 @@ enum PreferencesItemId {
   // Loading
   importPolicy,
   renamePolicy,
+  convertPolicy,
   autoExposeEnabled,
   subsceneFolderEnabled,
   removeSceneNumberFromLoadedLevelName,

--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -259,6 +259,9 @@ If \b scene is in +scenes/name.tnz return name,
 
   // if the path is codable with $scenefolder alias, replace it and return true
   bool codeFilePathWithSceneFolder(TFilePath &path) const;
+  
+  // return false if the scene doesn't belong to any project
+  bool isLonelyScene() const;
 
   bool isLoading() { return m_isLoading; }
   void setIsLoading(bool isLoading) { m_isLoading = isLoading; }

--- a/toonz/sources/include/toonz/tscenehandle.h
+++ b/toonz/sources/include/toonz/tscenehandle.h
@@ -63,6 +63,9 @@ public:
   void notifyRenamePolicyChanged(int policy) {
     emit renamePolicyChanged(policy);
   }
+  void notifyConvertPolicyChanged(int policy) {
+    emit convertPolicyChanged(policy);
+  }
 
   void setDirtyFlag(bool dirtyFlag) {
     if (m_dirtyFlag == dirtyFlag) return;
@@ -88,6 +91,7 @@ signals:
   void pixelUnitSelected(bool on);
   void importPolicyChanged(int policy);
   void renamePolicyChanged(int policy);
+  void convertPolicyChanged(int policy);
 };
 
 #endif  // TSCENEHANDLE_H

--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -104,6 +104,8 @@ void DVAPI convert(
     const TFrameId &tmplFId = TFrameId()  //!< frame format template
 );  //!< Converts a saved level to fullcolor, and saves the result.
 
+bool DVAPI isAAImage(TFilePath path);
+
 void DVAPI convertNaa2Tlv(
     const TFilePath &source,  //!< Level path to convert from.
     const TFilePath &dest,    //!< Level path to convert to.

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -1210,9 +1210,11 @@ bool LoadLevelPopup::execute() {
     args.row0 = m_posFrom->text().toInt() - 1;
 
     args.frameCount = m_posTo->text().toInt() - m_posFrom->text().toInt() + 1;
-
-    if ((int)getCurrentFIdsSet().size() != 0)
-      args.frameIdsSet.push_back(*getCurrentFIdsSet().begin());
+    
+    std::list<std::vector<TFrameId>> fidsSet = getCurrentFIdsSet();
+    if (!fidsSet.empty()) {
+        args.resourceDatas[0].m_frameIdSet = std::move(fidsSet.front());
+    }
 
     else if (m_notExistLabel->isVisible()) {
       TFrameId firstLoadingFId = m_fromFrame->getValue();
@@ -1229,7 +1231,7 @@ bool LoadLevelPopup::execute() {
       }
       if (!lastLoadingFId.getLetter().isEmpty())
         tmp_fids.push_back(lastLoadingFId);
-      args.frameIdsSet.push_back(tmp_fids);
+      args.resourceDatas[0].m_frameIdSet = std::move(tmp_fids);
     }
 
     TFrameId xFrom = m_xFrom->getValue();
@@ -1265,12 +1267,13 @@ bool LoadLevelPopup::execute() {
       args.resourceDatas.push_back(*it);
 
     std::list<std::vector<TFrameId>> fIdsSet = getCurrentFIdsSet();
-    if (fIdsSet.size() > 0) {
-      std::list<std::vector<TFrameId>>::const_iterator fIdIt;
-      for (fIdIt = fIdsSet.begin(); fIdIt != fIdsSet.end(); ++fIdIt)
-        args.frameIdsSet.insert(args.frameIdsSet.begin(), *fIdIt);
+    auto fIdIt = fIdsSet.begin();
+    auto rdIt = args.resourceDatas.begin();
+    while (fIdIt != fIdsSet.end() && rdIt != args.resourceDatas.end()) {
+        rdIt->m_frameIdSet = std::move(*fIdIt);
+        ++fIdIt;
+        ++rdIt;
     }
-
     args.cachingBehavior = IoCmd::LoadResourceArguments::CacheRasterBehavior(
         m_rasterCacheBehaviorComboBox->currentData().toInt());
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -34,6 +34,7 @@
 #include "toonzqt/swatchviewer.h"
 #include "toonzqt/tselectionhandle.h"
 #include "toonzqt/dvdialog.h"
+#include "toonzqt/imageutils.h"
 
 // ToonzLib includes
 #include "toonz/palettecontroller.h"
@@ -2582,7 +2583,7 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
   if(args.renamePolicy != LoadResourceArguments::RenamePolicy::NEVER)
       renameResources(rds);
   if(args.convertPolicy != LoadResourceArguments::ConvertPolicy::NEVER)
-      convertRaster2TLV(rds);
+      convertNAARaster2TLV(rds);
 
   if (progressDialog){
       progressDialog->reset();
@@ -2905,7 +2906,7 @@ QRegularExpression::ExtendedPatternSyntaxOption);
     }
 }
 
-void IoCmd::convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser) {
+void IoCmd::convertNAARaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser) {
     struct locals {
         static bool checkConvertPolicy(const TFilePath& path) {
             switch (Preferences::instance()->getIntValue(convertPolicy)) {
@@ -2941,7 +2942,7 @@ void IoCmd::convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& 
             return ret == 1;
         }
 
-        static bool getRange(const TFilePath& path, int& from, int& to) {
+        static bool getRange(const TFilePath& path, int& from, int& to, TFilePath &first) {
             TLevelP levelTmp;
             TLevelReaderP lrTmp = TLevelReaderP(path);
             if (lrTmp) {
@@ -2953,6 +2954,7 @@ void IoCmd::convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& 
                     if (start.getNumber() >= 0 && end.getNumber() >= 0) {
                         from = start.getNumber();
                         to = end.getNumber();
+                        first = lrTmp->getFrameReader(start)->getFilePath();
                         return true;
                     }
                 }
@@ -2960,9 +2962,6 @@ void IoCmd::convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& 
             return false;
         }
 
-        static bool isNAAImage(const TFilePath& path) {
-
-        }
     };//Locals
 
     static const QStringList rasterExts = {
@@ -2976,7 +2975,10 @@ void IoCmd::convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& 
             TFilePath dstPath = path.getParentDir() + TFilePath(path.getName()).withType("tlv");
             
             if (askUser && !locals::checkConvertPolicy(path))continue;
-            
+            int from, to;
+            TFilePath first;
+            if (!locals::getRange(path, from, to, first)) continue;
+            if (ImageUtils::isAAImage(first))continue;
             if (TSystem::doesExistFileOrLevel(dstPath)) {
                 OverwriteDialog dialog;
                 dstPath = dstPath.withName(dialog.execute(scene, dstPath, false));
@@ -2994,8 +2996,6 @@ void IoCmd::convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& 
                     continue;
                 }
             }
-            int from, to;
-            if(!locals::getRange(path, from, to)) continue;
             Convert2Tlv converter(path, TFilePath(), dstPath.getParentDir(), QString::fromStdWString(dstPath.getWideName())
 <<<<<<< HEAD
 <<<<<<< HEAD

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1914,8 +1914,9 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
     QString msg;
     msg = QObject::tr(
               "It is not possible to load the scene %1 because it does not "
-              "belong to any project.")
-              .arg(QString::fromStdWString(scenePath.getWideString()));
+              "belong to any project.\n"
+        "Please delete scenes.xml if this scene dones't belong to any project.")
+        .arg(QString::fromStdWString(scenePath.getWideString()));
     DVGui::warning(msg);
   }
   if (sceneProject && !sceneProject->isCurrent()) {

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1209,26 +1209,6 @@ inline TPaletteP dirtyWhite(const TPaletteP &plt) {
 }
 
 }  // namespace
-//---------------------------------------------------------------------------
-
-// Per ora e' usato solo per i formato "tzp" e "tzu".
-IoCmd::ConvertingPopup::ConvertingPopup(QWidget *parent, QString fileName)
-    : QDialog(parent) {
-  setModal(true);
-  setWindowFlags(Qt::Dialog | Qt::WindowTitleHint);
-  setMinimumSize(70, 50);
-  QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(5);
-  mainLayout->setSpacing(0);
-
-  QLabel *label = new QLabel(QString(
-      QObject::tr("Converting %1 images to tlv format...").arg(fileName)));
-  mainLayout->addWidget(label);
-
-  setLayout(mainLayout);
-}
-
-IoCmd::ConvertingPopup::~ConvertingPopup() {}
 
 //===========================================================================
 // IoCmd::saveSceneIfNeeded(message)
@@ -2599,12 +2579,14 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
   }
 
   if(args.renamePolicy != LoadResourceArguments::RenamePolicy::NEVER)
-      tryRenameResouces(rds);
+      renameResources(rds);
   if(args.convertPolicy != LoadResourceArguments::ConvertPolicy::NEVER)
-      tryConvertRaster2TLV(rds);
+      convertRaster2TLV(rds);
 
-  if (progressDialog)
+  if (progressDialog){
+      progressDialog->reset();
       progressDialog->setMaximum(rds.size());
+  }
   // LOAD IMPORTED FILE
   for (int i = 0; i < rds.size(); ++i) {
       TXshLevel* xl = 0;
@@ -2800,7 +2782,7 @@ bool IoCmd::importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
   return true;
 }
 
-void IoCmd::tryRenameResouces(std::vector<LoadResourceArguments::ResourceData>& rds) {
+void IoCmd::renameResources(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser) {
     struct locals {
         // call when loading levels
         static bool matchSequencePattern(const TFilePath& path) {
@@ -2820,7 +2802,6 @@ QRegularExpression::ExtendedPatternSyntaxOption);
         };
 
         static bool checkRenamePolicy(const TFilePath& path) {
-            // TODO: Check the Preference Policy
             switch (Preferences::instance()->getIntValue(renamePolicy)) {
             case 0:
                 break;
@@ -2884,7 +2865,8 @@ QRegularExpression::ExtendedPatternSyntaxOption);
     ToonzScene* scene = app->getCurrentScene()->getScene();
     for (auto rd = rds.begin(); rd != rds.end();++rd) {
         TFilePath& path = rd->m_path;
-        if (!locals::matchSequencePattern(path) ||
+        if (!locals::matchSequencePattern(path))continue;
+        if (askUser &&
             !locals::checkRenamePolicy(path)) continue;
         TFilePath levelPath = locals::getLevelPath(path);
         if (TSystem::doesExistFileOrLevel(levelPath)) {
@@ -2922,10 +2904,9 @@ QRegularExpression::ExtendedPatternSyntaxOption);
     }
 }
 
-void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds) {
+void IoCmd::convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser) {
     struct locals {
         static bool checkConvertPolicy(const TFilePath& path) {
-            // TODO: Check the Preference Policy for conversion
             switch (Preferences::instance()->getIntValue(convertPolicy)) {
             case 0:
                 break;  // Ask every time
@@ -2977,6 +2958,10 @@ void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData
             }
             return false;
         }
+
+        static bool isNAAImage(const TFilePath& path) {
+
+        }
     };//Locals
 
     static const QStringList rasterExts = {
@@ -2987,10 +2972,9 @@ void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData
         TFilePath& path = rd.m_path;
         if (path.getDots() == ".." && rasterExts.contains(QString::fromStdString(path.getType()).toLower())) {
             if (!path.isAbsolute()) path = scene->decodeFilePath(path);
-            TFilePath dstPath = scene->getDefaultLevelPath(TZP_XSHLEVEL, path.getWideName());
-            dstPath = scene->decodeFilePath(dstPath);
+            TFilePath dstPath = path.getParentDir() + TFilePath(path.getName()).withType("tlv");
             
-            if (!locals::checkConvertPolicy(path))continue;
+            if (askUser && !locals::checkConvertPolicy(path))continue;
             
             if (TSystem::doesExistFileOrLevel(dstPath)) {
                 OverwriteDialog dialog;
@@ -2998,6 +2982,7 @@ void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData
 
                 switch (dialog.getChoice()) {
                 case OverwriteDialog::RENAME:
+                    break;
                 case OverwriteDialog::KEEP_OLD:
                     continue;
                 case OverwriteDialog::OVERWRITE:
@@ -3012,11 +2997,16 @@ void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData
             if(!locals::getRange(path, from, to)) continue;
             Convert2Tlv converter(path, TFilePath(), dstPath.getParentDir(), QString::fromStdWString(dstPath.getWideName())
 <<<<<<< HEAD
+<<<<<<< HEAD
                 , from, to, false, TFilePath(), 20, 0, 50, false, true, scene->getCurrentCamera()->getDpi().x);
 =======
                 , from, to, false, TFilePath(), 0, 0, 50, false, true, 
                 Preferences::instance()->isIgnoreImageDpiEnabled() ? scene->getCurrentCamera()->getDpi().x : 0);
 >>>>>>> 286a81638 (To Set Color)
+=======
+                , from, to, false, TFilePath(), 20, 0, 50, false, true, 
+                Preferences::instance()->isIgnoreImageDpiEnabled() ? scene->getCurrentCamera()->getDpi().x : 0);
+>>>>>>> 0ea585f70 (Add AutoRename and Auto Convert Opetions when importing from .xdts)
             std::string e;
             converter.init(e);
             if (!e.empty()) {
@@ -3027,9 +3017,17 @@ void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData
             if (count) {
                 IoCmd::ConvertingPopup convertingPopup(
                     TApp::instance()->getMainWindow(),
-                    path.getQString());
+                    path.withoutParentDir().getQString());
+                convertingPopup.setMaximum(count);
                 convertingPopup.show();
-                for (int i = 0; i < count; ++i)converter.convertNext(e);
+                for (int i = 0; i < count; ++i){
+                    converter.convertNext(e);
+                    convertingPopup.setValue(i+1);
+                    if (convertingPopup.wasCanceled()) {
+                        converter.abort();
+                        break;
+                    }
+                }
                 convertingPopup.hide();
                 if (TSystem::doesExistFileOrLevel(dstPath))
                     path = scene->codeFilePath(dstPath);

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2974,12 +2974,11 @@ void IoCmd::convertNAARaster2TLV(std::vector<LoadResourceArguments::ResourceData
         if (path.getDots() == ".." && rasterExts.contains(QString::fromStdString(path.getType()).toLower())) {
             if (!path.isAbsolute()) path = scene->decodeFilePath(path);
             TFilePath dstPath = path.getParentDir() + TFilePath(path.getName()).withType("tlv");
-            
-            if (askUser && !locals::checkConvertPolicy(path))continue;
             int from, to;
             TFilePath first;
             if (!locals::getRange(path, from, to, first)) continue;
             if (ImageUtils::isAAImage(first))continue;
+            if (askUser && !locals::checkConvertPolicy(path))continue;
             if (TSystem::doesExistFileOrLevel(dstPath)) {
                 OverwriteDialog dialog;
                 dstPath = dstPath.withName(dialog.execute(scene, dstPath, false));
@@ -2998,17 +2997,8 @@ void IoCmd::convertNAARaster2TLV(std::vector<LoadResourceArguments::ResourceData
                 }
             }
             Convert2Tlv converter(path, TFilePath(), dstPath.getParentDir(), QString::fromStdWString(dstPath.getWideName())
-<<<<<<< HEAD
-<<<<<<< HEAD
-                , from, to, false, TFilePath(), 20, 0, 50, false, true, scene->getCurrentCamera()->getDpi().x);
-=======
                 , from, to, false, TFilePath(), 0, 0, 50, false, true, 
                 Preferences::instance()->isIgnoreImageDpiEnabled() ? scene->getCurrentCamera()->getDpi().x : 0);
->>>>>>> 286a81638 (To Set Color)
-=======
-                , from, to, false, TFilePath(), 20, 0, 50, false, true, 
-                Preferences::instance()->isIgnoreImageDpiEnabled() ? scene->getCurrentCamera()->getDpi().x : 0);
->>>>>>> 0ea585f70 (Add AutoRename and Auto Convert Opetions when importing from .xdts)
             std::string e;
             converter.init(e);
             if (!e.empty()) {

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2989,7 +2989,7 @@ void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData
             if (!path.isAbsolute()) path = scene->decodeFilePath(path);
             TFilePath dstPath = scene->getDefaultLevelPath(TZP_XSHLEVEL, path.getWideName());
             dstPath = scene->decodeFilePath(dstPath);
-
+            
             if (!locals::checkConvertPolicy(path))continue;
             
             if (TSystem::doesExistFileOrLevel(dstPath)) {
@@ -3019,10 +3019,21 @@ void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData
 >>>>>>> 286a81638 (To Set Color)
             std::string e;
             converter.init(e);
-            if (!e.empty()) continue;
-            for (int i = 0; i < converter.getFramesToConvertCount(); ++i)converter.convertNext(e);
-            if (TSystem::doesExistFileOrLevel(dstPath))
-                path = scene->codeFilePath(dstPath);
+            if (!e.empty()) {
+                DVGui::warning(QString("Failed to Convert\n%1").arg(path.getQString()));
+                continue;
+            }
+            int count = converter.getFramesToConvertCount();
+            if (count) {
+                IoCmd::ConvertingPopup convertingPopup(
+                    TApp::instance()->getMainWindow(),
+                    path.getQString());
+                convertingPopup.show();
+                for (int i = 0; i < count; ++i)converter.convertNext(e);
+                convertingPopup.hide();
+                if (TSystem::doesExistFileOrLevel(dstPath))
+                    path = scene->codeFilePath(dstPath);
+            }
         }
     }
 }

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -67,6 +67,7 @@
 #include "toonz/imagestyles.h"
 #include "toutputproperties.h"
 #include "toonz/studiopalette.h"
+#include "convert2tlv.h"
 
 // TnzCore includes
 #include "tofflinegl.h"
@@ -287,6 +288,8 @@ public:
     return dstPath;
   }
 };
+
+class 
 
 //===========================================================================
 // getLevelByPath(scene, actualPath)
@@ -2430,84 +2433,6 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
     static bool isDir(const LoadResourceArguments::ResourceData &rd) {
       return QFileInfo(rd.m_path.getQString()).isDir();
     }
-
-    // call when loading levels
-    static bool matchSequencePattern(const TFilePath &path) {
-      QRegularExpression pattern(
-          R"(
-  ^                           # Match the start of the string
-  .*?                         # Optional prefix
-  \d+  # allow aFilePrefix<number>.ext,ignore if less than 10 and no padding
-  \.                          # Match a dot (.)
-  (png|jpg|jpeg|bmp|tga|tiff) # Image extensions
-  $                           # Match the end of the string
-)",
-          QRegularExpression::CaseInsensitiveOption |
-              QRegularExpression::ExtendedPatternSyntaxOption);
-      return pattern.match(QString::fromStdString(path.getLevelName()))
-          .hasMatch();
-    };
-
-    static bool checkRenamePolicy(const TFilePath &path) {
-      // TODO: Check the Preference Policy
-      switch (Preferences::instance()->getIntValue(renamePolicy)) {
-      case 0:
-        break;
-      case 1:
-        return true;
-      case 2:
-        return false;
-      }
-      QString label =
-          QObject::tr(
-              "OpenToonz uses an underscore (_) or dot (.) as a frame "
-              "separator.\n"
-              "Would you like to add a separator to the image sequence?\n"
-              "\n%1 (and similar files)")
-              .arg(path.getQString());
-      QString checkBoxLabel = QObject::tr("Always do this action.");
-      QStringList buttons;
-      buttons << QObject::tr("Yes")
-              << QObject::tr("No, treat as single frame.");
-      DVGui::MessageAndCheckboxDialog *renameDialog =
-          DVGui::createMsgandCheckbox(DVGui::QUESTION, label, checkBoxLabel,
-                                      buttons, 1, Qt::Unchecked);
-      int ret     = renameDialog->exec();
-      int checked = renameDialog->getChecked();
-      if (checked) {
-        Preferences::instance()->setValue(renamePolicy, ret);
-        TApp::instance()->getCurrentScene()->notifyImportPolicyChanged(ret);
-      }
-      return ret == 1;
-    };
-
-    static bool isSharingSameParam(const TFilePath &path1,
-                                   const TFilePath &path2) {
-      std::wstring str1 = path1.getWideName();  // base name
-      std::wstring str2 = path2.getWideName();
-
-      str1.erase(std::remove_if(str1.begin(), str1.end(), ::iswdigit),
-                 str1.end());
-      str2.erase(std::remove_if(str2.begin(), str2.end(), ::iswdigit),
-                 str2.end());
-
-      return str1 == str2;
-    }
-
-    static TFilePath getLevelPath(TFilePath path) {
-      std::wstring levelBaseName = path.getWideName();
-
-      int i = levelBaseName.size();
-      while (i > 0 && std::iswdigit(levelBaseName[i - 1])) {
-        --i;
-      }
-      levelBaseName = levelBaseName.substr(0, i);
-
-      if (!levelBaseName.size())
-        levelBaseName = path.getParentDir().getWideName();
-      return path.withName(levelBaseName).withFrame();
-    }
-
   };  // locals
 
   if (args.resourceDatas.empty()) return 0;
@@ -2556,260 +2481,200 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
                                   LoadResourceArguments::IMPORT);
   }
 
-  std::vector<TFilePath> paths;
   int all = 0;  // Turn on to allow all duplicate
+  std::vector<LoadResourceArguments::ResourceData> rds;//Resources to be loaded
 
-  // Loop for all the resources to load
+  // Loop for all the resources to import (Include subScene)
   for (int r = 0; r < rCount; ++r) {
-    if (importDialog.aborted()) break;
+      if (importDialog.aborted()) break;
 
-    QString origName =
-        args.resourceDatas[r].m_path.withoutParentDir().getQString();
+      LoadResourceArguments::ResourceData rd(args.resourceDatas[r]);
+      TFilePath& path = rd.m_path;
+      QString origName = path.withoutParentDir().getQString();
 
-    LoadResourceArguments::ResourceData rd(args.resourceDatas[r]);
-    TFilePath &path = rd.m_path;
+      if (!path.isLevelName())
+          path = TFilePath(path.getLevelNameW()).withParentDir(path.getParentDir());
 
-    if (!rd.m_path.isLevelName())
-      path = TFilePath(path.getLevelNameW()).withParentDir(path.getParentDir());
-
-    if (std::find(paths.begin(), paths.end(), path) != paths.end()) {
-      if (!all) {
-        QString question =
-            QObject::tr(
-                "File '%1' will reload level '%2' as a duplicate column in the "
-                "xsheet.\n\nAllow duplicate?")
-                .arg(origName)
-                .arg(QString::fromStdString(path.getName()));
-        QString Yes    = QObject::tr("Allow");
-        QString YesAll = QObject::tr("Allow All Dups");
-        QString No     = QObject::tr("No");
-        QString NoAll  = QObject::tr("No to All Dups");
-        int ret        = DVGui::MsgBox(question, Yes, YesAll, No, NoAll, 0);
-        switch (ret) {
-        case 2:
-          all = 1;  // YesAll
-        case 1:
-          break;  // Yes
-        case 4:
-          all = 2;  // NoAll
-        case 3:
-          continue;
-        }
-      } else if (all == 2)
-        continue;
-    }
-    paths.push_back(path);
-
-    if (progressDialog) {
-      if (progressDialog->wasCanceled())
-        break;
-      else {
-        progressDialog->setLabelText(
-            DVGui::ProgressDialog::tr("Loading \"%1\"...")
-                .arg(path.getQString()));
-        progressDialog->setValue(r);
-
-        QCoreApplication::processEvents();
-      }
-    }
-
-    bool isLastResource = (r == rCount - 1);
-    importDialog.setIsLastResource(isLastResource);
-
-    bool isScene = (TFileType::getInfo(path) == TFileType::TOONZSCENE);
-
-    if (scene->isExternPath(path) || isScene) {
-      // extern resource: import or link?
-      int ret = importDialog.askImportQuestion(path);
-      if (ret == ResourceImportDialog::A_CANCEL) break;
-    }
-
-    // for the scene file
-    TXshLevel *xl = 0;
-    if (isScene) {
-      TFilePath oldDstFolder = importDialog.getDstFolder();
-      TFilePath dstFolder = (Preferences::instance()->isSubsceneFolderEnabled())
-                                ? TFilePath(path.getName())
-                                : TFilePath();
-
-      importDialog.setDstFolder(dstFolder);
-      importDialog.setIsLastResource(false);
-
-      // load the scene as subXsheet
-      try {
-        xl = loadChildLevel(scene, path, row0, col0, importDialog);
-        if (dstFolder != TFilePath())
-          app->getCurrentScene()->notifyCastFolderAdded(
-              scene->getLevelSet()->getDefaultFolder() + dstFolder);
-        // increment the number of resources actually loaded
-        ++loadedCount;
-        // move the column to the right
-        ++col0;
-        // register the loaded level to args
-        args.loadedLevels.push_back(xl);
-        app->getCurrentXsheet()->notifyXsheetSoundChanged();
-      } catch (...) {
-      }
-
-      importDialog.setIsLastResource(isLastResource);
-      importDialog.setDstFolder(oldDstFolder);
-
-      app->getCurrentColumn()->setColumnIndex(col0);
-
-      continue;
-    }
-    // for single level files
-    else if (path.getSepChar().isNull()) {
-      // for single frame
-      if (rCount == 1) {
-        try {
-          path = importDialog.process(scene, 0, path);
-        } catch (std::string msg) {
-          error(QString::fromStdString(msg));
-          continue;
-        }
-      }
-      // for sequence
-      else if (locals::matchSequencePattern(path) &&
-               locals::checkRenamePolicy(path)) {
-        TFilePathSet files;
-        TFilePath backup    = scene->codeFilePath(path);
-        TFilePath levelPath = locals::getLevelPath(path);
-        progressDialog->setLabelText(
-            QString("Loading \"%1\"...")
-                .arg(levelPath.withFrame().getQString()));
-        // Check for Existing Level
-        if (TSystem::doesExistFileOrLevel(levelPath)) {
-          OverwriteDialog dialog;
-          levelPath.withName(dialog.execute(scene, levelPath, false));
-
-          switch (dialog.getChoice()) {
-          case OverwriteDialog::KEEP_OLD:
-            while (r < rCount) {
-              path = args.resourceDatas[r].m_path;
-              if (backup.getParentDir() != path.getParentDir()) break;
-              if (!locals::isSharingSameParam(backup, path)) break;
-              ++r;
-            }
-            --r;
-            continue;
-
-          case OverwriteDialog::OVERWRITE :
-            TSystem::removeFileOrLevel(levelPath);
-          default :
-            break;
+      // duplicate check
+      auto isDuplicate = [&rd](const IoCmd::LoadResourceArguments::ResourceData& existingRd) {
+          return existingRd.m_path == rd.m_path;
+          };
+      if (std::find_if(rds.begin(), rds.end(), isDuplicate) != rds.end()) {
+          if (!all) {
+              QString question =
+                  QObject::tr(
+                      "File '%1' will reload level '%2' as a duplicate column in the "
+                      "xsheet.\n\nAllow duplicate?")
+                  .arg(origName)
+                  .arg(QString::fromStdString(path.getName()));
+              QString Yes = QObject::tr("Allow");
+              QString YesAll = QObject::tr("Allow All Dups");
+              QString No = QObject::tr("No");
+              QString NoAll = QObject::tr("No to All Dups");
+              int ret = DVGui::MsgBox(question, Yes, YesAll, No, NoAll, 0);
+              switch (ret) {
+              case 2:
+                  all = 1;  // YesAll
+              case 1:
+                  break;  // Yes
+              case 4:
+                  all = 2;  // NoAll
+              case 3:
+                  continue;
+              }
           }
-        }
-        // Load or Import the files
-        while (r < rCount) {
-          path = args.resourceDatas[r].m_path;
-          progressDialog->setValue(r);
+          else if (all == 2)
+              continue;
+      }
+
+      rds.push_back(rd);
+
+      if (progressDialog) {
+          if (progressDialog->wasCanceled())
+              break;
+          else {
+              progressDialog->setLabelText(
+                  DVGui::ProgressDialog::tr("Importing \"%1\"...")
+                  .arg(path.getQString()));
+              progressDialog->setValue(r);
+
+              QCoreApplication::processEvents();
+          }
+      }
+
+      bool isLastResource = (r == rCount - 1);
+      importDialog.setIsLastResource(isLastResource);
+
+      bool isScene = (TFileType::getInfo(path) == TFileType::TOONZSCENE);
+
+      if (scene->isExternPath(path) || isScene) {
+          // extern resource: import or link?
+          int ret = importDialog.askImportQuestion(path);
+          if (ret == ResourceImportDialog::A_CANCEL) break;
+      }
+
+      // SCENE FILE
+      if (isScene) {
+          TFilePath oldDstFolder = importDialog.getDstFolder();
+          TFilePath dstFolder = (Preferences::instance()->isSubsceneFolderEnabled())
+              ? TFilePath(path.getName())
+              : TFilePath();
+
+          importDialog.setDstFolder(dstFolder);
+          importDialog.setIsLastResource(false);
+
+          // load the scene as subXsheet
           try {
-            path = importDialog.process(scene, 0, path);
-          } catch (std::string msg) {
-            error(QString::fromStdString(msg));
-            continue;
+              auto xl = loadChildLevel(scene, path, row0, col0, importDialog);
+              if (dstFolder != TFilePath())
+                  app->getCurrentScene()->notifyCastFolderAdded(
+                      scene->getLevelSet()->getDefaultFolder() + dstFolder);
+              // increment the number of resources actually loaded
+              ++loadedCount;
+              // move the column to the right
+              ++col0;
+              // register the loaded level to args
+              args.loadedLevels.push_back(xl);
+              app->getCurrentXsheet()->notifyXsheetSoundChanged();
+          } catch (...){}
+
+          importDialog.setIsLastResource(isLastResource);
+          importDialog.setDstFolder(oldDstFolder);
+
+          app->getCurrentColumn()->setColumnIndex(col0);
+
+          continue;
+      }
+      // LEVEL FILE
+      else {
+          try {
+              path = importDialog.process(scene, 0, path);
+          }
+          catch (std::string msg) {
+              error(QString::fromStdString(msg));
+              continue;
           }
           if (importDialog.aborted()) break;
-          // and Same parent folder
-          if ((backup.getParentDir() != path.getParentDir()) ||
-              (!locals::isSharingSameParam(backup, path))) {
-            --r;
-            break;
+      }
+  }
+
+  if(args.renamePolicy != LoadResourceArguments::RenamePolicy::NEVER)
+      tryRenameResouces(rds);
+  if(args.convertPolicy != LoadResourceArguments::ConvertPolicy::NEVER)
+      tryConvertRaster2TLV(rds);
+
+  if (progressDialog)
+      progressDialog->setMaximum(rds.size());
+  // LOAD IMPORTED FILE
+  for (int i = 0; i < rds.size(); ++i) {
+      TXshLevel* xl = 0;
+      TFilePath path = rds[i].m_path;
+
+      if (progressDialog) {
+          if (progressDialog->wasCanceled())
+              break;
+          else {
+              progressDialog->setLabelText(
+                  DVGui::ProgressDialog::tr("Loading \"%1\"...")
+                  .arg(path.getQString()));
+              progressDialog->setValue(i);
+
+              QCoreApplication::processEvents();
           }
-          files.push_back(path);
-          ++r;
-        }
-        if (importDialog.aborted()) break;
-        if(TSystem::renameImageSequence(
-            files, levelPath,
-            backup.getWideName().substr(0,
-                backup.getWideName().find_last_not_of(L"0123456789") + 1)
-                    .size())) {
-          QCoreApplication::processEvents();
-          path = levelPath;
-        } else {
-          // Failed to rename Files
-          DVGui::warning(QString("Failed to rename files!"));
-          break;
-        }
-        
       }
-    }
-    // for other level files
-    else {
+      // LOAD PSD FILE
+      if (path.getType() == "psd") {
+          static PsdSettingsPopup* popup = 0;
+          if (!popup) {
+              popup = new PsdSettingsPopup();
+          }
+          popup->setPath(path);
+
+          int ret = popup->exec();
+          if (ret == 0) continue;
+
+          loadedCount += loadPSDResource(args, updateRecentFile, popup);
+
+          if (updateRecentFile)
+              RecentFiles::instance()->addFilePath(
+                  toQString(scene->decodeFilePath(path)), RecentFiles::Level);
+          continue;
+      }
+      // LOAD OTHER FILE
       try {
-        path = importDialog.process(scene, 0, path);
-        // path = scene->decodeFilePath(codedPath);
-      } catch (std::string msg) {
-        error(QString::fromStdString(msg));
-        continue;
+          // reuse TFrameIds retrieved by FileBrowser, m_frameIdSet
+          xl = ::loadResource(
+              scene, rds[i], args.castFolder, row0, col0, row1, col1, args.expose,
+              rds[i].m_frameIdSet,
+              args.xFrom, args.xTo, args.levelName, args.step, args.inc,
+              args.frameCount, args.doesFileActuallyExist);
+          if (updateRecentFile) {
+              RecentFiles::instance()->addFilePath(
+                  toQString(scene->decodeFilePath(path)), RecentFiles::Level);
+          }
+      } catch (TException& e) {
+          error(QString::fromStdWString(e.getMessage()));
       }
 
-      if (importDialog.aborted()) break;
-    }
-
-    if (path.getType() == "psd") {
-      static PsdSettingsPopup *popup = 0;
-      if (!popup) {
-        popup = new PsdSettingsPopup();
-      }
-      popup->setPath(path);
-
-      int ret = popup->exec();
-      if (ret == 0) continue;
-
-      loadedCount += loadPSDResource(args, updateRecentFile, popup);
-
-      if (updateRecentFile)
-        RecentFiles::instance()->addFilePath(
-            toQString(scene->decodeFilePath(path)), RecentFiles::Level);
-    } else {
-      // reuse TFrameIds retrieved by FileBrowser
-      std::vector<TFrameId> fIds;
-      if ((int)args.frameIdsSet.size() > r)  // if there is fIds to be reused
-      {
-        fIds = args.frameIdsSet[r];
-      }
-
-      try {
-        xl = ::loadResource(
-            scene, rd, args.castFolder, row0, col0, row1, col1, args.expose,
-#if (__cplusplus > 199711L)
-            std::move(fIds),
-#else
-            fIds,
-#endif
-            args.xFrom, args.xTo, args.levelName, args.step, args.inc,
-            args.frameCount, args.doesFileActuallyExist);
-        if (updateRecentFile) {
-          RecentFiles::instance()->addFilePath(
-              toQString(scene->decodeFilePath(path)), RecentFiles::Level);
-        }
-      } catch (TException &e) {
-        error(QString::fromStdWString(e.getMessage()));
-      }
       // if load success
-      if (xl) {
-        isSoundLevel = isSoundLevel || xl->getType() == SND_XSHLEVEL;
-        // register the loaded level to args
-        args.loadedLevels.push_back(xl);
-        // increment the number of loaded resources
-        ++loadedCount;
+      if (!xl)continue;
+      isSoundLevel = isSoundLevel || xl->getType() == SND_XSHLEVEL;
+      // register the loaded level to args
+      args.loadedLevels.push_back(xl);
+      // increment the number of loaded resources
+      ++loadedCount;
 
-        // load the image data of all frames to cache at the beginning
-        if (args.cachingBehavior != LoadResourceArguments::ON_DEMAND) {
-          TXshSimpleLevel *simpleLevel = xl->getSimpleLevel();
+      // load the image data of all frames to cache at the beginning
+      if (args.cachingBehavior != LoadResourceArguments::ON_DEMAND) {
+          TXshSimpleLevel* simpleLevel = xl->getSimpleLevel();
           if (simpleLevel && (simpleLevel->getType() == TZP_XSHLEVEL ||
-                              simpleLevel->getType() == OVL_XSHLEVEL)) {
-            bool cacheImagesAsWell =
-                (args.cachingBehavior ==
-                 LoadResourceArguments::ALL_ICONS_AND_IMAGES);
-            simpleLevel->loadAllIconsAndPutInCache(cacheImagesAsWell);
+              simpleLevel->getType() == OVL_XSHLEVEL)) {
+              bool cacheImagesAsWell =
+                  (args.cachingBehavior ==
+                      LoadResourceArguments::ALL_ICONS_AND_IMAGES);
+              simpleLevel->loadAllIconsAndPutInCache(cacheImagesAsWell);
           }
-        }
       }
-    }
   }
 
   if (loadedCount) app->getCurrentFrame()->setFrameIndex(row0);
@@ -2819,7 +2684,7 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
 
   // revert the cursor
   if (args.cachingBehavior == LoadResourceArguments::ALL_ICONS_AND_IMAGES)
-    QApplication::restoreOverrideCursor();
+      QApplication::restoreOverrideCursor();
 
   return loadedCount;
 }
@@ -2933,6 +2798,233 @@ bool IoCmd::importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
   }
 
   return true;
+}
+
+void IoCmd::tryRenameResouces(std::vector<LoadResourceArguments::ResourceData>& rds) {
+    struct locals {
+        // call when loading levels
+        static bool matchSequencePattern(const TFilePath& path) {
+            QRegularExpression pattern(
+                R"(
+  ^                           # Match the start of the string
+  .*?                         # Optional prefix
+  \d+                         # allow aFilePrefix<number>.ext
+  \.                          # Match a dot (.)
+  (png|jpg|jpeg|bmp|tga|tiff) # Image extensions
+  $                           # Match the end of the string
+)",
+QRegularExpression::CaseInsensitiveOption |
+QRegularExpression::ExtendedPatternSyntaxOption);
+            return pattern.match(QString::fromStdString(path.getLevelName()))
+                .hasMatch();
+        };
+
+        static bool checkRenamePolicy(const TFilePath& path) {
+            // TODO: Check the Preference Policy
+            switch (Preferences::instance()->getIntValue(renamePolicy)) {
+            case 0:
+                break;
+            case 1:
+                return true;
+            case 2:
+                return false;
+            }
+            QString label =
+                QObject::tr(
+                    "OpenToonz uses an underscore (_) or dot (.) as a frame "
+                    "separator.\n"
+                    "Would you like to add a separator to the image sequence?\n"
+                    "\n%1 (and similar files)")
+                .arg(path.getQString());
+            QString checkBoxLabel = QObject::tr("Always do this action.");
+            QStringList buttons;
+            buttons << QObject::tr("Yes")
+                << QObject::tr("No, treat as single frame.");
+            DVGui::MessageAndCheckboxDialog* renameDialog =
+                DVGui::createMsgandCheckbox(DVGui::QUESTION, label, checkBoxLabel,
+                    buttons, 1, Qt::Unchecked);
+            int ret = renameDialog->exec();
+            int checked = renameDialog->getChecked();
+            if (checked) {
+                Preferences::instance()->setValue(renamePolicy, ret);
+                TApp::instance()->getCurrentScene()->notifyImportPolicyChanged(ret);
+            }
+            return ret == 1;
+        };
+
+        static bool isSharingSameParam(const TFilePath& path1,
+            const TFilePath& path2) {
+            std::wstring str1 = path1.getWideName();  // base name
+            std::wstring str2 = path2.getWideName();
+
+            str1.erase(std::remove_if(str1.begin(), str1.end(), ::iswdigit),
+                str1.end());
+            str2.erase(std::remove_if(str2.begin(), str2.end(), ::iswdigit),
+                str2.end());
+
+            return str1 == str2;
+        }
+
+        static TFilePath getLevelPath(TFilePath path) {
+            std::wstring levelBaseName = path.getWideName();
+
+            int i = levelBaseName.size();
+            while (i > 0 && std::iswdigit(levelBaseName[i - 1])) {
+                --i;
+            }
+            levelBaseName = levelBaseName.substr(0, i);
+
+            if (!levelBaseName.size())
+                levelBaseName = path.getParentDir().getWideName();
+            return path.withName(levelBaseName).withFrame();
+        }
+    };  // locals
+
+    TApp* app = TApp::instance();
+    ToonzScene* scene = app->getCurrentScene()->getScene();
+    for (auto rd = rds.begin(); rd != rds.end();++rd) {
+        TFilePath& path = rd->m_path;
+        if (!locals::matchSequencePattern(path) ||
+            !locals::checkRenamePolicy(path)) continue;
+        TFilePath levelPath = locals::getLevelPath(path);
+        if (TSystem::doesExistFileOrLevel(levelPath)) {
+            OverwriteDialog dialog;
+            levelPath = levelPath.withName(dialog.execute(scene, levelPath, false));
+            if (dialog.getChoice() == OverwriteDialog::OVERWRITE)
+                TSystem::removeFileOrLevel(levelPath);
+        }
+        TFilePath &currentPath = rd->m_path;
+        TFilePathSet files;
+        files.push_back(currentPath);
+        auto nextRd = rd;
+        nextRd++;
+        for (; nextRd != rds.end();) {
+            if ((currentPath.getParentDir() == nextRd->m_path.getParentDir()) &&
+                (locals::isSharingSameParam(currentPath, nextRd->m_path))) {
+                files.push_back(nextRd->m_path);
+                nextRd = rds.erase(nextRd);
+            }
+            else break;
+        }
+        if (files.empty())continue;
+        if (TSystem::renameImageSequence(
+            files, levelPath,
+            currentPath.getWideName().substr(0,
+                currentPath.getWideName().find_last_not_of(L"0123456789") + 1)
+            .size())) {
+            QCoreApplication::processEvents();
+            currentPath = levelPath;
+        } else {
+            // Failed to rename Files
+            DVGui::warning(QString("Failed to rename files!\n%1").arg(rd->m_path.getQString()));
+            break;
+        }
+    }
+}
+
+void IoCmd::tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds) {
+    struct locals {
+        static bool checkConvertPolicy(const TFilePath& path) {
+            // TODO: Check the Preference Policy for conversion
+            switch (Preferences::instance()->getIntValue(convertPolicy)) {
+            case 0:
+                break;  // Ask every time
+            case 1:
+                return true;  // Always convert
+            case 2:
+                return false; // Never convert
+            }
+
+            QString label = QObject::tr(
+                "%1\n\nis an image sequence that can be converted into a TLV format "
+                "\nWould you like to convert it?")
+                .arg(path.getQString());
+
+            QString checkBoxLabel = QObject::tr("Always do this action.");
+            QStringList buttons;
+            buttons << QObject::tr("Yes") << QObject::tr("No, use as is");
+
+            DVGui::MessageAndCheckboxDialog* convertDialog =
+                DVGui::createMsgandCheckbox(DVGui::QUESTION, label, checkBoxLabel,
+                    buttons, 1, Qt::Unchecked);
+
+            int ret = convertDialog->exec();
+            int checked = convertDialog->getChecked();
+
+            if (checked) {
+                Preferences::instance()->setValue(convertPolicy, ret);
+                TApp::instance()->getCurrentScene()->notifyImportPolicyChanged(ret);
+            }
+
+            return ret == 1;
+        }
+
+        static bool getRange(const TFilePath& path, int& from, int& to) {
+            TLevelP levelTmp;
+            TLevelReaderP lrTmp = TLevelReaderP(path);
+            if (lrTmp) {
+                levelTmp = lrTmp->loadInfo();
+                TLevel::Table* t = levelTmp->getTable();
+                if (!t->empty()) {
+                    TFrameId start = t->begin()->first;
+                    TFrameId end = t->rbegin()->first;
+                    if (start.getNumber() >= 0 && end.getNumber() >= 0) {
+                        from = start.getNumber();
+                        to = end.getNumber();
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    };//Locals
+
+    static const QStringList rasterExts = {
+      "png", "jpg", "jpeg", "bmp", "tga" };
+    TApp* app = TApp::instance();
+    ToonzScene* scene = app->getCurrentScene()->getScene();
+    for (auto &rd : rds) {
+        TFilePath& path = rd.m_path;
+        if (path.getDots() == ".." && rasterExts.contains(QString::fromStdString(path.getType()).toLower())) {
+            if (!path.isAbsolute()) path = scene->decodeFilePath(path);
+            TFilePath dstPath = scene->getDefaultLevelPath(TZP_XSHLEVEL, path.getWideName());
+            dstPath = scene->decodeFilePath(dstPath);
+
+            if (!locals::checkConvertPolicy(path))continue;
+            
+            if (TSystem::doesExistFileOrLevel(dstPath)) {
+                OverwriteDialog dialog;
+                dstPath = dstPath.withName(dialog.execute(scene, dstPath, false));
+
+                switch (dialog.getChoice()) {
+                case OverwriteDialog::RENAME:
+                case OverwriteDialog::KEEP_OLD:
+                    continue;
+                case OverwriteDialog::OVERWRITE:
+                    TSystem::removeFileOrLevel(dstPath);
+                    TSystem::removeFileOrLevel(dstPath.withType("tpl"));
+                    break;
+                default:
+                    continue;
+                }
+            }
+            int from, to;
+            if(!locals::getRange(path, from, to)) continue;
+            Convert2Tlv converter(path, TFilePath(), dstPath.getParentDir(), QString::fromStdWString(dstPath.getWideName())
+<<<<<<< HEAD
+                , from, to, false, TFilePath(), 20, 0, 50, false, true, scene->getCurrentCamera()->getDpi().x);
+=======
+                , from, to, false, TFilePath(), 0, 0, 50, false, true, 
+                Preferences::instance()->isIgnoreImageDpiEnabled() ? scene->getCurrentCamera()->getDpi().x : 0);
+>>>>>>> 286a81638 (To Set Color)
+            std::string e;
+            converter.init(e);
+            if (!e.empty()) continue;
+            for (int i = 0; i < converter.getFramesToConvertCount(); ++i)converter.convertNext(e);
+            if (TSystem::doesExistFileOrLevel(dstPath))
+                path = scene->codeFilePath(dstPath);
+        }
+    }
 }
 
 //===========================================================================

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2968,6 +2968,7 @@ void IoCmd::convertNAARaster2TLV(std::vector<LoadResourceArguments::ResourceData
       "png", "jpg", "jpeg", "bmp", "tga" };
     TApp* app = TApp::instance();
     ToonzScene* scene = app->getCurrentScene()->getScene();
+    IoCmd::ConvertingPopup convertingPopup(TApp::instance()->getMainWindow(),0);
     for (auto &rd : rds) {
         TFilePath& path = rd.m_path;
         if (path.getDots() == ".." && rasterExts.contains(QString::fromStdString(path.getType()).toLower())) {
@@ -3016,10 +3017,9 @@ void IoCmd::convertNAARaster2TLV(std::vector<LoadResourceArguments::ResourceData
             }
             int count = converter.getFramesToConvertCount();
             if (count) {
-                IoCmd::ConvertingPopup convertingPopup(
-                    TApp::instance()->getMainWindow(),
-                    path.withoutParentDir().getQString());
+                convertingPopup.reset();
                 convertingPopup.setMaximum(count);
+                convertingPopup.setName(path.withoutParentDir().getQString());
                 convertingPopup.show();
                 for (int i = 0; i < count; ++i){
                     converter.convertNext(e);
@@ -3029,7 +3029,7 @@ void IoCmd::convertNAARaster2TLV(std::vector<LoadResourceArguments::ResourceData
                         break;
                     }
                 }
-                convertingPopup.hide();
+                //convertingPopup.hide();
                 if (TSystem::doesExistFileOrLevel(dstPath))
                     path = scene->codeFilePath(dstPath);
             }

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -190,7 +190,7 @@ public:
 
 class ConvertingPopup final : public DVGui::ProgressDialog {
 public:
-    IoCmd::ConvertingPopup::ConvertingPopup(QWidget* parent, QString fileName) 
+    ConvertingPopup(QWidget* parent, QString fileName) 
         : ProgressDialog(QString(
         QObject::tr("Converting %1 to tlv format...").arg(fileName)), 
             "Cancel", 0, 1, parent) {

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -15,6 +15,9 @@
 // Qt includes
 #include <QDialog>
 
+// TnzQt includes
+#include "toonzqt/dvdialog.h"
+
 // boost includes
 #include <boost/optional.hpp>
 
@@ -185,10 +188,15 @@ public:
 
 //------------------------------------------------------------------------
 
-class ConvertingPopup final : public QDialog {
+class ConvertingPopup final : public DVGui::ProgressDialog {
 public:
-  ConvertingPopup(QWidget *parent, QString fileName);
-  ~ConvertingPopup();
+    IoCmd::ConvertingPopup::ConvertingPopup(QWidget* parent, QString fileName) :ProgressDialog(QString(
+        QObject::tr("Converting %1 to tlv format...").arg(fileName)), "Cancel", 0, 1, parent) {
+    };
+    ~ConvertingPopup() {};
+    void setName(QString fileName) {
+        ProgressDialog::setLabelText(QObject::tr("Converting %1 to tlv format...")
+            .arg(fileName)); };
 };
 
 //------------------------------------------------------------------------
@@ -252,7 +260,12 @@ int loadResourceFolders(
         0  //!< Load block. May be nonzero in order to extend block data
            //!  access and finalization.
 );         //!< Loads the specified folders in current xsheet.
-           //!  \return  The actually loaded levels count.
+           //!  \return  The actually loaded levels count.           
+
+void renameResources(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser = true);
+
+void convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser = true);
+
 bool exposeLevel(TXshSimpleLevel *sl, int row, int col, bool insert = false,
                  bool overWrite = false);
 bool exposeLevel(TXshSimpleLevel *sl, int row, int col,
@@ -271,10 +284,6 @@ bool exposeComment(int row, int &col, QList<QString> commentList,
 
 bool importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
                    QList<QString> commentList, QString fileName);
-
-void tryRenameResouces(std::vector<LoadResourceArguments::ResourceData>& rds);
-
-void tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds);
 // If the scene will be saved in the different folder, check out the scene
 // cast.
 // if the cast contains the level specified with $scenefolder alias,

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -190,8 +190,10 @@ public:
 
 class ConvertingPopup final : public DVGui::ProgressDialog {
 public:
-    IoCmd::ConvertingPopup::ConvertingPopup(QWidget* parent, QString fileName) :ProgressDialog(QString(
-        QObject::tr("Converting %1 to tlv format...").arg(fileName)), "Cancel", 0, 1, parent) {
+    IoCmd::ConvertingPopup::ConvertingPopup(QWidget* parent, QString fileName) 
+        : ProgressDialog(QString(
+        QObject::tr("Converting %1 to tlv format...").arg(fileName)), 
+            "Cancel", 0, 1, parent) {
     };
     ~ConvertingPopup() {};
     void setName(QString fileName) {
@@ -262,9 +264,11 @@ int loadResourceFolders(
 );         //!< Loads the specified folders in current xsheet.
            //!  \return  The actually loaded levels count.           
 
-void renameResources(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser = true);
+void renameResources(std::vector<LoadResourceArguments::ResourceData>& rds, 
+    bool askUser = true);
 
-void convertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds, bool askUser = true);
+void convertNAARaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds, 
+    bool askUser = true);
 
 bool exposeLevel(TXshSimpleLevel *sl, int row, int col, bool insert = false,
                  bool overWrite = false);

--- a/toonz/sources/toonz/iocommand.h
+++ b/toonz/sources/toonz/iocommand.h
@@ -85,6 +85,9 @@ struct LoadResourceArguments {
   {
     TFilePath m_path;  //!< Path of the resource to be loaded.
 
+    // reuse TFrameIds retrieved by FileBrowser
+    std::vector<TFrameId> m_frameIdSet;
+
     boost::optional<LevelOptions>
         m_options;  //!< User-defined properties to be applied as a level.
 
@@ -101,12 +104,21 @@ struct LoadResourceArguments {
     LOAD,      //!< Resources are loaded from their original paths.
   };
 
+  enum class RenamePolicy {
+      ASK_USER,
+      RENAME,
+      NEVER,
+  };
+  
+  enum class ConvertPolicy {
+      ASK_USER,
+      CONVERT,
+      NEVER,
+  };
+
 public:
   std::vector<ResourceData>
       resourceDatas;  //!< [\p In/Out]  Data identifying a single resource.
-
-  // reuse TFrameIds retrieved by FileBrowser
-  std::vector<std::vector<TFrameId>> frameIdsSet;
 
   TFilePath castFolder;  //!< [\p In]      Cast panel folder where the resources
                          //! will be inserted.
@@ -122,6 +134,9 @@ public:
 
   ImportPolicy importPolicy;  //!< [\p In]      Policy adopted for resources
                               //! external to current scene.
+  RenamePolicy renamePolicy;  
+  ConvertPolicy convertPolicy; // Convert Raster to TLV
+
   bool expose;  //!< [\p In]      Whether resources must be exposed in the
                 //! xsheet.
 
@@ -151,6 +166,10 @@ public:
       , col1(-1)
       , importPolicy(static_cast<ImportPolicy>(
             Preferences::instance()->getDefaultImportPolicy()))
+      , renamePolicy(static_cast<RenamePolicy>(
+            Preferences::instance()->getDefaultRenamePolicy()))
+      , convertPolicy(static_cast<ConvertPolicy>(
+            Preferences::instance()->getDefaultConvertPolicy()))
       , expose(Preferences::instance()->isAutoExposeEnabled())
       , xFrom(-1)
       , xTo(-1)
@@ -253,6 +272,9 @@ bool exposeComment(int row, int &col, QList<QString> commentList,
 bool importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
                    QList<QString> commentList, QString fileName);
 
+void tryRenameResouces(std::vector<LoadResourceArguments::ResourceData>& rds);
+
+void tryConvertRaster2TLV(std::vector<LoadResourceArguments::ResourceData>& rds);
 // If the scene will be saved in the different folder, check out the scene
 // cast.
 // if the cast contains the level specified with $scenefolder alias,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1263,7 +1263,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Loading
       {importPolicy, tr("Default File Import Behavior:")},
       {renamePolicy, tr("Normalize Imported Image Sequences:")},
-      {convertPolicy, tr("Convert Imported Image Sequences to TLV:")},
+      {convertPolicy, tr("Convert Imported NAA Image Sequences to TLV:")},
       {autoExposeEnabled, tr("Expose Loaded Levels in Xsheet")},
       {autoRemoveUnusedLevels,
        tr("Automatically Remove Unused Levels From Scene Cast")},

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -965,6 +965,15 @@ void PreferencesPopup::onRenamePolicyExternallyChanged(int policy) {
   // update preferences data accordingly
   renamePolicyCombo->setCurrentIndex(policy);
 }
+
+//-----------------------------------------------------------------------------
+
+void PreferencesPopup::onConvertPolicyExternallyChanged(int policy) {
+    QComboBox* convertPolicyCombo = getUI<QComboBox*>(importPolicy);
+    // update preferences data accordingly
+    convertPolicyCombo->setCurrentIndex(policy);
+}
+
 //-----------------------------------------------------------------------------
 
 QWidget* PreferencesPopup::createUI(PreferencesItemId id,
@@ -1254,6 +1263,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Loading
       {importPolicy, tr("Default File Import Behavior:")},
       {renamePolicy, tr("Normalize Imported Image Sequences:")},
+      {convertPolicy, tr("Convert Imported Image Sequences to TLV:")},
       {autoExposeEnabled, tr("Expose Loaded Levels in Xsheet")},
       {autoRemoveUnusedLevels,
        tr("Automatically Remove Unused Levels From Scene Cast")},
@@ -1454,6 +1464,10 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
        {{tr("Always ask before renaming"), 0},
         {tr("Normalize sequence names automatically"), 1},
         {tr("Keep original filenames"), 2}}},
+        {convertPolicy,
+        {{tr("Always ask before converting"), 0},
+        {tr("Convert raster level automatically"), 1},
+        {tr("Do not convert"), 2}}},
       {rasterLevelCachingBehavior,
        {{tr("On Demand"), 0},
         {tr("All Icons"), 1},
@@ -1827,6 +1841,7 @@ QWidget* PreferencesPopup::createLoadingPage() {
 
   insertUI(importPolicy, lay, getComboItemList(importPolicy));
   insertUI(renamePolicy, lay, getComboItemList(renamePolicy));
+  insertUI(convertPolicy, lay, getComboItemList(convertPolicy));
   QGridLayout* autoExposeLay = insertGroupBoxUI(autoExposeEnabled, lay);
   { insertUI(autoRemoveUnusedLevels, autoExposeLay); }
   insertUI(subsceneFolderEnabled, lay);
@@ -1866,6 +1881,9 @@ QWidget* PreferencesPopup::createLoadingPage() {
   ret = ret && connect(TApp::instance()->getCurrentScene(),
                        SIGNAL(importPolicyChanged(int)), this,
                        SLOT(onImportPolicyExternallyChanged(int)));
+  ret = ret && connect(TApp::instance()->getCurrentScene(),
+                       SIGNAL(convertPolicyChanged(int)), this,
+                       SLOT(onConvertPolicyExternallyChanged(int)));
   ret = ret && connect(TApp::instance()->getCurrentScene(),
                        SIGNAL(renamePolicyChanged(int)), this,
                        SLOT(onRenamePolicyExternallyChanged(int)));

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -179,6 +179,7 @@ private slots:
   void onLevelFormatEdited();
   void onImportPolicyExternallyChanged(int policy);
   void onRenamePolicyExternallyChanged(int policy);
+  void onConvertPolicyExternallyChanged(int policy);
 };
 
 //**********************************************************************************

--- a/toonz/sources/toonz/xdtsimportpopup.cpp
+++ b/toonz/sources/toonz/xdtsimportpopup.cpp
@@ -217,7 +217,7 @@ void XDTSImportPopup::onPathChanged() {
   FileField* fileField = dynamic_cast<FileField*>(sender());
   if (!fileField) return;
   QString levelName = m_fields.key(fileField);
-  // make the field non-suggestive
+  // make the fields non-suggestive
   m_pathSuggestedLevels.removeAll(levelName);
 
   // if the path is specified under the sub-folder with the same name as the
@@ -263,6 +263,7 @@ void XDTSImportPopup::updateSuggestions(const QString samplePath) {
   }
 
   QMap<QString, FileField*>::iterator fieldsItr = m_fields.begin();
+  bool suggested = false;
   while (fieldsItr != m_fields.end()) {
     QString levelName    = fieldsItr.key();
     FileField* fileField = fieldsItr.value();
@@ -303,12 +304,13 @@ void XDTSImportPopup::updateSuggestions(const QString samplePath) {
         // back to parent folder
         suggestFolder.cdUp();
       }
+      if (found) suggested = true;
     }
     ++fieldsItr;
   }
 
   // fallBack search
-  if (m_pathSuggestedLevels.empty()) {
+  if (!suggested) {
       updateSuggestions(fp);
       return;
   }
@@ -350,18 +352,19 @@ void XDTSImportPopup::updateSuggestions(const TFilePath &path) {
         QMap<QString, FileField*>::iterator it = m_fields.begin();
         while (it != m_fields.end()) {
             QString levelName = it.key();
-            if (m_pathSuggestedLevels.contains(levelName)) {
-                ++it;
-                continue;
-            }
             FileField* fileField = it.value();
-            QString filePattern = ".*" + levelName + ".*" + ".{3,4}$";
-            int index = files.indexOf(QRegExp(filePattern));
-            if (index != -1) {
-                suggestFolderFound = true;
-                fileField->setPath(suggestFolder.filePath(files[index]));
-                files.removeAt(index);
-                m_pathSuggestedLevels.append(levelName);
+            if (fileField->getPath().isEmpty() ||
+                m_pathSuggestedLevels.contains(levelName)) {
+                QString filePattern = ".*" + levelName + ".*" + ".{3,4}$";
+                int index = files.indexOf(QRegExp(filePattern));
+                if (index != -1) {
+                    suggestFolderFound = true;
+                    TFilePath foundPath(suggestFolder.filePath(files[index]));
+                    TFilePath codedPath = m_scene->codeFilePath(foundPath);
+                    fileField->setPath(codedPath.getQString());
+                    files.removeAt(index);
+                    m_pathSuggestedLevels.append(levelName);
+                }
             }
             ++it;
         }

--- a/toonz/sources/toonz/xdtsimportpopup.cpp
+++ b/toonz/sources/toonz/xdtsimportpopup.cpp
@@ -2,6 +2,7 @@
 
 #include "tapp.h"
 #include "tsystem.h"
+#include "iocommand.h"
 #include "toonzqt/filefield.h"
 #include "toonz/toonzscene.h"
 #include "toonz/tscenehandle.h"
@@ -24,6 +25,59 @@ QIcon getColorChipIcon(TPixel32 color) {
   pm.fill(QColor(color.r, color.g, color.b));
   return QIcon(pm);
 }
+
+bool matchSequencePattern(const TFilePath& path) {
+    QRegularExpression pattern(
+        R"(
+  ^                           # Match the start of the string
+  .*?                         # Optional prefix
+  \d+                         # allow aFilePrefix<number>.ext
+  \.                          # Match a dot (.)
+  (png|jpg|jpeg|bmp|tga|tiff) # Image extensions
+  $                           # Match the end of the string
+)",
+QRegularExpression::CaseInsensitiveOption |
+QRegularExpression::ExtendedPatternSyntaxOption);
+    return pattern.match(QString::fromStdString(path.getLevelName()))
+        .hasMatch();
+};
+
+bool isSharingSameParam(QString name1,
+    QString name2) {
+    std::wstring str1 = name1.toStdWString();
+    std::wstring str2 = name2.toStdWString();
+
+    str1.erase(std::remove_if(str1.begin(), str1.end(), ::iswdigit),
+        str1.end());
+    str2.erase(std::remove_if(str2.begin(), str2.end(), ::iswdigit),
+        str2.end());
+
+    return str1 == str2;
+}
+
+void fetchSequence(std::vector<IoCmd::LoadResourceArguments::ResourceData>& rds) {
+    for (size_t i = 0; i < rds.size(); ++i) {
+        TFilePath currentPath = rds[i].m_path;
+        if (!matchSequencePattern(currentPath))continue;
+
+        TFilePath thisFolder = currentPath.getParentDir();
+        QDir dir(thisFolder.getQString());
+
+        QString searchPattern = "*" + QString::fromStdString(currentPath.getDottedType());
+        QStringList foundFiles = dir.entryList(QStringList(searchPattern), QDir::Files);
+        if (foundFiles.isEmpty()) continue;
+        QString thisFile = currentPath.withoutParentDir().getQString();
+        for (const QString& foundFile : foundFiles) {
+            if (thisFile == foundFile) continue;
+
+            if (isSharingSameParam(thisFile, foundFile)) {
+                IoCmd::LoadResourceArguments::ResourceData newData;
+                newData.m_path = thisFolder + foundFile.toStdWString();
+                rds.insert(rds.begin() + (++i), newData);
+            }
+        }
+    }
+}
 }  // namespace
 
 //=============================================================================
@@ -42,6 +96,11 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
   m_tick1Combo             = new QComboBox(this);
   m_tick2Combo             = new QComboBox(this);
   QList<QComboBox*> combos = {m_tick1Combo, m_tick2Combo};
+
+  m_renameCheckBox = new QCheckBox("Rename All Image Sequence", this);
+  m_renameCheckBox->setChecked(true);
+  m_convertCheckBox = new QCheckBox("Convert All Raster Level to Toonz Raster", this);
+  m_convertCheckBox->setChecked(true);
 
   if (m_isUext) {
     m_keyFrameCombo       = new QComboBox(this);
@@ -108,7 +167,7 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
   fieldsArea->setWidget(fieldsWidget);
   m_topLayout->addWidget(fieldsArea, 1);
 
-  // 棃廡 尨夋乛拞妱嶲峫偺僐儅儅乕僋偺儗僀傾僂僩偐傜両
+  // 来週 原画／中割参考のコママークのレイアウトから！
 
   // cell mark area
   QGroupBox* cellMarkGroupBox =
@@ -139,11 +198,16 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
 
   m_topLayout->addWidget(cellMarkGroupBox, 0, Qt::AlignRight);
 
+  QHBoxLayout* checkBoxLayout = new QHBoxLayout;
+  checkBoxLayout->addStretch();
+  checkBoxLayout->addWidget(m_renameCheckBox);
+  checkBoxLayout->addWidget(m_convertCheckBox);
+  m_topLayout->addLayout(checkBoxLayout);
   connect(loadButton, SIGNAL(clicked()), this, SLOT(accept()));
   connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
 
   addButtonBarWidget(loadButton, cancelButton);
-
+  this->adjustSize();
   updateSuggestions(scenePath.getQString());
 }
 
@@ -175,6 +239,7 @@ void XDTSImportPopup::updateSuggestions(const QString samplePath) {
   QStringList filters;
   filters << "*.bmp"
           << "*.jpg"
+          << "*.jpeg"
           << "*.nol"
           << "*.pic"
           << "*.pict"
@@ -242,6 +307,12 @@ void XDTSImportPopup::updateSuggestions(const QString samplePath) {
     ++fieldsItr;
   }
 
+  // fallBack search
+  if (m_pathSuggestedLevels.empty()) {
+      updateSuggestions(fp);
+      return;
+  }
+
   // repaint fields
   fieldsItr = m_fields.begin();
   while (fieldsItr != m_fields.end()) {
@@ -254,6 +325,80 @@ void XDTSImportPopup::updateSuggestions(const QString samplePath) {
     ++fieldsItr;
   }
 }
+
+//-----------------------------------------------------------------------------
+// FALL BACK
+void XDTSImportPopup::updateSuggestions(const TFilePath &path) {
+    QMap<QString, FileField*>::iterator fieldsItr = m_fields.begin();
+    QStringList filters;
+    filters << "*.bmp"
+        << "*.jpg"
+        << "*.jpeg"
+        << "*.nol"
+        << "*.pic"
+        << "*.pict"
+        << "*.pct"
+        << "*.png"
+        << "*.rgb"
+        << "*.sgi"
+        << "*.tga"
+        << "*.tif"
+        << "*.tiff";
+    bool suggestFolderFound = false;
+    QDir suggestFolder(path.getQString());
+    auto assignMatchingFiles = [&](QStringList& files) {
+        QMap<QString, FileField*>::iterator it = m_fields.begin();
+        while (it != m_fields.end()) {
+            QString levelName = it.key();
+            if (m_pathSuggestedLevels.contains(levelName)) {
+                ++it;
+                continue;
+            }
+            FileField* fileField = it.value();
+            QString filePattern = ".*" + levelName + ".*" + ".{3,4}$";
+            int index = files.indexOf(QRegExp(filePattern));
+            if (index != -1) {
+                suggestFolderFound = true;
+                fileField->setPath(suggestFolder.filePath(files[index]));
+                files.removeAt(index);
+                m_pathSuggestedLevels.append(levelName);
+            }
+            ++it;
+        }
+        };
+    
+    // Relative Paths
+    QStringList relPaths = suggestFolder.entryList(filters, QDir::Files | QDir::Readable | QDir::NoDotAndDotDot);
+    assignMatchingFiles(relPaths);
+
+    if (!suggestFolderFound) {
+        relPaths.clear();
+        QStringList subDirs = suggestFolder.entryList(QDir::Dirs | QDir::Readable | QDir::NoDotAndDotDot);
+        for (const QString& subDirName : subDirs) {
+            QDir subDir = suggestFolder;
+            if (!subDir.cd(subDirName)) continue;
+
+            QStringList filesInSubDir = subDir.entryList(filters, QDir::Files | QDir::Readable | QDir::NoDotAndDotDot);
+            for (const QString& file : filesInSubDir) {
+                relPaths.append(subDirName + "/" + file);
+            }
+        }
+        assignMatchingFiles(relPaths);
+    }
+
+    // repaint fields
+    fieldsItr = m_fields.begin();
+    while (fieldsItr != m_fields.end()) {
+        if (m_pathSuggestedLevels.contains(fieldsItr.key()))
+            fieldsItr.value()->setStyleSheet(
+                QString("#SuggestiveFileField "
+                    "QLineEdit{border-color:#2255aa;border-width:2px;}"));
+        else
+            fieldsItr.value()->setStyleSheet(QString(""));
+        ++fieldsItr;
+    }
+}
+
 
 //-----------------------------------------------------------------------------
 
@@ -276,4 +421,24 @@ void XDTSImportPopup::getMarkerIds(int& tick1Id, int& tick2Id, int& keyFrameId,
     keyFrameId       = -1;
     referenceFrameId = -1;
   }
+}
+
+void XDTSImportPopup::accept(){
+    std::vector<IoCmd::LoadResourceArguments::ResourceData> rds;
+    for (auto it = m_fields.constBegin(); it != m_fields.constEnd(); ++it) {
+        auto name = it.key();
+        auto field = it.value();
+    }
+    IoCmd::LoadResourceArguments::ResourceData d;
+    for (auto field : m_fields) rds.push_back(TFilePath(field->getPath()));
+    fetchSequence(rds);
+    IoCmd::renameResources(rds, !m_renameCheckBox->isChecked());
+    IoCmd::convertRaster2TLV(rds, !m_convertCheckBox->isChecked());// Only Generate Inks 
+    //TODO: Only convert NAA Images
+    if(rds.size() != m_fields.size())// User Cancel or ERROR
+        QDialog::accept();
+
+    int i = 0;
+    for (auto field : m_fields) field->setPath(rds[i++].m_path.getQString());
+    QDialog::accept();
 }

--- a/toonz/sources/toonz/xdtsimportpopup.cpp
+++ b/toonz/sources/toonz/xdtsimportpopup.cpp
@@ -439,7 +439,6 @@ void XDTSImportPopup::accept(){
         IoCmd::renameResources(rds, false);
     if(m_convertCheckBox->isChecked())
         IoCmd::convertNAARaster2TLV(rds, false);// Only Generate Inks 
-    //TODO: Only convert NAA Images
     if(rds.size() != m_fields.size())// User Cancel or ERROR
         QDialog::accept();
 

--- a/toonz/sources/toonz/xdtsimportpopup.cpp
+++ b/toonz/sources/toonz/xdtsimportpopup.cpp
@@ -97,9 +97,9 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
   m_tick2Combo             = new QComboBox(this);
   QList<QComboBox*> combos = {m_tick1Combo, m_tick2Combo};
 
-  m_renameCheckBox = new QCheckBox("Rename All Image Sequence", this);
+  m_renameCheckBox = new QCheckBox("Rename Image Sequence", this);
   m_renameCheckBox->setChecked(true);
-  m_convertCheckBox = new QCheckBox("Convert All Raster Level to Toonz Raster", this);
+  m_convertCheckBox = new QCheckBox("Convert NAA Raster to Toonz Raster", this);
   m_convertCheckBox->setChecked(true);
 
   if (m_isUext) {
@@ -432,8 +432,10 @@ void XDTSImportPopup::accept(){
     IoCmd::LoadResourceArguments::ResourceData d;
     for (auto field : m_fields) rds.push_back(TFilePath(field->getPath()));
     fetchSequence(rds);
-    IoCmd::renameResources(rds, !m_renameCheckBox->isChecked());
-    IoCmd::convertRaster2TLV(rds, !m_convertCheckBox->isChecked());// Only Generate Inks 
+    if(m_renameCheckBox->isChecked())
+        IoCmd::renameResources(rds, false);
+    if(m_convertCheckBox->isChecked())
+        IoCmd::convertNAARaster2TLV(rds, false);// Only Generate Inks 
     //TODO: Only convert NAA Images
     if(rds.size() != m_fields.size())// User Cancel or ERROR
         QDialog::accept();

--- a/toonz/sources/toonz/xdtsimportpopup.h
+++ b/toonz/sources/toonz/xdtsimportpopup.h
@@ -6,6 +6,8 @@
 #include "tfilepath.h"
 
 #include <QMap>
+#include <QCheckBox>
+
 namespace DVGui {
 class FileField;
 }
@@ -20,11 +22,15 @@ class XDTSImportPopup : public DVGui::Dialog {
 
   QComboBox *m_tick1Combo, *m_tick2Combo, *m_keyFrameCombo,
       *m_referenceFrameCombo;
+  QCheckBox *m_renameCheckBox,*m_convertCheckBox;
 
   bool m_isUext;  // whether if the loading xdts is unofficial extension (UEXT)
                   // version
 
   void updateSuggestions(const QString samplePath);
+
+  // Fallback Search
+  void updateSuggestions(const TFilePath &path);
 
 public:
   XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
@@ -34,6 +40,9 @@ public:
                     int& referenceFrameId);
 protected slots:
   void onPathChanged();
+
+protected:
+    void accept() override;
 };
 
 #endif

--- a/toonz/sources/toonz/xdtsio.cpp
+++ b/toonz/sources/toonz/xdtsio.cpp
@@ -583,10 +583,11 @@ bool XdtsIo::loadXdtsScene(ToonzScene *scene, const TFilePath &scenePath) {
   try {
     for (QString name : levelNames) {
       QString levelPath = popup.getLevelPath(name);
+      TFilePath path = TFilePath(levelPath);
       TXshLevel *level  = nullptr;
-      if (!levelPath.isEmpty())
-        level = scene->loadLevel(scene->decodeFilePath(TFilePath(levelPath)),
-                                 nullptr, name.toStdWString());
+      if (!levelPath.isEmpty()&& path.getSepChar() != "")
+              level = scene->loadLevel(scene->decodeFilePath(path),
+              nullptr, name.toStdWString());
       if (!level) {
         int levelType = Preferences::instance()->getDefLevelType();
         level         = scene->createNewLevel(levelType, name.toStdWString());

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -459,6 +459,7 @@ void Preferences::definePreferenceItems() {
   // Loading
   define(importPolicy, "importPolicy", QMetaType::Int, 0);  // Always ask
   define(renamePolicy, "renamePolicy", QMetaType::Int, 0); // Always ask
+  define(convertPolicy, "convertPolicy", QMetaType::Int, 0); // Always ask
   define(autoExposeEnabled, "autoExposeEnabled", QMetaType::Bool, true);
   define(subsceneFolderEnabled, "subsceneFolderEnabled", QMetaType::Bool, true);
   define(removeSceneNumberFromLoadedLevelName,

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1366,7 +1366,6 @@ TFilePath ToonzScene::codeFilePath(const TFilePath &path) const {
 
 //-----------------------------------------------------------------------------
 // if the path is codable with $scenefolder alias, replace it and return true
-
 bool ToonzScene::codeFilePathWithSceneFolder(TFilePath &path) const {
   // if the scene is untitled, then do nothing and return false
   if (isUntitled()) return false;
@@ -1376,6 +1375,11 @@ bool ToonzScene::codeFilePathWithSceneFolder(TFilePath &path) const {
     return true;
   }
   return false;
+}
+
+bool ToonzScene::isLonelyScene() const {
+    TFilePath sceneFolderPath = getProject()->getFolder("scenes", true);
+    return !sceneFolderPath.isAncestorOf(m_scenePath);
 }
 
 //-----------------------------------------------------------------------------
@@ -1406,11 +1410,15 @@ TFilePath ToonzScene::getDefaultLevelPath(int levelType,
     levelPath = TFilePath(levelName + L"..png");
   }
 
-  if (!isUntitled() && Preferences::instance()->getPathAliasPriority() ==
-                           Preferences::SceneFolderAlias)
-    return TFilePath("$scenefolder") + levelPath;
+  // In case scene is loaded from outside
+  if (!isUntitled() &&
+      Preferences::instance()->getPathAliasPriority() == Preferences::SceneFolderAlias)
+          return TFilePath("$scenefolder") + levelPath;
 
   std::string folderName = getFolderName(levelType);
+  if (!isUntitled() && isLonelyScene())
+      return TFilePath("$scenefolder") + TFilePath(folderName) + levelPath;
+
   if (project->getUseScenePath(folderName))
     return TFilePath("+" + folderName) + getSavePath() + levelPath;
   else

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -639,6 +639,67 @@ void convert(const TFilePath &source, const TFilePath &dest,
 
 //=============================================================================
 
+bool isAAImage(TFilePath path){
+    QImage img(path.getQString());
+    if (img.isNull())return false;
+
+    uint16_t width = img.width();
+    uint16_t height = img.height();
+    uint32_t lonelyPixelCount = 0;
+    uint32_t totalPixels = width * height;
+
+    std::unordered_map<uint32_t, uint32_t> colorCount;
+
+    const QRgb* imgData = reinterpret_cast<const QRgb*>(img.bits());
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            QRgb color = imgData[y * width + x];
+            colorCount[color]++;
+        }
+    }
+
+    uint32_t maxCount = 0;
+    QRgb mostCommonColor = 0;
+    for (const auto& pair : colorCount) {
+        if (pair.second > maxCount) {
+            maxCount = pair.second;
+            mostCommonColor = pair.first;
+        }
+    }
+
+    for (int y = 1; y < height - 1; ++y) {
+        int xcount = 0;
+        for (int x = 1; x < width - 1; ++x) {
+            QRgb centerColor = imgData[y * width + x];
+
+            if (centerColor == mostCommonColor) {
+                ++xcount;
+                continue;
+            }
+
+            int diffCount = 0;
+
+            if (imgData[y * width + (x - 1)] != centerColor) ++diffCount;
+            if (imgData[y * width + (x + 1)] != centerColor) ++diffCount;
+            if (imgData[(y - 1) * width + x] != centerColor) ++diffCount;
+            if (imgData[(y + 1) * width + x] != centerColor) ++diffCount;
+
+            if (diffCount == 4) {
+                lonelyPixelCount++;
+            }
+        }
+        if (xcount == width - 2)
+            totalPixels -= width;
+    }
+
+
+    double ratio = double(lonelyPixelCount) / (totalPixels + 1);
+    
+    const double value = 0.05 / 100;
+    return ratio > value;
+}
+
 void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
                     const TFrameId &from, const TFrameId &to,
                     FrameTaskNotifier *frameNotifier, TPalette *palette,


### PR DESCRIPTION
- [x] Add auto convert feature when loading resources (Only NAA Raster to TLV, trans to Ink layer)
- [x] AutoRename and auto Convert NAA Raster Images when importing from .xdts
- [x] Make lonely scene's New Level to be saved in $sceneFolder/relativePathSetBySandBox by default
- [x] Refactor sequence renaming
- [x] Refactor: move **LoadResourceArguments>FrameIdsSet** to **LoadResourceArguments>ResourceDatas>m_frameIds**

Note: lonely scene means the .tnz file without scenes.xml in the same folder.