### PR TITLE
Update normal fill logic of Toonz Raster

### DIFF
--- a/toonz/sources/common/trop/quickput.cpp
+++ b/toonz/sources/common/trop/quickput.cpp
@@ -4457,8 +4457,8 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
   int count = std::max({palette->getStyleCount(), TPixelCM32::getMaxInk(),
                         TPixelCM32::getMaxPaint()});
 
-  std::vector<TPixel32> paints(count, TPixel32::Red);
-  std::vector<TPixel32> inks(count, TPixel32::Red);
+  std::vector<TPixel32> paints(count+1, TPixel32::Red);
+  std::vector<TPixel32> inks(count+1, TPixel32::Red);
   if (globalColorScale != TPixel::Black)
     for (int i = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] = applyColorScaleCMapped(
@@ -4467,7 +4467,7 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
     for (int i = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] =
           ::premultiply(palette->getStyle(i)->getAverageColor());
-
+  
   dn->lock();
   up->lock();
   TPixelCM32 *upBasePix = up->pixels();

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -393,7 +393,8 @@ public:
     TRasterUndo::undo();
     TToonzImageP image = getImage();
     if (!image) return;
-    image->setSavebox(m_savebox);
+    if(m_saveboxOnly && !m_savebox.isEmpty())
+        image->setSavebox(m_savebox);
   }
   void redo() const override {
     TToonzImageP image = getImage();
@@ -1058,7 +1059,6 @@ void doRefFill(const TImageP &img, const TRaster32P &refImg, const TPointD &pos,
 
     // !autoPaintLines will temporary disable autopaint line feature
     if (plt && hasAutoInks(plt) && autopaintLines) params.m_palette = plt;
-    TRaster32P refRas;
     if (params.m_fillType == ALL || params.m_fillType == AREAS) {
       recomputeSavebox = fill(ras, params, &tileSaver, refImg);
     }
@@ -1079,7 +1079,7 @@ void doRefFill(const TImageP &img, const TRaster32P &refImg, const TPointD &pos,
         }
       TUndoManager::manager()->add(new RasterFillUndo(
           tileSet, params, sl, fid,
-          Preferences::instance()->getFillOnlySavebox(), std::move(refRas)));
+          Preferences::instance()->getFillOnlySavebox(), std::move(refImg)));
     }
 
     // al posto di updateFrame:

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -408,7 +408,10 @@ public:
     } else
       r = image->getRaster();
     if (m_params.m_fillType == ALL || m_params.m_fillType == AREAS) {
-      recomputeSavebox = fill(r, m_params, 0, m_refImg);
+      TTileSaverCM32 saver = TTileSaverCM32(r, TRasterUndo::m_tiles);
+      fill(r, m_params, &saver);
+      recomputeSavebox =
+          !getImage()->getSavebox().contains(TRasterUndo::m_tiles->getBBox());
     }
     if (m_params.m_fillType == ALL || m_params.m_fillType == LINES) {
       if (m_params.m_segment)
@@ -1072,7 +1075,9 @@ void doRefFill(const TImageP &img, const TRaster32P &refImg, const TPointD &pos,
     // !autoPaintLines will temporary disable autopaint line feature
     if (plt && hasAutoInks(plt) && autopaintLines) params.m_palette = plt;
     if (params.m_fillType == ALL || params.m_fillType == AREAS) {
-      recomputeSavebox = fill(ras, params, &tileSaver, refImg);
+      fill(ras, params, &tileSaver, refImg);
+      recomputeSavebox =
+          !ti->getSavebox().contains(tileSaver.getTileSet()->getBBox());
     }
     if (params.m_fillType == ALL || params.m_fillType == LINES) {
       if (params.m_segment)

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -4,6 +4,7 @@
 
 #include "toonz/fill.h"
 #include "toonz/ttilesaver.h"
+#include "toonz/ttileset.h"
 #include "tpalette.h"
 #include "tpixelutils.h"
 #include "trastercm.h"
@@ -539,7 +540,7 @@ int getMostFrequentNeighborStyleId(TRasterCM32P ras,
 //-----------------------------------------------------------------------------
 }  // namespace
 //-----------------------------------------------------------------------------
-/*-- The return value is whether the saveBox has been updated or not. --*/
+/*-- Return true if fill processed --*/
 bool fill(const TRasterCM32P &r, const FillParameters &params,
           TTileSaverCM32 *saver, const TRaster32P &Ref) {
   TPixelCM32 *pix, *limit, *pix0, *oldpix;
@@ -588,23 +589,6 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
 
   fillDepth = adjustFillDepth(fillDepth);
   
-  /*--Look at the colors in the four corners and update the saveBox if any of
-   * the colors change. --*/
-  TPixelCM32 borderIndex[4];
-  TPixelCM32 *borderPix[4];
-  pix            = r->pixels(0);
-  borderPix[0]   = pix;
-  borderIndex[0] = *pix;
-  pix += r->getLx() - 1;
-  borderPix[1]   = pix;
-  borderIndex[1] = *pix;
-  pix            = r->pixels(r->getLy() - 1);
-  borderPix[2]   = pix;
-  borderIndex[2] = *pix;
-  pix += r->getLx() - 1;
-  borderPix[3]   = pix;
-  borderIndex[3] = *pix;
-
   std::stack<FillSeed> seeds;
 
   fillRow(r, p, xa, xb, paint, params.m_palette, saver, params.m_prevailing,
@@ -661,14 +645,7 @@ bool fill(const TRasterCM32P &r, const FillParameters &params,
 
   if (refImagePut) TRop::eraseRefInks(r);
 
-  bool saveBoxChanged = false;
-  for (int i = 0; i < 4; i++) {
-    if (!((*borderPix[i]) == borderIndex[i])) {
-      saveBoxChanged = true;
-      break;
-    }
-  }
-  return saveBoxChanged;
+  return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -90,6 +90,8 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
   if (prevailing && tone == 0) {
     tmp_limit = pix + 10;  // edge stop fill == 10 per default
     if (limit > tmp_limit) limit = tmp_limit;
+    int preVailingInk,
+        oldPrevailingInk = 0;  // avoid prevailing different Ink styles
     for (; pix <= limit; pix++) {
       if (refImagePut && !USE_PREVAILING_REFER_FILL &&
           pix->getInk() == TPixelCM32::getMaxInk() &&
@@ -98,7 +100,12 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
       if (DEF_REGION_WITH_PAINT && pix->getPaint() != paintAtClickPos) break;
       if (pix->getPaint() == paint) break;
       if (pix->getTone() != 0) break;
+      if (prevailing) {
+        preVailingInk = pix->getInk();
+        if (oldPrevailingInk > 0 && preVailingInk != oldPrevailingInk) break;
+        oldPrevailingInk = preVailingInk;
     }
+  }
   }
 
   xb = p.x + pix - pix0 - 1;
@@ -146,6 +153,7 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
   if (prevailing && tone == 0) {
     tmp_limit = pix - 10;
     if (limit < tmp_limit) limit = tmp_limit;
+    int preVailingInk, oldPrevailingInk = 0;
     for (; pix >= limit; pix--) {
       if (refImagePut && !USE_PREVAILING_REFER_FILL &&
           pix->getInk() == TPixelCM32::getMaxInk() &&
@@ -154,7 +162,12 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
       if (DEF_REGION_WITH_PAINT && pix->getPaint() != paintAtClickPos) break;
       if (pix->getPaint() == paint) break;
       if (pix->getTone() != 0) break;
+      if (prevailing) {
+        preVailingInk = pix->getInk();
+        if (oldPrevailingInk > 0 && preVailingInk != oldPrevailingInk) break;
+        oldPrevailingInk = preVailingInk;
     }
+  }
   }
 
   xa = p.x + pix - pix0 + 1;
@@ -165,8 +178,7 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
     pix = line + xa;
     int n;
     for (n = 0; n < xb - xa + 1; n++, pix++) {
-      if (palette) {
-        if (pix->isPurePaint()) {
+      if (palette && pix->isPurePaint()) {
           TPoint pInk = nearestInkNotDiagonal(r, TPoint(xa + n, p.y));
           if (pInk != TPoint(-1, -1)) {
             TPixelCM32 *pixInk = (TPixelCM32 *)r->getRawData() +
@@ -178,7 +190,6 @@ void fillRow(const TRasterCM32P &r, const TPoint &p, int &xa, int &xb,
               inkFill(r, pInk, paint, 0, saver);
           }
         }
-      }
       if (refImagePut && pix->getInk() == TPixelCM32::getMaxInk() &&
           !DEF_REGION_WITH_PAINT)
         pix->setInk(paint);

--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -16,9 +16,6 @@
 
 #include "toonz/preferences.h"
 
-#define DEF_REGION_WITH_PAINT                                                  \
-  Preferences::instance()->getBoolValue(PreferencesItemId::DefRegionWithPaint)
-
 using namespace SkeletonLut;
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
# Summary
This PR fix and adjusts the fill logic to align with the newly added preference and improves code readability.
Mainly affect **the Normal Click Fill**, also affect area filler (ex. rectangle type) as they are inverted fill by calling the normal fill function.
The bugs related to area filler(such as freeHand and rectangle type) would be fixed in #6105

## Preference related

- **Define regions with both PAINT and INK**: This allows the fill result to stop at the edge of two different painted region
- **Do prevailing when refer fill**: This allows the fill result to paint over/behind the **PURE** INK lines

## Others
- Do not prevailing two different pure INK(tone = 0) while filling a row:
  - Old behavior(use No.4 style to fill)
  ```
  INK   0   0   1   1   1   2   2   3
  TONE  255 255 0   0   0   0   0   0
  PAINT 4   4   4   4   4   4   4   4
        ^start fill from this pixel
  ```
 
  - New behavior(use No.4 to fill)
  ```
  INK   0   0   1   1   1   2   2   3
  TONE  255 255 0   0   0   0   0   0
  PAINT 4   4   4   4   4   0   0   0
        ^start fill from this pixel
  ```
- fix crash if viewer trying to access the color of the max Index of palette (this happen when refer Image is caculating)
- extract adjustFillDepth() in fill.cpp
- Include reference image memory size in undo size calculation

# How to test
Here is my test cases for reference:
<img width="1442" height="437" alt="eb52bf2b-1bb0-4cb1-a990-2482fdf227df" src="https://github.com/user-attachments/assets/a052556c-30ef-4809-b593-1574a0299318" />
