### PR TITLE
Add inverted cursor feature at stroke end point

### DIFF
--- a/toonz/sources/common/tgl/tgl.cpp
+++ b/toonz/sources/common/tgl/tgl.cpp
@@ -160,6 +160,32 @@ void tglDrawCircle(const TPointD &center, double radius) {
   glPopMatrix();
 }
 
+void tglDrawInvertCursor(const TPointD& center,int gap, int len) {
+    TPointD up1 = center + TPointD(0.0, gap);
+    TPointD up2 = center + TPointD(0.0, gap + len);
+    TPointD down1 = center + TPointD(0.0, -gap);
+    TPointD down2 = center + TPointD(0.0, -gap - len);
+    TPointD left1 = center + TPointD(-gap, 0.0);
+    TPointD left2 = center + TPointD(-gap - len, 0.0);
+    TPointD right1 = center + TPointD(gap, 0.0);
+    TPointD right2 = center + TPointD(gap + len, 0.0);
+
+    glEnable(GL_COLOR_LOGIC_OP);
+    glLogicOp(GL_XOR);
+    tglColor(TPixel32::White); // 任意非黑色都行，关键是与背景异或
+
+    glLineWidth(1.2);
+    glBegin(GL_LINES);
+    tglVertex(up1);    tglVertex(up2);
+    tglVertex(down1);  tglVertex(down2);
+    tglVertex(left1);  tglVertex(left2);
+    tglVertex(right1); tglVertex(right2);
+    glEnd();
+    glLineWidth(1.0);
+
+    glDisable(GL_COLOR_LOGIC_OP);
+}
+
 //-----------------------------------------------------------------------------
 
 void tglDrawDisk(const TPointD &c, double r) {

--- a/toonz/sources/include/tgl.h
+++ b/toonz/sources/include/tgl.h
@@ -133,6 +133,8 @@ DVAPI double tglGetTextWidth(const std::string &s,
  */
 DVAPI void tglDrawCircle(const TPointD &c, double r);
 
+DVAPI void tglDrawInvertCursor(const TPointD &center, int gap, int len);
+
 /*!
  Draw circle of radius r with center c.
  Remark: it is possible set number of slices
@@ -184,9 +186,7 @@ inline void tglMultMatrix(const TAffine &aff) {
   glMultMatrixd(m);
 }
 
-inline void tglMultMatrix(const TAffine4 &aff) {
-  glMultMatrixd(aff.a);
-}
+inline void tglMultMatrix(const TAffine4 &aff) { glMultMatrixd(aff.a); }
 
 //=============================================================================
 

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -346,6 +346,9 @@ public:
   bool isCursorOutlineEnabled() const {
     return getBoolValue(cursorOutlineEnabled);
   }
+  bool isUseStrokeEndCursor() const {
+      return getBoolValue(useStrokeEndCursor);
+  }
   int getLevelBasedToolsDisplay() const {
     return getIntValue(levelBasedToolsDisplay);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -116,6 +116,7 @@ enum PreferencesItemId {
   cursorOutlineEnabled,
   levelBasedToolsDisplay,
   useCtrlAltToResizeBrush,
+  useStrokeEndCursor,
   tempToolSwitchTimer,
 
   //----------

--- a/toonz/sources/tnztools/cursormanager.cpp
+++ b/toonz/sources/tnztools/cursormanager.cpp
@@ -287,6 +287,9 @@ public:
 if (cursorType == ToolCursor::CURSOR_ARROW)
   cursor = Qt::ArrowCursor;
 else */
+    if (cursorType == ToolCursor::CURSOR_NONE)
+        return Qt::BlankCursor;
+    else
     if (cursorType == ToolCursor::ForbiddenCursor)
       cursor = Qt::ForbiddenCursor;
     else {

--- a/toonz/sources/tnztools/paintbrushtool.cpp
+++ b/toonz/sources/tnztools/paintbrushtool.cpp
@@ -38,6 +38,7 @@
 // For Qt translation support
 #include <QCoreApplication>
 
+
 using namespace ToolUtils;
 
 #define LINES L"Lines"

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -446,9 +446,9 @@ public:
     insertLevelAndFrameIfNeeded();
     TToonzImageP image = getImage();
     TRasterCM32P ras   = image->getRaster();
-    RasterStrokeGenerator rasterTrack(
-        ras, BRUSH, NONE, m_styleId, m_points[0], m_selective, 0,
-        m_modifierLockAlpha, !m_isPencil, m_isPaletteOrder);
+    RasterStrokeGenerator rasterTrack(ras, BRUSH, NONE, m_styleId, m_points[0],
+                                      m_selective, 0, m_modifierLockAlpha,
+                                      !m_isPencil, m_isPaletteOrder);
     if (m_isPaletteOrder) {
       QSet<int> aboveStyleIds;
       getAboveStyleIdSet(m_styleId, image->getPalette(), aboveStyleIds);
@@ -721,7 +721,6 @@ static void Smooth(std::vector<TThickPoint> &points, const int radius,
   }
 }
 
-
 //===================================================================
 //
 // ToonzRasterBrushTool
@@ -745,8 +744,7 @@ ToonzRasterBrushTool::ToonzRasterBrushTool(std::string name, int targetType)
     , m_isPrompting(false)
     , m_firstTime(true)
     , m_presetsLoaded(false)
-    , m_notifier(0)
-{
+    , m_notifier(0) {
   bind(targetType);
 
   m_rasThickness.setNonLinearSlider();
@@ -780,8 +778,7 @@ ToonzRasterBrushTool::ToonzRasterBrushTool(std::string name, int targetType)
   m_modifierAssistants         = new TModifierAssistants();
   m_modifierSegmentation       = new TModifierSegmentation();
   m_modifierSmoothSegmentation = new TModifierSegmentation(TPointD(1, 1), 3);
-  for(int i = 0; i < 3; ++i)
-    m_modifierSmooth[i]        = new TModifierSmooth();
+  for (int i = 0; i < 3; ++i) m_modifierSmooth[i] = new TModifierSmooth();
 #ifndef NDEBUG
   m_modifierTest = new TModifierTest();
 #endif
@@ -1053,29 +1050,34 @@ bool ToonzRasterBrushTool::askWrite(const TRect &rect) {
 //---------------------------------------------------------------------------------------------------
 
 void ToonzRasterBrushTool::updateModifiers() {
-  int smoothRadius = (int)round(m_smooth.getValue());
+  int smoothRadius                = (int)round(m_smooth.getValue());
   m_modifierAssistants->magnetism = m_assistants.getValue() ? 1 : 0;
-  m_inputmanager.drawPreview      = false; //!m_modifierAssistants->drawOnly;
+  m_inputmanager.drawPreview      = false;  //! m_modifierAssistants->drawOnly;
 
   m_modifierReplicate.clear();
   if (m_assistants.getValue())
-    TReplicator::scanReplicators(this, nullptr, &m_modifierReplicate, false, true, false, false, nullptr);
-  
+    TReplicator::scanReplicators(this, nullptr, &m_modifierReplicate, false,
+                                 true, false, false, nullptr);
+
   m_inputmanager.clearModifiers();
   m_inputmanager.addModifier(TInputModifierP(m_modifierTangents.getPointer()));
   if (smoothRadius > 0) {
-    m_inputmanager.addModifier(TInputModifierP(m_modifierSmoothSegmentation.getPointer()));
-    for(int i = 0; i < 3; ++i) {
+    m_inputmanager.addModifier(
+        TInputModifierP(m_modifierSmoothSegmentation.getPointer()));
+    for (int i = 0; i < 3; ++i) {
       m_modifierSmooth[i]->radius = smoothRadius;
-      m_inputmanager.addModifier(TInputModifierP(m_modifierSmooth[i].getPointer()));
+      m_inputmanager.addModifier(
+          TInputModifierP(m_modifierSmooth[i].getPointer()));
     }
   }
-  m_inputmanager.addModifier(TInputModifierP(m_modifierAssistants.getPointer()));
+  m_inputmanager.addModifier(
+      TInputModifierP(m_modifierAssistants.getPointer()));
 #ifndef NDEBUG
   m_inputmanager.addModifier(TInputModifierP(m_modifierTest.getPointer()));
 #endif
   m_inputmanager.addModifiers(m_modifierReplicate);
-  m_inputmanager.addModifier(TInputModifierP(m_modifierSegmentation.getPointer()));
+  m_inputmanager.addModifier(
+      TInputModifierP(m_modifierSegmentation.getPointer()));
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1096,20 +1098,23 @@ bool ToonzRasterBrushTool::preLeftButtonDown() {
 //---------------------------------------------------------------------------------------------------
 
 void ToonzRasterBrushTool::handleMouseEvent(MouseEventType type,
-                                          const TPointD &pos,
-                                          const TMouseEvent &e) {
+                                            const TPointD &pos,
+                                            const TMouseEvent &e) {
   TTimerTicks t = TToolTimer::ticks();
   bool alt      = e.getModifiersMask() & TMouseEvent::ALT_KEY;
   bool shift    = e.getModifiersMask() & TMouseEvent::SHIFT_KEY;
   bool control  = e.getModifiersMask() & TMouseEvent::CTRL_KEY;
 
-  if (shift && type == ME_DOWN && e.button() == Qt::LeftButton && !m_painting.active) {
+  if (shift && type == ME_DOWN && e.button() == Qt::LeftButton &&
+      !m_painting.active) {
     m_modifierAssistants->magnetism = 0;
     m_inputmanager.clearModifiers();
     m_inputmanager.addModifier(TInputModifierP(m_modifierLine.getPointer()));
-    m_inputmanager.addModifier(TInputModifierP(m_modifierAssistants.getPointer()));
+    m_inputmanager.addModifier(
+        TInputModifierP(m_modifierAssistants.getPointer()));
     m_inputmanager.addModifiers(m_modifierReplicate);
-    m_inputmanager.addModifier(TInputModifierP(m_modifierSegmentation.getPointer()));
+    m_inputmanager.addModifier(
+        TInputModifierP(m_modifierSegmentation.getPointer()));
     m_inputmanager.drawPreview = true;
   }
 
@@ -1124,13 +1129,13 @@ void ToonzRasterBrushTool::handleMouseEvent(MouseEventType type,
     THoverList hovers(1, pos);
     m_inputmanager.hoverEvent(hovers);
   } else {
-    int    deviceId    = e.isTablet() ? 1 : 0;
+    int deviceId       = e.isTablet() ? 1 : 0;
     double defPressure = m_isMyPaintStyleSelected ? 0.5 : 1.0;
-    bool   hasPressure = e.isTablet();
+    bool hasPressure   = e.isTablet();
     double pressure    = hasPressure ? e.m_pressure : defPressure;
-    bool   final       = type == ME_UP;
-    m_inputmanager.trackEvent(
-      deviceId, 0, pos, pressure, TPointD(), hasPressure, false, final, t);
+    bool final         = type == ME_UP;
+    m_inputmanager.trackEvent(deviceId, 0, pos, pressure, TPointD(),
+                              hasPressure, false, final, t);
     m_inputmanager.processTracks();
   }
 }
@@ -1138,15 +1143,15 @@ void ToonzRasterBrushTool::handleMouseEvent(MouseEventType type,
 //---------------------------------------------------------------------------------------------------
 
 void ToonzRasterBrushTool::leftButtonDown(const TPointD &pos,
-                                        const TMouseEvent &e) {
+                                          const TMouseEvent &e) {
   handleMouseEvent(ME_DOWN, pos, e);
 }
 void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
-                                        const TMouseEvent &e) {
+                                          const TMouseEvent &e) {
   handleMouseEvent(ME_DRAG, pos, e);
 }
 void ToonzRasterBrushTool::leftButtonUp(const TPointD &pos,
-                                      const TMouseEvent &e) {
+                                        const TMouseEvent &e) {
   handleMouseEvent(ME_UP, pos, e);
 }
 void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
@@ -1156,12 +1161,11 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 //--------------------------------------------------------------------------------------------------
 
 void ToonzRasterBrushTool::inputSetBusy(bool busy) {
-  if (m_painting.active == busy)
-    return;
-  
+  if (m_painting.active == busy) return;
+
   if (busy) {
     // begin painting
-    
+
     TTool::Application *app = TTool::getApplication();
     if (!app) return;
 
@@ -1171,66 +1175,71 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
     if (!m_enabled) return;
 
     m_painting.active = !!getImage(true);
-    if (!m_painting.active)
-      m_painting.active = !!touchImage();
-    if (!m_painting.active)
-      return;
-    
+    if (!m_painting.active) m_painting.active = !!touchImage();
+    if (!m_painting.active) return;
+
     // nel caso che il colore corrente sia un cleanup/studiopalette color
     // oppure il colore di un colorfield
     updateCurrentStyle();
     if (TColorStyle *cs = app->getCurrentLevelStyle()) {
-      m_painting.styleId = app->getCurrentLevelStyleIndex();
+      m_painting.styleId  = app->getCurrentLevelStyleIndex();
       TRasterStyleFx *rfx = cs->getRasterStyleFx();
-      if (!cs->isStrokeStyle() && (!rfx || !rfx->isInkStyle()))
-          { m_painting.active = false; return; }
+      if (!cs->isStrokeStyle() && (!rfx || !rfx->isInkStyle())) {
+        m_painting.active = false;
+        return;
+      }
     } else {
       m_painting.styleId = 1;
     }
-    
+
     m_painting.frameId = getFrameId();
 
     TImageP img = getImage(true);
     TToonzImageP ri(img);
     TRasterCM32P ras = ri->getRaster();
-    if (!ras)
-      { m_painting.active = false; return; }
-      
+    if (!ras) {
+      m_painting.active = false;
+      return;
+    }
+
     m_painting.tileSet   = new TTileSetCM32(ras->getSize());
     m_painting.tileSaver = new TTileSaverCM32(ras, m_painting.tileSet);
     m_painting.affectedRect.empty();
     setWorkAndBackupImages();
-    
+
     if (m_isMyPaintStyleSelected) {
       // init myPaint drawing
-      
+
       m_painting.myPaint.isActive = true;
       m_painting.myPaint.strokeSegmentRect.empty();
-      
+
       m_workRas->lock();
-      
+
       // prepare base brush
-      if ( TMyPaintBrushStyle *mypaintStyle = dynamic_cast<TMyPaintBrushStyle *>(app->getCurrentLevelStyle()) )
-        m_painting.myPaint.baseBrush.fromBrush( mypaintStyle->getBrush() ); else
-          m_painting.myPaint.baseBrush.fromDefaults();
+      if (TMyPaintBrushStyle *mypaintStyle =
+              dynamic_cast<TMyPaintBrushStyle *>(app->getCurrentLevelStyle()))
+        m_painting.myPaint.baseBrush.fromBrush(mypaintStyle->getBrush());
+      else
+        m_painting.myPaint.baseBrush.fromDefaults();
       double modifierSize = m_modifierSize.getValue() * log(2.0);
-      float baseSize = m_painting.myPaint.baseBrush.getBaseValue( MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC );
-      m_painting.myPaint.baseBrush.setBaseValue( MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC, baseSize + modifierSize );
-    } else
-    if (m_hardness.getValue() == 100 || m_pencil.getValue()) {
+      float baseSize      = m_painting.myPaint.baseBrush.getBaseValue(
+          MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC);
+      m_painting.myPaint.baseBrush.setBaseValue(
+          MYPAINT_BRUSH_SETTING_RADIUS_LOGARITHMIC, baseSize + modifierSize);
+    } else if (m_hardness.getValue() == 100 || m_pencil.getValue()) {
       // init pencil drawing
-      
-      m_painting.pencil.isActive = true;
+
+      m_painting.pencil.isActive   = true;
       m_painting.pencil.realPencil = m_pencil.getValue();
     } else {
       // init blured brush drawing (regular drawing)
-      
+
       m_painting.blured.isActive = true;
     }
-    
+
   } else {
     // finish painting
-    
+
     if (m_painting.myPaint.isActive) {
       // finish myPaint drawing
       m_workRas->unlock();
@@ -1240,13 +1249,14 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
     m_painting.tileSaver = nullptr;
 
     // add undo record
-    TFrameId frameId = m_painting.frameId.isEmptyFrame() ? getCurrentFid() : m_painting.frameId;
+    TFrameId frameId = m_painting.frameId.isEmptyFrame() ? getCurrentFid()
+                                                         : m_painting.frameId;
     if (m_painting.tileSet->getTileCount() > 0) {
       TTool::Application *app   = TTool::getApplication();
       TXshLevel *level          = app->getCurrentLevel()->getLevel();
       TXshSimpleLevelP simLevel = level->getSimpleLevel();
-      TRasterCM32P ras          = TToonzImageP( getImage(true) )->getRaster();
-      TRasterCM32P subras       = ras->extract(m_painting.affectedRect)->clone();
+      TRasterCM32P ras          = TToonzImageP(getImage(true))->getRaster();
+      TRasterCM32P subras = ras->extract(m_painting.affectedRect)->clone();
       TUndoManager::manager()->add(new MyPaintBrushUndo(
           m_painting.tileSet, simLevel.getPointer(), frameId, m_isFrameCreated,
           m_isLevelCreated, subras, m_painting.affectedRect.getP00()));
@@ -1259,17 +1269,16 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
 
     // Restore gap/autoclose Fill Check
     int tc = ToonzCheck::instance()->getChecks();
-    if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();    
+    if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();
 
     /*-- 作業中のフレームをリセット --*/
     m_painting.frameId = TFrameId();
 
-
     m_painting.myPaint.isActive = false;
-    m_painting.pencil.isActive = false;
-    m_painting.blured.isActive = false;
-    m_painting.active = false;
-    
+    m_painting.pencil.isActive  = false;
+    m_painting.blured.isActive  = false;
+    m_painting.active           = false;
+
     /*-- FIdを指定して、描画中にフレームが動いても、
       描画開始時のFidのサムネイルが更新されるようにする。--*/
     notifyImageChanged(frameId);
@@ -1279,65 +1288,63 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
 
 //--------------------------------------------------------------------------------------------------
 
-void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point, const TTrack &track, bool firstTrack, bool preview) {
-  if (!m_painting.active || preview)
-    return;
-  
+void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point,
+                                                const TTrack &track,
+                                                bool firstTrack, bool preview) {
+  if (!m_painting.active || preview) return;
+
   TImageP img = getImage(true);
   TToonzImageP ri(img);
   TRasterCM32P ras = ri->getRaster();
-  if (!ras)
-    return;
-  TPointD rasCenter = ras->getCenterD();
+  if (!ras) return;
+  TPointD rasCenter     = ras->getCenterD();
   TPointD fixedPosition = getCenteredCursorPos(point.position);
-  
 
   TRectD invalidateRect;
   bool firstPoint = track.size() == track.pointsAdded;
   bool lastPoint  = track.pointsAdded == 1 && track.finished();
-  
+
   // first point must be without handler, following points must be with handler
   // other behaviour is possible bug and must be ignored
   assert(firstPoint == !track.handler);
-  if (firstPoint != !track.handler)
-    return;
-  
+  if (firstPoint != !track.handler) return;
+
   double defPressure = m_painting.myPaint.isActive ? 0.5 : 1.0;
   double pressure    = m_pressure.getValue() ? point.pressure : defPressure;
-  
+
   if (m_painting.myPaint.isActive) {
     // mypaint case
-    
+
     // init brush
     MyPaintStroke *handler;
     if (firstPoint) {
-      handler = new MyPaintStroke(m_workRas, *this, m_painting.myPaint.baseBrush, false);
+      handler = new MyPaintStroke(m_workRas, *this,
+                                  m_painting.myPaint.baseBrush, false);
       handler->brush.beginStroke();
       track.handler = handler;
     }
-    handler = dynamic_cast<MyPaintStroke*>(track.handler.getPointer());
+    handler = dynamic_cast<MyPaintStroke *>(track.handler.getPointer());
     if (!handler) return;
-    
+
     // paint stroke
     m_painting.myPaint.strokeSegmentRect.empty();
-    handler->brush.strokeTo( fixedPosition + rasCenter, pressure,
-                             point.tilt, point.time - track.previous().time );
-    if (lastPoint)
-      handler->brush.endStroke();
-    
+    handler->brush.strokeTo(fixedPosition + rasCenter, pressure, point.tilt,
+                            point.time - track.previous().time);
+    if (lastPoint) handler->brush.endStroke();
+
     // update affected area
     TRect updateRect = m_painting.myPaint.strokeSegmentRect * ras->getBounds();
     m_painting.affectedRect += updateRect;
     if (!updateRect.isEmpty())
-      handler->brush.updateDrawing( ras, m_backupRas, m_painting.myPaint.strokeSegmentRect,
-                                    m_painting.styleId, m_modifierLockAlpha.getValue() );
-    
+      handler->brush.updateDrawing(
+          ras, m_backupRas, m_painting.myPaint.strokeSegmentRect,
+          m_painting.styleId, m_modifierLockAlpha.getValue());
+
     // determine invalidate rect
     invalidateRect += convert(m_painting.myPaint.strokeSegmentRect) - rasCenter;
-  } else
-  if (m_painting.pencil.isActive) {
+  } else if (m_painting.pencil.isActive) {
     // pencil case
-    
+
     // Pencilモードでなく、Hardness=100 の場合のブラシサイズを1段階下げる
     double thickness = computeThickness(pressure, m_rasThickness)*2;
     //if (!m_painting.pencil.realPencil && !m_modifierLine->getManager())
@@ -1348,10 +1355,11 @@ void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point, const 
     PencilStroke *handler;
     if (firstPoint) {
       DrawOrder drawOrder = (DrawOrder)m_drawOrder.getIndex();
-      handler = new PencilStroke( ras, BRUSH, NONE, m_painting.styleId, thickPoint, drawOrder != OverAll, 0,
-                                  m_modifierLockAlpha.getValue(), !m_painting.pencil.realPencil,
-                                  drawOrder == PaletteOrder );
-      
+      handler             = new PencilStroke(
+          ras, BRUSH, NONE, m_painting.styleId, thickPoint,
+          drawOrder != OverAll, 0, m_modifierLockAlpha.getValue(),
+          !m_painting.pencil.realPencil, drawOrder == PaletteOrder);
+
       // if the drawOrder mode = "Palette Order",
       // get styleId list which is above the current style in the palette
       if (drawOrder == PaletteOrder) {
@@ -1361,28 +1369,26 @@ void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point, const 
       }
       track.handler = handler;
     }
-    handler = dynamic_cast<PencilStroke*>(track.handler.getPointer());
+    handler = dynamic_cast<PencilStroke *>(track.handler.getPointer());
     if (!handler) return;
 
     // paint stroke
-    if (!firstPoint)
-      handler->brush.add(thickPoint);
-    
+    if (!firstPoint) handler->brush.add(thickPoint);
+
     // update affected area
     TRect strokeRect = handler->brush.getLastRect() * ras->getBounds();
-    m_painting.tileSaver->save( strokeRect );
+    m_painting.tileSaver->save(strokeRect);
     m_painting.affectedRect += strokeRect;
-    handler->brush.generateLastPieceOfStroke( m_painting.pencil.realPencil );
-    
+    handler->brush.generateLastPieceOfStroke(m_painting.pencil.realPencil);
+
     // determine invalidate rect
     invalidateRect += convert(strokeRect) - rasCenter;
-  } else
-  if (m_painting.blured.isActive) {
+  } else if (m_painting.blured.isActive) {
     // blured brush case (aka regular brush)
 
-    double maxThick = m_rasThickness.getValue().second;
+    double maxThick     = m_rasThickness.getValue().second;
     DrawOrder drawOrder = (DrawOrder)m_drawOrder.getIndex();
-    
+
     // init brush
     BluredStroke *handler;
     if (firstPoint) {
@@ -1396,7 +1402,7 @@ void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point, const 
       }
       track.handler = handler;
     }
-    handler = dynamic_cast<BluredStroke*>(track.handler.getPointer());
+    handler = dynamic_cast<BluredStroke *>(track.handler.getPointer());
     if (!handler) return;
 
     // paint stroke
@@ -1411,10 +1417,10 @@ void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point, const 
     updateWorkAndBackupRasters(m_painting.affectedRect);
     m_painting.tileSaver->save(strokeRect);
     handler->brush.addPoint(thickPoint, 1, !lastPoint);
-    handler->brush.updateDrawing( ras, m_backupRas, strokeRect,
-                                  m_painting.styleId, drawOrder,
-                                  m_modifierLockAlpha.getValue() );
-    
+    handler->brush.updateDrawing(ras, m_backupRas, strokeRect,
+                                 m_painting.styleId, drawOrder,
+                                 m_modifierLockAlpha.getValue());
+
     invalidateRect += convert(strokeRect) - rasCenter;
   }
 
@@ -1422,22 +1428,25 @@ void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point, const 
   if (firstTrack) {
     // for the first track we will paint cursor circle
     // here we will invalidate rects for it
-    double thickness = m_isMyPaintStyleSelected ? m_maxCursorThick : m_maxThick*0.5;
+    double thickness =
+        m_isMyPaintStyleSelected ? m_maxCursorThick : m_maxThick * 0.5;
     TPointD thickOffset(thickness + 1, thickness + 1);
-    invalidateRect += TRectD(m_brushPos    - thickOffset, m_brushPos    + thickOffset);
-    invalidateRect += TRectD(fixedPosition - thickOffset, fixedPosition + thickOffset);
+    invalidateRect +=
+        TRectD(m_brushPos - thickOffset, m_brushPos + thickOffset);
+    invalidateRect +=
+        TRectD(fixedPosition - thickOffset, fixedPosition + thickOffset);
     m_mousePos = point.position;
     m_brushPos = fixedPosition;
   }
- 
-  if (!invalidateRect.isEmpty())
-    invalidate(invalidateRect.enlarge(2));
+
+  if (!invalidateRect.isEmpty()) invalidate(invalidateRect.enlarge(20));
 }
 
 //---------------------------------------------------------------------------------------------------------------
 
 // 明日はここをMyPaintのときにカーソルを消せるように修正する！！！！！！
-void ToonzRasterBrushTool::inputMouseMove(const TPointD &position, const TInputState &state) {
+void ToonzRasterBrushTool::inputMouseMove(const TPointD &position,
+                                          const TInputState &state) {
   struct Locals {
     ToonzRasterBrushTool *m_this;
 
@@ -1469,11 +1478,9 @@ void ToonzRasterBrushTool::inputMouseMove(const TPointD &position, const TInputS
   TPointD halfThick(thickness * 0.5, thickness * 0.5);
   TRectD invalidateRect(m_brushPos - halfThick, m_brushPos + halfThick);
 
-  if ( Preferences::instance()->useCtrlAltToResizeBrushEnabled()
-    && state.isKeyPressed(TKey::control)
-    && state.isKeyPressed(TKey::alt)
-    && !state.isKeyPressed(TKey::shift) )
-  {
+  if (Preferences::instance()->useCtrlAltToResizeBrushEnabled() &&
+      state.isKeyPressed(TKey::control) && state.isKeyPressed(TKey::alt) &&
+      !state.isKeyPressed(TKey::shift)) {
     // Resize the brush if CTRL+ALT is pressed and the preference is enabled.
     const TPointD &diff = position - m_mousePos;
     double max          = diff.x / 2;
@@ -1492,7 +1499,7 @@ void ToonzRasterBrushTool::inputMouseMove(const TPointD &position, const TInputS
     invalidateRect += TRectD(position - halfThick, position + halfThick);
   }
 
-  invalidate(invalidateRect.enlarge(2));
+  invalidate(invalidateRect.enlarge(20));
 
   if (m_minThick == 0 && m_maxThick == 0) {
     m_minThick = m_rasThickness.getValue().first;
@@ -1513,9 +1520,13 @@ void ToonzRasterBrushTool::draw() {
   TImageP img = getImage(false, 1);
 
   if (getApplication()->getCurrentObject()->isSpline()) return;
-
+  bool useEndCursor = Preferences::instance()->isUseStrokeEndCursor();
+  if (useEndCursor &&
+      (m_maxThick < 8 || !Preferences::instance()->isCursorOutlineEnabled()))
+    tglDrawInvertCursor(m_brushPos + TPointD(0.5, 0.5), 8, 12);
   // If toggled off, don't draw brush outline
-  if (!Preferences::instance()->isCursorOutlineEnabled()) return;
+  if (!Preferences::instance()->isCursorOutlineEnabled())
+    return;
 
   // Draw the brush outline - change color when the Ink / Paint check is
   // activated
@@ -1591,7 +1602,8 @@ void ToonzRasterBrushTool::setWorkAndBackupImages() {
 
   if (!m_workRas || m_workRas->getLx() < dim.lx || m_workRas->getLy() < dim.ly)
     m_workRas = TRaster32P(dim);
-  if (!m_backupRas || m_backupRas->getLx() < dim.lx || m_backupRas->getLy() < dim.ly)
+  if (!m_backupRas || m_backupRas->getLx() < dim.lx ||
+      m_backupRas->getLy() < dim.ly)
     m_backupRas = TRasterCM32P(dim);
 
   m_workBackupRect.empty();
@@ -1605,7 +1617,8 @@ void ToonzRasterBrushTool::updateWorkAndBackupRasters(const TRect &rect) {
   TRasterCM32P ras = ti->getRaster();
 
   // work and backup rect will additionaly enlarged to 1/8 of it size
-  // in each affected direction to predict future possible enlargements in this direction
+  // in each affected direction to predict future possible enlargements in this
+  // direction
   const int denominator = 8;
   TRect enlargedRect    = rect + m_workBackupRect;
   int dx                = (enlargedRect.getLx() - 1) / denominator + 1;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -788,7 +788,7 @@ void ToonzVectorBrushTool::inputMouseMove(
     m_maxThick = m_thickness.getValue().second;
   }
 
-  invalidate(invalidateRect.enlarge(2));
+  invalidate(invalidateRect.enlarge(10));
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1091,7 +1091,7 @@ void ToonzVectorBrushTool::inputPaintTracks(const TTrackList &tracks) {
     if (m_isPath) {
       if (getViewer()) getViewer()->GLInvalidateRect(invalidateRect);
     } else {
-      invalidate(invalidateRect.enlarge(2));
+      invalidate(invalidateRect.enlarge(10));
     }
   }
 }
@@ -1570,8 +1570,13 @@ void ToonzVectorBrushTool::draw() {
 
   if (getApplication()->getCurrentObject()->isSpline()) return;
 
+  bool useEndCursor = Preferences::instance()->isUseStrokeEndCursor();
+  if (useEndCursor &&
+      (m_maxThick < 8 || !Preferences::instance()->isCursorOutlineEnabled()))
+      tglDrawInvertCursor(m_brushPos + TPointD(0.5, 0.5), 4, 6);
   // If toggled off, don't draw brush outline
-  if (!Preferences::instance()->isCursorOutlineEnabled()) return;
+  if (!Preferences::instance()->isCursorOutlineEnabled())
+      return;
 
   // Don't draw brush outline if picking guiding stroke
   if (getViewer()->getGuidedStrokePickerMode()) return;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -9,7 +9,7 @@
 #include <ttoonzimage.h>
 #include <tstroke.h>
 #include <toonz/strokegenerator.h>
-
+#include "toonz/preferences.h"
 #include <tools/tool.h>
 #include <tools/cursors.h>
 
@@ -90,16 +90,13 @@ public:
 //    Brush Tool declaration
 //************************************************************************
 
-class ToonzVectorBrushTool final : public TTool,
-                                   public TInputHandler
-{
+class ToonzVectorBrushTool final : public TTool, public TInputHandler {
   Q_DECLARE_TR_FUNCTIONS(ToonzVectorBrushTool)
 
 public:
   ToonzVectorBrushTool(std::string name, int targetType);
 
-  ToolType getToolType() const override
-    { return TTool::LevelWriteTool; }
+  ToolType getToolType() const override { return TTool::LevelWriteTool; }
   unsigned int getToolHints() const override;
 
   ToolOptionsBox *createOptionsBox() override;
@@ -120,7 +117,9 @@ public:
                       const TInputState &state) override;
   void inputSetBusy(bool busy) override;
   void inputPaintTracks(const TTrackList &tracks) override;
-  void inputInvalidateRect(const TRectD &bounds) override { invalidate(bounds); }
+  void inputInvalidateRect(const TRectD &bounds) override {
+    invalidate(bounds);
+  }
   TTool *inputGetTool() override { return this; };
 
   void draw() override;
@@ -131,7 +130,9 @@ public:
   int getCursorId() const override {
     if (m_viewer && m_viewer->getGuidedStrokePickerMode())
       return m_viewer->getGuidedStrokePickerCursor();
-    return ToolCursor::PenCursor;
+    return Preferences::instance()->isUseStrokeEndCursor()
+                 ? ToolCursor::CURSOR_NONE
+                 : ToolCursor::PenCursor;
   }
 
   TPropertyGroup *getProperties(int targetType) override;
@@ -162,14 +163,14 @@ public:
 
 protected:
   typedef std::vector<StrokeGenerator> TrackList;
-  typedef std::vector<TStroke*> StrokeList;
+  typedef std::vector<TStroke *> StrokeList;
   void deleteStrokes(StrokeList &strokes);
   void copyStrokes(StrokeList &dst, const StrokeList &src);
 
   void snap(const TPointD &pos, bool snapEnabled, bool withSelfSnap = false);
 
   void updateModifiers();
-  
+
   enum MouseEventType { ME_DOWN, ME_DRAG, ME_UP, ME_MOVE };
   void handleMouseEvent(MouseEventType type, const TPointD &pos,
                         const TMouseEvent &e);
@@ -204,7 +205,7 @@ protected:
   TSmartPointerT<TModifierTest> m_modifierTest;
 #endif
   TInputModifier::List m_modifierReplicate;
-  
+
   TrackList m_tracks;
   TrackList m_rangeTracks;
   StrokeList m_firstStrokes;
@@ -214,23 +215,21 @@ protected:
   double m_minThick, m_maxThick;
 
   // for snapping and framerange
-  int m_col, m_firstFrame, m_veryFirstFrame,
-      m_veryFirstCol, m_targetType;
+  int m_col, m_firstFrame, m_veryFirstFrame, m_veryFirstCol, m_targetType;
   double m_pixelSize, m_minDistance2;
-  
+
   bool m_snapped;
   bool m_snappedSelf;
   TPointD m_snapPoint;
   TPointD m_snapPointSelf;
-  
+
   TPointD m_mousePos;  //!< Current mouse position, in world coordinates.
   TPointD m_brushPos;  //!< World position the brush will be painted at.
 
   VectorBrushPresetManager
       m_presetsManager;  //!< Manager for presets of this tool instance
 
-  bool m_active, m_firstTime, m_isPath,
-       m_presetsLoaded, m_firstFrameRange;
+  bool m_active, m_firstTime, m_isPath, m_presetsLoaded, m_firstFrameRange;
 
   bool m_propertyUpdating;
 };

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1317,6 +1317,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {cursorOutlineEnabled, tr("Show Cursor Size Outlines")},
       {levelBasedToolsDisplay, tr("Toolbar Display Behaviour:")},
       {useCtrlAltToResizeBrush, tr("Use %1 to Resize Brush").arg(CtrlAltStr())},
+      {useStrokeEndCursor ,tr("Use Inverted Cursor at Stroke End")},
       {tempToolSwitchTimer,
        tr("Switch Tool Temporarily Keypress Length (ms):")},
 
@@ -2047,6 +2048,7 @@ QWidget* PreferencesPopup::createToolsPage() {
     insertUI(cursorBrushStyle, cursorOptionsLay,
              getComboItemList(cursorBrushStyle));
     insertUI(cursorOutlineEnabled, cursorOptionsLay);
+    insertUI(useStrokeEndCursor, cursorOptionsLay);
   }
   insertUI(levelBasedToolsDisplay, lay,
            getComboItemList(levelBasedToolsDisplay));

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -549,6 +549,7 @@ void Preferences::definePreferenceItems() {
   define(cursorBrushType, "cursorBrushType", QMetaType::QString, "Small");
   define(cursorBrushStyle, "cursorBrushStyle", QMetaType::QString, "Default");
   define(cursorOutlineEnabled, "cursorOutlineEnabled", QMetaType::Bool, true);
+  define(useStrokeEndCursor, "useStrokeEndCursor", QMetaType::Bool, true);
   define(levelBasedToolsDisplay, "levelBasedToolsDisplay", QMetaType::Int,
          0);  // Default
   define(useCtrlAltToResizeBrush, "useCtrlAltToResizeBrush", QMetaType::Bool,


### PR DESCRIPTION
Introduce an option to replace the cursor with a inverted cursor at Drawing Stroke's End Point for Vector and Toonz Raster Levels.
![图片](https://github.com/user-attachments/assets/8866db2a-3079-4fef-ae3f-e16b20992388)

The original behavior is to always show the system cursor instantly, which would generate a visual delay when drawing fast.
![2025-06-13 14-55-45_00-00-35 536_00-00-42 918- 00 05 588_00 13 137](https://github.com/user-attachments/assets/be3df3b1-9415-4c2d-b0fa-d8afa2cfcc18)

The new behavior would hide the system cursor, and always show the cursor at the brush position:
![BRUSHPOS](https://github.com/user-attachments/assets/272a6e95-607f-4eeb-b1ae-4569cf352037)

When the brush size is bigger than 8, the cursor would be replaced by brush circles.