### PR TITLE
Viewer Navigation Tools

### DIFF
--- a/toonz/sources/include/tools/toolcommandids.h
+++ b/toonz/sources/include/tools/toolcommandids.h
@@ -32,4 +32,9 @@
 #define T_Finger "T_Finger"
 #define T_EditAssistants "T_EditAssistants"
 
+// Viewer Navigation tools (available only during the shortcut key is pressed)
+#define T_ZoomView "T_ZoomView"
+#define T_RotateView "T_RotateView"
+#define T_HandView "T_HandView"
+
 #endif  // TOOL_COMMAND_IDS_H

--- a/toonz/sources/include/tools/toolhandle.h
+++ b/toonz/sources/include/tools/toolhandle.h
@@ -31,19 +31,9 @@ class QString;
 class DVAPI ToolHandle final : public QObject {
   Q_OBJECT
 
-  // Core tool state
   TTool *m_tool;
   QString m_toolName;
   int m_toolTargetType;
-
-  // Navigation state
-  struct NavigationState {
-    bool active = false;        // Whether navigation mode is active
-    QString originalTool;       // Tool to restore when exiting navigation
-    bool spacePressed = false;  // Space key state
-    bool shiftPressed = false;  // Shift key state
-    bool ctrlPressed  = false;  // Ctrl key state
-  } m_navState;
 
   QString m_storedToolName;
   QElapsedTimer m_storedToolTime;
@@ -60,17 +50,12 @@ public:
 
   const QString &getRequestedToolName() const { return m_toolName; }
 
-  // Navigation methods
-  void setSpacePressed(bool pressed);
-  void setShiftPressed(bool pressed);
-  void setCtrlPressed(bool pressed);
-  bool isSpacePressed() const { return m_navState.spacePressed; }
-  bool isNavigating() const { return m_navState.active; }
-
   // used to change tool for a short while (e.g. while keeping pressed a
   // short-key)
   void storeTool();
   void restoreTool();
+
+  bool isViewerNavigationToolSelected();
 
   // used to set a tool that is not listed in the toolbar (e.g. the
   // ShiftTraceTool).
@@ -87,11 +72,6 @@ public:
   void notifyToolComboBoxListChanged(std::string id) {
     emit toolComboBoxListChanged(id);
   }
-
-private:
-  // Navigation methods
-  void updateNavigationTool();  // Select appropriate navigation tool
-  void exitNavigation();        // Clean exit from navigation mode
 
 signals:
   void toolComboBoxListChanged(std::string);

--- a/toonz/sources/tnztools/toolhandle.cpp
+++ b/toonz/sources/tnztools/toolhandle.cpp
@@ -64,116 +64,33 @@ void ToolHandle::setTool(QString name) {
 
 //-----------------------------------------------------------------------------
 
-void ToolHandle::setSpacePressed(bool pressed) {
-  if (m_navState.spacePressed == pressed) return;
-
-  m_navState.spacePressed = pressed;
-
-  if (pressed) {
-    // Enter navigation mode
-    if (!m_navState.active) {
-      m_navState.active       = true;
-      m_navState.originalTool = m_toolName;
-    }
-
-    /**
-     * Check actual keyboard state to detect "buffered" modifier keys
-     * ______________________________________________________________
-     *
-     * Normally, we track modifier keys using 'setShiftPressed()' and
-     * 'setCtrlPressed()' when the user presses them. However, there's a case
-     * where a user [holds Shift or Ctrl before pressing Space]. In this case:
-     *
-     * - The Shift/Ctrl state might already be active 'before' space was pressed
-     * - If we don't check the keyboard state here, we'd assume Shift/Ctrl off
-     *  - This would result in the wrong tool being selected (e.g., T_Hand
-     * instead of T_Rotate)
-     *
-     * Example scenario:
-     * 1. User 'holds Shift' but 'setShiftPressed(true)' is not yet called
-     * 2. Pressed 'Space' -> navigation activates
-     * 3. If we don't check the keyboard here, we don't recognize Shift is held
-     * 4. The tool defaults to 'T_Hand' instead of 'T_Rotate' (incorrect!)
-     *
-     * This prevents that issue by explicitly checking what modifier keys are
-     * actually held.
-     */
-    m_navState.shiftPressed =
-        (QGuiApplication::queryKeyboardModifiers() & Qt::ShiftModifier) != 0;
-    m_navState.ctrlPressed =
-        (QGuiApplication::queryKeyboardModifiers() & Qt::ControlModifier) != 0;
-
-    updateNavigationTool(); // Select the correct tool based on modifiers
-  } else {
-    exitNavigation();
-  }
-}
-
-void ToolHandle::setShiftPressed(bool pressed) {
-  if (m_navState.shiftPressed == pressed) return;
-
-  m_navState.shiftPressed = pressed;
-
-  // If we're in navigation mode, update the tool selection
-  if (m_navState.active) {
-    updateNavigationTool();
-  }
-}
-
-void ToolHandle::setCtrlPressed(bool pressed) {
-  if (m_navState.ctrlPressed == pressed) return;
-
-  m_navState.ctrlPressed = pressed;
-
-  // If we're in navigation mode, update the tool selection
-  if (m_navState.active) {
-    updateNavigationTool();
-  }
-}
-
-void ToolHandle::updateNavigationTool() {
-  if (!m_navState.active) return;  // Only update if navigation mode is active
-
-  // Priority: Ctrl > Shift > Default (T_Hand)
-  if (m_navState.ctrlPressed) {
-    setTool("T_Zoom");
-  } else if (m_navState.shiftPressed) {
-    setTool("T_Rotate");
-  } else {
-    setTool("T_Hand");
-  }
-}
-
-void ToolHandle::exitNavigation() {
-  if (!m_navState.active) return;
-
-  // Restore the original tool before navigation mode was activated
-  if (!m_navState.originalTool.isEmpty()) {
-    setTool(m_navState.originalTool);
-    m_storedToolName = m_navState.originalTool;
-  }
-
-  // Reset navigation mode but PRESERVE modifier states for buffering
-  m_navState.active       = false;
-  m_navState.spacePressed = false;
-}
-
-//-----------------------------------------------------------------------------
-
 void ToolHandle::storeTool() {
-  m_storedToolName = m_toolName;
-  m_storedToolTime.start();
+  // navigation tools will not be stored
+  if (!isViewerNavigationToolSelected()) {
+    m_storedToolName = m_toolName;
+    m_storedToolTime.start();
+  }
 }
 
 //-----------------------------------------------------------------------------
 
 void ToolHandle::restoreTool() {
   // qDebug() << m_storedToolTime.elapsed();
+  // navigation tools will always return to the stored one even if the key press
+  // time is short
   if (m_storedToolName != m_toolName && m_storedToolName != "" &&
-      m_storedToolTime.elapsed() >
-          Preferences::instance()->getTempToolSwitchTimer()) {
+      (m_storedToolTime.elapsed() >
+           Preferences::instance()->getTempToolSwitchTimer() ||
+       isViewerNavigationToolSelected())) {
     setTool(m_storedToolName);
   }
+}
+
+//-----------------------------------------------------------------------------
+
+bool ToolHandle::isViewerNavigationToolSelected() {
+  return m_toolName == T_RotateView || m_toolName == T_ZoomView ||
+         m_toolName == T_HandView;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1681,12 +1681,12 @@ PaintbrushToolOptionsBox::PaintbrushToolOptionsBox(QWidget *parent, TTool *tool,
   m_selectiveMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Selective"));
   m_emptyOnlyMode =
-      dynamic_cast<ToolOptionCheckbox*>(m_controls.value("Empty Only"));
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Empty Only"));
 
   m_lockAlphaMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Lock Alpha"));
   m_FillingMode =
-      dynamic_cast<ToolOptionCheckbox*>(m_controls.value("Paint by Filling"));
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Paint by Filling"));
 
   if (m_colorMode->getProperty()->getValue() == L"Lines") {
     m_selectiveMode->setVisible(false);
@@ -2946,7 +2946,7 @@ void ToolOptions::onToolSwitched() {
   TTool *tool             = currTool->getTool();
 
   // Skip panel updates if we're in navigation mode
-  if (currTool && currTool->isSpacePressed()) {
+  if (currTool && currTool->isViewerNavigationToolSelected()) {
     return;
   }
 

--- a/toonz/sources/tnztools/viewtools.cpp
+++ b/toonz/sources/tnztools/viewtools.cpp
@@ -21,7 +21,8 @@ class ZoomTool final : public TTool {
   double m_factor;
 
 public:
-  ZoomTool() : TTool("T_Zoom"), m_dragging(false), m_oldX(0), m_factor(1) {
+  ZoomTool(std::string name)
+      : TTool(name), m_dragging(false), m_oldX(0), m_factor(1) {
     bind(TTool::AllTargets);
   }
 
@@ -31,10 +32,10 @@ public:
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override {
     if (!m_viewer) return;
-    m_dragging              = true;
-    int v                   = 1;
+    m_dragging = true;
+    int v      = 1;
     if (e.isAltPressed()) v = -1;
-    m_oldX                  = e.m_pos.x;
+    m_oldX = e.m_pos.x;
     // m_center = getViewer()->winToWorld(e.m_pos);
     m_center = TPointD(e.m_pos.x, e.m_pos.y);
     m_factor = 1;
@@ -81,7 +82,7 @@ public:
 
   int getCursorId() const override { return ToolCursor::ZoomCursor; }
 
-} zoomTool;
+} zoomTool("T_Zoom"), zoomViewTool("T_ZoomView");
 
 //=============================================================================
 // Hand Tool
@@ -92,7 +93,7 @@ class HandTool final : public TTool {
   TPointD m_oldPos;
 
 public:
-  HandTool() : TTool("T_Hand") { bind(TTool::AllTargets); }
+  HandTool(std::string name) : TTool(name) { bind(TTool::AllTargets); }
 
   ToolType getToolType() const override { return TTool::GenericTool; }
 
@@ -122,7 +123,7 @@ public:
 
   int getCursorId() const override { return ToolCursor::PanCursor; }
 
-} handTool;
+} handTool("T_Hand"), handViewTool("T_HandView");
 
 }  // namespace
 
@@ -130,8 +131,8 @@ public:
 // Rotate Tool
 //-----------------------------------------------------------------------------
 
-RotateTool::RotateTool()
-    : TTool("T_Rotate")
+RotateTool::RotateTool(std::string name)
+    : TTool(name)
     , m_dragging(false)
     , m_cameraCentered("Rotate On Camera Center", false)
     , m_angle(0) {
@@ -190,11 +191,11 @@ void RotateTool::draw() {
   if (m_cameraCentered.getValue())
     m_center = TPointD(0, 0);
   else {
-    TAffine aff                        = m_viewer->getViewMatrix().inv();
+    TAffine aff = m_viewer->getViewMatrix().inv();
     if (m_viewer->getIsFlippedX()) aff = aff * TScale(-1, 1);
     if (m_viewer->getIsFlippedY()) aff = aff * TScale(1, -1);
-    u                                  = u * sqrt(aff.det());
-    m_center                           = aff * TPointD(0, 0);
+    u        = u * sqrt(aff.det());
+    m_center = aff * TPointD(0, 0);
   }
   tglDrawSegment(TPointD(-u + m_center.x, m_center.y),
                  TPointD(u + m_center.x, m_center.y));
@@ -204,4 +205,4 @@ void RotateTool::draw() {
 
 int RotateTool::getCursorId() const { return ToolCursor::RotateCursor; }
 
-RotateTool rotateTool;
+RotateTool rotateTool("T_Rotate"), rotateViewTool("T_RotateView");

--- a/toonz/sources/tnztools/viewtools.h
+++ b/toonz/sources/tnztools/viewtools.h
@@ -24,7 +24,7 @@ class RotateTool final : public QObject, public TTool {
   TPropertyGroup m_prop;
 
 public:
-  RotateTool();
+  RotateTool(std::string name);
 
   ToolType getToolType() const override { return TTool::GenericTool; }
   void updateMatrix() override { return setMatrix(TAffine()); }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -505,7 +505,7 @@ void MainWindow::changeWindowTitle() {
                  QString::fromStdString(TEnv::getApplicationFullName());
 
   if (ShowBuildDateInTitle) {
-      name += " (built " __DATE__ " " __TIME__ ")";
+    name += " (built " __DATE__ " " __TIME__ ")";
   }
   setWindowTitle(name);
 }
@@ -1970,7 +1970,7 @@ void MainWindow::defineActions() {
                         "Replace Vectors with Simplified Vectors"),
       "");
   createMenuLevelAction(MI_FillHoles, QT_TR_NOOP("&Fill Holes..."), "",
-      "Fill small holes in Toonz Raster Level");
+                        "Fill small holes in Toonz Raster Level");
   createMenuLevelAction(MI_Tracking, QT_TR_NOOP("Tracking..."), "", "focus");
 
   // Menu - Xsheet
@@ -2548,6 +2548,11 @@ void MainWindow::defineActions() {
   createToolAction(T_Finger, "finger", QT_TR_NOOP("Finger Tool"), "");
   createToolAction(T_EditAssistants, "assistant", QT_TR_NOOP("Edit Assistants"),
                    "");
+  // Viewer Navigation tools (available only during the shortcut key is pressed)
+  createToolAction(T_ZoomView, "zoom", QT_TR_NOOP("Zoom View"), "Shift+Space");
+  createToolAction(T_RotateView, "rotate", QT_TR_NOOP("Rotate View"),
+                   "Ctrl+Space");
+  createToolAction(T_HandView, "hand", QT_TR_NOOP("Pan View"), "Space");
 
   /*-- Animate tool + mode switching shortcuts --*/
   createAction(MI_EditNextMode, QT_TR_NOOP("Animate Tool - Next Mode"), "",

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -429,15 +429,6 @@ void SceneViewer::onLeave() {
   if (CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked())
     TTool::getTool("T_ShiftTrace", TTool::ToonzImage)->onLeave();
 
-  // Reset navigation key states when mouse leaves viewer
-  // This prevents stuck states when keys are released while mouse is outside
-  ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
-  if (toolHandle) {
-    toolHandle->setSpacePressed(false);
-    toolHandle->setCtrlPressed(false);
-    toolHandle->setShiftPressed(false);
-  }
-
   update();
 }
 
@@ -528,7 +519,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     preEvent.m_button    = m_mouseButton;
     onRelease(preEvent);
   }
-  
+
   int devPixRatio = getDevPixRatio();
   QPointF curPos  = event.mousePos() * devPixRatio;
   bool cursorSet  = false;
@@ -623,8 +614,8 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     // grab screen picking for stop motion live view zoom
     if ((event.buttons() & Qt::LeftButton) &&
         StopMotion::instance()->m_canon->m_pickLiveViewZoom) {
-        StopMotion::instance()->m_canon->makeZoomPoint(pos);
-        return;
+      StopMotion::instance()->m_canon->makeZoomPoint(pos);
+      return;
     }
 #endif
     LocatorPopup *locator = TApp::instance()->getActiveLocator();
@@ -637,7 +628,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
       pos.x /= m_dpiScale.x;
       pos.y /= m_dpiScale.y;
     }
-    
+
     // qDebug() << "mouseMoveEvent. "  << (m_tabletEvent?"tablet":"mouse")
     //         << " pressure=" << m_pressure << " mouseButton=" << m_mouseButton
     //         << " buttonClicked=" << m_buttonClicked;
@@ -662,7 +653,7 @@ void SceneViewer::onMove(const TMouseEvent &event) {
     } else if (m_pressure == 0.0) {
       tool->mouseMove(pos, event);
     }
-    // Set the cursor of the current tool, 
+    // Set the cursor of the current tool,
     // when tool don't draw its own cursor (setToolCursor to None)
     if (!cursorSet) setToolCursor(this, tool->getCursorId());
 
@@ -1039,16 +1030,18 @@ void SceneViewer::wheelEvent(QWheelEvent *event) {
         CommandManager::instance()->execute("MI_PrevDrawing");
       }
     } else if (m_touchDevice == QTouchDevice::TouchPad) {
-        QPointF centerDelta = QPointF(event->angleDelta().x(), event->angleDelta().y());
-        panQt(centerDelta.toPoint());
-        m_panning = true;
+      QPointF centerDelta =
+          QPointF(event->angleDelta().x(), event->angleDelta().y());
+      panQt(centerDelta.toPoint());
+      m_panning = true;
     }
     // Mouse wheel zoom interfered with touchpad panning (touch enabled)
     // Now if touch is enabled, touchpads ignore the mouse wheel zoom
     else if ((m_gestureActive == true &&
               m_touchDevice == QTouchDevice::TouchScreen) ||
              m_gestureActive == false) {
-      zoomQt(event->position().toPoint() * getDevPixRatio(), exp(0.001 * delta));
+      zoomQt(event->position().toPoint() * getDevPixRatio(),
+             exp(0.001 * delta));
       m_panning = false;
     }
   }
@@ -1151,7 +1144,7 @@ void SceneViewer::touchEvent(QTouchEvent *e, int type) {
     // functional
     // on other devices, 1 finger panning is preferred
     if (e->touchPoints().count() == 1 &&
-         m_touchDevice == QTouchDevice::TouchScreen) {
+        m_touchDevice == QTouchDevice::TouchScreen) {
       QTouchEvent::TouchPoint panPoint = e->touchPoints().at(0);
       if (!m_panning) {
         QPointF deltaPoint = panPoint.pos() - m_firstPanPoint;
@@ -1292,7 +1285,7 @@ bool SceneViewer::event(QEvent *e) {
 
     // Disable keyboard shortcuts while the tool is busy with a mouse drag
     // operation.
-    if (tool->isDragging()) {
+    if (tool && tool->isDragging()) {
       e->accept();
     }
 
@@ -1423,212 +1416,177 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
   if (m_freezedStatus != NO_FREEZED) return;
   int key = event->key();
 
-  // Handle only initial key presses, not auto-repeat
-  if (!event->isAutoRepeat()) {
-    ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
-
-    switch (event->key()) {
-    case Qt::Key_Space:
-      toolHandle->setSpacePressed(true);
-      event->accept();
-      return;
-
-    case Qt::Key_Control:
-      toolHandle->setCtrlPressed(true);
-      event->accept();
-      return;
-
-    case Qt::Key_Shift:
-      toolHandle->setShiftPressed(true);
-      event->accept();
-      return;
-    }
-  }
-
-  // Check if we're in navigation mode before handling any other keys
-  ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
-  if (!toolHandle->isNavigating()) {
-    if (event->type() == QEvent::ShortcutOverride ||
-        event->type() == QEvent::KeyPress) {
-      if (!event->isAutoRepeat()) {
-        TApp::instance()->getCurrentTool()->storeTool();
-      }
-    }
-
-    // Handle Canon camera controls if enabled
+  // Handle Canon camera controls if enabled
 #ifdef WITH_CANON
-    if ((m_stopMotion->m_canon->m_pickLiveViewZoom ||
-         m_stopMotion->m_canon->m_zooming) &&
-        (key == Qt::Key_Left || key == Qt::Key_Right || key == Qt::Key_Up ||
-         key == Qt::Key_Down || key == Qt::Key_2 || key == Qt::Key_4 ||
-         key == Qt::Key_6 || key == Qt::Key_8)) {
-      // Handle camera zoom point adjustment
-      if (m_stopMotion->m_canon->m_liveViewZoomReadyToPick == true) {
-        if (key == Qt::Key_Left || key == Qt::Key_4) {
-          m_stopMotion->m_canon->m_liveViewZoomPickPoint.x -= 10;
-        }
-        if (key == Qt::Key_Right || key == Qt::Key_6) {
-          m_stopMotion->m_canon->m_liveViewZoomPickPoint.x += 10;
-        }
-        if (key == Qt::Key_Up || key == Qt::Key_8) {
-          m_stopMotion->m_canon->m_liveViewZoomPickPoint.y += 10;
-        }
-        if (key == Qt::Key_Down || key == Qt::Key_2) {
-          m_stopMotion->m_canon->m_liveViewZoomPickPoint.y -= 10;
-        }
-        if (m_stopMotion->m_canon->m_zooming) {
-          m_stopMotion->m_canon->setZoomPoint();
-        }
+  if ((m_stopMotion->m_canon->m_pickLiveViewZoom ||
+       m_stopMotion->m_canon->m_zooming) &&
+      (key == Qt::Key_Left || key == Qt::Key_Right || key == Qt::Key_Up ||
+       key == Qt::Key_Down || key == Qt::Key_2 || key == Qt::Key_4 ||
+       key == Qt::Key_6 || key == Qt::Key_8)) {
+    // Handle camera zoom point adjustment
+    if (m_stopMotion->m_canon->m_liveViewZoomReadyToPick == true) {
+      if (key == Qt::Key_Left || key == Qt::Key_4) {
+        m_stopMotion->m_canon->m_liveViewZoomPickPoint.x -= 10;
       }
-      m_stopMotion->m_canon->calculateZoomPoint();
-      event->accept();
-      return;
-    } else if (m_stopMotion->m_canon->m_pickLiveViewZoom &&
-               (key == Qt::Key_Escape || key == Qt::Key_Enter ||
-                key == Qt::Key_Return)) {
-      m_stopMotion->m_canon->toggleZoomPicking();
-      event->accept();
-      return;
-    } else
+      if (key == Qt::Key_Right || key == Qt::Key_6) {
+        m_stopMotion->m_canon->m_liveViewZoomPickPoint.x += 10;
+      }
+      if (key == Qt::Key_Up || key == Qt::Key_8) {
+        m_stopMotion->m_canon->m_liveViewZoomPickPoint.y += 10;
+      }
+      if (key == Qt::Key_Down || key == Qt::Key_2) {
+        m_stopMotion->m_canon->m_liveViewZoomPickPoint.y -= 10;
+      }
+      if (m_stopMotion->m_canon->m_zooming) {
+        m_stopMotion->m_canon->setZoomPoint();
+      }
+    }
+
+    m_stopMotion->m_canon->calculateZoomPoint();
+    event->accept();
+    return;
+  } else if (m_stopMotion->m_canon->m_pickLiveViewZoom &&
+             (key == Qt::Key_Escape || key == Qt::Key_Enter ||
+              key == Qt::Key_Return)) {
+    m_stopMotion->m_canon->toggleZoomPicking();
+    event->accept();
+    return;
+  } else
 #endif
 
-    // Handle stop motion capture
+  // Handle stop motion capture
 #if defined(x64)
-        if (m_stopMotion->m_liveViewStatus == 2 &&
-            (key == Qt::Key_Enter || key == Qt::Key_Return)) {
-      m_stopMotion->captureImage();
-      event->accept();
-      return;
-    }
+      if (m_stopMotion->m_liveViewStatus == 2 &&
+          (key == Qt::Key_Enter || key == Qt::Key_Return)) {
+    m_stopMotion->captureImage();
+    event->accept();
+    return;
+  }
 #endif
 
-    // Handle tool-specific key events and viewer shortcuts
-    auto ret = [&]() -> bool {
-      TTool *tool = TApp::instance()->getCurrentTool()->getTool();
-      if (!tool) return false;
+  // Handle tool-specific key events and viewer shortcuts
+  auto ret = [&]() -> bool {
+    TTool *tool = TApp::instance()->getCurrentTool()->getTool();
+    if (!tool) return false;
 
-      bool isTextToolActive = tool->getName() == T_Type && tool->isActive();
+    bool isTextToolActive = tool->getName() == T_Type && tool->isActive();
 
-      // Handle non-text tool shortcuts
-      if (!isTextToolActive) {
-        if (ViewerZoomer(this).exec(event)) return true;
-        if (SceneViewerShortcutReceiver(this).exec(event)) return true;
+    // Handle non-text tool shortcuts
+    if (!isTextToolActive) {
+      if (ViewerZoomer(this).exec(event)) return true;
+      if (SceneViewerShortcutReceiver(this).exec(event)) return true;
 
-        // Handle style switching shortcuts when appropriate
-        if (m_isStyleShortcutSwitchable &&
-            Preferences::instance()->isUseNumpadForSwitchingStylesEnabled() &&
-            (event->modifiers() == Qt::NoModifier ||
-             event->modifiers() == Qt::ShiftModifier ||
-             event->modifiers() == Qt::KeypadModifier) &&
-            ((Qt::Key_0 <= key && key <= Qt::Key_9) || key == Qt::Key_Tab ||
-             key == Qt::Key_Backtab)) {
-          // Handle fullscreen style shortcuts
-          if (parentWidget() &&
-              parentWidget()->windowState() & Qt::WindowFullScreen) {
-            StyleShortcutSwitchablePanel::onKeyPress(event);
-            return true;
-          }
-
-          event->ignore();
+      // Handle style switching shortcuts when appropriate
+      if (m_isStyleShortcutSwitchable &&
+          Preferences::instance()->isUseNumpadForSwitchingStylesEnabled() &&
+          (event->modifiers() == Qt::NoModifier ||
+           event->modifiers() == Qt::ShiftModifier ||
+           event->modifiers() == Qt::KeypadModifier) &&
+          ((Qt::Key_0 <= key && key <= Qt::Key_9) || key == Qt::Key_Tab ||
+           key == Qt::Key_Backtab)) {
+        // Handle fullscreen style shortcuts
+        if (parentWidget() &&
+            parentWidget()->windowState() & Qt::WindowFullScreen) {
+          StyleShortcutSwitchablePanel::onKeyPress(event);
           return true;
         }
 
-        // Handle onion skin ghost flip keys
-        if (CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked() &&
-            (Qt::Key_F1 <= key && key <= Qt::Key_F3)) {
-          OnionSkinMask osm =
-              TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
-          if (osm.getGhostFlipKey() != key) {
-            osm.appendGhostFlipKey(key);
-            TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
-            TApp::instance()
-                ->getCurrentOnionSkin()
-                ->notifyOnionSkinMaskChanged();
-          }
-          return true;
-        }
+        event->ignore();
+        return true;
       }
 
-      if (!tool->isEnabled()) return false;
-
-      tool->setViewer(this);
-
-      // Handle modifier keys that require immediate cursor updates
-      if (key == Qt::Key_Shift || key == Qt::Key_Control ||
-          key == Qt::Key_Alt || key == Qt::Key_AltGr) {
-        TMouseEvent toonzEvent;
-        initToonzEvent(toonzEvent, event);
-        toonzEvent.m_pos = TPointD(m_lastMousePos.x(),
-                                   (double)(height() - 1) - m_lastMousePos.y());
-
-        TPointD pos = tool->getMatrix().inv() * winToWorld(m_lastMousePos);
-
-        TObjectHandle *objHandle = TApp::instance()->getCurrentObject();
-        if ((tool->getToolType() & TTool::LevelTool) &&
-            !objHandle->isSpline()) {
-          pos.x /= m_dpiScale.x;
-          pos.y /= m_dpiScale.y;
+      // Handle onion skin ghost flip keys
+      if (CommandManager::instance()->getAction(MI_ShiftTrace)->isChecked() &&
+          (Qt::Key_F1 <= key && key <= Qt::Key_F3)) {
+        OnionSkinMask osm =
+            TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
+        if (osm.getGhostFlipKey() != key) {
+          osm.appendGhostFlipKey(key);
+          TApp::instance()->getCurrentOnionSkin()->setOnionSkinMask(osm);
+          TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
         }
-
-        tool->mouseMove(pos, toonzEvent);
-        setToolCursor(this, tool->getCursorId());
-      }
-
-      if (key == Qt::Key_Menu || key == Qt::Key_Meta) return false;
-
-      return tool->keyDown(event);
-    }();
-
-    // Handle frame navigation if no tool handled the key
-    if (!ret) {
-      if (changeFrameSkippingHolds(event)) return;
-
-      TFrameHandle *fh = TApp::instance()->getCurrentFrame();
-      int origFrame    = fh->getFrame();
-
-      // Handle frame navigation keys
-      if (key == Qt::Key_Up || key == Qt::Key_Left)
-        fh->prevFrame();
-      else if (key == Qt::Key_Down || key == Qt::Key_Right) {
-        // Allow creating new frames with down arrow in level mode
-        TFrameId newId = 0;
-        if (Preferences::instance()->getDownArrowLevelStripNewFrame() &&
-            fh->getFrameType() == TFrameHandle::LevelFrame) {
-          TXshSimpleLevel *level =
-              TApp::instance()->getCurrentLevel()->getLevel()->getSimpleLevel();
-          if (level) {
-            std::vector<TFrameId> fids;
-            level->getFids(fids);
-            if (!fids.empty()) {
-              int frameCount = (int)fids.size();
-              newId          = level->index2fid(frameCount);
-            }
-          }
-        }
-        fh->nextFrame(newId);
-      } else if (key == Qt::Key_Home)
-        fh->firstFrame();
-      else if (key == Qt::Key_End)
-        fh->lastFrame();
-
-      // Handle cell selection movement with arrow keys
-      if (Preferences::instance()->isUseArrowKeyToShiftCellSelectionEnabled() &&
-          fh->getFrameType() != TFrameHandle::LevelFrame) {
-        TCellSelection *cellSel =
-            dynamic_cast<TCellSelection *>(TSelection::getCurrent());
-        if (cellSel && !cellSel->isEmpty()) {
-          int r0, c0, r1, c1;
-          cellSel->getSelectedCells(r0, c0, r1, c1);
-          int shiftFrame = fh->getFrame() - origFrame;
-
-          cellSel->selectCells(r0 + shiftFrame, c0, r1 + shiftFrame, c1);
-          TApp::instance()->getCurrentSelection()->notifySelectionChanged();
-        }
+        return true;
       }
     }
 
-    update();
+    if (!tool->isEnabled()) return false;
+
+    tool->setViewer(this);
+
+    // Handle modifier keys that require immediate cursor updates
+    if (key == Qt::Key_Shift || key == Qt::Key_Control || key == Qt::Key_Alt ||
+        key == Qt::Key_AltGr) {
+      TMouseEvent toonzEvent;
+      initToonzEvent(toonzEvent, event);
+      toonzEvent.m_pos = TPointD(m_lastMousePos.x(),
+                                 (double)(height() - 1) - m_lastMousePos.y());
+
+      TPointD pos = tool->getMatrix().inv() * winToWorld(m_lastMousePos);
+
+      TObjectHandle *objHandle = TApp::instance()->getCurrentObject();
+      if ((tool->getToolType() & TTool::LevelTool) && !objHandle->isSpline()) {
+        pos.x /= m_dpiScale.x;
+        pos.y /= m_dpiScale.y;
+      }
+
+      tool->mouseMove(pos, toonzEvent);
+      setToolCursor(this, tool->getCursorId());
+    }
+
+    if (key == Qt::Key_Menu || key == Qt::Key_Meta) return false;
+
+    return tool->keyDown(event);
+  }();
+
+  // Handle frame navigation if no tool handled the key
+  if (!ret) {
+    if (changeFrameSkippingHolds(event)) return;
+
+    TFrameHandle *fh = TApp::instance()->getCurrentFrame();
+    int origFrame    = fh->getFrame();
+
+    // Handle frame navigation keys
+    if (key == Qt::Key_Up || key == Qt::Key_Left)
+      fh->prevFrame();
+    else if (key == Qt::Key_Down || key == Qt::Key_Right) {
+      // Allow creating new frames with down arrow in level mode
+      TFrameId newId = 0;
+      if (Preferences::instance()->getDownArrowLevelStripNewFrame() &&
+          fh->getFrameType() == TFrameHandle::LevelFrame) {
+        TXshSimpleLevel *level =
+            TApp::instance()->getCurrentLevel()->getLevel()->getSimpleLevel();
+        if (level) {
+          std::vector<TFrameId> fids;
+          level->getFids(fids);
+          if (!fids.empty()) {
+            int frameCount = (int)fids.size();
+            newId          = level->index2fid(frameCount);
+          }
+        }
+      }
+      fh->nextFrame(newId);
+    } else if (key == Qt::Key_Home)
+      fh->firstFrame();
+    else if (key == Qt::Key_End)
+      fh->lastFrame();
+
+    // Handle cell selection movement with arrow keys
+    if (Preferences::instance()->isUseArrowKeyToShiftCellSelectionEnabled() &&
+        fh->getFrameType() != TFrameHandle::LevelFrame) {
+      TCellSelection *cellSel =
+          dynamic_cast<TCellSelection *>(TSelection::getCurrent());
+      if (cellSel && !cellSel->isEmpty()) {
+        int r0, c0, r1, c1;
+        cellSel->getSelectedCells(r0, c0, r1, c1);
+        int shiftFrame = fh->getFrame() - origFrame;
+
+        cellSel->selectCells(r0 + shiftFrame, c0, r1 + shiftFrame, c1);
+        TApp::instance()->getCurrentSelection()->notifySelectionChanged();
+      }
+    }
   }
+
+  update();
 }
 
 //-----------------------------------------------------------------------------
@@ -1642,28 +1600,6 @@ void SceneViewer::keyReleaseEvent(QKeyEvent *event) {
   tool->setViewer(this);
 
   int key = event->key();
-
-  // Handle only real key releases, not auto-repeat
-  if (!event->isAutoRepeat()) {
-    ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
-
-    switch (event->key()) {
-    case Qt::Key_Space:
-      toolHandle->setSpacePressed(false);
-      event->accept();
-      return;
-
-    case Qt::Key_Control:
-      toolHandle->setCtrlPressed(false);
-      event->accept();
-      return;
-
-    case Qt::Key_Shift:
-      toolHandle->setShiftPressed(false);
-      event->accept();
-      return;
-    }
-  }
 
   // For modifier keys (shift/ctrl/etc), some tools (e.g. pinch) need to
   // update their cursor immediately without waiting for the next mouse move

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -133,30 +133,6 @@ void ShortcutViewer::onEditingFinished() {
   QKeySequence keySeq = keySequence();
   QString keyStr      = keySeq.toString();
 
-  // Check for reserved key combinations involving the Space key
-  if (keyStr.contains("Space", Qt::CaseInsensitive)) {
-    // Check for Space + Shift combination
-    if (keyStr.contains("Shift", Qt::CaseInsensitive)) {
-      setKeySequence(m_action->shortcut());  // Reset to the original shortcut
-      DVGui::warning(
-          tr("The Space + Shift combination is reserved for viewer rotation."));
-      return;
-    }
-
-    // Check for Space + Ctrl combination
-    if (keyStr.contains("Ctrl", Qt::CaseInsensitive)) {
-      setKeySequence(m_action->shortcut());  // Reset to the original shortcut
-      DVGui::warning(
-          tr("The Space + Ctrl combination is reserved for viewer zoom."));
-      return;
-    }
-
-    // Check for Space key alone
-    setKeySequence(m_action->shortcut());  // Reset to the original shortcut
-    DVGui::warning(tr("The Space key is reserved for viewer navigation."));
-    return;
-  }
-
   // Reset the keys pressed counter (used for tracking multi-key sequences)
   m_keysPressed = 0;
 

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -418,10 +418,6 @@ void CommandManager::enlargeIcon(CommandId id, const QSize dstSize) {
 
 // In menubarcommand.cpp
 void CommandManager::loadShortcuts() {
-  // Define reserved navigation shortcuts
-  const std::vector<std::string> reservedKeys = {"Space", "Shift+Space",
-                                                 "Ctrl+Space"};
-
   // Load shortcuts file
   TFilePath fp = ToonzFolder::getMyModuleDir() + TFilePath("shortcuts.ini");
 
@@ -443,25 +439,7 @@ void CommandManager::loadShortcuts() {
     std::string id   = ids.at(i).toStdString();
     QString shortcut = settings.value(ids.at(i), "").toString();
 
-    // Check if this is a reserved navigation shortcut
-    bool isReserved = false;
-    for (const std::string &reserved : reservedKeys) {
-      if (shortcut.toStdString() == reserved) {
-        isReserved = true;
-        break;
-      }
-    }
-
     QAction *action = getAction(&id[0], false);
-
-    if (isReserved) {
-      // Remove reserved shortcuts
-      settings.remove(ids.at(i));
-      if (action) {
-        action->setShortcut(QKeySequence());
-      }
-      continue;
-    }
 
     // Process non-reserved shortcuts
     if (action) {


### PR DESCRIPTION
This PR was implemented as an alternative to #5761 and #5775 , based on [this](https://github.com/opentoonz/opentoonz/pull/5761#issuecomment-3387918172) discussion.

This PR introduces three new tools; Pan View, Rotate View, and Zoom View.
These tools perform the same functions as the Hand, Rotate, and Zoom tools, but are used solely for temporary navigation while the shortcut key is pressed.
Unlike the original tools, it will return to the original tool even if the shortcut key is released quickly.

The default shortcut keys are assigned as follows:
- Pan View : `Space`
- Rotate View: `Shift` + `Space`
- Zoom View: `Ctrl` + `Space`

These can be customized in the Configure Shortcuts Dialog, just like other tools.