### PR TITLE
Fix: TCubic::getSpeed used an incorrect formula

### DIFF
--- a/toonz/sources/common/tgeometry/tcurves.cpp
+++ b/toonz/sources/common/tgeometry/tcurves.cpp
@@ -338,7 +338,7 @@ TPointD TCubic::getPoint(double t) const {
 //-----------------------------------------------------------------------------
 TPointD TCubic::getSpeed(double t) const {
   double s = 1 - t;
-  return 3.0 * ((m_p1 - m_p0) * s * s + 2 * (m_p2 - m_p0) * s * t +
+  return 3.0 * ((m_p1 - m_p0) * s * s + 2 * (m_p2 - m_p1) * s * t +
                 (m_p3 - m_p2) * t * t);
 }
 //=============================================================================


### PR DESCRIPTION
The Bézier derivative formula itself is standard calculus (Bernstein basis polynomial of degree 3).

Reference wikipedia: https://en.wikipedia.org/wiki/B%C3%A9zier_curve

---

Note: this reads better when wrapping is forced: e.g.

Before:

```.cc
  return 3.0 * ((m_p1 - m_p0) * s * s + 2 *
                (m_p2 - m_p0) * s * t + /* <- m_p0 is used a second time! */
                (m_p3 - m_p2) * t * t);
```

After:
```.cc
  return 3.0 * ((m_p1 - m_p0) * s * s + 2 *
                (m_p2 - m_p1) * s * t +
                (m_p3 - m_p2) * t * t);
```

---

The curve fitting will be higher quality, from a test in: https://github.com/ideasman42/curve-fit-nd

This shows a before and after (where after can fit the curve within the error margin using one less "vertex"):

Before:
![test_curve_freehand_01_before](https://github.com/user-attachments/assets/8e65e846-114f-4a6d-84e1-0ce5becb5a14)

After:
![test_curve_freehand_01_after](https://github.com/user-attachments/assets/cbbc2299-cf1e-4353-a5eb-a9fb54a727d6)

