### PR TITLE
fix: persist #6594 UI preferences in TEnv instead of QSettings

### DIFF
--- a/toonz/sources/toonz/brushpresetpanel.cpp
+++ b/toonz/sources/toonz/brushpresetpanel.cpp
@@ -1,4 +1,4 @@
-#include "brushpresetpanel.h"
+﻿#include "brushpresetpanel.h"
 
 // ToonzQt includes
 #include "tapp.h"
@@ -85,6 +85,37 @@ public:
   void removeName() { m_nameFld->setText(""); }
 };
 
+namespace {
+
+// Brush Preset Panel display prefs in user .env (TEnv), not the Windows registry.
+TEnv::IntVar BrushPresetPanelShowBorders("BrushPresetPanelShowBorders", 0);
+TEnv::IntVar BrushPresetPanelShowBackgrounds("BrushPresetPanelShowBackgrounds", 1);
+TEnv::IntVar BrushPresetPanelViewMode(
+    "BrushPresetPanelViewMode",
+    static_cast<int>(BrushPresetPanel::GridLarge));
+
+// One-time import of Part 1 display preferences from legacy QSettings.
+void migratePanelPrefsFromRegistryIfNeeded() {
+  static bool migrated = false;
+  if (migrated) return;
+  migrated = true;
+
+  QSettings settings;
+  if (!settings.contains("BrushPresetPanel/showBorders") &&
+      !settings.contains("BrushPresetPanel/viewMode"))
+    return;
+
+  BrushPresetPanelShowBorders =
+      settings.value("BrushPresetPanel/showBorders", false).toBool() ? 1 : 0;
+  BrushPresetPanelShowBackgrounds =
+      settings.value("BrushPresetPanel/showBackgrounds", true).toBool() ? 1 : 0;
+  BrushPresetPanelViewMode =
+      settings.value("BrushPresetPanel/viewMode",
+                     static_cast<int>(BrushPresetPanel::GridLarge))
+          .toInt();
+}
+
+}  // namespace
 //=============================================================================
 // BrushPresetItem implementation
 //=============================================================================
@@ -568,13 +599,13 @@ BrushPresetPanel::BrushPresetPanel(QWidget *parent)
     , m_showBorders(false)  // Borders disabled by default
     , m_showBackgrounds(true) {  // Backgrounds enabled by default
   
-  // Load preferences from settings FIRST (before creating UI)
-  QSettings settings;
-  m_showBorders = settings.value("BrushPresetPanel/showBorders", false).toBool();
-  m_showBackgrounds = settings.value("BrushPresetPanel/showBackgrounds", true).toBool();
+  // Load preferences from TEnv FIRST (before creating UI)
+  migratePanelPrefsFromRegistryIfNeeded();
+  m_showBorders = BrushPresetPanelShowBorders != 0;
+  m_showBackgrounds = BrushPresetPanelShowBackgrounds != 0;
   
   // Load view mode (default: GridLarge)
-  int savedViewMode = settings.value("BrushPresetPanel/viewMode", static_cast<int>(GridLarge)).toInt();
+  int savedViewMode = static_cast<int>(BrushPresetPanelViewMode);
   m_viewMode = static_cast<ViewMode>(savedViewMode);
   
   // NOW initialize UI (menu will be created with correct m_viewMode)
@@ -1418,9 +1449,8 @@ void BrushPresetPanel::onViewModeChanged(ViewMode mode) {
   setViewMode(mode);
   refreshPresetList();
   
-  // Save view preference in settings
-  QSettings settings;
-  settings.setValue("BrushPresetPanel/viewMode", static_cast<int>(mode));
+  // Save view preference in TEnv
+  BrushPresetPanelViewMode = static_cast<int>(mode);
 }
 
 //-----------------------------------------------------------------------------
@@ -1457,18 +1487,17 @@ void BrushPresetPanel::onShowHideActionTriggered() {
   if (!action) return;
   
   QString actionType = action->data().toString();
-  QSettings settings;
   
   if (actionType == "borders") {
     // Toggle borders state
     m_showBorders = action->isChecked();
     updateItemBorders();
-    settings.setValue("BrushPresetPanel/showBorders", m_showBorders);
+    BrushPresetPanelShowBorders = m_showBorders ? 1 : 0;
   } else if (actionType == "backgrounds") {
     // Toggle backgrounds state
     m_showBackgrounds = action->isChecked();
     updateItemBackgrounds();
-    settings.setValue("BrushPresetPanel/showBackgrounds", m_showBackgrounds);
+    BrushPresetPanelShowBackgrounds = m_showBackgrounds ? 1 : 0;
   }
 }
 
@@ -1516,4 +1545,3 @@ void BrushPresetPanel::reorganizeLayout(int newColumns) {
     }
   }
 }
-

--- a/toonz/sources/toonz/brushpresetpanel.cpp
+++ b/toonz/sources/toonz/brushpresetpanel.cpp
@@ -29,7 +29,6 @@
 #include <QScrollArea>
 #include <QGridLayout>
 #include <QPushButton>
-#include <QSettings>
 #include <QLabel>
 #include <QMessageBox>
 #include <QPainter>
@@ -93,27 +92,6 @@ TEnv::IntVar BrushPresetPanelShowBackgrounds("BrushPresetPanelShowBackgrounds", 
 TEnv::IntVar BrushPresetPanelViewMode(
     "BrushPresetPanelViewMode",
     static_cast<int>(BrushPresetPanel::GridLarge));
-
-// One-time import of Part 1 display preferences from legacy QSettings.
-void migratePanelPrefsFromRegistryIfNeeded() {
-  static bool migrated = false;
-  if (migrated) return;
-  migrated = true;
-
-  QSettings settings;
-  if (!settings.contains("BrushPresetPanel/showBorders") &&
-      !settings.contains("BrushPresetPanel/viewMode"))
-    return;
-
-  BrushPresetPanelShowBorders =
-      settings.value("BrushPresetPanel/showBorders", false).toBool() ? 1 : 0;
-  BrushPresetPanelShowBackgrounds =
-      settings.value("BrushPresetPanel/showBackgrounds", true).toBool() ? 1 : 0;
-  BrushPresetPanelViewMode =
-      settings.value("BrushPresetPanel/viewMode",
-                     static_cast<int>(BrushPresetPanel::GridLarge))
-          .toInt();
-}
 
 }  // namespace
 //=============================================================================
@@ -600,7 +578,6 @@ BrushPresetPanel::BrushPresetPanel(QWidget *parent)
     , m_showBackgrounds(true) {  // Backgrounds enabled by default
   
   // Load preferences from TEnv FIRST (before creating UI)
-  migratePanelPrefsFromRegistryIfNeeded();
   m_showBorders = BrushPresetPanelShowBorders != 0;
   m_showBackgrounds = BrushPresetPanelShowBackgrounds != 0;
   

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -48,6 +48,51 @@ ShortcutPopup *ShortcutPopup::s_instance = nullptr;
 // STD includes
 #include <vector>
 
+namespace {
+
+// Persist Configure Shortcuts UI state in the user profile (.env), not the
+// Windows registry (default QSettings).
+TEnv::StringVar ShortcutPopupExpandedFolders("ShortcutPopupExpandedFolders", "");
+TEnv::IntVar ShortcutPopupExpandedStateSaved("ShortcutPopupExpandedStateSaved",
+                                             0);
+TEnv::StringVar ShortcutPopupSearchText("ShortcutPopupSearchText", "");
+
+const QChar kFolderListSeparator(0x1e);
+
+QStringList expandedFoldersFromEnv() {
+  const QString stored =
+      QString::fromStdString((std::string)ShortcutPopupExpandedFolders);
+  if (stored.isEmpty()) return QStringList();
+  return stored.split(kFolderListSeparator, Qt::SkipEmptyParts);
+}
+
+void saveExpandedFoldersToEnv(const QStringList &expandedFolders) {
+  ShortcutPopupExpandedFolders =
+      expandedFolders.join(kFolderListSeparator).toStdString();
+}
+
+// One-time import from legacy QSettings (registry) into TEnv.
+void migrateShortcutPopupFromRegistryIfNeeded() {
+  static bool migrated = false;
+  if (migrated) return;
+  migrated = true;
+  if (ShortcutPopupExpandedStateSaved != 0) return;
+
+  QSettings settings;
+  if (!settings.contains("ShortcutPopup/expandedStateSaved")) return;
+
+  const QStringList expandedFolders =
+      settings.value("ShortcutPopup/expandedFolders").toStringList();
+  saveExpandedFoldersToEnv(expandedFolders);
+  ShortcutPopupExpandedStateSaved = 1;
+  if (settings.contains("ShortcutPopup/searchText")) {
+    ShortcutPopupSearchText =
+        settings.value("ShortcutPopup/searchText").toString().toStdString();
+  }
+}
+
+}  // namespace
+
 //=============================================================================
 // ShortcutItem
 // ------------
@@ -312,20 +357,16 @@ ShortcutTree::~ShortcutTree() {}
 //-----------------------------------------------------------------------------
 
 void ShortcutTree::saveExpandedState() {
-  QSettings settings;
-  QStringList expandedFolders = collectExpandedState();
-
-  settings.setValue("ShortcutPopup/expandedFolders", expandedFolders);
-  settings.setValue("ShortcutPopup/expandedStateSaved", true);
+  saveExpandedFoldersToEnv(collectExpandedState());
+  ShortcutPopupExpandedStateSaved = 1;
 }
 
 //-----------------------------------------------------------------------------
 
 void ShortcutTree::restoreExpandedState() {
-  QSettings settings;
-  bool hasSavedState = settings.contains("ShortcutPopup/expandedStateSaved");
-  QStringList expandedFolders =
-      settings.value("ShortcutPopup/expandedFolders").toStringList();
+  migrateShortcutPopupFromRegistryIfNeeded();
+  const bool hasSavedState = ShortcutPopupExpandedStateSaved != 0;
+  const QStringList expandedFolders = expandedFoldersFromEnv();
   QSignalBlocker blocker(this);
   applyExpandedState(expandedFolders, !hasSavedState);
 }
@@ -1125,24 +1166,23 @@ void ShortcutPopup::onSavePreset() {
 //-----------------------------------------------------------------------------
 
 void ShortcutPopup::showEvent(QShowEvent *se) {
+  migrateShortcutPopupFromRegistryIfNeeded();
   getCurrentPresetPref();
 
   // Refresh brush preset and size commands to ensure they're up-to-date
   ToolPresetCommandManager::instance()->refreshPresetCommands();
   ToolPresetCommandManager::instance()->refreshSizeCommands();
 
-  // Restore search term from QSettings
-  QSettings settings;
-  QString lastSearchTerm =
-      settings.value("ShortcutPopup/searchText", "").toString();
-
+  // Restore search term from TEnv
+  const QString lastSearchTerm =
+      QString::fromStdString((std::string)ShortcutPopupSearchText);
   // Step 1: Restore search text in the field WITHOUT triggering searchItems
   {
     QSignalBlocker blocker(m_searchEdit);
     m_searchEdit->setText(lastSearchTerm);
   }
 
-  // Step 2: Restore folder expansion state from QSettings
+  // Step 2: Restore folder expansion state from TEnv
   m_list->restoreExpandedState();
 
   // Step 3: If there was a search, apply filtering WITHOUT changing expansion
@@ -1177,10 +1217,8 @@ void ShortcutPopup::hideEvent(QHideEvent *he) {
     m_list->saveExpandedState();
   }
 
-  // Save search text to QSettings
-  QSettings settings;
-  settings.setValue("ShortcutPopup/searchText", m_searchEdit->text());
-
+  // Save search text to TEnv
+  ShortcutPopupSearchText = m_searchEdit->text().toStdString();
   DVGui::Dialog::hideEvent(he);
 }
 

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -50,8 +50,7 @@ ShortcutPopup *ShortcutPopup::s_instance = nullptr;
 
 namespace {
 
-// Persist Configure Shortcuts UI state in the user profile (.env), not the
-// Windows registry (default QSettings).
+// Persist Configure Shortcuts UI state in the user profile (.env).
 TEnv::StringVar ShortcutPopupExpandedFolders("ShortcutPopupExpandedFolders", "");
 TEnv::IntVar ShortcutPopupExpandedStateSaved("ShortcutPopupExpandedStateSaved",
                                              0);
@@ -69,26 +68,6 @@ QStringList expandedFoldersFromEnv() {
 void saveExpandedFoldersToEnv(const QStringList &expandedFolders) {
   ShortcutPopupExpandedFolders =
       expandedFolders.join(kFolderListSeparator).toStdString();
-}
-
-// One-time import from legacy QSettings (registry) into TEnv.
-void migrateShortcutPopupFromRegistryIfNeeded() {
-  static bool migrated = false;
-  if (migrated) return;
-  migrated = true;
-  if (ShortcutPopupExpandedStateSaved != 0) return;
-
-  QSettings settings;
-  if (!settings.contains("ShortcutPopup/expandedStateSaved")) return;
-
-  const QStringList expandedFolders =
-      settings.value("ShortcutPopup/expandedFolders").toStringList();
-  saveExpandedFoldersToEnv(expandedFolders);
-  ShortcutPopupExpandedStateSaved = 1;
-  if (settings.contains("ShortcutPopup/searchText")) {
-    ShortcutPopupSearchText =
-        settings.value("ShortcutPopup/searchText").toString().toStdString();
-  }
 }
 
 }  // namespace
@@ -364,7 +343,6 @@ void ShortcutTree::saveExpandedState() {
 //-----------------------------------------------------------------------------
 
 void ShortcutTree::restoreExpandedState() {
-  migrateShortcutPopupFromRegistryIfNeeded();
   const bool hasSavedState = ShortcutPopupExpandedStateSaved != 0;
   const QStringList expandedFolders = expandedFoldersFromEnv();
   QSignalBlocker blocker(this);
@@ -1166,7 +1144,6 @@ void ShortcutPopup::onSavePreset() {
 //-----------------------------------------------------------------------------
 
 void ShortcutPopup::showEvent(QShowEvent *se) {
-  migrateShortcutPopupFromRegistryIfNeeded();
   getCurrentPresetPref();
 
   // Refresh brush preset and size commands to ensure they're up-to-date

--- a/toonz/sources/toonz/shortcutpopup.h
+++ b/toonz/sources/toonz/shortcutpopup.h
@@ -68,8 +68,8 @@ public:
 
   void searchItems(const QString &searchWord = QString());
   void refreshTree(); // Rebuild the entire tree from CommandManager
-  void saveExpandedState(); // Save expansion state to QSettings
-  void restoreExpandedState(); // Restore expansion state from QSettings
+  void saveExpandedState();   // Save expansion state to TEnv (user .env)
+  void restoreExpandedState(); // Restore expansion state from TEnv (user .env)
 
 protected:
   // adds a block of QActions. commandType is a

--- a/toonz/sources/toonz/toolpropertiespanel.cpp
+++ b/toonz/sources/toonz/toolpropertiespanel.cpp
@@ -10,6 +10,9 @@
 #include "toonz/preferences.h"
 #include "toonz/mypaintbrushstyle.h"
 
+// TnzCore includes
+#include "tenv.h"
+
 // Tools includes
 #include "tools/tool.h"
 #include "tools/toolhandle.h"
@@ -36,7 +39,7 @@
 
 // Standard library
 #include <algorithm>  // For std::min
-#include <QSettings>
+#include <map>
 #include <QMenu>
 #include <QContextMenuEvent>
 #include <QIcon>
@@ -44,6 +47,60 @@
 #include <QPainter>
 #include <QStyleOptionToolButton>
 #include <QStyle>
+
+namespace {
+
+// Tool Properties Panel UI preferences (stored in user .env via TEnv).
+TEnv::IntVar ToolPropertiesUseSingleMaxSlider("ToolPropertiesUseSingleMaxSlider",
+                                              0);
+TEnv::IntVar ToolPropertiesShowLabels("ToolPropertiesShowLabels", 1);
+TEnv::IntVar ToolPropertiesShowNumericFields("ToolPropertiesShowNumericFields",
+                                             1);
+TEnv::IntVar ToolPropertiesShowBorders("ToolPropertiesShowBorders", 1);
+TEnv::IntVar ToolPropertiesShowBackgrounds("ToolPropertiesShowBackgrounds", 1);
+TEnv::IntVar ToolPropertiesShowIcons("ToolPropertiesShowIcons", 1);
+// Serialized map: "propName=0|1" entries separated by ';' (1 = expanded).
+TEnv::StringVar ToolPropertiesCollapsedStates("ToolPropertiesCollapsedStates",
+                                              "");
+
+std::map<std::string, bool> parseCollapsedStates() {
+  std::map<std::string, bool> result;
+  const QString stored =
+      QString::fromStdString((std::string)ToolPropertiesCollapsedStates);
+  const QStringList entries =
+      stored.split(';', Qt::SkipEmptyParts);
+  for (const QString &entry : entries) {
+    const int eq = entry.indexOf('=');
+    if (eq <= 0) continue;
+    const std::string name = entry.left(eq).toStdString();
+    result[name]           = entry.mid(eq + 1).toInt() != 0;
+  }
+  return result;
+}
+
+void writeCollapsedStates(const std::map<std::string, bool> &states) {
+  QStringList entries;
+  for (const auto &it : states) {
+    entries << QString::fromStdString(it.first) + "=" +
+                 QString::number(it.second ? 1 : 0);
+  }
+  ToolPropertiesCollapsedStates = entries.join(";").toStdString();
+}
+
+bool collapsedStateFromEnv(const std::string &propName, bool defaultExpanded) {
+  const std::map<std::string, bool> states = parseCollapsedStates();
+  const auto it                            = states.find(propName);
+  if (it == states.end()) return defaultExpanded;
+  return it->second;
+}
+
+void setCollapsedStateInEnv(const std::string &propName, bool expanded) {
+  std::map<std::string, bool> states = parseCollapsedStates();
+  states[propName]                   = expanded;
+  writeCollapsedStates(states);
+}
+
+}  // namespace
 
 //=============================================================================
 // ToolPropertyButton - Custom button with theme-aware painting
@@ -128,14 +185,13 @@ ToolPropertiesPanel::ToolPropertiesPanel(QWidget *parent)
     , m_showBackgrounds(true)      // Show option backgrounds by default
     , m_showIcons(true) {          // Show Cap/Join icons by default
   
-  // Load preferences from settings
-  QSettings settings;
-  m_useSingleMaxSlider = settings.value("ToolPropertiesPanel/useSingleMaxSlider", false).toBool();
-  m_showLabels = settings.value("ToolPropertiesPanel/showLabels", true).toBool();
-  m_showNumericFields = settings.value("ToolPropertiesPanel/showNumericFields", true).toBool();
-  m_showBorders = settings.value("ToolPropertiesPanel/showBorders", true).toBool();
-  m_showBackgrounds = settings.value("ToolPropertiesPanel/showBackgrounds", true).toBool();
-  m_showIcons = settings.value("ToolPropertiesPanel/showIcons", true).toBool();
+  // Load preferences from TEnv
+  m_useSingleMaxSlider = ToolPropertiesUseSingleMaxSlider != 0;
+  m_showLabels         = ToolPropertiesShowLabels != 0;
+  m_showNumericFields  = ToolPropertiesShowNumericFields != 0;
+  m_showBorders        = ToolPropertiesShowBorders != 0;
+  m_showBackgrounds    = ToolPropertiesShowBackgrounds != 0;
+  m_showIcons          = ToolPropertiesShowIcons != 0;
 
   initializeUI();
   connectSignals();
@@ -1767,10 +1823,9 @@ QWidget* ToolPropertiesPanel::createCollapsibleEnum(const QString &label,
   // Content (checkable buttons in a group)
   QWidget *content = new QWidget(container);
   
-  // Load saved collapse state from QSettings (persists between sessions)
-  QSettings settings;
-  QString settingsKey = QString("ToolPropertiesPanel/CollapsedState/%1").arg(QString::fromStdString(propName));
-  bool isExpanded = settings.value(settingsKey, false).toBool();  // Default: collapsed
+  // Load saved collapse state from TEnv (persists between sessions)
+  bool isExpanded =
+      collapsedStateFromEnv(propName, false);  // Default: collapsed
   content->setVisible(isExpanded);
   toggleButton->setChecked(isExpanded);
   toggleButton->setArrowType(isExpanded ? Qt::DownArrow : Qt::RightArrow);
@@ -1815,10 +1870,8 @@ QWidget* ToolPropertiesPanel::createCollapsibleEnum(const QString &label,
     content->setVisible(checked);
     toggleButton->setArrowType(checked ? Qt::DownArrow : Qt::RightArrow);
     
-    // Save collapsed state to QSettings for persistence
-    QSettings settings;
-    QString settingsKey = QString("ToolPropertiesPanel/CollapsedState/%1").arg(QString::fromStdString(propName));
-    settings.setValue(settingsKey, checked);
+    // Save collapsed state to TEnv for persistence
+    setCollapsedStateInEnv(propName, checked);
   });
   
   // Store propName in container for later use
@@ -1887,10 +1940,8 @@ QWidget* ToolPropertiesPanel::createCollapsibleEnumWithIcons(
   toggleButton->setAutoRaise(true);
   toggleButton->setFixedSize(16, 16);
   
-  // Load collapsed state from QSettings
-  QSettings settings;
-  QString settingsKey = QString("ToolPropertiesPanel/CollapsedState/%1").arg(QString::fromStdString(propName));
-  bool isExpanded = settings.value(settingsKey, true).toBool();
+  // Load collapsed state from TEnv
+  bool isExpanded = collapsedStateFromEnv(propName, true);
   toggleButton->setChecked(isExpanded);
   toggleButton->setArrowType(isExpanded ? Qt::DownArrow : Qt::RightArrow);
   
@@ -1985,9 +2036,7 @@ QWidget* ToolPropertiesPanel::createCollapsibleEnumWithIcons(
     content->setVisible(checked);
     toggleButton->setArrowType(checked ? Qt::DownArrow : Qt::RightArrow);
     
-    QSettings settings;
-    QString settingsKey = QString("ToolPropertiesPanel/CollapsedState/%1").arg(QString::fromStdString(propName));
-    settings.setValue(settingsKey, checked);
+    setCollapsedStateInEnv(propName, checked);
   });
   
   // Connect button group to property update
@@ -2688,39 +2737,37 @@ void ToolPropertiesPanel::onShowHideActionTriggered() {
   QString actionName = action->objectName();
   bool needsRefresh = false;
   
-  // Save preferences according to the action
-  QSettings settings;
-  
+  // Save preferences according to the action (TEnv)
   if (actionName == "singleSlider") {
     m_useSingleMaxSlider = action->isChecked();
-    settings.setValue("ToolPropertiesPanel/useSingleMaxSlider", m_useSingleMaxSlider);
+    ToolPropertiesUseSingleMaxSlider = m_useSingleMaxSlider ? 1 : 0;
     needsRefresh = true;
   } 
   else if (actionName == "showLabels") {
     m_showLabels = action->isChecked();
-    settings.setValue("ToolPropertiesPanel/showLabels", m_showLabels);
+    ToolPropertiesShowLabels = m_showLabels ? 1 : 0;
     needsRefresh = true;
   } 
   else if (actionName == "showNumeric") {
     m_showNumericFields = action->isChecked();
-    settings.setValue("ToolPropertiesPanel/showNumericFields", m_showNumericFields);
+    ToolPropertiesShowNumericFields = m_showNumericFields ? 1 : 0;
     needsRefresh = true;
   }
   else if (actionName == "showBorders") {
     m_showBorders = action->isChecked();
-    settings.setValue("ToolPropertiesPanel/showBorders", m_showBorders);
+    ToolPropertiesShowBorders = m_showBorders ? 1 : 0;
     updateContainerStylesheet();  // Update container stylesheet immediately
     needsRefresh = true;
   }
   else if (actionName == "showBackgrounds") {
     m_showBackgrounds = action->isChecked();
-    settings.setValue("ToolPropertiesPanel/showBackgrounds", m_showBackgrounds);
+    ToolPropertiesShowBackgrounds = m_showBackgrounds ? 1 : 0;
     updateContainerStylesheet();  // Update container stylesheet immediately
     needsRefresh = true;
   }
   else if (actionName == "showIcons") {
     m_showIcons = action->isChecked();
-    settings.setValue("ToolPropertiesPanel/showIcons", m_showIcons);
+    ToolPropertiesShowIcons = m_showIcons ? 1 : 0;
     needsRefresh = true;
   }
   


### PR DESCRIPTION
Follow-up to #6594: UI preferences from that PR are now saved in the user profile (TEnv / .env), not the Windows registry, as requested by @shun-iwasawa (same approach as Pencil Test Popup).

Affected: Configure Shortcuts, Tool Properties Panel, Brush Preset Panel (display options). Hope this addresses your feedback. Please tell me if anything is still missing. Thanks for the review.
