### PR TITLE
New Fx: Smoother Fx Iwa

### DIFF
--- a/stuff/config/current.txt
+++ b/stuff/config/current.txt
@@ -1628,6 +1628,10 @@
   <item>"STD_iwa_MotionFlowFx.normalizeType" "Normalize"	</item>
   <item>"STD_iwa_MotionFlowFx.normalizeRange" "Maximum Length"	</item>
 
+  <item>"STD_iwa_SmootherFx"	"Smoother Iwa"	</item>
+  <item>"STD_iwa_SmootherFx.threshold"	"Threshold"	</item>
+  <item>"STD_iwa_SmootherFx.softness"	"Softness"	</item>
+  
  <!------------------------------ Tiled Particles Iwa ------------------------------------------->
 
   <item>STD_iwa_TiledParticlesFx "Tiled Particles Iwa" </item>

--- a/stuff/profiles/layouts/fxs/STD_iwa_SmootherFx.xml
+++ b/stuff/profiles/layouts/fxs/STD_iwa_SmootherFx.xml
@@ -1,0 +1,6 @@
+<fxlayout>
+	<page name="Smoother Iwa">
+		<control>threshold</control>
+		<control>softness</control>
+	</page>
+</fxlayout>

--- a/stuff/profiles/layouts/fxs/fxs.lst
+++ b/stuff/profiles/layouts/fxs/fxs.lst
@@ -75,6 +75,7 @@
     STD_rgbmFadeFx 
     STD_rgbmScaleFx
     STD_sharpenFx 
+    STD_iwa_SmootherFx 
   </Image_Adjust>
   <Layer_Blending>
     addFx 

--- a/toonz/sources/common/tfx/trenderer.cpp
+++ b/toonz/sources/common/tfx/trenderer.cpp
@@ -1155,7 +1155,7 @@ void RenderTask::onFinished(TThread::RunnableP) {
 
     rendererImp->m_rasterPool
         .clear();  // Isn't this misplaced? Should be in the block
-  }                // below...
+  }  // below...
 
   // If no rendering task (of this or other render instances) is found...
   if (rendererImp->m_undoneTasks == 0) {
@@ -1394,6 +1394,8 @@ void TRendererImp::startRendering(
   std::vector<TRenderer::RenderData>::const_iterator it;
   std::map<std::string, RenderTask *>::iterator jt;
 
+  bool forcePreComputation = false;
+
   for (it = renderDatas.begin(); it != renderDatas.end(); ++it) {
     // Check for user cancels
     if (hasToDie(renderId)) return;
@@ -1427,6 +1429,11 @@ void TRendererImp::startRendering(
       rs.m_offScreenSurface->setFormat(QSurfaceFormat::defaultFormat());
       rs.m_offScreenSurface->create();
     }
+    // (dirty fix) If the render contains smootherFx, then force precomputation
+    // even when the viewer preview, so that the level column affine can be
+    // retrieved in NaAffineFx::doDryCompute
+    if (alias.find("iwa_SmootherFx") != std::string::npos)
+      forcePreComputation = true;
 
     // Search the alias among stored clusters - and store the frame
     jt = clusters.find(alias);
@@ -1460,7 +1467,7 @@ void TRendererImp::startRendering(
     //    Precomputing
     //----------------------------------------------------------------------
 
-    if (m_precomputingEnabled) {
+    if (m_precomputingEnabled || forcePreComputation) {
       // Set current maxTileSize for cache manager precomputation
       const TRenderSettings &rs = renderDatas[0].m_info;
       TPredictiveCacheManager::instance()->setMaxTileSize(rs.m_maxTileSize);

--- a/toonz/sources/include/trasterfx.h
+++ b/toonz/sources/include/trasterfx.h
@@ -432,6 +432,9 @@ public:
   bool isDpiAffine() const { return m_isDpiAffine; }
   std::string getPluginId() const override { return std::string(); }
 
+  void doDryCompute(TRectD &rect, double frame,
+                    const TRenderSettings &info) override;
+
 protected:
   TRasterFxPort m_port;
 
@@ -442,6 +445,25 @@ private:
   // not implemented
   NaAffineFx(const NaAffineFx &);
   NaAffineFx &operator=(const NaAffineFx &);
+};
+
+//**********************************************************************************************
+//    LevelColumnAffineFxRenderData  declaration
+//   this data will keep the level column dpi affine for an fx which need to be
+//   applied to the full sampled image (see Iwa_SmootherFx)
+//**********************************************************************************************
+
+class DVAPI LevelColumnAffineFxRenderData final : public TRasterFxRenderData {
+public:
+  TAffine m_aff;
+  bool m_isSet;
+
+public:
+  LevelColumnAffineFxRenderData() : m_isSet(false) {}
+
+  bool operator==(const TRasterFxRenderData &data) const override;
+  std::string toString() const override { return ""; }
+  float typeIndex() const override { return 1.f; }
 };
 
 //******************************************************************************

--- a/toonz/sources/stdfx/CMakeLists.txt
+++ b/toonz/sources/stdfx/CMakeLists.txt
@@ -290,6 +290,7 @@ set(SOURCES
     iwa_flowblurfx.cpp
     iwa_flowpaintbrushfx.cpp
     iwa_motionflowfx.cpp
+    iwa_smootherfx.cpp
 )
 
 if(OpenCV_FOUND)

--- a/toonz/sources/stdfx/iwa_smootherfx.cpp
+++ b/toonz/sources/stdfx/iwa_smootherfx.cpp
@@ -1,0 +1,125 @@
+/*-----------------------------------------------------------------------------
+ Iwa_SmootherFx
+ 二値画像にスムージングをかける
+ -------------------------------------------------------------------------------*/
+
+#include "stdfx.h"
+#include "tfxparam.h"
+
+#include "timage_io.h"
+#include "trop.h"
+
+//=============================================================================
+
+class Iwa_SmootherFx final : public TStandardRasterFx {
+  FX_PLUGIN_DECLARATION(Iwa_SmootherFx)
+
+  TRasterFxPort m_input;
+  TIntParamP m_threshold;
+  TDoubleParamP m_softness;
+
+  TAffine m_levelColumnAff;
+
+public:
+  Iwa_SmootherFx() : m_threshold(10), m_softness(50) {
+    bindParam(this, "threshold", m_threshold);
+    bindParam(this, "softness", m_softness);
+    addInputPort("Source", m_input);
+    m_threshold->setValueRange(0, 256);
+    m_softness->setValueRange(0., 100.);
+  }
+
+  ~Iwa_SmootherFx() {};
+
+  bool doGetBBox(double frame, TRectD& bBox,
+                 const TRenderSettings& info) override {
+    if (m_input.isConnected())
+      return m_input->doGetBBox(frame, bBox, info);
+    else {
+      bBox = TRectD();
+      return false;
+    }
+  }
+
+  void doCompute(TTile& tile, double frame, const TRenderSettings& ri) override;
+  bool canHandle(const TRenderSettings& info, double frame) override {
+    return false;
+  }
+  void doDryCompute(TRectD& rect, double frame,
+                    const TRenderSettings& info) override;
+};
+
+//------------------------------------------------------------------------------
+
+void Iwa_SmootherFx::doCompute(TTile& tile, double frame,
+                               const TRenderSettings& ri) {
+  if (!m_input.isConnected()) return;
+
+  int threshold   = m_threshold->getValue();
+  double softness = m_softness->getValue(frame);
+
+  TTile tileIn;
+  TRenderSettings new_sets(ri);
+
+  new_sets.m_affine = m_levelColumnAff.inv();
+
+  TAffine rev_aff     = ri.m_affine * new_sets.m_affine.inv();
+  TAffine rev_aff_inv = rev_aff.inv();
+  TRasterP tileRas(tile.getRaster());
+  TRectD tileRect(convert(tileRas->getBounds()) + tile.m_pos);
+
+  TPointD p00 = rev_aff_inv * tileRect.getP00();
+  TPointD p01 = rev_aff_inv * tileRect.getP01();
+  TPointD p10 = rev_aff_inv * tileRect.getP10();
+  TPointD p11 = rev_aff_inv * tileRect.getP11();
+  TRect in_rect;
+  in_rect.x0 = tfloor(std::min({p00.x, p10.x, p01.x, p11.x}));
+  in_rect.y0 = tfloor(std::min({p00.y, p10.y, p01.y, p11.y}));
+  in_rect.x1 = tceil(std::max({p00.x, p10.x, p01.x, p11.x}));
+  in_rect.y1 = tceil(std::max({p00.y, p10.y, p01.y, p11.y}));
+
+  m_input->allocateAndCompute(
+      tileIn, TPointD(in_rect.getP00().x, in_rect.getP00().y),
+      in_rect.getSize(), tile.getRaster(), frame, new_sets);
+
+  TRasterP inRas = tileIn.getRaster();
+  TRasterP aaRas = inRas->clone();
+  //! Inserts antialias around jaggy lines. Threshold is a pixel distance
+  //! intended from 0 to 256. Softness may vary from 0 to 100.
+  TRop::antialias(aaRas, inRas, threshold, softness);
+
+  TRenderSettings rev_sets(ri);
+  rev_sets.m_affine = rev_aff;
+  TRasterFx::applyAffine(tile, tileIn, rev_sets);
+}
+
+//------------------------------------------------------------------------------
+
+void Iwa_SmootherFx::doDryCompute(TRectD& rect, double frame,
+                                  const TRenderSettings& info) {
+  TRenderSettings ri(info);
+
+  LevelColumnAffineFxRenderData* levelColumnData;
+  bool found = false;
+  for (auto data : ri.m_data) {
+    levelColumnData =
+        dynamic_cast<LevelColumnAffineFxRenderData*>(data.getPointer());
+    if (levelColumnData) {
+      levelColumnData->m_isSet = false;
+      found                    = true;
+      break;
+    }
+  }
+  if (!found) {
+    levelColumnData = new LevelColumnAffineFxRenderData();
+    ri.m_data.push_back(levelColumnData);
+  }
+
+  TRasterFx::doDryCompute(rect, frame, ri);
+
+  if (levelColumnData->m_isSet) m_levelColumnAff = levelColumnData->m_aff;
+}
+
+//------------------------------------------------------------------------------
+
+FX_PLUGIN_IDENTIFIER(Iwa_SmootherFx, "iwa_SmootherFx");


### PR DESCRIPTION
This PR will introduce a new fx; Smoother Fx Iwa which is to apply antialiasing on the binalized image.

To apply anti-aliasing to level images, OT already has an option “Level Settings -> Add Antialiasing”.
However, when you want to make part of a level image semi-transparent (which is often the case for character shadows, for example), you need to use RGB Key Fx on the binary state image without anti-aliasing to extract the area.

This Fx is used to apply anti-aliasing to a binary level image AFTER performing necessary processing such as RGB Key.

The key feature of this effect is that it acquires the source level image at a pixel-perfect (“non-resampled”) size, performs anti-aliasing , and then resamples it as needed.

### EXAMPLE
#### Source image (binarized TGA)
<img height="250" alt="image" src="https://github.com/user-attachments/assets/aefadfb7-f325-47c5-a2b7-3c0507cf6e70" />

####  1. With conventional method
<img height="200" alt="image" src="https://github.com/user-attachments/assets/70680a79-e7fa-4bc9-98fc-f7152707bb17" />
<img height="450" alt="image" src="https://github.com/user-attachments/assets/59eff666-fa11-4058-af20-a56967c63f0d" />

####  2. With Smoother Fx Iwa 
<img height="200" alt="image" src="https://github.com/user-attachments/assets/dd5b9c8b-1bc8-43d3-8bd4-44081d05150e" />
<img height="450" alt="image" src="https://github.com/user-attachments/assets/a39a2661-95e4-4f22-afcf-5bf52ec77eb2" />


### PARAMETERS
- **Threshold** : The difference of the color channel value (0-255) recognized as the boundary for applying anti-aliasing. At the default value (10), it behaves the same as the Add Antialiasing option in Level Settings.
- **Softness** : Behaves the same as the Antialias Softness in the Level Settings.