### PR TITLE
Revert macOS version from 15 to 13 due to issues

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -21,7 +21,8 @@ on:
 jobs:
   macOS:
     timeout-minutes: 90 # Stop job if it exceeds expected build time
-    runs-on: macos-15
+    # Stick with macOS 13 to avoid arm64 headaches on macOS 15
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 
@@ -46,14 +47,16 @@ jobs:
               fi
             done
           }
+          
           brew update
           brew cleanup
-          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv superlu qt@5
+
+          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv qt@5
           brew unlink qt
 
       - name: Set up cache
         run: |
-          export PATH="/opt/homebrew/opt/ccache/libexec:$PATH"
+          export PATH="/usr/local/opt/ccache/libexec:$PATH"
           mkdir -p /Users/runner/.ccache
 
       - uses: actions/cache@v4
@@ -70,7 +73,7 @@ jobs:
 
       - name: Build
         run: |
-          export PKG_CONFIG_PATH="$(brew --prefix jpeg-turbo)/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
           cd toonz
           mkdir -p build
           cd build
@@ -79,7 +82,6 @@ jobs:
             -DQT_PATH=$(brew --prefix qt@5)/lib \
             -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
             -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 \
-            -DWITH_SYSTEM_SUPERLU=ON \
             -DWITH_TRANSLATION=OFF
           ninja -j $(sysctl -n hw.ncpu)
 
@@ -87,9 +89,7 @@ jobs:
         run: |
           cd toonz/build/toonz
           cp -pr ../../../stuff OpenToonz.app/portablestuff
-          QT_DEPLOY=$(brew --prefix qt@5)/bin/macdeployqt
-          echo "Using macdeployqt from: $QT_DEPLOY"
-          $QT_DEPLOY OpenToonz.app -verbose=0 -always-overwrite \
+          /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -verbose=0 -always-overwrite \
             -executable=OpenToonz.app/Contents/MacOS/lzocompress \
             -executable=OpenToonz.app/Contents/MacOS/lzodecompress \
             -executable=OpenToonz.app/Contents/MacOS/tcleanup \
@@ -115,18 +115,20 @@ jobs:
           cd toonz/build/toonz
           echo "Creating DMG..."
 
-          QT_DEPLOY=$(brew --prefix qt@5)/bin/macdeployqt
           ATTEMPT=1
-          until $QT_DEPLOY OpenToonz.app -dmg -verbose=0 && [ -f OpenToonz.dmg ]; do
+          until /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0 && [ -f OpenToonz.dmg ]; do
             echo "Attempt $ATTEMPT failed to build DMG."
+
             if [ $ATTEMPT -eq 10 ]; then
               echo ">>> DMG file creation failed after 10 attempts. Aborting!"
               exit 1
             fi
+
             ATTEMPT=$((ATTEMPT + 1))
-            echo "Retrying in 10 seconds..."
-            sleep 10
+            echo "Retrying in 5 seconds..."
+            sleep 5
           done
+
           echo "DMG created successfully."
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Since macOS 15 runs on ARM64 by default, while macOS 13 used x86_64, this has caused build issues due to architecture-specific dependency libraries. Therefore, this change reverts the CI to use macOS 13 until a developer with access to macOS can evaluate, test, and resolve the issue before moving to the any newer version.

A DMG file on macOS is not inherently a portable app, but it can be used to distribute it in a way that is somewhat similar to a portable app. Since we are experiencing delays with the nightly releases, I’d like to suggest that @RodneyBaker also include the .dmg file along with the Windows portable version release. There's no need to create a new release for this, just remove the current attachment and update it with the latest Windows portable build and the latest .dmg file. Repeat this maybe once a month or when an important fix is available, to avoid overloading you, since manually handling this can be a bit tedious.

I was waiting for @artisteacher to validate this, but I just remember that it was working before the workflow was changed to macOS 15, so I figured I'd submit it asap.