### PR TITLE
Add preference: Paint under/over INK in refer fill or gap close fill

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -26,6 +26,8 @@
 #include "preferences.h"
 #define DEF_REGION_WITH_PAINT                                                  \
   Preferences::instance()->getBoolValue(PreferencesItemId::DefRegionWithPaint)
+#define USE_PREVAILING_REFER_FILL                                               \
+  Preferences::instance()->getBoolValue(PreferencesItemId::ReferFillPrevailing)
 
 class TPalette;
 

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -111,6 +111,7 @@ enum PreferencesItemId {
   // dropdownShortcutsCycleOptions, // removed
   FillOnlysavebox,
   DefRegionWithPaint,
+  ReferFillPrevailing,
   multiLayerStylePickerEnabled,
   cursorBrushType,
   cursorBrushStyle,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1310,6 +1310,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {FillOnlysavebox, tr("Use the TLV Savebox to Limit Filling Operations")},
       {DefRegionWithPaint,
        tr("Define filling region with both PAINT and INK")},
+      { ReferFillPrevailing, tr("Paint under/over INK in refer fill") },
       {multiLayerStylePickerEnabled,
        tr("Multi Layer Style Picker: Switch Levels by Picking")},
       {cursorBrushType, tr("Basic Cursor Type:")},
@@ -2059,6 +2060,7 @@ QWidget* PreferencesPopup::createToolsPage() {
   // insertUI(dropdownShortcutsCycleOptions, lay,
   //         getComboItemList(dropdownShortcutsCycleOptions));
   insertUI(PreferencesItemId::DefRegionWithPaint, lay);
+  insertUI(PreferencesItemId::ReferFillPrevailing, lay);
   insertUI(FillOnlysavebox, lay);
   insertUI(multiLayerStylePickerEnabled, lay);
   QGridLayout* cursorOptionsLay = insertGroupBox(tr("Cursor Options"), lay);

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -48,11 +48,11 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
   /* vai a destra */
   TPixelCM32 *line = r->pixels(p.y);
 
-  pix0 = line + p.x;
-  pix = pix0;
-  limit = line + r->getBounds().x1;
+  pix0    = line + p.x;
+  pix     = pix0;
+  limit   = line + r->getBounds().x1;
   oldtone = pix->getTone();
-  tone = oldtone;
+  tone    = oldtone;
   for (; pix <= limit; pix++) {
     if (DEF_REGION_WITH_PAINT && pix->getPaint() != paintAtClickPos) break;
     if (pix->getPaint() == paint) break;
@@ -73,7 +73,7 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
           // check if the current pixel is NOT with the lowest tone among the
           // vertical neighbors as well
           if (p.y > 0 && p.y < r->getLy() - 1) {
-            TPixelCM32 *upPix = pix - r->getWrap();
+            TPixelCM32 *upPix   = pix - r->getWrap();
             TPixelCM32 *downPix = pix + r->getWrap();
             if (upPix->getTone() > pix->getTone() &&
                 downPix->getTone() > pix->getTone())
@@ -101,10 +101,10 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
 
   /* vai a sinistra */
 
-  pix = pix0;
-  limit = line + r->getBounds().x0;
+  pix     = pix0;
+  limit   = line + r->getBounds().x0;
   oldtone = pix->getTone();
-  tone = oldtone;
+  tone    = oldtone;
   for (pix--; pix >= limit; pix--) {
     if (DEF_REGION_WITH_PAINT && pix->getPaint() != paintAtClickPos) break;
     if (pix->getPaint() == paint) break;
@@ -125,7 +125,7 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
           // check if the current pixel is NOT with the lowest tone among the
           // vertical neighbors as well
           if (p.y > 0 && p.y < r->getLy() - 1) {
-            TPixelCM32 *upPix = pix - r->getWrap();
+            TPixelCM32 *upPix   = pix - r->getWrap();
             TPixelCM32 *downPix = pix + r->getWrap();
             if (upPix->getTone() > pix->getTone() &&
                 downPix->getTone() > pix->getTone())
@@ -184,13 +184,9 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
       for (n = 0; n < xb - xa + 1; n++, pix++) {
         if (pix->isPurePaint()) {
           TPixelCM32 *upPix = pix - r->getWrap();
-          TPixelCM32 *downPix = pix + r->getWrap();
-          if (upPix->getInk() == TPixelCM32::getMaxInk() &&
-              !DEF_REGION_WITH_PAINT)
-            upPix->setInk(paint);
-          if (downPix->getInk() == TPixelCM32::getMaxInk() &&
-              !DEF_REGION_WITH_PAINT)
-            downPix->setInk(paint);
+          TPixelCM32 *dnPix = pix + r->getWrap();
+          if (upPix->getInk() == TPixelCM32::getMaxInk()) upPix->setInk(paint);
+          if (dnPix->getInk() == TPixelCM32::getMaxInk()) dnPix->setInk(paint);
         }
       }
     }
@@ -207,11 +203,11 @@ void findSegment(const TRaster32P &r, const TPoint &p, int &xa, int &xb,
   /* vai a destra */
   TPixel32 *line = r->pixels(p.y);
 
-  pix0 = line + p.x;
-  pix = pix0;
-  limit = line + r->getBounds().x1;
+  pix0     = line + p.x;
+  pix      = pix0;
+  limit    = line + r->getBounds().x1;
   oldmatte = pix->m;
-  matte = oldmatte;
+  matte    = oldmatte;
   for (; pix <= limit; pix++) {
     if (*pix == color) break;
     matte = pix->m;
@@ -229,10 +225,10 @@ void findSegment(const TRaster32P &r, const TPoint &p, int &xa, int &xb,
   xb = p.x + pix - pix0 - 1;
 
   /* vai a sinistra */
-  pix = pix0;
-  limit = line + r->getBounds().x0;
+  pix      = pix0;
+  limit    = line + r->getBounds().x0;
   oldmatte = pix->m;
-  matte = oldmatte;
+  matte    = oldmatte;
   for (; pix >= limit; pix--) {
     if (*pix == color) break;
     matte = pix->m;
@@ -282,8 +278,8 @@ void fullColorFindSegment(const TRaster32P &r, const TPoint &p, int &xa,
   // check to the right
   TPixel32 *line = r->pixels(p.y);
 
-  pix0 = line + p.x;  // seed pixel
-  pix = pix0;
+  pix0  = line + p.x;  // seed pixel
+  pix   = pix0;
   limit = line + r->getBounds().x1;  // right end
 
   TPixel32 oldPix = *pix;
@@ -304,8 +300,8 @@ void fullColorFindSegment(const TRaster32P &r, const TPoint &p, int &xa,
   xb = p.x + pix - pix0 - 1;
 
   // check to the left
-  pix = pix0;                        // seed pixel
-  limit = line + r->getBounds().x0;  // left end
+  pix    = pix0;                      // seed pixel
+  limit  = line + r->getBounds().x0;  // left end
   oldPix = *pix;
   for (; pix >= limit; pix--) {
     // break if the target pixel is with the same as filling color
@@ -382,7 +378,7 @@ bool floodCheck(const TPixel32 &clickColor, const TPixel32 *targetPix,
 
   if (clickColor.m == 0) {
     int oldMatte = fullColorThreshMatte(oldPix->m, fillDepth);
-    int matte = fullColorThreshMatte(targetPix->m, fillDepth);
+    int matte    = fullColorThreshMatte(targetPix->m, fillDepth);
     return matte >= oldMatte && matte != 255;
   }
   int fillDepth2 = fillDepth * fillDepth;
@@ -508,7 +504,7 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
   /*- Return if clicked outside the screen -*/
   if (!bbbox.contains(p)) return false;
   /*- If the same color has already been painted, return -*/
-  pix0 = r->pixels(p.y) + p.x;
+  pix0                  = r->pixels(p.y) + p.x;
   int paintAtClickedPos = pix0->getPaint();
   if (paintAtClickedPos == paint)
     if (params.m_shiftFill) {
@@ -551,17 +547,17 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
    * the colors change. --*/
   TPixelCM32 borderIndex[4];
   TPixelCM32 *borderPix[4];
-  pix = r->pixels(0);
-  borderPix[0] = pix;
+  pix            = r->pixels(0);
+  borderPix[0]   = pix;
   borderIndex[0] = *pix;
   pix += r->getLx() - 1;
-  borderPix[1] = pix;
+  borderPix[1]   = pix;
   borderIndex[1] = *pix;
-  pix = r->pixels(r->getLy() - 1);
-  borderPix[2] = pix;
+  pix            = r->pixels(r->getLy() - 1);
+  borderPix[2]   = pix;
   borderIndex[2] = *pix;
   pix += r->getLx() - 1;
-  borderPix[3] = pix;
+  borderPix[3]   = pix;
   borderIndex[3] = *pix;
 
   std::stack<FillSeed> seeds;
@@ -575,21 +571,21 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
     FillSeed fs = seeds.top();
     seeds.pop();
 
-    xa = fs.m_xa;
-    xb = fs.m_xb;
+    xa   = fs.m_xa;
+    xb   = fs.m_xb;
     oldy = fs.m_y;
-    dy = fs.m_dy;
-    y = oldy + dy;
+    dy   = fs.m_dy;
+    y    = oldy + dy;
     if (y > bbbox.y1 || y < bbbox.y0) continue;
     pix = pix0 = r->pixels(y) + xa;
-    limit = r->pixels(y) + xb;
-    oldpix = r->pixels(oldy) + xa;
-    x = xa;
-    oldxd = (std::numeric_limits<int>::min)();
-    oldxc = (std::numeric_limits<int>::max)();
+    limit      = r->pixels(y) + xb;
+    oldpix     = r->pixels(oldy) + xa;
+    x          = xa;
+    oldxd      = (std::numeric_limits<int>::min)();
+    oldxc      = (std::numeric_limits<int>::max)();
     while (pix <= limit) {
       oldtone = threshTone(*oldpix, fillDepth);
-      tone = threshTone(*pix, fillDepth);
+      tone    = threshTone(*pix, fillDepth);
       // the last condition is added in order to prevent fill area from
       // protruding behind the colored line
       if (pix->getPaint() != paint && tone <= oldtone && tone != 0 &&
@@ -645,7 +641,7 @@ void fill(const TRaster32P &ras, const TRaster32P &ref,
 
   if (!bbbox.contains(params.m_p)) return;
 
-  TPaletteP plt = params.m_palette;
+  TPaletteP plt  = params.m_palette;
   TPixel32 color = plt->getStyle(params.m_styleId)->getMainColor();
   int fillDepth =
       params.m_shiftFill ? params.m_maxFillDepth : params.m_minFillDepth;
@@ -658,12 +654,12 @@ void fill(const TRaster32P &ras, const TRaster32P &ref,
   // it means that I filled the bg and the savebox needs to be recomputed!
   TPixel32 borderIndex;
   TPixel32 *borderPix = 0;
-  pix = workRas->pixels(0);
+  pix                 = workRas->pixels(0);
   int i;
   for (i = 0; i < workRas->getLx(); i++, pix++)  // border down
     if (pix->m == 0) {
       borderIndex = *pix;
-      borderPix = pix;
+      borderPix   = pix;
       break;
     }
   if (borderPix == 0)  // not found in border down...try border up (avoid left
@@ -673,7 +669,7 @@ void fill(const TRaster32P &ras, const TRaster32P &ref,
     for (i = 0; i < workRas->getLx(); i++, pix++)  // border up
       if (pix->m == 0) {
         borderIndex = *pix;
-        borderPix = pix;
+        borderPix   = pix;
         break;
       }
   }
@@ -691,21 +687,21 @@ void fill(const TRaster32P &ras, const TRaster32P &ref,
     FillSeed fs = seeds.top();
     seeds.pop();
 
-    xa = fs.m_xa;
-    xb = fs.m_xb;
+    xa   = fs.m_xa;
+    xb   = fs.m_xb;
     oldy = fs.m_y;
-    dy = fs.m_dy;
-    y = oldy + dy;
+    dy   = fs.m_dy;
+    y    = oldy + dy;
     if (y > bbbox.y1 || y < bbbox.y0) continue;
     pix = pix0 = workRas->pixels(y) + xa;
-    limit = workRas->pixels(y) + xb;
-    oldpix = workRas->pixels(oldy) + xa;
-    x = xa;
-    oldxd = (std::numeric_limits<int>::min)();
-    oldxc = (std::numeric_limits<int>::max)();
+    limit      = workRas->pixels(y) + xb;
+    oldpix     = workRas->pixels(oldy) + xa;
+    x          = xa;
+    oldxd      = (std::numeric_limits<int>::min)();
+    oldxc      = (std::numeric_limits<int>::max)();
     while (pix <= limit) {
-      oldMatte = threshMatte(oldpix->m, fillDepth);
-      matte = threshMatte(pix->m, fillDepth);
+      oldMatte  = threshMatte(oldpix->m, fillDepth);
+      matte     = threshMatte(pix->m, fillDepth);
       bool test = false;
       if (segments.find(y) != segments.end())
         test = isPixelInSegment(segments[y], x);
@@ -735,7 +731,7 @@ void fill(const TRaster32P &ras, const TRaster32P &ref,
 
   std::map<int, std::vector<std::pair<int, int>>>::iterator it;
   for (it = segments.begin(); it != segments.end(); it++) {
-    TPixel32 *line = ras->pixels(it->first);
+    TPixel32 *line    = ras->pixels(it->first);
     TPixel32 *refLine = 0;
     TPixel32 *refPix;
     if (ref) refLine = ref->pixels(it->first);
@@ -842,7 +838,7 @@ void fullColorFill(const TRaster32P &ras, const FillParameters &params,
 
   TPixel32 clickedPosColor = *(ras->pixels(y) + x);
 
-  TPaletteP plt = params.m_palette;
+  TPaletteP plt  = params.m_palette;
   TPixel32 color = plt->getStyle(params.m_styleId)->getMainColor();
 
   if (clickedPosColor == color) return;
@@ -870,11 +866,11 @@ void fullColorFill(const TRaster32P &ras, const FillParameters &params,
     FillSeed fs = seeds.top();
     seeds.pop();
 
-    xa = fs.m_xa;
-    xb = fs.m_xb;
+    xa   = fs.m_xa;
+    xb   = fs.m_xb;
     oldy = fs.m_y;
-    dy = fs.m_dy;
-    y = oldy + dy;
+    dy   = fs.m_dy;
+    y    = oldy + dy;
     // continue if the fill runs over image bounding
     if (y > bbbox.y1 || y < bbbox.y0) continue;
     // left end of the pixels to be filled
@@ -884,7 +880,7 @@ void fullColorFill(const TRaster32P &ras, const FillParameters &params,
     // left end of the fill seed pixels
     oldpix = ras->pixels(oldy) + xa;
 
-    x = xa;
+    x     = xa;
     oldxd = (std::numeric_limits<int>::min)();
     oldxc = (std::numeric_limits<int>::max)();
 
@@ -930,8 +926,8 @@ void fullColorFill(const TRaster32P &ras, const FillParameters &params,
 
   std::map<int, std::vector<std::pair<int, int>>>::iterator it;
   for (it = segments.begin(); it != segments.end(); it++) {
-    TPixel32 *line = ras->pixels(it->first);
-    TPixel32 *refLine = 0;
+    TPixel32 *line                                 = ras->pixels(it->first);
+    TPixel32 *refLine                              = 0;
     std::vector<std::pair<int, int>> segmentVector = it->second;
     for (int i = 0; i < (int)segmentVector.size(); i++) {
       std::pair<int, int> segment = segmentVector[i];

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -91,6 +91,10 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
     tmp_limit = pix + 10;  // edge stop fill == 10 per default
     if (limit > tmp_limit) limit = tmp_limit;
     for (; pix <= limit; pix++) {
+      if (refImagePut && !USE_PREVAILING_REFER_FILL &&
+          pix->getInk() == TPixelCM32::getMaxInk() &&
+          limit - pix <= (DEF_REGION_WITH_PAINT ? 10 : 9))
+        break;
       if (DEF_REGION_WITH_PAINT && pix->getPaint() != paintAtClickPos) break;
       if (pix->getPaint() == paint) break;
       if (pix->getTone() != 0) break;
@@ -143,6 +147,10 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
     tmp_limit = pix - 10;
     if (limit < tmp_limit) limit = tmp_limit;
     for (; pix >= limit; pix--) {
+      if (refImagePut && !USE_PREVAILING_REFER_FILL &&
+          pix->getInk() == TPixelCM32::getMaxInk() &&
+          pix - limit <= (DEF_REGION_WITH_PAINT ? 10 : 9))
+        break;
       if (DEF_REGION_WITH_PAINT && pix->getPaint() != paintAtClickPos) break;
       if (pix->getPaint() == paint) break;
       if (pix->getTone() != 0) break;
@@ -320,7 +328,7 @@ void fullColorFindSegment(const TRaster32P &r, const TPoint &p, int &xa,
 //-----------------------------------------------------------------------------
 
 class FillSeed {
- public:
+public:
   int m_xa, m_xb;
   int m_y, m_dy;
   FillSeed(int xa, int xb, int y, int dy)
@@ -534,14 +542,14 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
   assert(fillDepth >= 0 && fillDepth < 16);
 
   switch (TPixelCM32::getMaxTone()) {
-    case 15:
-      fillDepth = (15 - fillDepth);
-      break;
-    case 255:
-      fillDepth = ((15 - fillDepth) << 4) | (15 - fillDepth);
-      break;
-    default:
-      assert(false);
+  case 15:
+    fillDepth = (15 - fillDepth);
+    break;
+  case 255:
+    fillDepth = ((15 - fillDepth) << 4) | (15 - fillDepth);
+    break;
+  default:
+    assert(false);
   }
   /*--Look at the colors in the four corners and update the saveBox if any of
    * the colors change. --*/

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -545,6 +545,7 @@ void Preferences::definePreferenceItems() {
   //       int)
   define(FillOnlysavebox, "FillOnlysavebox", QMetaType::Bool, false);
   define(DefRegionWithPaint, "FillDefRegionWithPaint", QMetaType::Bool, true);
+  define(ReferFillPrevailing, "ReferFillPrevailing", QMetaType::Bool, false);
   define(multiLayerStylePickerEnabled, "multiLayerStylePickerEnabled",
          QMetaType::Bool, false);
   define(cursorBrushType, "cursorBrushType", QMetaType::QString, "Small");


### PR DESCRIPTION
This PR adds a preference option of whether to do prevailing paint for reference fill.
The current implementation didn’t consider the situation where the reference level might be down/left to the fill level.
This usually happens when the level is used as both the upon and down part of one image, for example, a character’s head and his front hair and back hair.

<img width="517" height="263" alt="图片" src="https://github.com/user-attachments/assets/89f774b0-58f9-4ba3-b8d0-c7f9b9c93731" />
