### PR TITLE
Better level convert/export/visualize/process

### DIFF
--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -308,6 +308,7 @@ set(SOURCES
     trackerpopup.cpp
     vectorguideddrawingpane.cpp
     vectorizerpopup.cpp
+    rasterizecommand.cpp
     vectorizerswatch.cpp
     versioncontrol.cpp
     versioncontroltimeline.cpp

--- a/toonz/sources/toonz/binarizepopup.cpp
+++ b/toonz/sources/toonz/binarizepopup.cpp
@@ -7,6 +7,7 @@
 #include "menubarcommandids.h"
 #include "cellselection.h"
 #include "filmstripselection.h"
+#include "selectionutils.h"
 
 // TnzQt includes
 #include "toonzqt/intfield.h"
@@ -346,6 +347,19 @@ int BinarizePopup::getSelectedFrames() {
       }
     }
   } else {
+      std::set<TXshLevel*> levels;
+      SelectionUtils::getSelectedLevels(levels);
+      for (auto level : levels){
+          if (!level)continue;
+          auto sl = level->getSimpleLevel();
+          std::vector<TFrameId> ids;
+          sl->getFids(ids);
+          for (auto id : ids) {
+              m_frames.push_back(std::make_pair(sl, id));
+              count++;
+          }
+
+      }
   }
   m_frameIndex = 0;
   return count;

--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -719,6 +719,7 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
   bool paletteSelected     = false;
   bool vectorLevelSelected = false;
   bool meshLevelSelected   = false;
+  bool toonzRasterLevelSelected = false;
   bool otherFileSelected   = false;
   int levelSelectedCount   = 0;
   for (it = indices.begin(); it != indices.end(); ++it) {
@@ -735,9 +736,11 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
     }
     levelSelectedCount++;
     if (sl->getType() == PLI_XSHLEVEL)
-      vectorLevelSelected = true;
+        vectorLevelSelected = true;
     else if (sl->getType() == MESH_XSHLEVEL)
-      meshLevelSelected = true;
+        meshLevelSelected = true;
+    else if (sl->getType() == TZP_XSHLEVEL)
+        toonzRasterLevelSelected = true;
     else
       otherFileSelected = true;
   }
@@ -761,6 +764,8 @@ QMenu *CastBrowser::getContextMenu(QWidget *parent, int index) {
   // MI_ConvertToVectors if only non-vector layers were selected
   if (!audioSelected && !paletteSelected && !vectorLevelSelected)
     menu->addAction(cm->getAction(MI_ConvertToVectors));
+  if (!audioSelected && !paletteSelected && !toonzRasterLevelSelected)
+      menu->addAction(cm->getAction(MI_ConvertToToonzRaster));
   menu->addSeparator();
   menu->addAction(cm->getAction(MI_RemoveLevel));
   menu->addAction(cm->getAction(MI_RemoveUnused));

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1572,8 +1572,6 @@ void TCellSelection::enableCommands() {
   enableCommand(this, MI_Reframe2, &TCellSelection::reframe2Cells);
   enableCommand(this, MI_Reframe3, &TCellSelection::reframe3Cells);
   enableCommand(this, MI_Reframe4, &TCellSelection::reframe4Cells);
-  enableCommand(this, MI_ConvertToToonzRaster,
-                &TCellSelection::convertToToonzRaster);
   enableCommand(this, MI_ConvertVectorToVector,
                 &TCellSelection::convertVectortoVector);
   enableCommand(this, MI_ReframeWithEmptyInbetweens,
@@ -3536,94 +3534,6 @@ void TCellSelection::renameMultiCells(QList<TXshCell> &cells) {
   TUndoManager::manager()->endBlock();
 }
 
-//=============================================================================
-// CreateLevelUndo
-//-----------------------------------------------------------------------------
-
-class CreateLevelUndo final : public TUndo {
-  int m_rowIndex;
-  int m_columnIndex;
-  int m_frameCount;
-  int m_oldLevelCount;
-  int m_step;
-  TXshSimpleLevelP m_sl;
-  bool m_areColumnsShifted;
-  bool m_keepLevel;
-
-public:
-  CreateLevelUndo(int row, int column, int frameCount, int step,
-                  bool areColumnsShifted, bool keepLevel = false)
-      : m_rowIndex(row)
-      , m_columnIndex(column)
-      , m_frameCount(frameCount)
-      , m_step(step)
-      , m_sl(0)
-      , m_keepLevel(keepLevel)
-      , m_areColumnsShifted(areColumnsShifted) {
-    TApp *app         = TApp::instance();
-    ToonzScene *scene = app->getCurrentScene()->getScene();
-    m_oldLevelCount   = scene->getLevelSet()->getLevelCount();
-  }
-  ~CreateLevelUndo() { m_sl = 0; }
-
-  void onAdd(TXshSimpleLevelP sl) { m_sl = sl; }
-
-  void undo() const override {
-    TApp *app         = TApp::instance();
-    ToonzScene *scene = app->getCurrentScene()->getScene();
-    TXsheet *xsh      = scene->getXsheet();
-    if (m_areColumnsShifted)
-      xsh->removeColumn(m_columnIndex);
-    else if (m_frameCount > 0)
-      xsh->removeCells(m_rowIndex, m_columnIndex, m_frameCount);
-    if (!m_keepLevel) {
-      TLevelSet *levelSet = scene->getLevelSet();
-      if (levelSet) {
-        int m = levelSet->getLevelCount();
-        while (m > 0 && m > m_oldLevelCount) {
-          --m;
-          TXshLevel *level = levelSet->getLevel(m);
-          if (level) levelSet->removeLevel(level);
-        }
-      }
-    }
-    app->getCurrentScene()->notifySceneChanged();
-    app->getCurrentScene()->notifyCastChange();
-    app->getCurrentXsheet()->notifyXsheetChanged();
-  }
-
-  void redo() const override {
-    if (!m_sl.getPointer()) return;
-    TApp *app         = TApp::instance();
-    ToonzScene *scene = app->getCurrentScene()->getScene();
-    scene->getLevelSet()->insertLevel(m_sl.getPointer());
-    TXsheet *xsh = scene->getXsheet();
-    if (m_areColumnsShifted) xsh->insertColumn(m_columnIndex);
-    std::vector<TFrameId> fids;
-    m_sl->getFids(fids);
-    int i = m_rowIndex;
-    int f = 0;
-    while (i < m_frameCount + m_rowIndex) {
-      TFrameId fid = (fids.size() != 0) ? fids[f] : i;
-      TXshCell cell(m_sl.getPointer(), fid);
-      f++;
-      xsh->setCell(i, m_columnIndex, cell);
-      int appo = i++;
-      while (i < m_step + appo) xsh->setCell(i++, m_columnIndex, cell);
-    }
-    app->getCurrentScene()->notifySceneChanged();
-    app->getCurrentScene()->notifyCastChange();
-    app->getCurrentXsheet()->notifyXsheetChanged();
-  }
-
-  int getSize() const override { return sizeof *this; }
-  QString getHistoryString() override {
-    return QObject::tr("Create Level %1  at Column %2")
-        .arg(QString::fromStdWString(m_sl->getName()))
-        .arg(QString::number(m_columnIndex + 1));
-  }
-};
-
 //-----------------------------------------------------------------------------
 // Convert selected vector cells to ToonzRaster
 
@@ -3639,7 +3549,7 @@ bool TCellSelection::areOnlyVectorCellsSelected() {
   if (firstCell.isEmpty()) {
     DVGui::error(QObject::tr("This command only works on vector cells."));
     return false;
-  }
+    }
 
   TXshSimpleLevel *sourceSl = firstCell.getSimpleLevel();
   if (!sourceSl || sourceSl->getType() != PLI_XSHLEVEL) {
@@ -3754,128 +3664,13 @@ public:
 };
 
 //-----------------------------------------------------------------------------
-// Convert selected vector cells to ToonzRaster
-
-void TCellSelection::convertToToonzRaster() {
-  // set up basics
-  int r0, c0, r1, c1;
-  getSelectedCells(r0, c0, r1, c1);
-
-  TApp *app = TApp::instance();
-  int row   = app->getCurrentFrame()->getFrame();
-  int col   = app->getCurrentColumn()->getColumnIndex();
-  int i;
-
-  ToonzScene *scene = app->getCurrentScene()->getScene();
-  TXsheet *xsh      = scene->getXsheet();
-
-  TXshCell firstCell        = xsh->getCell(r0, c0);
-  TXshSimpleLevel *sourceSl = firstCell.getSimpleLevel();
-
-  if (!areOnlyVectorCellsSelected()) return;
-
-  // set up new level
-  TXshSimpleLevel *sl = getNewToonzRasterLevel(sourceSl);
-
-  // get camera settings
-  TCamera *camera = app->getCurrentScene()->getScene()->getCurrentCamera();
-  double dpi      = camera->getDpi().x;
-  int xres        = camera->getRes().lx;
-  int yres        = camera->getRes().ly;
-
-  assert(sl);
-
-  sl->getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
-  sl->getProperties()->setDpi(dpi);
-  sl->getProperties()->setImageDpi(TPointD(dpi, dpi));
-  sl->getProperties()->setImageRes(TDimension(xres, yres));
-
-  TFrameId frameId = firstCell.getFrameId();
-  std::set<TFrameId> frameIdsSet;
-  std::vector<TFrameId> frameIds;
-  frameIds.push_back(frameId);
-  for (i = r0 + 1; i <= r1; i++) {
-    TXshCell newCell    = xsh->getCell(i, c0);
-    TFrameId newFrameId = xsh->getCell(i, c0).getFrameId();
-    if (newCell.getSimpleLevel() == sourceSl) {
-      if (std::find(frameIds.begin(), frameIds.end(), newCell.getFrameId()) ==
-          frameIds.end()) {
-        frameIds.push_back(newFrameId);
-      }
-    }
-  }
-
-  int totalImages = frameIds.size();
-  for (i = 0; i < totalImages; i++) {
-    frameIdsSet.insert(frameIds[i]);
-  }
-
-  DrawingData *data = new DrawingData();
-  data->setLevelFrames(sourceSl, frameIdsSet);
-
-  // This is where the copying actually happens
-  std::set<TFrameId> newFrameIds;
-  for (i = 0; i < totalImages; i++) {
-    TRasterCM32P raster(xres, yres);
-    raster->fill(TPixelCM32());
-    TToonzImageP firstImage(raster, TRect());
-    firstImage->setDpi(dpi, dpi);
-    TFrameId newFrameId = TFrameId(i + 1);
-    sl->setFrame(newFrameId, firstImage);
-    newFrameIds.insert(newFrameId);
-    firstImage->setSavebox(TRect(0, 0, xres - 1, yres - 1));
-  }
-
-  bool keepOriginalPalette;
-  bool success = data->getLevelFrames(
-      sl, newFrameIds, DrawingData::OVER_SELECTION, true, keepOriginalPalette,
-      true);  // setting is redo = true skips the
-              // question about the palette
-  std::vector<TFrameId> newFids;
-  sl->getFids(newFids);
-
-  // make a new column
-  col += 1;
-  TApp::instance()->getCurrentColumn()->setColumnIndex(col);
-  xsh->insertColumn(col);
-
-  CreateLevelUndo *undo = new CreateLevelUndo(row, col, totalImages, 1, true);
-  TUndoManager::manager()->add(undo);
-
-  // expose the new frames in the column
-  for (i = 0; i < totalImages; i++) {
-    for (int k = r0; k <= r1; k++) {
-      TXshCell oldCell = xsh->getCell(k, c0);
-      TXshCell newCell(sl, newFids[i]);
-      if (oldCell.getFrameId() == frameIds[i]) {
-        xsh->setCell(k, col, newCell);
-      }
-    }
-  }
-
-  invalidateIcons(sl, newFrameIds);
-  sl->save(sl->getPath(), TFilePath(), true);
-
-  DvDirModel::instance()->refreshFolder(sl->getPath().getParentDir());
-
-  undo->onAdd(sl);
-
-  app->getCurrentScene()->notifySceneChanged();
-  app->getCurrentScene()->notifyCastChange();
-  app->getCurrentXsheet()->notifyXsheetChanged();
-
-  app->getCurrentTool()->onImageChanged(
-      (TImage::Type)app->getCurrentImageType());
-}
-
-//-----------------------------------------------------------------------------
 // Convert selected vector cells to ToonzRaster and back to vecor
 
 void TCellSelection::convertVectortoVector() {
   // set up basics
   int r0, c0, r1, c1;
   getSelectedCells(r0, c0, r1, c1);
-
+  
   TApp *app = TApp::instance();
   int row   = app->getCurrentFrame()->getFrame();
   int col   = app->getCurrentColumn()->getColumnIndex();
@@ -3888,9 +3683,9 @@ void TCellSelection::convertVectortoVector() {
   TXshSimpleLevel *sourceSl = firstCell.getSimpleLevel();
   if (!areOnlyVectorCellsSelected()) return;
 
-  // set up new level name
-  TXshSimpleLevel *sl = getNewToonzRasterLevel(sourceSl);
-  assert(sl);
+      // set up new level name
+      TXshSimpleLevel *sl = getNewToonzRasterLevel(sourceSl);
+      assert(sl);
 
   // get camera settings
   TCamera *camera = app->getCurrentScene()->getScene()->getCurrentCamera();
@@ -3898,22 +3693,22 @@ void TCellSelection::convertVectortoVector() {
   int xres        = camera->getRes().lx;
   int yres        = camera->getRes().ly;
 
-  if (Preferences::instance()->getUseHigherDpiOnVectorSimplify()) {
-    dpi *= 2;
-    xres *= 2;
-    yres *= 2;
-  }
+      if (Preferences::instance()->getUseHigherDpiOnVectorSimplify()) {
+          dpi *= 2;
+          xres *= 2;
+          yres *= 2;
+      }
 
-  sl->getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
-  sl->getProperties()->setDpi(dpi);
-  sl->getProperties()->setImageDpi(TPointD(dpi, dpi));
-  sl->getProperties()->setImageRes(TDimension(xres, yres));
+      sl->getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
+      sl->getProperties()->setDpi(dpi);
+      sl->getProperties()->setImageDpi(TPointD(dpi, dpi));
+      sl->getProperties()->setImageRes(TDimension(xres, yres));
 
-  // Get the used FrameIds and images
-  // The cloned images are used in the undo.
+      // Get the used FrameIds and images
+      // The cloned images are used in the undo.
   TFrameId frameId = firstCell.getFrameId();
   std::set<TFrameId> frameIdsSet;
-  std::vector<TFrameId> frameIds;
+      std::vector<TFrameId> frameIds;
   std::vector<TImageP> oldImages;
   frameIds.push_back(frameId);
   oldImages.push_back(firstCell.getImage(false).getPointer()->cloneImage());
@@ -3936,67 +3731,67 @@ void TCellSelection::convertVectortoVector() {
   }
 
   DrawingData *data = new DrawingData();
-  data->setLevelFrames(sourceSl, frameIdsSet);
+      data->setLevelFrames(sourceSl, frameIdsSet);
 
-  // Make empty frames for the new data
-  std::set<TFrameId> newFrameIds;
-  for (i = 0; i < totalImages; i++) {
-    TRasterCM32P raster(xres, yres);
-    raster->fill(TPixelCM32());
-    TToonzImageP firstImage(raster, TRect());
-    firstImage->setDpi(dpi, dpi);
-    TFrameId newFrameId = TFrameId(i + 1);
-    sl->setFrame(newFrameId, firstImage);
-    newFrameIds.insert(newFrameId);
-    firstImage->setSavebox(TRect(0, 0, xres - 1, yres - 1));
-  }
+      // Make empty frames for the new data
+      std::set<TFrameId> newFrameIds;
+      for (i = 0; i < totalImages; i++) {
+          TRasterCM32P raster(xres, yres);
+          raster->fill(TPixelCM32());
+          TToonzImageP firstImage(raster, TRect());
+          firstImage->setDpi(dpi, dpi);
+          TFrameId newFrameId = TFrameId(i + 1);
+          sl->setFrame(newFrameId, firstImage);
+          newFrameIds.insert(newFrameId);
+          firstImage->setSavebox(TRect(0, 0, xres - 1, yres - 1));
+      }
 
-  // This is where the copying actually happens
-  // copy old frames to Toonz Raster
-  bool keepOriginalPalette;
-  bool success = data->getLevelFrames(
-      sl, newFrameIds, DrawingData::OVER_SELECTION, true, keepOriginalPalette,
-      true);  // setting is redo = true skips the
-              // question about the palette
-              // get the new FrameIds
-  std::vector<TFrameId> newFids;
-  sl->getFids(newFids);
+      // This is where the copying actually happens
+      // copy old frames to Toonz Raster
+      bool keepOriginalPalette;
+      bool success = data->getLevelFrames(
+          sl, newFrameIds, DrawingData::OVER_SELECTION, true, keepOriginalPalette,
+          true);  // setting is redo = true skips the
+      // question about the palette
+      // get the new FrameIds
+      std::vector<TFrameId> newFids;
+      sl->getFids(newFids);
 
-  // copy the Toonz Raster frames onto the old level
-  data->clear();
-  data->setLevelFrames(sl, newFrameIds);
-  if (Preferences::instance()->getKeepFillOnVectorSimplify())
-    data->setKeepVectorFills(true);
-  success = data->getLevelFrames(
-      sourceSl, frameIdsSet, DrawingData::OVER_SELECTION, true,
+      // copy the Toonz Raster frames onto the old level
+      data->clear();
+      data->setLevelFrames(sl, newFrameIds);
+      if (Preferences::instance()->getKeepFillOnVectorSimplify())
+          data->setKeepVectorFills(true);
+      success = data->getLevelFrames(
+          sourceSl, frameIdsSet, DrawingData::OVER_SELECTION, true,
       keepOriginalPalette, true);  // setting is redo = true skips the
-                                   // question about the palette
+      // question about the palette
 
-  // get clones of the new images for undo
-  std::vector<TImageP> newImages;
-  for (i = 0; i < totalImages; i++) {
-    newImages.push_back(sourceSl->getFrame(frameIds[i], false)->cloneImage());
-  }
+      // get clones of the new images for undo
+      std::vector<TImageP> newImages;
+      for (i = 0; i < totalImages; i++) {
+          newImages.push_back(sourceSl->getFrame(frameIds[i], false)->cloneImage());
+      }
 
   HookSet *oldLevelHooks = new HookSet();
   *oldLevelHooks         = *sourceSl->getHookSet();
 
-  TUndoManager::manager()->add(new VectorToVectorUndo(
-      sourceSl, frameIds, oldImages, newImages, oldLevelHooks));
+      TUndoManager::manager()->add(new VectorToVectorUndo(
+          sourceSl, frameIds, oldImages, newImages, oldLevelHooks));
 
-  invalidateIcons(sourceSl, frameIdsSet);
+      invalidateIcons(sourceSl, frameIdsSet);
 
-  // remove the toonz raster level
-  sl->clearFrames();
-  app->getCurrentScene()->getScene()->getLevelSet()->removeLevel(sl, true);
+      // remove the toonz raster level
+      sl->clearFrames();
+      app->getCurrentScene()->getScene()->getLevelSet()->removeLevel(sl, true);
 
-  app->getCurrentScene()->notifySceneChanged();
-  app->getCurrentScene()->notifyCastChange();
-  app->getCurrentXsheet()->notifyXsheetChanged();
+      app->getCurrentScene()->notifySceneChanged();
+      app->getCurrentScene()->notifyCastChange();
+      app->getCurrentXsheet()->notifyXsheetChanged();
 
-  app->getCurrentTool()->onImageChanged(
-      (TImage::Type)app->getCurrentImageType());
-}
+      app->getCurrentTool()->onImageChanged(
+          (TImage::Type)app->getCurrentImageType());
+  }
 
 void TCellSelection::fillEmptyCell() {
   if (isEmpty()) return;

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1638,7 +1638,6 @@ bool TCellSelection::isEnabledCommand(
                                         MI_Redo,
                                         MI_PasteNumbers,
                                         MI_PasteCellContent,
-                                        MI_ConvertToToonzRaster,
                                         MI_ConvertVectorToVector,
                                         MI_CreateBlankDrawing,
                                         MI_FillEmptyCell};

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -115,7 +115,6 @@ public:
   void reframe2Cells() { reframeCells(2); }
   void reframe3Cells() { reframeCells(3); }
   void reframe4Cells() { reframeCells(4); }
-  void convertToToonzRaster();
   void convertVectortoVector();
 
   void reframeWithEmptyInbetweens();

--- a/toonz/sources/toonz/columnselection.cpp
+++ b/toonz/sources/toonz/columnselection.cpp
@@ -28,42 +28,6 @@
 #include "ttoonzimage.h"
 #include "tundo.h"
 
-namespace {
-// obtain level set contained in the column specified by indices
-// it is used for checking and updating the scene cast when pasting
-// based on TXsheet::getUsedLevels
-void getLevelSetFromColumnIndices(const std::set<int>& indices,
-                                  std::set<TXshLevel*>& levelSet) {
-  TXsheet* xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
-  for (auto c : indices) {
-    TXshColumnP column = const_cast<TXsheet*>(xsh)->getColumn(c);
-    if (!column) continue;
-
-    TXshCellColumn* cellColumn = column->getCellColumn();
-    if (!cellColumn) continue;
-
-    int r0, r1;
-    if (!cellColumn->getRange(r0, r1)) continue;
-
-    TXshLevel* level = 0;
-    for (int r = r0; r <= r1; r++) {
-      TXshCell cell = cellColumn->getCell(r);
-      if (cell.isEmpty() || !cell.m_level) continue;
-
-      if (level != cell.m_level.getPointer()) {
-        level = cell.m_level.getPointer();
-        levelSet.insert(level);
-        if (level->getChildLevel()) {
-          TXsheet* childXsh = level->getChildLevel()->getXsheet();
-          childXsh->getUsedLevels(levelSet);
-        }
-      }
-    }
-  }
-}
-
-}  // namespace
-
 //=============================================================================
 // TColumnSelection
 //-----------------------------------------------------------------------------
@@ -356,4 +320,37 @@ void TColumnSelection::hideColumns() {
   // colonne)
   //  TApp::instance()->->notify(TColumnHeadChange());
   app->getCurrentScene()->setDirtyFlag(true);
+}
+
+// obtain level set contained in the column specified by indices
+// it is used for checking and updating the scene cast when pasting
+// based on TXsheet::getUsedLevels
+void TColumnSelection::getLevelSetFromColumnIndices(const std::set<int>& indices,
+    std::set<TXshLevel*>& levelSet) {
+    TXsheet* xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+    for (auto c : indices) {
+        TXshColumnP column = const_cast<TXsheet*>(xsh)->getColumn(c);
+        if (!column) continue;
+
+        TXshCellColumn* cellColumn = column->getCellColumn();
+        if (!cellColumn) continue;
+
+        int r0, r1;
+        if (!cellColumn->getRange(r0, r1)) continue;
+
+        TXshLevel* level = 0;
+        for (int r = r0; r <= r1; r++) {
+            TXshCell cell = cellColumn->getCell(r);
+            if (cell.isEmpty() || !cell.m_level) continue;
+
+            if (level != cell.m_level.getPointer()) {
+                level = cell.m_level.getPointer();
+                levelSet.insert(level);
+                if (level->getChildLevel()) {
+                    TXsheet* childXsh = level->getChildLevel()->getXsheet();
+                    childXsh->getUsedLevels(levelSet);
+                }
+            }
+        }
+    }
 }

--- a/toonz/sources/toonz/columnselection.h
+++ b/toonz/sources/toonz/columnselection.h
@@ -6,6 +6,7 @@
 #include "toonzqt/selection.h"
 #include "tgeometry.h"
 #include <set>
+#include "toonz/txshlevel.h"
 
 class ReframePopup;
 
@@ -54,6 +55,8 @@ public:
   void reframe4Cells() { reframeCells(4); }
 
   void reframeWithEmptyInbetweens();
+  static void getLevelSetFromColumnIndices(const std::set<int>& indices,
+      std::set<TXshLevel*>& levelSet);
 };
 
 #endif  // TCELLSELECTION_H

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -233,6 +233,7 @@ void ConvertPopup::Converter::convertLevel(
   }
 
   popup->m_notifier->notifyLevelCompleted(dstFileFullPath);
+  popup->m_convertedFileMap[sourceFileFullPath] = dstFileFullPath;
 }
 
 // to use legacy code
@@ -833,7 +834,8 @@ void ConvertPopup::setFiles(const std::vector<TFilePath> &fps) {
   m_imageDpi = 0.0;
 
   if (m_srcFilePaths.size() == 1) {
-    setWindowTitle(tr("Convert 1 Level"));
+    setWindowTitle(tr("Convert 1 Level : %1")
+        .arg(QString::fromStdString(fps[0].getName())));
     m_fileNameFld->setEnabled(true);
 
     m_fromFld->setEnabled(false);
@@ -886,6 +888,7 @@ void ConvertPopup::setFiles(const std::vector<TFilePath> &fps) {
 }
 
 void ConvertPopup::setFormat(QString format){
+    m_fileFormat->setDisabled(true);
     m_fileFormat->setCurrentIndex(m_fileFormat->findText(format));
 }
 
@@ -1263,6 +1266,7 @@ QString::number(m_srcFilePaths.size()-skipped)).arg(QString::number(m_srcFilePat
 
 void ConvertPopup::onLevelConverted(const TFilePath &fullPath) {
   IconGenerator::instance()->invalidate(fullPath);
+  
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -885,6 +885,10 @@ void ConvertPopup::setFiles(const std::vector<TFilePath> &fps) {
   // m_fileFormat->setCurrentIndex(areFullcolor?0:m_fileFormat->findText("tif"));
 }
 
+void ConvertPopup::setFormat(QString format){
+    m_fileFormat->setCurrentIndex(m_fileFormat->findText(format));
+}
+
 //-------------------------------------------------------------------
 
 Convert2Tlv *ConvertPopup::makeTlvConverter(const TFilePath &sourceFilePath) {

--- a/toonz/sources/toonz/convertpopup.h
+++ b/toonz/sources/toonz/convertpopup.h
@@ -54,7 +54,7 @@ class FrameTaskNotifier;
 */
 
 class ConvertPopup : public DVGui::Dialog {
-  Q_OBJECT
+    Q_OBJECT
 
 public:
   ConvertPopup(bool specifyInput = false);
@@ -65,7 +65,8 @@ public:
   bool isConverting() const { return m_isConverting; }
 
   void convertToTlv(bool toPainted);
-
+  TFilePath getConvetedPath(TFilePath path) 
+  {return m_convertedFileMap[path];};
   QString getDestinationType() const;
   QString getTlvMode() const;
   QString TlvMode_Unpainted;
@@ -128,6 +129,7 @@ private:
   DVGui::ProgressDialog *m_progressDialog;
 
   std::vector<TFilePath> m_srcFilePaths;
+  std::map<TFilePath, TFilePath> m_convertedFileMap;
   static QMap<std::string, TPropertyGroup *> m_formatProperties;
 
   bool m_isConverting;

--- a/toonz/sources/toonz/convertpopup.h
+++ b/toonz/sources/toonz/convertpopup.h
@@ -61,6 +61,7 @@ public:
   ~ConvertPopup();
 
   void setFiles(const std::vector<TFilePath> &fps);
+  void setFormat(QString format);
   bool isConverting() const { return m_isConverting; }
 
   void convertToTlv(bool toPainted);

--- a/toonz/sources/toonz/exportlevelcommand.cpp
+++ b/toonz/sources/toonz/exportlevelcommand.cpp
@@ -332,10 +332,11 @@ TToonzImageP ImageExporter::exportedToonzImage(TVectorImageP vi) {
   const TDimensionD &size = camera.getSize();
   const TDimension &res   = camera.getRes();
 
-  const TPointD pos(-0.5 * size.lx, -0.5 * size.ly);
+  //const TPointD pos(-0.5 * size.lx, -0.5 * size.ly);
 
-  // Render to toonz image
-  TToonzImageP ti = ToonzImageUtils::vectorToToonzImage(vi, aff, plt, pos, res);
+  // Render to toonz image keep the same with the converter in drawingdata.cpp
+  TToonzImageP ti = ToonzImageUtils::vectorToToonzImage(vi, aff, plt, 
+      TPointD(), res, 0 ,true);
   ti->setPalette(plt);
 
   if (m_opts.m_noAntialias) {

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1946,7 +1946,7 @@ void MainWindow::defineActions() {
   createMenuLevelAction(MI_ConvertToVectors,
                         QT_TR_NOOP("Convert to Vectors..."), "", "convert");
   createMenuLevelAction(MI_ConvertToToonzRaster,
-                        QT_TR_NOOP("Vectors to Toonz Raster"), "");
+                        QT_TR_NOOP("Convert to Toonz Raster..."), "");
   createMenuLevelAction(
       MI_ConvertVectorToVector,
       QT_TRANSLATE_NOOP("MainWindow",

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -899,6 +899,7 @@ QMenuBar *StackedMenuBar::createXsheetMenuBar() {
   addMenuItem(levelsMenu, MI_Renumber);
   addMenuItem(levelsMenu, MI_RevertToCleanedUp);
   addMenuItem(levelsMenu, MI_ConvertToVectors);
+  addMenuItem(levelsMenu, MI_ConvertToToonzRaster);
   addMenuItem(levelsMenu, MI_ConvertFileWithInput);
   addMenuItem(levelsMenu, MI_Tracking);
   addMenuItem(levelsMenu, MI_ExposeResource);

--- a/toonz/sources/toonz/rasterizecommand.cpp
+++ b/toonz/sources/toonz/rasterizecommand.cpp
@@ -1,0 +1,312 @@
+
+// Tnz6 includes
+#include "tapp.h"
+#include "menubarcommandids.h"
+#include "selectionutils.h"
+#include "convertpopup.h"
+
+// TnzQt includes
+#include "toonzqt/gutil.h"
+
+// TnzLib includes
+#include "toonz/txshsimplelevel.h"
+#include "toonz/txshleveltypes.h"
+#include "toonz/txsheet.h"
+#include "toonz/txshcell.h"
+#include "toonz/toonzscene.h"
+#include "toonz/levelset.h"
+#include "toonz/tscenehandle.h"
+#include "toonz/txsheethandle.h"
+#include "toonz/tcamera.h"
+
+// TnzCore includes
+#include "tsystem.h"
+#include "ttoonzimage.h"
+
+// Tnz6 includes
+#include "drawingdata.h"
+#include "xsheetviewer.h"
+
+// TnzTools includes
+#include "tools/toolhandle.h"
+
+// TnzQt includes
+#include "toonzqt/icongenerator.h"
+#include "toonzqt/menubarcommand.h"
+
+// TnzLib includes
+#include "toonz/preferences.h"
+#include "toonz/tcolumnhandle.h"
+
+// TnzCore includes
+#include "filebrowsermodel.h"
+
+using namespace DVGui;
+using namespace SelectionUtils;
+
+// Convert to ToonzRaster From Raster or Vector
+
+namespace {
+        
+    // CreateLevelUndo
+    class CreateLevelUndo final : public TUndo {
+        int m_rowIndex;
+        int m_columnIndex;
+        int m_frameCount;
+        int m_oldLevelCount;
+        int m_step;
+        TXshSimpleLevelP m_sl;
+        bool m_areColumnsShifted;
+        bool m_keepLevel;
+
+    public:
+        CreateLevelUndo(int row, int column, int frameCount, int step,
+            bool areColumnsShifted, bool keepLevel = false)
+            : m_rowIndex(row)
+            , m_columnIndex(column)
+            , m_frameCount(frameCount)
+            , m_step(step)
+            , m_sl(0)
+            , m_keepLevel(keepLevel)
+            , m_areColumnsShifted(areColumnsShifted) {
+            TApp* app = TApp::instance();
+            ToonzScene* scene = app->getCurrentScene()->getScene();
+            m_oldLevelCount = scene->getLevelSet()->getLevelCount();
+        }
+        ~CreateLevelUndo() { m_sl = 0; }
+
+        void onAdd(TXshSimpleLevelP sl) { m_sl = sl; }
+
+        void undo() const override {
+            TApp* app = TApp::instance();
+            ToonzScene* scene = app->getCurrentScene()->getScene();
+            TXsheet* xsh = scene->getXsheet();
+            if (m_areColumnsShifted)
+                xsh->removeColumn(m_columnIndex);
+            else if (m_frameCount > 0)
+                xsh->removeCells(m_rowIndex, m_columnIndex, m_frameCount);
+            if (!m_keepLevel) {
+                TLevelSet* levelSet = scene->getLevelSet();
+                if (levelSet) {
+                    int m = levelSet->getLevelCount();
+                    while (m > 0 && m > m_oldLevelCount) {
+                        --m;
+                        TXshLevel* level = levelSet->getLevel(m);
+                        if (level) levelSet->removeLevel(level);
+                    }
+                }
+            }
+            app->getCurrentScene()->notifySceneChanged();
+            app->getCurrentScene()->notifyCastChange();
+            app->getCurrentXsheet()->notifyXsheetChanged();
+        }
+
+        void redo() const override {
+            if (!m_sl.getPointer()) return;
+            TApp* app = TApp::instance();
+            ToonzScene* scene = app->getCurrentScene()->getScene();
+            scene->getLevelSet()->insertLevel(m_sl.getPointer());
+            TXsheet* xsh = scene->getXsheet();
+            if (m_areColumnsShifted) xsh->insertColumn(m_columnIndex);
+            std::vector<TFrameId> fids;
+            m_sl->getFids(fids);
+            int i = m_rowIndex;
+            int f = 0;
+            while (i < m_frameCount + m_rowIndex) {
+                TFrameId fid = (fids.size() != 0) ? fids[f] : i;
+                TXshCell cell(m_sl.getPointer(), fid);
+                f++;
+                xsh->setCell(i, m_columnIndex, cell);
+                int appo = i++;
+                while (i < m_step + appo) xsh->setCell(i++, m_columnIndex, cell);
+            }
+            app->getCurrentScene()->notifySceneChanged();
+            app->getCurrentScene()->notifyCastChange();
+            app->getCurrentXsheet()->notifyXsheetChanged();
+        }
+
+        int getSize() const override { return sizeof * this; }
+        QString getHistoryString() override {
+            return QObject::tr("Create Level %1  at Column %2")
+                .arg(QString::fromStdWString(m_sl->getName()))
+                .arg(QString::number(m_columnIndex + 1));
+        }
+    };
+
+    static TXshSimpleLevel* getNewToonzRasterLevel(
+        TXshSimpleLevel* sourceSl) {
+        ToonzScene* scene = TApp::instance()->getCurrentScene()->getScene();
+        TFilePath sourcePath = sourceSl->getPath();
+        std::wstring sourceName = sourcePath.getWideName();
+        TFilePath parentDir = sourceSl->getPath().getParentDir();
+        TFilePath fp = scene->getDefaultLevelPath(TZP_XSHLEVEL, sourceName)
+            .withParentDir(parentDir);
+        TFilePath actualFp = scene->decodeFilePath(fp);
+
+        int i = 1;
+        std::wstring newName = sourceName;
+        while (TSystem::doesExistFileOrLevel(actualFp)) {
+            newName = sourceName + QString::number(i).toStdWString();
+            fp = scene->getDefaultLevelPath(TZP_XSHLEVEL, newName)
+                .withParentDir(parentDir);
+            actualFp = scene->decodeFilePath(fp);
+            i++;
+        }
+        parentDir = scene->decodeFilePath(parentDir);
+
+        TXshLevel* level =
+            scene->createNewLevel(TZP_XSHLEVEL, newName, TDimension(), 0, fp);
+        TXshSimpleLevel* sl = dynamic_cast<TXshSimpleLevel*>(level);
+        return sl;
+    }
+
+    bool convertVector(TXshSimpleLevel* in, TXshSimpleLevel* out
+        , std::set<TFrameId>& frameIdsSet) {
+        assert(in->getType() == TXshLevelType::PLI_XSHLEVEL);
+        // get camera settings
+        TApp* app = TApp::instance();
+        TCamera* camera = app->getCurrentScene()->getScene()->getCurrentCamera();
+        double dpi = camera->getDpi().x;
+        int xres = camera->getRes().lx;
+        int yres = camera->getRes().ly;
+
+        in->getProperties()->setDpiPolicy(LevelProperties::DP_ImageDpi);
+        in->getProperties()->setDpi(dpi);
+        in->getProperties()->setImageDpi(TPointD(dpi, dpi));
+        in->getProperties()->setImageRes(TDimension(xres, yres));
+
+        std::vector<TFrameId> frameIds;
+        in->getFids(frameIds);
+        frameIdsSet = std::set<TFrameId>(frameIds.begin(), frameIds.end());
+        DrawingData* data = new DrawingData();
+        data->setLevelFrames(in, frameIdsSet);
+
+        // This is where the copying actually happens
+        for (auto id : frameIdsSet) {
+            TRasterCM32P raster(xres, yres);
+            raster->fill(TPixelCM32());
+            TToonzImageP firstImage(raster, TRect());
+            firstImage->setDpi(dpi, dpi);
+            out->setFrame(id, firstImage);
+            firstImage->setSavebox(TRect(0, 0, xres - 1, yres - 1));
+        }
+
+        bool keepOriginalPalette = false;
+        bool success = data->getLevelFrames(
+            out, frameIdsSet, DrawingData::OVER_SELECTION, true, keepOriginalPalette,
+            true);  // setting is redo = true skips the question about the palette
+        return success;
+    }
+
+    bool convertRaster(TXshSimpleLevel* in, TXshSimpleLevel* out,
+        std::set<TFrameId>& frameIdsSet)
+    {
+        return false;
+        ConvertPopup popup(false);
+        TFilePath path = TApp::instance()->getCurrentScene()->getScene()->decodeFilePath(in->getPath());
+        if (!TSystem::doesExistFileOrLevel(path))return false;
+        in->save();
+        popup.setFiles({path});
+        popup.setFormat("tlv");
+        popup.show();
+    }
+
+
+    //-----------------------------------------------------------------------------
+    // Convert from Vector/Raster to ToonzRaster
+    void exec() {
+        // set up basics
+        TApp* app = TApp::instance();
+        int row = app->getCurrentFrame()->getFrame();
+        int col = app->getCurrentColumn()->getColumnIndex();
+        int i;
+
+        ToonzScene* scene = app->getCurrentScene()->getScene();
+        TXsheet* xsh = scene->getXsheet();
+        int r0, c0, r1, c1;
+        std::set<TXshLevel*> levels;
+        bool isCellSelection = getSelectedLevels(levels, r0, c0, r1, c1);
+        if (levels.empty()) return;
+
+        int newIndexColumn = c1 + 1;
+        TUndoManager::manager()->beginBlock();
+        for (TXshLevel* level : levels) {
+            int type = level->getType();
+            if (type != TXshLevelType::PLI_XSHLEVEL &&
+                type != TXshLevelType::OVL_XSHLEVEL) continue;
+
+            TXshSimpleLevel* sourceSl = level->getSimpleLevel();
+            TXshSimpleLevel* rsl = getNewToonzRasterLevel(sourceSl);
+            assert(rsl);
+
+            std::set<TFrameId> frameIdsSet;
+            bool success =
+                (type == TXshLevelType::PLI_XSHLEVEL) ?
+                convertVector(sourceSl, rsl, frameIdsSet) :
+                convertRaster(sourceSl, rsl, frameIdsSet);
+            if (!success) continue;
+
+            int totalImages = frameIdsSet.size();
+
+            // expose the new frames
+            if (isCellSelection) {
+                TXsheet* xsheet = TApp::instance()->getCurrentXsheet()->getXsheet();
+                xsheet->insertColumn(newIndexColumn);
+
+                int r, c;
+                for (c = c0; c <= c1; c++) {
+                    for (r = r0; r <= r1; r++) {
+                        TXshCell cell = xsheet->getCell(r, c);
+                        TXshSimpleLevel* level =
+                            (!cell.isEmpty()) ? cell.getSimpleLevel() : 0;
+                        if (level != sourceSl) continue;
+                        TFrameId curFid = cell.getFrameId();
+                        for (auto const& fid : frameIdsSet) {
+                            if (fid.getNumber() ==
+                                curFid.getNumber() ||  // Hanno stesso numero di frame
+                                (fid.getNumber() == 1 &&
+                                    curFid.getNumber() ==
+                                    -2))  // La vecchia cella non ha numero di frame
+                                xsheet->setCell(r, newIndexColumn, TXshCell(rsl, fid));
+                        }
+                    }
+                }
+                newIndexColumn += 1;
+
+                CreateLevelUndo* undo = new CreateLevelUndo(row, newIndexColumn, totalImages, 1, true);
+                TUndoManager::manager()->add(undo);
+
+
+                invalidateIcons(rsl, frameIdsSet);
+                rsl->save(rsl->getPath(), TFilePath(), true);
+
+                DvDirModel::instance()->refreshFolder(rsl->getPath().getParentDir());
+
+                undo->onAdd(rsl);
+            }
+            else {
+                std::vector<TFrameId> gomi;
+                scene->getXsheet()->exposeLevel(
+                    0, scene->getXsheet()->getFirstFreeColumnIndex(), rsl, gomi);
+            }
+        }
+        TUndoManager::manager()->endBlock();
+
+        app->getCurrentScene()->notifySceneChanged();
+        app->getCurrentScene()->notifyCastChange();
+        app->getCurrentXsheet()->notifyXsheetChanged();
+
+        app->getCurrentTool()->onImageChanged(
+            (TImage::Type)app->getCurrentImageType());
+    }
+}//namespace
+
+//*****************************************************************************
+//    RasterizerPopupCommand instantiation
+//*****************************************************************************
+
+class RasterizerCommandHandler final : public MenuItemHandler {
+public:
+    RasterizerCommandHandler() : MenuItemHandler(MI_ConvertToToonzRaster) {};
+    void execute() override { ::exec(); };
+} rasterizerCommandHandler;

--- a/toonz/sources/toonz/selectionutils.cpp
+++ b/toonz/sources/toonz/selectionutils.cpp
@@ -49,8 +49,20 @@ namespace SelectionUtils{
             return false;
         }
         else if (columnSelection) {
-            TColumnSelection::getLevelSetFromColumnIndices(columnSelection->getIndices(), levels);
-            return false;
+            std::set<int> indices = columnSelection->getIndices();
+            if (indices.empty())return false;
+            TColumnSelection::getLevelSetFromColumnIndices(indices, levels);
+            r0 = INT_MAX, r1 = -1;
+            c0 = INT_MAX, c1 = -1;
+            for (int col : indices) {
+                int a, b;
+                xsheet->getCellRange(col, a, b);
+                if (a < r0) r0 = a;
+                if (b > r1) r1 = b;
+                if (col < c0) c0 = col;
+                if (col > c1) c1 = col;
+            }
+            return true;
         }
         else if (cellSelection) {
             cellSelection->getSelectedCells(r0, c0, r1, c1);
@@ -71,7 +83,7 @@ namespace SelectionUtils{
     }
     bool getSelectedLevels(std::set<TXshLevel*>& levels) {
         int r0, c0, r1, c1;
-        getSelectedLevels(levels, r0, c0, r1, c1);
+        return getSelectedLevels(levels, r0, c0, r1, c1);
     }
 }
 

--- a/toonz/sources/toonz/selectionutils.cpp
+++ b/toonz/sources/toonz/selectionutils.cpp
@@ -27,6 +27,55 @@
 #include <boost/range/counting_range.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
+namespace SelectionUtils{
+    bool getSelectedLevels(std::set<TXshLevel*>& levels, int& r0, int& c0, int& r1,
+        int& c1) {
+        TXsheet* xsheet = TApp::instance()->getCurrentXsheet()->getXsheet();
+
+        CastSelection* castSelection =
+            dynamic_cast<CastSelection*>(TSelection::getCurrent());
+        TCellSelection* cellSelection =
+            dynamic_cast<TCellSelection*>(TSelection::getCurrent());
+        TColumnSelection* columnSelection =
+            dynamic_cast<TColumnSelection*>(TSelection::getCurrent());
+
+        if (castSelection) {
+            std::vector<TXshLevel*> selectedLevels;
+            castSelection->getSelectedLevels(selectedLevels);
+
+            for (int i = 0; i < (int)selectedLevels.size(); ++i)
+                levels.insert(selectedLevels[i]);
+
+            return false;
+        }
+        else if (columnSelection) {
+            TColumnSelection::getLevelSetFromColumnIndices(columnSelection->getIndices(), levels);
+            return false;
+        }
+        else if (cellSelection) {
+            cellSelection->getSelectedCells(r0, c0, r1, c1);
+
+            for (int c = c0; c <= c1; ++c) {
+                for (int r = r0; r <= r1; ++r) {
+                    TXshCell cell = xsheet->getCell(r, c);
+
+                    if (TXshLevel* level = cell.isEmpty() ? 0 : cell.getSimpleLevel())
+                        levels.insert(level);
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+    bool getSelectedLevels(std::set<TXshLevel*>& levels) {
+        int r0, c0, r1, c1;
+        getSelectedLevels(levels, r0, c0, r1, c1);
+    }
+}
+
+
 //*********************************************************************************
 //    Local namespace
 //*********************************************************************************

--- a/toonz/sources/toonz/selectionutils.h
+++ b/toonz/sources/toonz/selectionutils.h
@@ -6,6 +6,8 @@
 // TnzCore includes
 #include "tfilepath.h"
 
+#include "toonz/txshlevel.h"
+
 // STL includes
 #include <set>
 #include <map>

--- a/toonz/sources/toonz/selectionutils.h
+++ b/toonz/sources/toonz/selectionutils.h
@@ -10,6 +10,12 @@
 #include <set>
 #include <map>
 
+namespace SelectionUtils {
+    bool getSelectedLevels(std::set<TXshLevel*>& levels, int& r0, int& c0, int& r1,
+        int& c1);
+    bool getSelectedLevels(std::set<TXshLevel*>& levels);
+}
+
 //==============================================================
 
 //    Forward declarations

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -7,6 +7,7 @@
 #include "fileselection.h"
 #include "castselection.h"
 #include "cellselection.h"
+#include "columnselection.h"
 #include "overwritepopup.h"
 #include "vectorizerswatch.h"
 #include "filebrowserpopup.h"
@@ -120,6 +121,8 @@ bool getSelectedLevels(std::set<TXshLevel *> &levels, int &r0, int &c0, int &r1,
       dynamic_cast<CastSelection *>(TSelection::getCurrent());
   TCellSelection *cellSelection =
       dynamic_cast<TCellSelection *>(TSelection::getCurrent());
+  TColumnSelection* columnSelection = 
+      dynamic_cast<TColumnSelection*>(TSelection::getCurrent());
 
   if (castSelection) {
     std::vector<TXshLevel *> selectedLevels;
@@ -129,7 +132,12 @@ bool getSelectedLevels(std::set<TXshLevel *> &levels, int &r0, int &c0, int &r1,
       levels.insert(selectedLevels[i]);
 
     return false;
-  } else if (cellSelection) {
+  }
+  else if (columnSelection) {
+      TColumnSelection::getLevelSetFromColumnIndices(columnSelection->getIndices(), levels);
+      return false;
+  }
+  else if (cellSelection) {
     cellSelection->getSelectedCells(r0, c0, r1, c1);
 
     for (int c = c0; c <= c1; ++c) {
@@ -143,7 +151,7 @@ bool getSelectedLevels(std::set<TXshLevel *> &levels, int &r0, int &c0, int &r1,
 
     return true;
   }
-
+  
   return false;
 }
 
@@ -343,7 +351,7 @@ int Vectorizer::doVectorize() {
 
   TXshSimpleLevel *sl = m_level.getPointer();
   if (!sl) return 0;
-
+  
   int rowCount = sl->getFrameCount();
   if (rowCount <= 0 || sl->isEmpty()) return 0;
 

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -12,6 +12,7 @@
 #include "vectorizerswatch.h"
 #include "filebrowserpopup.h"
 #include "menubarcommandids.h"
+#include "selectionutils.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -66,6 +67,7 @@
 #include <QToolButton>
 
 using namespace DVGui;
+using namespace SelectionUtils;
 
 //********************************************************************************
 //    Local namespace  classes
@@ -109,50 +111,6 @@ VectorizerParameters *getCurrentVectorizerParameters() {
       ->getScene()
       ->getProperties()
       ->getVectorizerParameters();
-}
-
-//-----------------------------------------------------------------------------
-
-bool getSelectedLevels(std::set<TXshLevel *> &levels, int &r0, int &c0, int &r1,
-                       int &c1) {
-  TXsheet *xsheet = TApp::instance()->getCurrentXsheet()->getXsheet();
-
-  CastSelection *castSelection =
-      dynamic_cast<CastSelection *>(TSelection::getCurrent());
-  TCellSelection *cellSelection =
-      dynamic_cast<TCellSelection *>(TSelection::getCurrent());
-  TColumnSelection* columnSelection = 
-      dynamic_cast<TColumnSelection*>(TSelection::getCurrent());
-
-  if (castSelection) {
-    std::vector<TXshLevel *> selectedLevels;
-    castSelection->getSelectedLevels(selectedLevels);
-
-    for (int i = 0; i < (int)selectedLevels.size(); ++i)
-      levels.insert(selectedLevels[i]);
-
-    return false;
-  }
-  else if (columnSelection) {
-      TColumnSelection::getLevelSetFromColumnIndices(columnSelection->getIndices(), levels);
-      return false;
-  }
-  else if (cellSelection) {
-    cellSelection->getSelectedCells(r0, c0, r1, c1);
-
-    for (int c = c0; c <= c1; ++c) {
-      for (int r = r0; r <= r1; ++r) {
-        TXshCell cell = xsheet->getCell(r, c);
-
-        if (TXshLevel *level = cell.isEmpty() ? 0 : cell.getSimpleLevel())
-          levels.insert(level);
-      }
-    }
-
-    return true;
-  }
-  
-  return false;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/vectorizerpopup.h
+++ b/toonz/sources/toonz/vectorizerpopup.h
@@ -320,7 +320,7 @@ private:
   TXshSimpleLevelP m_level;  //!< Input level to vectorize (only one level at a
                              //! time is dealt here).
   VectorizerParameters m_params;  //!< Vectorizer options to be applied
-
+  
   TXshSimpleLevelP m_vLevel;     //!< Output vectorized level
   std::vector<TFrameId> m_fids;  //!< Frame ids of the input \b m_level
 

--- a/toonz/sources/toonzlib/imagebuilders.cpp
+++ b/toonz/sources/toonzlib/imagebuilders.cpp
@@ -327,6 +327,7 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
                                TScale(sx,sy),
               TRect(), vi->getPalette());
           rd.m_antiAliasing = m_antiAliasing;
+          rd.m_show0ThickStrokes = Preferences::instance()->getShow0ThickLines();
 
           //Is this too slow?
           {
@@ -400,7 +401,7 @@ TImageP ImageRasterizer::build(int imFlags, void *extData) {
       }
     }
   }
-  
+  return TRasterImageP();
   // Error case: return a dummy image (is it really required?)
 
   TRaster32P ras(10,10);

--- a/toonz/sources/toonzlib/toonzimageutils.cpp
+++ b/toonz/sources/toonzlib/toonzimageutils.cpp
@@ -17,6 +17,9 @@
 #include "tsystem.h"
 #include "tstream.h"
 #include "tsimplecolorstyles.h"
+
+#include "toonz/preferences.h"
+
 //-------------------------------------------------------------------
 
 namespace {
@@ -115,7 +118,8 @@ TRect rasterizeRegion(TOfflineGL *&gl, TRect rasBounds, TRegion *region,
 
     TPalette *palette = new TPalette();
     TTranslation affine(-convert(rect.getP00()));
-    TVectorRenderData rd(affine, gl->getBounds(), palette, 0, true, true);
+    TVectorRenderData rd(affine, gl->getBounds(), palette, 0, true,
+        Preferences::instance()->getRasterizeAntialias());
 
     int oldStyle = region->getStyle();
     region->setStyle(1);
@@ -461,7 +465,8 @@ TToonzImageP ToonzImageUtils::vectorToToonzImage(
       }
       if (visible)
         fastAddInkStroke(ti, stroke, std::min(maxStyleId, stroke->getStyle()),
-                         false, false, clip, true, colors);
+                         false, false, clip, 
+            Preferences::instance()->getRasterizeAntialias(), colors);
     }
     i = k;
   }


### PR DESCRIPTION
### This PR would make these commands be able to get levels from level/cast/cells selection :

- Level-Convert-Convert to Vectors...
- Level-Convert-Convert to Toonz Raster... (was Vectors to Toonz Raster)
- Level-Adjust-Binarize
- Level-Export Level...

### Additional Improvements:

- Now **Convert to Toonz Raster** can convert Normal Raster with options
- Rasterize Vector with Anti Aliasing would apply to Level-Convert-Convert to Toonz Raster, when converting vector levels
- Fix the offset and thickness change when exporting ToonzVector to ToonzRaster
- Disable the Purple Block at middle when Visualize Vector as Raster is on and VectorImage is empty
- Apply show 0 Thickness line preference to Visualize Vector as Raster