### PR TITLE
feat(viewer): add Clear Viewer Content command

### DIFF
--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -323,6 +323,7 @@ set(SOURCES
     filmstripcommand.cpp
     iocommand.cpp
     levelcommand.cpp
+    viewercommand.cpp
     print.cpp
     subscenecommand.cpp
     svncleanupdialog.cpp

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1901,6 +1901,7 @@ void MainWindow::defineActions() {
   createMenuEditAction(MI_PasteInto, QT_TR_NOOP("&Paste Into"), "",
                        "paste_into");
   createMenuEditAction(MI_Clear, QT_TR_NOOP("&Delete"), "Del", "delete");
+  createMenuEditAction(MI_ClearViewerContent, QT_TR_NOOP("&Clear Viewer Content"), "", "clear_viewer");
   createMenuEditAction(MI_Insert, QT_TR_NOOP("&Insert"), "Ins", "insert");
   createMenuEditAction(MI_InsertAbove, QT_TR_NOOP("&Insert Above/After"),
                        "Shift+Ins", "insert_above_after");

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -458,6 +458,7 @@
 #define MI_OpenReportABug "MI_OpenReportABug"
 
 #define MI_ClearCacheFolder "MI_ClearCacheFolder"
+#define MI_ClearViewerContent "MI_ClearViewerContent"
 
 #define MI_VectorGuidedDrawing "MI_VectorGuidedDrawing"
 #define MI_OpenGuidedDrawingControls "MI_OpenGuidedDrawingControls"

--- a/toonz/sources/toonz/viewercommand.cpp
+++ b/toonz/sources/toonz/viewercommand.cpp
@@ -1,0 +1,82 @@
+
+#include "toonzqt/menubarcommand.h"
+#include "menubarcommandids.h"
+#include "tapp.h"
+#include "filmstripcommand.h"
+
+// TnzLib includes
+#include "toonz/tscenehandle.h"
+#include "toonz/txshlevelhandle.h"
+#include "toonz/tframehandle.h"
+#include "toonz/txsheethandle.h"
+#include "toonz/tcolumnhandle.h"
+#include "toonz/txshsimplelevel.h"
+#include "toonz/toonzscene.h"
+#include "toonz/txsheet.h"
+#include "toonz/txshcell.h"
+
+// TnzQt includes
+#include "toonzqt/dvdialog.h"
+
+#include <set>
+
+//=============================================================================
+// Clear Viewer Content Command
+// Clears the drawing content of the current frame visible in the viewer
+//-----------------------------------------------------------------------------
+
+class ClearViewerContentCommand final : public MenuItemHandler {
+public:
+  ClearViewerContentCommand() : MenuItemHandler(MI_ClearViewerContent) {}
+  
+  void execute() override {
+    TApp *app = TApp::instance();
+    
+    // Get current frame and level
+    TFrameHandle *fh = app->getCurrentFrame();
+    TXshSimpleLevel *sl = app->getCurrentLevel()->getSimpleLevel();
+    
+    if (!sl || sl->isReadOnly()) {
+      DVGui::warning(QObject::tr("Cannot clear: level is read-only or no level is selected."));
+      return;
+    }
+    
+    // Get the current frame ID based on viewing mode
+    TFrameId currentFid;
+    
+    if (fh->isEditingLevel()) {
+      // In Level Strip mode or Level editing mode
+      currentFid = fh->getFid();
+    } else {
+      // In Scene Viewer mode - get frame from xsheet
+      TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+      int row = fh->getFrame();
+      int col = app->getCurrentColumn()->getColumnIndex();
+      
+      if (row >= 0 && col >= 0) {
+        TXshCell cell = xsh->getCell(row, col);
+        if (!cell.isEmpty() && cell.getSimpleLevel() == sl) {
+          currentFid = cell.getFrameId();
+        }
+      }
+    }
+    
+    // Check if we have a valid frame to clear
+    if (currentFid == TFrameId::NO_FRAME || currentFid == TFrameId()) {
+      DVGui::warning(QObject::tr("No frame to clear."));
+      return;
+    }
+    
+    // Clear the frame content (replace with empty frame)
+    std::set<TFrameId> frames;
+    frames.insert(currentFid);
+    
+    // Use FilmstripCmd::clear to replace frame content with empty frame
+    // This preserves the frame in the timeline but clears its drawing content
+    FilmstripCmd::clear(sl, frames);
+    
+    // Refresh viewer and xsheet
+    app->getCurrentXsheet()->notifyXsheetChanged();
+  }
+} clearViewerContentCommand;
+


### PR DESCRIPTION
This command allows users to clear the content of a frame without removing the cell from the Xsheet or Timeline. The result is similar to the Delete command used in the Level Strip. It simplifies the process by avoiding the need to select content and click delete within the viewer panels.


<img width="575" height="639" alt="Clear viewer content" src="https://github.com/user-attachments/assets/dc3b2470-2bee-4911-bacb-7b67aa659a69" />


Key points :

- Clears the artwork within the frame faster.
- Maintains the animation timing.
- Supports keyboard shortcut assignment.
- Works in the Viewer and the Level Strip.