### PR TITLE
add naru lazy brush fx

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1723,5 +1723,24 @@
   <item>"STD_iwa_TiledParticlesFx.fadeout_color_fade"		"Fade-out Intensity"		</item>
   <item>"STD_iwa_TiledParticlesFx.source_gradation"		"Use Control Image Gradation"		</item>
   <item>"STD_iwa_TiledParticlesFx.pick_color_for_every_frame"	"Pick Control Image's Color for Every Frame"	</item>
+
+  <!------------------------------ Naru FXs ------------------------------------------->
+  
+  <item>"STD_naru_LazyBrushFx" 	"LazyBrush Naru" 		</item>
+  <item>"STD_naru_LazyBrushFx.mode" 		"Mode" 			</item>
+  <item>"STD_naru_LazyBrushFx.mask_color" 	"Mask Color" 	</item>
+  <item>"STD_naru_LazyBrushFx.undef_is_sink" 	"Fill Hole"	</item>
+  <item>"STD_naru_LazyBrushFx.auto_scribble" 	"Auto Mask Scribble"	</item>
+  <item>"STD_naru_LazyBrushFx.line_weight"	 	"Line's Weights"		</item>
+  <item>"STD_naru_LazyBrushFx.sink_pos" 	"Background Direction"	</item>
+  <item>"STD_naru_LazyBrushFx.lambda"	 	"Scribble Strength"		</item>
+  <item>"STD_naru_LazyBrushFx.scr_type" 	"Scribble Type"		</item>
+  <item>"STD_naru_LazyBrushFx.min_lightness" 	"Outline Cutoff"	</item>
+  <item>"STD_naru_LazyBrushFx.log_scale" 	"LoG Filter Scale"		</item>
+  <item>"STD_naru_LazyBrushFx.sigma"	 	"Filter Smoothness"			</item>
+  <item>"STD_naru_LazyBrushFx.alpha"	 	"Difficulty Passing Through Ink"			</item>
+  <item>"STD_naru_LazyBrushFx.auto_scribble_length" 	"Auto Scribble Margin"	</item>
+  <item>"STD_naru_LazyBrushFx.auto_scribble_threshold" 	"Auto Scribble Outline Threshold"	</item>
+
 </stringtable> 
 

--- a/stuff/doc/LICENSE/LICENSE_BKMaxflow.txt
+++ b/stuff/doc/LICENSE/LICENSE_BKMaxflow.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Yupei Qi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/stuff/profiles/layouts/fxs/STD_naru_LazyBrushFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_naru_LazyBrushFx.xml
@@ -1,0 +1,21 @@
+<fxlayout>
+  <page name="LazyBrush Config">
+    <control>mode</control>
+    <control>mask_color</control>
+    <control>undef_is_sink</control>
+    <control>auto_scribble</control>
+    <control>line_weight</control>
+    <control>sink_pos</control>
+
+   	<vbox shrink="0" label="Advanced">
+      <control>scr_type</control>
+      <control>min_lightness</control>
+      <control>log_scale</control>
+      <control>sigma</control>
+      <control>alpha</control>
+      <control>lambda</control>
+      <control>auto_scribble_length</control>
+      <control>auto_scribble_threshold</control>
+    </vbox>
+  </page>
+</fxlayout>

--- a/stuff/profiles/layouts/fxs/fxs.lst
+++ b/stuff/profiles/layouts/fxs/fxs.lst
@@ -170,6 +170,7 @@
     STD_solarizeFx
     STD_iwa_TangentFlowFx
     STD_iwa_MotionFlowFx
+    STD_naru_LazyBrushFx
   </Stylize>
   <Toonz_Level>
     STD_artContourFx

--- a/toonz/sources/stdfx/CMakeLists.txt
+++ b/toonz/sources/stdfx/CMakeLists.txt
@@ -91,6 +91,7 @@ set(HEADERS
     iwa_flowblurfx.h
     iwa_flowpaintbrushfx.h
     iwa_motionflowfx.h
+    naru_graph.h
 )
 
 if(OpenCV_FOUND)
@@ -291,6 +292,8 @@ set(SOURCES
     iwa_flowpaintbrushfx.cpp
     iwa_motionflowfx.cpp
     iwa_smootherfx.cpp
+    naru_lazybrush.cpp
+    naru_maxflow.cpp
 )
 
 if(OpenCV_FOUND)

--- a/toonz/sources/stdfx/naru_graph.h
+++ b/toonz/sources/stdfx/naru_graph.h
@@ -1,0 +1,105 @@
+#include "stdfx.h"
+#include <queue>
+
+#define TERMINAL ((Graph::arc*)1)
+#define ORPHAN ((Graph::arc*)2)
+
+class Graph {
+public:
+  typedef enum { SOURCE = 0, SINK = 1 } terminalType;
+
+  Graph(int maxNodeNum);
+  ~Graph();
+
+private:
+  struct node;
+  struct arc;
+
+  struct node {
+    arc* firstArc;
+    arc* parentArc;
+    bool isSink : 1;
+    int tCap;
+  };
+
+  struct arc {
+    node* headNode;
+    arc* nextArc;
+    arc* revArc;
+    int rCap;
+  };
+
+  node *nodes, *nodeLast;
+  arc *arcs, *arcLast;
+  int nodesNum, arcsNum;
+
+  std::queue<node*> activeQueue;
+  std::queue<node*> orphanQueue;
+
+  int flow;
+
+public:
+  void addEdge(int from, int to, int cap, int revCap) {
+    if ((arcLast - arcs) + 2 >= arcsNum) {
+      throw std::runtime_error("Maximum number of edges exceeded");
+    }
+    node* fromNode = nodes + from;
+    node* toNode   = nodes + to;
+
+    arc* newArc = arcLast++;
+    arc* revArc = arcLast++;
+
+    newArc->headNode   = toNode;
+    newArc->rCap       = cap;
+    newArc->nextArc    = fromNode->firstArc;
+    newArc->revArc     = revArc;
+    fromNode->firstArc = newArc;
+
+    revArc->headNode = fromNode;
+    revArc->rCap     = revCap;
+    revArc->nextArc  = toNode->firstArc;
+    revArc->revArc   = newArc;
+    toNode->firstArc = revArc;
+  }
+
+  void addTerminal(int nodeIndex, int tCap) { nodes[nodeIndex].tCap = tCap; }
+
+  terminalType getSegment(int nodeIndex, terminalType defaultType) {
+    if (nodes[nodeIndex].parentArc)
+      return nodes[nodeIndex].isSink ? SINK : SOURCE;
+    else
+      return defaultType;
+  }
+
+  void mincut();
+
+private:
+  void setActive(node* n) { activeQueue.push(n); }
+
+  node* nextActive() {
+    while (!activeQueue.empty()) {
+      node* n = activeQueue.front();
+      activeQueue.pop();
+      if (n->parentArc == ORPHAN) continue;
+      return n;
+    }
+    return nullptr;
+  }
+
+  void setOrphan(node* n) {
+    n->parentArc = ORPHAN;
+    orphanQueue.push(n);
+  }
+
+  node* nextOrphan() {
+    if (!orphanQueue.empty()) {
+      node* n = orphanQueue.front();
+      orphanQueue.pop();
+      return n;
+    } else
+      return nullptr;
+  }
+
+  void augment(arc* midArc);
+  void adopt();
+};

--- a/toonz/sources/stdfx/naru_lazybrush.cpp
+++ b/toonz/sources/stdfx/naru_lazybrush.cpp
@@ -1,0 +1,648 @@
+#include "trop.h"
+#include "tfxparam.h"
+#include <math.h>
+#include "stdfx.h"
+
+#include "naru_graph.h"
+
+#include "tparamset.h"
+#include "trasterfx.h"
+#include "tpixelutils.h"
+
+class naru_lazybrush final : public TStandardRasterFx {
+  FX_PLUGIN_DECLARATION(naru_lazybrush)
+
+  TRasterFxPort m_input;
+  TRasterFxPort m_ref;
+
+  TIntEnumParamP m_mode;
+  TPixelParamP m_maskcolor;
+  TIntEnumParamP m_scrtype;
+
+  TDoubleParamP m_minlightness;
+  TDoubleParamP m_logs;
+  TDoubleParamP m_sigma;
+  TDoubleParamP m_lambda;
+  TDoubleParamP m_alpha;
+  TDoubleParamP m_autoscrlen;
+  TDoubleParamP m_autoscrthresh;
+  TDoubleParamP m_lineweight;
+  TBoolParamP m_fillHole;
+  TIntEnumParamP m_sinkpos;
+  TBoolParamP m_autoScribble;
+
+public:
+  naru_lazybrush()
+      : m_mode(new TIntEnumParam(0, "Mask+Line"))
+      , m_maskcolor(TPixel32(200, 200, 200, 255))
+      , m_scrtype(new TIntEnumParam(0, "Soft"))
+      , m_minlightness(0.02f)
+      , m_logs(0.05f)
+      , m_sigma(1.5f)
+      , m_lambda(0.6f)
+      , m_alpha(100.f)
+      , m_autoscrlen(4.f)
+      , m_autoscrthresh(0.1f)
+      , m_lineweight(4.f)
+      , m_fillHole(true)
+      , m_sinkpos(new TIntEnumParam(0, "All"))
+      , m_autoScribble(true) {
+    bindParam(this, "mode", m_mode);
+    bindParam(this, "mask_color", m_maskcolor);
+    bindParam(this, "scr_type", m_scrtype);
+
+    bindParam(this, "min_lightness", m_minlightness);
+    bindParam(this, "log_scale", m_logs);
+    bindParam(this, "sigma", m_sigma);
+    bindParam(this, "lambda", m_lambda);
+    bindParam(this, "alpha", m_alpha);
+    bindParam(this, "auto_scribble_length", m_autoscrlen);
+    bindParam(this, "auto_scribble_threshold", m_autoscrthresh);
+    bindParam(this, "line_weight", m_lineweight);
+    bindParam(this, "undef_is_sink", m_fillHole);
+    bindParam(this, "sink_pos", m_sinkpos);
+    bindParam(this, "auto_scribble", m_autoScribble);
+
+    this->m_mode->addItem(1, "Mask");
+    this->m_mode->addItem(2, "LoG Filter");
+    this->m_mode->addItem(3, "Capacity Map");
+    this->m_mode->addItem(4, "Scribble Map");
+    this->m_scrtype->addItem(1, "Hard");
+
+    this->m_sinkpos->addItem(1, "Bottom-Left");
+    this->m_sinkpos->addItem(2, "Bottom-Center");
+    this->m_sinkpos->addItem(3, "Bottom-Right");
+    this->m_sinkpos->addItem(4, "Center-Right");
+    this->m_sinkpos->addItem(5, "Top-Right");
+    this->m_sinkpos->addItem(6, "Top-Center");
+    this->m_sinkpos->addItem(7, "Top-Left");
+    this->m_sinkpos->addItem(8, "Center-Left");
+
+    this->m_minlightness->setValueRange(0.f, 1.f);
+    this->m_logs->setValueRange(0.f, 5.f);
+    this->m_sigma->setValueRange(0.f, 5.f);
+    this->m_lambda->setValueRange(0.5f, 5.f);
+    this->m_alpha->setValueRange(1.f, 10000.f);
+    this->m_autoscrlen->setValueRange(1.f, 10.f);
+    this->m_autoscrthresh->setValueRange(0.f, 1.f);
+
+    addInputPort("Source", m_input);
+    addInputPort("Reference", m_ref);
+    enableComputeInFloat(true);
+  }
+
+  ~naru_lazybrush() {};
+
+  bool doGetBBox(double frame, TRectD& bBox,
+                 const TRenderSettings& info) override {
+    if (m_input.isConnected()) {
+      bBox = TConsts::infiniteRectD;
+      return true;
+    } else {
+      bBox = TRectD();
+      return false;
+    }
+  };
+
+  void doCompute(TTile& tile, double frame, const TRenderSettings&) override;
+
+  bool canHandle(const TRenderSettings& info, double frame) override {
+    return false;
+  }
+
+private:
+  const float gauKernel[3][3] = {
+      {1, 2, 1},
+      {2, 4, 2},
+      {1, 2, 1},
+  };
+  const float weightSum       = 16.f;
+  const float lapKernel[3][3] = {
+      {0, 1, 0},
+      {1, -4, 1},
+      {0, 1, 0},
+  };
+
+  int mode = 0;       // 0:Mask+Line, 1:Mask, 2:LoG Filter, 3:Scribble Map
+  TPixelF maskColor;  // マスクの色
+
+  const float LoG_draw_scale = 20.f;   // LoGフィルタの描画スケール
+  float LoG_s                = 0.05f;  // LoGフィルタのスケール
+
+  int idx(int x, int y, int w) { return y * w + x; }
+
+  //-------------------------------------------------------------------
+
+  template <typename PIXEL>
+  void doDraw(TRasterPT<PIXEL> ras, std::vector<float>& r,
+              std::vector<float>& g, std::vector<float>& b,
+              std::vector<float>& a);
+  template <typename PIXEL>
+  void doGrayScale(TRasterPT<PIXEL> ras, double frame,
+                   std::vector<float>& temp);
+  template <typename PIXEL>
+  void doLoG(TRasterPT<PIXEL> ras, double frame, std::vector<float>& gray,
+             std::vector<float>& lap);
+  template <typename PIXEL>
+  void doGraph(TRasterPT<PIXEL> ras, double frame, TRasterPT<PIXEL> refRas,
+               bool refer_sw, std::vector<float>& lap, Graph& g);
+  template <typename PIXEL>
+  void doColorize(TRasterPT<PIXEL> ras, double frame, Graph& g,
+                  std::vector<float>& gray);
+  template <typename PIXEL>
+  void process(TRasterPT<PIXEL> ras, double frame, TRasterPT<PIXEL> refRas,
+               bool refer_sw);
+};
+
+template <typename PIXEL>
+void naru_lazybrush::doDraw(TRasterPT<PIXEL> ras, std::vector<float>& r,
+                            std::vector<float>& g, std::vector<float>& b,
+                            std::vector<float>& a) {
+  int width  = ras->getLx();
+  int height = ras->getLy();
+
+  ras->lock();
+  for (int y = 0; y < height; ++y) {
+    PIXEL* pix = ras->pixels(y);
+    for (int x = 0; x < width; ++x) {
+      int p  = idx(x, y, width);
+      pix->r = (typename PIXEL::Channel)(maskColor.m * maskColor.r *
+                                         fmin(r[p], 1.f) *
+                                         (float)PIXEL::maxChannelValue);
+      pix->g = (typename PIXEL::Channel)(maskColor.m * maskColor.g *
+                                         fmin(g[p], 1.f) *
+                                         (float)PIXEL::maxChannelValue);
+      pix->b = (typename PIXEL::Channel)(maskColor.m * maskColor.b *
+                                         fmin(b[p], 1.f) *
+                                         (float)PIXEL::maxChannelValue);
+      pix->m = (typename PIXEL::Channel)(maskColor.m * fmin(a[p], 1.f) *
+                                         (float)PIXEL::maxChannelValue);
+      pix++;
+    }
+  }
+  ras->unlock();
+}
+
+template <typename PIXEL>
+void naru_lazybrush::doGrayScale(TRasterPT<PIXEL> ras, double frame,
+                                 std::vector<float>& gray) {
+  int width  = ras->getLx();
+  int height = ras->getLy();
+
+  float minLightness = m_minlightness->getValue(frame);
+
+  ras->lock();
+  for (int y = 0; y < height; ++y) {
+    PIXEL* pix = ras->pixels(y);
+    for (int x = 0; x < width; ++x) {
+      float m = (float)pix->m / (float)PIXEL::maxChannelValue;
+      if (m != 0) {
+        float r = (float)pix->r / (m * (float)PIXEL::maxChannelValue);
+        float g = (float)pix->g / (m * (float)PIXEL::maxChannelValue);
+        float b = (float)pix->b / (m * (float)PIXEL::maxChannelValue);
+        gray[idx(x, y, width)] =
+            fmax(0.299f * r + 0.587f * g + 0.114f * b, minLightness);
+      } else {
+        gray[idx(x, y, width)] = 1.0f;
+      }
+      pix++;
+    }
+  }
+  ras->unlock();
+}
+
+template <typename PIXEL>
+void naru_lazybrush::doLoG(TRasterPT<PIXEL> ras, double frame,
+                           std::vector<float>& gray, std::vector<float>& lap) {
+  int width  = ras->getLx();
+  int height = ras->getLy();
+
+  // ガウシアンフィルタ
+  std::vector<float> blurred(width * height, 0.0f);
+  for (int y = 1; y < height - 1; ++y) {
+    for (int x = 1; x < width - 1; ++x) {
+      float sum = 0.f;
+      for (int dy = -1; dy <= 1; ++dy) {
+        for (int dx = -1; dx <= 1; ++dx) {
+          sum += gray[idx(x + dx, y + dy, width)] * gauKernel[dy + 1][dx + 1];
+        }
+      }
+      blurred[idx(x, y, width)] = sum / weightSum;
+    }
+  }
+
+  // 境界値を設定
+  for (int x = 0; x < width; ++x) {
+    blurred[idx(x, 0, width)]          = blurred[idx(x, 1, width)];
+    blurred[idx(x, height - 1, width)] = blurred[idx(x, height - 2, width)];
+  }
+  for (int y = 0; y < height; ++y) {
+    blurred[idx(0, y, width)]         = blurred[idx(1, y, width)];
+    blurred[idx(width - 1, y, width)] = blurred[idx(width - 2, y, width)];
+  }
+
+  // ラプラシアンフィルタ
+  for (int y = 1; y < height - 1; ++y) {
+    for (int x = 1; x < width - 1; ++x) {
+      float sum = 0.f;
+      for (int dy = -1; dy <= 1; ++dy) {
+        for (int dx = -1; dx <= 1; ++dx) {
+          sum +=
+              blurred[idx(x + dx, y + dy, width)] * lapKernel[dy + 1][dx + 1];
+        }
+      }
+      lap[idx(x, y, width)] = fmax(LoG_s * sum, 0.0f);
+    }
+  }
+
+  for (int x = 0; x < width; ++x) {
+    lap[idx(x, 0, width)]          = lap[idx(x, 1, width)];
+    lap[idx(x, height - 1, width)] = lap[idx(x, height - 2, width)];
+  }
+  for (int y = 0; y < height; ++y) {
+    lap[idx(0, y, width)]         = lap[idx(1, y, width)];
+    lap[idx(width - 1, y, width)] = lap[idx(width - 2, y, width)];
+  }
+}
+
+template <typename PIXEL>
+void naru_lazybrush::doGraph(TRasterPT<PIXEL> ras, double frame,
+                             TRasterPT<PIXEL> refRas, bool refer_sw,
+                             std::vector<float>& lap, Graph& g) {
+  int width   = ras->getLx();
+  int height  = ras->getLy();
+  int rasSize = width * height;
+
+  // LoG to intensity
+  std::vector<float> intensity(rasSize, 0.0f);
+  float K = 2.f * (width + height);
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      int p        = idx(x, y, width);
+      intensity[p] = K * lap[p] + 1.f;
+      lap[p]       = lap[p] * LoG_draw_scale;
+    }
+  }
+
+  // set capasity
+  std::vector<float> weights(rasSize, 0.0f);
+  std::vector<float> capacity(rasSize, 0.0f);
+  float alpha        = m_alpha->getValue(frame);
+  float sigma        = m_sigma->getValue(frame);
+  float inv_sigmaSq2 = 1.0 / (2 * sigma * sigma);
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      int p = idx(x, y, width);
+      if (x < width - 1) {
+        int q = idx(x + 1, y, width);
+        float weight =
+            alpha * exp(-(intensity[p] + intensity[q]) * inv_sigmaSq2);
+        g.addEdge(p, q, weight, weight);
+      }
+      if (y < height - 1) {
+        int q = idx(x, y + 1, width);
+        float weight =
+            alpha * exp(-(intensity[p] + intensity[q]) * inv_sigmaSq2);
+        g.addEdge(p, q, weight, weight);
+      }
+      weights[p]  = intensity[p] / (K * LoG_s);
+      capacity[p] = exp(-intensity[p] * inv_sigmaSq2);
+    }
+  }
+
+  // Scribble
+  std::vector<float> refR(rasSize, 0.0f);
+  std::vector<float> refG(rasSize, 0.0f);
+  std::vector<float> refB(rasSize, 0.0f);
+  std::vector<float> scribbleR(rasSize, 0.0f);
+  std::vector<float> scribbleB(rasSize, 0.0f);
+  float lambda       = m_lambda->getValue(frame);
+  float softCapacity = floorf(lambda * alpha);
+  int scribbleType = m_scrtype->getValue();  // スクリブルタイプ 0:Soft, 1:Hard
+  int tLinkCap     = scribbleType == 0 ? softCapacity : K;
+  int sLinkCap     = scribbleType == 0 ? alpha - softCapacity : 0;
+  // Exist Reference
+  if (refer_sw) {
+    refRas->lock();
+    for (int y = 0; y < height; ++y) {
+      PIXEL* pix = refRas->pixels(y);
+      for (int x = 0; x < width; ++x) {
+        int p   = idx(x, y, width);
+        refR[p] = (float)pix->r / (float)PIXEL::maxChannelValue;
+        refG[p] = (float)pix->g / (float)PIXEL::maxChannelValue;
+        refB[p] = (float)pix->b / (float)PIXEL::maxChannelValue;
+        pix++;
+      }
+    }
+    refRas->unlock();
+    for (int y = 0; y < height; ++y) {
+      for (int x = 0; x < width; ++x) {
+        int p = idx(x, y, width);
+        if (refR[p] > 0.5f && refG[p] < 0.5f && refB[p] < 0.5f) {
+          g.addTerminal(p, tLinkCap - sLinkCap);
+          scribbleR[p] = 1.f;
+        } else if (refR[p] < 0.5f && refG[p] < 0.5f && refB[p] > 0.5f) {
+          g.addTerminal(p, sLinkCap - tLinkCap);
+          scribbleB[p] = 1.f;
+        }
+      }
+    }
+  }
+
+  float autoScribbleLength    = m_autoscrlen->getValue(frame);
+  float autoScribbleThreshold = m_autoscrthresh->getValue(frame);
+  float lineWeight            = m_lineweight->getValue(frame);
+  int sinkPos                 = m_sinkpos->getValue();
+  bool autoScribble           = m_autoScribble->getValue();
+  if (autoScribble) {
+    // Auto Scribble
+    for (int i = 0; i < width + height; ++i) {
+      float fcx0, fcx1, fcy0, fcy1, dx, dy;
+      if (i < width) {
+        fcx0 = i;
+        fcy0 = 0;
+        fcx1 = i;
+        fcy1 = height - 1;
+        dx   = 0;
+        dy   = 1;
+      } else {
+        fcx0 = 0;
+        fcy0 = i - width + 1;
+        fcx1 = width - 1;
+        fcy1 = i - width + 1;
+        dx   = 1;
+        dy   = 0;
+      }
+      bool onLine, pOnLine;
+      onLine  = false;
+      pOnLine = false;
+      fcx0 += dx * autoScribbleLength;
+      fcy0 += dy * autoScribbleLength;
+      for (int i = 0; i < 10000; ++i) {
+        fcx0 += dx;
+        fcy0 += dy;
+        int cx = fcx0;
+        int cy = fcy0;
+        if (cx < 0 || cx >= width - 1 || cy < 0 || cy >= height - 1) break;
+        int cp = idx(cx, cy, width);
+        if (weights[cp] > autoScribbleThreshold) {
+          fcx0 += dx * lineWeight;
+          fcy0 += dy * lineWeight;
+          onLine = true;
+        } else
+          onLine = false;
+        if (!onLine && pOnLine) {
+          g.addTerminal(cp, tLinkCap - sLinkCap);
+          scribbleR[cp] = 1.f;
+          break;
+        }
+        pOnLine = onLine;
+      }
+
+      onLine  = false;
+      pOnLine = false;
+      fcx1 -= dx * autoScribbleLength;
+      fcy1 -= dy * autoScribbleLength;
+      for (int i = 0; i < 10000; ++i) {
+        fcx1 -= dx;
+        fcy1 -= dy;
+        int cx = fcx1;
+        int cy = fcy1;
+        if (cx < 0 || cx >= width - 1 || cy < 0 || cy >= height - 1) break;
+        int cp = idx(cx, cy, width);
+        if (weights[cp] > autoScribbleThreshold) {
+          fcx1 -= dx * lineWeight;
+          fcy1 -= dy * lineWeight;
+          onLine = true;
+        } else
+          onLine = false;
+        if (!onLine && pOnLine) {
+          g.addTerminal(cp, tLinkCap - sLinkCap);
+          scribbleR[cp] = 1.f;
+          break;
+        }
+        pOnLine = onLine;
+      }
+    }
+  }
+
+  // 境界値を設定
+  int bdSize     = 2 * (width + height - 2);
+  int initInds[] = {0,
+                    width / 2,
+                    width,
+                    width + height / 2,
+                    width + height,
+                    width * 3 / 2 + height,
+                    width * 2 + height,
+                    width * 2 + height * 3 / 2};
+  std::vector<int> bdIdx(bdSize, false);
+  // 1 "Bottom-Left"
+  // 2 "Bottom-Center"
+  // 3 "Bottom-Right"
+  // 4 "Center-Right"
+  // 5 "Top-Right"
+  // 6 "Top-Center"
+  // 7 "Top-Left"
+  // 8 "Center-Left"
+  for (int i = 0; i < bdSize; ++i) {
+    int p;
+    if (i < width - 1)
+      p = idx(i, 0, width);
+    else if (i < width + height - 2)
+      p = idx(width - 1, i - width + 1, width);
+    else if (i < 2 * width + height - 3)
+      p = idx(width - 1 - (i - width - height + 2), height - 1, width);
+    else
+      p = idx(0, height - 1 - (i - 2 * width - height + 3), width);
+    bdIdx[i] = p;
+  }
+
+  if (sinkPos == 0) {
+    for (int i = 0; i < bdSize; ++i) {
+      int p = bdIdx[i];
+      g.addTerminal(p, -K);
+      scribbleB[p] = 1.f;
+    }
+  } else {
+    int initIdx = initInds[(sinkPos - 1)];
+    bool inside = false;
+    for (int i = 0; i < bdSize; ++i) {
+      int p = bdIdx[(initIdx + i + bdSize) % bdSize];
+      if (scribbleR[p] == 1.f) {
+        inside = true;
+        break;
+      }
+      g.addTerminal(p, -K);
+      scribbleB[p] = 1.f;
+    }
+    if (inside) {
+      for (int i = 0; i < bdSize; ++i) {
+        int p = bdIdx[(initIdx - i + bdSize) % bdSize];
+        if (scribbleR[p] == 1.f) break;
+        g.addTerminal(p, -K);
+        scribbleB[p] = 1.f;
+      }
+    }
+  }
+
+  std::vector<float> drawZero(rasSize, 0.0f);
+  std::vector<float> drawOne(rasSize, 1.0f);
+  if (mode == 2) {  // Draw LoG Filter
+    doDraw(ras, lap, lap, lap, drawOne);
+  } else if (mode == 3) {  // Draw Capacity Map
+    doDraw(ras, capacity, capacity, capacity, drawOne);
+  } else if (mode == 4) {  // Draw Scribble Map
+    doDraw(ras, scribbleR, drawZero, scribbleB, drawOne);
+  }
+}
+
+template <typename PIXEL>
+void naru_lazybrush::doColorize(TRasterPT<PIXEL> ras, double frame, Graph& g,
+                                std::vector<float>& gray) {
+  int width  = ras->getLx();
+  int height = ras->getLy();
+
+  bool fillHole = m_fillHole->getValue();
+  g.mincut();
+  std::vector<float> maskR(width * height, 0.0f);
+  std::vector<float> maskG(width * height, 0.0f);
+  std::vector<float> maskB(width * height, 0.0f);
+  std::vector<float> maskM(width * height, 0.0f);
+  // Mask
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      int p = idx(x, y, width);
+      if (!g.getSegment(p, fillHole ? g.SOURCE : g.SINK)) {  // SOURCE
+        maskR[p] = maskColor.m * maskColor.r;
+        maskG[p] = maskColor.m * maskColor.g;
+        maskB[p] = maskColor.m * maskColor.b;
+        maskM[p] = maskColor.m;
+      }
+    }
+  }
+
+  std::vector<float> lineR(width * height, 0.0f);
+  std::vector<float> lineG(width * height, 0.0f);
+  std::vector<float> lineB(width * height, 0.0f);
+  std::vector<float> lineM(width * height, 0.0f);
+  // Line
+  if (mode == 0) {
+    // line => (r, g, b, 1.), noLine => (r, g, b, 0.)
+    ras->lock();
+    for (int y = 0; y < height; ++y) {
+      PIXEL* pix = ras->pixels(y);
+      for (int x = 0; x < width; ++x) {
+        int p   = idx(x, y, width);
+        float m = (float)pix->m / (float)PIXEL::maxChannelValue;
+        if (m != 0) {
+          float r  = (float)pix->r / (float)PIXEL::maxChannelValue;
+          float g  = (float)pix->g / (float)PIXEL::maxChannelValue;
+          float b  = (float)pix->b / (float)PIXEL::maxChannelValue;
+          lineM[p] = (1.f - fmin(fmin(r, g), b)) * m;
+          lineR[p] = r;
+          lineG[p] = g;
+          lineB[p] = b;
+        }
+        pix++;
+      }
+    }
+    ras->unlock();
+  }
+  ras->lock();
+
+  // result => line + mask
+  for (int y = 0; y < height; ++y) {
+    PIXEL* pix = ras->pixels(y);
+    for (int x = 0; x < width; ++x) {
+      int p  = idx(x, y, width);
+      pix->r = (typename PIXEL::Channel)(
+          (maskR[p] * (1.f - lineM[p]) + lineM[p] * lineR[p]) *
+          (float)PIXEL::maxChannelValue);
+      pix->g = (typename PIXEL::Channel)(
+          (maskG[p] * (1.f - lineM[p]) + lineM[p] * lineG[p]) *
+          (float)PIXEL::maxChannelValue);
+      pix->b = (typename PIXEL::Channel)(
+          (maskB[p] * (1.f - lineM[p]) + lineM[p] * lineB[p]) *
+          (float)PIXEL::maxChannelValue);
+      pix->m = (typename PIXEL::Channel)(fmax(maskM[p], lineM[p]) *
+                                         (float)PIXEL::maxChannelValue);
+      pix++;
+    }
+    ras->unlock();
+  }
+}
+
+//------------------------------------------------------------------------------
+
+template <typename PIXEL>
+void naru_lazybrush::process(TRasterPT<PIXEL> ras, double frame,
+                             TRasterPT<PIXEL> refRas, bool refer_sw) {
+  int width   = ras->getLx();
+  int height  = ras->getLy();
+  int rasSize = width * height;
+  std::vector<float> gray(rasSize);
+  std::vector<float> lap(rasSize);
+
+  // params
+  mode      = m_mode->getValue();
+  maskColor = toPixelF(m_maskcolor->getValueD(frame));
+  LoG_s     = m_logs->getValue(frame);
+
+  // create graph
+  Graph g = Graph(rasSize);
+
+  doGrayScale<PIXEL>(ras, frame, gray);
+  doLoG<PIXEL>(ras, frame, gray, lap);
+  doGraph<PIXEL>(ras, frame, refRas, refer_sw, lap, g);
+  if (mode == 0 || mode == 1) {
+    doColorize<PIXEL>(ras, frame, g, gray);
+  }
+}
+
+void naru_lazybrush::doCompute(TTile& tile, double frame,
+                               const TRenderSettings& ri) {
+  if (!m_input.isConnected()) return;
+
+  // 1. 元画像全域のBBoxを取得
+  TRectD fullBBox;
+  m_input->getBBox(frame, fullBBox, ri);
+
+  // 2. 元画像全体ラスタを確保
+  TDimension size(0, 0);
+  size.lx = tceil(fullBBox.getLx());
+  size.ly = tceil(fullBBox.getLy());
+  TTile fullTile;
+  m_input->allocateAndCompute(fullTile, fullBBox.getP00(), size,
+                              tile.getRaster(), frame, ri);
+  TRasterP fullRas = fullTile.getRaster();
+
+  // 3. グラフ処理をフルラスタで実行
+  TRasterP refRas;
+  bool refer_sw = false;
+  if (m_ref.isConnected()) {
+    refer_sw = true;
+    TTile refTile;
+    m_ref->allocateAndCompute(refTile, fullBBox.getP00(), size, fullRas, frame,
+                              ri);
+    refRas = refTile.getRaster();
+  }
+
+  if (TRaster32P ras32 = fullRas)
+    process<TPixel32>(ras32, frame, refRas, refer_sw);
+  else if (TRaster64P ras64 = fullRas)
+    process<TPixel64>(ras64, frame, refRas, refer_sw);
+  else if (TRasterFP rasF = fullRas)
+    process<TPixelF>(rasF, frame, refRas, refer_sw);
+  else
+    throw TException("unsupported Pixel Type");
+
+  // 4. tile に結果をコピー
+  TRasterP tileRas      = tile.getRaster();
+  TPoint startTilingPos = convert(fullTile.m_pos - tile.m_pos);
+  tileRas->copy(fullRas, startTilingPos);
+}
+
+//------------------------------------------------------------------
+
+FX_PLUGIN_IDENTIFIER(naru_lazybrush, "naru_LazyBrushFx")

--- a/toonz/sources/stdfx/naru_maxflow.cpp
+++ b/toonz/sources/stdfx/naru_maxflow.cpp
@@ -1,0 +1,188 @@
+#include "naru_graph.h"
+
+Graph::Graph(int maxNodeNum) {
+  nodesNum = maxNodeNum;
+  arcsNum  = maxNodeNum * 4;
+  nodes    = new node[nodesNum];
+  arcs     = new arc[arcsNum];
+  nodeLast = nodes + nodesNum;
+  arcLast  = arcs;
+  flow     = 0;
+
+  for (int i = 0; i < maxNodeNum; ++i) {
+    nodes[i].firstArc  = nullptr;
+    nodes[i].parentArc = nullptr;
+    nodes[i].isSink    = false;
+    nodes[i].tCap      = 0;
+  }
+}
+
+Graph::~Graph() {
+  delete[] nodes;
+  delete[] arcs;
+}
+
+void Graph::augment(arc* midArc) {
+  node* n;
+  arc* arc;
+
+  int bottleneck = midArc->rCap;
+  // source tree
+  for (n = midArc->revArc->headNode;; n = arc->headNode) {
+    arc = n->parentArc;
+    if (arc == TERMINAL) break;
+    if (bottleneck > arc->revArc->rCap) bottleneck = arc->revArc->rCap;
+  }
+  if (bottleneck > n->tCap) bottleneck = n->tCap;
+  // sink tree
+  for (n = midArc->headNode;; n = arc->headNode) {
+    arc = n->parentArc;
+    if (arc == TERMINAL) break;
+    if (bottleneck > arc->rCap) bottleneck = arc->rCap;
+  }
+  if (bottleneck > -n->tCap) bottleneck = -n->tCap;
+
+  // augment flow
+  // source tree
+  for (n = midArc->revArc->headNode;; n = arc->headNode) {
+    arc = n->parentArc;
+    if (arc == TERMINAL) break;
+    arc->rCap += bottleneck;
+    arc->revArc->rCap -= bottleneck;
+    if (!arc->revArc->rCap) setOrphan(n);
+  }
+  n->tCap -= bottleneck;
+  if (!n->tCap) setOrphan(n);
+  // sink tree
+  for (n = midArc->headNode;; n = arc->headNode) {
+    arc = n->parentArc;
+    if (arc == TERMINAL) break;
+    arc->rCap -= bottleneck;
+    arc->revArc->rCap += bottleneck;
+    if (!arc->rCap) setOrphan(n);
+  }
+  n->tCap += bottleneck;
+  if (!n->tCap) setOrphan(n);
+  // mid arc
+  midArc->revArc->rCap += bottleneck;
+  midArc->rCap -= bottleneck;
+
+  flow += bottleneck;
+}
+
+void Graph::adopt() {
+  arc *arc, *arc2;
+  node *n, *nn;
+  for (n = nextOrphan(); n; n = nextOrphan()) {
+    // find a parent for the orphan node n
+    bool found = false;
+    if (!n->isSink) {
+      // source tree
+      for (arc = n->firstArc; arc; arc = arc->nextArc) {
+        if (!arc->revArc->rCap || arc->headNode->isSink ||
+            !arc->headNode->parentArc)
+          continue;
+        for (nn = arc->headNode;; nn = nn->parentArc->headNode) {
+          if (nn->parentArc == TERMINAL) {
+            // found a parent
+            n->parentArc = arc;
+            setActive(n);
+            found = true;
+            break;
+          } else if (nn->parentArc == ORPHAN)
+            break;
+          if (found) break;
+        }
+      }
+    } else {
+      // sink tree
+      for (arc = n->firstArc; arc; arc = arc->nextArc) {
+        if (!arc->rCap || !arc->headNode->isSink || !arc->headNode->parentArc)
+          continue;
+        for (nn = arc->headNode;; nn = nn->parentArc->headNode) {
+          if (nn->parentArc == TERMINAL) {
+            // found a parent
+            n->parentArc = arc;
+            setActive(n);
+            found = true;
+            break;
+          } else if (nn->parentArc == ORPHAN)
+            break;
+          if (found) break;
+        }
+      }
+    }
+
+    // no origin found
+    if (!found) {
+      for (arc = n->firstArc; arc; arc = arc->nextArc) {
+        nn   = arc->headNode;
+        arc2 = nn->parentArc;
+        if ((nn->isSink == n->isSink) && arc2) {
+          if (arc2 != TERMINAL && arc2 != ORPHAN && (arc2->headNode == n))
+            setOrphan(nn);
+        }
+      }
+    }
+  }
+}
+
+void Graph::mincut() {
+  // initialize active nodes
+  for (node* n = nodes; n < nodeLast; ++n) {
+    if (n->tCap > 0) {
+      n->isSink    = false;
+      n->parentArc = TERMINAL;
+      setActive(n);
+    } else if (n->tCap < 0) {
+      n->isSink    = true;
+      n->parentArc = TERMINAL;
+      setActive(n);
+    }
+  }
+
+  for (node* currentNode = nextActive(); currentNode;
+       currentNode       = nextActive()) {
+    // grow phase
+    node *n, *nn;
+    n = currentNode;
+    arc* arc;
+
+    if (!n->isSink) {
+      // grow source node
+      for (arc = n->firstArc; arc; arc = arc->nextArc) {
+        if (arc->rCap <= 0) continue;
+        nn = arc->headNode;
+        if (!nn->parentArc || nn->parentArc == ORPHAN) {
+          nn->isSink    = false;
+          nn->parentArc = arc->revArc;
+          setActive(nn);
+        } else if (nn->isSink) {
+          break;
+        }
+      }
+    } else {
+      // grow sink node
+      for (arc = n->firstArc; arc; arc = arc->nextArc) {
+        if (arc->revArc->rCap <= 0) continue;
+        nn = arc->headNode;
+        if (!nn->parentArc || nn->parentArc == ORPHAN) {
+          nn->isSink    = true;
+          nn->parentArc = arc->revArc;
+          setActive(nn);
+        } else if (!nn->isSink) {
+          arc = arc->revArc;
+          break;
+        }
+      }
+    }
+
+    // found path
+    if (arc) {
+      // augment phase
+      augment(arc);
+      // adopt phase
+      adopt();
+    }
+  }
+}


### PR DESCRIPTION
# OVERVIEW
This PR adds a new effect called Naru LazyBrush.
It extracts areas enclosed by black lines and generatees a mask.
This effect is useful, for example, for cutting out characters during a line test.

It is based on the paper "LazyBrush: Flexible Painting Tool for Hand-drawn Cartoons" by Daniel Sýkora et al., EUROGRAPHICS 2009.

# How to use
Naru LazyBrush Fx generates a mask from the source image.
By default, mask markers are placed automatically, as shown in the images below:

<table align="center">
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/8c97beda-7c87-4799-9c0a-f217446d99cd" width="300" height="600" /><br />
      <span>Source</span>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/705b5969-9a10-4c2e-8496-fb44565c956f" width="300" height="600" /><br />
      <span>Result</span>
    </td>
  </tr>
</table>



The effect also fills small gaps in the line art to some extent:

<table align="center">
  <tr>
    <td align="center">
      <img width="300" height="330" alt="rabbit" src="https://github.com/user-attachments/assets/69995d21-18d4-4e7e-b2c9-db4629301333" /><br />
      <span>Source</span>
    </td>
    <td align="center">
      <img width="300" height="330" alt="rabbit_color" src="https://github.com/user-attachments/assets/1f717924-ee53-4383-aefe-46d2a82692d1" /><br />
      <span>Result</span>
    </td>
  </tr>
</table>



You can manually place mask markers using red, and alpha markers using blue in a reference image, like this:

<table align="center">
  <tr>
    <td align="center">
      <img width="300" height="400" alt="rabbit_ref" src="https://github.com/user-attachments/assets/b8d73fc5-83ec-47f8-8dfa-f020ccea8d68" /><br />
      <span>Source + Reference</span>
    </td>
    <td align="center">
      <img width="300" height="400" alt="rabbit_ref_color" src="https://github.com/user-attachments/assets/d3f764d5-74f6-42e0-adc3-1d0c28aca3f6" /><br />
      <span>Result</span>
    </td>
  </tr>
</table>



# Parameters
- **Mode**: 
  - **Mask + Line (default)**: Generates a mask and overlays the source image.
  - **Mask**: Generates the mask only.
  - **LoG Filter**: Shows the result of the Laplacian of Gaussian filter.
  - **Capacity Map**: Displays the node capacity map used in the graph cut algorithm.
  - **Scribble Map**: Displays the map of scribbles (mask/alpha markers).

- **Mask Color**: The color used for the generated mask.
- **Fill Hole**: Controls whether fully enclosed spaces within other enclosed areas are marked as mask or alpha.
- **Auto Mask Scribble**: Automatically generates mask scribbles.
- **Line's Weights**: Enter the approximate thickness of the line art strokes in pixels.
- **Background Direction**: Decide on the general direction of the areas you want to make transparent.

**-- Advanced Parameters --**
- **Scribble Type**: Sets the type of scribble. Options: soft, hard.
- **Outline Cutoff**: Threshold for ignoring faint outlines based on brightness.
- **LoG Filter Scale**: Controls the scale of the Laplacian of Gaussian filter.
- **Filter Smoothness**: Determines how strongly ink influences the graph cut. (Lower values make it more sensitive to faint or blurry lines.)
- **Difficulty Passing Through Ink**: Adjusts how resistant ink is to being crossed by the segmentation algorithm. 
- **Scribble Strength**: Controls how strongly the scribbles influence the mask. (Lower values will correct mistakes more aggressively.)
- **Auto Scribble Margin**: Sets the margin distance from the image border where auto-scribbles will be generated.
- **Auto Scribble Outline Threshold**: Brightness threshold that triggers auto-scribbling.

# License
This Fx is based on _The Boykov-Kolmogorov Maxflow Algorithm_ from [https://github.com/Gnimuc/BKMaxflow.jl](https://github.com/Gnimuc/BKMaxflow.jl) which is published under MIT License.