### PR TITLE
Autoclose:  Transform input angle to radians and correct angle application

### DIFF
--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -137,7 +137,7 @@ public:
       : TTool("T_Tape")
       , m_closeType("Type:")                    // W_ToolOptions_CloseType
       , m_distance("Distance:", 1, 100, 10)     // W_ToolOptions_Distance
-      , m_angle("Angle:", 1, 180, 60)           // W_ToolOptions_Angle
+      , m_angle("Angle:", 1, 360, 60)           // W_ToolOptions_Angle
       , m_inkIndex("Style Index:", L"current")  // W_ToolOptions_InkIndex
       , m_opacity("Opacity:", 1, 255, 255)
       , m_multi("Frame Range", false)  // W_ToolOptions_FrameRange

--- a/toonz/sources/toonzlib/autoclose.cpp
+++ b/toonz/sources/toonzlib/autoclose.cpp
@@ -7,7 +7,7 @@
 #include "trastercm.h"
 #include "skeletonlut.h"
 
-#define AUT_SPOT_SAMPLES 40
+//#define AUT_SPOT_SAMPLES 40
 using namespace SkeletonLut;
 
 class TAutocloser::Imp {
@@ -17,6 +17,7 @@ public:
     UCHAR m_preseed;
     Seed(UCHAR *ptr, UCHAR preseed) : m_ptr(ptr), m_preseed(preseed) {}
   };
+  UINT m_aut_spot_samples;
 
   int m_closingDistance;
   double m_spotAngle;
@@ -536,11 +537,14 @@ void TAutocloser::Imp::findMeetingPoints(
     std::vector<TPoint> &endpoints, std::vector<Segment> &closingSegments) {
   int i;
   double alfa;
-  alfa  = m_spotAngle / AUT_SPOT_SAMPLES;
-  m_csp = cos(m_spotAngle / 5);
-  m_snp = sin(m_spotAngle / 5);
-  m_csm = cos(-m_spotAngle / 5);
-  m_snm = sin(-m_spotAngle / 5);
+  m_aut_spot_samples = (UINT)m_spotAngle;
+
+  m_spotAngle *= (M_PI / 180.0);
+  alfa  = m_spotAngle / m_aut_spot_samples;
+  m_csp = cos(m_spotAngle);
+  m_snp = sin(m_spotAngle);
+  m_csm = cos(-m_spotAngle);
+  m_snm = sin(-m_spotAngle);
   m_csa = cos(alfa);
   m_sna = sin(alfa);
   m_csb = cos(-alfa);
@@ -750,8 +754,7 @@ bool TAutocloser::Imp::exploreSpot(const Segment &s, TPoint &p) {
 
   x2a = x2b = (double)x2;
   y2a = y2b = (double)y2;
-
-  for (i = 0; i < AUT_SPOT_SAMPLES; i++) {
+  for (i = 0; i < m_aut_spot_samples; i++) {
     xnewa = x1 + (x2a - x1) * m_csa - (y2a - y1) * m_sna;
     ynewa = y1 + (y2a - y1) * m_csa + (x2a - x1) * m_sna;
     x3    = tround(xnewa);

--- a/toonz/sources/toonzlib/autoclose.cpp
+++ b/toonz/sources/toonzlib/autoclose.cpp
@@ -20,7 +20,7 @@ public:
   UINT m_aut_spot_samples;
 
   int m_closingDistance;
-  double m_spotAngle;
+  double m_spotAngle;  // Half Value
   int m_inkIndex;
   int m_opacity;
   TRasterP m_raster;
@@ -540,18 +540,24 @@ void TAutocloser::Imp::findMeetingPoints(
   m_aut_spot_samples = (UINT)m_spotAngle;
 
   m_spotAngle *= (M_PI / 180.0);
-  alfa  = m_spotAngle / m_aut_spot_samples;
-  m_csp = cos(m_spotAngle);
-  m_snp = sin(m_spotAngle);
-  m_csm = cos(-m_spotAngle);
-  m_snm = sin(-m_spotAngle);
+  
+  // spotResearchTwoPoints
+  // Angle Range: 0бу~36бу
+  double limitedAngle = m_spotAngle / 10;
+  m_csp = cos(limitedAngle);
+  m_snp = sin(limitedAngle);
+  m_csm = cos(-limitedAngle);
+  m_snm = sin(-limitedAngle);
+
+  // spotResearchOnePoints
+  alfa = m_spotAngle / m_aut_spot_samples;
   m_csa = cos(alfa);
   m_sna = sin(alfa);
   m_csb = cos(-alfa);
   m_snb = sin(-alfa);
 
   std::vector<Segment> orientedEndpoints(endpoints.size());
-  for (i                       = 0; i < (int)endpoints.size(); i++)
+  for (i = 0; i < (int)endpoints.size(); i++)
     orientedEndpoints[i].first = endpoints[i];
 
   int size = -1;
@@ -592,7 +598,7 @@ bool TAutocloser::Imp::spotResearchTwoPoints(
   while (current < (int)endpoints.size() - 1) {
     found = 0;
     for (i = current + 1; i < (int)marks.size(); i++) marks[i] = false;
-    distance                                                   = 0;
+    distance = 0;
 
     while (!found && (distance <= sqrDistance) && !allMarked(marks, current)) {
       closerIndex = closerPoint(endpoints, marks, current);

--- a/toonz/sources/toonzlib/autoclose.cpp
+++ b/toonz/sources/toonzlib/autoclose.cpp
@@ -1,12 +1,13 @@
 
 
+//#define AUTOCLOSE_DEBUG
+
 #include "texception.h"
 #include "toonz/autoclose.h"
 #include "trastercm.h"
 #include "skeletonlut.h"
 
-#define AUT_SPOT_SAMPLES 10
-
+#define AUT_SPOT_SAMPLES 40
 using namespace SkeletonLut;
 
 class TAutocloser::Imp {
@@ -32,6 +33,9 @@ public:
   int m_visited;
 
   double m_csp, m_snp, m_csm, m_snm, m_csa, m_sna, m_csb, m_snb;
+
+  // For Debug
+  std::vector<Segment> *m_currentClosingSegments;
 
   Imp(const TRasterP &r, int distance = 10, double angle = M_PI_2,
       int index = 0, int opacity = 0)
@@ -481,7 +485,6 @@ int TAutocloser::Imp::notInsidePath(const TPoint &p, const TPoint &q) {
 }
 
 /*------------------------------------------------------------------------*/
-
 int TAutocloser::Imp::exploreTwoSpots(const TAutocloser::Segment &s0,
                                       const TAutocloser::Segment &s1) {
   int x1a, y1a, x2a, y2a, x3a, y3a, x1b, y1b, x2b, y2b, x3b, y3b;
@@ -493,7 +496,10 @@ int TAutocloser::Imp::exploreTwoSpots(const TAutocloser::Segment &s0,
 
   TPoint p0aux = s0.second;
   TPoint p1aux = s1.second;
-
+#ifdef AUTOCLOSE_DEBUG
+  m_currentClosingSegments->push_back(s0);
+  m_currentClosingSegments->push_back(s1);
+#endif
   if (x1a == p0aux.x && y1a == p0aux.y) return 0;
   if (x1b == p1aux.x && y1b == p1aux.y) return 0;
 
@@ -506,6 +512,13 @@ int TAutocloser::Imp::exploreTwoSpots(const TAutocloser::Segment &s0,
   y2b = tround(y1b + (p1aux.x - x1b) * m_snp + (p1aux.y - y1b) * m_csp);
   x3b = tround(x1b + (p1aux.x - x1b) * m_csm - (p1aux.y - y1b) * m_snm);
   y3b = tround(y1b + (p1aux.x - x1b) * m_snm + (p1aux.y - y1b) * m_csm);
+
+#ifdef AUTOCLOSE_DEBUG
+  m_currentClosingSegments->push_back(Segment(s0.first, TPoint(x2a, y2a)));
+  m_currentClosingSegments->push_back(Segment(s0.first, TPoint(x3a, y3a)));
+  m_currentClosingSegments->push_back(Segment(s1.first, TPoint(x2b, y2b)));
+  m_currentClosingSegments->push_back(Segment(s1.first, TPoint(x3b, y3b)));
+#endif
 
   return (intersect_triangle(x1a, y1a, p0aux.x, p0aux.y, x2a, y2a, x1b, y1b,
                              p1aux.x, p1aux.y, x2b, y2b) ||
@@ -538,7 +551,9 @@ void TAutocloser::Imp::findMeetingPoints(
     orientedEndpoints[i].first = endpoints[i];
 
   int size = -1;
-
+#ifdef AUTOCLOSE_DEBUG
+  m_currentClosingSegments = &closingSegments;
+#endif
   while ((int)closingSegments.size() > size && !orientedEndpoints.empty()) {
     size = closingSegments.size();
     do
@@ -741,13 +756,17 @@ bool TAutocloser::Imp::exploreSpot(const Segment &s, TPoint &p) {
     ynewa = y1 + (y2a - y1) * m_csa + (x2a - x1) * m_sna;
     x3    = tround(xnewa);
     y3    = tround(ynewa);
+#ifdef AUTOCLOSE_DEBUG
+    m_currentClosingSegments->push_back(
+        Segment(s.first, TPoint(tround(xnewa), tround(ynewa))));
+#else
     if ((x3 != tround(x2a) || y3 != tround(y2a)) && x3 > 0 && x3 < lx &&
         y3 > 0 && y3 < ly &&
         exploreRay(
             getPtr(x1, y1),
             Segment(TPoint(x1, y1), TPoint(tround(xnewa), tround(ynewa))), p))
       return true;
-
+#endif
     x2a = xnewa;
     y2a = ynewa;
 
@@ -755,17 +774,25 @@ bool TAutocloser::Imp::exploreSpot(const Segment &s, TPoint &p) {
     ynewb = y1 + (y2b - y1) * m_csb + (x2b - x1) * m_snb;
     x3    = tround(xnewb);
     y3    = tround(ynewb);
+#ifdef AUTOCLOSE_DEBUG
+    m_currentClosingSegments->push_back(
+        Segment(s.first, TPoint(tround(xnewb), tround(ynewb))));
+#else
     if ((x3 != tround(x2b) || y3 != tround(y2b)) && x3 > 0 && x3 < lx &&
         y3 > 0 && y3 < ly &&
         exploreRay(
             getPtr(x1, y1),
             Segment(TPoint(x1, y1), TPoint(tround(xnewb), tround(ynewb))), p))
       return true;
-
+#endif
     x2b = xnewb;
     y2b = ynewb;
   }
+#ifdef AUTOCLOSE_DEBUG
+  return true;
+#else
   return false;
+#endif
 }
 
 /*------------------------------------------------------------------------*/


### PR DESCRIPTION
This PR fixes angle handling by converting degrees to radians for spot samples instead of treating the input angle directly as radians.

<table>
  <tr>
    <td align="center" valign="top">
      <b>Before</b><br>
      <img src="https://github.com/user-attachments/assets/c2737351-de8f-4fd3-97b0-3b93311cf768" width="450"/>
    </td>
    <td align="center" valign="top">
      <b>After</b><br>
      <img src="https://github.com/user-attachments/assets/89257846-7947-480d-8681-8fa573e1686a" width="450"/>
    </td>
  </tr>
</table>

