### PR TITLE
Revert File Browser behavior

### DIFF
--- a/toonz/sources/toonz/dvitemview.cpp
+++ b/toonz/sources/toonz/dvitemview.cpp
@@ -353,12 +353,11 @@ void DvItemSelection::selectNone() {
 
 void DvItemSelection::selectAll() {
   m_selectedIndices.clear();
-  
+
   // exclude the parent folder
   int i =
       m_model->getItemData(0, DvItemListModel::Name).toString() == ".." ? 1 : 0;
-  for (; i < m_model->getItemCount(); i++)
-      m_selectedIndices.insert(i);
+  for (; i < m_model->getItemCount(); i++) m_selectedIndices.insert(i);
   emit itemSelectionChanged();
 }
 
@@ -1187,10 +1186,6 @@ void DvItemViewerPanel::mousePressEvent(QMouseEvent *event) {
   bool isSelected = m_selection->isSelected(index);
   m_currentIndex  = index;
   if (event->button() == Qt::RightButton) {
-    // when a folder item is right-clicked, do nothing
-    if (getModel()->getItemData(index, DvItemListModel::IsFolder).toBool())
-      return;
-
     if (!isSelected) {
       m_selection->selectNone();
       if (!m_isPlayDelegateDisable) m_itemViewPlayDelegate->resetPlayWidget();
@@ -1304,8 +1299,9 @@ void DvItemViewerPanel::mouseMoveEvent(QMouseEvent *event) {
 
 //-----------------------------------------------------------------------------
 
-void DvItemViewerPanel::mouseReleaseEvent(QMouseEvent *) {
-  if (m_viewer) m_viewer->notifyClick(m_currentIndex);
+void DvItemViewerPanel::mouseReleaseEvent(QMouseEvent *event) {
+  if (m_viewer)
+    m_viewer->notifyClick(m_currentIndex, event->button() == Qt::LeftButton);
 }
 
 //-----------------------------------------------------------------------------
@@ -1419,7 +1415,7 @@ void DvItemViewerPanel::setThumbnailsView() {
 //-----------------------------------------------------------------------------
 
 void DvItemViewerPanel::exportFileList() {
-  auto project = TProjectManager::instance()->getCurrentProject();
+  auto project      = TProjectManager::instance()->getCurrentProject();
   ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
   TFilePath fp;
   if (scene) fp = scene->decodeFilePath(project->getFolder(TProject::Extras));

--- a/toonz/sources/toonz/dvitemview.h
+++ b/toonz/sources/toonz/dvitemview.h
@@ -76,7 +76,7 @@ public:
   // n.b. refreshData viene chiamato PRIMA di getItemCount() e getItemData()
   // vanno messe dentro refreshData() le operazioni "costose" di getItemData() e
   // getItemCount()
-  virtual void refreshData(){};
+  virtual void refreshData() {};
   virtual int getItemCount() const = 0;
   virtual int compareData(DataType dataType, int firstIndex, int secondIndex);
   virtual void sortByDataModel(DataType dataType, bool isDiscendent) {}
@@ -255,7 +255,7 @@ public:
   }
   QColor getSelectedItemBackground() const { return m_selectedItemBackground; }
 
-  //exposed view parameters
+  // exposed view parameters
   void setIconSize(QSize size) { m_iconSize = size; }
 
 private:
@@ -411,8 +411,8 @@ public:
   DvItemViewerPanel *getPanel() { return m_panel; }
 
   virtual void draw(QPainter &p) {}
-  void notifyClick(int index) {
-    emit clickedItem(index);
+  void notifyClick(int index, bool isLeftClick) {
+    if (isLeftClick) emit clickedItem(index);
     emit selectedItems(m_panel->getSelectedIndices());
   }
   void notifyDoubleClick(int index) {

--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -172,6 +172,7 @@ protected slots:
   void clearHistory();
 
   void renameAsToonzLevel();
+  void renameFolder();
   void updateAndEditVersionControl();
   void editVersionControl();
   void unlockVersionControl();
@@ -277,7 +278,8 @@ class RenameAsToonzPopup final : public DVGui::Dialog {
   QCheckBox *m_overwrite;
 
 public:
-  RenameAsToonzPopup(const QString name = "", int frames = -1);
+  RenameAsToonzPopup(const QString name = "", int frames = -1,
+                     bool isFolder = false);
 
   bool doOverwrite() { return m_overwrite->isChecked(); }
   QString getName() { return m_name->text(); }


### PR DESCRIPTION
This PR reverts  the left single-click to move folders in the File Browser according to the discussion which follows [this comment](https://github.com/opentoonz/opentoonz/pull/5760#issuecomment-3311011084).

This PR also enabled to delete (move to trash) and to rename folder via context menu.

Please note that if commands like moving or deleting multiple selected folders become necessary and are implemented in the future, similar to Explorer, behaviors like single-click for selecting items and double-click for moving folders may be re-introduced.