### PR TITLE
Reorganizing Command bar Checks Layout and inclusion of Vector guided controls

### DIFF
--- a/stuff/profiles/layouts/settings/commandbar.xml
+++ b/stuff/profiles/layouts/settings/commandbar.xml
@@ -44,13 +44,11 @@
     <separator/>
     <command>MI_ACheck</command>
     <command>MI_GCheck</command>
-    <separator/>
-    <command>MI_BCheck</command>
     <command>MI_TCheck</command>
-    <separator/>
-    <command>MI_PCheck</command>
-    <separator/>
+    <command>MI_BCheck</command>
     <command>MI_IOnly</command>
+    <separator/>
     <command>MI_ICheck</command>
+    <command>MI_PCheck</command>
     <separator/>
 </commandbar>


### PR DESCRIPTION
this PR reorganizes the Command bar checks layout, promoting the ones that work together as features side to side while adding in the Black BG check.

<img width="363" height="40" alt="image" src="https://github.com/user-attachments/assets/3792d4a8-f84f-43eb-bc8b-dba51b91dceb" />
<img width="963" height="527" alt="image" src="https://github.com/user-attachments/assets/af345540-a878-4dd3-a6f5-583bf3130af7" />
<img width="1284" height="708" alt="image" src="https://github.com/user-attachments/assets/b65c8fe4-8ad2-429e-b357-23363cb8fb63" />

