### PR TITLE
Fix memory leaks, dead stores and improve resource management

### DIFF
--- a/toonz/sources/toonz/cellkeyframeselection.h
+++ b/toonz/sources/toonz/cellkeyframeselection.h
@@ -7,7 +7,7 @@
 #include "cellselection.h"
 #include "keyframeselection.h"
 #include "tgeometry.h"
-#include <set>
+#include <memory>
 
 class TXsheetHandle;
 
@@ -16,18 +16,25 @@ class TXsheetHandle;
 //-----------------------------------------------------------------------------
 
 class TCellKeyframeSelection final : public TSelection {
-  TCellSelection *m_cellSelection;
-  TKeyframeSelection *m_keyframeSelection;
-
-  TXsheetHandle *m_xsheetHandle;
+  std::unique_ptr<TCellSelection> m_cellSelection;
+  std::unique_ptr<TKeyframeSelection> m_keyframeSelection;
+  TXsheetHandle *m_xsheetHandle = nullptr;
 
 public:
   TCellKeyframeSelection(TCellSelection *cellSelection,
                          TKeyframeSelection *keyframeSelection);
-  ~TCellKeyframeSelection();
+  ~TCellKeyframeSelection() = default;  // unique_ptr handles deletion
 
-  TCellSelection *getCellSelection() { return m_cellSelection; }
-  TKeyframeSelection *getKeyframeSelection() { return m_keyframeSelection; }
+  // Prohibit copying and moving
+  TCellKeyframeSelection(const TCellKeyframeSelection &)            = delete;
+  TCellKeyframeSelection &operator=(const TCellKeyframeSelection &) = delete;
+  TCellKeyframeSelection(TCellKeyframeSelection &&)                 = delete;
+  TCellKeyframeSelection &operator=(TCellKeyframeSelection &&)      = delete;
+
+  TCellSelection *getCellSelection() const { return m_cellSelection.get(); }
+  TKeyframeSelection *getKeyframeSelection() const {
+    return m_keyframeSelection.get();
+  }
 
   void setXsheetHandle(TXsheetHandle *xsheetHandle) {
     m_xsheetHandle = xsheetHandle;
@@ -42,43 +49,10 @@ public:
   void deleteCellsKeyframes();
   void cutCellsKeyframes();
 
-  //! \note: puo' anche essere r0>r1 o c0>c1
+  //! \note: r0, c0, r1, c1 can be in any order (r0>r1 or c0>c1)
   void selectCellsKeyframes(int r0, int c0, int r1, int c1);
   void selectCellKeyframe(int row, int col);
   void selectNone() override;
-
-  /*
-  void getSelectedCells(int &r0, int &c0, int &r1, int &c1) const;
-  Range getSelectedCells() const;
-
-bool isCellSelected(int r , int c) const;
-bool isRowSelected(int row) const;
-bool isColSelected(int col) const;
-
-bool areAllColSelectedLocked() const;
-
-  //commands
-void reverseCells();
-  void swingCells();
-  void incrementCells();
-void duplicateCells();
-  void randomCells();
-  void stepCells(int count);
-  void eachCells(int count);
-void step2Cells() {stepCells(2);}
-void step3Cells() {stepCells(3);}
-void step4Cells() {stepCells(4);}
-void each2Cells() {eachCells(2);}
-void each3Cells() {eachCells(3);}
-void each4Cells() {eachCells(4);}
-  void rollupCells();
-  void rolldownCells();
-
-  void setKeyframes();
-  void cloneLevel();
-void insertCells();
-
-void openTimeStretchPopup();*/
 };
 
 #endif  // TCELLKEYFRAMESELECTION_H

--- a/toonz/sources/toonz/cellselection.h
+++ b/toonz/sources/toonz/cellselection.h
@@ -6,6 +6,7 @@
 #include "toonzqt/selection.h"
 #include "tgeometry.h"
 #include <set>
+#include <QList>
 
 class TimeStretchPopup;
 class ReframePopup;
@@ -55,12 +56,12 @@ public:
   void cutCells();
   void cutCells(bool withoutCopy);
 
-  /*- セルの上書きペースト -*/
+  /*- Overwrite paste cells -*/
   void overWritePasteCells();
   // paste cell numbers only
   void overwritePasteNumbers();
 
-  //! \note: puo' anche essere r0>r1 o c0>c1
+  //! \note: r0, c0, r1, c1 can be in any order (r0>r1 or c0>c1)
   void selectCells(int r0, int c0, int r1, int c1);
   void selectCell(int row, int col);
   void selectNone() override;
@@ -127,7 +128,7 @@ public:
 
   static bool isEnabledCommand(std::string commandId);
 
-  void createBlankDrawing(int row, int col, bool inRange);
+  void createBlankDrawing(int row, int col, bool multiple);
   void createBlankDrawings();
   void fillEmptyCell();
   int getResizePivotRow() const { return m_resizePivotRow; }

--- a/toonz/sources/toonz/filebrowser.h
+++ b/toonz/sources/toonz/filebrowser.h
@@ -10,11 +10,11 @@
 #include <QCheckBox>
 #include <QList>
 #include <QModelIndex>
+
 #include "dvitemview.h"
 #include "tfilepath.h"
 #include "toonzqt/dvdialog.h"
 #include "versioncontrol.h"
-
 #include "tthread.h"
 
 class QLineEdit;
@@ -27,12 +27,13 @@ class QFileSystemWatcher;
 //-----------------------------------------------------------------------------
 
 //! FrameCountReader is the class responsible for calculation of levels' frame
-//! counts in the file browser. Since on many file formats this requires to
-//! open the level file and scan each frame (MOV-like), and on some machine
+//! counts in the file browser. Since on many file formats this requires to open
+//! the level file and scan each frame (MOV-like), and on some machine
 //! configurations such a task can be time consuming, we dedicate a separate
 //! thread for it - just like the icon generator does. Calculated frame counts
 //! are also stored for quick lookup once they have been calculated the first
 //! time.
+
 class FrameCountReader final : public QObject {
   Q_OBJECT
 
@@ -47,6 +48,9 @@ public:
 
 signals:
   void calculatedFrameCount();
+
+private:
+  Q_DISABLE_COPY_MOVE(FrameCountReader);
 };
 
 //-----------------------------------------------------------------------------
@@ -55,8 +59,10 @@ class FileBrowser final : public QFrame, public DvItemListModel {
   Q_OBJECT
 
 public:
-  FileBrowser(QWidget *parent, Qt::WindowFlags flags = Qt::WindowFlags(),
-              bool noContextMenu = false, bool multiSelectionEnabled = false);
+  explicit FileBrowser(QWidget *parent,
+                       Qt::WindowFlags flags      = Qt::WindowFlags(),
+                       bool noContextMenu         = false,
+                       bool multiSelectionEnabled = false);
   ~FileBrowser();
 
   void sortByDataModel(DataType dataType, bool isDiscendent) override;
@@ -74,16 +80,16 @@ public:
   QMenu *getContextMenu(QWidget *parent, int index) override;
 
   /*!
-  This function adds to the types to be filtered a new type;
-  if this function is never called, the default filter is all image
-  files and scene files and palette files
-  */
+This functions adds to the types to be filtered a new type;
+if this function is never  called, the default filter is all image
+files and scene files and palette files
+*/
   void addFilterType(const QString &type);
 
   /*!
-  The setFilterTypes function directly specifies the list of file
-  types to be displayed in the file browser.
-  */
+The setFilterTypes function directly specifies the list of file
+types to be displayed in the file browser.
+*/
   void setFilterTypes(const QStringList &types);
   const QStringList &getFilterTypes() const { return m_filter; }
   void removeFilterType(const QString &type);
@@ -100,11 +106,10 @@ public:
   std::string getDayDateString() const { return m_dayDateString; }
 
   static void refreshFolder(const TFilePath &folder);
-
   static void updateItemViewerPanel();
 
-  // returns true if the file has been renamed. After the call, fp contains
-  // the new path
+  // Returns true if the file was renamed. After the call, fp contains the new
+  // path.
   static bool renameFile(TFilePath &fp, QString newName);
 
   void makeCurrentProjectVisible();
@@ -147,7 +152,6 @@ public slots:
 
 protected slots:
   void refresh();
-
   void changeFolder(const QModelIndex &index);
   void onDataChanged(const QModelIndex &topLeft,
                      const QModelIndex &bottomRight);
@@ -187,7 +191,6 @@ protected slots:
   void getRevisionHistory();
 
   void onVersionControlCommandDone(const QStringList &files);
-
   void onFileSystemChanged(const QString &folderPath);
 
   // If filePath is a valid scene file, open it. Otherwise do nothing.
@@ -202,8 +205,8 @@ signals:
                          const std::list<std::vector<TFrameId>> &);
   void treeFolderChanged(const TFilePath &);
 
-  // for activating/deactivating the folder history buttons (back button &
-  // forward button)
+  // for activating/deactivating the folder history buttons( back button &
+  // forward button )
   void historyChanged(bool, bool);
 
 private:
@@ -244,7 +247,7 @@ private:
 
   // folder history
   QList<QModelIndex> m_indexHistoryList;
-  int m_currentPosition;
+  int m_currentPosition = 0;
 
   std::vector<Item> m_items;
   TFilePath m_folder;
@@ -255,37 +258,33 @@ private:
 private:
   void readFrameCount(Item &item);
   void readInfo(Item &item);
-
   void refreshCurrentFolderItems();
 
-  DvItemListModel::Status getItemVersionControlStatus(
-      const FileBrowser::Item &item);
+  DvItemListModel::Status getItemVersionControlStatus(const Item &item);
+
+  Q_DISABLE_COPY_MOVE(FileBrowser);
 };
 
 //--------------------------------------------------------------------
 class RenameAsToonzPopup final : public DVGui::Dialog {
   Q_OBJECT
+
   QPushButton *m_okBtn, *m_cancelBtn;
   DVGui::LineEdit *m_name;
   QCheckBox *m_overwrite;
 
 public:
-  RenameAsToonzPopup(const QString name = "", int frames = -1,
-                     bool isFolder = false);
+  explicit RenameAsToonzPopup(const QString &name = QString(), int frames = -1,
+                              bool isFolder = false);
 
-  bool doOverwrite() { return m_overwrite->isChecked(); }
-  QString getName() { return m_name->text(); }
+  bool doOverwrite() const { return m_overwrite->isChecked(); }
+  QString getName() const { return m_name->text(); }
+
+private slots:
+  void onOk();
 
 private:
-  // TPropertyGroup* getFormatProperties(const std::string &ext);
-
-public slots:
-  //! Starts the conversion.
-  // void onConvert();
-  // void onOptionsClicked();
-  void onOk();
+  Q_DISABLE_COPY_MOVE(RenameAsToonzPopup);
 };
 
-//-----------------------------------------------------------
-
-#endif
+#endif  // FILEBROWSER_INCLUDED

--- a/toonz/sources/toonz/fileselection.h
+++ b/toonz/sources/toonz/fileselection.h
@@ -6,6 +6,11 @@
 #include "dvitemview.h"
 #include "tfilepath.h"
 
+// Qt includes
+#include <QList>
+#include <QPointer>
+#include <memory>
+
 class InfoViewer;
 class ExportScenePopup;
 
@@ -14,16 +19,22 @@ class ExportScenePopup;
 //-----------------------------------------------------------------------------
 
 class FileSelection final : public DvItemSelection {
-  QList<InfoViewer *> m_infoViewers;
-  ExportScenePopup *m_exportScenePopup;
+  QList<QPointer<InfoViewer>> m_infoViewers;  // QPointer handles nullification
+  std::unique_ptr<ExportScenePopup> m_exportScenePopup;
 
 public:
   FileSelection();
-  ~FileSelection();
+  virtual ~FileSelection();
 
-  void getSelectedFiles(std::vector<TFilePath> &files);
+  // Prohibit copying and moving
+  FileSelection(const FileSelection&)            = delete;
+  FileSelection& operator=(const FileSelection&) = delete;
+  FileSelection(FileSelection&&)                 = delete;
+  FileSelection& operator=(FileSelection&&)      = delete;
 
-  // commands
+  void getSelectedFiles(std::vector<TFilePath>& files);
+
+  // Commands
   void enableCommands() override;
 
   void duplicateFiles();

--- a/toonz/sources/toonz/fillholespopup.h
+++ b/toonz/sources/toonz/fillholespopup.h
@@ -1,16 +1,37 @@
+#pragma once
+
+#ifndef FILLHOLESDIALOG_H
+#define FILLHOLESDIALOG_H
+
 #include "toonzqt/dvdialog.h"
 #include "toonzqt/intfield.h"
 #include <QProgressBar>
+
+#include <memory>  // for std::unique_ptr
+
+// Forward declaration
+namespace DVGui {
+class ProgressDialog;
+}
 
 class FillHolesDialog final : public DVGui::Dialog {
   Q_OBJECT
 
   DVGui::IntField* m_size;
-  DVGui::ProgressDialog* m_progressDialog;
+  std::unique_ptr<DVGui::ProgressDialog> m_progressDialog;  // automatic cleanup
 
 public:
-  FillHolesDialog();
+  explicit FillHolesDialog();
+  ~FillHolesDialog() = default;  // unique_ptr handles destruction
+
+  // Prohibit copying and moving
+  FillHolesDialog(const FillHolesDialog&)            = delete;
+  FillHolesDialog& operator=(const FillHolesDialog&) = delete;
+  FillHolesDialog(FillHolesDialog&&)                 = delete;
+  FillHolesDialog& operator=(FillHolesDialog&&)      = delete;
 
 protected slots:
   void apply();
 };
+
+#endif  // FILLHOLESDIALOG_H

--- a/toonz/sources/toonz/filmstripcommand.h
+++ b/toonz/sources/toonz/filmstripcommand.h
@@ -7,7 +7,9 @@
 #include "tfilepath.h"
 
 #include <set>
+#include <vector>
 
+// Forward declarations
 class TXshSimpleLevel;
 class TXshLevel;
 class TXshPaletteLevel;
@@ -18,14 +20,18 @@ class TXshSoundLevel;
 //-----------------------------------------------------------------------------
 
 namespace FilmstripCmd {
+
+// Add empty frames to the level
 void addFrames(TXshSimpleLevel *sl, int start, int end, int step);
 
+// Renumber frames in the level
 void renumber(TXshSimpleLevel *sl, std::set<TFrameId> &frames, int startFrame,
               int stepFrame);
 void renumber(TXshSimpleLevel *sl,
               const std::vector<std::pair<TFrameId, TFrameId>> &table,
               bool forceCallUpdateXSheet = false);
 
+// Copy/paste operations for frames
 void copy(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void paste(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void merge(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
@@ -36,34 +42,42 @@ void remove(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void insert(TXshSimpleLevel *sl, const std::set<TFrameId> &frames,
             bool withUndo);
 
+// Frame manipulation operations
 void reverse(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void swing(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void step(TXshSimpleLevel *sl, std::set<TFrameId> &frames, int step);
 void each(TXshSimpleLevel *sl, std::set<TFrameId> &frames, int each);
 
+// Duplicate operations
 void duplicateFrameWithoutUndo(TXshSimpleLevel *sl, TFrameId srcFrame,
                                TFrameId targetFrame);
 void duplicate(TXshSimpleLevel *sl, std::set<TFrameId> &frames, bool withUndo);
 
-// TODO vanno spostati in un altro posto
+// // TODO: Need to be moved to another location - Level to scene operations
 void moveToScene(TXshLevel *sl, std::set<TFrameId> &frames);
 void moveToScene(TXshSimpleLevel *sl);
 void moveToScene(TXshPaletteLevel *pl);
 void moveToScene(TXshSoundLevel *sl);
 
+// Inbetween interpolation types and functions
 enum InbetweenInterpolation { II_Linear, II_EaseIn, II_EaseOut, II_EaseInOut };
+
 void inbetweenWithoutUndo(TXshSimpleLevel *sl, const TFrameId &fid0,
                           const TFrameId &fid1,
                           InbetweenInterpolation interpolation);
 void inbetween(TXshSimpleLevel *sl, const TFrameId &fid0, const TFrameId &fid1,
                InbetweenInterpolation interpolation);
 
+// Renumber a single drawing
 void renumberDrawing(TXshSimpleLevel *sl, const TFrameId &oldFid,
                      const TFrameId &desiredNewFid);
+
 }  // namespace FilmstripCmd
 
+// Operator overload for TFrameId
 TFrameId operator+(const TFrameId &fid, int d);
 
+// Utility function to make space for frame IDs in a level
 void makeSpaceForFids(TXshSimpleLevel *sl,
                       const std::set<TFrameId> &framesToInsert);
 

--- a/toonz/sources/toonz/menubarpopup.h
+++ b/toonz/sources/toonz/menubarpopup.h
@@ -29,7 +29,14 @@ class MenuBarTree final : public QTreeWidget {
   void saveMenuRecursive(QXmlStreamWriter& writer, QTreeWidgetItem* parentItem);
 
 public:
-  MenuBarTree(TFilePath& path, QWidget* parent = 0);
+  explicit MenuBarTree(TFilePath& path, QWidget* parent = nullptr);
+
+  // Prohibit copying and moving
+  MenuBarTree(const MenuBarTree&)            = delete;
+  MenuBarTree& operator=(const MenuBarTree&) = delete;
+  MenuBarTree(MenuBarTree&&)                 = delete;
+  MenuBarTree& operator=(MenuBarTree&&)      = delete;
+
   void saveMenuTree();
 
 protected:
@@ -37,6 +44,7 @@ protected:
                     Qt::DropAction action) override;
   QStringList mimeTypes() const override;
   void contextMenuEvent(QContextMenuEvent* event) override;
+
 protected slots:
   void insertMenu();
   void removeItem();
@@ -49,11 +57,20 @@ protected slots:
 
 class MenuBarPopup final : public DVGui::Dialog {
   Q_OBJECT
-  CommandListTree* m_commandListTree;
-  MenuBarTree* m_menuBarTree;
+
+  CommandListTree* m_commandListTree = nullptr;
+  MenuBarTree* m_menuBarTree         = nullptr;
+  bool m_searchBusy                  = false;  // prevent reentrant search
 
 public:
-  MenuBarPopup(Room* room);
+  explicit MenuBarPopup(Room* room);
+
+  // Prohibit copying and moving
+  MenuBarPopup(const MenuBarPopup&)            = delete;
+  MenuBarPopup& operator=(const MenuBarPopup&) = delete;
+  MenuBarPopup(MenuBarPopup&&)                 = delete;
+  MenuBarPopup& operator=(MenuBarPopup&&)      = delete;
+
 protected slots:
   void onOkPressed();
   void onSearchTextChanged(const QString& text);

--- a/toonz/sources/toonz/previewer.h
+++ b/toonz/sources/toonz/previewer.h
@@ -4,25 +4,20 @@
 #define PREVIEWER_INCLUDED
 
 #include <memory>
+#include <vector>
 
 #include "traster.h"
 #include "tfx.h"
-
 #include "trenderer.h"
 
 #include <QObject>
 #include <QTimer>
 
-// forward declarations
+// Forward declarations
 class TRenderSettings;
 class TXshLevel;
 class TFrameId;
 class TFilePath;
-// class TRenderPort
-// {
-//     class RenderData;
-// };
-// class TRenderPort::RenderData;
 
 //=============================================================================
 // Previewer
@@ -37,9 +32,8 @@ class Previewer final : public QObject, public TFxObserver {
   Previewer(bool subcamera);
   ~Previewer();
 
-  // not implemented
-  Previewer(const Previewer &);
-  void operator=(const Previewer &);
+  // Prohibit copying and moving
+  Q_DISABLE_COPY_MOVE(Previewer)
 
 public:
   class Listener {
@@ -47,34 +41,31 @@ public:
     QTimer m_refreshTimer;
 
     Listener();
-    virtual ~Listener() {}
+    virtual ~Listener() = default;
 
     void requestTimedRefresh();
     virtual TRectD getPreviewRect() const = 0;
 
-    virtual void onRenderStarted(int frame){};
-    virtual void onRenderCompleted(int frame){};
-    virtual void onRenderFailed(int frame){};
+    virtual void onRenderStarted(int frame) {}
+    virtual void onRenderCompleted(int frame) {}
+    virtual void onRenderFailed(int frame) {}
 
     virtual void onPreviewUpdate() {}
   };
 
 public:
   static Previewer *instance(bool subcameraPreview = false);
-
   static void clearAll();
-
   static void suspendRendering(bool suspend);
 
-  void addListener(Listener *);
-  void removeListener(Listener *);
+  void addListener(Listener *listener);
+  void removeListener(Listener *listener);
 
   TRasterP getRaster(int frame, bool renderIfNeeded = true) const;
-  void addFramesToRenderQueue(const std::vector<int> frames) const;
+  void addFramesToRenderQueue(const std::vector<int> &frames) const;
   bool isFrameReady(int frame) const;
 
   bool doSaveRenderedFrames(TFilePath fp);
-
   bool isActive() const;
   bool isBusy() const;
 
@@ -87,7 +78,6 @@ public:
   void clear();
 
   std::vector<UCHAR> &getProgressBarStatus() const;
-
   void clearAllUnfinishedFrames();
 
 private:
@@ -97,14 +87,12 @@ private:
   void emitFailedFrame(const TRenderPort::RenderData &renderData);
 
 signals:
-
   void activedChanged();
   void startedFrame(TRenderPort::RenderData renderData);
   void renderedFrame(TRenderPort::RenderData renderData);
   void failedFrame(TRenderPort::RenderData renderData);
 
 public slots:
-
   void saveFrame();
   void saveRenderedFrames();
 
@@ -117,7 +105,6 @@ public slots:
   void onObjectChanged();
 
 protected slots:
-
   void onStartedFrame(TRenderPort::RenderData renderData);
   void onRenderedFrame(TRenderPort::RenderData renderData);
   void onFailedFrame(TRenderPort::RenderData renderData);


### PR DESCRIPTION
This pull request addresses issues reported by Clang Static Analyzer and consolidates multiple fixes focused on memory leak prevention and uninitialized memory issues.

* Replaced raw pointers with smart pointers (`std::unique_ptr`) in `FileBrowser`, `FillHolesPopup`, and `FilmstripCommand` to prevent memory leaks and ensure exception safety during undo operations.

*  Added null pointer checks before accessing levels (e.g., in `dRenumberCells`), initialized pointers with `nullptr`, and used `TXshSimpleLevelP` (smart pointer) to prevent use-after-free issues.

* Modernized signal/slot connections to use Qt5 syntax where applicable, and introduced `std::unique_ptr` for UI elements like `QMenu` and `QActionGroup`, using `.release()` only when transferring ownership to Qt's parent-child system. See: [6311](https://github.com/opentoonz/opentoonz/issues/6311)
 
* Removed unused variables ("dead stores") in multiple selection files, deleted redundant layout allocations, and translated all remaining Italian and Japanese comments to English for better maintainability.


Note: The analyzer reports over 30 files with potential memory leaks that require further investigation. This PR addresses a significant portion of these in the "Selection" and "Command" modules.  Reference: #6310