### PR TITLE
Add "Delete lines and areas" when deleting styles

### DIFF
--- a/toonz/sources/toonzlib/palettecmd.cpp
+++ b/toonz/sources/toonzlib/palettecmd.cpp
@@ -511,6 +511,7 @@ void eraseStylesInLevels(const std::set<TXshSimpleLevel *> &levels,
       else if (ti)
         TRop::eraseStyleIds(ti.getPointer(), styleIds);
     }
+    level->setDirtyFlag(true);
   }
 }
 

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -231,7 +231,7 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
     , m_layoutSpacing(5)
     , m_layoutMargin(0)
     , m_labelWidth(100)
-    , m_name() 
+    , m_name()
     , m_currentScreen(0) {  // Initialize to primary screen to prevent a crash
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setContentsMargins(0, 0, 0, 0);
@@ -307,9 +307,10 @@ Dialog::Dialog(QWidget *parent, bool hasButton, bool hasFixedSize,
       QScreen *screen = QGuiApplication::screenAt(parent->pos());
       m_currentScreen = screen ? QGuiApplication::screens().indexOf(screen) : 0;
     }
-    QRect screen = QGuiApplication::screens().at(m_currentScreen)->availableGeometry();
-    int x        = values.at(0).toInt();
-    int y        = values.at(1).toInt();
+    QRect screen =
+        QGuiApplication::screens().at(m_currentScreen)->availableGeometry();
+    int x = values.at(0).toInt();
+    int y = values.at(1).toInt();
 
     // make sure that the window is visible on the screen
     // all popups will popup on the active window the first time
@@ -363,18 +364,19 @@ void Dialog::hideEvent(QHideEvent *event) {
   int x = pos().rx();
   int y = pos().ry();
   // make sure the dialog is actually visible on a screen
-  auto screens = QGuiApplication::screens();
+  auto screens      = QGuiApplication::screens();
   int currentScreen = 0;
   for (int i = 0; i < screens.count(); i++) {
     if (screens[i]->geometry().contains(pos())) {
-        currentScreen = i;
-        break;
+      currentScreen = i;
+      break;
     } else {
       // if not - put it back on the main window
       currentScreen = m_currentScreen;
     }
   }
-  QRect screen = QGuiApplication::screens().at(currentScreen)->availableGeometry();
+  QRect screen =
+      QGuiApplication::screens().at(currentScreen)->availableGeometry();
 
   if (x > screen.right() - 50) x = screen.right() - 50;
   if (x < screen.left()) x = screen.left();
@@ -398,11 +400,13 @@ void Dialog::beginVLayout() {
   m_isMainVLayout = true;
 
   m_leftVLayout = new QVBoxLayout;
-  m_leftVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  m_leftVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin,
+                                    m_layoutMargin, m_layoutMargin);
   m_leftVLayout->setSpacing(m_layoutSpacing);
 
   m_rightVLayout = new QVBoxLayout;
-  m_rightVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  m_rightVLayout->setContentsMargins(m_layoutMargin, m_layoutMargin,
+                                     m_layoutMargin, m_layoutMargin);
   m_rightVLayout->setSpacing(m_layoutSpacing);
 }
 
@@ -415,7 +419,8 @@ void Dialog::endVLayout() {
   m_isMainVLayout = false;
 
   QHBoxLayout *layout = new QHBoxLayout;
-  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                             m_layoutMargin);
   layout->setSpacing(m_layoutSpacing);
   layout->setSizeConstraint(QLayout::SetFixedSize);
 
@@ -436,7 +441,8 @@ void Dialog::endVLayout() {
 void Dialog::beginHLayout() {
   m_isMainHLayout = true;
   m_mainHLayout   = new QHBoxLayout;
-  m_mainHLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  m_mainHLayout->setContentsMargins(m_layoutMargin, m_layoutMargin,
+                                    m_layoutMargin, m_layoutMargin);
   m_mainHLayout->setSpacing(m_layoutSpacing);
 }
 
@@ -497,7 +503,8 @@ void Dialog::addWidgets(QWidget *firstW, QWidget *secondW) {
     return;
   }
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                                 m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addWidget(firstW);
   pairLayout->addWidget(secondW);
@@ -563,7 +570,8 @@ layout containing
                 \b widget and \b layout and add it to horizontal layout.
 */
 void Dialog::addWidgetLayout(QWidget *widget, QLayout *layout) {
-  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  layout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                             m_layoutMargin);
   layout->setSpacing(m_layoutSpacing);
 
   if (m_isMainVLayout) {
@@ -574,7 +582,8 @@ void Dialog::addWidgetLayout(QWidget *widget, QLayout *layout) {
   }
 
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                                 m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addWidget(widget);
   pairLayout->addLayout(layout);
@@ -615,9 +624,11 @@ layout containing
                 \b firstL and \b secondL and add it to horizontal layout.
 */
 void Dialog::addLayouts(QLayout *firstL, QLayout *secondL) {
-  firstL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  firstL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                             m_layoutMargin);
   firstL->setSpacing(m_layoutSpacing);
-  secondL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  secondL->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                              m_layoutMargin);
   secondL->setSpacing(m_layoutSpacing);
 
   if (m_isMainVLayout) {
@@ -628,7 +639,8 @@ void Dialog::addLayouts(QLayout *firstL, QLayout *secondL) {
   }
 
   QHBoxLayout *pairLayout = new QHBoxLayout;
-  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin, m_layoutMargin);
+  pairLayout->setContentsMargins(m_layoutMargin, m_layoutMargin, m_layoutMargin,
+                                 m_layoutMargin);
   pairLayout->setSpacing(m_layoutSpacing);
   pairLayout->addLayout(firstL);
   pairLayout->addLayout(secondL);
@@ -716,8 +728,8 @@ int Dialog::getLayoutInsertedSpacing() { return m_layoutSpacing; }
 //-----------------------------------------------------------------------------
 /*! Set to \b margin margin of main part of dialog.
  */
-void Dialog::setTopMargin(int margin) { 
-    m_topLayout->setContentsMargins(margin, margin, margin, margin); 
+void Dialog::setTopMargin(int margin) {
+  m_topLayout->setContentsMargins(margin, margin, margin, margin);
 }
 
 //-----------------------------------------------------------------------------
@@ -1433,12 +1445,13 @@ int DVGui::eraseStylesInDemand(TPalette *palette, std::vector<int> styleIds,
                          "lines and areas in the animation level.\n") +
                      QObject::tr("How do you want to proceed?");
 
-  int ret = DVGui::MsgBox(question, QObject::tr("Delete Styles Only"),
-                          QObject::tr("Delete Styles, Lines and Areas"),
-                          QObject::tr("Cancel"), 0);
-  if (ret != 2) return (ret == 0 || ret == 3) ? 0 : 1;
+  int ret = DVGui::MsgBox(question, QObject::tr("Delete Styles Only"),    // 1
+                          QObject::tr("Delete Styles, Lines and Areas"),  // 2
+                          QObject::tr("Delete Lines and Areas"),          // 3
+                          QObject::tr("Cancel"), 0);                      // 4
+  if (ret != 2 && ret != 3) return (ret == 0 || ret == 4) ? 0 : 1;
 
-  // Inform the user that case 2 will not produce an undo if a raster-based
+  // Inform the user that case 2&3 will not produce an undo if a raster-based
   // level is detected
   if (std::any_of(levels.begin(), levels.end(), locals::isRasterLevel)) {
     std::vector<QString> buttons(2);
@@ -1456,7 +1469,8 @@ int DVGui::eraseStylesInDemand(TPalette *palette, std::vector<int> styleIds,
   PaletteCmd::eraseStyles(levels, styleIds);
   QApplication::restoreOverrideCursor();
 
-  return (assert(ret == 2), ret);  // return 2 ?     :D
+  assert(ret == 2 || ret == 3);
+  return ret == 2;  // return 2 ?     :D
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/dvdialog.cpp
+++ b/toonz/sources/toonzqt/dvdialog.cpp
@@ -1470,7 +1470,7 @@ int DVGui::eraseStylesInDemand(TPalette *palette, std::vector<int> styleIds,
   QApplication::restoreOverrideCursor();
 
   assert(ret == 2 || ret == 3);
-  return ret == 2;  // return 2 ?     :D
+  return ret == 2;  // return true if need to delete Styles     :D
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a new option when deleting style from palette:
<img width="589" height="133" alt="图片" src="https://github.com/user-attachments/assets/e433ffca-70e8-4ec7-95cd-447dcc1b6b01" />

- Add dirty flag to level after deleting lines and areas (won't show though)

This feature is useful when cell painting is finished and you want to clean the auto-paint lines while keeping the styles in the palette.