### PR TITLE
Remove feature: Use Ctrl to drag cells

### DIFF
--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3407,9 +3407,7 @@ void CellArea::mousePressEvent(QMouseEvent *event) {
     else if ((!xsh->getCell(row, col).isEmpty()) &&
                  o->rect(PredefinedRect::DRAG_AREA)
                      .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
-                     .contains(mouseInCell) ||
-             // Or Control Pressed
-             event->modifiers() & Qt::ControlModifier) {
+                     .contains(mouseInCell)) {
       TXshColumn *column = xsh->getColumn(col);
 
       if (column && !m_viewer->getCellSelection()->isCellSelected(row, col)) {


### PR DESCRIPTION
This PR removes the feature of holding Ctrl to drag cells without clicking the side bar.
To restore the feature of holding Ctrl to select both cells and keyframes.

Reference: #6913