### PR TITLE
Feat: Lazy load for rooms

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -190,6 +190,9 @@ public:
   PathAliasPriority getPathAliasPriority() const {
     return PathAliasPriority(getIntValue(pathAliasPriority));
   }
+  bool isLazyLoadRoomsEnabled() {
+      return getBoolValue(lazyLoadRooms);
+  }
 
   // Interface  tab
   QStringList getStyleSheetList() const { return m_styleSheetList; }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -13,6 +13,7 @@ enum PreferencesItemId {
   projectRoot,
   customProjectRoot,
   pathAliasPriority,
+  lazyLoadRooms,
 
   //----------
   // Interface

--- a/toonz/sources/toonz/cleanuppaletteviewer.cpp
+++ b/toonz/sources/toonz/cleanuppaletteviewer.cpp
@@ -40,7 +40,7 @@ int search(TPalette *plt, TCleanupStyle *style) {
   assert(false);
   return -1;
 }
-}
+}  // namespace
 
 //********************************************************************************
 //    CleanupPaletteViewer implementation
@@ -88,7 +88,7 @@ CleanupPaletteViewer::CleanupPaletteViewer(QWidget *parent)
   ret      = ret && connect(m_ph, SIGNAL(paletteSwitched()), SLOT(buildGUI()));
   ret      = ret && connect(m_ph, SIGNAL(paletteChanged()), SLOT(buildGUI()));
   ret      = ret && connect(m_ph, SIGNAL(colorStyleChanged(bool)),
-                       SLOT(onColorStyleChanged()));
+                            SLOT(onColorStyleChanged()));
 
   ret = ret && connect(m_add, SIGNAL(clicked(bool)), SLOT(onAddClicked(bool)));
   ret = ret &&
@@ -116,9 +116,9 @@ void CleanupPaletteViewer::buildGUI() {
                           ->getCurrentCleanupPalette()
                           ->getPalette();
   assert(palette);
-  bool ret = true;
-
-  int i, stylesCount = palette->getPage(0)->getStyleCount();
+  bool ret             = true;
+  TPalette::Page *page = palette->getPage(0);
+  int i, stylesCount = palette ? page ? page->getStyleCount() : 0 : 0;
   for (i = 0; i < stylesCount; ++i) {
     TCleanupStyle *cs =
         dynamic_cast<TCleanupStyle *>(palette->getPage(0)->getStyle(i));

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -10,8 +10,11 @@
 #include <map>
 #include <QAction>
 #include <QString>
+#include <QSettings>
 
 #include "../toonzqt/tdockwindows.h"
+
+#include <memory>
 
 class QStackedWidget;
 class TPanel;
@@ -25,12 +28,25 @@ class Room final : public TMainWindow {
 
   TFilePath m_path;
   QString m_name;
+  std::unique_ptr<QSettings> m_settings;
+
+  // For lazy loading
+  bool m_initialized;
 
 public:
   Room(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags())
-      : TMainWindow(parent, flags) {}
+      : TMainWindow(parent, flags)
+      , m_path()
+      , m_name()
+      , m_settings(nullptr)
+      , m_initialized(false) {}
 
   ~Room() {}
+
+  struct RoomLoadParams {
+    QString activeRoomName;
+    bool forceBuildGui = false;
+  };
 
   TFilePath getPath() const { return m_path; }
   void setPath(TFilePath path) { m_path = path; }
@@ -39,7 +55,14 @@ public:
   void setName(QString name) { m_name = name; }
 
   void save();
-  void load(const TFilePath &fp);
+  void load(const TFilePath &fp, RoomLoadParams &params);
+
+  bool notInitialized() const { return !m_initialized; }
+  void initialize() {
+    RoomLoadParams params;
+    params.forceBuildGui = true;
+    load(m_path, params);
+  }
 };
 
 //-----------------------------------------------------------------------------
@@ -190,7 +213,8 @@ private:
   QAction *createMiscAction(const char *id, const char *name,
                             const char *defaultShortcut);
   QAction *createToolOptionsAction(const char *id, const char *name,
-                                   const QString &defaultShortcut, const char *iconSVGName = "");
+                                   const QString &defaultShortcut,
+                                   const char *iconSVGName = "");
   QAction *createStopMotionAction(const char *id, const char *name,
                                   const QString &defaultShortcut,
                                   const char *iconSVGName = "");

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1220,6 +1220,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       //{ projectRoot,               tr("") },
       {customProjectRoot, tr("Custom Project Path(s):")},
       {pathAliasPriority, tr("Path Alias Priority:")},
+      {lazyLoadRooms, tr("Lazy Load Rooms")},
 
       // Interface
       {CurrentStyleSheetName, tr("Theme:")},
@@ -1668,6 +1669,7 @@ QWidget* PreferencesPopup::createGeneralPage() {
   }
 
   insertUI(pathAliasPriority, lay, getComboItemList(pathAliasPriority));
+  insertUI(lazyLoadRooms, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);
@@ -1696,6 +1698,19 @@ QWidget* PreferencesPopup::createGeneralPage() {
          "Standalone -> $scenefolder\n"
          "Project -> project folder aliases (+drawing...)");
   pathAliasPriorityCB->setItemData(3, autoBySceneToolTip, Qt::ToolTipRole);
+
+  QCheckBox* lazyLoadRoomsCheckBox = getUI<QCheckBox*>(lazyLoadRooms);
+  connect(lazyLoadRoomsCheckBox, &QCheckBox::stateChanged,
+          [lazyLoadRoomsCheckBox](int state) {
+          QString status = Preferences::instance()->isLazyLoadRoomsEnabled()
+              ? tr("enabled") : tr("disabled");
+          QString description = Preferences::instance()->isLazyLoadRoomsEnabled()
+              ? tr("rooms will load on demand")
+              : tr("all rooms load at startup");
+          QString lazyLoadRoomsToolTip = tr("Lazy loading %1 - %2").arg(status).arg(description);
+          lazyLoadRoomsCheckBox->setToolTip(lazyLoadRoomsToolTip);
+          });
+  lazyLoadRoomsCheckBox->stateChanged(Preferences::instance()->isLazyLoadRoomsEnabled());
 
   m_onEditedFuncMap.insert(autosaveEnabled,
                            &PreferencesPopup::onAutoSaveChanged);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -383,6 +383,7 @@ void Preferences::definePreferenceItems() {
          (int)ProjectFolderOnly);
 
   setCallBack(undoMemorySize, &Preferences::setUndoMemorySize);
+  define(lazyLoadRooms, "lazyLoadRooms", QMetaType::Bool, true);
 
   // Interface
   define(CurrentStyleSheetName, "CurrentStyleSheetName", QMetaType::QString,

--- a/toonz/sources/toonzlib/tpalettehandle.cpp
+++ b/toonz/sources/toonzlib/tpalettehandle.cpp
@@ -52,7 +52,7 @@ public:
 //-----------------------------------------------------------------------------
 
 TPaletteHandle::TPaletteHandle()
-    : m_palette(0), m_styleIndex(-1), m_styleParamIndex(-1) {
+    : m_palette(nullptr), m_styleIndex(-1), m_styleParamIndex(-1) {
   connectBroadcasts(this);
 }
 


### PR DESCRIPTION
This PR makes the panels in rooms to be created when current room switched, instead of initialize all of them when startup.

It can be toggled off in `Preferences>General`