### PR TITLE
Fix tool state not updating via shortcut due to missing addToUndo

### DIFF
--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
@@ -598,7 +598,7 @@ void ToolOptionsShortcutInvoker::notifyTool(TTool* tool, TProperty* p,
   std::string tempPropertyName = p->getName();
   if (addToUndo && tempPropertyName == "Maximum Gap")
     tempPropertyName = tempPropertyName + "withUndo";
-  tool->onPropertyChanged(tempPropertyName);
+  tool->onPropertyChanged(tempPropertyName, addToUndo);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes an issue where the Fill Tool (e.g., Freehand, Rectangle) wouldn't switch properly via keyboard shortcuts, as reported _Originally posted by @beeheemooth in https://github.com/opentoonz/opentoonz/issues/5828#issuecomment-2730953400_

![test](https://github.com/user-attachments/assets/5abcbf6d-3de7-44d0-979c-97ee9688fd6c)

Although `FillTool::onPropertyChanged` was updated to use the `addToUndo` parameter in [PR #4852](https://github.com/opentoonz/opentoonz/pull/4852), `ToolOptionsShortcutInvoker::notifyTool` in `tooloptionsshortcutinvoker.cpp` was still calling it using the old signature, omitting the flag.


This update forwards `addToUndo` correctly, ensuring tool behavior updates as expected when switching via shortcuts.

