### PR TITLE
ci: Fix macOS Qt6 symlink conflicts from OpenCV/VTK

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -44,7 +44,7 @@ jobs:
             fi
           done
           brew link --overwrite --force python@3.14 || true
-          
+
       - name: Install libraries
         run: |
           checkPkgAndInstall() {
@@ -56,10 +56,17 @@ jobs:
               fi
             done
           }
-          
+
           brew update
 
-          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv openjph openexr qt@5
+          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv openjph openexr
+
+          brew list --formula | grep '^qt' | grep -v '@5' | xargs -n1 brew unlink || true
+
+          brew install qt@5
+          brew unlink qt@5 || true
+          brew link qt@5 || true
+
       - name: Set up cache
         run: |
           export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
This PR fixes macOS CI failures caused by Homebrew’s opencv update (4.13.0), which now depends on vtk. That automatically installs Qt 6.10 modules, creating symlink conflicts when installing qt@5.

- Unlink all Qt6 formulas (`brew list | grep '^qt' | grep -v '@5' | xargs -n1 brew unlink`)
- Install qt@5 cleanly and force link

These changes restore the macOS build and future-proof it against new Qt6 modules.