### PR TITLE
Fix Eye Button in Classic Column Header

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1181,7 +1181,6 @@ void ColumnArea::DrawHeader::drawColumnName() const {
   bool nameBacklit = false;
   int rightadj     = -2;
   int leftadj      = 3;
-  int valign = o->isVerticalTimeline() ? Qt::AlignVCenter : Qt::AlignBottom;
 
   if (!isEmpty) {
     if (o->isVerticalTimeline() &&
@@ -1228,13 +1227,13 @@ void ColumnArea::DrawHeader::drawColumnName() const {
     p.drawText(columnName.translated(-columnName.topLeft())
                    .transposed()
                    .adjusted(5, 0, 0, 0),
-               Qt::AlignLeft | valign, cameraName);
+               Qt::AlignLeft | Qt::AlignVCenter, cameraName);
     p.restore();
     return;
   }
 
   p.drawText(columnName.adjusted(leftadj, 0, rightadj, 0),
-             Qt::AlignLeft | valign | Qt::TextSingleLine,
+             Qt::AlignLeft | Qt::AlignVCenter | Qt::TextSingleLine,
              QString(name.c_str()));
 }
 
@@ -2408,12 +2407,11 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
     else if (!isEmpty) {
       // grabbing the left side of the column enables column move
       if (o->rect(PredefinedRect::DRAG_LAYER).contains(mouseInCell) ||
-          /*(!o->flag(PredefinedFlag::DRAG_LAYER_VISIBLE)  // If dragbar hidden,
+          (!o->flag(PredefinedFlag::DRAG_LAYER_VISIBLE)  // If dragbar hidden,
                                                          // layer name/number
                                                          // becomes dragbar
-           && */  // also consider layer name/number as dragbar
-          (o->rect(PredefinedRect::LAYER_NUMBER).contains(mouseInCell) ||
-               o->rect(PredefinedRect::LAYER_NAME).contains(mouseInCell))) {
+           && (o->rect(PredefinedRect::LAYER_NUMBER).contains(mouseInCell) ||
+               o->rect(PredefinedRect::LAYER_NAME).contains(mouseInCell)))) {
         setDragTool(XsheetGUI::DragTool::makeColumnMoveTool(m_viewer));
       }
       // lock button
@@ -2422,8 +2420,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
         if (isCtrlPressed)
           m_doOnRelease = ToggleAllLock;
         else {
-          m_doOnMove =
-              column->isLocked() ? ToggleOffLock : ToggleOnLock;
+          m_doOnMove = column->isLocked() ? ToggleOffLock : ToggleOnLock;
           column->lock(!column->isLocked());
         }
       }

--- a/toonz/sources/toonzlib/orientation.cpp
+++ b/toonz/sources/toonzlib/orientation.cpp
@@ -1143,11 +1143,10 @@ LeftToRightOrientation::LeftToRightOrientation() {
   addRect(PredefinedRect::CELL_NAME, nameRect);
   addRect(PredefinedRect::CELL_NAME_WITH_KEYFRAME, nameRect);
   addRect(PredefinedRect::END_EXTENDER,
-      QRect(0, -EXTENDER_HEIGHT - 4,
-          EXTENDER_WIDTH, EXTENDER_HEIGHT));
+          QRect(0, -EXTENDER_HEIGHT - 4, EXTENDER_WIDTH, EXTENDER_HEIGHT));
   addRect(PredefinedRect::BEGIN_EXTENDER,
-      QRect(-EXTENDER_WIDTH, -EXTENDER_HEIGHT - 4,
-          EXTENDER_WIDTH, EXTENDER_HEIGHT));
+          QRect(-EXTENDER_WIDTH, -EXTENDER_HEIGHT - 4, EXTENDER_WIDTH,
+                EXTENDER_HEIGHT));
   addRect(PredefinedRect::KEYFRAME_AREA, keyRect);
   addRect(PredefinedRect::DRAG_AREA, QRect(0, 0, CELL_WIDTH, CELL_DRAG_HEIGHT));
   int markSize = CELL_HEIGHT / 2;  // 50% size (12px)
@@ -1279,9 +1278,11 @@ LeftToRightOrientation::LeftToRightOrientation() {
           rect(PredefinedRect::CONFIG_AREA));
   addRect(PredefinedRect::CAMERA_CONFIG, rect(PredefinedRect::CONFIG));
   addRect(PredefinedRect::DRAG_LAYER,
-          QRect(ICONS_WIDTH + THUMBNAIL_WIDTH + 1, 0,
-                LAYER_HEADER_WIDTH - ICONS_WIDTH - THUMBNAIL_WIDTH - 3,
-                CELL_DRAG_HEIGHT));
+          QRect(0, 0, -1, -1));  // hide drag handle in Timeline view
+  // addRect(PredefinedRect::DRAG_LAYER,
+  //         QRect(ICONS_WIDTH + THUMBNAIL_WIDTH + 1, 0,
+  //               LAYER_HEADER_WIDTH - ICONS_WIDTH - THUMBNAIL_WIDTH - 3,
+  //               CELL_DRAG_HEIGHT));
   addRect(PredefinedRect::LAYER_NAME, columnName);
   addRect(PredefinedRect::CAMERA_LAYER_NAME, rect(PredefinedRect::LAYER_NAME));
   addRect(PredefinedRect::LAYER_NUMBER,
@@ -1335,7 +1336,7 @@ LeftToRightOrientation::LeftToRightOrientation() {
 
   // Flags
   addFlag(PredefinedFlag::DRAG_LAYER_BORDER, false);
-  addFlag(PredefinedFlag::DRAG_LAYER_VISIBLE, true);
+  addFlag(PredefinedFlag::DRAG_LAYER_VISIBLE, false);
   addFlag(PredefinedFlag::LAYER_NAME_BORDER, true);
   addFlag(PredefinedFlag::LAYER_NAME_VISIBLE, true);
   addFlag(PredefinedFlag::LAYER_NUMBER_BORDER, true);


### PR DESCRIPTION
This PR fixes the "Eye" (preview toggle) button in the "Classic" column header layout that had become unclickable after the introduction of PR #5795 .

This PR also removed the drag handle in timeline column header, since it now functions the same as the column name area.
<img width="765" height="113" alt="image" src="https://github.com/user-attachments/assets/ebf54bb1-9754-4d98-a29c-25fb6ff9d337" />
