### PR TITLE
v1.8.0 RC

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.7.1.{build}
+version: 1.8.0.{build}
 
 environment:
   QT_PATH: "%APPVEYOR_BUILD_FOLDER%\\thirdparty\\qt\\5.15.2_wintab\\msvc2019_64"

--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.8.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.7.1</string>
+	<string>1.8.0</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>

--- a/toonz/sources/include/tversion.h
+++ b/toonz/sources/include/tversion.h
@@ -19,9 +19,9 @@ public:
 
 private:
   const char *applicationName     = "OpenToonz";
-  const float applicationVersion  = 1.7f;
-  const float applicationRevision = 1;
-  const char *applicationNote     = "";
+  const float applicationVersion  = 1.8f;
+  const float applicationRevision = 0;
+  const char *applicationNote     = "RC";
   const char *systemVarPrefix     = "TOONZ";
 };
 

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(VERSION 1.7.1)
+set(VERSION 1.8)
 
 set(MOC_HEADERS
     addfilmstripframespopup.h

--- a/toonz/sources/xdg-data/io.github.OpenToonz.appdata.xml
+++ b/toonz/sources/xdg-data/io.github.OpenToonz.appdata.xml
@@ -28,6 +28,6 @@
   </screenshots>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="1.7.1" date="2023-05-10"></release>
+    <release version="1.8.0" date="2026-06-15"></release>
   </releases>
 </component>


### PR DESCRIPTION
This PR changes the version number to v1.8.
It will be merged just before releasing v1.8 RC.

**[Note to self]** When releasing V1.8, remember to remove `RC` note in the line 24 of `toonz/sources/include/tversion.h`