### PR TITLE
Enable "Ignore AutoPaint Inks" function for RasterTape Tool

### DIFF
--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -241,9 +241,20 @@ public:
     std::vector<TAutocloser::Segment> segments;
 
     // ==== ALWAYS RECOMPUTE – NO CACHING ====
-    TAutocloser ac(raux, params.m_closingDistance, params.m_spotAngle,
-                   params.m_inkIndex, params.m_opacity);
-    ac.compute(segments);
+    if (AutocloseIgnoreAutoPaint) {
+      std::set<int> autoPaintInks;
+      TPalette *plt = sl->getPalette();
+      for (int i = 1; i < plt->getStyleCount(); ++i) {
+        if (plt->getStyle(i)->getFlags() != 0) autoPaintInks.insert(i);
+      }
+      TAutocloser ac(raux, params.m_closingDistance, params.m_spotAngle,
+                     params.m_inkIndex, params.m_opacity, autoPaintInks);
+      ac.compute(segments);
+    } else {
+      TAutocloser ac(raux, params.m_closingDistance, params.m_spotAngle,
+                     params.m_inkIndex, params.m_opacity);
+      ac.compute(segments);
+    }
 
     if (segments.empty()) return false;
 


### PR DESCRIPTION
This PR enables "Ignore AutoPaint Inks" function for raster tape tool.

<img width="1758" height="831" alt="图片" src="https://github.com/user-attachments/assets/07f1a57f-9dfc-4ba2-8460-cd2b6f20775d" />
