### PR TITLE
Fix dialog crash in Studio Palette by initializing m_currentScreen

### DIFF
--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -231,16 +231,17 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
     , m_layoutSpacing(5)
     , m_layoutMargin(0)
     , m_labelWidth(100)
-    , m_name() {
+    , m_name() 
+    , m_currentScreen(0) {  // Initialize to primary screen to prevent a crash
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   m_mainFrame = new QFrame(this);
   m_mainFrame->setObjectName("dialogMainFrame");
   m_mainFrame->setMinimumHeight(41);
   m_mainFrame->setFrameStyle(QFrame::StyledPanel);
   m_topLayout = new QVBoxLayout;
-  m_topLayout->setMargin(12);
+  m_topLayout->setContentsMargins(12, 12, 12, 12);
   m_topLayout->setSpacing(m_layoutSpacing);
   m_topLayout->setAlignment(Qt::AlignCenter);
   m_mainFrame->setLayout(m_topLayout);
@@ -257,7 +258,7 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
     m_buttonFrame->setFixedHeight(45);
 
     m_buttonLayout = new QHBoxLayout;
-    m_buttonLayout->setMargin(0);
+    m_buttonLayout->setContentsMargins(0, 0, 0, 0);
     m_buttonLayout->setSpacing(20);
     m_buttonLayout->setAlignment(Qt::AlignHCenter);
 
@@ -397,11 +398,11 @@ void Dialog::beginVLayout() {
   m_isMainVLayout = true;
 
   m_leftVLayout = new QVBoxLayout;
-  m_leftVLayout->setMargin(m_layoutMargin);
+  m_leftVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   m_leftVLayout->setSpacing(m_layoutSpacing);
 
   m_rightVLayout = new QVBoxLayout;
-  m_rightVLayout->setMargin(m_layoutMargin);
+  m_rightVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   m_rightVLayout->setSpacing(m_layoutSpacing);
 }
 
@@ -414,7 +415,7 @@ void Dialog::endVLayout() {
   m_isMainVLayout = false;
 
   QHBoxLayout *layout = new QHBoxLayout;
-  layout->setMargin(m_layoutMargin);
+  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   layout->setSpacing(m_layoutSpacing);
   layout->setSizeConstraint(QLayout::SetFixedSize);
 
@@ -435,7 +436,7 @@ void Dialog::endVLayout() {
 void Dialog::beginHLayout() {
   m_isMainHLayout = true;
   m_mainHLayout   = new QHBoxLayout;
-  m_mainHLayout->setMargin(m_layoutMargin);
+  m_mainHLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   m_mainHLayout->setSpacing(m_layoutSpacing);
 }
 
@@ -496,7 +497,7 @@ void Dialog::addWidgets(QWidget *firstW, QWidget *secondW) {
     return;
   }
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setMargin(m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addWidget(firstW);
   pairLayout->addWidget(secondW);
@@ -562,7 +563,7 @@ layout containing
                 \b widget and \b layout and add it to horizontal layout.
 */
 void Dialog::addWidgetLayout(QWidget *widget, QLayout *layout) {
-  layout->setMargin(m_layoutMargin);
+  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   layout->setSpacing(m_layoutSpacing);
 
   if (m_isMainVLayout) {
@@ -573,7 +574,7 @@ void Dialog::addWidgetLayout(QWidget *widget, QLayout *layout) {
   }
 
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setMargin(m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addWidget(widget);
   pairLayout->addLayout(layout);
@@ -614,9 +615,9 @@ layout containing
                 \b firstL and \b secondL and add it to horizontal layout.
 */
 void Dialog::addLayouts(QLayout *firstL, QLayout *secondL) {
-  firstL->setMargin(m_layoutMargin);
+  firstL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   firstL->setSpacing(m_layoutSpacing);
-  secondL->setMargin(m_layoutMargin);
+  secondL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   secondL->setSpacing(m_layoutSpacing);
 
   if (m_isMainVLayout) {
@@ -627,7 +628,7 @@ void Dialog::addLayouts(QLayout *firstL, QLayout *secondL) {
   }
 
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setMargin(m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addLayout(firstL);
   pairLayout->addLayout(secondL);
@@ -715,13 +716,15 @@ int Dialog::getLayoutInsertedSpacing() { return m_layoutSpacing; }
 //-----------------------------------------------------------------------------
 /*! Set to \b margin margin of main part of dialog.
  */
-void Dialog::setTopMargin(int margin) { m_topLayout->setMargin(margin); }
+void Dialog::setTopMargin(int margin) { 
+    m_topLayout->setContentsMargins(margin, margin, margin, margin); 
+}
 
 //-----------------------------------------------------------------------------
 /*! Set to \b margin margin of button part of dialog.
  */
 void Dialog::setButtonBarMargin(int margin) {
-  m_buttonLayout->setMargin(margin);
+  m_buttonLayout->setContentsMargins(margin, margin, margin, margin);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a crash that occurred when using "Adjust Current Palette to This Level" from the StudioPaletteTreeViewer context menu. The issue was found by @RodneyBaker and reported by _@Abel032 in https://github.com/opentoonz/opentoonz/issues/5966#issuecomment-2949960568_. Thanks, folks!

![图片](https://github.com/user-attachments/assets/22eac2fb-7439-4fd2-a594-a1c7e24a9261) 

- Initialize m_currentScreen to 0 in the Dialog constructor to prevent segmentation faults when accessing QGuiApplication::screens().at().
 - Replaces deprecated setMargin() calls with setContentsMargins() for layouts (not directly related to the bug)

This logic may need to be refactored in the future to better support multi-monitor setups, as suggested by comments already present in the source code
