### PR TITLE
Fix PNG Colormap serialization breaking scene loading

### DIFF
--- a/toonz/sources/image/png/tiio_png.cpp
+++ b/toonz/sources/image/png/tiio_png.cpp
@@ -569,14 +569,13 @@ private:
 //=========================================================
 
 Tiio::PngWriterProperties::PngWriterProperties()
-    : m_matte("Alpha Channel", true), m_colormap("Colormap", nullptr) {
+    : m_matte("Alpha Channel", true) {
   bind(m_matte);
-  bind(m_colormap);
+  // Colormap intentionally unbound to prevent XML serialization
 }
 
 void Tiio::PngWriterProperties::updateTranslation() {
   m_matte.setQStringName(tr("Alpha Channel"));
-  m_colormap.setQStringName(tr("Colormap"));
 }
 
 //=========================================================

--- a/toonz/sources/image/png/tiio_png.h
+++ b/toonz/sources/image/png/tiio_png.h
@@ -19,7 +19,6 @@ class PngWriterProperties final : public TPropertyGroup {
 public:
   // TEnumProperty m_pixelSize;
   TBoolProperty m_matte;
-  TPointerProperty m_colormap;
 
   PngWriterProperties();
   void updateTranslation() override;


### PR DESCRIPTION
This PR fixes a regression from PR #6595, reported by @Gaspard--, where the `Colormap` property in PNG format settings was serialized into scene XML files. This could lead to invalid pointer values, preventing scenes from loading correctly.

Specifically, saving a scene with PNG output would write the following line to the scene XML:

`<property name="Colormap" type="pointer" value="0000000000000000"/>`

OpenToonz cannot interpret this line, causing the scene to fail to load.

After this fix, new scenes will save correctly without writing the Colormap property, and scenes will load normally. Existing `.tnz` files containing the line still require manual cleanup.