### PR TITLE
fix increase minimum size of buttons in insertfxpopup

### DIFF
--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -276,20 +276,20 @@ InsertFxPopup::InsertFxPopup()
   addWidget(m_fxTree);
 
   QPushButton *insertBtn = new QPushButton(tr("Insert"), this);
-  insertBtn->setMinimumSize(65, 25);
+  insertBtn->setMinimumSize(90, 25);
   insertBtn->setObjectName("PushButton_NoPadding");
   connect(insertBtn, SIGNAL(clicked()), this, SLOT(onInsert()));
   insertBtn->setDefault(true);
   m_buttonLayout->addWidget(insertBtn);
 
   QPushButton *addBtn = new QPushButton(tr("Add"), this);
-  addBtn->setMinimumSize(65, 25);
+  addBtn->setMinimumSize(90, 25);
   addBtn->setObjectName("PushButton_NoPadding");
   connect(addBtn, SIGNAL(clicked()), this, SLOT(onAdd()));
   m_buttonLayout->addWidget(addBtn);
 
   QPushButton *replaceBtn = new QPushButton(tr("Replace"), this);
-  replaceBtn->setMinimumSize(65, 25);
+  replaceBtn->setMinimumSize(90, 25);
   replaceBtn->setObjectName("PushButton_NoPadding");
   connect(replaceBtn, SIGNAL(clicked()), this, SLOT(onReplace()));
   m_buttonLayout->addWidget(replaceBtn);


### PR DESCRIPTION
This Pr fixed UI issue from #2021 where FX Browser buttons (Insert, Add, Replace) were too narrow for longer translated strings. 

Minimum width increased from 65px to 90px to prevent text clipping and ensure consistent layout across languages.

fixes: #2021