### PR TITLE
Fix to stop writing unfilled regions to SVG

### DIFF
--- a/toonz/sources/image/svg/tiio_svg.cpp
+++ b/toonz/sources/image/svg/tiio_svg.cpp
@@ -1882,7 +1882,7 @@ TLevelWriterSvg::TLevelWriterSvg(const TFilePath &path, TPropertyGroup *winfo)
 
 static void writeRegion(TRegion *r, TPalette *plt, QTextStream &out,
                         double ly) {
-  if (r->getEdgeCount() == 0) return;
+  if (r->getEdgeCount() == 0 || !r->getStyle()) return;
   std::vector<const TQuadratic *> quadsOutline;
 
   for (int i = 0; i < (int)r->getEdgeCount(); i++) {


### PR DESCRIPTION
When vector drawings are converted to SVG, not only are strokes written to the SVG file, but all fillable regions internally tracked are included. Fillable regions are written to the SVG as stroke-less paths which may or may not have a fill color.

This fix stops writing unfilled regions to the SVG file. These are not necessary and serve no purpose. In other vector drawing programs, they are useless invisible shapes. Only regions with a fill color will be written to the file.

Tahoma port: https://github.com/tahoma2d/tahoma2d/pull/2007