### PR TITLE
Enable to load .xdts as scene from OS FileBrowser

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -782,7 +782,6 @@ int main(int argc, char *argv[]) {
     splash.showMessage(
         QString("Loading file '") + loadFilePath.getQString() + "'...",
         Qt::AlignCenter, Qt::white);
-    loadFilePath = loadFilePath.withType("tnz");
     if (TFileStatus(loadFilePath).doesExist()) IoCmd::loadScene(loadFilePath);
   }
 


### PR DESCRIPTION
This allows OT to load .xdts as scene from OS's File Browser.