### PR TITLE
fill holes: adjust the size to not limited(but still suggest a range of 1~25)

### DIFF
--- a/toonz/sources/toonz/fillholespopup.cpp
+++ b/toonz/sources/toonz/fillholespopup.cpp
@@ -51,7 +51,7 @@ FillHolesDialog::FillHolesDialog() : Dialog(0, true, true, "Fill Small Holes") {
   setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
 
   beginVLayout();
-  m_size = new IntField(this);
+  m_size = new IntField(this,false);
   m_size->setRange(1, 25);
   m_size->setValue(5);
   addWidget(tr("Size"), m_size);


### PR DESCRIPTION
So that user can type the value more than 25:
<img width="260" height="131" alt="图片" src="https://github.com/user-attachments/assets/87e769c5-3226-4075-8168-662f44c7ca0d" />

## How to test
Try to type a value that above 25, but it might be slow to fill.