### PR TITLE
Feature: Report missing/unknown XML tags during scene loading

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -24,6 +24,7 @@
 #include "expressionreferencemanager.h"
 #include "levelcommand.h"
 #include "columncommand.h"
+#include "tstreamexception.h"
 
 // TnzTools includes
 #include "tools/toolhandle.h"
@@ -1975,6 +1976,17 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
       scene->setProject(currentProject);
     }
     VersionControlManager::instance()->setFrameRange(scene->getLevelSet());
+  } catch (TException &e) {
+    printf("%s:%s TException ...:\n", __FILE__, __FUNCTION__);
+
+    QString detailMsg = QString::fromStdWString(e.getMessage());
+
+    QString msg =
+        QObject::tr("There were problems loading the scene %1.\nDetails:\n\n%2")
+            .arg(QString::fromStdWString(scenePath.getWideString()))
+            .arg(detailMsg);
+
+    DVGui::warning(msg);
   } catch (...) {
     printf("%s:%s Exception ...:\n", __FILE__, __FUNCTION__);
     QString msg;
@@ -2760,7 +2772,7 @@ bool IoCmd::importLipSync(TFilePath levelPath, QList<TFrameId> frameList,
                      .arg(toQString(levelPath)));
     return false;
   }
-  return true; 
+  return true;
 }
 
 // Use double value DPI as policy


### PR DESCRIPTION
This PR make it possible to know which tag in scene file(`.tnz`) is lost/unknown/broken while loading, so that user can choose to delete/fix them using text editor.

<img width="575" height="176" alt="图片" src="https://github.com/user-attachments/assets/09dec2ae-ce86-40f7-8092-ac2532c56d9d" />

## How to test
1. Corrupt a .tnz file (e.g., with a text editor).
2. Load it and check if the broken tags are reported.