### PR TITLE
Fix: Converted level has no palette

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2846,7 +2846,7 @@ void IoCmd::convertNAARaster2TLV(
   TApp *app                           = TApp::instance();
   ToonzScene *scene                   = app->getCurrentScene()->getScene();
   for (auto &rd : rds) {
-    TFilePath &path = rd.m_path;
+    TFilePath path = rd.m_path;
     if (path.getDots() == ".." &&
         rasterExts.contains(QString::fromStdString(path.getType()).toLower())) {
       if (!path.isAbsolute()) path = scene->decodeFilePath(path);
@@ -2905,7 +2905,8 @@ void IoCmd::convertNAARaster2TLV(
           }
         }
         convertingPopup.hide();
-        if (!convertingPopup.wasCanceled()) path = scene->codeFilePath(dstPath);
+        if (!convertingPopup.wasCanceled())
+          rd = LoadResourceArguments::ResourceData(dstPath);
       }
     }
   }


### PR DESCRIPTION
### How to reproduce

1. enable “Convert Imported NAA Image Sequences to TLV“
<img width="720" height="185" alt="图片" src="https://github.com/user-attachments/assets/ea7f7ce3-d3fb-4476-8cd5-757f5093e26c" />

2. Load sequence images(Anliased) from OT's browser
<img width="340" height="252" alt="图片" src="https://github.com/user-attachments/assets/02626378-8d3b-4a39-b382-2add8a41d37d" />

3. Do auto-conversion.

fixes #6875 
