### PR TITLE
fix(fillTool): avoid unintended savebox update for bound fill

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -1068,9 +1068,11 @@ void doRefFill(const TImageP &img, const TRaster32P &refImg, const TPointD &pos,
 
     if (Preferences::instance()->getFillOnlySavebox()) {
       TRectD bbox = ti->getBBox();
-      TRect ibbox = convert(bbox);
-      offs        = ibbox.getP00();
-      ras         = ti->getRaster()->extract(ibbox);
+      if (!bbox.isEmpty()) {
+        TRect ibbox = convert(bbox);
+        offs        = ibbox.getP00();
+        ras         = ti->getRaster()->extract(ibbox);
+      }
     }
 
     bool recomputeSavebox = false;


### PR DESCRIPTION
This PR fixes unintended savebox update only happen when this preference is toggled on:
<img width="671" height="238" alt="图片" src="https://github.com/user-attachments/assets/616bb3cc-afb0-420f-8c93-2fd9703351bc" />

- Also fix another issue: when saveBox is empty(erased by earser), fill tool can't work.

## Fill Tool:
| Before | After |
| ----- | ----- |
| ![1](https://github.com/user-attachments/assets/149d05ee-efc1-4ddd-bc73-fea2f2f151ca) | ![2](https://github.com/user-attachments/assets/ebc69996-eeac-451f-92d0-938a9c2bd813) |