### PR TITLE
Set desktop file name and window icon for the application

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -163,6 +163,8 @@ static void initToonzEnv(QHash<QString, QString> &argPathValues) {
 
   QCoreApplication::setOrganizationName("OpenToonz");
   QCoreApplication::setOrganizationDomain("");
+  QGuiApplication::setDesktopFileName("io.github.OpenToonz");
+  QGuiApplication::setWindowIcon(QIcon::fromTheme("io.github.OpenToonz"));
   QCoreApplication::setApplicationName(
       QString::fromStdString(TEnv::getApplicationName()));
 


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `OpenToonz`, but the desktop file is called as [`io.github.OpenToonz`](https://github.com/opentoonz/opentoonz/blob/97d623b1a2494adb92649286fefe07de8dadb631/toonz/sources/xdg-data/io.github.OpenToonz.desktop).

The window icon is commonly used by window managers and taskbars on X11.

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id