### PR TITLE
Refactor micro logic for ExportAllLevelsPopup

### DIFF
--- a/toonz/sources/toonz/exportalllevelspopup.cpp
+++ b/toonz/sources/toonz/exportalllevelspopup.cpp
@@ -423,35 +423,13 @@ void ExportAllLevelsPopup::updateOnSelection() {
 
 std::wstring ExportAllLevelsPopup::backFolderName(std::string colname,
                                                   std::wstring levelname) {
-  if (levelname == to_wstring(colname) || colname.substr(0, 3) == "Col")
-    return levelname;
-  else {
-    std::wstring foldername;
-    colname.erase(std::remove(colname.begin(), colname.end(), L'#'),
+  if (!colname.empty() && colname[0] == '#'){
+    colname.erase(std::remove(colname.begin(), colname.end(), '#'),
                   colname.end());
-
-    int pos = colname.find(L'_');  //  '_'
-    if (pos != std::wstring::npos) {
-      foldername += to_wstring(colname.substr(0, pos));
-    } else {
-      foldername += to_wstring(colname);
-      return foldername;
-    }
-
-    pos = colname.find(L'1');
-    if (pos != std::wstring::npos) {
-      foldername += to_wstring("_1gen");
-      colname.erase(pos);
-    } else {
-      pos = colname.find(L'2');
-      if (!pos == std::wstring::npos) {
-        foldername += to_wstring("_2gen");
-        colname.erase(pos);
-      }
-    }
-    
-    return foldername;
+    if (colname.find('_') != std::string::npos)//  '_'
+        return to_wstring(colname);
   }
+  return levelname;
 }
 
 bool ExportAllLevelsPopup::isAllLevelsExported() {


### PR DESCRIPTION
#### This PR changes the behavior of column name macros with '#' prefix when exporting levels.
To generate the suggest exported file name:
- If colname starts with #, all # characters are removed.
- If the cleaned colname contains an underscore _, return the cleaned colname as a wide string.
- Otherwise, return the original levelname unchanged.
