### PR TITLE
Adjust Cell Dragging behavior

### DIFF
--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -561,8 +561,9 @@ void LevelMoverTool::onClick(const QMouseEvent *e) {
   if (e->modifiers() & Qt::ShiftModifier ||
       // Or Dragging Frame Cell
       (r0 == r1 && c0 == c1) &&
-      getViewer()->getXsheet()->getCell(cellPosition)
-      != getViewer()->getXsheet()->getCell(row - 1, col))
+          getViewer()->getXsheet()->getCell(cellPosition) !=
+              getViewer()->getXsheet()->getCell(row - 1, col) &&
+          !getViewer()->getXsheet()->getCell(row + 1, col).isEmpty())
     m_qualifiers |= CellsMover::eInsertCells;
   if (e->modifiers() & Qt::AltModifier)
     m_qualifiers |= CellsMover::eOverwriteCells;

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3372,12 +3372,15 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
 
     // Drag Cells #1 : When "Always Drag Frame Cell" Selected and no modifiers
     else if (Preferences::instance()->isAlwaysDragFrameCell() &&
+             o->rect(PredefinedRect::CELL_NAME)
+                 .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
+                 .contains(mouseInCell) &&
              event->modifiers() == Qt::NoModifier &&
              (!xsh->getCell(row, col).isEmpty()) &&
              xsh->getCell(row, col) != xsh->getCell(row - 1, col)) {
       TXshColumn *column = xsh->getColumn(col);
 
-      if (column && !m_viewer->getCellSelection()->isCellSelected(row, col)) {
+      if (column) {
         // switch to that FrameCell
         m_viewer->setCurrentRow(row);
         m_viewer->setCurrentColumn(col);


### PR DESCRIPTION
## What this PR changes:

- Do not drag the single alone cell
![1](https://github.com/user-attachments/assets/a5a21c0f-308f-4ea3-b9ec-bfd20abf45cc)

- In "Always Drag Frame Cell" mode, enable to drag the drag bar to select the level range cells
![2](https://github.com/user-attachments/assets/8d88c1ac-3300-42d1-bbe9-a5aced2bbc3b)
