### PR TITLE
Fix -Wreturn-type warnings in iocommand and igs_rotate_blur

### DIFF
--- a/toonz/sources/stdfx/igs_rotate_blur.cpp
+++ b/toonz/sources/stdfx/igs_rotate_blur.cpp
@@ -228,9 +228,9 @@ public:
 
 private:
   // disable
-  Rotator();
-  Rotator(const Rotator&);
-  Rotator& operator=(const Rotator&) {}
+  Rotator() = delete;
+  Rotator(const Rotator&) = delete;
+  Rotator& operator=(const Rotator&) = delete;
 };
 //------------------------------------------------------------------
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2760,6 +2760,7 @@ bool IoCmd::importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
                      .arg(toQString(levelPath)));
     return false;
   }
+  return true; 
 }
 
 // Use double value DPI as policy


### PR DESCRIPTION
This PR fixes compiler warnings related to return types, as reported in issue #4469

- Replace the private declarations of default/copy constructors and assignment operator with `= delete` in `igs_rotate_blur.cpp` since we are using C++17.

- Add `return true` at the end of IoCmd::importLipSync in `iocommand.cpp` to ensure the function always returns a boolean, indicating successful import and exposure of lip-sync data.

These changes fix code and clean up `-Wreturn-type` warnings.

