### PR TITLE
Fix stuff folder initialization

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -181,6 +181,9 @@ static void initToonzEnv(QHash<QString, QString> &argPathValues) {
     fatalError("Folder \"" + toQString(stuffDir) +
                "\" not found or not readable");
 
+  // Setup third party
+  ThirdParty::initialize();
+
   Tiio::defineStd();
   initImageIo();
   initSoundIo();
@@ -442,21 +445,22 @@ int main(int argc, char *argv[]) {
 
   TEnv::setApplicationFileName(argv[0]);
 
-// splash screen (override with local file if present)
-QString exeDir = QCoreApplication::applicationDirPath();
-QString localSplashPath = QDir(exeDir).filePath("splash.svg");
+  // splash screen (override with local file if present)
+  QString exeDir          = QCoreApplication::applicationDirPath();
+  QString localSplashPath = QDir(exeDir).filePath("splash.svg");
 
-QPixmap splashPixmap;
+  QPixmap splashPixmap;
 
-if (QFileInfo(localSplashPath).exists() && QFileInfo(localSplashPath).isFile()) {
-  splashPixmap = QIcon(localSplashPath).pixmap(QSize(610, 344));
-  if (splashPixmap.isNull()) {
-    // fallback if loading fails
+  if (QFileInfo(localSplashPath).exists() &&
+      QFileInfo(localSplashPath).isFile()) {
+    splashPixmap = QIcon(localSplashPath).pixmap(QSize(610, 344));
+    if (splashPixmap.isNull()) {
+      // fallback if loading fails
+      splashPixmap = QIcon(":Resources/splash.svg").pixmap(QSize(610, 344));
+    }
+  } else {
     splashPixmap = QIcon(":Resources/splash.svg").pixmap(QSize(610, 344));
   }
-} else {
-  splashPixmap = QIcon(":Resources/splash.svg").pixmap(QSize(610, 344));
-}
 #ifdef _WIN32
   QFont font("Segoe UI", -1);
 #else
@@ -499,9 +503,6 @@ if (QFileInfo(localSplashPath).exists() && QFileInfo(localSplashPath).isFile()) 
   // Install run out of contiguous memory callback
   TBigMemoryManager::instance()->setRunOutOfContiguousMemoryHandler(
       &toonzRunOutOfContMemHandler);
-
-  // Setup third party
-  ThirdParty::initialize();
 
   // Toonz environment
   initToonzEnv(argumentPathValues);


### PR DESCRIPTION
This will fix #6948 . 

Move the calling of `ThirdParty::initialize()` in the function `initToonzEnv()` , just after configuring the stuff folders.

@Abel032
Could you please verify whether this change fulfills the original intent of #6240?