### PR TITLE
Update README badges with correct GitHub Actions workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [日本語](./doc/README_ja.md) [简体中文](./doc/README_chs.md)
 
 [![](https://ci.appveyor.com/api/projects/status/oa5l5pc964h8fv49/branch/master?svg=true)](https://ci.appveyor.com/project/opentoonz/opentoonz)
-[![](https://travis-ci.org/opentoonz/opentoonz.svg?branch=master)](https://travis-ci.org/opentoonz/opentoonz)
-[![](https://github.com/opentoonz/opentoonz/workflows/Build/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions)
+[![Build Windows](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_windows.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_windows.yml)
+[![Build macOS](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_macos.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_macos.yml)
+[![Build Linux](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_linux.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_linux.yml)
 [![Translation status](https://hosted.weblate.org/widgets/opentoonz/-/svg-badge.svg)](https://hosted.weblate.org/engage/opentoonz/)
+
 ## What is OpenToonz?
 
 OpenToonz is a 2D animation software published by 
@@ -22,12 +24,12 @@ Please refer to the OpenToonz site at <https://opentoonz.github.io/e/index.html>
 
 Please download and install OpenToonz from the latest installer at <https://opentoonz.github.io/e/index.html>.
 
-Older versions and unstable nightly build are also available at <https://github.com/opentoonz/opentoonz/releases>.
+Older versions and unstable nightly builds are also available at <https://github.com/opentoonz/opentoonz/releases>.
 
 ## How to Build Locally
 
 - [Windows](./doc/how_to_build_win.md)
-- [OS X](./doc/how_to_build_macosx.md)
+- [macOS](./doc/how_to_build_macosx.md)
 - [Linux](./doc/how_to_build_linux.md)
 - [BSD](./doc/how_to_build_bsd.md)
 
@@ -56,4 +58,4 @@ Can't develop but still want to help? Help us test individual Pull Requests befo
 
 ### Special Thanks
 
-This Open Source Program is developed from Toonz, a software originally created by Digital Video, S.p.A., Rome Italy
+This open-source program is developed from Toonz, a software originally created by Digital Video, S.p.A., Rome, Italy

--- a/doc/README_chs.md
+++ b/doc/README_chs.md
@@ -3,54 +3,55 @@
 [English](../README.md) [日本語](./README_ja.md) 
 
 [![](https://ci.appveyor.com/api/projects/status/oa5l5pc964h8fv49/branch/master?svg=true)](https://ci.appveyor.com/project/opentoonz/opentoonz)
-[![](https://travis-ci.org/opentoonz/opentoonz.svg?branch=master)](https://travis-ci.org/opentoonz/opentoonz)
-[![](https://github.com/opentoonz/opentoonz/workflows/Build/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions)
+[![Build Windows](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_windows.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_windows.yml)
+[![Build macOS](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_macos.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_macos.yml)
+[![Build Linux](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_linux.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_linux.yml)
 [![Translation status](https://hosted.weblate.org/widgets/opentoonz/-/svg-badge.svg)](https://hosted.weblate.org/engage/opentoonz/)
 
 ## 关于OpenToonz
 
-OpenToonz 是一个由[DWANGO](http://dwango.co.jp/english/)公开发布的二维动画软件，基于**Toonz Studio 吉卜力版本**， 最早由意大利公司[Digital Video, Inc.](http://www.toonz.com/)开发，并在多年的生产中为[吉卜力工作室](http://www.ghibli.jp/) 定制。
+OpenToonz 是一个由[DWANGO](http://dwango.co.jp/english/)公开坑布的二维动画软件，基于**Toonz Studio 坉坜力版本**， 最早由愝大利公坸[Digital Video, Inc.](http://www.toonz.com/)开坑，并在多年的生产中为[坉坜力工作室](http://www.ghibli.jp/) 定制。
 
-## 系统要求
+## 系统覝求
 
-请参考OpenToonz的官方网站：
+请坂考OpenToonz的官方网站：
 
 <https://opentoonz.github.io/e/index.html>
 
 ## 安装
 
-最新的安装包可以从这里下载：
+最新的安装包坯以从这里下载：
 
 <https://opentoonz.github.io/e/index.html>.
 
-旧版本以及夜间构建版可以从下面的链接下载: <https://github.com/opentoonz/opentoonz/releases>
+旧版本以坊夜间构建版坯以从下面的链接下载: <https://github.com/opentoonz/opentoonz/releases>
 
 ## 如何在本地构建
 
 - [Windows](./how_to_build_win_chs.md)
-- [OS X](./how_to_build_macosx.md)
+- [macOS](./how_to_build_macosx.md)
 - [Linux](./how_to_build_linux.md)
 - [BSD](./how_to_build_bsd.md)
 
-关于如何构建样式表，请参照[这里](./how_to_stylesheet.md).
+关于如何构建样弝表，请坂照[这里](./how_to_stylesheet.md).
 
-不懂开发但仍想帮忙？你可以帮助我们测试拉取请求，详情请查阅[这里](./how_to_test_prs_chs.md)。
+丝懂开坑但仝想帮忙？你坯以帮助我们测试拉坖请求，详情请查阅[这里](./how_to_test_prs_chs.md)。
 
 ## 社区
 
 - 分享使用心得或进行问题排查，请加入 [谷歌OpenToonz用户论坛](https://groups.google.com/forum/#!forum/opentoonz_en)。
-- 如果你在问题排查后发现了bug，或者你是个开发者，可以在 [Github issues](https://github.com/opentoonz/opentoonz/issues) 页搜索或发布。
+- 如果你在问题排查坎坑现了bug，或者你是个开坑者，坯以在 [Github issues](https://github.com/opentoonz/opentoonz/issues) 页杜索或坑布。
 
-## 许可证
+## 许坯话
 
-- 对于`thirdparty` 以及`stuff/library/mypaint brushes` 文件夹以外的内容基于Modified BSD License分发。
+- 对于`thirdparty` 以坊`stuff/library/mypaint brushes` 文件夹以外的内容基于Modified BSD License分坑。
   - [modified BSD license](../LICENSE.txt).
-  - 基于该许可证，该软件可以被自由用于个人或商业目的使用或修改。
+  - 基于该许坯话，该软件坯以被自由用于个人或商业目的使用或修改。
 - 对于 `thirdparty` 文件夹内的内容：
-  - 请参考对应的README或源码中的许可证。
+  - 请坂考对应的README或溝砝中的许坯话。
 - 对于 `stuff/library/mypaint brushes` 文件夹下的内容：
   - 请查看 `stuff/library/mypaint brushes/Licenses.txt` 的内容。
 
 ### 特别感谢
 
-原始程序从Toonz开发而来，这是一个由意大利罗马的公司 Digital Video, S.p.A.所开发的软件。
+原始程庝从Toonz开坑而来，这是一个由愝大利罗马的公坸 Digital Video, S.p.A.所开坑的软件。

--- a/doc/README_ja.md
+++ b/doc/README_ja.md
@@ -3,36 +3,38 @@
 [English](../README.md)
 
 [![](https://ci.appveyor.com/api/projects/status/oa5l5pc964h8fv49/branch/master?svg=true)](https://ci.appveyor.com/project/opentoonz/opentoonz)
-[![](https://travis-ci.org/opentoonz/opentoonz.svg?branch=master)](https://travis-ci.org/opentoonz/opentoonz)
-[![](https://github.com/opentoonz/opentoonz/workflows/Build/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions)
+[![Build Windows](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_windows.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_windows.yml)
+[![Build macOS](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_macos.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_macos.yml)
+[![Build Linux](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_linux.yml/badge.svg?branch=master)](https://github.com/opentoonz/opentoonz/actions/workflows/workflow_linux.yml)
+[![Translation status](https://hosted.weblate.org/widgets/opentoonz/-/svg-badge.svg)](https://hosted.weblate.org/engage/opentoonz/)
 
-## これは何？
+## 㝓れ㝯何？
 
-2D アニメーション制作ソフトウェアです。
-イタリアの Digital Video 社が開発し、株式会社スタジオジブリのカスタマイズを経て、ジブリ作品の制作に長年使われてきたソフトウェア `Toonz` が基になっています。
+2D アニメーション制作ソフトウェア㝧㝙。
+イタリア㝮 Digital Video 社㝌開発㝗〝株弝会社スタジオジブリ㝮カスタマイズを経㝦〝ジブリ作哝㝮制作㝫長年使ゝれ㝦㝝㝟ソフトウェア `Toonz` 㝌基㝫㝪㝣㝦㝄㝾㝙。
 
 ## 動作条件
 
-<https://opentoonz.github.io/> を参照してください。
+<https://opentoonz.github.io/> を坂照㝗㝦㝝㝠㝕㝄。
 
 ## インストール
 
-<https://opentoonz.github.io/> から最新安定版のインストーラーをダウンロードしてインストールしてください。
+<https://opentoonz.github.io/> 㝋ら最新安定版㝮インストーラーをダウンロード㝗㝦インストール㝗㝦㝝㝠㝕㝄。
 
-過去のバージョンと不安定な最新版も <https://github.com/opentoonz/opentoonz/releases> から利用することができます。
+靎去㝮ポージョン㝨丝安定㝪最新版も <https://github.com/opentoonz/opentoonz/releases> 㝋ら利用㝙る㝓㝨㝌㝧㝝㝾㝙。
 
 ## ビルド方法
 
 - [Windows](./how_to_build_win_ja.md)
-- [OS X](./how_to_build_macosx_ja.md)
+- [macOS](./how_to_build_macosx_ja.md)
 
 ### ライセンス
 
-- thirdparty ディレクトリ以外のファイル
+- thirdparty ディレクトリ以外㝮ファイル
   - [修正 BSD ライセンス](../LICENSE.txt)
-  - ライセンスに基づき、商用・非商用問わず、自由にソフトウェアの利用やソースコードの改変ができます
-- thirdparty ディレクトリ内のファイル
-  - 各ディレクトリ内の README やソースコードに記載されたライセンスに従ってください
+  - ライセンス㝫基㝥㝝〝商用・非商用啝ゝ㝚〝自由㝫ソフトウェア㝮利用やソースコード㝮改変㝌㝧㝝㝾㝙
+- thirdparty ディレクトリ内㝮ファイル
+  - 坄ディレクトリ内㝮 README やソースコード㝫記載㝕れ㝟ライセンス㝫従㝣㝦㝝㝠㝕㝄
 
 ### Special Thanks
-This Open Source Program is developed from Toonz, a software originally created by Digital Video, S.p.A., Rome Italy
+This open-source program is developed from Toonz, a software originally created by Digital Video, S.p.A., Rome, Italy


### PR DESCRIPTION
This PR updates the build status badges in the `README.md` to match the current GitHub Actions workflows:

- Windows (`workflow_windows.yml`)
- MacOS (`workflow_macos.yml`)
- Linux (`workflow_linux.yml`)

This also removes the Travis CI badge. Maybe it is still used internally for some tasks related to official releases,  but since it is not used in public/community development and does not reflect the current branch or build status, the reference has been removed.

Fixes [opentoonz/opentoonz#5962](https://github.com/opentoonz/opentoonz/issues/5962)