### PR TITLE
Optimize the Tape Tool and the Gap Close feature of Fill tool

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -2297,6 +2297,7 @@ void FillTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
         invalidate();
         return;
       }
+      computeRefImgsIfNeeded(params);
       std::string imgId =
           m_application ? m_level.getPointer()->getImageId(getCurrentFid(), 0)
                         : "";

--- a/toonz/sources/toonzlib/autoclose.cpp
+++ b/toonz/sources/toonzlib/autoclose.cpp
@@ -199,7 +199,7 @@ TRasterGR8P fillByteRaster(const TRasterCM32P &r, TRasterGR8P &bRaster) {
 
 #define SET_INK                                                                \
   if (buf->getTone() == buf->getMaxTone())                                     \
-    *buf = TPixelCM32(inkIndex, 0, 255 - opacity);
+    *buf = TPixelCM32(inkIndex, buf->getPaint(), 255 - opacity);
 // Check if a segment needs to be closed
 // Return true ¡ú needs closure; false ¡ú no closure needed
 bool needCloseSegment(const TRasterCM32P &r, const TAutocloser::Segment &s) {


### PR DESCRIPTION
# What this PR changes?
- [Recompute refer image and gap close when dragging to fill](https://github.com/opentoonz/opentoonz/commit/dec4d02910a7cce6e20135679a6d17f1b529637b)
- [Do not clear the paint when adding gap close lines](https://github.com/opentoonz/opentoonz/commit/2e7b64b070725046a316beede56839a17cfafd90)
They are really minor changes, that can't easily be noticed.

# How to test
- Create region that there are multiple gap close lines inside it, and drag to fill all these area, there should not remain line residue
- Fill the entire image with a not \#0 style, and then apply tape tool, there should not remain line residue