### PR TITLE
Fix empty source switching crash

### DIFF
--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -1790,6 +1790,7 @@ void FxSchematicPort::mouseMoveEvent(QGraphicsSceneMouseEvent *me) {
     targetPort->handleSnappedLinksOnDynamicPortFx(groupedPorts, portId,
                                                   thisPortId);
     SchematicLink *link = getLink(0);
+    if (!link) return;
     assert(link);
     SchematicLink *ghostLink = targetPort->makeLink(link->getOtherPort(this));
     if (ghostLink) {


### PR DESCRIPTION
 Crashes when trying to swap links between multiple input ports on some fx but there is actually nothing attached to any of the input ports. This is definitely user error, but some of the FX get a crash when trying to connect the sources of a single FX together.