### PR TITLE
Fix loading wrong env file

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -82,7 +82,9 @@ public:
                    QString("/Contents/Resources/SystemVar.ini");
 #else
 #ifdef HAIKU
-    settingsPath = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) + "/SystemVar.ini";
+    settingsPath =
+        QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation) +
+        "/SystemVar.ini";
 #else /* Generic Unix */
     // TODO: use QStandardPaths::ConfigLocation when we drop Qt4
     settingsPath = QDir::homePath();
@@ -179,16 +181,13 @@ public:
       m_applicationFullName += " " + m_version.getAppNote();
 
     m_moduleName  = m_version.getAppName();
-    // m_rootVarName value is usually inited by SetRootVarName(), but sometimes
-    // init would be called before SetRootVarName(), so init it here one time
-    m_rootVarName = "TOONZROOT";
-    //m_rootVarName = toUpper(m_version.getAppName()) + "ROOT";
+    m_rootVarName = m_version.getSystemVarPrefix() + "ROOT";
 #ifdef _WIN32
     // from v1.3, registry root is moved to SOFTWARE\\OpenToonz\\OpenToonz
     m_registryRoot =
         TFilePath("SOFTWARE\\OpenToonz\\") + m_version.getAppName();
 #endif
-    m_systemVarPrefix = m_version.getAppName();
+    m_systemVarPrefix = m_version.getSystemVarPrefix();
     updateEnvFile();
   }
 
@@ -217,12 +216,14 @@ public:
   std::string getModuleName() { return m_moduleName; }
 
   void setRootVarName(std::string varName) {
+    if (m_rootVarName == varName) return;
     m_rootVarName = varName;
     updateEnvFile();
   }
   std::string getRootVarName() { return m_rootVarName; }
 
   void setSystemVarPrefix(std::string prefix) {
+    if (m_systemVarPrefix == prefix) return;
     m_systemVarPrefix = prefix;
     updateEnvFile();
   }
@@ -599,11 +600,11 @@ std::string TEnv::getSystemVarPrefix() {
 }
 
 TFilePath TEnv::getStuffDir() {
-  //#ifdef MACOSX
-  // return TFilePath("/Applications/Toonz 5.0/Toonz 5.0 stuff");
-  //#else
+  // #ifdef MACOSX
+  //  return TFilePath("/Applications/Toonz 5.0/Toonz 5.0 stuff");
+  // #else
   return EnvGlobals::instance()->getStuffDir();
-  //#endif
+  // #endif
 }
 
 bool TEnv::getIsPortable() { return EnvGlobals::instance()->getIsPortable(); }

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -11,6 +11,7 @@ public:
   float getAppVersion(void);
   float getAppRevision(void);
   std::string getAppNote(void);
+  std::string getSystemVarPrefix(void);
   bool hasAppNote(void);
   std::string getAppVersionString(void);
   std::string getAppRevisionString(void);
@@ -21,6 +22,7 @@ private:
   const float applicationVersion  = 1.7f;
   const float applicationRevision = 1;
   const char *applicationNote     = "";
+  const char *systemVarPrefix     = "TOONZ";
 };
 
 std::string ToonzVersion::getAppName(void) {
@@ -38,6 +40,10 @@ float ToonzVersion::getAppRevision(void) {
 std::string ToonzVersion::getAppNote(void) {
   std::string appnote = applicationNote;
   return appnote;
+}
+std::string ToonzVersion::getSystemVarPrefix(void) {
+  std::string prefix = systemVarPrefix;
+  return prefix;
 }
 bool ToonzVersion::hasAppNote(void) { return *applicationNote != 0; }
 std::string ToonzVersion::getAppVersionString(void) {

--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -173,9 +173,6 @@ public:
     m_multi.setId("FrameRange");
     m_ignoreAP.setId("IgnoreautoPaintInks");
     m_closeType.setId("Type");
-    ToonzCheck::instance()->setAutocloseSettings(
-        AutocloseDistance, AutocloseAngle, AutocloseOpacity,
-        AutocloseIgnoreAutoPaint);
   }
 
   //------------------------------------------------------------
@@ -263,7 +260,7 @@ public:
           selArea = stroke->getBBox();
         }
 
-        myRect = ToonzImageUtils::convertWorldToRaster(selArea, ti);
+        myRect             = ToonzImageUtils::convertWorldToRaster(selArea, ti);
         TRect enlargedRect = myRect.enlarge(params.m_closingDistance);
         ras                = raux->extract(enlargedRect);
         delta              = enlargedRect.getP00();
@@ -288,7 +285,7 @@ public:
     } else if ((closeType == FREEHAND_CLOSE || closeType == POLYLINE_CLOSE) &&
                stroke) {
       checkSegments(segments, stroke, raux, delta);
-    };//Normal
+    };  // Normal
 
     std::vector<TAutocloser::Segment> segments2(segments);
 
@@ -324,7 +321,7 @@ public:
   }
 
   //============================================================
-  
+
   void multiApplyAutoclose(TFrameId firstFid, TFrameId lastFid,
                            TRectD firstRect, TRectD lastRect,
                            TStroke *firstStroke = 0, TStroke *lastStroke = 0) {
@@ -388,7 +385,7 @@ public:
     if (firstFrameId > lastFrameId) {
       std::swap(firstFrameId, lastFrameId);
     }
-    if(firstFrameId > lastFrameId) return;
+    if (firstFrameId > lastFrameId) return;
 
     std::vector<TFrameId> allFids;
     m_level->getFids(allFids);
@@ -526,24 +523,23 @@ public:
     } else if (m_multi.getValue() && m_firstFrameSelected)
       drawCross(m_firstPoint, 5);
 
-    //if (ToonzCheck::instance()->getChecks() & ToonzCheck::eAutoclose) {
-    //  auto fid = getCurrentFid();
-    //    auto Id =
-    //      getApplication()->getCurrentLevel()->getSimpleLevel()->getImageId(
-    //          fid, 0);
-    //  if (TAutocloser::hasSegmentCache(Id)) {
-    //    auto ti        = (TToonzImageP)m_level->getFrame(fid, false);
-    //    if (!ti) return;
-    //    TPointD center = ti->getRaster()->getCenterD();
-    //      tglColor(TPixel32::Red);
-    //    for (auto seg : TAutocloser::getSegmentCache(Id)) {
-    //      TPointD centerPos = convert((seg.first + seg.second) / 2) - center;
-    //      double radius     = std::sqrt(norm2(seg.first - seg.second)) / 2.0;
-    //      tglDrawCircle(centerPos, radius);
-    //    }
-    //  }
-    //}
-
+    // if (ToonzCheck::instance()->getChecks() & ToonzCheck::eAutoclose) {
+    //   auto fid = getCurrentFid();
+    //     auto Id =
+    //       getApplication()->getCurrentLevel()->getSimpleLevel()->getImageId(
+    //           fid, 0);
+    //   if (TAutocloser::hasSegmentCache(Id)) {
+    //     auto ti        = (TToonzImageP)m_level->getFrame(fid, false);
+    //     if (!ti) return;
+    //     TPointD center = ti->getRaster()->getCenterD();
+    //       tglColor(TPixel32::Red);
+    //     for (auto seg : TAutocloser::getSegmentCache(Id)) {
+    //       TPointD centerPos = convert((seg.first + seg.second) / 2) - center;
+    //       double radius     = std::sqrt(norm2(seg.first - seg.second)) / 2.0;
+    //       tglDrawCircle(centerPos, radius);
+    //     }
+    //   }
+    // }
   }
 
   //------------------------------------------------------------
@@ -594,8 +590,8 @@ public:
     m_selectingRect.empty();
     TTool::Application *app = TTool::getApplication();
     m_level                 = app->getCurrentLevel()->getLevel()
-                  ? app->getCurrentLevel()->getSimpleLevel()
-                  : 0;
+                                  ? app->getCurrentLevel()->getSimpleLevel()
+                                  : 0;
     m_firstFrameId = m_veryFirstFrameId = getFrameId();
     m_firstStroke                       = 0;
   }
@@ -736,6 +732,9 @@ public:
       m_opacity.setValue(AutocloseOpacity);
       m_multi.setValue(AutocloseRange ? 1 : 0);
       m_ignoreAP.setValue(AutocloseIgnoreAutoPaint ? 1 : 0);
+      ToonzCheck::instance()->setAutocloseSettings(
+          AutocloseDistance, AutocloseAngle, AutocloseOpacity,
+          AutocloseIgnoreAutoPaint);
       m_firstTime = false;
     }
     //			getApplication()->editImage();
@@ -831,7 +830,7 @@ public:
     vi.addStroke(app);
     vi.findRegions();
     std::vector<TAutocloser::Segment>::iterator it = segments.begin();
-    while(it != segments.end()) {
+    while (it != segments.end()) {
       int i;
       bool isContained = false;
       for (i = 0; i < (int)vi.getRegionCount(); i++) {
@@ -843,7 +842,8 @@ public:
       }
       if (!isContained)
         it = segments.erase(it);
-      else ++it;
+      else
+        ++it;
     }
   }
 
@@ -854,7 +854,7 @@ public:
       int i;
       bool isContained = false;
       if (rect.contains(convert(it->first + delta)) &&
-          rect.contains(convert(it->second+ delta))) {
+          rect.contains(convert(it->second + delta))) {
         isContained = true;
       }
       if (!isContained)

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -93,6 +93,7 @@ using namespace DVGui;
 
 TEnv::IntVar EnvSoftwareCurrentFontSize("SoftwareCurrentFontSize", 12);
 
+// These are the same as the default values. See tenv.cpp and tversion.h
 const char *rootVarName     = "TOONZROOT";
 const char *systemVarPrefix = "TOONZ";
 
@@ -707,13 +708,13 @@ int main(int argc, char *argv[]) {
     QWindowsWindowFunctions::setHasBorderInFullScreen(w.windowHandle(), true);
 #endif
 
-    // Qt have started to support Windows Ink from 5.12.
-    // Unlike WinTab API used in Qt 5.9 the tablet behaviors are different and
-    // are (at least, for OT) problematic. The customized Qt5.15.2 are made with
-    // cherry-picking the WinTab feature to be officially introduced from 6.0.
-    // See https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab for
-    // details. The following feature can only be used with the customized Qt,
-    // with WITH_WINTAB build option, and in Windows-x64 build.
+  // Qt have started to support Windows Ink from 5.12.
+  // Unlike WinTab API used in Qt 5.9 the tablet behaviors are different and
+  // are (at least, for OT) problematic. The customized Qt5.15.2 are made with
+  // cherry-picking the WinTab feature to be officially introduced from 6.0.
+  // See https://github.com/shun-iwasawa/qt5/releases/tag/v5.15.2_wintab for
+  // details. The following feature can only be used with the customized Qt,
+  // with WITH_WINTAB build option, and in Windows-x64 build.
 
 #ifdef WITH_WINTAB
   bool useQtNativeWinInk = Preferences::instance()->isQtNativeWinInkEnabled();
@@ -731,7 +732,7 @@ int main(int argc, char *argv[]) {
   // Parse inital stylesheet in ThemeManager
   themeManager.parseCustomPropertiesFromStylesheet(currentStyle);
 
-  //w.setWindowTitle(QString::fromStdString(TEnv::getApplicationFullName()));
+  // w.setWindowTitle(QString::fromStdString(TEnv::getApplicationFullName()));
   w.changeWindowTitle();
   if (TEnv::getIsPortable()) {
     splash.showMessage(offsetStr + "Starting OpenToonz Portable ...",


### PR DESCRIPTION
This PR fixes the following problem:

After introducing PR #6090 , the current project at OpenToonz launch now loads from the wrong ENV file.
(It has become `[TOONZROOT]/profiles/env/username.env` , not `[TOONZPROFILES]/env/username.env`.)

The direct cause of this issue was that the RasterTapeTool constructor referenced the TEnv values.
Since RasterTapeTool instance is created before [TEnv parameters are initialized](https://github.com/opentoonz/opentoonz/blob/master/toonz/sources/toonz/main.cpp#L151-L152), thus [VariableSet::load()](https://github.com/opentoonz/opentoonz/blob/master/toonz/sources/common/tapptools/tenv.cpp#L387) was being performed on an incorrect ENV file.
To fix this issue, I moved the functions referencing TEnv values into the `onActivate()` function, following the approach used in other tools.

On the other hand, another fundamental cause is that the initial values for `EnvGlobals::m_rootVarName` and `EnvGlobals::m_systemVarPrefix` are set to incorrect values in `EnvGlobals::init()`.
To make the source code more robust for future development, I set the initial values to the correct values using the newly introduced constant `ToonzVersion::systemVarPrefix`.