### PR TITLE
Prevent OS/theme background mismatch

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -2981,6 +2981,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: #dfdfdf;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Clay/Clay.qss
+++ b/stuff/config/qss/Clay/Clay.qss
@@ -2981,6 +2981,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: #dfdfdf;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2981,6 +2981,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: #d3d3d3;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default-Green/Default-Green.qss
+++ b/stuff/config/qss/Default-Green/Default-Green.qss
@@ -2981,6 +2981,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: #dfdfdf;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -2981,6 +2981,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: #dfdfdf;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Default/less/layouts/_misc.less
+++ b/stuff/config/qss/Default/less/layouts/_misc.less
@@ -89,3 +89,11 @@ QStatusBar {
     padding: 1 3;
   }
 }
+
+// Prevent OS/theme background mismatch for consistent text visibility
+// e.g., Canvas Size, Export Level, Convert to Vectors.
+ 
+DVGui--Separator {
+  alternate-background-color: @text-color;
+}
+

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2982,6 +2982,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: black;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2981,6 +2981,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: black;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */

--- a/stuff/config/qss/Synthwave/Synthwave.qss
+++ b/stuff/config/qss/Synthwave/Synthwave.qss
@@ -2981,6 +2981,9 @@ QStatusBar #StatusBarLabel {
   background-color: #ffffff;
   padding: 1 3;
 }
+DVGui--Separator {
+  alternate-background-color: #d3d3d3;
+}
 /* -----------------------------------------------------------------------------
    XSheet Viewer
 ----------------------------------------------------------------------------- */


### PR DESCRIPTION
The PR Added `alternate-background-color` to `DVGui--Separator` to ensure consistent appearance across different OS and user themes. Without this, the background color is inherited from the system, which can lead to poor contrast or unreadable text.

## Preview of Light Theme on Windows 10 (Using Default System Theme)
![export_level](https://github.com/user-attachments/assets/6ab3f0ea-97c9-4c5e-853c-22858cfb23b1)

I found this forgotten hack in an old Toonz theme, so it seems like a legacy workaround to avoid the issue. Maybe @konero could investigate this anomaly. That said, I placed the fix inside `_misc.less` because there’s a section for Unknowns + Legacy.

This issue occurs in **Export Level**, **Convert to Vectors**, and **Canvas Size**, in the text areas where this separator is present. Previously, the fix #4030 applied `alternate-background-color` to `QFrame`, and although it caused no functional issues, it didn’t feel right since it was applied globally.

