### PR TITLE
docs: update installation instructions for CMake 3.10

### DIFF
--- a/doc/how_to_build_bsd.md
+++ b/doc/how_to_build_bsd.md
@@ -5,7 +5,7 @@
 Building OpenToonz from source requires the following dependencies:
 - Git
 - GCC or Clang
-- CMake (3.4.1 or newer).
+- CMake (3.10 or newer)
 - Qt 5.x (5.15 or newer)
 - Boost (1.55 or newer)
 - LibPNG

--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -5,7 +5,7 @@
 Building OpenToonz from source requires the following dependencies:
 - Git
 - GCC or Clang
-- CMake (3.4.1 or newer).
+- CMake (3.10 or newer)
 - Qt 5.x (5.15 or newer)
 - Boost (1.55 or newer)
 - LibPNG

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -5,7 +5,7 @@
 - git
 - brew
 - Xcode
-- cmake (3.2.2 or later)
+- cmake (3.10 or later)
 - Qt 5.x (5.15 or later)
 - boost (1.55.0 or later)
 

--- a/doc/how_to_build_macosx_ja.md
+++ b/doc/how_to_build_macosx_ja.md
@@ -5,7 +5,7 @@
 - git
 - brew
 - Xcode
-- cmake (3.2.2以降)
+- cmake (3.10以降)
 - Qt 5.x (5.15以降)
 - boost　(1.55.0以降)
 


### PR DESCRIPTION
This PR updates to require CMake 3.10 or later.
