### PR TITLE
Fix crash on pasting external image into camera column

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2076,8 +2076,12 @@ void TCellSelection::pasteCells() {
   const RasterImageData *rasterImageData =
       dynamic_cast<const RasterImageData *>(mimeData);
   if (rasterImageData || clipImage.height() > 0) {
-    if (isEmpty())  // Nothing selected.
+    if (isEmpty()) return;
+    // Prevent pasting raster images into the camera column (c0 < 0)
+    if (c0 < 0) {
+      DVGui::warning(QObject::tr("Cannot paste into the camera column."));
       return;
+    }
 
     // get the current image and find out the type
     TImageP img = xsh->getCell(r0, c0).getImage(false);


### PR DESCRIPTION
This PR prevents a segmentation fault that occurred when pasting an external image (e.g., from a web browser) into the camera column by blocking paste operations in that column.

I considered implementing the same confirmation dialog used for other columns (which asks whether to paste into a **New Raster Level** or **Cancel**), but this would require additional testing since other paste scenarios would also need to be handled. Because it could also be triggered unintentionally, I opted for this simpler approach to provide a more immediate fix and prevent the crash, which could otherwise cause users to lose their work.

Closes #5370