### PR TITLE
Fix Automatic Path Alias Priority by Scene Type

### DIFF
--- a/toonz/sources/include/toonz/tproject.h
+++ b/toonz/sources/include/toonz/tproject.h
@@ -151,7 +151,7 @@ public:
   TFilePath getProjectPathByProjectFolder(const TFilePath &projectFolder);
 
   std::shared_ptr<TProject> loadSceneProject(const TFilePath &scenePath, 
-      bool* sceneStandAlone = 0);
+      bool* notFound = 0);
   void getFolderNames(std::vector<std::string> &names);
 
   void addListener(Listener *listener);

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -385,9 +385,9 @@ int ToonzScene::loadFrameCount(const TFilePath &fp) {
 void ToonzScene::loadNoResources(const TFilePath &fp) {
   clear();
 
-  TProjectManager *pm = TProjectManager::instance(); 
+  TProjectManager *pm  = TProjectManager::instance();
   bool sceneStandAlone = false;
-  auto sceneProject   = pm->loadSceneProject(fp, &sceneStandAlone);
+  auto sceneProject    = pm->loadSceneProject(fp, &sceneStandAlone);
   if (!sceneProject) return;
   if (sceneStandAlone) m_standAlone = true;
 
@@ -585,6 +585,9 @@ public:
 void ToonzScene::save(const TFilePath &fp, TXsheet *subxsh) {
   TFilePath oldScenePath = getScenePath();
   TFilePath newScenePath = fp;
+
+  if (newScenePath != oldScenePath)
+    TProjectManager::instance()->loadSceneProject(fp, &m_standAlone);
 
   CameraRedirection redir(this, subxsh);
 

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -386,10 +386,8 @@ void ToonzScene::loadNoResources(const TFilePath &fp) {
   clear();
 
   TProjectManager *pm  = TProjectManager::instance();
-  bool sceneStandAlone = false;
-  auto sceneProject    = pm->loadSceneProject(fp, &sceneStandAlone);
+  auto sceneProject    = pm->loadSceneProject(fp, &m_standAlone);
   if (!sceneProject) return;
-  if (sceneStandAlone) m_standAlone = true;
 
   loadTnzFile(fp);
   getXsheet()->updateFrameCount();

--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -1027,9 +1027,9 @@ std::shared_ptr<TProject> TProjectManager::getCurrentProject() {
    folder of a project root.
         \note \b scenePath must be an absolute path.\n
         Creates a new TProject. The caller gets ownership.
-        Sets *sceneStandAlone to true if scenes.xml not found */
+        Sets *notFound to true if scenes.xml not found */
 std::shared_ptr<TProject> TProjectManager::loadSceneProject(const TFilePath &scenePath, 
-    bool* sceneStandAlone) {
+    bool* notFound) {
   // cerca il file scenes.xml nella stessa directory della scena
   // oppure in una
   // directory superiore
@@ -1046,6 +1046,7 @@ std::shared_ptr<TProject> TProjectManager::loadSceneProject(const TFilePath &sce
     }
     folder = folder.getParentDir();
   }
+  if (notFound) *notFound = !found;
 
   // legge il path (o il nome) del progetto
   TFilePath projectPath;
@@ -1071,10 +1072,8 @@ std::shared_ptr<TProject> TProjectManager::loadSceneProject(const TFilePath &sce
     }
     if (projectPath == TFilePath()) return 0;
   }
-  else {
-    if (sceneStandAlone) *sceneStandAlone = true;
+  else 
     projectPath = getSandboxProjectPath();
-  }
 
   if (!TProject::isAProjectPath(projectPath)) {
     // in Toonz 5.1 e precedenti era un project name


### PR DESCRIPTION
What this PR changes:

- [update standalone flag when saving scene](https://github.com/opentoonz/opentoonz/commit/cd13bec26cac6c944349eae3df100bdafb5c4c27)(Help to use $scenefolder to code file path when saving a new scene to a folder not belongs to any project)
- [Refactor standAlone flag check](https://github.com/opentoonz/opentoonz/commit/79e4d363d92211d86b7e02adbb0cca7a3e940071)

# How to test

Switch `Preference>General>Path Alias Priority` to `Automatic by Scene` first.
- New a scene and try to import levels from outside and new levels, check their path in level settings.
- Open a scene that in a project folder, and test importing levels and creating new levels.
- Open a scene that do not in a project folder(no scenes.xml), and test importing and creating new levels.