### PR TITLE
Fix undo of autocreation in empty cell

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -492,8 +492,7 @@ void FullColorBrushTool::inputSetBusy(bool busy) {
   if (busy) {
     // begin paint
     TRasterImageP ri = (TRasterImageP)getImage(true);
-    if (!ri) ri = (TRasterImageP)touchImage();
-    if (!ri) return;
+    if (!ri) return;// ri = (TRasterImageP)touchImage(); touch in preLeftButtonDown
     TRasterP ras = ri->getRaster();
 
     if (!(m_workRaster && m_backUpRas)) setWorkAndBackupImages();

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -839,7 +839,7 @@ void ToonzVectorBrushTool::inputSetBusy(bool busy) {
     if ( app->getCurrentColumn()->getColumnIndex() < 0
       && !app->getCurrentFrame()->isEditingLevel() )
       return;
-    if (!getImage(true) || !touchImage())
+    if (!getImage(true))// Image is touched in preLeftButtonDown
       return;
     if (!app->getCurrentLevel()->getLevel())
       return;


### PR DESCRIPTION
## Issue Description
Select an empty cell and draw with the pen on a raster or vector level column. Then undo — the newly created frame should be undone.