### PR TITLE
Fix selection lost of export level popup

### DIFF
--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -632,7 +632,13 @@ void DvDirTreeView::enableCommands() {
 
 void DvDirTreeView::currentChanged(const QModelIndex &current,
                                    const QModelIndex &previous) {
-  if (m_globalSelectionEnabled) {
+  // Only refresh the global selection when user made first selection
+  // The first selection would be made by Qt after setting the data model
+  // (aka.previous selection is already valid before user selection)
+  // Old: change global selection when class first initialized
+  // New: change global selection only when user made first selection
+  // (In case of some command like exportLevel need info from global selection)
+  if (m_globalSelectionEnabled && previous.isValid()) {
     // Make current selection; needed to intercept the MI_Clear command
     makeCurrent();
   }

--- a/toonz/sources/toonz/exportlevelpopup.cpp
+++ b/toonz/sources/toonz/exportlevelpopup.cpp
@@ -395,14 +395,21 @@ void ExportLevelPopup::showEvent(QShowEvent *se) {
   }
 
   // WARNING: What happens it the restored selection is NO MORE VALID ?
-  //
-  // This Problem is caused because the global selection of dvitemview
-  // is on for default browserpopup , which whould cause the global
-  // selection to be cleared
   //          Consider that this popup is NOT MODAL !!
   //
   //          The same applies to all the other popups in
   //          filebrowserpopup.cpp...
+  //
+  // This Problem was caused because the global selection of dvitemview
+  // is on for default browserpopup , which whould cause the global
+  // selection to be cleared when filebrowser first initialized
+
+  // To resolve this problem:
+  // 1. when class initializing: m_browser->enableGlobalSelection(false);
+  // £¨this changed was not made since currently the change of broswer item
+  // won't trigger signal `selectionChanged`
+  // but only trigger signal `selectionSwitched` ( makeCurrent() ))
+  // 2. DO NOT overwrite global selection when classs is initialing
 
   updateOnSelection();  // Here the selection is used
 

--- a/toonz/sources/toonz/filebrowserpopup.cpp
+++ b/toonz/sources/toonz/filebrowserpopup.cpp
@@ -2273,8 +2273,6 @@ void ImportMagpieFilePopup::showEvent(QShowEvent *e) {
 
 BrowserPopup::BrowserPopup() : FileBrowserPopup("") {
   setOkText(tr("Choose"));
-  // DIRTY FIX!!!! this should never cause crash
-  m_browser->enableGlobalSelection(true);
 }
 
 bool BrowserPopup::execute() {

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1383,7 +1383,7 @@ void IoCmd::newScene() {
 
   if (!TApp::instance()->isApplicationStarting())
     QApplication::clipboard()->clear();
-  TSelection::setCurrent(0);
+  TSelection::setCurrent(nullptr);
   TUndoManager::manager()->reset();
 
   bool exist = TSystem::doesExistFileOrLevel(

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -1788,6 +1788,7 @@ public:
       selection->selectColumn(*it + dCol, true);
   }
   void onRelease(const CellPosition &pos) override {
+    TApp::instance()->getCurrentSelection()->notifySelectionChanged();
     int delta = m_lastCol - m_firstCol;
     if (delta != 0) {
       TColumnSelection *selection = getViewer()->getColumnSelection();


### PR DESCRIPTION
This PR fixes:

1. Can't export selected levels(columns/cells/cast) when `Export Level..` excuted first time.
2. Selected levels of `Export Level Popup` not update when xsheet column selection changed.

But I didn't fully understand how selection system of OT works, 
especially this function: `void DvDirTreeView::currentChanged()` in `dvdirtreeview.cpp`.