### PR TITLE
Fix tooloption assertion failure

### DIFF
--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1794,8 +1794,9 @@ FillToolOptionsBox::FillToolOptionsBox(QWidget *parent, TTool *tool,
                             SLOT(onOnionModeToggled(bool)));
   ret      = ret && connect(m_multiFrameMode, SIGNAL(toggled(bool)), this,
                             SLOT(onMultiFrameModeToggled(bool)));
-  ret      = ret && connect(m_closeGap, &ToolOptionCheckbox::toggled,
-                            m_gapCloseDistance, &QWidget::setEnabled);
+  if (m_closeGap)
+    ret = ret && connect(m_closeGap, &ToolOptionCheckbox::toggled,
+                         m_gapCloseDistance, &QWidget::setEnabled);
 
   assert(ret);
   onColorModeChanged(m_colorMode->getProperty()->getIndex());


### PR DESCRIPTION
This fix prevents an assertion failure that occurs when attempting to display the Fill Tool options in the Tool Option Bar.
Since the “Close Gap” option is bound only to the Toonz Raster Fill tool, `m_closeGap` will become null for the Vector Fill tool.
