### PR TITLE
Fix(XSheetDepth): Invisible after startup

### DIFF
--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -434,7 +434,7 @@ void XsheetViewer::positionSections() {
 
   if (Preferences::instance()->isShowXsheetBreadcrumbsEnabled()) {
     m_breadcrumbArea->showBreadcrumbs(true);
-    int w = visibleRegion().boundingRect().width();
+    int w = geometry().width();
     if (o->isVerticalTimeline())
       m_breadcrumbScrollArea->setGeometry(0, headerFrame.from(), w,
                                           XsheetGUI::BREADCRUMB_HEIGHT);


### PR DESCRIPTION
Fixed: The XSheet Depth bar is not visible after startup.
This issue usually does not occur on the Timeline.

Maybe we can replace all `visibleRegion().boundingRect()` to `geometry()`, but let's not replace them just in case.