### PR TITLE
MacOS fix: add MyPaint lib directory

### DIFF
--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -549,6 +549,8 @@ elseif(BUILD_ENV_APPLE)
         endif()
     endif()
 
+    target_link_directories(OpenToonz PRIVATE ${MYPAINT_LIB_LIBRARY_DIRS})
+
     target_link_libraries(OpenToonz
         Qt5::Core Qt5::Gui Qt5::Network Qt5::OpenGL Qt5::Svg Qt5::Xml
         Qt5::Script Qt5::Widgets Qt5::PrintSupport Qt5::Multimedia Qt5::MultimediaWidgets Qt5::UiTools


### PR DESCRIPTION
This PR is related to #6640 and aims to fix recent build failures in the Mac version of JenkinsCI.
At least in my environment, adding this single line has made the builds succeed.
Though I'm not sure why the GitHub Actions MacOS runner is able to build successfully without this fix...

NOTE: Please do not merge this PR until verifying the results on the Mac version of Jenkins.