### PR TITLE
Fix sub-xsheet icon generation crash

### DIFF
--- a/toonz/sources/toonzqt/icongenerator.cpp
+++ b/toonz/sources/toonzqt/icongenerator.cpp
@@ -902,13 +902,17 @@ public:
 TRaster32P XsheetIconRenderer::generateRaster(
     const TDimension &iconSize) const {
   ToonzScene *scene = m_xsheet->getScene();
-  TDimension res    = scene->getProperties()->getCameras().front()->getRes();
-  if (res.lx > iconSize.lx || res.ly > iconSize.ly) {
-    double sx = (double)iconSize.lx / res.lx;
-    double sy = (double)iconSize.ly / res.ly;
-    double s  = std::min(sx, sy);
-    res.lx    = tround(res.lx * s);
-    res.ly    = tround(res.ly * s);
+  TDimension res    = iconSize;
+  if (QCoreApplication::applicationName() == "ToonzPreview") {
+    res = scene->getCurrentCamera()->getRes();
+    if (res.lx > iconSize.lx || res.ly > iconSize.ly) {
+      double sx = (double)iconSize.lx / res.lx;
+      double sy = (double)iconSize.ly / res.ly;
+
+      double s  = std::min(sx, sy);
+      res.lx    = tround(res.lx * s);
+      res.ly    = tround(res.ly * s);
+    }
   }
   TRaster32P ras(res);
 


### PR DESCRIPTION
This behavior would cause OT to crash in current Nightly Build, this bug was introduced by this PR: #6293

![20260214025040_rec_](https://github.com/user-attachments/assets/fa9a4204-e629-4eb1-9c3a-b66a58d5bb43)
Need to avoid bug and test related functions when introducing new features.
This bug also caused because I didn't review my code, should use the normal "getCurrentCamera()" to get scene's default camera and make it only work for  component `toonzpreview.dll`.