### PR TITLE
Fix save level command

### DIFF
--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -72,6 +72,7 @@ public:
             once a proper path is specified by the user.                      */
 
   void setUntitled();  //!< Marks the scene as explicitly untitled.
+  void setTitled(); //Marks scene as titled after being saved
   bool isUntitled()
       const;  //!< Returns whether the scene path is empty, or the scene
               //!  is explicitly untitled.  \sa  Member function setUntitled().

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1586,6 +1586,7 @@ bool IoCmd::saveScene(int flags) {
     int ret = popup->exec();
     if (ret == QDialog::Accepted) {
       TApp::instance()->getCurrentScene()->setDirtyFlag(false);
+      scene->setTitled();
       return true;
     } else {
       TApp::instance()->getCurrentSelection()->setSelection(oldSelection);
@@ -1757,24 +1758,8 @@ bool IoCmd::saveAll(int flags) {
 
   // NOTE: saveScene already check saveInProgress
   bool result = saveScene(flags);
-
-  TApp *app         = TApp::instance();
-  ToonzScene *scene = app->getCurrentScene()->getScene();
-  bool untitled     = scene->isUntitled();
-  SceneResources resources(scene, 0);
-  // Must wait for current save to finish, just in case
-  while (TApp::instance()->isSaveInProgress())
-    ;
-
-  TApp::instance()->setSaveInProgress(true);
-  resources.save(scene->getScenePath());
-  TApp::instance()->setSaveInProgress(false);
-  resources.updatePaths();
-
-  // for update title bar
-  app->getCurrentLevel()->notifyLevelTitleChange();
-  app->getCurrentPalette()->notifyPaletteTitleChanged();
-  if (untitled) scene->setUntitled();
+  
+  saveNonSceneFiles();
 
   //End Label Notice
   if (result) {
@@ -1784,7 +1769,7 @@ bool IoCmd::saveAll(int flags) {
         "background-color: black; color: green; "
         "font-weight: bold; padding: 5px;");
   } else {
-    Label->setText("Save Failed");
+    Label->setText("Save All Failed");
     Label->setStyleSheet(
         "font-size: 20px;"
         "background-color: black; color: red; "
@@ -1799,13 +1784,12 @@ bool IoCmd::saveAll(int flags) {
 //===========================================================================
 // IoCmd::saveNonSceneFiles()
 //---------------------------------------------------------------------------
-
+// This command should not change any content in scene!
 void IoCmd::saveNonSceneFiles() {
   // try to save non scene files
 
   TApp *app         = TApp::instance();
   ToonzScene *scene = app->getCurrentScene()->getScene();
-  bool untitled     = scene->isUntitled();
   SceneResources resources(scene, 0);
   // Must wait for current save to finish, just in case
   while (TApp::instance()->isSaveInProgress())
@@ -1814,7 +1798,6 @@ void IoCmd::saveNonSceneFiles() {
   TApp::instance()->setSaveInProgress(true);
   resources.save(scene->getScenePath());
   TApp::instance()->setSaveInProgress(false);
-  if (untitled) scene->setUntitled();
   resources.updatePaths();
 
   // for update title bar
@@ -3111,14 +3094,12 @@ public:
       DVGui::warning(QObject::tr("No Current Scene"));
       return;  // non dovrebbe succedere mai
     }
-    TFilePath levelPath = sl->getPath();
-    levelPath           = scene->decodeFilePath(levelPath);
-    QString str         = QString::fromStdWString(levelPath.getWideString());
-    if (!(sl->getPath().isAbsolute() || !scene->isUntitled() ||
-          (!sl->getPath().isAbsolute() && !str.contains("untitled")))) {
-      error(QObject::tr("Save the scene first"));
-      return;
-    }
+    //TFilePath levelPath = sl->getPath();
+    //levelPath           = scene->decodeFilePath(levelPath);
+    //if (!levelPath.isAbsolute() && (scene->isUntitled() || scene->getSceneName().empty())) {
+    //  error(QObject::tr("Save the scene first") + levelPath.getQString());
+    //  return;
+    //}
 
     // reset the undo before save level
     if (Preferences::instance()->getBoolValue(resetUndoOnSavingLevel))

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -85,7 +85,7 @@ TEnv::IntVar EditShiftToggleAction("EditShiftToggleAction", 0);
 TEnv::IntVar ShowShiftOriginToggleAction("ShowShiftOriginToggleAction", 0);
 TEnv::IntVar NoShiftToggleAction("NoShiftToggleAction", 0);
 TEnv::IntVar TouchGestureControl("TouchGestureControl", 0);
-TEnv::IntVar ShowBuildDateInTitle("ShowBuildDateInTitle", 0);
+TEnv::IntVar ShowBuildDateInTitle("ShowBuildDateInTitle", 1);
 
 //=============================================================================
 namespace {

--- a/toonz/sources/toonzlib/sceneresources.cpp
+++ b/toonz/sources/toonzlib/sceneresources.cpp
@@ -492,11 +492,20 @@ void SceneResources::getResources() {
 
   for (it = levels.begin(); it != levels.end(); ++it) {
     TXshSimpleLevel *sl = (*it)->getSimpleLevel();
-    if (sl) m_resources.push_back(new SceneLevel(scene, sl));
+    if (sl) {
+        m_resources.push_back(new SceneLevel(scene, sl));
+        continue;
+    }
     TXshPaletteLevel *pl = (*it)->getPaletteLevel();
-    if (pl) m_resources.push_back(new ScenePalette(scene, pl));
+    if (pl) { 
+        m_resources.push_back(new ScenePalette(scene, pl));
+        continue; 
+    }
     TXshSoundLevel *sdl = (*it)->getSoundLevel();
-    if (sdl) m_resources.push_back(new SceneSound(scene, sdl));
+    if (sdl) {
+        m_resources.push_back(new SceneSound(scene, sdl));
+        continue;
+    }
   }
 }
 

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -327,8 +327,8 @@ std::shared_ptr<TProject> ToonzScene::getProject() const { return m_project; }
 //-----------------------------------------------------------------------------
 
 void ToonzScene::setScenePath(const TFilePath &fp) {
-  m_scenePath  = fp;
-  m_isUntitled = false;
+  m_scenePath = fp;
+  // m_isUntitled = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -386,7 +386,7 @@ void ToonzScene::loadNoResources(const TFilePath &fp) {
   clear();
 
   TProjectManager *pm = TProjectManager::instance();
-  auto sceneProject = pm->loadSceneProject(fp);
+  auto sceneProject   = pm->loadSceneProject(fp);
   if (!sceneProject) return;
 
   setProject(sceneProject);
@@ -552,6 +552,8 @@ void ToonzScene::setUntitled() {
   }
   m_scenePath = fp;
 }
+
+void ToonzScene::setTitled() { m_isUntitled = false; }
 
 //-----------------------------------------------------------------------------
 
@@ -1186,7 +1188,7 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     else {
       const Preferences &prefs = *Preferences::instance();
       int formatIdx            = prefs.matchLevelFormat(
-                     levelPath);  // Should I use actualPath here? It's mostly
+          levelPath);  // Should I use actualPath here? It's mostly
                                   // irrelevant anyway, it's for old tzp/tzu...
       if (formatIdx >= 0) {
         lp->options()   = prefs.levelFormat(formatIdx).m_options;
@@ -1241,7 +1243,7 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
 //-----------------------------------------------------------------------------
 
 TFilePath ToonzScene::decodeFilePath(const TFilePath &path) const {
-  auto project = getProject();
+  auto project        = getProject();
   bool projectIsEmpty = project->getFolderCount() ? false : true;
   TFilePath fp        = path;
 
@@ -1273,8 +1275,7 @@ TFilePath ToonzScene::decodeFilePath(const TFilePath &path) const {
       if (project) {
         h           = ::to_string(head.substr(1));
         TFilePath f = project->getFolder(h);
-        if (isLonelyScene())
-            return m_scenePath.getParentDir() + f + tail;
+        if (isLonelyScene()) return m_scenePath.getParentDir() + f + tail;
         if (f != TFilePath()) s = f.getWideString();
       }
     }
@@ -1380,8 +1381,8 @@ bool ToonzScene::codeFilePathWithSceneFolder(TFilePath &path) const {
 }
 
 bool ToonzScene::isLonelyScene() const {
-    TFilePath sceneFolderPath = getProject()->getFolder("scenes", true);
-    return !sceneFolderPath.isAncestorOf(m_scenePath);
+  TFilePath sceneFolderPath = getProject()->getFolder("scenes", true);
+  return !sceneFolderPath.isAncestorOf(m_scenePath) && !isUntitled();
 }
 
 //-----------------------------------------------------------------------------
@@ -1413,13 +1414,13 @@ TFilePath ToonzScene::getDefaultLevelPath(int levelType,
   }
 
   // In case scene is loaded from outside
-  if (!isUntitled() &&
-      Preferences::instance()->getPathAliasPriority() == Preferences::SceneFolderAlias)
-          return TFilePath("$scenefolder") + levelPath;
+  if (!isUntitled() && Preferences::instance()->getPathAliasPriority() ==
+                           Preferences::SceneFolderAlias)
+    return TFilePath("$scenefolder") + levelPath;
 
   std::string folderName = getFolderName(levelType);
   if (!isUntitled() && isLonelyScene())
-      return TFilePath("$scenefolder") + TFilePath(folderName) + levelPath;
+    return TFilePath("$scenefolder") + TFilePath(folderName) + levelPath;
 
   if (project->getUseScenePath(folderName))
     return TFilePath("+" + folderName) + getSavePath() + levelPath;


### PR DESCRIPTION
- Fix the ability to use save level command before scene being saved.
- Refactor to only remove scene's untitle flag when scene being saved.

- Show app built date in title by default

fixes #6005 