### PR TITLE
[doc] Sync Japanese README build section with English/Chinese

### DIFF
--- a/doc/README_ja.md
+++ b/doc/README_ja.md
@@ -27,6 +27,12 @@
 
 - [Windows](./how_to_build_win_ja.md)
 - [macOS](./how_to_build_macosx_ja.md)
+- [Linux](./how_to_build_linux.md)（英語）
+- [BSD](./how_to_build_bsd.md)（英語）
+
+スタイルシートのビルド方法は[こちら](./how_to_stylesheet.md)（英語）をご覧ください。
+
+開発はできないけれど協力したい方は、[こちらの手順](./how_to_test_prs.md)（英語）でマージ前のプルリクエストのテストにご協力いただけます。
 
 ### ライセンス
 


### PR DESCRIPTION
## Summary

The Japanese README (`doc/README_ja.md`) was never updated when Linux/BSD support, the stylesheet doc, and the "help test PRs" doc landed. The Simplified Chinese README ([added in #1925](https://github.com/opentoonz/opentoonz/commit/09c0d9df)) already mirrors all of these, so this PR brings `README_ja.md` in line with the same pattern.

This is a docs-only, 1-file, +6/-0 change.

## Problem

`doc/README_ja.md` "ビルド方法" still lists only Windows and macOS:

```markdown
## ビルド方法

- [Windows](./how_to_build_win_ja.md)
- [macOS](./how_to_build_macosx_ja.md)

### ライセンス
```

Whereas `doc/README_chs.md` (and `README.md`) have been kept current:

```markdown
## 如何在本地构建

- [Windows](./how_to_build_win_chs.md)
- [macOS](./how_to_build_macosx.md)
- [Linux](./how_to_build_linux.md)
- [BSD](./how_to_build_bsd.md)

关于如何构建样式表，请参照[这里](./how_to_stylesheet.md).

不懂开发但仍想帮忙？你可以帮助我们测试拉取请求，详情请查阅[这里](./how_to_test_prs_chs.md)。
```

Background — each of the missing links was added to the project at a known commit and was reflected in the English / Chinese READMEs but not in `README_ja.md`:

| Added | Commit / PR | EN README | ZH README | JA README |
| --- | --- | --- | --- | --- |
| Linux build doc | `3cb5de86` (Linux support) | ✅ | ✅ | ❌ |
| BSD build doc | `d3f29c32` (Create how_to_build_bsd.md) | ✅ | ✅ | ❌ |
| Stylesheet doc | #1972 | ✅ | ✅ | ❌ |
| Testing PRs doc | #2113 | ✅ | ✅ | ❌ |

## Solution

Add the four missing entries to `doc/README_ja.md`, matching the Chinese README's pattern of pointing to the English docs (with a 「（英語）」 suffix) when no Japanese version of that doc exists. The existing `how_to_build_win_ja.md` and `how_to_build_macosx_ja.md` links are unchanged.

```diff
 ## ビルド方法

 - [Windows](./how_to_build_win_ja.md)
 - [macOS](./how_to_build_macosx_ja.md)
+- [Linux](./how_to_build_linux.md)（英語）
+- [BSD](./how_to_build_bsd.md)（英語）
+
+スタイルシートのビルド方法は[こちら](./how_to_stylesheet.md)（英語）をご覧ください。
+
+開発はできないけれど協力したい方は、[こちらの手順](./how_to_test_prs.md)（英語）でマージ前のプルリクエストのテストにご協力いただけます。

 ### ライセンス
```

Wording notes:

- 「（英語）」 (full-width parens) is used after each English-only link, matching standard Japanese typography in the rest of the file (which uses full-width punctuation throughout).
- The stylesheet and test-PRs lines mirror the English README's structure (one prose line each, in です/ます form, to match the rest of `README_ja.md`).

## Out of scope

The Japanese README is also stale relative to the Chinese / English versions in a few other places — none of which I touched in this PR so the change stays reviewable:

- No `## コミュニティ` section (forum + issues links).
- No `## ドキュメント` section (pointer to `opentoonz_docs`).
- The licensing block does not yet mention `stuff/library/mypaint brushes/Licenses.txt` (added in #1124).

Happy to follow up on any/all of those in separate PRs if it would be helpful — kept this one tightly scoped to the build section so it's easy to review.

## Test plan

- [x] All four added link targets exist in `doc/`: `how_to_build_linux.md`, `how_to_build_bsd.md`, `how_to_stylesheet.md`, `how_to_test_prs.md` — verified with `ls`.
- [x] Diff is +6/-0, only `doc/README_ja.md` touched, no whitespace / formatting churn elsewhere.
- [x] Rendered preview: new bullets appear under existing macOS line; the two prose lines fall between the build list and the `### ライセンス` heading, matching the structure of `README_chs.md`.

## Related

- #1972 — Stylesheet doc added (EN/ZH README updated, JA missed)
- #2113 — Testing PR instructions added (EN/ZH README updated, JA missed)
- #1925 / 09c0d9df — Simplified Chinese README, which this PR mirrors for Japanese

Made with [Cursor](https://cursor.com)