### PR TITLE
Fix(t32birserv): Terminate the process when quiting or failing to init quickTime

### DIFF
--- a/toonz/sources/image/mov/tiio_mov_proxy.cpp
+++ b/toonz/sources/image/mov/tiio_mov_proxy.cpp
@@ -50,7 +50,12 @@ bool IsQuickTimeInstalled() {
 
   stream << (msg << QString("$isQTInstalled"));
 
-  if (tipc::readMessage(stream, msg) != "yes") return false;
+  if (tipc::readMessage(stream, msg) != "yes") {
+#ifdef _WIN32
+    tipc::terminateCurrentBackgroundProcess();
+#endif  // _WIN32
+    return false;
+  }
   return true;
 #else
   return false;

--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -221,18 +221,6 @@ void initImageIo(bool lightVersion) {
       TFileType::declare("apng", TFileType::RASTER_LEVEL);
       Tiio::defineWriterProperties("apng", new Tiio::APngWriterProperties());
     }
-    if (!IsQuickTimeInstalled()) {
-      if (Ffmpeg::checkFormat("mov")) {
-        TLevelWriter::define("mov", TLevelWriterFFMov::create, true);
-        TLevelReader::define("mov", TLevelReaderFFMov::create);
-        TFileType::declare("mov", TFileType::RASTER_LEVEL);
-        Tiio::defineWriterProperties("mov", new Tiio::FFMovWriterProperties());
-      }
-      if (Ffmpeg::checkFormat("3gp")) {
-        TLevelReader::define("3gp", TLevelReaderFFmpeg::create);
-        TFileType::declare("3gp", TFileType::RASTER_LEVEL);
-      }
-    }
     TLevelReader::define("webp", TLevelReaderFFmpeg::create);
     TFileType::declare("webp", TFileType::RASTER_LEVEL);
     TLevelReader::define("ffvideo", TLevelReaderFFmpeg::create);
@@ -264,7 +252,20 @@ void initImageIo(bool lightVersion) {
       TFileType::declare("3gp", TFileType::RASTER_LEVEL);
       Tiio::defineWriterProperties("3gp", new Tiio::MovWriterProperties());
     }
-
+#if !defined(_WIN32) || defined(x64) || (defined(_WIN32) && defined(__GNUC__))
+    else if (ThirdParty::checkFFmpeg()) {
+      if (Ffmpeg::checkFormat("mov")) {
+        TLevelWriter::define("mov", TLevelWriterFFMov::create, true);
+        TLevelReader::define("mov", TLevelReaderFFMov::create);
+        TFileType::declare("mov", TFileType::RASTER_LEVEL);
+        Tiio::defineWriterProperties("mov", new Tiio::FFMovWriterProperties());
+      }
+      if (Ffmpeg::checkFormat("3gp")) {
+        TLevelReader::define("3gp", TLevelReaderFFmpeg::create);
+        TFileType::declare("3gp", TFileType::RASTER_LEVEL);
+      }
+    }
+#endif
     /*
 #if (defined(_WIN32) && !defined(x64))
 

--- a/toonz/sources/include/tipc.h
+++ b/toonz/sources/include/tipc.h
@@ -8,6 +8,7 @@
 #include <QByteArray>
 #include <QLocalSocket>
 #include <QEventLoop>
+#include <QPointer>
 
 // STL includes
 #include <limits>
@@ -191,6 +192,10 @@ inline Message &reset(Message &msg) {
 namespace tipc {
 
 //---------------------- Connection-message utilities ----------------------
+#ifdef _WIN32
+static QPointer<QProcess> s_processPtr;
+DVAPI void terminateCurrentBackgroundProcess();
+#endif
 
 DVAPI bool startBackgroundProcess(QString cmdlineProgram,
                                   QStringList cmdlineArguments);


### PR DESCRIPTION
This PR adjusted the logic of launching `t32bitserv.exe` for Windows.
- Ensure that there are only one t32bitserv.exe running in background, close it when the application closed (By the QPointer)
- Terminate `t32bitsrv.exe` if it didn't find installed QuickTime.

To use the QuickTime encoder/decoder controlled by `t32bitserv.exe`, you need to download and install it from this [link](https://support.apple.com/en-us/106375).