### PR TITLE
Fix node rename not updating instantly in Animate Tool

### DIFF
--- a/toonz/sources/include/toonzqt/stageschematicnode.h
+++ b/toonz/sources/include/toonzqt/stageschematicnode.h
@@ -404,6 +404,10 @@ signals:
   void currentColumnChanged(int index);
   void editObject();
 
+public slots:
+  // Public wrapper slots for modern Qt5 connection syntax
+  void onHandleReleasedPublic() { onHandleReleased(); }
+
 protected slots:
   void onHandleReleased();
 };
@@ -567,7 +571,7 @@ protected slots:
 
 //========================================================
 //
-// class StageSchematicSplineNode
+// class StageSchematicGroupNode
 //
 //========================================================
 

--- a/toonz/sources/include/toonzqt/stageschematicscene.h
+++ b/toonz/sources/include/toonzqt/stageschematicscene.h
@@ -198,6 +198,17 @@ signals:
   void doCollapse(QList<TStageObjectId>);
   void doExplodeChild(QList<TStageObjectId>);
 
+public slots:
+  // Public wrapper slots for modern Qt5 connection syntax
+  void onResetCenterPublic() { onResetCenter(); }
+  void onEditGroupPublic() { onEditGroup(); }
+  void onCameraActivatePublic() { onCameraActivate(); }
+  void onRemoveSplinePublic() { onRemoveSpline(); }
+  void onSaveSplinePublic() { onSaveSpline(); }
+  void onLoadSplinePublic() { onLoadSpline(); }
+  void onPathToggledPublic(int state) { onPathToggled(state); }
+  void onCpToggledPublic(bool toggled) { onCpToggled(toggled); }
+
 protected slots:
   void onSelectionSwitched(TSelection *oldSel, TSelection *newSel) override;
 


### PR DESCRIPTION
This PR partially addresses #1885: Stage Schematic node renaming now updates immediately on the node itself and in the Animate Tool dropdown. There is no need to switch tabs, create nodes, or reload the scene to force a refresh.

- As part of the modern Qt/C++ refactor [#6311](https://github.com/opentoonz/opentoonz/issues/6311), all `signal/slot `connections were updated to the Qt5 connection syntax.
- Renaming is now asynchronous.
- Clean up dead code, remove unnecessary asserts, and add defensive checks where needed.
- Fixed a Clang analyzer memory leak warning.

Note: `StageSchematicGroupNode` still has a pre-existing bug and could potentially be refactored in the future to follow the SSOT principle, which seems like the best solution I can think of, although someone else might have a better idea. Currently, expanding or collapsing a group behaves as if it has two separate states. If two Stage Schematic windows are open, one with the group expanded and the other collapsed, changing the group name in one can crash the other because their states are not synchronized. This scenario is unusual, as it’s unlikely someone would open two Stage Schematic windows and edit the same group simultaneously in different states, but it’s still a bug anyway.