### PR TITLE
ci: Replace `macos-13` image with `macos-15-intel` image (GHA)

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -21,8 +21,14 @@ on:
 jobs:
   macOS:
     timeout-minutes: 90 # Stop job if it exceeds expected build time
-    # Stick with macOS 13 to avoid arm64 headaches on macOS 15
-    runs-on: macos-13
+    # GHA are sunsetting support for macOS 13 (Intel & Apple Silicon/arm) & will be fully unsupported on (December 4th 2025),
+    # See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ & https://github.com/actions/runner-images/issues/13046
+    # (Septemer 19th 2025) - Replacing `macos-13` runner image with the new `macos-15-intel` runner image to maintain macOS (Intel x64) support.
+    # See: https://github.com/actions/runner-images/issues/13045
+    # GHA (x86_64) SUNSETTING SUPPORT DEADLINE WARNING!!! `macos-15-intel` runner image will be the last available x86_64 image from Actions, and after (August 2027) the x86_64 architecture will not be supported on GitHub Actions.
+    # Xref.: https://github.com/actions/runner-images/issues/13045
+    # TODO: Change macOS GHA Runner Image to (Apple Silicon) based image on/prior to sunsetting of `macos-15-intel` (x86_64) runner image (August 2027)
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Replace `macos-13` runner image with the new `macos-15-intel` runner image, which will then be phased out in August 2027 (Ending all Intel x86_64 support on macOS).

* macOS 13 "Ventura" Runner Image is being "deprecated"

https://github.com/actions/runner-images/issues/13046
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

* macOS 15 "Sonoma" Intel-based image is now available in GitHub Actions

https://github.com/actions/runner-images/issues/13045

Closes #6067.