### PR TITLE
Fix blank frames on import

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -76,7 +76,7 @@ public:
 
   static bool checkFormat(std::string format);
 
-  // Getters with const
+  // Getters with const, now use mutable caching for performance
   double getFrameRate() const;
   TDimension getSize() const;
   int getFrameCount() const;
@@ -97,12 +97,16 @@ private:
   QString m_audioFormat;
   QStringList m_audioArgs;
 
-  double m_frameRate = 0.0;
-  int m_lx           = 0;
-  int m_ly           = 0;
-  int m_bpp          = 0;
-  int m_frameCount   = 0;
-  int m_startNumber  = std::numeric_limits<int>::max();
+  // Mutable members for caching inside const functions
+  mutable double m_frameRate = 0.0;
+  mutable int m_lx           = 0;
+  mutable int m_ly           = 0;
+  mutable int m_frameCount   = 0;
+  mutable bool m_infoCached =
+      false;  // indicates whether cache has been attempted
+
+  int m_bpp         = 0;
+  int m_startNumber = std::numeric_limits<int>::max();
   int m_ffmpegTimeoutMs;  // Value comes from constructor (user config)
   int m_sampleRate    = 0;
   int m_channelCount  = 0;


### PR DESCRIPTION
This PR fixes an issue introduced by #6521, where frames were appearing blank in the xsheet when importing MP4s, as reported by @RodneyBaker.

This patch should resolve the issue by ensuring a more robust frame extraction and retrieval process, especially for files with large frame counts.

* Changed frame naming from `%04d` to `%06d` to prevent indexing collisions and ensure compatibility with long video sequences.
* Implemented persistent metadata caching (LX, LY, FPS, Frame Count) via `.txt` files in the cache folder and `mutable` class members. This prevents redundant `ffprobe` calls that were causing UI lag and potential race conditions during frame loading.
* Improved the `getImage` logic to ensure the `QImage` is fully loaded and correctly converted to ARGB32 before being copied to the Toonz raster, preventing the "blank frame" syndrome.

