### PR TITLE
Fix AutoLipSync hang and cancellation with asynchronous Rhubarb

### DIFF
--- a/toonz/sources/toonz/lipsyncpopup.h
+++ b/toonz/sources/toonz/lipsyncpopup.h
@@ -69,7 +69,10 @@ protected:
   // Helper functions
   void generateThumbnails();
   void updateThumbnail(int index);
-  void onIconGenerated();
+
+private slots:
+  // Internal slot for icon generation updates
+  void onIconGenerated();  // Called when IconGenerator finishes generating thumbnails
 
 public slots:
   void onApplyButton();


### PR DESCRIPTION
This PR complements PR #6317, which refactored LipSyncPopup and AutoLipSyncPopup. It addresses long-standing issues in the Auto Lip Sync tool and improves user experience.

- Executes Rhubarb asynchronously, preventing UI freezes on large or slow audio files

- Enables safe user cancellation and proper cleanup of temporary files. In the legacy implementation, closing the Auto Lip Sync popup did not cancel the Rhubarb process, which continued running in the background, potentially confusing users and consuming system resources

- Adds a modal progress dialog with a Cancel button, disabling the close (“X”) button to avoid accidental closure

<img width="600" height="312" alt="autolipsync" src="https://github.com/user-attachments/assets/036fe695-3348-4b1b-9f6e-6012e292a7f8" />



