### PR TITLE
Workaround for LFS quota

### DIFF
--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
       - name: Install and Configure ccache
         run: |
           @echo on
@@ -64,6 +64,13 @@ jobs:
           7z x Qt5.15.2_wintab.zip
           move Qt5.15.2_wintab\5.15.2_wintab thirdparty\qt
         shell: cmd
+
+      - name: Install third-party prebuilt libs (LFS workaround)
+        run: |
+          @echo on
+          curl -fsSL -o thirdparty-libs.zip https://github.com/andeon/opentoonz-thirdparty-libs/releases/download/prebuilt-libs-v1/thirdparty-libs.zip
+          7z x -y thirdparty-libs.zip
+        shell: cmd    
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
 version: 1.7.1.{build}
+init:
+  - git lfs install --skip-smudge
 skip_commits:
   files:
     - 'doc/**'        # Skip everything inside doc/ (recursive)
@@ -18,6 +20,10 @@ install:
 - cmd: >-
     if exist "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" (echo OpenCV cached, skipping install) else (choco install opencv --version=4.11.0 --no-progress --yes --force)
 
+    curl -fsSL -o thirdparty-libs.zip https://github.com/andeon/opentoonz-thirdparty-libs/releases/download/prebuilt-libs-v1/thirdparty-libs.zip
+
+    7z x -y thirdparty-libs.zip
+    
     cd thirdparty
 
     copy /Y tiff-4.0.3\libtiff\tif_config.vc.h tiff-4.0.3\libtiff\tif_config.h


### PR DESCRIPTION
This PR introduces a workaround to bypass the Git LFS issue, ensuring the build can continue without interruption while we implement a more permanent solution.

It does not change the repository structure or remove Git LFS support. It simply disables LFS during the checkout step for Windows and AppVeyor workflows. The LFS-tracked pointer files are then replaced by downloading the exact same precompiled third-party libraries used in the official OpenToonz repository, provided through an external [release](https://github.com/andeon/opentoonz-thirdparty-libs/releases/tag/prebuilt-libs-v1).

_This issue with Git LFS currently affects only Windows builds, where critical third-party binaries (such as .dll and .lib files) are tracked via LFS and are needed during compilation. When the LFS quota is exceeded, these files are no longer downloadable through standard Git operations, breaking the Windows CI._

ref: https://github.com/opentoonz/opentoonz/issues/5914#issuecomment-2877558184