### PR TITLE
[WIP] Fix scene assets importing

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1836,7 +1836,7 @@ bool IoCmd::loadScene(ToonzScene &scene, const TFilePath &scenePath,
   if (scene.getProject()->getProjectPath() !=
       currentProject->getProjectPath()) {
     ResourceImportDialog resourceLoader;
-    // resourceLoader.setImportEnabled(true);
+    resourceLoader.setImportEnabled(import);
     ResourceImporter importer(&scene, currentProject, resourceLoader);
     SceneResources resources(&scene, scene.getXsheet());
     resources.accept(&importer);
@@ -1916,7 +1916,7 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
             "The Scene '%1' belongs to project '%2'.\nWhat do you want to do?")
             .arg(QString::fromStdWString(scenePath.getWideString()))
             .arg(sceneProjectName);
-    QString importAnswer        = QObject::tr("Import Scene");
+    QString importAnswer        = QObject::tr("Import Scene"); 
     QString switchProjectAnswer = QObject::tr("Change Project");
     QString cancelAnswer        = QObject::tr("Cancel");
     int ret = DVGui::MsgBox(question, importAnswer, switchProjectAnswer,
@@ -1967,7 +1967,15 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
     if (!scene->getProject() || scene->getProject()->getProjectPath() !=
                                     currentProject->getProjectPath()) {
       ResourceImportDialog resourceLoader;
-      // resourceLoader.setImportEnabled(true);
+      QString question =
+          QObject::tr(
+              "What do you want to do to the assets of the imported scene?")
+              .arg(QString::fromStdWString(scenePath.getWideString()));
+      QString importAnswer      = QObject::tr("Import All Assets to the project");
+      QString useAbsoluteAnswer = QObject::tr("Use Absolute Path");
+      int ret = DVGui::MsgBox(question, importAnswer, useAbsoluteAnswer, 0);
+
+      resourceLoader.setImportEnabled(ret == 1);
       ResourceImporter importer(scene, currentProject, resourceLoader);
       SceneResources resources(scene, scene->getXsheet());
       resources.accept(&importer);
@@ -2760,7 +2768,7 @@ bool IoCmd::importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
                      .arg(toQString(levelPath)));
     return false;
   }
-  return true; 
+  return true;
 }
 
 // Use double value DPI as policy


### PR DESCRIPTION
# Summery

There are 3 ways to transport scene's assets from a project/standalone scene to another project:
- Import a scene from outside
- Exporting a inside scene to an outside project
- Copy the scene file to the new project and reassign levels' path in the scene

The exporting function works: It copy the scene and assets to new project, and replace the absolute path with the alias path.
But importing function is broken for some reason: It only copy the scene file, won't copy the assets and they all leave absolute path.

This PR added back the feature of importing assets when importing the scene, but since importing and exporting use shared logic/function, but of them need to test.

# How to test
Test all feature related to scene loading and importing.
- Try to use the command `File>Load Scene` to load an outside scene and select to import it
- Try to `Load Scene` from OT's file browser
- Try to `Import Scene` from OT's file browser
- Try to `Export Scene` to other projects

# Something need to consider
After this recovery the `collectAssets()` in `exportscenepopup.cpp` is not necessary for exporting scene to project any more, because `loadSceneToProject()` will import all the assets now, but it won't affect the result as it's just doing the collecting/importing again.(collect equals import in this case)
I think it's possible to remove `collectAssets()` if export to project in export scene popup, and rename `loadSceneToProject()` to `importSceneToProject()`.
These adjustment must wait for #6157, but do not prevent the merge of this PR, since they are just refactoring.
I'll make the adjustment if #6157 is merged first.