### PR TITLE
Fix Fill Tool Segment for StyleId #3 by updating damInk

### DIFF
--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -373,7 +373,7 @@ void FullColorAreaFiller::rectFill(const TRect &rect,
 //=============================================================================
 // InkSegmenter
 
-const int damInk = 3;
+const int damInk = TPixelCM32::getMaxInk() - 1;
 
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR fixs frequent undo history issues and fill failures in Fill Tool (Lines Mode, Segment on) for Ink lines of style #3 in the palette.

<img width="1364" height="625" alt="图片" src="https://github.com/user-attachments/assets/d5368e25-5bb1-4d68-8e7a-f66890b09c21" />
