### PR TITLE
Fix(OCA): correct endTime

### DIFF
--- a/toonz/sources/toonz/ocaio.cpp
+++ b/toonz/sources/toonz/ocaio.cpp
@@ -330,11 +330,12 @@ void OCAData::build(ToonzScene *scene, TXsheet *xsheet, QString name,
 
   TOutputProperties *oprop = scene->getProperties()->getOutputProperties();
   m_startTime = 0;
-  m_endTime   = xsheet->getFrameCount() - 1;
+  m_endTime   = xsheet->getFrameCount();
+  // See https://oca.rxlab.guide/specs/root.html
 
   // Build a list of rows
   QList<int> rows;
-  for (int i = m_startTime; i <= m_endTime; i++) {
+  for (int i = m_startTime; i < m_endTime; i++) {
     rows.append(i);
   }
 


### PR DESCRIPTION
## Description
Fixes `endTime` value assignment to comply with OCA standard specification. The OCA standard defines `endTime` as an exclusive boundary representing the first frame number that is **not** part of the animation.

Reference: https://oca.rxlab.guide/specs/root.html