### PR TITLE
Revise UI terms for fill region and gap close options

### DIFF
--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -144,7 +144,7 @@ public:
       , m_inkIndex("Style Index:", L"current")  // W_ToolOptions_InkIndex
       , m_opacity("Opacity:", 1, 255, 255)
       , m_multi("Frame Range", false)  // W_ToolOptions_FrameRange
-      , m_ignoreAP("Ignore AutoPaint Inks", false)
+      , m_ignoreAP("Ignore AutoPaint Lines", false)
       , m_selecting(false)
       , m_selectingRect()
       , m_firstRect()

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1318,8 +1318,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // removed
       {FillOnlysavebox, tr("Use the TLV Savebox to Limit Filling Operations")},
       {DefRegionWithPaint,
-       tr("Define filling region with both PAINT and INK")},
-      { ReferFillPrevailing, tr("Paint under/over INK in refer fill") },
+       tr("Define Filling Region Using both Lines and Areas")},
+      { ReferFillPrevailing, tr("Paint Under Lines in Refer Fill and Gap Close") },
       {multiLayerStylePickerEnabled,
        tr("Multi Layer Style Picker: Switch Levels by Picking")},
       {cursorBrushType, tr("Basic Cursor Type:")},


### PR DESCRIPTION
| Option/Preference | Before | After |
| ----- | ----- | ----- |
| Tape Tool Option | Ignore AutoPaint Inks | Ignore AutoPaint Lines |
| Tools Preference | Define filling region with both PAINT and INK | Define Filling Region Using both Lines and Areas |
| Tools Preference | Paint under/over INK in refer fill | Paint Under Lines in Refer Fill and Gap Close |