### PR TITLE
Fix crash opening PLI files

### DIFF
--- a/toonz/sources/common/timage/tlevel.cpp
+++ b/toonz/sources/common/timage/tlevel.cpp
@@ -11,7 +11,8 @@ TLevel::TLevel()
     : TSmartObject(m_classCode)
     , m_name("")
     , m_table(new Table())
-    , m_palette(0) {}
+    , m_palette(0)
+    , m_partialLoad(false) {}
 
 //-------------------------------------------------
 

--- a/toonz/sources/common/tvectorimage/tcomputeregions.cpp
+++ b/toonz/sources/common/tvectorimage/tcomputeregions.cpp
@@ -1944,6 +1944,7 @@ void autoclose(double factor, vector<VIStroke *> &s, int ii, int jj,
 //-----------------------------------------------------------------------------
 
 TPointD inline getTangent(const IntersectedStroke &item) {
+  if (!item.m_edge.m_s) return TPointD();
   return (item.m_gettingOut ? 1 : -1) *
          item.m_edge.m_s->getSpeed(item.m_edge.m_w0, item.m_gettingOut);
 }
@@ -2485,6 +2486,7 @@ static TRegion *findRegion(VIList<Intersection> &intList, Intersection *p1,
       }
 
     } while (!p2->m_nextIntersection);
+    if (!p2->m_edge.m_s) continue;
 
     nextp1 = p2->m_nextIntersection;
     nextp2 = p2->m_nextStroke;

--- a/toonz/sources/image/pli/tiio_pli.cpp
+++ b/toonz/sources/image/pli/tiio_pli.cpp
@@ -811,7 +811,17 @@ TLevelP TLevelReaderPli::loadInfo() {
         (majorVersionNumber != 5 || minorVersionNumber < 5))
       return m_level;
     TPalette *palette = 0;
-    m_pli->loadInfo(m_readPalette, palette, m_contentHistory);
+        try {
+      m_pli->loadInfo(m_readPalette, palette, m_contentHistory);
+    } catch (TException &e) {
+      QString msg = QString::fromStdString(::to_string(e.getMessage()));
+      if (msg.contains("Not all frames loaded"))
+        m_level->setPartialLoad(true);
+      else
+        throw e;
+    } catch (...) {
+      throw;
+    }
     if (palette) m_level->setPalette(palette);
 
     for (int i = 0; i < m_pli->getFrameCount(); i++)

--- a/toonz/sources/include/tlevel.h
+++ b/toonz/sources/include/tlevel.h
@@ -30,6 +30,8 @@ private:
   Table *m_table;
   TPalette *m_palette;
 
+  bool m_partialLoad;
+
 public:
   TLevel();
   ~TLevel();
@@ -66,6 +68,9 @@ public:
 
   TPalette *getPalette();
   void setPalette(TPalette *);
+
+  void setPartialLoad(bool partial) { m_partialLoad = partial; }
+  bool isPartialLoad() { return m_partialLoad; }
 };
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -886,7 +886,8 @@ item.m_validInfo = true;*/
 //! calculated by using a dedicated thread and therefore cannot be simply
 //! classified as *valid* or *invalid* infos...
 void FileBrowser::readFrameCount(Item &item) {
-  if (TFileType::isViewable(TFileType::getInfo(item.m_path))) {
+  if (!item.m_isFolder &&
+      TFileType::isViewable(TFileType::getInfo(item.m_path))) {
     if (isMultipleFrameType(item.m_path.getType()))
       item.m_frameCount = m_frameCountReader.getFrameCount(item.m_path);
     else

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -1201,6 +1201,16 @@ void TXshSimpleLevel::load() {
     assert(lr);
 
     TLevelP level = lr->loadInfo();
+    if (level->isPartialLoad()) {
+      QString msg =
+          QString(
+              "File '%1' partially loaded. Not all frames were found. Possible "
+              "file corruption. Loaded what could be found.\nRecommend "
+              "replacing any bad frames in Level Strip and saving.")
+              .arg(QString::fromStdWString(m_path.getWideString()));
+      QMessageBox::warning(0, "File load warning", msg);
+      setDirtyFlag(true);
+    }
     if (level->getFrameCount() > 0) {
       const TImageInfo *info = lr->getImageInfo(level->begin()->first);
 


### PR DESCRIPTION
This PR addresses an issue where partially corrupted PLI files caused loading failures. The fix prevents crashes by ensuring safer file handling. The fix can be tested using the corrupted level file shared in the referenced issue: https://github.com/opentoonz/opentoonz/issues/5114

Ported from: https://github.com/tahoma2d/tahoma2d/pull/1530
Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>


**Ref:** https://github.com/opentoonz/opentoonz/issues/5114