### PR TITLE
Fix memory leaks and dead stores

### DIFF
--- a/toonz/sources/include/toonz/scriptbinding_centerline_vectorizer.h
+++ b/toonz/sources/include/toonz/scriptbinding_centerline_vectorizer.h
@@ -1,9 +1,9 @@
 #pragma once
-
 #ifndef SCRIPTBINDING_CENTERLINE_VECTORIZER_H
 #define SCRIPTBINDING_CENTERLINE_VECTORIZER_H
 
 #include "toonz/scriptbinding.h"
+#include <memory>
 
 class ToonzScene;
 class TXshSimpleLevel;
@@ -12,11 +12,10 @@ namespace TScriptBinding {
 
 class DVAPI CenterlineVectorizer final : public Wrapper {
   Q_OBJECT
-  CenterlineConfiguration *m_parameters;
+  std::unique_ptr<CenterlineConfiguration> m_parameters;
 
 public:
   CenterlineVectorizer();
-  ~CenterlineVectorizer();
 
   Q_INVOKABLE QScriptValue toString();
   WRAPPER_STD_METHODS(CenterlineVectorizer)
@@ -58,7 +57,7 @@ public:
   void setEir(bool v);
 
 private:
-  QScriptValue vectorizeImage(const TImageP &src1, TPalette *palette);
+  QScriptValue vectorizeImage(const TImageP &src, TPalette *palette);
 };
 
 }  // namespace TScriptBinding

--- a/toonz/sources/include/toonz/scriptbinding_outline_vectorizer.h
+++ b/toonz/sources/include/toonz/scriptbinding_outline_vectorizer.h
@@ -1,9 +1,9 @@
 #pragma once
-
 #ifndef SCRIPTBINDING_OUTLINE_VECTORIZER_H
 #define SCRIPTBINDING_OUTLINE_VECTORIZER_H
 
 #include "toonz/scriptbinding.h"
+#include <memory>
 
 class ToonzScene;
 class TXshSimpleLevel;
@@ -12,11 +12,10 @@ namespace TScriptBinding {
 
 class DVAPI OutlineVectorizer final : public Wrapper {
   Q_OBJECT
-  NewOutlineConfiguration *m_parameters;
+  std::unique_ptr<NewOutlineConfiguration> m_parameters;
 
 public:
   OutlineVectorizer();
-  ~OutlineVectorizer();
 
   Q_INVOKABLE QScriptValue toString();
   WRAPPER_STD_METHODS(OutlineVectorizer)

--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -17,6 +17,7 @@
 // TnzCore includes
 #include "traster.h"
 #include "trasterimage.h"
+#include "tpalette.h"  // for TPaletteP
 
 // Qt includes
 #include <QObject>
@@ -345,7 +346,7 @@ private:
   std::unique_ptr<LevelProperties> m_properties;
   std::unique_ptr<TContentHistory> m_contentHistory;
 
-  TPalette *m_palette;
+  TPaletteP m_palette;
 
   FramesSet m_frames;
 

--- a/toonz/sources/include/toonzqt/dvdialog.h
+++ b/toonz/sources/include/toonzqt/dvdialog.h
@@ -51,29 +51,27 @@ class MessageAndCheckboxDialog;
 
 void DVAPI MsgBoxInPopup(MsgType type, const QString &text);
 
-// ATTENZIONE: Valore di ritorno
-// 0 = l'utente ha chiuso la finestra (dovrebbe corrispondere ad un cancel o ad
-// un NO) - closed window
-// 1 = primo bottone da sx premuto - first button selected
-// 2 = secondo bottone da sx premuto - second button
-// 3 = terzo bottone da sx premuto - third button
-// 4 = fourth button
+// ATTENTION: Return values
+// 0 = user closed the window (should correspond to cancel or NO) - closed
+// window 1 = first button from left pressed - first button selected 2 = second
+// button from left pressed - second button 3 = third button from left pressed -
+// third button 4 = fourth button
 
 int DVAPI MsgBox(MsgType type, const QString &text,
                  const std::vector<QString> &buttons,
                  int defaultButtonIndex = 0, QWidget *parent = 0);
 
-// QUESTION: due bottoni user defined
+// QUESTION: two user-defined buttons
 int DVAPI MsgBox(const QString &text, const QString &button1,
                  const QString &button2, int defaultButtonIndex = 0,
                  QWidget *parent = 0);
 
-// QUESTION: tre bottoni user defined
+// QUESTION: three user-defined buttons
 int DVAPI MsgBox(const QString &text, const QString &button1,
                  const QString &button2, const QString &button3,
                  int defaultButtonIndex = 0, QWidget *parent = 0);
 
-// QUESTION: four botton user defined
+// QUESTION: four user-defined buttons
 int DVAPI MsgBox(const QString &text, const QString &button1,
                  const QString &button2, const QString &button3,
                  const QString &button4, int defaultButtonIndex = 0,
@@ -87,9 +85,6 @@ MessageAndCheckboxDialog DVAPI *createMsgandCheckbox(
     MsgType type, const QString &text, const QString &checkBoxText,
     const QStringList &buttons, int defaultButtonIndex,
     Qt::CheckState defaultCheckBoxState, QWidget *parent = 0);
-
-// void DVAPI error(const QString &msg);
-// void DVAPI info(const QString &msg);
 
 //-----------------------------------------------------------------------------
 
@@ -168,9 +163,6 @@ class DVAPI Dialog : public QDialog {
   bool m_hasButton;
   QString m_name;
   int m_currentScreen = -1;
-  // gmt. rendo m_buttonLayout protected per ovviare ad un problema
-  // sull'addButtonBarWidget(). cfr filebrowserpopup.cpp.
-  // Dobbiamo discutere di Dialog.
 
 protected:
   QHBoxLayout *m_buttonLayout;

--- a/toonz/sources/include/toonzqt/expressionfield.h
+++ b/toonz/sources/include/toonzqt/expressionfield.h
@@ -6,6 +6,7 @@
 #include "tgrammar.h"
 #include <QWidget>
 #include <QTextEdit>
+#include <memory>  // for std::unique_ptr
 
 #undef DVAPI
 #undef DVVAR
@@ -42,7 +43,7 @@ class DVAPI ExpressionField final : public QTextEdit {
   const TSyntax::Grammar *m_grammar;
 
   class SyntaxHighlighter;
-  SyntaxHighlighter *m_syntaxHighlighter;
+  std::unique_ptr<SyntaxHighlighter> m_syntaxHighlighter;
 
   QListView *m_completerPopup;
   int m_completerStartPos;
@@ -86,4 +87,4 @@ signals:
 }  // namespace DVGui
 //-----------------------------------------------------------------------------
 
-#endif  // FILEFIELD_H
+#endif  // EXPRESSIONFIELD_H

--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -51,8 +51,8 @@ class TFrameHandle;
 class PlaybackExecutor final : public QThread {
   Q_OBJECT
 
-  int m_fps;
-  bool m_abort;
+  int m_fps    = 25;
+  bool m_abort = false;
   QElapsedTimer m_timer;
 
 public:
@@ -103,8 +103,14 @@ class FlipSlider final : public QAbstractSlider {
   Q_PROPERTY(QColor startedColor READ getStartedColor WRITE setStartedColor)
   Q_PROPERTY(QColor finishedColor READ getFinishedColor WRITE setFinishedColor)
 
-  bool m_enabled;
-  const std::vector<UCHAR> *m_progressBarStatus;
+  bool m_enabled                                = false;
+  const std::vector<UCHAR> *m_progressBarStatus = nullptr;
+
+  // Disable copy (as the pointer is unowned)
+  FlipSlider(const FlipSlider &)            = delete;
+  FlipSlider &operator=(const FlipSlider &) = delete;
+  FlipSlider(FlipSlider &&)                 = delete;
+  FlipSlider &operator=(FlipSlider &&)      = delete;
 
 public:
   enum { PBFrameNotStarted, PBFrameStarted, PBFrameFinished };

--- a/toonz/sources/include/toonzqt/rasterimagedata.h
+++ b/toonz/sources/include/toonzqt/rasterimagedata.h
@@ -41,7 +41,7 @@ protected:
 
 public:
   RasterImageData();
-  ~RasterImageData();
+  ~RasterImageData() override;
 
   virtual void setData(const TRasterP &copiedRaster, const TPaletteP &palette,
                        double dpiX, double dpiY, const TDimension &dim,
@@ -70,7 +70,7 @@ public:
 //===================================================================
 // ToonzImageData
 //-------------------------------------------------------------------
-/*-- SelectionToolで選択した画像のデータ --*/
+/*-- Data for images selected with SelectionTool --*/
 class DVAPI ToonzImageData final : public RasterImageData {
   TRasterCM32P m_copiedRaster;
   TPaletteP m_palette;
@@ -80,7 +80,8 @@ class DVAPI ToonzImageData final : public RasterImageData {
 public:
   ToonzImageData();
   ToonzImageData(const ToonzImageData &);
-  ~ToonzImageData();
+  ~ToonzImageData() override;
+
   // data <- floating ti;
   void setData(const TRasterP &copiedRaster, const TPaletteP &palette,
                double dpiX, double dpiY, const TDimension &dim,
@@ -113,7 +114,7 @@ class DVAPI FullColorImageData final : public RasterImageData {
 public:
   FullColorImageData();
   FullColorImageData(const FullColorImageData &);
-  ~FullColorImageData();
+  ~FullColorImageData() override;
 
   // data <- floating ti;
   void setData(const TRasterP &copiedRaster, const TPaletteP &palette,

--- a/toonz/sources/toonzlib/scriptbinding_centerline_vectorizer.cpp
+++ b/toonz/sources/toonzlib/scriptbinding_centerline_vectorizer.cpp
@@ -8,24 +8,23 @@
 #include "toonz/Naa2TlvConverter.h"
 #include "tpalette.h"
 #include "ttoonzimage.h"
+#include <memory>  // for std::unique_ptr, std::make_unique
 
 namespace TScriptBinding {
 
-CenterlineVectorizer::CenterlineVectorizer() {
-  m_parameters = new CenterlineConfiguration();
-}
-
-CenterlineVectorizer::~CenterlineVectorizer() { delete m_parameters; }
-
+//----------------------------------------------------------
+CenterlineVectorizer::CenterlineVectorizer()
+    : m_parameters(std::make_unique<CenterlineConfiguration>()) {}
+//----------------------------------------------------------
 QScriptValue CenterlineVectorizer::toString() {
   return "Centerline Vectorizer";
 }
-
+//----------------------------------------------------------
 QScriptValue CenterlineVectorizer::ctor(QScriptContext *context,
                                         QScriptEngine *engine) {
   return create(engine, new CenterlineVectorizer());
 }
-
+//----------------------------------------------------------
 QScriptValue CenterlineVectorizer::vectorizeImage(const TImageP &src,
                                                   TPalette *palette) {
   VectorizerCore vc;
@@ -33,6 +32,7 @@ QScriptValue CenterlineVectorizer::vectorizeImage(const TImageP &src,
   double factor = Stage::inch;
   double dpix = factor / 72, dpiy = factor / 72;
   TPointD center;
+
   if (TRasterImageP ri = src) {
     ri->getDpi(dpix, dpiy);
     center = ri->getRaster()->getCenterD();
@@ -42,27 +42,28 @@ QScriptValue CenterlineVectorizer::vectorizeImage(const TImageP &src,
   } else {
     return context()->throwError(QObject::tr("Vectorization failed"));
   }
+
   if (dpix != 0.0 && dpiy != 0.0) dpiAff = TScale(factor / dpix, factor / dpiy);
-  factor                                 = norm(dpiAff * TPointD(1, 0));
+  factor = norm(dpiAff * TPointD(1, 0));
 
   m_parameters->m_affine     = dpiAff * TTranslation(-center);
   m_parameters->m_thickScale = factor;
 
-  palette->addRef();  // if there are no other references the vectorize() method
-                      // below can destroy the palette
-                      // BEFORE assigning it to the vector image
-  TVectorImageP vi = vc.vectorize(src, *m_parameters, palette);
-  vi->setPalette(palette);
-  palette->release();
+  // Hold the palette during vectorization – TPaletteP manages refcount
+  TPaletteP paletteHolder = palette;
+  TVectorImageP vi =
+      vc.vectorize(src, *m_parameters, paletteHolder.getPointer());
+  vi->setPalette(paletteHolder.getPointer());
 
   return engine()->newQObject(new Image(vi), QScriptEngine::AutoOwnership);
 }
-
+//----------------------------------------------------------
 QScriptValue CenterlineVectorizer::vectorize(QScriptValue arg) {
   Level *level = qscriptvalue_cast<Level *>(arg);
   Image *img   = qscriptvalue_cast<Image *>(arg);
   QString type;
-  TPalette *palette = 0;
+  TPaletteP palette;
+
   if (level) {
     type = level->getType();
     if (type != "Raster" && type != "ToonzRaster")
@@ -70,7 +71,7 @@ QScriptValue CenterlineVectorizer::vectorize(QScriptValue arg) {
     if (level->getFrameCount() <= 0)
       return context()->throwError(
           tr("Can't vectorize a level with no frames"));
-    palette = level->getSimpleLevel()->getPalette();
+    palette = level->getSimpleLevel()->getPalette();  // may be null
   } else if (img) {
     type = img->getType();
     if (type != "Raster" && type != "ToonzRaster")
@@ -83,9 +84,12 @@ QScriptValue CenterlineVectorizer::vectorize(QScriptValue arg) {
         tr("Bad argument (%1): should be an Image or a Level")
             .arg(arg.toString()));
   }
-  if (palette == 0) palette = new TPalette();
+
+  // If no palette was provided, create a new one.
+  if (!palette) palette = new TPalette();
+
   if (img) {
-    return vectorizeImage(img->getImg(), palette);
+    return vectorizeImage(img->getImg(), palette.getPointer());
   } else if (level) {
     QScriptValue newLevel = create(engine(), new Level());
     QList<TFrameId> fids;
@@ -94,9 +98,9 @@ QScriptValue CenterlineVectorizer::vectorize(QScriptValue arg) {
       TImageP srcImg = level->getImg(fid);
       if (srcImg && (srcImg->getType() == TImage::RASTER ||
                      srcImg->getType() == TImage::TOONZ_RASTER)) {
-        QScriptValue newFrame = vectorizeImage(srcImg, palette);
+        QScriptValue newFrame = vectorizeImage(srcImg, palette.getPointer());
         if (newFrame.isError()) {
-          return newFrame;
+          return newFrame;  // palette is automatically cleaned up
         }
         QScriptValueList args;
         args << QString::fromStdString(fid.expand()) << newFrame;
@@ -104,70 +108,62 @@ QScriptValue CenterlineVectorizer::vectorize(QScriptValue arg) {
       }
     }
     return newLevel;
-  } else {
-    // should never happen
-    return QScriptValue();
   }
+  // Unreachable
+  return QScriptValue();
 }
-
+//----------------------------------------------------------
 int CenterlineVectorizer::getThreshold() const {
   return m_parameters->m_threshold / 25;
 }
-
 void CenterlineVectorizer::setThreshold(int v) {
   m_parameters->m_threshold = v * 25;
 }
-
+//----------------------------------------------------------
 int CenterlineVectorizer::getAccuracy() const {
   return 10 - m_parameters->m_penalty;
 }
-
 void CenterlineVectorizer::setAccuracy(int v) {
   m_parameters->m_penalty = 10 - v;
 }
-
+//----------------------------------------------------------
 int CenterlineVectorizer::getDespeckling() const {
   return m_parameters->m_despeckling / 2;
 }
-
 void CenterlineVectorizer::setDespeckling(int v) {
   m_parameters->m_despeckling = v * 2;
 }
-
+//----------------------------------------------------------
 double CenterlineVectorizer::getMaxThickness() const {
   return m_parameters->m_maxThickness * 2.0;
 }
-
 void CenterlineVectorizer::setMaxThickness(double v) {
   m_parameters->m_maxThickness = v / 2.0;
 }
-
+//----------------------------------------------------------
 double CenterlineVectorizer::getThicknessCalibration() const {
   return m_parameters->m_thicknessRatio;
 }
-
 void CenterlineVectorizer::setThicknessCalibration(double v) {
   m_parameters->m_thicknessRatio = v;
 }
-
+//----------------------------------------------------------
 bool CenterlineVectorizer::getPreservePaintedAreas() const {
   return !m_parameters->m_leaveUnpainted;
 }
-
 void CenterlineVectorizer::setPreservePaintedAreas(bool v) {
   m_parameters->m_leaveUnpainted = !v;
 }
-
+//----------------------------------------------------------
 bool CenterlineVectorizer::getAddBorder() const {
   return m_parameters->m_makeFrame;
 }
-
 void CenterlineVectorizer::setAddBorder(bool v) {
   m_parameters->m_makeFrame = v;
 }
-
+//----------------------------------------------------------
 bool CenterlineVectorizer::getEir() const { return m_parameters->m_naaSource; }
-
 void CenterlineVectorizer::setEir(bool v) { m_parameters->m_naaSource = v; }
+//----------------------------------------------------------
 
 }  // namespace TScriptBinding

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -103,28 +103,28 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
                              bool hasSaveToolBar, bool hasPageCommand,
                              bool hasPasteColors)
     : QFrame(parent)
-    , m_tabBarContainer(0)
-    , m_pagesBar(0)
-    , m_paletteToolBar(0)
-    , m_savePaletteToolBar(0)
-    , m_pageViewer(0)
-    , m_pageViewerScrollArea(0)
+    , m_tabBarContainer(nullptr)
+    , m_pagesBar(nullptr)
+    , m_paletteToolBar(nullptr)
+    , m_savePaletteToolBar(nullptr)
+    , m_pageViewer(nullptr)
+    , m_pageViewerScrollArea(nullptr)
     , m_indexPageToDelete(-1)
     , m_viewType(viewType)
-    , m_frameHandle(0)
-    , m_paletteHandle(0)
-    , m_changeStyleCommand(0)
-    , m_xsheetHandle(0)
+    , m_frameHandle(nullptr)
+    , m_paletteHandle(nullptr)
+    , m_changeStyleCommand(nullptr)
+    , m_xsheetHandle(nullptr)
     , m_hasSavePaletteToolbar(hasSaveToolBar)
     , m_hasPageCommand(hasPageCommand)
     , m_isSaveActionEnabled(true)
-    , m_lockPaletteAction(0)
-    , m_lockPaletteToolButton(0)
+    , m_lockPaletteAction(nullptr)
+    , m_lockPaletteToolButton(nullptr)
     , m_toolbarOnTop(false)
     , m_showToolbarOnTopAct(nullptr)
-    , m_toolbarContainer(0)
+    , m_toolbarContainer(nullptr)
     , m_styleNameEditor(nullptr)
-    , m_hLayout(0) {
+    , m_hLayout(nullptr) {
   setObjectName("OnePixelMarginFrame");
   setFrameStyle(QFrame::StyledPanel);
 
@@ -191,14 +191,13 @@ PaletteViewer::PaletteViewer(QWidget *parent, PaletteViewType viewType,
   }
   setLayout(mainLayout);
 
-  connect(m_pagesBar, SIGNAL(currentChanged(int)), this,
-          SLOT(setPageView(int)));
-  connect(m_pagesBar, SIGNAL(movePage(int, int)), this,
-          SLOT(movePage(int, int)));
-  connect(m_pageViewer, SIGNAL(changeWindowTitleSignal()), this,
-          SLOT(changeWindowTitle()));
-  connect(m_pageViewer, SIGNAL(switchToPage(int)), this,
-          SLOT(onSwitchToPage(int)));
+  connect(m_pagesBar, &PaletteTabBar::currentChanged, this,
+          &PaletteViewer::setPageView);
+  connect(m_pagesBar, &PaletteTabBar::movePage, this, &PaletteViewer::movePage);
+  connect(m_pageViewer, &PageViewer::changeWindowTitleSignal, this,
+          &PaletteViewer::changeWindowTitle);
+  connect(m_pageViewer, &PageViewer::switchToPage, this,
+          &PaletteViewer::onSwitchToPage);
 
   changeWindowTitle();
 
@@ -317,29 +316,28 @@ void PaletteViewer::load(QSettings &settings) {
 void PaletteViewer::setPaletteHandle(TPaletteHandle *paletteHandle) {
   if (m_paletteHandle == paletteHandle) return;
 
-  bool ret = true;
-  if (m_paletteHandle) ret = ret && disconnect(m_paletteHandle, 0, this, 0);
+  if (m_paletteHandle) {
+    disconnect(m_paletteHandle, nullptr, this, nullptr);
+  }
 
   m_paletteHandle = paletteHandle;
 
   if (m_paletteHandle && isVisible()) {
-    ret = ret && connect(m_paletteHandle, SIGNAL(paletteSwitched()), this,
-                         SLOT(onPaletteSwitched()));
-    ret = ret && connect(m_paletteHandle, SIGNAL(paletteChanged()), this,
-                         SLOT(onPaletteChanged()));
-    ret = ret && connect(m_paletteHandle, SIGNAL(paletteChanged()), this,
-                         SLOT(changeWindowTitle()));
-    ret = ret && connect(m_paletteHandle, SIGNAL(paletteTitleChanged()), this,
-                         SLOT(changeWindowTitle()));
-    ret = ret && connect(m_paletteHandle, SIGNAL(colorStyleSwitched()), this,
-                         SLOT(onColorStyleSwitched()));
-    ret = ret && connect(m_paletteHandle, SIGNAL(colorStyleChanged(bool)), this,
-                         SLOT(changeWindowTitle()));
-    ret = ret && connect(m_paletteHandle, SIGNAL(paletteDirtyFlagChanged()),
-                         this, SLOT(changeWindowTitle()));
+    connect(m_paletteHandle, &TPaletteHandle::paletteSwitched, this,
+            &PaletteViewer::onPaletteSwitched);
+    connect(m_paletteHandle, &TPaletteHandle::paletteChanged, this,
+            &PaletteViewer::onPaletteChanged);
+    connect(m_paletteHandle, &TPaletteHandle::paletteChanged, this,
+            &PaletteViewer::changeWindowTitle);
+    connect(m_paletteHandle, &TPaletteHandle::paletteTitleChanged, this,
+            &PaletteViewer::changeWindowTitle);
+    connect(m_paletteHandle, &TPaletteHandle::colorStyleSwitched, this,
+            &PaletteViewer::onColorStyleSwitched);
+    connect(m_paletteHandle, &TPaletteHandle::colorStyleChanged, this,
+            &PaletteViewer::changeWindowTitle);
+    connect(m_paletteHandle, &TPaletteHandle::paletteDirtyFlagChanged, this,
+            &PaletteViewer::changeWindowTitle);
   }
-
-  assert(ret);
 
   if (m_viewType != CLEANUP_PALETTE)
     m_keyFrameButton->setPaletteHandle(m_paletteHandle);
@@ -367,7 +365,7 @@ void PaletteViewer::setXsheetHandle(TXsheetHandle *xsheetHandle) {
 }
 
 //-----------------------------------------------------------------------------
-/*!for clearing level cache after "paste style" command called from style
+/*! for clearing level cache after "paste style" command called from style
  * selection
  */
 void PaletteViewer::setLevelHandle(TXshLevelHandle *levelHandle) {
@@ -377,7 +375,7 @@ void PaletteViewer::setLevelHandle(TXshLevelHandle *levelHandle) {
 //-----------------------------------------------------------------------------
 
 TPalette *PaletteViewer::getPalette() {
-  if (!m_paletteHandle) return 0;
+  if (!m_paletteHandle) return nullptr;
   return m_paletteHandle->getPalette();
 }
 
@@ -396,12 +394,10 @@ void PaletteViewer::updateView() {
 
 void PaletteViewer::enableSaveAction(bool enable) {
   if (!m_savePaletteToolBar) return;
-  QList<QAction *> actions;
-  actions               = m_savePaletteToolBar->actions();
-  enable                = !getPalette() ? false : enable;
-  m_isSaveActionEnabled = enable;
-  int i;
-  for (i = 0; i < actions.count() - 1; i++) {
+  QList<QAction *> actions = m_savePaletteToolBar->actions();
+  enable                   = !getPalette() ? false : enable;
+  m_isSaveActionEnabled    = enable;
+  for (int i = 0; i < actions.count() - 1; ++i) {
     QAction *act = actions[i];
     if (act->text() == tr("&Save Palette As") ||
         act->text() == tr("&Save Palette"))
@@ -415,8 +411,8 @@ void PaletteViewer::enableSaveAction(bool enable) {
 void PaletteViewer::createTabBar() {
   m_pagesBar = new PaletteTabBar(this, m_hasPageCommand);
 
-  connect(m_pagesBar, SIGNAL(tabTextChanged(int)), this,
-          SLOT(onTabTextChanged(int)));
+  connect(m_pagesBar, &PaletteTabBar::tabTextChanged, this,
+          &PaletteViewer::onTabTextChanged);
 
   if (!getPalette()) return;
 
@@ -443,8 +439,8 @@ void PaletteViewer::createPaletteToolBar() {
       m_lockPaletteToolButton->setChecked(getPalette()->isLocked());
     }
 
-    connect(m_lockPaletteToolButton, SIGNAL(clicked(bool)), this,
-            SLOT(setIsLocked(bool)));
+     connect(m_lockPaletteToolButton, &QToolButton::clicked, this,
+            &PaletteViewer::setIsLocked);
     m_paletteToolBar->addWidget(m_lockPaletteToolButton);
   } else if (m_viewType == STUDIO_PALETTE) {
     QToolButton *toolButton = new QToolButton(this);
@@ -463,15 +459,15 @@ void PaletteViewer::createPaletteToolBar() {
       m_lockPaletteAction->setChecked(getPalette()->isLocked());
     }
 
-    connect(m_lockPaletteAction, SIGNAL(triggered(bool)), this,
-            SLOT(setIsLocked(bool)));
-    connect(m_lockPaletteAction, SIGNAL(toggled(bool)), toolButton,
-            SLOT(setChecked(bool)));
+    connect(m_lockPaletteAction, &QAction::triggered, this,
+            &PaletteViewer::setIsLocked);
+    connect(m_lockPaletteAction, &QAction::toggled, toolButton,
+            &QToolButton::setChecked);
 
     m_paletteToolBar->addWidget(toolButton);
   }
 
-  // Attenzione: alcune modifiche sono state fatte a livello di stylesheet
+  // Attention: some changes have been made at stylesheet level
   QToolButton *viewModeButton = new QToolButton(this);
   viewModeButton->setPopupMode(QToolButton::InstantPopup);
 
@@ -483,8 +479,8 @@ void PaletteViewer::createPaletteToolBar() {
 
   QActionGroup *viewModeGroup = new QActionGroup(viewMode);
   viewModeGroup->setExclusive(true);
-  connect(viewModeGroup, SIGNAL(triggered(QAction *)), this,
-          SLOT(onViewMode(QAction *)));
+  connect(viewModeGroup, &QActionGroup::triggered, this,
+          &PaletteViewer::onViewMode);
 
   auto addViewAction = [&](const QString &label, PageViewer::ViewMode mode) {
     QAction *viewAction = new QAction(label, viewMode);
@@ -504,8 +500,8 @@ void PaletteViewer::createPaletteToolBar() {
 
   QActionGroup *nameDisplayModeGroup = new QActionGroup(viewMode);
   nameDisplayModeGroup->setExclusive(true);
-  connect(nameDisplayModeGroup, SIGNAL(triggered(QAction *)), this,
-          SLOT(onNameDisplayMode(QAction *)));
+  connect(nameDisplayModeGroup, &QActionGroup::triggered, this,
+          &PaletteViewer::onNameDisplayMode);
 
   auto addNameDisplayAction = [&](const QString &label,
                                   PageViewer::NameDisplayMode mode) {
@@ -529,8 +525,8 @@ void PaletteViewer::createPaletteToolBar() {
   m_variableWidthAction->setCheckable(true);
   m_variableWidthAction->setChecked(true);
   viewMode->addAction(m_variableWidthAction);
-  connect(m_variableWidthAction, SIGNAL(toggled(bool)), this,
-          SLOT(toggleVariableWidth(bool)));
+  connect(m_variableWidthAction, &QAction::toggled, this,
+          &PaletteViewer::toggleVariableWidth);
 
   viewMode->addSeparator();
 
@@ -559,14 +555,14 @@ void PaletteViewer::createPaletteToolBar() {
 
   if (m_viewType != LEVEL_PALETTE) m_visibleGizmoAction->setVisible(false);
 
-  connect(m_visibleKeysAction, SIGNAL(toggled(bool)), this,
-          SLOT(toggleKeyframeVisibility(bool)));
-  connect(m_visibleNewAction, SIGNAL(toggled(bool)), this,
-          SLOT(toggleNewStylePageVisibility(bool)));
-  connect(m_visibleGizmoAction, SIGNAL(toggled(bool)), this,
-          SLOT(togglePaletteGizmoVisibility(bool)));
-  connect(m_visibleNameAction, SIGNAL(toggled(bool)), this,
-          SLOT(toggleNameEditorVisibility(bool)));
+  connect(m_visibleKeysAction, &QAction::toggled, this,
+          &PaletteViewer::toggleKeyframeVisibility);
+  connect(m_visibleNewAction, &QAction::toggled, this,
+          &PaletteViewer::toggleNewStylePageVisibility);
+  connect(m_visibleGizmoAction, &QAction::toggled, this,
+          &PaletteViewer::togglePaletteGizmoVisibility);
+  connect(m_visibleNameAction, &QAction::toggled, this,
+          &PaletteViewer::toggleNameEditorVisibility);
 
   viewMode->addMenu(visibleButtons);
 
@@ -576,19 +572,19 @@ void PaletteViewer::createPaletteToolBar() {
   else
     m_showToolbarOnTopAct->setText(tr("Set Toolbar Above Styles"));
   viewMode->addAction(m_showToolbarOnTopAct);
-  connect(m_showToolbarOnTopAct, SIGNAL(triggered()), this,
-          SLOT(toggleToolbarOnTop()));
+  connect(m_showToolbarOnTopAct, &QAction::triggered, this,
+          &PaletteViewer::toggleToolbarOnTop);
 
   QString str              = (ShowNewStyleButton) ? tr("Hide New Style Button")
                                                   : tr("Show New Style Button");
   QAction *showNewStyleBtn = viewMode->addAction(str);
-  connect(showNewStyleBtn, SIGNAL(triggered()), this,
-          SLOT(onShowNewStyleButtonToggled()));
+  connect(showNewStyleBtn, &QAction::triggered, this,
+          &PaletteViewer::onShowNewStyleButtonToggled);
 
   viewModeButton->setMenu(viewMode);
 
-  // Attenzione: avendo invertito la direzione devo aggiungere gli oggetti al
-  // contrario
+  // Attention: having reversed the direction I must add objects in reverse
+  // order
 
   m_paletteToolBar->addWidget(viewModeButton);
   m_paletteToolBar->addSeparator();
@@ -597,7 +593,8 @@ void PaletteViewer::createPaletteToolBar() {
 
   QAction *openStyleNameEditorAct = new QAction(tr("Name Editor"));
   openStyleNameEditorAct->setIcon(createQIcon("rename", true));
-  connect(openStyleNameEditorAct, &QAction::triggered, [&]() {
+  // Using a lambda for the triggered connection
+  connect(openStyleNameEditorAct, &QAction::triggered, [this]() {
     if (!m_styleNameEditor) {
       m_styleNameEditor = new StyleNameEditor(this);
       m_styleNameEditor->setPaletteHandle(getPaletteHandle());
@@ -617,8 +614,9 @@ void PaletteViewer::createPaletteToolBar() {
     // Clone palette gizmo action so visibility can be control
     QAction *palGizmo = new DVAction(m_sharedGizmoAction->icon(),
                                      m_sharedGizmoAction->text(), this);
+    // Using a lambda to forward the trigger
     connect(palGizmo, &QAction::triggered,
-            [&]() { m_sharedGizmoAction->trigger(); });
+            [this]() { m_sharedGizmoAction->trigger(); });
     m_paletteToolBar->addAction(palGizmo);
     m_toolbarParts.insert(TBVisPaletteGizmo, palGizmo);
     m_toolbarParts.insert(TBVisPaletteGizmo, m_paletteToolBar->addSeparator());
@@ -628,7 +626,7 @@ void PaletteViewer::createPaletteToolBar() {
     QAction *addPage;
     QIcon addPageIcon = createQIcon("newpage");
     addPage = new QAction(addPageIcon, tr("&New Page"), m_paletteToolBar);
-    connect(addPage, SIGNAL(triggered()), this, SLOT(addNewPage()));
+    connect(addPage, &QAction::triggered, this, &PaletteViewer::addNewPage);
 
     m_paletteToolBar->addAction(addPage);
     m_toolbarParts.insert(TBVisNewStylePage, addPage);
@@ -637,7 +635,7 @@ void PaletteViewer::createPaletteToolBar() {
   QIcon newColorIcon = createQIcon("newstyle");
   QAction *addColor =
       new QAction(newColorIcon, tr("&New Style"), m_paletteToolBar);
-  connect(addColor, SIGNAL(triggered()), this, SLOT(addNewColor()));
+  connect(addColor, &QAction::triggered, this, &PaletteViewer::addNewColor);
 
   m_paletteToolBar->addAction(addColor);
   m_toolbarParts.insert(TBVisNewStylePage, addColor);
@@ -669,36 +667,40 @@ void PaletteViewer::createSavePaletteToolBar() {
     return;
   }
 
-  // save palette as
-  QAction *saveAsPalette = new QAction(
-      createQIcon("saveas"), tr("&Save Palette As"), m_savePaletteToolBar);
-  // overwrite palette
-  QAction *savePalette = new QAction(createQIcon("save"), tr("&Save Palette"),
-                                     m_savePaletteToolBar);
-
+  // Create actions only for the relevant view type to avoid leaks
   if (m_viewType == STUDIO_PALETTE) {
-    connect(savePalette, SIGNAL(triggered()), this, SLOT(saveStudioPalette()));
+    // overwrite palette
+    QAction *savePalette = new QAction(createQIcon("save"), tr("&Save Palette"),
+                                       m_savePaletteToolBar);
+    connect(savePalette, &QAction::triggered, this,
+            &PaletteViewer::saveStudioPalette);
     m_savePaletteToolBar->addAction(savePalette);
   } else if (m_viewType == LEVEL_PALETTE) {
     // save load palette
     PaletteIconWidget *movePalette =
         new PaletteIconWidget(m_savePaletteToolBar);
-    connect(movePalette, SIGNAL(startDrag()), this, SLOT(startDragDrop()));
+    connect(movePalette, &PaletteIconWidget::startDrag, this,
+            &PaletteViewer::startDragDrop);
 
     QAction *act = m_savePaletteToolBar->addWidget(movePalette);
     act->setText(tr("&Move Palette"));
     m_savePaletteToolBar->addSeparator();
 
     // save palette as
-    connect(saveAsPalette, SIGNAL(triggered()),
+    QAction *saveAsPalette = new QAction(
+        createQIcon("saveas"), tr("&Save Palette As"), m_savePaletteToolBar);
+    // Forward to command manager's action
+    connect(saveAsPalette, &QAction::triggered,
             CommandManager::instance()->getAction("MI_SavePaletteAs"),
-            SIGNAL(triggered()));
+            &QAction::triggered);
     m_savePaletteToolBar->addAction(saveAsPalette);
 
     // overwrite palette
-    connect(savePalette, SIGNAL(triggered()),
+    QAction *savePalette = new QAction(createQIcon("save"), tr("&Save Palette"),
+                                       m_savePaletteToolBar);
+    connect(savePalette, &QAction::triggered,
             CommandManager::instance()->getAction("MI_OverwritePalette"),
-            SIGNAL(triggered()));
+            &QAction::triggered);
     m_savePaletteToolBar->addAction(savePalette);
   }
 
@@ -712,8 +714,8 @@ void PaletteViewer::updateTabBar() {
   int tabCount = m_pagesBar->count();
   int i;
 
-  // Se ci sono tab li butto
-  for (i = tabCount - 1; i >= 0; i--) m_pagesBar->removeTab(i);
+  // If there are tabs, remove them
+  for (i = tabCount - 1; i >= 0; --i) m_pagesBar->removeTab(i);
 
   TPalette *palette = getPalette();
   if (!palette) return;
@@ -721,8 +723,8 @@ void PaletteViewer::updateTabBar() {
   QIcon tabIcon = createQIcon("palette_tab");
   m_pagesBar->setIconSize(QSize(16, 16));
 
-  // Aggiungo i tab in funzione delle pagine di m_palette
-  for (i = 0; i < palette->getPageCount(); i++) {
+  // Add tabs according to m_palette pages
+  for (i = 0; i < palette->getPageCount(); ++i) {
     TPalette::Page *page = palette->getPage(i);
     std::wstring ws      = page->getName();
     QString pageName     = QString::fromStdWString(ws);
@@ -737,17 +739,15 @@ void PaletteViewer::updateTabBar() {
  */
 void PaletteViewer::updatePaletteToolBar() {
   if (!m_paletteToolBar) return;
-  QList<QAction *> actions;
-  actions                = m_paletteToolBar->actions();
-  TPalette *palette      = getPalette();
-  bool enable            = !palette ? false : true;
-  bool enableNewStyleAct = enable;
+  QList<QAction *> actions = m_paletteToolBar->actions();
+  TPalette *palette        = getPalette();
+  bool enable              = !palette ? false : true;
+  bool enableNewStyleAct   = enable;
   // limit the number of cleanup styles to 7
   if (palette && palette->isCleanupPalette())
     enableNewStyleAct = (palette->getStyleInPagesCount() < 8);
   if (m_viewType != CLEANUP_PALETTE) m_keyFrameButton->setEnabled(enable);
-  int i;
-  for (i = 0; i < actions.count(); i++) {
+  for (int i = 0; i < actions.count(); ++i) {
     QAction *act = actions[i];
     if (act->text() == tr("&New Style")) {
       act->setEnabled(enableNewStyleAct);
@@ -763,11 +763,9 @@ void PaletteViewer::updatePaletteToolBar() {
  */
 void PaletteViewer::updateSavePaletteToolBar() {
   if (!m_savePaletteToolBar) return;
-  QList<QAction *> actions;
-  actions     = m_savePaletteToolBar->actions();
-  bool enable = !getPalette() ? false : true;
-  int i;
-  for (i = 0; i < actions.count(); i++) {
+  QList<QAction *> actions = m_savePaletteToolBar->actions();
+  bool enable              = !getPalette() ? false : true;
+  for (int i = 0; i < actions.count(); ++i) {
     QAction *act = actions[i];
     if (act->text() == tr("&Save Palette As") ||
         act->text() == tr("&Save Palette") ||
@@ -809,7 +807,7 @@ void PaletteViewer::contextMenuEvent(QContextMenuEvent *event) {
   QMenu *menu = new QMenu(this);
   if (m_hasPageCommand) {
     QAction *newPage = menu->addAction(createQIcon("newpage"), tr("New Page"));
-    connect(newPage, SIGNAL(triggered()), SLOT(addNewPage()));
+    connect(newPage, &QAction::triggered, this, &PaletteViewer::addNewPage);
 
     if (m_pagesBar->geometry().contains(pos)) {
       int tabIndex         = m_pagesBar->tabAt(pos);
@@ -822,7 +820,8 @@ void PaletteViewer::contextMenuEvent(QContextMenuEvent *event) {
           m_indexPageToDelete = tabIndex;
           QAction *deletePage =
               menu->addAction(createQIcon("delete"), tr("Delete Page"));
-          connect(deletePage, SIGNAL(triggered()), SLOT(deletePage()));
+          connect(deletePage, &QAction::triggered, this,
+                  &PaletteViewer::deletePage);
         }
       }
     }
@@ -865,64 +864,52 @@ void PaletteViewer::showEvent(QShowEvent *) {
 
   if (!m_paletteHandle) return;
 
-  connect(m_paletteHandle, SIGNAL(paletteSwitched()), this,
-          SLOT(onPaletteSwitched()));
-  connect(m_paletteHandle, SIGNAL(paletteChanged()), this,
-          SLOT(onPaletteChanged()));
-  connect(m_paletteHandle, SIGNAL(paletteTitleChanged()), this,
-          SLOT(changeWindowTitle()));
-  connect(m_paletteHandle, SIGNAL(colorStyleSwitched()), this,
-          SLOT(onColorStyleSwitched()));
-  connect(m_paletteHandle, SIGNAL(colorStyleChanged(bool)), this,
-          SLOT(changeWindowTitle()));
-  connect(m_paletteHandle, SIGNAL(paletteDirtyFlagChanged()), this,
-          SLOT(changeWindowTitle()));
+  connect(m_paletteHandle, &TPaletteHandle::paletteSwitched, this,
+          &PaletteViewer::onPaletteSwitched);
+  connect(m_paletteHandle, &TPaletteHandle::paletteChanged, this,
+          &PaletteViewer::onPaletteChanged);
+  connect(m_paletteHandle, &TPaletteHandle::paletteTitleChanged, this,
+          &PaletteViewer::changeWindowTitle);
+  connect(m_paletteHandle, &TPaletteHandle::colorStyleSwitched, this,
+          &PaletteViewer::onColorStyleSwitched);
+  connect(m_paletteHandle, &TPaletteHandle::colorStyleChanged, this,
+          &PaletteViewer::changeWindowTitle);
+  connect(m_paletteHandle, &TPaletteHandle::paletteDirtyFlagChanged, this,
+          &PaletteViewer::changeWindowTitle);
 
   if (!m_frameHandle) return;
-  // Connessione necessaria per aggiornare lo stile in caso di palette animate.
-  connect(m_frameHandle, SIGNAL(frameSwitched()), this,
-          SLOT(onFrameSwitched()));
+  // Connection needed to update the style in case of animated palettes.
+  connect(m_frameHandle, &TFrameHandle::frameSwitched, this,
+          &PaletteViewer::onFrameSwitched);
 }
 
 //-----------------------------------------------------------------------------
 
 void PaletteViewer::hideEvent(QHideEvent *) {
-  disconnect(m_paletteHandle, SIGNAL(paletteSwitched()), this,
-             SLOT(onPaletteSwitched()));
-  disconnect(m_paletteHandle, SIGNAL(paletteChanged()), this,
-             SLOT(onPaletteChanged()));
-  disconnect(m_paletteHandle, SIGNAL(paletteTitleChanged()), this,
-             SLOT(changeWindowTitle()));
-  disconnect(m_paletteHandle, SIGNAL(colorStyleSwitched()), this,
-             SLOT(onColorStyleSwitched()));
-  disconnect(m_paletteHandle, SIGNAL(colorStyleChanged(bool)), this,
-             SLOT(changeWindowTitle()));
-  disconnect(m_paletteHandle, SIGNAL(paletteDirtyFlagChanged()), this,
-             SLOT(changeWindowTitle()));
-
-  if (!m_frameHandle) return;
-  disconnect(m_frameHandle, SIGNAL(frameSwitched()), this,
-             SLOT(onFrameSwitched()));
+  disconnect(m_paletteHandle, nullptr, this, nullptr);
+  if (m_frameHandle) disconnect(m_frameHandle, nullptr, this, nullptr);
 }
 
 //-----------------------------------------------------------------------------
-/*! If currente palette viewer exist verify event data, if is a PaletteData or
-has urls accept event.
+/*! If current palette viewer exists verify event data, if it is a PaletteData
+or has urls accept event.
 */
 void PaletteViewer::dragEnterEvent(QDragEnterEvent *event) {
   TPalette *palette = getPalette();
   if (!palette || m_viewType == CLEANUP_PALETTE) return;
 
-  const QMimeData *mimeData      = event->mimeData();
+  const QMimeData *mimeData = event->mimeData();
+  if (!mimeData) return;  // guard against null mimeData
+
   const PaletteData *paletteData = dynamic_cast<const PaletteData *>(mimeData);
 
   if (paletteData) {
-    // Sto "draggando" stili.
+    // Dragging styles.
     if (paletteData->hasStyleIndeces()) {
       m_pageViewer->createDropPage();
       if (!palette) onSwitchToPage(palette->getPageCount() - 1);
     }
-    // Accetto l'evento
+    // Accept the event
     event->acceptProposedAction();
     return;
   }
@@ -931,9 +918,8 @@ void PaletteViewer::dragEnterEvent(QDragEnterEvent *event) {
   QList<QUrl> urls = mimeData->urls();
   int count        = urls.size();
   if (count == 0) return;
-  // Accetto l'evento solo se ho tutte palette.
-  int i;
-  for (i = 0; i < count; i++) {
+  // Accept the event only if all are palettes.
+  for (int i = 0; i < count; ++i) {
     TFilePath path(urls[i].toLocalFile().toStdWString());
     if (!path.getType().empty() && path.getType() != "tpl") return;
   }
@@ -950,20 +936,20 @@ void PaletteViewer::dragEnterEvent(QDragEnterEvent *event) {
 void PaletteViewer::dropEvent(QDropEvent *event) {
   if (m_viewType == CLEANUP_PALETTE) return;
   const QMimeData *mimeData = event->mimeData();
+  if (!mimeData) return;
 
   QPoint tollBarPos      = m_savePaletteToolBar->mapFrom(this, event->pos());
   QAction *currentAction = m_savePaletteToolBar->actionAt(tollBarPos);
   bool loadPalette =
       currentAction && currentAction->text() == QString(tr("&Move Palette"));
 
-  // ho i path delle palette
+  // I have palette paths
   if (mimeData->hasUrls()) {
     QList<QUrl> urls = mimeData->urls();
     int count        = urls.size();
     if (count == 0) return;
 
-    int i;
-    for (i = 0; i < count; i++) {
+    for (int i = 0; i < count; ++i) {
       TFilePath path(urls[i].toLocalFile().toStdWString());
       if (!path.getType().empty() && path.getType() != "tpl") return;
       if (loadPalette && i == 0) {
@@ -1002,12 +988,12 @@ void PaletteViewer::dropEvent(QDropEvent *event) {
   const PaletteData *paletteData = dynamic_cast<const PaletteData *>(mimeData);
 
   if (!paletteData) return;
-  // Sto inserendo stili
+  // Inserting styles
   if (paletteData->hasStyleIndeces()) {
     m_pageViewer->drop(-1, mimeData);
     event->acceptProposedAction();
   } else {
-    // Ho la palette da inserire
+    // Inserting the palette
     TPalette *palette = paletteData->getPalette();
     if (getPalette() == palette) return;
     if (loadPalette) {
@@ -1026,7 +1012,7 @@ void PaletteViewer::dropEvent(QDropEvent *event) {
 }
 
 //-----------------------------------------------------------------------------
-/*! Start drag and drop; if current page exist set drag and drop event data.
+/*! Start drag and drop; if current page exists set drag and drop event data.
  */
 void PaletteViewer::startDragDrop() {
   TRepetitionGuard guard;
@@ -1044,7 +1030,8 @@ void PaletteViewer::startDragDrop() {
   paletteData->setPalette(palette);
   drag->setMimeData(paletteData);
 
-  Qt::DropAction dropAction = drag->exec(Qt::CopyAction | Qt::MoveAction);
+  drag->exec(Qt::CopyAction | Qt::MoveAction);
+  // dropAction is not used, so we don't store it
 }
 
 //-----------------------------------------------------------------------------
@@ -1056,7 +1043,7 @@ void PaletteViewer::clearStyleSelection() { m_pageViewer->clearSelection(); }
  */
 void PaletteViewer::setPageView(int currentIndexPage) {
   TPalette *palette    = getPalette();
-  TPalette::Page *page = palette ? palette->getPage(currentIndexPage) : 0;
+  TPalette::Page *page = palette ? palette->getPage(currentIndexPage) : nullptr;
   m_pageViewer->setPage(page);
 }
 
@@ -1077,8 +1064,7 @@ void PaletteViewer::addNewPage() {
 
 //-----------------------------------------------------------------------------
 /*! Create a new style in current page view of current palette viewer emit a
-signal
-to create a new style.
+signal to create a new style.
 */
 void PaletteViewer::addNewColor() {
   if (!getPalette() || getPalette()->isLocked()) return;
@@ -1100,9 +1086,8 @@ void PaletteViewer::deletePage() {
   if (m_xsheetHandle) {
     std::vector<int> styleIds;
     TPalette::Page *page = palette->getPage(m_indexPageToDelete);
-    if (!page) return;  // La pagina dovrebbe esserci sempre
-    int i;
-    for (i = 0; i < page->getStyleCount(); i++)
+    if (!page) return;  // The page should always exist
+    for (int i = 0; i < page->getStyleCount(); ++i)
       styleIds.push_back(page->getStyleId(i));
 
     int ret = DVGui::eraseStylesInDemand(palette, styleIds, m_xsheetHandle);
@@ -1192,8 +1177,8 @@ void PaletteViewer::saveStudioPalette() {
 void PaletteViewer::onColorStyleSwitched() {
   TPalette *palette = getPalette();
 
-  // se non c'e' palette, pageviewer p pagina corrente esco (non dovrebbe
-  // succedere mai)
+  // if there's no palette, pageviewer or current page exit (should never
+  // happen)
   if (!palette || !m_pageViewer) return;
   int styleIndex = m_paletteHandle->getStyleIndex();
 
@@ -1202,8 +1187,7 @@ void PaletteViewer::onColorStyleSwitched() {
   TPalette::Page *page = m_pageViewer->getPage();
   if (!page) return;
 
-  // faccio in modo che la pagina che contiene il colore selezionato diventi
-  // corrente
+  // make the page containing the selected color current
   int indexInPage = page->search(styleIndex);
   if (indexInPage == -1) {
     if (!palette->getStylePage(styleIndex)) return;

--- a/toonz/sources/toonzqt/pluginhost.h
+++ b/toonz/sources/toonzqt/pluginhost.h
@@ -198,7 +198,9 @@ public:
   ParamView *createParamView();
 
   bool isPlugin() const override { return true; }
-  bool isPluginZerary() const override { return pi_->desc_->is_geometric(); }
+  bool isPluginZerary() const override {
+    return pi_ ? pi_->desc_->is_geometric() : false;
+  }
 
   bool isZerary() const override { return isPluginZerary(); };
   void callStartRenderHandler() override;


### PR DESCRIPTION
This pull request addresses the final set of issues reported by the Clang Static Analyzer and modernizes the codebase across `toonzqt` and `toonzlib`, focusing on modernization and memory safety

- Replaced raw pointers with smart pointers and added null pointer guards to fix crashes in playback and drag-and-drop.

-  Migrated signals/slots to Qt5 syntax and used `std::unique_ptr` for UI components like `QActionGroup`. See: [6311](https://github.com/opentoonz/opentoonz/issues/6311)

-  Fixed division-by-zero in PlaybackExecutor, removed dead stores/unused variables in `flipconsole.cpp` and `dvdialog.cpp`, and translated legacy Italian/Japanese comments to English.

Note: This PR completes the planned fixes for memory-related warnings identified by the Clang Static Analyzer. However, this is only the tip of the iceberg, further analysis with dynamic tools and deeper architectural refactoring will be necessary to address more complex resource management issues that static analysis cannot detect. Reference: https://github.com/opentoonz/opentoonz/pull/6310