### PR TITLE
Fix registering multiple system var paths with command line qualifiers

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -274,7 +274,7 @@ public:
   }
 
   void setArgPathValue(std::string key, std::string value) {
-    m_argPathValues.emplace(key, value);
+    m_argPathValues.insert_or_assign(key, value);
     if (key == m_systemVarPrefix + "PROFILES") updateEnvFile();
   }
 


### PR DESCRIPTION
This PR fixes a long-standing bug that has remained since the introduction of #2143 (since 2018!).

- When specifying `-TOONZROOT` and other variables (such as `-TOONZPROFILES`, `-TOONZCONFIG`, etc.) together as command-line arguments, the values of `-TOONZPROFILES` or `-TOONZCONFIG` may not override the value specified by `-TOONZROOT`.

This was because I mistakenly believed that `std::map::insert` and `std::map::emplace` would overwrite values when the key already existed, just like `QMap::insert` does. My apologies!