### PR TITLE
Fix(fillTool): stroke fill one click crash with savebox limit

### DIFF
--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -861,6 +861,7 @@ void fillAreaWithUndo(const TImageP &img, const TRaster32P &ref,
     TRect rasBounds    = ras->getBounds();
     TRect rasStrokeBox = ToonzImageUtils::convertWorldToRaster(selArea, ti);
     TRect rasFillArea  = rasStrokeBox * rasBounds;
+    if (rasFillArea.isEmpty()) return;
 
     /*-- tileSetでFill範囲のRectをUndoに格納しておく --*/
     TTileSetCM32 *rasTileSet = new TTileSetCM32(ras->getSize());
@@ -886,7 +887,7 @@ void fillAreaWithUndo(const TImageP &img, const TRaster32P &ref,
     TRect auxStrokeBox = rasStrokeBox - offs;
     TRect auxBounds    = ras->getBounds();
     TRect auxFillArea  = auxStrokeBox * auxBounds;
-    if (auxBounds.isEmpty() || rasFillArea.isEmpty()) return;
+    if (auxFillArea.isEmpty()) return;
 
     AreaFiller filler(raux, ref, plt);
     if (!stroke) {

--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -465,6 +465,7 @@ void AreaFiller::strokeFill(const TRect &rect, TStroke *stroke, int color,
   if (color == 0) m_palette = 0;
 
   assert(!box.isEmpty());
+  if (box.isEmpty()) return;
   TRasterCM32P ras       = m_ras->extract(box);
   TRasterCM32P backupRas = ras->clone();
 


### PR DESCRIPTION
This PR fix a crash related to zero size raster image to be filled:
1. Enable `limit filling with Savebox`
2. Use fill tool, `freehand`  type on toonz raster level
3. single click outside of savebox