### PR TITLE
Fix rename cell field focus out behavior

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -42,6 +42,7 @@ class RenameCellField final : public QLineEdit {
   int m_col;
   XsheetViewer *m_viewer;
   bool m_isCtrlPrssed = false;
+  QString m_initialText;
 
 public:
   RenameCellField(QWidget *parent, XsheetViewer *viewer);


### PR DESCRIPTION
As [commented here](https://github.com/opentoonz/opentoonz/pull/6214#issuecomment-3424476296), this PR will modify the rename cell field behavior when it losing focus.
The condition for executing `renameCell()` when focusing out is changed from “the field is not empty” to “the field text has changed from when it was displayed”.

This modification will take care the following situation:
1. For example, assume you have a xsheet like this:
    <img width="96" height="160" alt="image" src="https://github.com/user-attachments/assets/bb7c6874-040e-4cec-9c3e-e72f8c8ee3b8" />

1. You want to change the number in the first three cells to `5`. 
    So you select the first cell, type `5`, and press `Enter`.
    <img width="488" height="163" alt="image" src="https://github.com/user-attachments/assets/b59a373c-4c39-4308-bed5-131f8f1b06fd" />

1. The change has been completed successfully. In order to finish renaming, you will click another cell to hide the Rename Cell Field.
    However, this operation changes the numbers starting from the fourth frame to hold cells with number `2`. In my opinion, this is an unintended result.
    <img width="344" height="160" alt="image" src="https://github.com/user-attachments/assets/c5872548-235d-45d6-aeae-7c58064d0d5c" />
