### PR TITLE
Added a link to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Can't develop but still want to help? Help us test individual Pull Requests befo
 - To share tips or to troubleshoot, join the [Google OpenToonz Users forum](https://groups.google.com/forum/#!forum/opentoonz_en)
 - If you found a bug with the software after troubleshooting, or are a developer, search the [Github issues](https://github.com/opentoonz/opentoonz/issues) and post there.
 
-## User Manual
+## Documentation
 
 - For general documentation, please [look here](https://github.com/opentoonz/opentoonz_docs).
 


### PR DESCRIPTION
Added a link to the documentation repo, https://github.com/opentoonz/opentoonz_docs , to the README. I just found it strange how there wasn't much mention of it, and it where you can find the link to the user manual, which is a much easier way to find it than through the community forum or the link in the issue menu.

I made an issue about this, it is issue #5983 