### PR TITLE
ci: cancel superseded GitHub Actions runs

### DIFF
--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -1,5 +1,9 @@
 name: Linux Build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 on:
   push:
     paths:

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -1,5 +1,9 @@
 name: MacOS Build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 on:
   push:
     paths:

--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -1,5 +1,9 @@
 name: Windows Build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.head_ref != '' }}
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- add a concurrency group to the Linux, macOS, and Windows GitHub Actions workflows
- cancel superseded pull request runs while keeping non-PR runs isolated by run id

## Testing
- reviewed the updated workflow YAML structure
- ran git diff --check

Fixes #6391.