### PR TITLE
Fix dummy ink pixel (Tone =255) ink texture crash

### DIFF
--- a/toonz/sources/common/trop/tropcm.cpp
+++ b/toonz/sources/common/trop/tropcm.cpp
@@ -367,7 +367,8 @@ TRasterP putSingleInkInRasterGR8(TRasterCM32P &rasIn, int inkId) {
     if (rasOut) pixOut = rasOut->pixels(y);
 
     while (pixIn < endPix) {
-      if (pixIn->getInk() == inkId) {
+      if (pixIn->getTone() != TPixelCM32::getMaxTone() &&
+          pixIn->getInk() == inkId) {
         assert(TPixelCM32::getMaxTone() == 0xff);
         if (!rasOut) {
           rasOut = TRasterGR8P(rasIn->getLx(), rasIn->getLy());
@@ -399,7 +400,8 @@ TRasterP putSingleInkInRasterRGBM(TRasterCM32P &rasIn, int inkId) {
     if (rasOut) pixOut = rasOut->pixels(y);
 
     while (pixIn < endPix) {
-      if (pixIn->getInk() == inkId) {
+      if (pixIn->getTone() != TPixelCM32::getMaxTone() &&
+          pixIn->getInk() == inkId) {
         assert(TPixelCM32::getMaxTone() == 0xff);
         if (!rasOut) {
           rasOut = TRaster32P(rasIn->getLx(), rasIn->getLy());

--- a/toonz/sources/toonzlib/imagestyles.cpp
+++ b/toonz/sources/toonzlib/imagestyles.cpp
@@ -967,7 +967,9 @@ bool TTextureStyle::doCompute(const Params &params) const {
     if (m_params.m_type == TTextureParams::AUTOMATIC) {
       TRect bBox;
       TRop::computeBBox(r, bBox);
-
+      
+      // Just in case of empty raster
+      if (bBox.isEmpty()) bBox = TRect(0,0,1,1);
       r = r->extract(bBox);
       p += r->getCenter() - computeCentroid(r);
     }


### PR DESCRIPTION
The crash is reported by user.

I can't reproduce the crash since it disappear very quickly if you draw something on the level,
but here is the scene that caused the crash:
[one-pixel-crash.zip](https://github.com/user-attachments/files/22576246/one-pixel-crash.zip)

Click on preview to trigger the crash, and the reason seems related to this single pixel:
<img width="650" height="503" alt="图片" src="https://github.com/user-attachments/assets/a8fcc768-53f2-43f6-9ddd-dde25ce810ad" />
