### PR TITLE
Fix Auto Close performance

### DIFF
--- a/toonz/sources/include/toonz/autoclose.h
+++ b/toonz/sources/include/toonz/autoclose.h
@@ -64,6 +64,8 @@ public:
 
   // draws the segments on the raster
   void draw(const std::vector<Segment> &segments);
+
+  // Cache management functions
   static bool hasSegmentCache(const std::string &id) {
     std::lock_guard<std::mutex> lock(m_mutex);
     return m_cache.find(id) != m_cache.end();
@@ -77,6 +79,22 @@ public:
     }
     static const std::vector<Segment> empty;
     return empty;
+  }
+
+  static void setSegmentCache(const std::string &id,
+                              const std::vector<Segment> &segments) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    constexpr size_t MAX_CACHE_SIZE = 50;  // maximum number of images in cache
+
+    m_cache[id] = segments;  // Stores or replaces
+
+    // Remove oldest entries if exceeding limit
+    if (m_cache.size() > MAX_CACHE_SIZE) {
+      auto it = m_cache.begin();
+      std::advance(it, m_cache.size() - MAX_CACHE_SIZE);
+      m_cache.erase(m_cache.begin(), it);
+    }
   }
 
   static void invalidateSegmentCache(const std::string &id) {


### PR DESCRIPTION
This PR aims to improve the performance of Auto Close. Related issue: [#6333](https://github.com/opentoonz/opentoonz/issues/6333)

Changes included:

- Implemented per-image segment caching with a limit of 50 entries.
- Added adaptive spatial grid acceleration in spotResearchTwoPoints with dynamic cell sizing based on endpoint density and closing distance.
- Introduced early bounding-box rejection and fallback to linear search for low endpoint counts (<40) to ensure optimal performance in all cases.
- Avoided aborts by commenting out asserts (e.g., on Linux Flatpak); also reduced unnecessary vector copies.
