### PR TITLE
Fix export board image

### DIFF
--- a/toonz/sources/toonz/boardsettingspopup.cpp
+++ b/toonz/sources/toonz/boardsettingspopup.cpp
@@ -1154,9 +1154,12 @@ void BoardSettingsPopup::onExportBoardImage() {
   QString levelName = QString::fromStdString(rendPath.getLevelName());
   int dotPos        = levelName.lastIndexOf('.');
 
-  QString fileName = baseName + rendPath.getSepChar() +
-                     boardSettings->fileNameSuffix() +
-                     levelName.right(levelName.size() - dotPos);
+  QString suffix = boardSettings->fileNameSuffix();
+  // if the suffix starts with "." or "_", then replace the sepchar
+  if (!suffix.startsWith('.') && !suffix.startsWith('_'))
+    suffix.prepend(rendPath.getSepChar());
+  QString fileName =
+      baseName + suffix + levelName.right(levelName.size() - dotPos);
 
   popup.setFilename(TFilePath(fileName));
 


### PR DESCRIPTION
Regarding the default filename for Export Board Image in the Board Settings, this PR correctly reflects the functionality to override the output settings' separate character when the suffix begins with an underscore ("_") or period (".").