### PR TITLE
Fix New Folder refresh issue in File Browser

### DIFF
--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -286,9 +286,16 @@ void DvDirTreeViewDelegate::commitAndCloseEditor() {
   NodeEditor *editor = qobject_cast<NodeEditor *>(sender());
   emit commitData(editor);
   emit closeEditor(editor);
-  FileBrowser *fileBrowser =
-      dynamic_cast<FileBrowser *>(m_treeView->parentWidget());
+  QWidget* w = m_treeView;
+  FileBrowser* fileBrowser = nullptr;
+  while (w) {
+      fileBrowser = qobject_cast<FileBrowser*>(w);
+      if (fileBrowser) break;
+      w = w->parentWidget();
+  }
+
   if (fileBrowser) fileBrowser->onTreeFolderChanged();
+
 }
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix File Browser's **Folder** LineEdit not refreshing after creating  new folder and renaming it.
<img width="879" height="313" alt="图片" src="https://github.com/user-attachments/assets/9db242be-f6d5-46cd-bd68-404e449862b2" />

It's a usable workaround, not best practice.