### PR TITLE
Set minimum required CMake version to 3.10

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_BUILD_TYPE_INIT Release)
 


### PR DESCRIPTION
This updates the CMakeLists.txt to require a minimum CMake version of 3.10

After extensive testing with AppVeyor, macOS and Windows, everything appears to be working well. So it makes sense to raise the minimum required version, it avoids the deprecation warning and ensures future compatibility across multiple environments. Many of the configurations and changes to make it work were done in https://github.com/opentoonz/opentoonz/pull/6108

Example warning:
```
 CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
 Compatibility with CMake < 3.10 will be removed from a future version of  CMake.
```
ref: https://github.com/opentoonz/opentoonz/pull/5835
ref: https://github.com/opentoonz/opentoonz/pull/6108