### PR TITLE
Set proper window flag on preferences pop-up for Mac OSX

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1615,6 +1615,10 @@ PreferencesPopup::PreferencesPopup()
   }
   setLayout(mainLayout);
 
+#ifdef MACOSX
+  setWindowFlags(Qt::Tool);
+#endif
+
   bool ret = connect(categoryList, SIGNAL(currentRowChanged(int)),
                      stackedWidget, SLOT(setCurrentIndex(int)));
 


### PR DESCRIPTION
The majority of pop up windows such as AdjustLevelsPopup are children of DVGui::Dialog which sets the the window flag of the QDialog to Qt::Tool which prevents the panels such as timeline from covering the window all the time. I added this to the constructor of preferencepopup to mirror the behavior.

Closes #5863
