### PR TITLE
Restore the function to select cell ranges by clicking the sidebar

### DIFF
--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -388,10 +388,10 @@ void Preferences::definePreferenceItems() {
   define(CurrentStyleSheetName, "CurrentStyleSheetName", QMetaType::QString,
          "Default");
 
-// Qt has a bug in recent versions that Menu item does not show correctly
-// (QTBUG-90242). The current OT handles this issue by applying an extra adjustment
-// for Qt versions 5.9.x.
-// Update: Issue confirmed fixed in Qt 5.12.8 and above, no longer affecting Qt 5.15 and later.
+  // Qt has a bug in recent versions that Menu item does not show correctly
+  // (QTBUG-90242). The current OT handles this issue by applying an extra
+  // adjustment for Qt versions 5.9.x. Update: Issue confirmed fixed in
+  // Qt 5.12.8 and above, no longer affecting Qt 5.15 and later.
   QString defaultAditionalSheet = "";
 
   define(additionalStyleSheet, "additionalStyleSheet", QMetaType::QString,
@@ -458,7 +458,7 @@ void Preferences::definePreferenceItems() {
 
   // Loading
   define(importPolicy, "importPolicy", QMetaType::Int, 0);  // Always ask
-  define(renamePolicy, "renamePolicy", QMetaType::Int, 0); // Always ask
+  define(renamePolicy, "renamePolicy", QMetaType::Int, 0);  // Always ask
   define(autoExposeEnabled, "autoExposeEnabled", QMetaType::Bool, true);
   define(subsceneFolderEnabled, "subsceneFolderEnabled", QMetaType::Bool, true);
   define(removeSceneNumberFromLoadedLevelName,
@@ -554,7 +554,8 @@ void Preferences::definePreferenceItems() {
          0);  // Default
   define(useCtrlAltToResizeBrush, "useCtrlAltToResizeBrush", QMetaType::Bool,
          true);
-  define(clickTwiceToCreateArcs, "clickTwiceToCreateArcs", QMetaType::Bool, true);
+  define(clickTwiceToCreateArcs, "clickTwiceToCreateArcs", QMetaType::Bool,
+         true);
   define(tempToolSwitchTimer, "tempToolSwitchTimer", QMetaType::Int, 500, 1,
          std::numeric_limits<int>::max());
 
@@ -564,8 +565,7 @@ void Preferences::definePreferenceItems() {
   define(xsheetStep, "xsheetStep", QMetaType::Int, 10, 0,
          std::numeric_limits<int>::max());
   define(xsheetAutopanEnabled, "xsheetAutopanEnabled", QMetaType::Bool, true);
-  define(alwaysDragFrameCell, "alwaysDragFrameCell", QMetaType::Bool,
-         true);
+  define(alwaysDragFrameCell, "alwaysDragFrameCell", QMetaType::Bool, false);
   define(DragCellsBehaviour, "DragCellsBehaviour", QMetaType::Int,
          1);  // Cells and Column Data
   define(deleteCommandBehavior, "deleteCommandBehavior", QMetaType::Int,
@@ -1105,9 +1105,9 @@ int Preferences::levelFormatsCount() const {
 //-----------------------------------------------------------------
 
 int Preferences::matchLevelFormat(const TFilePath &fp) const {
-  LevelFormatVector::const_iterator lft =
-      std::find_if(m_levelFormats.begin(), m_levelFormats.end(),
-                   [&fp](const LevelFormat &format) { return format.matches(fp); });
+  LevelFormatVector::const_iterator lft = std::find_if(
+      m_levelFormats.begin(), m_levelFormats.end(),
+      [&fp](const LevelFormat &format) { return format.matches(fp); });
 
   return (lft != m_levelFormats.end()) ? lft - m_levelFormats.begin() : -1;
 }


### PR DESCRIPTION
This PR will restore the function to select cell ranges by clicking the sidebar, which had been disabled after introducing #5906 , as reported by @Ahl76 in [this comment](https://github.com/opentoonz/opentoonz/pull/5906#issuecomment-3140019311).

@Abel032 could you please check if this change does not break your original intension of #5906.

This PR also made the `Always Drag Frame Cell` preference option to be disabled by default. This is because users unaware of this option may accidentally drag and move cells in the xsheet without realizing it, and mess up the cells' correct order.
@Abel032 , please don't feel bad about it, I think this option is particularly useful for adjusting timing during animation.  However, unless it's clear that the vast majority wants it, I believe that when introducing an option that changes the existing user experience, it's better to set the default value to OFF at release and require explicit activation by the user.

Whether to change this option to ON by default could be discussed in a separate pull request after release.
Thank you for your kind understanding.