### PR TITLE
Fix: Premultiply background color for Export Level Commands

### DIFF
--- a/toonz/sources/include/tpixelutils.h
+++ b/toonz/sources/include/tpixelutils.h
@@ -73,8 +73,8 @@ inline T overPixT(const T &bot, const T &top) {
   UINT max = T::maxChannelValue;
 
   if (top.m == max) return top;
-
   if (top.m == 0) return bot;
+  if (bot.m == 0) return top;
 
   TUINT32 r = top.r + bot.r * (max - top.m) / max;
   TUINT32 g = top.g + bot.g * (max - top.m) / max;
@@ -88,8 +88,8 @@ template <>
 inline TPixelF overPixT<TPixelF, float>(const TPixelF &bot,
                                         const TPixelF &top) {
   if (top.m >= 1.f) return top;
-
   if (top.m <= 0.f) return bot;
+  if (bot.m <= 0.f) return top;
 
   float r = top.r + bot.r * (1.f - top.m);
   float g = top.g + bot.g * (1.f - top.m);

--- a/toonz/sources/toonz/exportlevelcommand.h
+++ b/toonz/sources/toonz/exportlevelcommand.h
@@ -63,6 +63,7 @@ struct ExportLevelOptions {
   const TPropertyGroup *m_props;  //!< File Format Properties for the export.
 
   TPixel32 m_bgColor;  //!< Background color to be applied under the image.
+  // Need to be premultiplied before set as background color
   TCamera m_camera;  //!< Stores field and resolution settings for PLI exports.
 
   //! \remark   In single frame exports, the transform applied to the frame is


### PR DESCRIPTION
## Issue Description
The stroke's background of exported Image do not follow the background setting.
This happens when exporting ToonzRaster Level to Raster Level using the "Export Level..." command.
The problem is caused by not do premultiply for the background color is before paint it as background.

### Before:
![图片](https://github.com/user-attachments/assets/4e639093-7974-4e4f-8972-dbdffeff6596)
### After:
![图片](https://github.com/user-attachments/assets/1bb14d29-3a05-4c23-89d2-ade9411f4e43)