### PR TITLE
Fix enabling tool options on Vector Select All

### DIFF
--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -619,6 +619,9 @@ void StrokeSelection::selectAll() {
   StrokeSelection *selection = dynamic_cast<StrokeSelection *>(
       TTool::getApplication()->getCurrentSelection()->getSelection());
   if (selection) selection->notifyView();
+  TTool::getApplication()
+      ->getCurrentTool()
+      ->notifyToolChanged();  // Refreshes toolbar values
 }
 
 //=============================================================================


### PR DESCRIPTION
When you select all on a vector level it doesn't activate the attribute boxes in the tool option bar.

https://github.com/tahoma2d/tahoma2d/issues/1596

T2d port:  https://github.com/tahoma2d/tahoma2d/pull/1626