### PR TITLE
Fix and preserve double values in DoubleLineEdit

### DIFF
--- a/toonz/sources/image/pli/pli_io.cpp
+++ b/toonz/sources/image/pli/pli_io.cpp
@@ -1469,9 +1469,10 @@ void ParsedPliImp::readFloatData(double &val, TUINT32 &bufOffs) {
   isNegative = readDynamicData(valInt, bufOffs);
   readDynamicData(valDec, bufOffs);
 
-  val = valInt + (double)valDec / 65536.0;  // 2^16
-
-  if (valInt == 0 && isNegative) val = -val;
+  if (isNegative)
+    val = (double)valInt - (double)valDec / 65536.0;  // 2^16
+  else
+    val = (double)valInt + (double)valDec / 65536.0;  // 2^16
 
   // m_currDynamicTypeBytesNum = currDynamicTypeBytesNumSaved;
 }


### PR DESCRIPTION
This PR fixes drifting of double values in custom vector brushes and ensures DoubleLineEdit updates correctly.

Ported from https://github.com/tahoma2d/tahoma2d/pull/1961  
Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>

This update also increases `setMaxLength` from 7 to 9 to allow the display of values including the millimeter unit (`mm`). Some default values in fields were previously cutting off the unit, although this change is purely cosmetic.

Note: Indentation has been updated to match the default `.clang-format`.

Ref: https://github.com/opentoonz/opentoonz/pull/6204