### PR TITLE
Fix duplicate levels of folder command

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2481,7 +2481,7 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
     if (importDialog.aborted()) break;
 
     LoadResourceArguments::ResourceData rd(args.resourceDatas[r]);
-    TFilePath &path  = rd.m_path;
+    TFilePath path   = rd.m_path;
     QString origName = path.withoutParentDir().getQString();
 
     if (!path.isLevelName())
@@ -2489,8 +2489,13 @@ int IoCmd::loadResources(LoadResourceArguments &args, bool updateRecentFile,
 
     // duplicate check
     auto isDuplicate =
-        [&rd](const IoCmd::LoadResourceArguments::ResourceData &existingRd) {
-          return existingRd.m_path == rd.m_path;
+        [&path,
+         scene](const IoCmd::LoadResourceArguments::ResourceData &existingRd) {
+          if (!existingRd.m_path.isAbsolute() || !path.isAbsolute())
+            return scene->decodeFilePath(existingRd.m_path) ==
+                   scene->decodeFilePath(path);
+          else
+            return existingRd.m_path == path;
         };
     if (std::find_if(rds.begin(), rds.end(), isDuplicate) != rds.end()) {
       if (!all) {

--- a/toonz/sources/toonz/loadfoldercommand.cpp
+++ b/toonz/sources/toonz/loadfoldercommand.cpp
@@ -195,7 +195,7 @@ TFilePath retasResourcePath(const TFilePath &fp) {
 
 static const FormatData l_formatDatas[] = {
     // Changed QRegExp patterns to QRegularExpression
-    {QRegularExpression(R"(.+\.[0-9]{4,4}.*\..*)"), &multiframeResourcePath,
+    {QRegularExpression(R"(.+[._][0-9]{4,4}.*\..*)"), &multiframeResourcePath,
      nullptr},
     {QRegularExpression(R"(.+[0-9]{4,4}\.tga)",
                         QRegularExpression::CaseInsensitiveOption),


### PR DESCRIPTION
This PR fixes a bug discovered by @shun-iwasawa in #6084

### How to reproduce
1. Use `Load Folder` command to load a project folder(e.g., +extras)
<img width="257" height="322" alt="图片" src="https://github.com/user-attachments/assets/34a4bd70-e9de-43d5-a7db-b9da7d5243e1" />
<img width="584" height="384" alt="图片" src="https://github.com/user-attachments/assets/98b76f2b-7e4d-4263-8365-b93fbf6c281d" />

2.1 Sequence with dot(.) separator would be loaded correctly
<img width="1377" height="400" alt="图片" src="https://github.com/user-attachments/assets/1da54706-e3bb-4507-8e43-0fb07b016036" />
2.2 Sequence with underscore(_) would wrongly duplicate and expose without notice dialog.
<img width="1781" height="392" alt="图片" src="https://github.com/user-attachments/assets/7a8be3c7-0a5c-427e-af9e-cff8f51c4b10" /> 
