### PR TITLE
Fix brush size input for non-English locales

### DIFF
--- a/toonz/sources/include/toonzqt/doublefield.h
+++ b/toonz/sources/include/toonzqt/doublefield.h
@@ -60,6 +60,8 @@ protected:
   void mousePressEvent(QMouseEvent *) override;
   void mouseMoveEvent(QMouseEvent *) override;
   void mouseReleaseEvent(QMouseEvent *) override;
+  // Override the keyPressEvent to allow users to type a comma as a decimal separator.
+  void keyPressEvent(QKeyEvent *event) override;
 
 signals:
   /*! To emit when value change. */

--- a/toonz/sources/toonzqt/doublefield.cpp
+++ b/toonz/sources/toonzqt/doublefield.cpp
@@ -1,6 +1,9 @@
 
 
 #include <math.h>
+#include <array>
+#include <QtGlobal>
+
 #include "toonzqt/doublefield.h"
 #include "toonzqt/dvdialog.h"
 #include "tunit.h"
@@ -22,20 +25,22 @@ void DoubleValueLineEdit::focusOutEvent(QFocusEvent *e) {
   getRange(minValue, maxValue);
 
   bool isOutOfRange;
-  /*---誤差を吸収する---*/
+  // Absorb rounding errors
   MeasuredDoubleLineEdit *lineEdit =
       qobject_cast<MeasuredDoubleLineEdit *>(this);
   if (lineEdit) {
     int decimal  = lineEdit->getDecimals();
-    isOutOfRange = (value < minValue - pow(0.1, decimal + 1) ||
-                    value > maxValue + pow(0.1, decimal + 1));
-  } else
+    isOutOfRange = (value < minValue - std::pow(0.1, decimal + 1) ||
+                    value > maxValue + std::pow(0.1, decimal + 1));
+  } else {
     isOutOfRange = (value < minValue || value > maxValue);
+  }
 
   if (isOutOfRange) {
     setValue(tcrop(value, minValue, maxValue));
     emit editingFinished();
   }
+
   QLineEdit::focusOutEvent(e);
   m_isTyping = false;
 }
@@ -46,6 +51,7 @@ void DoubleValueLineEdit::mousePressEvent(QMouseEvent *e) {
   if (e->buttons() == Qt::MiddleButton) {
     m_xMouse           = e->x();
     m_mouseDragEditing = true;
+    e->accept();
   } else {
     QLineEdit::mousePressEvent(e);
     if (!m_isTyping) {  // only the first click will select all
@@ -58,24 +64,42 @@ void DoubleValueLineEdit::mousePressEvent(QMouseEvent *e) {
 //-----------------------------------------------------------------------------
 
 void DoubleValueLineEdit::mouseMoveEvent(QMouseEvent *e) {
-  if (e->buttons() == Qt::MiddleButton) {
+  if (m_mouseDragEditing && (e->buttons() & Qt::MiddleButton)) {
     setValue(getValue() + ((e->x() - m_xMouse) / 2));
     m_xMouse = e->x();
     emit valueChanged();
-  } else
+    e->accept();
+  } else {
     QLineEdit::mouseMoveEvent(e);
+  }
 }
 
 //-----------------------------------------------------------------------------
 
 void DoubleValueLineEdit::mouseReleaseEvent(QMouseEvent *e) {
-  if ((e->buttons() == Qt::NoButton && m_mouseDragEditing)) {
+  if (m_mouseDragEditing && e->buttons() == Qt::NoButton) {
     m_mouseDragEditing = false;
     clearFocus();
-  } else
+    e->accept();
+  } else {
     QLineEdit::mouseReleaseEvent(e);
+  }
 }
 
+//-----------------------------------------------------------------------------
+
+void DoubleValueLineEdit::keyPressEvent(QKeyEvent *event) {
+    // Allow users to type comma as decimal separator by converting it to a dot.
+    if (event->text() == ",") {
+        QKeyEvent dotEvent(QEvent::KeyPress, Qt::Key_Period, Qt::NoModifier, ".");
+        QLineEdit::keyPressEvent(&dotEvent);
+    } else if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+        emit editingFinished();
+        clearFocus();
+    } else {
+        QLineEdit::keyPressEvent(event);
+    }
+}
 //=============================================================================
 // DoubleValueField
 //-----------------------------------------------------------------------------
@@ -95,13 +119,13 @@ DoubleValueField::DoubleValueField(QWidget *parent,
 
   field->setMaximumWidth(100);
 
-  //---layout
+  //---- layout
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0,0,0,0);
   layout->setSpacing(5);
   {
     QVBoxLayout *vLayout = new QVBoxLayout(field);
-    vLayout->setMargin(0);
+    vLayout->setContentsMargins(0,0,0,0);
     vLayout->setSpacing(0);
     {
       vLayout->addWidget(m_lineEdit);
@@ -112,7 +136,7 @@ DoubleValueField::DoubleValueField(QWidget *parent,
   }
   setLayout(layout);
 
-  //----signal/slot connections
+  //---- signal/slot connections
   bool ret = true;
   ret      = ret && connect(m_lineEdit, SIGNAL(valueChanged()),
                        SLOT(onLineEditValueChanged()));
@@ -120,11 +144,11 @@ DoubleValueField::DoubleValueField(QWidget *parent,
                        SLOT(onRollerValueChanged(bool)));
   ret      = ret && connect(m_slider, SIGNAL(valueChanged(int)),
                        SLOT(onSliderChanged(int)));
-  ret      = ret &&
-        connect(m_slider, SIGNAL(sliderReleased()), SLOT(onSliderReleased()));
-  ret = ret && connect(m_lineEdit, SIGNAL(editingFinished()), this,
+  ret      = ret && connect(m_slider, SIGNAL(sliderReleased()),
+                       SLOT(onSliderReleased()));
+  ret      = ret && connect(m_lineEdit, SIGNAL(editingFinished()), this,
                        SIGNAL(valueEditedByHand()));
-  ret = ret && connect(m_slider, SIGNAL(sliderReleased()), this,
+  ret      = ret && connect(m_slider, SIGNAL(sliderReleased()), this,
                        SIGNAL(valueEditedByHand()));
   assert(ret);
 
@@ -133,7 +157,7 @@ DoubleValueField::DoubleValueField(QWidget *parent,
   layout->addWidget(m_spaceWidget, 1, Qt::AlignLeft);
 
   setRange(-100.0, 100.0);
-  
+
   double value = getValue();
   m_roller->setValue(value);
   m_slider->setValue(value2pos(value));
@@ -142,30 +166,40 @@ DoubleValueField::DoubleValueField(QWidget *parent,
 //-----------------------------------------------------------------------------
 
 double DoubleValueField::pos2value(int x) const {
-  int dicimal = m_lineEdit->getDecimals();
-  if (m_isLinearSlider) return (double)x * pow(0.1, dicimal);
+  const int decimal = m_lineEdit->getDecimals();
+  if (m_isLinearSlider) return static_cast<double>(x) * std::pow(0.1, decimal);
 
-  // nonlinear slider case
-  double rangeSize = (double)(m_slider->maximum() - m_slider->minimum());
-  double posRatio  = (double)(x - m_slider->minimum()) / rangeSize;
-  double t;
-  if (posRatio <= 0.5)
-    t = 0.04 * posRatio;
-  else if (posRatio <= 0.75)
-    t = -0.02 + 0.08 * posRatio;
-  else if (posRatio <= 0.9)
-    t = -0.26 + 0.4 * posRatio;
-  else
-    t = -8.0 + 9.0 * posRatio;
-  double sliderValue = round((double)m_slider->minimum() + rangeSize * t);
-  return sliderValue * pow(0.1, dicimal);
+  // nonlinear slider case - use constexpr where is possible
+  static constexpr std::array<double, 4> thresholds{0.5, 0.75, 0.9, 1.0};
+  const double rangeSize = static_cast<double>(m_slider->maximum() - m_slider->minimum());
+  
+  // Safety check for zero range
+  if (std::abs(rangeSize) < std::numeric_limits<double>::epsilon()) {
+      return static_cast<double>(x) * std::pow(0.1, decimal);
+  }
+  
+  const double posRatio = static_cast<double>(x - m_slider->minimum()) / rangeSize;
+
+  double t = 0.0;
+  if (posRatio <= thresholds[0]) {
+      t = 0.04 * posRatio;
+  } else if (posRatio <= thresholds[1]) {
+      t = -0.02 + 0.08 * posRatio;
+  } else if (posRatio <= thresholds[2]) {
+      t = -0.26 + 0.4 * posRatio;
+  } else {
+      t = -8.0 + 9.0 * posRatio;
+  }
+
+  const double sliderValue = std::round(static_cast<double>(m_slider->minimum()) + rangeSize * t);
+  return sliderValue * std::pow(0.1, decimal);
 }
 
 //-----------------------------------------------------------------------------
 
 int DoubleValueField::value2pos(double v) const {
-  int dicimal        = m_lineEdit->getDecimals();
-  double sliderValue = round(v * pow(10., dicimal));
+  int decimal        = m_lineEdit->getDecimals();
+  double sliderValue = round(v * std::pow(10., decimal));
   if (m_isLinearSlider) return (int)sliderValue;
 
   // nonlinear slider case
@@ -196,9 +230,9 @@ void DoubleValueField::setRange(double minValue, double maxValue) {
 
   m_roller->setRange(minValue, maxValue);
 
-  int dicimal   = m_lineEdit->getDecimals();
-  int sliderMax = (int)round(maxValue * pow(10., dicimal));
-  int sliderMin = (int)round(minValue * pow(10., dicimal));
+  int decimal   = m_lineEdit->getDecimals();
+  int sliderMax = (int)round(maxValue * std::pow(10., decimal));
+  int sliderMin = (int)round(minValue * std::pow(10., decimal));
 
   m_slider->setRange(sliderMin, sliderMax);
 
@@ -208,13 +242,21 @@ void DoubleValueField::setRange(double minValue, double maxValue) {
 //-----------------------------------------------------------------------------
 
 void DoubleValueField::setValue(double value) {
-  if (m_lineEdit->getValue() == value) return;
+  if (!std::isfinite(value) || qFuzzyCompare(m_lineEdit->getValue() + 1.0, value + 1.0)) return;
+  double minValue, maxValue;
+  getRange(minValue, maxValue);
+  value = std::clamp(value, minValue, maxValue);
+  bool signalsBlocked = m_slider->blockSignals(true);
   m_lineEdit->setValue(value);
   m_roller->setValue(value);
-  m_slider->setValue(value2pos(value));
-  // forzo il repaint... non sempre si aggiorna e l'update non sembra risolvere
-  // il ptroblema!!!
-  m_slider->repaint();
+  int newSliderPos = value2pos(value);
+  if (m_slider->value() != newSliderPos) {
+    m_slider->setValue(newSliderPos);
+    // Force repaint()... sometimes it doesn't update and update doesn't seem to solve the problem!!!
+    // try use update() for now
+    m_slider->update();
+  }
+  m_slider->blockSignals(signalsBlocked);
 }
 
 //-----------------------------------------------------------------------------
@@ -266,16 +308,13 @@ bool DoubleValueField::isRollerEnabled() { return m_roller->isEnabled(); }
 void DoubleValueField::onSliderChanged(int sliderPos) {
   double val = pos2value(sliderPos);
 
-  // Controllo necessario per evitare che il segnale di cambiamento venga emesso
-  // piu' volte.
-  if (m_lineEdit->getValue() == val ||
-      (m_roller->getValue() == val && m_roller->isVisible()))
+  // Control necessary to prevent the change signal from being emitted more than once.
+  if (qFuzzyCompare(m_lineEdit->getValue() + 1.0, val + 1.0) ||
+      (qFuzzyCompare(m_roller->getValue() + 1.0, val + 1.0) && m_roller->isVisible()))
     return;
   m_lineEdit->setValue(val);
   m_roller->setValue(val);
-  // Faccio in modo che il cursore sia sulla prima cifra, cosi' se la stringa
-  // da visualizzare e' piu' lunga del campo le cifre che vengono troncate sono
-  // le ultime e non le prime (dovrebbero essere quelle dopo la virgola).
+  // Make the cursor on the first digit, so if the string to display is longer than the field the digits that are truncated are the last ones and not the first (they should be the ones after the decimal point).
   m_lineEdit->setCursorPosition(0);
 
   emit valueChanged(true);
@@ -285,12 +324,11 @@ void DoubleValueField::onSliderChanged(int sliderPos) {
 
 void DoubleValueField::onLineEditValueChanged() {
   double value = m_lineEdit->getValue();
-  int dicimal  = m_lineEdit->getDecimals();
+  int decimal  = m_lineEdit->getDecimals();
 
-  // Control necessary to prevent the change signal from being emitted more than
-  // once.
-  if ((pos2value(m_slider->value()) == value && m_slider->isVisible()) ||
-      (m_roller->getValue() == value && m_roller->isVisible()))
+  // Control necessary to prevent the change signal from being emitted more than once.
+  if ((qFuzzyCompare(pos2value(m_slider->value()) + 1.0, value + 1.0) && m_slider->isVisible()) ||
+      (qFuzzyCompare(m_roller->getValue() + 1.0, value + 1.0) && m_roller->isVisible()))
     return;
   m_slider->setValue(value2pos(value));
   m_roller->setValue(value);
@@ -302,19 +340,18 @@ void DoubleValueField::onLineEditValueChanged() {
 void DoubleValueField::onRollerValueChanged(bool isDragging) {
   double value = m_roller->getValue();
 
-  if (value == m_lineEdit->getValue()) {
-    assert(pos2value(m_slider->value()) == value || !m_slider->isVisible());
-    // Se isDragging e' falso e' giusto che venga emessa la notifica di
-    // cambiamento.
+  if (qFuzzyCompare(value + 1.0, m_lineEdit->getValue() + 1.0)) {
+    assert(qFuzzyCompare(pos2value(m_slider->value()) + 1.0, value + 1.0) || !m_slider->isVisible());
+    // If isDragging is false, it's right that the change notification is emitted.
     if (!isDragging) emit valueChanged(isDragging);
     return;
   }
   m_slider->setValue(value2pos(value));
   m_lineEdit->setValue(value);
 
-  // Faccio in modo che il cursore sia sulla prima cifra, cosi' se la stringa
-  // da visualizzare e' piu' lunga del campo le cifre che vengono troncate sono
-  // le ultime e non le prime (dovrebbero essere quelle dopo la virgola).
+  // Make the cursor on the first digit, so if the string to display
+  // is longer than the field the digits that are truncated are the 
+  // last ones and not the first (they should be the ones after the decimal point).
   m_lineEdit->setCursorPosition(0);
 
   emit valueChanged(isDragging);
@@ -329,6 +366,8 @@ DoubleLineEdit::DoubleLineEdit(QWidget *parent, double value)
   m_validator =
       new QDoubleValidator(-(std::numeric_limits<double>::max)(),
                            (std::numeric_limits<double>::max)(), 5, this);
+  m_validator->setLocale(QLocale::c());
+
   setValidator(m_validator);
 
   setValue(value);
@@ -340,23 +379,25 @@ DoubleLineEdit::DoubleLineEdit(QWidget *parent, double value)
 //-----------------------------------------------------------------------------
 
 void DoubleLineEdit::setValue(double value) {
+  if (!std::isfinite(value)) return;
   double minValue, maxValue;
   getRange(minValue, maxValue);
-  if (value < minValue) value = minValue;
-  if (value > maxValue) value = maxValue;
+  value = std::clamp(value, minValue, maxValue);
   QString str;
   str.setNum(value);
-  setText(str);
-
-  // Faccio in modo che il cursore sia sulla prima cifra, cosi' se la stringa
-  // da visualizzare e' piu' lunga del campo le cifre che vengono troncate sono
-  // le ultime e non le prime (dovrebbero essere quelle dopo la virgola).
-  setCursorPosition(0);
+  int pos = 0;
+  if (m_validator->validate(str, pos) == QValidator::Acceptable) {
+    setText(str);
+    // Ensures only decimals are truncated, not leading digits.
+    setCursorPosition(0);
+  }
 }
 
 //-----------------------------------------------------------------------------
 
-double DoubleLineEdit::getValue() { return text().toDouble(); }
+double DoubleLineEdit::getValue() {
+  return QLocale::c().toDouble(text());
+}
 
 //-----------------------------------------------------------------------------
 
@@ -389,11 +430,12 @@ DoubleField::DoubleField(QWidget *parent, bool isRollerHide, int decimals)
     : DoubleValueField(parent, new DoubleLineEdit(0)) {
   if (isRollerHide) enableRoller(false);
 
-  DoubleLineEdit *lineEdit = dynamic_cast<DoubleLineEdit *>(m_lineEdit);
+  DoubleLineEdit *lineEdit = qobject_cast<DoubleLineEdit *>(m_lineEdit);
+  assert(lineEdit);
   lineEdit->setDecimals(decimals);
 
-  /*--rollerにもStepを設定--*/
-  if (!isRollerHide) m_roller->setStep(pow(0.1, decimals));
+  // Set step for roller too
+  if (!isRollerHide) m_roller->setStep(std::pow(0.1, decimals));
 }
 
 //=============================================================================
@@ -547,6 +589,7 @@ void MeasuredDoubleLineEdit::mousePressEvent(QMouseEvent *e) {
   if ((e->buttons() == Qt::MiddleButton) || m_labelClicked) {
     m_xMouse           = e->x();
     m_mouseDragEditing = true;
+    e->accept();
   } else {
     QLineEdit::mousePressEvent(e);
     if (!m_isTyping) {  // only the first click will select all
@@ -559,29 +602,32 @@ void MeasuredDoubleLineEdit::mousePressEvent(QMouseEvent *e) {
 //-----------------------------------------------------------------------------
 
 void MeasuredDoubleLineEdit::mouseMoveEvent(QMouseEvent *e) {
-  if ((e->buttons() == Qt::MiddleButton) || m_labelClicked) {
-    int precision = (m_maxValue > 100) ? 0 : ((m_maxValue > 10) ? 1 : 2);
+  if ((m_mouseDragEditing && (e->buttons() & Qt::MiddleButton)) || m_labelClicked) {
+    int precision = getDecimals();
     m_value->modifyValue((e->x() - m_xMouse) / 2, precision);
     m_xMouse = e->x();
     valueToText();
     m_modified = false;
-  } else
+    e->accept();
+  } else {
     QLineEdit::mouseMoveEvent(e);
+  }
 }
 
 //-----------------------------------------------------------------------------
 
 void MeasuredDoubleLineEdit::mouseReleaseEvent(QMouseEvent *e) {
-  if ((e->buttons() == Qt::NoButton && m_mouseDragEditing) || m_labelClicked) {
+  if ((m_mouseDragEditing && e->buttons() == Qt::NoButton) || m_labelClicked) {
     m_xMouse   = -1;
     m_modified = true;
     onEditingFinished();
     clearFocus();
     m_mouseDragEditing = false;
     m_labelClicked     = false;
-
-  } else
+    e->accept();
+  } else {
     QLineEdit::mouseReleaseEvent(e);
+  }
 }
 
 void MeasuredDoubleLineEdit::receiveMousePress(QMouseEvent *e) {
@@ -608,22 +654,20 @@ MeasuredDoubleField::MeasuredDoubleField(QWidget *parent, bool isRollerHide)
   if (isRollerHide) enableRoller(false);
 }
 
-///----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 void MeasuredDoubleField::setMeasure(std::string measureName) {
-  MeasuredDoubleLineEdit *lineEdit =
-      dynamic_cast<MeasuredDoubleLineEdit *>(m_lineEdit);
+  MeasuredDoubleLineEdit *lineEdit = qobject_cast<MeasuredDoubleLineEdit *>(m_lineEdit);
   assert(lineEdit);
   lineEdit->setMeasure(measureName);
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 void MeasuredDoubleField::setDecimals(int decimals) {
   MeasuredDoubleLineEdit *lineEdit =
       qobject_cast<MeasuredDoubleLineEdit *>(m_lineEdit);
   if (lineEdit) lineEdit->setDecimals(decimals);
-
-  /*--- rollerにもStepを設定 ---*/
-  if (isRollerEnabled()) m_roller->setStep(pow(0.1, std::max(decimals - 1, 1)));
+  // Set step for roller too
+  if (isRollerEnabled()) m_roller->setStep(std::pow(0.1, std::max(decimals - 1, 1)));
 }


### PR DESCRIPTION
This PR fixes the issue reported in #5471 where users with non-English system locales could not input decimal values in brush size fields. Neither dot (.) nor comma (,) worked to set decimal values, and the brush size didn’t update when typing these values.

English users are encouraged to test and verify that no unintended side effects occur due to this change.

Now, decimal values like 0.3 or 0,3 can be entered regardless of system language or locale. This is especially helpful in locales where the numeric keypad uses a comma as the decimal separator (e.g., pt-BR, fr-FR, es-ES), improving usability and input speed.

I replaced `m_slider->repaint();` with `m_slider->update();`. Apparently, `update()` had issues in Qt versions prior to 5.15, but these have since been fixed. It’s now the preferred approach in recent Qt versions to ensure the UI updates correctly without impacting performance.

Changes:

- Allow both comma and dot as decimal separators
- Ensure the brush size field updates correctly when typing decimal values
- Improve code quality using modern C++ features
- Standardize UI layout margins for consistency

Ref: #5471

**Ps:** I noticed that the Smooth field in the `vector level` rounds values when typing, which is unrelated to this PR. This may also happen with other fields and will need to be reviewed in the future.