### PR TITLE
Fix Fill Check refresh bug introduced in #5039

### DIFF
--- a/toonz/sources/common/twain/ttwain_winM.c
+++ b/toonz/sources/common/twain/ttwain_winM.c
@@ -106,7 +106,7 @@ void setupUI(void) {
   SetFrontProcess(&psn);
 #ifndef HAVE_DOCK_TILE
 /* We end up with the ugly console dock icon; let's override it */
-/*char *iconfile = "/tmp/image.png";
+/* char *iconfile = "/tmp/image.png";
   CFURLRef url = CFURLCreateFromFileSystemRepresentation (kCFAllocatorDefault,
                                                           (UInt8 *)iconfile,
                                                           strlen (iconfile),
@@ -115,8 +115,8 @@ void setupUI(void) {
   CGDataProviderRef png = CGDataProviderCreateWithURL (url);
   CGImageRef icon = CGImageCreateWithPNGDataProvider (png, NULL, TRUE,
                                              kCGRenderingIntentDefault);
-
-  /* Voodoo magic fix inspired by java_swt launcher */
+*/
+/* Voodoo magic fix inspired by java_swt launcher */
 /* Without this the icon setting doesn't work about half the time. */
 // CGrafPtr p = BeginQDContextForApplicationDockTile();
 // EndQDContextForApplicationDockTile(p);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1257,6 +1257,10 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
     }
     m_painting.tileSet = nullptr;
 
+    // Restore gap/autoclose Fill Check
+    int tc = ToonzCheck::instance()->getChecks();
+    if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();    
+
     /*-- 作業中のフレームをリセット --*/
     m_painting.frameId = TFrameId();
 

--- a/toonz/sources/toonzlib/tframehandle.cpp
+++ b/toonz/sources/toonzlib/tframehandle.cpp
@@ -14,16 +14,16 @@
 
 namespace {
 
-/*#if 0
- int getCurrentSceneFrameCount()
+#if 0
+/* int getCurrentSceneFrameCount()
   {
     return 100; //
   TApp::instance()->getCurrentScene()->getScene()->getFrameCount();
   }*/
 
-/*void getCurrentScenePlayRange(int &r0, int &r1, int &step)
+/* void getCurrentScenePlayRange(int &r0, int &r1, int &step)
   {
-    /*
+
     ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
     scene->getProperties()->getPreviewProperties()->getRange(r0, r1, step);
     if(r0>r1)
@@ -31,11 +31,11 @@ namespace {
       r0 = 0;
       r1 = scene->getFrameCount()-1;
     }
-    */
-/*   r0 = 0;
+
+  r0 = 0;
     r1 = getCurrentSceneFrameCount()-1;
-  }
-#endif */
+  }*/
+#endif
 
 bool getCurrentLevelFids(std::vector<TFrameId> &fids) {
   /*


### PR DESCRIPTION
This PR addresses the issue reported in [#5876: Fill Check Refresh failure without adjacent Assistants level](https://github.com/opentoonz/opentoonz/issues/5876).

It reintroduces the `eGap` (Fill Check) and `eAutoclose` checks with appropriate calls to `invalidate()` to ensure proper refresh of Fill Check rendering. 

The bug was introduced in PR #5039, where these checks were removed. It's unclear whether the original developer had a different refactoring plan in mind, but the current state results in rendering artifacts. This fix restores expected behavior for now, though the approach may need to be revisited in the future.

This commit also fixes -Wcomment warnings caused by nested block comments in the following files and lines :

- twain/ttwain_winM.c: lines 115-125
- toonzlib/tframehandle.cpp: lines 20-30

These warnings are specific to the Clang compiler due to its stricter comment parsing.