### PR TITLE
Style Picker: OrganizePalette: move picked style to current style page

### DIFF
--- a/toonz/sources/include/toonz/palettecmd.h
+++ b/toonz/sources/include/toonz/palettecmd.h
@@ -104,9 +104,10 @@ DVAPI void renamePalettePage(TPaletteHandle *paletteHandle, int pageIndex,
 DVAPI void renamePaletteStyle(TPaletteHandle *paletteHandle,
                               const std::wstring &newName);
 
-/* called in ColorModelViewer::pick() - move selected style to the first page */
+/* called in ColorModelViewer::pick() - move selected style after current style */
 DVAPI void organizePaletteStyle(TPaletteHandle *paletteHandle, int styleId,
-                                const TColorStyle::PickedPosition &point);
+                                const TColorStyle::PickedPosition &point,
+                                int oldStyleId);
 
 /*
 called in ColorModelViewer::repickFromColorModel().
@@ -115,6 +116,6 @@ Pick color from the img for all styles with "picked position" value.
 DVAPI void pickColorByUsingPickedPosition(TPaletteHandle *paletteHandle,
                                           TImageP img, int frame);
 
-}  // namespace
+}  // namespace PaletteCmd
 
 #endif

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2622,7 +2622,7 @@ StylePickerToolOptionsBox::StylePickerToolOptionsBox(
          "the current style in current level."));
   organizePaletteCB->setToolTip(
       tr("With this option being activated, the picked style will be\nmoved to "
-         "the end of the first page of the palette."));
+         "the end of the current style's page of the palette."));
 
   if (m_realTimePickMode) {
     connect(m_realTimePickMode, SIGNAL(toggled(bool)), m_currentStyleLabel,

--- a/toonz/sources/toonz/colormodelviewer.cpp
+++ b/toonz/sources/toonz/colormodelviewer.cpp
@@ -369,7 +369,8 @@ void ColorModelViewer::pick(const QPoint &p) {
         TPoint point = picker.getRasterPoint(pos);
         int frame    = m_flipConsole->getCurrentFrame() - 1;
         PaletteCmd::organizePaletteStyle(
-            ph, styleIndex, TColorStyle::PickedPosition(point, frame));
+            ph, styleIndex, TColorStyle::PickedPosition(point, frame),
+            ph->getStyleIndex());
         return;
       } else if (spTool->isReplaceStyleActive() && level &&
                  level->getPalette() == currentPalette) {


### PR DESCRIPTION
Old: Move the picked to the end of 1st page in palette
New: Move picked style to the end of current style's page in palette

## How to test

This feature only available in color model viewer, try to import color model so that there would be at least 2 pages in palette.
And then select one style in one page and pick style in another page from the color model viewer.