### PR TITLE
FillTool: Add gap close distance option

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -521,6 +521,7 @@ class FillToolOptionsBox final : public ToolOptionsBox {
   ToolOptionCheckbox *m_selectiveMode, *m_segmentMode, *m_onionMode,
       *m_multiFrameMode, *m_autopaintMode, *m_closeGap, *m_referFill;
   ToolOptionPairSlider *m_fillDepthField;
+  ToolOptionIntSlider* m_gapCloseDistance;
 
 public:
   FillToolOptionsBox(QWidget *parent, TTool *tool, TPaletteHandle *pltHandle,

--- a/toonz/sources/include/toonz/autoclose.h
+++ b/toonz/sources/include/toonz/autoclose.h
@@ -10,6 +10,7 @@
 #include "tgeometry.h"
 #include "traster.h"
 #include <set>
+#include "tenv.h"
 
 #undef DVAPI
 #undef DVVAR
@@ -21,11 +22,18 @@
 #define DVVAR DV_IMPORT_VAR
 #endif
 
+extern TEnv::StringVar AutocloseVectorType;
+extern TEnv::IntVar AutocloseDistance;
+extern TEnv::DoubleVar AutocloseAngle;
+extern TEnv::IntVar AutocloseRange;
+extern TEnv::IntVar AutocloseOpacity;
+extern TEnv::IntVar AutocloseIgnoreAutoPaint;
+
 struct AutocloseSettings {
-  int m_closingDistance = 10;
+  int m_closingDistance = 30;
   double m_spotAngle    = 60.0;
   int m_opacity         = 255;
-  bool m_ignoreAPInks        = true;
+  bool m_ignoreAPInks        = false;
 
   AutocloseSettings() = default;
 

--- a/toonz/sources/include/toonz/stage2.h
+++ b/toonz/sources/include/toonz/stage2.h
@@ -82,6 +82,7 @@ public:
                             bool ignoreAP) {
     autoCloseSettings =
         AutocloseSettings(distance, angle, opacity, ignoreAP);
+    TAutocloser::clearSegmentCache();
   }
 
   private : int m_mask;

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -102,6 +102,7 @@ class FillTool final : public QObject, public TTool {
   TBoolProperty m_closeGap;
   TBoolProperty m_referFill;
   TDoubleProperty m_maxGapDistance;
+  TIntProperty m_gapCloseDistance;
   AreaFillTool *m_areaFillTool;
   NormalLineFillTool *m_normalLineFillTool;
 

--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -34,7 +34,7 @@
 using namespace ToolUtils;
 
 TEnv::StringVar AutocloseVectorType("InknpaintAutocloseVectorType", "Normal");
-TEnv::DoubleVar AutocloseDistance("InknpaintAutocloseDistance", 10.0);
+TEnv::IntVar AutocloseDistance("InknpaintAutocloseDistance", 30);
 TEnv::DoubleVar AutocloseAngle("InknpaintAutocloseAngle", 60.0);
 TEnv::IntVar AutocloseRange("InknpaintAutocloseRange", 0);
 TEnv::IntVar AutocloseOpacity("InknpaintAutocloseOpacity", 255);
@@ -114,7 +114,7 @@ class RasterTapeTool final : public TTool {
 
   // TBoolProperty  m_isRect;
   TEnumProperty m_closeType;
-  TDoubleProperty m_distance;
+  TIntProperty m_distance;
   TDoubleProperty m_angle;
   TStyleIndexProperty m_inkIndex;
   TIntProperty m_opacity;
@@ -737,6 +737,7 @@ public:
           AutocloseIgnoreAutoPaint);
       m_firstTime = false;
     }
+
     //			getApplication()->editImage();
     resetMulti();
   }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1781,6 +1781,9 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Close Gap"));
   m_referFill =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Refer Fill"));
+  m_gapCloseDistance = dynamic_cast<ToolOptionIntSlider *>(
+      m_controls.value("Gap Close Distance:"));
+
   bool ret = connect(m_colorMode, SIGNAL(currentIndexChanged(int)), this,
                      SLOT(onColorModeChanged(int)));
   ret      = ret && connect(m_toolType, SIGNAL(currentIndexChanged(int)), this,
@@ -1789,6 +1792,9 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
                             SLOT(onOnionModeToggled(bool)));
   ret      = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
                             SLOT(onMultiFrameModeToggled(bool)));
+  ret      = ret && connect(m_closeGap, &ToolOptionCheckbox::toggled,
+                            m_gapCloseDistance, &QWidget::setEnabled);
+
   assert(ret);
   onColorModeChanged(m_colorMode->getProperty()->getIndex());
   onToolTypeChanged(m_toolType->getProperty()->getIndex());


### PR DESCRIPTION
The gap close distance option is synced to the one of `raster tape tool`.
This PR also changes:

- The distance slider of `raster tape tool` is int type now.
- The default value of close distance changed from 10 to 30