### PR TITLE
Allow Custom Splash Screen

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -442,9 +442,21 @@ int main(int argc, char *argv[]) {
 
   TEnv::setApplicationFileName(argv[0]);
 
-  // splash screen
-  QPixmap splashPixmap = QIcon(":Resources/splash.svg").pixmap(QSize(610, 344));
+// splash screen (override with local file if present)
+QString exeDir = QCoreApplication::applicationDirPath();
+QString localSplashPath = QDir(exeDir).filePath("splash.svg");
 
+QPixmap splashPixmap;
+
+if (QFileInfo(localSplashPath).exists() && QFileInfo(localSplashPath).isFile()) {
+  splashPixmap = QIcon(localSplashPath).pixmap(QSize(610, 344));
+  if (splashPixmap.isNull()) {
+    // fallback if loading fails
+    splashPixmap = QIcon(":Resources/splash.svg").pixmap(QSize(610, 344));
+  }
+} else {
+  splashPixmap = QIcon(":Resources/splash.svg").pixmap(QSize(610, 344));
+}
 #ifdef _WIN32
   QFont font("Segoe UI", -1);
 #else


### PR DESCRIPTION
This PR enables users to change the splash screen or use the OpenToonz default.

To display the custom splash place an SVG file named splash.svg in the Opentoonz program directory.  This is the same directory as Opentoonz.exe.

