### PR TITLE
Replace deprecated QLayout::setMargin() with setContentsMargins()

### DIFF
--- a/toonz/sources/stopmotion/stopmotioncontroller.cpp
+++ b/toonz/sources/stopmotion/stopmotioncontroller.cpp
@@ -338,12 +338,12 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
 
   QVBoxLayout *controlLayout = new QVBoxLayout();
   controlLayout->setSpacing(0);
-  controlLayout->setMargin(5);
+  controlLayout->setContentsMargins(5, 5, 5, 5);
 
   {
     {
       QGridLayout *camLay = new QGridLayout();
-      camLay->setMargin(0);
+      camLay->setContentsMargins(0, 0, 0, 0);
       camLay->setSpacing(3);
       {
         camLay->addWidget(new QLabel(tr("Camera:"), this), 0, 0,
@@ -365,18 +365,18 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
       controlLayout->addLayout(camLay, 0);
 
       QVBoxLayout *fileLay = new QVBoxLayout();
-      fileLay->setMargin(8);
+      fileLay->setContentsMargins(8, 8, 8, 8);
       fileLay->setSpacing(5);
       {
         QGridLayout *levelLay = new QGridLayout();
-        levelLay->setMargin(0);
+        levelLay->setContentsMargins(0, 0, 0, 0);
         levelLay->setHorizontalSpacing(3);
         levelLay->setVerticalSpacing(5);
         {
           levelLay->addWidget(new QLabel(tr("Name:"), this), 0, 0,
                               Qt::AlignRight);
           QHBoxLayout *nameLay = new QHBoxLayout();
-          nameLay->setMargin(0);
+          nameLay->setContentsMargins(0, 0, 0, 0);
           nameLay->setSpacing(2);
           {
             nameLay->addWidget(m_previousLevelButton, 0);
@@ -390,7 +390,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
                               Qt::AlignRight);
 
           QHBoxLayout *frameLay = new QHBoxLayout();
-          frameLay->setMargin(0);
+          frameLay->setContentsMargins(0, 0, 0, 0);
           frameLay->setSpacing(2);
           {
             frameLay->addWidget(m_previousFrameButton, 0);
@@ -406,7 +406,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
         fileLay->addLayout(levelLay, 0);
 
         QHBoxLayout *fileTypeLay = new QHBoxLayout();
-        fileTypeLay->setMargin(0);
+        fileTypeLay->setContentsMargins(0, 0, 0, 0);
         fileTypeLay->setSpacing(3);
         {
           fileTypeLay->addWidget(new QLabel(tr("File Type:"), this), 0);
@@ -417,7 +417,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
         fileLay->addLayout(fileTypeLay, 0);
 
         QHBoxLayout *saveInLay = new QHBoxLayout();
-        saveInLay->setMargin(0);
+        saveInLay->setContentsMargins(0, 0, 0, 0);
         saveInLay->setSpacing(3);
         {
           saveInLay->addWidget(new QLabel(tr("Save In:"), this), 0);
@@ -430,14 +430,14 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
       controlLayout->addWidget(fileFrame, 0);
 
       QGridLayout *displayLay = new QGridLayout();
-      displayLay->setMargin(8);
+      displayLay->setContentsMargins(8, 8, 8, 8);
       displayLay->setHorizontalSpacing(3);
       displayLay->setVerticalSpacing(5);
       {
         displayLay->addWidget(new QLabel(tr("XSheet Frame:"), this), 0, 0,
                               Qt::AlignRight);
         QHBoxLayout *xsheetLay = new QHBoxLayout();
-        xsheetLay->setMargin(0);
+        xsheetLay->setContentsMargins(0, 0, 0, 0);
         xsheetLay->setSpacing(2);
         {
           xsheetLay->addWidget(m_previousXSheetFrameButton, Qt::AlignLeft);
@@ -499,11 +499,11 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     m_exposureCombo->setFixedWidth(fontMetrics().horizontalAdvance("000000") + 25);
     QVBoxLayout *settingsLayout = new QVBoxLayout;
     settingsLayout->setSpacing(0);
-    settingsLayout->setMargin(5);
+    settingsLayout->setContentsMargins(5, 5, 5, 5);
 
     QGridLayout *settingsGridLayout = new QGridLayout;
     {
-      settingsGridLayout->setMargin(0);
+      settingsGridLayout->setContentsMargins(0, 0, 0, 0);
       settingsGridLayout->setSpacing(3);
       settingsGridLayout->addWidget(m_cameraSettingsLabel, 0, 0, 1, 2,
                                     Qt::AlignCenter);
@@ -572,7 +572,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
 
     QVBoxLayout *webcamSettingsLayout = new QVBoxLayout;
     webcamSettingsLayout->setSpacing(0);
-    webcamSettingsLayout->setMargin(5);
+    webcamSettingsLayout->setContentsMargins(5, 5, 5, 5);
     QHBoxLayout *webcamLabelLayout = new QHBoxLayout();
     m_webcamLabel = new QLabel(tr("insert webcam name here"), this);
     webcamLabelLayout->addStretch();
@@ -597,7 +597,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     webcamSettingsLayout->addSpacing(5);
 
     QGridLayout *webcamGridLay = new QGridLayout();
-    webcamGridLay->setMargin(0);
+    webcamGridLay->setContentsMargins(0, 0, 0, 0);
     webcamGridLay->setSpacing(3);
     webcamGridLay->setColumnStretch(0, 0);
     webcamGridLay->setColumnStretch(1, 1);
@@ -732,7 +732,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     QVBoxLayout *optionsOutsideLayout = new QVBoxLayout;
     QGridLayout *optionsLayout        = new QGridLayout;
     optionsLayout->setSpacing(3);
-    optionsLayout->setMargin(5);
+    optionsLayout->setContentsMargins(5, 5, 5, 5);
     QGridLayout *webcamLayout   = new QGridLayout;
     QGridLayout *dslrLayout     = new QGridLayout;
     QGridLayout *checkboxLayout = new QGridLayout;
@@ -753,7 +753,7 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     webcamBox->hide();
 
     QGridLayout *timerLay = new QGridLayout();
-    timerLay->setMargin(8);
+    timerLay->setContentsMargins(8, 8, 8, 8);
     timerLay->setHorizontalSpacing(3);
     timerLay->setVerticalSpacing(5);
     {
@@ -911,11 +911,11 @@ StopMotionController::StopMotionController(QWidget *parent) : QWidget(parent) {
     controlButtonFrame->setLayout(controlButtonLay);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
-    mainLayout->setMargin(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(0);
     {
       QHBoxLayout *hLayout = new QHBoxLayout;
-      hLayout->setMargin(0);
+      hLayout->setContentsMargins(0, 0, 0, 0);
       {
         hLayout->addSpacing(4);
         hLayout->addWidget(m_tabBar);

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -91,13 +91,13 @@ ToolOptionsBox::ToolOptionsBox(QWidget *parent, bool isScrollable)
   setFixedHeight(26);
 
   m_layout = new QHBoxLayout;
-  m_layout->setMargin(0);
+  m_layout->setContentsMargins(0, 0, 0, 0);
   m_layout->setSpacing(5);
   m_layout->addSpacing(5);
 
   if (isScrollable) {
     QHBoxLayout *hLayout = new QHBoxLayout;
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(0);
     setLayout(hLayout);
 
@@ -592,7 +592,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
 
     // Pick combobox only available on "All" axis mode
     QHBoxLayout *pickLay = new QHBoxLayout();
-    pickLay->setMargin(0);
+    pickLay->setContentsMargins(0, 0, 0, 0);
     pickLay->setSpacing(0);
     {
       pickLay->addSpacing(5);
@@ -608,7 +608,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Position
       QFrame *posFrame    = new QFrame(this);
       QHBoxLayout *posLay = new QHBoxLayout();
-      posLay->setMargin(0);
+      posLay->setContentsMargins(0, 0, 0, 0);
       posLay->setSpacing(0);
       posFrame->setLayout(posLay);
       {
@@ -656,7 +656,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Rotation
       QFrame *rotFrame    = new QFrame(this);
       QHBoxLayout *rotLay = new QHBoxLayout();
-      rotLay->setMargin(0);
+      rotLay->setContentsMargins(0, 0, 0, 0);
       rotLay->setSpacing(0);
       rotFrame->setLayout(rotLay);
       {
@@ -680,7 +680,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Scale
       QFrame *scaleFrame    = new QFrame(this);
       QHBoxLayout *scaleLay = new QHBoxLayout();
-      scaleLay->setMargin(0);
+      scaleLay->setContentsMargins(0, 0, 0, 0);
       scaleLay->setSpacing(0);
       scaleFrame->setLayout(scaleLay);
       {
@@ -725,7 +725,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Shear
       QFrame *shearFrame    = new QFrame(this);
       QHBoxLayout *shearLay = new QHBoxLayout();
-      shearLay->setMargin(0);
+      shearLay->setContentsMargins(0, 0, 0, 0);
       shearLay->setSpacing(0);
       shearFrame->setLayout(shearLay);
       {
@@ -757,7 +757,7 @@ ArrowToolOptionsBox::ArrowToolOptionsBox(
       // Center Position
       QFrame *centerPosFrame    = new QFrame(this);
       QHBoxLayout *centerPosLay = new QHBoxLayout();
-      centerPosLay->setMargin(0);
+      centerPosLay->setContentsMargins(0, 0, 0, 0);
       centerPosLay->setSpacing(0);
       centerPosFrame->setLayout(centerPosLay);
       {
@@ -2293,7 +2293,7 @@ RulerToolOptionsBox::RulerToolOptionsBox(QWidget *parent, TTool *tool)
 
   // layout
   QHBoxLayout *lay = new QHBoxLayout();
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
   lay->setSpacing(3);
   {
     lay->addWidget(new QLabel(tr("X:", "ruler tool option"), this), 0);
@@ -2896,7 +2896,7 @@ HandToolOptionsBox::HandToolOptionsBox(QWidget *parent, TTool *tool,
 
 ToolOptions::ToolOptions() : m_panel(0) {
   QHBoxLayout *mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   setLayout(mainLayout);
 }

--- a/toonz/sources/toonz/addfilmstripframespopup.cpp
+++ b/toonz/sources/toonz/addfilmstripframespopup.cpp
@@ -31,7 +31,7 @@ AddFilmstripFramesPopup::AddFilmstripFramesPopup()
   m_cancelBtn = new QPushButton(tr("Cancel"), this);
 
   QGridLayout *upperLay = new QGridLayout();
-  upperLay->setMargin(0);
+  upperLay->setContentsMargins(0, 0, 0, 0);
   upperLay->setSpacing(5);
   {
     upperLay->addWidget(new QLabel(tr("From Frame:"), this), 0, 0,
@@ -50,7 +50,7 @@ AddFilmstripFramesPopup::AddFilmstripFramesPopup()
   upperLay->setColumnStretch(1, 1);
   m_topLayout->addLayout(upperLay, 1);
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(m_okBtn);

--- a/toonz/sources/toonz/adjustlevelspopup.cpp
+++ b/toonz/sources/toonz/adjustlevelspopup.cpp
@@ -130,7 +130,7 @@ public:
 
 EditableMarksBar::EditableMarksBar(QWidget *parent) : QFrame(parent) {
   QVBoxLayout *layout = new QVBoxLayout;
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(2);
   setLayout(layout);
 
@@ -157,7 +157,7 @@ EditableMarksBar::EditableMarksBar(QWidget *parent) : QFrame(parent) {
 
   // Add fields layout
   QHBoxLayout *hLayout = new QHBoxLayout;
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   hLayout->setContentsMargins(4, 0, 5, 0);
   layout->addLayout(hLayout);
 

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -170,12 +170,12 @@ AudioRecordingPopup::AudioRecordingPopup()
   m_refreshDevicesButton->setToolTip(
       tr("Refresh list of connected audio input devices"));
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(8);
 
   QVBoxLayout *mainLay = new QVBoxLayout();
   mainLay->setSpacing(3);
-  mainLay->setMargin(3);
+  mainLay->setContentsMargins(3, 3, 3, 3);
   {
     QGridLayout *recordGridLay = new QGridLayout();
     recordGridLay->setHorizontalSpacing(2);

--- a/toonz/sources/toonz/autoinputcellnumberpopup.cpp
+++ b/toonz/sources/toonz/autoinputcellnumberpopup.cpp
@@ -260,7 +260,7 @@ AutoInputCellNumberPopup::AutoInputCellNumberPopup()
   m_buttonFrame->setFixedHeight(45);
 
   m_buttonLayout = new QHBoxLayout;
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   m_buttonLayout->setAlignment(Qt::AlignHCenter);
   {

--- a/toonz/sources/toonz/batchserversviewer.cpp
+++ b/toonz/sources/toonz/batchserversviewer.cpp
@@ -263,7 +263,7 @@ BatchServersViewer::BatchServersViewer(QWidget *parent, Qt::WindowFlags flags)
   setObjectName("OnePixelMarginFrame");
 
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(15);
+  layout->setContentsMargins(15, 15, 15, 15);
   layout->setSpacing(8);
 
   layout->addWidget(new QLabel(tr("Process with:")), row, 0, Qt::AlignRight);

--- a/toonz/sources/toonz/boardsettingspopup.cpp
+++ b/toonz/sources/toonz/boardsettingspopup.cpp
@@ -385,7 +385,7 @@ ItemInfoView::ItemInfoView(QWidget* parent) : QStackedWidget(parent) {
   //----- layout
 
   QGridLayout* mainLay = new QGridLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setHorizontalSpacing(3);
   mainLay->setVerticalSpacing(10);
   {
@@ -398,13 +398,13 @@ ItemInfoView::ItemInfoView(QWidget* parent) : QStackedWidget(parent) {
     mainLay->addWidget(m_typeCombo, 1, 1);
 
     QVBoxLayout* extraInfoLay = new QVBoxLayout();
-    extraInfoLay->setMargin(0);
+    extraInfoLay->setContentsMargins(0, 0, 0, 0);
     extraInfoLay->setSpacing(0);
     {
       extraInfoLay->addWidget(m_textEdit, 1);
 
       QGridLayout* imgPropLay = new QGridLayout();
-      imgPropLay->setMargin(0);
+      imgPropLay->setContentsMargins(0, 0, 0, 0);
       imgPropLay->setHorizontalSpacing(3);
       imgPropLay->setVerticalSpacing(10);
       {
@@ -425,7 +425,7 @@ ItemInfoView::ItemInfoView(QWidget* parent) : QStackedWidget(parent) {
       extraInfoLay->addSpacing(5);
 
       QGridLayout* fontPropLay = new QGridLayout();
-      fontPropLay->setMargin(0);
+      fontPropLay->setContentsMargins(0, 0, 0, 0);
       fontPropLay->setHorizontalSpacing(3);
       fontPropLay->setVerticalSpacing(10);
       {
@@ -701,11 +701,11 @@ ItemListView::ItemListView(QWidget* parent) : QWidget(parent) {
   m_list->setMaximumWidth(225);
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(5);
   {
     QVBoxLayout* buttonsLay = new QVBoxLayout();
-    buttonsLay->setMargin(0);
+    buttonsLay->setContentsMargins(0, 0, 0, 0);
     buttonsLay->setSpacing(3);
     {
       buttonsLay->addWidget(newItemBtn, 0);
@@ -890,15 +890,15 @@ BoardSettingsPopup::BoardSettingsPopup(QWidget* parent)
   //--- layout
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(10);
   {
     QVBoxLayout* leftLay = new QVBoxLayout();
-    leftLay->setMargin(0);
+    leftLay->setContentsMargins(0, 0, 0, 0);
     leftLay->setSpacing(0);
     {
       QHBoxLayout* leftTopLay = new QHBoxLayout();
-      leftTopLay->setMargin(5);
+      leftTopLay->setContentsMargins(5, 5, 5, 5);
       leftTopLay->setSpacing(3);
       {
         leftTopLay->addWidget(new QLabel(tr("Duration (frames):"), this), 0);
@@ -924,7 +924,7 @@ BoardSettingsPopup::BoardSettingsPopup(QWidget* parent)
     mainLay->addLayout(leftLay, 1);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(0);
+    rightLay->setContentsMargins(0, 0, 0, 0);
     rightLay->setSpacing(15);
     {
       rightLay->addWidget(m_itemInfoView, 0);

--- a/toonz/sources/toonz/cameracapturelevelcontrol.cpp
+++ b/toonz/sources/toonz/cameracapturelevelcontrol.cpp
@@ -287,12 +287,12 @@ CameraCaptureLevelControl::CameraCaptureLevelControl(QWidget* parent)
   m_gammaFld->setToolTip(tr("Gamma Value"));
 
   QVBoxLayout* mainLay = new QVBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(4);
   {
     mainLay->addWidget(m_histogram, 0, Qt::AlignHCenter);
     QHBoxLayout* fieldsLay = new QHBoxLayout();
-    fieldsLay->setMargin(1);
+    fieldsLay->setContentsMargins(1, 1, 1, 1);
     fieldsLay->setSpacing(0);
     {
       fieldsLay->addWidget(m_blackFld, 0);

--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -87,11 +87,11 @@ CameraSettingsPopup::CameraSettingsPopup()
 
   //---- layout
   QVBoxLayout *mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(8);
   {
     QHBoxLayout *nameLay = new QHBoxLayout();
-    nameLay->setMargin(0);
+    nameLay->setContentsMargins(0, 0, 0, 0);
     nameLay->setSpacing(3);
     {
       nameLay->addWidget(new QLabel(tr("Name:")), 0);

--- a/toonz/sources/toonz/canvassizepopup.cpp
+++ b/toonz/sources/toonz/canvassizepopup.cpp
@@ -152,7 +152,7 @@ PeggingWidget::PeggingWidget(QWidget *parent)
 
   QGridLayout *gridLayout = new QGridLayout(this);
   gridLayout->setSpacing(1);
-  gridLayout->setMargin(1);
+  gridLayout->setContentsMargins(1, 1, 1, 1);
 
   m_buttonGroup = new QButtonGroup();
   m_buttonGroup->setExclusive(true);

--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -468,7 +468,7 @@ CastBrowser::CastBrowser(QWidget *parent, Qt::WindowFlags flags)
   QFrame *box = new QFrame(this);
   box->setFrameStyle(QFrame::StyledPanel);
   QVBoxLayout *boxLayout = new QVBoxLayout(box);
-  boxLayout->setMargin(0);
+  boxLayout->setContentsMargins(0, 0, 0, 0);
   boxLayout->setSpacing(0);
 
   m_folderName = new QLabel("", box);

--- a/toonz/sources/toonz/cleanuppaletteviewer.cpp
+++ b/toonz/sources/toonz/cleanuppaletteviewer.cpp
@@ -67,13 +67,13 @@ CleanupPaletteViewer::CleanupPaletteViewer(QWidget *parent)
   //----- layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   {
     mainLayout->addWidget(m_scrollArea, 1);
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;
     buttonLayout->setSpacing(7);
-    buttonLayout->setMargin(0);
+    buttonLayout->setContentsMargins(0, 0, 0, 0);
     {
       buttonLayout->addWidget(m_add);
       buttonLayout->addWidget(m_remove);
@@ -109,7 +109,7 @@ void CleanupPaletteViewer::buildGUI() {
   m_scrollWidget->setLayout(scrollLayout);
 
   scrollLayout->setSpacing(10);
-  scrollLayout->setMargin(0);
+  scrollLayout->setContentsMargins(0, 0, 0, 0);
 
   TPalette *palette = TApp::instance()
                           ->getPaletteController()

--- a/toonz/sources/toonz/cleanuppopup.cpp
+++ b/toonz/sources/toonz/cleanuppopup.cpp
@@ -316,7 +316,7 @@ CleanupPopup::CleanupPopup()
 
   //---layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   mainLayout->setSpacing(5);
   {
     mainLayout->addWidget(m_progressLabel, 0);
@@ -325,13 +325,13 @@ CleanupPopup::CleanupPopup()
     mainLayout->addWidget(m_cleanupQuestionLabel);
 
     QVBoxLayout *imgBoxLay = new QVBoxLayout();
-    imgBoxLay->setMargin(5);
+    imgBoxLay->setContentsMargins(5, 5, 5, 5);
     { imgBoxLay->addWidget(m_imageViewer); }
     m_imgViewBox->setLayout(imgBoxLay);
     mainLayout->addWidget(m_imgViewBox, 1);
 
     QHBoxLayout *buttonLay = new QHBoxLayout();
-    buttonLay->setMargin(0);
+    buttonLay->setContentsMargins(0, 0, 0, 0);
     buttonLay->setSpacing(5);
     {
       buttonLay->addWidget(m_cleanupButton);

--- a/toonz/sources/toonz/cleanupsettingspane.cpp
+++ b/toonz/sources/toonz/cleanupsettingspane.cpp
@@ -167,11 +167,11 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
   //----layout
   QVBoxLayout *mainLay = new QVBoxLayout();
   mainLay->setSpacing(2);
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   {
     // Autocenter
     QGridLayout *autocenterLay = new QGridLayout();
-    autocenterLay->setMargin(5);
+    autocenterLay->setContentsMargins(5, 5, 5, 5);
     autocenterLay->setSpacing(3);
     {
       autocenterLay->addWidget(new QLabel(tr("Pegbar Holes")), 0, 0,
@@ -188,7 +188,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Rotate&Flip
     QGridLayout *rotFlipLay = new QGridLayout();
-    rotFlipLay->setMargin(5);
+    rotFlipLay->setContentsMargins(5, 5, 5, 5);
     rotFlipLay->setSpacing(3);
     {
       rotFlipLay->addWidget(new QLabel(tr("Rotate")), 0, 0,
@@ -207,7 +207,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Camera
     QVBoxLayout *cleanupCameraFrameLay = new QVBoxLayout();
-    cleanupCameraFrameLay->setMargin(0);
+    cleanupCameraFrameLay->setContentsMargins(0, 0, 0, 0);
     cleanupCameraFrameLay->setSpacing(0);
     { cleanupCameraFrameLay->addWidget(m_cameraWidget); }
     cameraFrame->setLayout(cleanupCameraFrameLay);
@@ -215,7 +215,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Cleanup Palette
     QGridLayout *lineProcLay = new QGridLayout();
-    lineProcLay->setMargin(5);
+    lineProcLay->setContentsMargins(5, 5, 5, 5);
     lineProcLay->setSpacing(3);
     {
       lineProcLay->addWidget(new QLabel(tr("Line Processing:")), 0, 0,
@@ -251,7 +251,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
 
     // Bottom Parts
     QHBoxLayout *pathLay = new QHBoxLayout();
-    pathLay->setMargin(0);
+    pathLay->setContentsMargins(0, 0, 0, 0);
     pathLay->setSpacing(3);
     {
       pathLay->addWidget(new QLabel(tr("Save In")), 0);
@@ -262,7 +262,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
     mainLay->addSpacing(5);
 
     QHBoxLayout *saveLoadLay = new QHBoxLayout();
-    saveLoadLay->setMargin(0);
+    saveLoadLay->setContentsMargins(0, 0, 0, 0);
     saveLoadLay->setSpacing(1);
     {
       saveLoadLay->addWidget(saveBtn);

--- a/toonz/sources/toonz/cleanupsettingspopup.cpp
+++ b/toonz/sources/toonz/cleanupsettingspopup.cpp
@@ -51,7 +51,7 @@ CleanupTab::CleanupTab() {
 
   mainLayout->setSizeConstraint(QLayout::SetMinimumSize);
   mainLayout->setSpacing(0);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QWidget *settingsBox = new QWidget(this);
   mainLayout->addWidget(settingsBox);
@@ -62,7 +62,7 @@ CleanupTab::CleanupTab() {
 
   settingsLayout->setSizeConstraint(QLayout::SetMaximumSize);
   settingsLayout->setSpacing(9);
-  settingsLayout->setMargin(12);
+  settingsLayout->setContentsMargins(12, 12, 12, 12);
 
   int row = 0;
 
@@ -133,7 +133,7 @@ CleanupTab::CleanupTab() {
   flipWidget->setLayout(flipLayout);
 
   flipLayout->setSizeConstraint(QLayout::SetFixedSize);
-  flipLayout->setMargin(0);
+  flipLayout->setContentsMargins(0, 0, 0, 0);
 
   m_flipX = new DVGui::CheckBox(tr("Horizontal"), flipWidget);
   flipLayout->addWidget(m_flipX, 0, Qt::AlignLeft);
@@ -254,7 +254,7 @@ ProcessingTab::ProcessingTab() {
   m_settingsFrame->setLayout(settingsLayout);
 
   settingsLayout->setSpacing(9);
-  settingsLayout->setMargin(6);
+  settingsLayout->setContentsMargins(6, 6, 6, 6);
   settingsLayout->setSizeConstraint(QLayout::SetMinimumSize);
   settingsLayout->setColumnStretch(1, 1);  // needed when lpNone
 
@@ -510,7 +510,7 @@ void CameraTab::onGenericSettingsChange() {
 CleanupSettings::CleanupSettings(QWidget *parent)
     : QWidget(parent), m_attached(false) {
   QVBoxLayout *vLayout = new QVBoxLayout(this);
-  vLayout->setMargin(1);  // NOTE: This works to show the 1-pix black border,
+  vLayout->setContentsMargins(1, 1, 1, 1);  // NOTE: This works to show the 1-pix black border,
                           // because this is a QWidget (not QFrame) heir...
   setLayout(vLayout);
 
@@ -520,7 +520,7 @@ CleanupSettings::CleanupSettings(QWidget *parent)
   TabBarContainter *tabBarContainer = new TabBarContainter(this);
   QHBoxLayout *hLayout              = new QHBoxLayout(tabBarContainer);
 
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   hLayout->setAlignment(Qt::AlignLeft);
   hLayout->addSpacing(6);
 
@@ -602,7 +602,7 @@ CleanupSettings::CleanupSettings(QWidget *parent)
   QHBoxLayout *toolBarLayout = new QHBoxLayout(toolBarWidget);
   toolBarWidget->setLayout(toolBarLayout);
 
-  toolBarLayout->setMargin(0);
+  toolBarLayout->setContentsMargins(0, 0, 0, 0);
   toolBarLayout->setSpacing(0);
 
   QToolBar *leftToolBar = new QToolBar(toolBarWidget);

--- a/toonz/sources/toonz/cleanupswatch.cpp
+++ b/toonz/sources/toonz/cleanupswatch.cpp
@@ -23,7 +23,7 @@ CleanupSwatch::CleanupSwatch(QWidget *parent, int lx, int ly)
 {
   setStyleSheet("background: transparent");
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
 
   m_leftSwatch = new CleanupSwatchArea(this, true);

--- a/toonz/sources/toonz/colormodelbehaviorpopup.cpp
+++ b/toonz/sources/toonz/colormodelbehaviorpopup.cpp
@@ -62,7 +62,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
 
   QGroupBox* paletteBox   = new QGroupBox(this);
   QVBoxLayout* paletteLay = new QVBoxLayout();
-  paletteLay->setMargin(15);
+  paletteLay->setContentsMargins(15, 15, 15, 15);
   paletteLay->setSpacing(15);
 
   paletteLay->addWidget(keepColorModelPltButton);
@@ -132,7 +132,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
     m_colorChipOrder->setExclusive(true);
 
     QGridLayout* pickColorLay = new QGridLayout();
-    pickColorLay->setMargin(10);
+    pickColorLay->setContentsMargins(10, 10, 10, 10);
     pickColorLay->setHorizontalSpacing(5);
     pickColorLay->setVerticalSpacing(10);
     {
@@ -141,7 +141,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
       pickColorLay->addWidget(m_pickColorCombo, 0, 1, Qt::AlignLeft);
 
       QGridLayout* colorChipGridLay = new QGridLayout();
-      colorChipGridLay->setMargin(0);
+      colorChipGridLay->setContentsMargins(0, 0, 0, 0);
       colorChipGridLay->setHorizontalSpacing(5);
       colorChipGridLay->setVerticalSpacing(10);
       {
@@ -157,7 +157,7 @@ ColorModelBehaviorPopup::ColorModelBehaviorPopup(
         colorChipGridLay->addWidget(new QLabel(tr("Chip Order:"), this), 2, 0,
                                     Qt::AlignRight | Qt::AlignVCenter);
         QHBoxLayout* orderLay = new QHBoxLayout();
-        orderLay->setMargin(0);
+        orderLay->setContentsMargins(0, 0, 0, 0);
         orderLay->setSpacing(0);
         {
           orderLay->addWidget(upperLeftOrderBtn, 0);

--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -55,7 +55,7 @@ ComboViewerPanel::ComboViewerPanel(QWidget *parent, Qt::WindowFlags flags)
     m_mainLayout->insertWidget(1, m_toolOptions, 0);
 
     QGridLayout *viewerL = new QGridLayout();
-    viewerL->setMargin(0);
+    viewerL->setContentsMargins(0, 0, 0, 0);
     viewerL->setSpacing(0);
     {
       viewerL->addWidget(m_vRuler, 1, 0);

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -514,11 +514,11 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
   QLineEdit* searchEdit = new QLineEdit(this);
 
   //--- layout
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
   {
     QGridLayout* mainUILay = new QGridLayout();
-    mainUILay->setMargin(5);
+    mainUILay->setContentsMargins(5, 5, 5, 5);
     mainUILay->setHorizontalSpacing(8);
     mainUILay->setVerticalSpacing(5);
     {
@@ -528,7 +528,7 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
       mainUILay->addWidget(m_menuBarTree, 1, 0, 2, 1);
 
       QHBoxLayout* searchLay = new QHBoxLayout();
-      searchLay->setMargin(0);
+      searchLay->setContentsMargins(0, 0, 0, 0);
       searchLay->setSpacing(5);
       {
         searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
@@ -548,7 +548,7 @@ CommandBarPopup::CommandBarPopup(bool isXsheetToolbar)
     m_topLayout->addLayout(mainUILay, 1);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(30);
   {
     m_buttonLayout->addStretch(1);

--- a/toonz/sources/toonz/convertfolderpopup.cpp
+++ b/toonz/sources/toonz/convertfolderpopup.cpp
@@ -190,14 +190,14 @@ ConvertResultPopup::ConvertResultPopup(QString log, TFilePath path)
   edit->setReadOnly(true);
 
   QVBoxLayout* mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(10);
   {
     mainLay->addWidget(edit, 1);
     mainLay->addWidget(new QLabel(tr("Do you want to save the log?")), 0);
 
     QHBoxLayout* buttonsLay = new QHBoxLayout();
-    buttonsLay->setMargin(0);
+    buttonsLay->setContentsMargins(0, 0, 0, 0);
     buttonsLay->setSpacing(10);
     buttonsLay->setAlignment(Qt::AlignCenter);
     {
@@ -253,11 +253,11 @@ ConvertFolderPopup::ConvertFolderPopup()
   m_progressDialog->setWindowModality(Qt::WindowModal);
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     QHBoxLayout* folderLay = new QHBoxLayout();
-    folderLay->setMargin(0);
+    folderLay->setContentsMargins(0, 0, 0, 0);
     folderLay->setSpacing(5);
     {
       folderLay->addWidget(new QLabel(tr("Folder to convert:"), this), 0);
@@ -266,11 +266,11 @@ ConvertFolderPopup::ConvertFolderPopup()
     m_topLayout->addLayout(folderLay, 0);
 
     QHBoxLayout* mainLay = new QHBoxLayout();
-    mainLay->setMargin(0);
+    mainLay->setContentsMargins(0, 0, 0, 0);
     mainLay->setSpacing(5);
     {
       QVBoxLayout* leftLay = new QVBoxLayout();
-      leftLay->setMargin(0);
+      leftLay->setContentsMargins(0, 0, 0, 0);
       leftLay->setSpacing(5);
       {
         leftLay->addWidget(m_skip, 0);
@@ -283,7 +283,7 @@ ConvertFolderPopup::ConvertFolderPopup()
     }
     m_topLayout->addLayout(mainLay, 1);
   }
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   {
     m_buttonLayout->addWidget(m_okBtn);

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -407,11 +407,11 @@ ConvertPopup::ConvertPopup(bool specifyInput)
   m_progressDialog->setWindowModality(Qt::WindowModal);
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     QGridLayout *upperLay = new QGridLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(5);
     {
       int row = 0;
@@ -463,7 +463,7 @@ ConvertPopup::ConvertPopup(bool specifyInput)
     m_topLayout->addWidget(m_tlvFrame);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   {
     m_buttonLayout->addWidget(m_okBtn);

--- a/toonz/sources/toonz/custompaneleditorpopup.cpp
+++ b/toonz/sources/toonz/custompaneleditorpopup.cpp
@@ -325,7 +325,7 @@ void CustomPanelEditorPopup::createFields() {
     gridLay = dynamic_cast<QGridLayout*>(m_UiFieldsContainer->layout());
   else {
     gridLay = new QGridLayout();
-    gridLay->setMargin(15);
+    gridLay->setContentsMargins(15, 15, 15, 15);
     gridLay->setHorizontalSpacing(10);
     gridLay->setVerticalSpacing(15);
     gridLay->setColumnStretch(0, 0);
@@ -698,11 +698,11 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
   beginHLayout();
 
   QVBoxLayout* leftLay = new QVBoxLayout();
-  leftLay->setMargin(0);
+  leftLay->setContentsMargins(0, 0, 0, 0);
   leftLay->setSpacing(10);
   {
     QHBoxLayout* templateLay = new QHBoxLayout();
-    templateLay->setMargin(0);
+    templateLay->setContentsMargins(0, 0, 0, 0);
     templateLay->setSpacing(5);
     {
       templateLay->addWidget(new QLabel(tr("Template:"), this), 0);
@@ -715,12 +715,12 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
   addLayout(leftLay);
 
   QVBoxLayout* rightLay = new QVBoxLayout();
-  rightLay->setMargin(0);
+  rightLay->setContentsMargins(0, 0, 0, 0);
   rightLay->setSpacing(10);
   {
     rightLay->addWidget(commandItemListLabel, 0);
     QHBoxLayout* searchLay = new QHBoxLayout();
-    searchLay->setMargin(0);
+    searchLay->setContentsMargins(0, 0, 0, 0);
     searchLay->setSpacing(5);
     {
       searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
@@ -735,7 +735,7 @@ CustomPanelEditorPopup::CustomPanelEditorPopup()
 
   m_buttonLayout->addStretch(1);
   QHBoxLayout* nameLay = new QHBoxLayout();
-  nameLay->setMargin(0);
+  nameLay->setContentsMargins(0, 0, 0, 0);
   nameLay->setSpacing(3);
   {
     nameLay->addWidget(new QLabel(tr("Panel name:"), this), 0);

--- a/toonz/sources/toonz/custompanelmanager.cpp
+++ b/toonz/sources/toonz/custompanelmanager.cpp
@@ -210,7 +210,7 @@ void CustomPanelManager::initializeControl(QWidget* customWidget) {
 
     if (customControl) {
       QHBoxLayout* lay = new QHBoxLayout();
-      lay->setMargin(0);
+      lay->setContentsMargins(0, 0, 0, 0);
       lay->setSpacing(0);
       lay->addWidget(customControl);
       widget->setLayout(lay);

--- a/toonz/sources/toonz/duplicatepopup.cpp
+++ b/toonz/sources/toonz/duplicatepopup.cpp
@@ -100,11 +100,11 @@ DuplicatePopup::DuplicatePopup()
 
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(10);
+  mainLayout->setContentsMargins(10, 10, 10, 10);
   mainLayout->setSpacing(10);
   {
     QHBoxLayout *upperLay = new QHBoxLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(5);
     {
       upperLay->addWidget(new QLabel(tr("Times:"), this), 0);
@@ -116,7 +116,7 @@ DuplicatePopup::DuplicatePopup()
     mainLayout->addLayout(upperLay, 0);
 
     QHBoxLayout *bottomLay = new QHBoxLayout();
-    bottomLay->setMargin(0);
+    bottomLay->setContentsMargins(0, 0, 0, 0);
     bottomLay->setSpacing(10);
     {
       bottomLay->addWidget(m_okBtn);

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -1696,7 +1696,7 @@ NodeEditor::NodeEditor(QWidget *parent, QRect rect, int leftMargin)
   setGeometry(rect);
   m_lineEdit          = new LineEdit();
   QHBoxLayout *layout = new QHBoxLayout();
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->addSpacing(leftMargin);
   layout->addWidget(m_lineEdit);
   setLayout(layout);

--- a/toonz/sources/toonz/exportcameratrackpopup.cpp
+++ b/toonz/sources/toonz/exportcameratrackpopup.cpp
@@ -335,17 +335,17 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
   cancelButton->setFocusPolicy(Qt::NoFocus);
   //----------
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(m_previewArea, 1);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(10);
+    rightLay->setContentsMargins(10, 10, 10, 10);
     rightLay->setSpacing(10);
 
     QGridLayout* appearanceLay = new QGridLayout();
-    appearanceLay->setMargin(0);
+    appearanceLay->setContentsMargins(0, 0, 0, 0);
     appearanceLay->setHorizontalSpacing(5);
     appearanceLay->setVerticalSpacing(10);
     {
@@ -366,7 +366,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
 
     QGroupBox* cameraRectGB    = new QGroupBox(tr("Camera Rectangles"), this);
     QGridLayout* cameraRectLay = new QGridLayout();
-    cameraRectLay->setMargin(10);
+    cameraRectLay->setContentsMargins(10, 10, 10, 10);
     cameraRectLay->setHorizontalSpacing(5);
     cameraRectLay->setVerticalSpacing(10);
     {
@@ -383,7 +383,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
 
     QGroupBox* trackLineGB    = new QGroupBox(tr("Track Lines"), this);
     QGridLayout* trackLineLay = new QGridLayout();
-    trackLineLay->setMargin(10);
+    trackLineLay->setContentsMargins(10, 10, 10, 10);
     trackLineLay->setHorizontalSpacing(10);
     trackLineLay->setVerticalSpacing(10);
     {
@@ -403,7 +403,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
 
     QGroupBox* frameNumberGB    = new QGroupBox(tr("Frame Numbers"), this);
     QGridLayout* frameNumberLay = new QGridLayout();
-    frameNumberLay->setMargin(10);
+    frameNumberLay->setContentsMargins(10, 10, 10, 10);
     frameNumberLay->setHorizontalSpacing(5);
     frameNumberLay->setVerticalSpacing(10);
     {
@@ -428,7 +428,7 @@ ExportCameraTrackPopup::ExportCameraTrackPopup()
     rightLay->addStretch(1);
 
     QHBoxLayout* buttonsLay = new QHBoxLayout();
-    buttonsLay->setMargin(5);
+    buttonsLay->setContentsMargins(5, 5, 5, 5);
     buttonsLay->setSpacing(20);
     {
       buttonsLay->addWidget(exportButton, 0);

--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -250,13 +250,13 @@ ExportLevelPopup::ExportLevelPopup()
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(3);
   {
     mainLayout->addWidget(tabBarContainer, 0);
 
     QHBoxLayout *tabBarLayout = new QHBoxLayout;
-    tabBarLayout->setMargin(0);
+    tabBarLayout->setContentsMargins(0, 0, 0, 0);
     {
       tabBarLayout->addSpacing(6);
       tabBarLayout->addWidget(tabBar);
@@ -267,7 +267,7 @@ ExportLevelPopup::ExportLevelPopup()
     stackedWidget->addWidget(m_browser);
     // Export Options Page
     QVBoxLayout *eoPageLayout = new QVBoxLayout;
-    eoPageLayout->setMargin(0);
+    eoPageLayout->setContentsMargins(0, 0, 0, 0);
     eoPageLayout->setSpacing(0);
     {
       // top area - options
@@ -305,14 +305,14 @@ ExportLevelPopup::ExportLevelPopup()
     //-------------- Buttons Toolbar ---------------------
     QHBoxLayout *bottomLay = new QHBoxLayout();
     bottomLay->setObjectName("bottomLay");
-    bottomLay->setMargin(5);
+    bottomLay->setContentsMargins(5, 5, 5, 5);
     bottomLay->setSpacing(3);
     {
       bottomLay->addWidget(m_nameFieldLabel);
       bottomLay->addWidget(m_nameField, 1);
 
       QHBoxLayout *fileFormatLayout = new QHBoxLayout;
-      fileFormatLayout->setMargin(0);
+      fileFormatLayout->setContentsMargins(0, 0, 0, 0);
       fileFormatLayout->setSpacing(8);
       fileFormatLayout->setAlignment(Qt::AlignHCenter);
       {
@@ -765,7 +765,7 @@ ExportLevelPopup::ExportOptions::ExportOptions(QWidget *parent)
       QGridLayout *layout = locals::newGridLayout();
       m_pliOptions->setLayout(layout);
 
-      layout->setMargin(0);
+      layout->setContentsMargins(0, 0, 0, 0);
 
       int row = 0;
 

--- a/toonz/sources/toonz/exportpanel.cpp
+++ b/toonz/sources/toonz/exportpanel.cpp
@@ -790,7 +790,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
   box->setStyleSheet("#exportPanel { margin: 1px; border: 0px; }");
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   mainLayout->setAlignment(Qt::AlignTop);
   // ClipList
@@ -806,7 +806,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
   settingsBox->setObjectName("settingsBox");
   settingsBox->setFrameStyle(QFrame::StyledPanel);
   QVBoxLayout *settingsLayout = new QVBoxLayout();
-  settingsLayout->setMargin(15);
+  settingsLayout->setContentsMargins(15, 15, 15, 15);
   settingsLayout->setSpacing(5);
   settingsLayout->setAlignment(Qt::AlignTop);
 
@@ -817,7 +817,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
 
   // Label + saveInFileFld
   QHBoxLayout *saveIn = new QHBoxLayout;
-  saveIn->setMargin(0);
+  saveIn->setContentsMargins(0, 0, 0, 0);
   saveIn->setSpacing(5);
   m_saveInFileFld = new DVGui::FileField(settingsBox);
   m_saveInFileFld->setPath(QString::fromStdWString(scenePath.getWideString()));
@@ -829,7 +829,7 @@ ExportPanel::ExportPanel(QWidget *parent, Qt::WindowFlags flags)
 
   // Label + m_fileNameFld
   QHBoxLayout *fileNname = new QHBoxLayout;
-  fileNname->setMargin(0);
+  fileNname->setContentsMargins(0, 0, 0, 0);
   fileNname->setSpacing(5);
   m_fileNameFld =
       new DVGui::LineEdit(QString::fromStdWString(sceneName), settingsBox);

--- a/toonz/sources/toonz/exportxsheetpdf.cpp
+++ b/toonz/sources/toonz/exportxsheetpdf.cpp
@@ -1962,16 +1962,16 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
   exportBtn->setObjectName("LargeSizedText");
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(5);
   {
     QVBoxLayout* previewLay = new QVBoxLayout();
-    previewLay->setMargin(0);
+    previewLay->setContentsMargins(0, 0, 0, 0);
     previewLay->setSpacing(0);
     {
       previewLay->addWidget(m_previewArea, 1);
       QHBoxLayout* prevBtnLay = new QHBoxLayout();
-      prevBtnLay->setMargin(15);
+      prevBtnLay->setContentsMargins(15, 15, 15, 15);
       prevBtnLay->setSpacing(10);
       {
         prevBtnLay->addStretch(1);
@@ -1985,20 +1985,20 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
     mainLay->addLayout(previewLay, 1);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(0);
+    rightLay->setContentsMargins(0, 0, 0, 0);
     rightLay->setSpacing(10);
     {
       QScrollArea* scrollArea = new QScrollArea(this);
       scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
       QWidget* scrollPanel    = new QWidget(this);
       QVBoxLayout* controlLay = new QVBoxLayout();
-      controlLay->setMargin(20);
+      controlLay->setContentsMargins(20, 20, 20, 20);
       controlLay->setSpacing(10);
       {
         QGroupBox* tmplGBox = new QGroupBox(tr("Template Settings"), this);
 
         QGridLayout* tmplLay = new QGridLayout();
-        tmplLay->setMargin(10);
+        tmplLay->setContentsMargins(10, 10, 10, 10);
         tmplLay->setHorizontalSpacing(5);
         tmplLay->setVerticalSpacing(10);
         {
@@ -2032,7 +2032,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
         QGroupBox* exportGBox = new QGroupBox(tr("Export Settings"), this);
 
         QGridLayout* exportLay = new QGridLayout();
-        exportLay->setMargin(10);
+        exportLay->setContentsMargins(10, 10, 10, 10);
         exportLay->setHorizontalSpacing(5);
         exportLay->setVerticalSpacing(10);
         {
@@ -2056,7 +2056,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
                                Qt::AlignLeft | Qt::AlignVCenter);
 
           QGridLayout* checksLay = new QGridLayout();
-          checksLay->setMargin(0);
+          checksLay->setContentsMargins(0, 0, 0, 0);
           checksLay->setHorizontalSpacing(10);
           checksLay->setVerticalSpacing(10);
           {
@@ -2105,7 +2105,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
       rightLay->addWidget(scrollArea, 1);
 
       QGridLayout* saveLay = new QGridLayout();
-      saveLay->setMargin(15);
+      saveLay->setContentsMargins(15, 15, 15, 15);
       saveLay->setHorizontalSpacing(5);
       saveLay->setVerticalSpacing(10);
       {
@@ -2121,7 +2121,7 @@ ExportXsheetPdfPopup::ExportXsheetPdfPopup()
       rightLay->addLayout(saveLay, 0);
 
       QHBoxLayout* btnLay = new QHBoxLayout();
-      btnLay->setMargin(10);
+      btnLay->setContentsMargins(10, 10, 10, 10);
       btnLay->setSpacing(10);
       {
         btnLay->addStretch(1);

--- a/toonz/sources/toonz/filebrowser.cpp
+++ b/toonz/sources/toonz/filebrowser.cpp
@@ -188,13 +188,13 @@ FileBrowser::FileBrowser(QWidget *parent, Qt::WindowFlags flags,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setSpacing(2);
   {
     mainLayout->addWidget(buttonBar);
 
     QHBoxLayout *folderLay = new QHBoxLayout();
-    folderLay->setMargin(0);
+    folderLay->setContentsMargins(0, 0, 0, 0);
     folderLay->setSpacing(0);
     {
       folderLay->addWidget(folderLabel, 0);
@@ -204,7 +204,7 @@ FileBrowser::FileBrowser(QWidget *parent, Qt::WindowFlags flags,
 
     m_mainSplitter->addWidget(m_folderTreeView);
     QVBoxLayout *boxLayout = new QVBoxLayout(box);
-    boxLayout->setMargin(0);
+    boxLayout->setContentsMargins(0, 0, 0, 0);
     boxLayout->setSpacing(0);
     {
       boxLayout->addWidget(titleBar, 0);

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -114,13 +114,13 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
   // layout
   if (!(options & CUSTOM_LAYOUT)) {
     QVBoxLayout *mainLayout = new QVBoxLayout();
-    mainLayout->setMargin(0);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
     mainLayout->setSpacing(3);
     {
       mainLayout->addWidget(m_browser, 1);
 
       QHBoxLayout *bottomLay = new QHBoxLayout();
-      bottomLay->setMargin(5);
+      bottomLay->setContentsMargins(5, 5, 5, 5);
       bottomLay->setSpacing(3);
       {
         bottomLay->addWidget(m_nameFieldLabel, 0);
@@ -131,7 +131,7 @@ FileBrowserPopup::FileBrowserPopup(const QString &title, Options options,
       if (m_customWidget) mainLayout->addWidget(m_customWidget);
 
       QHBoxLayout *buttonsLay = new QHBoxLayout();
-      buttonsLay->setMargin(5);
+      buttonsLay->setContentsMargins(5, 5, 5, 5);
       buttonsLay->setSpacing(15);
       {
         buttonsLay->addStretch();
@@ -772,13 +772,13 @@ LoadLevelPopup::LoadLevelPopup()
   //----layout
   auto createVBoxLayout = [](int margin, int spacing) {
     QVBoxLayout *layout = new QVBoxLayout();
-    layout->setMargin(margin);
+    layout->setContentsMargins(margin, margin, margin, margin);
     layout->setSpacing(spacing);
     return layout;
   };
   auto createHBoxLayout = [](int margin, int spacing) {
     QHBoxLayout *layout = new QHBoxLayout();
-    layout->setMargin(margin);
+    layout->setContentsMargins(margin, margin, margin, margin);
     layout->setSpacing(spacing);
     return layout;
   };
@@ -832,7 +832,7 @@ LoadLevelPopup::LoadLevelPopup()
     QHBoxLayout *bottomLay = createHBoxLayout(0, 10);
     {
       QGridLayout *levelLay = new QGridLayout();
-      levelLay->setMargin(5);
+      levelLay->setContentsMargins(5, 5, 5, 5);
       levelLay->setSpacing(5);
       {
         levelLay->addWidget(new QLabel(tr("Level Name:"), this), 0, 0,
@@ -866,7 +866,7 @@ LoadLevelPopup::LoadLevelPopup()
       bottomLay->addWidget(m_levelPropertiesFrame, 0);
 
       QGridLayout *arrLay = new QGridLayout();
-      arrLay->setMargin(5);
+      arrLay->setContentsMargins(5, 5, 5, 5);
       arrLay->setSpacing(5);
       {
         arrLay->addWidget(new QLabel(tr("From:"), this), 0, 0,
@@ -1932,7 +1932,7 @@ LoadColorModelPopup::LoadColorModelPopup()
 
   // layout
   QHBoxLayout *mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   mainLayout->setSpacing(5);
   {
     mainLayout->addStretch(1);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1541,7 +1541,7 @@ Filmstrip::Filmstrip(QWidget *parent, Qt::WindowFlags flags) : QWidget(parent) {
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_chooseLevelCombo, 0);

--- a/toonz/sources/toonz/flipbook.cpp
+++ b/toonz/sources/toonz/flipbook.cpp
@@ -210,7 +210,7 @@ FlipBook::FlipBook(QWidget *parent, QString viewerTitle,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(fsWidget, 1);
@@ -386,7 +386,7 @@ LoadImagesPopup::LoadImagesPopup(FlipBook *flip)
 
   // layout
   QHBoxLayout *frameRangeLayout = new QHBoxLayout();
-  frameRangeLayout->setMargin(5);
+  frameRangeLayout->setContentsMargins(5, 5, 5, 5);
   frameRangeLayout->setSpacing(5);
   {
     frameRangeLayout->addStretch(1);

--- a/toonz/sources/toonz/formatsettingspopups.cpp
+++ b/toonz/sources/toonz/formatsettingspopups.cpp
@@ -68,7 +68,7 @@ FormatSettingsPopup::FormatSettingsPopup(QWidget *parent,
   setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint);
 
   m_mainLayout = new QGridLayout();
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setVerticalSpacing(5);
   m_mainLayout->setHorizontalSpacing(5);
   m_mainLayout->setColumnStretch(0, 0);

--- a/toonz/sources/toonz/fxparameditorpopup.cpp
+++ b/toonz/sources/toonz/fxparameditorpopup.cpp
@@ -50,7 +50,7 @@ FxParamEditorPopup::FxParamEditorPopup()
   fxSettings->setCurrentFx();
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(10);
   { mainLayout->addWidget(fxSettings); }
   setLayout(mainLayout);

--- a/toonz/sources/toonz/histogrampopup.cpp
+++ b/toonz/sources/toonz/histogrampopup.cpp
@@ -45,7 +45,7 @@ HistogramPopup::HistogramPopup(QString title)
   m_histogram = new ComboHistogram(this);
 
   QVBoxLayout *mainLay = new QVBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(0);
   { mainLay->addWidget(m_histogram); }
   setLayout(mainLay);

--- a/toonz/sources/toonz/historypane.cpp
+++ b/toonz/sources/toonz/historypane.cpp
@@ -201,7 +201,7 @@ HistoryPane::HistoryPane(QWidget *parent, Qt::WindowFlags flags)
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   { mainLayout->addWidget(m_frameArea, 1); }
   setLayout(mainLayout);
 

--- a/toonz/sources/toonz/insertfxpopup.cpp
+++ b/toonz/sources/toonz/insertfxpopup.cpp
@@ -223,7 +223,7 @@ InsertFxPopup::InsertFxPopup()
   QHBoxLayout *searchLay = new QHBoxLayout();
   QLineEdit *searchEdit  = new QLineEdit(this);
 
-  searchLay->setMargin(0);
+  searchLay->setContentsMargins(0, 0, 0, 0);
   searchLay->setSpacing(5);
   searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
   searchLay->addWidget(searchEdit);

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -219,11 +219,11 @@ LevelCreatePopup::LevelCreatePopup()
   okBtn->setDefault(true);
 
   //--- layout
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
   {
     QGridLayout *guiLay = new QGridLayout();
-    guiLay->setMargin(10);
+    guiLay->setContentsMargins(10, 10, 10, 10);
     guiLay->setVerticalSpacing(10);
     guiLay->setHorizontalSpacing(5);
     {
@@ -283,7 +283,7 @@ LevelCreatePopup::LevelCreatePopup()
     m_topLayout->addLayout(guiLay, 1);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(30);
   {
     m_buttonLayout->addStretch(1);

--- a/toonz/sources/toonz/levelsettingspopup.cpp
+++ b/toonz/sources/toonz/levelsettingspopup.cpp
@@ -450,13 +450,13 @@ LevelSettingsPopup::LevelSettingsPopup()
   m_activateFlags[m_colorSpaceGammaFld]   = linearFlag;
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     //--Name&Path
     QGroupBox *nameBox      = new QGroupBox(tr("Name && Path"), this);
     QGridLayout *nameLayout = new QGridLayout();
-    nameLayout->setMargin(5);
+    nameLayout->setContentsMargins(5, 5, 5, 5);
     nameLayout->setSpacing(5);
     {
       nameLayout->addWidget(new QLabel(tr("Name:"), this), 0, 0,
@@ -483,7 +483,7 @@ LevelSettingsPopup::LevelSettingsPopup()
     else
       dpiBox = new QGroupBox(tr("DPI && Resolution"), this);
     QGridLayout *dpiLayout = new QGridLayout();
-    dpiLayout->setMargin(5);
+    dpiLayout->setContentsMargins(5, 5, 5, 5);
     dpiLayout->setSpacing(5);
     {
       dpiLayout->addWidget(m_dpiTypeOm, 0, 1, 1, 3);
@@ -523,7 +523,7 @@ LevelSettingsPopup::LevelSettingsPopup()
 
     //---subsampling
     QGridLayout *bottomLay = new QGridLayout();
-    bottomLay->setMargin(3);
+    bottomLay->setContentsMargins(3, 3, 3, 3);
     bottomLay->setSpacing(3);
     {
       bottomLay->addWidget(m_softnessLabel, 0, 0);

--- a/toonz/sources/toonz/locatorpopup.cpp
+++ b/toonz/sources/toonz/locatorpopup.cpp
@@ -20,7 +20,7 @@ LocatorPopup::LocatorPopup(QWidget *parent, Qt::WindowFlags flags)
 
   //---- layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->addWidget(m_viewer, 1);
   setLayout(mainLayout);
 

--- a/toonz/sources/toonz/magpiefileimportpopup.cpp
+++ b/toonz/sources/toonz/magpiefileimportpopup.cpp
@@ -65,7 +65,7 @@ MagpieFileImportPopup::MagpieFileImportPopup()
   fromToWidget->setFixedHeight(DVGui::WidgetHeight);
   fromToWidget->setFixedSize(210, DVGui::WidgetHeight);
   QHBoxLayout *fromToLayout = new QHBoxLayout(fromToWidget);
-  fromToLayout->setMargin(0);
+  fromToLayout->setContentsMargins(0, 0, 0, 0);
   fromToLayout->setSpacing(0);
   m_fromField = new DVGui::IntLineEdit(fromToWidget, 1, 1, 1);
   fromToLayout->addWidget(m_fromField, 0, Qt::AlignLeft);
@@ -111,7 +111,7 @@ MagpieFileImportPopup::MagpieFileImportPopup()
   frame->setStyleSheet(
       "#LipSynkViewer { border: 1px solid rgb(150,150,150); }");
   QVBoxLayout *frameLayout = new QVBoxLayout(frame);
-  frameLayout->setMargin(0);
+  frameLayout->setContentsMargins(0, 0, 0, 0);
   frameLayout->setSpacing(0);
   std::vector<int> buttonMask = {FlipConsole::eRate,
                                  FlipConsole::eSound,

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -455,7 +455,7 @@ MainWindow::MainWindow(const QString &argumentLayoutFileName, QWidget *parent,
 centralWidget->setFrameStyle(QFrame::StyledPanel);
 centralWidget->setObjectName("centralWidget");
 QHBoxLayout *centralWidgetLayout = new QHBoxLayout;
-centralWidgetLayout->setMargin(3);
+centralWidgetLayout->setContentsMargins(3, 3, 3, 3);
 centralWidgetLayout->addWidget(m_stackedWidget);
 centralWidget->setLayout(centralWidgetLayout);*/
 

--- a/toonz/sources/toonz/matchline.cpp
+++ b/toonz/sources/toonz/matchline.cpp
@@ -396,11 +396,11 @@ MatchlinesDialog::MatchlinesDialog()
 
   //----layout
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(5);
   {
     QGridLayout *inkUsageLay = new QGridLayout();
-    inkUsageLay->setMargin(5);
+    inkUsageLay->setContentsMargins(5, 5, 5, 5);
     inkUsageLay->setSpacing(5);
     {
       inkUsageLay->addWidget(m_button1, 0, 0, 1, 2);
@@ -414,11 +414,11 @@ MatchlinesDialog::MatchlinesDialog()
     m_topLayout->addWidget(inkUsageGroupBox);
 
     QVBoxLayout *lineOrderLay = new QVBoxLayout();
-    lineOrderLay->setMargin(5);
+    lineOrderLay->setContentsMargins(5, 5, 5, 5);
     lineOrderLay->setSpacing(5);
     {
       QGridLayout *buttonsLay = new QGridLayout();
-      buttonsLay->setMargin(0);
+      buttonsLay->setContentsMargins(0, 0, 0, 0);
       buttonsLay->setSpacing(5);
       {
         buttonsLay->addWidget(new QLabel(tr("L-Up R-Down"), this), 0, 1);
@@ -441,7 +441,7 @@ MatchlinesDialog::MatchlinesDialog()
       lineOrderLay->addLayout(buttonsLay, 1);
 
       QHBoxLayout *inkPrevalenceLay = new QHBoxLayout();
-      inkPrevalenceLay->setMargin(0);
+      inkPrevalenceLay->setContentsMargins(0, 0, 0, 0);
       inkPrevalenceLay->setSpacing(5);
       {
         inkPrevalenceLay->addWidget(new QLabel(tr("Line Prevalence"), this), 0);
@@ -455,7 +455,7 @@ MatchlinesDialog::MatchlinesDialog()
     m_topLayout->addStretch();
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(okBtn);
@@ -992,11 +992,11 @@ DeleteInkDialog::DeleteInkDialog(const QString &str, int inkIndex)
   okBtn->setDefault(true);
 
   //--- layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(10);
   {
     QGridLayout *upperLay = new QGridLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(5);
     {
       upperLay->addWidget(new QLabel(tr("Style Index:"), this), 0, 0,
@@ -1010,7 +1010,7 @@ DeleteInkDialog::DeleteInkDialog(const QString &str, int inkIndex)
     m_topLayout->addLayout(upperLay);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(okBtn);

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1596,11 +1596,11 @@ TopBar::TopBar(QWidget *parent) : QToolBar(parent) {
 
   QHBoxLayout *mainLayout = new QHBoxLayout();
   mainLayout->setSpacing(0);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   {
     QVBoxLayout *menuLayout = new QVBoxLayout();
     menuLayout->setSpacing(0);
-    menuLayout->setMargin(0);
+    menuLayout->setContentsMargins(0, 0, 0, 0);
     {
       menuLayout->addStretch(1);
       menuLayout->addWidget(m_stackedMenuBar, 0);

--- a/toonz/sources/toonz/menubarpopup.cpp
+++ b/toonz/sources/toonz/menubarpopup.cpp
@@ -351,11 +351,11 @@ MenuBarPopup::MenuBarPopup(Room* room)
 
   //--- layout
   QVBoxLayout* mainLay = new QVBoxLayout();
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
   {
     QGridLayout* mainUILay = new QGridLayout();
-    mainUILay->setMargin(5);
+    mainUILay->setContentsMargins(5, 5, 5, 5);
     mainUILay->setHorizontalSpacing(8);
     mainUILay->setVerticalSpacing(5);
     {
@@ -364,7 +364,7 @@ MenuBarPopup::MenuBarPopup(Room* room)
       mainUILay->addWidget(m_menuBarTree, 1, 0, 2, 1);
 
       QHBoxLayout* searchLay = new QHBoxLayout();
-      searchLay->setMargin(0);
+      searchLay->setContentsMargins(0, 0, 0, 0);
       searchLay->setSpacing(5);
       {
         searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
@@ -384,7 +384,7 @@ MenuBarPopup::MenuBarPopup(Room* room)
     m_topLayout->addLayout(mainUILay, 1);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(30);
   {
     m_buttonLayout->addStretch(1);

--- a/toonz/sources/toonz/ocaio.cpp
+++ b/toonz/sources/toonz/ocaio.cpp
@@ -414,7 +414,7 @@ void ExportOCACommand::execute() {
     rasVectors->setChecked(true);
 
     QGridLayout *customLay = new QGridLayout();
-    customLay->setMargin(5);
+    customLay->setContentsMargins(5, 5, 5, 5);
     customLay->setSpacing(5);
     customLay->addWidget(exrImageFormat, 0, 0);
     customLay->addWidget(rasVectors, 1, 0);

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -190,7 +190,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
 
   // preview settings
   if (isPreview) {
-    m_topLayout->setMargin(5);
+    m_topLayout->setContentsMargins(5, 5, 5, 5);
     m_topLayout->addWidget(panel, 0);
     return;
   }
@@ -227,10 +227,10 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
   renderButton->setIconSize(QSize(20, 20));
   renderButton->setFixedWidth(200);
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   {
     QHBoxLayout *presetLay = new QHBoxLayout();
-    presetLay->setMargin(0);
+    presetLay->setContentsMargins(0, 0, 0, 0);
     presetLay->setSpacing(5);
     {
       presetLay->addStretch(1);
@@ -243,7 +243,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     m_topLayout->addLayout(presetLay, 0);
 
     QHBoxLayout *middleLay = new QHBoxLayout();
-    middleLay->setMargin(0);
+    middleLay->setContentsMargins(0, 0, 0, 0);
     middleLay->setSpacing(5);
     {
       middleLay->addWidget(categoryList, 0);
@@ -317,7 +317,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
     m_moreBox   = createMoreSettingsBox();
   }
   QVBoxLayout *lay = new QVBoxLayout();
-  lay->setMargin(5);
+  lay->setContentsMargins(5, 5, 5, 5);
   lay->setSpacing(3);
   {
     lay->addWidget(m_cameraLabel, 0);
@@ -325,7 +325,7 @@ QFrame *OutputSettingsPopup::createPanel(bool isPreview) {
     lay->addSpacing(10);
 
     QHBoxLayout *colorLabelLay = new QHBoxLayout();
-    colorLabelLay->setMargin(0);
+    colorLabelLay->setContentsMargins(0, 0, 0, 0);
     colorLabelLay->setSpacing(0);
     {
       colorLabelLay->addWidget(m_colorLabel, 0);
@@ -391,12 +391,12 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   //-----
 
   QVBoxLayout *lay = new QVBoxLayout();
-  lay->setMargin(10);
+  lay->setContentsMargins(10, 10, 10, 10);
   lay->setSpacing(10);
   {
     // Output Camera
     QHBoxLayout *outCamLay = new QHBoxLayout();
-    outCamLay->setMargin(0);
+    outCamLay->setContentsMargins(0, 0, 0, 0);
     outCamLay->setSpacing(5);
     {
       outCamLay->addWidget(new QLabel(tr("Output Camera:"), this), 0);
@@ -407,7 +407,7 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
 
     if (!isPreview) {
       QVBoxLayout *camParamLay = new QVBoxLayout();
-      camParamLay->setMargin(5);
+      camParamLay->setContentsMargins(5, 5, 5, 5);
       camParamLay->setSpacing(0);
       {
         camParamLay->addWidget(m_cameraSettings);
@@ -419,7 +419,7 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
 
     // Frame start/end
     QGridLayout *frameShrinkLay = new QGridLayout();
-    frameShrinkLay->setMargin(0);
+    frameShrinkLay->setContentsMargins(0, 0, 0, 0);
     frameShrinkLay->setHorizontalSpacing(5);
     frameShrinkLay->setVerticalSpacing(10);
     {
@@ -517,7 +517,7 @@ QFrame *OutputSettingsPopup::createColorSettingsBox(bool isPreview) {
   }
 
   QGridLayout *gridLay = new QGridLayout();
-  gridLay->setMargin(5);
+  gridLay->setContentsMargins(5, 5, 5, 5);
   gridLay->setHorizontalSpacing(5);
   gridLay->setVerticalSpacing(10);
   {
@@ -609,12 +609,12 @@ QFrame *OutputSettingsPopup::createFileSettingsBox(bool isPreview) {
   //-----
 
   QVBoxLayout *lay = new QVBoxLayout();
-  lay->setMargin(10);
+  lay->setContentsMargins(10, 10, 10, 10);
   lay->setSpacing(10);
   {
     if (!isPreview) {
       QGridLayout *upperGridLay = new QGridLayout();
-      upperGridLay->setMargin(0);
+      upperGridLay->setContentsMargins(0, 0, 0, 0);
       upperGridLay->setHorizontalSpacing(5);
       upperGridLay->setVerticalSpacing(10);
       {
@@ -636,7 +636,7 @@ QFrame *OutputSettingsPopup::createFileSettingsBox(bool isPreview) {
     }
 
     QGridLayout *bottomGridLay = new QGridLayout();
-    bottomGridLay->setMargin(0);
+    bottomGridLay->setContentsMargins(0, 0, 0, 0);
     bottomGridLay->setHorizontalSpacing(5);
     bottomGridLay->setVerticalSpacing(10);
     {
@@ -741,7 +741,7 @@ QFrame *OutputSettingsPopup::createMoreSettingsBox() {
   //-----
 
   QGridLayout *lay = new QGridLayout();
-  lay->setMargin(5);
+  lay->setContentsMargins(5, 5, 5, 5);
   lay->setHorizontalSpacing(5);
   lay->setVerticalSpacing(10);
   {

--- a/toonz/sources/toonz/overwritepopup.cpp
+++ b/toonz/sources/toonz/overwritepopup.cpp
@@ -81,7 +81,7 @@ OverwriteDialog::OverwriteDialog()
   m_suffix->setEnabled(false);
 
   QHBoxLayout *boxLayout = new QHBoxLayout();
-  boxLayout->setMargin(0);
+  boxLayout->setContentsMargins(0, 0, 0, 0);
   boxLayout->setSpacing(0);
   boxLayout->addWidget(m_rename);
   boxLayout->addWidget(m_suffix);

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1013,11 +1013,11 @@ PencilTestSaveInFolderPopup::PencilTestSaveInFolderPopup(QWidget* parent)
   addButtonBarWidget(okBtn, cancelBtn);
 
   //---- layout
-  m_topLayout->setMargin(10);
+  m_topLayout->setContentsMargins(10, 10, 10, 10);
   m_topLayout->setSpacing(10);
   {
     QGridLayout* saveInLay = new QGridLayout();
-    saveInLay->setMargin(0);
+    saveInLay->setContentsMargins(0, 0, 0, 0);
     saveInLay->setHorizontalSpacing(3);
     saveInLay->setVerticalSpacing(0);
     {
@@ -1033,11 +1033,11 @@ PencilTestSaveInFolderPopup::PencilTestSaveInFolderPopup(QWidget* parent)
     m_topLayout->addWidget(m_subFolderCB, 0, Qt::AlignLeft);
 
     QVBoxLayout* subFolderLay = new QVBoxLayout();
-    subFolderLay->setMargin(0);
+    subFolderLay->setContentsMargins(0, 0, 0, 0);
     subFolderLay->setSpacing(10);
     {
       QGridLayout* infoLay = new QGridLayout();
-      infoLay->setMargin(10);
+      infoLay->setContentsMargins(10, 10, 10, 10);
       infoLay->setHorizontalSpacing(3);
       infoLay->setVerticalSpacing(10);
       {
@@ -1059,7 +1059,7 @@ PencilTestSaveInFolderPopup::PencilTestSaveInFolderPopup(QWidget* parent)
       subFolderLay->addWidget(infoGroupBox, 0);
 
       QGridLayout* subNameLay = new QGridLayout();
-      subNameLay->setMargin(10);
+      subNameLay->setContentsMargins(10, 10, 10, 10);
       subNameLay->setHorizontalSpacing(3);
       subNameLay->setVerticalSpacing(10);
       {
@@ -1460,7 +1460,7 @@ void SubCameraButton::onSaveSubCamera() {
     QDialogButtonBox* buttonBox =
         new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     QVBoxLayout* lay = new QVBoxLayout();
-    lay->setMargin(5);
+    lay->setContentsMargins(5, 5, 5, 5);
     lay->setSpacing(10);
     lay->addWidget(*lineEdit);
     lay->addWidget(buttonBox);
@@ -1734,11 +1734,11 @@ PencilTestPopup::PencilTestPopup()
   m_dpiBtn->setObjectName("SubcameraButton");
 
   //---- layout ----
-  m_topLayout->setMargin(10);
+  m_topLayout->setContentsMargins(10, 10, 10, 10);
   m_topLayout->setSpacing(10);
   {
     QHBoxLayout* camLay = new QHBoxLayout();
-    camLay->setMargin(0);
+    camLay->setContentsMargins(0, 0, 0, 0);
     camLay->setSpacing(3);
     {
       camLay->addWidget(new QLabel(tr("Camera:"), this), 0);
@@ -1756,7 +1756,7 @@ PencilTestPopup::PencilTestPopup()
       camLay->addSpacing(10);
       camLay->addWidget(m_subcameraButton, 0);
       QHBoxLayout* subCamLay = new QHBoxLayout();
-      subCamLay->setMargin(0);
+      subCamLay->setContentsMargins(0, 0, 0, 0);
       subCamLay->setSpacing(3);
       {
         subCamLay->addWidget(new IconView("edit_scale", tr("Size"), this), 0);
@@ -1791,28 +1791,28 @@ PencilTestPopup::PencilTestPopup()
     m_topLayout->addLayout(camLay, 0);
 
     QHBoxLayout* bottomLay = new QHBoxLayout();
-    bottomLay->setMargin(0);
+    bottomLay->setContentsMargins(0, 0, 0, 0);
     bottomLay->setSpacing(10);
     {
       bottomLay->addWidget(m_videoWidget, 1);
 
       QVBoxLayout* rightLay = new QVBoxLayout();
-      rightLay->setMargin(0);
+      rightLay->setContentsMargins(0, 0, 0, 0);
       rightLay->setSpacing(5);
       {
         QVBoxLayout* fileLay = new QVBoxLayout();
-        fileLay->setMargin(8);
+        fileLay->setContentsMargins(8, 8, 8, 8);
         fileLay->setSpacing(5);
         {
           QGridLayout* levelLay = new QGridLayout();
-          levelLay->setMargin(0);
+          levelLay->setContentsMargins(0, 0, 0, 0);
           levelLay->setHorizontalSpacing(3);
           levelLay->setVerticalSpacing(5);
           {
             levelLay->addWidget(new QLabel(tr("Name:"), this), 0, 0,
                                 Qt::AlignRight);
             QHBoxLayout* nameLay = new QHBoxLayout();
-            nameLay->setMargin(0);
+            nameLay->setContentsMargins(0, 0, 0, 0);
             nameLay->setSpacing(2);
             {
               nameLay->addWidget(m_previousLevelButton, 0);
@@ -1825,7 +1825,7 @@ PencilTestPopup::PencilTestPopup()
                                 Qt::AlignRight);
 
             QHBoxLayout* frameLay = new QHBoxLayout();
-            frameLay->setMargin(0);
+            frameLay->setContentsMargins(0, 0, 0, 0);
             frameLay->setSpacing(2);
             {
               frameLay->addWidget(m_frameNumberEdit, 1);
@@ -1838,7 +1838,7 @@ PencilTestPopup::PencilTestPopup()
           fileLay->addLayout(levelLay, 0);
 
           QHBoxLayout* fileTypeLay = new QHBoxLayout();
-          fileTypeLay->setMargin(0);
+          fileTypeLay->setContentsMargins(0, 0, 0, 0);
           fileTypeLay->setSpacing(3);
           {
             fileTypeLay->addWidget(new QLabel(tr("File Type:"), this), 0);
@@ -1854,7 +1854,7 @@ PencilTestPopup::PencilTestPopup()
         rightLay->addWidget(fileFrame, 0);
 
         QGridLayout* imageLay = new QGridLayout();
-        imageLay->setMargin(8);
+        imageLay->setContentsMargins(8, 8, 8, 8);
         imageLay->setHorizontalSpacing(3);
         imageLay->setVerticalSpacing(5);
         {
@@ -1882,7 +1882,7 @@ PencilTestPopup::PencilTestPopup()
 
         // Calibration
         QGridLayout* calibLay = new QGridLayout();
-        calibLay->setMargin(8);
+        calibLay->setContentsMargins(8, 8, 8, 8);
         calibLay->setHorizontalSpacing(3);
         calibLay->setVerticalSpacing(5);
         {
@@ -1890,7 +1890,7 @@ PencilTestPopup::PencilTestPopup()
           calibLay->addWidget(m_calibration.loadBtn, 0, 1);
           calibLay->addWidget(m_calibration.exportBtn, 0, 2);
           QHBoxLayout* lay = new QHBoxLayout();
-          lay->setMargin(0);
+          lay->setContentsMargins(0, 0, 0, 0);
           lay->setSpacing(5);
           lay->addWidget(m_calibration.capBtn, 1);
           lay->addWidget(m_calibration.label, 0);
@@ -1902,7 +1902,7 @@ PencilTestPopup::PencilTestPopup()
         rightLay->addWidget(m_calibration.groupBox, 0);
 
         QGridLayout* onionSkinLay = new QGridLayout();
-        onionSkinLay->setMargin(8);
+        onionSkinLay->setContentsMargins(8, 8, 8, 8);
         onionSkinLay->setHorizontalSpacing(3);
         onionSkinLay->setVerticalSpacing(5);
         {
@@ -1917,7 +1917,7 @@ PencilTestPopup::PencilTestPopup()
         rightLay->addWidget(m_onionSkinGBox);
 
         QHBoxLayout* timerLay = new QHBoxLayout();
-        timerLay->setMargin(8);
+        timerLay->setContentsMargins(8, 8, 8, 8);
         timerLay->setSpacing(3);
         {
           timerLay->addWidget(new QLabel(tr("Interval(sec):"), this), 0,
@@ -3825,7 +3825,7 @@ QWidget* PencilTestPopup::createDpiMenuWidget() {
   m_customDpiField->setValidator(new QDoubleValidator(1.0, 2000.0, 6));
 
   QGridLayout* layout = new QGridLayout();
-  layout->setMargin(10);
+  layout->setContentsMargins(10, 10, 10, 10);
   layout->setHorizontalSpacing(5);
   layout->setVerticalSpacing(10);
   {

--- a/toonz/sources/toonz/pltgizmopopup.cpp
+++ b/toonz/sources/toonz/pltgizmopopup.cpp
@@ -462,7 +462,7 @@ ValueAdjuster::ValueAdjuster(QWidget *parent, Qt::WindowFlags flags)
   m_valueLineEdit->setRange(0, 1000);
   //----layout
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(1);
   {
     layout->addWidget(plusBut, 0);
@@ -511,7 +511,7 @@ ValueShifter::ValueShifter(bool isHue, QWidget *parent, Qt::WindowFlags flags)
 
   //----layout
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(1);
   {
     layout->addWidget(plusBut, 0);
@@ -548,7 +548,7 @@ void ValueShifter::onClickedMinus() {
 ColorFader::ColorFader(QString name, QWidget *parent, Qt::WindowFlags flags)
     : QWidget(parent) {
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(6);
   layout->setSizeConstraint(QLayout::SetFixedSize);
 
@@ -606,11 +606,11 @@ PltGizmoPopup::PltGizmoPopup()
   QPushButton *zeroMatteButton = new QPushButton(tr("Zero Alpha"), this);
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(3);
   {
     QGridLayout *upperLay = new QGridLayout();
-    upperLay->setMargin(0);
+    upperLay->setContentsMargins(0, 0, 0, 0);
     upperLay->setSpacing(3);
     {
       upperLay->addWidget(new QLabel(tr("Scale (%)"), this), 0, 1);
@@ -644,11 +644,11 @@ PltGizmoPopup::PltGizmoPopup()
 
     QGroupBox *fadeBox   = new QGroupBox(tr("Fade to Color"), this);
     QVBoxLayout *fadeLay = new QVBoxLayout();
-    fadeLay->setMargin(3);
+    fadeLay->setContentsMargins(3, 3, 3, 3);
     fadeLay->setSpacing(3);
     {
       QHBoxLayout *colorLay = new QHBoxLayout();
-      colorLay->setMargin(0);
+      colorLay->setContentsMargins(0, 0, 0, 0);
       colorLay->setSpacing(4);
       {
         colorLay->addWidget(new QLabel(tr("Color"), this), 0);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -67,7 +67,7 @@ namespace {
 enum DpiPolicy { DP_ImageDpi, DP_CustomDpi };
 
 inline void setupLayout(QGridLayout* lay, int margin = 15) {
-  lay->setMargin(margin);
+  lay->setContentsMargins(margin, margin, margin, margin);
   lay->setHorizontalSpacing(5);
   lay->setVerticalSpacing(10);
   lay->setColumnStretch(2, 1);
@@ -97,7 +97,7 @@ SizeField::SizeField(QSize min, QSize max, QSize value, QWidget* parent)
       new DVGui::IntLineEdit(this, value.height(), min.height(), max.height());
   QHBoxLayout* lay = new QHBoxLayout();
   lay->setSpacing(5);
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
   lay->addWidget(m_fieldX, 1);
   lay->addWidget(new QLabel("x", this), 0);
   lay->addWidget(m_fieldY, 1);
@@ -399,7 +399,7 @@ PreferencesPopup::Display30bitChecker::Display30bitChecker(
 30bit display is available in the current configuration.");
 
   QVBoxLayout* lay = new QVBoxLayout();
-  lay->setMargin(10);
+  lay->setContentsMargins(10, 10, 10, 10);
   lay->setSpacing(10);
   {
     lay->addWidget(view8bit);
@@ -1166,7 +1166,7 @@ void PreferencesPopup::insertDualUIs(
   layout->addWidget(new QLabel(getUIString(leftId), this), row, 0,
                     Qt::AlignRight | Qt::AlignVCenter);
   QHBoxLayout* innerLay = new QHBoxLayout();
-  innerLay->setMargin(0);
+  innerLay->setContentsMargins(0, 0, 0, 0);
   innerLay->setSpacing(10);
   {
     innerLay->addWidget(createUI(leftId, leftComboItems), 0);
@@ -1612,12 +1612,12 @@ PreferencesPopup::PreferencesPopup()
   stackedWidget->addWidget(createTouchTabletPage());
 
   QHBoxLayout* mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     // Category
     QVBoxLayout* categoryLayout = new QVBoxLayout();
-    categoryLayout->setMargin(5);
+    categoryLayout->setContentsMargins(5, 5, 5, 5);
     categoryLayout->setSpacing(10);
     categoryLayout->addWidget(categoryList, 1);
     mainLayout->addLayout(categoryLayout, 0);
@@ -1894,7 +1894,7 @@ QWidget* PreferencesPopup::createLoadingPage() {
   lay->addWidget(new QLabel(tr("Level Settings by File Format:")), row, 0,
                  Qt::AlignRight | Qt::AlignVCenter);
   QHBoxLayout* levelFormatLay = new QHBoxLayout();
-  levelFormatLay->setMargin(0);
+  levelFormatLay->setContentsMargins(0, 0, 0, 0);
   levelFormatLay->setSpacing(5);
   {
     levelFormatLay->addWidget(m_levelFormatNames);

--- a/toonz/sources/toonz/projectpopup.cpp
+++ b/toonz/sources/toonz/projectpopup.cpp
@@ -329,7 +329,7 @@ Note that this mode uses regular expression for file name validation and may slo
   m_letterCountCombo->addItem(tr("Unlimited"), 0);
 
   //----layout
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(10);
   {
     m_topLayout->addWidget(tabWidget, 1);
@@ -338,13 +338,13 @@ Note that this mode uses regular expression for file name validation and may slo
 
     QWidget *projectFolderPanel = new QWidget(this);
     QVBoxLayout *pfLayout       = new QVBoxLayout();
-    pfLayout->setMargin(5);
+    pfLayout->setContentsMargins(5, 5, 5, 5);
     pfLayout->setSpacing(10);
     {
       pfLayout->addWidget(m_treeView, 0);
 
       QGridLayout *upperLayout = new QGridLayout();
-      upperLayout->setMargin(5);
+      upperLayout->setContentsMargins(5, 5, 5, 5);
       upperLayout->setHorizontalSpacing(5);
       upperLayout->setVerticalSpacing(10);
       {
@@ -395,7 +395,7 @@ Note that this mode uses regular expression for file name validation and may slo
     // file path settings
     QWidget *filePathPanel = new QWidget(this);
     QVBoxLayout *fpLayout  = new QVBoxLayout();
-    fpLayout->setMargin(5);
+    fpLayout->setContentsMargins(5, 5, 5, 5);
     fpLayout->setSpacing(10);
     {
       fpLayout->addWidget(standardRB, 0);
@@ -403,7 +403,7 @@ Note that this mode uses regular expression for file name validation and may slo
 
       // add some indent
       QGridLayout *customLay = new QGridLayout();
-      customLay->setMargin(10);
+      customLay->setContentsMargins(10, 10, 10, 10);
       customLay->setHorizontalSpacing(10);
       customLay->setVerticalSpacing(10);
       {
@@ -661,7 +661,7 @@ ProjectCreatePopup::ProjectCreatePopup() : ProjectPopup(true) {
   connect(okBtn, SIGNAL(clicked()), this, SLOT(createProject()));
   connect(cancelBtn, SIGNAL(clicked()), this, SLOT(reject()));
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(20);
   {
     m_buttonLayout->addStretch();

--- a/toonz/sources/toonz/psdsettingspopup.cpp
+++ b/toonz/sources/toonz/psdsettingspopup.cpp
@@ -185,7 +185,7 @@ PsdSettingsPopup::PsdSettingsPopup()
 
   QGridLayout *gridMode = new QGridLayout();
   gridMode->setColumnMinimumWidth(0, 65);
-  gridMode->setMargin(0);
+  gridMode->setContentsMargins(0, 0, 0, 0);
   gridMode->addWidget(modeLbl, 0, 0, Qt::AlignRight);
   gridMode->addWidget(m_loadMode, 0, 1, Qt::AlignLeft);
   gridMode->addWidget(m_modeDescription, 1, 1, Qt::AlignLeft);

--- a/toonz/sources/toonz/reframepopup.cpp
+++ b/toonz/sources/toonz/reframepopup.cpp
@@ -33,7 +33,7 @@ ReframePopup::ReframePopup()
   m_blank->setObjectName("LargeSizedText");
   // layout
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(new QLabel(tr("Number of steps:"), this));
@@ -41,7 +41,7 @@ ReframePopup::ReframePopup()
     mainLay->addWidget(new QLabel(tr("s"), this));
 
     QHBoxLayout* blankLay = new QHBoxLayout();
-    blankLay->setMargin(0);
+    blankLay->setContentsMargins(0, 0, 0, 0);
     blankLay->setSpacing(5);
     {
       blankLay->addSpacing(10);
@@ -55,7 +55,7 @@ ReframePopup::ReframePopup()
   m_topLayout->addLayout(mainLay);
 
   QHBoxLayout* textLay = new QHBoxLayout();
-  textLay->setMargin(0);
+  textLay->setContentsMargins(0, 0, 0, 0);
   {
     textLay->addStretch(1);
     textLay->addWidget(m_blankCellCountLbl);

--- a/toonz/sources/toonz/scanpopup.cpp
+++ b/toonz/sources/toonz/scanpopup.cpp
@@ -509,7 +509,7 @@ AutocenterPopup::AutocenterPopup() : DVGui::Dialog(0, false, true) {
   QGridLayout *settingsLayout = new QGridLayout(this);
   settingsLayout->setSizeConstraint(QLayout::SetFixedSize);
   settingsLayout->setSpacing(5);
-  settingsLayout->setMargin(12);
+  settingsLayout->setContentsMargins(12, 12, 12, 12);
   int row = 0;
 
   // AutoCenter

--- a/toonz/sources/toonz/scenebrowser.cpp
+++ b/toonz/sources/toonz/scenebrowser.cpp
@@ -171,13 +171,13 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WindowFlags flags,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setSpacing(2);
   {
     mainLayout->addWidget(buttonBar);
 
     QHBoxLayout *folderLay = new QHBoxLayout();
-    folderLay->setMargin(0);
+    folderLay->setContentsMargins(0, 0, 0, 0);
     folderLay->setSpacing(0);
     {
       folderLay->addWidget(folderLabel, 0);
@@ -187,7 +187,7 @@ SceneBrowser::SceneBrowser(QWidget *parent, Qt::WindowFlags flags,
 
     // m_mainSplitter->addWidget(m_folderTreeView);
     QVBoxLayout *boxLayout = new QVBoxLayout(box);
-    boxLayout->setMargin(0);
+    boxLayout->setContentsMargins(0, 0, 0, 0);
     boxLayout->setSpacing(0);
     {
       boxLayout->addWidget(titleBar, 0);

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -173,7 +173,7 @@ CellMarksPopup::CellMarksPopup(QWidget *parent) : QDialog(parent) {
                                                 ->getCellMarks();
 
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(10);
+  layout->setContentsMargins(10, 10, 10, 10);
   layout->setHorizontalSpacing(5);
   layout->setVerticalSpacing(10);
   {
@@ -290,7 +290,7 @@ ColorFiltersPopup::ColorFiltersPopup(QWidget *parent) : QDialog(parent) {
                                                      ->getColorFilters();
 
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(10);
+  layout->setContentsMargins(10, 10, 10, 10);
   layout->setHorizontalSpacing(5);
   layout->setVerticalSpacing(10);
   {
@@ -509,7 +509,7 @@ SceneSettingsPopup::SceneSettingsPopup()
 
   // layout
   QGridLayout *mainLayout = new QGridLayout();
-  mainLayout->setMargin(10);
+  mainLayout->setContentsMargins(10, 10, 10, 10);
   mainLayout->setHorizontalSpacing(5);
   mainLayout->setVerticalSpacing(15);
   {

--- a/toonz/sources/toonz/separatecolorspopup.cpp
+++ b/toonz/sources/toonz/separatecolorspopup.cpp
@@ -660,11 +660,11 @@ SeparateColorsPopup::SeparateColorsPopup()
   //----
   {
     QVBoxLayout* leftLay = new QVBoxLayout();
-    leftLay->setMargin(5);
+    leftLay->setContentsMargins(5, 5, 5, 5);
     leftLay->setSpacing(5);
     {
       QHBoxLayout* previewLay = new QHBoxLayout();
-      previewLay->setMargin(0);
+      previewLay->setContentsMargins(0, 0, 0, 0);
       previewLay->setSpacing(5);
       {
         previewLay->addWidget(new QLabel(tr("Preview Frame:"), this), 0,
@@ -690,11 +690,11 @@ SeparateColorsPopup::SeparateColorsPopup()
     mainSplitter->addWidget(leftWidget);
 
     QVBoxLayout* rightLay = new QVBoxLayout();
-    rightLay->setMargin(10);
+    rightLay->setContentsMargins(10, 10, 10, 10);
     rightLay->setSpacing(10);
     {
       QGridLayout* upperLay = new QGridLayout();
-      upperLay->setMargin(0);
+      upperLay->setContentsMargins(0, 0, 0, 0);
       upperLay->setHorizontalSpacing(5);
       upperLay->setVerticalSpacing(10);
       {
@@ -722,7 +722,7 @@ SeparateColorsPopup::SeparateColorsPopup()
         upperLay->addWidget(m_borderSmoothnessFld, 6, 1);
 
         QGridLayout* maskLay = new QGridLayout();
-        maskLay->setMargin(10);
+        maskLay->setContentsMargins(10, 10, 10, 10);
         maskLay->setHorizontalSpacing(5);
         maskLay->setVerticalSpacing(10);
         {
@@ -744,14 +744,14 @@ SeparateColorsPopup::SeparateColorsPopup()
       rightLay->addLayout(upperLay, 0);
 
       QGridLayout* middleLay = new QGridLayout();
-      middleLay->setMargin(0);
+      middleLay->setContentsMargins(0, 0, 0, 0);
       middleLay->setHorizontalSpacing(5);
       middleLay->setVerticalSpacing(10);
       {
         middleLay->addWidget(new QLabel(tr("Start:"), this), 0, 0,
                              Qt::AlignRight);
         QHBoxLayout* rangeLay = new QHBoxLayout();
-        rangeLay->setMargin(0);
+        rangeLay->setContentsMargins(0, 0, 0, 0);
         rangeLay->setSpacing(5);
         {
           rangeLay->addWidget(m_fromFld, 0);
@@ -796,7 +796,7 @@ SeparateColorsPopup::SeparateColorsPopup()
       rightLay->addSpacing(10);
 
       QHBoxLayout* saveLoadLay = new QHBoxLayout();
-      saveLoadLay->setMargin(0);
+      saveLoadLay->setContentsMargins(0, 0, 0, 0);
       saveLoadLay->setSpacing(0);
       {
         saveLoadLay->addWidget(saveSettingsBtn, 1);
@@ -807,7 +807,7 @@ SeparateColorsPopup::SeparateColorsPopup()
       rightLay->addSpacing(10);
 
       QHBoxLayout* buttonLay = new QHBoxLayout();
-      buttonLay->setMargin(0);
+      buttonLay->setContentsMargins(0, 0, 0, 0);
       buttonLay->setSpacing(0);
       {
         buttonLay->addWidget(m_autoBtn, 0);

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -430,11 +430,11 @@ ShortcutPopup::ShortcutPopup()
 
   QLineEdit *searchEdit = new QLineEdit(this);
 
-  m_topLayout->setMargin(5);
+  m_topLayout->setContentsMargins(5, 5, 5, 5);
   m_topLayout->setSpacing(8);
   {
     QHBoxLayout *searchLay = new QHBoxLayout();
-    searchLay->setMargin(0);
+    searchLay->setContentsMargins(0, 0, 0, 0);
     searchLay->setSpacing(5);
     {
       searchLay->addWidget(new QLabel(tr("Search:"), this), 0);
@@ -443,7 +443,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addLayout(searchLay, 0);
 
     QVBoxLayout *listLay = new QVBoxLayout();
-    listLay->setMargin(0);
+    listLay->setContentsMargins(0, 0, 0, 0);
     listLay->setSpacing(0);
     {
       listLay->addWidget(noSearchResultLabel, 0,
@@ -453,7 +453,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addLayout(listLay, 1);
 
     QHBoxLayout *bottomLayout = new QHBoxLayout();
-    bottomLayout->setMargin(0);
+    bottomLayout->setContentsMargins(0, 0, 0, 0);
     bottomLayout->setSpacing(1);
     {
       bottomLayout->addWidget(m_sViewer, 1);
@@ -462,7 +462,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addLayout(bottomLayout, 0);
     m_topLayout->addSpacing(10);
     QHBoxLayout *presetLay = new QHBoxLayout();
-    presetLay->setMargin(5);
+    presetLay->setContentsMargins(5, 5, 5, 5);
     presetLay->setSpacing(5);
     {
       presetLay->addWidget(new QLabel(tr("Preset:"), this), 0);
@@ -475,7 +475,7 @@ ShortcutPopup::ShortcutPopup()
     m_topLayout->addWidget(presetBox, 0, Qt::AlignCenter);
     m_topLayout->addSpacing(10);
     QHBoxLayout *exportLay = new QHBoxLayout();
-    exportLay->setMargin(0);
+    exportLay->setContentsMargins(0, 0, 0, 0);
     exportLay->setSpacing(5);
     {
       exportLay->addWidget(m_exportButton, 0);

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -183,7 +183,7 @@ StartupPopup::StartupPopup()
   m_buttonFrame->setFixedHeight(34);
 
   //--- layout
-  m_topLayout->setMargin(0);
+  m_topLayout->setContentsMargins(0, 0, 0, 0);
   m_topLayout->setSpacing(0);
   {
     QGridLayout *guiLay      = new QGridLayout();
@@ -191,7 +191,7 @@ StartupPopup::StartupPopup()
     QGridLayout *newSceneLay = new QGridLayout();
     QWidget *newSceneWidget  = new QWidget();
     m_recentSceneLay         = new QVBoxLayout();
-    guiLay->setMargin(10);
+    guiLay->setContentsMargins(10, 10, 10, 10);
     guiLay->setVerticalSpacing(10);
     guiLay->setHorizontalSpacing(10);
 
@@ -199,7 +199,7 @@ StartupPopup::StartupPopup()
 
     //--- Project
     projectLay->setSpacing(8);
-    projectLay->setMargin(8);
+    projectLay->setContentsMargins(8, 8, 8, 8);
     {
       projectLay->addWidget(m_projectsCB, 0, 0, 1, 3);
       projectLay->addWidget(newProjectButton, 1, 0);
@@ -213,7 +213,7 @@ StartupPopup::StartupPopup()
     m_scenesTab->addTab(m_existingList, tr("Open Existing Scene"));
 
     //--- New scene
-    newSceneLay->setMargin(8);
+    newSceneLay->setContentsMargins(8, 8, 8, 8);
     newSceneLay->setVerticalSpacing(8);
     newSceneLay->setHorizontalSpacing(8);
     {
@@ -230,7 +230,7 @@ StartupPopup::StartupPopup()
                              Qt::AlignRight | Qt::AlignVCenter);
       QHBoxLayout *resListLay = new QHBoxLayout();
       resListLay->setSpacing(3);
-      resListLay->setMargin(1);
+      resListLay->setContentsMargins(1, 1, 1, 1);
       {
         resListLay->addWidget(m_presetCombo, 1);
         resListLay->addWidget(m_addPresetBtn, 0);
@@ -267,7 +267,7 @@ StartupPopup::StartupPopup()
     guiLay->addWidget(m_scenesTab, 2, 0, 4, 1, Qt::AlignTop);
 
     //--- Recent scenes
-    m_recentSceneLay->setMargin(5);
+    m_recentSceneLay->setContentsMargins(5, 5, 5, 5);
     m_recentSceneLay->setSpacing(2);
     {
       // Recent Scene List
@@ -279,7 +279,7 @@ StartupPopup::StartupPopup()
     m_topLayout->addLayout(guiLay, 0);
   }
 
-  m_buttonLayout->setMargin(0);
+  m_buttonLayout->setContentsMargins(0, 0, 0, 0);
   m_buttonLayout->setSpacing(10);
   {
     m_buttonLayout->addWidget(m_showAtStartCB, Qt::AlignLeft);

--- a/toonz/sources/toonz/svncommitdialog.cpp
+++ b/toonz/sources/toonz/svncommitdialog.cpp
@@ -63,7 +63,7 @@ SVNCommitDialog::SVNCommitDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   m_treeWidget = new QTreeWidget;
   m_treeWidget->header()->hide();
@@ -79,7 +79,7 @@ SVNCommitDialog::SVNCommitDialog(QWidget *parent, const QString &workingDir,
     mainLayout->addWidget(m_treeWidget);
 
     QHBoxLayout *belowTreeLayout = new QHBoxLayout;
-    belowTreeLayout->setMargin(0);
+    belowTreeLayout->setContentsMargins(0, 0, 0, 0);
 
     m_selectionCheckBox = new QCheckBox(tr("Select / Deselect All"), 0);
     connect(m_selectionCheckBox, SIGNAL(clicked(bool)), this,
@@ -127,7 +127,7 @@ SVNCommitDialog::SVNCommitDialog(QWidget *parent, const QString &workingDir,
   formLayout->setLabelAlignment(Qt::AlignRight);
   formLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
   formLayout->setSpacing(10);
-  formLayout->setMargin(0);
+  formLayout->setContentsMargins(0, 0, 0, 0);
 
   m_commentTextEdit = new QPlainTextEdit;
   m_commentTextEdit->setMaximumHeight(50);
@@ -930,7 +930,7 @@ SVNCommitFrameRangeDialog::SVNCommitFrameRangeDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 

--- a/toonz/sources/toonz/svndeletedialog.cpp
+++ b/toonz/sources/toonz/svndeletedialog.cpp
@@ -56,7 +56,7 @@ SVNDeleteDialog::SVNDeleteDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -100,7 +100,7 @@ SVNDeleteDialog::SVNDeleteDialog(QWidget *parent, const QString &workingDir,
   formLayout->setLabelAlignment(Qt::AlignRight);
   formLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
   formLayout->setSpacing(10);
-  formLayout->setMargin(0);
+  formLayout->setContentsMargins(0, 0, 0, 0);
 
   m_commentTextEdit = new QPlainTextEdit;
   m_commentTextEdit->setMaximumHeight(50);

--- a/toonz/sources/toonz/svnlockdialog.cpp
+++ b/toonz/sources/toonz/svnlockdialog.cpp
@@ -58,7 +58,7 @@ SVNLockDialog::SVNLockDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -93,7 +93,7 @@ SVNLockDialog::SVNLockDialog(QWidget *parent, const QString &workingDir,
   formLayout->setLabelAlignment(Qt::AlignRight);
   formLayout->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
   formLayout->setSpacing(10);
-  formLayout->setMargin(0);
+  formLayout->setContentsMargins(0, 0, 0, 0);
 
   m_commentTextEdit = new QPlainTextEdit;
   m_commentTextEdit->setMaximumHeight(50);
@@ -454,7 +454,7 @@ SVNLockInfoDialog::SVNLockInfoDialog(QWidget *parent, const SVNStatus &status)
   setMinimumSize(300, 150);
 
   QFormLayout *mainLayout = new QFormLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setLabelAlignment(Qt::AlignLeft);
 
   mainLayout->addRow(tr("<b>Edited By:</b>"), new QLabel(m_status.m_lockOwner));

--- a/toonz/sources/toonz/svnlockframerangedialog.cpp
+++ b/toonz/sources/toonz/svnlockframerangedialog.cpp
@@ -38,7 +38,7 @@ SVNLockFrameRangeDialog::SVNLockFrameRangeDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -355,7 +355,7 @@ SVNLockMultiFrameRangeDialog::SVNLockMultiFrameRangeDialog(
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -640,7 +640,7 @@ SVNUnlockFrameRangeDialog::SVNUnlockFrameRangeDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -875,7 +875,7 @@ SVNUnlockMultiFrameRangeDialog::SVNUnlockMultiFrameRangeDialog(
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 

--- a/toonz/sources/toonz/svnrevertdialog.cpp
+++ b/toonz/sources/toonz/svnrevertdialog.cpp
@@ -48,7 +48,7 @@ SVNRevertDialog::SVNRevertDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -78,7 +78,7 @@ SVNRevertDialog::SVNRevertDialog(QWidget *parent, const QString &workingDir,
   if (!m_folderOnly) {
     mainLayout->addSpacing(10);
     QHBoxLayout *checkBoxLayout = new QHBoxLayout;
-    checkBoxLayout->setMargin(0);
+    checkBoxLayout->setContentsMargins(0, 0, 0, 0);
     m_revertSceneContentsCheckBox = new QCheckBox(this);
     connect(m_revertSceneContentsCheckBox, SIGNAL(toggled(bool)), this,
             SLOT(onRevertSceneContentsToggled(bool)));

--- a/toonz/sources/toonz/svnupdateandlockdialog.cpp
+++ b/toonz/sources/toonz/svnupdateandlockdialog.cpp
@@ -46,7 +46,7 @@ SVNUpdateAndLockDialog::SVNUpdateAndLockDialog(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 

--- a/toonz/sources/toonz/svnupdatedialog.cpp
+++ b/toonz/sources/toonz/svnupdatedialog.cpp
@@ -51,7 +51,7 @@ SVNUpdateDialog::SVNUpdateDialog(QWidget *parent, const QString &workingDir,
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setAlignment(Qt::AlignHCenter);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
 
@@ -91,7 +91,7 @@ SVNUpdateDialog::SVNUpdateDialog(QWidget *parent, const QString &workingDir,
 
   if (!isFolderOnly) {
     QHBoxLayout *checkBoxLayout = new QHBoxLayout;
-    checkBoxLayout->setMargin(0);
+    checkBoxLayout->setContentsMargins(0, 0, 0, 0);
     m_updateSceneContentsCheckBox = new QCheckBox(this);
     m_updateSceneContentsCheckBox->setChecked(false);
     m_updateSceneContentsCheckBox->setText(tr("Get Scene Contents"));

--- a/toonz/sources/toonz/tasksviewer.cpp
+++ b/toonz/sources/toonz/tasksviewer.cpp
@@ -90,7 +90,7 @@ QWidget *TasksViewer::createToolBar() {
   add("delete", tr("&Remove"), saveToolbar, SLOT(remove(bool)), tr("Remove"));
 
   QVBoxLayout *toolbarLayout = new QVBoxLayout(toolBarWidget);
-  toolbarLayout->setMargin(0);
+  toolbarLayout->setContentsMargins(0, 0, 0, 0);
   toolbarLayout->setSpacing(0);
   {
     toolbarLayout->addWidget(cmdToolbar);
@@ -128,7 +128,7 @@ TasksViewer::TasksViewer(QWidget *parent, Qt::WindowFlags flags)
   box                  = new QFrame(this);
   QVBoxLayout *vLayout = new QVBoxLayout(box);
   box->setLayout(vLayout);
-  vLayout->setMargin(0);
+  vLayout->setContentsMargins(0, 0, 0, 0);
   vLayout->setSpacing(0);
 
   vLayout->addWidget(createToolBar());
@@ -795,7 +795,7 @@ TaskSheet::TaskSheet(TasksViewer *owner) : QScrollArea(owner) {
   m_viewer = owner;
 
   QGridLayout *layout = new QGridLayout(contentWidget);
-  layout->setMargin(15);
+  layout->setContentsMargins(15, 15, 15, 15);
   layout->setSpacing(8);
   layout->setColumnStretch(3, 1);
   layout->setColumnStretch(5, 1);
@@ -837,7 +837,7 @@ TaskSheet::TaskSheet(TasksViewer *owner) : QScrollArea(owner) {
   m_boxComposer = new QFrame(contentWidget);
   m_boxComposer->setMinimumHeight(150);
   QGridLayout *layout1 = new QGridLayout(m_boxComposer);
-  layout1->setMargin(0);
+  layout1->setContentsMargins(0, 0, 0, 0);
   layout1->setSpacing(8);
   m_boxComposer->setLayout(layout1);
   ::create(m_outputPath, layout1, tr("Output:"), row1++, 4);
@@ -883,7 +883,7 @@ TaskSheet::TaskSheet(TasksViewer *owner) : QScrollArea(owner) {
   // tcleanupper Box
   m_boxCleanup         = new QFrame(contentWidget);
   QGridLayout *layout2 = new QGridLayout(m_boxCleanup);
-  layout2->setMargin(0);
+  layout2->setContentsMargins(0, 0, 0, 0);
   layout2->setSpacing(8);
   m_boxCleanup->setLayout(layout2);
   ::create(m_visible, layout2, tr("Visible Only"), 0);

--- a/toonz/sources/toonz/vectorguideddrawingpane.cpp
+++ b/toonz/sources/toonz/vectorguideddrawingpane.cpp
@@ -102,7 +102,7 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
   connect(m_FlipPrevDirectionBtn, SIGNAL(clicked()), action, SLOT(trigger()));
 
   QGridLayout *mainlayout = new QGridLayout();
-  mainlayout->setMargin(5);
+  mainlayout->setContentsMargins(5, 5, 5, 5);
   mainlayout->setSpacing(2);
   {
     QLabel *guideFrameLabel = new QLabel(this);
@@ -114,7 +114,7 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
     selectGuideStrokeLabel->setText(tr("Select Guide Stroke:"));
     mainlayout->addWidget(selectGuideStrokeLabel, 1, 0, Qt::AlignRight);
     QHBoxLayout *selectBtnLayout = new QHBoxLayout();
-    selectBtnLayout->setMargin(0);
+    selectBtnLayout->setContentsMargins(0, 0, 0, 0);
     selectBtnLayout->setSpacing(2);
     {
       selectBtnLayout->addWidget(m_selectPrevGuideBtn, 0);
@@ -128,7 +128,7 @@ VectorGuidedDrawingPane::VectorGuidedDrawingPane(QWidget *parent,
     flipGuideStrokeLabel->setText(tr("Flip Guide Stroke:"));
     mainlayout->addWidget(flipGuideStrokeLabel, 2, 0, Qt::AlignRight);
     QHBoxLayout *flipBtnLayout = new QHBoxLayout();
-    flipBtnLayout->setMargin(0);
+    flipBtnLayout->setContentsMargins(0, 0, 0, 0);
     flipBtnLayout->setSpacing(2);
     {
       flipBtnLayout->addWidget(m_FlipPrevDirectionBtn, 0);

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -439,7 +439,7 @@ VectorizerPopup::VectorizerPopup(QWidget *parent, Qt::WindowFlags flags)
     QHBoxLayout *toolbarsLayout = new QHBoxLayout(toolbarsContainer);
     toolbarsContainer->setLayout(toolbarsLayout);
 
-    toolbarsLayout->setMargin(0);
+    toolbarsLayout->setContentsMargins(0, 0, 0, 0);
     toolbarsLayout->setSpacing(0);
 
     QToolBar *spacingToolBar = new QToolBar(

--- a/toonz/sources/toonz/vectorizerswatch.cpp
+++ b/toonz/sources/toonz/vectorizerswatch.cpp
@@ -414,7 +414,7 @@ VectorizerSwatchArea::VectorizerSwatchArea(QWidget *parent) {
   setLayout(lay);
   lay->addWidget(m_leftSwatch);
   lay->addWidget(m_rightSwatch);
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
 
   setMinimumHeight(150);
 

--- a/toonz/sources/toonz/versioncontroltimeline.cpp
+++ b/toonz/sources/toonz/versioncontroltimeline.cpp
@@ -44,7 +44,7 @@ using namespace DVGui;
 
 TimelineWidget::TimelineWidget(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
 
   QLabel *label = new QLabel(tr("Recent Version"));
@@ -123,7 +123,7 @@ SVNTimeline::SVNTimeline(QWidget *parent, const QString &workingDir,
           this, SLOT(onSelectionChanged()));
 
   QHBoxLayout *checkBoxLayout = new QHBoxLayout;
-  checkBoxLayout->setMargin(0);
+  checkBoxLayout->setContentsMargins(0, 0, 0, 0);
   m_sceneContentsCheckBox = new QCheckBox(this);
   m_sceneContentsCheckBox->setVisible(m_fileName.endsWith(".tnz"));
   connect(m_sceneContentsCheckBox, SIGNAL(toggled(bool)), this,
@@ -135,7 +135,7 @@ SVNTimeline::SVNTimeline(QWidget *parent, const QString &workingDir,
   checkBoxLayout->addStretch();
 
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->addLayout(hLayout);
   mainLayout->addWidget(m_timelineWidget);
   mainLayout->addSpacing(5);

--- a/toonz/sources/toonz/versioncontrolwidget.cpp
+++ b/toonz/sources/toonz/versioncontrolwidget.cpp
@@ -17,7 +17,7 @@
 DateChooserWidget::DateChooserWidget(QWidget *parent)
     : QWidget(parent), m_selectedRadioIndex(0) {
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setAlignment(Qt::AlignTop);
 
   // Time
@@ -178,7 +178,7 @@ QString DateChooserWidget::getRevisionString() const {
 ConflictWidget::ConflictWidget(QWidget *parent)
     : QWidget(parent), m_button1Text(tr("Mine")), m_button2Text(tr("Theirs")) {
   m_mainLayout = new QVBoxLayout;
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setAlignment(Qt::AlignTop);
   setLayout(m_mainLayout);
 }
@@ -228,7 +228,7 @@ DoubleRadioWidget::DoubleRadioWidget(const QString &button1Text,
 
 {
   QHBoxLayout *mainLayout = new QHBoxLayout;
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   m_firstButton = new QRadioButton(button1Text);
   connect(m_firstButton, SIGNAL(clicked()), this, SIGNAL(valueChanged()));

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -93,7 +93,7 @@ BaseViewerPanel::BaseViewerPanel(QWidget *parent, Qt::WindowFlags flags)
   setFrameStyle(QFrame::StyledPanel);
 
   m_mainLayout = new QVBoxLayout();
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setSpacing(0);
 
   // Viewer
@@ -966,7 +966,7 @@ SceneViewerPanel::SceneViewerPanel(QWidget *parent, Qt::WindowFlags flags)
 
   {
     QGridLayout *viewerL = new QGridLayout();
-    viewerL->setMargin(0);
+    viewerL->setContentsMargins(0, 0, 0, 0);
     viewerL->setSpacing(0);
     {
       viewerL->addWidget(vRuler, 1, 0);

--- a/toonz/sources/toonz/xdtsimportpopup.cpp
+++ b/toonz/sources/toonz/xdtsimportpopup.cpp
@@ -183,7 +183,7 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
   QWidget* fieldsWidget = new QWidget(this);
 
   QGridLayout* fieldsLay = new QGridLayout();
-  fieldsLay->setMargin(0);
+  fieldsLay->setContentsMargins(0, 0, 0, 0);
   fieldsLay->setHorizontalSpacing(10);
   fieldsLay->setVerticalSpacing(10);
   fieldsLay->addWidget(new QLabel(tr("Level Name"), this), 0, 0,
@@ -214,7 +214,7 @@ XDTSImportPopup::XDTSImportPopup(QStringList levelNames, ToonzScene* scene,
   QGroupBox* cellMarkGroupBox =
       new QGroupBox(tr("Cell marks for XDTS symbols"));
   QGridLayout* markLay = new QGridLayout();
-  markLay->setMargin(10);
+  markLay->setContentsMargins(10, 10, 10, 10);
   markLay->setVerticalSpacing(10);
   markLay->setHorizontalSpacing(5);
   {

--- a/toonz/sources/toonz/xdtsio.cpp
+++ b/toonz/sources/toonz/xdtsio.cpp
@@ -778,14 +778,14 @@ void ExportXDTSCommand::execute() {
     // errors in applications other than XDTS Viewer.
 
     QVBoxLayout *customLay = new QVBoxLayout();
-    customLay->setMargin(5);
+    customLay->setContentsMargins(5, 5, 5, 5);
     customLay->setSpacing(10);
     {
       QGroupBox *cellMarkGroupBox =
           new QGroupBox(QObject::tr("Cell marks for XDTS symbols"));
 
       QGridLayout *cellMarkLay = new QGridLayout();
-      cellMarkLay->setMargin(10);
+      cellMarkLay->setContentsMargins(10, 10, 10, 10);
       cellMarkLay->setVerticalSpacing(10);
       cellMarkLay->setHorizontalSpacing(5);
       {
@@ -812,7 +812,7 @@ void ExportXDTSCommand::execute() {
       customLay->addWidget(cellMarkGroupBox, 0, Qt::AlignRight);
 
       QHBoxLayout *bottomLay = new QHBoxLayout();
-      bottomLay->setMargin(0);
+      bottomLay->setContentsMargins(0, 0, 0, 0);
       bottomLay->setSpacing(10);
       {
         bottomLay->addWidget(new QLabel(QObject::tr("Target column")), 1,

--- a/toonz/sources/toonz/xshbreadcrumbs.cpp
+++ b/toonz/sources/toonz/xshbreadcrumbs.cpp
@@ -300,7 +300,7 @@ void BreadcrumbArea::updateBreadcrumbs() {
 
   // Now let's put everything in a layout
   m_breadcrumbLayout = new QHBoxLayout();
-  m_breadcrumbLayout->setMargin(0);
+  m_breadcrumbLayout->setContentsMargins(0, 0, 0, 0);
   m_breadcrumbLayout->setSpacing(0);
   {
     if (!m_viewer->orientation()->isVerticalTimeline())
@@ -319,7 +319,7 @@ void BreadcrumbArea::updateBreadcrumbs() {
   m_breadcrumbLayout->addStretch(1);
 
   QHBoxLayout *hLayout = new QHBoxLayout;
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   hLayout->setSpacing(0);
   setLayout(hLayout);
 

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -1949,14 +1949,14 @@ m_value->setFont(font);*/
   }
 
   QGridLayout *mainLayout = new QGridLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setHorizontalSpacing(6);
   mainLayout->setVerticalSpacing(6);
   {
     mainLayout->addWidget(new QLabel(tr("Opacity:"), this), 0, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
     QHBoxLayout *hlayout = new QHBoxLayout;
-    hlayout->setMargin(0);
+    hlayout->setContentsMargins(0, 0, 0, 0);
     hlayout->setSpacing(3);
     {
       hlayout->addWidget(m_slider);
@@ -1972,7 +1972,7 @@ m_value->setFont(font);*/
 
     if (m_lockBtn) {
       QHBoxLayout *lockLay = new QHBoxLayout();
-      lockLay->setMargin(0);
+      lockLay->setContentsMargins(0, 0, 0, 0);
       lockLay->setSpacing(3);
       {
         lockLay->addWidget(m_lockBtn, 0);
@@ -2122,12 +2122,12 @@ SoundColumnPopup::SoundColumnPopup(QWidget *parent)
   QLabel *sliderLabel = new QLabel(tr("Volume:"), this);
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(3);
+  mainLayout->setContentsMargins(3, 3, 3, 3);
   mainLayout->setSpacing(3);
   {
     QHBoxLayout *hlayout = new QHBoxLayout;
     // hlayout->setContentsMargins(0, 3, 0, 3);
-    hlayout->setMargin(0);
+    hlayout->setContentsMargins(0, 0, 0, 0);
     hlayout->setSpacing(3);
     hlayout->addWidget(sliderLabel, 0);
     hlayout->addWidget(m_slider);

--- a/toonz/sources/toonz/xshnoteviewer.cpp
+++ b/toonz/sources/toonz/xshnoteviewer.cpp
@@ -63,7 +63,7 @@ NotePopup::NotePopup(XsheetViewer *viewer, int noteIndex)
   beginVLayout();
 
   QGridLayout *layout = new QGridLayout(this);
-  layout->setMargin(1);
+  layout->setContentsMargins(1, 1, 1, 1);
   layout->setColumnStretch(7, 10);
   layout->setColumnStretch(8, 10);
   int row = 0;
@@ -573,7 +573,7 @@ void NoteArea::createLayout() {
               SLOT(onClickHamburger()));
     }
     QVBoxLayout *lay = new QVBoxLayout();
-    lay->setMargin(5);
+    lay->setContentsMargins(5, 5, 5, 5);
     lay->setSpacing(5);
     lay->addWidget(m_hamburgerButton, 1, Qt::AlignCenter);
     setLayout(lay);
@@ -585,14 +585,14 @@ void NoteArea::createLayout() {
 
   // has two elements: main layout and header panel
   QVBoxLayout *panelLayout = new QVBoxLayout();
-  panelLayout->setMargin(1);
+  panelLayout->setContentsMargins(1, 1, 1, 1);
   panelLayout->setSpacing(0);
   {
     QBoxLayout *mainLayout = new QBoxLayout(QBoxLayout::Direction(
         o->dimension(PredefinedDimension::QBOXLAYOUT_DIRECTION)));
     Qt::AlignmentFlag centerAlign =
         Qt::AlignmentFlag(o->dimension(PredefinedDimension::CENTER_ALIGN));
-    mainLayout->setMargin(1);
+    mainLayout->setContentsMargins(1, 1, 1, 1);
     mainLayout->setSpacing(0);
     {
       mainLayout->addWidget(m_flipOrientationButton, 0, centerAlign);
@@ -600,7 +600,7 @@ void NoteArea::createLayout() {
       mainLayout->addStretch(1);
 
       QHBoxLayout *buttonsLayout = new QHBoxLayout();
-      buttonsLayout->setMargin(0);
+      buttonsLayout->setContentsMargins(0, 0, 0, 0);
       buttonsLayout->setSpacing(0);
       {
         buttonsLayout->addWidget(m_precNoteButton, 0);

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -287,7 +287,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
 
   QVBoxLayout *mainLay = new QVBoxLayout();
   mainLay->setSpacing(3);
-  mainLay->setMargin(3);
+  mainLay->setContentsMargins(3, 3, 3, 3);
   {
     QGridLayout *gridLay = new QGridLayout();
     gridLay->setHorizontalSpacing(2);
@@ -328,7 +328,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
 
     QHBoxLayout *resListLay = new QHBoxLayout();
     resListLay->setSpacing(3);
-    resListLay->setMargin(1);
+    resListLay->setContentsMargins(1, 1, 1, 1);
     {
       resListLay->addWidget(m_presetListOm, 1);
       resListLay->addWidget(m_addPresetBtn, 0);

--- a/toonz/sources/toonzqt/cleanupcamerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/cleanupcamerasettingswidget.cpp
@@ -44,7 +44,7 @@ CleanupCameraSettingsWidget::CleanupCameraSettingsWidget() {
 
   //--- layout
   QVBoxLayout *mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(m_cameraWidget);
@@ -52,7 +52,7 @@ CleanupCameraSettingsWidget::CleanupCameraSettingsWidget() {
     QGridLayout *offsetLay = new QGridLayout();
     offsetLay->setHorizontalSpacing(3);
     offsetLay->setVerticalSpacing(3);
-    offsetLay->setMargin(3);
+    offsetLay->setContentsMargins(3, 3, 3, 3);
     {
       offsetLay->addWidget(new QLabel(tr("Y")), 0, 0);
       offsetLay->addWidget(m_offsY, 0, 1);

--- a/toonz/sources/toonzqt/colorfield.cpp
+++ b/toonz/sources/toonzqt/colorfield.cpp
@@ -299,7 +299,7 @@ ChannelField::ChannelField(QWidget *parent, const QString &string, int value,
 
   //----layout
   QGridLayout *mainLayout = new QGridLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(3);
   {
     mainLayout->addWidget(channelName, 0, 0);
@@ -447,7 +447,7 @@ ColorField::ColorField(QWidget *parent, bool isAlphaActive, TPixel32 color,
     , m_useStyleEditor(useStyleEditor) {
   setMaximumHeight(squareSize);
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(5);
 
   layout->setSizeConstraint(QLayout::SetFixedSize);
@@ -839,13 +839,13 @@ CleanupColorField::CleanupColorField(QWidget *parent,
   //---- layout
 
   QHBoxLayout *mainLay = new QHBoxLayout();
-  mainLay->setMargin(8);
+  mainLay->setContentsMargins(8, 8, 8, 8);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(m_colorSample, 0);
 
     QVBoxLayout *paramLay = new QVBoxLayout();
-    paramLay->setMargin(0);
+    paramLay->setContentsMargins(0, 0, 0, 0);
     paramLay->setSpacing(3);
     {
       paramLay->addWidget(m_brightnessChannel);

--- a/toonz/sources/toonzqt/combohistogram.cpp
+++ b/toonz/sources/toonzqt/combohistogram.cpp
@@ -322,11 +322,11 @@ ChannelHisto::ChannelHisto(int channelIndex, bool *showComparePtr,
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(2);
   {
     QHBoxLayout *titleLay = new QHBoxLayout();
-    titleLay->setMargin(0);
+    titleLay->setContentsMargins(0, 0, 0, 0);
     titleLay->setSpacing(2);
     {
       titleLay->addWidget(new QLabel(label, this), 0);
@@ -510,13 +510,13 @@ ComboHistogram::ComboHistogram(QWidget *parent)
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   mainLayout->setSpacing(5);
   {
     mainLayout->addWidget(m_histograms[4]);  // RGB
 
     QHBoxLayout *labelLay = new QHBoxLayout();
-    labelLay->setMargin(0);
+    labelLay->setContentsMargins(0, 0, 0, 0);
     labelLay->setSpacing(0);
     {
       labelLay->addWidget(new QLabel(tr("Picked Color"), this), 0);
@@ -532,7 +532,7 @@ ComboHistogram::ComboHistogram(QWidget *parent)
     mainLayout->addWidget(m_rectAverageRgbLabel, 0, Qt::AlignCenter);
 
     QHBoxLayout *infoParamLay = new QHBoxLayout();
-    infoParamLay->setMargin(5);
+    infoParamLay->setContentsMargins(5, 5, 5, 5);
     infoParamLay->setSpacing(3);
     {
       infoParamLay->addWidget(new QLabel(tr("X:"), this), 1,
@@ -544,7 +544,7 @@ ComboHistogram::ComboHistogram(QWidget *parent)
 
       // range control
       QHBoxLayout *rangeLay = new QHBoxLayout();
-      rangeLay->setMargin(0);
+      rangeLay->setContentsMargins(0, 0, 0, 0);
       rangeLay->setSpacing(0);
       {
         rangeLay->addWidget(m_rangeUpBtn, 0);

--- a/toonz/sources/toonzqt/doublepairfield.cpp
+++ b/toonz/sources/toonzqt/doublepairfield.cpp
@@ -54,7 +54,7 @@ DoubleValuePairField::DoubleValuePairField(QWidget *parent,
 
   //---- layout
   QHBoxLayout *m_mainLayout = new QHBoxLayout;
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setSpacing(3);
   {
     m_mainLayout->addWidget(m_leftLabel, 1);

--- a/toonz/sources/toonzqt/dvtextedit.cpp
+++ b/toonz/sources/toonzqt/dvtextedit.cpp
@@ -232,7 +232,7 @@ void DvTextEdit::createMiniToolBar() {
 
   QVBoxLayout *m_mainLayout = new QVBoxLayout(m_miniToolBar);
   m_mainLayout->setSizeConstraint(QLayout::SetFixedSize);
-  m_mainLayout->setMargin(2);
+  m_mainLayout->setContentsMargins(2, 2, 2, 2);
   m_mainLayout->setSpacing(2);
   m_mainLayout->addWidget(toolBarUp);
   m_mainLayout->addWidget(toolBarDown);

--- a/toonz/sources/toonzqt/filefield.cpp
+++ b/toonz/sources/toonzqt/filefield.cpp
@@ -41,7 +41,7 @@ FileField::FileField(QWidget *parent, QString path, bool readOnly,
   setFocusProxy(m_field);
 
   QHBoxLayout *mainLayout = new QHBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(1);
   {
     mainLayout->addWidget(m_field, 5);

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -501,7 +501,7 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, std::vector<int> gadgetsMask,
 
   if (m_gadgetsMask.size() == 0) return;
 
-  // mainLayout->setMargin(1);
+  // mainLayout->setContentsMargins(1, 1, 1, 1);
   // mainLayout->setSpacing(0);
 
   // create toolbars other than frame slider
@@ -511,7 +511,7 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, std::vector<int> gadgetsMask,
     m_playToolBarContainer = new ToolBarContainer();
 
     QHBoxLayout *hLayout = new QHBoxLayout;
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->setSpacing(0);
     hLayout->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
     {
@@ -1852,7 +1852,7 @@ QFrame *FlipConsole::createFrameSlider() {
   // layout
   QHBoxLayout *frameSliderLayout = new QHBoxLayout();
   frameSliderLayout->setSpacing(5);
-  frameSliderLayout->setMargin(2);
+  frameSliderLayout->setContentsMargins(2, 2, 2, 2);
   {
     frameSliderLayout->addWidget(m_editCurrFrame, 0);
     frameSliderLayout->addWidget(m_currFrameSlider, 1);
@@ -1892,7 +1892,7 @@ QFrame *FlipConsole::createFpsSlider() {
 
   QHBoxLayout *hLay = new QHBoxLayout();
   hLay->setSpacing(0);
-  hLay->setMargin(0);
+  hLay->setContentsMargins(0, 0, 0, 0);
   {
     hLay->addWidget(m_fpsLabel, 0);
     hLay->addWidget(m_fpsField, 0);

--- a/toonz/sources/toonzqt/functionsegmentviewer.cpp
+++ b/toonz/sources/toonzqt/functionsegmentviewer.cpp
@@ -87,7 +87,7 @@ SpeedInOutSegmentPage::SpeedInOutSegmentPage(FunctionSegmentViewer *parent)
   QGridLayout *mainLayout = new QGridLayout();
   mainLayout->setHorizontalSpacing(5);
   mainLayout->setVerticalSpacing(5);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addWidget(new QLabel(tr("First Speed:")), 0, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
@@ -376,7 +376,7 @@ EaseInOutSegmentPage::EaseInOutSegmentPage(bool isPercentage,
 
   QGridLayout *mainLayout = new QGridLayout();
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addWidget(new QLabel(tr("Ease Out:")), 0, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
@@ -496,7 +496,7 @@ FunctionExpressionSegmentPage::FunctionExpressionSegmentPage(
   //---- layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(2);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addSpacing(3);
     mainLayout->addWidget(new QLabel(tr("Expression:")));
@@ -678,14 +678,14 @@ FileSegmentPage::FileSegmentPage(FunctionSegmentViewer *parent)
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addWidget(new QLabel(tr("File Path:")), 0);
     mainLayout->addWidget(m_fileFld);
 
     QGridLayout *bottomLay = new QGridLayout();
     bottomLay->setSpacing(5);
-    bottomLay->setMargin(0);
+    bottomLay->setContentsMargins(0, 0, 0, 0);
     {
       bottomLay->addWidget(new QLabel(tr("Column:")), 0, 0,
                            Qt::AlignRight | Qt::AlignVCenter);
@@ -785,7 +785,7 @@ SimilarShapeSegmentPage::SimilarShapeSegmentPage(FunctionSegmentViewer *parent)
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(2);
-  mainLayout->setMargin(2);
+  mainLayout->setContentsMargins(2, 2, 2, 2);
   {
     mainLayout->addSpacing(3);
     mainLayout->addWidget(new QLabel(tr("Reference Curve:")));
@@ -982,18 +982,18 @@ FunctionSegmentViewer::FunctionSegmentViewer(QWidget *parent,
 
   QVBoxLayout *mainLayout = new QVBoxLayout();
   mainLayout->setSpacing(5);
-  mainLayout->setMargin(5);
+  mainLayout->setContentsMargins(5, 5, 5, 5);
   {
     m_topbar                  = new QWidget();
     QVBoxLayout *topbarLayout = new QVBoxLayout();
     topbarLayout->setSpacing(5);
-    topbarLayout->setMargin(0);
+    topbarLayout->setContentsMargins(0, 0, 0, 0);
     {
       topbarLayout->addWidget(m_paramNameLabel);
 
       QHBoxLayout *upperLay = new QHBoxLayout();
       upperLay->setSpacing(3);
-      upperLay->setMargin(0);
+      upperLay->setContentsMargins(0, 0, 0, 0);
       {
         upperLay->addWidget(new QLabel(tr("From"), this), 0);
         upperLay->addWidget(m_fromFld, 1);
@@ -1008,7 +1008,7 @@ FunctionSegmentViewer::FunctionSegmentViewer(QWidget *parent,
 
       QHBoxLayout *bottomLay = new QHBoxLayout();
       bottomLay->setSpacing(3);
-      bottomLay->setMargin(0);
+      bottomLay->setContentsMargins(0, 0, 0, 0);
       {
         bottomLay->addWidget(typeLabel, 0);
         bottomLay->addWidget(m_typeCombo, 1);
@@ -1025,7 +1025,7 @@ FunctionSegmentViewer::FunctionSegmentViewer(QWidget *parent,
     mainLayout->addWidget(applyButton);
 
     QHBoxLayout *moveLay = new QHBoxLayout();
-    moveLay->setMargin(0);
+    moveLay->setContentsMargins(0, 0, 0, 0);
     moveLay->setSpacing(0);
     {
       moveLay->addWidget(m_prevCurveButton, 0);

--- a/toonz/sources/toonzqt/functionsheet.cpp
+++ b/toonz/sources/toonzqt/functionsheet.cpp
@@ -205,7 +205,7 @@ FunctionSheetButtonArea::FunctionSheetButtonArea(QWidget *parent)
   m_syncSizeBtn->setToolTip(tr("Toggle synchronizing zoom with xsheet"));
 
   QVBoxLayout *layout = new QVBoxLayout();
-  layout->setMargin(2);
+  layout->setContentsMargins(2, 2, 2, 2);
   layout->setSpacing(0);
   {
     layout->addStretch();

--- a/toonz/sources/toonzqt/functionviewer.cpp
+++ b/toonz/sources/toonzqt/functionviewer.cpp
@@ -130,7 +130,7 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
           Preferences::FunctionEditorToggle::ShowFunctionSpreadsheetInPopup;
 
   m_leftLayout = new QVBoxLayout();
-  m_leftLayout->setMargin(0);
+  m_leftLayout->setContentsMargins(0, 0, 0, 0);
   m_leftLayout->setSpacing(0);
   {
     if (!toolBarOnBottom) m_leftLayout->addWidget(m_toolbar);
@@ -157,7 +157,7 @@ FunctionViewer::FunctionViewer(QWidget *parent, Qt::WindowFlags flags)
   addWidget(leftPanel);
 
   QVBoxLayout *rightLayout = new QVBoxLayout();
-  rightLayout->setMargin(0);
+  rightLayout->setContentsMargins(0, 0, 0, 0);
   rightLayout->setSpacing(5);
   {
     rightLayout->addWidget(m_segmentViewer, 0);

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -109,7 +109,7 @@ ParamsPage::ParamsPage(QWidget *parent, ParamViewer *paramViewer)
   setFrameStyle(QFrame::StyledPanel);
 
   m_mainLayout = new QGridLayout(this);
-  m_mainLayout->setMargin(12);
+  m_mainLayout->setContentsMargins(12, 12, 12, 12);
   m_mainLayout->setVerticalSpacing(10);
   m_mainLayout->setHorizontalSpacing(5);
 
@@ -130,7 +130,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
   // metodo, per sicurezza verifico.
   if (isVertical == false && !m_horizontalLayout) {
     m_horizontalLayout = new QHBoxLayout();
-    m_horizontalLayout->setMargin(0);
+    m_horizontalLayout->setContentsMargins(0, 0, 0, 0);
     m_horizontalLayout->setSpacing(5);
   }
 
@@ -236,7 +236,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
     } else if (tagName == "hbox") {
       int currentRow     = m_mainLayout->rowCount();
       m_horizontalLayout = new QHBoxLayout();
-      m_horizontalLayout->setMargin(0);
+      m_horizontalLayout->setContentsMargins(0, 0, 0, 0);
       m_horizontalLayout->setSpacing(5);
       setPageField(is, fx, false);
       m_mainLayout->addLayout(m_horizontalLayout, currentRow, 1, 1, 2);
@@ -251,7 +251,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
           std::string label   = is.getTagAttribute("label");
           QCheckBox *checkBox = new QCheckBox(this);
           QHBoxLayout *sepLay = new QHBoxLayout();
-          sepLay->setMargin(0);
+          sepLay->setContentsMargins(0, 0, 0, 0);
           sepLay->setSpacing(5);
           sepLay->addWidget(checkBox, 0);
           sepLay->addWidget(new Separator(QString::fromStdString(label), this),
@@ -300,7 +300,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
         QGridLayout *keepMainLay = m_mainLayout;
         // temporary switch the layout
         m_mainLayout = new QGridLayout();
-        m_mainLayout->setMargin(0);
+        m_mainLayout->setContentsMargins(0, 0, 0, 0);
         m_mainLayout->setVerticalSpacing(10);
         m_mainLayout->setHorizontalSpacing(5);
         m_mainLayout->setColumnStretch(0, 0);
@@ -502,7 +502,7 @@ void ParamsPage::addWidget(QWidget *field, bool isVertical) {
   } else {
     if (!m_horizontalLayout) {
       m_horizontalLayout = new QHBoxLayout();
-      m_horizontalLayout->setMargin(0);
+      m_horizontalLayout->setContentsMargins(0, 0, 0, 0);
       m_horizontalLayout->setSpacing(5);
     }
     m_horizontalLayout->addWidget(field);
@@ -728,11 +728,11 @@ ParamsPageSet::ParamsPageSet(QWidget *parent, Qt::WindowFlags flags)
 
   //----layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     QHBoxLayout *hLayout = new QHBoxLayout();
-    hLayout->setMargin(0);
+    hLayout->setContentsMargins(0, 0, 0, 0);
     hLayout->addSpacing(0);
     {
       hLayout->addWidget(m_tabBar);
@@ -1079,13 +1079,13 @@ ParamViewer::ParamViewer(QWidget *parent, Qt::WindowFlags flags)
   showSwatchButton->setFocusPolicy(Qt::NoFocus);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_tablePageSet, 1);
 
     QHBoxLayout *showPreviewButtonLayout = new QHBoxLayout(this);
-    showPreviewButtonLayout->setMargin(3);
+    showPreviewButtonLayout->setContentsMargins(3, 3, 3, 3);
     showPreviewButtonLayout->setSpacing(3);
     {
       showPreviewButtonLayout->addWidget(showSwatchButton, 0);
@@ -1238,7 +1238,7 @@ FxSettings::FxSettings(QWidget *parent, const TPixel32 &checkCol1,
   addWidget(m_paramViewer);
 
   QVBoxLayout *swatchLayout = new QVBoxLayout(swatchContainer);
-  swatchLayout->setMargin(0);
+  swatchLayout->setContentsMargins(0, 0, 0, 0);
   swatchLayout->setSpacing(0);
   {
     swatchLayout->addWidget(m_viewer, 0, Qt::AlignHCenter);

--- a/toonz/sources/toonzqt/hexcolornames.cpp
+++ b/toonz/sources/toonzqt/hexcolornames.cpp
@@ -515,7 +515,7 @@ HexColorNamesEditor::HexColorNamesEditor(QWidget *parent)
                                   QSizePolicy::Preferred);
   m_importButton = new QPushButton(tr("Import"));
   m_exportButton = new QPushButton(tr("Export"));
-  bottomLay->setMargin(8);
+  bottomLay->setContentsMargins(8, 8, 8, 8);
   bottomLay->setSpacing(5);
   bottomLay->addWidget(m_autoCompleteCb);
   bottomLay->addWidget(m_importButton);

--- a/toonz/sources/toonzqt/histogram.cpp
+++ b/toonz/sources/toonzqt/histogram.cpp
@@ -366,7 +366,7 @@ HistogramView::HistogramView(QWidget *parent, QColor color)
   setMinimumHeight(120 + 10 * 2 + 2);  // 10 == margin of internal widget
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(7);
 
   m_histogramGraph = new HistogramGraph(this, color);
@@ -518,7 +518,7 @@ Histogram::Histogram(QWidget *parent) : QWidget(parent) {
   setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   setLayout(mainLayout);
 

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -949,7 +949,7 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
 
 FullScreenWidget::FullScreenWidget(QWidget *parent) : QWidget(parent) {
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
 
   // Attach see-through window signal so this can detect opacity changes

--- a/toonz/sources/toonzqt/intfield.cpp
+++ b/toonz/sources/toonzqt/intfield.cpp
@@ -276,13 +276,13 @@ IntField::IntField(QWidget *parent, bool isMaxRangeLimited, bool isRollerHide,
     , m_isLinearSlider(true) {
   setObjectName("IntField");
   QHBoxLayout *layout = new QHBoxLayout(this);
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(5);
 
   QWidget *field = new QWidget(this);
   field->setMaximumWidth(43);
   QVBoxLayout *vLayout = new QVBoxLayout(field);
-  vLayout->setMargin(0);
+  vLayout->setContentsMargins(0, 0, 0, 0);
   vLayout->setSpacing(0);
 
   m_lineEdit = new DVGui::IntLineEdit(field);

--- a/toonz/sources/toonzqt/intpairfield.cpp
+++ b/toonz/sources/toonzqt/intpairfield.cpp
@@ -49,7 +49,7 @@ IntPairField::IntPairField(QWidget *parent, bool isMaxRangeLimited)
 
   //----layout
   QHBoxLayout *m_mainLayout = new QHBoxLayout;
-  m_mainLayout->setMargin(0);
+  m_mainLayout->setContentsMargins(0, 0, 0, 0);
   m_mainLayout->setSpacing(5);
   {
     m_mainLayout->addWidget(m_leftLabel, 1);

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -159,7 +159,7 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
   createToolBar();
 
   QHBoxLayout *toolBarLayout = new QHBoxLayout(toolBarWidget);
-  toolBarLayout->setMargin(0);
+  toolBarLayout->setContentsMargins(0, 0, 0, 0);
   toolBarLayout->setSpacing(0);
   {
     toolBarLayout->addWidget(m_savePaletteToolBar, 0, Qt::AlignLeft);
@@ -173,11 +173,11 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
   m_tabBarContainer = new TabBarContainter(this);
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     m_hLayout = new QHBoxLayout;
-    m_hLayout->setMargin(0);
+    m_hLayout->setContentsMargins(0, 0, 0, 0);
     {
       m_hLayout->addWidget(m_pagesBar, 0);
       m_hLayout->addStretch(1);

--- a/toonz/sources/toonzqt/paramfield.cpp
+++ b/toonz/sources/toonzqt/paramfield.cpp
@@ -636,7 +636,7 @@ ParamField::ParamField(QWidget *parent, QString paramName, const TParamP &param,
     , m_description(QString::fromStdString(param->getDescription())) {
   QString str;
   m_layout = new QHBoxLayout(this);
-  m_layout->setMargin(0);
+  m_layout->setContentsMargins(0, 0, 0, 0);
   m_layout->setSpacing(5);
 }
 
@@ -1130,7 +1130,7 @@ RgbLinkButtons::RgbLinkButtons(QString str1, QString str2, QWidget *parent,
   swapButton->setFixedHeight(21);
 
   QHBoxLayout *lay = new QHBoxLayout();
-  lay->setMargin(0);
+  lay->setContentsMargins(0, 0, 0, 0);
   lay->setSpacing(5);
   {
     lay->addWidget(copyButton, 0);

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -834,7 +834,7 @@ SchematicViewer::SchematicViewer(QWidget *parent)
 
   // layout
   QVBoxLayout *mainLayout = new QVBoxLayout();
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     mainLayout->addWidget(m_viewer, 1);
@@ -842,7 +842,7 @@ SchematicViewer::SchematicViewer(QWidget *parent)
     QFrame *bottomFrame = new QFrame(this);
     bottomFrame->setObjectName("SchematicBottomFrame");
     QHBoxLayout *horizontalLayout = new QHBoxLayout();
-    horizontalLayout->setMargin(0);
+    horizontalLayout->setContentsMargins(0, 0, 0, 0);
     horizontalLayout->setSpacing(0);
     {
       horizontalLayout->addWidget(m_commonToolbar);

--- a/toonz/sources/toonzqt/spectrumfield.cpp
+++ b/toonz/sources/toonzqt/spectrumfield.cpp
@@ -329,7 +329,7 @@ SpectrumField::SpectrumField(QWidget *parent, TPixel32 color)
   setFixedHeight(60);
 
   QVBoxLayout *layout = new QVBoxLayout();
-  layout->setMargin(m_margin);
+  layout->setContentsMargins(m_margin, m_margin, m_margin, m_margin);
   layout->setSpacing(m_spacing);
 
   m_spectrumbar = new SpectrumBar(this, color);

--- a/toonz/sources/toonzqt/spreadsheetviewer.cpp
+++ b/toonz/sources/toonzqt/spreadsheetviewer.cpp
@@ -585,7 +585,7 @@ SpreadsheetViewer::SpreadsheetViewer(QWidget *parent)
 
   //---- layout
   QGridLayout *layout = new QGridLayout();
-  layout->setMargin(0);
+  layout->setContentsMargins(0, 0, 0, 0);
   layout->setSpacing(0);
   {
     layout->addWidget(m_columnScrollArea, 0, 1);

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -2407,7 +2407,7 @@ SettingBox::SettingBox(QWidget *parent, int index)
 {
         QHBoxLayout* hLayout = new QHBoxLayout(this);
         hLayout->setSpacing(5);
-        hLayout->setMargin(0);
+        hLayout->setContentsMargins(0, 0, 0, 0);
         hLayout->addSpacing(10);
         m_name = new QLabel(this);
         m_name->setFixedSize(82,20);

--- a/toonz/sources/toonzqt/stylenameeditor.cpp
+++ b/toonz/sources/toonzqt/stylenameeditor.cpp
@@ -48,14 +48,14 @@ NewWordDialog::NewWordDialog(QWidget* parent) {
 
   // layout
   QVBoxLayout* mainLay = new QVBoxLayout();
-  mainLay->setMargin(5);
+  mainLay->setContentsMargins(5, 5, 5, 5);
   mainLay->setSpacing(5);
   {
     mainLay->addWidget(new QLabel(tr("Enter new word"), this), 0,
                        Qt::AlignLeft | Qt::AlignVCenter);
     mainLay->addWidget(m_lineEdit, 0);
     QHBoxLayout* buttonsLay = new QHBoxLayout();
-    buttonsLay->setMargin(3);
+    buttonsLay->setContentsMargins(3, 3, 3, 3);
     buttonsLay->setSpacing(20);
     {
       buttonsLay->addSpacing(1);
@@ -179,7 +179,7 @@ EasyInputArea::EasyInputArea(QWidget* parent) : QWidget(parent) {
   loadList();
 
   QHBoxLayout* mainLay = new QHBoxLayout();
-  mainLay->setMargin(0);
+  mainLay->setContentsMargins(0, 0, 0, 0);
   mainLay->setSpacing(3);
   for (int a = 0; a < WORD_COLUMN_AMOUNT; a++) {
     m_scrollArea[a] = new QScrollArea(this);
@@ -187,7 +187,7 @@ EasyInputArea::EasyInputArea(QWidget* parent) : QWidget(parent) {
 
     QFrame* wordPanel       = new QFrame(this);
     QGridLayout* buttonsLay = new QGridLayout();
-    buttonsLay->setMargin(3);
+    buttonsLay->setContentsMargins(3, 3, 3, 3);
     buttonsLay->setSpacing(3);
     {
       int row = 0;
@@ -373,11 +373,11 @@ StyleNameEditor::StyleNameEditor(QWidget* parent)
   easyInputArea->setFocusPolicy(Qt::NoFocus);
 
   // QVBoxLayout* mainLayout = new QVBoxLayout();
-  m_topLayout->setMargin(10);
+  m_topLayout->setContentsMargins(10, 10, 10, 10);
   m_topLayout->setSpacing(5);
   {
     QHBoxLayout* inputLayout = new QHBoxLayout();
-    inputLayout->setMargin(0);
+    inputLayout->setContentsMargins(0, 0, 0, 0);
     inputLayout->setSpacing(3);
     {
       inputLayout->addWidget(new QLabel(tr("Style Name"), this), 0);
@@ -386,7 +386,7 @@ StyleNameEditor::StyleNameEditor(QWidget* parent)
     m_topLayout->addLayout(inputLayout, 0);
 
     QHBoxLayout* buttonLayout = new QHBoxLayout();
-    buttonLayout->setMargin(0);
+    buttonLayout->setContentsMargins(0, 0, 0, 0);
     buttonLayout->setSpacing(3);
     {
       buttonLayout->addWidget(m_okButton);
@@ -398,7 +398,7 @@ StyleNameEditor::StyleNameEditor(QWidget* parent)
     m_topLayout->addSpacing(5);
 
     QHBoxLayout* labelLay = new QHBoxLayout();
-    labelLay->setMargin(0);
+    labelLay->setContentsMargins(0, 0, 0, 0);
     labelLay->setSpacing(3);
     {
       labelLay->addWidget(new QLabel(tr("Easy Inputs"), this), 1,

--- a/toonz/sources/toonzqt/tdockwindows.cpp
+++ b/toonz/sources/toonzqt/tdockwindows.cpp
@@ -37,7 +37,7 @@ TMainWindow::TMainWindow(QWidget *parent, Qt::WindowFlags flags)
 
   // Set a vertical layout to include menu bars
   QVBoxLayout *vlayout = new QVBoxLayout;
-  vlayout->setMargin(0);
+  vlayout->setContentsMargins(0, 0, 0, 0);
   vlayout->setSpacing(4);
   setLayout(vlayout);
 

--- a/toonz/sources/toonzqt/tmessageviewer.cpp
+++ b/toonz/sources/toonzqt/tmessageviewer.cpp
@@ -138,11 +138,11 @@ TMessageViewer::TMessageViewer(QWidget *parent) : QFrame(parent) {
   setFrameStyle(QFrame::StyledPanel);
   setObjectName("OnePixelMarginFrame");
   QVBoxLayout *vLayout = new QVBoxLayout();
-  vLayout->setMargin(0);
+  vLayout->setContentsMargins(0, 0, 0, 0);
   QFrame *fr = new QFrame();
 
   QHBoxLayout *hLayout = new QHBoxLayout();
-  hLayout->setMargin(0);
+  hLayout->setContentsMargins(0, 0, 0, 0);
   fr->setLayout(hLayout);
   fr->setFixedHeight(24);
   fr->setStyleSheet("background-color: rgb(210,210,210); color: black;");

--- a/toonz/sources/toonzqt/tonecurvefield.cpp
+++ b/toonz/sources/toonzqt/tonecurvefield.cpp
@@ -890,11 +890,11 @@ ToneCurveField::ToneCurveField(QWidget *parent,
   //------ layout
 
   QVBoxLayout *mainLayout = new QVBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
     QHBoxLayout *channelListLayout = new QHBoxLayout();
-    channelListLayout->setMargin(0);
+    channelListLayout->setContentsMargins(0, 0, 0, 0);
     channelListLayout->setSpacing(0);
     channelListLayout->setAlignment(Qt::AlignCenter);
     {
@@ -910,12 +910,12 @@ ToneCurveField::ToneCurveField(QWidget *parent,
     mainLayout->addLayout(channelListLayout, 0);
 
     QGridLayout *bottomLayout = new QGridLayout();
-    bottomLayout->setMargin(0);
+    bottomLayout->setContentsMargins(0, 0, 0, 0);
     bottomLayout->setHorizontalSpacing(5);
     bottomLayout->setVerticalSpacing(0);
     {
       QVBoxLayout *currentValLayout = new QVBoxLayout();
-      currentValLayout->setMargin(0);
+      currentValLayout->setContentsMargins(0, 0, 0, 0);
       currentValLayout->setSpacing(0);
       currentValLayout->setAlignment(Qt::AlignLeft);
       {


### PR DESCRIPTION
This PR continues the modernization of OpenToonz’s Qt codebase, focusing on replacing all occurrences of the deprecated `QLayout::setMargin()` calls with `setContentsMargins()`.  See: [#6311](https://github.com/opentoonz/opentoonz/issues/6311)

- Replaced `setMargin(0)` with `setContentsMargins(0, 0, 0, 0)`.
- No functional changes, purely modernization.

**Note:** The `CMakeLists.txt` was used to find deprecated (legacy 32-bit) files from the active code. Legacy files, such as `cameracapturelevelcontrol_qt.cpp` and `penciltestpopup_qt.cpp`, are only used in 32-bit builds, which are no longer officially supported. The `setMargin` was not updated there. In the future, these files should be moved from, or commented out in, the `CMakeLists.txt` for later exclusion.

For example, `setMargin` was not updated in the file `toonz/studiopaletteviewer.cpp` because it is dead code and no longer used. The active file, `toonzqt/studiopaletteviewer.cpp`, has already been updated. To better organize the repository and preserve legacy or orphaned (dead code) files for reference, it may be helpful to create a `/deprecated` folder inside each relevant source directory and move these files there first. Later, they can be clearly excluded from the repository once it is decided how these files will be handled.


