### PR TITLE
ci: Switch to Visual Studio 2019 (Previous) for stability

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ skip_commits:
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 configuration: Release
 platform: x64
 clone_depth: 1


### PR DESCRIPTION
This ensures a stable build environment while we work on further upgrades.

I think it’s better to switch back to the previous Visual Studio 2019 for now, just to stabilize things. I’ll create another PR to test the future upgrade.

Thanks to @xavier2k6 for spotting this.

Co-authored-by: xavier2k6 xavier2k6 <42386382+xavier2k6@users.noreply.github.com>