### PR TITLE
Fix SVG import crash with non-ASCII file paths on Windows

### DIFF
--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -1793,7 +1793,15 @@ struct NSVGimage *nsvgParseFromFile(const char *filename) {
   char *data              = NULL;
   struct NSVGimage *image = NULL;
 
+#if defined(_WIN32)
+  wchar_t wfilename[1024];
+  if (MultiByteToWideChar(CP_UTF8, 0, filename, -1, wfilename, 1024) > 0) {
+      fp = _wfopen(wfilename, L"rb");
+  }
+#else
   fp = fopen(filename, "rb");
+#endif
+  
   if (!fp) goto error;
   fseek(fp, 0, SEEK_END);
   size = ftell(fp);

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1057,7 +1057,7 @@ TFilePath ToonzScene::getImportedLevelPath(const TFilePath path) const {
 
 //-----------------------------------------------------------------------------
 
-/* tzp,tzu->tlv */
+/* tzp,tzu->tlv, svg->pli */
 bool ToonzScene::convertLevelIfNeeded(TFilePath &levelPath) {
   LevelType ltype = getLevelType(levelPath);
   TFilePath fp    = levelPath;


### PR DESCRIPTION
Here are some non-ASCII characters as examples:
- 中文
- 日本語