### PR TITLE
fix: Duplicate Save of saved scene

### DIFF
--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -56,7 +56,8 @@ public:
   std::shared_ptr<TProject> getProject() const;  //!< Returns a pointer to the project holding a scene instance.
   void setProject(std::shared_ptr<TProject>);  //!< Associates a scene to a project.
 
-  void setScenePath(const TFilePath &p);  //!< Sets the scene's file path.
+  void setScenePath(const TFilePath &p, 
+      bool changeToTitled = true);  //!< Sets the scene's file path.
   TFilePath getScenePath() const {
     return m_scenePath;
   }  //!< Returns the scene's file path.

--- a/toonz/sources/toonzlib/sceneresources.cpp
+++ b/toonz/sources/toonzlib/sceneresources.cpp
@@ -513,7 +513,9 @@ void SceneResources::getResources() {
 
 void SceneResources::save(const TFilePath newScenePath) {
   TFilePath oldScenePath = m_scene->getScenePath();
-  m_scene->setScenePath(newScenePath);
+  // TODO: The save path of resources should not be decided by changing scene's property,
+  // refactor and remove setScenePath
+  m_scene->setScenePath(newScenePath, false);
   bool failedSave = false;
   for (int i = 0; i < (int)m_resources.size(); i++) {
     m_resources[i]->save();
@@ -533,7 +535,7 @@ void SceneResources::save(const TFilePath newScenePath) {
     DVGui::warning(QObject::tr("Failed to save the following resources:\n") +
                    "  " + failedList.join("\n  "));
   }
-  m_scene->setScenePath(oldScenePath);
+  m_scene->setScenePath(oldScenePath, false);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -326,9 +326,9 @@ std::shared_ptr<TProject> ToonzScene::getProject() const { return m_project; }
 
 //-----------------------------------------------------------------------------
 
-void ToonzScene::setScenePath(const TFilePath &fp) {
+void ToonzScene::setScenePath(const TFilePath &fp, bool changeToTitled) {
   m_scenePath = fp;
-  // m_isUntitled = false;
+  if(changeToTitled)m_isUntitled = false;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Issue Description
Current nightly build would ask for saving again after opening a saved scene and saving all.

---

The save path of resources should not be decided by changing scene's property, it's a little dirty.
I think we need to change this part of code in the future, to separate the resources saving and scene saving.