### PR TITLE
ci: Remove the 'brew unlink qt' step from the macOS workflow

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -3,11 +3,11 @@ name: MacOS Build
 on:
   push:
     paths:
-      - '**/*'                   # Include all files in the repository
-      - '!appveyor.yml'          # Ignore changes in AppVeyor
-      - '!README.md'             # Exclude README
-      - '!doc/**'                # Exclude documentation
-      - '!**/.github/**'         # Exclude everything in .github folder
+      - '**/*'                                  # Include all files in the repository
+      - '!appveyor.yml'                         # Ignore changes in AppVeyor
+      - '!README.md'                            # Exclude README
+      - '!doc/**'                               # Exclude documentation
+      - '!**/.github/**'                        # Exclude everything in .github folder
       - '.github/workflows/workflow_macos.yml'  # Include MacOs workflow file
   pull_request:
     paths:
@@ -20,7 +20,7 @@ on:
 
 jobs:
   macOS:
-    timeout-minutes: 90 # Stop job if it exceeds expected build time
+    timeout-minutes: 120 # Stop job if it exceeds expected build time
     # GHA are sunsetting support for macOS 13 (Intel & Apple Silicon/arm) & will be fully unsupported on (December 4th 2025),
     # See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ & https://github.com/actions/runner-images/issues/13046
     # (Septemer 19th 2025) - Replacing `macos-13` runner image with the new `macos-15-intel` runner image to maintain macOS (Intel x64) support.
@@ -60,7 +60,6 @@ jobs:
           brew update
           brew cleanup
           checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv openjph openexr qt@5
-          brew unlink qt
       - name: Set up cache
         run: |
           export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
Since the build process already uses explicit paths via `brew --prefix qt@5`, unlinking the default qt formula is unnecessary and could lead to errors.

Homebrew installs `qt@5` as keg-only, and all references in the workflow explicitly use its path, so `brew unlink qt` is redundant.