### PR TITLE
fix: Preview not Updating for New Toonz Raster Levels editted with Fill Tool

### DIFF
--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -296,9 +296,9 @@ LevelCreatePopup::LevelCreatePopup()
   //---- signal-slot connections
   bool ret = true;
   ret      = ret && connect(m_levelTypeOm, SIGNAL(currentIndexChanged(int)),
-                       SLOT(onLevelTypeChanged(int)));
+                            SLOT(onLevelTypeChanged(int)));
   ret      = ret && connect(m_frameFormatBtn, SIGNAL(clicked()), this,
-                       SLOT(onFrameFormatButton()));
+                            SLOT(onFrameFormatButton()));
   ret      = ret && connect(okBtn, SIGNAL(clicked()), this, SLOT(onOkBtn()));
   ret      = ret && connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
   ret =
@@ -642,6 +642,12 @@ bool LevelCreatePopup::apply() {
       ti->setDpi(dpi, dpi);
       sl->setFrame(fid, ti);
       ti->setSavebox(TRect(0, 0, xres - 1, yres - 1));
+
+      // This update should be called at least once, or it won't be rendered
+      // Almost every level tool will call ToolUtils::updateSavebox() to update
+      // But since fill tool tend to not update the savebox, we call it here
+      TImageInfo* info = sl->getFrameInfo(fid, true);
+      ImageBuilder::setImageInfo(*info, ti.getPointer());
     } else if (lType == OVL_XSHLEVEL) {
       TRaster32P raster(xres, yres);
       raster->clear();


### PR DESCRIPTION
This PR adds image info to ImageBuilder when creating new toonz raster levels.

This initialization behavior is usually always called by `ToolUtils::updateSaveBox()` when tools edits current level, but for `Fill Tool` it's not very good to update every with both preferences `Tools>Use the TLV Savebox to Limit Filling Operations` and `Minimize Savebox after Editing` ON.
Because it may minmize the savebox and cause it impossible to fill outside of the savebox or cuase the unintended expend of savebox if user adjusted the savebox manually to limit the filling.

So the old code checks if one corner of 4 corners in the image is changed to decide whether updating the savebox to avoid the trigger of `updateSaveBox()`,
I refactored the logic to check the bbox of tileSets (which would be used for undo) to decide whether updating the savebox so that the savebox won't update when the fill just triggered one corner.
Ref: #6113 

But this caused an issue:
The default savebox of the image is the resolution of image, so fill tool won't update since it's always larger than or equal to the filled area. This leads to the image remaining uninitialized.

This PR resolved the issue by initializing the ImageBuilder when toonz raster level first created : )