### PR TITLE
Fix Output Settings > Linear Color Space Checkbox

### DIFF
--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -542,8 +542,8 @@ QFrame *OutputSettingsPopup::createColorSettingsBox(bool isPreview) {
   bool ret = true;
   ret      = ret && connect(m_channelWidthOm, SIGNAL(currentIndexChanged(int)),
                             SLOT(onChannelWidthChanged(int)));
-  ret      = ret && connect(m_linearColorSpaceChk, SIGNAL(stateChanged(int)),
-                            SLOT(onLinearColorSpaceChecked(int)));
+  ret      = ret && connect(m_linearColorSpaceChk, SIGNAL(clicked(bool)),
+                            SLOT(onLinearColorSpaceClicked(bool)));
 
   ret = ret && connect(m_colorSpaceGammaFld, SIGNAL(editingFinished()),
                        SLOT(onColorSpaceGammaEdited()));
@@ -1447,11 +1447,11 @@ void OutputSettingsPopup::onChannelWidthChanged(int type) {
 }
 //-----------------------------------------------------------------------------
 
-void OutputSettingsPopup::onLinearColorSpaceChecked(int state) {
+void OutputSettingsPopup::onLinearColorSpaceClicked(bool checked) {
   if (!getCurrentScene()) return;
   TOutputProperties *prop = getProperties();
   TRenderSettings rs      = prop->getRenderSettings();
-  rs.m_linearColorSpace   = (state == Qt::Checked);
+  rs.m_linearColorSpace   = checked;
   // force floating point when compute in linear color space
   if (rs.m_linearColorSpace) {
     prop->setNonlinearBpp(rs.m_bpp);
@@ -1465,7 +1465,7 @@ void OutputSettingsPopup::onLinearColorSpaceChecked(int state) {
       getCurrentScene()->getProperties()->getPreviewProperties();
   if (!m_isPreviewSettings && prev_prop->isColorSettingsSynced()) {
     TRenderSettings prev_rs    = prev_prop->getRenderSettings();
-    prev_rs.m_linearColorSpace = (state == Qt::Checked);
+    prev_rs.m_linearColorSpace = checked;
     if (prev_rs.m_linearColorSpace) {
       prev_prop->setNonlinearBpp(prev_rs.m_bpp);
       prev_rs.m_bpp = 128;

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -118,7 +118,7 @@ protected slots:
   void onFrameFldEditFinished();
   void onResampleChanged(int type);
   void onChannelWidthChanged(int type);
-  void onLinearColorSpaceChecked(int state);
+  void onLinearColorSpaceClicked(bool checked);
   void onColorSpaceGammaEdited();
   void onGammaFldEditFinished();
   void onDominantFieldChanged(int type);


### PR DESCRIPTION
This PR fixes the following problem:

[STEP TO REPRODUCE]
- Prepare two scenes: one with `Output Settings > Linear Color Space` set to `ON` (Scene A), and another with `Output Settings > Linear Color Space` set to `OFF` and `Channel Width` set to `16bit` (Scene B).
- Load Scene A and open Output Settings dialog.
- While Output Settings is displayed, load Scene B.

This causes the value of `Output Settings > Channel Width` to be incorrectly displayed as `8bit` instead of `16bit`.

The cause of the issue is that updating the `Linear Color Space` UI triggers a change to the `Channel Width`. This action should only occur when users click the checkbox.