### PR TITLE
Improve Freehand Fill Visualization in ToonzRaster

### DIFF
--- a/toonz/sources/include/toonz/strokegenerator.h
+++ b/toonz/sources/include/toonz/strokegenerator.h
@@ -98,6 +98,8 @@ In caso affermativo li cancella.
   //! Visualizza tutti i frammenti
   void drawAllFragments();
 
+  void drawFilledStroke();
+
   // Only keep first and last points. Used for straight lines
   void removeMiddlePoints();
 

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -1246,9 +1246,9 @@ void AreaFillTool::draw() {
     glEnd();
     glPopMatrix();
   } else if ((m_type == FREEHAND || m_type == FREEPICK) && !m_track.isEmpty()) {
-    tglColor(TPixel::Red);
+    tglColor(TPixelRGBM32(128, 128, 255, 76));
     glPushMatrix();
-    m_track.drawAllFragments();
+    m_track.drawFilledStroke();
     glPopMatrix();
   }
 }


### PR DESCRIPTION
Shows which areas the Fill Tool's freeHand type will fill.
(e.g., the No.1 area in the example image)

![图片](https://github.com/user-attachments/assets/6b4ec0a2-b1df-483b-a71c-c1384bd199e1)