### PR TITLE
Fix memory leaks and improve resource management across audio loaders and OpenGL

### DIFF
--- a/toonz/sources/image/sgi/filesgi.cpp
+++ b/toonz/sources/image/sgi/filesgi.cpp
@@ -42,8 +42,6 @@
 #endif
 #include <stdarg.h>
 
-using namespace std;
-
 // IMAGERGB: SGI image header structure
 struct IMAGERGB {
   unsigned short imagic;  // Magic number
@@ -230,7 +228,7 @@ static IMAGERGB *iopen(int fd, OpenMode openMode, unsigned int type,
     image->wastebytes = 0;
     image->dorev      = dorev;
     if (do_rgb_write_header(image, f) != IMAGERGB_HEADER_SIZE) {
-      cout << "iopen: error on write of image header\n" << endl;
+      std::cout << "iopen: error on write of image header\n" << std::endl;
       free(image);
       return nullptr;
     }
@@ -238,7 +236,7 @@ static IMAGERGB *iopen(int fd, OpenMode openMode, unsigned int type,
   } else {
     // READ mode
     if (do_rgb_read_header(image, f) != IMAGERGB_HEADER_SIZE) {
-      cout << "iopen: error on read of image header" << endl;
+      std::cout << "iopen: error on read of image header" << std::endl;
       free(image);
       return nullptr;
     }
@@ -251,7 +249,8 @@ static IMAGERGB *iopen(int fd, OpenMode openMode, unsigned int type,
     }
 
     if (image->imagic != IMAGIC) {
-      cout << "iopen: bad magic in image file " << image->imagic << endl;
+      std::cout << "iopen: bad magic in image file " << image->imagic
+                << std::endl;
       free(image);
       return nullptr;
     }
@@ -264,7 +263,7 @@ static IMAGERGB *iopen(int fd, OpenMode openMode, unsigned int type,
     image->rowsize  = (TINT32 *)malloc(tablesize);
 
     if (image->rowstart == nullptr || image->rowsize == nullptr) {
-      cout << "iopen: error on table alloc" << endl;
+      std::cout << "iopen: error on table alloc" << std::endl;
       free(image->rowstart);
       free(image->rowsize);
       free(image);
@@ -312,7 +311,7 @@ static IMAGERGB *iopen(int fd, OpenMode openMode, unsigned int type,
   if ((image->tmpbuf = ibufalloc(image, BPP(image->type))) == nullptr) {
     char xs[1024];
     snprintf(xs, sizeof(xs), "%d", image->xsize);
-    TSystem::outputDebug(string("iopen: error on tmpbuf alloc %d\n") + xs);
+    TSystem::outputDebug(std::string("iopen: error on tmpbuf alloc %d\n") + xs);
     if (ISRLE(image->type)) {
       free(image->rowstart);
       free(image->rowsize);
@@ -414,7 +413,7 @@ static void img_rle_expand(unsigned short *rlebuf, int ibpp,
 
     EXPAND_CODE(unsigned short);
   } else {
-    cout << "rle_expand: bad bpp: " << ibpp << " " << obpp << endl;
+    std::cout << "rle_expand: bad bpp: " << ibpp << " " << obpp << std::endl;
   }
 }
 
@@ -473,7 +472,7 @@ static int img_badrow(IMAGERGB *image, int y, int z) {
 static TUINT32 img_seek(IMAGERGB *image, unsigned int y, unsigned int z,
                         unsigned int offs) {
   if (img_badrow(image, y, z)) {
-    cout << "imglib: row number out of range" << endl;
+    std::cout << "imglib: row number out of range" << std::endl;
     return (TUINT32)EOF;
   }
   image->x = 0;
@@ -492,7 +491,7 @@ static TUINT32 img_seek(IMAGERGB *image, unsigned int y, unsigned int z,
                      (y * image->xsize + z * image->xsize * image->ysize) *
                          BPP(image->type));
     default:
-      cout << "img_seek: weird dim" << endl;
+      std::cout << "img_seek: weird dim" << std::endl;
       break;
     }
   } else if (ISRLE(image->type)) {
@@ -504,11 +503,11 @@ static TUINT32 img_seek(IMAGERGB *image, unsigned int y, unsigned int z,
     case 3:
       return img_optseek(image, offs + image->rowstart[y + z * image->ysize]);
     default:
-      cout << "img_seek: weird dim" << endl;
+      std::cout << "img_seek: weird dim" << std::endl;
       break;
     }
   } else {
-    cout << "img_seek: weird image type" << endl;
+    std::cout << "img_seek: weird image type" << std::endl;
   }
   return 0;
 }
@@ -541,7 +540,7 @@ static int new_getrow(IMAGERGB *image, void *buffer, UINT y, UINT z) {
         return image->xsize;
       }
     default:
-      cout << "getrow: weird bpp" << endl;
+      std::cout << "getrow: weird bpp" << std::endl;
       break;
     }
   } else if (ISRLE(image->type)) {
@@ -564,11 +563,11 @@ static int new_getrow(IMAGERGB *image, void *buffer, UINT y, UINT z) {
         return image->xsize;
       }
     default:
-      cout << "getrow: weird bpp" << endl;
+      std::cout << "getrow: weird bpp" << std::endl;
       break;
     }
   } else {
-    cout << "getrow: weird image type" << endl;
+    std::cout << "getrow: weird image type" << std::endl;
   }
   return -1;
 }
@@ -690,7 +689,7 @@ static TINT32 img_rle_compact(unsigned short *expbuf, int ibpp,
     COMPACT_CODE(unsigned short);
     return (TINT32)(optr - rlebuf);
   } else {
-    cout << "rle_compact: bad bpp: " << ibpp << " " << obpp;
+    std::cout << "rle_compact: bad bpp: " << ibpp << " " << obpp;
     return 0;
   }
 }
@@ -856,7 +855,7 @@ void SgiReader::open(FILE *file) {
   prop->m_endianness.setValue(m_header->dorev == 1 ? L"Big Endian"
                                                    : L"Little Endian");
   prop->m_compressed.setValue(ISRLE(m_header->type) ? true : false);
-  wstring pixelSize;
+  std::wstring pixelSize;
   int ps = m_info.m_bitsPerSample * m_info.m_samplePerPixel;
   if (ps == 8)
     pixelSize = L"8 bits (Greyscale)";
@@ -1065,7 +1064,7 @@ void SgiWriter::open(FILE *file, const TImageInfo &info) {
   if (!p) {
     throw std::runtime_error("Bits Per Pixel property not found");
   }
-  string str          = ::to_string(p->getValue());
+  std::string str     = ::to_string(p->getValue());
   int bitPerPixel     = atoi(str.c_str());
   int channelBytesNum = 1;
   int dim             = 3;

--- a/toonz/sources/include/stdfx/shadingcontext.h
+++ b/toonz/sources/include/stdfx/shadingcontext.h
@@ -13,6 +13,7 @@
 
 // Qt includes
 #include <QDateTime>
+#include <QString>
 #include <QOpenGLFramebufferObjectFormat>
 #include <QOpenGLWidget>
 
@@ -30,9 +31,7 @@
 
 //    Forward declarations
 
-class QObject;
 class QOpenGLShaderProgram;
-class QDateTime;
 class QOffscreenSurface;
 
 //=========================================================
@@ -54,12 +53,13 @@ public:
   void doneCurrent();
 
   /*!
-Resizes the output buffer to the specified size. Requires that
-the context is made current before invocation. In case lx or ly are 0,
-the context's output buffer is destroyed.
-*/
-  void resize(int lx, int ly, const QOpenGLFramebufferObjectFormat &fmt =
-                                  QOpenGLFramebufferObjectFormat());
+  Resizes the output buffer to the specified size. Requires that
+  the context is made current before invocation. In case lx or ly are 0,
+  the context's output buffer is destroyed.
+  */
+  void resize(int lx, int ly,
+              const QOpenGLFramebufferObjectFormat &fmt =
+                  QOpenGLFramebufferObjectFormat());
 
   QOpenGLFramebufferObjectFormat format() const;
   TDimension size() const;
@@ -79,12 +79,12 @@ the context's output buffer is destroyed.
   std::pair<QOpenGLShaderProgram *, QDateTime> shaderData(
       const QString &shaderName) const;
 
-  GLuint loadTexture(const TRasterP &src, GLuint texUnit);  //!< Loads a texture
-                                                            //! and binds it to
-  //! the specified
-  //! texture unit.
-  //!  \return  The OpenGL texture id of the loaded texture.      \param src
-  //!  Loaded texture.  \param texUnit  Unit the texture will be bound to.
+  GLuint loadTexture(const TRasterP &src,
+                     GLuint texUnit);  //!< Loads a texture and binds it to
+                                       //! the specified texture unit.
+  //!  \return  The OpenGL texture id of the loaded texture.
+  //!  \param src  Loaded texture.
+  //!  \param texUnit  Unit the texture will be bound to.
   void unloadTexture(GLuint texId);  //!< Releases the specified texture id.
 
   //! Renders the active shader program to the specified raster.
@@ -103,7 +103,7 @@ private:
   ShadingContext &operator=(const ShadingContext &);
 };
 
-class TQOpenGLWidget : public QOpenGLWidget {
+class DVAPI TQOpenGLWidget : public QOpenGLWidget {
 public:
   TQOpenGLWidget();
   void initializeGL() override;

--- a/toonz/sources/sound/mp3/tsio_mp3.h
+++ b/toonz/sources/sound/mp3/tsio_mp3.h
@@ -4,25 +4,26 @@
 #define TSIO_MP3_INCLUDED
 
 #include "tsound_io.h"
+#include <memory>
 
 //==========================================================
 /*!
-The class TSoundTrackReaderMp3 reads audio files having
-.mp3 extension
+The class TSoundTrackReaderMp3 reads audio files with
+the .mp3 extension
 */
 class TSoundTrackReaderMp3 final : public TSoundTrackReader {
 public:
   TSoundTrackReaderMp3(const TFilePath &fp);
-  ~TSoundTrackReaderMp3() {}
+  ~TSoundTrackReaderMp3() = default;
 
   /*!
-Loads the .mp3 audio file whose path has been specified in the constructor.
-It returns a TSoundTrackP created from the audio file
+Loads the .mp3 audio file whose path was specified in the constructor.
+Returns a TSoundTrackP created from the audio file
 */
   TSoundTrackP load() override;
 
   /*!
-Returns a soundtrack reader able to read .mp3 audio files
+Returns a soundtrack reader capable of reading .mp3 audio files
 */
   static TSoundTrackReader *create(const TFilePath &fp) {
     return new TSoundTrackReaderMp3(fp);
@@ -32,6 +33,18 @@ Returns a soundtrack reader able to read .mp3 audio files
 class FfmpegAudio {
 public:
   TFilePath getRawAudio(TFilePath path);
+
+  // Optional: add explicit constructor and destructor
+  FfmpegAudio()  = default;
+  ~FfmpegAudio() = default;
+
+  // Disable copy and assignment to avoid issues
+  FfmpegAudio(const FfmpegAudio &)            = delete;
+  FfmpegAudio &operator=(const FfmpegAudio &) = delete;
+
+  // Allow move if necessary
+  FfmpegAudio(FfmpegAudio &&)            = default;
+  FfmpegAudio &operator=(FfmpegAudio &&) = default;
 
 private:
   TFilePath getFfmpegCache();

--- a/toonz/sources/sound/wav/tsio_wav.cpp
+++ b/toonz/sources/sound/wav/tsio_wav.cpp
@@ -1,3 +1,5 @@
+
+
 #include <memory>
 
 #include "tmachine.h"
@@ -6,24 +8,22 @@
 #include "tfilepath_io.h"
 #include "tsioutils.h"
 
-using namespace std;
-
 #if !defined(TNZ_LITTLE_ENDIAN)
 TNZ_LITTLE_ENDIAN undefined !!
 #endif
 
-//==============================================================================
+    //==============================================================================
 
-// TWAVChunk: classe base per i vari chunk WAV
+    // TWAVChunk: base class for various WAV chunks
 
-class TWAVChunk {
+    class TWAVChunk {
 public:
   static TINT32 HDR_LENGTH;
 
-  string m_name;
-  TINT32 m_length;  // lunghezza del chunk in byte
+  std::string m_name;
+  TINT32 m_length;  // chunk length in bytes
 
-  TWAVChunk(string name, TINT32 length) : m_name(name), m_length(length) {}
+  TWAVChunk(std::string name, TINT32 length) : m_name(name), m_length(length) {}
 
   virtual ~TWAVChunk() {}
 
@@ -32,9 +32,9 @@ public:
     return true;
   }
 
-  void skip(Tifstream &is) { is.seekg(m_length, ios::cur); }
+  void skip(Tifstream &is) { is.seekg(m_length, std::ios::cur); }
 
-  static bool readHeader(Tifstream &is, string &name, TINT32 &length) {
+  static bool readHeader(Tifstream &is, std::string &name, TINT32 &length) {
     char cName[5];
     TINT32 len = 0;
     memset(cName, 0, sizeof(cName));
@@ -46,11 +46,11 @@ public:
     is.read((char *)&len, sizeof(len));
     if (is.fail()) return false;
 
-    // il formato WAV memorizza i dati come little-endian
-    // se la piattaforma non e' little-endian bisogna scambiare i byte
+    // WAV format stores data as little-endian
+    // if platform is not little-endian, bytes need to be swapped
     if (!TNZ_LITTLE_ENDIAN) len = swapTINT32(len);
 
-    name   = string(cName);
+    name   = std::string(cName);
     length = len;
     return true;
   }
@@ -60,14 +60,14 @@ TINT32 TWAVChunk::HDR_LENGTH = 8;
 
 //====================================================================
 
-//  FMT Chunk: Chunk contenente le informazioni sulla traccia
+// FMT Chunk: Chunk containing track information
 
 class TFMTChunk final : public TWAVChunk {
 public:
   static TINT32 LENGTH;
 
   USHORT m_encodingType;  // PCM, ...
-  USHORT m_chans;         // numero di canali
+  USHORT m_chans;         // number of channels
   TUINT32 m_sampleRate;
   TUINT32 m_avgBytesPerSecond;
   USHORT m_bytesPerSample;
@@ -97,7 +97,7 @@ public:
     return true;
   }
 
-  bool write(ofstream &os) {
+  bool write(Tofstream &os) {
     TUINT32 length         = m_length;
     USHORT type            = m_encodingType;
     USHORT chans           = m_chans;
@@ -133,7 +133,7 @@ TINT32 TFMTChunk::LENGTH = TWAVChunk::HDR_LENGTH + 16;
 
 //====================================================================
 
-//  DATA Chunk: Chunk contenente i campioni
+// DATA Chunk: Chunk containing samples
 
 class TDATAChunk final : public TWAVChunk {
 public:
@@ -142,14 +142,14 @@ public:
   TDATAChunk(TINT32 length) : TWAVChunk("data", length) {}
 
   bool read(Tifstream &is) override {
-    // alloca il buffer dei campioni
+    // allocate sample buffer
     m_samples.reset(new UCHAR[m_length]);
     if (!m_samples) return false;
     is.read((char *)m_samples.get(), m_length);
     return true;
   }
 
-  bool write(ofstream &os) {
+  bool write(Tofstream &os) {
     TINT32 length = m_length;
 
     if (!TNZ_LITTLE_ENDIAN) {
@@ -179,59 +179,63 @@ TSoundTrackP TSoundTrackReaderWav::load() {
 
   if (!is) throw TException(m_path.getWideString() + L" : File doesn't exist");
 
-  // legge il nome del chunk
+  // read chunk name
   is.read((char *)&chunkName, sizeof(chunkName) - 1);
   chunkName[4] = '\0';
 
-  // legge la lunghezza del chunk
+  // read chunk length
   is.read((char *)&chunkLength, sizeof(chunkLength));
 
   if (!TNZ_LITTLE_ENDIAN) chunkLength = swapTINT32(chunkLength);
 
-  // legge il RIFFType
+  // read RIFFType
   is.read((char *)&RIFFType, sizeof(RIFFType) - 1);
   RIFFType[4] = '\0';
 
-  // per i .wav il RIFFType DEVE essere uguale a "WAVE"
-  if ((string(RIFFType, 4) != "WAVE"))
+  // for .wav files, RIFFType MUST be "WAVE"
+  if ((std::string(RIFFType, 4) != "WAVE"))
     throw TException("The WAV file doesn't contain the WAVE form");
 
-  TFMTChunk *fmtChunk   = 0;
-  TDATAChunk *dataChunk = 0;
+  // Use smart pointers to prevent memory leaks
+  std::unique_ptr<TFMTChunk> fmtChunk;
+  std::unique_ptr<TDATAChunk> dataChunk;
 
   while (!is.eof()) {
-    string name   = "";
-    TINT32 length = 0;
+    std::string name = "";
+    TINT32 length    = 0;
 
     bool ret = TWAVChunk::readHeader(is, name, length);
 
     if (!ret) break;
 
-    // legge solo i chunk che ci interessano, ossia FMT e DATA
+    // only read chunks we care about, i.e., FMT and DATA
 
     if (name == "fmt ") {
-      // legge i dati del chunk FMT
-      fmtChunk = new TFMTChunk(length);
+      // read FMT chunk data
+      fmtChunk.reset(new TFMTChunk(length));
       fmtChunk->read(is);
 
-      // considera il byte di pad alla fine del chunk nel caso
-      // in cui la lunghezza di questi e' dispari
+      // consider pad byte at end of chunk if length is odd
       if (length & 1) {
         is.seekg((long)is.tellg() + 1);
       }
     } else if (name == "data") {
-      // legge i dati del chunk DATA
-      dataChunk = new TDATAChunk(length);
+      // If we already have a data chunk, delete it before creating new
+      // one This handles the case where there might be multiple data chunks
+      if (dataChunk) {
+        dataChunk.reset();
+      }
 
+      // read DATA chunk data
+      dataChunk.reset(new TDATAChunk(length));
       dataChunk->read(is);
 
-      // considera il byte di pad alla fine del chunk nel caso
-      // in cui la lunghezza di questi e' dispari
+      // consider pad byte at end of chunk if length is odd
       if (length & 1) {
         is.seekg((long)is.tellg() + 1);
       }
     } else {
-      // spostati nello stream di un numero di byte pari a length
+      // skip to next chunk by moving forward by length bytes
       if (length & 1)
         is.seekg((long)is.tellg() + (long)length + 1);
       else
@@ -243,7 +247,7 @@ TSoundTrackP TSoundTrackReaderWav::load() {
 
   if (fmtChunk && dataChunk) {
     TINT32 sampleCount = dataChunk->m_length / fmtChunk->m_bytesPerSample;
-    int sampleType = 0;
+    int sampleType     = 0;
 
     if (fmtChunk->m_encodingType == 1)  // WAVE_FORMAT_PCM
       sampleType = (fmtChunk->m_bitPerSample == 8) ? TSound::UINT : TSound::INT;
@@ -287,8 +291,8 @@ TSoundTrackP TSoundTrackReaderWav::load() {
     }
   }
 
-  if (fmtChunk) delete fmtChunk;
-  if (dataChunk) delete dataChunk;
+  // Smart pointers automatically clean up memory, no need for delete
+  // The destructors will be called automatically when function returns
 
   return track;
 }

--- a/toonz/sources/sound/wav/tsio_wav.h
+++ b/toonz/sources/sound/wav/tsio_wav.h
@@ -13,7 +13,7 @@ The class TSoundTrackReaderWav reads audio files having
 class TSoundTrackReaderWav final : public TSoundTrackReader {
 public:
   TSoundTrackReaderWav(const TFilePath &fp);
-  ~TSoundTrackReaderWav() {}
+  ~TSoundTrackReaderWav() = default;
 
   /*!
 Loads the .wav audio file whose path has been specified in the constructor.
@@ -38,7 +38,7 @@ The class TSoundTrackWriterWav writes audio file having
 class TSoundTrackWriterWav final : public TSoundTrackWriter {
 public:
   TSoundTrackWriterWav(const TFilePath &fp);
-  ~TSoundTrackWriterWav() {}
+  ~TSoundTrackWriterWav() = default;
 
   /*!
 Saves the information of the soundtrack in .wav audio file

--- a/toonz/sources/stdfx/iwa_soapbubblefx.h
+++ b/toonz/sources/stdfx/iwa_soapbubblefx.h
@@ -13,6 +13,15 @@ Inherits Iwa_SpectrumFx.
 
 #include "iwa_spectrumfx.h"
 
+// Forward declarations for Qt types
+class QRect;
+template <class T>
+class QList;
+class QSize;
+
+// Forward declarations for internal types
+struct float3;
+
 class Iwa_SoapBubbleFx final : public Iwa_SpectrumFx {
   FX_PLUGIN_DECLARATION(Iwa_SoapBubbleFx)
 

--- a/toonz/sources/stdfx/shadingcontext.cpp
+++ b/toonz/sources/stdfx/shadingcontext.cpp
@@ -47,9 +47,8 @@ public:
 TQOpenGLWidget::TQOpenGLWidget() {}
 
 void TQOpenGLWidget::initializeGL() {
-  QOffscreenSurface *surface = new QOffscreenSurface();
-  // context()->create();
-  // context()->makeCurrent(surface);
+  // Removed unused QOffscreenSurface creation
+  // No OpenGL initialization needed here for this widget
 }
 
 //*****************************************************************
@@ -118,12 +117,10 @@ ShadingContext::ShadingContext(QOffscreenSurface *surface) : m_imp(new Imp) {
   m_imp->m_context->create();
   m_imp->m_context->makeCurrent(m_imp->m_surface);
 
-  // m_imp->m_pixelBuffer->context()->create();
-  // m_imp->m_fbo(new QOpenGLFramebufferObject(1, 1));
   makeCurrent();
-   if( GLEW_VERSION_3_2 ) {
-       glewExperimental = GL_TRUE;
-   }
+  if (GLEW_VERSION_3_2) {
+    glewExperimental = GL_TRUE;
+  }
   glewInit();
   doneCurrent();
 }
@@ -141,10 +138,6 @@ ShadingContext::~ShadingContext() {
 //--------------------------------------------------------
 
 ShadingContext::Support ShadingContext::support() {
-  // return !QGLPixelBuffer::hasOpenGLPbuffers()
-  //           ? NO_PIXEL_BUFFER
-  //           : !QOpenGLShaderProgram::hasOpenGLShaderPrograms() ? NO_SHADERS :
-  //           OK;
   return !QOpenGLShaderProgram::hasOpenGLShaderPrograms() ? NO_SHADERS : OK;
 }
 
@@ -153,42 +146,15 @@ ShadingContext::Support ShadingContext::support() {
 bool ShadingContext::isValid() const { return m_imp->m_context->isValid(); }
 
 //--------------------------------------------------------
-/*
-QGLFormat ShadingContext::defaultFormat(int channelsSize)
-{
-  QGL::FormatOptions opts =
-    QGL::SingleBuffer     |
-    QGL::NoAccumBuffer    |
-    QGL::NoDepthBuffer    |                           // I guess it could be
-necessary to let at least
-    QGL::NoOverlay        |                           // the depth buffer
-enabled... Fragment shaders could
-    QGL::NoSampleBuffers  |                           // use it...
-    QGL::NoStencilBuffer  |
-    QGL::NoStereoBuffers;
-
-  QGLFormat fmt(opts);
-  fmt.setDirectRendering(true);                       // Just to be explicit -
-USE HARDWARE ACCELERATION
-
-  fmt.setRedBufferSize(channelsSize);
-  fmt.setGreenBufferSize(channelsSize);
-  fmt.setBlueBufferSize(channelsSize);
-  fmt.setAlphaBufferSize(channelsSize);
-
-  // TODO: 64-bit mode should be settable here
-
-  return fmt;
-}
-*/
-//--------------------------------------------------------
 
 void ShadingContext::makeCurrent() {
   m_imp->m_context->moveToThread(QThread::currentThread());
-  m_imp->m_context.reset(new QOpenGLContext());
-  QSurfaceFormat format;
-  m_imp->m_context->setFormat(format);
-  m_imp->m_context->create();
+  // Not create new context, use existing one
+  if (!m_imp->m_context->isValid()) {
+    QSurfaceFormat format;
+    m_imp->m_context->setFormat(format);
+    m_imp->m_context->create();
+  }
   m_imp->m_context->makeCurrent(m_imp->m_surface);
 }
 
@@ -210,11 +176,7 @@ void ShadingContext::resize(int lx, int ly,
   if (lx == 0 || ly == 0) {
     m_imp->m_fbo.reset(0);
   } else {
-    bool get                         = m_imp->m_fbo.get();
-    QOpenGLContext *currContext      = m_imp->m_context->currentContext();
-    bool yes                         = false;
-    if (currContext) bool yes        = true;
-    while (!currContext) currContext = m_imp->m_context->currentContext();
+    QOpenGLContext *currContext = QOpenGLContext::currentContext();
     m_imp->m_fbo.reset(new QOpenGLFramebufferObject(lx, ly, fmt));
     assert(m_imp->m_fbo->isValid());
 


### PR DESCRIPTION
This pull request addresses issues reported by Clang Static Analyzer and consolidates multiple fixes focused on memory leak prevention, uninitialized memory issues.

`tsio_mp3.cpp, tsio_mp3.h` - Fixed memory leak in TSoundTrackReaderMp3::load() by replacing raw pointers with std::unique_ptr, enhanced cache file handling in getRawAudio() by validating cache existence.

`tsio_wav.cpp, tsio_wav.h` - Fixed a potential memory leak by replacing raw pointers with std::unique_ptr for TFMTChunk and TDATAChunk.

`iwa_soapbubblefx.cpp` - Fixed a memory leak in do_distance_transform() by replacing a raw pointer with std::unique_ptr<float[]>, Fixed uninitialized memory in dt() by initializing the z array and uninitialized memory in processNoise() by initializing the noise_phases array.

`shadingcontext.cpp, shadingcontext.h` - Fixed a memory leak in TQOpenGLWidget::initializeGL() by removing an unused QOffscreenSurface, Fixed makeCurrent() to avoid creating a new OpenGL context on every call; the existing context is now reused when valid. **_Todo: If TQOpenGLWidget is used only internally, the DVAPI macro can be safely removed._**

`filesgi.cpp` - Removed `using namespace std;` to improve code safety and consistency. See: https://github.com/opentoonz/opentoonz/issues/6311

Note: Clang Static Analyzer reports over 30 files with potential memory leaks that require further analysis, as some warnings may be false positives. Ref: https://github.com/opentoonz/opentoonz/pull/6310