### PR TITLE
Refactor: Update deprecated Qt functions

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -26,16 +26,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Remove symlinks
+      - name: Clean Python symlinks
         run: |
-          # Remove existing symlinks before installing Python
-          for symlink in 2to3 idle3 pydoc3 python3 python3-config \
-                         2to3-3.11 idle3.11 pydoc3.11 python3.11 python3.11-config \
-                         2to3-3.12 idle3.12 pydoc3.12 python3.12 python3.12-config \
-                         idle3.13 pydoc3.13 python3.13 python3.13-config; do
-            rm -f /usr/local/bin/$symlink
+          # Remove potentially conflicting Python symlinks
+          find /usr/local/bin -type l \( -name "python*" -o -name "pip*" -o -name "2to3*" -o -name "idle*" -o -name "pydoc*" \) \
+            -exec sh -c 'file -b {} | grep -q "symbolic link to .*Python.framework" && echo "Removing {}" && rm {}' \;
+          # Ensure Homebrew Python is properly linked
+          for py_version in python@3.11 python@3.12 python@3.13; do
+            if brew list --versions $py_version >/dev/null; then
+              brew unlink $py_version || true
+            fi
           done
-
+          brew link --overwrite --force python@3.13 || true
+          
       - name: Install libraries
         run: |
           checkPkgAndInstall() {
@@ -50,15 +53,12 @@ jobs:
           
           brew update
           brew cleanup
-
           checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv qt@5
           brew unlink qt
-
       - name: Set up cache
         run: |
           export PATH="/usr/local/opt/ccache/libexec:$PATH"
           mkdir -p /Users/runner/.ccache
-
       - uses: actions/cache@v4
         with:
           path: /Users/runner/.ccache
@@ -70,7 +70,6 @@ jobs:
           cd thirdparty/tiff-4.0.3
           CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./configure --disable-lzma
           make -j $(sysctl -n hw.ncpu)
-
       - name: Build
         run: |
           export PKG_CONFIG_PATH="/usr/local/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
@@ -84,7 +83,6 @@ jobs:
             -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 \
             -DWITH_TRANSLATION=OFF
           ninja -j $(sysctl -n hw.ncpu)
-
       - name: Introduce Libraries and Stuff
         run: |
           cd toonz/build/toonz
@@ -97,7 +95,6 @@ jobs:
             -executable=OpenToonz.app/Contents/MacOS/tconverter \
             -executable=OpenToonz.app/Contents/MacOS/tfarmcontroller \
             -executable=OpenToonz.app/Contents/MacOS/tfarmserver
-
       - name: Modify Library Paths
         run: |
           cd toonz/build/toonz/OpenToonz.app/Contents/Frameworks
@@ -109,28 +106,22 @@ jobs:
               fi
             done
           done
-
       - name: Create Artifact
         run: |
           cd toonz/build/toonz
           echo "Creating DMG..."
-
           ATTEMPT=1
           until /usr/local/opt/qt@5/bin/macdeployqt OpenToonz.app -dmg -verbose=0 && [ -f OpenToonz.dmg ]; do
             echo "Attempt $ATTEMPT failed to build DMG."
-
             if [ $ATTEMPT -eq 10 ]; then
               echo ">>> DMG file creation failed after 10 attempts. Aborting!"
               exit 1
             fi
-
             ATTEMPT=$((ATTEMPT + 1))
             echo "Retrying in 5 seconds..."
             sleep 5
           done
-
           echo "DMG created successfully."
-
       - uses: actions/upload-artifact@v4
         with:
           name: Opentoonz-${{ runner.os }}-${{ github.sha }}

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -43,7 +43,7 @@ class TToonzImage;
 class TMeshImage;
 class QPainter;
 class QPolygon;
-class QMatrix;
+class QTransform;
 
 namespace Stage {
 class Player;
@@ -284,7 +284,7 @@ public:
   int getNodesCount();
   void clearNodes();
 
-  TRasterP getRaster(int index, QMatrix &matrix);
+  TRasterP getRaster(int index, QTransform &matrix);
 
   void flushRasterImages();
   void drawRasterImages(QPainter &p, QPolygon cameraRect);
@@ -355,7 +355,7 @@ public:
 
   void onImage(const Stage::Player &data) override;
   void onVectorImage(TVectorImage *vi, const Stage::Player &data);
-  void onRasterImage(TRasterImage *ri, const Stage::Player &data);
+  void onRasterImage(TRasterImage *ri, const Stage::Player &data) override;
   void onToonzImage(TToonzImage *ti, const Stage::Player &data);
 
   void beginMask() override;

--- a/toonz/sources/include/toonz/tframehandle.h
+++ b/toonz/sources/include/toonz/tframehandle.h
@@ -4,7 +4,7 @@
 #define TFRAMEHANDLE_H
 
 #include <QObject>
-#include <QTime>
+#include <QElapsedTimer>
 #include "tfilepath.h"
 #include "toonz/txshsoundcolumn.h"
 
@@ -51,7 +51,7 @@ private:
   TXsheet *m_xsheet;
   std::pair<int, int> m_scrubRange;
   double m_fps;
-  QTime m_clock;
+  QElapsedTimer m_clock;
 
   // void startPlaying(bool looping);
   // void stopPlaying();
@@ -87,7 +87,7 @@ public:
   bool isEditingLevel() const { return getFrameType() == LevelFrame; }
   bool isEditingScene() const { return getFrameType() == SceneFrame; }
 
-  // i  metodi seguenti funzionano sia con LevelFrame sia con SceneFrame
+  // The following methods work with both LevelFrame and SceneFrame
   int getMaxFrameIndex() const;
   int getFrameIndex() const;
   QString getFrameIndexName(int index) const;

--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -200,7 +200,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
   m_saveInFolderPopup = new PencilTestSaveInFolderPopup(this);
   m_cameraListCombo   = new QComboBox(this);
   m_resolutionCombo   = new QComboBox(this);
-  m_resolutionCombo->setFixedWidth(fontMetrics().width("0000 x 0000") + 25);
+  m_resolutionCombo->setFixedWidth(fontMetrics().horizontalAdvance("0000 x 0000") + 25);
   m_resolutionLabel                 = new QLabel(tr("Resolution: "), this);
   m_cameraStatusLabel               = new QLabel(tr("Camera Status"), this);
   QPushButton *refreshCamListButton = new QPushButton(tr("Refresh"), this);
@@ -496,7 +496,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     m_pictureStyleCombo   = new QComboBox(this);
     m_cameraSettingsLabel = new QLabel(tr("Camera Model"), this);
     m_cameraModeLabel     = new QLabel(tr("Camera Mode"), this);
-    m_exposureCombo->setFixedWidth(fontMetrics().width("000000") + 25);
+    m_exposureCombo->setFixedWidth(fontMetrics().horizontalAdvance("000000") + 25);
     QVBoxLayout *settingsLayout = new QVBoxLayout;
     settingsLayout->setSpacing(0);
     settingsLayout->setMargin(5);
@@ -1619,7 +1619,7 @@ void StopMotionController::refreshCameraList(QString activeCamera) {
         std::string name = webcams.at(c).deviceName().toStdString();
         QString camDesc  = webcams.at(c).description();
         m_cameraListCombo->addItem(camDesc);
-        maxTextLength = std::max(maxTextLength, fontMetrics().width(camDesc));
+        maxTextLength = std::max(maxTextLength, fontMetrics().horizontalAdvance(camDesc));
       }
     }
 #ifdef WITH_CANON

--- a/toonz/sources/stopmotion/stopmotionlight.cpp
+++ b/toonz/sources/stopmotion/stopmotionlight.cpp
@@ -5,7 +5,8 @@
 
 #include <QDialog>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QGuiApplication>
+#include <QScreen>  
 #include <QWindow>
 
 TEnv::IntVar StopMotionBlackCapture("StopMotionBlackCapture", 0);
@@ -19,7 +20,7 @@ StopMotionLight::StopMotionLight() {
   m_fullScreen1 = new QDialog();
   m_fullScreen1->setModal(false);
   m_fullScreen1->setStyleSheet("background-color:black;");
-  m_screenCount = QApplication::desktop()->screenCount();
+  m_screenCount = QGuiApplication::screens().size();
   if (m_screenCount > 1) {
     m_fullScreen2 = new QDialog();
     m_fullScreen2->setModal(false);
@@ -119,19 +120,19 @@ void StopMotionLight::showOverlays() {
   bool isTimeLapse = StopMotion::instance()->m_isTimeLapse;
   if ((getBlackCapture() || m_useScreen1Overlay) && !isTimeLapse) {
     m_fullScreen1->showFullScreen();
-    m_fullScreen1->setGeometry(QApplication::desktop()->screenGeometry(0));
+    m_fullScreen1->setGeometry(QGuiApplication::screens()[0]->geometry());
     shown = true;
   }
   if (m_screenCount > 1 && (getBlackCapture() || m_useScreen2Overlay) &&
       !isTimeLapse) {
     m_fullScreen2->showFullScreen();
-    m_fullScreen2->setGeometry(QApplication::desktop()->screenGeometry(1));
+    m_fullScreen2->setGeometry(QGuiApplication::screens()[1]->geometry());
     shown = true;
   }
   if (m_screenCount > 2 && (getBlackCapture() || m_useScreen3Overlay) &&
       !isTimeLapse) {
     m_fullScreen3->showFullScreen();
-    m_fullScreen3->setGeometry(QApplication::desktop()->screenGeometry(2));
+    m_fullScreen3->setGeometry(QGuiApplication::screens()[2]->geometry());
     shown = true;
   }
 

--- a/toonz/sources/tnztools/plastictool.cpp
+++ b/toonz/sources/tnztools/plastictool.cpp
@@ -416,7 +416,7 @@ PlasticToolOptionsBox::PlasticToolOptionsBox(QWidget *parent, TTool *tool,
         new GenericToolOptionsBox(0, tool, pltHandle, m, 0, false);
 
   meshifyButton->setFixedHeight(20);
-  int buttonWidth = fontMetrics().width(meshifyButton->text()) + 20;
+  int buttonWidth = fontMetrics().horizontalAdvance(meshifyButton->text()) + 20;
   meshifyButton->setFixedWidth(buttonWidth);
   QAction *meshifyAction =
       CommandManager::instance()->getAction("A_ToolOption_Meshify");

--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -1013,7 +1013,7 @@ void SkeletonTool::drawHooks() {
   // glColor3d(0,1,1);
   // tglDrawRect(0,100,Stage::inch,110);
 
-  QTime time;
+  QElapsedTimer time;
   time.start();
 
   m_magicLinks.clear();

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2488,7 +2488,7 @@ RGBPickerToolOptionsBox::RGBPickerToolOptionsBox(
       CommandManager::instance()->getAction("A_ToolOption_PickScreen");
 
   QPushButton *button = new QPushButton(tr("Pick Screen"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 10;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(pickScreenAction);
@@ -2632,9 +2632,9 @@ ShiftTraceToolOptionBox::ShiftTraceToolOptionBox(QWidget *parent, TTool *tool)
 
   m_prevFrame->setFixedSize(10, 21);
   m_afterFrame->setFixedSize(10, 21);
-  int buttonWidth = fontMetrics().width(m_resetPrevGhostBtn->text()) + 10;
+  int buttonWidth = fontMetrics().horizontalAdvance(m_resetPrevGhostBtn->text()) + 10;
   m_resetPrevGhostBtn->setFixedWidth(buttonWidth);
-  buttonWidth = fontMetrics().width(m_resetAfterGhostBtn->text()) + 10;
+  buttonWidth = fontMetrics().horizontalAdvance(m_resetAfterGhostBtn->text()) + 10;
   m_resetAfterGhostBtn->setFixedWidth(buttonWidth);
 
   m_layout->addWidget(m_prevFrame, 0);
@@ -2760,7 +2760,7 @@ ZoomToolOptionsBox::ZoomToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_ZoomReset);
 
   QPushButton *button = new QPushButton(tr("Reset Zoom"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 10;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetZoomAction);
@@ -2787,7 +2787,7 @@ RotateToolOptionsBox::RotateToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_RotateReset);
 
   QPushButton *button = new QPushButton(tr("Reset Rotation"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 10;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetRotationAction);
@@ -2814,7 +2814,7 @@ HandToolOptionsBox::HandToolOptionsBox(QWidget *parent, TTool *tool,
       CommandManager::instance()->getAction(VB_PositionReset);
 
   QPushButton *button = new QPushButton(tr("Reset Position"));
-  int buttonWidth     = fontMetrics().width(button->text()) + 10;
+  int buttonWidth     = fontMetrics().horizontalAdvance(button->text()) + 10;
   button->setFixedWidth(buttonWidth);
   button->setFixedHeight(20);
   button->addAction(resetPositionAction);

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -137,7 +137,7 @@ ToolOptionSlider::ToolOptionSlider(TTool *tool, TDoubleProperty *property,
   // set the maximum width of the widget according to the text length (with 5
   // pixels margin)
   txt.fill('0', textMaxLength);
-  int widgetWidth = fontMetrics().width(txt) + 5;
+  int widgetWidth = fontMetrics().horizontalAdvance(txt) + 5;
   m_lineEdit->parentWidget()->setMaximumWidth(widgetWidth);
   // set the maximum width of the slider to 250 pixels
   setMaximumWidth(250 + widgetWidth);
@@ -191,7 +191,7 @@ ToolOptionPairSlider::ToolOptionPairSlider(TTool *tool,
   // set the maximum width of the widget according to the text length (with 5
   // pixels margin)
   txt.fill('0', textMaxLength);
-  int widgetWidth = fontMetrics().width(txt) + 5;
+  int widgetWidth = fontMetrics().horizontalAdvance(txt) + 5;
   m_leftLineEdit->setFixedWidth(widgetWidth);
   m_rightLineEdit->setFixedWidth(widgetWidth);
   m_leftMargin  = widgetWidth + 12;
@@ -361,7 +361,7 @@ void ToolOptionCombo::loadEntries() {
                       }");
       }
     }
-    int tmpWidth = fontMetrics().width(items[i].UIName);
+    int tmpWidth = fontMetrics().horizontalAdvance(items[i].UIName);
     if (tmpWidth > maxWidth) maxWidth = tmpWidth;
   }
 
@@ -898,7 +898,7 @@ void MeasuredValueField::receiveMouseRelease(QMouseEvent *e) {
 namespace {
 // calculate maximum field size (once) with 10 pixels margin
 int getMaximumWidthForEditToolField(QWidget *widget) {
-  static int fieldMaxWidth = widget->fontMetrics().width("-0000.00 field") + 10;
+  static int fieldMaxWidth = widget->fontMetrics().horizontalAdvance("-0000.00 field") + 10;
   return fieldMaxWidth;
 }
 }  // namespace
@@ -1235,7 +1235,7 @@ void PropertyMenuButton::onActionTriggered(QAction *action) {
 namespace {
 // calculate maximum field size (once) with 10 pixels margin
 int getMaximumWidthForSelectionToolField(QWidget *widget) {
-  static int fieldMaxWidth = widget->fontMetrics().width("-000.00 %") + 10;
+  static int fieldMaxWidth = widget->fontMetrics().horizontalAdvance("-000.00 %") + 10;
   return fieldMaxWidth;
 }
 }  // namespace

--- a/toonz/sources/toonz/autolipsyncpopup.cpp
+++ b/toonz/sources/toonz/autolipsyncpopup.cpp
@@ -726,7 +726,7 @@ void AutoLipSyncPopup::onOutputReady() {
                .replace("\\\"", "")
                .replace("\"", "");
   QStringList outputList =
-      output.mid(2, (output.size() - 4)).split(", ", QString::SkipEmptyParts);
+      output.mid(2, (output.size() - 4)).split(", ", Qt::SkipEmptyParts);
   if (outputList.size()) {
     QStringList outputType = outputList.at(0).split(": ");
     if (outputType.at(1) == "progress") {

--- a/toonz/sources/toonz/canvassizepopup.cpp
+++ b/toonz/sources/toonz/canvassizepopup.cpp
@@ -224,8 +224,7 @@ void PeggingWidget::createButton(QPushButton **button,
   QPixmap pix(1, 1);
   switch (position) {
   case e00:
-    pix = m_topRightPix.transformed(QMatrix().rotate(-90),
-                                    Qt::SmoothTransformation);
+    pix = m_topRightPix.transformed(QTransform().rotate(-90), Qt::SmoothTransformation);
     break;
   case e01:
     pix = m_topPix;
@@ -234,21 +233,19 @@ void PeggingWidget::createButton(QPushButton **button,
     pix = m_topRightPix;
     break;
   case e10:
-    pix = m_topPix.transformed(QMatrix().rotate(-90), Qt::SmoothTransformation);
+    pix = m_topPix.transformed(QTransform().rotate(-90), Qt::SmoothTransformation);
     break;
   case e12:
-    pix = m_topPix.transformed(QMatrix().rotate(90), Qt::SmoothTransformation);
+    pix = m_topPix.transformed(QTransform().rotate(90), Qt::SmoothTransformation);
     break;
   case e20:
-    pix = m_topRightPix.transformed(QMatrix().rotate(180),
-                                    Qt::SmoothTransformation);
+    pix = m_topRightPix.transformed(QTransform().rotate(180), Qt::SmoothTransformation);
     break;
   case e21:
-    pix = m_topPix.transformed(QMatrix().rotate(180), Qt::SmoothTransformation);
+    pix = m_topPix.transformed(QTransform().rotate(180), Qt::SmoothTransformation);
     break;
   case e22:
-    pix = m_topRightPix.transformed(QMatrix().rotate(90),
-                                    Qt::SmoothTransformation);
+    pix = m_topRightPix.transformed(QTransform().rotate(90), Qt::SmoothTransformation);
     break;
   default:
     break;
@@ -263,12 +260,12 @@ void PeggingWidget::on00() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_00->setIcon(pix);
-  m_01->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_01->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
   m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
-  m_10->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_10->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_02->setIcon(pix);
@@ -285,17 +282,17 @@ void PeggingWidget::on01() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_01->setIcon(pix);
-  m_00->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_00->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
   m_10->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
   m_12->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
-  m_02->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_02->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
 
   m_20->setIcon(pix);
@@ -310,12 +307,12 @@ void PeggingWidget::on02() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_02->setIcon(pix);
-  m_01->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_01->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
   m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_12->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_12->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -332,17 +329,17 @@ void PeggingWidget::on10() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_10->setIcon(pix);
-  m_00->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_00->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
   m_01->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
   m_21->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
-  m_20->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_20->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_02->setIcon(pix);
@@ -358,24 +355,24 @@ void PeggingWidget::on11() {
   pix.fill(Qt::transparent);
   m_11->setIcon(pix);
   m_00->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_01->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_01->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
   m_02->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_10->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_10->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
-  m_12->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_12->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
   m_20->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_21->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_21->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
   m_22->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? -90 : 90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? -90 : 90),
                                 Qt::SmoothTransformation));
 }
 
@@ -386,17 +383,17 @@ void PeggingWidget::on12() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_12->setIcon(pix);
-  m_02->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_02->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
   m_01->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
   m_21->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 0 : 180),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 0 : 180),
                                 Qt::SmoothTransformation));
-  m_22->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 0 : 180),
+  m_22->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 0 : 180),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -411,12 +408,12 @@ void PeggingWidget::on20() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_20->setIcon(pix);
-  m_10->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_10->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
   m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_21->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_21->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -433,17 +430,17 @@ void PeggingWidget::on21() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_21->setIcon(pix);
-  m_20->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_20->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
   m_10->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_11->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_11->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
   m_12->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 180 : 0),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 180 : 0),
                                 Qt::SmoothTransformation));
-  m_22->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? -90 : 90),
+  m_22->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? -90 : 90),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);
@@ -458,12 +455,12 @@ void PeggingWidget::on22() {
   QPixmap pix(30, 30);
   pix.fill(Qt::transparent);
   m_22->setIcon(pix);
-  m_12->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLy ? 180 : 0),
+  m_12->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLy ? 180 : 0),
                                      Qt::SmoothTransformation));
   m_11->setIcon(
-      m_topRightPix.transformed(QMatrix().rotate(m_cutLx || m_cutLy ? 90 : -90),
+      m_topRightPix.transformed(QTransform().rotate(m_cutLx || m_cutLy ? 90 : -90),
                                 Qt::SmoothTransformation));
-  m_21->setIcon(m_topPix.transformed(QMatrix().rotate(m_cutLx ? 90 : -90),
+  m_21->setIcon(m_topPix.transformed(QTransform().rotate(m_cutLx ? 90 : -90),
                                      Qt::SmoothTransformation));
 
   m_00->setIcon(pix);

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -274,7 +274,7 @@ void DvDirTreeViewDelegate::setModelData(QWidget *editor,
                                          const QModelIndex &index) const {
   if (index.data().canConvert(QMetaType::QString)) {
     NodeEditor *nodeEditor = qobject_cast<NodeEditor *>(editor);
-    model->setData(index, qVariantFromValue(
+    model->setData(index, QVariant::fromValue(
                               nodeEditor->getText()));  // starEditor->text()));
   } else
     QAbstractItemDelegate::setModelData(editor, model, index);

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -797,7 +797,7 @@ LoadLevelPopup::LoadLevelPopup()
     QHBoxLayout *subsequenceHeadLay = createHBoxLayout(0, 5);
     {
       QFontMetrics metrics(font());
-      subsequenceHeadLay->addSpacing(metrics.width("File name:") + 3);
+      subsequenceHeadLay->addSpacing(metrics.horizontalAdvance("File name:") + 3);
       subsequenceHeadLay->addWidget(m_notExistLabel, 0);
       subsequenceHeadLay->addStretch(1);
 

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1091,7 +1091,7 @@ void FilmstripFrames::mouseMoveEvent(QMouseEvent *e) {
     } else
       stopAutoPanning();
     update();
-  } else if (e->buttons() & Qt::MidButton) {
+  } else if (e->buttons() & Qt::MiddleButton) {
     // scroll con il tasto centrale
     pos = e->globalPos();
     if (m_isVertical) {
@@ -1149,12 +1149,12 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
   else if (event->key() == Qt::Key_PageDown) {
     if (m_isVertical) {
       int frameHeight   = m_iconSize.height();
-      int visibleHeight = visibleRegion().rects()[0].height();
+      int visibleHeight = visibleRegion().begin()[0].height();
       int visibleFrames = double(visibleHeight) / double(frameHeight);
       scroll(visibleFrames * frameHeight);
     } else {
       int frameWidth    = m_iconSize.width();
-      int visibleWidth  = visibleRegion().rects()[0].width();
+      int visibleWidth  = visibleRegion().begin()[0].width();
       int visibleFrames = double(visibleWidth) / double(frameWidth);
       scroll(visibleFrames * frameWidth);
     }
@@ -1162,12 +1162,12 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
   } else if (event->key() == Qt::Key_PageUp) {
     if (m_isVertical) {
       int frameHeight   = m_iconSize.height();
-      int visibleHeight = visibleRegion().rects()[0].height();
+      int visibleHeight = visibleRegion().begin()[0].height();
       int visibleFrames = double(visibleHeight) / double(frameHeight);
       scroll(-visibleFrames * frameHeight);
     } else {
       int frameWidth    = m_iconSize.width();
-      int visibleWidth  = visibleRegion().rects()[0].width();
+      int visibleWidth  = visibleRegion().begin()[0].width();
       int visibleFrames = double(visibleWidth) / double(frameWidth);
       scroll(-visibleFrames * frameWidth);
     }
@@ -1184,7 +1184,7 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
 //-----------------------------------------------------------------------------
 
 void FilmstripFrames::wheelEvent(QWheelEvent *event) {
-  scroll(-event->delta());
+  scroll(-event->angleDelta().y());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/frameheadgadget.cpp
+++ b/toonz/sources/toonz/frameheadgadget.cpp
@@ -255,7 +255,7 @@ bool FrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
         return false;
       }
       viewer->update();
-    } else if (mouseEvent->buttons() & Qt::MidButton)
+    } else if (mouseEvent->buttons() & Qt::MiddleButton)
       return false;
   } else
     return false;
@@ -833,7 +833,7 @@ bool FilmstripFrameHeadGadget::eventFilter(QObject *obj, QEvent *e) {
         return false;
       }
       viewer->update();
-    } else if (mouseEvent->buttons() & Qt::MidButton)
+    } else if (mouseEvent->buttons() & Qt::MiddleButton)
       return false;
   } else
     return false;

--- a/toonz/sources/toonz/matchline.cpp
+++ b/toonz/sources/toonz/matchline.cpp
@@ -942,10 +942,10 @@ std::vector<int> string2Indexes(const QString &values) {
   std::vector<int> ret;
   int i, j;
   bool ok;
-  QStringList vals = values.split(',', QString::SkipEmptyParts);
+  QStringList vals = values.split(',', Qt::SkipEmptyParts);
   for (i = 0; i < vals.size(); i++) {
     if (vals.at(i).contains('-')) {
-      QStringList vals1 = vals.at(i).split('-', QString::SkipEmptyParts);
+      QStringList vals1 = vals.at(i).split('-', Qt::SkipEmptyParts);
       if (vals1.size() != 2) return std::vector<int>();
       int from = vals1.at(0).toInt(&ok);
       if (!ok) return std::vector<int>();

--- a/toonz/sources/toonz/mergecmapped.cpp
+++ b/toonz/sources/toonz/mergecmapped.cpp
@@ -659,10 +659,10 @@ std::vector<int> string2Indexes(const QString &values) {
   std::vector<int> ret;
   int i, j;
   bool ok;
-  QStringList vals = values.split(',', QString::SkipEmptyParts);
+  QStringList vals = values.split(',', Qt::SkipEmptyParts);
   for (i = 0; i < vals.size(); i++) {
     if (vals.at(i).contains('-')) {
-      QStringList vals1 = vals.at(i).split('-', QString::SkipEmptyParts);
+      QStringList vals1 = vals.at(i).split('-', Qt::SkipEmptyParts);
       if (vals1.size() != 2) return std::vector<int>();
       int from = vals1.at(0).toInt(&ok);
       if (!ok) return std::vector<int>();

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1640,7 +1640,7 @@ PencilTestPopup::PencilTestPopup()
   m_dpiMenuWidget = createDpiMenuWidget();
   //----
 
-  m_resolutionCombo->setMaximumWidth(fontMetrics().width("0000 x 0000") + 25);
+  m_resolutionCombo->setMaximumWidth(fontMetrics().horizontalAdvance("0000 x 0000") + 25);
   m_fileTypeCombo->addItems({"jpg", "png", "tga", "tif"});
   m_fileTypeCombo->setCurrentText(QString::fromStdString(CamCapFileType));
 
@@ -1725,7 +1725,7 @@ PencilTestPopup::PencilTestPopup()
   m_calibration.label->hide();
   m_calibration.exportBtn->setEnabled(false);
 
-  int subCameraFieldWidth = fontMetrics().width("00000") + 5;
+  int subCameraFieldWidth = fontMetrics().horizontalAdvance("00000") + 5;
   m_subWidthFld->setFixedWidth(subCameraFieldWidth);
   m_subHeightFld->setFixedWidth(subCameraFieldWidth);
   m_subXPosFld->setFixedWidth(subCameraFieldWidth);
@@ -2155,7 +2155,7 @@ void PencilTestPopup::refreshCameraList() {
   for (int c = 0; c < cameras.size(); c++) {
     QString camDesc = cameras.at(c).description();
     m_cameraListCombo->addItem(camDesc);
-    maxTextLength = std::max(maxTextLength, fontMetrics().width(camDesc));
+    maxTextLength = std::max(maxTextLength, fontMetrics().horizontalAdvance(camDesc));
   }
   m_cameraListCombo->setMaximumWidth(maxTextLength + 25);
   m_cameraListCombo->setEnabled(true);
@@ -2494,7 +2494,7 @@ int PencilTestPopup::translateIndex(int camIndex) {
     // Get the human-friendly name of the device
     UINT32 cchName;
 
-    for (int i = 0; i < count; i++) {
+    for (UINT32 i = 0; i < count; i++) {
       hr = devices[i]->GetAllocatedString(MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME,
                                           &nameString, &cchName);
       if (nameString == desc) {

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1135,7 +1135,7 @@ void PreferencesPopup::insertUI(PreferencesItemId id, QGridLayout* layout,
     else {
       bool isWideComboBox = false;
       for (auto cbItem : comboItems) {
-        if (widget->fontMetrics().width(cbItem.first) > 100) {
+        if (widget->fontMetrics().horizontalAdvance(cbItem.first) > 100) {
           isWideComboBox = true;
           break;
         }

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -560,18 +560,22 @@ void SceneBrowser::refreshCurrentFolderItems() {
         // とりあえず残すが、FileInfoの取得に時間がかかるようならオプション化も検討
         // 2015/12/28 shun_iwasawa
         QFileInfo fileInfo(QString::fromStdWString(it->getWideString()));
+        // Get creation time safely across platforms
+        QDateTime creationTime = fileInfo.birthTime();
+        if (!creationTime.isValid())
+          creationTime = fileInfo.metadataChangeTime();  // or fileInfo.lastModified()
+
         // Update level infos
-        if (levelItem.m_creationDate.isNull() ||
-            (fileInfo.created() < levelItem.m_creationDate))
-          levelItem.m_creationDate = fileInfo.created();
-        if (levelItem.m_modifiedDate.isNull() ||
-            (fileInfo.lastModified() > levelItem.m_modifiedDate))
+        if (levelItem.m_creationDate.isNull() || creationTime < levelItem.m_creationDate)
+          levelItem.m_creationDate = creationTime;
+
+        if (levelItem.m_modifiedDate.isNull() || fileInfo.lastModified() > levelItem.m_modifiedDate)
           levelItem.m_modifiedDate = fileInfo.lastModified();
+
         levelItem.m_fileSize += fileInfo.size();
 
-        // store frameId
+        // Store frame ID
         levelItem.m_frameIds.push_back(tFrameId);
-
         levelItem.m_frameCount++;
       }
     }
@@ -756,8 +760,12 @@ void SceneBrowser::readInfo(Item &item) {
   TFilePath fp = item.m_path;
   QFileInfo info(toQString(fp));
   if (info.exists()) {
-    item.m_creationDate = info.created();
-    item.m_modifiedDate = info.lastModified();
+    // Use birthTime(), fall back to metadataChangeTime() if unavailable
+    item.m_creationDate = info.birthTime();
+    if (!item.m_creationDate.isValid()) {
+        item.m_creationDate = info.metadataChangeTime();
+    }
+    item.m_modifiedDate = info.lastModified(); 
     item.m_fileType     = info.suffix();
     item.m_fileSize     = info.size();
     if (fp.getType() == "tnz") {

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -83,7 +83,7 @@
 // Qt includes
 #include <QMenu>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QInputMethod>
 #include <QGLContext>
 #include <QOpenGLFramebufferObject>
@@ -2658,7 +2658,7 @@ double SceneViewer::getZoomScaleFittingWithScreen() {
   // add small margin on the edge of the image
   int margin = 20;
   // get the desktop resolution
-  QRect rec = QApplication::desktop()->screenGeometry();
+  QRect rec = QApplication::primaryScreen()->geometry();
 
   // fit to either direction
   int moni_x = rec.width() - (margin * 2);

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -600,7 +600,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     }
 
     // if the middle mouse button is pressed while dragging, then do panning
-    if (event.buttons() & Qt::MidButton) {
+    if (event.buttons() & Qt::MiddleButton) {
       // panning
       QPointF p = curPos - m_pos;
       if (m_pos == QPointF() && p.manhattanLength() > 300) return;
@@ -682,8 +682,8 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     m_pos          = curPos;
     m_tabletMove   = false;
     m_toolSwitched = false;
-  } else if (m_mouseButton == Qt::MidButton) {
-    if ((event.buttons() & Qt::MidButton) == 0) m_mouseButton = Qt::NoButton;
+  } else if (m_mouseButton == Qt::MiddleButton) {
+    if ((event.buttons() & Qt::MiddleButton) == 0) m_mouseButton = Qt::NoButton;
     // scrub with shift and middle click
     else if (event.isShiftPressed() && event.isCtrlPressed()) {
       if (curPos.x() > m_pos.x()) {
@@ -758,7 +758,7 @@ void SceneViewer::onPress(const TMouseEvent &event) {
 
   // when using tablet, avoid unexpected drawing behavior occurs when
   // middle-click
-  if (m_tabletEvent && m_mouseButton == Qt::MidButton &&
+  if (m_tabletEvent && m_mouseButton == Qt::MiddleButton &&
       event.isLeftButtonPressed()) {
     return;
   }
@@ -1045,7 +1045,7 @@ void SceneViewer::wheelEvent(QWheelEvent *event) {
     else if ((m_gestureActive == true &&
               m_touchDevice == QTouchDevice::TouchScreen) ||
              m_gestureActive == false) {
-      zoomQt(event->pos() * getDevPixRatio(), exp(0.001 * delta));
+      zoomQt(event->position().toPoint() * getDevPixRatio(), exp(0.001 * delta));
       m_panning = false;
     }
   }
@@ -1305,7 +1305,7 @@ bool SceneViewer::event(QEvent *e) {
   }
 
   // discard too frequent move events
-  static QTime clock;
+  static QElapsedTimer clock;
   if (e->type() == QEvent::MouseButtonPress)
     clock.start();
   else if (e->type() == QEvent::MouseMove) {

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -39,6 +39,7 @@
 #include <QPushButton>
 #include <QMainWindow>
 #include <QApplication>
+#include <QScreen>
 #include <QDesktopWidget>
 #include <QMessageBox>
 #include <QTextStream>
@@ -49,7 +50,6 @@
 #include <QMouseEvent>
 #include <QDesktopServices>
 
-using namespace std;
 using namespace DVGui;
 
 namespace {
@@ -416,11 +416,12 @@ void StartupPopup::showEvent(QShowEvent *) {
   refreshRecentScenes();
   refreshExistingScenes();
   // center window
-  int currentScreen =
-      QApplication::desktop()->screenNumber(TApp::instance()->getMainWindow());
-  QPoint activeMonitorCenter =
-      QApplication::desktop()->availableGeometry(currentScreen).center();
-  QPoint thisPopupCenter         = this->rect().center();
+  QScreen *screen = QGuiApplication::screenAt(TApp::instance()->getMainWindow()->pos());
+  if (!screen) {
+    screen = QGuiApplication::primaryScreen();
+  }
+  QPoint activeMonitorCenter = screen->availableGeometry().center();
+  QPoint thisPopupCenter = this->rect().center();
   QPoint centeredOnActiveMonitor = activeMonitorCenter - thisPopupCenter;
   this->move(centeredOnActiveMonitor);
 }
@@ -850,7 +851,7 @@ bool StartupPopup::parsePresetString(const QString &str, QString &name,
   in order to keep compatibility with default (Harlequin's) reslist.txt
   */
 
-  QStringList tokens = str.split(",", QString::SkipEmptyParts);
+  QStringList tokens = str.split(",", Qt::SkipEmptyParts);
 
   if (!(tokens.count() == 3 ||
         (!forCleanup && tokens.count() == 4) || /*- with "fx x fy" token -*/

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -29,9 +29,7 @@
 
 #include "expressionreferencemanager.h"
 
-#if defined(x64)
 #include "stopmotioncontroller.h"
-#endif
 
 #include "tasksviewer.h"
 #include "batchserversviewer.h"
@@ -84,7 +82,6 @@
 #include "toonz/toonzfolders.h"
 #include "toonz/fxcommand.h"
 #include "toonz/tstageobjectcmd.h"
-
 
 #include "../../toonz/locatorpopup.h"
 
@@ -240,10 +237,11 @@ void SchematicScenePanel::onDeleteFxs(const FxSelection *selection) {
   if (!ColumnCmd::checkExpressionReferences(colIndices, fxs)) return;
 
   TApp *app = TApp::instance();
-  TFxCommand::deleteSelection(selection->getFxs().toStdList(),
-                              selection->getLinks().toStdList(),
-                              selection->getColumnIndexes().toStdList(),
-                              app->getCurrentXsheet(), app->getCurrentFx());
+  TFxCommand::deleteSelection(
+      std::list<TFxP>(selection->getFxs().begin(), selection->getFxs().end()),
+      std::list<Link>(selection->getLinks().begin(), selection->getLinks().end()),
+      std::list<int>(selection->getColumnIndexes().begin(), selection->getColumnIndexes().end()),
+      app->getCurrentXsheet(), app->getCurrentFx());
 }
 
 //-----------------------------------------------------------------------------
@@ -256,8 +254,9 @@ void SchematicScenePanel::onDeleteStageObjects(
 
   TApp *app = TApp::instance();
   TStageObjectCmd::deleteSelection(
-      selection->getObjects().toVector().toStdVector(),
-      selection->getLinks().toStdList(), selection->getSplines().toStdList(),
+      std::vector<TStageObjectId>(selection->getObjects().toVector().begin(), selection->getObjects().toVector().end()),
+      std::list<QPair<TStageObjectId, TStageObjectId>>(selection->getLinks().begin(), selection->getLinks().end()),
+      std::list<int>(selection->getSplines().begin(), selection->getSplines().end()),
       app->getCurrentXsheet(), app->getCurrentObject(), app->getCurrentFx());
 }
 
@@ -1571,7 +1570,7 @@ void FxSettingsPanel::restoreFloatingPanelState() {
 
   QRect geom = settings.value("geometry", saveGeometry()).toRect();
   // check if it can be visible in the current screen
-  if (!(geom & QApplication::desktop()->availableGeometry(this)).isEmpty())
+  if (!(geom & this->screen()->availableGeometry()).isEmpty())
     move(geom.topLeft());
 
   // FxSettings has no optional settings (SaveLoadQSettings) to load

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -69,7 +69,7 @@ protected slots:
   void onPaletteSwitched();
   void onFreezeButtonToggled(bool isFrozen);
   void onSceneSwitched();
-  void onPreferenceChanged(const QString &prefName);
+  void onPreferenceChanged(const QString &prefName) override;
 };
 
 //=========================================================

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -1501,7 +1501,7 @@ void CellArea::drawExtenderHandles(QPainter &p) {
           .translated(selected.bottomRight() + smartTabPosOffset);
   p.setPen(Qt::black);
   p.setBrush(SmartTabColor);
-  p.drawRoundRect(m_levelExtenderRect, xyRadius.x(), xyRadius.y());
+   p.drawRoundedRect(m_levelExtenderRect, xyRadius.x(), xyRadius.y());
   QColor color = (distance > 0 && ((selRow1 + 1 - offset) % distance) != 0)
                      ? m_viewer->getLightLineColor()
                      : m_viewer->getMarkerLineColor();
@@ -1517,7 +1517,7 @@ void CellArea::drawExtenderHandles(QPainter &p) {
                                    .translated(properPoint + smartTabPosOffset);
     p.setPen(Qt::black);
     p.setBrush(SmartTabColor);
-    p.drawRoundRect(m_upperLevelExtenderRect, xyRadius.x(), xyRadius.y());
+    p.drawRoundedRect(m_upperLevelExtenderRect, xyRadius.x(), xyRadius.y());
     QColor color = (distance > 0 && ((selRow0 - offset) % distance) != 0)
                        ? m_viewer->getLightLineColor()
                        : m_viewer->getMarkerLineColor();
@@ -2180,7 +2180,7 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
     QString text           = QString::fromStdWString(levelName);
     QFontMetrics fm(font);
     QString elidaName =
-        elideText(text, fm, nameRect.width() - fm.width(fnum), QString("~"));
+        elideText(text, fm, nameRect.width() - fm.horizontalAdvance(fnum), QString("~"));
     p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
   }
 }
@@ -2361,7 +2361,7 @@ void CellArea::drawSoundTextCell(QPainter &p, int row, int col) {
 
   QFontMetrics metric(font);
 
-  int charWidth = metric.width(text, 1);
+  int charWidth = metric.horizontalAdvance(text, 1);
   if ((charWidth * 2) > nameRect.width()) nameRect.adjust(-2, 0, 4, 0);
 
   QString elidaName = elideText(text, metric, nameRect.width(), "~");
@@ -2866,7 +2866,7 @@ void CellArea::drawPaletteCell(QPainter &p, int row, int col,
 
     QString text      = QString::fromStdWString(levelName);
     QString elidaName = elideText(
-        text, fm, nameRect.width() - fm.width(numberStr) - 2, QString("~"));
+        text, fm, nameRect.width() - fm.horizontalAdvance(numberStr) - 2, QString("~"));
 
     if (!sameLevel || isAfterMarkers)
       p.drawText(nameRect, Qt::AlignLeft | Qt::AlignBottom, elidaName);
@@ -3397,7 +3397,7 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
         setDragTool(XsheetGUI::DragTool::makeSelectionTool(m_viewer));
     }
     m_viewer->dragToolClick(event);
-  } else if (event->button() == Qt::MidButton) {
+  } else if (event->button() == Qt::MiddleButton) {
     m_pos       = event->pos();
     m_isPanning = true;
   }

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -512,7 +512,7 @@ void ChangeObjectParent::refresh() {
   for (i = 0; i < pegbarListID.size(); i++)
     addText(pegbarListID.at(i), pegbarListTr.at(i), pegbarListColor.at(i));
 
-  m_width = fontMetrics().width(theLongestTxt) + 32;
+  m_width = fontMetrics().horizontalAdvance(theLongestTxt) + 32;
   selectCurrent(currentId);
 }
 
@@ -1341,11 +1341,11 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   std::string handle = xsh->getStageObject(columnId)->getParentHandle();
   if (handle == "B") handleWidth = 0;  // Default handle
 
-  int width = QFontMetrics(font).width(name);
+  int width = QFontMetrics(font).horizontalAdvance(name);
 
   while (width > o->rect(PredefinedRect::PEGBAR_NAME).width() - handleWidth) {
     name.remove(-1, 1000);
-    width = QFontMetrics(font).width(name);
+    width = QFontMetrics(font).horizontalAdvance(name);
   }
 
   // pegbar name
@@ -2566,7 +2566,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     m_viewer->dragToolClick(event);
     update();
 
-  } else if (event->button() == Qt::MidButton) {
+  } else if (event->button() == Qt::MiddleButton) {
     m_pos       = event->pos();
     m_isPanning = true;
   }

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1206,9 +1206,9 @@ void XsheetViewer::wheelEvent(QWheelEvent *event) {
   case Qt::MouseEventNotSynthesized: {
     if (0 != (event->modifiers() & Qt::ControlModifier) &&
         event->angleDelta().y() != 0) {
-      QPoint pos(event->pos().x() - m_columnArea->geometry().width() +
+      QPoint pos(event->position().x() - m_columnArea->geometry().width() +
                      m_cellArea->visibleRegion().boundingRect().left(),
-                 event->pos().y());
+                 event->position().y());
       int targetFrame = xyToPosition(pos).frame();
 
       int newFactor =

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1149,7 +1149,7 @@ void RowArea::mousePressEvent(QMouseEvent *event) {
     event->accept();
   }  // left-click
      // pan by middle-drag
-  else if (event->button() == Qt::MidButton) {
+  else if (event->button() == Qt::MiddleButton) {
     m_pos       = event->pos();
     m_isPanning = true;
   }

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -56,7 +56,7 @@
 #include <QPainter>
 #include <QPolygon>
 #include <QThreadStorage>
-#include <QMatrix>
+#include <QTransform>
 #include <QThread>
 #include <QGuiApplication>
 
@@ -416,7 +416,7 @@ void RasterPainter::clearNodes() { m_nodes.clear(); }
 
 //-----------------------------------------------------------------------------
 
-TRasterP RasterPainter::getRaster(int index, QMatrix &matrix) {
+TRasterP RasterPainter::getRaster(int index, QTransform &matrix) {
   if ((int)m_nodes.size() <= index) return TRasterP();
 
   if (m_nodes[index].m_onionMode != Node::eOnionSkinNone) return TRasterP();
@@ -435,7 +435,7 @@ TRasterP RasterPainter::getRaster(int index, QMatrix &matrix) {
   rect = rect * TRect(0, 0, m_dim.lx - 1, m_dim.ly - 1);
 
   TAffine aff = TTranslation(-rect.x0, -rect.y0) * m_nodes[index].m_aff;
-  matrix      = QMatrix(aff.a11, aff.a21, aff.a12, aff.a22, aff.a13, aff.a23);
+  matrix      = QTransform(aff.a11, aff.a21, aff.a12, aff.a22, aff.a13, aff.a23);
 
   return m_nodes[index].m_raster;
 }
@@ -718,10 +718,10 @@ void RasterPainter::drawRasterImages(QPainter &p, QPolygon cameraPol) {
     p.resetTransform();
     TRasterP ras = m_nodes[i].m_raster;
     TAffine aff  = TTranslation(-rect.x0, -rect.y0) * flipY * m_nodes[i].m_aff;
-    QMatrix matrix(aff.a11, aff.a21, aff.a12, aff.a22, aff.a13, aff.a23);
+    QTransform matrix(aff.a11, aff.a12, aff.a21, aff.a22, aff.a13, aff.a23); // Updated line
     QImage image = rasterToQImage(ras);
     if (image.isNull()) continue;
-    p.setMatrix(matrix);
+    p.setWorldTransform(matrix);
     p.drawImage(rect.getP00().x, rect.getP00().y, image);
   }
 

--- a/toonz/sources/toonzlib/tframehandle.cpp
+++ b/toonz/sources/toonzlib/tframehandle.cpp
@@ -14,8 +14,8 @@
 
 namespace {
 
-#if 0
-/* int getCurrentSceneFrameCount()
+/*#if 0
+ int getCurrentSceneFrameCount()
   {
     return 100; //
   TApp::instance()->getCurrentScene()->getScene()->getFrameCount();
@@ -34,8 +34,8 @@ namespace {
     */
 /*   r0 = 0;
     r1 = getCurrentSceneFrameCount()-1;
-  }*/
-#endif
+  }
+#endif */
 
 bool getCurrentLevelFids(std::vector<TFrameId> &fids) {
   /*
@@ -132,8 +132,8 @@ void TFrameHandle::nextFrame(TFrameId id) {
     std::vector<TFrameId>::iterator it;
     it = std::upper_bound(m_fids.begin(), m_fids.end(), m_fid);
     if (it == m_fids.end()) {
-      // non c'e' nessun frame del livello oltre m_fid. Non vado oltre al primo
-      // frame dopo l'ultimo.
+      // There is no frame of the level beyond m_fid. Do not go past the first
+      // frame after the last one.
       // TXshSimpleLevel *sl =
       // TApp::instance()->getCurrentLevel()->getSimpleLevel();
       if (id != 0) {
@@ -157,12 +157,12 @@ void TFrameHandle::prevFrame() {
     if (m_fids.size() <= 0) return;
     std::vector<TFrameId>::iterator it;
     it = std::lower_bound(m_fids.begin(), m_fids.end(), m_fid);
-    // tornando indietro non vado prima del primo frame del livello
+    // when going backward, do not go before the first frame of the level
     if (it != m_fids.end() && it != m_fids.begin()) {
       --it;
       setFid(*it);
     } else {
-      // se sono dopo l'ultimo, vado all'ultimo
+      // if it after the last one, go to the last frame
       if (!m_fids.empty() && m_fid > m_fids.back()) setFid(m_fids.back());
     }
   } else {
@@ -241,14 +241,15 @@ void TFrameHandle::setTimer(int frameRate) {
 void TFrameHandle::timerEvent(QTimerEvent *event) {
   assert(isScrubbing());
 
-  int elapsedTime = m_clock.elapsed();
-  int frame       = m_scrubRange.first + elapsedTime * m_fps / 1000;
-  int lastFrame   = m_scrubRange.second;
+  qint64 elapsedTime = m_clock.elapsed();
+  int frame = m_scrubRange.first + elapsedTime * m_fps / 1000;
+  int lastFrame = m_scrubRange.second;
   if (frame >= lastFrame) {
     if (m_frame != lastFrame) setFrame(lastFrame);
     stopScrubbing();
-  } else
+  } else {
     setFrame(frame);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1073,7 +1073,7 @@ static TFilePath getLevelPathAndSetNameWithPsdLevelName(
     retfp = TFilePath(
         QString::fromStdWString(retfp.getWideString()).replace("##", "#"));
   }
-  QStringList list = name.split("#", QString::SkipEmptyParts);
+  QStringList list = name.split("#", Qt::SkipEmptyParts);
 
   if (list.size() >= 2 && list.at(1) != "frames") {
     bool hasLayerId;

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -45,7 +45,6 @@
 #include <QTextStream>
 #include <QString>
 
-using namespace std;
 using namespace DVGui;
 
 namespace {
@@ -240,16 +239,16 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
 
   m_lxFld->setMeasure("camera.lx");
   m_lyFld->setMeasure("camera.ly");
-  m_lxFld->setRange(numeric_limits<double>::epsilon(),
-                    numeric_limits<double>::infinity());
-  m_lyFld->setRange(numeric_limits<double>::epsilon(),
-                    numeric_limits<double>::infinity());
+  m_lxFld->setRange(std::numeric_limits<double>::epsilon(),
+                    std::numeric_limits<double>::infinity());
+  m_lyFld->setRange(std::numeric_limits<double>::epsilon(),
+                    std::numeric_limits<double>::infinity());
 
   m_xResFld->setRange(1, 10000000);
   m_yResFld->setRange(1, 10000000);
 
-  m_xDpiFld->setRange(1, numeric_limits<double>::infinity());
-  m_yDpiFld->setRange(1, numeric_limits<double>::infinity());
+  m_xDpiFld->setRange(1, std::numeric_limits<double>::infinity());
+  m_yDpiFld->setRange(1, std::numeric_limits<double>::infinity());
 
   m_fspChk->setFixedSize(20, 20);
   m_fspChk->setCheckable(true);
@@ -474,7 +473,7 @@ bool CameraSettingsWidget::parsePresetString(const QString &str, QString &name,
   in order to keep compatibility with default (Harlequin's) reslist.txt
   */
 
-  QStringList tokens = str.split(",", QString::SkipEmptyParts);
+  QStringList tokens = str.split(",", Qt::SkipEmptyParts);
 
   if (!(tokens.count() == 3 ||
         (!forCleanup && tokens.count() == 4) || /*- with "fx x fy" token -*/

--- a/toonz/sources/toonzqt/functionselection.cpp
+++ b/toonz/sources/toonzqt/functionselection.cpp
@@ -712,7 +712,7 @@ int FunctionSelection::getCommonSegmentType(bool inclusive) {
 QList<int> FunctionSelection::getSelectedKeyIndices(TDoubleParam *curve) {
   for (auto selectedParam : m_selectedKeyframes) {
     if (curve == selectedParam.first) {
-      QList<int> ret = selectedParam.second.toList();
+      QList<int> ret = selectedParam.second.values();
       std::sort(ret.begin(), ret.end());
       return ret;
     }

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -426,9 +426,9 @@ void FxPalettePainter::paint(QPainter *painter,
   painter->setPen(Qt::NoPen);
 
   if (m_parent->isNormalIconView())
-    painter->drawRoundRect(QRectF(0, 0, m_width, m_height), 35, 99);
+    painter->drawRoundedRect(QRectF(0, 0, m_width, m_height), 35, 99);
   else
-    painter->drawRoundRect(QRectF(0, 0, m_width, m_height), 10, 30);
+    painter->drawRoundedRect(QRectF(0, 0, m_width, m_height), 10, 30);
 
   // draw icon
   QRect paletteRect;
@@ -1256,7 +1256,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxInputPort:
     case eFxGroupedInPort: {
       QRect targetRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       static QIcon fxPortRedIcon(":Resources/fxport_red.svg");
       static QIcon fxPortPassThroughRedIcon(":Resources/fxport_pt_red.svg");
       QPixmap redPm = (m_isPassThrough)
@@ -1268,7 +1268,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxOutputPort:
     case eFxGroupedOutPort: {
       QRect sourceRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       static QIcon fxPortBlueIcon(":Resources/fxport_blue.svg");
       QPixmap bluePm = fxPortBlueIcon.pixmap(sourceRect.size());
       sourceRect     = QRect(0, 0, bluePm.width(), bluePm.height());
@@ -1292,7 +1292,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxLinkPort:  // LinkPort
     default: {
       QRect sourceRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       QPixmap linkPm =
           QIcon(":Resources/schematic_link.svg").pixmap(sourceRect.size());
       painter->drawPixmap(boundingRect().toRect(), linkPm);
@@ -1316,7 +1316,7 @@ void FxSchematicPort::paint(QPainter *painter,
     case eFxLinkPort:  // LinkPort
     {
       QRect sourceRect =
-          scene()->views()[0]->matrix().mapRect(boundingRect()).toRect();
+          scene()->views()[0]->transform().mapRect(boundingRect()).toRect();
       QPixmap linkPm = QIcon(":Resources/schematic_link_small.svg")
                            .pixmap(sourceRect.size());
       painter->drawPixmap(boundingRect().toRect(), linkPm);
@@ -3672,8 +3672,9 @@ void FxGroupNode::onNameChanged() {
   setFlag(QGraphicsItem::ItemIsSelectable, true);
   FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
   if (!fxScene) return;
-  TFxCommand::renameGroup(m_groupedFxs.toStdList(), m_name.toStdWString(),
-                          false, fxScene->getXsheetHandle());
+  std::list<TFxP> fxsList(m_groupedFxs.begin(), m_groupedFxs.end());
+  TFxCommand::renameGroup(fxsList, m_name.toStdWString(),
+                         false, fxScene->getXsheetHandle());
   update();
 }
 
@@ -3803,7 +3804,7 @@ void FxPassThroughPainter::paint(QPainter *painter,
   if (!m_showName) return;
 
   QFont fnt = painter->font();
-  int width = QFontMetrics(fnt).width(m_name) + 1;
+  int width = QFontMetrics(fnt).horizontalAdvance(m_name) + 1;
   QRectF nameArea(0, 0, width, 14);
 
   if (m_parent->isNormalIconView()) {
@@ -3974,7 +3975,7 @@ void FxSchematicPassThroughNode::mouseDoubleClickEvent(
 #endif
   }
   static QFont font(fontName, 10, QFont::Normal);
-  int width = QFontMetrics(font).width(m_name);
+  int width = QFontMetrics(font).horizontalAdvance(m_name);
   QRectF nameArea(0, 0, width, 14);
 
   m_nameItem->setPlainText(m_name);

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -147,7 +147,7 @@ void ColumnPainter::paint(QPainter *painter,
   }
 
   if (levelType == PLT_XSHLEVEL)
-    painter->drawRoundRect(0, 0, m_width, m_height, 32, 99);
+    painter->drawRoundedRect(0, 0, m_width, m_height, 32, 99, Qt::RelativeSize);
   else
     painter->drawRect(0, 0, m_width, m_height);
 
@@ -640,7 +640,7 @@ void SplinePainter::paint(QPainter *painter,
 
   painter->setBrush(viewer->getSplineColor());
   painter->setPen(Qt::NoPen);
-  painter->drawRoundRect(QRectF(0, 0, m_width, m_height), 20, 99);
+  painter->drawRoundedRect(QRectF(0, 0, m_width, m_height), 20, 99, Qt::RelativeSize);
   if (m_parent->isOpened()) {
     // Draw the pixmap
     painter->setBrush(Qt::NoBrush);
@@ -747,7 +747,7 @@ void StageSchematicNodePort::paint(QPainter *painter,
     painter->drawText(boundingRect(), text, textOption);
   } else {
     QRect imgRect(2, 2, 14, 14);
-    QRect sourceRect = scene->views()[0]->matrix().mapRect(imgRect);
+    QRect sourceRect = scene->views()[0]->transform().mapRect(imgRect);
     QPixmap pixmap;
 
     if (getType() == eStageParentPort || getType() == eStageParentGroupPort) {
@@ -903,7 +903,7 @@ void StageSchematicSplinePort::paint(QPainter *painter,
                                      const QStyleOptionGraphicsItem *option,
                                      QWidget *widget) {
   QRect sourceRect =
-      scene()->views()[0]->matrix().mapRect(boundingRect().toRect());
+      scene()->views()[0]->transform().mapRect(boundingRect().toRect());
   QPixmap pixmap;
 
   if (!m_parent->isParentPort()) {
@@ -1787,7 +1787,7 @@ void StageSchematicColumnNode::paint(QPainter *painter,
   if (scene && scene->getCurrentObject() == id)
     painter->setPen(viewer->getSelectedNodeTextColor());
   QFontMetrics metrix(font);
-  int srcWidth  = metrix.width(colNumber);
+  int srcWidth  = metrix.horizontalAdvance(colNumber);
   int srcHeight = metrix.height();
   QPointF pos(m_cameraStandToggle->pos() -
               QPointF(srcWidth + 1, -srcHeight + 3));

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -876,7 +876,7 @@ void HexagonalColorWheel::mouseReleaseEvent(QMouseEvent *event) {
 void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
   QLineF p(m_wp[0] + m_wheelPosition, QPointF(pos));
   QLineF horizontal(0, 0, 1, 0);
-  float theta = (p.dy() < 0) ? p.angle(horizontal) : 360 - p.angle(horizontal);
+  float theta = (p.dy() < 0) ? p.angleTo(horizontal) : 360 - p.angleTo(horizontal);
   float phi   = theta;
   while (phi >= 60.0f) phi -= 60.0f;
   phi -= 30.0f;
@@ -1342,7 +1342,7 @@ ColorChannelControl::ColorChannelControl(ColorChannel channel, QWidget *parent)
   m_label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
 
   m_field->setObjectName("colorSliderField");
-  m_field->setFixedWidth(fontMetrics().width('0') * 4);
+  m_field->setFixedWidth(fontMetrics().horizontalAdvance('0') * 4);
   m_field->setMinimumHeight(7);
 
   addButton->setObjectName("colorSliderAddButton");


### PR DESCRIPTION
This PR updates the codebase to replace deprecated Qt functions and patterns with modern alternatives, maintaining existing behavior. These changes improve compatibility with newer Qt versions and eliminate compiler warnings (such as C4996), helping ensure future maintainability.

Notable updates include:

- Replaced deprecated `QTime` with `QElapsedTimer` for timing operations
- Updated `QMatrix` to `QTransform` for transformation handling
- Changed `MidButton` to `MiddleButton` for mouse button naming
- Migrated `QString::SkipEmptyParts` to `Qt::SkipEmptyParts`
- Replaced `QDesktopWidget` with `QScreen` for screen handling
- Updated `fontMetrics().width()` to `horizontalAdvance()` for text metrics

In addition to the items listed above, many other deprecated functions and patterns were updated throughout the codebase.

ref:  #5799, #5801