### PR TITLE
Hide global set keys when no skeleton created

### DIFF
--- a/toonz/sources/tnztools/plastictool_animate.cpp
+++ b/toonz/sources/tnztools/plastictool_animate.cpp
@@ -188,6 +188,7 @@ void PlasticTool::leftButtonUp_animate(const TPointD &pos,
 void PlasticTool::addContextMenuActions_animate(QMenu *menu) {
   bool ret = true;
 
+  if (m_sd.getPointer() == nullptr) return;
   if (!m_svSel.isEmpty()) {
     QAction *setKey = menu->addAction(tr("Set Key"));
     ret = ret && connect(setKey, SIGNAL(triggered()), &l_plasticTool,


### PR DESCRIPTION
Hide global set keys when there's no skeleton created to prevent crashes. 
Tahoma port: https://github.com/tahoma2d/tahoma2d/pull/574