### PR TITLE
Add fallback path suggestion with fuzzy name matching to XDTS Import Popup

### DIFF
--- a/toonz/sources/toonz/xdtsimportpopup.h
+++ b/toonz/sources/toonz/xdtsimportpopup.h
@@ -26,6 +26,9 @@ class XDTSImportPopup : public DVGui::Dialog {
 
   void updateSuggestions(const QString samplePath);
 
+  // Fallback Search
+  void updateSuggestions(const TFilePath &path);
+
 public:
   XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
                   TFilePath scenePath, bool isUextVersion);


### PR DESCRIPTION
This PR adds an internal fallback path suggestion feature to XDTS Import Popup.

- Triggered only when the original search finds no matching file.
- Uses fuzzy name matching. Files containing the level name can be suggested.
- Searches all first-level subfolders under the given path and the given path itself.