### PR TITLE
Fix scene thumbnail backgrounds

### DIFF
--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -1222,8 +1222,7 @@ QPixmap StartupScenesList::createScenePreview(const QString &name,
       painter.setPen(pen);
       painter.drawRect((m_iconSize.width() - scaledPixmap.width()) / 2,
                        (m_iconSize.height() - scaledPixmap.height()) / 2,
-                       scaledPixmap.width() - 1,
-                       scaledPixmap.height() - 1);
+                       scaledPixmap.width() - 1, scaledPixmap.height() - 1);
       return pixmap;
     }
   }
@@ -1232,15 +1231,13 @@ QPixmap StartupScenesList::createScenePreview(const QString &name,
   return pixmap;
 }
 
-void StartupScenesList::clearScenes() {
-    clear();
-}
+void StartupScenesList::clearScenes() { clear(); }
 
 void StartupScenesList::addScene(const QString &name, const QString &path) {
   QPixmap pixmap;
   if (path == ":")
-    pixmap =
-        generateIconPixmap("new_scene", 1.0, m_iconSize, Qt::KeepAspectRatio);
+    pixmap = createQIcon("new_scene", false)
+                 .pixmap(m_iconSize, QIcon::Normal, QIcon::Off);
   else
     pixmap = createScenePreview(name, TFilePath(path));
   QIcon icon(pixmap);


### PR DESCRIPTION
Added white Backdrop for Transparent images.

<img width="742" height="557" alt="image" src="https://github.com/user-attachments/assets/c1bd27a6-453b-4f99-95df-dcb735a7f4be" />
     
 Co Authored by: @justburner @manongjohn 
