### PR TITLE
Preference: Use QuickTime coder

### DIFF
--- a/toonz/sources/image/mov/tiio_mov_proxy.cpp
+++ b/toonz/sources/image/mov/tiio_mov_proxy.cpp
@@ -22,6 +22,7 @@
 #include <QDataStream>
 
 #include "tiio_mov_proxy.h"
+#include <toonz/preferences.h>
 
 /*
   For a list of supported commands through the 32-bit background server,
@@ -39,6 +40,7 @@ bool IsQuickTimeInstalled() {
   // in tnzcore lib, the other in image. The core version is currently NEVER
   // USED
   // throughout Toonz, even if it's EXPORT-defined.
+  if (!Preferences::instance()->isUseQuickTimeBackend()) return false;
   QLocalSocket socket;
   if (!tipc::startSlaveConnection(&socket, t32bitsrv::srvName(), 3000,
                                   t32bitsrv::srvCmdlinePrg(),

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -294,6 +294,7 @@ public:
   int getFfmpegTimeout() { return getIntValue(ffmpegTimeout); }
   QString getFastRenderPath() const { return getStringValue(fastRenderPath); }
   bool getFfmpegMultiThread() const { return getBoolValue(ffmpegMultiThread); }
+  bool isUseQuickTimeBackend() const { return getBoolValue(quickTimeBackend); }
   QString getRhubarbPath() const { return getStringValue(rhubarbPath); }
   int getRhubarbTimeout() { return getIntValue(rhubarbTimeout); }
 

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -81,6 +81,7 @@ enum PreferencesItemId {
   ffmpegTimeout,
   fastRenderPath,
   ffmpegMultiThread,
+  quickTimeBackend,
   rhubarbPath,
   rhubarbTimeout,
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1283,6 +1283,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {fastRenderPath, tr("Fast Render Path:")},
       {ffmpegMultiThread,
        tr("Allow Multi-Thread in FFMPEG Rendering (UNSTABLE)")},
+      {quickTimeBackend, tr("Use QuickTime to code .mov and .3gp (If installed)")},
       {rhubarbPath, tr("Rhubarb Path:")},
       {rhubarbTimeout, tr("Rhubarb Timeout:")},
 
@@ -1984,6 +1985,7 @@ QWidget* PreferencesPopup::createImportExportPage() {
          "but a random crash might occur, use at your own risk."),
       lay);
   insertUI(ffmpegMultiThread, lay);
+  insertUI(quickTimeBackend, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -500,6 +500,7 @@ void Preferences::definePreferenceItems() {
          std::numeric_limits<int>::max());
   define(fastRenderPath, "fastRenderPath", QMetaType::QString, "desktop");
   define(ffmpegMultiThread, "ffmpegMultiThread", QMetaType::Bool, false);
+  define(quickTimeBackend, "quickTimeBacend", QMetaType::Bool, false);
   define(rhubarbPath, "rhubarbPath", QMetaType::QString, "");
   define(rhubarbTimeout, "rhubarbTimeout", QMetaType::Int, 600, 0,
          std::numeric_limits<int>::max());


### PR DESCRIPTION
On some computers it takes long time to start `t32bitserv.exe` and detect/load installed QuickTime coder, this PR adds a new preference to `Import/Export` tab, the default value is off.

<img width="611" height="384" alt="图片" src="https://github.com/user-attachments/assets/918a91a1-ff65-454a-a861-41c0d158dca6" />
