### PR TITLE
Fix Tape tool crash

### DIFF
--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -37,7 +37,7 @@ TEnv::StringVar AutocloseVectorType("InknpaintAutocloseVectorType", "Normal");
 TEnv::DoubleVar AutocloseDistance("InknpaintAutocloseDistance", 10.0);
 TEnv::DoubleVar AutocloseAngle("InknpaintAutocloseAngle", 60.0);
 TEnv::IntVar AutocloseRange("InknpaintAutocloseRange", 0);
-TEnv::IntVar AutocloseOpacity("InknpaintAutocloseOpacity", 0);
+TEnv::IntVar AutocloseOpacity("InknpaintAutocloseOpacity", 255);
 TEnv::IntVar AutocloseIgnoreAutoPaint("AutocloseIgnoreAutoPaint", 0);
 
 #define NORMAL_CLOSE L"Normal"


### PR DESCRIPTION
## Issue
In a complete new install or using the portable stuff, create a toonz raster level and switch to tape tool, would cause the crash.

FIX:
- Set default value of autoClose Opacity to 255