### PR TITLE
Remove recolor painted lines feature of areafiller

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -159,6 +159,9 @@ private:
                           int color, bool onlyUnfilled, bool fillPaints,
                           bool fillInks, bool defRegionWithPaint,
                           bool usePrevailingReferFill);
+  void fillRegionExcept(const TRasterCM32P &ras, TRegion *r, int positive,
+                        int negative, int color, bool fillInks,
+                        bool fillAllautoPaintLines);
 };
 
 class DVAPI FullColorAreaFiller {


### PR DESCRIPTION
This PR removes a feature of repaint painted lines beside enclosed regions(the enclosed region has the same style as the painted lines), this can avoid unintended repainting, especially in AA Image case.


| Old | New |
| ----- | ----- |
| ![before](https://github.com/user-attachments/assets/785a77a7-e2c0-4ac0-8a50-bb39cbd456c5) | ![after](https://github.com/user-attachments/assets/eda44cc6-bb12-4b95-aa30-f5eb54d976c4) |


But user can still paint painted lines by `Lines Mode`, or use `Ctrl` to only paint autoPaint lines.
