### PR TITLE
Refactor "Use lnverted Cursor Stroke End"

### DIFF
--- a/toonz/sources/common/tgl/tgl.cpp
+++ b/toonz/sources/common/tgl/tgl.cpp
@@ -160,32 +160,6 @@ void tglDrawCircle(const TPointD &center, double radius) {
   glPopMatrix();
 }
 
-void tglDrawInvertCursor(const TPointD& center,int gap, int len) {
-    TPointD up1 = center + TPointD(0.0, gap);
-    TPointD up2 = center + TPointD(0.0, gap + len);
-    TPointD down1 = center + TPointD(0.0, -gap);
-    TPointD down2 = center + TPointD(0.0, -gap - len);
-    TPointD left1 = center + TPointD(-gap, 0.0);
-    TPointD left2 = center + TPointD(-gap - len, 0.0);
-    TPointD right1 = center + TPointD(gap, 0.0);
-    TPointD right2 = center + TPointD(gap + len, 0.0);
-
-    glEnable(GL_COLOR_LOGIC_OP);
-    glLogicOp(GL_XOR);
-    tglColor(TPixel32::White); // 任意非黑色都行，关键是与背景异或
-
-    glLineWidth(1.2);
-    glBegin(GL_LINES);
-    tglVertex(up1);    tglVertex(up2);
-    tglVertex(down1);  tglVertex(down2);
-    tglVertex(left1);  tglVertex(left2);
-    tglVertex(right1); tglVertex(right2);
-    glEnd();
-    glLineWidth(1.0);
-
-    glDisable(GL_COLOR_LOGIC_OP);
-}
-
 //-----------------------------------------------------------------------------
 
 void tglDrawDisk(const TPointD &c, double r) {

--- a/toonz/sources/include/tgl.h
+++ b/toonz/sources/include/tgl.h
@@ -133,8 +133,6 @@ DVAPI double tglGetTextWidth(const std::string &s,
  */
 DVAPI void tglDrawCircle(const TPointD &c, double r);
 
-DVAPI void tglDrawInvertCursor(const TPointD &center, int gap, int len);
-
 /*!
  Draw circle of radius r with center c.
  Remark: it is possible set number of slices

--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -19,6 +19,9 @@
 #include <QString>
 #include <QPoint>
 
+#include "toonzqt/glwidget_for_highdpi.h"
+#include "toonzqt/imageutils.h"
+
 #undef DVAPI
 #undef DVVAR
 #ifdef TNZTOOLS_EXPORTS
@@ -623,7 +626,7 @@ public:
   OpenGL).
 */
 
-class TToolViewer {
+class TToolViewer : public GLWidgetForHighDpi {
 protected:
   ImagePainter::VisualSettings
       m_visualSettings;  //!< Settings used by the Viewer to draw scene contents
@@ -634,7 +637,8 @@ protected:
   QWidget *m_viewerWidget  = nullptr;
 
 public:
-  TToolViewer(QWidget *widget) : m_viewerWidget(widget) {}
+  TToolViewer(QWidget *widget, ImageUtils::FullScreenWidget* parent = nullptr) : 
+      m_viewerWidget(widget), GLWidgetForHighDpi(parent) {}
   virtual ~TToolViewer() {}
 
   const ImagePainter::VisualSettings &visualSettings() const {

--- a/toonz/sources/include/tools/toolutils.h
+++ b/toonz/sources/include/tools/toolutils.h
@@ -105,6 +105,10 @@ QRadialGradient getBrushPad(int size, double hardness);
 
 //-----------------------------------------------------------------------------
 
+
+void drawCursor(TToolViewer* viewer, TTool* tool,
+    TPointD pos, int toolCursorId);
+
 //! Divide il primo rettangolo in piu' sottorettsngoli, in base all'intersezione
 //! con il secondo
 QList<TRect> splitRect(const TRect &first, const TRect &second);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -7,6 +7,7 @@
 #include "tools/toolutils.h"
 #include "tools/tooloptions.h"
 #include "tools/replicator.h"
+#include "tools/cursors.h"
 
 // TnzQt includes
 #include "toonzqt/dvdialog.h"
@@ -1521,10 +1522,9 @@ void ToonzRasterBrushTool::draw() {
   TImageP img = getImage(false, 1);
 
   if (getApplication()->getCurrentObject()->isSpline()) return;
-  bool useEndCursor = Preferences::instance()->isUseStrokeEndCursor();
-  if (useEndCursor &&
-      (m_maxThick < 8 || !Preferences::instance()->isCursorOutlineEnabled()))
-    tglDrawInvertCursor(m_brushPos + TPointD(0.5, 0.5), 8, 12);
+  if (Preferences::instance()->isUseStrokeEndCursor())
+      ToolUtils::drawCursor(m_viewer, this, m_brushPos, ToolCursor::PenCursor);
+
   // If toggled off, don't draw brush outline
   if (!Preferences::instance()->isCursorOutlineEnabled())
     return;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1575,10 +1575,9 @@ void ToonzVectorBrushTool::draw() {
 
   if (getApplication()->getCurrentObject()->isSpline()) return;
 
-  bool useEndCursor = Preferences::instance()->isUseStrokeEndCursor();
-  if (useEndCursor &&
-      (m_maxThick < 8 || !Preferences::instance()->isCursorOutlineEnabled()))
-      tglDrawInvertCursor(m_brushPos + TPointD(0.5, 0.5), 4, 6);
+  if (Preferences::instance()->isUseStrokeEndCursor())
+    ToolUtils::drawCursor(m_viewer ,this, m_brushPos, ToolCursor::PenCursor);
+
   // If toggled off, don't draw brush outline
   if (!Preferences::instance()->isCursorOutlineEnabled())
       return;

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1317,7 +1317,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {cursorOutlineEnabled, tr("Show Cursor Size Outlines")},
       {levelBasedToolsDisplay, tr("Toolbar Display Behaviour:")},
       {useCtrlAltToResizeBrush, tr("Use %1 to Resize Brush").arg(CtrlAltStr())},
-      {useStrokeEndCursor, tr("Use Inverted Cursor at Stroke End")},
+      {useStrokeEndCursor, tr("Draw Cursor at End of Stroke")},
       {clickTwiceToCreateArcs, tr("Click Twice to Create Arcs") },
       {tempToolSwitchTimer,
        tr("Switch Tool Temporarily Keypress Length (ms):")},

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -759,8 +759,7 @@ public:
 //-----------------------------------------------------------------------------
 
 SceneViewer::SceneViewer(ImageUtils::FullScreenWidget *parent)
-    : GLWidgetForHighDpi(parent)
-    , TToolViewer(this)
+    : TToolViewer(this,parent)
     , m_pressure(0)
     , m_lastMousePos(0, 0)
     , m_mouseButton(Qt::NoButton)

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -13,7 +13,6 @@
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
 #include "toonzqt/flipconsole.h"
-#include "toonzqt/glwidget_for_highdpi.h"
 
 // TnzTools includes
 #include "tools/tool.h"
@@ -63,8 +62,7 @@ public:
 // SceneViewer
 //-----------------------------------------------------------------------------
 
-class SceneViewer final : public GLWidgetForHighDpi,
-                          public TToolViewer,
+class SceneViewer final : public TToolViewer,
                           public Previewer::Listener {
   Q_OBJECT
 
@@ -216,7 +214,7 @@ public:
   void onRenderStarted(int frame) override;
   void onRenderCompleted(int frame) override;
   void onPreviewUpdate() override;
-
+  
   bool isPreviewEnabled() const { return m_previewMode != NO_PREVIEW; }
   int getPreviewMode() const { return m_previewMode; }
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -65,6 +65,7 @@
 #include <QDebug>
 #include <QMimeData>
 #include <QGestureEvent>
+#include <QPainter>
 
 // definito - per ora - in tapp.cpp
 extern QString updateToolEnableStatus(TTool *tool);
@@ -527,7 +528,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     preEvent.m_button    = m_mouseButton;
     onRelease(preEvent);
   }
-
+  
   int devPixRatio = getDevPixRatio();
   QPointF curPos  = event.mousePos() * devPixRatio;
   bool cursorSet  = false;
@@ -636,7 +637,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
       pos.x /= m_dpiScale.x;
       pos.y /= m_dpiScale.y;
     }
-
+    
     // qDebug() << "mouseMoveEvent. "  << (m_tabletEvent?"tablet":"mouse")
     //         << " pressure=" << m_pressure << " mouseButton=" << m_mouseButton
     //         << " buttonClicked=" << m_buttonClicked;
@@ -661,6 +662,8 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     } else if (m_pressure == 0.0) {
       tool->mouseMove(pos, event);
     }
+    // Set the cursor of the current tool, 
+    // when tool don't draw its own cursor (setToolCursor to None)
     if (!cursorSet) setToolCursor(this, tool->getCursorId());
 
     if (m_toolHasAssistants &&


### PR DESCRIPTION
fixes #6046 

And new option name:
<img width="393" height="235" alt="图片" src="https://github.com/user-attachments/assets/265f64a6-fe99-4fc4-8e3e-3ccc1ae9cf23" />

Now the cursor would be exactly same with the old one, 
only the position of cursor would be changed to the end of stroke.