### PR TITLE
Fix preview undo collapse crash

### DIFF
--- a/toonz/sources/common/tfx/trenderer.cpp
+++ b/toonz/sources/common/tfx/trenderer.cpp
@@ -884,6 +884,8 @@ void TRendererImp::notifyRenderFinished(bool isCanceled) {
   for (PortContainerIterator it = portsCopy.begin(); it != portsCopy.end();
        ++it)
     (*it)->onRenderFinished();
+
+  rootFx = TRasterFxP();
 }
 
 //================================================================================


### PR DESCRIPTION
This fixes a crash that occurs when you enter preview mode, collapse columns and then undo.

Tahoma2D port:  https://github.com/tahoma2d/tahoma2d/pull/1650