### PR TITLE
Revert References of Global Cleanup Parameters

### DIFF
--- a/toonz/sources/toonz/cleanupsettingsmodel.cpp
+++ b/toonz/sources/toonz/cleanupsettingsmodel.cpp
@@ -127,7 +127,7 @@ public:
       return false;
     }
 
-    CleanupSettingsModel::instance()->loadSettings(loadPath);
+    CleanupSettingsModel::instance()->loadSettings(loadPath, true);
     return true;
   }
 };
@@ -346,6 +346,12 @@ void CleanupSettingsModel::commitChanges(int action) {
     m_backupParams.assign(currentParams, false);
 
     currentParams->setDirtyFlag(true);
+
+    // Deal with scene stuff
+    if (m_clnPath.isEmpty()) {
+      CleanupParameters::GlobalParameters.assign(currentParams);
+    }
+
     TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   }
 
@@ -353,7 +359,7 @@ void CleanupSettingsModel::commitChanges(int action) {
   int maxAction =
       std::max(action, m_action);  // Add previuosly required actions
   action   = std::min(maxAction,
-                    m_allowedActions);  // But only up to the allowed action
+                      m_allowedActions);  // But only up to the allowed action
   m_action = (action == maxAction)
                  ? NONE
                  : maxAction;  // Then, update the previously required action
@@ -451,7 +457,7 @@ void CleanupSettingsModel::onSceneSwitched() {
   // copy them there.
   CleanupParameters *params = getCurrentParameters();
   CleanupParameters::GlobalParameters.assign(params);
-  
+
   // The cleanupper always uses current cleanup parameters. It has to be
   // specified somewhere,
   // so let's do it once here.
@@ -567,11 +573,7 @@ bool CleanupSettingsModel::saveSettingsIfNeeded() {
     int ret = DVGui::MsgBox(question, QObject::tr("Save"),
                             QObject::tr("Discard"), QObject::tr("Cancel"), 0);
     if (ret == 1) {
-      // WARNING: This is legacy behavior, but is it really needed? I think
-      // there should be no further
-      // request of user interaction - why invoking the popup to choose the save
-      // path?
-      promptSave();
+      saveSettings(m_clnPath);
     } else if (ret == 3)
       return false;
   }
@@ -663,7 +665,8 @@ bool CleanupSettingsModel::loadSettings(CleanupParameters *params,
 
 //-----------------------------------------------------------------------------
 
-bool CleanupSettingsModel::loadSettings(const TFilePath &clnPath) {
+bool CleanupSettingsModel::loadSettings(const TFilePath &clnPath,
+                                        bool isCalledFromLoadSettingsPopup) {
   CleanupParameters *cp = getCurrentParameters();
   if (!loadSettings(cp, clnPath)) return false;
 
@@ -672,6 +675,12 @@ bool CleanupSettingsModel::loadSettings(const TFilePath &clnPath) {
       ->getCurrentCleanupPalette()
       ->setPalette(cp->m_cleanupPalette.getPointer());
 
+  // When this function is called from LoadSettingsPopup, store the loaded
+  // parameters in the Global settings
+  if (isCalledFromLoadSettingsPopup && m_clnPath.isEmpty()) {
+    CleanupParameters::GlobalParameters.assign(
+        cp);  // The global settings are being changed
+  }
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   m_backupParams.assign(cp, false);
 

--- a/toonz/sources/toonz/cleanupsettingsmodel.h
+++ b/toonz/sources/toonz/cleanupsettingsmodel.h
@@ -143,7 +143,8 @@ public:
   void setCommitMask(CommitMask allowedProcessing);
 
   void saveSettings(const TFilePath &clnPath);
-  bool loadSettings(const TFilePath &clnPath);
+  bool loadSettings(const TFilePath &clnPath,
+                    bool isCalledFromLoadSettingsPopup = false);
 
   //! Prompts to save current settings in case they have been modified. Returns
   //! false if the

--- a/toonz/sources/toonz/cleanupsettingspane.cpp
+++ b/toonz/sources/toonz/cleanupsettingspane.cpp
@@ -209,7 +209,9 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
     QVBoxLayout *cleanupCameraFrameLay = new QVBoxLayout();
     cleanupCameraFrameLay->setContentsMargins(0, 0, 0, 0);
     cleanupCameraFrameLay->setSpacing(0);
-    { cleanupCameraFrameLay->addWidget(m_cameraWidget); }
+    {
+      cleanupCameraFrameLay->addWidget(m_cameraWidget);
+    }
     cameraFrame->setLayout(cleanupCameraFrameLay);
     mainLay->addWidget(cameraFrame, 0);
 
@@ -276,11 +278,11 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
   //-----signal-slot connections
   bool ret = true;
   ret      = ret && connect(m_autocenterBox, SIGNAL(clicked(bool)),
-                       SLOT(onGenericSettingsChange()));
+                            SLOT(onGenericSettingsChange()));
   ret      = ret && connect(m_pegHolesOm, SIGNAL(activated(int)),
-                       SLOT(onGenericSettingsChange()));
+                            SLOT(onGenericSettingsChange()));
   ret      = ret && connect(m_fieldGuideOm, SIGNAL(activated(int)),
-                       SLOT(onGenericSettingsChange()));
+                            SLOT(onGenericSettingsChange()));
 
   ret = ret && connect(m_rotateOm, SIGNAL(activated(int)),
                        SLOT(onGenericSettingsChange()));
@@ -312,8 +314,8 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
       ret && connect(saveBtn, SIGNAL(pressed()), this, SLOT(onSaveSettings()));
 
   ret = ret && connect(loadBtn, SIGNAL(pressed()), model, SLOT(promptLoad()));
-  ret = ret && connect(resetBtn, SIGNAL(pressed()), this,
-                       SLOT(onRestoreSettings()));
+  ret = ret &&
+        connect(resetBtn, SIGNAL(pressed()), this, SLOT(onRestoreSettings()));
 
   assert(ret);
 }
@@ -332,9 +334,9 @@ void CleanupSettingsPane::showEvent(QShowEvent *se) {
 
     bool ret = true;
     ret      = ret && connect(model, SIGNAL(imageSwitched()), this,
-                         SLOT(onImageSwitched()));
+                              SLOT(onImageSwitched()));
     ret      = ret && connect(model, SIGNAL(modelChanged(bool)), this,
-                         SLOT(updateGui(bool)));
+                              SLOT(updateGui(bool)));
     ret = ret && connect(model, SIGNAL(clnLoaded()), this, SLOT(onClnLoaded()));
     assert(ret);
 
@@ -366,9 +368,9 @@ void CleanupSettingsPane::hideEvent(QHideEvent *he) {
 
     bool ret = true;
     ret      = ret && disconnect(model, SIGNAL(imageSwitched()), this,
-                            SLOT(onImageSwitched()));
+                                 SLOT(onImageSwitched()));
     ret      = ret && disconnect(model, SIGNAL(modelChanged(bool)), this,
-                            SLOT(updateGui(bool)));
+                                 SLOT(updateGui(bool)));
     ret      = ret &&
           disconnect(model, SIGNAL(clnLoaded()), this, SLOT(onClnLoaded()));
     assert(ret);
@@ -411,8 +413,9 @@ void CleanupSettingsPane::updateGui(CleanupParameters *params,
   m_pathField->setPath(toQString(m_path));
 
   m_lineProcessing->setCurrentIndex(params->m_lineProcessingMode);
-  m_antialias->setCurrentIndex(
-      params->m_postAntialias ? 2 : params->m_noAntialias ? 1 : 0);
+  m_antialias->setCurrentIndex(params->m_postAntialias ? 2
+                               : params->m_noAntialias ? 1
+                                                       : 0);
   m_sharpness->setValue(params->m_sharpness);
   m_despeckling->setValue(params->m_despeckling);
   m_aaValue->setValue(params->m_aaValue);

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1371,8 +1371,8 @@ void IoCmd::newScene() {
   app->getCurrentObject()->setIsSpline(false);
   app->getCurrentColumn()->setColumnIndex(0);
 
-  // CleanupParameters *cp = scene->getProperties()->getCleanupParameters();
-  // CleanupParameters::GlobalParameters.assign(cp);
+  CleanupParameters *cp = scene->getProperties()->getCleanupParameters();
+  CleanupParameters::GlobalParameters.assign(cp);
   // CleanupSettingsModel::onSceneSwitched()
 
   // updateCleanupSettingsPopup();
@@ -1503,9 +1503,12 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
 
   // Don't store current cleanup parameters to scene's parameters' cache if
   // autosave (would save to scene file) .
+  CleanupParameters *cp = scene->getProperties()->getCleanupParameters();
+  CleanupParameters keepCP(*cp);
   if (!isAutosave) {
-    CleanupParameters::GlobalParameters.assign(
-        scene->getProperties()->getCleanupParameters());
+    // In case of a .cln file be loaded into GlobalParemeters,
+    // we should also write these info into .tnz (scene file)
+    cp->assign(&CleanupParameters::GlobalParameters, false);
   }
 
   // Must wait for current save to finish, just in case
@@ -1520,6 +1523,13 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
     DVGui::error(QObject::tr("Couldn't save %1").arg(toQString(scenePath)));
   }
   TApp::instance()->setSaveInProgress(false);
+
+  cp->assign(&keepCP);
+  // Make sure that the current cleanup palette is set to currentParams' palette
+  TApp::instance()
+      ->getPaletteController()
+      ->getCurrentCleanupPalette()
+      ->setPalette(cp->m_cleanupPalette.getPointer());
 
   // in case of saving subxsheet, revert the level paths after saving
   revertOrgLevelPaths();
@@ -2019,8 +2029,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   PreviewFxManager::instance()->reset();
   // updateCleanupSettingsPopup();
   /*- CleanupParameterの更新 -*/  // CleanupSettingsModel::onSceneSwitched()
-  // CleanupParameters *cp = scene->getProperties()->getCleanupParameters();
-  // CleanupParameters::GlobalParameters.assign(cp);
+  CleanupParameters *cp = scene->getProperties()->getCleanupParameters();
+  CleanupParameters::GlobalParameters.assign(cp);
   CacheFxCommand::instance()->onSceneLoaded();
 
 #ifdef USE_SQLITE_HDPOOL

--- a/toonz/sources/toonzlib/cleanupparameters.cpp
+++ b/toonz/sources/toonzlib/cleanupparameters.cpp
@@ -301,8 +301,12 @@ void CleanupParameters::assign(const CleanupParameters *param,
   // In modern Toonz scenes, there always is a cleanup palette.
   // In older Toonz scenes, it may be missing. In this case, leave the current
   // one.
-  if (clonePalette && param->m_cleanupPalette)
-    m_cleanupPalette = param->m_cleanupPalette->clone();
+  if (param->m_cleanupPalette) {
+    if (clonePalette)
+      m_cleanupPalette = param->m_cleanupPalette->clone();
+    else
+      m_cleanupPalette->assign(param->m_cleanupPalette.getPointer());
+  }
 
   m_offx_lock     = param->m_offx_lock;
   m_offy_lock     = param->m_offy_lock;
@@ -382,7 +386,7 @@ void CleanupParameters::saveData(TOStream &os) const {
 void CleanupParameters::loadData(TIStream &is, bool globalParams) {
   if (globalParams) {
     CleanupParameters cp;
-    assign(&cp);
+    assign(&cp, false);
   }
 
   std::string tagName;


### PR DESCRIPTION
This PR is related to #5746 and #5891. This attempt to restore the functionality of the Global Parameter while preventing the crash.
As I mentioned in [this comment](https://github.com/opentoonz/opentoonz/pull/5746#issuecomment-4418174095), the Global Parameter in Cleanup Settings is intended to hold scene-wide settings, and I have reverted some code necessary for that functionality.

As far as I've tested it in my environment, the crash issue doesn't seem to be occurring.

@Abel032 Could you please let me know if you have any concerns about this?