### PR TITLE
Fix(XshToolBar): Invisible after startup

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -415,7 +415,7 @@ void XsheetViewer::positionSections() {
 
   if (Preferences::instance()->isShowXSheetToolbarEnabled()) {
     m_toolbar->showToolbar(true);
-    int w = visibleRegion().boundingRect().width();
+    int w = geometry().width();
     m_toolbarScrollArea->setGeometry(0, 0, w, XsheetGUI::TOOLBAR_HEIGHT);
     m_toolbar->setFixedWidth(w);
     if (o->isVerticalTimeline()) {


### PR DESCRIPTION
Fixed: The XSheet Toolbar is not visible after startup.
This issue usually does not occur on the Timeline.