### PR TITLE
Fix color wheel pointer and replace layout margins

### DIFF
--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -876,7 +876,7 @@ void HexagonalColorWheel::mouseReleaseEvent(QMouseEvent *event) {
 void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
   QLineF p(m_wp[0] + m_wheelPosition, QPointF(pos));
   QLineF horizontal(0, 0, 1, 0);
-  float theta = (p.dy() < 0) ? p.angleTo(horizontal) : 360 - p.angleTo(horizontal);
+  float theta = (p.dy() >= 0) ? horizontal.angleTo(p) : 360 - p.angleTo(horizontal);
   float phi   = theta;
   while (phi >= 60.0f) phi -= 60.0f;
   phi -= 30.0f;
@@ -1243,7 +1243,7 @@ ColorSliderBar::ColorSliderBar(QWidget *parent, Qt::Orientation orientation)
     layout = new QVBoxLayout(this);
 
   layout->setSpacing(0);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->addWidget(first, 0, Qt::AlignCenter);
   layout->addWidget(m_colorSlider, 1);
   layout->addWidget(last, 0, Qt::AlignCenter);
@@ -1363,7 +1363,7 @@ ColorChannelControl::ColorChannelControl(ColorChannel channel, QWidget *parent)
   subButton->setFocusPolicy(Qt::NoFocus);
 
   QHBoxLayout *mainLayout = new QHBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(1);
   {
     mainLayout->addWidget(m_label, 0);
@@ -1623,21 +1623,21 @@ PlainColorPage::PlainColorPage(QWidget *parent)
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(0);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   {
     QHBoxLayout *wheelLayout = new QHBoxLayout();
-    wheelLayout->setMargin(5);
+    wheelLayout->setContentsMargins(5, 5, 5, 5);
     wheelLayout->setSpacing(0);
     { wheelLayout->addWidget(m_hexagonalColorWheel); }
     m_wheelFrame->setLayout(wheelLayout);
     m_vSplitter->addWidget(m_wheelFrame);
 
     QVBoxLayout *slidersLayout = new QVBoxLayout();
-    slidersLayout->setMargin(0);
+    slidersLayout->setContentsMargins(0, 0, 0, 0);
     slidersLayout->setSpacing(0);
     {
       QVBoxLayout *hsvLayout = new QVBoxLayout();
-      hsvLayout->setMargin(4);
+      hsvLayout->setContentsMargins(4, 4, 4, 4);
       hsvLayout->setSpacing(4);
       {
         hsvLayout->addWidget(m_channelControls[eHue]);
@@ -1648,14 +1648,14 @@ PlainColorPage::PlainColorPage(QWidget *parent)
       slidersLayout->addWidget(m_hsvFrame, 3);
 
       QVBoxLayout *alphaLayout = new QVBoxLayout();
-      alphaLayout->setMargin(4);
+      alphaLayout->setContentsMargins(4, 4, 4, 4);
       alphaLayout->setSpacing(4);
       { alphaLayout->addWidget(m_channelControls[eAlpha]); }
       m_alphaFrame->setLayout(alphaLayout);
       slidersLayout->addWidget(m_alphaFrame, 1);
 
       QVBoxLayout *rgbLayout = new QVBoxLayout();
-      rgbLayout->setMargin(4);
+      rgbLayout->setContentsMargins(4, 4, 4, 4);
       rgbLayout->setSpacing(4);
       {
         rgbLayout->addWidget(m_channelControls[eRed]);
@@ -2507,7 +2507,7 @@ SettingsPage::SettingsPage(QWidget *parent)
   setWidget(paramsContainer);
 
   QVBoxLayout *paramsContainerLayout = new QVBoxLayout(this);
-  paramsContainerLayout->setMargin(10);
+  paramsContainerLayout->setContentsMargins(10, 10, 10, 10);
   paramsContainerLayout->setSpacing(10);
   paramsContainer->setLayout(paramsContainerLayout);
 
@@ -2522,7 +2522,7 @@ SettingsPage::SettingsPage(QWidget *parent)
 
   // Prepare the style parameters layout
   m_paramsLayout = new QGridLayout;
-  m_paramsLayout->setMargin(0);
+  m_paramsLayout->setContentsMargins(0, 0, 0, 0);
   m_paramsLayout->setVerticalSpacing(8);
   m_paramsLayout->setHorizontalSpacing(5);
   paramsContainerLayout->addLayout(m_paramsLayout);
@@ -2934,11 +2934,11 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
   QFrame *bottomWidget = createBottomWidget();
   /* ------- layout ------- */
   QGridLayout *mainLayout = new QGridLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     QHBoxLayout *hLayout = new QHBoxLayout;
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     {
       hLayout->addSpacing(0);
       hLayout->addWidget(m_styleBar);
@@ -3110,7 +3110,7 @@ QFrame *StyleEditor::createBottomWidget() {
 
   /* ------ layout ------ */
   QHBoxLayout *mainLayout = new QHBoxLayout;
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_autoButton);
@@ -3119,11 +3119,11 @@ QFrame *StyleEditor::createBottomWidget() {
     mainLayout->addSpacing(4);
 
     QVBoxLayout *colorLay = new QVBoxLayout();
-    colorLay->setMargin(0);
+    colorLay->setContentsMargins(0, 0, 0, 0);
     colorLay->setSpacing(2);
     {
       QHBoxLayout *chipLay = new QHBoxLayout();
-      chipLay->setMargin(0);
+      chipLay->setContentsMargins(0, 0, 0, 0);
       chipLay->setSpacing(0);
       {
         chipLay->addWidget(m_newColor, 1);
@@ -3137,7 +3137,7 @@ QFrame *StyleEditor::createBottomWidget() {
     mainLayout->addSpacing(4);
 
     QVBoxLayout *hexLay = new QVBoxLayout();
-    hexLay->setMargin(0);
+    hexLay->setContentsMargins(0, 0, 0, 0);
     hexLay->setSpacing(2);
     {
       hexLay->addWidget(m_hexLineEdit);
@@ -3201,12 +3201,12 @@ QFrame *StyleEditor::createTexturePage() {
 
   /* ------ layout ------ */
   QVBoxLayout *outsideLayout = new QVBoxLayout();
-  outsideLayout->setMargin(0);
+  outsideLayout->setContentsMargins(0, 0, 0, 0); 
   outsideLayout->setSpacing(0);
   outsideLayout->setSizeConstraint(QLayout::SetNoConstraint);
   {
     QVBoxLayout *insideLayout = new QVBoxLayout();
-    insideLayout->setMargin(0);
+    insideLayout->setContentsMargins(0, 0, 0, 0);
     insideLayout->setSpacing(0);
     insideLayout->setSizeConstraint(QLayout::SetNoConstraint);
     { insideLayout->addWidget(m_textureStylePage); }
@@ -3219,7 +3219,7 @@ QFrame *StyleEditor::createTexturePage() {
     outsideLayout->addWidget(m_textureArea);
 
     QHBoxLayout *searchLayout = new QHBoxLayout();
-    searchLayout->setMargin(2);
+    searchLayout->setContentsMargins(2, 2, 2, 2);
     searchLayout->setSpacing(0);
     searchLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -3267,7 +3267,7 @@ QFrame *StyleEditor::createVectorPage() {
 
   /* ------ layout ------ */
   QVBoxLayout *vectorOutsideLayout = new QVBoxLayout();
-  vectorOutsideLayout->setMargin(0);
+  vectorOutsideLayout->setContentsMargins(0, 0, 0, 0);
   vectorOutsideLayout->setSpacing(0);
   vectorOutsideLayout->setSizeConstraint(QLayout::SetNoConstraint);
   {
@@ -3281,7 +3281,7 @@ QFrame *StyleEditor::createVectorPage() {
     vectorOutsideLayout->addLayout(vectorButtonLayout);
 
     QVBoxLayout *vectorLayout = new QVBoxLayout();
-    vectorLayout->setMargin(0);
+    vectorLayout->setContentsMargins(0, 0, 0, 0);
     vectorLayout->setSpacing(0);
     vectorLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -3297,7 +3297,7 @@ QFrame *StyleEditor::createVectorPage() {
     vectorOutsideLayout->addWidget(m_vectorsArea);
 
     QHBoxLayout *searchLayout = new QHBoxLayout();
-    searchLayout->setMargin(2);
+    searchLayout->setContentsMargins(2, 2, 2, 2);
     searchLayout->setSpacing(0);
     searchLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
@@ -3342,12 +3342,12 @@ QFrame *StyleEditor::createMyPaintPage() {
 
   /* ------ layout ------ */
   QVBoxLayout *outsideLayout = new QVBoxLayout();
-  outsideLayout->setMargin(0);
+  outsideLayout->setContentsMargins(0, 0, 0, 0);
   outsideLayout->setSpacing(0);
   outsideLayout->setSizeConstraint(QLayout::SetNoConstraint);
   {
     QVBoxLayout *insideLayout = new QVBoxLayout();
-    insideLayout->setMargin(0);
+    insideLayout->setContentsMargins(0, 0, 0, 0);
     insideLayout->setSpacing(0);
     insideLayout->setSizeConstraint(QLayout::SetNoConstraint);
     { insideLayout->addWidget(m_mypaintBrushesStylePage); }
@@ -3359,7 +3359,7 @@ QFrame *StyleEditor::createMyPaintPage() {
     outsideLayout->addWidget(m_mypaintArea);
 
     QHBoxLayout *searchLayout = new QHBoxLayout();
-    searchLayout->setMargin(2);
+    searchLayout->setContentsMargins(2, 2, 2, 2);
     searchLayout->setSpacing(0);
     searchLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {


### PR DESCRIPTION
This PR fixes an issue in the Style Editor where the color wheel pointer was not positioned correctly. The problem was reported by _@Abel032 in https://github.com/opentoonz/opentoonz/issues/5966#issuecomment-2943138189._ **Thanks, Abel!** 

https://github.com/user-attachments/assets/7dba0616-bb03-45dc-ad2b-34f43ab6e606

- Corrects the theta angle calculation for accurate color wheel pointer positioning
- Replaces deprecated setMargin() calls with setContentsMargins() for layouts (_not directly related to the bug_)