### PR TITLE
fix Linux Plastic rendering on Sub-Xsheets

### DIFF
--- a/toonz/sources/toonzlib/textureutils.cpp
+++ b/toonz/sources/toonzlib/textureutils.cpp
@@ -192,7 +192,7 @@ DrawableTextureDataP texture_utils::getTextureData(const TXsheet *xsh,
   bbox = (cameraAff.inv() * bbox).enlarge(1.0);
 
 // Render the xsheet on the specified bbox
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
   xsh->getScene()->renderFrame(tex, frame, xsh, bbox, TAffine());
 #else
   // The call below will change context (I know, it's a shame :( )

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -50,7 +50,7 @@ TOfflineGL *currentOfflineGL = 0;
 
 #include <QProgressDialog>
 
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
 #include <QSurfaceFormat>
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
@@ -385,8 +385,8 @@ int ToonzScene::loadFrameCount(const TFilePath &fp) {
 void ToonzScene::loadNoResources(const TFilePath &fp) {
   clear();
 
-  TProjectManager *pm  = TProjectManager::instance();
-  auto sceneProject    = pm->loadSceneProject(fp, &m_standAlone);
+  TProjectManager *pm = TProjectManager::instance();
+  auto sceneProject   = pm->loadSceneProject(fp, &m_standAlone);
   if (!sceneProject) return;
 
   loadTnzFile(fp);
@@ -777,7 +777,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
   TRect clipRect(ras->getBounds());
 
 // fix for plastic tool applied to subxsheet
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
   QSurfaceFormat format;
   format.setProfile(QSurfaceFormat::CompatibilityProfile);
 
@@ -794,7 +794,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
   ogl.makeCurrent();
 #endif
   {
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
     std::unique_ptr<QOpenGLFramebufferObject> fb(
         new QOpenGLFramebufferObject(ras->getLx(), ras->getLy()));
 
@@ -825,7 +825,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 
     painter.flushRasterImages();
     glFlush();
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
     QImage img =
         fb->toImage().scaled(QSize(ras->getLx(), ras->getLy()),
                              Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
@@ -844,7 +844,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
     TRop::over(ras, ogl.getRaster());
 #endif
   }
-#ifdef MACOSX
+#if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
   glMatrixMode(GL_MODELVIEW), glPopMatrix();
   glMatrixMode(GL_PROJECTION), glPopMatrix();
 


### PR DESCRIPTION
This PR addresses an issue in the Linux build where using the Plastic Tool on Sub-Xsheets leads to rendering inconsistencies and visibility loss in the Scene Table, as reported by @samstyle in #6776.

Ported from https://github.com/tahoma2d/tahoma2d/pull/1628
Co-Authored-By: manongjohn <19245851+manongjohn@users.noreply.github.com>

Now it should work correctly as expected.

Ref: https://github.com/opentoonz/opentoonz/issues/6776