### PR TITLE
ci: Update AppVeyor configuration to use VS2022 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,11 @@
 version: 1.7.1.{build}
 
 environment:
-  QT_PATH: '%APPVEYOR_BUILD_FOLDER%\thirdparty\qt\5.15.2_wintab\msvc2019_64'
+  QT_PATH: "%APPVEYOR_BUILD_FOLDER%\\thirdparty\\qt\\5.15.2_wintab\\msvc2019_64"
+  OPENCV_VERSION: "4.11.0"
+  OPENCV_DLL: "C:\\Tools\\opencv\\build\\x64\\vc16\\bin\\opencv_world4110.dll"
+  BOOST_ROOT: "C:\\Libraries\\boost_1_89_0"
+  MSVC_VERSION: "Visual Studio 17 2022"
 
 init:
   - git lfs install --skip-smudge  # Avoid issue with GitHub LFS quota
@@ -14,7 +18,7 @@ skip_commits:
 pull_requests:
   do_not_increment_build_number: true
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 platform: x64
 clone_depth: 1
@@ -25,7 +29,7 @@ cache:
 install:
   # Install OpenCV if not cached
   - cmd: >-
-      if exist "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" (echo OpenCV cached, skipping install) else (choco install opencv --version=4.11.0 --no-progress --yes --force || exit /b 1 & echo Installed OpenCV)
+      if exist "%OPENCV_DLL%" (echo OpenCV cached, skipping install) else (choco install opencv --version=%OPENCV_VERSION% --no-progress --yes --force || exit /b 1 & echo Installed OpenCV)
 
   # Download and extract custom Qt 5.15.2 with WinTab support
   - cmd: >-
@@ -63,15 +67,9 @@ install:
   - cmd: >-
       cd thirdparty
 
-      if not exist tiff-4.0.3\libtiff\tif_config.vc.h (echo tif_config.vc.h not found & exit /b 1)
-
       copy /Y tiff-4.0.3\libtiff\tif_config.vc.h tiff-4.0.3\libtiff\tif_config.h || exit /b 1
 
-      if not exist tiff-4.0.3\libtiff\tiffconf.vc.h (echo tiffconf.vc.h not found & exit /b 1)
-
       copy /Y tiff-4.0.3\libtiff\tiffconf.vc.h tiff-4.0.3\libtiff\tiffconf.h || exit /b 1
-
-      if not exist libpng-1.6.21\scripts\pnglibconf.h.prebuilt (echo pnglibconf.h.prebuilt not found & exit /b 1)
 
       copy /Y libpng-1.6.21\scripts\pnglibconf.h.prebuilt libpng-1.6.21\pnglibconf.h || exit /b 1
 
@@ -83,13 +81,13 @@ install:
   - cmd: >-
       if not exist "%QT_PATH%\bin\qmake.exe" (echo QT_PATH does not exist or is invalid: %QT_PATH% & exit /b 1)
 
-      if not exist "C:\Libraries\boost_1_89_0" (echo Boost not found at C:\Libraries\boost_1_89_0 & exit /b 1)
+      if not exist "%BOOST_ROOT%" (echo Boost not found && exit /b 1)
 
       cd toonz
 
       mkdir %PLATFORM% && cd %PLATFORM%
 
-      cmake ..\sources -G "Visual Studio 16 2019" -Ax64 -DQT_PATH="%QT_PATH%" -DBOOST_ROOT="C:\Libraries\boost_1_89_0" -DOpenCV_DIR="C:\Tools\opencv\build" -DWITH_WINTAB=ON || exit /b 1
+      cmake ..\sources -G "%MSVC_VERSION%" -T v142 -Ax64 -DQT_PATH="%QT_PATH%" -DBOOST_ROOT="%BOOST_ROOT%" -DOpenCV_DIR="C:\Tools\opencv\build" -DWITH_WINTAB=ON || exit /b 1
 
       echo CMake configuration completed
 
@@ -109,19 +107,11 @@ after_build:
 
   # Copy required DLLs
   - cmd: >-
-      if not exist ..\..\thirdparty\glut\3.7.6\lib\glut64.dll (echo glut64.dll not found & exit /b 1)
-
       copy /Y ..\..\thirdparty\glut\3.7.6\lib\glut64.dll %CONFIGURATION% || exit /b 1
-
-      if not exist ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll (echo glew32.dll not found & exit /b 1)
 
       copy /Y ..\..\thirdparty\glew\glew-1.9.0\bin\64bit\glew32.dll %CONFIGURATION% || exit /b 1
 
-      if not exist "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" (echo opencv_world4110.dll not found & exit /b 1)
-
-      copy /Y "C:\Tools\opencv\build\x64\vc16\bin\opencv_world4110.dll" %CONFIGURATION% || exit /b 1
-
-      if not exist ..\..\thirdparty\libmypaint\dist\64 (echo libmypaint DLLs not found & exit /b 1)
+      copy /Y "%OPENCV_DLL%" %CONFIGURATION% || exit /b 1
 
       xcopy /Y /E ..\..\thirdparty\libmypaint\dist\64\*.dll %CONFIGURATION% || exit /b 1
 
@@ -129,8 +119,6 @@ after_build:
 
   # Package portable resources
   - cmd: >-
-      if not exist ..\..\stuff (echo stuff directory not found & exit /b 1)
-
       mkdir "%CONFIGURATION%\portablestuff" || exit /b 1
 
       xcopy /Y /E ..\..\stuff "%CONFIGURATION%\portablestuff" || exit /b 1


### PR DESCRIPTION
This PR updates the AppVeyor build configuration to use the Visual Studio 2022 image.

Additionally, some new `environment` variables have been added to facilitate maintainability.

We had been monitoring several intermittent crashes and other anomalies that might have been related to the previous build environment (see ref: [opentoonz/opentoonz#6127](https://github.com/opentoonz/opentoonz/pull/6127)). Had these issues been confirmed, the configuration might have needed to be downgraded.

So far this week, I haven't observed any issues in the current Windows workflow using the custom Qt 5.15.2_wintab build with VS2022. It’s unclear whether the improvement is due to recent code changes, local Windows updates, or updates to the image itself, but the workflow appears stable at the moment.