### PR TITLE
Resolve preferences compatibility

### DIFF
--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -829,6 +829,16 @@ void Preferences::resolveCompatibility() {
     setValue(rasterLevelCachingBehavior,
              m_settings->value("initialLoadTlvCachingBehavior").toInt());
   }
+  // "inputCellsWithoutDoubleClicking" is changed to "cellInputMethod", adding a
+  // new default option "Input by Numpad". If the conventional option is
+  // activated, set the new option to "Input by Single Click" to keep
+  // compatibility.
+  if (m_settings->contains("inputCellsWithoutDoubleClickingEnabled") &&
+      !m_settings->contains("cellInputMethod")) {
+    if (m_settings->value("inputCellsWithoutDoubleClickingEnabled").toBool() ==
+        true)
+      setValue(cellInputMethod, 2);
+  }
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
Related to #6214 , this PR will resolve compatibility of the `Cell Input Method` preference option.
If the `Input Cells Without Double Clicking` option is activated, the default value of  `Cell Input Method`  will become `Input by Single Click` to maintain usability and avoid confusion in case the number keys are already assigned as shortcuts for certain commands.