### PR TITLE
Refactor AreaFiller of Fill tool

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -132,6 +132,9 @@ else fill ink and paint in rect.
   bool rectFill(const TRect &rect, int color, bool onlyUnfilled,
                 bool fillPaints, bool fillInks);
 
+  // Only for Fill Check
+  bool rectFastFill(const TRect& rect, int color);
+
   /*!
 Fill the raster region contained in spline \b s with \b color.
 \n If  \b fillPaints is false fill only ink in region contained in spline;

--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -21,6 +21,7 @@
 #include "tpixelcm.h"
 #include "traster.h"
 #include "trastercm.h"
+#include "tropcm.h"
 
 #include "preferences.h"
 #define DEF_REGION_WITH_PAINT                                                  \
@@ -169,5 +170,23 @@ else fill ink and paint in rect.
   void rectFill(const TRect &rect, const FillParameters &params,
                 bool onlyUnfilled);
 };
+
+class RefImageGuard {
+    const TRasterCM32P& m_r;
+    bool m_refPlaced;
+
+public:
+    RefImageGuard(const TRasterCM32P& raster, const TRaster32P& Ref)
+        : m_r(raster), m_refPlaced(Ref.getPointer() != nullptr) {
+        m_r->lock();
+        if (m_refPlaced) TRop::putRefImage(const_cast<TRasterCM32P&>(m_r), Ref);
+    }
+
+    ~RefImageGuard() {
+        m_r->unlock();
+        if (m_refPlaced) TRop::eraseRefInks(const_cast<TRasterCM32P&>(m_r));
+    }
+};
+
 
 #endif

--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -13,7 +13,6 @@
 #define DVVAR DV_IMPORT_VAR
 #endif
 
-
 #include <set>
 #include "ttilesaver.h"
 #include "timage.h"
@@ -26,7 +25,7 @@
 #include "preferences.h"
 #define DEF_REGION_WITH_PAINT                                                  \
   Preferences::instance()->getBoolValue(PreferencesItemId::DefRegionWithPaint)
-#define USE_PREVAILING_REFER_FILL                                               \
+#define USE_PREVAILING_REFER_FILL                                              \
   Preferences::instance()->getBoolValue(PreferencesItemId::ReferFillPrevailing)
 
 class TPalette;
@@ -40,7 +39,7 @@ public:
   int m_maxFillDepth;
   bool m_shiftFill;
   TPoint m_p;
-  TPalette *m_palette;
+  TPalette *m_palette;  // Whether to fill autoPaint Ink
   bool m_prevailing;
 
   FillParameters()
@@ -77,7 +76,7 @@ class TTileSaverFullColor;
 
 // returns true if the savebox is changed typically, if you fill the bg)
 DVAPI bool fill(const TRasterCM32P &r, const FillParameters &params,
-                TTileSaverCM32 *saver  = 0,
+                TTileSaverCM32 *saver = 0,
                 const TRaster32P &ref = TRaster32P());
 
 DVAPI void fill(const TRaster32P &ras, const TRaster32P &ref,
@@ -116,12 +115,13 @@ class DVAPI AreaFiller {
   TRaster32P m_refRas;
   TRect m_bounds;
   Pixel *m_pixels;
-  TPalette* m_palette;
+  TPalette *m_palette;
   int m_wrap;
   int m_color;
-  
+
 public:
-  AreaFiller(const TRasterCM32P &ras, const TRaster32P& ref = TRaster32P(), TPalette *palette = nullptr);
+  AreaFiller(const TRasterCM32P &ras, const TRaster32P &ref = TRaster32P(),
+             TPalette *palette = nullptr);
   ~AreaFiller();
   /*!
 Fill \b rect in raster with \b color.
@@ -129,7 +129,7 @@ Fill \b rect in raster with \b color.
 else if \b fillInks is false fill only paint delimited by ink;
 else fill ink and paint in rect.
 */
-  bool rectFill(const TRect &rect, const TRect &saveBox, int color, bool onlyUnfilled,
+  bool rectFill(const TRect &rect, int color, bool onlyUnfilled,
                 bool fillPaints, bool fillInks);
 
   /*!
@@ -138,8 +138,13 @@ Fill the raster region contained in spline \b s with \b color.
 else if \b fillInks is false fill only paint delimited by ink;
 else fill ink and paint in region contained in spline.
 */
-  void strokeFill(const TRect& rect, TStroke *s, int color, bool onlyUnfilled, bool fillPaints,
-                  bool fillInks);
+  void strokeFill(const TRect &rect, TStroke *s, int color, bool onlyUnfilled,
+                  bool fillPaints, bool fillInks);
+
+private:
+  const void processPixel(TPixelCM32 &pix, const TPixelCM32 &bak, bool invert,
+                          int color, bool onlyUnfilled, bool fillPaints,
+                          bool fillInks);
 };
 
 class DVAPI FullColorAreaFiller {

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -458,6 +458,7 @@ public:
 //-----------------------------------------------------------------------------
 
 class RasterRectFillUndo final : public TRasterUndo {
+  TRect m_saveBox;
   TRect m_fillArea;
   int m_paintId;
   std::wstring m_colorType;
@@ -471,11 +472,12 @@ public:
     if (m_s) delete m_s;
   }
 
-  RasterRectFillUndo(TTileSetCM32 *tileSet, TStroke *s, TRect fillArea,
-                     int paintId, TXshSimpleLevel *level,
+  RasterRectFillUndo(TTileSetCM32 *tileSet, TStroke *s, TRect oldSaveBox,
+                     TRect fillArea, int paintId, TXshSimpleLevel *level,
                      std::wstring colorType, bool onlyUnfilled,
                      const TFrameId &fid, TRaster32P refImg, TPalette *palette)
       : TRasterUndo(tileSet, level, fid, false, false, 0, false)
+      , m_saveBox(oldSaveBox)
       , m_fillArea(fillArea)
       , m_paintId(paintId)
       , m_colorType(colorType)
@@ -486,20 +488,24 @@ public:
   }
 
   void redo() const override {
-    TToonzImageP image = getImage();
-    if (!image) return;
-    TRasterCM32P ras = image->getRaster();
+    TToonzImageP ti = getImage();
+    if (!ti) return;
+    TRasterCM32P ras;
+    TRect r = m_saveBox;
+    if (r.isEmpty())
+      ras = ti->getRaster();
+    else
+      ras = ti->getRaster()->extract(r);
     AreaFiller filler(ras, m_refImg, m_palette);
     if (!m_s)
-      filler.rectFill(m_fillArea, image->getSavebox(), m_paintId,
-                      m_onlyUnfilled, m_colorType != LINES,
-                      m_colorType != AREAS);
+      filler.rectFill(m_fillArea, m_paintId, m_onlyUnfilled,
+                      m_colorType != LINES, m_colorType != AREAS);
     else
       filler.strokeFill(m_fillArea, m_s, m_paintId, m_onlyUnfilled,
                         m_colorType != LINES, m_colorType != AREAS);
 
     if (m_palette) {
-      TRect rect   = m_fillArea;
+      TRect rect   = m_saveBox;
       TRect bounds = ras->getBounds();
       if (bounds.overlaps(rect)) {
         rect *= bounds;
@@ -862,18 +868,16 @@ void fillAreaWithUndo(const TImageP &img, const TRaster32P &ref,
   if (TToonzImageP ti = img) {
     // allargo di 1 la savebox, perche cosi' il rectfill di tutta l'immagine fa
     // una sola fillata
-    TRasterCM32P ras = ti->getRaster();
-    TRect refSavebox = ref ? ref->getBounds() : TRect();
-    // TRect enlargedSavebox = (ti->getSavebox().enlarge(1) + refSavebox) *
-    // ras->getBounds();
-    TRect strokeBox      = ToonzImageUtils::convertWorldToRaster(selArea, ti);
-    TRect savebox        = ti->getSavebox();
-    TRect rasterFillArea = strokeBox * savebox;
-    if (rasterFillArea.isEmpty()) return;
+    TRasterCM32P ras;
+    ras = ti->getRaster();
+
+    TRect rasBounds    = ras->getBounds();
+    TRect rasStrokeBox = ToonzImageUtils::convertWorldToRaster(selArea, ti);
+    TRect rasFillArea  = rasStrokeBox * rasBounds;
 
     /*-- tileSetでFill範囲のRectをUndoに格納しておく --*/
-    TTileSetCM32 *tileSet = new TTileSetCM32(ras->getSize());
-    tileSet->add(ras, rasterFillArea);
+    TTileSetCM32 *rasTileSet = new TTileSetCM32(ras->getSize());
+    rasTileSet->add(ras, rasFillArea);
 
     // Don't use ti to get palette
     TPalette *plt = sl->getPalette();
@@ -881,46 +885,57 @@ void fillAreaWithUndo(const TImageP &img, const TRaster32P &ref,
     // !autopaintLines will temporary disable autopaint line feature
     if ((plt && !hasAutoInks(plt)) || !autopaintLines) plt = 0;
 
-    TRasterCM32P raux = ras;
+    TPoint offs(0, 0);
+    TRect rasSaveBox;
+    TRasterCM32P raux;
+    if (Preferences::instance()->getFillOnlySavebox()) {
+      TRectD bbox = ti->getBBox();
+      rasSaveBox  = convert(bbox);
+      offs        = rasSaveBox.getP00();
+      raux        = ti->getRaster()->extract(rasSaveBox);
+    } else
+      raux = ti->getRaster();
 
-    if (ref && ti->getSize() != ref->getSize()) {
-      TRect saveBox = ti->getSavebox();
-      raux          = raux->extract(saveBox);
-    }
+    TRect auxStrokeBox = rasStrokeBox - offs;
+    TRect auxBounds    = ras->getBounds();
+    TRect auxFillArea  = auxStrokeBox * auxBounds;
+    if (auxBounds.isEmpty() || rasFillArea.isEmpty()) return;
+
     AreaFiller filler(raux, ref, plt);
     if (!stroke) {
-      bool ret =
-          filler.rectFill(rasterFillArea, ti->getSavebox(), cs, onlyUnfilled,
-                          colorType != LINES, colorType != AREAS);
+      bool ret = filler.rectFill(auxFillArea, cs, onlyUnfilled,
+                                 colorType != LINES, colorType != AREAS);
       if (!ret) {
-        delete tileSet;
+        delete rasTileSet;
         return;
       }
       if (plt) {
-        TRect rect   = rasterFillArea;
-        TRect bounds = ras->getBounds();
+        TRect rect   = auxFillArea;
+        TRect bounds = raux->getBounds();
         if (bounds.overlaps(rect)) {
           rect *= bounds;
           const TTileSetCM32::Tile *tile =
-              tileSet->getTile(tileSet->getTileCount() - 1);
+              rasTileSet->getTile(rasTileSet->getTileCount() - 1);
           TRasterCM32P rbefore;
           tile->getRaster(rbefore);
-          fillautoInks(ras, rect, rbefore, plt);
+          fillautoInks(raux, rect, rbefore, plt);
         }
       }
     } else {
-      if (stroke) stroke->transform(TTranslation(convert(ras->getCenter())));
-      if (ref)
-        stroke->transform(TTranslation(-convert(ti->getSavebox().getP00())));
-      filler.strokeFill(rasterFillArea, stroke, cs, onlyUnfilled,
+      TPointD total = convert(ras->getCenter()) - convert(offs) -
+                      TPointD(auxFillArea.x0, auxFillArea.y0);
+      stroke->transform(TTranslation(total));
+      filler.strokeFill(auxFillArea, stroke, cs, onlyUnfilled,
                         colorType != LINES, colorType != AREAS);
+      // Restore original position because the stroke might be used
+      // for calculating inbetween frames
+      stroke->transform(TTranslation(-total));
     }
 
     // ToolUtils::updateSaveBox(sl, fid);
-
     TUndoManager::manager()->add(
-        new RasterRectFillUndo(tileSet, stroke, rasterFillArea, cs, sl,
-                               colorType, onlyUnfilled, fid, ref, plt));
+        new RasterRectFillUndo(rasTileSet, stroke, rasSaveBox, auxFillArea, cs,
+                               sl, colorType, onlyUnfilled, fid, ref, plt));
   } else if (TVectorImageP vi = img) {
     TPalette *palette = vi->getPalette();
     assert(palette);
@@ -2041,7 +2056,6 @@ void FillTool::buildFillInfo(const FillParameters &params) {
 void FillTool::computeRefImgsIfNeeded(const FillParameters &params) {
   assert(!m_slFidsPairs.empty());
   m_refImgTable.clear();
-  if (params.m_fillType == LINES) return;
   auto app = getApplication();
   bool referFill =
       m_referFill.getValue() && app->getCurrentFrame()->isEditingScene();
@@ -2070,7 +2084,7 @@ void FillTool::computeRefImgsIfNeeded(const FillParameters &params) {
     TToonzImageP ti = (TToonzImageP)img;
     if (!ti) continue;
 
-    auto raux             = ti->getRaster();
+    auto raux = ti->getRaster();
     raux->lock();
     auto imgId            = sl->getImageId(fid, 0);
     TPointD saveboxOffset = TPointD(0, 0);
@@ -2091,7 +2105,7 @@ void FillTool::computeRefImgsIfNeeded(const FillParameters &params) {
       drawReferImage(ras, xsh, m_beginCell.col, slFidToRow[{sl, fid}],
                      saveboxOffset);
     if (closeGap) gapClose(ras, raux, sl, referFill);
-    
+
     raux->unlock();
   }
 }

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2071,6 +2071,7 @@ void FillTool::computeRefImgsIfNeeded(const FillParameters &params) {
     if (!ti) continue;
 
     auto raux             = ti->getRaster();
+    raux->lock();
     auto imgId            = sl->getImageId(fid, 0);
     TPointD saveboxOffset = TPointD(0, 0);
     if (fillOnlySavebox) {
@@ -2090,6 +2091,8 @@ void FillTool::computeRefImgsIfNeeded(const FillParameters &params) {
       drawReferImage(ras, xsh, m_beginCell.col, slFidToRow[{sl, fid}],
                      saveboxOffset);
     if (closeGap) gapClose(ras, raux, sl, referFill);
+    
+    raux->unlock();
   }
 }
 

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -399,6 +399,7 @@ public:
   void undo() const override {
     TRasterUndo::undo();
     TToonzImageP image = getImage();
+    if(m_refGapFill) TRop::eraseRefInks(image->getRaster());
     if (!image) return;
     if (m_saveboxOnly && !m_savebox.isEmpty()) image->setSavebox(m_savebox);
   }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1812,8 +1812,6 @@ void FillToolOptionsBox::onColorModeChanged(int index) {
   }
   enabled = range[index] != L"Lines" && !m_multiFrameMode->isChecked();
   m_onionMode->setEnabled(enabled);
-  if(m_referFill) m_referFill->setEnabled(enabled);
-  if(m_closeGap) m_closeGap->setEnabled(enabled);
 }
 
 //-----------------------------------------------------------------------------
@@ -1827,15 +1825,14 @@ void FillToolOptionsBox::onToolTypeChanged(int index) {
   enabled = enabled || (m_colorMode->getProperty()->getValue() != L"Lines" &&
                         !m_multiFrameMode->isChecked());
   m_onionMode->setEnabled(enabled);
-  enabled = range[index] != L"Polyline";
-  if (m_referFill) m_referFill->setEnabled(enabled);
-  if (m_closeGap) m_closeGap->setEnabled(enabled);
 }
 
 //-----------------------------------------------------------------------------
 
 void FillToolOptionsBox::onOnionModeToggled(bool value) {
   m_multiFrameMode->setEnabled(!value);
+  if (m_referFill) m_referFill->setEnabled(!value);
+  if (m_closeGap) m_closeGap->setEnabled(!value);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -583,7 +583,9 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
   bool refImagePut = Ref.getPointer();
   if (refImagePut) {
     if (*(Ref->pixels(p.y) + p.x) != TPixel32(0, 0, 0, 0)) return false;
-    if (saver) saver->save(Ref->getBounds());
+    // !!!! To Save Undo Memory saved refer pixel would be cleared
+    // in rasterFillUndo::undo !!!!
+    // if (saver) saver->save(Ref->getBounds());
     TRop::putRefImage(r, Ref);
   }
 
@@ -642,7 +644,7 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
     }
     if (oldxd > 0) seeds.push(FillSeed(oldxc, oldxd, y, dy));
   }
-
+  
   if (refImagePut) TRop::eraseRefInks(r);
 
   return true;

--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -183,25 +183,15 @@ void fillautoInks(TRasterCM32P &rin, TRect &rect, const TRasterCM32P &rbefore,
 
 //-----------------------------------------------------------------------------
 
-bool AreaFiller::rectFill(const TRect &rect, const TRect &saveBox, int color,
-                          bool onlyUnfilled, bool fillPaints, bool fillInks) {
+bool AreaFiller::rectFill(const TRect &rect, int color, bool onlyUnfilled,
+                          bool fillPaints, bool fillInks) {
   // Viene trattato il caso fillInks
   /*- In case of FillInk only -*/
-  if (!fillPaints) {
-    assert(fillInks);
-    assert(m_ras->getBounds().contains(rect));
-    if (m_refRas) TRop::putRefImage(m_ras, m_refRas);
-    for (int y = rect.y0; y <= rect.y1; y++) {
-      TPixelCM32 *pix = m_ras->pixels(y) + rect.x0;
-      for (int x = rect.x0; x <= rect.x1; x++, pix++) pix->setInk(color);
-    }
-    if (m_refRas) TRop::eraseRefInks(m_ras);
-    return true;
-  }
+  m_ras->lock();
+  TRect r = m_bounds * rect;
 
   if (m_refRas) TRop::putRefImage(m_ras, m_refRas);
 
-  TRect r = m_bounds * rect;
   int dx  = r.x1 - r.x0;
   int dy  = (r.y1 - r.y0) * m_wrap;
   if (dx < 2 || dy < 2)  // rect degenere(area contenuta nulla), skippo.
@@ -225,15 +215,15 @@ bool AreaFiller::rectFill(const TRect &rect, const TRect &saveBox, int color,
 
   TPixelCM32 *upPix = ras->pixels(0);
   TPixelCM32 *dnPix = backupRas->pixels(ly - 1);
-  bool fillOnlySaveBox =
-      saveBox != TRect() && Preferences::instance()->getFillOnlySavebox();
-  bool topSame    = (fillOnlySaveBox ? rect.y0 == saveBox.y0 : rect.x1 == rect.y0);
-  bool bottomSame = (fillOnlySaveBox ? rect.y1 == saveBox.y1 : rect.x1 == m_bounds.y1);
-  bool leftSame   = (fillOnlySaveBox ? rect.x0 == saveBox.x0 : rect.x1 == m_bounds.x0);
-  bool rightSame  = (fillOnlySaveBox ? rect.x1 == saveBox.x1 : rect.x1 == m_bounds.x1);
+  bool topSame      = r.y0 == m_bounds.y0;
+  bool bottomSame   = r.y1 == m_bounds.y1;
+  bool leftSame     = r.x0 == m_bounds.x0;
+  bool rightSame    = r.x1 == m_bounds.x1;
 
-  int sameCount = Preferences::instance()->getFillOnlySavebox() ?
-      (int)topSame + (int)bottomSame + (int)leftSame + (int)rightSame : 0;
+  int sameCount =
+      Preferences::instance()->getFillOnlySavebox()
+          ? (int)topSame + (int)bottomSame + (int)leftSame + (int)rightSame
+          : 0;
 
   // --- Top Edge ---
   if (!(sameCount != 4 && topSame)) {
@@ -284,21 +274,13 @@ bool AreaFiller::rectFill(const TRect &rect, const TRect &saveBox, int color,
   for (int y = 0; y < ly; ++y) {
     TPixelCM32 *pix = ras->pixels(y);
     TPixelCM32 *bak = backupRas->pixels(y);
-    for (int x = 0; x < lx; ++x, ++pix, ++bak) {
-      if (fillInks && !pix->isPurePaint()) pix->setInk(color);
-      if (!DEF_REGION_WITH_PAINT && pix->getInk() == TPixelCM32::getMaxInk())
-        pix->setInk(color);
-      if (pix->getPaint() == TPixelCM32::getMaxPaint())
-        pix->setPaint(bak->getPaint());
-      else if (onlyUnfilled && pix->getPaint() != 0)
-        continue;
-      else
-        pix->setPaint(color);
-    }
+    for (int x = 0; x < lx; ++x, ++pix, ++bak)
+      processPixel(*pix, *bak, true, color, onlyUnfilled, fillPaints, fillInks);
   }
 
   if (m_refRas) TRop::eraseRefInks(m_ras);
 
+  m_ras->unlock();
   return true;
 }
 
@@ -308,13 +290,13 @@ void AreaFiller::strokeFill(const TRect &rect, TStroke *stroke, int color,
                             bool onlyUnfilled, bool fillPaints, bool fillInks) {
   m_ras->lock();
   if (m_refRas) TRop::putRefImage(m_ras, m_refRas);
-  TRect box              = rect;
+  TRect box  = rect;
   TRect bbox = m_ras->getBounds();
   box *= bbox;
 
+  assert(!box.isEmpty());
   TRasterCM32P ras       = m_ras->extract(box);
   TRasterCM32P backupRas = ras->clone();
-  stroke->transform(TTranslation(-box.x0, -box.y0));
 
   // std::vector<std::pair<TPoint, int>> seeds;
   // computeSeeds(m_ras, stroke, seeds);
@@ -332,32 +314,51 @@ void AreaFiller::strokeFill(const TRect &rect, TStroke *stroke, int color,
   for (int y = 0; y < ly; ++y) {
     TPixelCM32 *pix = ras->pixels(y);
     TPixelCM32 *bak = backupRas->pixels(y);
-    for (int x = 0; x < lx; ++x, ++pix, ++bak) {
-      if (pix->getPaint() == TPixelCM32::getMaxPaint()) {
-        if (!DEF_REGION_WITH_PAINT && pix->getInk() == TPixelCM32::getMaxInk())
-          pix->setInk(color);
-        if (m_palette && m_palette->getStyle(pix->getInk())->getFlags() != 0)
-          pix->setInk(color);
-        if (fillInks && !pix->isPurePaint()) pix->setInk(color);
-        if (fillPaints) {
-          if (onlyUnfilled && bak->getPaint() != 0) {
-            pix->setPaint(bak->getPaint());
-            continue;
-          } else
-            pix->setPaint(color);
-        } else
-          pix->setPaint(bak->getPaint());
-      } else
-        pix->setPaint(bak->getPaint());
-    }
+    for (int x = 0; x < lx; ++x, ++pix, ++bak)
+      processPixel(*pix, *bak, false, color, onlyUnfilled, fillPaints,
+                   fillInks);
   }
-
-  stroke->transform(TTranslation(box.x0, box.y0));
-  // stroke->transform(TTranslation(convert(-m_ras->getCenter())));
-  //  restoreColors(m_ras, seeds);
-
   if (m_refRas) TRop::eraseRefInks(m_ras);
   m_ras->unlock();
+}
+
+const void AreaFiller::processPixel(
+    TPixelCM32 &pix, const TPixelCM32 &bak, bool invert, int color,
+    bool onlyUnfilled, bool fillPaints,
+    bool fillInks) { /*--- Process Area need to be painted */
+  if (invert ? pix.getPaint() != TPixelCM32::getMaxPaint()
+             : pix.getPaint() == TPixelCM32::getMaxPaint()) {
+    /*--- Process ALL Lines  ---*/
+    if (fillInks && !pix.isPurePaint()) pix.setInk(color);  // Paint all inks
+    /*--- Process refer/auto-paint Lines  ---*/
+    else {
+      // paint refer lines
+      if (pix.getInk() == TPixelCM32::getMaxInk() && !DEF_REGION_WITH_PAINT)
+        pix.setInk(color);
+      // paint auto-paint lines
+      if (m_palette && m_palette->getStyle(pix.getInk())->getFlags() != 0)
+        pix.setInk(color);
+    }
+    /*--- Process ALL PAINT  ---*/
+    if (fillPaints) {
+      // do not paint if not empty pixel
+      if (onlyUnfilled && bak.getPaint() != 0) pix.setPaint(bak.getPaint());
+      // do not paint under refer pure INK
+      else if (!USE_PREVAILING_REFER_FILL &&
+               pix.getInk() == TPixelCM32::getMaxInk() && pix.isPureInk())
+        pix.setPaint(bak.getPaint());
+      // restore paint under maxPaint
+      else
+        pix.setPaint(color);
+    }
+    // Restore Area should not be filled
+    // !fillPaints and pix not inked case
+    else
+      pix.setPaint(bak.getPaint());
+  }
+  /*--- Restore Area should not be filled */
+  else
+    pix.setPaint(bak.getPaint());
 }
 
 //=============================================================================

--- a/toonz/sources/toonzlib/imagepainter.cpp
+++ b/toonz/sources/toonzlib/imagepainter.cpp
@@ -77,7 +77,7 @@ inline void quickput(const TRasterP &rout, const TRasterP &rin,
 
       if (tc & ToonzCheck::eGap) {
         srcCM32 = srcCM32->clone();
-        AreaFiller(srcCM32).rectFill(srcCM32->getBounds(), TRect(), 1, true, true,
+        AreaFiller(srcCM32).rectFill(srcCM32->getBounds(), 1, true, true,
                                      false);
       }
 

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -564,8 +564,7 @@ void RasterPainter::flushRasterImages() {
         plt        = m_nodes[i].m_palette->clone();
         gapCheckIndex = plt->addStyle(TPixel::Magenta);
         if (tc & ToonzCheck::eGap)
-          AreaFiller(srcCm).rectFill(m_nodes[i].m_savebox,TRect(), 1, true, true,
-                                     false);
+          AreaFiller(srcCm).rectFill(m_nodes[i].m_savebox, 1, true, true, false);
         if (tc & ToonzCheck::eAutoclose && m_nodes[i].m_onionMode == Node::eOnionSkinNone) {
           auto settings = ToonzCheck::instance()->getAutocloseSettings();
           std::set<int> autoPaints;
@@ -583,7 +582,7 @@ void RasterPainter::flushRasterImages() {
             int gapFillIndex =
                 plt->addStyle(TPixelRGBM32(244, 186, 148, 0xff));  // orange
             plt->getStyle(gapFillIndex)->setFlags(1);
-            AreaFiller(srcCm).rectFill(m_nodes[i].m_savebox,TRect(), gapFillIndex,
+            AreaFiller(srcCm).rectFill(m_nodes[i].m_savebox, gapFillIndex,
                                        true, true, false);
           }
         }

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -564,7 +564,7 @@ void RasterPainter::flushRasterImages() {
         plt        = m_nodes[i].m_palette->clone();
         gapCheckIndex = plt->addStyle(TPixel::Magenta);
         if (tc & ToonzCheck::eGap)
-          AreaFiller(srcCm).rectFill(m_nodes[i].m_savebox, 1, true, true, false);
+          AreaFiller(srcCm).rectFastFill(m_nodes[i].m_savebox, 1);
         if (tc & ToonzCheck::eAutoclose && m_nodes[i].m_onionMode == Node::eOnionSkinNone) {
           auto settings = ToonzCheck::instance()->getAutocloseSettings();
           std::set<int> autoPaints;
@@ -582,8 +582,7 @@ void RasterPainter::flushRasterImages() {
             int gapFillIndex =
                 plt->addStyle(TPixelRGBM32(244, 186, 148, 0xff));  // orange
             plt->getStyle(gapFillIndex)->setFlags(1);
-            AreaFiller(srcCm).rectFill(m_nodes[i].m_savebox, gapFillIndex,
-                                       true, true, false);
+            AreaFiller(srcCm).rectFastFill(m_nodes[i].m_savebox, gapFillIndex);
           }
         }
       } else


### PR DESCRIPTION
# Summary
This PR mainly fix the support of `refer fill` and `gap close` options in `area filler` type, and fixes the laggy of `Fill Check`.
<img width="142" height="99" alt="图片" src="https://github.com/user-attachments/assets/e7bc570f-ffa2-48fb-a9d5-9d96aa9ace22" />

## Other changes are as follows:
- Mange refer image with RAII
- Add lock to the refer level's image before generating the refer Image
- Fix out of bounds crash in stagevisitor

# How to test

Here is my test cases for reference:
<img width="1965" height="484" alt="图片" src="https://github.com/user-attachments/assets/6add5673-8c90-4dc9-86a8-7ba08d577fb3" />
I also tested `Fill Check`, it works with less delay now(almost the same as other check modes' speed)