### PR TITLE
 Display file paths in Scene Cast

### DIFF
--- a/toonz/sources/toonz/castviewer.cpp
+++ b/toonz/sources/toonz/castviewer.cpp
@@ -18,6 +18,8 @@
 #include "toonz/levelset.h"
 #include "toonz/toonzscene.h"
 #include "toonz/txshsimplelevel.h"
+#include "toonz/txshpalettelevel.h"
+#include "toonz/txshsoundlevel.h"
 #include "toonz/txshleveltypes.h"
 
 // TnzQt includes
@@ -481,7 +483,9 @@ CastBrowser::CastBrowser(QWidget *parent, Qt::WindowFlags flags)
   castSelection->setBrowser(this);
   viewerPanel->setSelection(castSelection);
   viewerPanel->addColumn(DvItemListModel::FrameCount, 50);
+  viewerPanel->addColumn(DvItemListModel::FullPath, 300);
   m_itemViewer->setModel(this);
+  m_itemViewer->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
 
   DvItemViewerTitleBar *titleBar = new DvItemViewerTitleBar(m_itemViewer, box);
   // titleBar->hide();
@@ -627,7 +631,16 @@ QVariant CastBrowser::getItemData(int index, DataType dataType,
     return item->getToolTip();
   else if (dataType == FrameCount)
     return item->getFrameCount();
-  else if (dataType == VersionControlStatus) {
+  else if (dataType == FullPath) {
+    ToonzScene *scene   = TApp::instance()->getCurrentScene()->getScene();
+    TXshSimpleLevel *sl = item->getSimpleLevel();
+    if (sl) return scene->decodeFilePath(sl->getPath()).getQString();
+    TXshPaletteLevel *pl = item->getPaletteLevel();
+    if (pl) return scene->decodeFilePath(pl->getPath()).getQString();
+    TXshSoundLevel *ml = item->getSoundLevel();
+    if (ml) return scene->decodeFilePath(ml->getPath()).getQString();
+    return "";
+  } else if (dataType == VersionControlStatus) {
     if (!item->exists())
       return VC_Missing;
     else

--- a/toonz/sources/toonz/dvitemview.cpp
+++ b/toonz/sources/toonz/dvitemview.cpp
@@ -1435,6 +1435,7 @@ void DvItemViewerPanel::exportFileList() {
   if (data.open(QFile::WriteOnly)) {
     QTextStream out(&data);
 
+    out << "Name,Frames,Path\n";
     for (int index = 0; index < getItemCount(); index++) {
       if (getModel()->getItemData(index, DvItemListModel::IsFolder).toBool())
         continue;
@@ -1443,13 +1444,16 @@ void DvItemViewerPanel::exportFileList() {
         DvItemListModel::DataType dataType = m_columns[i].first;
 
         if (dataType != DvItemListModel::Name &&
-            dataType != DvItemListModel::FrameCount)
+            dataType != DvItemListModel::FrameCount &&
+            dataType != DvItemListModel::FullPath)
           continue;
 
         QString value = getModel()->getItemDataAsString(index, dataType);
 
         out << value;
-        if (dataType == DvItemListModel::Name) out << ",";
+        if (dataType == DvItemListModel::Name ||
+            dataType == DvItemListModel::FrameCount)
+          out << ",";
       }
       out << ('\n');
     }


### PR DESCRIPTION
This PR adds the path column to the Scene Cast to make it easy to see where all your assets are, especially if you Load assets instead of Import and/or if the level name differs from the actual file name. Path will also be in the Export File List.

 this is a Tahoma port: [Thanks MJ](https://github.com/tahoma2d/tahoma2d/pull/639)