### PR TITLE
Fix(viewer): Background visualization in Level Editing

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1573,6 +1573,7 @@ void SceneViewer::drawCameraStand() {
 
     TToonzImageP ti  = image;
     TRasterImageP ri = image;
+    TVectorImageP vi = image;
     if (ti) {
       TRect imgRect(0, 0, ti->getSize().lx - 1, ti->getSize().ly - 1);
       TRectD bbox = ToonzImageUtils::convertRasterToWorld(imgRect, ti);
@@ -1600,6 +1601,16 @@ void SceneViewer::drawCameraStand() {
           imgRectColor = Preferences::instance()->getLevelEditorBoxColor();
         ToolUtils::fillRect(imgRect * ri->getSubsampling(), imgRectColor);
       }
+    } else if (vi) {
+      TRectD bbox = vi->getBBox();
+
+      TPixel32 imgRectColor;
+      // draw black rectangle instead, if the BlackBG check is ON
+      if (ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg)
+        imgRectColor = TPixel::Black;
+      else
+        imgRectColor = Preferences::instance()->getLevelEditorBoxColor();
+      ToolUtils::fillRect(bbox, imgRectColor);
     }
     glPopMatrix();
   }


### PR DESCRIPTION
This PR fixes an issue: The Raster Level's background in `level editing mode` doesn't match image's real bounds:
- Scene Viewer in Level Editing Mode(Raster Level) : [Raster Background not correct](https://github.com/tahoma2d/tahoma2d/pull/1941/commits/d79a27d5e789e4495be1c90187d88636cb2d8e6f)

And also added the background drawing feature to vector level
- Scene Viewer in Level Editing Mode(Vector Level) : [Draw background rectangle for vector level in levelEditing mode](https://github.com/tahoma2d/tahoma2d/pull/1941/commits/022df925a74102c56c76c05bf3839d39657bcf2a)

| Level Type | Before | After |
| ----- | ----- | ----- |
| Raster | <img width="469" height="437" alt="图片" src="https://github.com/user-attachments/assets/02d9328c-5e19-4b59-a877-30461889ef2c" /> | <img width="446" height="389" alt="图片" src="https://github.com/user-attachments/assets/98fe86cd-05b6-4f9b-bb3a-674221874ae7" /> |
| Vector | <img width="368" height="324" alt="图片" src="https://github.com/user-attachments/assets/1c0ef013-04cf-4ebe-860e-1923cb19689b" /> | <img width="503" height="389" alt="图片" src="https://github.com/user-attachments/assets/e7018c12-f7f2-4496-addb-c9154c0e335c" /> |
