### PR TITLE
Add Brazilian Portuguese (pt_BR) translation

### DIFF
--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -660,11 +660,11 @@ if(WITH_TRANSLATION)
     # Language data and display names
     # ---------------------------------------------------------------------
     set(LANG_CODES
-    japanese italian french spanish chinese german russian korean czech
+    japanese italian french spanish chinese german russian korean czech portuguese_brazil
       )
 
     set(LANG_DISPLAY_NAMES
-    "日本語" "Italiano" "Français" "Español" "中文" "Deutsch" "Русский" "한국어" "Čeština"
+    "日本語" "Italiano" "Français" "Español" "中文" "Deutsch" "Русский" "한국어" "Čeština" "Português (Brasil)"
       )
 
     list(LENGTH LANG_CODES CODE_COUNT)

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -664,7 +664,7 @@ if(WITH_TRANSLATION)
       )
 
     set(LANG_DISPLAY_NAMES
-    "日本語" "Italiano" "Français" "Español" "中文" "Deutsch" "Русский" "한국어" "Čeština" "Portuguese (Brazil)"
+    "日本語" "Italiano" "Français" "Español" "中文" "Deutsch" "Русский" "한국어" "Čeština" "Portuguese"
       )
 
     list(LENGTH LANG_CODES CODE_COUNT)

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -664,7 +664,7 @@ if(WITH_TRANSLATION)
       )
 
     set(LANG_DISPLAY_NAMES
-    "日本語" "Italiano" "Français" "Español" "中文" "Deutsch" "Русский" "한국어" "Čeština" "Português (Brasil)"
+    "日本語" "Italiano" "Français" "Español" "中文" "Deutsch" "Русский" "한국어" "Čeština" "Portuguese (Brazil)"
       )
 
     list(LENGTH LANG_CODES CODE_COUNT)

--- a/toonz/sources/translations/portuguese_brazil/colorfx.ts
+++ b/toonz/sources/translations/portuguese_brazil/colorfx.ts
@@ -1,0 +1,750 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR" sourcelanguage="en">
+<context>
+    <name>ArtisticSolidColor</name>
+    <message>
+        <source>Irregular</source>
+        <translation>Irregular</translation>
+    </message>
+    <message>
+        <source>Horiz Offset</source>
+        <translation>Deslocamento Horizontal</translation>
+    </message>
+    <message>
+        <source>Vert Offset</source>
+        <translation>Deslocamento Vertical</translation>
+    </message>
+    <message>
+        <source>Noise</source>
+        <translation>Ruído</translation>
+    </message>
+</context>
+<context>
+    <name>FlowLineStrokeStyle</name>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Extension</source>
+        <translation>Extensão</translation>
+    </message>
+    <message>
+        <source>Width Scale</source>
+        <translation>Escala de largura</translation>
+    </message>
+    <message>
+        <source>Straighten Ends</source>
+        <translation>Endireite as pontas</translation>
+    </message>
+    <message>
+        <source>Flow Line</source>
+        <translation>Linha de Fluxo</translation>
+    </message>
+</context>
+<context>
+    <name>MovingSolidColor</name>
+    <message>
+        <source>Offset</source>
+        <translation>Desvio</translation>
+    </message>
+    <message>
+        <source>Horiz Offset</source>
+        <translation>Deslocamento Horizontal</translation>
+    </message>
+    <message>
+        <source>Vert Offset</source>
+        <translation>Deslocamento Vertical</translation>
+    </message>
+</context>
+<context>
+    <name>OutlineViewerStyle</name>
+    <message>
+        <source>OutlineViewer(OnlyDebug)</source>
+        <translation>OutlineViewer (apenasDebug)</translation>
+    </message>
+    <message>
+        <source>Control Point</source>
+        <translation>Ponto de controle</translation>
+    </message>
+    <message>
+        <source>Center Line</source>
+        <translation>Linha Central</translation>
+    </message>
+    <message>
+        <source>Outline Mode</source>
+        <translation>Modo de contorno</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+    <message>
+        <source>distance</source>
+        <translation>distância</translation>
+    </message>
+</context>
+<context>
+    <name>ShadowStyle</name>
+    <message>
+        <source>Hatched Shading</source>
+        <translation>Sombreamento hachurado</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation>Comprimento</translation>
+    </message>
+</context>
+<context>
+    <name>ShadowStyle2</name>
+    <message>
+        <source>Plain Shadow</source>
+        <translation>Sombra Simples</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+</context>
+<context>
+    <name>TAirbrushRasterStyle</name>
+    <message>
+        <source>Airbrush</source>
+        <translation>Aerógrafo</translation>
+    </message>
+    <message>
+        <source>Blur value</source>
+        <translation>Valor de desfoque</translation>
+    </message>
+</context>
+<context>
+    <name>TBiColorStrokeStyle</name>
+    <message>
+        <source>Shade</source>
+        <translation>Sombra</translation>
+    </message>
+</context>
+<context>
+    <name>TBlendRasterStyle</name>
+    <message>
+        <source>Blend</source>
+        <translation>Mistura</translation>
+    </message>
+</context>
+<context>
+    <name>TBlendStrokeStyle2</name>
+    <message>
+        <source>Fade</source>
+        <translation>Desaparecer</translation>
+    </message>
+    <message>
+        <source>Border Fade</source>
+        <translation>Esmaecimento da borda</translation>
+    </message>
+    <message>
+        <source>Fade In</source>
+        <translation>Desaparecer</translation>
+    </message>
+    <message>
+        <source>Fade Out</source>
+        <translation>Desaparecer</translation>
+    </message>
+</context>
+<context>
+    <name>TBraidStrokeStyle</name>
+    <message>
+        <source>Plait</source>
+        <translation>Trança</translation>
+    </message>
+    <message>
+        <source>Twirl</source>
+        <translation>Girar</translation>
+    </message>
+</context>
+<context>
+    <name>TBubbleStrokeStyle</name>
+    <message>
+        <source>Bubbles</source>
+        <translation>Bolhas</translation>
+    </message>
+</context>
+<context>
+    <name>TChainStrokeStyle</name>
+    <message>
+        <source>Chain</source>
+        <translation>Corrente</translation>
+    </message>
+</context>
+<context>
+    <name>TChalkFillStyle</name>
+    <message>
+        <source>Chalk</source>
+        <translation>Giz</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Dot Size</source>
+        <translation>Tamanho do ponto</translation>
+    </message>
+</context>
+<context>
+    <name>TChalkStrokeStyle2</name>
+    <message>
+        <source>Chalk</source>
+        <translation>Giz</translation>
+    </message>
+    <message>
+        <source>Border Fade</source>
+        <translation>Esmaecimento da borda</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Fade In</source>
+        <translation>Desaparecer</translation>
+    </message>
+    <message>
+        <source>Fade Out</source>
+        <translation>Desaparecer</translation>
+    </message>
+    <message>
+        <source>Noise</source>
+        <translation>Ruído</translation>
+    </message>
+</context>
+<context>
+    <name>TCheckedFillStyle</name>
+    <message>
+        <source>Square</source>
+        <translation>Quadrado</translation>
+    </message>
+    <message>
+        <source>Horiz Dist</source>
+        <translation>Distância Horiz</translation>
+    </message>
+    <message>
+        <source>Horiz Angle</source>
+        <translation>Ângulo em amarelo</translation>
+    </message>
+    <message>
+        <source>Vert Dist</source>
+        <translation>Dist.Vert</translation>
+    </message>
+    <message>
+        <source>Vert Angle</source>
+        <translation>Ângulo vertical</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+<context>
+    <name>TChessFillStyle</name>
+    <message>
+        <source>Chessboard</source>
+        <translation>Tabuleiro de xadrez</translation>
+    </message>
+    <message>
+        <source>Horiz Size</source>
+        <translation>Tamanho Amarelo</translation>
+    </message>
+    <message>
+        <source>Vert Size</source>
+        <translation>Tamanho vertical</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+</context>
+<context>
+    <name>TCircleStripeFillStyle</name>
+    <message>
+        <source>Concentric</source>
+        <translation>Concêntrico</translation>
+    </message>
+    <message>
+        <source>X Position</source>
+        <translation>Posição X</translation>
+    </message>
+    <message>
+        <source>Y Position</source>
+        <translation>Posição Y</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+<context>
+    <name>TCrystallizeStrokeStyle</name>
+    <message>
+        <source>Tulle</source>
+        <translation>Tule</translation>
+    </message>
+    <message>
+        <source>Crease</source>
+        <translation>Vinco</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>Opacidade</translation>
+    </message>
+</context>
+<context>
+    <name>TDottedFillStyle</name>
+    <message>
+        <source>Polka Dots</source>
+        <translation>Bolinhas</translation>
+    </message>
+    <message>
+        <source>Dot Size</source>
+        <translation>Tamanho do ponto</translation>
+    </message>
+    <message>
+        <source>Dot Distance</source>
+        <translation>Distância do ponto</translation>
+    </message>
+</context>
+<context>
+    <name>TDottedLineStrokeStyle</name>
+    <message>
+        <source>Vanishing</source>
+        <translation>Desaparecimento</translation>
+    </message>
+    <message>
+        <source>Fade In</source>
+        <translation>Desaparecer</translation>
+    </message>
+    <message>
+        <source>Dash</source>
+        <translation>Traço</translation>
+    </message>
+    <message>
+        <source>Fade Out</source>
+        <translation>Desaparecer</translation>
+    </message>
+    <message>
+        <source>Gap</source>
+        <translation>Brecha</translation>
+    </message>
+</context>
+<context>
+    <name>TDualColorStrokeStyle2</name>
+    <message>
+        <source>Striped</source>
+        <translation>Listrado</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+</context>
+<context>
+    <name>TFriezeStrokeStyle2</name>
+    <message>
+        <source>Curl</source>
+        <translation>Enrolar</translation>
+    </message>
+    <message>
+        <source>Twirl</source>
+        <translation>Girar</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+<context>
+    <name>TFurStrokeStyle</name>
+    <message>
+        <source>Herringbone</source>
+        <translation>Espinha de peixe</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+</context>
+<context>
+    <name>TGraphicPenStrokeStyle</name>
+    <message>
+        <source>Dashes</source>
+        <translation>Traços</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+</context>
+<context>
+    <name>TLinGradFillStyle</name>
+    <message>
+        <source>Linear Gradient</source>
+        <translation>Gradiente Linear</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>X Position</source>
+        <translation>Posição X</translation>
+    </message>
+    <message>
+        <source>Y Position</source>
+        <translation>Posição Y</translation>
+    </message>
+    <message>
+        <source>Smoothness</source>
+        <translation>Suavidade</translation>
+    </message>
+</context>
+<context>
+    <name>TLongBlendStrokeStyle2</name>
+    <message>
+        <source>Watercolor</source>
+        <translation>Aquarela</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+</context>
+<context>
+    <name>TMatrioskaStrokeStyle</name>
+    <message>
+        <source>Toothpaste</source>
+        <translation>Pasta de dente</translation>
+    </message>
+    <message>
+        <source>Stripes</source>
+        <translation>Listras</translation>
+    </message>
+</context>
+<context>
+    <name>TMosaicFillStyle</name>
+    <message>
+        <source>Stained Glass</source>
+        <translation>Vitral</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Distortion</source>
+        <translation>Distorção</translation>
+    </message>
+    <message>
+        <source>Min Thick</source>
+        <translation>Mínimo de espessura</translation>
+    </message>
+    <message>
+        <source>Max Thick</source>
+        <translation>Espessura máxima</translation>
+    </message>
+</context>
+<context>
+    <name>TMultiLineStrokeStyle2</name>
+    <message>
+        <source>Gouache</source>
+        <translation>Guache</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+    <message>
+        <source>Noise</source>
+        <translation>Ruído</translation>
+    </message>
+</context>
+<context>
+    <name>TNoColorRasterStyle</name>
+    <message>
+        <source>Markup</source>
+        <translation>Marcação</translation>
+    </message>
+</context>
+<context>
+    <name>TNormal2StrokeStyle</name>
+    <message>
+        <source>Bump</source>
+        <translation>Ressalto</translation>
+    </message>
+    <message>
+        <source>Light X Pos</source>
+        <translation>Luz X Pos.</translation>
+    </message>
+    <message>
+        <source>Light Y Pos</source>
+        <translation>Posição Y de luz</translation>
+    </message>
+    <message>
+        <source>Shininess</source>
+        <translation>Brilho</translation>
+    </message>
+    <message>
+        <source>Plastic</source>
+        <translation>Plástico</translation>
+    </message>
+</context>
+<context>
+    <name>TPatchFillStyle</name>
+    <message>
+        <source>Beehive</source>
+        <translation>Colméia</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Distortion</source>
+        <translation>Distorção</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+<context>
+    <name>TPointShadowFillStyle</name>
+    <message>
+        <source>Sponge Shading</source>
+        <translation>Sombreamento Esponja</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Point Size</source>
+        <translation>Tamanho do ponto</translation>
+    </message>
+</context>
+<context>
+    <name>TRadGradFillStyle</name>
+    <message>
+        <source>Radial Gradient</source>
+        <translation>Gradiente Radial</translation>
+    </message>
+    <message>
+        <source>X Position</source>
+        <translation>Posição X</translation>
+    </message>
+    <message>
+        <source>Y Position</source>
+        <translation>Posição Y</translation>
+    </message>
+    <message>
+        <source>Radius</source>
+        <translation>Raio</translation>
+    </message>
+    <message>
+        <source>Smoothness</source>
+        <translation>Suavidade</translation>
+    </message>
+</context>
+<context>
+    <name>TRopeStrokeStyle</name>
+    <message>
+        <source>Rope</source>
+        <translation>Corda</translation>
+    </message>
+    <message>
+        <source>Tilt</source>
+        <translation>Inclinar</translation>
+    </message>
+</context>
+<context>
+    <name>TRubberFillStyle</name>
+    <message>
+        <source>Blob</source>
+        <translation>bolha</translation>
+    </message>
+    <message>
+        <source>Intensity</source>
+        <translation>Intensidade</translation>
+    </message>
+</context>
+<context>
+    <name>TSawToothStrokeStyle</name>
+    <message>
+        <source>Jagged</source>
+        <translation>Irregular</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+</context>
+<context>
+    <name>TSinStrokeStyle</name>
+    <message>
+        <source>Wave</source>
+        <translation>Aceno</translation>
+    </message>
+    <message>
+        <source>Frequency</source>
+        <translation>Freqüência</translation>
+    </message>
+</context>
+<context>
+    <name>TSketchStrokeStyle</name>
+    <message>
+        <source>Fuzz</source>
+        <translation>Fuzz</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+</context>
+<context>
+    <name>TSprayStrokeStyle</name>
+    <message>
+        <source>Circlets</source>
+        <translation>argolas</translation>
+    </message>
+    <message>
+        <source>Border Fade</source>
+        <translation>Esmaecimento da borda</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+</context>
+<context>
+    <name>TStripeFillStyle</name>
+    <message>
+        <source>Banded</source>
+        <translation>Com faixas</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+<context>
+    <name>TTissueStrokeStyle</name>
+    <message>
+        <source>Gauze</source>
+        <translation>Gaze</translation>
+    </message>
+    <message>
+        <source>Density</source>
+        <translation>Densidade</translation>
+    </message>
+    <message>
+        <source>Border Size</source>
+        <translation>Tamanho da borda</translation>
+    </message>
+</context>
+<context>
+    <name>TTwirlStrokeStyle</name>
+    <message>
+        <source>Ribbon</source>
+        <translation>Fita</translation>
+    </message>
+    <message>
+        <source>Twirl</source>
+        <translation>Girar</translation>
+    </message>
+    <message>
+        <source>Shade</source>
+        <translation>Sombra</translation>
+    </message>
+</context>
+<context>
+    <name>TZigzTSinStrokeStyleagStrokeStyle</name>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+<context>
+    <name>TZigzagStrokeStyle</name>
+    <message>
+        <source>Zigzag</source>
+        <translation>Ziguezague</translation>
+    </message>
+    <message>
+        <source>Min Distance</source>
+        <translation>Distância mínima</translation>
+    </message>
+    <message>
+        <source>Max Distance</source>
+        <translation>Distância máxima</translation>
+    </message>
+    <message>
+        <source>Min Angle</source>
+        <translation>Ângulo mínimo</translation>
+    </message>
+    <message>
+        <source>Max Angle</source>
+        <translation>Ângulo máximo</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+</TS>

--- a/toonz/sources/translations/portuguese_brazil/image.ts
+++ b/toonz/sources/translations/portuguese_brazil/image.ts
@@ -1,0 +1,748 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es_UY">
+<context>
+    <name>APngWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="225" />
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="226" />
+        <source>Looping</source>
+        <translation>Looping</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_apng.cpp" line="227" />
+        <source>Write as .png</source>
+        <translation>Escreva como .png</translation>
+    </message>
+</context>
+<context>
+    <name>AviWriterProperties</name>
+    <message>
+        <location filename="../../image/avi/tiio_avi.cpp" line="1210" />
+        <source>Codec</source>
+        <translation>Codec</translation>
+    </message>
+    <message>
+        <location filename="../../image/avi/tiio_avi.cpp" line="1211" />
+        <source>Uncompressed</source>
+        <translation>Descompactado</translation>
+    </message>
+</context>
+<context>
+    <name>ExrWriterProperties</name>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="290" />
+        <source>Bits Per Pixel</source>
+        <translatorcomment>Bits por pÃ­xel</translatorcomment>
+        <translation>Bits por pixel</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="292" />
+        <source>48(RGB Half Float)</source>
+        <translation>48 (meio flutuador RGB)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="293" />
+        <source>64(RGBA Half Float)</source>
+        <translation>64 (meio flutuador RGBA)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="294" />
+        <source>96(RGB Float)</source>
+        <translation>96 (RGB flutuante)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="295" />
+        <source>128(RGBA Float)</source>
+        <translation>128 (flutuador RGBA)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="299" />
+        <source>Compression Type</source>
+        <translation>Tipo de compressão</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="301" />
+        <source>No compression</source>
+        <translation>Sem compressão</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="304" />
+        <source>Run Length Encoding (RLE)</source>
+        <translation>Codificação de comprimento de execução (RLE)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="307" />
+        <source>ZIP compression per Scanline (ZIPS)</source>
+        <translation>Compressão ZIP por Scanline (ZIPS)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="310" />
+        <source>ZIP compression per scanline band (ZIP)</source>
+        <translation>Compressão ZIP por banda de scanline (ZIP)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="313" />
+        <source>PIZ-based wavelet compression (PIZ)</source>
+        <translation>Compressão wavelet baseada em PIZ (PIZ)</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="315" />
+        <source>Storage Type</source>
+        <translation>Tipo de armazenamento</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="316" />
+        <source>Scan-line based</source>
+        <translation>Baseado em linha de varredura</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="317" />
+        <source>Tile based</source>
+        <translation>Baseado em bloco</translation>
+    </message>
+    <message>
+        <location filename="../../image/exr/tiio_exr.cpp" line="319" />
+        <source>Color Space Gamma</source>
+        <translation>Gama de espaço de cores</translation>
+    </message>
+</context>
+<context>
+    <name>FFMovWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="234" />
+        <source>Quality</source>
+        <translation>Qualidade</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ff_mov.cpp" line="235" />
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+</context>
+<context>
+    <name>GifWriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="327" />
+        <source>Global Palette</source>
+        <translation>Paleta Global</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="328" />
+        <source>Global Palette + Sierra Dither</source>
+        <translation>Paleta Global + Sierra Dither</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="329" />
+        <source>Global Palette + Bayer2 Dither</source>
+        <translation>Paleta Global + Dither Bayer2</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="330" />
+        <source>Global Palette + Bayer1 Dither</source>
+        <translation>Paleta Global + Pontilhamento Bayer1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="331" />
+        <source>Diff Palette</source>
+        <translation>Paleta de diferenças</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="332" />
+        <source>Diff Palette + Sierra Dither</source>
+        <translation>Paleta Diff + Sierra Dither</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="333" />
+        <source>Diff Palette + Bayer2 Dither</source>
+        <translation>Paleta Diff + pontilhamento Bayer2</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="334" />
+        <source>Diff Palette + Bayer1 Dither</source>
+        <translation>Paleta Diff + pontilhamento Bayer1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="335" />
+        <source>New Pal Per Frame</source>
+        <translation>Novo amigo por quadro</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="336" />
+        <source>New Pal Per Frame + Sierra Dither</source>
+        <translation>Novo Pal por quadro + Sierra Dither</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="337" />
+        <source>New Pal Per Frame + Bayer2 Dither</source>
+        <translation>Novo Pal por quadro + pontilhamento Bayer2</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="338" />
+        <source>New Pal Per Frame + Bayer1 Dither</source>
+        <translation>Novo Pal por quadro + pontilhamento Bayer1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="339" />
+        <source>Opaque, Dither, 256 Colors Only</source>
+        <translation>Opaco, pontilhado, apenas 256 cores</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="352" />
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="353" />
+        <source>Looping</source>
+        <translation>Looping</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="354" />
+        <source>Mode</source>
+        <translation>Modo</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_gif.cpp" line="355" />
+        <source>Max Colors</source>
+        <translation>Máximo de cores</translation>
+    </message>
+    <message>
+        <source>Generate Palette</source>
+        <translation>Gerar paleta</translation>
+    </message>
+</context>
+<context>
+    <name>Mp4WriterProperties</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_mp4.cpp" line="234" />
+        <source>Quality</source>
+        <translation>Qualidade</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_mp4.cpp" line="235" />
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+</context>
+<context>
+    <name>PngWriterProperties</name>
+    <message>
+        <location filename="../../image/png/tiio_png.cpp" line="578" />
+        <source>Alpha Channel</source>
+        <translation>Canal Alfa</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="71" />
+        <source>Cannot create FFmpeg cache directory: %1</source>
+        <translation>Não foi possível criar o diretório de cache do FFmpeg:% 1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="107" />
+        <source>Cannot save non-raster image to FFmpeg</source>
+        <translation>Não é possível salvar imagem não raster no FFmpeg</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="113" />
+        <source>Invalid or empty raster for FFmpeg</source>
+        <translation>Raster inválido ou vazio para FFmpeg</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="127" />
+        <source>Failed to clone raster for FFmpeg</source>
+        <translation>Falha ao clonar raster para FFmpeg</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="136" />
+        <source>Failed to allocate 32-bit raster for FFmpeg</source>
+        <translation>Falha ao alocar raster de 32 bits para FFmpeg</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="163" />
+        <source>Failed to convert raster to 32-bit ARGB (after clamp)</source>
+        <translation>Falha ao converter raster em ARGB de 32 bits (após fixação)</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="174" />
+        <source>Failed to create QImage for intermediate file</source>
+        <translation>Falha ao criar QImage para arquivo intermediário</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="185" />
+        <source>Failed to save intermediate image: %1</source>
+        <translation>Falha ao salvar a imagem intermediária: % 1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="223" />
+        <source>FFmpeg process failed for: %1</source>
+        <translation>O processo FFmpeg falhou para: %1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="273" />
+        <source>FFmpeg returned error-code: %1</source>
+        <translation>O FFmpeg retornou o código de erro:% 1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="307" />
+        <source>Cannot open audio file for writing: %1</source>
+        <translation>Não foi possível abrir o arquivo de áudio para gravação:% 1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="312" />
+        <source>Failed to write audio data to file</source>
+        <translation>Falha ao gravar dados de áudio no arquivo</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="378" />
+        <source>Size error: %1
+</source>
+        <translation>Erro de tamanho: %1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="386" />
+        <source>Frame rate error: %1
+</source>
+        <translation>Erro na taxa de quadros: %1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="394" />
+        <source>Frame count error: %1
+</source>
+        <translation>Erro na contagem de quadros: %1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="401" />
+        <source>Failed to retrieve %1 from video via ffprobe.
+Error details:
+%2Using available data and fallback values where necessary.
+Note: Zero values in dimensions, frame count or frame rate indicate that the information could not be retrieved.</source>
+        <translation>Falha ao recuperar %1 do vídeo via ffprobe.
+Detalhes do erro:
+%2Usando dados disponíveis e valores alternativos quando necessário.
+Nota: Valores zero em dimensões, contagem de quadros ou taxa de quadros indicam que as informações não puderam ser recuperadas.</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="561" />
+        <source>Unable to determine frame count for: %1</source>
+        <translation>Não foi possível determinar a contagem de quadros para: %1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="609" />
+        <source>FFmpeg failed to extract frames from: %1
+Check file and codec support.</source>
+        <translation>O FFmpeg falhou ao extrair quadros de:% 1
+Verifique o suporte a arquivos e codecs.</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="695" />
+        <source>Failed to delete file: %1
+%2</source>
+        <translation>Falha ao excluir o arquivo: %1
+%2</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="835" />
+        <source>Failed to extract frames from movie: %1</source>
+        <translation>Falha ao extrair fotogramas do filme:% 1</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="260" />
+        <location filename="../../image/ffmpeg/tiio_ffmpeg.cpp" line="276" />
+        <source>FFmpeg timed out.
+Please check the file for errors.
+If the file doesn't play or is incomplete, 
+Please try raising the FFmpeg timeout in Preferences.</source>
+        <translation>O tempo limite do FFmpeg expirou.
+Verifique se há erros no arquivo.
+Se o arquivo não for reproduzido ou estiver incompleto, 
+Tente aumentar o tempo limite do FFmpeg em Preferências.</translation>
+    </message>
+</context>
+<context>
+    <name>SgiWriterProperties</name>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1196" />
+        <source>Bits Per Pixel</source>
+        <translation>Bits por pixel</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1197" />
+        <source>24 bits</source>
+        <translation>24 bits</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1198" />
+        <source>32 bits</source>
+        <translation>32 bits</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1199" />
+        <source>48 bits</source>
+        <translation>48 bits</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1200" />
+        <source>64 bits</source>
+        <translation>64 bits</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1201" />
+        <source>8 bits (Greyscale)</source>
+        <translation>8 bits (escala de cinza)</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1202" />
+        <source>Endianness</source>
+        <translation>Endianismo</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1203" />
+        <source>Big Endian</source>
+        <translation>Big Endian</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1204" />
+        <source>Little Endian</source>
+        <translation>Pequeno Endian</translation>
+    </message>
+    <message>
+        <location filename="../../image/sgi/filesgi.cpp" line="1205" />
+        <source>RLE-Compressed</source>
+        <translation>Comprimido RLE</translation>
+    </message>
+</context>
+<context>
+    <name>SpriteWriterProperties</name>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="312" />
+        <source>Top Padding</source>
+        <translation>Preenchimento superior</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="313" />
+        <source>Bottom Padding</source>
+        <translation>Preenchimento inferior</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="314" />
+        <source>Left Padding</source>
+        <translation>Preenchimento Esquerdo</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="315" />
+        <source>Right Padding</source>
+        <translation>Preenchimento direito</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="316" />
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="317" />
+        <source>Format</source>
+        <translation>Formatar</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="318" />
+        <source>Grid</source>
+        <translation>Grade</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="319" />
+        <source>Vertical</source>
+        <translation>Vertical</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="320" />
+        <source>Horizontal</source>
+        <translation>Horizontal</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="321" />
+        <source>Individual</source>
+        <translation>Individual</translation>
+    </message>
+    <message>
+        <location filename="../../image/sprite/tiio_sprite.cpp" line="322" />
+        <source>Trim Empty Space</source>
+        <translation>Aparar espaço vazio</translation>
+    </message>
+</context>
+<context>
+    <name>SvgWriterProperties</name>
+    <message>
+        <location filename="../../image/svg/tiio_svg.cpp" line="2087" />
+        <source>Stroke Mode</source>
+        <translation>Modo de traço</translation>
+    </message>
+    <message>
+        <location filename="../../image/svg/tiio_svg.cpp" line="2088" />
+        <source>Outline Quality</source>
+        <translation>Qualidade do esboço</translation>
+    </message>
+    <message>
+        <location filename="../../image/svg/tiio_svg.cpp" line="2089" />
+        <source>Centerline</source>
+        <translation>Linha central</translation>
+    </message>
+    <message>
+        <location filename="../../image/svg/tiio_svg.cpp" line="2090" />
+        <source>Outline</source>
+        <translation>Contorno</translation>
+    </message>
+    <message>
+        <location filename="../../image/svg/tiio_svg.cpp" line="2091" />
+        <source>High</source>
+        <translation>Alto</translation>
+    </message>
+    <message>
+        <location filename="../../image/svg/tiio_svg.cpp" line="2092" />
+        <source>Medium</source>
+        <translation>Médio</translation>
+    </message>
+    <message>
+        <location filename="../../image/svg/tiio_svg.cpp" line="2093" />
+        <source>Low</source>
+        <translation>Baixo</translation>
+    </message>
+</context>
+<context>
+    <name>TgaWriterProperties</name>
+    <message>
+        <location filename="../../image/tga/tiio_tga.cpp" line="523" />
+        <source>Bits Per Pixel</source>
+        <translation>Bits por pixel</translation>
+    </message>
+    <message>
+        <location filename="../../image/tga/tiio_tga.cpp" line="524" />
+        <source>16 bits</source>
+        <translation>16 bits</translation>
+    </message>
+    <message>
+        <location filename="../../image/tga/tiio_tga.cpp" line="525" />
+        <source>24 bits</source>
+        <translation>24 bits</translation>
+    </message>
+    <message>
+        <location filename="../../image/tga/tiio_tga.cpp" line="526" />
+        <source>32 bits</source>
+        <translation>32 bits</translation>
+    </message>
+    <message>
+        <location filename="../../image/tga/tiio_tga.cpp" line="527" />
+        <source>Compression</source>
+        <translation>Compressão</translation>
+    </message>
+</context>
+<context>
+    <name>TifWriterProperties</name>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="730" />
+        <source>Byte Ordering</source>
+        <translation>Ordenação de Bytes</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="731" />
+        <source>Compression Type</source>
+        <translation>Tipo de compressão</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="732" />
+        <source>Bits Per Pixel</source>
+        <translation>Bits por pixel</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="733" />
+        <source>24(RGB)</source>
+        <translation>24(RGB)</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="734" />
+        <source>48(RGB)</source>
+        <translation>48(RGB)</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="735" />
+        <source> 1(BW)</source>
+        <translation>1(PN)</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="736" />
+        <source> 8(GREYTONES)</source>
+        <translation>8 (TONS DE CINZENTO)</translation>
+    </message>
+    <message>
+        <source>32(RGBM)</source>
+        <translation>32(RGBM)</translation>
+    </message>
+    <message>
+        <source>64(RGBM)</source>
+        <translation>64(RGBM)</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="737" />
+        <source>32(RGBA)</source>
+        <translation>32(RGBA)</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="738" />
+        <source>64(RGBA)</source>
+        <translation>64(RGBA)</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="739" />
+        <source>Orientation</source>
+        <translation>Orientação</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="740" />
+        <source>Top Left</source>
+        <translation>Canto superior esquerdo</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="741" />
+        <source>Top Right</source>
+        <translation>Canto superior direito</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="742" />
+        <source>Bottom Right</source>
+        <translation>Canto inferior direito</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="743" />
+        <source>Bottom Left</source>
+        <translation>Inferior Esquerdo</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="744" />
+        <source>Left Top</source>
+        <translation>Superior Esquerdo</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="745" />
+        <source>Left Bottom</source>
+        <translation>Inferior Esquerdo</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="746" />
+        <source>Right Top</source>
+        <translation>Superior direito</translation>
+    </message>
+    <message>
+        <location filename="../../image/tif/tiio_tif.cpp" line="747" />
+        <source>Right Bottom</source>
+        <translation>Inferior Direito</translation>
+    </message>
+</context>
+<context>
+    <name>WebmWriterProperties</name>
+    <message>
+        <source>Quality</source>
+        <translation>Qualidade</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="309" />
+        <source>Placebo (Smallest File)</source>
+        <translation>Placebo (menor arquivo)</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="310" />
+        <source>Very Slow</source>
+        <translation>Muito lento</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="311" />
+        <source>Slower</source>
+        <translation>Mais devagar</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="312" />
+        <source>Slow</source>
+        <translation>Lento</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="313" />
+        <source>Medium</source>
+        <translation>Médio</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="314" />
+        <source>Fast</source>
+        <translation>Rápido</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="315" />
+        <source>Faster</source>
+        <translation>Mais rápido</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="316" />
+        <source>Very Fast</source>
+        <translation>Muito rápido</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="318" />
+        <source>Ultra Fast (Largest File)</source>
+        <translation>Ultrarrápido (arquivo maior)</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="322" />
+        <source>Every Frame</source>
+        <translation>Cada quadro</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="323" />
+        <source>Every Second</source>
+        <translation>Cada segundo</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="324" />
+        <source>Every 2 Seconds</source>
+        <translation>A cada 2 segundos</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="325" />
+        <source>Every 5 Seconds</source>
+        <translation>A cada 5 segundos</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="326" />
+        <source>Every 10 Seconds</source>
+        <translation>A cada 10 segundos</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="331" />
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="332" />
+        <source>Encoding Speed</source>
+        <translation>Velocidade de codificação</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="333" />
+        <source>Keyframe Interval</source>
+        <translation>Intervalo de quadro-chave</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="334" />
+        <source>Preserve Alpha</source>
+        <translation>Preservar Alfa</translation>
+    </message>
+    <message>
+        <location filename="../../image/ffmpeg/tiio_webm.cpp" line="335" />
+        <source>Lossless</source>
+        <translation>Sem perdas</translation>
+    </message>
+</context>
+</TS>

--- a/toonz/sources/translations/portuguese_brazil/tnzcore.ts
+++ b/toonz/sources/translations/portuguese_brazil/tnzcore.ts
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR" sourcelanguage="en">
+<context>
+    <name>BmpWriterProperties</name>
+    <message>
+        <source>Bits Per Pixel</source>
+        <translation>Bits por pixel</translation>
+    </message>
+    <message>
+        <source>24 bits</source>
+        <translation>24 bits</translation>
+    </message>
+    <message>
+        <source>8 bits (Greyscale)</source>
+        <translation>8 bits (escala de cinza)</translation>
+    </message>
+</context>
+<context>
+    <name>JpgWriterProperties</name>
+    <message>
+        <source>Quality</source>
+        <translation>Qualidade</translation>
+    </message>
+    <message>
+        <source>Smoothing</source>
+        <translation>Suavização</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>colors</source>
+        <translation>cores</translation>
+    </message>
+    <message>
+        <source>Unidentified Action</source>
+        <translation>Ação não identificada</translation>
+    </message>
+    <message>
+        <source>Skipping frame.</source>
+        <translation>Pulando quadro.</translation>
+    </message>
+    <message>
+        <source>Malformed frame name</source>
+        <translation>Nome do quadro malformado</translation>
+    </message>
+</context>
+<context>
+    <name>TCenterLineStrokeStyle</name>
+    <message>
+        <source>Constant</source>
+        <translation>Constante</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+</context>
+<context>
+    <name>TRasterImagePatternStrokeStyle</name>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>Rotação</translation>
+    </message>
+</context>
+<context>
+    <name>TVectorImagePatternStrokeStyle</name>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>Rotação</translation>
+    </message>
+</context>
+</TS>

--- a/toonz/sources/translations/portuguese_brazil/tnztools.ts
+++ b/toonz/sources/translations/portuguese_brazil/tnztools.ts
@@ -1,0 +1,2401 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR" sourcelanguage="en">
+<context>
+    <name>ArrowToolOptionsBox</name>
+    <message>
+        <source>Pick:</source>
+        <translation>Escolha:</translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation>Posição</translation>
+    </message>
+    <message>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <source>Y:</source>
+        <translation>E:</translation>
+    </message>
+    <message>
+        <source>Z:</source>
+        <translation>Z:</translation>
+    </message>
+    <message>
+        <source>SO:</source>
+        <translation>ENTÃO:</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>Rotação</translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <source>Global:</source>
+        <translation>Global:</translation>
+    </message>
+    <message>
+        <source>H:</source>
+        <translation>H:</translation>
+    </message>
+    <message>
+        <source>V:</source>
+        <translation>V:</translation>
+    </message>
+    <message>
+        <source>Maintain:</source>
+        <translation>Manter:</translation>
+    </message>
+    <message>
+        <source>Shear</source>
+        <translation>Cisalhamento</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>Centro</translation>
+    </message>
+    <message>
+        <source>Lock</source>
+        <translation>Trancar</translation>
+    </message>
+    <message>
+        <source>(</source>
+        <translation>(</translation>
+    </message>
+    <message>
+        <source>)</source>
+        <translation>)</translation>
+    </message>
+    <message>
+        <source>Center Position</source>
+        <translation>Posição central</translation>
+    </message>
+    <message>
+        <source>Position:</source>
+        <translation>Posição:</translation>
+    </message>
+    <message>
+        <source>Rotation:</source>
+        <translation>Rotação:</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Mesa de animação</translation>
+    </message>
+    <message>
+        <source>Flip Object Horizontally</source>
+        <translatorcomment>Invertir objeto horizontalmente</translatorcomment>
+        <translation>Virar objeto horizontalmente</translation>
+    </message>
+    <message>
+        <source>Flip Object Vertically</source>
+        <translation>Virar objeto verticalmente</translation>
+    </message>
+    <message>
+        <source>Rotate Object Left</source>
+        <translation>Girar objeto para a esquerda</translation>
+    </message>
+    <message>
+        <source>Rotate Object Right</source>
+        <translation>Girar objeto para a direita</translation>
+    </message>
+</context>
+<context>
+    <name>BrushTool</name>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+    <message>
+        <source>Hardness:</source>
+        <translation>Dureza:</translation>
+    </message>
+    <message>
+        <source>Accuracy:</source>
+        <translation>Precisão:</translation>
+    </message>
+    <message>
+        <source>Selective</source>
+        <translation>Seletivo</translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation>Predefinição:</translation>
+    </message>
+    <message>
+        <source>Break Sharp Angles</source>
+        <translation>Quebre ângulos agudos</translation>
+    </message>
+    <message>
+        <source>Pencil Mode</source>
+        <translation>Modo Lápis</translation>
+    </message>
+    <message>
+        <source>Pressure Sensitivity</source>
+        <translation>Sensibilidade à Pressão</translation>
+    </message>
+    <message>
+        <source>Cap</source>
+        <translation>Boné</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation>Juntar</translation>
+    </message>
+    <message>
+        <source>Miter:</source>
+        <translation>Mitra:</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Break</source>
+        <translation>Quebrar</translation>
+    </message>
+    <message>
+        <source>Pencil</source>
+        <translation>Lápis</translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation>Pressão</translation>
+    </message>
+    <message>
+        <source>Smooth:</source>
+        <translation>Suave:</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation>Faixa:</translation>
+    </message>
+    <message>
+        <source>Snap</source>
+        <translation>Encaixe</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Desligado</translation>
+    </message>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>In</source>
+        <translation>Em</translation>
+    </message>
+    <message>
+        <source>Out</source>
+        <translation>Fora</translation>
+    </message>
+    <message>
+        <source>In&amp;Out</source>
+        <translation>Entrada e saída</translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation>Baixo</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>Alto</translation>
+    </message>
+    <message>
+        <source>Butt cap</source>
+        <translation>Tampa traseira</translation>
+    </message>
+    <message>
+        <source>Round cap</source>
+        <translation>Boné redondo</translation>
+    </message>
+    <message>
+        <source>Projecting cap</source>
+        <translation>Tampa de projeção</translation>
+    </message>
+    <message>
+        <source>Miter join</source>
+        <translation>Junção de mitra</translation>
+    </message>
+    <message>
+        <source>Round join</source>
+        <translation>Junção redonda</translation>
+    </message>
+    <message>
+        <source>Bevel join</source>
+        <translation>Junção chanfrada</translation>
+    </message>
+    <message>
+        <source>Med</source>
+        <translation>Com</translation>
+    </message>
+    <message>
+        <source>Draw Order:</source>
+        <translation>Ordem do sorteio:</translation>
+    </message>
+    <message>
+        <source>Over All</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <source>Under All</source>
+        <translation>Abaixo de tudo</translation>
+    </message>
+    <message>
+        <source>Palette Order</source>
+        <translation>Ordem da paleta</translation>
+    </message>
+</context>
+<context>
+    <name>BrushToolOptionsBox</name>
+    <message>
+        <source>Preset Name</source>
+        <translation>Nome predefinido</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>ControlPointEditorTool</name>
+    <message>
+        <source>Auto Select Drawing</source>
+        <translation>Seleção automática de desenho</translation>
+    </message>
+    <message>
+        <source>Snap</source>
+        <translation>Encaixe</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand</source>
+        <translation>À mão livre</translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation>Baixo</translation>
+    </message>
+    <message>
+        <source>Med</source>
+        <translation>Com</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>Alto</translation>
+    </message>
+</context>
+<context>
+    <name>ControlPointSelection</name>
+    <message>
+        <source>Set Linear Control Point</source>
+        <translation>Definir ponto de controle linear</translation>
+    </message>
+    <message>
+        <source>Set Nonlinear Control Point</source>
+        <translation>Definir ponto de controle não linear</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::StyleIndexLineEdit</name>
+    <message>
+        <source>current</source>
+        <translation>atual</translation>
+    </message>
+</context>
+<context>
+    <name>EditAssistantsTool</name>
+    <message>
+        <source>&lt;choose to create&gt;</source>
+        <translation>&lt;escolha criar&gt;</translation>
+    </message>
+    <message>
+        <source>Assistant Type</source>
+        <translation>Tipo de assistente</translation>
+    </message>
+    <message>
+        <source>Order</source>
+        <translation>Ordem</translation>
+    </message>
+</context>
+<context>
+    <name>EditTool</name>
+    <message>
+        <source>Scale Constraint:</source>
+        <translation>Restrição de escala:</translation>
+    </message>
+    <message>
+        <source>Auto Select Column</source>
+        <translation>Coluna de seleção automática</translation>
+    </message>
+    <message>
+        <source>Global Key</source>
+        <translation>Chave Global</translation>
+    </message>
+    <message>
+        <source>Lock Center X</source>
+        <translation>Bloquear Centro X</translation>
+    </message>
+    <message>
+        <source>Lock Center Y</source>
+        <translation>Bloquear Centro Y</translation>
+    </message>
+    <message>
+        <source>Lock Position X</source>
+        <translation>Posição de bloqueio X</translation>
+    </message>
+    <message>
+        <source>Lock Position Y</source>
+        <translation>Posição de bloqueio Y</translation>
+    </message>
+    <message>
+        <source>Lock Rotation</source>
+        <translation>Rotação de bloqueio</translation>
+    </message>
+    <message>
+        <source>Lock Shear H</source>
+        <translation>Bloqueio de cisalhamento H</translation>
+    </message>
+    <message>
+        <source>Lock Shear V</source>
+        <translation>Bloqueio de cisalhamento V</translation>
+    </message>
+    <message>
+        <source>Lock Scale H</source>
+        <translation>Escala de bloqueio H</translation>
+    </message>
+    <message>
+        <source>Lock Scale V</source>
+        <translation>Escala de bloqueio V</translation>
+    </message>
+    <message>
+        <source>Lock Global Scale</source>
+        <translation>Bloquear escala global</translation>
+    </message>
+    <message>
+        <source>X and Y Positions</source>
+        <translation>Posições X e Y</translation>
+    </message>
+    <message>
+        <source>Z Position</source>
+        <translation>Posição Z</translation>
+    </message>
+    <message>
+        <source>SO</source>
+        <translation>ENTÃO</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>Rotação</translation>
+    </message>
+    <message>
+        <source>Global Scale</source>
+        <translation>Escala Global</translation>
+    </message>
+    <message>
+        <source>Horizontal and Vertical Scale</source>
+        <translation>Escala Horizontal e Vertical</translation>
+    </message>
+    <message>
+        <source>Shear</source>
+        <translation>Cisalhamento</translation>
+    </message>
+    <message>
+        <source>Center Position</source>
+        <translation>Posição central</translation>
+    </message>
+    <message>
+        <source>Active Axis</source>
+        <translation>Eixo Ativo</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>A/R</source>
+        <translation>Contas a receber</translation>
+    </message>
+    <message>
+        <source>Mass</source>
+        <translation>Massa</translation>
+    </message>
+    <message>
+        <source>Column</source>
+        <translation>Coluna</translation>
+    </message>
+    <message>
+        <source>Pegbar</source>
+        <translation>Barra de pinos</translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation>Posição</translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>Centro</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation>Todos</translation>
+    </message>
+</context>
+<context>
+    <name>EraserTool</name>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Hardness:</source>
+        <translation>Dureza:</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Selective</source>
+        <translation>Seletivo</translation>
+    </message>
+    <message>
+        <source>Invert</source>
+        <translation>Invertido</translation>
+    </message>
+    <message>
+        <source>Frame Range</source>
+        <translation>Faixa de quadros</translation>
+    </message>
+    <message>
+        <source>Pencil Mode</source>
+        <translation>Modo Lápis</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normal</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand</source>
+        <translation>À mão livre</translation>
+    </message>
+    <message>
+        <source>Polyline</source>
+        <translation>Polilinha</translation>
+    </message>
+    <message>
+        <source>Lines</source>
+        <translation>Linhas</translation>
+    </message>
+    <message>
+        <source>Areas</source>
+        <translation>Áreas</translation>
+    </message>
+    <message>
+        <source>Lines &amp; Areas</source>
+        <translation>Linhas e áreas</translation>
+    </message>
+    <message>
+        <source>Segment</source>
+        <translation>Segmento</translation>
+    </message>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>Ease In</source>
+        <translation>Facilidade</translation>
+    </message>
+    <message>
+        <source>Ease Out</source>
+        <translation>Facilite</translation>
+    </message>
+    <message>
+        <source>Ease In/Out</source>
+        <translation>Facilidade de entrada/saída</translation>
+    </message>
+</context>
+<context>
+    <name>FillTool</name>
+    <message>
+        <source>Frame Range</source>
+        <translation>Faixa de quadros</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Selective</source>
+        <translation>Seletivo</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Onion Skin</source>
+        <translation>Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Fill Depth</source>
+        <translation>Profundidade de preenchimento</translation>
+    </message>
+    <message>
+        <source>Segment</source>
+        <translation>Segmento</translation>
+    </message>
+    <message>
+        <source>Autopaint Lines</source>
+        <translation>Linhas de pintura automática</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normal</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand</source>
+        <translation>À mão livre</translation>
+    </message>
+    <message>
+        <source>Polyline</source>
+        <translation>Polilinha</translation>
+    </message>
+    <message>
+        <source>Lines</source>
+        <translation>Linhas</translation>
+    </message>
+    <message>
+        <source>Areas</source>
+        <translation>Áreas</translation>
+    </message>
+    <message>
+        <source>Lines &amp; Areas</source>
+        <translation>Linhas e áreas</translation>
+    </message>
+    <message>
+        <source>Maximum Gap</source>
+        <translation>Lacuna Máxima</translation>
+    </message>
+    <message>
+        <source>Pick+Freehand</source>
+        <translation>Escolha + Mão Livre</translation>
+    </message>
+    <message>
+        <source>Empty Only</source>
+        <translation>Apenas vazio</translation>
+    </message>
+    <message>
+        <source>Close Gap</source>
+        <translation>Fechar lacuna</translation>
+    </message>
+    <message>
+        <source>Refer Fill</source>
+        <translation>Consulte Preenchimento</translation>
+    </message>
+    <message>
+        <source>Gap Close Distance:</source>
+        <translation>Distância próxima da lacuna:</translation>
+    </message>
+    <message>
+        <source>Extend Fill</source>
+        <translation>Estender preenchimento</translation>
+    </message>
+</context>
+<context>
+    <name>FingerTool</name>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Invert</source>
+        <translation>Invertido</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation>Escolha</translation>
+    </message>
+    <message>
+        <source>Empty Only</source>
+        <translation>Apenas vazio</translation>
+    </message>
+</context>
+<context>
+    <name>FullColorBrushTool</name>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+    <message>
+        <source>Pressure Sensitivity</source>
+        <translation>Sensibilidade à Pressão</translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation>Opacidade:</translation>
+    </message>
+    <message>
+        <source>Hardness:</source>
+        <translation>Dureza:</translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation>Predefinição:</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation>Pressão</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>Opacidade</translation>
+    </message>
+    <message>
+        <source>Eraser</source>
+        <translation>Apagador</translation>
+    </message>
+    <message>
+        <source>Lock Alpha</source>
+        <translation>Bloquear Alfa</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>Assistants</source>
+        <translation>Assistentes</translation>
+    </message>
+</context>
+<context>
+    <name>FullColorEraserTool</name>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation>Opacidade:</translation>
+    </message>
+    <message>
+        <source>Hardness:</source>
+        <translation>Dureza:</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Invert</source>
+        <translation>Invertido</translation>
+    </message>
+    <message>
+        <source>Frame Range</source>
+        <translation>Faixa de quadros</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normal</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand</source>
+        <translation>À mão livre</translation>
+    </message>
+    <message>
+        <source>Polyline</source>
+        <translation>Polilinha</translation>
+    </message>
+    <message>
+        <source>MultiArc</source>
+        <translation>MultiArco</translation>
+    </message>
+</context>
+<context>
+    <name>FullColorFillTool</name>
+    <message>
+        <source>Fill Depth</source>
+        <translation>Profundidade de preenchimento</translation>
+    </message>
+</context>
+<context>
+    <name>HandToolOptionsBox</name>
+    <message>
+        <source>Reset Position</source>
+        <translation>Redefinir posição</translation>
+    </message>
+</context>
+<context>
+    <name>HookTool</name>
+    <message>
+        <source>Snap</source>
+        <translation>Encaixe</translation>
+    </message>
+</context>
+<context>
+    <name>MagnetTool</name>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+</context>
+<context>
+    <name>PaintBrushTool</name>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Selective</source>
+        <translation>Seletivo</translation>
+    </message>
+    <message>
+        <source>Lines</source>
+        <translation>Linhas</translation>
+    </message>
+    <message>
+        <source>Areas</source>
+        <translation>Áreas</translation>
+    </message>
+    <message>
+        <source>Lines &amp; Areas</source>
+        <translation>Linhas e áreas</translation>
+    </message>
+    <message>
+        <source>Lock Alpha</source>
+        <translation>Bloquear Alfa</translation>
+    </message>
+    <message>
+        <source>Empty Only</source>
+        <translation>Apenas vazio</translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation>Escolha</translation>
+    </message>
+    <message>
+        <source>Paint by Filling</source>
+        <translation>Pintar por Preenchimento</translation>
+    </message>
+</context>
+<context>
+    <name>PinchTool</name>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Corner:</source>
+        <translation>Canto:</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation>Manual</translation>
+    </message>
+</context>
+<context>
+    <name>PlasticTool</name>
+    <message>
+        <source>Build Skeleton</source>
+        <translation>Construir Esqueleto</translation>
+    </message>
+    <message>
+        <source>Paint Rigid</source>
+        <translation>Pintar Rígido</translation>
+    </message>
+    <message>
+        <source>Animate</source>
+        <translation>Animar</translation>
+    </message>
+    <message>
+        <source>Rigid</source>
+        <translation>Rígido</translation>
+    </message>
+    <message>
+        <source>Flex</source>
+        <translation>Flexível</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Vertex Name:</source>
+        <translation>Nome do vértice:</translation>
+    </message>
+    <message>
+        <source>Allow Stretching</source>
+        <translation>Permitir alongamento</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+    <message>
+        <source>Keep Distance</source>
+        <translation>Mantenha distância</translation>
+    </message>
+    <message>
+        <source>Global Key</source>
+        <translation>Chave Global</translation>
+    </message>
+    <message>
+        <source>A group of skeletons already exists for current column. Replacing it will also substitute any existing vertex animation.
+
+Do you want to continue?</source>
+        <translation>Já existe um grupo de esqueletos para a coluna atual. Substituí-lo também substituirá qualquer animação de vértice existente.
+
+Você quer continuar?</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Copy Skeleton</source>
+        <translation>Copiar Esqueleto</translation>
+    </message>
+    <message>
+        <source>Paste Skeleton</source>
+        <translation>Colar esqueleto</translation>
+    </message>
+    <message>
+        <source>Delete Vertex</source>
+        <translation>Excluir vértice</translation>
+    </message>
+    <message>
+        <source>Set Key</source>
+        <translation>Definir chave</translation>
+    </message>
+    <message>
+        <source>Set Rest Key</source>
+        <translation>Definir chave de descanso</translation>
+    </message>
+    <message>
+        <source>Show Mesh</source>
+        <translation>Mostrar malha</translation>
+    </message>
+    <message>
+        <source>Show Rigidity</source>
+        <translation>Mostrar rigidez</translation>
+    </message>
+    <message>
+        <source>Show SO</source>
+        <translation>Mostrar SO</translation>
+    </message>
+    <message>
+        <source>Show Skeleton Onion Skin</source>
+        <translation>Mostrar Casca de Cebola esqueleto</translation>
+    </message>
+    <message>
+        <source>The previous vertex name will be discarded, and all associated keys will be lost.
+
+Do you want to proceed?</source>
+        <translation>O nome do vértice anterior será descartado e todas as chaves associadas serão perdidas.
+
+Você quer prosseguir?</translation>
+    </message>
+    <message>
+        <source>Set Global Key</source>
+        <translation>Definir chave global</translation>
+    </message>
+    <message>
+        <source>Set Global Rest Key</source>
+        <translation>Definir chave de descanso global</translation>
+    </message>
+    <message>
+        <source>Edit Mesh</source>
+        <translation>Editar malha</translation>
+    </message>
+    <message>
+        <source>Snap To Mesh</source>
+        <translation>Ajustar à malha</translation>
+    </message>
+    <message>
+        <source>Angle Bounds</source>
+        <translation>Limites de ângulo</translation>
+    </message>
+    <message>
+        <source>Swap Edge</source>
+        <translation>Trocar borda</translation>
+    </message>
+    <message>
+        <source>Collapse Edge</source>
+        <translation>Recolher borda</translation>
+    </message>
+    <message>
+        <source>Split Edge</source>
+        <translation>Borda dividida</translation>
+    </message>
+    <message>
+        <source>Cut Mesh</source>
+        <translation>Corte de malha</translation>
+    </message>
+</context>
+<context>
+    <name>PlasticToolOptionsBox</name>
+    <message>
+        <source>Create Mesh</source>
+        <translation>Criar malha</translation>
+    </message>
+    <message>
+        <source>Skeleton:</source>
+        <translation>Esqueleto:</translation>
+    </message>
+    <message>
+        <source>SO</source>
+        <translation>ENTÃO</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+</context>
+<context>
+    <name>PrimitiveParam</name>
+    <message>
+        <source>Shape:</source>
+        <translation>Forma:</translation>
+    </message>
+    <message>
+        <source>Thickness:</source>
+        <translation>Grossura:</translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation>Opacidade:</translation>
+    </message>
+    <message>
+        <source>Hardness:</source>
+        <translation>Dureza:</translation>
+    </message>
+    <message>
+        <source>Polygon Sides:</source>
+        <translation>Lados do polígono:</translation>
+    </message>
+    <message>
+        <source>Auto Group</source>
+        <translation>Grupo Automático</translation>
+    </message>
+    <message>
+        <source>Auto Fill</source>
+        <translation>Preenchimento automático</translation>
+    </message>
+    <message>
+        <source>Selective</source>
+        <translation>Seletivo</translation>
+    </message>
+    <message>
+        <source>Pencil Mode</source>
+        <translation>Modo Lápis</translation>
+    </message>
+    <message>
+        <source>Cap</source>
+        <translation>Boné</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation>Juntar</translation>
+    </message>
+    <message>
+        <source>Miter:</source>
+        <translation>Mitra:</translation>
+    </message>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Snap</source>
+        <translation>Encaixe</translation>
+    </message>
+    <message>
+        <source>Rectangle</source>
+        <translation>Retângulo</translation>
+    </message>
+    <message>
+        <source>Circle</source>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>Elipse</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>Linha</translation>
+    </message>
+    <message>
+        <source>Polyline</source>
+        <translation>Polilinha</translation>
+    </message>
+    <message>
+        <source>Arc</source>
+        <translation>Arco</translation>
+    </message>
+    <message>
+        <source>Polygon</source>
+        <translation>Polígono</translation>
+    </message>
+    <message>
+        <source>Butt cap</source>
+        <translation>Tampa traseira</translation>
+    </message>
+    <message>
+        <source>Round cap</source>
+        <translation>Boné redondo</translation>
+    </message>
+    <message>
+        <source>Projecting cap</source>
+        <translation>Tampa de projeção</translation>
+    </message>
+    <message>
+        <source>Miter join</source>
+        <translation>Junção de mitra</translation>
+    </message>
+    <message>
+        <source>Round join</source>
+        <translation>Junção redonda</translation>
+    </message>
+    <message>
+        <source>Bevel join</source>
+        <translation>Junção chanfrada</translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation>Baixo</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>Alto</translation>
+    </message>
+    <message>
+        <source>Med</source>
+        <translation>Com</translation>
+    </message>
+    <message>
+        <source>MultiArc</source>
+        <translation>MultiArco</translation>
+    </message>
+    <message>
+        <source>Smooth</source>
+        <translation>Suave</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation>Girar</translation>
+    </message>
+    <message>
+        <source>Empty Only</source>
+        <translation>Apenas vazio</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>Opacidade</translation>
+    </message>
+</context>
+<context>
+    <name>PumpTool</name>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Accuracy:</source>
+        <translation>Precisão:</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Min:</source>
+        <translation>Mínimo:</translation>
+    </message>
+    <message>
+        <source>Max:</source>
+        <translation>Máx.:</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>The copied selection cannot be pasted in the current drawing.</source>
+        <translation>A seleção copiada não pode ser colada no desenho atual.</translation>
+    </message>
+    <message>
+        <source>The current column is locked.</source>
+        <translation>A coluna atual está bloqueada.</translation>
+    </message>
+    <message>
+        <source>The current column is not visible in Camera Stand.</source>
+        <translation>A coluna atual não está visível no suporte da câmera.</translation>
+    </message>
+    <message>
+        <source>It is not possible to edit the audio column.</source>
+        <translation>Não é possível editar a coluna de áudio.</translation>
+    </message>
+    <message>
+        <source>It is not possible to edit the Magpie column.</source>
+        <translation>Não é possível editar a coluna Magpie.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on a Level column.</source>
+        <translation>A ferramenta atual não pode ser usada em uma coluna de Nível.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on a Mesh column.</source>
+        <translation>A ferramenta atual não pode ser usada em uma coluna de Malha.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used in Level Strip mode.</source>
+        <translation>A ferramenta atual não pode ser usada no modo Level Strip.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used to edit a motion path.</source>
+        <translation>A ferramenta atual não pode ser usada para editar um caminho de movimento.</translation>
+    </message>
+    <message>
+        <source>The current level is not editable.</source>
+        <translation>O nível atual não é editável.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on a Vector Level.</source>
+        <translation>A ferramenta atual não pode ser usada em um nível vetorial.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on a Toonz Level.</source>
+        <translation>A ferramenta atual não pode ser usada em um nível Toonz.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on a Raster Level.</source>
+        <translation>A ferramenta atual não pode ser usada em um nível Raster.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on a Mesh Level.</source>
+        <translation>A ferramenta atual não pode ser usada em um nível de malha.</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on a mesh-deformed level</source>
+        <translation>A ferramenta atual não pode ser usada em um nível de malha deformada</translation>
+    </message>
+    <message>
+        <source>The current frame is locked: any editing is forbidden.</source>
+        <translation>O quadro atual está bloqueado: qualquer edição é proibida.</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation>Colar</translation>
+    </message>
+    <message>
+        <source>Move Center</source>
+        <translation>Mover Centro</translation>
+    </message>
+    <message>
+        <source>RGB Picker (R%1, G%2, B%3)</source>
+        <translation>Seletor RGB (R%1, G%2, B%3)</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Grupo</translation>
+    </message>
+    <message>
+        <source>Ungroup</source>
+        <translation>Desagrupar</translation>
+    </message>
+    <message>
+        <source>Move Group</source>
+        <translation>Mover grupo</translation>
+    </message>
+    <message>
+        <source>Modify Fx Gadget  </source>
+        <translation>Modificar gadget Fx</translation>
+    </message>
+    <message>
+        <source>%1   Level : %2  Frame : %3</source>
+        <translation>% 1 Nível: % 2 Quadro: % 3</translation>
+    </message>
+    <message>
+        <source>Modify Stroke Tool</source>
+        <translation>Ferramenta Modificar Traço</translation>
+    </message>
+    <message>
+        <source>Modify Spline</source>
+        <translation>Modificar Spline</translation>
+    </message>
+    <message>
+        <source>Deform Raster</source>
+        <translation>Deformar Raster</translation>
+    </message>
+    <message>
+        <source>Transform Raster</source>
+        <translation>Transformar Raster</translation>
+    </message>
+    <message>
+        <source>Set Save Box : (X%1,Y%2,W%3,H%4)-&gt;(X%5,Y%6,W%7,H%8)</source>
+        <translation>Definir caixa de salvamento: (X%1,Y%2,W%3,H%4)-&gt;(X%5,Y%6,W%7,H%8)</translation>
+    </message>
+    <message>
+        <source>The current column is hidden.</source>
+        <translation>A coluna atual está oculta.</translation>
+    </message>
+    <message>
+        <source>Note columns can only be edited in the xsheet or timeline.</source>
+        <translation>As colunas de notas só podem ser editadas na xsheet ou na linha do tempo.</translation>
+    </message>
+    <message>
+        <source> to Front</source>
+        <translation>para frente</translation>
+    </message>
+    <message>
+        <source> to Forward</source>
+        <translation>para encaminhar</translation>
+    </message>
+    <message>
+        <source> to Back</source>
+        <translation>para trás</translation>
+    </message>
+    <message>
+        <source> to Backward</source>
+        <translation>para trás</translation>
+    </message>
+    <message>
+        <source>The selection cannot be updated. It is not editable.</source>
+        <translation>A seleção não pode ser atualizada. Não é editável.</translation>
+    </message>
+    <message>
+        <source>The selection cannot be deleted. It is not editable.</source>
+        <translation>A seleção não pode ser excluída. Não é editável.</translation>
+    </message>
+    <message>
+        <source>The selection cannot be pasted. It is not editable.</source>
+        <translation>A seleção não pode ser colada. Não é editável.</translation>
+    </message>
+    <message>
+        <source>The selection cannot be grouped. It is not editable.</source>
+        <translation>A seleção não pode ser agrupada. Não é editável.</translation>
+    </message>
+    <message>
+        <source>The selection cannot be entered. It is not editable.</source>
+        <translation>A seleção não pode ser inserida. Não é editável.</translation>
+    </message>
+    <message>
+        <source>The selection cannot be ungrouped. It is not editable.</source>
+        <translation>A seleção não pode ser desagrupada. Não é editável.</translation>
+    </message>
+    <message>
+        <source>The selection cannot be moved. It is not editable.</source>
+        <translation>A seleção não pode ser movida. Não é editável.</translation>
+    </message>
+    <message>
+        <source>Snap At Intersection</source>
+        <translation>Snap na interseção</translation>
+    </message>
+    <message>
+        <source>Sort Vector Strokes With Palette Order Level : %1 Frame : %2</source>
+        <translation>Classificar traços vetoriais com nível de ordem da paleta: %1 Quadro: %2</translation>
+    </message>
+    <message>
+        <source>Sort Vector Strokes With Palette Order Level : %1</source>
+        <translation>Classificar traços vetoriais com nível de ordem de paleta:% 1</translation>
+    </message>
+    <message>
+        <source>The current tool cannot be used on: </source>
+        <translation>A ferramenta atual não pode ser usada em:</translation>
+    </message>
+    <message>
+        <source>, </source>
+        <translation>, </translation>
+    </message>
+    <message>
+        <source>You can use this tool on empty cell in Xsheet/Timeline.</source>
+        <translation>Você pode usar esta ferramenta em uma célula vazia no Xsheet/Timeline.</translation>
+    </message>
+    <message>
+        <source>You can use this tool with: </source>
+        <translation>Você pode usar esta ferramenta com:</translation>
+    </message>
+    <message>
+        <source>Or just choose an empty cell in Xsheet/Timeline.</source>
+        <translation>Ou apenas escolha uma célula vazia no Xsheet/Timeline.</translation>
+    </message>
+</context>
+<context>
+    <name>RGBPickerTool</name>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Passive Pick</source>
+        <translation>Escolha Passiva</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normal</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand</source>
+        <translation>À mão livre</translation>
+    </message>
+    <message>
+        <source>Polyline</source>
+        <translation>Polilinha</translation>
+    </message>
+</context>
+<context>
+    <name>RGBPickerToolOptionsBox</name>
+    <message>
+        <source>Pick Screen</source>
+        <translation>Escolher tela</translation>
+    </message>
+</context>
+<context>
+    <name>RasterSelectionTool</name>
+    <message>
+        <source>Modify Savebox</source>
+        <translation>Modificar Savebox</translation>
+    </message>
+    <message>
+        <source>No Antialiasing</source>
+        <translation>Sem antialiasing</translation>
+    </message>
+</context>
+<context>
+    <name>RasterTapeTool</name>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Distance:</source>
+        <translation>Distância:</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation>Índice de estilo:</translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation>Opacidade:</translation>
+    </message>
+    <message>
+        <source>Frame Range</source>
+        <translation>Faixa de quadros</translation>
+    </message>
+    <message>
+        <source>Angle:</source>
+        <translation>Ângulo:</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normal</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand</source>
+        <translation>À mão livre</translation>
+    </message>
+    <message>
+        <source>Polyline</source>
+        <translation>Polilinha</translation>
+    </message>
+    <message>
+        <source>current</source>
+        <translation>atual</translation>
+    </message>
+    <message>
+        <source>Ignore AutoPaint Inks</source>
+        <translation>Ignorar tintas AutoPaint</translation>
+    </message>
+</context>
+<context>
+    <name>RotateTool</name>
+    <message>
+        <source>Rotate On Camera Center</source>
+        <translation>Girar no centro da câmera</translation>
+    </message>
+    <message>
+        <source>Rotate by Step</source>
+        <translation>Girar passo a passo</translation>
+    </message>
+    <message>
+        <source>Step Angle:</source>
+        <translation>Ângulo de passo:</translation>
+    </message>
+    <message>
+        <source>Rotate Left/Right Angle:</source>
+        <translation>Girar ângulo esquerdo/direito:</translation>
+    </message>
+</context>
+<context>
+    <name>RotateToolOptionsBox</name>
+    <message>
+        <source>Reset Rotation</source>
+        <translation>Redefinir rotação</translation>
+    </message>
+</context>
+<context>
+    <name>RulerToolOptionsBox</name>
+    <message>
+        <source>X:</source>
+        <comment>ruler tool option</comment>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <source>Y:</source>
+        <comment>ruler tool option</comment>
+        <translation>E:</translation>
+    </message>
+    <message>
+        <source>W:</source>
+        <comment>ruler tool option</comment>
+        <translation>C:</translation>
+    </message>
+    <message>
+        <source>H:</source>
+        <comment>ruler tool option</comment>
+        <translation>H:</translation>
+    </message>
+    <message>
+        <source>A:</source>
+        <comment>ruler tool option</comment>
+        <translation>UM:</translation>
+    </message>
+    <message>
+        <source>L:</source>
+        <comment>ruler tool option</comment>
+        <translation>eu:</translation>
+    </message>
+</context>
+<context>
+    <name>SelectionTool</name>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand</source>
+        <translation>À mão livre</translation>
+    </message>
+    <message>
+        <source>Polyline</source>
+        <translation>Polilinha</translation>
+    </message>
+</context>
+<context>
+    <name>SelectionToolOptionsBox</name>
+    <message>
+        <source>H:</source>
+        <translation>H:</translation>
+    </message>
+    <message>
+        <source>V:</source>
+        <translation>V:</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>Rotação</translation>
+    </message>
+    <message>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <source>Y:</source>
+        <translation>E:</translation>
+    </message>
+    <message>
+        <source>Thickness</source>
+        <translation>Grossura</translation>
+    </message>
+    <message>
+        <source>Link</source>
+        <translation>Link</translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation>Escala</translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation>Posição</translation>
+    </message>
+    <message>
+        <source>Flip Selection Horizontally</source>
+        <translation>Inverter seleção horizontalmente</translation>
+    </message>
+    <message>
+        <source>Flip Selection Vertically</source>
+        <translation>Inverter seleção verticalmente</translation>
+    </message>
+    <message>
+        <source>Rotate Selection Left</source>
+        <translation>Girar seleção para a esquerda</translation>
+    </message>
+    <message>
+        <source>Rotate Selection Right</source>
+        <translation>Girar seleção para a direita</translation>
+    </message>
+</context>
+<context>
+    <name>ShiftTraceToolOptionBox</name>
+    <message>
+        <source>Reset Previous</source>
+        <translation>Redefinir anterior</translation>
+    </message>
+    <message>
+        <source>Reset Following</source>
+        <translation>Redefinir seguinte</translation>
+    </message>
+    <message>
+        <source>Previous Drawing</source>
+        <translation>Desenho Anterior</translation>
+    </message>
+    <message>
+        <source>Following Drawing</source>
+        <translation>Seguindo o desenho</translation>
+    </message>
+</context>
+<context>
+    <name>SkeletonTool</name>
+    <message>
+        <source>Show Only Active Skeleton</source>
+        <translation>Mostrar apenas esqueleto ativo</translation>
+    </message>
+    <message>
+        <source>Global Key</source>
+        <translation>Chave Global</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Reset Pinned Center</source>
+        <translation>Redefinir centro fixado</translation>
+    </message>
+    <message>
+        <source>Build Skeleton</source>
+        <translation>Construir Esqueleto</translation>
+    </message>
+    <message>
+        <source>Animate</source>
+        <translation>Animar</translation>
+    </message>
+    <message>
+        <source>Inverse Kinematics</source>
+        <translation>Cinemática Inversa</translation>
+    </message>
+</context>
+<context>
+    <name>StylePickerTool</name>
+    <message>
+        <source>No current level.</source>
+        <translation>Nenhum nível atual.</translation>
+    </message>
+    <message>
+        <source>Current level has no available palette.</source>
+        <translation>O nível atual não tem paleta disponível.</translation>
+    </message>
+    <message>
+        <source>Palette must have more than one palette to be organized.</source>
+        <translation>A paleta deve ter mais de uma paleta para ser organizada.</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Passive Pick</source>
+        <translation>Escolha Passiva</translation>
+    </message>
+    <message>
+        <source>Organize Palette</source>
+        <translation>Organizar paleta</translation>
+    </message>
+    <message>
+        <source>Lines</source>
+        <translation>Linhas</translation>
+    </message>
+    <message>
+        <source>Areas</source>
+        <translation>Áreas</translation>
+    </message>
+    <message>
+        <source>Lines &amp; Areas</source>
+        <translation>Linhas e áreas</translation>
+    </message>
+    <message>
+        <source>No available palette.</source>
+        <translation>Nenhuma paleta disponível.</translation>
+    </message>
+    <message>
+        <source>Palette to be organized must have more than one page.</source>
+        <translation>A paleta a ser organizada deve ter mais de uma página.</translation>
+    </message>
+</context>
+<context>
+    <name>StylePickerToolOptionsBox</name>
+    <message>
+        <source>With this option being activated, the picked style will be
+moved to the end of the first page of the palette.</source>
+        <translation>Com esta opção ativada, o estilo escolhido será
+movido para o final da primeira página da paleta.</translation>
+    </message>
+    <message>
+        <source>With this option being activated, the picked style will replace
+the current style in current level.</source>
+        <translation>Com esta opção ativada, o estilo escolhido substituirá
+o estilo atual no nível atual.</translation>
+    </message>
+    <message>
+        <source>With this option being activated, the picked style will be
+moved to the end of the current style's page of the palette.</source>
+        <translation>Com esta opção ativada, o estilo escolhido será
+movido para o final da página do estilo atual da paleta.</translation>
+    </message>
+</context>
+<context>
+    <name>TAssistant</name>
+    <message>
+        <source>Magnetism</source>
+        <translation>Magnetismo</translation>
+    </message>
+</context>
+<context>
+    <name>TAssistantBase</name>
+    <message>
+        <source>Enabled</source>
+        <translation>Habilitado</translation>
+    </message>
+</context>
+<context>
+    <name>TAssistantEllipse</name>
+    <message>
+        <source>Fish Eye</source>
+        <translation>Olho de peixe</translation>
+    </message>
+    <message>
+        <source>Circle</source>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <source>Grid</source>
+        <translation>Grade</translation>
+    </message>
+    <message>
+        <source>Depth Grid</source>
+        <translation>Grade de profundidade</translation>
+    </message>
+    <message>
+        <source>Flip Grids</source>
+        <translation>Inverter grades</translation>
+    </message>
+    <message>
+        <source>Ellipse</source>
+        <translation>Elipse</translation>
+    </message>
+    <message>
+        <source>Restrict A</source>
+        <translation>Restringir A</translation>
+    </message>
+    <message>
+        <source>Restrict B</source>
+        <translation>Restringir B</translation>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation>Repita</translation>
+    </message>
+    <message>
+        <source>Perspective</source>
+        <translation>Perspectiva</translation>
+    </message>
+    <message>
+        <source>Depth</source>
+        <translation>Profundidade</translation>
+    </message>
+</context>
+<context>
+    <name>TAssistantPerspective</name>
+    <message>
+        <source>Perspective</source>
+        <translation>Perspectiva</translation>
+    </message>
+    <message>
+        <source>Parallel X</source>
+        <translation>Paralelo X</translation>
+    </message>
+    <message>
+        <source>Parallel Y</source>
+        <translation>Paralelo Y</translation>
+    </message>
+    <message>
+        <source>Parallel Z</source>
+        <translation>Paralelo Z</translation>
+    </message>
+    <message>
+        <source>Grid XY</source>
+        <translation>Grade XY</translation>
+    </message>
+    <message>
+        <source>Grid YZ</source>
+        <translation>Grade YZ</translation>
+    </message>
+    <message>
+        <source>Grid ZX</source>
+        <translation>Grade ZX</translation>
+    </message>
+    <message>
+        <source>Show Box</source>
+        <translation>Mostrar caixa</translation>
+    </message>
+</context>
+<context>
+    <name>TAssistantVanishingPoint</name>
+    <message>
+        <source>Vanishing Point</source>
+        <translation>Ponto de Fuga</translation>
+    </message>
+    <message>
+        <source>Pass Through</source>
+        <translation>Passar</translation>
+    </message>
+    <message>
+        <source>Grid</source>
+        <translation>Grade</translation>
+    </message>
+    <message>
+        <source>Perspective</source>
+        <translation>Perspectiva</translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation>Linha</translation>
+    </message>
+    <message>
+        <source>Restrict A</source>
+        <translation>Restringir A</translation>
+    </message>
+    <message>
+        <source>Restrict B</source>
+        <translation>Restringir B</translation>
+    </message>
+    <message>
+        <source>Parallel</source>
+        <translation>Paralelo</translation>
+    </message>
+</context>
+<context>
+    <name>TReplicator</name>
+    <message>
+        <source>Skip First Tracks</source>
+        <translation>Pular as primeiras faixas</translation>
+    </message>
+    <message>
+        <source>Skip Last Tracks</source>
+        <translation>Pular últimas faixas</translation>
+    </message>
+</context>
+<context>
+    <name>TReplicatorAffine</name>
+    <message>
+        <source>Replicator Affine</source>
+        <translation>Replicador Afim</translation>
+    </message>
+    <message>
+        <source>Fix Scale</source>
+        <translation>Escala fixa</translation>
+    </message>
+    <message>
+        <source>Fix Aspect</source>
+        <translation>Corrigir aspecto</translation>
+    </message>
+    <message>
+        <source>Fix Angle</source>
+        <translation>Fixar ângulo</translation>
+    </message>
+    <message>
+        <source>Fix Skew</source>
+        <translation>Corrigir distorção</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation>Contar</translation>
+    </message>
+    <message>
+        <source>Inv. Count</source>
+        <translation>Inv. Contar</translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation>Pressão</translation>
+    </message>
+</context>
+<context>
+    <name>TReplicatorGrid</name>
+    <message>
+        <source>Replicator Grid</source>
+        <translation>Grade replicadora</translation>
+    </message>
+    <message>
+        <source>Fix Angle</source>
+        <translation>Fixar ângulo</translation>
+    </message>
+    <message>
+        <source>Fix Skew</source>
+        <translation>Corrigir distorção</translation>
+    </message>
+    <message>
+        <source>Mirror A</source>
+        <translation>Espelho A</translation>
+    </message>
+    <message>
+        <source>Mirror B</source>
+        <translation>Espelho B</translation>
+    </message>
+    <message>
+        <source>Count A</source>
+        <translation>Contagem A</translation>
+    </message>
+    <message>
+        <source>Inv. Count A</source>
+        <translation>Inv. Contagem A</translation>
+    </message>
+    <message>
+        <source>Count B</source>
+        <translation>Contagem B</translation>
+    </message>
+    <message>
+        <source>Inv. Count B</source>
+        <translation>Inv. Contagem B</translation>
+    </message>
+</context>
+<context>
+    <name>TReplicatorJitter</name>
+    <message>
+        <source>Jitter</source>
+        <translation>Tremor</translation>
+    </message>
+    <message>
+        <source>Period</source>
+        <translation>Período</translation>
+    </message>
+    <message>
+        <source>Amplitude</source>
+        <translation>Amplitude</translation>
+    </message>
+    <message>
+        <source>Fix First Point</source>
+        <translation>Corrija o primeiro ponto</translation>
+    </message>
+    <message>
+        <source>Fix Last Point</source>
+        <translation>Corrigir o último ponto</translation>
+    </message>
+</context>
+<context>
+    <name>TReplicatorMirror</name>
+    <message>
+        <source>Replicator Mirror</source>
+        <translation>Espelho replicador</translation>
+    </message>
+    <message>
+        <source>Discrete Angle</source>
+        <translation>Ângulo Discreto</translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation>Pressão</translation>
+    </message>
+</context>
+<context>
+    <name>TReplicatorStar</name>
+    <message>
+        <source>Replicator Star</source>
+        <translation>Estrela Replicadora</translation>
+    </message>
+    <message>
+        <source>Discrete Angle</source>
+        <translation>Ângulo Discreto</translation>
+    </message>
+    <message>
+        <source>Mirror</source>
+        <translation>Espelho</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation>Contar</translation>
+    </message>
+</context>
+<context>
+    <name>TTool</name>
+    <message>
+        <source>Toonz Vector Level</source>
+        <translation>Nível de vetor Toonz</translation>
+    </message>
+    <message>
+        <source>Toonz Raster Level</source>
+        <translation>Nível Raster Toonz</translation>
+    </message>
+    <message>
+        <source>Raster Level</source>
+        <translation>Nível raster</translation>
+    </message>
+    <message>
+        <source>Mesh Level</source>
+        <translation>Nível de malha</translation>
+    </message>
+    <message>
+        <source>Assistants Level</source>
+        <translation>Nível de assistentes</translation>
+    </message>
+</context>
+<context>
+    <name>ToonzRasterBrushTool</name>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Hardness:</source>
+        <translation>Dureza:</translation>
+    </message>
+    <message>
+        <source>Smooth:</source>
+        <translation>Suave:</translation>
+    </message>
+    <message>
+        <source>Draw Order:</source>
+        <translation>Ordem do sorteio:</translation>
+    </message>
+    <message>
+        <source>Over All</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <source>Under All</source>
+        <translation>Abaixo de tudo</translation>
+    </message>
+    <message>
+        <source>Palette Order</source>
+        <translation>Ordem da paleta</translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation>Predefinição:</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>Pencil</source>
+        <translation>Lápis</translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation>Pressão</translation>
+    </message>
+    <message>
+        <source>Lock Alpha</source>
+        <translation>Bloquear Alfa</translation>
+    </message>
+    <message>
+        <source>Assistants</source>
+        <translation>Assistentes</translation>
+    </message>
+</context>
+<context>
+    <name>ToonzVectorBrushTool</name>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Accuracy:</source>
+        <translation>Precisão:</translation>
+    </message>
+    <message>
+        <source>Smooth:</source>
+        <translation>Suave:</translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation>Predefinição:</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>Break</source>
+        <translation>Quebrar</translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation>Pressão</translation>
+    </message>
+    <message>
+        <source>Cap</source>
+        <translation>Boné</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation>Juntar</translation>
+    </message>
+    <message>
+        <source>Miter:</source>
+        <translation>Mitra:</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation>Faixa:</translation>
+    </message>
+    <message>
+        <source>Snap</source>
+        <translation>Encaixe</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Desligado</translation>
+    </message>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>In</source>
+        <translation>Em</translation>
+    </message>
+    <message>
+        <source>Out</source>
+        <translation>Fora</translation>
+    </message>
+    <message>
+        <source>In&amp;Out</source>
+        <translation>Entrada e saída</translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation>Baixo</translation>
+    </message>
+    <message>
+        <source>Med</source>
+        <translation>Com</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>Alto</translation>
+    </message>
+    <message>
+        <source>Butt cap</source>
+        <translation>Tampa traseira</translation>
+    </message>
+    <message>
+        <source>Round cap</source>
+        <translation>Boné redondo</translation>
+    </message>
+    <message>
+        <source>Projecting cap</source>
+        <translation>Tampa de projeção</translation>
+    </message>
+    <message>
+        <source>Miter join</source>
+        <translation>Junção de mitra</translation>
+    </message>
+    <message>
+        <source>Round join</source>
+        <translation>Junção redonda</translation>
+    </message>
+    <message>
+        <source>Bevel join</source>
+        <translation>Junção chanfrada</translation>
+    </message>
+    <message>
+        <source>Draw Order:</source>
+        <translation>Ordem do sorteio:</translation>
+    </message>
+    <message>
+        <source>Over All</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <source>Under All</source>
+        <translation>Abaixo de tudo</translation>
+    </message>
+    <message>
+        <source>Palette Order</source>
+        <translation>Ordem da paleta</translation>
+    </message>
+    <message>
+        <source>Assistants</source>
+        <translation>Assistentes</translation>
+    </message>
+</context>
+<context>
+    <name>TrackerTool</name>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <source>Y:</source>
+        <translation>E:</translation>
+    </message>
+</context>
+<context>
+    <name>TypeTool</name>
+    <message>
+        <source>Font:</source>
+        <translation>Fonte:</translation>
+    </message>
+    <message>
+        <source>Style:</source>
+        <translation>Estilo:</translation>
+    </message>
+    <message>
+        <source>Vertical Orientation</source>
+        <translation>Orientação vertical</translation>
+    </message>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+</context>
+<context>
+    <name>VectorSelectionTool</name>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Preserve Thickness</source>
+        <translation>Preservar espessura</translation>
+    </message>
+    <message>
+        <source>Cap</source>
+        <translation>Boné</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation>Juntar</translation>
+    </message>
+    <message>
+        <source>Miter:</source>
+        <translation>Mitra:</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <source>Selected Frames</source>
+        <translation>Quadros selecionados</translation>
+    </message>
+    <message>
+        <source>Whole Level</source>
+        <translation>Nível inteiro</translation>
+    </message>
+    <message>
+        <source>Same Style</source>
+        <translation>Mesmo estilo</translation>
+    </message>
+    <message>
+        <source>Same Style on Selected Frames</source>
+        <translation>Mesmo estilo nas quadros selecionadas</translation>
+    </message>
+    <message>
+        <source>Same Style on Whole Level</source>
+        <translation>Mesmo estilo em todo o nível</translation>
+    </message>
+    <message>
+        <source>Boundary Strokes</source>
+        <translation>Traços de limite</translation>
+    </message>
+    <message>
+        <source>Boundaries on Selected Frames</source>
+        <translation>Limites em quadros selecionados</translation>
+    </message>
+    <message>
+        <source>Boundaries on Whole Level</source>
+        <translation>Limites em todo o nível</translation>
+    </message>
+    <message>
+        <source>Butt cap</source>
+        <translation>Tampa traseira</translation>
+    </message>
+    <message>
+        <source>Round cap</source>
+        <translation>Boné redondo</translation>
+    </message>
+    <message>
+        <source>Projecting cap</source>
+        <translation>Tampa de projeção</translation>
+    </message>
+    <message>
+        <source>Miter join</source>
+        <translation>Junção de mitra</translation>
+    </message>
+    <message>
+        <source>Round join</source>
+        <translation>Junção redonda</translation>
+    </message>
+    <message>
+        <source>Bevel join</source>
+        <translation>Junção chanfrada</translation>
+    </message>
+    <message>
+        <source>Include Intersection</source>
+        <translation>Incluir intersecção</translation>
+    </message>
+</context>
+<context>
+    <name>VectorTapeTool</name>
+    <message>
+        <source>Smooth</source>
+        <translation>Suave</translation>
+    </message>
+    <message>
+        <source>Join Vectors</source>
+        <translation>Junte-se a vetores</translation>
+    </message>
+    <message>
+        <source>Distance</source>
+        <translation>Distância</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Endpoint to Endpoint</source>
+        <translation>Ponto final a ponto final</translation>
+    </message>
+    <message>
+        <source>Endpoint to Line</source>
+        <translation>Ponto final para linha</translation>
+    </message>
+    <message>
+        <source>Line to Line</source>
+        <translation>Linha a Linha</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normal</translation>
+    </message>
+    <message>
+        <source>Rectangular</source>
+        <translation>Retangular</translation>
+    </message>
+</context>
+<context>
+    <name>ZoomToolOptionsBox</name>
+    <message>
+        <source>Reset Zoom</source>
+        <translation>Redefinir zoom</translation>
+    </message>
+</context>
+</TS>

--- a/toonz/sources/translations/portuguese_brazil/toonz.ts
+++ b/toonz/sources/translations/portuguese_brazil/toonz.ts
@@ -1,0 +1,19118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR" sourcelanguage="en">
+<context>
+    <name>AddFilmstripFramesPopup</name>
+    <message>
+        <source>Add Frames</source>
+        <translation>Adicionar quadros</translation>
+    </message>
+    <message>
+        <source>From Frame:</source>
+        <translation>Do quadro:</translation>
+    </message>
+    <message>
+        <source>To Frame:</source>
+        <translation>Para enquadrar:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>AdjustLevelsPopup</name>
+    <message>
+        <source>Adjust Levels</source>
+        <translation>Ajustar níveis</translation>
+    </message>
+    <message>
+        <source>Clamp</source>
+        <translation>Braçadeira</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>Reiniciar</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+</context>
+<context>
+    <name>AdjustThicknessPopup</name>
+    <message>
+        <source>Adjust Thickness</source>
+        <translation>Ajustar espessura</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Scale Thickness</source>
+        <translation>Espessura da escala</translation>
+    </message>
+    <message>
+        <source>Add Thickness</source>
+        <translation>Adicionar espessura</translation>
+    </message>
+    <message>
+        <source>Constant Thickness</source>
+        <translation>Espessura Constante</translation>
+    </message>
+    <message>
+        <source>Start:</source>
+        <translation>Começar:</translation>
+    </message>
+    <message>
+        <source>End:</source>
+        <translation>Fim:</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+</context>
+<context>
+    <name>AntialiasPopup</name>
+    <message>
+        <source>Apply Antialias</source>
+        <translation>Aplicar antialias</translation>
+    </message>
+    <message>
+        <source>Threshold:</source>
+        <translation>Limite:</translation>
+    </message>
+    <message>
+        <source>Softness:</source>
+        <translation>Suavidade:</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+</context>
+<context>
+    <name>ApplyMatchlinesCommand</name>
+    <message>
+        <source>It is not possible to apply the match lines because no column was selected.</source>
+        <translation>Não é possível aplicar as linhas coincidentes porque nenhuma coluna foi selecionada.</translation>
+    </message>
+    <message>
+        <source>It is not possible to apply the match lines because two columns have to be selected.</source>
+        <translation>Não é possível aplicar as linhas coincidentes porque é necessário selecionar duas colunas.</translation>
+    </message>
+</context>
+<context>
+    <name>AudioRecordingPopup</name>
+    <message>
+        <source>Audio Recording</source>
+        <translation>Gravação de áudio</translation>
+    </message>
+    <message>
+        <source>Save and Insert</source>
+        <translation>Salvar e inserir</translation>
+    </message>
+    <message>
+        <source>Sync with XSheet</source>
+        <translation>Sincronizar com XSheet</translation>
+    </message>
+    <message>
+        <source> </source>
+        <translation />
+    </message>
+    <message>
+        <source>The microphone is not available: 
+Please select a different device or check the microphone.</source>
+        <translation>O microfone não está disponível: 
+Selecione um dispositivo diferente ou verifique o microfone.</translation>
+    </message>
+    <message>
+        <source>Sync with XSheet/Timeline</source>
+        <translation>Sincronizar com XSheet/Linha do tempo</translation>
+    </message>
+    <message>
+        <source>Device: </source>
+        <translation>Dispositivo:</translation>
+    </message>
+    <message>
+        <source>Sample rate: </source>
+        <translation>Taxa de amostragem:</translation>
+    </message>
+    <message>
+        <source>Sample format: </source>
+        <translation>Formato de amostra:</translation>
+    </message>
+    <message>
+        <source>8000 Hz</source>
+        <translation>8.000Hz</translation>
+    </message>
+    <message>
+        <source>11025 Hz</source>
+        <translation>11.025Hz</translation>
+    </message>
+    <message>
+        <source>22050 Hz</source>
+        <translation>22.050Hz</translation>
+    </message>
+    <message>
+        <source>44100 Hz</source>
+        <translation>44.100Hz</translation>
+    </message>
+    <message>
+        <source>48000 Hz</source>
+        <translation>48.000Hz</translation>
+    </message>
+    <message>
+        <source>96000 Hz</source>
+        <translation>96.000Hz</translation>
+    </message>
+    <message>
+        <source>Mono 8-Bits</source>
+        <translation>Mono 8 bits</translation>
+    </message>
+    <message>
+        <source>Stereo 8-Bits</source>
+        <translation>Estéreo de 8 bits</translation>
+    </message>
+    <message>
+        <source>Mono 16-Bits</source>
+        <translation>Mono 16 bits</translation>
+    </message>
+    <message>
+        <source>Stereo 16-Bits</source>
+        <translation>Estéreo de 16 bits</translation>
+    </message>
+    <message>
+        <source>Audio input device to record</source>
+        <translation>Dispositivo de entrada de áudio para gravar</translation>
+    </message>
+    <message>
+        <source>Number of samples per second, 44.1KHz = CD Quality</source>
+        <translation>Número de amostras por segundo, 44,1 KHz = Qualidade do CD</translation>
+    </message>
+    <message>
+        <source>Number of channels and bits per sample, 16-bits recommended</source>
+        <translation>Número de canais e bits por amostra, recomendado 16 bits</translation>
+    </message>
+    <message>
+        <source>Play animation from current frame while recording/playback</source>
+        <translation>Reproduzir animação do quadro atual durante a gravação/reprodução</translation>
+    </message>
+    <message>
+        <source>Save recording and insert into new column</source>
+        <translation>Salve a gravação e insira em uma nova coluna</translation>
+    </message>
+    <message>
+        <source>Refresh list of connected audio input devices</source>
+        <translation>Atualizar lista de dispositivos de entrada de áudio conectados</translation>
+    </message>
+    <message>
+        <source>Record failed: 
+Make sure there's XSheet or Timeline in the room.</source>
+        <translation>Falha no registro: 
+Certifique-se de que haja XSheet ou Timeline na sala.</translation>
+    </message>
+    <message>
+        <source>Failed to save WAV file:
+Make sure you have write permissions in folder.</source>
+        <translation>Falha ao salvar o arquivo WAV:
+Certifique-se de ter permissões de gravação na pasta.</translation>
+    </message>
+    <message>
+        <source>Audio format unsupported:
+Nearest format will be internally used.</source>
+        <translation>Formato de áudio não suportado:
+O formato mais próximo será usado internamente.</translation>
+    </message>
+    <message>
+        <source>192000 Hz</source>
+        <translation>192.000Hz</translation>
+    </message>
+    <message>
+        <source>Mono 24-Bits</source>
+        <translation>Mono 24 bits</translation>
+    </message>
+    <message>
+        <source>Stereo 24-Bits</source>
+        <translation>Estéreo de 24 bits</translation>
+    </message>
+    <message>
+        <source>Mono 32-Bits</source>
+        <translation>Mono 32 bits</translation>
+    </message>
+    <message>
+        <source>Stereo 32-Bits</source>
+        <translation>Estéreo de 32 bits</translation>
+    </message>
+    <message>
+        <source>Bind to Current Room</source>
+        <translation>Vincular à sala atual</translation>
+    </message>
+</context>
+<context>
+    <name>AutoInputCellNumberPopup</name>
+    <message>
+        <source>Auto Input Cell Number</source>
+        <translation>Número de célula de entrada automática</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation>Inserir</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>with</source>
+        <translation>com</translation>
+    </message>
+    <message>
+        <source>frames increment</source>
+        <translation>incremento de quadros</translation>
+    </message>
+    <message>
+        <source>inserting</source>
+        <translation>inserindo</translation>
+    </message>
+    <message>
+        <source>empty cell intervals</source>
+        <translation>intervalos de células vazias</translation>
+    </message>
+    <message>
+        <source>cell steps</source>
+        <translation>passos de célula</translation>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation>Repita</translation>
+    </message>
+    <message>
+        <source>times</source>
+        <translation>vezes</translation>
+    </message>
+    <message>
+        <source>No available cells or columns are selected.</source>
+        <translation>Nenhuma célula ou coluna disponível está selecionada.</translation>
+    </message>
+    <message>
+        <source>Selected level has no frames between From and To.</source>
+        <translation>O nível selecionado não possui quadros entre De e Até.</translation>
+    </message>
+    <message>
+        <source>Setting this value 0 will automatically 
+pick up all frames in the selected level.</source>
+        <translation>Definir este valor como 0 irá automaticamente 
+pegue todos os quadros no nível selecionado.</translation>
+    </message>
+    <message>
+        <source>From frame</source>
+        <translation>Do quadro</translation>
+    </message>
+    <message>
+        <source> </source>
+        <comment>from frame</comment>
+        <translation />
+    </message>
+    <message>
+        <source>To frame</source>
+        <translation>Para enquadrar</translation>
+    </message>
+    <message>
+        <source> </source>
+        <comment>to frame</comment>
+        <translation />
+    </message>
+</context>
+<context>
+    <name>AutoLipSyncPopup</name>
+    <message>
+        <source>Auto Lip Sync</source>
+        <translation>Sincronização labial automática</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>A I Drawing</source>
+        <translation>Um desenho eu</translation>
+    </message>
+    <message>
+        <source>O Drawing</source>
+        <translation>Ó Desenho</translation>
+    </message>
+    <message>
+        <source>E Drawing</source>
+        <translation>E Desenho</translation>
+    </message>
+    <message>
+        <source>U Drawing</source>
+        <translation>U Desenho</translation>
+    </message>
+    <message>
+        <source>L Drawing</source>
+        <translation>L Desenho</translation>
+    </message>
+    <message>
+        <source>W Q Drawing</source>
+        <translation>W Q Desenho</translation>
+    </message>
+    <message>
+        <source>M B P Drawing</source>
+        <translation>Desenho M B P</translation>
+    </message>
+    <message>
+        <source>F V Drawing</source>
+        <translation>Desenho F V</translation>
+    </message>
+    <message>
+        <source>Rest Drawing</source>
+        <translation>Desenho de descanso</translation>
+    </message>
+    <message>
+        <source>C D G K N R S Th Y Z</source>
+        <translation>C D G K N R S Th Y Z</translation>
+    </message>
+    <message>
+        <source>Extend Rest Drawing to End Marker</source>
+        <translation>Estender o desenho restante até o marcador final</translation>
+    </message>
+    <message>
+        <source>Audio Source: </source>
+        <translation>Fonte de áudio:</translation>
+    </message>
+    <message>
+        <source>Audio Script (Optional, Improves accuracy): </source>
+        <translation>Script de áudio (opcional, melhora a precisão):</translation>
+    </message>
+    <message>
+        <source>A script significantly increases the accuracy of the lip sync.</source>
+        <translation>Um script aumenta significativamente a precisão da sincronização labial.</translation>
+    </message>
+    <message>
+        <source>Previous Drawing</source>
+        <translation>Desenho Anterior</translation>
+    </message>
+    <message>
+        <source>Next Drawing</source>
+        <translation>Próximo desenho</translation>
+    </message>
+    <message>
+        <source>Insert at Frame: </source>
+        <translation>Inserir no quadro:</translation>
+    </message>
+    <message>
+        <source>Thumbnails are not available for sub-Xsheets.
+Please use the frame numbers for reference.</source>
+        <translation>As miniaturas não estão disponíveis para sub-Xsheets.
+Por favor, use os números dos quadros como referência.</translation>
+    </message>
+    <message>
+        <source>Unable to apply lip sync data to this column type</source>
+        <translation>Não foi possível aplicar dados de sincronização labial a este tipo de coluna</translation>
+    </message>
+    <message>
+        <source>Rhubarb not found, please set the location in Preferences.</source>
+        <translation>Rhubarb não encontrado, defina o local em Preferências.</translation>
+    </message>
+    <message>
+        <source>Choose File...</source>
+        <translation>Escolha Arquivo...</translation>
+    </message>
+    <message>
+        <source>Please choose an audio file and try again.</source>
+        <translation>Escolha um arquivo de áudio e tente novamente.</translation>
+    </message>
+    <message>
+        <source>Rhubarb Processing Error:
+
+</source>
+        <translation>Erro de processamento de Rhubarb:</translation>
+    </message>
+    <message>
+        <source>Please choose a lip sync data file to continue.</source>
+        <translation>Escolha um arquivo de dados de sincronização labial para continuar.</translation>
+    </message>
+    <message>
+        <source>Cannot find the file specified. 
+Please choose a valid lip sync data file to continue.</source>
+        <translation>Não é possível localizar o arquivo especificado. 
+Escolha um arquivo de dados de sincronização labial válido para continuar.</translation>
+    </message>
+    <message>
+        <source>Unable to open the file: 
+</source>
+        <translation>Não foi possível abrir o arquivo:</translation>
+    </message>
+    <message>
+        <source>Invalid data file.
+ Please choose a valid lip sync data file to continue.</source>
+        <translation>Arquivo de dados inválido.
+ Escolha um arquivo de dados de sincronização labial válido para continuar.</translation>
+    </message>
+    <message>
+        <source>SubXSheet Frame </source>
+        <translation>Quadro SubXSheet</translation>
+    </message>
+    <message>
+        <source>Drawing: </source>
+        <translation>Desenho:</translation>
+    </message>
+    <message>
+        <source>Analyzing audio...</source>
+        <translation>Analisando áudio...</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Frame </source>
+        <translation>Quadro</translation>
+    </message>
+    <message>
+        <source>Audio file field is not available.</source>
+        <translation>O campo arquivo de áudio não está disponível.</translation>
+    </message>
+    <message>
+        <source>Please select an audio file first.</source>
+        <translation>Selecione um arquivo de áudio primeiro.</translation>
+    </message>
+    <message>
+        <source>Audio file does not exist.</source>
+        <translation>O arquivo de áudio não existe.</translation>
+    </message>
+    <message>
+        <source>Rhubarb process timed out after %1 seconds. The process may be stuck.</source>
+        <translation>O processo do Rhubarb expirou após %1 segundos. O processo pode estar travado.</translation>
+    </message>
+    <message>
+        <source>Rhubarb process crashed.</source>
+        <translation>O processo do Rhubarb travou.</translation>
+    </message>
+    <message>
+        <source>Rhubarb failed to start. Check if the path is correct.</source>
+        <translation>Rhubarb não conseguiu iniciar. Verifique se o caminho está correto.</translation>
+    </message>
+    <message>
+        <source>Rhubarb crashed during execution.</source>
+        <translation>Rhubarb caiu durante a execução.</translation>
+    </message>
+    <message>
+        <source>Rhubarb process timed out.</source>
+        <translation>O processo de Rhubarb expirou.</translation>
+    </message>
+    <message>
+        <source>Communication error with Rhubarb process.</source>
+        <translation>Erro de comunicação com o processo Rhubarb.</translation>
+    </message>
+    <message>
+        <source>Unknown error occurred with Rhubarb.</source>
+        <translation>Ocorreu um erro desconhecido com o Rhubarb.</translation>
+    </message>
+    <message>
+        <source>Cancelling...</source>
+        <translation>Cancelando...</translation>
+    </message>
+</context>
+<context>
+    <name>AutocenterPopup</name>
+    <message>
+        <source>Autocenter</source>
+        <translation>Centro de automóveis</translation>
+    </message>
+    <message>
+        <source>Pegbar Holes:</source>
+        <translation>Furos de barra:</translation>
+    </message>
+    <message>
+        <source>Field Guide:</source>
+        <translation>Guia de campo:</translation>
+    </message>
+</context>
+<context>
+    <name>BaseViewerPanel</name>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation>Mostrar/ocultar GUI</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation>Barra de ferramentas de reprodução</translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation>Controle deslizante de quadro</translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation>Área segura (clique com o botão direito para selecionar)</translation>
+    </message>
+    <message>
+        <source>Field Guide</source>
+        <translation>Guia de campo</translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation>Vista do suporte da câmera</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation>Visualização 3D</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation>Visualização da câmera</translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation>Congelar</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation>Visualização da subcâmera</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation>Sem título</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation>Cena:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation>::   Quadro:</translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation>:: Zoom:</translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation>(Invertido)</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation>::   Nível:</translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation>Nível:</translation>
+    </message>
+</context>
+<context>
+    <name>BatchServersViewer</name>
+    <message>
+        <source>Process with:</source>
+        <translation>Processar com:</translation>
+    </message>
+    <message>
+        <source>Local</source>
+        <translation>Local</translation>
+    </message>
+    <message>
+        <source>Render Farm</source>
+        <translation>Fazenda de renderização</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>IP Address:</source>
+        <translation>Endereço IP:</translation>
+    </message>
+    <message>
+        <source>Port Number:</source>
+        <translation>Número da porta:</translation>
+    </message>
+    <message>
+        <source>Tasks:</source>
+        <translation>Tarefas:</translation>
+    </message>
+    <message>
+        <source>State:</source>
+        <translation>Estado:</translation>
+    </message>
+    <message>
+        <source>Number of CPU:</source>
+        <translation>Número de CPU:</translation>
+    </message>
+    <message>
+        <source>Physical Memory:</source>
+        <translation>Memória Física:</translation>
+    </message>
+    <message>
+        <source>Farm Global Root:</source>
+        <translation>Raiz Global da Fazenda:</translation>
+    </message>
+    <message>
+        <source>In order to use the render farm you have to define the Farm Global Root first.</source>
+        <translation>Para usar o farm de renderização, você deve primeiro definir a raiz global do farm.</translation>
+    </message>
+    <message>
+        <source>The Farm Global Root folder doesn't exist
+Please create this folder before using the render farm.</source>
+        <translation>A pasta Farm Global Root não existe
+Crie esta pasta antes de usar o Renderizar farm.</translation>
+    </message>
+    <message>
+        <source>Unable to connect to the ToonzFarm Controller
+   The Controller should run on %1 at port %2
+   Please start the Controller before using the ToonzFarm</source>
+        <translation>Não é possível conectar ao controlador ToonzFarm
+   O Controlador deverá rodar em % 1 na porta % 2
+   Por favor, inicie o controlador antes de usar o ToonzFarm</translation>
+    </message>
+</context>
+<context>
+    <name>BatchesController</name>
+    <message>
+        <source>Tasks</source>
+        <translation>Tarefas</translation>
+    </message>
+    <message>
+        <source>The Task List is empty!</source>
+        <translation>A Lista de Tarefas está vazia!</translation>
+    </message>
+    <message>
+        <source>The current task list has been modified.
+Do you want to save your changes?</source>
+        <translation>A lista de tarefas atual foi modificada.
+Quer salvar suas alterações?</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Discard</source>
+        <translation>Descartar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>The %1 task is currently active.
+Stop it or wait for its completion before removing it.</source>
+        <translation>A tarefa %1 está atualmente ativa.
+Pare-o ou aguarde a sua conclusão antes de removê-lo.</translation>
+    </message>
+</context>
+<context>
+    <name>BinarizePopup</name>
+    <message>
+        <source>Binarize</source>
+        <translation>Binarizar</translation>
+    </message>
+    <message>
+        <source>Alpha</source>
+        <translation>Alfa</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>No raster frames selected</source>
+        <translation>Nenhum quadro raster selecionado</translation>
+    </message>
+    <message>
+        <source>Binarizing images</source>
+        <translation>Binarizando imagens</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>BoardSettingsPopup</name>
+    <message>
+        <source>Clapperboard Settings</source>
+        <translation>Configurações da claquete</translation>
+    </message>
+    <message>
+        <source>Load Preset</source>
+        <translation>Carregar predefinição</translation>
+    </message>
+    <message>
+        <source>Save as Preset</source>
+        <translation>Salvar como predefinição</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Duration (frames):</source>
+        <translation>Duração (quadros):</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>Texto</translation>
+    </message>
+    <message>
+        <source>Project name</source>
+        <translation>Nome do projeto</translation>
+    </message>
+    <message>
+        <source>Scene name</source>
+        <translation>Nome da cena</translation>
+    </message>
+    <message>
+        <source>Duration : Frame</source>
+        <translation>Duração: Quadro</translation>
+    </message>
+    <message>
+        <source>Duration : Sec + Frame</source>
+        <translation>Duração: Segundo + Quadro</translation>
+    </message>
+    <message>
+        <source>Duration : HH:MM:SS:FF</source>
+        <translation>Duração: HH:MM:SS:FF</translation>
+    </message>
+    <message>
+        <source>Current date</source>
+        <translation>Data atual</translation>
+    </message>
+    <message>
+        <source>Current date and time</source>
+        <translation>Data e hora atuais</translation>
+    </message>
+    <message>
+        <source>User name</source>
+        <translation>Nome de usuário</translation>
+    </message>
+    <message>
+        <source>Scene location : Aliased path</source>
+        <translation>Localização da cena: caminho com alias</translation>
+    </message>
+    <message>
+        <source>Scene location : Full path</source>
+        <translation>Localização da cena: Caminho completo</translation>
+    </message>
+    <message>
+        <source>Output location : Aliased path</source>
+        <translation>Local de saída: caminho com alias</translation>
+    </message>
+    <message>
+        <source>Output location : Full path</source>
+        <translation>Local de saída: caminho completo</translation>
+    </message>
+    <message>
+        <source>Image</source>
+        <translation>Imagem</translation>
+    </message>
+    <message>
+        <source>Export Board Image</source>
+        <translation>Exportar imagem do quadro</translation>
+    </message>
+    <message>
+        <source>File Name Suffix:</source>
+        <translation>Sufixo do nome do arquivo:</translation>
+    </message>
+    <message>
+        <source>File name suffix can't be empty.</source>
+        <translation>O sufixo do nome do arquivo não pode estar vazio.</translation>
+    </message>
+    <message>
+        <source>There is no board image to export.</source>
+        <translation>Não há imagem de quadro para exportar.</translation>
+    </message>
+    <message>
+        <source>It is not possible to save because the selected file format is not supported.</source>
+        <translation>Não é possível salvar porque o formato de arquivo selecionado não é compatível.</translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+</context>
+<context>
+    <name>BoardView</name>
+    <message>
+        <source>Please set the duration more than 0 frame first, or the clapperboard settings will not be saved in the scene at all!</source>
+        <translation>Defina a duração para mais de 0 quadro primeiro, ou as configurações da claquete não serão salvas na cena!</translation>
+    </message>
+</context>
+<context>
+    <name>BrightnessAndContrastPopup</name>
+    <message>
+        <source>Brightness and Contrast</source>
+        <translation>Brilho e Contraste</translation>
+    </message>
+    <message>
+        <source>Brightness:</source>
+        <translation>Brilho:</translation>
+    </message>
+    <message>
+        <source>Contrast:</source>
+        <translation>Contraste:</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+</context>
+<context>
+    <name>BrowserPopup</name>
+    <message>
+        <source>Choose</source>
+        <translation>Escolher</translation>
+    </message>
+    <message>
+        <source>Path %1 doesn't exists.</source>
+        <translation>O caminho% 1 não existe.</translation>
+    </message>
+</context>
+<context>
+    <name>BrushPresetPanel</name>
+    <message>
+        <source>No brush tool selected</source>
+        <translation>Nenhuma ferramenta de pincel selecionada</translation>
+    </message>
+    <message>
+        <source>Remove selected preset</source>
+        <translation>Remover predefinição selecionada</translation>
+    </message>
+    <message>
+        <source>Add current settings as new preset</source>
+        <translation>Adicione as configurações atuais como uma nova predefinição</translation>
+    </message>
+    <message>
+        <source>Refresh preset list</source>
+        <translation>Atualizar lista predefinida</translation>
+    </message>
+    <message>
+        <source>View mode</source>
+        <translation>Modo de visualização</translation>
+    </message>
+    <message>
+        <source>Brush Presets</source>
+        <translation>Predefinições de pincel</translation>
+    </message>
+    <message>
+        <source>Vector Brush</source>
+        <translation>Pincel vetorial</translation>
+    </message>
+    <message>
+        <source>Toonz Raster Brush</source>
+        <translation>Pincel raster Toonz</translation>
+    </message>
+    <message>
+        <source>MyPaint Brush</source>
+        <translation>Pincel MyPaint</translation>
+    </message>
+    <message>
+        <source>MyPaint Brush Tnz</source>
+        <translation>Pincel MyPaint Tnz</translation>
+    </message>
+    <message>
+        <source>Raster Brush</source>
+        <translation>Pincel raster</translation>
+    </message>
+    <message>
+        <source>Invalid Name</source>
+        <translation>Nome inválido</translation>
+    </message>
+    <message>
+        <source>Please enter a valid preset name.</source>
+        <translation>Insira um nome predefinido válido.</translation>
+    </message>
+    <message>
+        <source>Add Preset</source>
+        <translation>Adicionar predefinição</translation>
+    </message>
+    <message>
+        <source>Please use the [+] button in the Tool Options Bar to add new presets.
+
+The new preset will automatically appear in this panel.</source>
+        <translation>Use o botão [+] na barra de opções de ferramentas para adicionar novas predefinições.
+
+A nova predefinição aparecerá automaticamente neste painel.</translation>
+    </message>
+    <message>
+        <source>Remove Preset</source>
+        <translation>Remover predefinição</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove the preset '%1'?</source>
+        <translation>Tem certeza de que deseja remover a predefinição '%1'?</translation>
+    </message>
+    <message>
+        <source>Please use the [-] button in the Tool Options Bar to remove presets.
+
+The change will automatically be reflected in this panel.</source>
+        <translation>Use o botão [-] na barra de opções de ferramentas para remover predefinições.
+
+A alteração será refletida automaticamente neste painel.</translation>
+    </message>
+    <message>
+        <source>List</source>
+        <translation>Lista</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>Pequeno</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation>Médio</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>Grande</translation>
+    </message>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation>Mostrar/ocultar GUI</translation>
+    </message>
+    <message>
+        <source>Cell Borders</source>
+        <translation>Fronteiras celulares</translation>
+    </message>
+    <message>
+        <source>Cell Backgrounds</source>
+        <translation>Fundos de células</translation>
+    </message>
+    <message>
+        <source> [WIP]</source>
+        <translation>[WIP]</translation>
+    </message>
+</context>
+<context>
+    <name>CameraCaptureLevelControl</name>
+    <message>
+        <source>Black Point Value</source>
+        <translation>Valor do ponto preto</translation>
+    </message>
+    <message>
+        <source>White Point Value</source>
+        <translation>Valor do ponto branco</translation>
+    </message>
+    <message>
+        <source>Threshold Value</source>
+        <translation>Valor limite</translation>
+    </message>
+    <message>
+        <source>Gamma Value</source>
+        <translation>Valor gama</translation>
+    </message>
+</context>
+<context>
+    <name>CameraCaptureLevelHistogram</name>
+    <message>
+        <source>Click to Update Histogram</source>
+        <translation>Clique para atualizar o histograma</translation>
+    </message>
+    <message>
+        <source>Drag to Move White Point</source>
+        <translation>Arraste para mover o ponto branco</translation>
+    </message>
+    <message>
+        <source>Drag to Move Gamma</source>
+        <translation>Arraste para mover gama</translation>
+    </message>
+    <message>
+        <source>Drag to Move Black Point</source>
+        <translation>Arraste para mover o ponto preto</translation>
+    </message>
+    <message>
+        <source>Drag to Move Threshold Point</source>
+        <translation>Arraste para mover o ponto limite</translation>
+    </message>
+</context>
+<context>
+    <name>CameraSettingsPopup</name>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Camera#%1 Settings</source>
+        <translation>Configurações da câmera#%1</translation>
+    </message>
+    <message>
+        <source>Current Camera Settings</source>
+        <translation>Configurações atuais da câmera</translation>
+    </message>
+</context>
+<context>
+    <name>CameraTrackPreviewArea</name>
+    <message>
+        <source>Fit To Window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+</context>
+<context>
+    <name>Canon</name>
+    <message>
+        <source>AC Power</source>
+        <translation>Alimentação CA</translation>
+    </message>
+    <message>
+        <source>Full</source>
+        <translation>Completo</translation>
+    </message>
+</context>
+<context>
+    <name>CanvasSizePopup</name>
+    <message>
+        <source>Canvas Size</source>
+        <translation>Tamanho da tela</translation>
+    </message>
+    <message>
+        <source>Current Size</source>
+        <translation>Tamanho atual</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>New Size</source>
+        <translation>Novo tamanho</translation>
+    </message>
+    <message>
+        <source>Unit:</source>
+        <translation>Unidade:</translation>
+    </message>
+    <message>
+        <source>Relative</source>
+        <translation>Relativo</translation>
+    </message>
+    <message>
+        <source>Anchor</source>
+        <translation>Âncora</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Resize</source>
+        <translation>Redimensionar</translation>
+    </message>
+    <message>
+        <source>The new canvas size is smaller than the current one.
+Do you want to crop the canvas?</source>
+        <translation>O novo tamanho da tela é menor que o atual.
+Você quer cortar a tela?</translation>
+    </message>
+    <message>
+        <source>Crop</source>
+        <translation>Cortar</translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation>pixel</translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation>milímetros</translation>
+    </message>
+    <message>
+        <source>cm</source>
+        <translation>cm</translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation>campo</translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation>polegada</translation>
+    </message>
+</context>
+<context>
+    <name>CaptureSettingsPopup</name>
+    <message>
+        <source>Define Device</source>
+        <translation>Definir dispositivo</translation>
+    </message>
+    <message>
+        <source>V Resolution</source>
+        <translation>Resolução V</translation>
+    </message>
+    <message>
+        <source>H Resolution</source>
+        <translation>Resolução H</translation>
+    </message>
+    <message>
+        <source>White Calibration</source>
+        <translation>Calibração de Branco</translation>
+    </message>
+    <message>
+        <source>Capture</source>
+        <translation>Capturar</translation>
+    </message>
+    <message>
+        <source>Brightness:</source>
+        <translation>Brilho:</translation>
+    </message>
+    <message>
+        <source>Contrast:</source>
+        <translation>Contraste:</translation>
+    </message>
+    <message>
+        <source> Upside-down</source>
+        <translation>De cabeça para baixo</translation>
+    </message>
+    <message>
+        <source>A Device is Connected.</source>
+        <translation>Um dispositivo está conectado.</translation>
+    </message>
+    <message>
+        <source>No cameras found.</source>
+        <translation>Nenhuma câmera encontrada.</translation>
+    </message>
+    <message>
+        <source>Device Disconnected.</source>
+        <translation>Dispositivo desconectado.</translation>
+    </message>
+    <message>
+        <source>No Device Defined.</source>
+        <translation>Nenhum dispositivo definido.</translation>
+    </message>
+</context>
+<context>
+    <name>CastBrowser</name>
+    <message>
+        <source>It is not possible to edit the selected file.</source>
+        <translation>Não é possível editar o arquivo selecionado.</translation>
+    </message>
+    <message>
+        <source>It is not possible to edit more than one file at once.</source>
+        <translation>Não é possível editar mais de um arquivo ao mesmo tempo.</translation>
+    </message>
+    <message>
+        <source>It is not possible to show the folder containing the selected file, as the file has not been saved yet.</source>
+        <translation>Não é possível mostrar a pasta que contém o arquivo selecionado, pois o arquivo ainda não foi salvo.</translation>
+    </message>
+    <message>
+        <source>It is not possible to view the selected file, as the file has not been saved yet.</source>
+        <translation>Não é possível visualizar o arquivo selecionado, pois o arquivo ainda não foi salvo.</translation>
+    </message>
+    <message>
+        <source>It is not possible to show the info of the selected file, as the file has not been saved yet.</source>
+        <translation>Não é possível mostrar as informações do arquivo selecionado, pois o arquivo ainda não foi salvo.</translation>
+    </message>
+</context>
+<context>
+    <name>CastTreeViewer</name>
+    <message>
+        <source>Delete folder </source>
+        <translation>Excluir pasta</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+</context>
+<context>
+    <name>CellMarksPopup</name>
+    <message>
+        <source>Cell Marks Settings</source>
+        <translation>Configurações de marcas de células</translation>
+    </message>
+</context>
+<context>
+    <name>ChooseCameraDialog</name>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>CleanupPopup</name>
+    <message>
+        <source>Do you want to cleanup this frame?</source>
+        <translation>Você quer limpar este quadro?</translation>
+    </message>
+    <message>
+        <source>Cleanup</source>
+        <translation>Limpar</translation>
+    </message>
+    <message>
+        <source>Cleanup in progress</source>
+        <translation>Limpeza em andamento</translation>
+    </message>
+    <message>
+        <source>Skip</source>
+        <translation>Pular</translation>
+    </message>
+    <message>
+        <source>Cleanup All</source>
+        <translation>Limpar tudo</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Cleanup in progress: </source>
+        <translation>Limpeza em andamento:</translation>
+    </message>
+    <message>
+        <source>It is not possible to cleanup: the cleanup list is empty.</source>
+        <translation>Não é possível limpar: a lista de limpeza está vazia.</translation>
+    </message>
+    <message>
+        <source>The resulting resolution of level "%1"
+does not match with that of previously cleaned up level drawings.
+
+Please set the right camera resolution and closest field, or choose to delete
+the existing level and create a new one when running the cleanup process.</source>
+        <translation>A resolução resultante do nível "%1"
+não corresponde aos desenhos de nível previamente limpos.
+
+Defina a resolução correta da câmera e o campo mais próximo ou opte por excluir
+o nível existente e crie um novo ao executar o processo de limpeza.</translation>
+    </message>
+    <message>
+        <source>Selected drawings will overwrite the original files after the cleanup process.
+Do you want to continue?</source>
+        <translation>Os desenhos selecionados substituirão os arquivos originais após o processo de limpeza.
+Você quer continuar?</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>There were errors opening the existing level "%1".
+
+Please choose to delete the existing level and create a new one
+when running the cleanup process.</source>
+        <translation>Ocorreram erros ao abrir o nível existente "%1".
+
+Por favor, escolha excluir o nível existente e criar um novo
+ao executar o processo de limpeza.</translation>
+    </message>
+    <message>
+        <source>Couldn't create directory "%1"</source>
+        <translation>Não foi possível criar o diretório "%1"</translation>
+    </message>
+    <message>
+        <source>Couldn't open "%1" for write</source>
+        <translation>Não foi possível abrir "% 1" para escrita</translation>
+    </message>
+    <message>
+        <source>Couldn't remove file "%1"</source>
+        <translation>Não foi possível remover o arquivo "%1"</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>Exibir</translation>
+    </message>
+    <message>
+        <source> : Cleanup in progress</source>
+        <translation>: Limpeza em andamento</translation>
+    </message>
+</context>
+<context>
+    <name>CleanupPopup::OverwriteDialog</name>
+    <message>
+        <source>Warning!</source>
+        <translation>Aviso!</translation>
+    </message>
+    <message>
+        <source>Cleanup all selected drawings overwriting those previously cleaned up.</source>
+        <translation>Limpa todos os desenhos selecionados, substituindo aqueles previamente limpos.</translation>
+    </message>
+    <message>
+        <source>Cleanup only non-cleaned up drawings and keep those previously cleaned up.</source>
+        <translation>Limpe apenas os desenhos não limpos e mantenha aqueles previamente limpos.</translation>
+    </message>
+    <message>
+        <source>Delete existing level and create a new level with selected drawings only.</source>
+        <translation>Exclua o nível existente e crie um novo nível apenas com os desenhos selecionados.</translation>
+    </message>
+    <message>
+        <source>Rename the new level adding the suffix </source>
+        <translation>Renomeie o novo nível adicionando o sufixo</translation>
+    </message>
+    <message>
+        <source>File "%1" already exists.
+What do you want to do?</source>
+        <translation>O arquivo "%1" já existe.
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Cleanup all selected drawings overwriting those previously cleaned up.*</source>
+        <translation>Limpe todos os desenhos selecionados, substituindo aqueles limpos anteriormente.*</translation>
+    </message>
+    <message>
+        <source>Cleanup only non-cleaned up drawings and keep those previously cleaned up.*</source>
+        <translation>Limpe apenas os desenhos não limpos e mantenha aqueles previamente limpos.*</translation>
+    </message>
+    <message>
+        <source>This is Re-Cleanup. Overwrite only to the no-paint files.</source>
+        <translation>Esta é a nova limpeza. Substitua apenas os arquivos sem pintura.</translation>
+    </message>
+    <message>
+        <source>* Palette will not be changed.</source>
+        <translation>* A paleta não será alterada.</translation>
+    </message>
+</context>
+<context>
+    <name>CleanupSettings</name>
+    <message>
+        <source>Cleanup</source>
+        <translation>Limpar</translation>
+    </message>
+    <message>
+        <source>Processing</source>
+        <translation>Processamento</translation>
+    </message>
+    <message>
+        <source>Camera</source>
+        <translation>Câmera</translation>
+    </message>
+    <message>
+        <source>Toggle Swatch Preview</source>
+        <translation>Alternar visualização da amostra</translation>
+    </message>
+    <message>
+        <source>Toggle Opacity Check</source>
+        <translation>Alternar verificação de opacidade</translation>
+    </message>
+    <message>
+        <source>Save Settings</source>
+        <translation>Salvar configurações</translation>
+    </message>
+    <message>
+        <source>Load Settings</source>
+        <translation>Carregar configurações</translation>
+    </message>
+    <message>
+        <source>Reset Settings</source>
+        <translation>Redefinir configurações</translation>
+    </message>
+    <message>
+        <source>Cleanup Settings</source>
+        <translation>Configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>Cleanup Settings: %1</source>
+        <translation>Configurações de limpeza: %1</translation>
+    </message>
+</context>
+<context>
+    <name>CleanupSettingsPane</name>
+    <message>
+        <source>Horizontal</source>
+        <translation>Horizontal</translation>
+    </message>
+    <message>
+        <source>Vertical</source>
+        <translation>Vertical</translation>
+    </message>
+    <message>
+        <source>MLAA Intensity:</source>
+        <translation>Intensidade MLAA:</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>Reiniciar</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Morphological</source>
+        <translation>Morfológico</translation>
+    </message>
+    <message>
+        <source>Greyscale</source>
+        <translation>Escala de cinza</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Rotate</source>
+        <translation>Girar</translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation>Virar</translation>
+    </message>
+    <message>
+        <source>Line Processing:</source>
+        <translation>Processamento de linha:</translation>
+    </message>
+    <message>
+        <source>Antialias:</source>
+        <translation>Antialias:</translation>
+    </message>
+    <message>
+        <source>Sharpness:</source>
+        <translation>Nitidez:</translation>
+    </message>
+    <message>
+        <source>Despeckling:</source>
+        <translation>Remoção de manchas:</translation>
+    </message>
+    <message>
+        <source>Save In</source>
+        <translation>Salvar em</translation>
+    </message>
+    <message>
+        <source>Please fill the Save In field.</source>
+        <translation>Preencha o campo Salvar em.</translation>
+    </message>
+    <message>
+        <source>Cleanup Settings (Global)</source>
+        <translation>Configurações de limpeza (global)</translation>
+    </message>
+    <message>
+        <source>Cleanup Settings: </source>
+        <translation>Configurações de limpeza:</translation>
+    </message>
+    <message>
+        <source>Cleanup Settings</source>
+        <translation>Configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>Cleanup Settings: %1</source>
+        <translation>Configurações de limpeza: %1</translation>
+    </message>
+    <message>
+        <source>Autocenter</source>
+        <translation>Centro de automóveis</translation>
+    </message>
+    <message>
+        <source>Pegbar Holes</source>
+        <translation>Furos de barra</translation>
+    </message>
+    <message>
+        <source>Field Guide</source>
+        <translation>Guia de campo</translation>
+    </message>
+    <message>
+        <source>Bottom</source>
+        <translation>Fundo</translation>
+    </message>
+    <message>
+        <source>Top</source>
+        <translation>Principal</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>Esquerda</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>Certo</translation>
+    </message>
+    <message>
+        <source>Format:</source>
+        <translation>Formatar:</translation>
+    </message>
+</context>
+<context>
+    <name>CleanupTab</name>
+    <message>
+        <source>Autocenter</source>
+        <translation>Centro de automóveis</translation>
+    </message>
+    <message>
+        <source>Pegbar Holes:</source>
+        <translation>Furos de barra:</translation>
+    </message>
+    <message>
+        <source>Field Guide:</source>
+        <translation>Guia de campo:</translation>
+    </message>
+    <message>
+        <source>Rotate:</source>
+        <translation>Girar:</translation>
+    </message>
+    <message>
+        <source>Flip:</source>
+        <translation>Virar:</translation>
+    </message>
+    <message>
+        <source>Horizontal</source>
+        <translation>Horizontal</translation>
+    </message>
+    <message>
+        <source>Vertical</source>
+        <translation>Vertical</translation>
+    </message>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+</context>
+<context>
+    <name>ClipListViewer</name>
+    <message>
+        <source>Load Scene</source>
+        <translation>Carregar cena</translation>
+    </message>
+</context>
+<context>
+    <name>CloneLevelUndo::LevelNamePopup</name>
+    <message>
+        <source>Clone Level</source>
+        <translation>Nível de clone</translation>
+    </message>
+    <message>
+        <source>Level Name:</source>
+        <translation>Nome do nível:</translation>
+    </message>
+</context>
+<context>
+    <name>ColorFiltersPopup</name>
+    <message>
+        <source>Color Filters Settings</source>
+        <translation>Configurações de filtros de cores</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation>Claro</translation>
+    </message>
+    <message>
+        <source>Color Filter %1</source>
+        <translation>Filtro de Cor % 1</translation>
+    </message>
+</context>
+<context>
+    <name>ColorModelBehaviorPopup</name>
+    <message>
+        <source>Select the Palette Operation</source>
+        <translation>Selecione a operação da paleta</translation>
+    </message>
+    <message>
+        <source>Overwrite the destination palette.</source>
+        <translation>Substitua a paleta de destino.</translation>
+    </message>
+    <message>
+        <source>Keep the destination palette and apply it to the color model.</source>
+        <translation>Mantenha a paleta de destino e aplique-a ao modelo de cores.</translation>
+    </message>
+    <message>
+        <source>The color model palette is different from the destination palette.
+What do you want to do? </source>
+        <translation>A paleta do modelo de cores é diferente da paleta de destino.
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Add color model's palette to the destination palette.</source>
+        <translation>Adicione a paleta do modelo de cores à paleta de destino.</translation>
+    </message>
+    <message>
+        <source>Picking Colors from Raster Image</source>
+        <translation>Escolhendo cores da imagem raster</translation>
+    </message>
+    <message>
+        <source>Pick Every Colors as Different Styles</source>
+        <translation>Escolha todas as cores como estilos diferentes</translation>
+    </message>
+    <message>
+        <source>Integrate Similar Colors as One Style</source>
+        <translation>Integre cores semelhantes como um estilo</translation>
+    </message>
+    <message>
+        <source>Pick Colors in Color Chip Grid</source>
+        <translation>Escolha cores na grade de chips de cores</translation>
+    </message>
+    <message>
+        <source>Horizontal - Top to bottom</source>
+        <translation>Horizontal – De cima para baixo</translation>
+    </message>
+    <message>
+        <source>Horizontal - Bottom to top</source>
+        <translation>Horizontal - De baixo para cima</translation>
+    </message>
+    <message>
+        <source>Vertical - Left to right</source>
+        <translation>Vertical - Da esquerda para a direita</translation>
+    </message>
+    <message>
+        <source>Pick Type:</source>
+        <translation>Tipo de escolha:</translation>
+    </message>
+    <message>
+        <source>Grid Line Color:</source>
+        <translation>Cor da linha de grade:</translation>
+    </message>
+    <message>
+        <source>Grid Line Width:</source>
+        <translation>Largura da linha de grade:</translation>
+    </message>
+    <message>
+        <source>Chip Order:</source>
+        <translation>Pedido de chips:</translation>
+    </message>
+</context>
+<context>
+    <name>ColorModelViewer</name>
+    <message>
+        <source>Color Model</source>
+        <translation>Modelo de cores</translation>
+    </message>
+    <message>
+        <source>Use Current Frame</source>
+        <translation>Usar quadro atual</translation>
+    </message>
+    <message>
+        <source>Remove Color Model</source>
+        <translation>Remover modelo de cores</translation>
+    </message>
+    <message>
+        <source>It is not possible to retrieve the color model set for the current level.</source>
+        <translation>Não é possível recuperar o modelo de cores definido para o nível atual.</translation>
+    </message>
+    <message>
+        <source>Reset View</source>
+        <translation>Redefinir visualização</translation>
+    </message>
+    <message>
+        <source>Fit to Window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+    <message>
+        <source>Update Colors by Using Picked Positions</source>
+        <translation>Atualizar cores usando posições escolhidas</translation>
+    </message>
+</context>
+<context>
+    <name>ComboViewerPanel</name>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation>Área segura (clique com o botão direito para selecionar)</translation>
+    </message>
+    <message>
+        <source>Field Guide</source>
+        <translation>Guia de campo</translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation>Vista do suporte da câmera</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation>Visualização 3D</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation>Visualização da câmera</translation>
+    </message>
+    <message>
+        <source>Freeze</source>
+        <translation>Congelar</translation>
+    </message>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation>Mostrar/ocultar GUI</translation>
+    </message>
+    <message>
+        <source>Toolbar</source>
+        <translation>Barra de ferramentas</translation>
+    </message>
+    <message>
+        <source>Tool Options Bar</source>
+        <translation>Barra de opções de ferramentas</translation>
+    </message>
+    <message>
+        <source>Console</source>
+        <translation>Console</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation>Visualização da subcâmera</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation>Sem título</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation>Cena:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation>::   Quadro:</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation>::   Nível:</translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation>Nível:</translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation>(Invertido)</translation>
+    </message>
+    <message>
+        <source>[SCENE]: </source>
+        <translation>[CENA]:</translation>
+    </message>
+    <message>
+        <source>[LEVEL]: </source>
+        <translation>[NÍVEL]:</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation>Barra de ferramentas de reprodução</translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation>Controle deslizante de quadro</translation>
+    </message>
+</context>
+<context>
+    <name>CommandBar</name>
+    <message>
+        <source>Customize Command Bar</source>
+        <translation>Personalizar barra de comandos</translation>
+    </message>
+</context>
+<context>
+    <name>CommandBarListTree</name>
+    <message>
+        <source>----Separator----</source>
+        <translation>----Separador----</translation>
+    </message>
+</context>
+<context>
+    <name>CommandBarPopup</name>
+    <message>
+        <source>XSheet Toolbar</source>
+        <translation>Barra de ferramentas XSheet</translation>
+    </message>
+    <message>
+        <source>Customize XSheet Toolbar</source>
+        <translation>Personalizar a barra de ferramentas XSheet</translation>
+    </message>
+    <message>
+        <source>Command Bar</source>
+        <translation>Barra de comando</translation>
+    </message>
+    <message>
+        <source>Customize Command Bar</source>
+        <translation>Personalizar barra de comandos</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Toolbar Items</source>
+        <translation>Itens da barra de ferramentas</translation>
+    </message>
+    <message>
+        <source>Duplicated commands will be ignored. Only the last one will appear in the menu bar.</source>
+        <translation>Comandos duplicados serão ignorados. Apenas o último aparecerá na barra de menu.</translation>
+    </message>
+    <message>
+        <source>Search:</source>
+        <translation>Procurar:</translation>
+    </message>
+</context>
+<context>
+    <name>CommandBarTree</name>
+    <message>
+        <source>Remove "%1"</source>
+        <translation>Remover "%1"</translation>
+    </message>
+</context>
+<context>
+    <name>CommandListTree</name>
+    <message>
+        <source>----Separator----</source>
+        <translation>----Separador----</translation>
+    </message>
+</context>
+<context>
+    <name>ConflictWidget</name>
+    <message>
+        <source>Mine</source>
+        <translation>Meu</translation>
+    </message>
+    <message>
+        <source>Theirs</source>
+        <translation>Deles</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertFolderPopup</name>
+    <message>
+        <source>Level %1 already exists; skipped.
+</source>
+        <translation>O nível %1 já existe; ignorado.</translation>
+    </message>
+    <message>
+        <source>Failed to remove existing level %1; skipped.
+</source>
+        <translation>Falha ao remover o nível %1 existente; ignorado.</translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation>Convertendo o nível %1 de %2: %3</translation>
+    </message>
+    <message>
+        <source>Convert aborted.
+</source>
+        <translation>Conversão abortada.</translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation>O nível %1 não possui quadro; ignorado.</translation>
+    </message>
+    <message>
+        <source>Convert TZP In Folder</source>
+        <translation>Converter TZP em pasta</translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation>Converter</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation>Ignorar arquivos existentes</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder</source>
+        <translation>Aplicar à subpasta</translation>
+    </message>
+    <message>
+        <source>Convert TZP in Folder</source>
+        <translation>Converter TZP em pasta</translation>
+    </message>
+    <message>
+        <source>Folder to convert:</source>
+        <translation>Pasta para converter:</translation>
+    </message>
+    <message>
+        <source>[SKIP] </source>
+        <translation>[PULAR]</translation>
+    </message>
+    <message>
+        <source>[OVERWRITE] </source>
+        <translation>[Substituir]</translation>
+    </message>
+    <message>
+        <source>Target folder is not specified.</source>
+        <translation>A pasta de destino não foi especificada.</translation>
+    </message>
+    <message>
+        <source>No files will be converted.</source>
+        <translation>Nenhum arquivo será convertido.</translation>
+    </message>
+    <message>
+        <source>Cofirmation</source>
+        <translation>Cofirmação</translation>
+    </message>
+    <message>
+        <source>Converting %1 files. Are you sure?</source>
+        <translation>Convertendo %1 arquivos. Tem certeza?</translation>
+    </message>
+    <message>
+        <source>Convert TZP in folder
+</source>
+        <translation>Converter TZP em pasta</translation>
+    </message>
+    <message>
+        <source>Target Folder: %1
+</source>
+        <translation>Pasta de destino:% 1</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files: %1
+</source>
+        <translation>Ignorar arquivos existentes:% 1</translation>
+    </message>
+    <message>
+        <source>Apply to Subfolder: %1
+</source>
+        <translation>Aplicar à subpasta: %1</translation>
+    </message>
+    <message>
+        <source>Approx. levels to be converted: %1
+
+</source>
+        <translation>Aprox. níveis a serem convertidos: % 1</translation>
+    </message>
+    <message>
+        <source>Started: </source>
+        <translation>Iniciado:</translation>
+    </message>
+    <message>
+        <source>Convert aborted:</source>
+        <translation>Conversão abortada:</translation>
+    </message>
+    <message>
+        <source>Convert completed:</source>
+        <translation>Conversão concluída:</translation>
+    </message>
+    <message>
+        <source>  %1 level(s) done, %2 level(s) skipped with %3 error(s).
+</source>
+        <translation>%1 nível(s) concluído(s), %2 nível(s) ignorado(s) com %3 erro(s).</translation>
+    </message>
+    <message>
+        <source>Ended: </source>
+        <translation>Terminou:</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertPopup</name>
+    <message>
+        <source>Convert</source>
+        <translation>Converter</translation>
+    </message>
+    <message>
+        <source>Start:</source>
+        <translation>Começar:</translation>
+    </message>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+    <message>
+        <source>File Format:</source>
+        <translation>Formato de arquivo:</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Converting %1</source>
+        <translation>Convertendo % 1</translation>
+    </message>
+    <message>
+        <source>Convert... </source>
+        <translation>Converter...</translation>
+    </message>
+    <message>
+        <source>Bg Color:</source>
+        <translation>Cor Bg:</translation>
+    </message>
+    <message>
+        <source>Skip Existing Files</source>
+        <translation>Ignorar arquivos existentes</translation>
+    </message>
+    <message>
+        <source>Convert 1 Level</source>
+        <translation>Converter 1 nível</translation>
+    </message>
+    <message>
+        <source>Convert %1 Levels</source>
+        <translation>Converter níveis %1</translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation>Convertendo o nível %1 de %2: %3</translation>
+    </message>
+    <message>
+        <source>Unpainted File Folder:</source>
+        <translation>Pasta de arquivo não pintada:</translation>
+    </message>
+    <message>
+        <source> Unpainted File Suffix:</source>
+        <translation>Sufixo de arquivo não pintado:</translation>
+    </message>
+    <message>
+        <source>Apply Autoclose</source>
+        <translation>Aplicar fechamento automático</translation>
+    </message>
+    <message>
+        <source>Keep Original Antialiasing</source>
+        <translation>Mantenha o antialiasing original</translation>
+    </message>
+    <message>
+        <source>Add Antialiasing with Intensity:</source>
+        <translation>Adicione Antialiasing com Intensidade:</translation>
+    </message>
+    <message>
+        <source>Remove Antialiasing using Threshold:</source>
+        <translation>Remova o antialiasing usando Threshold:</translation>
+    </message>
+    <message>
+        <source>                      Palette:</source>
+        <translation>Paleta:</translation>
+    </message>
+    <message>
+        <source>Tolerance:</source>
+        <translation>Tolerância:</translation>
+    </message>
+    <message>
+        <source>File to convert:</source>
+        <translation>Arquivo para converter:</translation>
+    </message>
+    <message>
+        <source>Output Name:</source>
+        <translation>Nome de saída:</translation>
+    </message>
+    <message>
+        <source>Same as Painted</source>
+        <translation>O mesmo que Pintado</translation>
+    </message>
+    <message>
+        <source>No unpainted suffix specified: cannot convert.</source>
+        <translation>Nenhum sufixo não pintado especificado: não é possível converter.</translation>
+    </message>
+    <message>
+        <source>Level </source>
+        <translation>Nível</translation>
+    </message>
+    <message>
+        <source> already exists; skipped</source>
+        <translation>já existe; ignorado</translation>
+    </message>
+    <message>
+        <source>Generating level </source>
+        <translation>Gerando nível</translation>
+    </message>
+    <message>
+        <source> converted to tlv.</source>
+        <translation>convertido para tlv.</translation>
+    </message>
+    <message>
+        <source>No output filename specified: please choose a valid level name.</source>
+        <translation>Nenhum nome de arquivo de saída especificado: escolha um nome de nível válido.</translation>
+    </message>
+    <message>
+        <source>End:</source>
+        <translation>Fim:</translation>
+    </message>
+    <message>
+        <source>Level %1 converted to TLV Format</source>
+        <translation>Nível %1 convertido para formato TLV</translation>
+    </message>
+    <message>
+        <source>Warning: Level %1 NOT converted to TLV Format</source>
+        <translation>Aviso: Nível %1 NÃO convertido para formato TLV</translation>
+    </message>
+    <message>
+        <source>Converted %1 out of %2 Levels to TLV Format</source>
+        <translation>Converteu %1 de %2 níveis para o formato TLV</translation>
+    </message>
+    <message>
+        <source>Level %1 already exists; skipped.</source>
+        <translation>O nível %1 já existe; ignorado.</translation>
+    </message>
+    <message>
+        <source>Level %1 has no frame; skipped.</source>
+        <translation>O nível %1 não possui quadro; ignorado.</translation>
+    </message>
+    <message>
+        <source>Unpainted tlv</source>
+        <translation>TLV sem pintura</translation>
+    </message>
+    <message>
+        <source>Painted tlv from two images</source>
+        <translation>tlv pintado a partir de duas imagens</translation>
+    </message>
+    <message>
+        <source>Painted tlv from non AA source</source>
+        <translation>Tlv pintado de fonte não AA</translation>
+    </message>
+    <message>
+        <source>Create new palette</source>
+        <translation>Criar nova paleta</translation>
+    </message>
+    <message>
+        <source>Stroke Mode:</source>
+        <translation>Modo de traço:</translation>
+    </message>
+    <message>
+        <source>Centerline</source>
+        <translation>Linha central</translation>
+    </message>
+    <message>
+        <source>Outline</source>
+        <translation>Contorno</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Warning: Can't read palette '%1' </source>
+        <translation>Aviso: não é possível ler a paleta '%1'</translation>
+    </message>
+    <message>
+        <source>Convert completed with %1 error(s) and %2 level(s) skipped</source>
+        <translation>Conversão concluída com %1 erros e %2 níveis ignorados</translation>
+    </message>
+    <message>
+        <source>Convert completed with %1 error(s) </source>
+        <translation>Conversão concluída com %1 erro(s)</translation>
+    </message>
+    <message>
+        <source>%1 level(s) skipped</source>
+        <translation>%1 nível(s) ignorado(s)</translation>
+    </message>
+    <message>
+        <source>Unpainted tlv from non AA source</source>
+        <translation>Tlv sem pintura de fonte não AA</translation>
+    </message>
+    <message>
+        <source>Remove dot before frame number</source>
+        <translation>Remova o ponto antes do número do quadro</translation>
+    </message>
+    <message>
+        <source>  End:</source>
+        <translation>Fim:</translation>
+    </message>
+    <message>
+        <source>File Name:</source>
+        <translation>Nome do arquivo:</translation>
+    </message>
+    <message>
+        <source>Save Backup to "nopaint" Folder</source>
+        <translation>Salve o backup na pasta "nopaint"</translation>
+    </message>
+    <message>
+        <source>Antialias:</source>
+        <translation>Antialias:</translation>
+    </message>
+    <message>
+        <source>Palette:</source>
+        <translation>Paleta:</translation>
+    </message>
+    <message>
+        <source>Append Default Palette</source>
+        <translation>Anexar paleta padrão</translation>
+    </message>
+    <message>
+        <source>When activated, styles of the default palette
+($TOONZSTUDIOPALETTE\cleanup_default.tpl) will 
+be appended to the palette after conversion in 
+order to save the effort of creating styles 
+before color designing.</source>
+        <translation>Quando ativado, os estilos da paleta padrão
+($TOONZSTUDIOPALETTE\cleanup_default.tpl) irá 
+ser anexado à paleta após a conversão em 
+para economizar o esforço de criação de estilos 
+antes do design de cores.</translation>
+    </message>
+    <message>
+        <source>Remove Unused Styles from Input Palette</source>
+        <translation>Remover estilos não utilizados da paleta de entrada</translation>
+    </message>
+    <message>
+        <source>Image DPI</source>
+        <translation>DPI da imagem</translation>
+    </message>
+    <message>
+        <source>Current Camera DPI</source>
+        <translation>DPI atual da câmera</translation>
+    </message>
+    <message>
+        <source>Custom DPI</source>
+        <translation>DPI personalizado</translation>
+    </message>
+    <message>
+        <source>Specify the policy for setting DPI of converted tlv. 
+If you select the "Image DPI" option and the source image does not 
+contain the dpi information, then the current camera dpi will be used.
+</source>
+        <translation>Especifique a política para definir o DPI do tlv convertido. 
+Se você selecionar a opção "Imagem DPI" e a imagem de origem não 
+contiver as informações de dpi, o dpi atual da câmera será usado.</translation>
+    </message>
+    <message>
+        <source>Dpi:</source>
+        <translation>Dpi:</translation>
+    </message>
+    <message>
+        <source>Level %1 converting to same file format; skipped.</source>
+        <translation>Nível %1 convertendo para o mesmo formato de arquivo; ignorado.</translation>
+    </message>
+    <message>
+        <source>When activated, styles of the default palette
+($TOONZSTUDIOPALETTE\Global Palettes\Default Palettes\Cleanup_Palette.tpl) will 
+be appended to the palette after conversion in 
+order to save the effort of creating styles 
+before color designing.</source>
+        <translation>Quando ativado, os estilos da paleta padrão
+($TOONZSTUDIOPALETTE\Global Palettes\Default Palettes\Cleanup_Palette.tpl) irá 
+ser anexado à paleta após a conversão em 
+para economizar o esforço de criação de estilos 
+antes do design de cores.</translation>
+    </message>
+    <message>
+        <source>Convert 1 Level : %1</source>
+        <translation>Converter 1 nível: %1</translation>
+    </message>
+</context>
+<context>
+    <name>ConvertResultPopup</name>
+    <message>
+        <source>Save log file..</source>
+        <translation>Salvar arquivo de log..</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Do you want to save the log?</source>
+        <translation>Deseja salvar o registro?</translation>
+    </message>
+</context>
+<context>
+    <name>CrashHandler</name>
+    <message>
+        <source>&lt;b&gt;OpenToonz crashed unexpectedly.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;O OpenToonz travou inesperadamente.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>A crash report has been generated.</source>
+        <translation>Um relatório de falha foi gerado.</translation>
+    </message>
+    <message>
+        <source>To report, click 'Open Issue Webpage' to access OpenToonz's Issues page on GitHub.</source>
+        <translation>Para relatar, clique em 'Abrir página de problemas' para acessar a página de problemas do OpenToonz no GitHub.</translation>
+    </message>
+    <message>
+        <source>Click on the 'New issue' button and fill out the form.</source>
+        <translation>Clique no botão 'Nova edição' e preencha o formulário.</translation>
+    </message>
+    <message>
+        <source>System Configuration and Problem Details:</source>
+        <translation>Configuração do sistema e detalhes do problema:</translation>
+    </message>
+    <message>
+        <source>Copy to Clipboard</source>
+        <translation>Copiar para a área de transferência</translation>
+    </message>
+    <message>
+        <source>Open Issue Webpage</source>
+        <translation>Abrir página do problema</translation>
+    </message>
+    <message>
+        <source>Open Reports Folder</source>
+        <translation>Abrir pasta de relatórios</translation>
+    </message>
+    <message>
+        <source>Close Application</source>
+        <translation>Fechar aplicativo</translation>
+    </message>
+    <message>
+        <source>OpenToonz crashed!</source>
+        <translation>OpenToonz travou!</translation>
+    </message>
+    <message>
+        <source>Application is in unstable state and must be restarted.</source>
+        <translation>O aplicativo está em estado instável e deve ser reiniciado.</translation>
+    </message>
+    <message>
+        <source>Resuming is not recommended and may lead to an unrecoverable crash.</source>
+        <translation>A retomada não é recomendada e pode levar a uma falha irrecuperável.</translation>
+    </message>
+    <message>
+        <source>Ignore advice and try to resume program?</source>
+        <translation>Ignorar conselhos e tentar retomar o programa?</translation>
+    </message>
+    <message>
+        <source>Ignore crash?</source>
+        <translation>Ignorar falha?</translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelEditorPopup</name>
+    <message>
+        <source>Template folder %1 not found.</source>
+        <translation>Pasta de modelos% 1 não encontrada.</translation>
+    </message>
+    <message>
+        <source>Template files not found.</source>
+        <translation>Arquivos de modelo não encontrados.</translation>
+    </message>
+    <message>
+        <source>%1 (Edit)</source>
+        <translation>% 1 (Editar)</translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation>Botão</translation>
+    </message>
+    <message>
+        <source>Scroller</source>
+        <translation>Rolador</translation>
+    </message>
+    <message>
+        <source>Please input the panel name.</source>
+        <translation>Por favor insira o nome do painel.</translation>
+    </message>
+    <message>
+        <source>The custom panel %1 already exists. Do you want to overwrite?</source>
+        <translation>O painel personalizado %1 já existe. Você deseja sobrescrever?</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Failed to create folder.</source>
+        <translation>Falha ao criar pasta.</translation>
+    </message>
+    <message>
+        <source>Failed to open the template.</source>
+        <translation>Falha ao abrir o modelo.</translation>
+    </message>
+    <message>
+        <source>Failed to open the file for writing.</source>
+        <translation>Falha ao abrir o arquivo para gravação.</translation>
+    </message>
+    <message>
+        <source>Custom Panel Editor</source>
+        <translation>Editor de painel personalizado</translation>
+    </message>
+    <message>
+        <source>a control in the panel</source>
+        <translation>um controle no painel</translation>
+    </message>
+    <message>
+        <source>Command List</source>
+        <translation>Lista de comandos</translation>
+    </message>
+    <message>
+        <source>Register</source>
+        <translation>Cadastre-se</translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation>Modelo:</translation>
+    </message>
+    <message>
+        <source>Search:</source>
+        <translation>Procurar:</translation>
+    </message>
+    <message>
+        <source>Panel name:</source>
+        <translation>Nome do painel:</translation>
+    </message>
+</context>
+<context>
+    <name>CustomPanelUIField</name>
+    <message>
+        <source>Drag and set command</source>
+        <translation>Comando arrastar e definir</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::ProgressDialog</name>
+    <message>
+        <source>Loading "%1"...</source>
+        <translation>Carregando "%1"...</translation>
+    </message>
+    <message>
+        <source>Importing "%1"...</source>
+        <translation>Importando "%1"...</translation>
+    </message>
+</context>
+<context>
+    <name>DateChooserWidget</name>
+    <message>
+        <source>time ago.</source>
+        <translation>há algum tempo.</translation>
+    </message>
+    <message>
+        <source>days ago.</source>
+        <translation>dias atrás.</translation>
+    </message>
+    <message>
+        <source>weeks ago.</source>
+        <translation>semanas atrás.</translation>
+    </message>
+    <message>
+        <source>( Custom date )</source>
+        <translation>(Data personalizada)</translation>
+    </message>
+</context>
+<context>
+    <name>DefineScannerPopup</name>
+    <message>
+        <source>Define Scanner</source>
+        <translation>Definir scanner</translation>
+    </message>
+    <message>
+        <source>Scanner Driver:</source>
+        <translation>Driver do scanner:</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>TWAIN</source>
+        <translation>DOIS</translation>
+    </message>
+    <message>
+        <source>Internal</source>
+        <translation>Interno</translation>
+    </message>
+</context>
+<context>
+    <name>DeleteInkDialog</name>
+    <message>
+        <source>Delete Lines</source>
+        <translation>Excluir linhas</translation>
+    </message>
+    <message>
+        <source>Style Index: </source>
+        <translation>Índice de estilo:</translation>
+    </message>
+    <message>
+        <source>Apply to Frames: </source>
+        <translation>Aplicar aos quadros:</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Style Index:</source>
+        <translation>Índice de estilo:</translation>
+    </message>
+    <message>
+        <source>Apply to Frames:</source>
+        <translation>Aplicar aos quadros:</translation>
+    </message>
+</context>
+<context>
+    <name>DuplicatePopup</name>
+    <message>
+        <source>Repeat</source>
+        <translation>Repita</translation>
+    </message>
+    <message>
+        <source>Times:</source>
+        <translation>Horários:</translation>
+    </message>
+    <message>
+        <source>Up to Frame:</source>
+        <translation>Até o quadro:</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+</context>
+<context>
+    <name>DvDirTreeView</name>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation>Pegar</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation>Colocar...</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Atualizar</translation>
+    </message>
+    <message>
+        <source>Cleanup</source>
+        <translation>Limpar</translation>
+    </message>
+    <message>
+        <source>Delete folder </source>
+        <translation>Excluir pasta</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Refresh operation failed:
+</source>
+        <translation>Falha na operação de atualização:</translation>
+    </message>
+    <message>
+        <source>Purge</source>
+        <translation>Purga</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete the folder.</source>
+        <translation>Não é possível excluir a pasta.</translation>
+    </message>
+    <message>
+        <source>Refreshing...</source>
+        <translation>Refrescante...</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation>Ocorreu um erro ao copiar % 1 para % 2</translation>
+    </message>
+    <message>
+        <source>The local path does not exist:</source>
+        <translation>O caminho local não existe:</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation>Desbloquear</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>Reverter</translation>
+    </message>
+</context>
+<context>
+    <name>DvItemViewerButtonBar</name>
+    <message>
+        <source>Up One Level</source>
+        <translation>Subir um nível</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation>Nova pasta</translation>
+    </message>
+    <message>
+        <source>Thumbnails View</source>
+        <translation>Visualização de miniaturas</translation>
+    </message>
+    <message>
+        <source>List View</source>
+        <translation>Visualização de lista</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation>Voltar</translation>
+    </message>
+    <message>
+        <source>Forward</source>
+        <translation>Avançar</translation>
+    </message>
+    <message>
+        <source>Icons View</source>
+        <translation>Visualização de ícones</translation>
+    </message>
+    <message>
+        <source>Export File List</source>
+        <translation>Exportar lista de arquivos</translation>
+    </message>
+    <message>
+        <source>Up</source>
+        <translation>Acima</translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation>Novo</translation>
+    </message>
+    <message>
+        <source>Icon</source>
+        <translation>Ícone</translation>
+    </message>
+    <message>
+        <source>List</source>
+        <translation>Lista</translation>
+    </message>
+</context>
+<context>
+    <name>DvItemViewerPanel</name>
+    <message>
+        <source>Save File List</source>
+        <translation>Salvar lista de arquivos</translation>
+    </message>
+    <message>
+        <source>File List (*.csv)</source>
+        <translation>Lista de arquivos (*.csv)</translation>
+    </message>
+</context>
+<context>
+    <name>DvTopBar</name>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Scan &amp;&amp; Cleanup</source>
+        <translation>Digitalizar e limpar</translation>
+    </message>
+    <message>
+        <source>Level</source>
+        <translation>Nível</translation>
+    </message>
+    <message>
+        <source>Xsheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>Cells</source>
+        <translation>Células</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>Exibir</translation>
+    </message>
+    <message>
+        <source>Windows</source>
+        <translation>Windows</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation>Digitalizar</translation>
+    </message>
+</context>
+<context>
+    <name>ExportAllLevelsPopup</name>
+    <message>
+        <source>Export All</source>
+        <translation>Exportar tudo</translation>
+    </message>
+    <message>
+        <source>Skip</source>
+        <translation>Pular</translation>
+    </message>
+    <message>
+        <source>No level found in the camera view or levels are null!!</source>
+        <translation>Nenhum nível encontrado na visualização da câmera ou os níveis são nulos!!</translation>
+    </message>
+    <message>
+        <source>Please select a Folder!</source>
+        <translation>Selecione uma pasta!</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation>Não é possível criar a pasta %1.</translation>
+    </message>
+    <message>
+        <source>Export failed,please delete exported files and try again.</source>
+        <translation>Falha na exportação. Exclua os arquivos exportados e tente novamente.</translation>
+    </message>
+</context>
+<context>
+    <name>ExportCalibrationFilePopup</name>
+    <message>
+        <source>Export Camera Calibration Settings</source>
+        <translation>Exportar configurações de calibração da câmera</translation>
+    </message>
+</context>
+<context>
+    <name>ExportCameraTrackPopup</name>
+    <message>
+        <source>Export Camera Track</source>
+        <translation>Exportar trilha da câmera</translation>
+    </message>
+    <message>
+        <source>Draw On Keyframes</source>
+        <translation>Desenhar em quadros-chave</translation>
+    </message>
+    <message>
+        <source>Draw On Navigation Tags</source>
+        <translation>Desenhar em tags de navegação</translation>
+    </message>
+    <message>
+        <source>Top Left</source>
+        <translation>Canto superior esquerdo</translation>
+    </message>
+    <message>
+        <source>Top Right</source>
+        <translation>Canto superior direito</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>Centro</translation>
+    </message>
+    <message>
+        <source>Bottom Left</source>
+        <translation>Inferior Esquerdo</translation>
+    </message>
+    <message>
+        <source>Bottom Right</source>
+        <translation>Canto inferior direito</translation>
+    </message>
+    <message>
+        <source>Draw Numbers On Track Line</source>
+        <translation>Desenhe números na linha da trilha</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Specify frame numbers where the camera rectangles will be drawn. Separate numbers by comma "," .</source>
+        <translation>Especifique os números dos quadros onde os retângulos da câmera serão desenhados. Separe os números por vírgula "," .</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>All frames</source>
+        <translation>Todos os quadros</translation>
+    </message>
+    <message>
+        <source>Every 2 frames</source>
+        <translation>A cada 2 quadros</translation>
+    </message>
+    <message>
+        <source>Every 3 frames</source>
+        <translation>A cada 3 quadros</translation>
+    </message>
+    <message>
+        <source>Every 4 frames</source>
+        <translation>A cada 4 quadros</translation>
+    </message>
+    <message>
+        <source>Every 5 frames</source>
+        <translation>A cada 5 quadros</translation>
+    </message>
+    <message>
+        <source>Every 6 frames</source>
+        <translation>A cada 6 quadros</translation>
+    </message>
+    <message>
+        <source>Every 8 frames</source>
+        <translation>A cada 8 quadros</translation>
+    </message>
+    <message>
+        <source>Every 10 frames</source>
+        <translation>A cada 10 quadros</translation>
+    </message>
+    <message>
+        <source>Every 12 frames</source>
+        <translation>A cada 12 quadros</translation>
+    </message>
+    <message>
+        <source>Target Column:</source>
+        <translation>Coluna de destino:</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Fundo:</translation>
+    </message>
+    <message>
+        <source>Line Color:</source>
+        <translation>Cor da linha:</translation>
+    </message>
+    <message>
+        <source>Camera Rectangles</source>
+        <translation>Retângulos de câmera</translation>
+    </message>
+    <message>
+        <source>Specify Frames Manually:</source>
+        <translation>Especifique quadros manualmente:</translation>
+    </message>
+    <message>
+        <source>Track Lines</source>
+        <translation>Linhas de trilha</translation>
+    </message>
+    <message>
+        <source>Graduation Marks Interval:</source>
+        <translation>Intervalo de notas de formatura:</translation>
+    </message>
+    <message>
+        <source>Frame Numbers</source>
+        <translation>Números de quadros</translation>
+    </message>
+    <message>
+        <source>Camera Rect Corner:</source>
+        <translation>Canto reto da câmera:</translation>
+    </message>
+    <message>
+        <source>Font Family:</source>
+        <translation>Família de fontes:</translation>
+    </message>
+    <message>
+        <source>Font Size:</source>
+        <translation>Tamanho da fonte:</translation>
+    </message>
+    <message>
+        <source>Col %1 (%2)</source>
+        <translation>Coluna %1 (%2)</translation>
+    </message>
+    <message>
+        <source>Please specify one of the following file formats; jpg, jpeg, bmp, png, and tif</source>
+        <translation>Especifique um dos seguintes formatos de arquivo; jpg, jpeg, bmp, png e tif</translation>
+    </message>
+</context>
+<context>
+    <name>ExportCurrentSceneCommandHandler</name>
+    <message>
+        <source>You must save the current scene first.</source>
+        <translation>Você deve salvar a cena atual primeiro.</translation>
+    </message>
+</context>
+<context>
+    <name>ExportCurvePopup</name>
+    <message>
+        <source>Export Curve</source>
+        <translation>Curva de Exportação</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+</context>
+<context>
+    <name>ExportLevelPopup</name>
+    <message>
+        <source>Export Level</source>
+        <translation>Nível de exportação</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Format:</source>
+        <translation>Formatar:</translation>
+    </message>
+    <message>
+        <source>Retas Compliant</source>
+        <translation>Compatível com Retas</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+    <message>
+        <source>Export Options</source>
+        <translation>Opções de exportação</translation>
+    </message>
+    <message>
+        <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? "  |</source>
+        <translation>O nome do arquivo não pode estar vazio nem conter nenhum dos seguintes caracteres:(nova linha) \ / : * ? " |</translation>
+    </message>
+    <message>
+        <source>File Browser</source>
+        <translation>Navegador de arquivos</translation>
+    </message>
+    <message>
+        <source>Export Level: No Level Selected</source>
+        <translation>Nível de exportação: nenhum nível selecionado</translation>
+    </message>
+    <message>
+        <source>Export Level: %1 Level Selected</source>
+        <translation>Nível de exportação: %1 nível selecionado</translation>
+    </message>
+    <message>
+        <source>Please select a folder!</source>
+        <translation>Selecione uma pasta!</translation>
+    </message>
+    <message>
+        <source>Please select at least one level(column).</source>
+        <translation>Selecione pelo menos um nível (coluna).</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation>Não é possível criar a pasta %1.</translation>
+    </message>
+    <message>
+        <source>Please type file name!</source>
+        <translation>Por favor digite o nome do arquivo!</translation>
+    </message>
+</context>
+<context>
+    <name>ExportLevelPopup::ExportOptions</name>
+    <message>
+        <source>Background Color:</source>
+        <translation>Cor de fundo:</translation>
+    </message>
+    <message>
+        <source>No Antialias</source>
+        <translation>No Antialias</translation>
+    </message>
+    <message>
+        <source>Vectors Export Box</source>
+        <translation>Caixa de exportação de vetores</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>H Resolution:</source>
+        <translation>Resolução H:</translation>
+    </message>
+    <message>
+        <source>V Resolution:</source>
+        <translation>Resolução V:</translation>
+    </message>
+    <message>
+        <source>DPI: </source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>Scale:</source>
+        <translation>Escala:</translation>
+    </message>
+    <message>
+        <source>Vectors Thickness</source>
+        <translation>Espessura dos Vetores</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Scale Thickness</source>
+        <translation>Espessura da escala</translation>
+    </message>
+    <message>
+        <source>Add Thickness</source>
+        <translation>Adicionar espessura</translation>
+    </message>
+    <message>
+        <source>Constant Thickness</source>
+        <translation>Espessura Constante</translation>
+    </message>
+    <message>
+        <source>Start:</source>
+        <translation>Começar:</translation>
+    </message>
+    <message>
+        <source>End:</source>
+        <translation>Fim:</translation>
+    </message>
+    <message>
+        <source>Width: </source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height: </source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>Create Folder(equal file name)</source>
+        <translation>Criar pasta (nome de arquivo igual)</translation>
+    </message>
+</context>
+<context>
+    <name>ExportOCACommand</name>
+    <message>
+        <source>Save Images in EXR Format</source>
+        <translation>Salvar imagens em formato EXR</translation>
+    </message>
+    <message>
+        <source>Rasterize Vectors</source>
+        <translation>Rasterizar vetores</translation>
+    </message>
+    <message>
+        <source>Frame Offset: </source>
+        <translation>Deslocamento do quadro:</translation>
+    </message>
+    <message>
+        <source>Checked: Images are saved as EXR
+Unchecked: Images are saved as PNG</source>
+        <translation>Verificado: as imagens são salvas como EXR
+Desmarcado: as imagens são salvas como PNG</translation>
+    </message>
+    <message>
+        <source>Checked: Rasterize into EXR/PNG
+Unchecked: Vectors are saved as SVG</source>
+        <translation>Verificado: Rasterizar em EXR/PNG
+Desmarcado: os vetores são salvos como SVG</translation>
+    </message>
+    <message>
+        <source>Starting Frame Offset</source>
+        <translation>Deslocamento de quadro inicial</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation>Esconder</translation>
+    </message>
+    <message>
+        <source>Exporting...</source>
+        <translation>Exportador...</translation>
+    </message>
+    <message>
+        <source>Starting...</source>
+        <translation>Começando...</translation>
+    </message>
+    <message>
+        <source>Export Reference Layers</source>
+        <translation>Exportar camadas de referência</translation>
+    </message>
+    <message>
+        <source>Checked: Layers with Preview Visible OFF are also exported
+Unchecked: Only layers with Preview Visible ON are exported</source>
+        <translation>Verificado: Camadas com Visualização Visível DESLIGADA também são exportadas
+Desmarcado: Somente camadas com Visualização Visível ATIVADA são exportadas</translation>
+    </message>
+</context>
+<context>
+    <name>ExportPanel</name>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>File Name:</source>
+        <translation>Nome do arquivo:</translation>
+    </message>
+    <message>
+        <source>File Format:</source>
+        <translation>Formato de arquivo:</translation>
+    </message>
+    <message>
+        <source>Use Markers</source>
+        <translation>Usar marcadores</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+</context>
+<context>
+    <name>ExportScenePopup</name>
+    <message>
+        <source>Export Scene</source>
+        <translation>Exportar cena</translation>
+    </message>
+    <message>
+        <source>Choose Existing Project</source>
+        <translation>Escolha o projeto existente</translation>
+    </message>
+    <message>
+        <source>Create New Project</source>
+        <translation>Criar novo projeto</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>The folder you selected is not a project.</source>
+        <translation>A pasta que você selecionou não é um projeto.</translation>
+    </message>
+    <message>
+        <source>There was an error exporting the scene.</source>
+        <translation>Ocorreu um erro ao exportar a cena.</translation>
+    </message>
+    <message>
+        <source>The project name cannot be empty or contain any of the following characters:(new line)   \ / : * ? "  |</source>
+        <translation>O nome do projeto não pode estar vazio nem conter nenhum dos seguintes caracteres:(nova linha) \ / : * ? " |</translation>
+    </message>
+    <message>
+        <source>The project name you specified is already used.</source>
+        <translation>O nome do projeto que você especificou já está em uso.</translation>
+    </message>
+    <message>
+        <source>Create In:</source>
+        <translation>Criar em:</translation>
+    </message>
+    <message>
+        <source>Project '%1' already exists</source>
+        <translation>O projeto '%1' já existe</translation>
+    </message>
+    <message>
+        <source>Export as Standalone Scene</source>
+        <translation>Exportar como cena autônoma</translation>
+    </message>
+    <message>
+        <source>Export To:</source>
+        <translation>Exportar para:</translation>
+    </message>
+    <message>
+        <source>Target folder already exists and not empty.
+ %1</source>
+        <translation>A pasta de destino já existe e não está vazia.
+ % 1</translation>
+    </message>
+</context>
+<context>
+    <name>ExportXDTSCommand</name>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation>Todas as colunas</translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation>Somente colunas ativas</translation>
+    </message>
+    <message>
+        <source>Inbetween symbol mark</source>
+        <translation>Marca de símbolo intermediário</translation>
+    </message>
+    <message>
+        <source>Reverse sheet symbol mark</source>
+        <translation>Marca de símbolo de folha reversa</translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation>Coluna de destino</translation>
+    </message>
+</context>
+<context>
+    <name>ExportXsheetPdfPopup</name>
+    <message>
+        <source>Export Xsheet PDF</source>
+        <translation>Exportar PDF do Xsheet</translation>
+    </message>
+    <message>
+        <source>Print Export DateTime</source>
+        <translation>Imprimir data e hora de exportação</translation>
+    </message>
+    <message>
+        <source>Print Scene Path</source>
+        <translation>Imprimir caminho da cena</translation>
+    </message>
+    <message>
+        <source>Print Soundtrack</source>
+        <translation>Imprimir trilha sonora</translation>
+    </message>
+    <message>
+        <source>Print Scene Name</source>
+        <translation>Imprimir nome da cena</translation>
+    </message>
+    <message>
+        <source>Put Serial Frame Numbers Over Pages</source>
+        <translation>Coloque números de quadro de série nas páginas</translation>
+    </message>
+    <message>
+        <source>Print Level Names On The Bottom</source>
+        <translation>Imprimir nomes de níveis na parte inferior</translation>
+    </message>
+    <message>
+        <source>Print Dialogue</source>
+        <translation>Imprimir diálogo</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>Texto</translation>
+    </message>
+    <message>
+        <source>Image</source>
+        <translation>Imagem</translation>
+    </message>
+    <message>
+        <source>&lt; Prev</source>
+        <translation>&lt; Anterior</translation>
+    </message>
+    <message>
+        <source>Next &gt;</source>
+        <translation>Próximo &gt;</translation>
+    </message>
+    <message>
+        <source>Export PDF</source>
+        <translation>Exportar PDF</translation>
+    </message>
+    <message>
+        <source>Export PNG</source>
+        <translation>Exportar PNG</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>ACTIONS</source>
+        <translation>AÇÕES</translation>
+    </message>
+    <message>
+        <source>CELLS</source>
+        <translation>CÉLULAS</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message>
+        <source>More Than 3 Continuous Cells</source>
+        <translation>Mais de 3 células contínuas</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Template Settings</source>
+        <translation>Configurações do modelo</translation>
+    </message>
+    <message>
+        <source>Template:</source>
+        <translation>Modelo:</translation>
+    </message>
+    <message>
+        <source>Line color:</source>
+        <translation>Cor da linha:</translation>
+    </message>
+    <message>
+        <source>Template font:</source>
+        <translation>Fonte do modelo:</translation>
+    </message>
+    <message>
+        <source>Logo:</source>
+        <translation>Logotipo:</translation>
+    </message>
+    <message>
+        <source>Export Settings</source>
+        <translation>Exportar configurações</translation>
+    </message>
+    <message>
+        <source>Output area:</source>
+        <translation>Área de saída:</translation>
+    </message>
+    <message>
+        <source>Output font:</source>
+        <translation>Fonte de saída:</translation>
+    </message>
+    <message>
+        <source>Continuous line:</source>
+        <translation>Linha contínua:</translation>
+    </message>
+    <message>
+        <source>Inbetween mark:</source>
+        <translation>Marca intermediária:</translation>
+    </message>
+    <message>
+        <source>Reverse sheet mark:</source>
+        <translation>Marca de folha reversa:</translation>
+    </message>
+    <message>
+        <source>Keyframe mark:</source>
+        <translation>Marca de quadro-chave:</translation>
+    </message>
+    <message>
+        <source>Memo:</source>
+        <translation>Memorando:</translation>
+    </message>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>B4 size, 3 seconds sheet</source>
+        <translation>Tamanho B4, folha de 3 segundos</translation>
+    </message>
+    <message>
+        <source>B4 size, 6 seconds sheet</source>
+        <translation>Tamanho B4, folha de 6 segundos</translation>
+    </message>
+    <message>
+        <source>A3 size, 3 seconds sheet</source>
+        <translation>Tamanho A3, folha de 3 segundos</translation>
+    </message>
+    <message>
+        <source>A3 size, 6 seconds sheet</source>
+        <translation>Tamanho A3, folha de 6 segundos</translation>
+    </message>
+    <message>
+        <source>Col%1</source>
+        <translation>Coluna% 1</translation>
+    </message>
+    <message>
+        <source>The preset file %1 is not valid.</source>
+        <translation>O arquivo predefinido %1 não é válido.</translation>
+    </message>
+    <message numerus="yes">
+        <source>%n page(s)</source>
+        <translation>%n páginas</translation>
+    </message>
+    <message>
+        <source>%1 x %2 pages</source>
+        <translation>%1 x %2 páginas</translation>
+    </message>
+    <message>
+        <source>Please specify the file name.</source>
+        <translation>Especifique o nome do arquivo.</translation>
+    </message>
+    <message>
+        <source>The file %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>A folder %1 does not exist.
+Do you want to create it?</source>
+        <translation>A pasta% 1 não existe.
+Você quer criá-lo?</translation>
+    </message>
+    <message>
+        <source>Failed to create folder %1.</source>
+        <translation>Falha ao criar a pasta %1.</translation>
+    </message>
+    <message>
+        <source>Frame length:</source>
+        <translation>Comprimento do quadro:</translation>
+    </message>
+    <message>
+        <source>Inbetween mark 1:</source>
+        <translation>Entre a marca 1:</translation>
+    </message>
+    <message>
+        <source>Inbetween mark 2:</source>
+        <translation>Entre a marca 2:</translation>
+    </message>
+    <message>
+        <source>Export CSV</source>
+        <translation>Exportar CSV</translation>
+    </message>
+    <message>
+        <source>Failed to create file %1.</source>
+        <translation>Falha ao criar o arquivo %1.</translation>
+    </message>
+</context>
+<context>
+    <name>ExpressionReferenceManager</name>
+    <message>
+        <source>Expression monitoring restarted: "%1"</source>
+        <translation>Monitoramento de expressão reiniciado: "%1"</translation>
+    </message>
+    <message>
+        <source>Expression modified: "%1" key at frame %2, %3 -&gt; %4</source>
+        <translation>Expressão modificada: chave "%1" no quadro %2, %3 -&gt; %4</translation>
+    </message>
+    <message>
+        <source>Following parameters will lose reference in expressions:</source>
+        <translation>Os seguintes parâmetros perderão referência nas expressões:</translation>
+    </message>
+    <message>
+        <source>(To be in the sub xsheet)</source>
+        <translation>(Para estar na subxsheet)</translation>
+    </message>
+    <message>
+        <source>Do you want to continue the operation anyway ?</source>
+        <translation>Você deseja continuar a operação mesmo assim?</translation>
+    </message>
+    <message>
+        <source>(In the current xsheet)</source>
+        <translation>(Na xsheet atual)</translation>
+    </message>
+    <message>
+        <source>(To be brought from the subxsheet)</source>
+        <translation>(Para ser trazido da subxsheet)</translation>
+    </message>
+    <message>
+        <source>
+Do you want to explode anyway ?</source>
+        <translation>Você quer explodir de qualquer maneira?</translation>
+    </message>
+    <message>
+        <source>(In a sub xsheet)</source>
+        <translation>(Em uma subplanilha)</translation>
+    </message>
+    <message>
+        <source>Following parameters may contain broken references in expressions:</source>
+        <translation>Os seguintes parâmetros podem conter referências quebradas em expressões:</translation>
+    </message>
+    <message>
+        <source>Do you want to save the scene anyway ?</source>
+        <translation>Você quer salvar a cena mesmo assim?</translation>
+    </message>
+</context>
+<context>
+    <name>FarmServerListView</name>
+    <message>
+        <source>Activate</source>
+        <translation>Ativar</translation>
+    </message>
+    <message>
+        <source>Deactivate</source>
+        <translation>Desativar</translation>
+    </message>
+</context>
+<context>
+    <name>FileBrowser</name>
+    <message>
+        <source>Folder: </source>
+        <translation>Pasta:</translation>
+    </message>
+    <message>
+        <source>Can't change file extension</source>
+        <translation>Não é possível alterar a extensão do arquivo</translation>
+    </message>
+    <message>
+        <source>Can't set a drawing number</source>
+        <translation>Não é possível definir um número de desenho</translation>
+    </message>
+    <message>
+        <source>Can't rename. File already exists: </source>
+        <translation>Não é possível renomear. O arquivo já existe:</translation>
+    </message>
+    <message>
+        <source>Couldn't rename </source>
+        <translation>Não foi possível renomear</translation>
+    </message>
+    <message>
+        <source>Preview Screensaver</source>
+        <translation>Visualizar protetor de tela</translation>
+    </message>
+    <message>
+        <source>Install Screensaver</source>
+        <translation>Instalar protetor de tela</translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation>Carregar como sub-planilha</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Renomear</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation>Converter para TLV pintado</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation>Converter para TLV sem pintura</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation>Controle de versão</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation>Salvar cena</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation>Nome da cena:</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation>Aviso: o nível %1 já existe; substituir?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation>Concluído: todos os níveis convertidos para o formato TLV</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation>Concluído: 2 níveis convertidos para o formato TLV</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation>Editar intervalo de quadros...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation>Colocar...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>Reverter</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation>Pegar</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation>Obter revisão...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation>Desbloquear</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation>Editar informações</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation>Histórico de revisões...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation>Desbloquear intervalo de quadros</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation>Nova pasta</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation>Ocorreu um erro ao copiar % 1 para % 2</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation>Converter para Tlv sem pintura</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation>Converter para Tlv pintado</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation>Não é possível criar a pasta %1.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation>Alguns arquivos que você deseja editar estão abertos no momento. Feche-os primeiro.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation>Alguns arquivos que você deseja desbloquear estão abertos no momento. Feche-os primeiro.</translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation>Falha ao abrir pasta</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation>O caminho da pasta de entrada era inválido.</translation>
+    </message>
+    <message>
+        <source>Level %1 already exists
+Do you want to duplicate it?</source>
+        <translation>O nível % 1 já existe
+Você quer duplicá-lo?</translation>
+    </message>
+    <message>
+        <source>Duplicate</source>
+        <translation>Duplicado</translation>
+    </message>
+    <message>
+        <source>Don't Duplicate</source>
+        <translation>Não duplique</translation>
+    </message>
+</context>
+<context>
+    <name>FileBrowserPopup</name>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>File name:</source>
+        <translation>Nome do arquivo:</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source>To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>Invalid file</source>
+        <translation>Arquivo inválido</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Folder name:</source>
+        <translation>Nome da pasta:</translation>
+    </message>
+</context>
+<context>
+    <name>FileData</name>
+    <message>
+        <source>It is not possible to find the %1 level.</source>
+        <translation>Não é possível encontrar o nível %1.</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1</source>
+        <translation>Ocorreu um erro ao copiar % 1</translation>
+    </message>
+</context>
+<context>
+    <name>FileSelection</name>
+    <message>
+        <source>Abort</source>
+        <translation>Abortar</translation>
+    </message>
+    <message>
+        <source>Collecting assets...</source>
+        <translation>Coletando ativos...</translation>
+    </message>
+    <message>
+        <source>Importing scenes...</source>
+        <translation>Importando cenas...</translation>
+    </message>
+</context>
+<context>
+    <name>FileSettingsPopup</name>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>File Format:</source>
+        <translation>Formato de arquivo:</translation>
+    </message>
+</context>
+<context>
+    <name>FillHolesDialog</name>
+    <message>
+        <source>Fill Small Holes</source>
+        <translation>Preencha pequenos buracos</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No Toonz Raster Level Selected</source>
+        <translation>Nenhum nível de raster Toonz selecionado</translation>
+    </message>
+    <message>
+        <source>Filling Holes...</source>
+        <translation>Preenchendo Buracos...</translation>
+    </message>
+</context>
+<context>
+    <name>Filmstrip</name>
+    <message>
+        <source>Level Strip</source>
+        <translation>Faixa de nível</translation>
+    </message>
+    <message>
+        <source>Level:  </source>
+        <translation>Nível:</translation>
+    </message>
+    <message>
+        <source>- No Current Level -</source>
+        <translation>- Sem nível atual -</translation>
+    </message>
+</context>
+<context>
+    <name>FilmstripFrameHeadGadget</name>
+    <message>
+        <source>Click to Toggle Fixed Onion Skin</source>
+        <translation>Clique para alternar a Casca de Cebola fixa</translation>
+    </message>
+    <message>
+        <source>Click / Drag to Toggle Onion Skin</source>
+        <translation>Clique / arraste para alternar a Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Drag to Extend Onion Skin, Double Click to Toggle All</source>
+        <translation>Arraste para estender a casca da cebola, clique duas vezes para alternar tudo</translation>
+    </message>
+    <message>
+        <source>Click to Reset Shift &amp; Trace Markers to Neighbor Frames
+Hold F2 Key on the Viewer to Show This Frame Only</source>
+        <translation>Clique para redefinir marcadores de deslocamento e rastreamento para quadros vizinhos
+Segure a tecla F2 no visualizador para mostrar apenas este quadro</translation>
+    </message>
+    <message>
+        <source>Click to Hide This Frame from Shift &amp; Trace
+Hold F1 Key on the Viewer to Show This Frame Only</source>
+        <translation>Clique para ocultar este quadro de Shift &amp; Trace
+Segure a tecla F1 no visualizador para mostrar apenas este quadro</translation>
+    </message>
+    <message>
+        <source>Click to Hide This Frame from Shift &amp; Trace
+Hold F3 Key on the Viewer to Show This Frame Only</source>
+        <translation>Clique para ocultar este quadro de Shift &amp; Trace
+Segure a tecla F3 no visualizador para mostrar apenas este quadro</translation>
+    </message>
+    <message>
+        <source>Click to Move Shift &amp; Trace Marker</source>
+        <translation>Clique para mover o marcador Shift e Trace</translation>
+    </message>
+</context>
+<context>
+    <name>FilmstripFrames</name>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>no icon</source>
+        <translation>nenhum ícone</translation>
+    </message>
+    <message>
+        <source>Auto Inbetween</source>
+        <translation>Intermediário automático</translation>
+    </message>
+    <message>
+        <source>INBETWEEN</source>
+        <translation>ENTRE</translation>
+    </message>
+    <message>
+        <source>Panel Settings</source>
+        <translation>Configurações do painel</translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
+        <translation>Alternar orientação</translation>
+    </message>
+    <message>
+        <source>Show/Hide Drop Down Menu</source>
+        <translation>Mostrar/ocultar menu suspenso</translation>
+    </message>
+    <message>
+        <source>Show/Hide Level Navigator</source>
+        <translation>Mostrar/ocultar navegador de nível</translation>
+    </message>
+    <message>
+        <source>Select Level</source>
+        <translation>Selecione o nível</translation>
+    </message>
+</context>
+<context>
+    <name>FlipBook</name>
+    <message>
+        <source>Flipbook</source>
+        <translation>Flipbook</translation>
+    </message>
+    <message>
+        <source>It is not possible to save Flipbook content.</source>
+        <translation>Não é possível salvar o conteúdo do Flipbook.</translation>
+    </message>
+    <message>
+        <source>Saved %1 frames out of %2 in %3</source>
+        <translation>Foram salvos %1 quadros de %2 em %3</translation>
+    </message>
+    <message>
+        <source>Rendered Frames  ::  From %1 To %2  ::  Step %3</source>
+        <translation>Quadros renderizados :: De % 1 a % 2 :: Etapa % 3</translation>
+    </message>
+    <message>
+        <source>  ::  Shrink </source>
+        <translation>::  Encolher</translation>
+    </message>
+    <message>
+        <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? "  |</source>
+        <translation>O nome do arquivo não pode estar vazio nem conter nenhum dos seguintes caracteres:(nova linha) \ / : * ? " |</translation>
+    </message>
+    <message>
+        <source>It is not possible to save because the selected file format is not supported.</source>
+        <translation>Não é possível salvar porque o formato de arquivo selecionado não é compatível.</translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>There are no rendered images to save.</source>
+        <translation>Não há imagens renderizadas para salvar.</translation>
+    </message>
+    <message>
+        <source>It is not possible to take or compare snapshots for Toonz vector levels.</source>
+        <translation>Não é possível tirar ou comparar instantâneos para níveis de vetor Toonz.</translation>
+    </message>
+    <message>
+        <source>Gamma : %1</source>
+        <translation>Gama: %1</translation>
+    </message>
+</context>
+<context>
+    <name>FlipbookPanel</name>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation>Área segura (clique com o botão direito para selecionar)</translation>
+    </message>
+    <message>
+        <source>Minimize</source>
+        <translation>Minimizar</translation>
+    </message>
+</context>
+<context>
+    <name>FormatSettingsPopup</name>
+    <message>
+        <source>File Settings</source>
+        <translation>Configurações de arquivo</translation>
+    </message>
+    <message>
+        <source>Configure Codec</source>
+        <translation>Configurar codec</translation>
+    </message>
+    <message>
+        <source>. (period)</source>
+        <translation>. (período)</translation>
+    </message>
+    <message>
+        <source>_ (underscore)</source>
+        <translation>_ (sublinhado)</translation>
+    </message>
+    <message>
+        <source>No padding</source>
+        <translation>Sem preenchimento</translation>
+    </message>
+    <message>
+        <source>Frame Number Format</source>
+        <translation>Formato do número do quadro</translation>
+    </message>
+    <message>
+        <source>Separate Character:</source>
+        <translation>Personagem separado:</translation>
+    </message>
+    <message>
+        <source>Padding:</source>
+        <translation>Preenchimento:</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>FrameHeadGadget</name>
+    <message>
+        <source>Current Frame</source>
+        <translation>Quadro atual</translation>
+    </message>
+    <message>
+        <source>Relative Onion Skin Toggle</source>
+        <translation>Alternar Casca de Cebola relativa</translation>
+    </message>
+    <message>
+        <source>Fixed Onion Skin Toggle</source>
+        <translation>Alternância de Casca de Cebola fixa</translation>
+    </message>
+</context>
+<context>
+    <name>FxParamEditorPopup</name>
+    <message>
+        <source>Fx Settings</source>
+        <translation>Configurações de câmbio</translation>
+    </message>
+</context>
+<context>
+    <name>ImageViewer</name>
+    <message>
+        <source>Flipbook Histogram</source>
+        <translation>Histograma de flipbook</translation>
+    </message>
+    <message>
+        <source>Clone Preview</source>
+        <translation>Visualização do clone</translation>
+    </message>
+    <message>
+        <source>Unfreeze Preview</source>
+        <translation>Pré-visualização do descongelamento</translation>
+    </message>
+    <message>
+        <source>Freeze Preview</source>
+        <translation>Pré-visualização congelada</translation>
+    </message>
+    <message>
+        <source>Regenerate Preview</source>
+        <translation>Pré-visualização regenerada</translation>
+    </message>
+    <message>
+        <source>Regenerate Frame Preview</source>
+        <translation>Regenerar visualização do quadro</translation>
+    </message>
+    <message>
+        <source>Reset View</source>
+        <translation>Redefinir visualização</translation>
+    </message>
+    <message>
+        <source>Fit To Window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+    <message>
+        <source>Exit Full Screen Mode</source>
+        <translation>Sair do modo de tela cheia</translation>
+    </message>
+    <message>
+        <source>Full Screen Mode</source>
+        <translation>Modo de tela inteira</translation>
+    </message>
+    <message>
+        <source>Load Images</source>
+        <translation>Carregar imagens</translation>
+    </message>
+    <message>
+        <source>Append Images</source>
+        <translation>Anexar imagens</translation>
+    </message>
+    <message>
+        <source>Save Images</source>
+        <translation>Salvar imagens</translation>
+    </message>
+    <message>
+        <source>Show Histogram</source>
+        <translation>Mostrar histograma</translation>
+    </message>
+    <message>
+        <source>Swap Compared Images</source>
+        <translation>Trocar imagens comparadas</translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation>:: Zoom:</translation>
+    </message>
+    <message>
+        <source>Load / Append Images</source>
+        <translation>Carregar/anexar imagens</translation>
+    </message>
+</context>
+<context>
+    <name>ImportMagpieFilePopup</name>
+    <message>
+        <source>Import Magpie File</source>
+        <translation>Importar arquivo Magpie</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>%1 does not exist.</source>
+        <translation>%1 não existe.</translation>
+    </message>
+    <message>
+        <source>Import Toonz Lip Sync File</source>
+        <translation>Importar arquivo de sincronização labial Toonz</translation>
+    </message>
+</context>
+<context>
+    <name>InbetweenDialog</name>
+    <message>
+        <source>Inbetween</source>
+        <translation>Entre</translation>
+    </message>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>Ease In</source>
+        <translation>Facilidade</translation>
+    </message>
+    <message>
+        <source>Ease Out</source>
+        <translation>Facilite</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out</source>
+        <translation>Facilidade de entrada/facilidade</translation>
+    </message>
+    <message>
+        <source>Interpolation:</source>
+        <translation>Interpolação:</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>InsertFxPopup</name>
+    <message>
+        <source>FX Browser</source>
+        <translation>Navegador FX</translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation>Inserir</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Macro</source>
+        <translation>macro</translation>
+    </message>
+    <message>
+        <source>Remove Macro FX</source>
+        <translation>Remover macro FX</translation>
+    </message>
+    <message>
+        <source>Remove Preset</source>
+        <translation>Remover predefinição</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete %1?</source>
+        <translation>Tem certeza de que deseja excluir% 1?</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete %1.</source>
+        <translation>Não é possível excluir %1.</translation>
+    </message>
+    <message>
+        <source>Search:</source>
+        <translation>Procurar:</translation>
+    </message>
+</context>
+<context>
+    <name>IoCmd::ConvertingPopup</name>
+    <message>
+        <source>Error occurred.</source>
+        <translation>Ocorreu um erro.</translation>
+    </message>
+</context>
+<context>
+    <name>ItemInfoView</name>
+    <message>
+        <source>Bold</source>
+        <translation>Audacioso</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation>itálico</translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation>Ignorar</translation>
+    </message>
+    <message>
+        <source>Keep</source>
+        <translation>Manter</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Path:</source>
+        <translation>Caminho:</translation>
+    </message>
+    <message>
+        <source>Aspect Ratio:</source>
+        <translation>Proporção:</translation>
+    </message>
+    <message>
+        <source>Font:</source>
+        <translation>Fonte:</translation>
+    </message>
+    <message>
+        <source>Max Size:</source>
+        <translation>Tamanho máximo:</translation>
+    </message>
+    <message>
+        <source>No item selected.</source>
+        <translation>Nenhum item selecionado.</translation>
+    </message>
+    <message>
+        <source>Item</source>
+        <translation>Item</translation>
+    </message>
+</context>
+<context>
+    <name>ItemListView</name>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+    <message>
+        <source>Move Up</source>
+        <translation>Subir</translation>
+    </message>
+    <message>
+        <source>Move Down</source>
+        <translation>Mover para baixo</translation>
+    </message>
+</context>
+<context>
+    <name>LayerFooterPanel</name>
+    <message>
+        <source>Zoom in/out of timeline</source>
+        <translation>Aumentar/diminuir zoom na linha do tempo</translation>
+    </message>
+    <message>
+        <source>Zoom in (Ctrl-click to zoom in all the way)</source>
+        <translation>Ampliar (Ctrl-clique para ampliar totalmente)</translation>
+    </message>
+    <message>
+        <source>Zoom out (Ctrl-click to zoom out all the way)</source>
+        <translation>Diminuir zoom (Ctrl-clique para diminuir totalmente o zoom)</translation>
+    </message>
+    <message>
+        <source>Zoom in/out of xsheet</source>
+        <translation>Aumentar/diminuir zoom do xsheet</translation>
+    </message>
+    <message>
+        <source>%1 frames per page</source>
+        <translation>%1 quadros por página</translation>
+    </message>
+</context>
+<context>
+    <name>LayerHeaderPanel</name>
+    <message>
+        <source>Preview Visibility Toggle All</source>
+        <translation>Visibilidade da visualização Alternar tudo</translation>
+    </message>
+    <message>
+        <source>Camera Stand Visibility Toggle All</source>
+        <translation>Visibilidade do suporte da câmera Alternar tudo</translation>
+    </message>
+    <message>
+        <source>Lock Toggle All</source>
+        <translation>Bloquear Alternar tudo</translation>
+    </message>
+</context>
+<context>
+    <name>LevelCreatePopup</name>
+    <message>
+        <source>New Level</source>
+        <translation>Novo nível</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source>Increment:</source>
+        <translation>Incremento:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Type:</source>
+        <translation>Tipo:</translation>
+    </message>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation>Criar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No level name specified: please choose a valid level name</source>
+        <translation>Nenhum nome de nível especificado: escolha um nome de nível válido</translation>
+    </message>
+    <message>
+        <source>Invalid frame range</source>
+        <translation>Intervalo de Quadros inválido</translation>
+    </message>
+    <message>
+        <source>Invalid increment value</source>
+        <translation>Valor de incremento inválido</translation>
+    </message>
+    <message>
+        <source>Invalid step value</source>
+        <translation>Valor de etapa inválido</translation>
+    </message>
+    <message>
+        <source>The level name specified is already used: please choose a different level name</source>
+        <translation>O nome do nível especificado já está em uso: escolha um nome de nível diferente</translation>
+    </message>
+    <message>
+        <source>Folder %1 doesn't exist.
+Do you want to create it?</source>
+        <translation>A pasta% 1 não existe.
+Você quer criá-lo?</translation>
+    </message>
+    <message>
+        <source>Unable to create</source>
+        <translation>Não foi possível criar</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>Toonz Vector Level</source>
+        <translation>Nível de vetor Toonz</translation>
+    </message>
+    <message>
+        <source>Toonz Raster Level</source>
+        <translation>Nível Raster Toonz</translation>
+    </message>
+    <message>
+        <source>Raster Level</source>
+        <translation>Nível raster</translation>
+    </message>
+    <message>
+        <source>Scan Level</source>
+        <translation>Nível de verificação</translation>
+    </message>
+    <message>
+        <source>Format:</source>
+        <translation>Formatar:</translation>
+    </message>
+    <message>
+        <source>Frame Format</source>
+        <translation>Formato do quadro</translation>
+    </message>
+    <message>
+        <source>Assistants Level</source>
+        <translation>Nível de assistentes</translation>
+    </message>
+    <message>
+        <source>Unable to create %1</source>
+        <translation>Não foi possível criar % 1</translation>
+    </message>
+</context>
+<context>
+    <name>LevelSettingsPopup</name>
+    <message>
+        <source>Level Settings</source>
+        <translation>Configurações de nível</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Path:</source>
+        <translation>Caminho:</translation>
+    </message>
+    <message>
+        <source>Scan Path:</source>
+        <translation>Caminho de digitalização:</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>Forced Squared Pixel</source>
+        <translation>Pixel Quadrado Forçado</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>Use Camera DPI</source>
+        <translation>Usar DPI da câmera</translation>
+    </message>
+    <message>
+        <source>Camera DPI:</source>
+        <translation>DPI da câmera:</translation>
+    </message>
+    <message>
+        <source>Image DPI:</source>
+        <translation>DPI da imagem:</translation>
+    </message>
+    <message>
+        <source>Image Resolution:</source>
+        <translation>Resolução de imagem:</translation>
+    </message>
+    <message>
+        <source>Premultiply</source>
+        <translation>Pré-multiplicar</translation>
+    </message>
+    <message>
+        <source>White As Transparent</source>
+        <translation>Branco como transparente</translation>
+    </message>
+    <message>
+        <source>      Subsampling:</source>
+        <translation>Subamostragem:</translation>
+    </message>
+    <message>
+        <source>The file %1 is not a sound level.</source>
+        <translation>O arquivo% 1 não é um nível de som.</translation>
+    </message>
+    <message>
+        <source>Add Antialiasing</source>
+        <translation>Adicionar suavização</translation>
+    </message>
+    <message>
+        <source>Antialias Softness:</source>
+        <translation>Suavidade antialias:</translation>
+    </message>
+    <message>
+        <source>Subsampling:</source>
+        <translation>Subamostragem:</translation>
+    </message>
+    <message>
+        <source>Name &amp;&amp; Path</source>
+        <translation>Nome &amp;&amp; Caminho</translation>
+    </message>
+    <message>
+        <source>DPI &amp;&amp; Resolution</source>
+        <translation>DPI e resolução</translation>
+    </message>
+    <message>
+        <source>Resolution:</source>
+        <translation>Resolução:</translation>
+    </message>
+    <message>
+        <source>Resolution</source>
+        <translation>Resolução</translation>
+    </message>
+    <message>
+        <source>Image DPI</source>
+        <translation>DPI da imagem</translation>
+    </message>
+    <message>
+        <source>Custom DPI</source>
+        <translation>DPI personalizado</translation>
+    </message>
+    <message>
+        <source>Scan level</source>
+        <translation>Nível de verificação</translation>
+    </message>
+    <message>
+        <source>Toonz Vector level</source>
+        <translation>Nível de vetor Toonz</translation>
+    </message>
+    <message>
+        <source>Toonz Raster level</source>
+        <translation>Nível Raster Toonz</translation>
+    </message>
+    <message>
+        <source>Raster level</source>
+        <translation>Nível raster</translation>
+    </message>
+    <message>
+        <source>Mesh level</source>
+        <translation>Nível de malha</translation>
+    </message>
+    <message>
+        <source>Palette level</source>
+        <translation>Nível de paleta</translation>
+    </message>
+    <message>
+        <source>Sound Column</source>
+        <translation>Coluna de som</translation>
+    </message>
+    <message>
+        <source>[Various]</source>
+        <translation>[Vários]</translation>
+    </message>
+    <message>
+        <source>SubXsheet Level</source>
+        <translation>Nível SubXsheet</translation>
+    </message>
+    <message>
+        <source>Another Level Type</source>
+        <translation>Outro tipo de nível</translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation>Gama de espaço de cores:</translation>
+    </message>
+</context>
+<context>
+    <name>LineTestCapturePane</name>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Frame:</source>
+        <translation>Quadro:</translation>
+    </message>
+    <message>
+        <source>Increment:</source>
+        <translation>Incremento:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>New     </source>
+        <translation>Novo</translation>
+    </message>
+    <message>
+        <source>Overwite     </source>
+        <translation>Sobrecarga</translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation>Inserir</translation>
+    </message>
+    <message>
+        <source> Onion Skin  </source>
+        <translation>Casca de Cebola</translation>
+    </message>
+    <message>
+        <source> View Frame</source>
+        <translation>Ver quadro</translation>
+    </message>
+    <message>
+        <source>Fade:</source>
+        <translation>Desaparecer:</translation>
+    </message>
+    <message>
+        <source> Connection</source>
+        <translation>Conexão</translation>
+    </message>
+    <message>
+        <source>       Capture       </source>
+        <translation>Capturar</translation>
+    </message>
+    <message>
+        <source>Capture Settings</source>
+        <translation>Configurações de captura</translation>
+    </message>
+    <message>
+        <source>   File Settings    </source>
+        <translation>Configurações de arquivo</translation>
+    </message>
+    <message>
+        <source>Bad Selection.</source>
+        <translation>Seleção ruim.</translation>
+    </message>
+    <message>
+        <source>No Device Defined.</source>
+        <translation>Nenhum dispositivo definido.</translation>
+    </message>
+    <message>
+        <source>Cannot connect Camera</source>
+        <translation>Não é possível conectar a câmera</translation>
+    </message>
+    <message>
+        <source>Device Disconnected.</source>
+        <translation>Dispositivo desconectado.</translation>
+    </message>
+    <message>
+        <source>LineTest Capture</source>
+        <translation>Captura de teste de linha</translation>
+    </message>
+</context>
+<context>
+    <name>LineTestPane</name>
+    <message>
+        <source>Preview</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation>Sem título</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation>Cena:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation>::   Quadro:</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation>::   Nível:</translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation>Nível:</translation>
+    </message>
+</context>
+<context>
+    <name>LinesFadePopup</name>
+    <message>
+        <source>Color Fade</source>
+        <translation>Desbotamento da cor</translation>
+    </message>
+    <message>
+        <source>Fade:</source>
+        <translation>Desaparecer:</translation>
+    </message>
+    <message>
+        <source>Intensity:</source>
+        <translation>Intensidade:</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+</context>
+<context>
+    <name>LipSyncPopup</name>
+    <message>
+        <source>Apply Lip Sync Data</source>
+        <translation>Aplicar dados de sincronização labial</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>A I Drawing</source>
+        <translation>Um desenho eu</translation>
+    </message>
+    <message>
+        <source>O Drawing</source>
+        <translation>Ó Desenho</translation>
+    </message>
+    <message>
+        <source>E Drawing</source>
+        <translation>E Desenho</translation>
+    </message>
+    <message>
+        <source>U Drawing</source>
+        <translation>U Desenho</translation>
+    </message>
+    <message>
+        <source>L Drawing</source>
+        <translation>L Desenho</translation>
+    </message>
+    <message>
+        <source>W Q Drawing</source>
+        <translation>W Q Desenho</translation>
+    </message>
+    <message>
+        <source>M B P Drawing</source>
+        <translation>Desenho M B P</translation>
+    </message>
+    <message>
+        <source>F V Drawing</source>
+        <translation>Desenho F V</translation>
+    </message>
+    <message>
+        <source>Rest Drawing</source>
+        <translation>Desenho de descanso</translation>
+    </message>
+    <message>
+        <source>C D G K N R S Th Y Z</source>
+        <translation>C D G K N R S Th Y Z</translation>
+    </message>
+    <message>
+        <source>Extend Rest Drawing to End Marker</source>
+        <translation>Estender o desenho restante até o marcador final</translation>
+    </message>
+    <message>
+        <source>Previous Drawing</source>
+        <translation>Desenho Anterior</translation>
+    </message>
+    <message>
+        <source>Next Drawing</source>
+        <translation>Próximo desenho</translation>
+    </message>
+    <message>
+        <source>Insert at Frame: </source>
+        <translation>Inserir no quadro:</translation>
+    </message>
+    <message>
+        <source>Lip Sync Data File: </source>
+        <translation>Arquivo de dados de sincronização labial:</translation>
+    </message>
+    <message>
+        <source>Thumbnails are not available for sub-Xsheets.
+Please use the frame numbers for reference.</source>
+        <translation>As miniaturas não estão disponíveis para sub-Xsheets.
+Por favor, use os números dos quadros como referência.</translation>
+    </message>
+    <message>
+        <source>Unable to apply lip sync data to this column type</source>
+        <translation>Não foi possível aplicar dados de sincronização labial a este tipo de coluna</translation>
+    </message>
+    <message>
+        <source>SubXSheet Frame </source>
+        <translation>Quadro SubXSheet</translation>
+    </message>
+    <message>
+        <source>Unable to open the file: 
+</source>
+        <translation>Não foi possível abrir o arquivo:</translation>
+    </message>
+    <message>
+        <source>Invalid data file.</source>
+        <translation>Arquivo de dados inválido.</translation>
+    </message>
+    <message>
+        <source>Drawing: </source>
+        <translation>Desenho:</translation>
+    </message>
+    <message>
+        <source>Frame </source>
+        <translation>Quadro</translation>
+    </message>
+    <message>
+        <source>Invalid configuration or data.</source>
+        <translation>Configuração ou dados inválidos.</translation>
+    </message>
+    <message>
+        <source>Invalid data file. Need at least one phoneme entry.</source>
+        <translation>Arquivo de dados inválido. Precisa de pelo menos uma entrada de fonema.</translation>
+    </message>
+</context>
+<context>
+    <name>LoadBoardPresetFilePopup</name>
+    <message>
+        <source>Load Clapperboard Settings Preset</source>
+        <translation>Carregar predefinições de configurações da claquete</translation>
+    </message>
+</context>
+<context>
+    <name>LoadCalibrationFilePopup</name>
+    <message>
+        <source>Load Camera Calibration Settings</source>
+        <translation>Carregar configurações de calibração da câmera</translation>
+    </message>
+</context>
+<context>
+    <name>LoadColorModelPopup</name>
+    <message>
+        <source>Load Color Model</source>
+        <translation>Carregar modelo de cores</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Palette from Frame:</source>
+        <translation>Paleta do quadro:</translation>
+    </message>
+    <message>
+        <source>Frames :</source>
+        <translation>Quadros:</translation>
+    </message>
+</context>
+<context>
+    <name>LoadCurvePopup</name>
+    <message>
+        <source>Load Curve</source>
+        <translation>Curva de Carga</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+</context>
+<context>
+    <name>LoadFolderPopup</name>
+    <message>
+        <source>Load Folder</source>
+        <translation>Carregar pasta</translation>
+    </message>
+</context>
+<context>
+    <name>LoadImagesPopup</name>
+    <message>
+        <source>Load Images</source>
+        <translation>Carregar imagens</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source>To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Shrink:</source>
+        <translation>Encolher:</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Append Images</source>
+        <translation>Anexar imagens</translation>
+    </message>
+    <message>
+        <source>Append</source>
+        <translation>Acrescentar</translation>
+    </message>
+    <message>
+        <source>Load / Append Images</source>
+        <translation>Carregar/anexar imagens</translation>
+    </message>
+</context>
+<context>
+    <name>LoadLevelPopup</name>
+    <message>
+        <source>On Demand</source>
+        <translation>Sob demanda</translation>
+    </message>
+    <message>
+        <source>All Icons</source>
+        <translation>Todos os ícones</translation>
+    </message>
+    <message>
+        <source>All Icons &amp; Images</source>
+        <translation>Todos os ícones e imagens</translation>
+    </message>
+    <message>
+        <source>Load Level</source>
+        <translation>Nível de carga</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>%1 does not exist.</source>
+        <translation>%1 não existe.</translation>
+    </message>
+    <message>
+        <source>TLV Caching Behavior</source>
+        <translation>Comportamento de cache TLV</translation>
+    </message>
+    <message>
+        <source>Load Subsequence Level</source>
+        <translation>Carregar nível de subsequência</translation>
+    </message>
+    <message>
+        <source>Arrangement in Xsheet</source>
+        <translation>Organização no Xsheet</translation>
+    </message>
+    <message>
+        <source>(FILE DOES NOT EXIST)</source>
+        <translation>(ARQUIVO NÃO EXISTE)</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source> To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source> Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source> Inc:</source>
+        <translation>Inc:</translation>
+    </message>
+    <message>
+        <source>Level Name:</source>
+        <translation>Nome do nível:</translation>
+    </message>
+    <message>
+        <source> Frames:</source>
+        <translation>Quadros:</translation>
+    </message>
+    <message>
+        <source>::</source>
+        <translation>::</translation>
+    </message>
+    <message>
+        <source>Level Settings &amp; Arrangement in Xsheet</source>
+        <translation>Configurações e organização de níveis no Xsheet</translation>
+    </message>
+    <message>
+        <source>Premultiply</source>
+        <translation>Pré-multiplicar</translation>
+    </message>
+    <message>
+        <source>White As Transparent</source>
+        <translation>Branco como transparente</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>Antialias Softness:</source>
+        <translation>Suavidade antialias:</translation>
+    </message>
+    <message>
+        <source>Subsampling:</source>
+        <translation>Subamostragem:</translation>
+    </message>
+    <message>
+        <source>Raster Level Caching Behavior</source>
+        <translation>Comportamento de cache em nível raster</translation>
+    </message>
+</context>
+<context>
+    <name>LoadScenePopup</name>
+    <message>
+        <source>Load Scene</source>
+        <translation>Carregar cena</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source> is not a scene file.</source>
+        <translation>não é um arquivo de cena.</translation>
+    </message>
+    <message>
+        <source> does not exist.</source>
+        <translation>não existe.</translation>
+    </message>
+</context>
+<context>
+    <name>LoadSettingsPopup</name>
+    <message>
+        <source>Load Cleanup Settings</source>
+        <translation>Carregar configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>%1 does not exist.</source>
+        <translation>%1 não existe.</translation>
+    </message>
+</context>
+<context>
+    <name>LoadSubScenePopup</name>
+    <message>
+        <source>Load Sub-Xsheet</source>
+        <translation>Carregar Sub-Xsheet</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source> is not a scene file.</source>
+        <translation>não é um arquivo de cena.</translation>
+    </message>
+    <message>
+        <source> does not exist.</source>
+        <translation>não existe.</translation>
+    </message>
+</context>
+<context>
+    <name>LoadTaskListPopup</name>
+    <message>
+        <source>Load Task List</source>
+        <translation>Carregar lista de tarefas</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source> does not exist.</source>
+        <translation>não existe.</translation>
+    </message>
+    <message>
+        <source>It is possible to load only TNZBAT files.</source>
+        <translation>É possível carregar apenas arquivos TNZBAT.</translation>
+    </message>
+</context>
+<context>
+    <name>LoadTaskPopup</name>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source> does not exist.</source>
+        <translation>não existe.</translation>
+    </message>
+    <message>
+        <source>Add Render Task to Batch List</source>
+        <translation>Adicionar tarefa de renderização à lista de lotes</translation>
+    </message>
+    <message>
+        <source>Add Cleanup Task to Batch List</source>
+        <translation>Adicionar tarefa de limpeza à lista de lotes</translation>
+    </message>
+    <message>
+        <source>%1 is not a TNZ file.</source>
+        <translation>%1 não é um arquivo TNZ.</translation>
+    </message>
+    <message>
+        <source> you can load only TNZ files for render task.</source>
+        <translation>você pode carregar apenas arquivos TNZ para tarefa de renderização.</translation>
+    </message>
+    <message>
+        <source> you can load only TNZ or CLN files for cleanup task.</source>
+        <translation>você pode carregar apenas arquivos TNZ ou CLN para tarefas de limpeza.</translation>
+    </message>
+</context>
+<context>
+    <name>LocatorPopup</name>
+    <message>
+        <source>Locator</source>
+        <translation>Localizador</translation>
+    </message>
+</context>
+<context>
+    <name>MagpieFileImportPopup</name>
+    <message>
+        <source>Import Magpie File</source>
+        <translation>Importar arquivo Magpie</translation>
+    </message>
+    <message>
+        <source>Frame Range</source>
+        <translation>Faixa de quadros</translation>
+    </message>
+    <message>
+        <source>To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source>Animation Level</source>
+        <translation>Nível de animação</translation>
+    </message>
+    <message>
+        <source>Level:</source>
+        <translation>Nível:</translation>
+    </message>
+    <message>
+        <source>Phoneme</source>
+        <translation>Fonema</translation>
+    </message>
+    <message>
+        <source>Import</source>
+        <translation>Importar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>The file path is missing.</source>
+        <translation>O caminho do arquivo está faltando.</translation>
+    </message>
+    <message>
+        <source>Import Toonz Lip Sync File</source>
+        <translation>Importar arquivo de sincronização labial Toonz</translation>
+    </message>
+    <message>
+        <source>To: </source>
+        <translation>Para:</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <source>Cannot delete</source>
+        <translation>Não é possível excluir</translation>
+    </message>
+    <message>
+        <source>Visit Web Site</source>
+        <translation>Visite o site</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>&amp;New Scene</source>
+        <translation>&amp;Nova cena</translation>
+    </message>
+    <message>
+        <source>&amp;Load Scene...</source>
+        <translation>&amp;Carregar cena...</translation>
+    </message>
+    <message>
+        <source>&amp;Save Scene</source>
+        <translation>&amp;Salvar cena</translation>
+    </message>
+    <message>
+        <source>&amp;Save Scene As...</source>
+        <translation>&amp;Salvar cena como...</translation>
+    </message>
+    <message>
+        <source>&amp;Revert Scene</source>
+        <translation>&amp;Reverter cena</translation>
+    </message>
+    <message>
+        <source>&amp;Open Recent Scene File</source>
+        <translation>&amp;Abrir arquivo de cena recente</translation>
+    </message>
+    <message>
+        <source>&amp;Open Recent Level File</source>
+        <translation>&amp;Abrir arquivo de nível recente</translation>
+    </message>
+    <message>
+        <source>&amp;Clear Recent Scene File List</source>
+        <translation>&amp;Limpar lista de arquivos de cenas recentes</translation>
+    </message>
+    <message>
+        <source>&amp;Clear Recent level File List</source>
+        <translation>&amp;Limpar lista de arquivos de nível recente</translation>
+    </message>
+    <message>
+        <source>&amp;New Level...</source>
+        <translation>&amp;Novo nível...</translation>
+    </message>
+    <message>
+        <source>&amp;Load Level...</source>
+        <translation>&amp;Nível de carga...</translation>
+    </message>
+    <message>
+        <source>&amp;Save Level</source>
+        <translation>&amp;Salvar nível</translation>
+    </message>
+    <message>
+        <source>&amp;Save Level As...</source>
+        <translation>&amp;Salvar nível como...</translation>
+    </message>
+    <message>
+        <source>&amp;Export Level...</source>
+        <translation>&amp;Nível de exportação...</translation>
+    </message>
+    <message>
+        <source>&amp;Save Palette As...</source>
+        <translation>&amp;Salvar paleta como...</translation>
+    </message>
+    <message>
+        <source>&amp;Save Palette</source>
+        <translation>&amp;Salvar paleta</translation>
+    </message>
+    <message>
+        <source>&amp;Load Color Model...</source>
+        <translation>&amp;Carregar modelo de cor...</translation>
+    </message>
+    <message>
+        <source>&amp;Import Magpie File...</source>
+        <translation>&amp;Importar arquivo Magpie...</translation>
+    </message>
+    <message>
+        <source>&amp;New Project...</source>
+        <translation>&amp;Novo projeto...</translation>
+    </message>
+    <message>
+        <source>&amp;Project Settings...</source>
+        <translation>&amp;Configurações do projeto...</translation>
+    </message>
+    <message>
+        <source>&amp;Save Default Settings</source>
+        <translation>&amp;Salvar configurações padrão</translation>
+    </message>
+    <message>
+        <source>&amp;Output Settings...</source>
+        <translation>&amp;Configurações de saída...</translation>
+    </message>
+    <message>
+        <source>&amp;Preview Settings...</source>
+        <translation>&amp;Configurações de visualização...</translation>
+    </message>
+    <message>
+        <source>&amp;Render</source>
+        <translation>&amp;Renderizar</translation>
+    </message>
+    <message>
+        <source>&amp;Preview</source>
+        <translation>&amp;Visualizar</translation>
+    </message>
+    <message>
+        <source>&amp;Save Previewed Frames</source>
+        <translation>&amp;Salvar quadros pré-visualizados</translation>
+    </message>
+    <message>
+        <source>&amp;Regenerate Preview</source>
+        <translation>&amp;Regenerar visualização</translation>
+    </message>
+    <message>
+        <source>&amp;Regenerate Frame Preview</source>
+        <translation>&amp;Regenerar visualização do quadro</translation>
+    </message>
+    <message>
+        <source>&amp;Clone Preview</source>
+        <translation>&amp;Clonar visualização</translation>
+    </message>
+    <message>
+        <source>&amp;Freeze//Unfreeze Preview</source>
+        <translation>&amp;Congelar//Descongelar visualização</translation>
+    </message>
+    <message>
+        <source>Freeze Preview</source>
+        <translation>Pré-visualização congelada</translation>
+    </message>
+    <message>
+        <source>Unfreeze Preview</source>
+        <translation>Pré-visualização do descongelamento</translation>
+    </message>
+    <message>
+        <source>&amp;Save As Preset</source>
+        <translation>&amp;Salvar como predefinição</translation>
+    </message>
+    <message>
+        <source>&amp;Preferences...</source>
+        <translation>&amp;Preferências...</translation>
+    </message>
+    <message>
+        <source>&amp;Configure Shortcuts...</source>
+        <translation>&amp;Configurar atalhos...</translation>
+    </message>
+    <message>
+        <source>&amp;Print Xsheet</source>
+        <translation>&amp;Imprimir planilha X</translation>
+    </message>
+    <message>
+        <source>&amp;Print Current Frame...</source>
+        <translation>&amp;Imprimir quadro atual...</translation>
+    </message>
+    <message>
+        <source>&amp;Quit</source>
+        <translation>&amp;Desistir</translation>
+    </message>
+    <message>
+        <source>&amp;Select All</source>
+        <translation>&amp;Selecionar tudo</translation>
+    </message>
+    <message>
+        <source>&amp;Invert Selection</source>
+        <translation>&amp;Inverter seleção</translation>
+    </message>
+    <message>
+        <source>&amp;Undo</source>
+        <translation>&amp;Desfazer</translation>
+    </message>
+    <message>
+        <source>&amp;Redo</source>
+        <translation>&amp;Refazer</translation>
+    </message>
+    <message>
+        <source>&amp;Cut</source>
+        <translation>&amp;Corte</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation>&amp;Cópia</translation>
+    </message>
+    <message>
+        <source>&amp;Paste</source>
+        <translation>&amp;Colar</translation>
+    </message>
+    <message>
+        <source>&amp;Merge</source>
+        <translation>&amp;Mesclar</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Into</source>
+        <translation>&amp;Colar em</translation>
+    </message>
+    <message>
+        <source>Paste RGBA Values</source>
+        <translation>Colar valores RGBA</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Excluir</translation>
+    </message>
+    <message>
+        <source>&amp;Insert</source>
+        <translation>&amp;Inserir</translation>
+    </message>
+    <message>
+        <source>&amp;Group</source>
+        <translation>&amp;Grupo</translation>
+    </message>
+    <message>
+        <source>&amp;Ungroup</source>
+        <translation>&amp;Desagrupar</translation>
+    </message>
+    <message>
+        <source>&amp;Bring to Front</source>
+        <translation>&amp;Trazer para frente</translation>
+    </message>
+    <message>
+        <source>&amp;Bring Forward</source>
+        <translation>&amp;Apresentar</translation>
+    </message>
+    <message>
+        <source>&amp;Send Back</source>
+        <translation>&amp;Enviar de volta</translation>
+    </message>
+    <message>
+        <source>&amp;Send Backward</source>
+        <translation>&amp;Enviar para trás</translation>
+    </message>
+    <message>
+        <source>&amp;Enter Group</source>
+        <translation>&amp;Entrar no grupo</translation>
+    </message>
+    <message>
+        <source>&amp;Exit Group</source>
+        <translation>&amp;Sair do grupo</translation>
+    </message>
+    <message>
+        <source>&amp;Remove Vector Overflow</source>
+        <translation>&amp;Remover estouro de vetor</translation>
+    </message>
+    <message>
+        <source>&amp;Define Scanner...</source>
+        <translation>&amp;Definir Scanner...</translation>
+    </message>
+    <message>
+        <source>&amp;Scan Settings...</source>
+        <translation>&amp;Configurações de digitalização...</translation>
+    </message>
+    <message>
+        <source>&amp;Scan</source>
+        <translation>&amp;Escanear</translation>
+    </message>
+    <message>
+        <source>&amp;Set Cropbox</source>
+        <translation>&amp;Definir caixa de corte</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Cropbox</source>
+        <translation>&amp;Redefinir caixa de corte</translation>
+    </message>
+    <message>
+        <source>&amp;Cleanup Settings...</source>
+        <translation>&amp;Configurações de limpeza...</translation>
+    </message>
+    <message>
+        <source>&amp;Preview Cleanup</source>
+        <translation>&amp;Visualizar limpeza</translation>
+    </message>
+    <message>
+        <source>&amp;Camera Test</source>
+        <translation>Teste de &amp;câmera</translation>
+    </message>
+    <message>
+        <source>&amp;Cleanup</source>
+        <translation>&amp;Limpar</translation>
+    </message>
+    <message>
+        <source>&amp;Add Frames...</source>
+        <translation>&amp;Adicionar quadros...</translation>
+    </message>
+    <message>
+        <source>&amp;Renumber...</source>
+        <translation>&amp;Renumerar...</translation>
+    </message>
+    <message>
+        <source>&amp;Replace Level...</source>
+        <translation>&amp;Substituir Nível...</translation>
+    </message>
+    <message>
+        <source>&amp;Revert to Cleaned Up</source>
+        <translation>&amp;Reverter para Limpo</translation>
+    </message>
+    <message>
+        <source>&amp;Revert to Last Saved Version</source>
+        <translation>&amp;Reverter para a última versão salva</translation>
+    </message>
+    <message>
+        <source>&amp;Expose in Xsheet</source>
+        <translation>&amp;Expor no Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Display in Level Strip</source>
+        <translation>&amp;Exibir na Faixa de Nível</translation>
+    </message>
+    <message>
+        <source>&amp;Level Settings...</source>
+        <translation>&amp;Configurações de nível...</translation>
+    </message>
+    <message>
+        <source>&amp;Brightness and Contrast...</source>
+        <translation>&amp;Brilho e contraste...</translation>
+    </message>
+    <message>
+        <source>&amp;Color Fade...</source>
+        <translation>&amp;Cor desbotada...</translation>
+    </message>
+    <message>
+        <source>&amp;Canvas Size...</source>
+        <translation>&amp;Tamanho da tela...</translation>
+    </message>
+    <message>
+        <source>&amp;Info...</source>
+        <translation>&amp;Informações...</translation>
+    </message>
+    <message>
+        <source>&amp;View...</source>
+        <translation>&amp;Visualizar...</translation>
+    </message>
+    <message>
+        <source>&amp;Remove All Unused Levels</source>
+        <translation>&amp;Remover todos os níveis não utilizados</translation>
+    </message>
+    <message>
+        <source>&amp;Scene Settings...</source>
+        <translation>&amp;Configurações de cena...</translation>
+    </message>
+    <message>
+        <source>&amp;Camera Settings...</source>
+        <translation>&amp;Configurações da câmera...</translation>
+    </message>
+    <message>
+        <source>&amp;Open Sub-xsheet</source>
+        <translation>&amp;Abrir subplanilha</translation>
+    </message>
+    <message>
+        <source>&amp;Close Sub-xsheet</source>
+        <translation>&amp;Fechar Subplanilha</translation>
+    </message>
+    <message>
+        <source>Explode Sub-xsheet</source>
+        <translation>Explodir Sub-xsheet</translation>
+    </message>
+    <message>
+        <source>Collapse</source>
+        <translation>Colapso</translation>
+    </message>
+    <message>
+        <source>&amp;Save Sub-xsheet As...</source>
+        <translation>&amp;Salvar subplanilha como...</translation>
+    </message>
+    <message>
+        <source>Resequence</source>
+        <translation>Resequência</translation>
+    </message>
+    <message>
+        <source>Clone Sub-xsheet</source>
+        <translation>Clonar Sub-xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Apply Match Lines...</source>
+        <translation>&amp;Aplicar linhas de correspondência...</translation>
+    </message>
+    <message>
+        <source>&amp;Delete Match Lines</source>
+        <translation>&amp;Excluir linhas de correspondência</translation>
+    </message>
+    <message>
+        <source>&amp;Delete Lines...</source>
+        <translation>&amp;Excluir linhas...</translation>
+    </message>
+    <message>
+        <source>&amp;Merge Levels</source>
+        <translation>&amp;Mesclar Níveis</translation>
+    </message>
+    <message>
+        <source>&amp;New FX...</source>
+        <translation>&amp;Novo FX...</translation>
+    </message>
+    <message>
+        <source>&amp;New Output</source>
+        <translation>&amp;Nova saída</translation>
+    </message>
+    <message>
+        <source>&amp;Edit FX...</source>
+        <translation>&amp;Editar FX...</translation>
+    </message>
+    <message>
+        <source>Insert Frame</source>
+        <translation>Inserir quadro</translation>
+    </message>
+    <message>
+        <source>Remove Frame</source>
+        <translation>Remover quadro</translation>
+    </message>
+    <message>
+        <source>Insert Multiple Keys</source>
+        <translation>Insira várias chaves</translation>
+    </message>
+    <message>
+        <source>Remove Multiple Keys</source>
+        <translation>Remover várias chaves</translation>
+    </message>
+    <message>
+        <source>&amp;Reverse</source>
+        <translation>&amp;Reverter</translation>
+    </message>
+    <message>
+        <source>&amp;Swing</source>
+        <translation>&amp;Balanço</translation>
+    </message>
+    <message>
+        <source>&amp;Random</source>
+        <translation>&amp;Aleatório</translation>
+    </message>
+    <message>
+        <source>&amp;Autoexpose</source>
+        <translation>&amp;Exposição automática</translation>
+    </message>
+    <message>
+        <source>&amp;Repeat...</source>
+        <translation>&amp;Repita...</translation>
+    </message>
+    <message>
+        <source>&amp;Step 2</source>
+        <translation>&amp;Etapa 2</translation>
+    </message>
+    <message>
+        <source>&amp;Step 3</source>
+        <translation>&amp;Etapa 3</translation>
+    </message>
+    <message>
+        <source>&amp;Step 4</source>
+        <translation>&amp;Etapa 4</translation>
+    </message>
+    <message>
+        <source>&amp;Each 2</source>
+        <translation>&amp;Cada 2</translation>
+    </message>
+    <message>
+        <source>&amp;Each 3</source>
+        <translation>&amp;Cada 3</translation>
+    </message>
+    <message>
+        <source>&amp;Each 4</source>
+        <translation>&amp;Cada 4</translation>
+    </message>
+    <message>
+        <source>&amp;Roll Up</source>
+        <translation>&amp;Arregaçar</translation>
+    </message>
+    <message>
+        <source>&amp;Roll Down</source>
+        <translation>&amp;Rolar para baixo</translation>
+    </message>
+    <message>
+        <source>&amp;Time Stretch...</source>
+        <translation>&amp;Ampliação de tempo...</translation>
+    </message>
+    <message>
+        <source>&amp;Duplicate Drawing  </source>
+        <translation>&amp;Duplicar desenho</translation>
+    </message>
+    <message>
+        <source>&amp;Clone</source>
+        <translation>&amp;Clone</translation>
+    </message>
+    <message>
+        <source>Drawing Substitution Forward</source>
+        <translation>Desenho de substituição para frente</translation>
+    </message>
+    <message>
+        <source>Drawing Substitution Backward</source>
+        <translation>Substituição de desenho para trás</translation>
+    </message>
+    <message>
+        <source>Similar Drawing Substitution Forward</source>
+        <translation>Substituição de desenho semelhante para frente</translation>
+    </message>
+    <message>
+        <source>Similar Drawing Substitution Backward</source>
+        <translation>Substituição de desenho semelhante para trás</translation>
+    </message>
+    <message>
+        <source>&amp;Set Key</source>
+        <translation>&amp;Definir chave</translation>
+    </message>
+    <message>
+        <source>&amp;Camera Box</source>
+        <translation>&amp;Caixa da câmera</translation>
+    </message>
+    <message>
+        <source>&amp;Table</source>
+        <translation>&amp;Mesa de animação</translation>
+    </message>
+    <message>
+        <source>&amp;Field Guide</source>
+        <translation>&amp;Guia de campo</translation>
+    </message>
+    <message>
+        <source>&amp;Safe Area</source>
+        <translation>&amp;Área Segura</translation>
+    </message>
+    <message>
+        <source>&amp;Camera BG Color</source>
+        <translation>Cor de fundo da &amp;câmera</translation>
+    </message>
+    <message>
+        <source>&amp;Transparency Check  </source>
+        <translation>&amp;Verificação de transparência</translation>
+    </message>
+    <message>
+        <source>&amp;Ink Check</source>
+        <translation>&amp;Verificação de tinta</translation>
+    </message>
+    <message>
+        <source>&amp;Paint Check</source>
+        <translation>Verificação de &amp;pintura</translation>
+    </message>
+    <message>
+        <source>&amp;Fill Check</source>
+        <translation>Verificação de &amp;preenchimento</translation>
+    </message>
+    <message>
+        <source>&amp;Black BG Check</source>
+        <translation>&amp;Verificação de glicemia preta</translation>
+    </message>
+    <message>
+        <source>&amp;Gap Check</source>
+        <translation>&amp;Verificação de lacunas</translation>
+    </message>
+    <message>
+        <source>&amp;Visualize Vector As Raster</source>
+        <translation>&amp;Visualizar vetor como raster</translation>
+    </message>
+    <message>
+        <source>&amp;Histogram</source>
+        <translation>&amp;Histograma</translation>
+    </message>
+    <message>
+        <source>&amp;Capture</source>
+        <translation>&amp;Capturar</translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation>Jogar</translation>
+    </message>
+    <message>
+        <source>Loop</source>
+        <translation>Laço</translation>
+    </message>
+    <message>
+        <source>Pause</source>
+        <translation>Pausa</translation>
+    </message>
+    <message>
+        <source>First Frame</source>
+        <translation>Primeiro quadro</translation>
+    </message>
+    <message>
+        <source>Last Frame</source>
+        <translation>Último quadro</translation>
+    </message>
+    <message>
+        <source>Previous Frame</source>
+        <translation>Quadro Anterior</translation>
+    </message>
+    <message>
+        <source>Next Frame</source>
+        <translation>Próximo quadro</translation>
+    </message>
+    <message>
+        <source>Red Channel</source>
+        <translation>Canal Vermelho</translation>
+    </message>
+    <message>
+        <source>Green Channel</source>
+        <translation>Canal Verde</translation>
+    </message>
+    <message>
+        <source>Blue Channel</source>
+        <translation>Canal Azul</translation>
+    </message>
+    <message>
+        <source>Matte Channel</source>
+        <translation>Canal fosco</translation>
+    </message>
+    <message>
+        <source>Red Channel Greyscale</source>
+        <translation>Escala de cinza do canal vermelho</translation>
+    </message>
+    <message>
+        <source>Green Channel Greyscale</source>
+        <translation>Escala de cinza do canal verde</translation>
+    </message>
+    <message>
+        <source>Blue Channel Greyscale</source>
+        <translation>Escala de cinza do canal azul</translation>
+    </message>
+    <message>
+        <source>&amp;Lock Room Panes</source>
+        <translation>&amp;Bloquear painéis da sala</translation>
+    </message>
+    <message>
+        <source>&amp;File Browser</source>
+        <translation>&amp;Navegador de arquivos</translation>
+    </message>
+    <message>
+        <source>&amp;Flipbook</source>
+        <translation>&amp;Fliplivro</translation>
+    </message>
+    <message>
+        <source>&amp;Function Editor</source>
+        <translation>Editor de &amp;funções</translation>
+    </message>
+    <message>
+        <source>&amp;Level Strip</source>
+        <translation>&amp;Faixa de nível</translation>
+    </message>
+    <message>
+        <source>&amp;Palette</source>
+        <translation>&amp;Paleta</translation>
+    </message>
+    <message>
+        <source>&amp;Palette Gizmo</source>
+        <translation>&amp;Paleta Gizmo</translation>
+    </message>
+    <message>
+        <source>&amp;Delete Unused Styles</source>
+        <translation>&amp;Excluir estilos não utilizados</translation>
+    </message>
+    <message>
+        <source>&amp;Tasks</source>
+        <translation>&amp;Tarefas</translation>
+    </message>
+    <message>
+        <source>&amp;Batch Servers</source>
+        <translation>&amp;Servidores em lote</translation>
+    </message>
+    <message>
+        <source>&amp;Color Model</source>
+        <translation>&amp;Modelo de cores</translation>
+    </message>
+    <message>
+        <source>&amp;Studio Palette</source>
+        <translation>Paleta &amp;Studio</translation>
+    </message>
+    <message>
+        <source>&amp;Schematic</source>
+        <translation>&amp;Esquemático</translation>
+    </message>
+    <message>
+        <source>Toggle FX/Stage schematic</source>
+        <translation>Alternar esquema FX/Stage</translation>
+    </message>
+    <message>
+        <source>&amp;Scene Cast</source>
+        <translation>&amp;Elenco de cena</translation>
+    </message>
+    <message>
+        <source>&amp;Style Editor</source>
+        <translation>Editor de &amp;estilos</translation>
+    </message>
+    <message>
+        <source>&amp;Toolbar</source>
+        <translation>&amp;Barra de ferramentas</translation>
+    </message>
+    <message>
+        <source>&amp;Tool Option Bar</source>
+        <translation>&amp;Barra de opções de ferramentas</translation>
+    </message>
+    <message>
+        <source>&amp;Viewer</source>
+        <translation>&amp;Visualizador</translation>
+    </message>
+    <message>
+        <source>&amp;LineTest Viewer</source>
+        <translation>&amp;LineTest Viewer</translation>
+    </message>
+    <message>
+        <source>&amp;LineTest Capture</source>
+        <translation>Captura de teste de &amp;linha</translation>
+    </message>
+    <message>
+        <source>&amp;Xsheet</source>
+        <translation>&amp;Xplanilha</translation>
+    </message>
+    <message>
+        <source>&amp;Reset to Default Rooms</source>
+        <translation>&amp;Redefinir para salas padrão</translation>
+    </message>
+    <message>
+        <source>Onion Skin</source>
+        <translation>Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Duplicate</source>
+        <translation>Duplicado</translation>
+    </message>
+    <message>
+        <source>Show Folder Contents</source>
+        <translation>Mostrar conteúdo da pasta</translation>
+    </message>
+    <message>
+        <source>Convert...</source>
+        <translation>Converter...</translation>
+    </message>
+    <message>
+        <source>Collect Assets</source>
+        <translation>Coletar ativos</translation>
+    </message>
+    <message>
+        <source>Import Scene</source>
+        <translation>Cena de importação</translation>
+    </message>
+    <message>
+        <source>Export Scene...</source>
+        <translation>Exportar cena...</translation>
+    </message>
+    <message>
+        <source>Premultiply</source>
+        <translation>Pré-multiplicar</translation>
+    </message>
+    <message>
+        <source>Convert to Vectors...</source>
+        <translation>Converter em vetores...</translation>
+    </message>
+    <message>
+        <source>Tracking...</source>
+        <translation>Monitorando...</translation>
+    </message>
+    <message>
+        <source>Remove Level</source>
+        <translation>Remover nível</translation>
+    </message>
+    <message>
+        <source>Add As Render Task</source>
+        <translation>Adicionar como tarefa de renderização</translation>
+    </message>
+    <message>
+        <source>Add As Cleanup Task</source>
+        <translation>Adicionar como tarefa de limpeza</translation>
+    </message>
+    <message>
+        <source>Select All Keys in this Frame</source>
+        <translation>Selecione todas as chaves neste quadro</translation>
+    </message>
+    <message>
+        <source>Select All Keys in this Column</source>
+        <translation>Selecione todas as chaves nesta coluna</translation>
+    </message>
+    <message>
+        <source>Select All Keys</source>
+        <translation>Selecione todas as chaves</translation>
+    </message>
+    <message>
+        <source>Select All Following Keys</source>
+        <translation>Selecione todas as seguintes chaves</translation>
+    </message>
+    <message>
+        <source>Select All Previous Keys</source>
+        <translation>Selecione todas as chaves anteriores</translation>
+    </message>
+    <message>
+        <source>Select Previous Keys in this Column</source>
+        <translation>Selecione as chaves anteriores nesta coluna</translation>
+    </message>
+    <message>
+        <source>Select Following Keys in this Column</source>
+        <translation>Selecione as seguintes chaves nesta coluna</translation>
+    </message>
+    <message>
+        <source>Select Previous Keys in this Frame</source>
+        <translation>Selecione as chaves anteriores neste quadro</translation>
+    </message>
+    <message>
+        <source>Select Following Keys in this Frame</source>
+        <translation>Selecione as seguintes chaves neste quadro</translation>
+    </message>
+    <message>
+        <source>Invert Key Selection</source>
+        <translation>Inverter seleção de chave</translation>
+    </message>
+    <message>
+        <source>Set Acceleration</source>
+        <translation>Definir aceleração</translation>
+    </message>
+    <message>
+        <source>Set Deceleration</source>
+        <translation>Definir desaceleração</translation>
+    </message>
+    <message>
+        <source>Set Constant Speed</source>
+        <translation>Definir velocidade constante</translation>
+    </message>
+    <message>
+        <source>Reset Interpolation</source>
+        <translation>Redefinir interpolação</translation>
+    </message>
+    <message>
+        <source>Fold Column</source>
+        <translation>Coluna Dobrada</translation>
+    </message>
+    <message>
+        <source>Activate this column only</source>
+        <translation>Ative apenas esta coluna</translation>
+    </message>
+    <message>
+        <source>Activate selected columns</source>
+        <translation>Ativar colunas selecionadas</translation>
+    </message>
+    <message>
+        <source>Activate all columns</source>
+        <translation>Ative todas as colunas</translation>
+    </message>
+    <message>
+        <source>Deactivate selected columns</source>
+        <translation>Desativar colunas selecionadas</translation>
+    </message>
+    <message>
+        <source>Deactivate all columns</source>
+        <translation>Desative todas as colunas</translation>
+    </message>
+    <message>
+        <source>Toggle columns activation</source>
+        <translation>Alternar ativação de colunas</translation>
+    </message>
+    <message>
+        <source>Enable this column only</source>
+        <translation>Ativar apenas esta coluna</translation>
+    </message>
+    <message>
+        <source>Enable selected columns</source>
+        <translation>Habilitar colunas selecionadas</translation>
+    </message>
+    <message>
+        <source>Enable all columns</source>
+        <translation>Habilitar todas as colunas</translation>
+    </message>
+    <message>
+        <source>Disable all columns</source>
+        <translation>Desabilitar todas as colunas</translation>
+    </message>
+    <message>
+        <source>Disable selected columns</source>
+        <translation>Desabilitar colunas selecionadas</translation>
+    </message>
+    <message>
+        <source>Swap enabled columns</source>
+        <translation>Trocar colunas habilitadas</translation>
+    </message>
+    <message>
+        <source>Lock this column only</source>
+        <translation>Bloquear apenas esta coluna</translation>
+    </message>
+    <message>
+        <source>Lock selected columns</source>
+        <translation>Bloquear colunas selecionadas</translation>
+    </message>
+    <message>
+        <source>Lock all columns</source>
+        <translation>Bloquear todas as colunas</translation>
+    </message>
+    <message>
+        <source>Unlock selected columns</source>
+        <translation>Desbloquear colunas selecionadas</translation>
+    </message>
+    <message>
+        <source>Unlock all columns</source>
+        <translation>Desbloquear todas as colunas</translation>
+    </message>
+    <message>
+        <source>Swap locked columns</source>
+        <translation>Trocar colunas bloqueadas</translation>
+    </message>
+    <message>
+        <source>Edit Tool</source>
+        <translation>Ferramenta de edição</translation>
+    </message>
+    <message>
+        <source>Selection Tool</source>
+        <translation>Ferramenta de seleção</translation>
+    </message>
+    <message>
+        <source>Brush Tool</source>
+        <translation>Ferramenta Pincel</translation>
+    </message>
+    <message>
+        <source>Geometric Tool</source>
+        <translation>Ferramenta Geométrica</translation>
+    </message>
+    <message>
+        <source>Type Tool</source>
+        <translation>Ferramenta de tipo</translation>
+    </message>
+    <message>
+        <source>Fill Tool</source>
+        <translation>Ferramenta de preenchimento</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Areas</source>
+        <translation>Ferramenta Preenchimento - Áreas</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Lines</source>
+        <translation>Ferramenta Preenchimento - Linhas</translation>
+    </message>
+    <message>
+        <source>Paint Brush Tool</source>
+        <translation>Ferramenta Pincel</translation>
+    </message>
+    <message>
+        <source>Eraser Tool</source>
+        <translation>Ferramenta Borracha</translation>
+    </message>
+    <message>
+        <source>Tape Tool</source>
+        <translation>Ferramenta Fita</translation>
+    </message>
+    <message>
+        <source>Style Picker Tool</source>
+        <translation>Ferramenta seletor de estilo</translation>
+    </message>
+    <message>
+        <source>Style Picker Tool - Areas</source>
+        <translation>Ferramenta Seletor de Estilo - Áreas</translation>
+    </message>
+    <message>
+        <source>Style Picker Tool - Lines</source>
+        <translation>Ferramenta Seletor de Estilo - Linhas</translation>
+    </message>
+    <message>
+        <source>RGB Picker Tool</source>
+        <translation>Ferramenta seletor RGB</translation>
+    </message>
+    <message>
+        <source>Control Point Editor Tool</source>
+        <translation>Ferramenta Editor de Ponto de Controle</translation>
+    </message>
+    <message>
+        <source>Pinch Tool</source>
+        <translation>Ferramenta de pinça</translation>
+    </message>
+    <message>
+        <source>Pump Tool</source>
+        <translation>Ferramenta de bomba</translation>
+    </message>
+    <message>
+        <source>Magnet Tool</source>
+        <translation>Ferramenta magnética</translation>
+    </message>
+    <message>
+        <source>Bender Tool</source>
+        <translation>Ferramenta Dobradora</translation>
+    </message>
+    <message>
+        <source>Iron Tool</source>
+        <translation>Ferramenta de Ferro</translation>
+    </message>
+    <message>
+        <source>Cutter Tool</source>
+        <translation>Ferramenta de corte</translation>
+    </message>
+    <message>
+        <source>Skeleton Tool</source>
+        <translation>Ferramenta Esqueleto</translation>
+    </message>
+    <message>
+        <source>Tracker Tool</source>
+        <translation>Ferramenta Rastreador</translation>
+    </message>
+    <message>
+        <source>Hook Tool</source>
+        <translation>Ferramenta Gancho</translation>
+    </message>
+    <message>
+        <source>Zoom Tool</source>
+        <translation>Ferramenta Zoom</translation>
+    </message>
+    <message>
+        <source>Rotate Tool</source>
+        <translation>Ferramenta Girar</translation>
+    </message>
+    <message>
+        <source>Hand Tool</source>
+        <translation>Ferramenta manual</translation>
+    </message>
+    <message>
+        <source>Zoom In</source>
+        <translation>Ampliar</translation>
+    </message>
+    <message>
+        <source>Zoom Out</source>
+        <translation>Diminuir zoom</translation>
+    </message>
+    <message>
+        <source>Reset View</source>
+        <translation>Redefinir visualização</translation>
+    </message>
+    <message>
+        <source>Fit to Window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+    <message>
+        <source>Actual Pixel Size</source>
+        <translation>Tamanho real do pixel</translation>
+    </message>
+    <message>
+        <source>Show//Hide Full Screen</source>
+        <translation>Mostrar // Ocultar tela inteira</translation>
+    </message>
+    <message>
+        <source>Full Screen Mode</source>
+        <translation>Modo de tela inteira</translation>
+    </message>
+    <message>
+        <source>Exit Full Screen Mode</source>
+        <translation>Sair do modo de tela cheia</translation>
+    </message>
+    <message>
+        <source>Global Key</source>
+        <translation>Chave Global</translation>
+    </message>
+    <message>
+        <source>Increase brush hardness</source>
+        <translation>Aumentar a dureza do pincel</translation>
+    </message>
+    <message>
+        <source>Decrease brush hardness</source>
+        <translation>Diminuir a dureza do pincel</translation>
+    </message>
+    <message>
+        <source>Auto Group</source>
+        <translation>Grupo Automático</translation>
+    </message>
+    <message>
+        <source>Break sharp angles</source>
+        <translation>Quebre ângulos agudos</translation>
+    </message>
+    <message>
+        <source>Frame range</source>
+        <translation>Faixa de quadros</translation>
+    </message>
+    <message>
+        <source>Inverse Kinematics</source>
+        <translation>Cinemática Inversa</translation>
+    </message>
+    <message>
+        <source>Invert</source>
+        <translation>Invertido</translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation>Manual</translation>
+    </message>
+    <message>
+        <source>Onion skin</source>
+        <translation>Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Orientation</source>
+        <translation>Orientação</translation>
+    </message>
+    <message>
+        <source>Pencil Mode</source>
+        <translation>Modo Lápis</translation>
+    </message>
+    <message>
+        <source>Preserve Thickness</source>
+        <translation>Preservar espessura</translation>
+    </message>
+    <message>
+        <source>Pressure sensibility</source>
+        <translation>Sensibilidade à pressão</translation>
+    </message>
+    <message>
+        <source>Segment Ink</source>
+        <translation>Tinta de Segmento</translation>
+    </message>
+    <message>
+        <source>Selective</source>
+        <translation>Seletivo</translation>
+    </message>
+    <message>
+        <source>Smooth</source>
+        <translation>Suave</translation>
+    </message>
+    <message>
+        <source>Snap</source>
+        <translation>Encaixe</translation>
+    </message>
+    <message>
+        <source>Auto Select Drawing</source>
+        <translation>Seleção automática de desenho</translation>
+    </message>
+    <message>
+        <source>Auto Fill</source>
+        <translation>Preenchimento automático</translation>
+    </message>
+    <message>
+        <source>Join Vectors</source>
+        <translation>Junte-se a vetores</translation>
+    </message>
+    <message>
+        <source>Show Only Active Skeleton</source>
+        <translation>Mostrar apenas esqueleto ativo</translation>
+    </message>
+    <message>
+        <source>Brush Preset</source>
+        <translation>Predefinição de pincel</translation>
+    </message>
+    <message>
+        <source>Geometric Shape</source>
+        <translation>Forma Geométrica</translation>
+    </message>
+    <message>
+        <source>Geometric Edge</source>
+        <translation>Borda Geométrica</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation>Modo</translation>
+    </message>
+    <message>
+        <source>Areas Mode</source>
+        <translation>Modo Áreas</translation>
+    </message>
+    <message>
+        <source>Lines Mode</source>
+        <translation>Modo de linhas</translation>
+    </message>
+    <message>
+        <source>Lines &amp; Areas Mode</source>
+        <translation>Modo Linhas e Áreas</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>Normal Type</source>
+        <translation>Tipo normal</translation>
+    </message>
+    <message>
+        <source>Rectangular Type</source>
+        <translation>Tipo Retangular</translation>
+    </message>
+    <message>
+        <source>Freehand Type</source>
+        <translation>Tipo à mão livre</translation>
+    </message>
+    <message>
+        <source>Polyline Type</source>
+        <translation>Tipo de polilinha</translation>
+    </message>
+    <message>
+        <source>TypeTool Font</source>
+        <translation>Fonte TypeTool</translation>
+    </message>
+    <message>
+        <source>TypeTool Size</source>
+        <translation>TipoTamanho da ferramenta</translation>
+    </message>
+    <message>
+        <source>TypeTool Style</source>
+        <translation>Estilo TypeTool</translation>
+    </message>
+    <message>
+        <source>Active Axis</source>
+        <translation>Eixo Ativo</translation>
+    </message>
+    <message>
+        <source>Active Axis - Position</source>
+        <translation>Eixo Ativo - Posição</translation>
+    </message>
+    <message>
+        <source>Active Axis - Rotation</source>
+        <translation>Eixo Ativo - Rotação</translation>
+    </message>
+    <message>
+        <source>Active Axis - Scale</source>
+        <translation>Eixo Ativo - Escala</translation>
+    </message>
+    <message>
+        <source>Active Axis - Shear</source>
+        <translation>Eixo Ativo - Cisalhamento</translation>
+    </message>
+    <message>
+        <source>Active Axis - Center</source>
+        <translation>Eixo Ativo - Centro</translation>
+    </message>
+    <message>
+        <source>Build Skeleton Mode</source>
+        <translation>Modo Construir Esqueleto</translation>
+    </message>
+    <message>
+        <source>Animate Mode</source>
+        <translation>Modo Animar</translation>
+    </message>
+    <message>
+        <source>Inverse Kinematics Mode</source>
+        <translation>Modo Cinemática Inversa</translation>
+    </message>
+    <message>
+        <source>None Pick Mode</source>
+        <translation>Nenhum modo de seleção</translation>
+    </message>
+    <message>
+        <source>Column Pick Mode</source>
+        <translation>Modo de seleção de coluna</translation>
+    </message>
+    <message>
+        <source>Pegbar Pick Mode</source>
+        <translation>Modo de seleção Pegbar</translation>
+    </message>
+    <message>
+        <source>Drawing</source>
+        <translation>Desenho</translation>
+    </message>
+    <message>
+        <source>Animation</source>
+        <translation>Animação</translation>
+    </message>
+    <message>
+        <source>Browser</source>
+        <translation>Navegador</translation>
+    </message>
+    <message>
+        <source>Pltedit</source>
+        <translation>Pltedit</translation>
+    </message>
+    <message>
+        <source>Farm</source>
+        <translation>Fazenda</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Step</source>
+        <translation>&amp;Redefinir etapa</translation>
+    </message>
+    <message>
+        <source>&amp;Increase Step</source>
+        <translation>&amp;Aumentar passo</translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Step</source>
+        <translation>&amp;Diminuir etapa</translation>
+    </message>
+    <message>
+        <source>Reload qss</source>
+        <translation>Recarregar qss</translation>
+    </message>
+    <message>
+        <source>&amp;Autocenter...</source>
+        <translation>&amp;Autocenter...</translation>
+    </message>
+    <message>
+        <source>&amp;Binarize...</source>
+        <translation>&amp;Binarizar...</translation>
+    </message>
+    <message>
+        <source>&amp;Autorenumber</source>
+        <translation>&amp;Renumeração automática</translation>
+    </message>
+    <message>
+        <source>&amp;Field Guide in Capture Window</source>
+        <translation>&amp;Guia de campo na janela de captura</translation>
+    </message>
+    <message>
+        <source>&amp;Guide</source>
+        <translation>&amp;Guia</translation>
+    </message>
+    <message>
+        <source>&amp;Ruler</source>
+        <translation>&amp;Governante</translation>
+    </message>
+    <message>
+        <source>Shift and Trace</source>
+        <translation>Mudança e rastreamento</translation>
+    </message>
+    <message>
+        <source>Edit Shift</source>
+        <translation>Editar turno</translation>
+    </message>
+    <message>
+        <source>No Shift</source>
+        <translation>Sem mudança</translation>
+    </message>
+    <message>
+        <source>Reset Shift</source>
+        <translation>Redefinir turno</translation>
+    </message>
+    <message>
+        <source>Next Drawing</source>
+        <translation>Próximo desenho</translation>
+    </message>
+    <message>
+        <source>Prev Drawing</source>
+        <translation>Desenho Anterior</translation>
+    </message>
+    <message>
+        <source>Toggle Autofill on Current Palette Color</source>
+        <translation>Alternar preenchimento automático na cor da paleta atual</translation>
+    </message>
+    <message>
+        <source>&amp;Export</source>
+        <translation>&amp;Exportar</translation>
+    </message>
+    <message>
+        <source>Increase max brush thickness</source>
+        <translation>Aumentar a espessura máxima do pincel</translation>
+    </message>
+    <message>
+        <source>Decrease max brush thickness</source>
+        <translation>Diminuir a espessura máxima do pincel</translation>
+    </message>
+    <message>
+        <source>Increase min brush thickness</source>
+        <translation>Aumentar a espessura mínima do pincel</translation>
+    </message>
+    <message>
+        <source>Decrease min brush thickness</source>
+        <translation>Diminuir a espessura mínima do pincel</translation>
+    </message>
+    <message>
+        <source>Pick Screen</source>
+        <translation>Escolher tela</translation>
+    </message>
+    <message>
+        <source>&amp;Blend colors</source>
+        <translation>&amp;Misturar cores</translation>
+    </message>
+    <message>
+        <source>Linetest</source>
+        <translation>Teste de linha</translation>
+    </message>
+    <message>
+        <source>&amp;Load As Sub-xsheet...</source>
+        <translation>&amp;Carregar como sub-planilha...</translation>
+    </message>
+    <message>
+        <source>&amp;Convert File...</source>
+        <translation>&amp;Converter arquivo...</translation>
+    </message>
+    <message>
+        <source>Run Script...</source>
+        <translation>Executar script...</translation>
+    </message>
+    <message>
+        <source>Open Script Console...</source>
+        <translation>Abra o console de scripts...</translation>
+    </message>
+    <message>
+        <source>&amp;Antialias...</source>
+        <translation>&amp;Antialias...</translation>
+    </message>
+    <message>
+        <source>Adjust Levels...</source>
+        <translation>Ajustar níveis...</translation>
+    </message>
+    <message>
+        <source>&amp;Raster Bounding Box</source>
+        <translation>&amp;Caixa delimitadora raster</translation>
+    </message>
+    <message>
+        <source>Link Flipbooks</source>
+        <translation>Vincular flipbooks</translation>
+    </message>
+    <message>
+        <source>&amp;Message Center</source>
+        <translation>&amp;Centro de mensagens</translation>
+    </message>
+    <message>
+        <source>&amp;Cleanup Settings</source>
+        <translation>&amp;Configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>Plastic Tool</source>
+        <translation>Ferramenta de plástico</translation>
+    </message>
+    <message>
+        <source>Create Mesh</source>
+        <translation>Criar malha</translation>
+    </message>
+    <message>
+        <source>&amp;Merge Tlv Levels...</source>
+        <translation>&amp;Mesclar Níveis Tlv...</translation>
+    </message>
+    <message>
+        <source>&amp;Load Folder...</source>
+        <translation>&amp;Carregar pasta...</translation>
+    </message>
+    <message>
+        <source>Toggle &amp;Opacity Check</source>
+        <translation>Alternar verificação de &amp;opacidade</translation>
+    </message>
+    <message>
+        <source>Adjust Thickness...</source>
+        <translation>Ajustar espessura...</translation>
+    </message>
+    <message>
+        <source>Inks &amp;Only</source>
+        <translation>Tintas e somente</translation>
+    </message>
+    <message>
+        <source>Next Step</source>
+        <translation>Próxima etapa</translation>
+    </message>
+    <message>
+        <source>Prev Step</source>
+        <translation>Etapa anterior</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation>Sem título</translation>
+    </message>
+    <message>
+        <source>Cleanup</source>
+        <translation>Limpar</translation>
+    </message>
+    <message>
+        <source>PltEdit</source>
+        <translation>Plt</translation>
+    </message>
+    <message>
+        <source>InknPaint</source>
+        <translation>InknPaint</translation>
+    </message>
+    <message>
+        <source>Xsheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>&amp;Load Recent Image Files</source>
+        <translation>&amp;Carregar arquivos de imagem recentes</translation>
+    </message>
+    <message>
+        <source>&amp;Clear Recent Flipbook Image List</source>
+        <translation>&amp;Limpar lista de imagens recentes do flipbook</translation>
+    </message>
+    <message>
+        <source>Preview Fx</source>
+        <translation>Pré-visualização FX</translation>
+    </message>
+    <message>
+        <source>&amp;Insert Paste</source>
+        <translation>&amp;Inserir Colar</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Color &amp;&amp; Name</source>
+        <translation>&amp;Colar cor e&amp; nome</translation>
+    </message>
+    <message>
+        <source>Paste Color</source>
+        <translation>Colar cor</translation>
+    </message>
+    <message>
+        <source>Paste Name</source>
+        <translation>Colar nome</translation>
+    </message>
+    <message>
+        <source>Get Color from Studio Palette</source>
+        <translation>Obtenha cores da paleta Studio</translation>
+    </message>
+    <message>
+        <source>&amp;Opacity Check</source>
+        <translation>&amp;Verificação de opacidade</translation>
+    </message>
+    <message>
+        <source>&amp;Replace Parent Directory...</source>
+        <translation>&amp;Substituir diretório pai...</translation>
+    </message>
+    <message>
+        <source>1's</source>
+        <translation>1's</translation>
+    </message>
+    <message>
+        <source>2's</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <source>3's</source>
+        <translation>3</translation>
+    </message>
+    <message>
+        <source>4's</source>
+        <translation>4's</translation>
+    </message>
+    <message>
+        <source>&amp;Ink#1 Check</source>
+        <translation>Verificação de &amp;Tinta#1</translation>
+    </message>
+    <message>
+        <source>Compare to Snapshot</source>
+        <translation>Comparar com instantâneo</translation>
+    </message>
+    <message>
+        <source>Show This Only</source>
+        <translation>Mostrar apenas isto</translation>
+    </message>
+    <message>
+        <source>Show Selected</source>
+        <translation>Mostrar selecionado</translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation>Mostrar tudo</translation>
+    </message>
+    <message>
+        <source>Hide Selected</source>
+        <translation>Ocultar selecionado</translation>
+    </message>
+    <message>
+        <source>Hide All</source>
+        <translation>Ocultar tudo</translation>
+    </message>
+    <message>
+        <source>Toggle Show/Hide</source>
+        <translation>Alternar Mostrar/Ocultar</translation>
+    </message>
+    <message>
+        <source>ON This Only</source>
+        <translation>SOMENTE Nisto</translation>
+    </message>
+    <message>
+        <source>ON Selected</source>
+        <translation>LIGADO Selecionado</translation>
+    </message>
+    <message>
+        <source>ON All</source>
+        <translation>LIGADO em tudo</translation>
+    </message>
+    <message>
+        <source>OFF All</source>
+        <translation>DESLIGAR tudo</translation>
+    </message>
+    <message>
+        <source>OFF Selected</source>
+        <translation>DESLIGADO Selecionado</translation>
+    </message>
+    <message>
+        <source>Swap ON/OFF</source>
+        <translation>Trocar ON/OFF</translation>
+    </message>
+    <message>
+        <source>Lock This Only</source>
+        <translation>Bloqueie apenas isso</translation>
+    </message>
+    <message>
+        <source>Lock Selected</source>
+        <translation>Bloqueio selecionado</translation>
+    </message>
+    <message>
+        <source>Lock All</source>
+        <translation>Bloquear tudo</translation>
+    </message>
+    <message>
+        <source>Unlock Selected</source>
+        <translation>Desbloqueio selecionado</translation>
+    </message>
+    <message>
+        <source>Unlock All</source>
+        <translation>Desbloquear tudo</translation>
+    </message>
+    <message>
+        <source>Swap Lock/Unlock</source>
+        <translation>Trocar bloqueio/desbloqueio</translation>
+    </message>
+    <message>
+        <source>Hide Upper Columns</source>
+        <translation>Ocultar colunas superiores</translation>
+    </message>
+    <message>
+        <source>Ruler Tool</source>
+        <translation>Ferramenta Régua</translation>
+    </message>
+    <message>
+        <source>Finger Tool</source>
+        <translation>Ferramenta de dedo</translation>
+    </message>
+    <message>
+        <source>Brush size - Increase max</source>
+        <translation>Tamanho do pincel - Aumentar máximo</translation>
+    </message>
+    <message>
+        <source>Brush size - Decrease max</source>
+        <translation>Tamanho do pincel - Diminuir máx.</translation>
+    </message>
+    <message>
+        <source>Brush size - Increase min</source>
+        <translation>Tamanho do pincel - Aumentar min</translation>
+    </message>
+    <message>
+        <source>Brush size - Decrease min</source>
+        <translation>Tamanho do pincel - Diminuir min</translation>
+    </message>
+    <message>
+        <source>Brush hardness - Increase</source>
+        <translation>Dureza da escova - Aumentar</translation>
+    </message>
+    <message>
+        <source>Brush hardness - Decrease</source>
+        <translation>Dureza do pincel - Diminuir</translation>
+    </message>
+    <message>
+        <source>Mode - Areas</source>
+        <translation>Modo - Áreas</translation>
+    </message>
+    <message>
+        <source>Mode - Lines</source>
+        <translation>Modo - Linhas</translation>
+    </message>
+    <message>
+        <source>Mode - Lines &amp; Areas</source>
+        <translation>Modo - Linhas e Áreas</translation>
+    </message>
+    <message>
+        <source>Type - Normal</source>
+        <translation>Tipo - Normal</translation>
+    </message>
+    <message>
+        <source>Type - Rectangular</source>
+        <translation>Tipo - Retangular</translation>
+    </message>
+    <message>
+        <source>Type - Freehand</source>
+        <translation>Tipo - à mão livre</translation>
+    </message>
+    <message>
+        <source>Type - Polyline</source>
+        <translation>Tipo - Polilinha</translation>
+    </message>
+    <message>
+        <source>About OpenToonz</source>
+        <translation>Sobre o OpenToonz</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>&amp;Save All</source>
+        <translation>&amp;Salvar tudo</translation>
+    </message>
+    <message>
+        <source>Toggle Edit in Place</source>
+        <translation>Alternar edição no local</translation>
+    </message>
+    <message>
+        <source>&amp;ComboViewer</source>
+        <translation>&amp;ComboViewer</translation>
+    </message>
+    <message>
+        <source>&amp;History</source>
+        <translation>&amp;História</translation>
+    </message>
+    <message>
+        <source>&amp;About OpenToonz...</source>
+        <translation>&amp;Sobre o OpenToonz...</translation>
+    </message>
+    <message>
+        <source>Refresh Folder Tree</source>
+        <translation>Atualizar árvore de pastas</translation>
+    </message>
+    <message>
+        <source>&amp;Save All Levels</source>
+        <translation>&amp;Salvar todos os níveis</translation>
+    </message>
+    <message>
+        <source>&amp;Camera Capture...</source>
+        <translation>&amp;Captura de câmera...</translation>
+    </message>
+    <message>
+        <source>Toggle Maximize Panel</source>
+        <translation>Alternar Painel Maximizar</translation>
+    </message>
+    <message>
+        <source>Toggle Main Window's Full Screen Mode</source>
+        <translation>Alternar modo de tela inteira da janela principal</translation>
+    </message>
+    <message>
+        <source>Onion Skin Toggle</source>
+        <translation>Alternar Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Zero Thick Lines</source>
+        <translation>Zero linhas grossas</translation>
+    </message>
+    <message>
+        <source>Pressure Sensitivity</source>
+        <translation>Sensibilidade à Pressão</translation>
+    </message>
+    <message>
+        <source>Toggle Link to Studio Palette</source>
+        <translation>Alternar link para a paleta Studio</translation>
+    </message>
+    <message>
+        <source>Remove Reference to Studio Palette</source>
+        <translation>Remover referência à paleta Studio</translation>
+    </message>
+    <message>
+        <source>&amp;Startup Popup...</source>
+        <translation>Pop-up de &amp;inicialização...</translation>
+    </message>
+    <message>
+        <source>&amp;Fast Render to MP4</source>
+        <translation>&amp;Renderização rápida para MP4</translation>
+    </message>
+    <message>
+        <source>Record Audio</source>
+        <translation>Gravar áudio</translation>
+    </message>
+    <message>
+        <source>&amp;Pencil Test...</source>
+        <translation>&amp;Teste de lápis...</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Atualizar</translation>
+    </message>
+    <message>
+        <source>Toggle XSheet Toolbar</source>
+        <translation>Alternar barra de ferramentas XSheet</translation>
+    </message>
+    <message>
+        <source>Snap Sensitivity</source>
+        <translation>Sensibilidade instantânea</translation>
+    </message>
+    <message>
+        <source>&amp;New Vector Level</source>
+        <translation>&amp;Novo nível de vetor</translation>
+    </message>
+    <message>
+        <source>New Vector Level</source>
+        <translation>Novo nível vetorial</translation>
+    </message>
+    <message>
+        <source>&amp;New Toonz Raster Level</source>
+        <translation>&amp;Novo nível raster Toonz</translation>
+    </message>
+    <message>
+        <source>New Toonz Raster Level</source>
+        <translation>Novo nível raster Toonz</translation>
+    </message>
+    <message>
+        <source>&amp;New Raster Level</source>
+        <translation>&amp;Novo nível de varredura</translation>
+    </message>
+    <message>
+        <source>New Raster Level</source>
+        <translation>Novo nível raster</translation>
+    </message>
+    <message>
+        <source>Alpha Channel</source>
+        <translation>Canal Alfa</translation>
+    </message>
+    <message>
+        <source>&amp;Command Bar</source>
+        <translation>&amp;Barra de comandos</translation>
+    </message>
+    <message>
+        <source>Auto Input Cell Number...</source>
+        <translation>Número de célula de entrada automática...</translation>
+    </message>
+    <message>
+        <source>Reframe with Empty Inbetweens...</source>
+        <translation>Reenquadrar com espaços vazios...</translation>
+    </message>
+    <message>
+        <source>&amp;Toggle Edit In Place</source>
+        <translation>&amp;Alternar Editar no local</translation>
+    </message>
+    <message>
+        <source>&amp;Reload</source>
+        <translation>&amp;Recarregar</translation>
+    </message>
+    <message>
+        <source>New Note Level</source>
+        <translation>Novo nível de nota</translation>
+    </message>
+    <message>
+        <source>&amp;Apply Lip Sync Data to Column</source>
+        <translation>&amp;Aplicar dados de sincronização labial à coluna</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Numbers</source>
+        <translation>&amp;Colar números</translation>
+    </message>
+    <message>
+        <source>Toggle Current Time Indicator</source>
+        <translation>Alternar indicador de hora atual</translation>
+    </message>
+    <message>
+        <source>Vectors to Toonz Raster</source>
+        <translation>Vetores para Toonz Raster</translation>
+    </message>
+    <message>
+        <source>Replace Vectors with Simplified Vectors</source>
+        <translation>Substitua vetores por vetores simplificados</translation>
+    </message>
+    <message>
+        <source>Flip Viewer Horiontally</source>
+        <translation>Virar visualizador horizontalmente</translation>
+    </message>
+    <message>
+        <source>Flip Viewer Vertically</source>
+        <translation>Virar o visualizador verticalmente</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Autopaint Lines</source>
+        <translation>Ferramenta Preenchimento - Linhas de pintura automática</translation>
+    </message>
+    <message>
+        <source>&amp;Export Soundtrack</source>
+        <translation>&amp;Exportar trilha sonora</translation>
+    </message>
+    <message>
+        <source>&amp;Touch Gesture Control</source>
+        <translation>Controle de gestos de &amp;toque</translation>
+    </message>
+    <message>
+        <source>Remove Empty Columns</source>
+        <translation>Remover colunas vazias</translation>
+    </message>
+    <message>
+        <source>Animate Tool</source>
+        <translation>Ferramenta Animar</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Insert</source>
+        <translation>&amp;Colar Inserir</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Insert Above/After</source>
+        <translation>&amp;Colar Inserir Acima/Depois</translation>
+    </message>
+    <message>
+        <source>&amp;Insert Above/After</source>
+        <translation>&amp;Inserir acima/depois</translation>
+    </message>
+    <message>
+        <source>&amp;Fill In Empty Cells</source>
+        <translation>&amp;Preencher células vazias</translation>
+    </message>
+    <message>
+        <source>Toggle Cursor Size Outline</source>
+        <translation>Alternar contorno do tamanho do cursor</translation>
+    </message>
+    <message>
+        <source>Brush Tool - Draw Order</source>
+        <translation>Ferramenta Pincel - Ordem de desenho</translation>
+    </message>
+    <message>
+        <source>Active Axis - All</source>
+        <translation>Eixo Ativo - Todos</translation>
+    </message>
+    <message>
+        <source>&amp;Timeline</source>
+        <translation>&amp;Linha do tempo</translation>
+    </message>
+    <message>
+        <source>Linear Interpolation</source>
+        <translation>Interpolação Linear</translation>
+    </message>
+    <message>
+        <source>Speed In / Speed Out Interpolation</source>
+        <translation>Interpolação de entrada/saída de velocidade</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out Interpolation</source>
+        <translation>Interpolação de entrada/saída facilitada</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out (%) Interpolation</source>
+        <translation>Interpolação de entrada/saída facilitada (%)</translation>
+    </message>
+    <message>
+        <source>Exponential Interpolation</source>
+        <translation>Interpolação Exponencial</translation>
+    </message>
+    <message>
+        <source>Expression Interpolation</source>
+        <translation>Interpolação de Expressão</translation>
+    </message>
+    <message>
+        <source>File Interpolation</source>
+        <translation>Interpolação de arquivos</translation>
+    </message>
+    <message>
+        <source>Constant Interpolation</source>
+        <translation>Interpolação Constante</translation>
+    </message>
+    <message>
+        <source>Separate Colors...</source>
+        <translation>Cores separadas...</translation>
+    </message>
+    <message>
+        <source>Flip Viewer Horizontally</source>
+        <translation>Virar visualizador horizontalmente</translation>
+    </message>
+    <message>
+        <source>&amp;Send to Back</source>
+        <translation>&amp;Enviar para trás</translation>
+    </message>
+    <message>
+        <source>Reset Zoom</source>
+        <translation>Redefinir zoom</translation>
+    </message>
+    <message>
+        <source>Reset Rotation</source>
+        <translation>Redefinir rotação</translation>
+    </message>
+    <message>
+        <source>Reset Position</source>
+        <translation>Redefinir posição</translation>
+    </message>
+    <message>
+        <source>Brush Tool - Eraser (Raster option)</source>
+        <translation>Ferramenta Pincel - Borracha (opção Raster)</translation>
+    </message>
+    <message>
+        <source>Brush Tool - Lock Alpha</source>
+        <translation>Ferramenta Pincel - Bloqueio Alfa</translation>
+    </message>
+    <message>
+        <source>http://opentoonz.readthedocs.io</source>
+        <translation>http://opentoonz.readthedocs.io</translation>
+    </message>
+    <message>
+        <source>&amp;Import Toonz Lip Sync File...</source>
+        <translation>&amp;Importar arquivo de sincronização labial Toonz...</translation>
+    </message>
+    <message>
+        <source>Export Exchange Digital Time Sheet (XDTS)</source>
+        <translation>Exportar folha de ponto digital do Exchange (XDTS)</translation>
+    </message>
+    <message>
+        <source>&amp;Clear Cache Folder</source>
+        <translation>&amp;Limpar pasta de cache</translation>
+    </message>
+    <message>
+        <source>Show/Hide Xsheet Camera Column</source>
+        <translation>Mostrar/ocultar coluna da câmera Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Create Blank Drawing</source>
+        <translation>&amp;Criar desenho em branco</translation>
+    </message>
+    <message>
+        <source>&amp;Shift Keys Down</source>
+        <translation>&amp;Shift para baixo</translation>
+    </message>
+    <message>
+        <source>&amp;Shift Keys Up</source>
+        <translation>&amp;Shift para cima</translation>
+    </message>
+    <message>
+        <source>Next Key</source>
+        <translation>Próxima chave</translation>
+    </message>
+    <message>
+        <source>Prev Key</source>
+        <translation>Chave anterior</translation>
+    </message>
+    <message>
+        <source>&amp;FX Editor</source>
+        <translation>Editor &amp;FX</translation>
+    </message>
+    <message>
+        <source>&amp;Stop Motion Controls</source>
+        <translation>&amp;Controles de Stop Motion</translation>
+    </message>
+    <message>
+        <source>&amp;Online Manual...</source>
+        <translation>&amp;Manual on-line...</translation>
+    </message>
+    <message>
+        <source>Select Next Frame Guide Stroke</source>
+        <translation>Selecione o próximo traço da guia de quadro</translation>
+    </message>
+    <message>
+        <source>Select Previous Frame Guide Stroke</source>
+        <translation>Selecione o traçado anterior da guia de quadro</translation>
+    </message>
+    <message>
+        <source>Select Prev &amp;&amp; Next Frame Guide Strokes</source>
+        <translation>Selecione os traços do guia de quadro anterior e seguinte</translation>
+    </message>
+    <message>
+        <source>Reset Guide Stroke Selections</source>
+        <translation>Redefinir seleções de traçado guia</translation>
+    </message>
+    <message>
+        <source>Tween Selected Guide Strokes</source>
+        <translation>Interpolação de traços guia selecionados</translation>
+    </message>
+    <message>
+        <source>Tween Guide Strokes to Selected</source>
+        <translation>Interpolação de traços de guia para selecionados</translation>
+    </message>
+    <message>
+        <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
+        <translation>Selecione Traços de guia e modo de interpolação</translation>
+    </message>
+    <message>
+        <source>Capture Stop Motion Frame</source>
+        <translation>Capturar quadro de stop motion</translation>
+    </message>
+    <message>
+        <source>Raise Stop Motion Opacity</source>
+        <translation>Aumentar a opacidade do Stop Motion</translation>
+    </message>
+    <message>
+        <source>Lower Stop Motion Opacity</source>
+        <translation>Menor opacidade do Stop Motion</translation>
+    </message>
+    <message>
+        <source>Toggle Stop Motion Live View</source>
+        <translation>Alternar visualização ao vivo de stop motion</translation>
+    </message>
+    <message>
+        <source>Toggle Stop Motion Zoom</source>
+        <translation>Alternar zoom de stop motion</translation>
+    </message>
+    <message>
+        <source>Lower Stop Motion Level Subsampling</source>
+        <translation>Subamostragem de nível inferior de stop motion</translation>
+    </message>
+    <message>
+        <source>Raise Stop Motion Level Subsampling</source>
+        <translation>Aumentar a subamostragem do nível de stop motion</translation>
+    </message>
+    <message>
+        <source>Go to Stop Motion Insert Frame</source>
+        <translation>Vá para Stop Motion Inserir quadro</translation>
+    </message>
+    <message>
+        <source>Clear Cache Folder</source>
+        <translation>Limpar pasta de cache</translation>
+    </message>
+    <message>
+        <source>There are no unused items in the cache folder.</source>
+        <translation>Não há itens não utilizados na pasta cache.</translation>
+    </message>
+    <message>
+        <source>Deleting the following items:
+</source>
+        <translation>Excluindo os seguintes itens:</translation>
+    </message>
+    <message>
+        <source>&lt;DIR&gt; </source>
+        <translation>&lt;DIR&gt;</translation>
+    </message>
+    <message>
+        <source>   ... and %1 more items
+</source>
+        <translation>... e mais %1 itens</translation>
+    </message>
+    <message>
+        <source>
+Are you sure?
+
+N.B. Make sure you are not running another process of OpenToonz,
+or you may delete necessary files for it.</source>
+        <translation>Tem certeza?
+
+N. B. Certifique-se de não estar executando outro processo do OpenToonz,
+ou você pode excluir os arquivos necessários para isso.</translation>
+    </message>
+    <message>
+        <source>Can't delete %1 : </source>
+        <translation>Não foi possível excluir% 1:</translation>
+    </message>
+    <message>
+        <source>https://github.com/opentoonz/opentoonz/releases/latest</source>
+        <translation>https://github.com/opentoonz/opentoonz/releases/latest</translation>
+    </message>
+    <message>
+        <source>https://groups.google.com/forum/#!forum/opentoonz_en</source>
+        <translation>https://groups.google.com/forum/#!forum/opentoonz_en</translation>
+    </message>
+    <message>
+        <source>To report a bug, click on the button below to open a web browser window for OpenToonz's Issues page on https://github.com.  Click on the 'New issue' button and fill out the form.</source>
+        <translation>Para relatar um bug, clique no botão abaixo para abrir uma janela do navegador da web para a página de problemas do OpenToonz em https://github.com.  Clique no botão 'Nova edição' e preencha o formulário.</translation>
+    </message>
+    <message>
+        <source>Vector Guided Drawing</source>
+        <translation>Desenho guiado por vetor</translation>
+    </message>
+    <message>
+        <source>Short Play</source>
+        <translation>Jogo curto</translation>
+    </message>
+    <message>
+        <source>&amp;What's New...</source>
+        <translation>&amp;O que há de novo...</translation>
+    </message>
+    <message>
+        <source>&amp;Community Forum...</source>
+        <translation>&amp;Fórum da comunidade...</translation>
+    </message>
+    <message>
+        <source>&amp;Report a Bug...</source>
+        <translation>&amp;Informar um bug...</translation>
+    </message>
+    <message>
+        <source>Guided Drawing Controls</source>
+        <translation>Controles de desenho guiado</translation>
+    </message>
+    <message>
+        <source>Flip Next Guide Stroke Direction</source>
+        <translation>Inverter a próxima direção do traço do guia</translation>
+    </message>
+    <message>
+        <source>Flip Previous Guide Stroke Direction</source>
+        <translation>Inverter a direção do traço do guia anterior</translation>
+    </message>
+    <message>
+        <source>Save All</source>
+        <translation>Salvar tudo</translation>
+    </message>
+    <message>
+        <source>&amp;Paste as a Copy</source>
+        <translation>&amp;Colar como cópia</translation>
+    </message>
+    <message>
+        <source>&amp;Move to Back</source>
+        <translation>&amp;Mover para Trás</translation>
+    </message>
+    <message>
+        <source>&amp;Move Back One</source>
+        <translation>&amp;Voltar Um</translation>
+    </message>
+    <message>
+        <source>&amp;Move Forward One</source>
+        <translation>&amp;Avançar Um</translation>
+    </message>
+    <message>
+        <source>&amp;Move to Front</source>
+        <translation>&amp;Mover para a frente</translation>
+    </message>
+    <message>
+        <source>&amp;Open Sub-Xsheet</source>
+        <translation>&amp;Abrir Subplanilha</translation>
+    </message>
+    <message>
+        <source>&amp;Close Sub-Xsheet</source>
+        <translation>&amp;Fechar Subplanilha</translation>
+    </message>
+    <message>
+        <source>Explode Sub-Xsheet</source>
+        <translation>Explodir Sub-Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Save Sub-Xsheet As...</source>
+        <translation>&amp;Salvar sub-planilha como...</translation>
+    </message>
+    <message>
+        <source>Clone Sub-Xsheet</source>
+        <translation>Clonar Sub-Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Clone Cells</source>
+        <translation>&amp;Clone células</translation>
+    </message>
+    <message>
+        <source>Reframe on 1's</source>
+        <translation>Reestruturar em 1's</translation>
+    </message>
+    <message>
+        <source>Reframe on 2's</source>
+        <translation>Reestruturar em 2</translation>
+    </message>
+    <message>
+        <source>Reframe on 3's</source>
+        <translation>Reestruturar em 3</translation>
+    </message>
+    <message>
+        <source>Reframe on 4's</source>
+        <translation>Reestruturar em 4</translation>
+    </message>
+    <message>
+        <source>Previous Drawing</source>
+        <translation>Desenho Anterior</translation>
+    </message>
+    <message>
+        <source>Previous Step</source>
+        <translation>Etapa anterior</translation>
+    </message>
+    <message>
+        <source>Previous Key</source>
+        <translation>Chave Anterior</translation>
+    </message>
+    <message>
+        <source>About OpenToonz...</source>
+        <translation>Sobre o OpenToonz...</translation>
+    </message>
+    <message>
+        <source>Online Manual...</source>
+        <translation>Manual on-line...</translation>
+    </message>
+    <message>
+        <source>What's New...</source>
+        <translation>O que há de novo...</translation>
+    </message>
+    <message>
+        <source>Community Forum...</source>
+        <translation>Fórum da comunidade...</translation>
+    </message>
+    <message>
+        <source>Report a Bug...</source>
+        <translation>Reportar um bug...</translation>
+    </message>
+    <message>
+        <source>Geometric Shape Rectangle</source>
+        <translation>Retângulo de forma geométrica</translation>
+    </message>
+    <message>
+        <source>Geometric Shape Circle</source>
+        <translation>Círculo de Forma Geométrica</translation>
+    </message>
+    <message>
+        <source>Geometric Shape Ellipse</source>
+        <translation>Elipse de forma geométrica</translation>
+    </message>
+    <message>
+        <source>Geometric Shape Line</source>
+        <translation>Linha de forma geométrica</translation>
+    </message>
+    <message>
+        <source>Geometric Shape Polyline</source>
+        <translation>Polilinha de forma geométrica</translation>
+    </message>
+    <message>
+        <source>Geometric Shape Arc</source>
+        <translation>Arco de Forma Geométrica</translation>
+    </message>
+    <message>
+        <source>Geometric Shape MultiArc</source>
+        <translation>Forma Geométrica MultiArc</translation>
+    </message>
+    <message>
+        <source>Geometric Shape Polygon</source>
+        <translation>Polígono de forma geométrica</translation>
+    </message>
+    <message>
+        <source>Mode - Lines &amp;&amp; Areas</source>
+        <translation>Modo - Linhas e Áreas</translation>
+    </message>
+    <message>
+        <source>Mode - Endpoint to Endpoint</source>
+        <translation>Modo - Endpoint a Endpoint</translation>
+    </message>
+    <message>
+        <source>Mode - Endpoint to Line</source>
+        <translation>Modo - Ponto Final para Linha</translation>
+    </message>
+    <message>
+        <source>Mode - Line to Line</source>
+        <translation>Modo - Linha a Linha</translation>
+    </message>
+    <message>
+        <source>Type - Segment</source>
+        <translation>Tipo - Segmento</translation>
+    </message>
+    <message>
+        <source>TypeTool Style - Oblique</source>
+        <translation>Estilo TypeTool - Oblíquo</translation>
+    </message>
+    <message>
+        <source>TypeTool Style - Regular</source>
+        <translation>Estilo TypeTool - Regular</translation>
+    </message>
+    <message>
+        <source>TypeTool Style - Bold Oblique</source>
+        <translation>Estilo TypeTool - Negrito Oblíquo</translation>
+    </message>
+    <message>
+        <source>TypeTool Style - Bold</source>
+        <translation>Estilo TypeTool - Negrito</translation>
+    </message>
+    <message>
+        <source>Skeleton Mode</source>
+        <translation>Modo Esqueleto</translation>
+    </message>
+    <message>
+        <source>Edit Mesh Mode</source>
+        <translation>Editar modo de malha</translation>
+    </message>
+    <message>
+        <source>Paint Rigid Mode</source>
+        <translation>Pintar modo rígido</translation>
+    </message>
+    <message>
+        <source>Animate Tool - Next Mode</source>
+        <translation>Ferramenta Animar - Próximo Modo</translation>
+    </message>
+    <message>
+        <source>Animate Tool - Position</source>
+        <translation>Ferramenta Animar - Posição</translation>
+    </message>
+    <message>
+        <source>Animate Tool - Rotation</source>
+        <translation>Ferramenta Animar - Rotação</translation>
+    </message>
+    <message>
+        <source>Animate Tool - Scale</source>
+        <translation>Ferramenta Animar - Escala</translation>
+    </message>
+    <message>
+        <source>Animate Tool - Shear</source>
+        <translation>Ferramenta Animar - Cisalhar</translation>
+    </message>
+    <message>
+        <source>Animate Tool - Center</source>
+        <translation>Ferramenta Animar - Centro</translation>
+    </message>
+    <message>
+        <source>Animate Tool - All</source>
+        <translation>Ferramenta Animar - Tudo</translation>
+    </message>
+    <message>
+        <source>Selection Tool - Next Type</source>
+        <translation>Ferramenta de Seleção - Próximo Tipo</translation>
+    </message>
+    <message>
+        <source>Selection Tool - Rectangular</source>
+        <translation>Ferramenta Seleção - Retangular</translation>
+    </message>
+    <message>
+        <source>Selection Tool - Freehand</source>
+        <translation>Ferramenta de seleção - à mão livre</translation>
+    </message>
+    <message>
+        <source>Selection Tool - Polyline</source>
+        <translation>Ferramenta de seleção - Polilinha</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Next Shape</source>
+        <translation>Ferramenta Geométrica - Próxima Forma</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Rectangle</source>
+        <translation>Ferramenta Geométrica - Retângulo</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Circle</source>
+        <translation>Ferramenta Geométrica - Círculo</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Ellipse</source>
+        <translation>Ferramenta Geométrica - Elipse</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Line</source>
+        <translation>Ferramenta Geométrica - Linha</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Polyline</source>
+        <translation>Ferramenta Geométrica - Polilinha</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Arc</source>
+        <translation>Ferramenta Geométrica - Arco</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - MultiArc</source>
+        <translation>Ferramenta Geométrica - MultiArc</translation>
+    </message>
+    <message>
+        <source>Geometric Tool - Polygon</source>
+        <translation>Ferramenta Geométrica - Polígono</translation>
+    </message>
+    <message>
+        <source>Type Tool - Next Style</source>
+        <translation>Ferramenta Tipo - Próximo Estilo</translation>
+    </message>
+    <message>
+        <source>Type Tool - Oblique</source>
+        <translation>Ferramenta Tipo - Oblíqua</translation>
+    </message>
+    <message>
+        <source>Type Tool - Regular</source>
+        <translation>Ferramenta Tipo - Regular</translation>
+    </message>
+    <message>
+        <source>Type Tool - Bold Oblique</source>
+        <translation>Ferramenta Tipo - Negrito Oblíquo</translation>
+    </message>
+    <message>
+        <source>Type Tool - Bold</source>
+        <translation>Ferramenta Tipo - Negrito</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Next Type</source>
+        <translation>Ferramenta Preenchimento - Próximo Tipo</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Normal</source>
+        <translation>Ferramenta Preenchimento - Normal</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Rectangular</source>
+        <translation>Ferramenta Preenchimento - Retangular</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Freehand</source>
+        <translation>Ferramenta Preenchimento - Mão Livre</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Polyline</source>
+        <translation>Ferramenta Preenchimento - Polilinha</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Next Mode</source>
+        <translation>Ferramenta Preenchimento - Próximo Modo</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Lines &amp; Areas</source>
+        <translation>Ferramenta Preenchimento - Linhas e Áreas</translation>
+    </message>
+    <message>
+        <source>Eraser Tool - Next Type</source>
+        <translation>Ferramenta Borracha - Próximo Tipo</translation>
+    </message>
+    <message>
+        <source>Eraser Tool - Normal</source>
+        <translation>Ferramenta Borracha - Normal</translation>
+    </message>
+    <message>
+        <source>Eraser Tool - Rectangular</source>
+        <translation>Ferramenta Borracha - Retangular</translation>
+    </message>
+    <message>
+        <source>Eraser Tool - Freehand</source>
+        <translation>Ferramenta Borracha - Mão Livre</translation>
+    </message>
+    <message>
+        <source>Eraser Tool - Polyline</source>
+        <translation>Ferramenta Borracha - Polilinha</translation>
+    </message>
+    <message>
+        <source>Eraser Tool - Segment</source>
+        <translation>Ferramenta Borracha - Segmento</translation>
+    </message>
+    <message>
+        <source>Tape Tool - Next Type</source>
+        <translation>Ferramenta Fita - Próximo Tipo</translation>
+    </message>
+    <message>
+        <source>Tape Tool - Normal</source>
+        <translation>Ferramenta Fita - Normal</translation>
+    </message>
+    <message>
+        <source>Tape Tool - Rectangular</source>
+        <translation>Ferramenta Fita - Retangular</translation>
+    </message>
+    <message>
+        <source>Tape Tool - Next Mode</source>
+        <translation>Ferramenta Fita - Próximo Modo</translation>
+    </message>
+    <message>
+        <source>Tape Tool - Endpoint to Endpoint</source>
+        <translation>Ferramenta Fita - Ponto Final a Ponto Final</translation>
+    </message>
+    <message>
+        <source>Tape Tool - Endpoint to Line</source>
+        <translation>Ferramenta Fita - Ponto Final para Linha</translation>
+    </message>
+    <message>
+        <source>Tape Tool - Line to Line</source>
+        <translation>Ferramenta Fita - Linha a Linha</translation>
+    </message>
+    <message>
+        <source>Style Picker Tool - Next Mode</source>
+        <translation>Ferramenta Seletor de Estilo - Próximo Modo</translation>
+    </message>
+    <message>
+        <source>Style Picker Tool - Lines &amp; Areas</source>
+        <translation>Ferramenta Seletor de Estilo - Linhas e Áreas</translation>
+    </message>
+    <message>
+        <source>RGB Picker Tool - Next Type</source>
+        <translation>Ferramenta Seletor RGB - Próximo Tipo</translation>
+    </message>
+    <message>
+        <source>RGB Picker Tool - Normal</source>
+        <translation>Ferramenta Seletor RGB - Normal</translation>
+    </message>
+    <message>
+        <source>RGB Picker Tool - Rectangular</source>
+        <translation>Ferramenta Seletor RGB - Retangular</translation>
+    </message>
+    <message>
+        <source>RGB Picker Tool - Freehand</source>
+        <translation>Ferramenta Seletor RGB - Mão Livre</translation>
+    </message>
+    <message>
+        <source>RGB Picker Tool - Polyline</source>
+        <translation>Ferramenta Seletor RGB - Polilinha</translation>
+    </message>
+    <message>
+        <source>Skeleton Tool - Next Mode</source>
+        <translation>Ferramenta Esqueleto - Próximo Modo</translation>
+    </message>
+    <message>
+        <source>Skeleton Tool - Build Skeleton</source>
+        <translation>Ferramenta Esqueleto - Construir Esqueleto</translation>
+    </message>
+    <message>
+        <source>Skeleton Tool - Animate</source>
+        <translation>Ferramenta Esqueleto - Animar</translation>
+    </message>
+    <message>
+        <source>Skeleton Tool - Inverse Kinematics</source>
+        <translation>Ferramenta Esqueleto - Cinemática Inversa</translation>
+    </message>
+    <message>
+        <source>Plastic Tool - Next Mode</source>
+        <translation>Ferramenta de Plástico - Próximo Modo</translation>
+    </message>
+    <message>
+        <source>Plastic Tool - Edit Mesh</source>
+        <translation>Ferramenta Plástico - Editar Malha</translation>
+    </message>
+    <message>
+        <source>Plastic Tool - Paint Rigid</source>
+        <translation>Ferramenta de Plástico - Pintura Rígida</translation>
+    </message>
+    <message>
+        <source>Plastic Tool - Build Skeleton</source>
+        <translation>Ferramenta de Plástico - Construir Esqueleto</translation>
+    </message>
+    <message>
+        <source>Plastic Tool - Animate</source>
+        <translation>Ferramenta de Plástico - Animar</translation>
+    </message>
+    <message>
+        <source>&amp;Export Stop Motion Image Sequence</source>
+        <translation>&amp;Exportar sequência de imagens em stop motion</translation>
+    </message>
+    <message>
+        <source>Pick Focus Check Location</source>
+        <translation>Escolha o local de verificação de foco</translation>
+    </message>
+    <message>
+        <source>Remove frame before Stop Motion Camera</source>
+        <translation>Remova o quadro antes da câmera Stop Motion</translation>
+    </message>
+    <message>
+        <source>Next Frame including Stop Motion Camera</source>
+        <translation>Próximo quadro incluindo câmera Stop Motion</translation>
+    </message>
+    <message>
+        <source>Show original live view images.</source>
+        <translation>Mostrar imagens originais de visualização ao vivo.</translation>
+    </message>
+    <message>
+        <source>&amp;Export Xsheet to PDF</source>
+        <translation>&amp;Exportar Xsheet para PDF</translation>
+    </message>
+    <message>
+        <source>Export TVPaint JSON File</source>
+        <translation>Exportar arquivo JSON do TVPaint</translation>
+    </message>
+    <message>
+        <source>&amp;Apply Auto Lip Sync to Column</source>
+        <translation>&amp;Aplicar sincronização labial automática à coluna</translation>
+    </message>
+    <message>
+        <source>Zoom In And Fit Floating Panel</source>
+        <translation>Amplie e ajuste o painel flutuante</translation>
+    </message>
+    <message>
+        <source>Zoom Out And Fit Floating Panel</source>
+        <translation>Diminuir zoom e ajustar painel flutuante</translation>
+    </message>
+    <message>
+        <source>Set Cell Mark </source>
+        <translation>Definir marca de célula</translation>
+    </message>
+    <message>
+        <source>Reset rooms to their default?</source>
+        <translation>Redefinir as salas para o padrão?</translation>
+    </message>
+    <message>
+        <source>All user rooms will be lost!</source>
+        <translation>Todas as salas de usuários serão perdidas!</translation>
+    </message>
+    <message>
+        <source>Reset Rooms</source>
+        <translation>Redefinir salas</translation>
+    </message>
+    <message>
+        <source>You must restart OpenToonz, close it now?</source>
+        <translation>Você deve reiniciar o OpenToonz, fechá-lo agora?</translation>
+    </message>
+    <message>
+        <source>&amp;Convert TZP Files In Folder...</source>
+        <translation>&amp;Converter arquivos TZP na pasta...</translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation>Exportar animação Abrir Cel (OCA)</translation>
+    </message>
+    <message>
+        <source>&amp;Export Current Scene</source>
+        <translation>&amp;Exportar cena atual</translation>
+    </message>
+    <message>
+        <source>&amp;Export Camera Track</source>
+        <translation>&amp;Exportar trilha da câmera</translation>
+    </message>
+    <message>
+        <source>Toggle Navigation Tag</source>
+        <translation>Alternar tag de navegação</translation>
+    </message>
+    <message>
+        <source>Next Tag</source>
+        <translation>Próxima etiqueta</translation>
+    </message>
+    <message>
+        <source>Previous Tag</source>
+        <translation>Etiqueta anterior</translation>
+    </message>
+    <message>
+        <source>Edit Tag</source>
+        <translation>Editar etiqueta</translation>
+    </message>
+    <message>
+        <source>Remove Tags</source>
+        <translation>Remover tags</translation>
+    </message>
+    <message>
+        <source>Toggle Blank Frames</source>
+        <translation>Alternar quadros em branco</translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Preview</source>
+        <translation>Alternar visualização do visualizador</translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Sub-camera Preview</source>
+        <translation>Alternar visualização da subcâmera do visualizador</translation>
+    </message>
+    <message>
+        <source>&amp;Preproduction Board</source>
+        <translation>&amp;Quadro de pré-produção</translation>
+    </message>
+    <message>
+        <source>Toggle Main Window's See Through Mode</source>
+        <translation>Alternar o modo transparente da janela principal</translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panels</source>
+        <translation>&amp;Painéis personalizados</translation>
+    </message>
+    <message>
+        <source>&amp;Custom Panel Editor...</source>
+        <translation>&amp;Editor de painel personalizado...</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Cell Content</source>
+        <translation>&amp;Colar conteúdo da célula</translation>
+    </message>
+    <message>
+        <source>&amp;Viewer Histogram</source>
+        <translation>&amp;Visualizador Histograma</translation>
+    </message>
+    <message>
+        <source>Paint Brush - Next Mode</source>
+        <translation>Pincel - Próximo modo</translation>
+    </message>
+    <message>
+        <source>Paint Brush - Areas</source>
+        <translation>Pincel - Áreas</translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines</source>
+        <translation>Pincel - Linhas</translation>
+    </message>
+    <message>
+        <source>Paint Brush - Lines &amp; Areas</source>
+        <translation>Pincel - Linhas e Áreas</translation>
+    </message>
+    <message>
+        <source>Fill Tool - Pick+Freehand</source>
+        <translation>Ferramenta Preenchimento - Escolher + Mão Livre</translation>
+    </message>
+    <message>
+        <source>Type - Pick+Freehand</source>
+        <translation>Tipo - Escolha + Mão Livre</translation>
+    </message>
+    <message>
+        <source>Flip Selection/Object Horizontally</source>
+        <translation>Inverter seleção/objeto horizontalmente</translation>
+    </message>
+    <message>
+        <source>Flip Selection/Object Vertically</source>
+        <translation>Inverter seleção/objeto verticalmente</translation>
+    </message>
+    <message>
+        <source>Rotate Selection/Object Left</source>
+        <translation>Girar seleção/objeto para a esquerda</translation>
+    </message>
+    <message>
+        <source>Rotate Selection/Object Right</source>
+        <translation>Girar seleção/objeto para a direita</translation>
+    </message>
+    <message>
+        <source>Import Open Cel Animation (OCA)</source>
+        <translation>Importar animação Abrir Cel (OCA)</translation>
+    </message>
+    <message>
+        <source>&amp;New Assistant Level</source>
+        <translation>&amp;Novo nível de assistente</translation>
+    </message>
+    <message>
+        <source>Toggle Sub-Xsheet Navigation Bar</source>
+        <translation>Alternar barra de navegação da sub-planilha</translation>
+    </message>
+    <message>
+        <source>Edit Assistants</source>
+        <translation>Editar assistentes</translation>
+    </message>
+    <message>
+        <source>Show build date in title</source>
+        <translation>Mostrar data de construção no título</translation>
+    </message>
+    <message>
+        <source>&amp;Save Scene Only</source>
+        <translation>&amp;Salvar apenas cena</translation>
+    </message>
+    <message>
+        <source>&amp;Set Scene Settings as Default</source>
+        <translation>&amp;Definir configurações de cena como padrão</translation>
+    </message>
+    <message>
+        <source>Export Stylos Exchange Format(SXF)</source>
+        <translation>Formato de troca de canetas de exportação (SXF)</translation>
+    </message>
+    <message>
+        <source>&amp;Clear Viewer Content</source>
+        <translation>&amp;Limpar conteúdo do visualizador</translation>
+    </message>
+    <message>
+        <source>&amp;Export All Levels... </source>
+        <translation>&amp;Exportar todos os níveis...</translation>
+    </message>
+    <message>
+        <source>&amp;Sort Strokes with Palette Order</source>
+        <translation>&amp;Classificar traços com ordem de paleta</translation>
+    </message>
+    <message>
+        <source>Convert to Toonz Raster...</source>
+        <translation>Converter para Toonz Raster...</translation>
+    </message>
+    <message>
+        <source>&amp;Fill Holes...</source>
+        <translation>&amp;Preencher Buracos...</translation>
+    </message>
+    <message>
+        <source>Show Shift Origin</source>
+        <translation>Mostrar origem do turno</translation>
+    </message>
+    <message>
+        <source>&amp;Brush Presets</source>
+        <translation>&amp;Predefinições de pincel</translation>
+    </message>
+    <message>
+        <source>&amp;Tool Properties</source>
+        <translation>&amp;Propriedades da ferramenta</translation>
+    </message>
+    <message>
+        <source>&amp;Locator</source>
+        <translation>&amp;Localizador</translation>
+    </message>
+    <message>
+        <source>Toggle Viewer Indicators</source>
+        <translation>Alternar indicadores do visualizador</translation>
+    </message>
+    <message>
+        <source>Zoom View</source>
+        <translation>Visualização ampliada</translation>
+    </message>
+    <message>
+        <source>Rotate View</source>
+        <translation>Girar visualização</translation>
+    </message>
+    <message>
+        <source>Pan View</source>
+        <translation>Vista panorâmica</translation>
+    </message>
+    <message>
+        <source>Empty Only</source>
+        <translation>Apenas vazio</translation>
+    </message>
+    <message>
+        <source>Eraser Type - MultiArc</source>
+        <translation>Tipo de borracha - MultiArc</translation>
+    </message>
+    <message>
+        <source>Rotate Viewer Left</source>
+        <translation>Girar visualizador para a esquerda</translation>
+    </message>
+    <message>
+        <source>Rotate Viewer Right</source>
+        <translation>Girar visualizador para a direita</translation>
+    </message>
+    <message>
+        <source>Rotate View Left</source>
+        <translation>Girar visualização para a esquerda</translation>
+    </message>
+    <message>
+        <source>Rotate View Right</source>
+        <translation>Girar visualização para a direita</translation>
+    </message>
+    <message>
+        <source>Viewer Scrub</source>
+        <translation>Limpeza do visualizador</translation>
+    </message>
+    <message>
+        <source> [WIP]</source>
+        <translation>[WIP]</translation>
+    </message>
+    <message>
+        <source>This feature is a work in progress.
+Please be advised that it may have incomplete implementation or cause unexpected behavior.
+We welcome your feedback and assistance with its development!</source>
+        <translation>Este recurso é um trabalho em andamento.
+Informamos que pode ter implementação incompleta ou causar comportamento inesperado.
+Agradecemos seus comentários e assistência em seu desenvolvimento!</translation>
+    </message>
+</context>
+<context>
+    <name>MatchlinesDialog</name>
+    <message>
+        <source> Apply Match Lines</source>
+        <translation>Aplicar linhas de correspondência</translation>
+    </message>
+    <message>
+        <source>Add Match Line Styles</source>
+        <translation>Adicionar estilos de linha de correspondência</translation>
+    </message>
+    <message>
+        <source>Use Style: </source>
+        <translation>Estilo de uso:</translation>
+    </message>
+    <message>
+        <source>Line Prevalence</source>
+        <translation>Prevalência de linha</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Apply Match Lines</source>
+        <translation>Aplicar linhas de correspondência</translation>
+    </message>
+    <message>
+        <source>Add Match Line Inks</source>
+        <translation>Adicionar tintas de linha correspondente</translation>
+    </message>
+    <message>
+        <source>Use Ink: </source>
+        <translation>Usar tinta:</translation>
+    </message>
+    <message>
+        <source>Ink Usage</source>
+        <translation>Uso de tinta</translation>
+    </message>
+    <message>
+        <source>Line Stacking Order</source>
+        <translation>Ordem de empilhamento de linha</translation>
+    </message>
+    <message>
+        <source>L-Up R-Down</source>
+        <translation>L-para cima R-para baixo</translation>
+    </message>
+    <message>
+        <source>L-Down R-Up</source>
+        <translation>L para baixo R para cima</translation>
+    </message>
+    <message>
+        <source>Keep
+Halftone</source>
+        <translation>Mantenha
+Meio-tom</translation>
+    </message>
+    <message>
+        <source>Fill
+Gaps</source>
+        <translation>Preencher
+Lacunas</translation>
+    </message>
+    <message>
+        <source>Merge Inks</source>
+        <translation>Mesclar tintas</translation>
+    </message>
+    <message>
+        <source>Merge Inks : If the target level has the same style as the match line ink
+(i.e. with the same index and the same color), the existing style will be used.
+Otherwise, a new style will be added to "match lines" page.</source>
+        <translation>Mesclar tintas: se o nível de destino tiver o mesmo estilo da tinta da linha de correspondência
+(ou seja, com o mesmo índice e a mesma cor), será utilizado o estilo existente.
+Caso contrário, um novo estilo será adicionado à página "linhas correspondentes".</translation>
+    </message>
+</context>
+<context>
+    <name>MenuBarPopup</name>
+    <message>
+        <source>Customize Menu Bar of Room "%1"</source>
+        <translation>Personalizar a barra de menu da sala "%1"</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>%1 Menu Bar</source>
+        <translation>Barra de Menu % 1</translation>
+    </message>
+    <message>
+        <source>Menu Items</source>
+        <translation>Itens do cardápio</translation>
+    </message>
+    <message>
+        <source>N.B. If you put unique title to submenu, it may not be translated to another language.
+N.B. Duplicated commands will be ignored. Only the last one will appear in the menu bar.</source>
+        <translation>N. B. Se você colocar um título exclusivo no submenu, ele poderá não ser traduzido para outro idioma.
+N. B. Comandos duplicados serão ignorados. Apenas o último aparecerá na barra de menu.</translation>
+    </message>
+    <message>
+        <source>Search:</source>
+        <translation>Procurar:</translation>
+    </message>
+</context>
+<context>
+    <name>MenuBarTree</name>
+    <message>
+        <source>Insert Menu</source>
+        <translation>Inserir Menu</translation>
+    </message>
+    <message>
+        <source>Insert Submenu</source>
+        <translation>Inserir submenu</translation>
+    </message>
+    <message>
+        <source>Remove "%1"</source>
+        <translation>Remover "%1"</translation>
+    </message>
+    <message>
+        <source>New Menu</source>
+        <translation>Novo cardápio</translation>
+    </message>
+</context>
+<context>
+    <name>MergeCmappedCommand</name>
+    <message>
+        <source>It is not possible to merge tlv columns because no column was selected.</source>
+        <translation>Não é possível mesclar colunas tlv porque nenhuma coluna foi selecionada.</translation>
+    </message>
+    <message>
+        <source>It is not possible to merge tlv columns because at least two columns have to be selected.</source>
+        <translation>Não é possível mesclar colunas tlv porque pelo menos duas colunas devem ser selecionadas.</translation>
+    </message>
+    <message>
+        <source>Merging Tlv Levels...</source>
+        <translation>Mesclando níveis Tlv...</translation>
+    </message>
+</context>
+<context>
+    <name>MergeCmappedDialog</name>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source> Merge Tlv Levels</source>
+        <translation>Mesclar níveis Tlv</translation>
+    </message>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>File Name:</source>
+        <translation>Nome do arquivo:</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Level %1 already exists! Are you sure you want to overwrite it?</source>
+        <translation>O nível %1 já existe! Tem certeza de que deseja substituí-lo?</translation>
+    </message>
+</context>
+<context>
+    <name>MergeColumnsCommand</name>
+    <message>
+        <source>It is not possible to execute the merge column command because no column was selected.</source>
+        <translation>Não é possível executar o comando mesclar coluna porque nenhuma coluna foi selecionada.</translation>
+    </message>
+    <message>
+        <source>It is not possible to execute the merge column command  because only one columns is  selected.</source>
+        <translation>Não é possível executar o comando mesclar coluna porque apenas uma coluna está selecionada.</translation>
+    </message>
+</context>
+<context>
+    <name>MeshifyPopup</name>
+    <message>
+        <source>A level with the preferred path "%1" already exists.
+What do you want to do?</source>
+        <translation>Já existe um nível com o caminho preferencial "%1".
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Delete the old level entirely</source>
+        <translation>Exclua totalmente o nível antigo</translation>
+    </message>
+    <message>
+        <source>Keep the old level and overwrite processed frames</source>
+        <translation>Mantenha o nível antigo e substitua os quadros processados</translation>
+    </message>
+    <message>
+        <source>Choose a different path (%1)</source>
+        <translation>Escolha um caminho diferente (%1)</translation>
+    </message>
+    <message>
+        <source>Create Mesh</source>
+        <translation>Criar malha</translation>
+    </message>
+    <message>
+        <source>Mesh Edges Length:</source>
+        <translation>Comprimento das bordas da malha:</translation>
+    </message>
+    <message>
+        <source>Rasterization DPI:</source>
+        <translation>DPI de rasterização:</translation>
+    </message>
+    <message>
+        <source>Mesh Margin (pixels):</source>
+        <translation>Margem da malha (pixels):</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Mesh Creation in progress...</source>
+        <translation>Criação de malha em andamento...</translation>
+    </message>
+    <message>
+        <source>Current selection contains mixed image and mesh level types</source>
+        <translation>A seleção atual contém tipos mistos de imagem e nível de malha</translation>
+    </message>
+    <message>
+        <source>Current selection contains no image or mesh level types</source>
+        <translation>A seleção atual não contém tipos de imagem ou nível de malha</translation>
+    </message>
+</context>
+<context>
+    <name>MyScannerListener</name>
+    <message>
+        <source>Scanning in progress: </source>
+        <translation>Verificação em andamento:</translation>
+    </message>
+    <message>
+        <source>The pixel type is not supported.</source>
+        <translation>O tipo de pixel não é compatível.</translation>
+    </message>
+    <message>
+        <source>The scanning process is completed.</source>
+        <translation>O processo de digitalização está concluído.</translation>
+    </message>
+    <message>
+        <source>There was an error during the scanning process.</source>
+        <translation>Ocorreu um erro durante o processo de digitalização.</translation>
+    </message>
+    <message>
+        <source>Please, place the next paper drawing on the scanner flatbed, then select the relevant command in the TWAIN interface.</source>
+        <translation>Por favor, coloque o próximo desenho em papel na mesa do scanner e selecione o comando relevante na interface TWAIN.</translation>
+    </message>
+    <message>
+        <source>Please, place the next paper drawing on the scanner flatbed, then click the Scan button.</source>
+        <translation>Por favor, coloque o próximo desenho em papel na mesa do scanner e clique no botão Digitalizar.</translation>
+    </message>
+</context>
+<context>
+    <name>MyVideoWidget</name>
+    <message>
+        <source>Camera is not available</source>
+        <translation>A câmera não está disponível</translation>
+    </message>
+</context>
+<context>
+    <name>MyViewFinder</name>
+    <message>
+        <source>Camera is not available</source>
+        <translation>A câmera não está disponível</translation>
+    </message>
+</context>
+<context>
+    <name>NavTagEditorPopup</name>
+    <message>
+        <source>Edit Tag</source>
+        <translation>Editar etiqueta</translation>
+    </message>
+    <message>
+        <source>Frame %1 Label:</source>
+        <translation>Rótulo do quadro %1:</translation>
+    </message>
+    <message>
+        <source>Magenta</source>
+        <translation>Magenta</translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation>Vermelho</translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation>Verde</translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation>Azul</translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation>Amarelo</translation>
+    </message>
+    <message>
+        <source>Cyan</source>
+        <translation>Ciano</translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation>Branco</translation>
+    </message>
+    <message>
+        <source>Dark Magenta</source>
+        <translation>Magenta Escuro</translation>
+    </message>
+    <message>
+        <source>Dark Red</source>
+        <translation>Vermelho Escuro</translation>
+    </message>
+    <message>
+        <source>Dark Green</source>
+        <translation>Verde Escuro</translation>
+    </message>
+    <message>
+        <source>Dark Blue</source>
+        <translation>Azul escuro</translation>
+    </message>
+    <message>
+        <source>Dark Yellow</source>
+        <translation>Amarelo escuro</translation>
+    </message>
+    <message>
+        <source>Dark Cyan</source>
+        <translation>Ciano Escuro</translation>
+    </message>
+    <message>
+        <source>Dark Gray</source>
+        <translation>Cinza Escuro</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Cor:</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>OutputSettingsPopup</name>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>File Name:</source>
+        <translation>Nome do arquivo:</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+    <message>
+        <source>File Format:</source>
+        <translation>Formato de arquivo:</translation>
+    </message>
+    <message>
+        <source>Output Camera:</source>
+        <translation>Câmera de saída:</translation>
+    </message>
+    <message>
+        <source>Use Sub-Camera</source>
+        <translation>Use subcâmera</translation>
+    </message>
+    <message>
+        <source>To Frame:</source>
+        <translation>Para enquadrar:</translation>
+    </message>
+    <message>
+        <source>From Frame:</source>
+        <translation>Do quadro:</translation>
+    </message>
+    <message>
+        <source>Shrink:</source>
+        <translation>Encolher:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Fx Schematic Flows</source>
+        <translation>Fluxos Esquemáticos FX</translation>
+    </message>
+    <message>
+        <source>Fx Schematic Terminal Nodes</source>
+        <translation>Nós terminais esquemáticos Fx</translation>
+    </message>
+    <message>
+        <source>Multiple Rendering: </source>
+        <translation>Renderização múltipla:</translation>
+    </message>
+    <message>
+        <source>Do stereoscopy</source>
+        <translation>Faça estereoscopia</translation>
+    </message>
+    <message>
+        <source>Apply Shrink to Main Viewer</source>
+        <translation>Aplicar redução ao visualizador principal</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <source>Improved</source>
+        <translation>Melhorou</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>Alto</translation>
+    </message>
+    <message>
+        <source>Resample Balance:</source>
+        <translation>Saldo de nova amostra:</translation>
+    </message>
+    <message>
+        <source>Channel Width:</source>
+        <translation>Largura do canal:</translation>
+    </message>
+    <message>
+        <source>Gamma:</source>
+        <translation>Gama:</translation>
+    </message>
+    <message>
+        <source>Odd (NTSC)</source>
+        <translation>Ímpar (NTSC)</translation>
+    </message>
+    <message>
+        <source>Even (PAL)</source>
+        <translation>Par (PAL)</translation>
+    </message>
+    <message>
+        <source>Dominant Field:</source>
+        <translation>Campo Dominante:</translation>
+    </message>
+    <message>
+        <source>to FPS:</source>
+        <translation>para FPS:</translation>
+    </message>
+    <message>
+        <source>Stretch from FPS:</source>
+        <translation>Alongamento do FPS:</translation>
+    </message>
+    <message>
+        <source>Single</source>
+        <translation>Solteiro</translation>
+    </message>
+    <message>
+        <source>Half</source>
+        <translation>Metade</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation>Todos</translation>
+    </message>
+    <message>
+        <source>Dedicated CPUs:</source>
+        <translation>CPUs dedicadas:</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>Grande</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation>Médio</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>Pequeno</translation>
+    </message>
+    <message>
+        <source>Render Tile:</source>
+        <translation>Renderizar bloco:</translation>
+    </message>
+    <message>
+        <source>Preview Settings</source>
+        <translation>Configurações de visualização</translation>
+    </message>
+    <message>
+        <source>Output Settings</source>
+        <translation>Configurações de saída</translation>
+    </message>
+    <message>
+        <source>8 bits</source>
+        <translation>8 bits</translation>
+    </message>
+    <message>
+        <source>16 bits</source>
+        <translation>16 bits</translation>
+    </message>
+    <message>
+        <source>Columns</source>
+        <translation>Colunas</translation>
+    </message>
+    <message>
+        <source>Camera Shift:</source>
+        <translation>Mudança de câmera:</translation>
+    </message>
+    <message>
+        <source>Stereoscopic Render:</source>
+        <translation>Renderização estereoscópica:</translation>
+    </message>
+    <message>
+        <source>Camera Settings</source>
+        <translation>Configurações da câmera</translation>
+    </message>
+    <message>
+        <source>File Settings</source>
+        <translation>Configurações de arquivo</translation>
+    </message>
+    <message>
+        <source>Other Settings</source>
+        <translation>Outras configurações</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+    <message>
+        <source>Triangle filter</source>
+        <translation>Filtro triangular</translation>
+    </message>
+    <message>
+        <source>Mitchell-Netravali filter</source>
+        <translation>Filtro Mitchell-Netravali</translation>
+    </message>
+    <message>
+        <source>Cubic convolution, a = .5</source>
+        <translation>Convolução cúbica, a = 0,5</translation>
+    </message>
+    <message>
+        <source>Cubic convolution, a = .75</source>
+        <translation>Convolução cúbica, a = 0,75</translation>
+    </message>
+    <message>
+        <source>Cubic convolution, a = 1</source>
+        <translation>Convolução cúbica, a = 1</translation>
+    </message>
+    <message>
+        <source>Hann window, rad = 2</source>
+        <translation>Janela de Hann, rad = 2</translation>
+    </message>
+    <message>
+        <source>Hann window, rad = 3</source>
+        <translation>Janela de Hann, rad = 3</translation>
+    </message>
+    <message>
+        <source>Hamming window, rad = 2</source>
+        <translation>Janela de Hamming, rad = 2</translation>
+    </message>
+    <message>
+        <source>Hamming window, rad = 3</source>
+        <translation>Janela de Hamming, rad = 3</translation>
+    </message>
+    <message>
+        <source>Lanczos window, rad = 2</source>
+        <translation>Janela de Lanczos, rad = 2</translation>
+    </message>
+    <message>
+        <source>Lanczos window, rad = 3</source>
+        <translation>Janela de Lanczos, rad = 3</translation>
+    </message>
+    <message>
+        <source>Gaussian convolution</source>
+        <translation>Convolução gaussiana</translation>
+    </message>
+    <message>
+        <source>Closest Pixel (Nearest Neighbor)</source>
+        <translation>Pixel mais próximo (vizinho mais próximo)</translation>
+    </message>
+    <message>
+        <source>Bilinear</source>
+        <translation>Bilinear</translation>
+    </message>
+    <message>
+        <source>8 bit</source>
+        <translation>8 bits</translation>
+    </message>
+    <message>
+        <source>16 bit</source>
+        <translation>16 bits</translation>
+    </message>
+    <message>
+        <source>Presets:</source>
+        <translation>Predefinições:</translation>
+    </message>
+    <message>
+        <source>Frame Start:</source>
+        <translation>Início do quadro:</translation>
+    </message>
+    <message>
+        <source>End:</source>
+        <translation>Fim:</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Frame Rate (linked to Scene Settings):</source>
+        <translation>Taxa de quadros (vinculada às configurações de cena):</translation>
+    </message>
+    <message>
+        <source>  To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>Multiple Rendering:</source>
+        <translation>Renderização múltipla:</translation>
+    </message>
+    <message>
+        <source>Add preset</source>
+        <translation>Adicionar predefinição</translation>
+    </message>
+    <message>
+        <source>Enter the name for the output settings preset.</source>
+        <translation>Insira o nome da predefinição de configurações de saída.</translation>
+    </message>
+    <message>
+        <source>Add output settings preset</source>
+        <translation>Adicionar predefinições de configurações de saída</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>Remove preset</source>
+        <translation>Remover predefinição</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Aviso</translation>
+    </message>
+    <message>
+        <source>Render</source>
+        <translation>Renderizar</translation>
+    </message>
+    <message>
+        <source>Add Clapperboard</source>
+        <translation>Adicionar claquete</translation>
+    </message>
+    <message>
+        <source>Edit Clapperboard...</source>
+        <translation>Editar claquete...</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width</source>
+        <translation>Salve as configurações de saída atuais.
+Os parâmetros a serem salvos são:
+- Configurações da câmera
+- Pasta do projeto a ser salva
+- Formato de arquivo
+- Opções de arquivo
+- Reamostrar saldo
+- Largura do canal</translation>
+    </message>
+    <message>
+        <source>Camera</source>
+        <translation>Câmera</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation>Mais</translation>
+    </message>
+    <message>
+        <source>More Settings</source>
+        <translation>Mais configurações</translation>
+    </message>
+    <message>
+        <source>Frame Rate:</source>
+        <translation>Taxa de quadros:</translation>
+    </message>
+    <message>
+        <source>(linked to Scene Settings)</source>
+        <translation>(vinculado às configurações de cena)</translation>
+    </message>
+    <message>
+        <source>Save current output settings.
+The parameters to be saved are:
+- Camera settings
+- Project folder to be saved in
+- File format
+- File options
+- Resample Balance
+- Channel width
+- Linear Color Space
+- Color Space Gamma</source>
+        <translation>Salve as configurações de saída atuais.
+Os parâmetros a serem salvos são:
+- Configurações da câmera
+- Pasta do projeto a ser salva
+- Formato de arquivo
+- Opções de arquivo
+- Reamostrar saldo
+- Largura do canal
+- Espaço de cores linear
+- Gama de espaço de cores</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Color Settings</source>
+        <translation>Configurações de cores</translation>
+    </message>
+    <message>
+        <source>Sync with Output Settings</source>
+        <translation>Sincronizar com configurações de saída</translation>
+    </message>
+    <message>
+        <source>32 bit Floating point</source>
+        <translation>Ponto flutuante de 32 bits</translation>
+    </message>
+    <message>
+        <source>On rendering, color values will be temporarily converted to linear light from nonlinear RGB values by using color space gamma.</source>
+        <translation>Na renderização, os valores de cores serão temporariamente convertidos em luz linear a partir de valores RGB não lineares usando gama de espaço de cores.</translation>
+    </message>
+    <message>
+        <source>Color Space Gamma value is used for conversion between the linear and nonlinear color spaces,
+when the "Linear Color Space" option is enabled.</source>
+        <translation>O valor Color Space Gamma é usado para conversão entre os espaços de cores lineares e não lineares,
+quando a opção "Espaço de cores linear" está habilitada.</translation>
+    </message>
+    <message>
+        <source>
+Input less than 1.0 to sync the value with the output settings.</source>
+        <translation>Insira menos de 1,0 para sincronizar o valor com as configurações de saída.</translation>
+    </message>
+    <message>
+        <source>Linear Color Space:</source>
+        <translation>Espaço de cores linear:</translation>
+    </message>
+    <message>
+        <source>Color Space Gamma:</source>
+        <translation>Gama de espaço de cores:</translation>
+    </message>
+</context>
+<context>
+    <name>OverwriteDialog</name>
+    <message>
+        <source>Warning!</source>
+        <translation>Aviso!</translation>
+    </message>
+    <message>
+        <source>Keep existing file</source>
+        <translation>Manter arquivo existente</translation>
+    </message>
+    <message>
+        <source>Overwrite the existing file with the new one</source>
+        <translation>Substitua o arquivo existente pelo novo</translation>
+    </message>
+    <message>
+        <source>Rename the new file adding the suffix</source>
+        <translation>Renomeie o novo arquivo adicionando o sufixo</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Apply to All</source>
+        <translation>Aplicar a todos</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+What do you want to do?</source>
+        <translation>O arquivo %1 já existe.
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>The suffix field is empty. Please specify a suffix.</source>
+        <translation>O campo de sufixo está vazio. Especifique um sufixo.</translation>
+    </message>
+    <message>
+        <source>File %1 exists as well; please choose a different suffix.</source>
+        <translation>O arquivo %1 também existe; escolha um sufixo diferente.</translation>
+    </message>
+    <message>
+        <source>Level "%1" already exists.
+
+What do you want to do?</source>
+        <translation>O nível "%1" já existe.
+
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Skip</source>
+        <translation>Pular</translation>
+    </message>
+    <message>
+        <source>File "%1" already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo "%1" já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>File "%1" already exists.
+What do you want to do?</source>
+        <translation>O arquivo "%1" já existe.
+O que você quer fazer?</translation>
+    </message>
+</context>
+<context>
+    <name>PaletteViewerPanel</name>
+    <message>
+        <source>Freeze</source>
+        <translation>Congelar</translation>
+    </message>
+</context>
+<context>
+    <name>PencilTestPopup</name>
+    <message>
+        <source>Camera Capture</source>
+        <translation>Captura de câmera</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Atualizar</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+    <message>
+        <source>Save images as they are captured</source>
+        <translation>Salve as imagens conforme elas são capturadas</translation>
+    </message>
+    <message>
+        <source>Image adjust</source>
+        <translation>Ajuste de imagem</translation>
+    </message>
+    <message>
+        <source>Upside down</source>
+        <translation>De cabeça para baixo</translation>
+    </message>
+    <message>
+        <source>Capture white BG</source>
+        <translation>Capturar glicemia branca</translation>
+    </message>
+    <message>
+        <source>Display</source>
+        <translation>Mostrar</translation>
+    </message>
+    <message>
+        <source>Show onion skin</source>
+        <translation>Mostrar Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Interval timer</source>
+        <translation>Temporizador de intervalo</translation>
+    </message>
+    <message>
+        <source>Use interval timer</source>
+        <translation>Usar temporizador de intervalo</translation>
+    </message>
+    <message>
+        <source>Capture
+[Return key]</source>
+        <translation>Capturar
+[Tecla de retorno]</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Next Level</source>
+        <translation>Próximo nível</translation>
+    </message>
+    <message>
+        <source>Camera:</source>
+        <translation>Câmera:</translation>
+    </message>
+    <message>
+        <source>Resolution:</source>
+        <translation>Resolução:</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Frame:</source>
+        <translation>Quadro:</translation>
+    </message>
+    <message>
+        <source>File Type:</source>
+        <translation>Tipo de arquivo:</translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>Color type:</source>
+        <translation>Tipo de cor:</translation>
+    </message>
+    <message>
+        <source>Threshold:</source>
+        <translation>Limite:</translation>
+    </message>
+    <message>
+        <source>Contrast:</source>
+        <translation>Contraste:</translation>
+    </message>
+    <message>
+        <source>Brightness:</source>
+        <translation>Brilho:</translation>
+    </message>
+    <message>
+        <source>BG reduction:</source>
+        <translation>Redução de glicemia:</translation>
+    </message>
+    <message>
+        <source>Opacity(%):</source>
+        <translation>Opacidade(%):</translation>
+    </message>
+    <message>
+        <source>Interval(sec):</source>
+        <translation>Intervalo (seg):</translation>
+    </message>
+    <message>
+        <source>No camera found</source>
+        <translation>Nenhuma câmera encontrada</translation>
+    </message>
+    <message>
+        <source>- Select camera -</source>
+        <translation>- Selecione a câmera -</translation>
+    </message>
+    <message>
+        <source>Start Capturing
+[Return key]</source>
+        <translation>Comece a capturar
+[Tecla de retorno]</translation>
+    </message>
+    <message>
+        <source>Stop Capturing
+[Return key]</source>
+        <translation>Pare de capturar
+[Tecla de retorno]</translation>
+    </message>
+    <message>
+        <source>No level name specified: please choose a valid level name</source>
+        <translation>Nenhum nome de nível especificado: escolha um nome de nível válido</translation>
+    </message>
+    <message>
+        <source>Folder %1 doesn't exist.
+Do you want to create it?</source>
+        <translation>A pasta% 1 não existe.
+Você quer criá-lo?</translation>
+    </message>
+    <message>
+        <source>Unable to create</source>
+        <translation>Não foi possível criar</translation>
+    </message>
+    <message>
+        <source>The level name specified is already used: please choose a different level name.</source>
+        <translation>O nome do nível especificado já está em uso: escolha um nome de nível diferente.</translation>
+    </message>
+    <message>
+        <source>The save in path specified does not match with the existing level.</source>
+        <translation>O caminho para salvar especificado não corresponde ao nível existente.</translation>
+    </message>
+    <message>
+        <source>The captured image size does not match with the existing level.</source>
+        <translation>O tamanho da imagem capturada não corresponde ao nível existente.</translation>
+    </message>
+    <message>
+        <source>File %1 does exist.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>Failed to load %1.</source>
+        <translation>Falha ao carregar %1.</translation>
+    </message>
+    <message>
+        <source>Video Capture Filter Settings...</source>
+        <translation>Configurações do filtro de captura de vídeo...</translation>
+    </message>
+    <message>
+        <source>Load Selected Image</source>
+        <translation>Carregar imagem selecionada</translation>
+    </message>
+    <message>
+        <source>No image selected.  Please select an image in the Xsheet.</source>
+        <translation>Nenhuma imagem selecionada.  Selecione uma imagem no Xsheet.</translation>
+    </message>
+    <message>
+        <source>The selected image is not in a raster level.</source>
+        <translation>A imagem selecionada não está em nível raster.</translation>
+    </message>
+    <message>
+        <source>The selected image size does not match the current camera settings.</source>
+        <translation>O tamanho da imagem selecionado não corresponde às configurações atuais da câmera.</translation>
+    </message>
+    <message>
+        <source>Pencil Test</source>
+        <translation>Teste de lápis</translation>
+    </message>
+    <message>
+        <source>Capture</source>
+        <translation>Capturar</translation>
+    </message>
+    <message>
+        <source>Subfolder</source>
+        <translation>Subpasta</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <comment>frame id</comment>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Previous Level</source>
+        <translation>Nível anterior</translation>
+    </message>
+    <message>
+        <source>UNDEFINED WARNING</source>
+        <translation>AVISO INDEFINIDO</translation>
+    </message>
+    <message>
+        <source>The level is not registered in the scene, but exists in the file system.</source>
+        <translation>O nível não está registrado na cena, mas existe no sistema de arquivos.</translation>
+    </message>
+    <message>
+        <source>WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho da imagem salva é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>WARNING</source>
+        <translation>AVISO</translation>
+    </message>
+    <message>
+        <source>
+Frame %1 exists.</source>
+        <translation>O quadro %1 existe.</translation>
+    </message>
+    <message>
+        <source>
+Frames %1 exist.</source>
+        <translation>Os quadros %1 existem.</translation>
+    </message>
+    <message>
+        <source>OVERWRITE 1 of</source>
+        <translation>SUBSTITUIR 1 de</translation>
+    </message>
+    <message>
+        <source>ADD to</source>
+        <translation>Adicionar à</translation>
+    </message>
+    <message>
+        <source> %1 frame</source>
+        <translation>%1 quadro</translation>
+    </message>
+    <message>
+        <source> %1 frames</source>
+        <translation>%1 quadros</translation>
+    </message>
+    <message>
+        <source>The level will be newly created.</source>
+        <translation>O nível será criado recentemente.</translation>
+    </message>
+    <message>
+        <source>NEW</source>
+        <translation>NOVO</translation>
+    </message>
+    <message>
+        <source>The level is already registered in the scene.</source>
+        <translation>O nível já está registrado na cena.</translation>
+    </message>
+    <message>
+        <source>
+NOTE : The level is not saved.</source>
+        <translation>NOTA: O nível não é salvo.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Failed to get image size of the existing level %1.</source>
+        <translation>AVISO: Falha ao obter o tamanho da imagem do nível existente %1.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho do nível existente é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
+          %2.</source>
+        <translation>AVISO: Conflitos de nomes de nível. Jáexiste um nível % 1 na cena com o caminho                        
+          %2.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho do nível com o mesmo nome é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>WARNING : Level path conflicts. There already is a level with the path %1                        
+          in the scene with the name %2.</source>
+        <translation>AVISO: Conflitos de caminho de nível. Jáexiste um nível com o caminho % 1                        
+          na cena com o nome %2.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho do nível com o mesmo caminho é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho da imagem salva é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Grayscale</source>
+        <translation>Tons de cinza</translation>
+    </message>
+    <message>
+        <source>Black &amp; White</source>
+        <translation>Preto e branco</translation>
+    </message>
+    <message>
+        <source>Subcamera</source>
+        <translation>Subcâmera</translation>
+    </message>
+    <message>
+        <source>Use Direct Show Webcam Drivers</source>
+        <translation>Use drivers de webcam Direct Show</translation>
+    </message>
+    <message>
+        <source>Use MJPG with Webcam</source>
+        <translation>Use MJPG com webcam</translation>
+    </message>
+    <message>
+        <source>Onion skin</source>
+        <translation>Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Calibration</source>
+        <translation>Calibração</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Start calibration</source>
+        <translation>Iniciar calibração</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Open Readme.txt for Camera calibration...</source>
+        <translation>Abra o Readme.txt para calibração da câmera...</translation>
+    </message>
+    <message>
+        <source>Failed to save calibration settings.</source>
+        <translation>Falha ao salvar as configurações de calibração.</translation>
+    </message>
+    <message>
+        <source>Do you want to restart camera calibration?</source>
+        <translation>Deseja reiniciar a calibração da câmera?</translation>
+    </message>
+    <message>
+        <source>Couldn't load %1</source>
+        <translation>Não foi possível carregar % 1</translation>
+    </message>
+    <message>
+        <source>Overwriting the current calibration. Are you sure?</source>
+        <translation>Substituindo a calibração atual. Tem certeza?</translation>
+    </message>
+    <message>
+        <source>Couldn't save %1</source>
+        <translation>Não foi possível salvar % 1</translation>
+    </message>
+    <message>
+        <source>DPI:Auto</source>
+        <translation>DPI: Automático</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Position</source>
+        <translation>Posição</translation>
+    </message>
+    <message>
+        <source>DPI:%1</source>
+        <translation>DPI:%1</translation>
+    </message>
+    <message>
+        <source>This option specifies DPI for newly created levels.
+Adding frames to the existing level won't refer to this value.
+Auto: If the subcamera is not active, apply the current camera dpi.
+      If the subcamera is active, compute the dpi so that
+      the image will fit to the camera frame.
+Custom : Always use the custom dpi specified here.</source>
+        <translation>Esta opção especifica o DPI para níveis recém-criados.
+Adicionar quadros ao nível existente não fará referência a esse valor.
+Auto: Se a subcâmera não estiver ativa, aplique o dpi atual da câmera.
+      Se a subcâmera estiver ativa, calcule o dpi para que
+      a imagem caberá no quadro da câmera.
+Personalizado: sempre use o dpi personalizado especificado aqui.</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>Personalizado</translation>
+    </message>
+    <message>
+        <source>Save Current Image Adjust Parameters As Default</source>
+        <translation>Salvar parâmetros de ajuste de imagem atuais como padrão</translation>
+    </message>
+    <message>
+        <source>BG Reduction is set but the White BG image is missing. Please capture the White BG again.</source>
+        <translation>A redução de GS está definida, mas a imagem de GS branca está faltando. Por favor, capture o BG Branco novamente.</translation>
+    </message>
+    <message>
+        <source>Do you want to save the current parameters as the default values?</source>
+        <translation>Deseja salvar os parâmetros atuais como valores padrão?</translation>
+    </message>
+</context>
+<context>
+    <name>PencilTestSaveInFolderPopup</name>
+    <message>
+        <source>Create Subfolder</source>
+        <translation>Criar subpasta</translation>
+    </message>
+    <message>
+        <source>Infomation</source>
+        <translation>Informação</translation>
+    </message>
+    <message>
+        <source>Subfolder Name</source>
+        <translation>Nome da subpasta</translation>
+    </message>
+    <message>
+        <source>Auto Format:</source>
+        <translation>Formatação automática:</translation>
+    </message>
+    <message>
+        <source>Show This on Launch of the Camera Capture</source>
+        <translation>Mostre isso no início da captura da câmera</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>C- + Sequence + Scene</source>
+        <translation>C- + Sequência + Cena</translation>
+    </message>
+    <message>
+        <source>Sequence + Scene</source>
+        <translation>Sequência + Cena</translation>
+    </message>
+    <message>
+        <source>Episode + Sequence + Scene</source>
+        <translation>Episódio + Sequência + Cena</translation>
+    </message>
+    <message>
+        <source>Project + Episode + Sequence + Scene</source>
+        <translation>Projeto + Episódio + Sequência + Cena</translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>Project:</source>
+        <translation>Projeto:</translation>
+    </message>
+    <message>
+        <source>Episode:</source>
+        <translation>Episódio:</translation>
+    </message>
+    <message>
+        <source>Sequence:</source>
+        <translation>Sequência:</translation>
+    </message>
+    <message>
+        <source>Scene:</source>
+        <translation>Cena:</translation>
+    </message>
+    <message>
+        <source>Subfolder Name:</source>
+        <translation>Nome da subpasta:</translation>
+    </message>
+    <message>
+        <source>Subfolder name should not be empty.</source>
+        <translation>O nome da subpasta não deve estar vazio.</translation>
+    </message>
+    <message>
+        <source>Subfolder name should not contain following characters:  * . " / \ [ ] : ; | = , </source>
+        <translation>O nome da subpasta não deve conter os seguintes caracteres: * . " /\[ ] : ; | = ,</translation>
+    </message>
+    <message>
+        <source>Folder %1 already exists.</source>
+        <translation>A pasta %1 já existe.</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation>Não é possível criar a pasta %1.</translation>
+    </message>
+    <message>
+        <source>Set As Default</source>
+        <translation>Definir como padrão</translation>
+    </message>
+    <message>
+        <source>Set the current "Save In" path as the default.</source>
+        <translation>Defina o caminho "Salvar em" atual como padrão.</translation>
+    </message>
+    <message>
+        <source>Save Scene in Subfolder</source>
+        <translation>Salvar cena na subpasta</translation>
+    </message>
+    <message>
+        <source>Save the current scene in the subfolder.
+          Set the output folder path to the subfolder as well.</source>
+        <translation>Salve a cena atual na subpasta.
+          Defina também o caminho da pasta de saída para a subpasta.</translation>
+    </message>
+    <message>
+        <source>Create the Destination Subfolder to Save</source>
+        <translation>Crie a subpasta de destino para salvar</translation>
+    </message>
+    <message>
+        <source>Save the current scene in the subfolder.
+Set the output folder path to the subfolder as well.</source>
+        <translation>Salve a cena atual na subpasta.
+Defina também o caminho da pasta de saída para a subpasta.</translation>
+    </message>
+    <message>
+        <source>Information</source>
+        <translation>Informação</translation>
+    </message>
+</context>
+<context>
+    <name>PltGizmoPopup</name>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation>Paleta Gizmo</translation>
+    </message>
+    <message>
+        <source>Luminance:</source>
+        <translation>Luminância:</translation>
+    </message>
+    <message>
+        <source>Saturation:</source>
+        <translation>Saturação:</translation>
+    </message>
+    <message>
+        <source>Hue:</source>
+        <translation>Matiz:</translation>
+    </message>
+    <message>
+        <source>Transparency:</source>
+        <translation>Transparência:</translation>
+    </message>
+    <message>
+        <source>Fade to Color</source>
+        <translation>Desbotar para colorir</translation>
+    </message>
+    <message>
+        <source>              Color:</source>
+        <translation>Cor:</translation>
+    </message>
+    <message>
+        <source>Fade</source>
+        <translation>Desaparecer</translation>
+    </message>
+    <message>
+        <source>Blend</source>
+        <translation>Mistura</translation>
+    </message>
+    <message>
+        <source>Full Matte</source>
+        <translation>Totalmente fosco</translation>
+    </message>
+    <message>
+        <source>Zero Matte</source>
+        <translation>Zero fosco</translation>
+    </message>
+    <message>
+        <source>Scale (%)</source>
+        <translation>Escala (%)</translation>
+    </message>
+    <message>
+        <source>Shift (value)</source>
+        <translation>Mudança (valor)</translation>
+    </message>
+    <message>
+        <source>Value</source>
+        <translation>Valor</translation>
+    </message>
+    <message>
+        <source>Saturation</source>
+        <translation>Saturação</translation>
+    </message>
+    <message>
+        <source>Hue</source>
+        <translation>Matiz</translation>
+    </message>
+    <message>
+        <source>Matte</source>
+        <translation>Fosco</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Full Alpha</source>
+        <translation>Alfa completo</translation>
+    </message>
+    <message>
+        <source>Zero Alpha</source>
+        <translation>Zero Alfa</translation>
+    </message>
+    <message>
+        <source>Alpha</source>
+        <translation>Alfa</translation>
+    </message>
+    <message>
+        <source>Bind to Current Room</source>
+        <translation>Vincular à sala atual</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesPopup</name>
+    <message>
+        <source>Preferences</source>
+        <translation>Preferências</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Em geral</translation>
+    </message>
+    <message>
+        <source>Use Default Viewer for Movie Formats</source>
+        <translation>Use o visualizador padrão para formatos de filme</translation>
+    </message>
+    <message>
+        <source>Save Automatically Every Minutes</source>
+        <translation>Salvar automaticamente a cada minuto</translation>
+    </message>
+    <message>
+        <source>Backup Animation Levels when Saving</source>
+        <translation>Níveis de animação de backup ao salvar</translation>
+    </message>
+    <message>
+        <source>Cells Only</source>
+        <translation>Apenas células</translation>
+    </message>
+    <message>
+        <source>Cells and Column Data</source>
+        <translation>Dados de células e colunas</translation>
+    </message>
+    <message>
+        <source>Cell-dragging Behaviour:</source>
+        <translation>Comportamento de arrastar células:</translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation>Interface</translation>
+    </message>
+    <message>
+        <source>Style:</source>
+        <translation>Estilo:</translation>
+    </message>
+    <message>
+        <source>Open Flipbook after Rendering</source>
+        <translation>Abra o Flipbook após a renderização</translation>
+    </message>
+    <message>
+        <source>Unit:</source>
+        <translation>Unidade:</translation>
+    </message>
+    <message>
+        <source>Camera Unit:</source>
+        <translation>Unidade de câmera:</translation>
+    </message>
+    <message>
+        <source>Flipbook Shrink:</source>
+        <translation>Encolher flipbook:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Height*:</source>
+        <translation>Altura*:</translation>
+    </message>
+    <message>
+        <source>Loading</source>
+        <translation>Carregando</translation>
+    </message>
+    <message>
+        <source>Expose Loaded Levels in Xsheet</source>
+        <translation>Expor níveis carregados no Xsheet</translation>
+    </message>
+    <message>
+        <source>Create Sub-folder when Importing Sub-Xsheet</source>
+        <translation>Criar subpasta ao importar sub-Xsheet</translation>
+    </message>
+    <message>
+        <source>Drawing</source>
+        <translation>Desenho</translation>
+    </message>
+    <message>
+        <source>Keep Original Cleaned Up Drawings As Backup</source>
+        <translation>Mantenha os desenhos originais limpos como backup</translation>
+    </message>
+    <message>
+        <source>Animation</source>
+        <translation>Animação</translation>
+    </message>
+    <message>
+        <source>Default Interpolation: </source>
+        <translation>Interpolação padrão:</translation>
+    </message>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>Speed In / Speed Out</source>
+        <translation>Velocidade de entrada/saída</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out</source>
+        <translation>Facilidade de entrada/facilidade</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out %</source>
+        <translation>Facilidade de entrada/facilidade %</translation>
+    </message>
+    <message>
+        <source>Animation Step:</source>
+        <translation>Etapa de animação:</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Blank Frames:</source>
+        <translation>Quadros em branco:</translation>
+    </message>
+    <message>
+        <source>Blank Frames Color:</source>
+        <translation>Cor dos quadros em branco:</translation>
+    </message>
+    <message>
+        <source>Display in a New Flipbook Window</source>
+        <translation>Exibir em uma nova janela de flipbook</translation>
+    </message>
+    <message>
+        <source>Rewind after Playback</source>
+        <translation>Retroceder após a reprodução</translation>
+    </message>
+    <message>
+        <source>Onion Skin</source>
+        <translation>Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>   Following Frames Correction: </source>
+        <translation>Seguinte Correção de Quadros:</translation>
+    </message>
+    <message>
+        <source>Display Lines Only</source>
+        <translation>Exibir apenas linhas</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation>Controle de versão</translation>
+    </message>
+    <message>
+        <source>Automatically Refresh Folder Contents</source>
+        <translation>Atualizar automaticamente o conteúdo da pasta</translation>
+    </message>
+    <message>
+        <source>Undo Memory Size (MB):</source>
+        <translation>Desfazer tamanho da memória (MB):</translation>
+    </message>
+    <message>
+        <source>Render Task Chunk Size:</source>
+        <translation>Tamanho do bloco da tarefa de renderização:</translation>
+    </message>
+    <message>
+        <source>Show Info in Rendered Frames</source>
+        <translation>Mostrar informações em quadros renderizados</translation>
+    </message>
+    <message>
+        <source>cm</source>
+        <translation>cm</translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation>milímetros</translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation>polegada</translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation>campo</translation>
+    </message>
+    <message>
+        <source>Xsheet Autopan during Playback</source>
+        <translation>Panorama automático do Xsheet durante a reprodução</translation>
+    </message>
+    <message>
+        <source>Level Strip Frames Width*:</source>
+        <translation>Largura das quadros da faixa de nível*:</translation>
+    </message>
+    <message>
+        <source>Capture</source>
+        <translation>Capturar</translation>
+    </message>
+    <message>
+        <source>        Frame Rate:</source>
+        <translation>Taxa de quadros:</translation>
+    </message>
+    <message>
+        <source>Scan File Format:</source>
+        <translation>Formato do arquivo de digitalização:</translation>
+    </message>
+    <message>
+        <source>Default Level Type:</source>
+        <translation>Tipo de nível padrão:</translation>
+    </message>
+    <message>
+        <source>Toonz Vector Level</source>
+        <translation>Nível de vetor Toonz</translation>
+    </message>
+    <message>
+        <source>Toonz Raster Level</source>
+        <translation>Nível Raster Toonz</translation>
+    </message>
+    <message>
+        <source>Raster Level</source>
+        <translation>Nível raster</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>Autocreation:</source>
+        <translation>Autocriação:</translation>
+    </message>
+    <message>
+        <source>Minimize Savebox after Editing</source>
+        <translation>Minimize o Savebox após a edição</translation>
+    </message>
+    <message>
+        <source>Use the TLV Savebox to Limit Filling Operations</source>
+        <translation>Use o TLV Savebox para limitar as operações de preenchimento</translation>
+    </message>
+    <message>
+        <source>Paper Thickness:</source>
+        <translation>Espessura do papel:</translation>
+    </message>
+    <message>
+        <source>Transparency Check</source>
+        <translation>Verificação de transparência</translation>
+    </message>
+    <message>
+        <source>Ink Color on White BG:</source>
+        <translation>Cor da tinta em branco BG:</translation>
+    </message>
+    <message>
+        <source>Ink Color on Black BG:</source>
+        <translation>Cor da tinta em preto BG:</translation>
+    </message>
+    <message>
+        <source> Paint Color: </source>
+        <translation>Cor da pintura:</translation>
+    </message>
+    <message>
+        <source>Fit to Flipbook</source>
+        <translation>Ajustar ao Flipbook</translation>
+    </message>
+    <message>
+        <source>New Level Format</source>
+        <translation>Novo formato de nível</translation>
+    </message>
+    <message>
+        <source>Assign the new level format name:</source>
+        <translation>Atribua o nome do novo formato de nível:</translation>
+    </message>
+    <message>
+        <source>New Format</source>
+        <translation>Novo formato</translation>
+    </message>
+    <message>
+        <source>Visualization</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Show Lines with Thickness 0</source>
+        <translation>Mostrar linhas com espessura 0</translation>
+    </message>
+    <message>
+        <source>Antialiased region boundaries</source>
+        <translation>Limites de região suavizados</translation>
+    </message>
+    <message>
+        <source>Level Settings by File Format:</source>
+        <translation>Configurações de nível por formato de arquivo:</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Xsheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>Next/Previous Step Frames:</source>
+        <translation>Quadros da etapa seguinte/anterior:</translation>
+    </message>
+    <message>
+        <source>Ignore Alpha Channel on Levels in Column 1</source>
+        <translation>Ignore o canal alfa nos níveis da coluna 1</translation>
+    </message>
+    <message>
+        <source>Minimize Raster Memory Fragmentation*</source>
+        <translation>Minimize a fragmentação da memória raster*</translation>
+    </message>
+    <message>
+        <source>* Changes will take effect the next time you run OpenToonz</source>
+        <translation>* As alterações entrarão em vigor na próxima vez que você executar o OpenToonz</translation>
+    </message>
+    <message>
+        <source>Move Current Frame by Clicking on Xsheet / Numerical Columns Cell Area</source>
+        <translation>Mova o quadro atual clicando na área da célula Xsheet / colunas numéricas</translation>
+    </message>
+    <message>
+        <source>Enable Actual Pixel View on Scene Editing Mode</source>
+        <translation>Ativar visualização de pixels reais no modo de edição de cena</translation>
+    </message>
+    <message>
+        <source>Display Level Name on Each Marker</source>
+        <translation>Exibir nome do nível em cada marcador</translation>
+    </message>
+    <message>
+        <source>Show Raster Images Darken Blended in Camstand View</source>
+        <translation>Mostrar imagens raster escurecidas mescladas no Camstand Exibir</translation>
+    </message>
+    <message>
+        <source>Show "ABC" Appendix to the Frame Number in Xsheet Cell</source>
+        <translation>Mostrar o apêndice "ABC" ao número do quadro na célula do Xsheet</translation>
+    </message>
+    <message>
+        <source>Automatically Remove Scene Number from Loaded Level Name</source>
+        <translation>Remover automaticamente o número da cena do nome do nível carregado</translation>
+    </message>
+    <message>
+        <source>Multi Layer Style Picker: Switch Levels by Picking</source>
+        <translation>Seletor de estilo multicamada: alterne os níveis escolhendo</translation>
+    </message>
+    <message>
+        <source>Onion Skin ON</source>
+        <translation>Casca de Cebola LIGADA</translation>
+    </message>
+    <message>
+        <source>Enable Version Control*</source>
+        <translation>Ativar controle de versão*</translation>
+    </message>
+    <message>
+        <source>Category</source>
+        <translation>Categoria</translation>
+    </message>
+    <message>
+        <source>Level Strip Icon Size*:</source>
+        <translation>Tamanho do ícone da faixa de nível*:</translation>
+    </message>
+    <message>
+        <source>x</source>
+        <translation>x</translation>
+    </message>
+    <message>
+        <source>Viewer Shrink:</source>
+        <translation>Redução do visualizador:</translation>
+    </message>
+    <message>
+        <source>Viewer BG Color:</source>
+        <translation>Cor BG do visualizador:</translation>
+    </message>
+    <message>
+        <source>Preview BG Color:</source>
+        <translation>Visualizar cor BG:</translation>
+    </message>
+    <message>
+        <source>Chessboard Color 1:</source>
+        <translation>Cor do tabuleiro de xadrez 1:</translation>
+    </message>
+    <message>
+        <source>Chessboard Color 2:</source>
+        <translation>Cor do tabuleiro de xadrez 2:</translation>
+    </message>
+    <message>
+        <source>Viewer Zoom Center:</source>
+        <translation>Centro de zoom do visualizador:</translation>
+    </message>
+    <message>
+        <source>Language*:</source>
+        <translation>Linguagem*:</translation>
+    </message>
+    <message>
+        <source>Default TLV Caching Behavior</source>
+        <translation>Comportamento de cache TLV padrão</translation>
+    </message>
+    <message>
+        <source>Column Icon</source>
+        <translation>Ícone de coluna</translation>
+    </message>
+    <message>
+        <source>Default Interpolation:</source>
+        <translation>Interpolação padrão:</translation>
+    </message>
+    <message>
+        <source>Following Frames Correction:</source>
+        <translation>Seguinte Correção de Quadros:</translation>
+    </message>
+    <message>
+        <source>Previous Frames Correction:</source>
+        <translation>Correção de quadros anteriores:</translation>
+    </message>
+    <message>
+        <source>Paint Color:</source>
+        <translation>Cor da pintura:</translation>
+    </message>
+    <message>
+        <source>Replace Toonz Level after SaveLevelAs command</source>
+        <translation>Substitua o nível Toonz após o comando SaveLevelAs</translation>
+    </message>
+    <message>
+        <source>Show Keyframes on Cell Area</source>
+        <translation>Mostrar quadros-chave na área da célula</translation>
+    </message>
+    <message>
+        <source>Mouse Cursor</source>
+        <translation>Cursor do mouse</translation>
+    </message>
+    <message>
+        <source>Viewer Center</source>
+        <translation>Central do visualizador</translation>
+    </message>
+    <message>
+        <source>On Demand</source>
+        <translation>Sob demanda</translation>
+    </message>
+    <message>
+        <source>All Icons</source>
+        <translation>Todos os ícones</translation>
+    </message>
+    <message>
+        <source>All Icons &amp; Images</source>
+        <translation>Todos os ícones e imagens</translation>
+    </message>
+    <message>
+        <source>At Once</source>
+        <translation>De uma vez</translation>
+    </message>
+    <message>
+        <source>Pick Every Colors as Different Styles</source>
+        <translation>Escolha todas as cores como estilos diferentes</translation>
+    </message>
+    <message>
+        <source>Integrate Similar Colors as One Style</source>
+        <translation>Integre cores semelhantes como um estilo</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation>Desabilitado</translation>
+    </message>
+    <message>
+        <source>Enabled</source>
+        <translation>Habilitado</translation>
+    </message>
+    <message>
+        <source>Use Xsheet as Animation Sheet</source>
+        <translation>Use Xsheet como folha de animação</translation>
+    </message>
+    <message>
+        <source>Palette Type on Loading Raster Image as Color Model</source>
+        <translation>Tipo de paleta ao carregar imagem raster como modelo de cores</translation>
+    </message>
+    <message>
+        <source>Save Automatically</source>
+        <translation>Salvar automaticamente</translation>
+    </message>
+    <message>
+        <source>Automatically Save the Scene File</source>
+        <translation>Salvar automaticamente o arquivo de cena</translation>
+    </message>
+    <message>
+        <source>Automatically Save Non-Scene Files</source>
+        <translation>Salvar automaticamente arquivos fora da cena</translation>
+    </message>
+    <message>
+        <source>My Documents/OpenToonz*</source>
+        <translation>Meus Documentos/OpenToonz*</translation>
+    </message>
+    <message>
+        <source>Desktop/OpenToonz*</source>
+        <translation>Desktop/OpenToonz*</translation>
+    </message>
+    <message>
+        <source>Stuff Folder*</source>
+        <translation>Pasta de coisas*</translation>
+    </message>
+    <message>
+        <source>Custom*</source>
+        <translation>Personalizado*</translation>
+    </message>
+    <message>
+        <source>Custom Project Path(s):</source>
+        <translation>Caminho(s) de projeto personalizado(s):</translation>
+    </message>
+    <message>
+        <source>Advanced: Multiple paths can be separated by ** (No Spaces)</source>
+        <translation>Avançado: vários caminhos podem ser separados por ** (sem espaços)</translation>
+    </message>
+    <message>
+        <source>All imported images will use the same DPI</source>
+        <translation>Todas as imagens importadas usarão o mesmo DPI</translation>
+    </message>
+    <message>
+        <source>Import/Export</source>
+        <translation>Importar/Exportar</translation>
+    </message>
+    <message>
+        <source>Show Onion Skin During Playback</source>
+        <translation>Mostrar Casca de Cebola durante a reprodução</translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation>pixel</translation>
+    </message>
+    <message>
+        <source>Interval (Minutes):</source>
+        <translation>Intervalo (minutos):</translation>
+    </message>
+    <message>
+        <source>Additional Project Locations</source>
+        <translation>Locais adicionais do projeto</translation>
+    </message>
+    <message>
+        <source>Pixels Only:</source>
+        <translation>Somente pixels:</translation>
+    </message>
+    <message>
+        <source>Rooms *:</source>
+        <translation>Quartos*:</translation>
+    </message>
+    <message>
+        <source>OpenToonz can use FFmpeg for additional file formats.</source>
+        <translation>OpenToonz pode usar FFmpeg para formatos de arquivo adicionais.</translation>
+    </message>
+    <message>
+        <source>FFmpeg is not bundled with OpenToonz</source>
+        <translation>FFmpeg não vem junto com OpenToonz</translation>
+    </message>
+    <message>
+        <source>NOTE: This is an experimental feature.</source>
+        <translation>NOTA: Este é um recurso experimental.</translation>
+    </message>
+    <message>
+        <source>Please SAVE YOUR WORK before exporting in MP4, WEBM, or GIF format.</source>
+        <translation>SALVE SEU TRABALHO antes de exportar em formato MP4, WEBM ou GIF.</translation>
+    </message>
+    <message>
+        <source>Please provide the path where FFmpeg is located on your computer.</source>
+        <translation>Forneça o caminho onde o FFmpeg está localizado no seu computador.</translation>
+    </message>
+    <message>
+        <source>FFmpeg Path:</source>
+        <translation>Caminho FFmpeg:</translation>
+    </message>
+    <message>
+        <source>Number of seconds to wait for FFmpeg to complete processing the output:</source>
+        <translation>Número de segundos de espera para que o FFmpeg conclua o processamento da saída:</translation>
+    </message>
+    <message>
+        <source>Note: FFmpeg begins working once all images have been processed.</source>
+        <translation>Nota: O FFmpeg começa a funcionar assim que todas as imagens forem processadas.</translation>
+    </message>
+    <message>
+        <source>FFmpeg Timeout:</source>
+        <translation>Tempo limite do FFmpeg:</translation>
+    </message>
+    <message>
+        <source>Show Startup Window when OpenToonz Starts</source>
+        <translation>Mostrar janela de inicialização quando o OpenToonz inicia</translation>
+    </message>
+    <message>
+        <source>Numpad keys are assigned to the following commands.
+Is it OK to release these shortcuts?</source>
+        <translation>As teclas do teclado numérico são atribuídas aos seguintes comandos.
+Posso liberar esses atalhos?</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Use Numpad and Tab keys for Switching Styles</source>
+        <translation>Use as teclas Numpad e Tab para alternar estilos</translation>
+    </message>
+    <message>
+        <source>Rooms*:</source>
+        <translation>Quartos*:</translation>
+    </message>
+    <message>
+        <source>Please indicate where you would like exports from Fast Render (MP4) to go.</source>
+        <translation>Indique para onde você gostaria que as exportações do Fast Renderizar (MP4) fossem.</translation>
+    </message>
+    <message>
+        <source>Fast Render Path:</source>
+        <translation>Caminho de renderização rápida:</translation>
+    </message>
+    <message>
+        <source>Replace Level after SaveLevelAs command</source>
+        <translation>Substituir nível após comando SaveLevelAs</translation>
+    </message>
+    <message>
+        <source>Use Arrow Key to Shift Cell Selection</source>
+        <translation>Use a tecla de seta para mudar a seleção de células</translation>
+    </message>
+    <message>
+        <source>Enable to Input Cells without Double Clicking</source>
+        <translation>Habilite a entrada de células sem clicar duas vezes</translation>
+    </message>
+    <message>
+        <source>Watch File System and Update File Browser Automatically</source>
+        <translation>Monitorar o sistema de arquivos e atualizar automaticamente o navegador de arquivos</translation>
+    </message>
+    <message>
+        <source>Use Camera DPI for All Imported Images</source>
+        <translation>Use o DPI da câmera para todas as imagens importadas</translation>
+    </message>
+    <message>
+        <source>Show Toolbar in the Xsheet</source>
+        <translation>Mostrar barra de ferramentas no Xsheet</translation>
+    </message>
+    <message>
+        <source>Expand Function Editor Header to Match XSheet Toolbar Height (Requires Restart)</source>
+        <translation>Expanda o cabeçalho do editor de funções para corresponder à altura da barra de ferramentas XSheet (requer reinicialização)</translation>
+    </message>
+    <message>
+        <source>Show Column Numbers in Column Headers</source>
+        <translation>Mostrar números de colunas em cabeçalhos de colunas</translation>
+    </message>
+    <message>
+        <source>Always ask before loading or importing</source>
+        <translation>Sempre pergunte antes de carregar ou importar</translation>
+    </message>
+    <message>
+        <source>Always import the file to the current project</source>
+        <translation>Sempre importe o arquivo para o projeto atual</translation>
+    </message>
+    <message>
+        <source>Always load the file from the current location</source>
+        <translation>Sempre carregue o arquivo do local atual</translation>
+    </message>
+    <message>
+        <source>Strokes</source>
+        <translation>Traços</translation>
+    </message>
+    <message>
+        <source>Guides</source>
+        <translation>Guias</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation>Todos</translation>
+    </message>
+    <message>
+        <source>Default File Import Behavior:</source>
+        <translation>Comportamento padrão de importação de arquivo:</translation>
+    </message>
+    <message>
+        <source>Default TLV Caching Behavior:</source>
+        <translation>Comportamento de cache TLV padrão:</translation>
+    </message>
+    <message>
+        <source>Column Icon:</source>
+        <translation>Ícone da coluna:</translation>
+    </message>
+    <message>
+        <source>Palette Type on Loading Raster Image as Color Model:</source>
+        <translation>Tipo de paleta ao carregar imagem raster como modelo de cores:</translation>
+    </message>
+    <message>
+        <source>Vector Snapping:</source>
+        <translation>Ajuste vetorial:</translation>
+    </message>
+    <message>
+        <source>New Levels Default to the Current Camera Size</source>
+        <translation>Novos níveis são padronizados para o tamanho atual da câmera</translation>
+    </message>
+    <message>
+        <source>Enable OpenToonz Commands' Shortcut Keys While Renaming Cell</source>
+        <translation>Habilite as teclas de atalho dos comandos do OpenToonz ao renomear a célula</translation>
+    </message>
+    <message>
+        <source>Life is too short for Comic Sans</source>
+        <translation>A vida é muito curta para a Comic Sans</translation>
+    </message>
+    <message>
+        <source>Good luck.  You're on your own from here.</source>
+        <translation>Boa sorte.  Você está sozinho a partir daqui.</translation>
+    </message>
+    <message>
+        <source>Font*:</source>
+        <translation>Fonte*:</translation>
+    </message>
+    <message>
+        <source>Font Weight *:</source>
+        <translation>Peso da fonte *:</translation>
+    </message>
+    <message>
+        <source>Arrow Markers</source>
+        <translation>Marcadores de seta</translation>
+    </message>
+    <message>
+        <source>Animated Guide</source>
+        <translation>Guia animado</translation>
+    </message>
+    <message>
+        <source>Vector Guided Style:</source>
+        <translation>Estilo guiado por vetor:</translation>
+    </message>
+    <message>
+        <source>Layout Preference*:</source>
+        <translation>Preferência de layout*:</translation>
+    </message>
+    <message>
+        <source>Keep fill when using "Replace Vectors" command</source>
+        <translation>Mantenha o preenchimento ao usar o comando "Substituir vetores"</translation>
+    </message>
+    <message>
+        <source>Use higher DPI for calculations - Slower but more accurate</source>
+        <translation>Use DPI mais alto para cálculos – mais lento, mas mais preciso</translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation>Ferramentas</translation>
+    </message>
+    <message>
+        <source>Expand Function Editor Header to Match Xsheet Toolbar Height (Requires Restart)</source>
+        <translation>Expanda o cabeçalho do editor de funções para corresponder à altura da barra de ferramentas do Xsheet (requer reinicialização)</translation>
+    </message>
+    <message>
+        <source>Sync Level Strip Drawing Number Changes with the Xsheet</source>
+        <translation>Sincronizar alterações no número do desenho da faixa de nível com o Xsheet</translation>
+    </message>
+    <message>
+        <source>Show Current Time Indicator (Timeline Mode only)</source>
+        <translation>Mostrar indicador de tempo atual (somente modo linha do tempo)</translation>
+    </message>
+    <message>
+        <source>Project Folder Aliases (+drawings, +scenes, etc.)</source>
+        <translation>Aliases da pasta do projeto (+desenhos, +cenas, etc.)</translation>
+    </message>
+    <message>
+        <source>Scene Folder Alias ($scenefolder)</source>
+        <translation>Alias ​​da pasta de cena ($scenefolder)</translation>
+    </message>
+    <message>
+        <source>Use Project Folder Aliases Only</source>
+        <translation>Use apenas aliases de pasta de projeto</translation>
+    </message>
+    <message>
+        <source>This option defines which alias to be used
+if both are possible on coding file path.</source>
+        <translation>Esta opção define qual alias a ser usado
+se ambos forem possíveis no caminho do arquivo de codificação.</translation>
+    </message>
+    <message>
+        <source>Open the dropdown to display all options</source>
+        <translation>Abra o menu suspenso para exibir todas as opções</translation>
+    </message>
+    <message>
+        <source>Cycle through the available options</source>
+        <translation>Percorra as opções disponíveis</translation>
+    </message>
+    <message>
+        <source>Path Alias Priority:</source>
+        <translation>Prioridade do alias do caminho:</translation>
+    </message>
+    <message>
+        <source>Replace Vectors with Simplified Vectors Command</source>
+        <translation>Comando Substituir Vetores por Vetores Simplificados</translation>
+    </message>
+    <message>
+        <source>Dropdown Shortcuts:</source>
+        <translation>Atalhos suspensos:</translation>
+    </message>
+    <message>
+        <source>Show Raster Images Darken Blended</source>
+        <translation>Mostrar imagens raster escurecidas mescladas</translation>
+    </message>
+    <message>
+        <source>Antialiased Region Boundaries</source>
+        <translation>Limites de região suavizados</translation>
+    </message>
+    <message>
+        <source>Down Arrow at End of Level Strip Creates a New Frame</source>
+        <translation>A seta para baixo na faixa de final de nível cria um novo quadro</translation>
+    </message>
+    <message>
+        <source>Expand Function Editor Header to Match Xsheet Toolbar Height*</source>
+        <translation>Expanda o cabeçalho do editor de funções para corresponder à altura da barra de ferramentas do Xsheet*</translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation>Cores</translation>
+    </message>
+    <message>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <source>Weight *:</source>
+        <translation>Peso *:</translation>
+    </message>
+    <message>
+        <source>OpenToonz can use FFmpeg for additional file formats.
+</source>
+        <translation>OpenToonz pode usar FFmpeg para formatos de arquivo adicionais.</translation>
+    </message>
+    <message>
+        <source>FFmpeg is not bundled with OpenToonz.
+</source>
+        <translation>O FFmpeg não vem com o OpenToonz.</translation>
+    </message>
+    <message>
+        <source>Column Header Layout*:</source>
+        <translation>Layout do cabeçalho da coluna*:</translation>
+    </message>
+    <message>
+        <source>Color Calibration using 3D Look-up Table*</source>
+        <translation>Calibração de cores usando tabela de consulta 3D*</translation>
+    </message>
+    <message>
+        <source>Enable auto-stretch frame</source>
+        <translation>Ativar quadro de alongamento automático</translation>
+    </message>
+    <message>
+        <source>Show Cursor Size Outlines</source>
+        <translation>Mostrar contornos do tamanho do cursor</translation>
+    </message>
+    <message>
+        <source>Check for the Latest Version of OpenToonz on Launch</source>
+        <translation>Verifique a versão mais recente do OpenToonz no lançamento</translation>
+    </message>
+    <message>
+        <source>Choosing this option will set initial location of all file browsers to $scenefolder.
+Also the initial output destination for new scenes will be set to $scenefolder as well.</source>
+        <translation>Escolher esta opção definirá a localização inicial de todos os navegadores de arquivos como $scenefolder.
+Além disso, o destino de saída inicial para novas cenas também será definido como $scenefolder.</translation>
+    </message>
+    <message>
+        <source>Graph Editor Opens in Popup</source>
+        <translation>Editor de gráfico abre em pop-up</translation>
+    </message>
+    <message>
+        <source>Spreadsheet Opens in Popup</source>
+        <translation>Planilha abre em pop-up</translation>
+    </message>
+    <message>
+        <source>Toggle Between Graph Editor and Spreadsheet</source>
+        <translation>Alternar entre editor de gráfico e planilha</translation>
+    </message>
+    <message>
+        <source>Function Editor*:</source>
+        <translation>Editor de Função*:</translation>
+    </message>
+    <message>
+        <source>3DLUT File for [%1]*:</source>
+        <translation>Arquivo 3DLUT para [%1]*:</translation>
+    </message>
+    <message>
+        <source>Cursor Options</source>
+        <translation>Opções de cursor</translation>
+    </message>
+    <message>
+        <source>Basic Cursor Type:</source>
+        <translation>Tipo de cursor básico:</translation>
+    </message>
+    <message>
+        <source>Cursor Style:</source>
+        <translation>Estilo do cursor:</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>Pequeno</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>Grande</translation>
+    </message>
+    <message>
+        <source>Crosshair</source>
+        <translation>Mira</translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <source>Left-Handed</source>
+        <translation>Canhoto</translation>
+    </message>
+    <message>
+        <source>Simple</source>
+        <translation>Simples</translation>
+    </message>
+    <message>
+        <source>Classic</source>
+        <translation>Clássico</translation>
+    </message>
+    <message>
+        <source>Classic-revised</source>
+        <translation>Clássico revisado</translation>
+    </message>
+    <message>
+        <source>Compact</source>
+        <translation>Compactar</translation>
+    </message>
+    <message>
+        <source>Saving</source>
+        <translation>Salvando</translation>
+    </message>
+    <message>
+        <source>Use Onion Skin Colors for Reference Drawings of Shift and Trace</source>
+        <translation>Use cores de Casca de Cebola para desenhos de referência de deslocamento e traçado</translation>
+    </message>
+    <message>
+        <source>Tablet Settings</source>
+        <translation>Configurações do tablet</translation>
+    </message>
+    <message>
+        <source>Enable Windows Ink Support* (EXPERIMENTAL)</source>
+        <translation>Habilitar suporte do Windows Ink* (EXPERIMENTAL)</translation>
+    </message>
+    <message>
+        <source>Constant</source>
+        <translation>Constante</translation>
+    </message>
+    <message>
+        <source>Exponential</source>
+        <translation>Exponencial</translation>
+    </message>
+    <message>
+        <source>Expression </source>
+        <translation>Expressão</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Style*:</source>
+        <translation>Estilo*:</translation>
+    </message>
+    <message>
+        <source>Matte color is used for background when overwriting raster levels with transparent pixels
+in non alpha-enabled image format.</source>
+        <translation>A cor fosca é usada para plano de fundo ao substituir níveis raster por pixels transparentes
+em formato de imagem não habilitado para alfa.</translation>
+    </message>
+    <message>
+        <source>Matte color:</source>
+        <translation>Cor fosca:</translation>
+    </message>
+    <message>
+        <source>Current Column Color:</source>
+        <translation>Cor da coluna atual:</translation>
+    </message>
+    <message>
+        <source>Backup Scene and Animation Levels when Saving</source>
+        <translation>Faça backup dos níveis de cena e animação ao salvar</translation>
+    </message>
+    <message>
+        <source># of backups to keep:</source>
+        <translation>Nº de backups a serem mantidos:</translation>
+    </message>
+    <message>
+        <source>Enable Autocreation</source>
+        <translation>Habilitar criação automática</translation>
+    </message>
+    <message>
+        <source>Numbering System:</source>
+        <translation>Sistema de numeração:</translation>
+    </message>
+    <message>
+        <source>Enable Auto-stretch Frame</source>
+        <translation>Ativar quadro de alongamento automático</translation>
+    </message>
+    <message>
+        <source>Enable Creation in Hold Cells</source>
+        <translation>Habilitar criação em células de retenção</translation>
+    </message>
+    <message>
+        <source>Enable Autorenumber</source>
+        <translation>Ativar numeração automática</translation>
+    </message>
+    <message>
+        <source>Toolbar Display Behaviour:</source>
+        <translation>Comportamento de exibição da barra de ferramentas:</translation>
+    </message>
+    <message>
+        <source>Show Camera Column</source>
+        <translation>Mostrar coluna da câmera</translation>
+    </message>
+    <message>
+        <source>Level Editor Box Color:</source>
+        <translation>Cor da caixa do editor de níveis:</translation>
+    </message>
+    <message>
+        <source>Incremental</source>
+        <translation>Incremental</translation>
+    </message>
+    <message>
+        <source>Enable Tools For Level Only</source>
+        <translation>Habilitar ferramentas apenas para nível</translation>
+    </message>
+    <message>
+        <source>Show Tools For Level Only</source>
+        <translation>Mostrar ferramentas apenas para nível</translation>
+    </message>
+    <message>
+        <source>Touch/Tablet Settings</source>
+        <translation>Configurações de toque/tablet</translation>
+    </message>
+    <message>
+        <source>Enable Touch Gesture Controls</source>
+        <translation>Ativar controles de gestos de toque</translation>
+    </message>
+    <message>
+        <source>Number of Frames to Play for Short Play:</source>
+        <translation>Número de quadros a serem reproduzidos em reprodução curta:</translation>
+    </message>
+    <message>
+        <source>Switch to dark icons</source>
+        <translation>Mudar para ícones escuros</translation>
+    </message>
+    <message>
+        <source>Level Strip Thumbnail Size*:</source>
+        <translation>Tamanho da miniatura da faixa de nível*:</translation>
+    </message>
+    <message>
+        <source>Color Calibration using 3D Look-up Table</source>
+        <translation>Calibração de cores usando tabela de consulta 3D</translation>
+    </message>
+    <message>
+        <source>3DLUT File for [%1]:</source>
+        <translation>Arquivo 3DLUT para [%1]:</translation>
+    </message>
+    <message>
+        <source>Clear Undo History when Saving Levels</source>
+        <translation>Limpar histórico de desfazer ao salvar níveis</translation>
+    </message>
+    <message>
+        <source>Use %1 to Resize Brush</source>
+        <translation>Use % 1 para redimensionar o pincel</translation>
+    </message>
+    <message>
+        <source>Switch Tool Temporarily Keypress Length (ms):</source>
+        <translation>Alternar ferramenta temporariamente Comprimento do pressionamento de tecla (ms):</translation>
+    </message>
+    <message>
+        <source>[Experimental Feature] </source>
+        <translation>[Recurso Experimental]</translation>
+    </message>
+    <message>
+        <source>Automatically Modify Expression On Moving Referenced Objects</source>
+        <translation>Modificar automaticamente a expressão ao mover objetos referenciados</translation>
+    </message>
+    <message>
+        <source>Edit Additional Style Sheet..</source>
+        <translation>Editar folha de estilo adicional..</translation>
+    </message>
+    <message>
+        <source>Icon Theme*:</source>
+        <translation>Tema do ícone*:</translation>
+    </message>
+    <message>
+        <source>Show Icons In Menu*</source>
+        <translation>Mostrar ícones no menu*</translation>
+    </message>
+    <message>
+        <source>Use Qt's Native Windows Ink Support*
+(CAUTION: This options is for maintenance purpose. 
+ Do not activate this option or the tablet won't work properly.)</source>
+        <translation>Use o suporte nativo do Windows Ink do Qt*
+(CUIDADO: Esta opção é para fins de manutenção. 
+ Não ative esta opção ou o tablet não funcionará corretamente.)</translation>
+    </message>
+    <message>
+        <source>30bit Display*</source>
+        <translation>Tela de 30 bits*</translation>
+    </message>
+    <message>
+        <source>Automatically Remove Unused Levels From Scene Cast</source>
+        <translation>Remover automaticamente níveis não utilizados do elenco de cena</translation>
+    </message>
+    <message>
+        <source>Allow Multi-Thread in FFMPEG Rendering (UNSTABLE)</source>
+        <translation>Permitir multi-thread na renderização FFMPEG (INSTABLE)</translation>
+    </message>
+    <message>
+        <source>Rhubarb Path:</source>
+        <translation>Caminho do Rhubarb:</translation>
+    </message>
+    <message>
+        <source>Rhubarb Timeout:</source>
+        <translation>Tempo limite do Rhubarb:</translation>
+    </message>
+    <message>
+        <source>Default Raster / Scan Level Format:</source>
+        <translation>Formato padrão de raster/nível de digitalização:</translation>
+    </message>
+    <message>
+        <source>Level Name Display:</source>
+        <translation>Exibição do nome do nível:</translation>
+    </message>
+    <message>
+        <source>Number of Frames to Play 
+for Short Play:</source>
+        <translation>Número de quadros para reproduzir 
+para jogo curto:</translation>
+    </message>
+    <message>
+        <source>Minimum</source>
+        <translation>Mínimo</translation>
+    </message>
+    <message>
+        <source>Display on Each Marker</source>
+        <translation>Exibir em cada marcador</translation>
+    </message>
+    <message>
+        <source>Display on Column Header</source>
+        <translation>Exibir no cabeçalho da coluna</translation>
+    </message>
+    <message>
+        <source>Auto Lip-Sync</source>
+        <translation>Sincronização labial automática</translation>
+    </message>
+    <message>
+        <source>Check Availability</source>
+        <translation>Verifique a disponibilidade</translation>
+    </message>
+    <message>
+        <source>Enabling multi-thread rendering will render significantly faster 
+but a random crash might occur, use at your own risk.</source>
+        <translation>Ativar a renderização multithread renderizará significativamente mais rápido 
+mas pode ocorrer uma falha aleatória, use por sua conta e risco.</translation>
+    </message>
+    <message>
+        <source>OpenToonz can use Rhubarb for auto lip-syncing.
+</source>
+        <translation>OpenToonz pode usar Rhubarb para sincronização labial automática.</translation>
+    </message>
+    <message>
+        <source>Rhubarb is not bundled with OpenToonz.
+</source>
+        <translation>O Rhubarb não vem com o OpenToonz.</translation>
+    </message>
+    <message>
+        <source>Please provide the path where Rhubarb is located on your computer.</source>
+        <translation>Forneça o caminho onde o Rhubarb está localizado em seu computador.</translation>
+    </message>
+    <message>
+        <source>Number of seconds to wait for Rhubarb to complete processing the audio:</source>
+        <translation>Número de segundos de espera para que o Rhubarb conclua o processamento do áudio:</translation>
+    </message>
+    <message>
+        <source>Show Column Parent's Color in the Xsheet</source>
+        <translation>Mostrar a cor do pai da coluna no Xsheet</translation>
+    </message>
+    <message>
+        <source>Raster Level Caching Behavior:</source>
+        <translation>Comportamento de cache em nível raster:</translation>
+    </message>
+    <message>
+        <source>Delete Command Behaviour:</source>
+        <translation>Excluir comportamento do comando:</translation>
+    </message>
+    <message>
+        <source>Paste Cells Behaviour:</source>
+        <translation>Comportamento de colar células:</translation>
+    </message>
+    <message>
+        <source>Highlight Line Every Second</source>
+        <translation>Linha de destaque a cada segundo</translation>
+    </message>
+    <message>
+        <source>Show Current Time Indicator</source>
+        <translation>Mostrar indicador de hora atual</translation>
+    </message>
+    <message>
+        <source>Triangle Top Left</source>
+        <translation>Triângulo Superior Esquerdo</translation>
+    </message>
+    <message>
+        <source>Triangle Top Right</source>
+        <translation>Triângulo Superior Direito</translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Left</source>
+        <translation>Triângulo Inferior Esquerdo</translation>
+    </message>
+    <message>
+        <source>Triangle Bottom Right</source>
+        <translation>Triângulo Inferior Direito</translation>
+    </message>
+    <message>
+        <source>Triangle Up</source>
+        <translation>Triângulo para cima</translation>
+    </message>
+    <message>
+        <source>Triangle Down</source>
+        <translation>Triângulo para baixo</translation>
+    </message>
+    <message>
+        <source>Triangle Left</source>
+        <translation>Triângulo Esquerdo</translation>
+    </message>
+    <message>
+        <source>Triangle Right</source>
+        <translation>Triângulo à Direita</translation>
+    </message>
+    <message>
+        <source>Clear Cell / Frame</source>
+        <translation>Limpar célula/quadro</translation>
+    </message>
+    <message>
+        <source>Remove and Shift Cells / Frames Up</source>
+        <translation>Remover e deslocar células/quadros para cima</translation>
+    </message>
+    <message>
+        <source>Insert Paste Whole Data</source>
+        <translation>Inserir Colar Dados Inteiros</translation>
+    </message>
+    <message>
+        <source>Overwrite Paste Cell Numbers</source>
+        <translation>Substituir e colar números de células</translation>
+    </message>
+    <message>
+        <source>Show Sub-Xsheet Navigation Bar</source>
+        <translation>Mostrar barra de navegação da sub-planilha</translation>
+    </message>
+    <message>
+        <source>Expand Function Editor Header to Match Xsheet Header Height*</source>
+        <translation>Expanda o cabeçalho do editor de funções para corresponder à altura do cabeçalho do Xsheet*</translation>
+    </message>
+    <message>
+        <source>Unify Preview and Camstand Visibility Toggles</source>
+        <translation>Alternadores de visualização unificada e visibilidade do Camstand</translation>
+    </message>
+    <message>
+        <source>Link Column Name with Level</source>
+        <translation>Vincular nome da coluna com nível</translation>
+    </message>
+    <message>
+        <source>Disable Dragging Cells</source>
+        <translation>Desativar arrastar células</translation>
+    </message>
+    <message>
+        <source>Xsheet Tools</source>
+        <translation>Ferramentas Xsheet</translation>
+    </message>
+    <message>
+        <source>This option will do the following:
+- When setting a cell in the empty column, level name will be copied to the column name
+- Typing the cell without level name in the empty column will try to use a level with the same name as the column
+The behavior may be changed in the future development.</source>
+        <translation>Esta opção fará o seguinte:
+- Ao definir uma célula na coluna vazia, o nome do nível será copiado para o nome da coluna
+- Digitar a célula sem nome do nível na coluna vazia tentará usar um nível com o mesmo nome da coluna
+O comportamento pode ser alterado no desenvolvimento futuro.</translation>
+    </message>
+    <message>
+        <source>Add Info water mark in Rendered Frames</source>
+        <translation>Adicionar marca d'água de informações em quadros renderizados</translation>
+    </message>
+    <message>
+        <source>Lazy Load Rooms</source>
+        <translation>Salas de carga lenta</translation>
+    </message>
+    <message>
+        <source>Zoom In/Out Center:</source>
+        <translation>Centralizar mais/menos zoom:</translation>
+    </message>
+    <message>
+        <source>Show Room Bind Buttons*</source>
+        <translation>Mostrar botões de vinculação de sala*</translation>
+    </message>
+    <message>
+        <source>Show Viewer Indicators</source>
+        <translation>Mostrar indicadores do visualizador</translation>
+    </message>
+    <message>
+        <source>Rasterize Vector with Anti Aliasing</source>
+        <translation>Rasterizar vetor com anti-aliasing</translation>
+    </message>
+    <message>
+        <source>Normalize Imported Image Sequences:</source>
+        <translation>Normalizar sequências de imagens importadas:</translation>
+    </message>
+    <message>
+        <source>Convert Imported NAA Image Sequences to TLV:</source>
+        <translation>Converter sequências de imagens NAA importadas em TLV:</translation>
+    </message>
+    <message>
+        <source>Use QuickTime to decode/code .mov and .3gp (If Installed)</source>
+        <translation>Use QuickTime para decodificar/codificar .mov e .3gp (se instalado)</translation>
+    </message>
+    <message>
+        <source>Minimize Savebox after Editing (Toonz Raster Level)</source>
+        <translation>Minimize o Savebox após a edição (nível Toonz Raster)</translation>
+    </message>
+    <message>
+        <source>Define Filling Region Using both Lines and Areas</source>
+        <translation>Definir região de preenchimento usando linhas e áreas</translation>
+    </message>
+    <message>
+        <source>Paint Under Lines in Refer Fill</source>
+        <translation>Pintar sob as linhas no preenchimento de referência</translation>
+    </message>
+    <message>
+        <source>Style Picker: Switch Current Level by Picking on Multi Layer</source>
+        <translation>Seletor de estilo: alterne o nível atual selecionando multicamadas</translation>
+    </message>
+    <message>
+        <source>Brush Tool: Use %1 to Resize</source>
+        <translation>Ferramenta Pincel: Use% 1 para redimensionar</translation>
+    </message>
+    <message>
+        <source>Draw Cursor at End of Stroke</source>
+        <translation>Desenhar cursor no final do traço</translation>
+    </message>
+    <message>
+        <source>Geometric Tool: Click Twice to Create Arcs</source>
+        <translation>Ferramenta geométrica: clique duas vezes para criar arcos</translation>
+    </message>
+    <message>
+        <source>Handle Size (%):</source>
+        <translation>Tamanho da alça (%):</translation>
+    </message>
+    <message>
+        <source>Handle Color:</source>
+        <translation>Cor da alça:</translation>
+    </message>
+    <message>
+        <source>Always Drag Frame Cell</source>
+        <translation>Sempre arraste a célula do quadro</translation>
+    </message>
+    <message>
+        <source>Cell Input Method:</source>
+        <translation>Método de entrada de célula:</translation>
+    </message>
+    <message>
+        <source>Preview Movie Formats in Default System Viewer</source>
+        <translation>Visualizar formatos de filme no visualizador padrão do sistema</translation>
+    </message>
+    <message>
+        <source>Number of Frames to Play 
+for Short Play Command:</source>
+        <translation>Número de quadros para reproduzir 
+para comando de reprodução curta:</translation>
+    </message>
+    <message>
+        <source>Always Open New Flipbook Window </source>
+        <translation>Sempre abra a nova janela do Flipbook</translation>
+    </message>
+    <message>
+        <source>Fit to Flipbook when Flipbook Window Open</source>
+        <translation>Ajustar ao Flipbook quando a janela do Flipbook estiver aberta</translation>
+    </message>
+    <message>
+        <source>Ink Check Color:</source>
+        <translation>Cor de verificação de tinta:</translation>
+    </message>
+    <message>
+        <source>Ink#1 Check Color:</source>
+        <translation>Cor de verificação da tinta nº 1:</translation>
+    </message>
+    <message>
+        <source>Paint Check Color:</source>
+        <translation>Cor de verificação de pintura:</translation>
+    </message>
+    <message>
+        <source>Automatic by Scene</source>
+        <translation>Automático por Cena</translation>
+    </message>
+    <message>
+        <source>Always ask before renaming</source>
+        <translation>Sempre pergunte antes de renomear</translation>
+    </message>
+    <message>
+        <source>Normalize sequence names automatically</source>
+        <translation>Normalize nomes de sequência automaticamente</translation>
+    </message>
+    <message>
+        <source>Keep original filenames</source>
+        <translation>Mantenha os nomes dos arquivos originais</translation>
+    </message>
+    <message>
+        <source>Always ask before converting</source>
+        <translation>Sempre pergunte antes de converter</translation>
+    </message>
+    <message>
+        <source>Convert raster level automatically</source>
+        <translation>Converta o nível raster automaticamente</translation>
+    </message>
+    <message>
+        <source>Do not convert</source>
+        <translation>Não converta</translation>
+    </message>
+    <message>
+        <source>Input by Double Click Only</source>
+        <translation>Entrada apenas por clique duplo</translation>
+    </message>
+    <message>
+        <source>Input by Numpad</source>
+        <translation>Entrada pelo teclado numérico</translation>
+    </message>
+    <message>
+        <source>Input by Single Click</source>
+        <translation>Entrada por clique único</translation>
+    </message>
+    <message>
+        <source>Preview/Render</source>
+        <translation>Pré-visualizar/renderizar</translation>
+    </message>
+    <message>
+        <source>Load/Import</source>
+        <translation>Carregar/Importar</translation>
+    </message>
+    <message>
+        <source>Decoder/Encoder</source>
+        <translation>Decodificador/codificador</translation>
+    </message>
+    <message>
+        <source>Vector Visualize</source>
+        <translation>Visualização vetorial</translation>
+    </message>
+    <message>
+        <source>Addons</source>
+        <translation>Complementos</translation>
+    </message>
+    <message>
+        <source>Automatically sets folder based on scene type:
+Standalone -&gt; $scenefolder
+Project -&gt; project folder aliases (+drawing...)</source>
+        <translation>Define automaticamente a pasta com base no tipo de cena:
+Autônomo -&gt; $scenefolder
+Projeto -&gt; aliases da pasta do projeto (+desenho...)</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <translation>habilitado</translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <translation>desabilitado</translation>
+    </message>
+    <message>
+        <source>rooms will load on demand</source>
+        <translation>as salas serão carregadas sob demanda</translation>
+    </message>
+    <message>
+        <source>all rooms load at startup</source>
+        <translation>todas as salas são carregadas na inicialização</translation>
+    </message>
+    <message>
+        <source>Lazy loading %1 - %2</source>
+        <translation>Carregamento lento % 1 - % 2</translation>
+    </message>
+    <message>
+        <source>Default Level Size</source>
+        <translation>Tamanho do nível padrão</translation>
+    </message>
+    <message>
+        <source>Fill Tool Options (Toonz Raster Level)</source>
+        <translation>Opções de ferramenta de preenchimento (nível Toonz Raster)</translation>
+    </message>
+    <message>
+        <source>Brush Cursor Options</source>
+        <translation>Opções de cursor de pincel</translation>
+    </message>
+    <message>
+        <source>Animate Tool</source>
+        <translation>Ferramenta Animar</translation>
+    </message>
+    <message>
+        <source>Xsheet Column Area</source>
+        <translation>Área da coluna Xsheet</translation>
+    </message>
+    <message>
+        <source>Xsheet Cell Area</source>
+        <translation>Área da célula do Xsheet</translation>
+    </message>
+    <message>
+        <source>Viewer</source>
+        <translation>Visualizador</translation>
+    </message>
+    <message>
+        <source>Play Control</source>
+        <translation>Controle de jogo</translation>
+    </message>
+    <message>
+        <source>Render</source>
+        <translation>Renderizar</translation>
+    </message>
+    <message>
+        <source>Ink and Paint Check</source>
+        <translation>Verificação de tinta e pintura</translation>
+    </message>
+    <message>
+        <source>Windows Explorer Thumbnails (Shell Extension)</source>
+        <translation>Miniaturas do Windows Explorer (extensão Shell)</translation>
+    </message>
+    <message>
+        <source>Enable thumbnails for OpenToonz files (.tnz, .pli, .tlv) in Windows Explorer. 
+Administrator privileges are required; you may need to restart Explorer for changes to take effect.</source>
+        <translation>Habilite miniaturas para arquivos OpenToonz (.tnz, .pli, .tlv) no Windows Explorer. 
+São necessários privilégios de administrador; pode ser necessário reiniciar o Explorer para que as alterações tenham efeito.</translation>
+    </message>
+    <message>
+        <source>Uninstall</source>
+        <translation>Desinstalar</translation>
+    </message>
+    <message>
+        <source>Install</source>
+        <translation>Instalar</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesPopup::AdditionalStyleEdit</name>
+    <message>
+        <source>Additional Style Sheet</source>
+        <translation>Folha de estilo adicional</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesPopup::Display30bitChecker</name>
+    <message>
+        <source>Check 30bit display availability</source>
+        <translation>Verificar disponibilidade de exibição em 30 bits</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>If the lower gradient looks smooth and has no banding compared to the upper gradient,
+30bit display is available in the current configuration.</source>
+        <translation>Se o gradiente inferior parecer suave e não tiver faixas em comparação com o gradiente superior,
+A exibição de 30 bits está disponível na configuração atual.</translation>
+    </message>
+</context>
+<context>
+    <name>PreferencesPopup::FormatProperties</name>
+    <message>
+        <source>Level Settings by File Format</source>
+        <translation>Configurações de nível por formato de arquivo</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Regular Expression:</source>
+        <translation>Expressão regular:</translation>
+    </message>
+    <message>
+        <source>Priority</source>
+        <translation>Prioridade</translation>
+    </message>
+</context>
+<context>
+    <name>PresetNamePopup</name>
+    <message>
+        <source>Enter Preset Name</source>
+        <translation>Insira o nome predefinido</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>Previewer</name>
+    <message>
+        <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? "  |</source>
+        <translation>O nome do arquivo não pode estar vazio nem conter nenhum dos seguintes caracteres:(nova linha) \ / : * ? " |</translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+</context>
+<context>
+    <name>ProcessingTab</name>
+    <message>
+        <source>Line Processing:</source>
+        <translation>Processamento de linha:</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Greyscale</source>
+        <translation>Escala de cinza</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Antialias:</source>
+        <translation>Antialias:</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <source>Morphological</source>
+        <translation>Morfológico</translation>
+    </message>
+    <message>
+        <source>Autoadjust:</source>
+        <translation>Ajuste automático:</translation>
+    </message>
+    <message>
+        <source>Sharpness:</source>
+        <translation>Nitidez:</translation>
+    </message>
+    <message>
+        <source>Despeckling:</source>
+        <translation>Remoção de manchas:</translation>
+    </message>
+    <message>
+        <source>MLAA Intensity:</source>
+        <translation>Intensidade MLAA:</translation>
+    </message>
+</context>
+<context>
+    <name>ProjectCreatePopup</name>
+    <message>
+        <source>New Project</source>
+        <translation>Novo Projeto</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Project Name cannot be empty or contain any of the following characters:
+ \ / : * ? " &lt; &gt; |</source>
+        <translation>O Nome do Projeto não pode estar vazio nem conter nenhum dos seguintes caracteres:
+ \/:*? " &lt; &gt; |</translation>
+    </message>
+    <message>
+        <source>Bad project name: '%1' looks like an absolute file path</source>
+        <translation>Nome de projeto incorreto: '%1' parece um caminho de arquivo absoluto</translation>
+    </message>
+    <message>
+        <source>Project '%1' already exists</source>
+        <translation>O projeto '%1' já existe</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 project.</source>
+        <translation>Não é possível criar o projeto %1.</translation>
+    </message>
+</context>
+<context>
+    <name>ProjectPopup</name>
+    <message>
+        <source>Project Name:</source>
+        <translation>Nome do Projeto:</translation>
+    </message>
+    <message>
+        <source>Append $scenepath to +drawings</source>
+        <translation>Anexar $scenepath a +desenhos</translation>
+    </message>
+    <message>
+        <source>Append $scenepath to +inputs</source>
+        <translation>Anexar $scenepath a +inputs</translation>
+    </message>
+    <message>
+        <source>Append $scenepath to +extras</source>
+        <translation>Anexar $scenepath a +extras</translation>
+    </message>
+    <message>
+        <source>Project:</source>
+        <translation>Projeto:</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>Personalizado</translation>
+    </message>
+    <message>
+        <source>Accept Non-alphabet Suffix</source>
+        <translation>Aceitar sufixo não alfabético</translation>
+    </message>
+    <message>
+        <source>In the standard mode files with the following file name are handled as sequential images:
+[LEVEL_NAME]["."or"_"][FRAME_NUMBER][SUFFIX].[EXTENSION]
+For [SUFFIX] zero or one occurrences of alphabet (a-z, A-Z) can be used in the standard mode.</source>
+        <translation>No modo padrão, os arquivos com o seguinte nome de arquivo são tratados como imagens sequenciais:
+[LEVEL_NAME]["."ou"_"][FRAME_NUMBER][SUFFIX].[EXTENSION]
+Para [SUFFIX], zero ou uma ocorrência do alfabeto (a-z, A-Z) pode ser usada no modo padrão.</translation>
+    </message>
+    <message>
+        <source>In the custom mode you can customize the file path rules.
+Note that this mode uses regular expression for file name validation and may slow the operation.</source>
+        <translation>No modo personalizado você pode personalizar as regras de caminho de arquivo.
+Observe que este modo usa expressão regular para validação de nome de arquivo e pode retardar a operação.</translation>
+    </message>
+    <message>
+        <source>1</source>
+        <translation>1</translation>
+    </message>
+    <message>
+        <source>2</source>
+        <translation>2</translation>
+    </message>
+    <message>
+        <source>3</source>
+        <translation>3</translation>
+    </message>
+    <message>
+        <source>5</source>
+        <translation>5</translation>
+    </message>
+    <message>
+        <source>Unlimited</source>
+        <translation>Ilimitado</translation>
+    </message>
+    <message>
+        <source>Project Folder</source>
+        <translation>Pasta do Projeto</translation>
+    </message>
+    <message>
+        <source>Maximum Letter Count For Suffix</source>
+        <translation>Contagem máxima de letras para sufixo</translation>
+    </message>
+    <message>
+        <source>File Path Rules</source>
+        <translation>Regras de caminho de arquivo</translation>
+    </message>
+</context>
+<context>
+    <name>ProjectSettingsPopup</name>
+    <message>
+        <source>Project Settings</source>
+        <translation>Configurações do projeto</translation>
+    </message>
+</context>
+<context>
+    <name>PsdSettingsPopup</name>
+    <message>
+        <source>Load PSD File</source>
+        <translation>Carregar arquivo PSD</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Path:</source>
+        <translation>Caminho:</translation>
+    </message>
+    <message>
+        <source>Expose in a Sub-xsheet</source>
+        <translation>Expor em uma sub-planilha</translation>
+    </message>
+    <message>
+        <source>Load As:</source>
+        <translation>Carregar como:</translation>
+    </message>
+    <message>
+        <source>Group Option</source>
+        <translation>Opção de grupo</translation>
+    </message>
+    <message>
+        <source>Ignore groups</source>
+        <translation>Ignorar grupos</translation>
+    </message>
+    <message>
+        <source>Expose layers in a group as columns in a sub-xsheet</source>
+        <translation>Expor camadas em um grupo como colunas em uma subplanilha</translation>
+    </message>
+    <message>
+        <source>Expose layers in a group as frames in a column</source>
+        <translation>Expor camadas em um grupo como quadros em uma coluna</translation>
+    </message>
+    <message>
+        <source>FileName#LayerName</source>
+        <translation>Nome do arquivo#Nome da camada</translation>
+    </message>
+    <message>
+        <source>LayerName</source>
+        <translation>Nome da Camada</translation>
+    </message>
+    <message>
+        <source>Level Name:</source>
+        <translation>Nome do nível:</translation>
+    </message>
+    <message>
+        <source>Single Image</source>
+        <translation>Imagem única</translation>
+    </message>
+    <message>
+        <source>Frames</source>
+        <translation>Quadros</translation>
+    </message>
+    <message>
+        <source>Columns</source>
+        <translation>Colunas</translation>
+    </message>
+    <message>
+        <source>Flatten visible document layers into a single image. Layer styles are maintained.</source>
+        <translation>Achate as camadas visíveis do documento em uma única imagem. Os estilos de camada são mantidos.</translation>
+    </message>
+    <message>
+        <source>Load document layers as frames into a single xsheet column.</source>
+        <translation>Carregue camadas de documentos como quadros em uma única coluna xsheet.</translation>
+    </message>
+    <message>
+        <source>Load document layers as xhseet columns.</source>
+        <translation>Carregue camadas de documentos como colunas xhseet.</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>QApplication</name>
+    <message>
+        <source>Quit</source>
+        <translation>Desistir</translation>
+    </message>
+    <message>
+        <source>New Scene</source>
+        <translation>Nova cena</translation>
+    </message>
+    <message>
+        <source>Load Scene</source>
+        <translation>Carregar cena</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>System date tampered.</source>
+        <translation>Data do sistema adulterada.</translation>
+    </message>
+    <message>
+        <source>No more Undo operations available.</source>
+        <translation>Não há mais operações de desfazer disponíveis.</translation>
+    </message>
+    <message>
+        <source>No more Redo operations available.</source>
+        <translation>Não há mais operações de Refazer disponíveis.</translation>
+    </message>
+    <message>
+        <source>An update is available for this software.
+Visit the Web site for more information.</source>
+        <translation>Uma atualização está disponível para este software.
+Visite o site para obter mais informações.</translation>
+    </message>
+    <message>
+        <source>Quit</source>
+        <translation>Desistir</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Rendered Frames  ::  From %1 To %2  ::  Step %3</source>
+        <translation>Quadros renderizados :: De % 1 a % 2 :: Etapa % 3</translation>
+    </message>
+    <message>
+        <source>Preview FX :: %1 </source>
+        <translation>Visualizar FX :: %1</translation>
+    </message>
+    <message>
+        <source>Batch Servers</source>
+        <translation>Servidores em lote</translation>
+    </message>
+    <message>
+        <source>Scene Cast</source>
+        <translation>Elenco de cena</translation>
+    </message>
+    <message>
+        <source>The color model palette is different from the destination palette.
+What do you want to do? </source>
+        <translation>A paleta do modelo de cores é diferente da paleta de destino.
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Overwrite the destination palette.</source>
+        <translation>Substitua a paleta de destino.</translation>
+    </message>
+    <message>
+        <source>Keep the destination palette and apply it to the color model.</source>
+        <translation>Mantenha a paleta de destino e aplique-a ao modelo de cores.</translation>
+    </message>
+    <message>
+        <source>Color Model</source>
+        <translation>Modelo de cores</translation>
+    </message>
+    <message>
+        <source>Duplicate</source>
+        <translation>Duplicado</translation>
+    </message>
+    <message>
+        <source>Don't Duplicate</source>
+        <translation>Não duplique</translation>
+    </message>
+    <message>
+        <source>File Browser</source>
+        <translation>Navegador de arquivos</translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation>Nível:</translation>
+    </message>
+    <message>
+        <source>Tasks</source>
+        <translation>Tarefas</translation>
+    </message>
+    <message>
+        <source>Schematic</source>
+        <translation>Esquemático</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to override </source>
+        <translation>Tem certeza de que deseja substituir</translation>
+    </message>
+    <message>
+        <source>Override</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Palette</source>
+        <translation>Paleta</translation>
+    </message>
+    <message>
+        <source>Studio Palette</source>
+        <translation>Paleta de estúdio</translation>
+    </message>
+    <message>
+        <source>Style Editor</source>
+        <translation>Editor de estilo</translation>
+    </message>
+    <message>
+        <source>Viewer</source>
+        <translation>Visualizador</translation>
+    </message>
+    <message>
+        <source>Tool Options</source>
+        <translation>Opções de ferramentas</translation>
+    </message>
+    <message>
+        <source>FlipBook</source>
+        <translation>FlipBook</translation>
+    </message>
+    <message>
+        <source>Function Editor</source>
+        <translation>Editor de funções</translation>
+    </message>
+    <message>
+        <source>LineTest Viewer</source>
+        <translation>Visualizador LineTest</translation>
+    </message>
+    <message>
+        <source>Xsheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>No data to paste.</source>
+        <translation>Não há dados para colar.</translation>
+    </message>
+    <message>
+        <source>It is not possible to paste the cells: there is a circular reference.</source>
+        <translation>Não é possível colar as células: existe uma referência circular.</translation>
+    </message>
+    <message>
+        <source> Task added to the Batch Render List.</source>
+        <translation>Tarefa adicionada à lista de renderização em lote.</translation>
+    </message>
+    <message>
+        <source> Task added to the Batch Cleanup List.</source>
+        <translation>Tarefa adicionada à lista de limpeza em lote.</translation>
+    </message>
+    <message>
+        <source>Deleting %1. Are you sure?</source>
+        <translation>Excluindo %1. Tem certeza?</translation>
+    </message>
+    <message numerus="yes">
+        <source>Deleting %n files. Are you sure?</source>
+        <translation>Excluindo %n arquivos. Tem certeza?</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>You are going to premultiply selected files.
+The operation cannot be undone: are you sure?</source>
+        <translation>Você irá pré-multiplicar os arquivos selecionados.
+A operação não pode ser desfeita: tem certeza?</translation>
+    </message>
+    <message>
+        <source>Premultiply</source>
+        <translation>Pré-multiplicar</translation>
+    </message>
+    <message>
+        <source>There are no assets to collect</source>
+        <translation>Não há bens para coletar</translation>
+    </message>
+    <message>
+        <source>One asset imported</source>
+        <translation>Um ativo importado</translation>
+    </message>
+    <message>
+        <source>%1 assets imported</source>
+        <translation>%1 recursos importados</translation>
+    </message>
+    <message>
+        <source>No scene imported</source>
+        <translation>Nenhuma cena importada</translation>
+    </message>
+    <message>
+        <source>One scene imported</source>
+        <translation>Uma cena importada</translation>
+    </message>
+    <message>
+        <source>%1 scenes imported</source>
+        <translation>%1 cenas importadas</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Choose Folder</source>
+        <translation>Escolha a pasta</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation>Digitalizar</translation>
+    </message>
+    <message>
+        <source>Don't Scan</source>
+        <translation>Não digitalize</translation>
+    </message>
+    <message>
+        <source>The current selection is invalid.</source>
+        <translation>A seleção atual é inválida.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track the level:
+allocation error.</source>
+        <translation>Não é possível rastrear o nível:
+erro de alocação.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track the level:
+no region defined.</source>
+        <translation>Não é possível rastrear o nível:
+nenhuma região definida.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track specified regions:
+more than 30 regions defined.</source>
+        <translation>Não é possível rastrear regiões específicas:
+mais de 30 regiões definidas.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track specified regions:
+defined regions are not valid.</source>
+        <translation>Não é possível rastrear regiões específicas:
+regiões definidas não são válidas.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track specified regions:
+some regions are too wide.</source>
+        <translation>Não é possível rastrear regiões específicas:
+algumas regiões são muito amplas.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track specified regions:
+some regions are too high.</source>
+        <translation>Não é possível rastrear regiões específicas:
+algumas regiões são muito altas.</translation>
+    </message>
+    <message>
+        <source>Frame Start Error</source>
+        <translation>Erro de início de quadro</translation>
+    </message>
+    <message>
+        <source>Frame End Error</source>
+        <translation>Erro de final de quadro</translation>
+    </message>
+    <message>
+        <source>Threshold Distance Error</source>
+        <translation>Erro de distância limite</translation>
+    </message>
+    <message>
+        <source>No Frame Found</source>
+        <translation>Nenhum quadro encontrado</translation>
+    </message>
+    <message>
+        <source>It is not possible to track specified regions:
+the selected level is not valid.</source>
+        <translation>Não é possível rastrear regiões específicas:
+o nível selecionado não é válido.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track the level:
+no level selected.</source>
+        <translation>Não é possível rastrear o nível:
+nenhum nível selecionado.</translation>
+    </message>
+    <message>
+        <source>It is not possible to track specified regions:
+the level has to be saved first.</source>
+        <translation>Não é possível rastrear regiões específicas:
+o nível deve ser salvo primeiro.</translation>
+    </message>
+    <message>
+        <source>It is not possible to paste the columns: there is a circular reference.</source>
+        <translation>Não é possível colar as colunas: existe uma referência circular.</translation>
+    </message>
+    <message>
+        <source>Converting %1 images to tlv format...</source>
+        <translation>Convertendo %1 imagens para o formato tlv...</translation>
+    </message>
+    <message>
+        <source>File %1 doesn't belong to the current project.
+Do you want to import it or load it from its original location?</source>
+        <translation>O arquivo %1 não pertence ao projeto atual.
+Deseja importá-lo ou carregá-lo de seu local original?</translation>
+    </message>
+    <message>
+        <source>Import</source>
+        <translation>Importar</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>The camera settings of the scene you are loading as sub-xsheet are different from those of your current scene. What you want to do?</source>
+        <translation>As configurações da câmera da cena que você está carregando como subfolha são diferentes daquelas da cena atual. O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Keep the sub-xsheet original camera settings.</source>
+        <translation>Mantenha as configurações originais da câmera sub-xsheet.</translation>
+    </message>
+    <message>
+        <source>Apply the current scene camera settings to the sub-xsheet.</source>
+        <translation>Aplique as configurações atuais da câmera de cena à subfolha.</translation>
+    </message>
+    <message>
+        <source>%1: the current scene has been modified.
+Do you want to save your changes?</source>
+        <translation>%1: a cena atual foi modificada.
+Quer salvar suas alterações?</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Discard</source>
+        <translation>Descartar</translation>
+    </message>
+    <message>
+        <source>%1 has an invalid file extension.</source>
+        <translation>%1 tem uma extensão de arquivo inválida.</translation>
+    </message>
+    <message>
+        <source>%1 is an invalid path.</source>
+        <translation>%1 é um caminho inválido.</translation>
+    </message>
+    <message>
+        <source>The scene %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>A cena %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>The Scene '%1' belongs to project '%2'.
+What do you want to do?</source>
+        <translation>A cena '%1' pertence ao projeto '%2'.
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Import Scene</source>
+        <translation>Cena de importação</translation>
+    </message>
+    <message>
+        <source>Change Project</source>
+        <translation>Alterar projeto</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to save the Default Settings?</source>
+        <translation>Tem certeza de que deseja salvar as configurações padrão?</translation>
+    </message>
+    <message>
+        <source>Revert: the current scene has been modified.
+Are you sure you want to revert to previous version?</source>
+        <translation>Reverter: a cena atual foi modificada.
+Tem certeza de que deseja reverter para a versão anterior?</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>Reverter</translation>
+    </message>
+    <message>
+        <source>No unused levels</source>
+        <translation>Nenhum nível não utilizado</translation>
+    </message>
+    <message>
+        <source>No cleaned up drawings available for the current selection.</source>
+        <translation>Não há desenhos limpos disponíveis para a seleção atual.</translation>
+    </message>
+    <message>
+        <source>No saved drawings available for the current selection.</source>
+        <translation>Nenhum desenho salvo disponível para a seleção atual.</translation>
+    </message>
+    <message>
+        <source>Select an empty cell or a sub-xsheet cell.</source>
+        <translation>Selecione uma célula vazia ou uma célula de sub-planilha.</translation>
+    </message>
+    <message>
+        <source>Collapsing columns: what you want to do?</source>
+        <translation>Recolher colunas: o que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Include relevant pegbars in the sub-xsheet as well.</source>
+        <translation>Inclua também pegbars relevantes na sub-planilha.</translation>
+    </message>
+    <message>
+        <source>Include only selected columns in the sub-xsheet.</source>
+        <translation>Inclui apenas colunas selecionadas na subplanilha.</translation>
+    </message>
+    <message>
+        <source>Exploding Sub-xsheet: what you want to do?</source>
+        <translation>Explodindo Sub-xsheet: o que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Bring relevant pegbars in the main xsheet.</source>
+        <translation>Traga pegbars relevantes na xsheet principal.</translation>
+    </message>
+    <message>
+        <source>Bring only columns in the main xsheet.</source>
+        <translation>Traga apenas colunas na xsheet principal.</translation>
+    </message>
+    <message>
+        <source>Invalid selection: each selected column must contain one single level with increasing frame numbering.</source>
+        <translation>Seleção inválida: cada coluna selecionada deve conter um único nível com numeração crescente de quadros.</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete lines because no column, cell or level strip frame was selected.</source>
+        <translation>Não é possível excluir linhas porque nenhuma coluna, célula ou quadro de faixa de nível foi selecionado.</translation>
+    </message>
+    <message>
+        <source>The %1 file has been generated</source>
+        <translation>O arquivo % 1 foi gerado</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Edited</source>
+        <translation>Editado</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>Normal</translation>
+    </message>
+    <message>
+        <source>To Update</source>
+        <translation>Para atualizar</translation>
+    </message>
+    <message>
+        <source>Modified</source>
+        <translation>Modificado</translation>
+    </message>
+    <message>
+        <source>Locked</source>
+        <translation>Bloqueado</translation>
+    </message>
+    <message>
+        <source>Unversioned</source>
+        <translation>Não versionado</translation>
+    </message>
+    <message>
+        <source>Missing</source>
+        <translation>Ausente</translation>
+    </message>
+    <message>
+        <source>%1  has an invalid extension format.</source>
+        <translation>%1 tem um formato de extensão inválido.</translation>
+    </message>
+    <message>
+        <source>Deactivate Onion Skin</source>
+        <translation>Desativar Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Limit Onion Skin To Level</source>
+        <translation>Limitar a casca da cebola ao nível</translation>
+    </message>
+    <message>
+        <source>Extend Onion Skin To Scene</source>
+        <translation>Estenda a casca da cebola para a cena</translation>
+    </message>
+    <message>
+        <source>Activate Onion Skin</source>
+        <translation>Ativar Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Don't Overwrite</source>
+        <translation>Não sobrescreva</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete the selected cleanup color?</source>
+        <translation>Tem certeza de que deseja excluir a cor de limpeza selecionada?</translation>
+    </message>
+    <message>
+        <source>The rooms will be reset the next time you run Toonz.</source>
+        <translation>As salas serão redefinidas na próxima vez que você executar o Toonz.</translation>
+    </message>
+    <message>
+        <source>Saving previewed frames....</source>
+        <translation>Salvando quadros visualizados....</translation>
+    </message>
+    <message>
+        <source>The command cannot be executed because the scene is empty.</source>
+        <translation>O comando não pode ser executado porque a cena está vazia.</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation>Aviso: o nível %1 já existe; substituir?</translation>
+    </message>
+    <message>
+        <source>Change project</source>
+        <translation>Alterar projeto</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete the selection.</source>
+        <translation>Não é possível excluir a seleção.</translation>
+    </message>
+    <message>
+        <source>It is not possible to paste vectors in the current cell.</source>
+        <translation>Não é possível colar vetores na célula atual.</translation>
+    </message>
+    <message>
+        <source>It is not possible to paste image on the current cell.</source>
+        <translation>Não é possível colar a imagem na célula atual.</translation>
+    </message>
+    <message>
+        <source>It is not possible to paste data: there is nothing to paste.</source>
+        <translation>Não é possível colar dados: não há nada para colar.</translation>
+    </message>
+    <message>
+        <source>The copied selection cannot be pasted in the current drawing.</source>
+        <translation>A seleção copiada não pode ser colada no desenho atual.</translation>
+    </message>
+    <message>
+        <source>A filename cannot be empty or contain any of the following characters:
+ \ / : * ? " &lt; &gt; |</source>
+        <translation>Um nome de arquivo não pode estar vazio ou conter qualquer um dos seguintes caracteres:
+ \/:*? " &lt; &gt; |</translation>
+    </message>
+    <message>
+        <source>The palette %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>A paleta %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>Cannot load Color Model in current palette.</source>
+        <translation>Não é possível carregar o modelo de cores na paleta atual.</translation>
+    </message>
+    <message>
+        <source>Image DPI</source>
+        <translation>DPI da imagem</translation>
+    </message>
+    <message>
+        <source>Custom DPI</source>
+        <translation>DPI personalizado</translation>
+    </message>
+    <message>
+        <source>Create project</source>
+        <translation>Criar projeto</translation>
+    </message>
+    <message>
+        <source>There are no frames to scan.</source>
+        <translation>Não há quadros para digitalizar.</translation>
+    </message>
+    <message>
+        <source>TWAIN is not available.</source>
+        <translation>TWAIN não está disponível.</translation>
+    </message>
+    <message>
+        <source>Couldn't save %1</source>
+        <translation>Não foi possível salvar % 1</translation>
+    </message>
+    <message>
+        <source>No level selected!</source>
+        <translation>Nenhum nível selecionado!</translation>
+    </message>
+    <message>
+        <source>Exporting level of %1 frames in %2</source>
+        <translation>Exportando o nível de % 1 quadros em % 2</translation>
+    </message>
+    <message>
+        <source>Warning: file %1 already exists.</source>
+        <translation>Aviso: o arquivo %1 já existe.</translation>
+    </message>
+    <message>
+        <source>Continue Exporting</source>
+        <translation>Continuar exportando</translation>
+    </message>
+    <message>
+        <source>Stop Exporting</source>
+        <translation>Pare de exportar</translation>
+    </message>
+    <message>
+        <source>The level %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O nível %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>The soundtrack %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>A trilha sonora %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>File %1 doesn't look like a TOONZ Scene</source>
+        <translation>O arquivo % 1 não se parece com uma cena TOONZ</translation>
+    </message>
+    <message>
+        <source>It is not possible to load the scene %1 because it does not belong to any project.</source>
+        <translation>Não é possível carregar a cena %1 porque ela não pertence a nenhum projeto.</translation>
+    </message>
+    <message>
+        <source>There were problems loading the scene %1.
+ Some files may be missing.</source>
+        <translation>Ocorreram problemas ao carregar a cena %1.
+ Alguns arquivos podem estar faltando.</translation>
+    </message>
+    <message>
+        <source>There were problems loading the scene %1.
+Some levels have not been loaded because their version is not supported</source>
+        <translation>Ocorreram problemas ao carregar a cena %1.
+Alguns níveis não foram carregados porque sua versão não é suportada</translation>
+    </message>
+    <message>
+        <source>It is not possible to load the level %1</source>
+        <translation>Nãoépossível carregar o nível % 1</translation>
+    </message>
+    <message>
+        <source>Save the scene first</source>
+        <translation>Salve a cena primeiro</translation>
+    </message>
+    <message>
+        <source>It is not possible to load the %1 level.</source>
+        <translation>Não é possível carregar o nível %1.</translation>
+    </message>
+    <message>
+        <source>The scene %1 doesn't exist.</source>
+        <translation>A cena %1 não existe.</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete the used level %1.</source>
+        <translation>Não é possível excluir o nível usado %1.</translation>
+    </message>
+    <message>
+        <source>The Revert to Last Saved command is not supported for the current selection.</source>
+        <translation>O comando Reverter para o último salvo não é compatível com a seleção atual.</translation>
+    </message>
+    <message>
+        <source>The selected column is empty.</source>
+        <translation>A coluna selecionada está vazia.</translation>
+    </message>
+    <message>
+        <source>Selected cells must be in the same column.</source>
+        <translation>As células selecionadas devem estar na mesma coluna.</translation>
+    </message>
+    <message>
+        <source>Match lines can be deleted from Toonz raster levels only</source>
+        <translation>As linhas correspondentes podem ser excluídas apenas dos níveis raster Toonz</translation>
+    </message>
+    <message>
+        <source>Partially Edited</source>
+        <translation>Parcialmente editado</translation>
+    </message>
+    <message>
+        <source>Partially Locked</source>
+        <translation>Parcialmente bloqueado</translation>
+    </message>
+    <message>
+        <source>Partially Modified</source>
+        <translation>Parcialmente Modificado</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>Caminho</translation>
+    </message>
+    <message>
+        <source>Date Created</source>
+        <translation>Data de criação</translation>
+    </message>
+    <message>
+        <source>Date Modified</source>
+        <translation>Data de modificação</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Frames</source>
+        <translation>Quadros</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation>Controle de versão</translation>
+    </message>
+    <message>
+        <source>Installing %1 again could fix the problem.</source>
+        <translation>Instalar %1 novamente pode resolver o problema.</translation>
+    </message>
+    <message>
+        <source>It is not possible to apply match lines to a column containing more than one level.</source>
+        <translation>Não é possível aplicar linhas de correspondência a uma coluna que contenha mais de um nível.</translation>
+    </message>
+    <message>
+        <source>It is not possible to use a match lines column containing more than one level.</source>
+        <translation>Não é possível utilizar uma coluna de linhas de correspondência contendo mais de um nível.</translation>
+    </message>
+    <message>
+        <source>Match lines can be applied to Toonz raster levels only.</source>
+        <translation>As linhas de correspondência podem ser aplicadas apenas aos níveis raster Toonz.</translation>
+    </message>
+    <message>
+        <source>The style index you specified is not available in the palette of the destination level.</source>
+        <translation>O índice de estilo especificado não está disponível na paleta do nível de destino.</translation>
+    </message>
+    <message>
+        <source>The style index range you specified is not valid: please separate values with a comma (e.g. 1,2,5) or with a dash (e.g. 4-7 will refer to indexes 4, 5, 6 and 7).</source>
+        <translation>O intervalo de índice de estilo que você especificou não é válido: separe os valores com uma vírgula (por exemplo, 1,2,5) ou com um traço (por exemplo, 4-7 se referirá aos índices 4, 5, 6 e 7).</translation>
+    </message>
+    <message>
+        <source>The frame range you specified is not valid: please separate values with a comma (e.g. 1,2,5) or with a dash (e.g. 4-7 will refer to frames 4, 5, 6 and 7).</source>
+        <translation>O intervalo de quadros que você especificou não é válido: separe os valores com uma vírgula (por exemplo, 1,2,5) ou com um traço (por exemplo, 4-7 se referirá aos quadros 4, 5, 6 e 7).</translation>
+    </message>
+    <message>
+        <source>No drawing is available in the frame range you specified.</source>
+        <translation>Nenhum desenho está disponível no intervalo de quadros especificado.</translation>
+    </message>
+    <message>
+        <source>The merge command is not available for greytones images.</source>
+        <translation>O comando merge não está disponível para imagens em tons de cinza.</translation>
+    </message>
+    <message>
+        <source>It is not possible to perform a merging involving more than one level per column.</source>
+        <translation>Não é possível realizar uma fusão envolvendo mais de um nível por coluna.</translation>
+    </message>
+    <message>
+        <source>Only raster levels can be merged to a raster level.</source>
+        <translation>Somente níveis raster podem ser mesclados em um nível raster.</translation>
+    </message>
+    <message>
+        <source>Only vector levels can be merged to a vector level.</source>
+        <translation>Somente níveis vetoriais podem ser mesclados em um nível vetorial.</translation>
+    </message>
+    <message>
+        <source>It is possible to merge only Toonz vector levels or standard raster levels.</source>
+        <translation>É possível mesclar apenas níveis vetoriais Toonz ou níveis raster padrão.</translation>
+    </message>
+    <message>
+        <source>It is not possible to display the file %1: no player associated with its format</source>
+        <translation>Nãoépossível mostrar o arquivo % 1: não existe nenhum leitor associado ao seu formato</translation>
+    </message>
+    <message>
+        <source>The specified name is already assigned to the %1 file.</source>
+        <translation>O nome especificado já está atribuído ao arquivo %1.</translation>
+    </message>
+    <message>
+        <source>It is not possible to rename the %1 file.</source>
+        <translation>Não é possível renomear o arquivo %1.</translation>
+    </message>
+    <message>
+        <source>It is not possible to copy the %1 file.</source>
+        <translation>Não é possível copiar o arquivo %1.</translation>
+    </message>
+    <message>
+        <source>It is not possible to save the curve.</source>
+        <translation>Não é possível salvar a curva.</translation>
+    </message>
+    <message>
+        <source>It is not possible to load the curve.</source>
+        <translation>Não é possível carregar a curva.</translation>
+    </message>
+    <message>
+        <source>It is not possible to export data.</source>
+        <translation>Não é possível exportar dados.</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>LineTest Capture</source>
+        <translation>Captura de teste de linha</translation>
+    </message>
+    <message>
+        <source>It is not possible to save images in camera stand view.</source>
+        <translation>Não é possível salvar imagens na visualização do suporte da câmera.</translation>
+    </message>
+    <message>
+        <source>The preview images are not ready yet.</source>
+        <translation>As imagens de visualização ainda não estão prontas.</translation>
+    </message>
+    <message>
+        <source>A convertion task is in progress! wait until it stops or cancel it</source>
+        <translation>Uma tarefa de conversão está em andamento! espere até parar ou cancele</translation>
+    </message>
+    <message>
+        <source>Error loading scene %1 :%2</source>
+        <translation>Erro ao carregar a cena % 1 :% 2</translation>
+    </message>
+    <message>
+        <source>Error loading scene %1</source>
+        <translation>Erro ao carregar a cena % 1</translation>
+    </message>
+    <message>
+        <source>There was an error saving the %1 scene.</source>
+        <translation>Ocorreu um erro ao salvar a cena %1.</translation>
+    </message>
+    <message>
+        <source>It is not possible to export the scene %1 because it does not belong to any project.</source>
+        <translation>Não é possível exportar a cena %1 porque ela não pertence a nenhum projeto.</translation>
+    </message>
+    <message>
+        <source>Continue to All</source>
+        <translation>Continuar para todos</translation>
+    </message>
+    <message>
+        <source>The selected paper format is not available for %1.</source>
+        <translation>O formato de papel selecionado não está disponível para %1.</translation>
+    </message>
+    <message>
+        <source>No TWAIN scanner is available</source>
+        <translation>Nenhum scanner TWAIN está disponível</translation>
+    </message>
+    <message>
+        <source>No scanner is available</source>
+        <translation>Nenhum scanner está disponível</translation>
+    </message>
+    <message>
+        <source>The autocentering failed on the current drawing.</source>
+        <translation>A centralização automática falhou no desenho atual.</translation>
+    </message>
+    <message>
+        <source>Some of the selected drawings were already scanned. Do you want to scan them again?</source>
+        <translation>Alguns dos desenhos selecionados já foram digitalizados. Deseja digitalizá-los novamente?</translation>
+    </message>
+    <message>
+        <source>There was an error saving frames for the %1 level.</source>
+        <translation>Ocorreu um erro ao salvar quadros para o nível %1.</translation>
+    </message>
+    <message>
+        <source>It is not possible to create folder : %1</source>
+        <translation>Não é possível criar a pasta: %1</translation>
+    </message>
+    <message>
+        <source>It is not possible to create a folder.</source>
+        <translation>Não é possível criar uma pasta.</translation>
+    </message>
+    <message>
+        <source>The resolution of the output camera does not fit with the options chosen for the output file format.</source>
+        <translation>A resolução da câmera de saída não corresponde às opções escolhidas para o formato do arquivo de saída.</translation>
+    </message>
+    <message>
+        <source>It is not possible to complete the rendering.</source>
+        <translation>Não é possível concluir a renderização.</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+    <message>
+        <source>The cleanup settings file for the %1 level already exists.
+ Do you want to overwrite it?</source>
+        <translation>O arquivo de configurações de limpeza para o nível %1 já existe.
+ Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>The cleanup settings for the current level have been modified...
+
+Do you want to save your changes?</source>
+        <translation>As configurações de limpeza do nível atual foram modificadas...
+
+Quer salvar suas alterações?</translation>
+    </message>
+    <message>
+        <source>Cleanup Settings</source>
+        <translation>Configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>The scene %1 was created with Toonz and cannot be loaded in LineTest.</source>
+        <translation>A cena %1 foi criada com Toonz e não pode ser carregada no LineTest.</translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>Message Center</source>
+        <translation>Centro de Mensagens</translation>
+    </message>
+    <message>
+        <source>Script Console</source>
+        <translation>Console de scripts</translation>
+    </message>
+    <message>
+        <source>The level you are using has not a valid palette.</source>
+        <translation>O nível que você está usando não possui uma paleta válida.</translation>
+    </message>
+    <message>
+        <source>Run script</source>
+        <translation>Executar script</translation>
+    </message>
+    <message>
+        <source>Level </source>
+        <translation>Nível</translation>
+    </message>
+    <message>
+        <source> already exists! Are you sure you want to overwrite it?</source>
+        <translation>já existe! Tem certeza de que deseja substituí-lo?</translation>
+    </message>
+    <message>
+        <source>It is not possible to merge tlv columns containing more than one level</source>
+        <translation>Não é possível mesclar colunas tlv contendo mais de um nível</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Selected folders don't belong to the current project.
+Do you want to import them or load from their original location?</source>
+        <translation>As pastas selecionadas não pertencem ao projeto atual.
+Deseja importá-los ou carregá-los do local original?</translation>
+    </message>
+    <message>
+        <source>Move Cleanup Camera</source>
+        <translation>Mover câmera de limpeza</translation>
+    </message>
+    <message>
+        <source>Scale Cleanup Camera</source>
+        <translation>Câmera de limpeza de escala</translation>
+    </message>
+    <message>
+        <source>Delete and Re-cleanup : The following files will be deleted.
+
+</source>
+        <translation>Excluir e limpar novamente: Os seguintes arquivos serão excluídos.</translation>
+    </message>
+    <message>
+        <source>
+Are you sure ?</source>
+        <translation>Tem certeza ?</translation>
+    </message>
+    <message>
+        <source>Replace with copied palette</source>
+        <translation>Substituir pela paleta copiada</translation>
+    </message>
+    <message>
+        <source>Keep original palette</source>
+        <translation>Mantenha a paleta original</translation>
+    </message>
+    <message>
+        <source>Insert Frame  at Frame %1</source>
+        <translation>Inserir Quadro na Quadro % 1</translation>
+    </message>
+    <message>
+        <source>Remove Frame  at Frame %1</source>
+        <translation>Remover Quadro na Quadro % 1</translation>
+    </message>
+    <message>
+        <source>Insert Multiple Keys  at Frame %1</source>
+        <translation>Inserir Múltiplas Chaves no Quadro % 1</translation>
+    </message>
+    <message>
+        <source>Remove Multiple Keys  at Frame %1</source>
+        <translation>Remover Múltiplas Chaves no Quadro % 1</translation>
+    </message>
+    <message>
+        <source>Set Keyframe : %1</source>
+        <translation>Definir quadro-chave:% 1</translation>
+    </message>
+    <message>
+        <source>Close SubXsheet</source>
+        <translation>Fechar SubXsheet</translation>
+    </message>
+    <message>
+        <source>Select a sub-xsheet cell.</source>
+        <translation>Selecione uma célula da sub-planilha.</translation>
+    </message>
+    <message>
+        <source>Collapse</source>
+        <translation>Colapso</translation>
+    </message>
+    <message>
+        <source>Collapse (Fx)</source>
+        <translation>Recolher (Fx)</translation>
+    </message>
+    <message>
+        <source>Explode</source>
+        <translation>Explodir</translation>
+    </message>
+    <message>
+        <source>Delete Level  : %1</source>
+        <translation>Nível de exclusão:% 1</translation>
+    </message>
+    <message>
+        <source>Revert To %1  : Level %2</source>
+        <translation>Reverter para% 1: Nível% 2</translation>
+    </message>
+    <message>
+        <source>Load Level  %1</source>
+        <translation>Nível de carga % 1</translation>
+    </message>
+    <message>
+        <source>Load and Replace Level  %1</source>
+        <translation>Carregar e Substituir Nível %1</translation>
+    </message>
+    <message>
+        <source>Expose Level  %1</source>
+        <translation>Expor Nível % 1</translation>
+    </message>
+    <message>
+        <source> Following file(s) are modified.
+
+</source>
+        <translation>Os seguintes arquivos são modificados.</translation>
+    </message>
+    <message>
+        <source>
+Are you sure to </source>
+        <translation>Você tem certeza</translation>
+    </message>
+    <message>
+        <source> anyway ?</source>
+        <translation>de qualquer forma ?</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Overwrite Palette</source>
+        <translation>Paleta de substituição</translation>
+    </message>
+    <message>
+        <source>Don't Overwrite Palette</source>
+        <translation>Não sobrescreva a paleta</translation>
+    </message>
+    <message>
+        <source>No Current Level</source>
+        <translation>Nenhum nível atual</translation>
+    </message>
+    <message>
+        <source>No Current Scene</source>
+        <translation>Nenhuma cena atual</translation>
+    </message>
+    <message>
+        <source>Save level Failed</source>
+        <translation>Salvar nível falhou</translation>
+    </message>
+    <message>
+        <source>Paste  : Level %1 : Frame </source>
+        <translation>Colar: Nível %1: Quadro</translation>
+    </message>
+    <message>
+        <source>Delete Frames  : Level %1 : Frame </source>
+        <translation>Excluir Quadros: Nível %1: Quadro</translation>
+    </message>
+    <message>
+        <source>Cut Frames  : Level %1 : Frame </source>
+        <translation>Quadros Cortadas: Nível %1: Quadro</translation>
+    </message>
+    <message>
+        <source>Add Frames  : Level %1 : Frame </source>
+        <translation>Adicionar Quadros: Nível %1: Quadro</translation>
+    </message>
+    <message>
+        <source>Renumber  : Level %1</source>
+        <translation>Renumerar: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Insert  : Level %1</source>
+        <translation>Inserir: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Reverse  : Level %1</source>
+        <translation>Reverso: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Swing  : Level %1</source>
+        <translation>Balanço: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Step %1  : Level %2</source>
+        <translation>Passo% 1: Nível% 2</translation>
+    </message>
+    <message>
+        <source>Each %1  : Level %2</source>
+        <translation>Cada % 1: Nível % 2</translation>
+    </message>
+    <message>
+        <source>Duplicate  : Level %1</source>
+        <translation>Duplicado: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Move Level to Scene  : Level %1</source>
+        <translation>Mover o Nível para a Cena: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Paste Column :  </source>
+        <translation>Colar coluna:</translation>
+    </message>
+    <message>
+        <source>Delete Column :  </source>
+        <translation>Excluir coluna:</translation>
+    </message>
+    <message>
+        <source>Insert Column :  </source>
+        <translation>Inserir coluna:</translation>
+    </message>
+    <message>
+        <source>Resequence :  Col%1</source>
+        <translation>Resequência: Col% 1</translation>
+    </message>
+    <message>
+        <source>Clone Sub-xsheet :  Col%1</source>
+        <translation>Clonar sub-planilha: Col% 1</translation>
+    </message>
+    <message>
+        <source>Clear Cells :  Col%1</source>
+        <translation>Limpar células: Col% 1</translation>
+    </message>
+    <message>
+        <source>Reverse</source>
+        <translation>Reverter</translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <translation>Balanço</translation>
+    </message>
+    <message>
+        <source>Autoexpose</source>
+        <translation>Exposição automática</translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <translation>aleatório</translation>
+    </message>
+    <message>
+        <source>Step %1</source>
+        <translation>Passo % 1</translation>
+    </message>
+    <message>
+        <source>Each %1</source>
+        <translation>Cada % 1</translation>
+    </message>
+    <message>
+        <source>Reframe to %1's</source>
+        <translation>Reenquadrar para %1's</translation>
+    </message>
+    <message>
+        <source>Roll Up</source>
+        <translation>Enrole</translation>
+    </message>
+    <message>
+        <source>Roll Down</source>
+        <translation>Rolar para baixo</translation>
+    </message>
+    <message>
+        <source>Clone  Level : %1 &gt; %2</source>
+        <translation>Nível de clonagem: %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Clone  Levels : </source>
+        <translation>Níveis de clone:</translation>
+    </message>
+    <message>
+        <source>Time Stretch</source>
+        <translation>Alongamento de tempo</translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation>Paleta Gizmo</translation>
+    </message>
+    <message>
+        <source>Create Level %1  at Column %2</source>
+        <translation>Criar o Nível %1 na Coluna %2</translation>
+    </message>
+    <message>
+        <source>Do you want to expose the renamed level ?</source>
+        <translation>Você deseja expor o nível renomeado?</translation>
+    </message>
+    <message>
+        <source>Expose</source>
+        <translation>Expor</translation>
+    </message>
+    <message>
+        <source>Don't expose</source>
+        <translation>Não exponha</translation>
+    </message>
+    <message>
+        <source>Paste Key Frames</source>
+        <translation>Colar quadros-chave</translation>
+    </message>
+    <message>
+        <source>Delete Key Frames</source>
+        <translation>Excluir quadros-chave</translation>
+    </message>
+    <message>
+        <source>Copy File</source>
+        <translation>Copiar arquivo</translation>
+    </message>
+    <message>
+        <source>Paste  File  : </source>
+        <translation>Colar arquivo:</translation>
+    </message>
+    <message>
+        <source>Duplicate  File  : </source>
+        <translation>Arquivo duplicado:</translation>
+    </message>
+    <message>
+        <source>Paste Cells</source>
+        <translation>Colar células</translation>
+    </message>
+    <message>
+        <source>Delete Cells</source>
+        <translation>Excluir células</translation>
+    </message>
+    <message>
+        <source>Cut Cells</source>
+        <translation>Cortar células</translation>
+    </message>
+    <message>
+        <source>Insert Cells</source>
+        <translation>Inserir células</translation>
+    </message>
+    <message>
+        <source>Paste (Strokes)</source>
+        <translation>Colar (traços)</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation>Colar</translation>
+    </message>
+    <message>
+        <source>Paste (Raster)</source>
+        <translation>Colar (Raster)</translation>
+    </message>
+    <message>
+        <source>Overwrite Paste Cells</source>
+        <translation>Substituir e colar células</translation>
+    </message>
+    <message>
+        <source>Cannot paste data 
+ Nothing to paste</source>
+        <translation>Não é possível colar dados 
+ Nada para colar</translation>
+    </message>
+    <message>
+        <source>Modify Play Range  : %1 - %2</source>
+        <translation>Modificar intervalo de reprodução: %1 - %2</translation>
+    </message>
+    <message>
+        <source>Modify Play Range  : %1 - %2  &gt;  %3 - %4</source>
+        <translation>Modificar intervalo de reprodução: %1 - %2 &gt; %3 - %4</translation>
+    </message>
+    <message>
+        <source>Use Level Extender</source>
+        <translation>Use extensor de nível</translation>
+    </message>
+    <message>
+        <source>Modify Sound Level</source>
+        <translation>Modificar o nível de som</translation>
+    </message>
+    <message>
+        <source>Move Columns</source>
+        <translation>Mover colunas</translation>
+    </message>
+    <message>
+        <source>Change Pegbar</source>
+        <translation>Alterar Pegbar</translation>
+    </message>
+    <message>
+        <source>Rename Cell  at Column %1  Frame %2</source>
+        <translation>Renomear Célula na Coluna % 1 Quadro % 2</translation>
+    </message>
+    <message>
+        <source>Move Level</source>
+        <translation>Mover nível</translation>
+    </message>
+    <message>
+        <source>Combo Viewer</source>
+        <translation>Visualizador de combinação</translation>
+    </message>
+    <message>
+        <source>Move Level to Cast Folder</source>
+        <translation>Mover nível para pasta de transmissão</translation>
+    </message>
+    <message>
+        <source>Merge Raster Levels</source>
+        <translation>Mesclar níveis raster</translation>
+    </message>
+    <message>
+        <source>Delete Matchline  : Level %1</source>
+        <translation>Excluir Matchline: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Apply Matchline  : Column%1 &lt; Column%2</source>
+        <translation>Aplicar Matchline: Coluna%1 &lt;Coluna%2</translation>
+    </message>
+    <message>
+        <source>Move Keyframe</source>
+        <translation>Mover quadro-chave</translation>
+    </message>
+    <message>
+        <source>Inbetween  : Level %1,  </source>
+        <translation>Entre: Nível %1,</translation>
+    </message>
+    <message>
+        <source>It is not possible to track the level:
+undefined error.</source>
+        <translation>Não é possível rastrear o nível:
+erro indefinido.</translation>
+    </message>
+    <message>
+        <source>Palette Gizmo  %1</source>
+        <translation>Paleta de dispositivos % 1</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Aviso</translation>
+    </message>
+    <message>
+        <source>Palette is locked.</source>
+        <translation>A paleta está bloqueada.</translation>
+    </message>
+    <message>
+        <source>Move keyframe handle  : %1  Handle of the keyframe %2</source>
+        <translation>Mover identificador do quadro-chave: % 1 Identificador do quadro-chave % 2</translation>
+    </message>
+    <message>
+        <source>Toggle cycle of  %1</source>
+        <translation>Alternar ciclo de % 1</translation>
+    </message>
+    <message>
+        <source>History</source>
+        <translation>História</translation>
+    </message>
+    <message>
+        <source>[Drag] to move position</source>
+        <translation>[Arraste] para mover a posição</translation>
+    </message>
+    <message>
+        <source>----Separator----</source>
+        <translation>----Separador----</translation>
+    </message>
+    <message>
+        <source>[Drag] to move position, [Double Click] to edit title</source>
+        <translation>[Arraste] para mover a posição, [Clique duas vezes] para editar o título</translation>
+    </message>
+    <message>
+        <source>Incorrect file</source>
+        <translation>Arquivo incorreto</translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to copy separator to menu bar</source>
+        <translation>[Arrastar e Soltar] para copiar o separador para a barra de menu</translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to copy command to menu bar</source>
+        <translation>[Arrastar e Soltar] para copiar o comando para a barra de menu</translation>
+    </message>
+    <message>
+        <source>Cannot open menubar settings template file. Re-installing Toonz will solve this problem.</source>
+        <translation>Não é possível abrir o arquivo de modelo de configurações da barra de menu. A reinstalação do Toonz resolverá esse problema.</translation>
+    </message>
+    <message>
+        <source>Visit Web Site</source>
+        <translation>Visite o site</translation>
+    </message>
+    <message>
+        <source>https://opentoonz.github.io/e/</source>
+        <translation>https://opentoonz.github.io/e/</translation>
+    </message>
+    <message>
+        <source>Change current drawing %1</source>
+        <translation>Alterar o desenho actual % 1</translation>
+    </message>
+    <message>
+        <source>Sensitivity Error</source>
+        <translation>Erro de sensibilidade</translation>
+    </message>
+    <message>
+        <source>Add color model's palette to the destination palette.</source>
+        <translation>Adicione a paleta do modelo de cores à paleta de destino.</translation>
+    </message>
+    <message>
+        <source>%1: the current scene has been modified.
+What would you like to do?</source>
+        <translation>%1: a cena atual foi modificada.
+O que você gostaria de fazer?</translation>
+    </message>
+    <message>
+        <source>Save All</source>
+        <translation>Salvar tudo</translation>
+    </message>
+    <message>
+        <source>Save Scene Only</source>
+        <translation>Salvar apenas cena</translation>
+    </message>
+    <message>
+        <source>Discard Changes</source>
+        <translation>Descartar alterações</translation>
+    </message>
+    <message>
+        <source> The following file(s) have been modified.
+
+</source>
+        <translation>Os seguintes arquivos foram modificados.</translation>
+    </message>
+    <message>
+        <source>
+What would you like to do? </source>
+        <translation>O que você gostaria de fazer?</translation>
+    </message>
+    <message>
+        <source>Save Changes</source>
+        <translation>Salvar alterações</translation>
+    </message>
+    <message>
+        <source> Anyway</source>
+        <translation>De qualquer forma</translation>
+    </message>
+    <message>
+        <source>This scene is incompatible with pixels only mode of the current OpenToonz version.
+What would you like to do?</source>
+        <translation>Esta cena é incompatível com o modo somente pixels da versão atual do OpenToonz.
+O que você gostaria de fazer?</translation>
+    </message>
+    <message>
+        <source>Turn off pixels only mode</source>
+        <translation>Desative o modo somente pixels</translation>
+    </message>
+    <message>
+        <source>Keep pixels only mode on and resize the scene</source>
+        <translation>Mantenha o modo somente pixels ativado e redimensione a cena</translation>
+    </message>
+    <message>
+        <source>Hide Zero Thickness Lines</source>
+        <translation>Ocultar linhas de espessura zero</translation>
+    </message>
+    <message>
+        <source>Show Zero Thickness Lines</source>
+        <translation>Mostrar linhas de espessura zero</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>The file name already exists.
+Do you want to overwrite it?</source>
+        <translation>O nome do arquivo já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>Deleting "%1".
+Are you sure?</source>
+        <translation>Excluindo "%1".
+Tem certeza?</translation>
+    </message>
+    <message>
+        <source>FFmpeg not found, please set the location in the Preferences and restart.</source>
+        <translation>FFmpeg não encontrado, defina o local nas Preferências e reinicie.</translation>
+    </message>
+    <message>
+        <source>Skipping frame.</source>
+        <translation>Pulando quadro.</translation>
+    </message>
+    <message>
+        <source>Toonz cannot Save this Level</source>
+        <translation>Toonz não pode salvar este nível</translation>
+    </message>
+    <message>
+        <source>Set Keyframe  : %1  at Frame %2</source>
+        <translation>Definir quadro-chave:% 1 no quadro% 2</translation>
+    </message>
+    <message>
+        <source>Always do this action.</source>
+        <translation>Sempre faça esta ação.</translation>
+    </message>
+    <message>
+        <source>The selected scene could not be found.</source>
+        <translation>A cena selecionada não foi encontrada.</translation>
+    </message>
+    <message>
+        <source>Layer name</source>
+        <translation>Nome da camada</translation>
+    </message>
+    <message>
+        <source>Command Bar</source>
+        <translation>Barra de comando</translation>
+    </message>
+    <message>
+        <source>Auto Input Cell Numbers : %1</source>
+        <translation>Números de células de entrada automática:% 1</translation>
+    </message>
+    <message>
+        <source>Insert</source>
+        <translation>Inserir</translation>
+    </message>
+    <message>
+        <source>Reframe to %1's with %2 blanks</source>
+        <translation>Reestruturar para % 1 com % 2 espaços em branco</translation>
+    </message>
+    <message>
+        <source>Stage Schematic</source>
+        <translation>Esquema de Estágio</translation>
+    </message>
+    <message>
+        <source>Fx Schematic</source>
+        <translation>Esquema FX</translation>
+    </message>
+    <message>
+        <source>Cannot Read XML File</source>
+        <translation>Não é possível ler o arquivo XML</translation>
+    </message>
+    <message>
+        <source>New Note Level</source>
+        <translation>Novo nível de nota</translation>
+    </message>
+    <message>
+        <source>The following level(s) use path with $scenefolder alias.
+
+</source>
+        <translation>Os níveis a seguir usam o caminho com o alias $scenefolder.</translation>
+    </message>
+    <message>
+        <source>
+They will not be opened properly when you load the scene next time.
+What do you want to do?</source>
+        <translation>Eles não serão abertos corretamente na próxima vez que você carregar a cena.
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Copy the levels to correspondent paths</source>
+        <translation>Copie os níveis para os caminhos correspondentes</translation>
+    </message>
+    <message>
+        <source>Decode all $scenefolder aliases</source>
+        <translation>Decodifique todos os aliases de $scenefolder</translation>
+    </message>
+    <message>
+        <source>Save the scene only</source>
+        <translation>Salve apenas a cena</translation>
+    </message>
+    <message>
+        <source>Overwrite for All</source>
+        <translation>Substituir para todos</translation>
+    </message>
+    <message>
+        <source>Don't Overwrite for All</source>
+        <translation>Não sobrescreva para todos</translation>
+    </message>
+    <message>
+        <source>Failed to overwrite %1</source>
+        <translation>Falha ao substituir % 1</translation>
+    </message>
+    <message>
+        <source>Apply Lip Sync Data</source>
+        <translation>Aplicar dados de sincronização labial</translation>
+    </message>
+    <message>
+        <source>Paste Numbers</source>
+        <translation>Colar números</translation>
+    </message>
+    <message>
+        <source>It is not possible to paste the cells: Some column is locked or column type is not match.</source>
+        <translation>Não é possível colar as células: alguma coluna está bloqueada ou o tipo de coluna não corresponde.</translation>
+    </message>
+    <message>
+        <source>This command only works on vector cells.</source>
+        <translation>Este comando funciona apenas em células vetoriais.</translation>
+    </message>
+    <message>
+        <source>Please select only one column for this command.</source>
+        <translation>Selecione apenas uma coluna para este comando.</translation>
+    </message>
+    <message>
+        <source>All selected cells must belong to the same level.</source>
+        <translation>Todas as células selecionadas devem pertencer ao mesmo nível.</translation>
+    </message>
+    <message>
+        <source>Simplify Vectors : Level %1</source>
+        <translation>Simplificar Vetores: Nível % 1</translation>
+    </message>
+    <message>
+        <source>Change Text at Column %1  Frame %2</source>
+        <translation>Alterar o Texto na Coluna % 1 Quadro % 2</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>The scene is not yet saved and the output destination is set to $scenefolder.
+Save the scene first.</source>
+        <translation>A cena ainda não foi salva e o destino de saída está definido como $scenefolder.
+Salve a cena primeiro.</translation>
+    </message>
+    <message>
+        <source>A prior save of Scene '%1' was critically interupted. 
+
+A partial save file was generated and changes may be manually salvaged from '%2'.
+
+Do you wish to continue loading the last good save or stop and try to salvage the prior save?</source>
+        <translation>Um salvamento anterior da cena '%1' foi interrompido criticamente. 
+
+Um arquivo salvo parcial foi gerado e as alterações podem ser salvas manualmente de '%2'.
+
+Você deseja continuar carregando o último salvamento válido ou parar e tentar salvar o salvamento anterior?</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation>Continuar</translation>
+    </message>
+    <message>
+        <source>File '%1' will reload level '%2' as a duplicate column in the xsheet.
+
+Allow duplicate?</source>
+        <translation>O arquivo '%1' recarregará o nível '%2' como uma coluna duplicada na xsheet.
+
+Permitir duplicado?</translation>
+    </message>
+    <message>
+        <source>Allow</source>
+        <translation>Permitir</translation>
+    </message>
+    <message>
+        <source>Allow All Dups</source>
+        <translation>Permitir todas as duplicações</translation>
+    </message>
+    <message>
+        <source>No to All Dups</source>
+        <translation>Não a todos os idiotas</translation>
+    </message>
+    <message>
+        <source>Hide cursor size outline</source>
+        <translation>Ocultar o contorno do tamanho do cursor</translation>
+    </message>
+    <message>
+        <source>Show cursor size outline</source>
+        <translation>Mostrar contorno do tamanho do cursor</translation>
+    </message>
+    <message>
+        <source>Fill In Empty Cells</source>
+        <translation>Preencha células vazias</translation>
+    </message>
+    <message>
+        <source>Check for the latest version on launch.</source>
+        <translation>Verifique a versão mais recente no lançamento.</translation>
+    </message>
+    <message>
+        <source>Nothing to replace: no cells or columns selected.</source>
+        <translation>Nada para substituir: nenhuma célula ou coluna selecionada.</translation>
+    </message>
+    <message>
+        <source>Couldn't load %1</source>
+        <translation>Não foi possível carregar % 1</translation>
+    </message>
+    <message>
+        <source>Apply Antialias</source>
+        <translation>Aplicar antialias</translation>
+    </message>
+    <message>
+        <source>The Reload command is not supported for the current selection.</source>
+        <translation>O comando Recarregar não é suportado para a seleção atual.</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <source>No Palette loaded.</source>
+        <translation>Nenhuma paleta carregada.</translation>
+    </message>
+    <message>
+        <source>A separation task is in progress! wait until it stops or cancel it</source>
+        <translation>Uma tarefa de separação está em andamento! espere até parar ou cancele</translation>
+    </message>
+    <message>
+        <source>Duplicate Frame in XSheet</source>
+        <translation>Quadro duplicado no XSheet</translation>
+    </message>
+    <message>
+        <source>Please enable "Sync Level Strip Drawing Number Changes with the XSheet" preference option
+to use the duplicate command in the xsheet / timeline.</source>
+        <translation>Ative a opção de preferência "Sincronizar alterações no número do desenho da faixa de nível com o XSheet"
+para usar o comando duplicado no xsheet/timeline.</translation>
+    </message>
+    <message>
+        <source>Please select only one layer to duplicate a frame.</source>
+        <translation>Selecione apenas uma camada para duplicar um quadro.</translation>
+    </message>
+    <message>
+        <source>Please select only one frame to duplicate.</source>
+        <translation>Selecione apenas um quadro para duplicar.</translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <translation>Linha do Tempo</translation>
+    </message>
+    <message>
+        <source>The qualifier %1 is not a valid key name. Skipping.</source>
+        <translation>O qualificador %1 não é um nome de chave válido. Pulando.</translation>
+    </message>
+    <message>
+        <source>Clear All Onion Skin Markers</source>
+        <translation>Limpar todos os marcadores de Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Clear All Fixed Onion Skin Markers</source>
+        <translation>Limpar todos os marcadores fixos de Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Clear All Relative Onion Skin Markers</source>
+        <translation>Limpar todos os marcadores relativos de Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Always Overwrite in This Scene</source>
+        <translation>Sempre sobrescrever nesta cena</translation>
+    </message>
+    <message>
+        <source>    + %1 more level(s) 
+</source>
+        <translation>+ %1 nível(s) adicional(is)</translation>
+    </message>
+    <message>
+        <source>Fx Settings</source>
+        <translation>Configurações de câmbio</translation>
+    </message>
+    <message>
+        <source>Save Curve</source>
+        <translation>Salvar curva</translation>
+    </message>
+    <message>
+        <source>Load Curve</source>
+        <translation>Curva de Carga</translation>
+    </message>
+    <message>
+        <source>Export Curve</source>
+        <translation>Curva de Exportação</translation>
+    </message>
+    <message>
+        <source>Rendering frame %1 / %2</source>
+        <comment>RenderListener</comment>
+        <translation>Renderizando quadro % 1 / % 2</translation>
+    </message>
+    <message>
+        <source>Precomputing %1 Frames</source>
+        <comment>RenderListener</comment>
+        <translation>Pré-computando quadros %1</translation>
+    </message>
+    <message>
+        <source> of %1</source>
+        <comment>RenderListener</comment>
+        <translation>de % 1</translation>
+    </message>
+    <message>
+        <source>Finalizing render, please wait.</source>
+        <comment>RenderListener</comment>
+        <translation>Finalizando a renderização, aguarde.</translation>
+    </message>
+    <message>
+        <source>Aborting render...</source>
+        <comment>RenderListener</comment>
+        <translation>Abortando a renderização...</translation>
+    </message>
+    <message>
+        <source>Building Schematic...</source>
+        <comment>RenderCommand</comment>
+        <translation>Esquema de construção...</translation>
+    </message>
+    <message>
+        <source>column </source>
+        <comment>MultimediaProgressBar label (mode name)</comment>
+        <translation>coluna</translation>
+    </message>
+    <message>
+        <source>layer </source>
+        <comment>MultimediaProgressBar label (mode name)</comment>
+        <translation>camada</translation>
+    </message>
+    <message>
+        <source>Rendering %1%2, frame %3 / %4</source>
+        <comment>MultimediaProgressBar label</comment>
+        <translation>Renderizando %1%2, quadro %3 / %4</translation>
+    </message>
+    <message>
+        <source>Rendering %1 frames of %2</source>
+        <comment>MultimediaProgressBar</comment>
+        <translation>Renderizando % 1 quadros de % 2</translation>
+    </message>
+    <message>
+        <source>%1 of %2</source>
+        <comment>MultimediaProgressBar - [totalframe] of [path]</comment>
+        <translation>% 1 de % 2</translation>
+    </message>
+    <message>
+        <source>Aborting render...</source>
+        <comment>MultimediaProgressBar</comment>
+        <translation>Abortando a renderização...</translation>
+    </message>
+    <message>
+        <source>It is not possible to write the output:  the file</source>
+        <comment>RenderCommand</comment>
+        <translation>Não é possível escrever a saída: o arquivo</translation>
+    </message>
+    <message>
+        <source>s are read only.</source>
+        <comment>RenderCommand</comment>
+        <translation>s são somente leitura.</translation>
+    </message>
+    <message>
+        <source> is read only.</source>
+        <comment>RenderCommand</comment>
+        <translation>é somente leitura.</translation>
+    </message>
+    <message>
+        <source>Save Cleanup Settings</source>
+        <translation>Salvar configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>Load Cleanup Settings</source>
+        <translation>Carregar configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>It is not possible to find the %1 level.</source>
+        <comment>FileData</comment>
+        <translation>Não é possível encontrar o nível %1.</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1</source>
+        <comment>FileData</comment>
+        <translation>Ocorreu um erro ao copiar % 1</translation>
+    </message>
+    <message>
+        <source>Clone Level</source>
+        <comment>CloneLevelUndo::LevelNamePopup</comment>
+        <translation>Nível de clone</translation>
+    </message>
+    <message>
+        <source>Level Name:</source>
+        <comment>CloneLevelUndo::LevelNamePopup</comment>
+        <translation>Nome do nível:</translation>
+    </message>
+    <message>
+        <source>Collecting assets...</source>
+        <translation>Coletando ativos...</translation>
+    </message>
+    <message>
+        <source>Abort</source>
+        <translation>Abortar</translation>
+    </message>
+    <message>
+        <source>Importing scenes...</source>
+        <translation>Importando cenas...</translation>
+    </message>
+    <message>
+        <source>It is not possible to execute the merge column command because no column was selected.</source>
+        <translation>Não é possível executar o comando mesclar coluna porque nenhuma coluna foi selecionada.</translation>
+    </message>
+    <message>
+        <source>It is not possible to execute the merge column command because only one columns is selected.</source>
+        <translation>Não é possível executar o comando mesclar coluna porque apenas uma coluna está selecionada.</translation>
+    </message>
+    <message>
+        <source>It is not possible to apply the match lines because no column was selected.</source>
+        <translation>Não é possível aplicar as linhas coincidentes porque nenhuma coluna foi selecionada.</translation>
+    </message>
+    <message>
+        <source>It is not possible to apply the match lines because two columns have to be selected.</source>
+        <translation>Não é possível aplicar as linhas coincidentes porque é necessário selecionar duas colunas.</translation>
+    </message>
+    <message>
+        <source>It is not possible to merge tlv columns because no column was selected.</source>
+        <translation>Não é possível mesclar colunas tlv porque nenhuma coluna foi selecionada.</translation>
+    </message>
+    <message>
+        <source>It is not possible to merge tlv columns because at least two columns have to be selected.</source>
+        <translation>Não é possível mesclar colunas tlv porque pelo menos duas colunas devem ser selecionadas.</translation>
+    </message>
+    <message>
+        <source>Merging Tlv Levels...</source>
+        <translation>Mesclando níveis Tlv...</translation>
+    </message>
+    <message>
+        <source>Save Previewed Images</source>
+        <translation>Salvar imagens visualizadas</translation>
+    </message>
+    <message>
+        <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? "  |</source>
+        <translation>O nome do arquivo não pode estar vazio nem conter nenhum dos seguintes caracteres:(nova linha) \ / : * ? " |</translation>
+    </message>
+    <message>
+        <source>Unsopporter raster format, cannot save</source>
+        <translation>Formato raster não compatível, não é possível salvar</translation>
+    </message>
+    <message>
+        <source>Cannot create %1 : %2</source>
+        <comment>Previewer warning %1:path %2:message</comment>
+        <translation>Não foi possível criar % 1 : % 2</translation>
+    </message>
+    <message>
+        <source>Cannot create %1</source>
+        <comment>Previewer warning %1:path</comment>
+        <translation>Não foi possível criar o % 1</translation>
+    </message>
+    <message>
+        <source>Saved %1 frames out of %2 in %3</source>
+        <comment>Previewer %1:savedframes %2:framecount %3:filepath</comment>
+        <translation>Foram salvos %1 quadros de %2 em %3</translation>
+    </message>
+    <message>
+        <source>Canceled! </source>
+        <comment>Previewer</comment>
+        <translation>Cancelado!</translation>
+    </message>
+    <message>
+        <source>No frame to save!</source>
+        <translation>Nenhum quadro para salvar!</translation>
+    </message>
+    <message>
+        <source>Already saving!</source>
+        <translation>Já salvando!</translation>
+    </message>
+    <message>
+        <source>Warning!</source>
+        <comment>OverwriteDialog</comment>
+        <translation>Aviso!</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <comment>OverwriteDialog</comment>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Skip</source>
+        <comment>OverwriteDialog</comment>
+        <translation>Pular</translation>
+    </message>
+    <message>
+        <source>File "%1" already exists.
+Do you want to overwrite it?</source>
+        <comment>OverwriteDialog</comment>
+        <translation>O arquivo "%1" já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>%1 does not exist.</source>
+        <translation>%1 não existe.</translation>
+    </message>
+    <message>
+        <source>The file %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>The file %1 has been exported successfully.</source>
+        <translation>O arquivo %1 foi exportado com sucesso.</translation>
+    </message>
+    <message>
+        <source>Open containing folder</source>
+        <translation>Abra a pasta que contém</translation>
+    </message>
+    <message>
+        <source>Please enable "Show Keyframes on Cell Area" to show or hide the camera column.</source>
+        <translation>Ative "Mostrar quadros-chave na área da célula" para mostrar ou ocultar a coluna da câmera.</translation>
+    </message>
+    <message>
+        <source>The chosen folder path does not exist.
+Do you want to create it?</source>
+        <translation>O caminho da pasta escolhido não existe.
+Você quer criá-lo?</translation>
+    </message>
+    <message>
+        <source>Create</source>
+        <translation>Criar</translation>
+    </message>
+    <message>
+        <source>Edit Level Settings : %1</source>
+        <translation>Editar configurações de nível: %1</translation>
+    </message>
+    <message>
+        <source>Shift Key Frames Down</source>
+        <translation>Deslocar quadros-chave para baixo</translation>
+    </message>
+    <message>
+        <source>Shift Key Frames Up</source>
+        <translation>Shift Key Quadros para cima</translation>
+    </message>
+    <message>
+        <source>Create Blank Drawing</source>
+        <translation>Criar desenho em branco</translation>
+    </message>
+    <message>
+        <source>Duplicate Drawing</source>
+        <translation>Desenho duplicado</translation>
+    </message>
+    <message>
+        <source>Unable to create a blank drawing on the camera column</source>
+        <translation>Não é possível criar um desenho em branco na coluna da câmera</translation>
+    </message>
+    <message>
+        <source>The current column is locked</source>
+        <translation>A coluna atual está bloqueada</translation>
+    </message>
+    <message>
+        <source>Cannot create a blank drawing on the current column</source>
+        <translation>Não é possível criar um desenho em branco na coluna atual</translation>
+    </message>
+    <message>
+        <source>The current level is not editable</source>
+        <translation>O nível atual não é editável</translation>
+    </message>
+    <message>
+        <source>Unable to create a blank drawing on the current column</source>
+        <translation>Não é possível criar um desenho em branco na coluna atual</translation>
+    </message>
+    <message>
+        <source>Unable to replace the current drawing with a blank drawing</source>
+        <translation>Não é possível substituir o desenho atual por um desenho em branco</translation>
+    </message>
+    <message>
+        <source>There are no drawings in the camera column to duplicate</source>
+        <translation>Não há desenhos na coluna da câmera para duplicar</translation>
+    </message>
+    <message>
+        <source>Cannot duplicate a drawing in the current column</source>
+        <translation>Não é possível duplicar um desenho na coluna atual</translation>
+    </message>
+    <message>
+        <source>Unable to duplicate a drawing on the current column</source>
+        <translation>Não é possível duplicar um desenho na coluna atual</translation>
+    </message>
+    <message>
+        <source>Unable to replace the current or next drawing with a duplicate drawing</source>
+        <translation>Não é possível substituir o desenho atual ou o próximo por um desenho duplicado</translation>
+    </message>
+    <message>
+        <source>Stop Motion Controller</source>
+        <translation>Controlador de movimento de parada</translation>
+    </message>
+    <message>
+        <source>Camera Column Switch :  </source>
+        <translation>Interruptor de coluna da câmera:</translation>
+    </message>
+    <message>
+        <source>Vector Guided Drawing Controls</source>
+        <translation>Controles de desenho guiado por vetor</translation>
+    </message>
+    <message>
+        <source>Vector Guided Drawing</source>
+        <translation>Desenho guiado por vetor</translation>
+    </message>
+    <message>
+        <source>Group strokes by vector levels?</source>
+        <translation>Agrupar traços por níveis vetoriais?</translation>
+    </message>
+    <message>
+        <source>Merge Vector Levels</source>
+        <translation>Mesclar níveis de vetor</translation>
+    </message>
+    <message>
+        <source>Report a Bug</source>
+        <translation>Reportar um bug</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>No columns can be exported.</source>
+        <translation>Nenhuma coluna pode ser exportada.</translation>
+    </message>
+    <message>
+        <source>Export Exchange Digital Time Sheet (XDTS)</source>
+        <translation>Exportar folha de ponto digital do Exchange (XDTS)</translation>
+    </message>
+    <message>
+        <source>Maintain parenting relationships in the sub-xsheet as well.</source>
+        <translation>Mantenha relacionamentos parentais também na subplanilha.</translation>
+    </message>
+    <message>
+        <source>Include the selected columns in the sub-xsheet without parenting info.</source>
+        <translation>Incluir as colunas selecionadas na subplanilha sem informações parentais.</translation>
+    </message>
+    <message>
+        <source>Maintain parenting relationships in the main xsheet.</source>
+        <translation>Mantenha relacionamentos parentais na xsheet principal.</translation>
+    </message>
+    <message>
+        <source>Bring columns in the main xsheet without parenting.</source>
+        <translation>Traga colunas na xsheet principal sem pai.</translation>
+    </message>
+    <message>
+        <source>and %1 more item(s).</source>
+        <translation>e mais %1 item(s).</translation>
+    </message>
+    <message>
+        <source>Convert to Vectors</source>
+        <translation>Converter em vetores</translation>
+    </message>
+    <message>
+        <source>There are no copied cells to duplicate.</source>
+        <translation>Não há células copiadas para duplicar.</translation>
+    </message>
+    <message>
+        <source>Cannot paste cells on locked layers.</source>
+        <translation>Não é possível colar células em camadas bloqueadas.</translation>
+    </message>
+    <message>
+        <source>Can't place drawings on the camera column.</source>
+        <translation>Não é possível colocar desenhos na coluna da câmera.</translation>
+    </message>
+    <message>
+        <source>Cannot duplicate frames in read only levels</source>
+        <translation>Não é possível duplicar quadros em níveis somente leitura</translation>
+    </message>
+    <message>
+        <source>Can only duplicate frames in image sequence levels.</source>
+        <translation>Só é possível duplicar quadros em níveis de sequência de imagens.</translation>
+    </message>
+    <message>
+        <source>Toggle vector column as mask. </source>
+        <translation>Alternar coluna de vetor como máscara.</translation>
+    </message>
+    <message>
+        <source>Script file %1 does not exists.</source>
+        <translation>O arquivo de script %1 não existe.</translation>
+    </message>
+    <message>
+        <source>Add Level to Scene Cast : %1</source>
+        <translation>Adicionar nível ao elenco de cena: %1</translation>
+    </message>
+    <message>
+        <source>The Premultiply options in the following levels are disabled, since PNG files are premultiplied on loading in the current version: %1</source>
+        <translation>As opções de Pré-multiplicação nos seguintes níveis estão desativadas, pois os arquivos PNG são pré-multiplicados ao serem carregados na versão atual: %1</translation>
+    </message>
+    <message>
+        <source>Restart</source>
+        <translation>Reiniciar</translation>
+    </message>
+    <message>
+        <source>+</source>
+        <comment>XSheetPDF</comment>
+        <translation>+</translation>
+    </message>
+    <message>
+        <source>'</source>
+        <comment>XSheetPDF:second</comment>
+        <translation>'</translation>
+    </message>
+    <message>
+        <source>"</source>
+        <comment>XSheetPDF:frame</comment>
+        <translation>"</translation>
+    </message>
+    <message>
+        <source>TOT</source>
+        <comment>XSheetPDF</comment>
+        <translation>PARA</translation>
+    </message>
+    <message>
+        <source>th</source>
+        <comment>XSheetPDF</comment>
+        <translation>o</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <comment>XSheetPDF CellMark</comment>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Dot</source>
+        <comment>XSheetPDF CellMark</comment>
+        <translation>Ponto</translation>
+    </message>
+    <message>
+        <source>Circle</source>
+        <comment>XSheetPDF CellMark</comment>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <source>Filled circle</source>
+        <comment>XSheetPDF CellMark</comment>
+        <translation>Círculo preenchido</translation>
+    </message>
+    <message>
+        <source>Asterisk</source>
+        <comment>XSheetPDF CellMark</comment>
+        <translation>Asterisco</translation>
+    </message>
+    <message>
+        <source>ACTION</source>
+        <comment>XSheetPDF</comment>
+        <translation>AÇÃO</translation>
+    </message>
+    <message>
+        <source>S</source>
+        <comment>XSheetPDF</comment>
+        <translation>S</translation>
+    </message>
+    <message>
+        <source>CELL</source>
+        <comment>XSheetPDF</comment>
+        <translation>CÉLULA</translation>
+    </message>
+    <message>
+        <source>CAMERA</source>
+        <comment>XSheetPDF</comment>
+        <translation>CÂMERA</translation>
+    </message>
+    <message>
+        <source>EPISODE</source>
+        <comment>XSheetPDF</comment>
+        <translation>EPISÓDIO</translation>
+    </message>
+    <message>
+        <source>SEQ.</source>
+        <comment>XSheetPDF</comment>
+        <translation>SEQ.</translation>
+    </message>
+    <message>
+        <source>SCENE</source>
+        <comment>XSheetPDF</comment>
+        <translation>CENA</translation>
+    </message>
+    <message>
+        <source>TIME</source>
+        <comment>XSheetPDF</comment>
+        <translation>TEMPO</translation>
+    </message>
+    <message>
+        <source>NAME</source>
+        <comment>XSheetPDF</comment>
+        <translation>NOME</translation>
+    </message>
+    <message>
+        <source>SHEET</source>
+        <comment>XSheetPDF</comment>
+        <translation>FOLHA</translation>
+    </message>
+    <message>
+        <source>TITLE</source>
+        <comment>XSheetPDF</comment>
+        <translation>TÍTULO</translation>
+    </message>
+    <message>
+        <source>CAMERAMAN</source>
+        <comment>XSheetPDF</comment>
+        <translation>CÂMERA</translation>
+    </message>
+    <message>
+        <source>Create folder</source>
+        <translation>Criar pasta</translation>
+    </message>
+    <message>
+        <source>TVPaint JSON file cannot be exported from untitled scene. Save the scene first.</source>
+        <translation>O arquivo JSON do TVPaint não pode ser exportado de uma cena sem título. Salve a cena primeiro.</translation>
+    </message>
+    <message>
+        <source>No columns can be exported. Please note the followings:
+ - The level files must be placed at the same or child folder relative to the scene file.
+ - Currently only the columns containing raster levels can be exported.</source>
+        <translation>Nenhuma coluna pode ser exportada. Observe o seguinte:
+ - Os arquivos de nível devem ser colocados na mesma pasta ou pasta filha relativa ao arquivo de cena.
+ - Atualmente apenas as colunas contendo níveis raster podem ser exportadas.</translation>
+    </message>
+    <message>
+        <source>Export TVPaint JSON File</source>
+        <translation>Exportar arquivo JSON do TVPaint</translation>
+    </message>
+    <message>
+        <source>Removed unused level %1 from the scene cast. (This behavior can be disabled in Preferences.)</source>
+        <translation>Removido o nível %1 não utilizado do elenco de cena. (Este comportamento pode ser desativado em Preferências.)</translation>
+    </message>
+    <message>
+        <source>Removed unused levels from the scene cast. (This behavior can be disabled in Preferences.)</source>
+        <translation>Níveis não utilizados removidos do elenco da cena. (Este comportamento pode ser desativado em Preferências.)</translation>
+    </message>
+    <message>
+        <source>A prior save of Scene '%1' was critically interrupted. 
+
+A partial save file was generated and changes may be manually salvaged from '%2'.
+
+Do you wish to continue loading the last good save or stop and try to salvage the prior save?</source>
+        <translation>Um salvamento anterior da cena '%1' foi interrompido criticamente. 
+
+Um arquivo salvo parcial foi gerado e as alterações podem ser salvas manualmente de '%2'.
+
+Você deseja continuar carregando o último salvamento válido ou parar e tentar salvar o salvamento anterior?</translation>
+    </message>
+    <message>
+        <source>Edit Cell Mark #%1</source>
+        <translation>Editar marca de célula #%1</translation>
+    </message>
+    <message>
+        <source>A conversion task is in progress! wait until it stops or cancel it</source>
+        <translation>Uma tarefa de conversão está em andamento! espere até parar ou cancele</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <comment>Cell Mark</comment>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Set Cell Mark at Column %1  Frame %2 to %3</source>
+        <translation>Definir Marca de Célula na Coluna % 1 Quadro % 2 a % 3</translation>
+    </message>
+    <message>
+        <source>Apply Auto Lip Sync</source>
+        <translation>Aplicar sincronização labial automática</translation>
+    </message>
+    <message>
+        <source>Export Camera Track Image</source>
+        <translation>Exportar imagem da trilha da câmera</translation>
+    </message>
+    <message>
+        <source>Save log text</source>
+        <translation>Salvar texto do registro</translation>
+    </message>
+    <message>
+        <source>The log file already exists.
+ Do you want to overwrite it?</source>
+        <translation>O arquivo de log já existe.
+ Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>Layer: </source>
+        <translation>Camada:</translation>
+    </message>
+    <message>
+        <source>Export Open Cel Animation (OCA)</source>
+        <translation>Exportar animação Abrir Cel (OCA)</translation>
+    </message>
+    <message>
+        <source>%1 has been exported successfully.</source>
+        <translation>%1 foi exportado com sucesso.</translation>
+    </message>
+    <message>
+        <source>All columns</source>
+        <translation>Todas as colunas</translation>
+    </message>
+    <message>
+        <source>Only active columns</source>
+        <translation>Somente colunas ativas</translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation>Marca de célula para símbolo intermediário 1 (O)</translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation>Marca de célula para símbolo intermediário 2 (*)</translation>
+    </message>
+    <message>
+        <source>Target column</source>
+        <translation>Coluna de destino</translation>
+    </message>
+    <message>
+        <source>Loading Raster Images To Cache...</source>
+        <translation>Carregando imagens raster para cache...</translation>
+    </message>
+    <message>
+        <source>Remove Frames  : Level %1 : Frame </source>
+        <translation>Remover Quadros: Nível %1: Quadro</translation>
+    </message>
+    <message>
+        <source>Can't paste full raster data on a non full raster level.</source>
+        <translation>Não é possível colar dados raster completos em um nível raster não completo.</translation>
+    </message>
+    <message>
+        <source>Edit Color Filter #%1</source>
+        <translation>Editar Filtro de Cor #%1</translation>
+    </message>
+    <message>
+        <source>Preproduction Board</source>
+        <translation>Quadro de pré-produção</translation>
+    </message>
+    <message>
+        <source>Copy Columns</source>
+        <comment>TColumnSelection</comment>
+        <translation>Copiar Colunas</translation>
+    </message>
+    <message>
+        <source>Paste Columns</source>
+        <comment>TColumnSelection</comment>
+        <translation>Colar colunas</translation>
+    </message>
+    <message>
+        <source>Cut Columns</source>
+        <comment>TColumnSelection</comment>
+        <translation>Cortar colunas</translation>
+    </message>
+    <message>
+        <source>Delete Columns</source>
+        <comment>TColumnSelection</comment>
+        <translation>Excluir colunas</translation>
+    </message>
+    <message>
+        <source>Insert Columns</source>
+        <comment>TColumnSelection</comment>
+        <translation>Inserir colunas</translation>
+    </message>
+    <message>
+        <source>Copy Cells</source>
+        <comment>TCellSelection</comment>
+        <translation>Copiar células</translation>
+    </message>
+    <message>
+        <source>Paste Cells</source>
+        <comment>TCellSelection</comment>
+        <translation>Colar células</translation>
+    </message>
+    <message>
+        <source>Overwrite Paste Cells</source>
+        <comment>TCellSelection</comment>
+        <translation>Substituir e colar células</translation>
+    </message>
+    <message>
+        <source>Cut Cells</source>
+        <comment>TCellSelection</comment>
+        <translation>Cortar células</translation>
+    </message>
+    <message>
+        <source>Delete Cells</source>
+        <comment>TCellSelection</comment>
+        <translation>Excluir células</translation>
+    </message>
+    <message>
+        <source>Insert Cells</source>
+        <comment>TCellSelection</comment>
+        <translation>Inserir células</translation>
+    </message>
+    <message>
+        <source>Pasting external image from clipboard.
+
+What do you want to do?</source>
+        <translation>Colando imagem externa da área de transferência.
+
+O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>New raster level</source>
+        <translation>Novo nível raster</translation>
+    </message>
+    <message>
+        <source>The rooms will be reset the next time you run OpenToonz.</source>
+        <translation>As salas serão redefinidas na próxima vez que você executar o OpenToonz.</translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to copy separator to %1</source>
+        <translation>[Arrastar e Soltar] para copiar o separador para% 1</translation>
+    </message>
+    <message>
+        <source>[Drag&amp;Drop] to copy command to %1</source>
+        <translation>[Arrastar e Soltar] para copiar o comando para %1</translation>
+    </message>
+    <message>
+        <source>Keyframe Symbol:</source>
+        <translation>Símbolo do quadro-chave:</translation>
+    </message>
+    <message>
+        <source>Reference Frame Symbol:</source>
+        <translation>Símbolo do Quadro de Referência:</translation>
+    </message>
+    <message>
+        <source>Unable to create OCA folder.</source>
+        <translation>Não foi possível criar a pasta OCA.</translation>
+    </message>
+    <message>
+        <source>Unable to open OCA file for saving.</source>
+        <translation>Não é possível abrir o arquivo OCA para salvar.</translation>
+    </message>
+    <message>
+        <source>Unable to create folder for saving layers.</source>
+        <translation>Não foi possível criar uma pasta para salvar camadas.</translation>
+    </message>
+    <message>
+        <source>Import Open Cel Animation (OCA)</source>
+        <translation>Importar animação Abrir Cel (OCA)</translation>
+    </message>
+    <message>
+        <source>OCA Import cancelled : empty filepath.</source>
+        <translation>Importação OCA cancelada: caminho de arquivo vazio.</translation>
+    </message>
+    <message>
+        <source>OCA Import file : %1</source>
+        <translation>Arquivo de importação OCA: %1</translation>
+    </message>
+    <message>
+        <source>Do you want to import or load image files from their original location?</source>
+        <translation>Deseja importar ou carregar arquivos de imagem do local original?</translation>
+    </message>
+    <message>
+        <source>Failed to load OCA file: %1</source>
+        <translation>Falha ao carregar o arquivo OCA: %1</translation>
+    </message>
+    <message>
+        <source>Unable to open OCA file for loading.</source>
+        <translation>Não foi possível abrir o arquivo OCA para carregamento.</translation>
+    </message>
+    <message>
+        <source>Reading OCA file: %1</source>
+        <translation>Lendo arquivo OCA: %1</translation>
+    </message>
+    <message>
+        <source>Parse error at %1 while loading OCA file.</source>
+        <translation>Erro de análise em %1 ao carregar o arquivo OCA.</translation>
+    </message>
+    <message>
+        <source>Blending mode '%1' not implemented for %2 '%3'</source>
+        <translation>Modo de mesclagem '%1' não implementado para %2 '%3'</translation>
+    </message>
+    <message>
+        <source>Skipped %1 '%2'. No image file indicated.</source>
+        <translation>Ignorado %1 '%2'. Nenhum arquivo de imagem indicado.</translation>
+    </message>
+    <message>
+        <source>Unable to load images for %1 '%2'.</source>
+        <translation>Não foi possível carregar imagens para %1 '%2'.</translation>
+    </message>
+    <message>
+        <source>Sub-layers in grouplayer '%1' will be imported without grouping.</source>
+        <translation>As subcamadas na camada de grupo '%1' serão importadas sem agrupamento.</translation>
+    </message>
+    <message>
+        <source>Skipping unimplemented %1 '%2'</source>
+        <translation>Ignorando %1 '%2' não implementado</translation>
+    </message>
+    <message>
+        <source>Ignore all future warnings and errors.</source>
+        <translation>Ignore todos os avisos e erros futuros.</translation>
+    </message>
+    <message>
+        <source>Inbetween Symbol1 (O):</source>
+        <translation>Entre o Símbolo1 (O):</translation>
+    </message>
+    <message>
+        <source>Inbetween Symbol2 (*):</source>
+        <translation>Entre Símbolo2 (*):</translation>
+    </message>
+    <message>
+        <source>The visibility toggles of following columns are modified 
+due to "Unify Preview and Camstand Visibility Toggles" preference option : 
+  %1</source>
+        <translation>As alternâncias de visibilidade das colunas seguintes foram modificadas 
+devido à opção de preferência "Unificar visualização e alternância de visibilidade do Camstand": 
+  % 1</translation>
+    </message>
+    <message>
+        <source>Cell marks for XDTS symbols</source>
+        <translation>Marcas de células para símbolos XDTS</translation>
+    </message>
+    <message>
+        <source>The Keyframe and the Reference Frame symbols will be exported in an unofficial format,
+which may not be displayed correctly or may cause errors in applications other than XDTS Viewer.</source>
+        <translation>Os símbolos Quadro-chave e Reference Quadro serão exportados em um formato não oficial,
+que podem não ser exibidos corretamente ou causar erros em outros aplicativos além do XDTS Viewer.</translation>
+    </message>
+    <message>
+        <source>Error while loading SXF scene: %1</source>
+        <translation>Erro ao carregar a cena SXF:% 1</translation>
+    </message>
+    <message>
+        <source>SXF data has no frames to import.</source>
+        <translation>Os dados SXF não possuem quadros para importar.</translation>
+    </message>
+    <message>
+        <source>Import SXF Area</source>
+        <translation>Importar área SXF</translation>
+    </message>
+    <message>
+        <source>ACTION</source>
+        <translation>AÇÃO</translation>
+    </message>
+    <message>
+        <source>CELL</source>
+        <translation>CÉLULA</translation>
+    </message>
+    <message>
+        <source>Current XSheet is emepty.</source>
+        <translation>O XSheet atual está vazio.</translation>
+    </message>
+    <message>
+        <source>ACTION &amp; CELL</source>
+        <translation>AÇÃO E CÉLULA</translation>
+    </message>
+    <message>
+        <source>Direction</source>
+        <translation>Direção</translation>
+    </message>
+    <message>
+        <source>Enter text here...
+Supports multiple lines</source>
+        <translation>Digite o texto aqui...
+Suporta múltiplas linhas</translation>
+    </message>
+    <message>
+        <source>Large Font</source>
+        <translation>Fonte Grande</translation>
+    </message>
+    <message>
+        <source>Text Encoding:</source>
+        <translation>Codificação de texto:</translation>
+    </message>
+    <message>
+        <source>Cell marks for SXF symbols</source>
+        <translation>Marcas de células para símbolos SXF</translation>
+    </message>
+    <message>
+        <source>Inbetween Symbol1 (â—‹)</source>
+        <translation>Entre o Símbolo1 (â—‹)</translation>
+    </message>
+    <message>
+        <source>Inbetween Symbol2 (â—):</source>
+        <translation>Entre o Símbolo2 (â—):</translation>
+    </message>
+    <message>
+        <source>Target Column:</source>
+        <translation>Coluna de destino:</translation>
+    </message>
+    <message>
+        <source>Export Area:</source>
+        <translation>Área de exportação:</translation>
+    </message>
+    <message>
+        <source>Export SXF File</source>
+        <translation>Exportar arquivo SXF</translation>
+    </message>
+    <message>
+        <source>Failed to export SXF file.%1</source>
+        <translation>Falha ao exportar o arquivo SXF.%1</translation>
+    </message>
+    <message>
+        <source>Cannot clear: level is read-only or no level is selected.</source>
+        <translation>Não é possível limpar: o nível é somente leitura ou nenhum nível está selecionado.</translation>
+    </message>
+    <message>
+        <source>No frame to clear.</source>
+        <translation>Nenhum quadro para limpar.</translation>
+    </message>
+    <message>
+        <source>Add separator for Frames</source>
+        <translation>Adicionar separador para quadros</translation>
+    </message>
+    <message>
+        <source>It is not possible to load the scene %1 because it does not belong to any project.
+Please delete scenes.xml if this scene dones't belong to any project.</source>
+        <translation>Não é possível carregar a cena %1 porque ela não pertence a nenhum projeto.
+Por favor, exclua cenas.xml se esta cena não pertencer a nenhum projeto.</translation>
+    </message>
+    <message>
+        <source>There were problems loading the scene %1.
+Details:
+
+%2</source>
+        <translation>Ocorreram problemas ao carregar a cena %1.
+Detalhes:
+
+%2</translation>
+    </message>
+    <message>
+        <source>%1
+
+is an image sequence that can be converted into a TLV format 
+Would you like to convert it?</source>
+        <translation>% 1
+
+é uma sequência de imagens que pode ser convertida em formato TLV 
+Você gostaria de convertê-lo?</translation>
+    </message>
+    <message>
+        <source>No, use as is</source>
+        <translation>Não, use como está</translation>
+    </message>
+    <message>
+        <source>Image sequence detected, but the filenames are missing a separator: 
+OpenToonz requires a separator (such as an underscore (_) or dot (.) 
+between the name and the frame number to recognize sequences properly.
+Example: A0001.png â†’ A.0001.png
+
+Would you like OpenToonz to automatically add a dot to fix the sequence format?
+
+%1 (and similar files)</source>
+        <translation>Sequência de imagens detectada, mas falta um separador nos nomes dos arquivos: 
+OpenToonz requer um separador (como sublinhado (_) ou ponto (.) 
+entre o nome e o número do quadro para reconhecer as sequências corretamente.
+Exemplo: A0001.png → A.0001.png
+
+Gostaria que o OpenToonz adicionasse automaticamente um ponto para corrigir o formato da sequência?
+
+% 1 (e arquivos similares)</translation>
+    </message>
+    <message>
+        <source>Yes, add dot</source>
+        <translation>Sim, adicione ponto</translation>
+    </message>
+    <message>
+        <source>No, treat as single frame</source>
+        <translation>Não, trate como quadro único</translation>
+    </message>
+    <message>
+        <source>Hide Viewer Indicators</source>
+        <translation>Ocultar indicadores do visualizador</translation>
+    </message>
+    <message>
+        <source>Show Viewer Indicators</source>
+        <translation>Mostrar indicadores do visualizador</translation>
+    </message>
+    <message>
+        <source>Create Level %1 at Column %2</source>
+        <translation>Criar o Nível %1 na Coluna %2</translation>
+    </message>
+    <message>
+        <source>Paste File: </source>
+        <translation>Colar arquivo:</translation>
+    </message>
+    <message>
+        <source>Duplicate File: </source>
+        <translation>Arquivo duplicado:</translation>
+    </message>
+    <message>
+        <source>Task added to the Batch Render List.</source>
+        <translation>Tarefa adicionada à lista de renderização em lote.</translation>
+    </message>
+    <message>
+        <source>Task added to the Batch Cleanup List.</source>
+        <translation>Tarefa adicionada à lista de limpeza em lote.</translation>
+    </message>
+    <message>
+        <source>Deleting folder %1. Are you sure?</source>
+        <translation>Excluindo a pasta %1. Tem certeza?</translation>
+    </message>
+    <message>
+        <source>A conversion task is in progress! Wait until it stops or cancel it.</source>
+        <translation>Uma tarefa de conversão está em andamento! Espere até que pare ou cancele.</translation>
+    </message>
+    <message>
+        <source>Error loading scene %1 : %2</source>
+        <translation>Erro ao carregar a cena % 1 : % 2</translation>
+    </message>
+    <message>
+        <source>Error saving scene %1</source>
+        <translation>Erro ao guardar a cena % 1</translation>
+    </message>
+    <message>
+        <source>A separation task is in progress! Wait until it stops or cancel it.</source>
+        <translation>Uma tarefa de separação está em andamento! Espere até que pare ou cancele.</translation>
+    </message>
+    <message>
+        <source>Cannot paste into the camera column.</source>
+        <translation>Não é possível colar na coluna da câmera.</translation>
+    </message>
+    <message>
+        <source>Brush Presets</source>
+        <translation>Predefinições de pincel</translation>
+    </message>
+    <message>
+        <source>Tool Properties</source>
+        <translation>Propriedades da ferramenta</translation>
+    </message>
+    <message>
+        <source>Fx Browser</source>
+        <translation>Navegador FX</translation>
+    </message>
+    <message>
+        <source>Locator</source>
+        <translation>Localizador</translation>
+    </message>
+    <message>
+        <source>The specified name is already assigned to the folder.</source>
+        <translation>O nome especificado já está atribuído à pasta.</translation>
+    </message>
+    <message>
+        <source>Unsupported raster format, cannot save</source>
+        <translation>Formato raster não suportado, não é possível salvar</translation>
+    </message>
+    <message>
+        <source>Bind to Current Room</source>
+        <translation>Vincular à sala atual</translation>
+    </message>
+    <message>
+        <source>Converting %1 to tlv format...</source>
+        <translation>Convertendo %1 para formato tlv...</translation>
+    </message>
+    <message>
+        <source> [WIP]</source>
+        <translation>[WIP]</translation>
+    </message>
+</context>
+<context>
+    <name>ReframePopup</name>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>steps</source>
+        <translation>passos</translation>
+    </message>
+    <message>
+        <source>with</source>
+        <translation>com</translation>
+    </message>
+    <message>
+        <source>(</source>
+        <translation>(</translation>
+    </message>
+    <message>
+        <source> blank cells will be inserted.)</source>
+        <translation>células em branco serão inseridas.)</translation>
+    </message>
+    <message>
+        <source>Reframe with Empty Inbetweens</source>
+        <translation>Reenquadrar com espaços vazios</translation>
+    </message>
+    <message>
+        <source>empty inbetweens</source>
+        <translation>vazio no meio</translation>
+    </message>
+    <message>
+        <source>Number of steps:</source>
+        <translation>Número de etapas:</translation>
+    </message>
+    <message>
+        <source>s</source>
+        <translation>é</translation>
+    </message>
+    <message>
+        <source>(%1 blank cells will be inserted.)</source>
+        <translation>(%1 células em branco serão inseridas.)</translation>
+    </message>
+</context>
+<context>
+    <name>RenameAsToonzPopup</name>
+    <message>
+        <source>Rename</source>
+        <translation>Renomear</translation>
+    </message>
+    <message>
+        <source>Renaming File </source>
+        <translation>Renomeando arquivo</translation>
+    </message>
+    <message>
+        <source>Creating an animation level of %1 frames</source>
+        <translation>Criando um nível de animação de %1 quadros</translation>
+    </message>
+    <message>
+        <source>Delete Original Files</source>
+        <translation>Excluir arquivos originais</translation>
+    </message>
+    <message>
+        <source>Level Name:</source>
+        <translation>Nome do nível:</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>The file name cannot be empty or contain any of the following characters:(new line)  \ / : * ? "  |</source>
+        <translation>O nome do arquivo não pode estar vazio nem conter nenhum dos seguintes caracteres:(nova linha) \ / : * ? " |</translation>
+    </message>
+    <message>
+        <source>Renaming Folder </source>
+        <translation>Renomeando pasta</translation>
+    </message>
+    <message>
+        <source>Folder Name:</source>
+        <translation>Nome da pasta:</translation>
+    </message>
+</context>
+<context>
+    <name>RenderController</name>
+    <message>
+        <source>Continue</source>
+        <translation>Continuar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Exporting ...</source>
+        <translation>Exportando...</translation>
+    </message>
+    <message>
+        <source>Abort</source>
+        <translation>Abortar</translation>
+    </message>
+    <message>
+        <source>Exporting</source>
+        <translation>Exportador</translation>
+    </message>
+    <message>
+        <source>The %1 scene contains an audio file with different characteristics from the one used in the first exported scene.
+The audio file will not be included in the rendered clip.</source>
+        <translation>A cena %1 contém um arquivo de áudio com características diferentes daquela usada na primeira cena exportada.
+O arquivo de áudio não será incluído no clipe renderizado.</translation>
+    </message>
+    <message>
+        <source>The %1  scene has a different resolution from the %2 scene.
+                           The output result may differ from what you expect. What do you want to do?</source>
+        <translation>A cena %1 tem uma resolução diferente da cena %2.
+                           O resultado de saída pode ser diferente do esperado. O que você quer fazer?</translation>
+    </message>
+    <message>
+        <source>Please specify an file name.</source>
+        <translation>Especifique um nome de arquivo.</translation>
+    </message>
+    <message>
+        <source>Drag a scene into the box to export a scene.</source>
+        <translation>Arraste uma cena para a caixa para exportar uma cena.</translation>
+    </message>
+    <message>
+        <source>The %1 scene contains a plastic deformed level.
+These levels can't be exported with this tool.</source>
+        <translation>A cena %1 contém um nível plástico deformado.
+Estes níveis não podem ser exportados com esta ferramenta.</translation>
+    </message>
+</context>
+<context>
+    <name>RenderListener</name>
+    <message>
+        <source>Finalizing render, please wait.</source>
+        <translation>Finalizando a renderização, aguarde.</translation>
+    </message>
+</context>
+<context>
+    <name>RenumberPopup</name>
+    <message>
+        <source>Renumber</source>
+        <translation>Renumerar</translation>
+    </message>
+    <message>
+        <source>Start:</source>
+        <translation>Começar:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>ReplaceLevelPopup</name>
+    <message>
+        <source>Replace Level</source>
+        <translation>Substituir nível</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Nothing to replace: no cells selected.</source>
+        <translation>Nada para substituir: nenhuma célula selecionada.</translation>
+    </message>
+    <message>
+        <source>File not found
+</source>
+        <translation>Arquivo não encontrado</translation>
+    </message>
+</context>
+<context>
+    <name>ReplaceParentDirectoryPopup</name>
+    <message>
+        <source>Replace Parent Directory</source>
+        <translation>Substituir diretório pai</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Nothing to replace: no cells or columns selected.</source>
+        <translation>Nada para substituir: nenhuma célula ou coluna selecionada.</translation>
+    </message>
+    <message>
+        <source>The level paths have been replaced as follows:
+
+</source>
+        <translation>Os caminhos de nível foram substituídos da seguinte forma:</translation>
+    </message>
+    <message>
+        <source>%1 : No change was made.
+</source>
+        <translation>%1: Nenhuma alteração foi feita.</translation>
+    </message>
+    <message>
+        <source>%1 : %2 -&gt; %3
+</source>
+        <translation>% 1: % 2 -&gt; % 3</translation>
+    </message>
+</context>
+<context>
+    <name>RoomTabWidget</name>
+    <message>
+        <source>New Room</source>
+        <translation>Novo quarto</translation>
+    </message>
+    <message>
+        <source>Delete Room</source>
+        <translation>Excluir sala</translation>
+    </message>
+    <message>
+        <source>Room</source>
+        <translation>Sala</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to remove room %1</source>
+        <translation>Tem a certeza que deseja remover a sala % 1</translation>
+    </message>
+    <message>
+        <source>Delete Room "%1"</source>
+        <translation>Excluir sala "%1"</translation>
+    </message>
+    <message>
+        <source>Customize Menu Bar of Room "%1"</source>
+        <translation>Personalizar a barra de menu da sala "%1"</translation>
+    </message>
+</context>
+<context>
+    <name>Ruler</name>
+    <message>
+        <source>Click to create an horizontal guide</source>
+        <translation>Clique para criar uma guia horizontal</translation>
+    </message>
+    <message>
+        <source>Click to create a vertical guide</source>
+        <translation>Clique para criar uma guia vertical</translation>
+    </message>
+    <message>
+        <source>Click and drag to move guide</source>
+        <translation>Clique e arraste para mover o guia</translation>
+    </message>
+    <message>
+        <source>Left click and drag to move guide. Right click to delete guide</source>
+        <translation>Clique com o botão esquerdo e arraste para mover a guia. Clique com o botão direito para excluir o guia</translation>
+    </message>
+    <message>
+        <source>Left-click and drag to move guide, right-click to delete guide.</source>
+        <translation>Clique com o botão esquerdo e arraste para mover a guia, clique com o botão direito para excluir a guia.</translation>
+    </message>
+    <message>
+        <source>Click to create a horizontal guide</source>
+        <translation>Clique para criar uma guia horizontal</translation>
+    </message>
+</context>
+<context>
+    <name>SVNCleanupDialog</name>
+    <message>
+        <source>Version Control: Cleanup</source>
+        <translation>Controle de versão: limpeza</translation>
+    </message>
+    <message>
+        <source>Cleaning up %1...</source>
+        <translation>Limpando% 1...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Cleanup done.</source>
+        <translation>Limpeza concluída.</translation>
+    </message>
+</context>
+<context>
+    <name>SVNCommitDialog</name>
+    <message>
+        <source>Version Control: Put changes</source>
+        <translation>Controle de versão: colocar alterações</translation>
+    </message>
+    <message>
+        <source>Select / Deselect All</source>
+        <translation>Selecionar/desmarcar tudo</translation>
+    </message>
+    <message>
+        <source>0 Selected / 0 Total</source>
+        <translation>0 Selecionado / 0 Total</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Comment:</source>
+        <translation>Comentário:</translation>
+    </message>
+    <message>
+        <source>Put Scene Contents</source>
+        <translation>Coloque o conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Put</source>
+        <translation>Colocar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Adding %1 items...</source>
+        <translation>Adicionando %1 itens...</translation>
+    </message>
+    <message>
+        <source>Set needs-lock property...</source>
+        <translation>Definir propriedade de bloqueio de necessidades...</translation>
+    </message>
+    <message>
+        <source>Committing %1 items...</source>
+        <translation>Confirmando %1 itens...</translation>
+    </message>
+    <message>
+        <source>Put done successfully.</source>
+        <translation>Colocado concluído com sucesso.</translation>
+    </message>
+    <message>
+        <source>Putting %1 items...</source>
+        <translation>Colocando %1 itens...</translation>
+    </message>
+    <message>
+        <source>No items to put.</source>
+        <translation>Não há itens para colocar.</translation>
+    </message>
+    <message>
+        <source>%1 items to put.</source>
+        <translation>%1 itens a serem colocados.</translation>
+    </message>
+    <message>
+        <source>%1 Selected / %2 Total</source>
+        <translation>%1 selecionado/%2 total</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Version Control: Commit changes</source>
+        <translation>Controle de versão: confirmar alterações</translation>
+    </message>
+    <message>
+        <source>Commit Scene Contents</source>
+        <translation>Confirmar conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Commit</source>
+        <translation>Comprometer-se</translation>
+    </message>
+    <message>
+        <source>Setting needs-lock property...</source>
+        <translation>Configurando propriedade de bloqueio de necessidades...</translation>
+    </message>
+    <message>
+        <source>Commit completed successfully.</source>
+        <translation>Confirmação concluída com sucesso.</translation>
+    </message>
+    <message>
+        <source>No items to commit.</source>
+        <translation>Nenhum item para confirmar.</translation>
+    </message>
+    <message>
+        <source>%1 items to commit.</source>
+        <translation>%1 itens a serem confirmados.</translation>
+    </message>
+</context>
+<context>
+    <name>SVNCommitFrameRangeDialog</name>
+    <message>
+        <source>Version Control: Put</source>
+        <translation>Controle de versão: colocar</translation>
+    </message>
+    <message>
+        <source>Note: the file will be updated too.</source>
+        <translation>Nota: o arquivo também será atualizado.</translation>
+    </message>
+    <message>
+        <source>Comment:</source>
+        <translation>Comentário:</translation>
+    </message>
+    <message>
+        <source>Put</source>
+        <translation>Colocar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Put done successfully.</source>
+        <translation>Colocado concluído com sucesso.</translation>
+    </message>
+    <message>
+        <source>Locking file...</source>
+        <translation>Bloqueando arquivo...</translation>
+    </message>
+    <message>
+        <source>Getting frame range edit information...</source>
+        <translation>Obtendo informações de edição do intervalo de quadros...</translation>
+    </message>
+    <message>
+        <source>No frame range edited.</source>
+        <translation>Nenhum intervalo de quadros editado.</translation>
+    </message>
+    <message>
+        <source>Updating frame range edit information...</source>
+        <translation>Atualizando informações de edição do intervalo de quadros...</translation>
+    </message>
+    <message>
+        <source>Putting changes...</source>
+        <translation>Colocando alterações...</translation>
+    </message>
+    <message>
+        <source>Updating file...</source>
+        <translation>Atualizando arquivo...</translation>
+    </message>
+    <message>
+        <source>Adding hook file to repository...</source>
+        <translation>Adicionando arquivo hook ao repositório...</translation>
+    </message>
+    <message>
+        <source>Setting the needs-lock property to hook file...</source>
+        <translation>Configurando a propriedade need-lock para conectar o arquivo...</translation>
+    </message>
+    <message>
+        <source>Version Control: Commit Frame Range</source>
+        <translation>Controle de versão: intervalo de quadros de confirmação</translation>
+    </message>
+    <message>
+        <source>Commit</source>
+        <translation>Comprometer-se</translation>
+    </message>
+    <message>
+        <source>Commit completed successfully.</source>
+        <translation>Confirmação concluída com sucesso.</translation>
+    </message>
+    <message>
+        <source>Committing changes...</source>
+        <translation>Confirmando alterações...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>SVNConfigWriter</name>
+    <message>
+        <source>Select</source>
+        <translation>Selecione</translation>
+    </message>
+</context>
+<context>
+    <name>SVNDeleteDialog</name>
+    <message>
+        <source>Version Control: Delete</source>
+        <translation>Controle de Versão: Excluir</translation>
+    </message>
+    <message>
+        <source>Delete folder that contains %1 items.</source>
+        <translation>Exclua a pasta que contém %1 itens.</translation>
+    </message>
+    <message>
+        <source>Delete empty folder.</source>
+        <translation>Exclua a pasta vazia.</translation>
+    </message>
+    <message>
+        <source>Delete %1 items.</source>
+        <translation>Exclua %1 itens.</translation>
+    </message>
+    <message>
+        <source>Comment:</source>
+        <translation>Comentário:</translation>
+    </message>
+    <message>
+        <source>Delete Scene Contents</source>
+        <translation>Excluir conteúdo da cena</translation>
+    </message>
+    <message>
+        <source> Keep Local Copy</source>
+        <translation>Manter cópia local</translation>
+    </message>
+    <message>
+        <source>Delete Local Copy </source>
+        <translation>Excluir cópia local</translation>
+    </message>
+    <message>
+        <source>Delete on Server </source>
+        <translation>Excluir no servidor</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Deleting %1 items...</source>
+        <translation>Excluindo %1 itens...</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>You are deleting items also on repository. Are you sure ?</source>
+        <translation>Você está excluindo itens também no repositório. Tem certeza ?</translation>
+    </message>
+</context>
+<context>
+    <name>SVNFrameRangeLockInfoDialog</name>
+    <message>
+        <source>Version Control: Edit Info</source>
+        <translation>Controle de versão: editar informações</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>No frame range edited.</source>
+        <translation>Nenhum intervalo de quadros editado.</translation>
+    </message>
+    <message>
+        <source>%1 on %2 is editing frames from %3 to %4.</source>
+        <translation>%1 em %2 está editando quadros de %3 a %4.</translation>
+    </message>
+</context>
+<context>
+    <name>SVNLockDialog</name>
+    <message>
+        <source>Version Control: Edit</source>
+        <translation>Controle de Versão: Editar</translation>
+    </message>
+    <message>
+        <source>Version Control: Unlock</source>
+        <translation>Controle de Versão: Desbloquear</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Comment:</source>
+        <translation>Comentário:</translation>
+    </message>
+    <message>
+        <source>Edit Scene Contents</source>
+        <translation>Editar conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Unlock Scene Contents</source>
+        <translation>Desbloquear conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation>Desbloquear</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No items to edit.</source>
+        <translation>Nenhum item para editar.</translation>
+    </message>
+    <message>
+        <source>No items to unlock.</source>
+        <translation>Nenhum item para desbloquear.</translation>
+    </message>
+    <message>
+        <source>%1 items to edit.</source>
+        <translation>%1 itens para editar.</translation>
+    </message>
+    <message>
+        <source>%1 items to unlock.</source>
+        <translation>%1 itens para desbloquear.</translation>
+    </message>
+    <message>
+        <source>Editing %1 items...</source>
+        <translation>Editando %1 itens...</translation>
+    </message>
+    <message>
+        <source>Unlocking %1 items...</source>
+        <translation>Desbloqueando %1 itens...</translation>
+    </message>
+</context>
+<context>
+    <name>SVNLockFrameRangeDialog</name>
+    <message>
+        <source>Version Control: Edit Frame Range</source>
+        <translation>Controle de versão: editar intervalo de quadros</translation>
+    </message>
+    <message>
+        <source>Temporary Lock file...</source>
+        <translation>Arquivo de bloqueio temporário...</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source>To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>Comment:</source>
+        <translation>Comentário:</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No frame range edited.</source>
+        <translation>Nenhum intervalo de quadros editado.</translation>
+    </message>
+    <message>
+        <source>Getting frame range edit information...</source>
+        <translation>Obtendo informações de edição do intervalo de quadros...</translation>
+    </message>
+    <message>
+        <source>%1 on %2 is editing frames from %3 to %4.</source>
+        <translation>%1 em %2 está editando quadros de %3 a %4.</translation>
+    </message>
+</context>
+<context>
+    <name>SVNLockInfoDialog</name>
+    <message>
+        <source>Version Control: Edit Info</source>
+        <translation>Controle de versão: editar informações</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;Edited By:&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Editado por:&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;Host:&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Anfitrião:&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;Comment:&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Comentário:&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;Date:&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Data:&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>SVNLockMultiFrameRangeDialog</name>
+    <message>
+        <source>Version Control: Edit Frame Range</source>
+        <translation>Controle de versão: editar intervalo de quadros</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source>To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>Comment:</source>
+        <translation>Comentário:</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No frame range edited.</source>
+        <translation>Nenhum intervalo de quadros editado.</translation>
+    </message>
+    <message>
+        <source>Editing %1 items...</source>
+        <translation>Editando %1 itens...</translation>
+    </message>
+    <message>
+        <source>%1 is editing frames from %2 to %3</source>
+        <translation>% 1 está editando quadros de % 2 a % 3</translation>
+    </message>
+</context>
+<context>
+    <name>SVNMultiFrameRangeLockInfoDialog</name>
+    <message>
+        <source>Version Control: Edit Info</source>
+        <translation>Controle de versão: editar informações</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>No frame range edited.</source>
+        <translation>Nenhum intervalo de quadros editado.</translation>
+    </message>
+    <message>
+        <source>%1 is editing frames from %2 to %3</source>
+        <translation>% 1 está editando quadros de % 2 a % 3</translation>
+    </message>
+</context>
+<context>
+    <name>SVNPurgeDialog</name>
+    <message>
+        <source>Version Control: Purge</source>
+        <translation>Controle de versão: purga</translation>
+    </message>
+    <message>
+        <source>Note: the file will be updated too.</source>
+        <translation>Nota: o arquivo também será atualizado.</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Purge</source>
+        <translation>Purga</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No items to purge.</source>
+        <translation>Não há itens para limpar.</translation>
+    </message>
+    <message>
+        <source>%1 items to purge.</source>
+        <translation>%1 itens a serem eliminados.</translation>
+    </message>
+    <message>
+        <source>Purging files...</source>
+        <translation>Limpando arquivos...</translation>
+    </message>
+</context>
+<context>
+    <name>SVNRevertDialog</name>
+    <message>
+        <source>Version Control: Revert changes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Revert Scene Contents</source>
+        <translation>Reverter conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>Reverter</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No items to revert.</source>
+        <translation>Não há itens para reverter.</translation>
+    </message>
+    <message>
+        <source>%1 items to revert.</source>
+        <translation>%1 itens a serem revertidos.</translation>
+    </message>
+    <message>
+        <source>Reverting %1 items...</source>
+        <translation>Revertendo %1 itens...</translation>
+    </message>
+    <message>
+        <source>Revert done successfully.</source>
+        <translation>Reverter feito com sucesso.</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>SVNRevertFrameRangeDialog</name>
+    <message>
+        <source>Version Control: Revert Frame Range changes</source>
+        <translation>Controle de versão: reverter alterações no intervalo de quadros</translation>
+    </message>
+    <message>
+        <source>1 item to revert.</source>
+        <translation>1 item para reverter.</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>Reverter</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Reverting 1 item...</source>
+        <translation>Revertendo 1 item...</translation>
+    </message>
+    <message>
+        <source>Revert done successfully.</source>
+        <translation>Reverter feito com sucesso.</translation>
+    </message>
+    <message>
+        <source>Reverting %1 items...</source>
+        <translation>Revertendo %1 itens...</translation>
+    </message>
+    <message>
+        <source>It is not possible to revert the file.</source>
+        <translation>Não é possível reverter o arquivo.</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>SVNTimeline</name>
+    <message>
+        <source>Version Control: Timeline </source>
+        <translation>Controle de Versão: Linha do Tempo</translation>
+    </message>
+    <message>
+        <source>Getting file history...</source>
+        <translation>Obtendo histórico de arquivos...</translation>
+    </message>
+    <message>
+        <source>Get Scene Contents</source>
+        <translation>Obtenha o conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Get Last Revision</source>
+        <translation>Obtenha a última revisão</translation>
+    </message>
+    <message>
+        <source>Get Selected Revision</source>
+        <translation>Obtenha a revisão selecionada</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>Data</translation>
+    </message>
+    <message>
+        <source>Author</source>
+        <translation>Autor</translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <source>Revision</source>
+        <translation>Revisão</translation>
+    </message>
+    <message>
+        <source>Getting the status for %1...</source>
+        <translation>Obtendo o status de %1...</translation>
+    </message>
+    <message>
+        <source>Getting %1 to revision %2...</source>
+        <translation>Obtendo % 1 para revisão % 2...</translation>
+    </message>
+    <message>
+        <source>Getting %1 items to revision %2...</source>
+        <translation>Obtendo %1 itens para revisão %2...</translation>
+    </message>
+    <message>
+        <source>Getting %1...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <source>Getting %1 items...</source>
+        <translation type="unfinished" />
+    </message>
+</context>
+<context>
+    <name>SVNUnlockFrameRangeDialog</name>
+    <message>
+        <source>Version Control: Unlock Frame Range</source>
+        <translation>Controle de versão: desbloquear intervalo de quadros</translation>
+    </message>
+    <message>
+        <source>Note: the file will be updated too. Are you sure ?</source>
+        <translation>Nota: o arquivo também será atualizado. Tem certeza ?</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation>Desbloquear</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Unlock done successfully.</source>
+        <translation>Desbloqueio realizado com sucesso.</translation>
+    </message>
+    <message>
+        <source>Locking file...</source>
+        <translation>Bloqueando arquivo...</translation>
+    </message>
+    <message>
+        <source>Getting frame range edit information...</source>
+        <translation>Obtendo informações de edição do intervalo de quadros...</translation>
+    </message>
+    <message>
+        <source>No frame range edited.</source>
+        <translation>Nenhum intervalo de quadros editado.</translation>
+    </message>
+    <message>
+        <source>Updating frame range edit information...</source>
+        <translation>Atualizando informações de edição do intervalo de quadros...</translation>
+    </message>
+    <message>
+        <source>Putting changes...</source>
+        <translation>Colocando alterações...</translation>
+    </message>
+    <message>
+        <source>Updating file...</source>
+        <translation>Atualizando arquivo...</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>SVNUnlockMultiFrameRangeDialog</name>
+    <message>
+        <source>Version Control: Unlock Frame Range</source>
+        <translation>Controle de versão: desbloquear intervalo de quadros</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation>Desbloquear</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Unlocking %1 items...</source>
+        <translation>Desbloqueando %1 itens...</translation>
+    </message>
+    <message>
+        <source>No items to unlock.</source>
+        <translation>Nenhum item para desbloquear.</translation>
+    </message>
+    <message>
+        <source>%1 items to unlock.</source>
+        <translation>%1 itens para desbloquear.</translation>
+    </message>
+</context>
+<context>
+    <name>SVNUpdateAndLockDialog</name>
+    <message>
+        <source>Version Control: Edit</source>
+        <translation>Controle de Versão: Editar</translation>
+    </message>
+    <message>
+        <source>Comment:</source>
+        <translation>Comentário:</translation>
+    </message>
+    <message>
+        <source>Edit Scene Contents</source>
+        <translation>Editar conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Get And Edit </source>
+        <translation>Obtenha e edite</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>No items to edit.</source>
+        <translation>Nenhum item para editar.</translation>
+    </message>
+    <message>
+        <source>%1 items to edit.</source>
+        <translation>%1 itens para editar.</translation>
+    </message>
+    <message>
+        <source>Updating %1 items...</source>
+        <translation>Atualizando %1 itens...</translation>
+    </message>
+    <message>
+        <source>Editing %1 items...</source>
+        <translation>Editando %1 itens...</translation>
+    </message>
+</context>
+<context>
+    <name>SVNUpdateDialog</name>
+    <message>
+        <source>Version Control: Update</source>
+        <translation>Controle de versão: atualização</translation>
+    </message>
+    <message>
+        <source>Getting repository status...</source>
+        <translation>Obtendo status do repositório...</translation>
+    </message>
+    <message>
+        <source>Get Scene Contents</source>
+        <translation>Obtenha o conteúdo da cena</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation>Atualizar</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>%1 items to update.</source>
+        <translation>%1 itens a serem atualizados.</translation>
+    </message>
+    <message>
+        <source>Update to:</source>
+        <translation>Atualizar para:</translation>
+    </message>
+    <message>
+        <source>Some conflict found. Select..</source>
+        <translation>Algum conflito encontrado. Selecione..</translation>
+    </message>
+    <message>
+        <source>No items to update.</source>
+        <translation>Nenhum item para atualizar.</translation>
+    </message>
+    <message>
+        <source>Some items are currently modified in your working copy.
+Please commit or revert changes first.</source>
+        <translation>Alguns itens estão atualmente modificados em sua cópia de trabalho.
+Confirme ou reverta as alterações primeiro.</translation>
+    </message>
+    <message>
+        <source>Updating items...</source>
+        <translation>Atualizando itens...</translation>
+    </message>
+    <message>
+        <source>Updating to their items...</source>
+        <translation>Atualizando seus itens...</translation>
+    </message>
+</context>
+<context>
+    <name>SaveBoardImagePopup</name>
+    <message>
+        <source>Export Board Image</source>
+        <translation>Exportar imagem do quadro</translation>
+    </message>
+</context>
+<context>
+    <name>SaveBoardPresetFilePopup</name>
+    <message>
+        <source>Save Clapperboard Settings As Preset</source>
+        <translation>Salvar configurações da claquete como predefinições</translation>
+    </message>
+</context>
+<context>
+    <name>SaveCurvePopup</name>
+    <message>
+        <source>Save Curve</source>
+        <translation>Salvar curva</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>SaveImagesPopup</name>
+    <message>
+        <source>Save Flipbook Images</source>
+        <translation>Salvar imagens do flipbook</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>SaveLevelAsPopup</name>
+    <message>
+        <source>Save Level</source>
+        <translation>Salvar nível</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>SaveLogTxtPopup</name>
+    <message>
+        <source>Failed to open the file %1</source>
+        <translation>Não foi possível abrir o arquivo % 1</translation>
+    </message>
+</context>
+<context>
+    <name>SavePaletteAsPopup</name>
+    <message>
+        <source>Save Palette</source>
+        <translation>Salvar paleta</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>SavePresetPopup</name>
+    <message>
+        <source>Save Preset</source>
+        <translation>Salvar predefinição</translation>
+    </message>
+    <message>
+        <source>Preset Name:</source>
+        <translation>Nome predefinido:</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the preset folder %1.</source>
+        <translation>Não é possível criar a pasta predefinida %1.</translation>
+    </message>
+    <message>
+        <source>Do you want to overwrite?</source>
+        <translation>Você deseja sobrescrever?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+</context>
+<context>
+    <name>SavePreviewedPopup</name>
+    <message>
+        <source>Save Previewed Images</source>
+        <translation>Salvar imagens visualizadas</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>SaveSceneAsPopup</name>
+    <message>
+        <source>Save Scene</source>
+        <translation>Salvar cena</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>SaveSettingsPopup</name>
+    <message>
+        <source>Save Cleanup Settings</source>
+        <translation>Salvar configurações de limpeza</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>SaveSubSceneAsPopup</name>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Sub-xsheet</source>
+        <translation>Sub-xplanilha</translation>
+    </message>
+</context>
+<context>
+    <name>SaveTaskListPopup</name>
+    <message>
+        <source>Save Task List</source>
+        <translation>Salvar lista de tarefas</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+</context>
+<context>
+    <name>ScanSettingsPopup</name>
+    <message>
+        <source>Scan Settings</source>
+        <translation>Configurações de digitalização</translation>
+    </message>
+    <message>
+        <source>[no scanner]</source>
+        <translation>[sem scanner]</translation>
+    </message>
+    <message>
+        <source>Paper Format:</source>
+        <translation>Formato do papel:</translation>
+    </message>
+    <message>
+        <source>Reverse Order</source>
+        <translation>Ordem inversa</translation>
+    </message>
+    <message>
+        <source>Paper Feeder</source>
+        <translation>Alimentador de papel</translation>
+    </message>
+    <message>
+        <source>Dpi: </source>
+        <translation>Dpi:</translation>
+    </message>
+    <message>
+        <source>Mode:</source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Brightness: </source>
+        <translation>Brilho:</translation>
+    </message>
+    <message>
+        <source>Threshold: </source>
+        <translation>Limite:</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowser</name>
+    <message>
+        <source>Some files that you want to edit are currently opened. Close them first.</source>
+        <translation>Alguns arquivos que você deseja editar estão abertos no momento. Feche-os primeiro.</translation>
+    </message>
+    <message>
+        <source>Some files that you want to unlock are currently opened. Close them first.</source>
+        <translation>Alguns arquivos que você deseja desbloquear estão abertos no momento. Feche-os primeiro.</translation>
+    </message>
+    <message>
+        <source>Folder: </source>
+        <translation>Pasta:</translation>
+    </message>
+    <message>
+        <source>Open folder failed</source>
+        <translation>Falha ao abrir pasta</translation>
+    </message>
+    <message>
+        <source>The input folder path was invalid.</source>
+        <translation>O caminho da pasta de entrada era inválido.</translation>
+    </message>
+    <message>
+        <source>Can't change file extension</source>
+        <translation>Não é possível alterar a extensão do arquivo</translation>
+    </message>
+    <message>
+        <source>Can't set a drawing number</source>
+        <translation>Não é possível definir um número de desenho</translation>
+    </message>
+    <message>
+        <source>Can't rename. File already exists: </source>
+        <translation>Não é possível renomear. O arquivo já existe:</translation>
+    </message>
+    <message>
+        <source>Couldn't rename </source>
+        <translation>Não foi possível renomear</translation>
+    </message>
+    <message>
+        <source>Load As Sub-xsheet</source>
+        <translation>Carregar como sub-planilha</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Renomear</translation>
+    </message>
+    <message>
+        <source>Convert to Painted TLV</source>
+        <translation>Converter para TLV pintado</translation>
+    </message>
+    <message>
+        <source>Convert to Unpainted TLV</source>
+        <translation>Converter para TLV sem pintura</translation>
+    </message>
+    <message>
+        <source>Version Control</source>
+        <translation>Controle de versão</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Edit Frame Range...</source>
+        <translation>Editar intervalo de quadros...</translation>
+    </message>
+    <message>
+        <source>Put...</source>
+        <translation>Colocar...</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>Reverter</translation>
+    </message>
+    <message>
+        <source>Get</source>
+        <translation>Pegar</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Get Revision...</source>
+        <translation>Obter revisão...</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation>Desbloquear</translation>
+    </message>
+    <message>
+        <source>Edit Info</source>
+        <translation>Editar informações</translation>
+    </message>
+    <message>
+        <source>Revision History...</source>
+        <translation>Histórico de revisões...</translation>
+    </message>
+    <message>
+        <source>Unlock Frame Range</source>
+        <translation>Desbloquear intervalo de quadros</translation>
+    </message>
+    <message>
+        <source>Save Scene</source>
+        <translation>Salvar cena</translation>
+    </message>
+    <message>
+        <source>Scene name:</source>
+        <translation>Nome da cena:</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1 to %2</source>
+        <translation>Ocorreu um erro ao copiar % 1 para % 2</translation>
+    </message>
+    <message>
+        <source>Convert To Unpainted Tlv</source>
+        <translation>Converter para Tlv sem pintura</translation>
+    </message>
+    <message>
+        <source>Warning: level %1 already exists; overwrite?</source>
+        <translation>Aviso: o nível %1 já existe; substituir?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Done: All Levels  converted to TLV Format</source>
+        <translation>Concluído: todos os níveis convertidos para o formato TLV</translation>
+    </message>
+    <message>
+        <source>Convert To Painted Tlv</source>
+        <translation>Converter para Tlv pintado</translation>
+    </message>
+    <message>
+        <source>Done: 2 Levels  converted to TLV Format</source>
+        <translation>Concluído: 2 níveis convertidos para o formato TLV</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation>Nova pasta</translation>
+    </message>
+    <message>
+        <source>It is not possible to create the %1 folder.</source>
+        <translation>Não é possível criar a pasta %1.</translation>
+    </message>
+</context>
+<context>
+    <name>SceneBrowserButtonBar</name>
+    <message>
+        <source>Create new scene</source>
+        <translation>Criar nova cena</translation>
+    </message>
+    <message>
+        <source>Create scene</source>
+        <translation>Criar cena</translation>
+    </message>
+</context>
+<context>
+    <name>SceneSettingsPopup</name>
+    <message>
+        <source>Scene Settings</source>
+        <translation>Configurações de cena</translation>
+    </message>
+    <message>
+        <source>          Frame Rate:</source>
+        <translation>Taxa de quadros:</translation>
+    </message>
+    <message>
+        <source>Camera BG Color:</source>
+        <translation>Cor BG da câmera:</translation>
+    </message>
+    <message>
+        <source>Viewer BG Color:</source>
+        <translation>Cor BG do visualizador:</translation>
+    </message>
+    <message>
+        <source>Preview BG Color:</source>
+        <translation>Visualizar cor BG:</translation>
+    </message>
+    <message>
+        <source>Checkerboard Color 1:</source>
+        <translation>Cor do tabuleiro de xadrez 1:</translation>
+    </message>
+    <message>
+        <source>Checkerboard Color 2:</source>
+        <translation>Cor do tabuleiro de xadrez 2:</translation>
+    </message>
+    <message>
+        <source>Image Subsampling:</source>
+        <translation>Subamostragem de imagem:</translation>
+    </message>
+    <message>
+        <source>      Marker Interval:</source>
+        <translation>Intervalo do marcador:</translation>
+    </message>
+    <message>
+        <source>A/R:</source>
+        <translation>Contas a receber:</translation>
+    </message>
+    <message>
+        <source>Safe Area Box 2:</source>
+        <translation>Caixa de Área Segura 2:</translation>
+    </message>
+    <message>
+        <source>Safe Area Box 1:</source>
+        <translation>Caixa de área segura 1:</translation>
+    </message>
+    <message>
+        <source>TLV Subsampling:</source>
+        <translation>Subamostragem TLV:</translation>
+    </message>
+    <message>
+        <source>Start Frame:</source>
+        <translation>Quadro inicial:</translation>
+    </message>
+    <message>
+        <source>Level And Column Icon:</source>
+        <translation>Ícone de nível e coluna:</translation>
+    </message>
+    <message>
+        <source>Field Guide Size:</source>
+        <translation>Tamanho do guia de campo:</translation>
+    </message>
+    <message>
+        <source>Frame Rate:</source>
+        <translation>Taxa de quadros:</translation>
+    </message>
+    <message>
+        <source>Marker Interval:</source>
+        <translation>Intervalo do marcador:</translation>
+    </message>
+    <message>
+        <source>  Start Frame:</source>
+        <translation>Quadro inicial:</translation>
+    </message>
+    <message>
+        <source>Enable Column Color Filter and Transparency for Rendering</source>
+        <translation>Ativar filtro de cores de coluna e transparência para renderização</translation>
+    </message>
+    <message>
+        <source>Edit Cell Marks</source>
+        <translation>Editar marcas de células</translation>
+    </message>
+    <message>
+        <source>Cell Marks:</source>
+        <translation>Marcas de células:</translation>
+    </message>
+    <message>
+        <source>Edit Column Color Filters</source>
+        <translation>Editar filtros de cores de coluna</translation>
+    </message>
+</context>
+<context>
+    <name>SceneViewer</name>
+    <message>
+        <source>FROZEN</source>
+        <translation>CONGELADO</translation>
+    </message>
+    <message>
+        <source>Motion Path Selected</source>
+        <translation>Caminho de movimento selecionado</translation>
+    </message>
+    <message>
+        <source>Transparency Check</source>
+        <translation>Verificação de transparência</translation>
+    </message>
+    <message>
+        <source>Ink Check</source>
+        <translation>Verificação de tinta</translation>
+    </message>
+    <message>
+        <source>Ink#1 Check</source>
+        <translation>Verificação de tinta nº 1</translation>
+    </message>
+    <message>
+        <source>Paint Check</source>
+        <translation>Verificação de pintura</translation>
+    </message>
+    <message>
+        <source>Inks Only Check</source>
+        <translation>Verificação apenas de tintas</translation>
+    </message>
+    <message>
+        <source>Black BG Check</source>
+        <translation>Verificação de glicemia preta</translation>
+    </message>
+    <message>
+        <source>Fill Check</source>
+        <translation>Verificação de preenchimento</translation>
+    </message>
+    <message>
+        <source>Gap Check</source>
+        <translation>Verificação de lacuna</translation>
+    </message>
+</context>
+<context>
+    <name>SceneViewerContextMenu</name>
+    <message>
+        <source>Swap Compared Images</source>
+        <translation>Trocar imagens comparadas</translation>
+    </message>
+    <message>
+        <source>Save Previewed Frames</source>
+        <translation>Salvar quadros visualizados</translation>
+    </message>
+    <message>
+        <source>Regenerate Preview</source>
+        <translation>Pré-visualização regenerada</translation>
+    </message>
+    <message>
+        <source>Regenerate Frame Preview</source>
+        <translation>Regenerar visualização do quadro</translation>
+    </message>
+    <message>
+        <source>Select </source>
+        <translation>Selecione</translation>
+    </message>
+    <message>
+        <source>Show </source>
+        <translation>Mostrar</translation>
+    </message>
+    <message>
+        <source>Hide </source>
+        <translation>Esconder</translation>
+    </message>
+    <message>
+        <source>Show / Hide</source>
+        <translation>Mostrar/Ocultar</translation>
+    </message>
+    <message>
+        <source>Reset Subcamera</source>
+        <translation>Redefinir subcâmera</translation>
+    </message>
+    <message>
+        <source>Select Camera</source>
+        <translation>Selecione Câmera</translation>
+    </message>
+    <message>
+        <source>Select Pegbar</source>
+        <translation>Selecione PegBar</translation>
+    </message>
+    <message>
+        <source>Select Column</source>
+        <translation>Selecione Coluna</translation>
+    </message>
+    <message>
+        <source>Vector Guided Drawing</source>
+        <translation>Desenho guiado por vetor</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Desligado</translation>
+    </message>
+    <message>
+        <source>Closest Drawing</source>
+        <translation>Desenho mais próximo</translation>
+    </message>
+    <message>
+        <source>Farthest Drawing</source>
+        <translation>Desenho mais distante</translation>
+    </message>
+    <message>
+        <source>All Drawings</source>
+        <translation>Todos os desenhos</translation>
+    </message>
+    <message>
+        <source>Show %1</source>
+        <translation>Mostrar % 1</translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation>Ocultar % 1</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Mesa de animação</translation>
+    </message>
+    <message>
+        <source>Select %1</source>
+        <translation>Selecione % 1</translation>
+    </message>
+    <message>
+        <source>Flip View</source>
+        <translation>Inverter visualização</translation>
+    </message>
+    <message>
+        <source>Reset View</source>
+        <translation>Redefinir visualização</translation>
+    </message>
+    <message>
+        <source>Auto Inbetween</source>
+        <translation>Intermediário automático</translation>
+    </message>
+    <message>
+        <source>Linear Interpolation</source>
+        <translation>Interpolação Linear</translation>
+    </message>
+    <message>
+        <source>Ease In Interpolation</source>
+        <translation>Facilidade na interpolação</translation>
+    </message>
+    <message>
+        <source>Ease Out Interpolation</source>
+        <translation>Facilitar a interpolação</translation>
+    </message>
+    <message>
+        <source>Ease In/Out Interpolation</source>
+        <translation>Facilidade de interpolação de entrada/saída</translation>
+    </message>
+    <message>
+        <source>Rotate View</source>
+        <translation>Girar visualização</translation>
+    </message>
+</context>
+<context>
+    <name>SceneViewerPanel</name>
+    <message>
+        <source>Freeze</source>
+        <translation>Congelar</translation>
+    </message>
+    <message>
+        <source>Camera Stand View</source>
+        <translation>Vista do suporte da câmera</translation>
+    </message>
+    <message>
+        <source>3D View</source>
+        <translation>Visualização 3D</translation>
+    </message>
+    <message>
+        <source>Camera View</source>
+        <translation>Visualização da câmera</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Sub-camera Preview</source>
+        <translation>Visualização da subcâmera</translation>
+    </message>
+    <message>
+        <source>Untitled</source>
+        <translation>Sem título</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation>Cena:</translation>
+    </message>
+    <message>
+        <source>   ::   Frame: </source>
+        <translation>::   Quadro:</translation>
+    </message>
+    <message>
+        <source>   ::   Level: </source>
+        <translation>::   Nível:</translation>
+    </message>
+    <message>
+        <source>Level: </source>
+        <translation>Nível:</translation>
+    </message>
+    <message>
+        <source>  ::  Zoom : </source>
+        <translation>:: Zoom:</translation>
+    </message>
+    <message>
+        <source>Safe Area (Right Click to Select)</source>
+        <translation>Área segura (clique com o botão direito para selecionar)</translation>
+    </message>
+    <message>
+        <source>Field Guide</source>
+        <translation>Guia de campo</translation>
+    </message>
+    <message>
+        <source> (Flipped)</source>
+        <translation>(Invertido)</translation>
+    </message>
+    <message>
+        <source>[SCENE]: </source>
+        <translation>[CENA]:</translation>
+    </message>
+    <message>
+        <source>[LEVEL]: </source>
+        <translation>[NÍVEL]:</translation>
+    </message>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation>Mostrar/ocultar GUI</translation>
+    </message>
+    <message>
+        <source>Playback Toolbar</source>
+        <translation>Barra de ferramentas de reprodução</translation>
+    </message>
+    <message>
+        <source>Frame Slider</source>
+        <translation>Controle deslizante de quadro</translation>
+    </message>
+</context>
+<context>
+    <name>SeparateColorsPopup</name>
+    <message>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message>
+        <source>Preview</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Separate</source>
+        <translation>Separar</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Sub Color 3:</source>
+        <translation>Subcor 3:</translation>
+    </message>
+    <message>
+        <source>Alpha Matting</source>
+        <translation>Tapete Alfa</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation>Principal</translation>
+    </message>
+    <message>
+        <source>Sub1</source>
+        <translation>Sub1</translation>
+    </message>
+    <message>
+        <source>Sub2</source>
+        <translation>Sub2</translation>
+    </message>
+    <message>
+        <source>Sub3</source>
+        <translation>Sub3</translation>
+    </message>
+    <message>
+        <source>Pick Color</source>
+        <translation>Escolha a cor</translation>
+    </message>
+    <message>
+        <source>Show Mask</source>
+        <translation>Mostrar máscara</translation>
+    </message>
+    <message>
+        <source>Show Alpha</source>
+        <translation>Mostrar alfa</translation>
+    </message>
+    <message>
+        <source>Preview Frame:</source>
+        <translation>Quadro de visualização:</translation>
+    </message>
+    <message>
+        <source>Paper Color:</source>
+        <translation>Cor do papel:</translation>
+    </message>
+    <message>
+        <source>Main Color:</source>
+        <translation>Cor principal:</translation>
+    </message>
+    <message>
+        <source>Sub Color 1:</source>
+        <translation>Subcor 1:</translation>
+    </message>
+    <message>
+        <source>Sub Color 2:</source>
+        <translation>Subcor 2:</translation>
+    </message>
+    <message>
+        <source>Sub Adjust:</source>
+        <translation>Subajuste:</translation>
+    </message>
+    <message>
+        <source>Border Smooth:</source>
+        <translation>Borda Suave:</translation>
+    </message>
+    <message>
+        <source>Mask Threshold:</source>
+        <translation>Limite de máscara:</translation>
+    </message>
+    <message>
+        <source>Mask Radius:</source>
+        <translation>Raio da máscara:</translation>
+    </message>
+    <message>
+        <source>Start:</source>
+        <translation>Começar:</translation>
+    </message>
+    <message>
+        <source>End:</source>
+        <translation>Fim:</translation>
+    </message>
+    <message>
+        <source>Format:</source>
+        <translation>Formatar:</translation>
+    </message>
+    <message>
+        <source>Save in:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>File Suffix:</source>
+        <translation>Sufixo do arquivo:</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Separate by colors ... </source>
+        <translation>Separe por cores...</translation>
+    </message>
+    <message>
+        <source>Separate 1 Level</source>
+        <translation>Separe 1 nível</translation>
+    </message>
+    <message>
+        <source>Separate %1 Levels</source>
+        <translation>Níveis %1 separados</translation>
+    </message>
+    <message>
+        <source>Critical</source>
+        <translation>Crítico</translation>
+    </message>
+    <message>
+        <source>Failed to access the destination folder!</source>
+        <translation>Falha ao acessar a pasta de destino!</translation>
+    </message>
+    <message>
+        <source>Separating %1</source>
+        <translation>Separando % 1</translation>
+    </message>
+    <message>
+        <source>Converting level %1 of %2: %3</source>
+        <translation>Convertendo o nível %1 de %2: %3</translation>
+    </message>
+    <message>
+        <source>Save Settings</source>
+        <translation>Salvar configurações</translation>
+    </message>
+    <message>
+        <source>Load Settings</source>
+        <translation>Carregar configurações</translation>
+    </message>
+    <message>
+        <source>Failed to load %1.</source>
+        <translation>Falha ao carregar %1.</translation>
+    </message>
+    <message>
+        <source>Failed to create the folder.</source>
+        <translation>Falha ao criar a pasta.</translation>
+    </message>
+</context>
+<context>
+    <name>SeparateSwatch</name>
+    <message>
+        <source>Sub Color 3</source>
+        <translation>Subcor 3</translation>
+    </message>
+    <message>
+        <source>Original</source>
+        <translation>Original</translation>
+    </message>
+    <message>
+        <source>Main Color</source>
+        <translation>Cor Principal</translation>
+    </message>
+    <message>
+        <source>Sub Color 1</source>
+        <translation>Subcor 1</translation>
+    </message>
+    <message>
+        <source>Sub Color 2</source>
+        <translation>Subcor 2</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutPopup</name>
+    <message>
+        <source>Configure Shortcuts</source>
+        <translation>Configurar atalhos</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+    <message>
+        <source>Couldn't find any matching command.</source>
+        <translation>Não foi possível encontrar nenhum comando correspondente.</translation>
+    </message>
+    <message>
+        <source>Export Current Shortcuts</source>
+        <translation>Exportar atalhos atuais</translation>
+    </message>
+    <message>
+        <source>Delete Current Preset</source>
+        <translation>Excluir predefinição atual</translation>
+    </message>
+    <message>
+        <source>Save Current Shortcuts as New Preset</source>
+        <translation>Salvar atalhos atuais como nova predefinição</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Use selected preset as shortcuts</source>
+        <translation>Use predefinições selecionadas como atalhos</translation>
+    </message>
+    <message>
+        <source>Clear All Shortcuts</source>
+        <translation>Limpar todos os atalhos</translation>
+    </message>
+    <message>
+        <source>This will erase ALL shortcuts. Continue?</source>
+        <translation>Isso apagará TODOS os atalhos. Continuar?</translation>
+    </message>
+    <message>
+        <source>This will overwrite all current shortcuts. Continue?</source>
+        <translation>Isso substituirá todos os atalhos atuais. Continuar?</translation>
+    </message>
+    <message>
+        <source>A file named </source>
+        <translation>Um arquivo chamado</translation>
+    </message>
+    <message>
+        <source> already exists.  Do you want to replace it?</source>
+        <translation>já existe.  Você quer substituí-lo?</translation>
+    </message>
+    <message>
+        <source>OpenToonz - Setting Shortcuts</source>
+        <translation>OpenToonz - Configurando atalhos</translation>
+    </message>
+    <message>
+        <source>Included presets cannot be deleted.</source>
+        <translation>As predefinições incluídas não podem ser excluídas.</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete the preset: </source>
+        <translation>Tem certeza de que deseja excluir a predefinição:</translation>
+    </message>
+    <message>
+        <source>?</source>
+        <translation>?</translation>
+    </message>
+    <message>
+        <source>Load from file...</source>
+        <translation>Carregar do arquivo...</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Shortcut Presets</source>
+        <translation>Predefinições de atalho</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Save As</source>
+        <translation>Salvar como</translation>
+    </message>
+    <message>
+        <source>Search:</source>
+        <translation>Procurar:</translation>
+    </message>
+    <message>
+        <source>Preset:</source>
+        <translation>Predefinição:</translation>
+    </message>
+    <message>
+        <source>Saving Shortcuts</source>
+        <translation>Salvando atalhos</translation>
+    </message>
+    <message>
+        <source>Setting Shortcuts</source>
+        <translation>Configurando atalhos</translation>
+    </message>
+    <message>
+        <source>Enter Preset Name</source>
+        <translation>Insira o nome predefinido</translation>
+    </message>
+    <message>
+        <source>Preset Name:</source>
+        <translation>Nome predefinido:</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutTree</name>
+    <message>
+        <source>Menu Commands</source>
+        <translation>Comandos de menu</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Scan &amp; Cleanup</source>
+        <translation>Digitalizar e limpar</translation>
+    </message>
+    <message>
+        <source>Level</source>
+        <translation>Nível</translation>
+    </message>
+    <message>
+        <source>Xsheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>Cells</source>
+        <translation>Células</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>Exibir</translation>
+    </message>
+    <message>
+        <source>Windows</source>
+        <translation>Windows</translation>
+    </message>
+    <message>
+        <source>Right-click Menu Commands</source>
+        <translation>Comandos de menu do botão direito</translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation>Ferramentas</translation>
+    </message>
+    <message>
+        <source>Tool Modifiers</source>
+        <translation>Modificadores de ferramentas</translation>
+    </message>
+    <message>
+        <source>Visualization</source>
+        <translation>Visualização</translation>
+    </message>
+    <message>
+        <source>Playback Controls</source>
+        <translation>Controles de reprodução</translation>
+    </message>
+    <message>
+        <source>RGBA Channels</source>
+        <translation>Canais RGBA</translation>
+    </message>
+    <message>
+        <source>Fill</source>
+        <translation>Preencher</translation>
+    </message>
+    <message>
+        <source>Misc</source>
+        <translation>Diversos</translation>
+    </message>
+    <message>
+        <source>Playback</source>
+        <translation>Reprodução</translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation>Jogar</translation>
+    </message>
+    <message>
+        <source>Render</source>
+        <translation>Renderizar</translation>
+    </message>
+    <message>
+        <source>Help</source>
+        <translation>Ajuda</translation>
+    </message>
+    <message>
+        <source>Stop Motion</source>
+        <translation>Parar movimento</translation>
+    </message>
+    <message>
+        <source>Cell Mark</source>
+        <translation>Marca de célula</translation>
+    </message>
+    <message>
+        <source>SubMenu Commands</source>
+        <translation>Comandos de submenu</translation>
+    </message>
+    <message>
+        <source>Advanced</source>
+        <translation>Avançado</translation>
+    </message>
+    <message>
+        <source>Custom Panels</source>
+        <translation>Painéis personalizados</translation>
+    </message>
+    <message>
+        <source>Brush Presets</source>
+        <translation>Predefinições de pincel</translation>
+    </message>
+    <message>
+        <source>Brush Sizes</source>
+        <translation>Tamanhos de pincel</translation>
+    </message>
+    <message>
+        <source>Special Modifier Keys</source>
+        <translation>Teclas modificadoras especiais</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutViewer</name>
+    <message>
+        <source>%1 is already assigned to '%2'
+Assign to '%3'?</source>
+        <translation>% 1 já está atribuído a '% 2'
+Atribuir a '%3'?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>'%1' is already assigned to '%2'
+Assign to '%3'?</source>
+        <translation>'%1' já está atribuído a '%2'
+Atribuir a '%3'?</translation>
+    </message>
+    <message>
+        <source>Initial sequence '%1' is assigned to '%2' which takes priority.
+Assign shortcut sequence anyway?</source>
+        <translation>A sequência inicial '%1' é atribuída a '%2' que tem prioridade.
+Atribuir sequência de atalhos mesmo assim?</translation>
+    </message>
+</context>
+<context>
+    <name>StackedMenuBar</name>
+    <message>
+        <source>Files</source>
+        <translation>Arquivos</translation>
+    </message>
+    <message>
+        <source>Scan</source>
+        <translation>Digitalizar</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Configurações</translation>
+    </message>
+    <message>
+        <source>Processing</source>
+        <translation>Processamento</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <source>Windows</source>
+        <translation>Windows</translation>
+    </message>
+    <message>
+        <source>Other Windows</source>
+        <translation>Outras janelas</translation>
+    </message>
+    <message>
+        <source>Customize</source>
+        <translation>Personalizar</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>Exibir</translation>
+    </message>
+    <message>
+        <source>Tools</source>
+        <translation>Ferramentas</translation>
+    </message>
+    <message>
+        <source>More Tools</source>
+        <translation>Mais ferramentas</translation>
+    </message>
+    <message>
+        <source>Checks</source>
+        <translation>Cheques</translation>
+    </message>
+    <message>
+        <source>Render</source>
+        <translation>Renderizar</translation>
+    </message>
+    <message>
+        <source>Draw</source>
+        <translation>Empate</translation>
+    </message>
+    <message>
+        <source>Xsheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>Subxsheet</source>
+        <translation>Subxplanilha</translation>
+    </message>
+    <message>
+        <source>Levels</source>
+        <translation>Níveis</translation>
+    </message>
+    <message>
+        <source>Cells</source>
+        <translation>Células</translation>
+    </message>
+    <message>
+        <source>Reframe</source>
+        <translation>Reestruturar</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation>Etapa</translation>
+    </message>
+    <message>
+        <source>Each</source>
+        <translation>Cada</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Scan &amp;&amp; Cleanup</source>
+        <translation>Digitalizar e limpar</translation>
+    </message>
+    <message>
+        <source>Level</source>
+        <translation>Nível</translation>
+    </message>
+    <message>
+        <source>Failed to load menu %1</source>
+        <translation>Falha ao carregar o menu % 1</translation>
+    </message>
+    <message>
+        <source>Failed to add command %1</source>
+        <translation>Falha ao adicionar o comando % 1</translation>
+    </message>
+    <message>
+        <source>Help</source>
+        <translation>Ajuda</translation>
+    </message>
+    <message>
+        <source>Cannot open menubar settings file %1</source>
+        <translation>Não foi possível abrir o arquivo de configuração da barra de menu % 1</translation>
+    </message>
+    <message>
+        <source>Failed to create menubar</source>
+        <translation>Falha ao criar barra de menu</translation>
+    </message>
+    <message>
+        <source>Project Management</source>
+        <translation>Gerenciamento de projetos</translation>
+    </message>
+    <message>
+        <source>Import</source>
+        <translation>Importar</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Script</source>
+        <translation>Roteiro</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Grupo</translation>
+    </message>
+    <message>
+        <source>Arrange</source>
+        <translation>Arranjo</translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <source>Adjust</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <source>Optimize</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation>Converter</translation>
+    </message>
+    <message>
+        <source>Drawing Substitution</source>
+        <translation>Substituição de desenho</translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation>Jogar</translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Espaço de trabalho</translation>
+    </message>
+</context>
+<context>
+    <name>StartupPopup</name>
+    <message>
+        <source>OpenToonz Startup</source>
+        <translation>Inicialização do OpenToonz</translation>
+    </message>
+    <message>
+        <source>Choose Project</source>
+        <translation>Escolha o projeto</translation>
+    </message>
+    <message>
+        <source>Create a New Scene</source>
+        <translation>Crie uma nova cena</translation>
+    </message>
+    <message>
+        <source>Open Scene</source>
+        <translation>Cena aberta</translation>
+    </message>
+    <message>
+        <source>Scene Name:</source>
+        <translation>Nome da cena:</translation>
+    </message>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <source>Resolution:</source>
+        <translation>Resolução:</translation>
+    </message>
+    <message>
+        <source>Frame Rate:</source>
+        <translation>Taxa de quadros:</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+    <message>
+        <source>Show this at startup</source>
+        <translation>Mostre isso na inicialização</translation>
+    </message>
+    <message>
+        <source>Create Scene</source>
+        <translation>Criar cena</translation>
+    </message>
+    <message>
+        <source>New Project...</source>
+        <translation>Novo projeto...</translation>
+    </message>
+    <message>
+        <source>Open Another Scene...</source>
+        <translation>Abra outra cena...</translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation>pixel</translation>
+    </message>
+    <message>
+        <source>cm</source>
+        <translation>cm</translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation>milímetros</translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation>polegada</translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation>campo</translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>Camera Size:</source>
+        <translation>Tamanho da câmera:</translation>
+    </message>
+    <message>
+        <source>Units:</source>
+        <translation>Unidades:</translation>
+    </message>
+    <message>
+        <source>No Recent Scenes</source>
+        <translation>Nenhuma cena recente</translation>
+    </message>
+    <message>
+        <source>The name cannot be empty.</source>
+        <translation>O nome não pode ficar vazio.</translation>
+    </message>
+    <message>
+        <source>The chosen file path is not valid.</source>
+        <translation>O caminho do arquivo escolhido não é válido.</translation>
+    </message>
+    <message>
+        <source>The width must be 1 or more.</source>
+        <translation>A largura deve ser 1 ou mais.</translation>
+    </message>
+    <message>
+        <source>The height must be 1 or more.</source>
+        <translation>A altura deve ser 1 ou mais.</translation>
+    </message>
+    <message>
+        <source>The frame rate must be 1 or more.</source>
+        <translation>A taxa de quadros deve ser 1 ou mais.</translation>
+    </message>
+    <message>
+        <source>Preset name</source>
+        <translation>Nome predefinido</translation>
+    </message>
+    <message>
+        <source>Enter the name for %1</source>
+        <translation>Introduza o nome para % 1</translation>
+    </message>
+    <message>
+        <source>Error : Preset Name is Invalid</source>
+        <translation>Erro: o nome predefinido é inválido</translation>
+    </message>
+    <message>
+        <source>The preset name must not use ','(comma).</source>
+        <translation>O nome predefinido não deve usar ','(vírgula).</translation>
+    </message>
+    <message>
+        <source>Bad camera preset</source>
+        <translation>Predefinição de câmera ruim</translation>
+    </message>
+    <message>
+        <source>'%1' doesn't seem to be a well formed camera preset. 
+Possibly the preset file has been corrupted</source>
+        <translation>'%1' não parece ser uma predefinição de câmera bem formada. 
+Possivelmente o arquivo predefinido foi corrompido</translation>
+    </message>
+    <message>
+        <source>The width must be greater than zero.</source>
+        <translation>A largura deve ser maior que zero.</translation>
+    </message>
+    <message>
+        <source>The height must be greater than zero.</source>
+        <translation>A altura deve ser maior que zero.</translation>
+    </message>
+    <message>
+        <source>Automatically Save Every </source>
+        <translation>Salvar automaticamente todos</translation>
+    </message>
+    <message>
+        <source>Minutes</source>
+        <translation>Minutos</translation>
+    </message>
+    <message>
+        <source>Current Project</source>
+        <translation>Projeto Atual</translation>
+    </message>
+    <message>
+        <source>Recent Scenes [Project]</source>
+        <translation>Cenas Recentes [Projeto]</translation>
+    </message>
+    <message>
+        <source>Failed to create the folder.</source>
+        <translation>Falha ao criar a pasta.</translation>
+    </message>
+    <message>
+        <source>Open Project...</source>
+        <translation>Abrir projeto...</translation>
+    </message>
+    <message>
+        <source>Explore Folder</source>
+        <translation>Explorar pasta</translation>
+    </message>
+    <message>
+        <source>Open Existing Scene</source>
+        <translation>Abrir cena existente</translation>
+    </message>
+    <message>
+        <source>New Scene</source>
+        <translation>Nova cena</translation>
+    </message>
+</context>
+<context>
+    <name>StopMotion</name>
+    <message>
+        <source>No</source>
+        <comment>frame id</comment>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>No level name specified: please choose a valid level name</source>
+        <translation>Nenhum nome de nível especificado: escolha um nome de nível válido</translation>
+    </message>
+    <message>
+        <source>The level name specified is already used: please choose a different level name.</source>
+        <translation>O nome do nível especificado já está em uso: escolha um nome de nível diferente.</translation>
+    </message>
+    <message>
+        <source>The save in path specified does not match with the existing level.</source>
+        <translation>O caminho para salvar especificado não corresponde ao nível existente.</translation>
+    </message>
+    <message>
+        <source>The captured image size does not match with the existing level.</source>
+        <translation>O tamanho da imagem capturada não corresponde ao nível existente.</translation>
+    </message>
+    <message>
+        <source>File %1 already exists.
+Do you want to overwrite it?</source>
+        <translation>O arquivo %1 já existe.
+Você quer sobrescrevê-lo?</translation>
+    </message>
+    <message>
+        <source>Failed to load %1.</source>
+        <translation>Falha ao carregar %1.</translation>
+    </message>
+    <message>
+        <source>Folder %1 doesn't exist.
+Do you want to create it?</source>
+        <translation>A pasta% 1 não existe.
+Você quer criá-lo?</translation>
+    </message>
+    <message>
+        <source>Unable to create</source>
+        <translation>Não foi possível criar</translation>
+    </message>
+    <message>
+        <source>UNDEFINED WARNING</source>
+        <translation>AVISO INDEFINIDO</translation>
+    </message>
+    <message>
+        <source>The level is not registered in the scene, but exists in the file system.</source>
+        <translation>O nível não está registrado na cena, mas existe no sistema de arquivos.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The saved image size is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho da imagem salva é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>WARNING </source>
+        <translation>AVISO</translation>
+    </message>
+    <message>
+        <source>
+Frame %1 exists.</source>
+        <translation>O quadro %1 existe.</translation>
+    </message>
+    <message>
+        <source>
+Frames %1 exist.</source>
+        <translation>Os quadros %1 existem.</translation>
+    </message>
+    <message>
+        <source>OVERWRITE 1 of</source>
+        <translation>SUBSTITUIR 1 de</translation>
+    </message>
+    <message>
+        <source>ADD to</source>
+        <translation>Adicionar à</translation>
+    </message>
+    <message>
+        <source> %1 frame</source>
+        <translation>%1 quadro</translation>
+    </message>
+    <message>
+        <source> %1 frames</source>
+        <translation>%1 quadros</translation>
+    </message>
+    <message>
+        <source>The level will be newly created.</source>
+        <translation>O nível será criado recentemente.</translation>
+    </message>
+    <message>
+        <source>NEW</source>
+        <translation>NOVO</translation>
+    </message>
+    <message>
+        <source>The level is already registered in the scene.</source>
+        <translation>O nível já está registrado na cena.</translation>
+    </message>
+    <message>
+        <source>
+NOTE : The level is not saved.</source>
+        <translation>NOTA: O nível não é salvo.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Failed to get image size of the existing level %1.</source>
+        <translation>AVISO: Falha ao obter o tamanho da imagem do nível existente %1.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The existing level size is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho do nível existente é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>WARNING : Level name conflicts. There already is a level %1 in the scene with the path                        
+          %2.</source>
+        <translation>AVISO: Conflitos de nomes de nível. Jáexiste um nível % 1 na cena com o caminho                        
+          %2.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same name is is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho do nível com o mesmo nome é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>WARNING : Level path conflicts. There already is a level with the path %1                        
+          in the scene with the name %2.</source>
+        <translation>AVISO: Conflitos de caminho de nível. Jáexiste um nível com o caminho % 1                        
+          na cena com o nome %2.</translation>
+    </message>
+    <message>
+        <source>
+WARNING : Image size mismatch. The size of level with the same path is %1 x %2.</source>
+        <translation>AVISO: Incompatibilidade de tamanho de imagem. O tamanho do nível com o mesmo caminho é %1 x %2.</translation>
+    </message>
+    <message>
+        <source>WARNING</source>
+        <translation>AVISO</translation>
+    </message>
+    <message>
+        <source>No camera selected.</source>
+        <translation>Nenhuma câmera selecionada.</translation>
+    </message>
+    <message>
+        <source>Please start live view before capturing an image.</source>
+        <translation>Inicie a visualização ao vivo antes de capturar uma imagem.</translation>
+    </message>
+    <message>
+        <source>Cannot capture webcam image unless live view is active.</source>
+        <translation>Não é possível capturar imagens da webcam a menos que a visualização ao vivo esteja ativa.</translation>
+    </message>
+    <message>
+        <source>Please start live view before using time lapse.</source>
+        <translation>Inicie a visualização ao vivo antes de usar o lapso de tempo.</translation>
+    </message>
+    <message>
+        <source>Cannot capture image unless live view is active.</source>
+        <translation>Não é possível capturar imagem a menos que a visualização ao vivo esteja ativa.</translation>
+    </message>
+    <message>
+        <source>No level exists with the current name.</source>
+        <translation>Não existe nenhum nível com o nome atual.</translation>
+    </message>
+    <message>
+        <source>This is not an image level.</source>
+        <translation>Este não é um nível de imagem.</translation>
+    </message>
+    <message>
+        <source>This is not a stop motion level.</source>
+        <translation>Este não é um nível de stop motion.</translation>
+    </message>
+    <message>
+        <source>Could not find an xsheet level with  the current level</source>
+        <translation>Não foi possível encontrar um nível do xsheet com o nível atual</translation>
+    </message>
+    <message>
+        <source>No export path given.</source>
+        <translation>Nenhum caminho de exportação fornecido.</translation>
+    </message>
+    <message>
+        <source>Could not find the source file.</source>
+        <translation>Não foi possível encontrar o arquivo de origem.</translation>
+    </message>
+    <message>
+        <source>Overwrite existing files?</source>
+        <translation>Substituir arquivos existentes?</translation>
+    </message>
+    <message>
+        <source>An error occurred.  Aborting.</source>
+        <translation>Ocorreu um erro.  Abortando.</translation>
+    </message>
+    <message>
+        <source>Successfully exported %1 images.</source>
+        <translation>Exportadas %1 imagens com sucesso.</translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionController</name>
+    <message>
+        <source>Controls</source>
+        <translation>Controles</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Configurações</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+    <message>
+        <source>Resolution: </source>
+        <translation>Resolução:</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Atualizar</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Webcam Settings...</source>
+        <translation>Configurações da webcam...</translation>
+    </message>
+    <message>
+        <source>Capture</source>
+        <translation>Capturar</translation>
+    </message>
+    <message>
+        <source>Next Level</source>
+        <translation>Próximo nível</translation>
+    </message>
+    <message>
+        <source>Next New</source>
+        <translation>Próximo Novo</translation>
+    </message>
+    <message>
+        <source>Previous Level</source>
+        <translation>Nível anterior</translation>
+    </message>
+    <message>
+        <source>Next Frame</source>
+        <translation>Próximo quadro</translation>
+    </message>
+    <message>
+        <source>Last Frame</source>
+        <translation>Último quadro</translation>
+    </message>
+    <message>
+        <source>Previous Frame</source>
+        <translation>Quadro Anterior</translation>
+    </message>
+    <message>
+        <source>Next XSheet Frame</source>
+        <translation>Próximo quadro XSheet</translation>
+    </message>
+    <message>
+        <source>Previous XSheet Frame</source>
+        <translation>Quadro XSheet Anterior</translation>
+    </message>
+    <message>
+        <source>Current Frame</source>
+        <translation>Quadro atual</translation>
+    </message>
+    <message>
+        <source>Set to the Current Playhead Location</source>
+        <translation>Definir para o local atual do Playhead</translation>
+    </message>
+    <message>
+        <source>Start Live View</source>
+        <translation>Iniciar visualização ao vivo</translation>
+    </message>
+    <message>
+        <source>Zoom</source>
+        <translation>Zoom</translation>
+    </message>
+    <message>
+        <source>Pick Zoom</source>
+        <translation>Escolha Zoom</translation>
+    </message>
+    <message>
+        <source>&lt;</source>
+        <translation>&lt;</translation>
+    </message>
+    <message>
+        <source>&gt;</source>
+        <translation>&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;&lt;</source>
+        <translation>&lt;&lt;</translation>
+    </message>
+    <message>
+        <source>&gt;&gt;</source>
+        <translation>&gt;&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;&lt;&lt;</source>
+        <translation>&lt;&lt;&lt;</translation>
+    </message>
+    <message>
+        <source>&gt;&gt;&gt;</source>
+        <translation>&gt;&gt;&gt;</translation>
+    </message>
+    <message>
+        <source>Camera:</source>
+        <translation>Câmera:</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Frame:</source>
+        <translation>Quadro:</translation>
+    </message>
+    <message>
+        <source>File Type:</source>
+        <translation>Tipo de arquivo:</translation>
+    </message>
+    <message>
+        <source>Save In:</source>
+        <translation>Salvar em:</translation>
+    </message>
+    <message>
+        <source>XSheet Frame:</source>
+        <translation>Quadro XSheet:</translation>
+    </message>
+    <message>
+        <source>Camera Model</source>
+        <translation>Modelo de câmera</translation>
+    </message>
+    <message>
+        <source>Camera Mode</source>
+        <translation>Modo Câmera</translation>
+    </message>
+    <message>
+        <source>Temperature: </source>
+        <translation>Temperatura:</translation>
+    </message>
+    <message>
+        <source>Shutter Speed: </source>
+        <translation>Velocidade do obturador:</translation>
+    </message>
+    <message>
+        <source>Iso: </source>
+        <translation>Iso:</translation>
+    </message>
+    <message>
+        <source>Aperture: </source>
+        <translation>Abertura:</translation>
+    </message>
+    <message>
+        <source>Exposure: </source>
+        <translation>Exposição:</translation>
+    </message>
+    <message>
+        <source>Image Quality: </source>
+        <translation>Qualidade de imagem:</translation>
+    </message>
+    <message>
+        <source>Picture Style: </source>
+        <translation>Estilo de imagem:</translation>
+    </message>
+    <message>
+        <source>White Balance: </source>
+        <translation>Balanço de branco:</translation>
+    </message>
+    <message>
+        <source>Webcam Options</source>
+        <translation>Opções de webcam</translation>
+    </message>
+    <message>
+        <source>DSLR Options</source>
+        <translation>Opções DSLR</translation>
+    </message>
+    <message>
+        <source>Place the frame in the XSheet</source>
+        <translation>Coloque a quadro no XSheet</translation>
+    </message>
+    <message>
+        <source>Use Direct Show Webcam Drivers</source>
+        <translation>Use drivers de webcam Direct Show</translation>
+    </message>
+    <message>
+        <source>Black Screen for Capture</source>
+        <translation>Tela preta para captura</translation>
+    </message>
+    <message>
+        <source>Use Reduced Resolution Images</source>
+        <translation>Use imagens de resolução reduzida</translation>
+    </message>
+    <message>
+        <source>Use MJPG with Webcam</source>
+        <translation>Use MJPG com webcam</translation>
+    </message>
+    <message>
+        <source>Place on XSheet</source>
+        <translation>Coloque no XSheet</translation>
+    </message>
+    <message>
+        <source>Use Numpad Shortcuts When Active</source>
+        <translation>Use atalhos do teclado numérico quando ativo</translation>
+    </message>
+    <message>
+        <source>Show Live View on All Frames</source>
+        <translation>Mostrar visualização ao vivo em todos os quadros</translation>
+    </message>
+    <message>
+        <source>Capture Review Time: </source>
+        <translation>Tempo de revisão da captura:</translation>
+    </message>
+    <message>
+        <source>Level Subsampling: </source>
+        <translation>Subamostragem de nível:</translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation>Opacidade:</translation>
+    </message>
+    <message>
+        <source>No camera detected.</source>
+        <translation>Nenhuma câmera detectada.</translation>
+    </message>
+    <message>
+        <source>No camera detected</source>
+        <translation>Nenhuma câmera detectada</translation>
+    </message>
+    <message>
+        <source>- Select camera -</source>
+        <translation>- Selecione a câmera -</translation>
+    </message>
+    <message>
+        <source>Mode: </source>
+        <translation>Modo:</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation>Desabilitado</translation>
+    </message>
+    <message>
+        <source>Stop Live View</source>
+        <translation>Parar a visualização ao vivo</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Luz</translation>
+    </message>
+    <message>
+        <source>Motion</source>
+        <translation>Movimento</translation>
+    </message>
+    <message>
+        <source>Camera Status</source>
+        <translation>Status da câmera</translation>
+    </message>
+    <message>
+        <source>Show original live view images in timeline</source>
+        <translation>Mostrar imagens originais de visualização ao vivo na linha do tempo</translation>
+    </message>
+    <message>
+        <source>Check</source>
+        <translation>Verificar</translation>
+    </message>
+    <message>
+        <source>Zoom in to check focus</source>
+        <translation>Aumente o zoom para verificar o foco</translation>
+    </message>
+    <message>
+        <source>Pick</source>
+        <translation>Escolha</translation>
+    </message>
+    <message>
+        <source>Set focus check location</source>
+        <translation>Definir local de verificação de foco</translation>
+    </message>
+    <message>
+        <source>Select a camera to change settings.</source>
+        <translation>Selecione uma câmera para alterar as configurações.</translation>
+    </message>
+    <message>
+        <source>insert webcam name here</source>
+        <translation>insira o nome da webcam aqui</translation>
+    </message>
+    <message>
+        <source>Manual Focus</source>
+        <translation>Foco manual</translation>
+    </message>
+    <message>
+        <source>Focus: </source>
+        <translation>Foco:</translation>
+    </message>
+    <message>
+        <source>Brightness: </source>
+        <translation>Brilho:</translation>
+    </message>
+    <message>
+        <source>Contrast: </source>
+        <translation>Contraste:</translation>
+    </message>
+    <message>
+        <source>Gain: </source>
+        <translation>Ganho:</translation>
+    </message>
+    <message>
+        <source>Saturation: </source>
+        <translation>Saturação:</translation>
+    </message>
+    <message>
+        <source>More</source>
+        <translation>Mais</translation>
+    </message>
+    <message>
+        <source>Time Lapse</source>
+        <translation>Lapso de tempo</translation>
+    </message>
+    <message>
+        <source>Use time lapse</source>
+        <translation>Usar lapso de tempo</translation>
+    </message>
+    <message>
+        <source>Interval(sec):</source>
+        <translation>Intervalo (seg):</translation>
+    </message>
+    <message>
+        <source>Blackout all Screens</source>
+        <translation>Apagar todas as telas</translation>
+    </message>
+    <message>
+        <source>Test</source>
+        <translation>Teste</translation>
+    </message>
+    <message>
+        <source>Screen 1</source>
+        <translation>Tela 1</translation>
+    </message>
+    <message>
+        <source>Screen 2</source>
+        <translation>Tela 2</translation>
+    </message>
+    <message>
+        <source>Screen 3</source>
+        <translation>Tela 3</translation>
+    </message>
+    <message>
+        <source>Motion Control</source>
+        <translation>Controle de movimento</translation>
+    </message>
+    <message>
+        <source>Port: </source>
+        <translation>Porta:</translation>
+    </message>
+    <message>
+        <source> - Battery: </source>
+        <translation>- Bateria:</translation>
+    </message>
+    <message>
+        <source>Aperture: Auto</source>
+        <translation>Vagas: Carro</translation>
+    </message>
+    <message>
+        <source>Shutter Speed: Auto</source>
+        <translation>Velocidade do obturador: Automático</translation>
+    </message>
+    <message>
+        <source>Start Capturing</source>
+        <translation>Comece a capturar</translation>
+    </message>
+    <message>
+        <source>Stop Capturing</source>
+        <translation>Pare de capturar</translation>
+    </message>
+    <message>
+        <source>Use Time Lapse</source>
+        <translation>Usar lapso de tempo</translation>
+    </message>
+    <message>
+        <source>Requires restarting camera when toggled
+NP 1 = Previous Frame
+NP 2 = Next Frame
+NP 3 = Jump To Camera
+NP 5 = Toggle Live View
+NP 6 = Short Play
+NP 8 = Loop
+NP 0 = Play
+Period = Use Live View Images
+Plus = Raise Opacity
+Minus = Lower Opacity
+Enter = Capture
+BackSpace = Remove Frame
+Multiply = Toggle Zoom
+Divide = Focus Check</source>
+        <translation>Requer reiniciar a câmera quando alternado
+NP 1 = Quadro Anterior
+NP 2 = Próximo Quadro
+NP 3 = Ir para a câmera
+NP 5 = Alternar visualização ao vivo
+NP 6 = Jogo Curto
+NP 8 = Laço
+NP 0 = Jogar
+Período = Usar imagens de visualização ao vivo
+Mais = Aumentar a opacidade
+Menos = Menor Opacidade
+Enter = Capturar
+BackSpace = Remover Quadro
+Multiplicar = Alternar Zoom
+Divisão = verificação de foco</translation>
+    </message>
+    <message>
+        <source>Show Camera Below Other Levels</source>
+        <translation>Mostrar câmera abaixo de outros níveis</translation>
+    </message>
+    <message>
+        <source>Play Sound on Capture</source>
+        <translation>Reproduzir som na captura</translation>
+    </message>
+    <message>
+        <source>Make a click sound on each capture</source>
+        <translation>Faça um som de clique em cada captura</translation>
+    </message>
+</context>
+<context>
+    <name>StopMotionSerial</name>
+    <message>
+        <source>No Device</source>
+        <translation>Nenhum dispositivo</translation>
+    </message>
+</context>
+<context>
+    <name>SubCameraButton</name>
+    <message>
+        <source>Save Current Subcamera</source>
+        <translation>Salvar subcâmera atual</translation>
+    </message>
+    <message>
+        <source>Delete Preset</source>
+        <translation>Excluir predefinição</translation>
+    </message>
+    <message>
+        <source>Delete %1</source>
+        <translation>Excluir % 1</translation>
+    </message>
+    <message>
+        <source>Overwriting the existing subcamera preset. Are you sure?</source>
+        <translation>Substituindo a predefinição de subcâmera existente. Tem certeza?</translation>
+    </message>
+    <message>
+        <source>Question</source>
+        <translation>Pergunta</translation>
+    </message>
+    <message>
+        <source>Deleting the subcamera preset %1. Are you sure?</source>
+        <translation>Excluindo a predefinição da subcâmera %1. Tem certeza?</translation>
+    </message>
+</context>
+<context>
+    <name>SubSheetBar</name>
+    <message>
+        <source>Sub-scene controls: 
+Click the arrow button to create a new sub-xsheet</source>
+        <translation>Controles de subcena: 
+Clique no botão de seta para criar uma nova sub-planilha</translation>
+    </message>
+    <message>
+        <source>Disable Edit in Place</source>
+        <translation>Desativar edição no local</translation>
+    </message>
+    <message>
+        <source>Enable Edit in Place</source>
+        <translation>Ativar edição no local</translation>
+    </message>
+    <message>
+        <source>Exit Sub-xsheet (1 Level Up)</source>
+        <translation>Sair da sub-planilha (1 nível acima)</translation>
+    </message>
+    <message>
+        <source>Exit Sub-xsheet (2 Levels Up)</source>
+        <translation>Sair da sub-planilha (2 níveis acima)</translation>
+    </message>
+    <message>
+        <source>Exit Sub-xsheet (3 or More Levels Up)</source>
+        <translation>Sair da Sub-xsheet (3 ou mais níveis acima)</translation>
+    </message>
+    <message>
+        <source>Enter Sub-xsheet</source>
+        <translation>Digite Sub-xsheet</translation>
+    </message>
+    <message>
+        <source>Current Scene</source>
+        <translation>Cena atual</translation>
+    </message>
+</context>
+<context>
+    <name>T</name>
+    <message>
+        <source>Nothing to replace: no cells or columns selected.</source>
+        <translation>Nada para substituir: nenhuma célula ou coluna selecionada.</translation>
+    </message>
+</context>
+<context>
+    <name>TApp</name>
+    <message>
+        <source>Error allocating memory: not enough memory.</source>
+        <translation>Erro ao alocar memória: memória insuficiente.</translation>
+    </message>
+    <message>
+        <source>It is not possible to save automatically an untitled scene.</source>
+        <translation>Não é possível salvar automaticamente uma cena sem título.</translation>
+    </message>
+    <message>
+        <source>It is not possible to automatically save an untitled scene.</source>
+        <translation>Não é possível salvar automaticamente uma cena sem título.</translation>
+    </message>
+</context>
+<context>
+    <name>TPanel</name>
+    <message>
+        <source>Bind to Current Room</source>
+        <translation>Vincular à sala atual</translation>
+    </message>
+</context>
+<context>
+    <name>TPanelTitleBarButtonForPreview</name>
+    <message>
+        <source>Current frame</source>
+        <translation>Quadro atual</translation>
+    </message>
+    <message>
+        <source>All preview range frames</source>
+        <translation>Todos os quadros do intervalo de visualização</translation>
+    </message>
+    <message>
+        <source>Selected cells - Auto play</source>
+        <translation>Células selecionadas - Reprodução automática</translation>
+    </message>
+</context>
+<context>
+    <name>TaskSheet</name>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Status:</source>
+        <translation>Status:</translation>
+    </message>
+    <message>
+        <source>Command Line:</source>
+        <translation>Linha de comando:</translation>
+    </message>
+    <message>
+        <source>Server:</source>
+        <translation>Servidor:</translation>
+    </message>
+    <message>
+        <source>Submitted By:</source>
+        <translation>Enviado por:</translation>
+    </message>
+    <message>
+        <source>Submitted On:</source>
+        <translation>Enviado em:</translation>
+    </message>
+    <message>
+        <source>Submission Date:</source>
+        <translation>Data de envio:</translation>
+    </message>
+    <message>
+        <source>Start Date:</source>
+        <translation>Data de início:</translation>
+    </message>
+    <message>
+        <source>Completion Date:</source>
+        <translation>Data de conclusão:</translation>
+    </message>
+    <message>
+        <source>Duration:</source>
+        <translation>Duração:</translation>
+    </message>
+    <message>
+        <source>Step Count:</source>
+        <translation>Contagem de passos:</translation>
+    </message>
+    <message>
+        <source>Failed Steps:</source>
+        <translation>Etapas com falha:</translation>
+    </message>
+    <message>
+        <source>Priority:</source>
+        <translation>Prioridade:</translation>
+    </message>
+    <message>
+        <source>Output:</source>
+        <translation>Saída:</translation>
+    </message>
+    <message>
+        <source>Frames per Chunk:</source>
+        <translation>Quadros por pedaço:</translation>
+    </message>
+    <message>
+        <source>From:</source>
+        <translation>De:</translation>
+    </message>
+    <message>
+        <source>To:</source>
+        <translation>Para:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Shrink:</source>
+        <translation>Encolher:</translation>
+    </message>
+    <message>
+        <source>Multiple Rendering:</source>
+        <translation>Renderização múltipla:</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Fx Schematic Flows</source>
+        <translation>Fluxos Esquemáticos FX</translation>
+    </message>
+    <message>
+        <source>Fx Schematic Terminal Nodes</source>
+        <translation>Nós terminais esquemáticos Fx</translation>
+    </message>
+    <message>
+        <source>Dedicated CPUs:</source>
+        <translation>CPUs dedicadas:</translation>
+    </message>
+    <message>
+        <source>Single</source>
+        <translation>Solteiro</translation>
+    </message>
+    <message>
+        <source>Half</source>
+        <translation>Metade</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation>Todos</translation>
+    </message>
+    <message>
+        <source>Render Tile:</source>
+        <translation>Renderizar bloco:</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>Grande</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation>Médio</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>Pequeno</translation>
+    </message>
+    <message>
+        <source>Visible Only</source>
+        <translation>Apenas visível</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Dependencies:</source>
+        <translation>Dependências:</translation>
+    </message>
+    <message>
+        <source>Remove -&gt;</source>
+        <translation>Remover -&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;- Add</source>
+        <translation>&lt;- Adicionar</translation>
+    </message>
+    <message>
+        <source>Multimedia:</source>
+        <translation>Multimídia:</translation>
+    </message>
+    <message>
+        <source>NoPaint</source>
+        <translation>sem pintura</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Desligado</translation>
+    </message>
+    <message>
+        <source>Remove &gt;&gt;</source>
+        <translation>Remover &gt;&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;&lt; Add</source>
+        <translation>&lt;&lt; Adicionar</translation>
+    </message>
+    <message>
+        <source>Successful Steps:</source>
+        <translation>Etapas bem-sucedidas:</translation>
+    </message>
+    <message>
+        <source>Suspended</source>
+        <translation>Suspenso</translation>
+    </message>
+    <message>
+        <source>Waiting</source>
+        <translation>Esperando</translation>
+    </message>
+    <message>
+        <source>Running</source>
+        <translation>Correndo</translation>
+    </message>
+    <message>
+        <source>Completed</source>
+        <translation>Concluído</translation>
+    </message>
+    <message>
+        <source>Failed</source>
+        <translation>Fracassado</translation>
+    </message>
+    <message>
+        <source>TaskUnknown</source>
+        <translation>TarefaDesconhecida</translation>
+    </message>
+</context>
+<context>
+    <name>TaskTreeModel</name>
+    <message>
+        <source>Are you sure you want to remove ALL tasks?</source>
+        <translation>Tem certeza de que deseja remover TODAS as tarefas?</translation>
+    </message>
+    <message>
+        <source>Remove All</source>
+        <translation>Remover tudo</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>TaskTreeView</name>
+    <message>
+        <source>Start</source>
+        <translation>Começar</translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation>Parar</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+</context>
+<context>
+    <name>TasksViewer</name>
+    <message>
+        <source>&amp;Start</source>
+        <translation>&amp;Começar</translation>
+    </message>
+    <message>
+        <source>&amp;Stop</source>
+        <translation>&amp;Parar</translation>
+    </message>
+    <message>
+        <source>&amp;Add Render Task</source>
+        <translation>&amp;Adicionar tarefa de renderização</translation>
+    </message>
+    <message>
+        <source>&amp;Add Cleanup Task</source>
+        <translation>&amp;Adicionar tarefa de limpeza</translation>
+    </message>
+    <message>
+        <source>&amp;Save Task List</source>
+        <translation>&amp;Salvar lista de tarefas</translation>
+    </message>
+    <message>
+        <source>&amp;Save Task List As</source>
+        <translation>&amp;Salvar lista de tarefas como</translation>
+    </message>
+    <message>
+        <source>&amp;Load Task List</source>
+        <translation>&amp;Carregar lista de tarefas</translation>
+    </message>
+    <message>
+        <source>&amp;Remove</source>
+        <translation>&amp;Remover</translation>
+    </message>
+    <message>
+        <source>Start</source>
+        <translation>Começar</translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation>Parar</translation>
+    </message>
+    <message>
+        <source>Add Render</source>
+        <translation>Adicionar renderização</translation>
+    </message>
+    <message>
+        <source>Add Cleanup</source>
+        <translation>Adicionar limpeza</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Save As</source>
+        <translation>Salvar como</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+</context>
+<context>
+    <name>TestPanel</name>
+    <message>
+        <source>Left:</source>
+        <translation>Esquerda:</translation>
+    </message>
+    <message>
+        <source>Right:</source>
+        <translation>Certo:</translation>
+    </message>
+</context>
+<context>
+    <name>TimeStretchPopup</name>
+    <message>
+        <source>Time Stretch</source>
+        <translation>Alongamento de tempo</translation>
+    </message>
+    <message>
+        <source>Selected Cells</source>
+        <translation>Células Selecionadas</translation>
+    </message>
+    <message>
+        <source>Selected Frame Range</source>
+        <translation>Intervalo de quadros selecionado</translation>
+    </message>
+    <message>
+        <source>Whole Xsheet</source>
+        <translation>Planilha inteira</translation>
+    </message>
+    <message>
+        <source>Stretch:</source>
+        <translation>Esticar:</translation>
+    </message>
+    <message>
+        <source>New Range:</source>
+        <translation>Nova gama:</translation>
+    </message>
+    <message>
+        <source>Old Range:</source>
+        <translation>Faixa Antiga:</translation>
+    </message>
+    <message>
+        <source>Stretch</source>
+        <translation>Esticar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>TimelineWidget</name>
+    <message>
+        <source>Recent Version</source>
+        <translation>Versão recente</translation>
+    </message>
+    <message>
+        <source>Older Version</source>
+        <translation>Versão mais antiga</translation>
+    </message>
+</context>
+<context>
+    <name>ToolPropertiesPanel</name>
+    <message>
+        <source>Tool Properties</source>
+        <translation>Propriedades da ferramenta</translation>
+    </message>
+    <message>
+        <source>Tool Properties - %1</source>
+        <translation>Propriedades da Ferramenta - %1</translation>
+    </message>
+    <message>
+        <source>Properties for Fill tool - Coming soon!</source>
+        <translation>Propriedades da ferramenta Preenchimento - Em breve!</translation>
+    </message>
+    <message>
+        <source>Properties for Eraser tool - Coming soon!</source>
+        <translation>Propriedades da ferramenta Borracha - Em breve!</translation>
+    </message>
+    <message>
+        <source>Properties for this tool - Coming soon!</source>
+        <translation>Propriedades desta ferramenta - Em breve!</translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation>Tamanho</translation>
+    </message>
+    <message>
+        <source>Hardness</source>
+        <translation>Dureza</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>Opacidade</translation>
+    </message>
+    <message>
+        <source>Lock Alpha</source>
+        <translation>Bloquear Alfa</translation>
+    </message>
+    <message>
+        <source>Pencil Mode</source>
+        <translation>Modo Lápis</translation>
+    </message>
+    <message>
+        <source>Draw Order</source>
+        <translation>Ordem do sorteio</translation>
+    </message>
+    <message>
+        <source>Cap</source>
+        <translation>Boné</translation>
+    </message>
+    <message>
+        <source>Join</source>
+        <translation>Juntar</translation>
+    </message>
+    <message>
+        <source>Smooth</source>
+        <translation>Suave</translation>
+    </message>
+    <message>
+        <source>Assistants</source>
+        <translation>Assistentes</translation>
+    </message>
+    <message>
+        <source>Pressure</source>
+        <translation>Pressão</translation>
+    </message>
+    <message>
+        <source>Accuracy</source>
+        <translation>Precisão</translation>
+    </message>
+    <message>
+        <source>Break Angles</source>
+        <translation>Quebrar ângulos</translation>
+    </message>
+    <message>
+        <source>Frame Range</source>
+        <translation>Faixa de quadros</translation>
+    </message>
+    <message>
+        <source>Snap</source>
+        <translation>Encaixe</translation>
+    </message>
+    <message>
+        <source>Sensitivity</source>
+        <translation>Sensibilidade</translation>
+    </message>
+    <message>
+        <source>Miter</source>
+        <translation>Mitra</translation>
+    </message>
+    <message>
+        <source>Modifier Size</source>
+        <translation>Tamanho do modificador</translation>
+    </message>
+    <message>
+        <source>Modifier Opacity</source>
+        <translation>Opacidade do modificador</translation>
+    </message>
+    <message>
+        <source>Eraser</source>
+        <translation>Apagador</translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <translation>Mínimo</translation>
+    </message>
+    <message>
+        <source>Max</source>
+        <translation>Máx.</translation>
+    </message>
+    <message>
+        <source>Min:</source>
+        <translation>Mínimo:</translation>
+    </message>
+    <message>
+        <source>Max:</source>
+        <translation>Máx.:</translation>
+    </message>
+    <message>
+        <source>GUI Show / Hide</source>
+        <translation>Mostrar/ocultar GUI</translation>
+    </message>
+    <message>
+        <source>Single Slider (Max Only)</source>
+        <translation>Controle deslizante único (apenas no máximo)</translation>
+    </message>
+    <message>
+        <source>Show Labels</source>
+        <translation>Mostrar rótulos</translation>
+    </message>
+    <message>
+        <source>Show Numeric Fields</source>
+        <translation>Mostrar campos numéricos</translation>
+    </message>
+    <message>
+        <source>Cell Borders</source>
+        <translation>Fronteiras celulares</translation>
+    </message>
+    <message>
+        <source>Cell Backgrounds</source>
+        <translation>Fundos de células</translation>
+    </message>
+    <message>
+        <source>Show Icons</source>
+        <translation>Mostrar ícones</translation>
+    </message>
+</context>
+<context>
+    <name>Toolbar</name>
+    <message>
+        <source>Collapse toolbar</source>
+        <translation>Recolher barra de ferramentas</translation>
+    </message>
+    <message>
+        <source>Expand toolbar</source>
+        <translation>Expandir barra de ferramentas</translation>
+    </message>
+</context>
+<context>
+    <name>TopBar</name>
+    <message>
+        <source>Lock Rooms Tab</source>
+        <translation>Aba Bloquear Salas</translation>
+    </message>
+</context>
+<context>
+    <name>TrackerPopup</name>
+    <message>
+        <source>Tracking Settings</source>
+        <translation>Configurações de rastreamento</translation>
+    </message>
+    <message>
+        <source>Threshold:</source>
+        <translation>Limite:</translation>
+    </message>
+    <message>
+        <source>Variable Region Size</source>
+        <translation>Tamanho variável da região</translation>
+    </message>
+    <message>
+        <source>Include Background</source>
+        <translation>Incluir plano de fundo</translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation>Acompanhar</translation>
+    </message>
+    <message>
+        <source>Processing...</source>
+        <translation>Processamento...</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Sensitivity:</source>
+        <translation>Sensibilidade:</translation>
+    </message>
+</context>
+<context>
+    <name>VectorGuidedDrawingPane</name>
+    <message>
+        <source>Off</source>
+        <translation>Desligado</translation>
+    </message>
+    <message>
+        <source>Closest</source>
+        <translation>Mais próximo</translation>
+    </message>
+    <message>
+        <source>Farthest</source>
+        <translation>Mais distante</translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation>Todos</translation>
+    </message>
+    <message>
+        <source>Auto Inbetween</source>
+        <translation>Intermediário automático</translation>
+    </message>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>Ease In</source>
+        <translation>Facilidade</translation>
+    </message>
+    <message>
+        <source>Ease Out</source>
+        <translation>Facilite</translation>
+    </message>
+    <message>
+        <source>EaseIn/Out</source>
+        <translation>Facilidade de entrada/saída</translation>
+    </message>
+    <message>
+        <source>Previous</source>
+        <translation>Anterior</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>Próximo</translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation>Ambos</translation>
+    </message>
+    <message>
+        <source>Reset</source>
+        <translation>Reiniciar</translation>
+    </message>
+    <message>
+        <source>Tween Selected Guide Strokes</source>
+        <translation>Interpolação de traços guia selecionados</translation>
+    </message>
+    <message>
+        <source>Tween Guide Strokes to Selected</source>
+        <translation>Interpolação de traços de guia para selecionados</translation>
+    </message>
+    <message>
+        <source>Select Guide Strokes &amp;&amp; Tween Mode</source>
+        <translation>Selecione Traços de guia e modo de interpolação</translation>
+    </message>
+    <message>
+        <source>Guide Frames:</source>
+        <translation>Quadros de guia:</translation>
+    </message>
+    <message>
+        <source>Select Guide Stroke:</source>
+        <translation>Selecione Traço guia:</translation>
+    </message>
+    <message>
+        <source>Flip Guide Stroke:</source>
+        <translation>Traço de guia de inversão:</translation>
+    </message>
+    <message>
+        <source>Interpolation:</source>
+        <translation>Interpolação:</translation>
+    </message>
+</context>
+<context>
+    <name>VectorizerPopup</name>
+    <message>
+        <source>Convert-to-Vector Settings</source>
+        <translation>Configurações de conversão em vetor</translation>
+    </message>
+    <message>
+        <source>Centerline</source>
+        <translation>Linha central</translation>
+    </message>
+    <message>
+        <source>Outline</source>
+        <translation>Contorno</translation>
+    </message>
+    <message>
+        <source>Preserve Painted Areas</source>
+        <translation>Preservar áreas pintadas</translation>
+    </message>
+    <message>
+        <source>TLV Levels</source>
+        <translation>Níveis de TLV</translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation>Converter</translation>
+    </message>
+    <message>
+        <source>The current selection is invalid.</source>
+        <translation>A seleção atual é inválida.</translation>
+    </message>
+    <message>
+        <source>Cannot convert to vector the current selection.</source>
+        <translation>Não é possível converter em vetor a seleção atual.</translation>
+    </message>
+    <message>
+        <source>Add Border</source>
+        <translation>Adicionar borda</translation>
+    </message>
+    <message>
+        <source>Conversion in progress: </source>
+        <translation>Conversão em andamento:</translation>
+    </message>
+    <message>
+        <source>Corners</source>
+        <translation>Cantos</translation>
+    </message>
+    <message>
+        <source>Raster Levels</source>
+        <translation>Níveis rasterizados</translation>
+    </message>
+    <message>
+        <source>Toggle Swatch Preview</source>
+        <translation>Alternar visualização da amostra</translation>
+    </message>
+    <message>
+        <source>Toggle Centerlines Check</source>
+        <translation>Alternar verificação de linhas de centro</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation>Modo</translation>
+    </message>
+    <message>
+        <source>Threshold</source>
+        <translation>Limite</translation>
+    </message>
+    <message>
+        <source>Accuracy</source>
+        <translation>Precisão</translation>
+    </message>
+    <message>
+        <source>Despeckling</source>
+        <translation>Remoção de manchas</translation>
+    </message>
+    <message>
+        <source>Max Thickness</source>
+        <translation>Espessura máxima</translation>
+    </message>
+    <message>
+        <source>Start:</source>
+        <translation>Começar:</translation>
+    </message>
+    <message>
+        <source>End:</source>
+        <translation>Fim:</translation>
+    </message>
+    <message>
+        <source>Thickness Calibration</source>
+        <translation>Calibração de Espessura</translation>
+    </message>
+    <message>
+        <source>Full color non-AA images</source>
+        <translation>Imagens coloridas não AA</translation>
+    </message>
+    <message>
+        <source>Enhanced ink recognition</source>
+        <translation>Reconhecimento de tinta aprimorado</translation>
+    </message>
+    <message>
+        <source>Adherence</source>
+        <translation>Adesão</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Ângulo</translation>
+    </message>
+    <message>
+        <source>Curve Radius</source>
+        <translation>Raio da Curva</translation>
+    </message>
+    <message>
+        <source>Max Colors</source>
+        <translation>Máximo de cores</translation>
+    </message>
+    <message>
+        <source>Transparent Color</source>
+        <translation>Cor Transparente</translation>
+    </message>
+    <message>
+        <source>Tone Threshold</source>
+        <translation>Limiar de tom</translation>
+    </message>
+    <message>
+        <source>Save Settings</source>
+        <translation>Salvar configurações</translation>
+    </message>
+    <message>
+        <source>Load Settings</source>
+        <translation>Carregar configurações</translation>
+    </message>
+    <message>
+        <source>Reset Settings</source>
+        <translation>Redefinir configurações</translation>
+    </message>
+    <message>
+        <source>File could not be opened for read</source>
+        <translation>Não foi possível abrir o arquivo para leitura</translation>
+    </message>
+    <message>
+        <source>File could not be opened for write</source>
+        <translation>O arquivo não pôde ser aberto para gravação</translation>
+    </message>
+    <message>
+        <source>Save Vectorizer Parameters</source>
+        <translation>Salvar parâmetros do vetorizador</translation>
+    </message>
+    <message>
+        <source>Load Vectorizer Parameters</source>
+        <translation>Carregar parâmetros do vetorizador</translation>
+    </message>
+    <message>
+        <source>Align Boundary Strokes Direction</source>
+        <translation>Alinhar a direção dos traços de limite</translation>
+    </message>
+    <message>
+        <source>Align boundary strokes direction to be the same.
+(clockwise, i.e. left to right as viewed from inside of the shape)</source>
+        <translation>Alinhe a direção dos traços de limite para que sejam iguais.
+(no sentido horário, ou seja, da esquerda para a direita, visto de dentro da forma)</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+</context>
+<context>
+    <name>VersionControl</name>
+    <message>
+        <source>The version control configuration file is empty or wrongly defined.
+Please refer to the user guide for details.</source>
+        <translation>O arquivo de configuração de controle de versão está vazio ou definido incorretamente.
+Consulte o guia do usuário para obter detalhes.</translation>
+    </message>
+    <message>
+        <source>The version control client application specified on the configuration file cannot be found.
+Please refer to the user guide for details.</source>
+        <translation>O aplicativo cliente de controle de versão especificado no arquivo de configuração não pode ser encontrado.
+Consulte o guia do usuário para obter detalhes.</translation>
+    </message>
+    <message>
+        <source>The version control client application is not installed on your computer.
+Subversion 1.5 or later is required.
+Please refer to the user guide for details.</source>
+        <translation>O aplicativo cliente de controle de versão não está instalado em seu computador.
+É necessário o Subversion 1.5 ou posterior.
+Consulte o guia do usuário para obter detalhes.</translation>
+    </message>
+    <message>
+        <source>The version control client application installed on your computer needs to be updated, otherwise some features may not be available.
+Subversion 1.5 or later is required.
+Please refer to the user guide for details.</source>
+        <translation>O aplicativo cliente de controle de versão instalado em seu computador precisa ser atualizado, caso contrário, alguns recursos poderão não estar disponíveis.
+É necessário o Subversion 1.5 ou posterior.
+Consulte o guia do usuário para obter detalhes.</translation>
+    </message>
+</context>
+<context>
+    <name>ViewerHistogramPopup</name>
+    <message>
+        <source>Viewer Histogram</source>
+        <translation>Histograma do visualizador</translation>
+    </message>
+</context>
+<context>
+    <name>XDTSImportPopup</name>
+    <message>
+        <source>Importing XDTS file %1</source>
+        <translation>Importando o arquivo XDTS % 1</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translation>Carregar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Please specify the level locations. Suggested paths are input in the fields with blue border.</source>
+        <translation>Especifique os locais dos níveis. Os caminhos sugeridos são inseridos nos campos com borda azul.</translation>
+    </message>
+    <message>
+        <source>Level Name</source>
+        <translation>Nome do nível</translation>
+    </message>
+    <message>
+        <source>Level Path</source>
+        <translation>Caminho de nível</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Inbetween symbol mark</source>
+        <translation>Marca de símbolo intermediário</translation>
+    </message>
+    <message>
+        <source>Reverse sheet symbol mark</source>
+        <translation>Marca de símbolo de folha reversa</translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 1 (O)</source>
+        <translation>Marca de célula para símbolo intermediário 1 (O)</translation>
+    </message>
+    <message>
+        <source>Cell Mark for Inbetween Symbol 2 (*)</source>
+        <translation>Marca de célula para símbolo intermediário 2 (*)</translation>
+    </message>
+    <message>
+        <source>Importing %1 file %2</source>
+        <translation>Importando o arquivo % 1 % 2</translation>
+    </message>
+    <message>
+        <source>Rename Image Sequence</source>
+        <translation>Renomear sequência de imagens</translation>
+    </message>
+    <message>
+        <source>Do not Convert</source>
+        <translation>Não converta</translation>
+    </message>
+    <message>
+        <source>Convert Every Level with Settings Popup</source>
+        <translation>Converta todos os níveis com pop-up de configurações</translation>
+    </message>
+    <message>
+        <source>Convert Unpainted Aliasing Raster(Inks Only)</source>
+        <translation>Converter raster de alias não pintado (somente tintas)</translation>
+    </message>
+    <message>
+        <source>Append Default Palette</source>
+        <translation>Anexar paleta padrão</translation>
+    </message>
+    <message>
+        <source>When activated, styles of the default palette
+($TOONZSTUDIOPALETTE\Global Palettes\Default Palettes\Cleanup_Palette.tpl) will 
+be appended to the palette after conversion</source>
+        <translation>Quando ativado, os estilos da paleta padrão
+($TOONZSTUDIOPALETTE\Global Palettes\Default Palettes\Cleanup_Palette.tpl) irá 
+ser anexado à paleta após a conversão</translation>
+    </message>
+    <message>
+        <source>Image DPI</source>
+        <translation>DPI da imagem</translation>
+    </message>
+    <message>
+        <source>Current Camera DPI</source>
+        <translation>DPI atual da câmera</translation>
+    </message>
+    <message>
+        <source>Custom DPI</source>
+        <translation>DPI personalizado</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>Cell marks for %1 symbols</source>
+        <translation>Marcas de células para símbolos %1</translation>
+    </message>
+    <message>
+        <source>Inbetween Symbol1 (%1):</source>
+        <translation>Entre o Símbolo1 (%1):</translation>
+    </message>
+    <message>
+        <source>Inbetween Symbol2 (%1):</source>
+        <translation>Entre o Símbolo2 (%1):</translation>
+    </message>
+    <message>
+        <source>Keyframe Symbol:</source>
+        <translation>Símbolo do quadro-chave:</translation>
+    </message>
+    <message>
+        <source>Reference Frame Symbol:</source>
+        <translation>Símbolo do Quadro de Referência:</translation>
+    </message>
+    <message>
+        <source>Convert Raster to TLV : </source>
+        <translation>Converter Raster em TLV:</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::BreadcrumbArea</name>
+    <message>
+        <source>  &gt;  </source>
+        <translation>  &gt;  </translation>
+    </message>
+    <message>
+        <source>  |  </source>
+        <translation>  |  </translation>
+    </message>
+    <message>
+        <source>---</source>
+        <translation>---</translation>
+    </message>
+    <message>
+        <source>Main</source>
+        <translation>Principal</translation>
+    </message>
+    <message>
+        <source>Xsheet Depth:</source>
+        <translation>Profundidade da folha X:</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::CellArea</name>
+    <message>
+        <source>Click to select keyframe, drag to move it</source>
+        <translation>Clique para selecionar o quadro-chave, arraste para movê-lo</translation>
+    </message>
+    <message>
+        <source>Click and drag to set the acceleration range</source>
+        <translation>Clique e arraste para definir a faixa de aceleração</translation>
+    </message>
+    <message>
+        <source>Click and drag to set the deceleration range</source>
+        <translation>Clique e arraste para definir a faixa de desaceleração</translation>
+    </message>
+    <message>
+        <source>Set the cycle of previous keyframes</source>
+        <translation>Defina o ciclo dos quadros-chave anteriores</translation>
+    </message>
+    <message>
+        <source>Click and drag to move the selection</source>
+        <translation>Clique e arraste para mover a seleção</translation>
+    </message>
+    <message>
+        <source>Click and drag to play</source>
+        <translation>Clique e arraste para jogar</translation>
+    </message>
+    <message>
+        <source>Click and drag to repeat selected cells</source>
+        <translation>Clique e arraste para repetir as células selecionadas</translation>
+    </message>
+    <message>
+        <source>Open Memo</source>
+        <translation>Abrir memorando</translation>
+    </message>
+    <message>
+        <source>Delete Memo</source>
+        <translation>Excluir memorando</translation>
+    </message>
+    <message>
+        <source>Reframe</source>
+        <translation>Reestruturar</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation>Etapa</translation>
+    </message>
+    <message>
+        <source>Each</source>
+        <translation>Cada</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Edit Cell Numbers</source>
+        <translation>Editar números de células</translation>
+    </message>
+    <message>
+        <source>Replace Level</source>
+        <translation>Substituir nível</translation>
+    </message>
+    <message>
+        <source>Replace with</source>
+        <translation>Substitua por</translation>
+    </message>
+    <message>
+        <source>Paste Special</source>
+        <translation>Colar especial</translation>
+    </message>
+    <message>
+        <source>Edit Image</source>
+        <translation>Editar imagem</translation>
+    </message>
+    <message>
+        <source>Lip Sync</source>
+        <translation>Sincronização labial</translation>
+    </message>
+    <message>
+        <source>Cell Mark</source>
+        <translation>Marca de célula</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Interpolation on %1's</source>
+        <translation>Interpolação em %1's</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ChangeObjectParent</name>
+    <message>
+        <source>Table</source>
+        <translation>Mesa de animação</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ColumnArea</name>
+    <message>
+        <source>Click to select camera</source>
+        <translation>Clique para selecionar a câmera</translation>
+    </message>
+    <message>
+        <source>Camera Stand Toggle</source>
+        <translation>Alternar suporte da câmera</translation>
+    </message>
+    <message>
+        <source>Render Toggle</source>
+        <translation>Alternar renderização</translation>
+    </message>
+    <message>
+        <source>Lock Toggle</source>
+        <translation>Alternar bloqueio</translation>
+    </message>
+    <message>
+        <source>Click to play the soundtrack back</source>
+        <translation>Clique para reproduzir a trilha sonora</translation>
+    </message>
+    <message>
+        <source>Set the volume of the soundtrack</source>
+        <translation>Defina o volume da trilha sonora</translation>
+    </message>
+    <message>
+        <source>Click to select the type of motion path</source>
+        <translation>Clique para selecionar o tipo de caminho de movimento</translation>
+    </message>
+    <message>
+        <source>Click to select column, drag to move it</source>
+        <translation>Clique para selecionar a coluna, arraste para movê-la</translation>
+    </message>
+    <message>
+        <source>Click to unlink column</source>
+        <translation>Clique para desvincular coluna</translation>
+    </message>
+    <message>
+        <source>Click and drag to link column</source>
+        <translation>Clique e arraste para vincular a coluna</translation>
+    </message>
+    <message>
+        <source>Master column of linked columns</source>
+        <translation>Coluna mestre de colunas vinculadas</translation>
+    </message>
+    <message>
+        <source>&amp;Subsampling 1</source>
+        <translation>&amp;Subamostragem 1</translation>
+    </message>
+    <message>
+        <source>&amp;Subsampling 2</source>
+        <translation>&amp;Subamostragem 2</translation>
+    </message>
+    <message>
+        <source>&amp;Subsampling 3</source>
+        <translation>&amp;Subamostragem 3</translation>
+    </message>
+    <message>
+        <source>&amp;Subsampling 4</source>
+        <translation>&amp;Subamostragem 4</translation>
+    </message>
+    <message>
+        <source>Preview Visibility Toggle</source>
+        <translation>Alternar visibilidade de visualização</translation>
+    </message>
+    <message>
+        <source>Camera Stand Visibility Toggle</source>
+        <translation>Alternar visibilidade do suporte da câmera</translation>
+    </message>
+    <message>
+        <source>Alt + Click to Toggle Thumbnail</source>
+        <translation>Alt + Clique para alternar miniatura</translation>
+    </message>
+    <message>
+        <source>Reframe</source>
+        <translation>Reestruturar</translation>
+    </message>
+    <message>
+        <source>Subsampling</source>
+        <translation>Subamostragem</translation>
+    </message>
+    <message>
+        <source>Click to select column</source>
+        <translation>Clique para selecionar a coluna</translation>
+    </message>
+    <message>
+        <source>Click to select column, drag to move it, double-click to edit</source>
+        <translation>Clique para selecionar a coluna, arraste para movê-la, clique duas vezes para editar</translation>
+    </message>
+    <message>
+        <source>Click to select column, double-click to edit</source>
+        <translation>Clique para selecionar a coluna, clique duas vezes para editar</translation>
+    </message>
+    <message>
+        <source>Additional column settings</source>
+        <translation>Configurações adicionais de coluna</translation>
+    </message>
+    <message>
+        <source>&amp;Insert Before</source>
+        <translation>&amp;Inserir antes</translation>
+    </message>
+    <message>
+        <source>&amp;Insert After</source>
+        <translation>&amp;Inserir depois</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Insert Before</source>
+        <translation>&amp;Colar Inserir Antes</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Insert After</source>
+        <translation>&amp;Colar Inserir Depois</translation>
+    </message>
+    <message>
+        <source>&amp;Insert Below</source>
+        <translation>&amp;Inserir abaixo</translation>
+    </message>
+    <message>
+        <source>&amp;Insert Above</source>
+        <translation>&amp;Inserir acima</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Insert Below</source>
+        <translation>&amp;Colar inserção abaixo</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Insert Above</source>
+        <translation>&amp;Colar inserção acima</translation>
+    </message>
+    <message>
+        <source>Hide Camera Column</source>
+        <translation>Ocultar coluna da câmera</translation>
+    </message>
+    <message>
+        <source>Show Camera Column</source>
+        <translation>Mostrar coluna da câmera</translation>
+    </message>
+    <message>
+        <source>Unlock</source>
+        <translation>Desbloquear</translation>
+    </message>
+    <message>
+        <source>Lock</source>
+        <translation>Trancar</translation>
+    </message>
+    <message>
+        <source>Click to select parent handle</source>
+        <translation>Clique para selecionar o identificador pai</translation>
+    </message>
+    <message>
+        <source>Click to select parent object</source>
+        <translation>Clique para selecionar o objeto pai</translation>
+    </message>
+    <message>
+        <source>Show Column Parent Colors</source>
+        <translation>Mostrar cores principais da coluna</translation>
+    </message>
+    <message>
+        <source>Show the column parent's color in the Xsheet</source>
+        <translation>Mostrar a cor do pai da coluna no Xsheet</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::ColumnTransparencyPopup</name>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation>Vermelho</translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation>Verde</translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation>Azul</translation>
+    </message>
+    <message>
+        <source>DarkYellow</source>
+        <translation>Amarelo escuro</translation>
+    </message>
+    <message>
+        <source>DarkCyan</source>
+        <translation>Ciano Escuro</translation>
+    </message>
+    <message>
+        <source>DarkMagenta</source>
+        <translation>Magenta Escuro</translation>
+    </message>
+    <message>
+        <source>N.B. Filter doesn't affect vector levels</source>
+        <translation>N. B. O filtro não afeta os níveis do vetor</translation>
+    </message>
+    <message>
+        <source>Filter:</source>
+        <translation>Filtro:</translation>
+    </message>
+    <message>
+        <source>Opacity:</source>
+        <translation>Opacidade:</translation>
+    </message>
+    <message>
+        <source>Lock Column</source>
+        <translation>Coluna de bloqueio</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::NoteArea</name>
+    <message>
+        <source>Frame</source>
+        <translation>Quadro</translation>
+    </message>
+    <message>
+        <source>Sec Frame</source>
+        <translation>Segundo Quadro</translation>
+    </message>
+    <message>
+        <source>6sec Sheet</source>
+        <translation>Folha de 6 segundos</translation>
+    </message>
+    <message>
+        <source>3sec Sheet</source>
+        <translation>Folha de 3 segundos</translation>
+    </message>
+    <message>
+        <source>Toggle Xsheet/Timeline</source>
+        <translation>Alternar Xsheet/Linha do tempo</translation>
+    </message>
+    <message>
+        <source>Add New Memo</source>
+        <translation>Adicionar novo memorando</translation>
+    </message>
+    <message>
+        <source>Previous Memo</source>
+        <translation>Memorando Anterior</translation>
+    </message>
+    <message>
+        <source>Next Memo</source>
+        <translation>Próximo memorando</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::NotePopup</name>
+    <message>
+        <source>Memo</source>
+        <translation>Memorando</translation>
+    </message>
+    <message>
+        <source>Post</source>
+        <translation>Publicar</translation>
+    </message>
+    <message>
+        <source>Discard</source>
+        <translation>Descartar</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::RowArea</name>
+    <message>
+        <source>Onion Skin Toggle</source>
+        <translation>Alternar Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Current Frame</source>
+        <translation>Quadro atual</translation>
+    </message>
+    <message>
+        <source>Relative Onion Skin Toggle</source>
+        <translation>Alternar Casca de Cebola relativa</translation>
+    </message>
+    <message>
+        <source>Fixed Onion Skin Toggle</source>
+        <translation>Alternância de Casca de Cebola fixa</translation>
+    </message>
+    <message>
+        <source>Playback Start Marker</source>
+        <translation>Marcador de início de reprodução</translation>
+    </message>
+    <message>
+        <source>Playback End Marker</source>
+        <translation>Marcador de fim de reprodução</translation>
+    </message>
+    <message>
+        <source>Set Start Marker</source>
+        <translation>Definir marcador inicial</translation>
+    </message>
+    <message>
+        <source>Set Stop Marker</source>
+        <translation>Definir marcador de parada</translation>
+    </message>
+    <message>
+        <source>Remove Markers</source>
+        <translation>Remover marcadores</translation>
+    </message>
+    <message>
+        <source>Curren Frame</source>
+        <translation>Quadro Curren</translation>
+    </message>
+    <message>
+        <source>Preview This</source>
+        <translation>Pré-visualizar isto</translation>
+    </message>
+    <message>
+        <source>Double Click to Toggle Onion Skin</source>
+        <translation>Clique duas vezes para alternar a Casca de Cebola</translation>
+    </message>
+    <message>
+        <source>Pinned Center : Col%1%2</source>
+        <translation>Centro Fixado: Col%1%2</translation>
+    </message>
+    <message>
+        <source>Set Auto Markers</source>
+        <translation>Definir marcadores automáticos</translation>
+    </message>
+    <message>
+        <source>Click to Reset Shift &amp; Trace Markers to Neighbor Frames
+Hold F2 Key on the Viewer to Show This Frame Only</source>
+        <translation>Clique para redefinir marcadores de deslocamento e rastreamento para quadros vizinhos
+Segure a tecla F2 no visualizador para mostrar apenas este quadro</translation>
+    </message>
+    <message>
+        <source>Click to Hide This Frame from Shift &amp; Trace
+Hold F1 Key on the Viewer to Show This Frame Only</source>
+        <translation>Clique para ocultar este quadro de Shift &amp; Trace
+Segure a tecla F1 no visualizador para mostrar apenas este quadro</translation>
+    </message>
+    <message>
+        <source>Click to Hide This Frame from Shift &amp; Trace
+Hold F3 Key on the Viewer to Show This Frame Only</source>
+        <translation>Clique para ocultar este quadro de Shift &amp; Trace
+Segure a tecla F3 no visualizador para mostrar apenas este quadro</translation>
+    </message>
+    <message>
+        <source>Click to Move Shift &amp; Trace Marker</source>
+        <translation>Clique para mover o marcador Shift e Trace</translation>
+    </message>
+    <message>
+        <source>Tag: %1</source>
+        <translation>Etiqueta: %1</translation>
+    </message>
+    <message>
+        <source>Tags</source>
+        <translation>Etiquetas</translation>
+    </message>
+    <message>
+        <source>Frame %1</source>
+        <translation>Quadro % 1</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::SoundColumnPopup</name>
+    <message>
+        <source>Volume:</source>
+        <translation>Volume:</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::Toolbar</name>
+    <message>
+        <source>New Vector Level</source>
+        <translation>Novo nível vetorial</translation>
+    </message>
+    <message>
+        <source>New Toonz Raster Level</source>
+        <translation>Novo nível raster Toonz</translation>
+    </message>
+    <message>
+        <source>New Raster Level</source>
+        <translation>Novo nível raster</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetGUI::XSheetToolbar</name>
+    <message>
+        <source>Customize XSheet Toolbar</source>
+        <translation>Personalizar a barra de ferramentas XSheet</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetPdfPreviewArea</name>
+    <message>
+        <source>Fit To Window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+</context>
+<context>
+    <name>XsheetViewer</name>
+    <message>
+        <source>Untitled</source>
+        <translation>Sem título</translation>
+    </message>
+    <message>
+        <source>Scene: </source>
+        <translation>Cena:</translation>
+    </message>
+    <message>
+        <source> Frames</source>
+        <translation>Quadros</translation>
+    </message>
+    <message>
+        <source>  (Sub)</source>
+        <translation>(Sub)</translation>
+    </message>
+    <message>
+        <source>  Level: </source>
+        <translation>Nível:</translation>
+    </message>
+    <message>
+        <source>   Selected: </source>
+        <translation>Selecionado:</translation>
+    </message>
+    <message>
+        <source> frame : </source>
+        <translation>quadro :</translation>
+    </message>
+    <message>
+        <source> frames * </source>
+        <translation>quadros *</translation>
+    </message>
+    <message>
+        <source> column</source>
+        <translation>coluna</translation>
+    </message>
+    <message>
+        <source> columns</source>
+        <translation>colunas</translation>
+    </message>
+    <message>
+        <source>Zoom in/out of timeline</source>
+        <translation>Aumentar/diminuir zoom na linha do tempo</translation>
+    </message>
+    <message>
+        <source>   ::   Project: </source>
+        <translation>::   Projeto:</translation>
+    </message>
+    <message>
+        <source> Frame</source>
+        <translation>Quadro</translation>
+    </message>
+</context>
+</TS>

--- a/toonz/sources/translations/portuguese_brazil/toonz.ts
+++ b/toonz/sources/translations/portuguese_brazil/toonz.ts
@@ -3438,10 +3438,13 @@ Desmarcado: Somente camadas com Visualização Visível ATIVADA são exportadas<
         <source>The preset file %1 is not valid.</source>
         <translation>O arquivo predefinido %1 não é válido.</translation>
     </message>
-    <message numerus="yes">
-        <source>%n page(s)</source>
-        <translation>%n páginas</translation>
-    </message>
+	<message numerus="yes">
+		<source>%n page(s)</source>
+		<translation>
+			<numerusform>%n página</numerusform>
+			<numerusform>%n páginas</numerusform>
+		</translation>
+	</message>
     <message>
         <source>%1 x %2 pages</source>
         <translation>%1 x %2 páginas</translation>
@@ -11583,10 +11586,13 @@ O que você quer fazer?</translation>
         <source>Deleting %1. Are you sure?</source>
         <translation>Excluindo %1. Tem certeza?</translation>
     </message>
-    <message numerus="yes">
-        <source>Deleting %n files. Are you sure?</source>
-        <translation>Excluindo %n arquivos. Tem certeza?</translation>
-    </message>
+	<message numerus="yes">
+		<source>Deleting %n files. Are you sure?</source>
+		<translation>
+			<numerusform>Excluindo %n arquivo. Tem certeza?</numerusform>
+			<numerusform>Excluindo %n arquivos. Tem certeza?</numerusform>
+		</translation>
+	</message>
     <message>
         <source>Delete</source>
         <translation>Excluir</translation>

--- a/toonz/sources/translations/portuguese_brazil/toonzlib.ts
+++ b/toonz/sources/translations/portuguese_brazil/toonzlib.ts
@@ -1,0 +1,804 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR" sourcelanguage="en">
+<context>
+    <name>Preferences</name>
+    <message>
+        <source>Retas Level Format</source>
+        <translation>Formato de nível Retas</translation>
+    </message>
+    <message>
+        <source>Adobe Photoshop</source>
+        <translation>Adobe Photoshop</translation>
+    </message>
+    <message>
+        <source>PNG</source>
+        <translation>png</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>No restrictions for uncompressed avi video</source>
+        <translation>Sem restrições para vídeo AVI não compactado</translation>
+    </message>
+    <message>
+        <source>video width must be a multiple of %1</source>
+        <translation>a largura do vídeo deve ser um múltiplo de % 1</translation>
+    </message>
+    <message>
+        <source>video length must be a multiple of %1</source>
+        <translation>a duração do vídeo deve ser um múltiplo de % 1</translation>
+    </message>
+    <message>
+        <source>No restrictions for this codec</source>
+        <translation>Sem restrições para este codec</translation>
+    </message>
+    <message>
+        <source>Resolution restrictions:</source>
+        <translation>Restrições de resolução:</translation>
+    </message>
+    <message>
+        <source>It is not possible to communicate with the codec.
+ Probably the codec cannot work correctly.</source>
+        <translation>Não é possível comunicar com o codec.
+ Provavelmente o codec não funciona corretamente.</translation>
+    </message>
+    <message>
+        <source>%1-%2</source>
+        <translation>%1-%2</translation>
+    </message>
+    <message>
+        <source>%1</source>
+        <translation>% 1</translation>
+    </message>
+    <message>
+        <source>Expected %1 argument(s) in %2, got %3</source>
+        <translation>Esperado(s) %1 argumento(s) em % 2, obtido % 3</translation>
+    </message>
+    <message>
+        <source>%1 is not a valid color (valid color names are 'red', 'transparent', '#FF8800', ecc.)</source>
+        <translation>%1 não é uma cor válida (os nomes de cores válidos são 'vermelho', 'transparente', '#FF8800', etc.)</translation>
+    </message>
+    <message>
+        <source>Vectorization failed</source>
+        <translation>Falha na vetorização</translation>
+    </message>
+    <message>
+        <source>Argument doesn't look like a file path : %1</source>
+        <translation>O argumento não se parece com um caminho de arquivo:% 1</translation>
+    </message>
+    <message>
+        <source>Bad argument (%1): should be an Image (not empty)</source>
+        <translation>Argumento incorreto (%1): deveria ser uma imagem (não vazia)</translation>
+    </message>
+    <message>
+        <source>Argument '%1' does not look like a FrameId</source>
+        <translation>O argumento '%1' não se parece com um FrameId</translation>
+    </message>
+    <message>
+        <source>First argument must be a scene : %1</source>
+        <translation>O primeiro argumento deve ser uma cena: % 1</translation>
+    </message>
+    <message>
+        <source>Can't render empty scene</source>
+        <translation>Não é possível renderizar uma cena vazia</translation>
+    </message>
+    <message>
+        <source>The autocentering failed on the current drawing.</source>
+        <translation>A centralização automática falhou no desenho atual.</translation>
+    </message>
+    <message>
+        <source>New Camera  %1</source>
+        <translation>Nova Câmara % 1</translation>
+    </message>
+    <message>
+        <source>New Pegbar  %1</source>
+        <translation>Novo Pegbar % 1</translation>
+    </message>
+    <message>
+        <source>Set Active Camera  %1 &gt; %2</source>
+        <translation>Definir câmera ativa %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Remove Spline  %1</source>
+        <translation>Remover Spline % 1</translation>
+    </message>
+    <message>
+        <source>New Motion Path  %1</source>
+        <translation>Novo Caminho de Movimento % 1</translation>
+    </message>
+    <message>
+        <source>Link Motion Path  %1 &gt; %2</source>
+        <translation>Vincular caminho de movimento %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Remove Object  %1</source>
+        <translation>Remover Objeto % 1</translation>
+    </message>
+    <message>
+        <source>Remove Column  </source>
+        <translation>Remover coluna</translation>
+    </message>
+    <message>
+        <source>Load into Current Palette  &gt; %1</source>
+        <translation>Carregar na Paleta Atual &gt; %1</translation>
+    </message>
+    <message>
+        <source>Replace with Current Palette  &gt; %1</source>
+        <translation>Substituir pela Paleta Atual &gt; % 1</translation>
+    </message>
+    <message>
+        <source>Delete Studio Palette  : %1</source>
+        <translation>Excluir paleta do Studio: %1</translation>
+    </message>
+    <message>
+        <source>Create Studio Palette  : %1</source>
+        <translation>Criar paleta do Studio: %1</translation>
+    </message>
+    <message>
+        <source>Delete Studio Palette Folder  : %1</source>
+        <translation>Excluir pasta da paleta do Studio:% 1</translation>
+    </message>
+    <message>
+        <source>Create Studio Palette Folder  : %1</source>
+        <translation>Criar pasta da paleta do Studio: %1</translation>
+    </message>
+    <message>
+        <source>Move Studio Palette Folder  : %1 : %2 &gt; %3</source>
+        <translation>Mover pasta da paleta do Studio: %1 : %2 &gt; %3</translation>
+    </message>
+    <message>
+        <source>Arrange Styles  in Palette %1</source>
+        <translation>Organizar Estilos na Paleta % 1</translation>
+    </message>
+    <message>
+        <source>Create Style#%1  in Palette %2</source>
+        <translation>Criar Estilo#%1 na Paleta %2</translation>
+    </message>
+    <message>
+        <source>Add Style  to Palette %1</source>
+        <translation>Adicionar Estilo à Paleta % 1</translation>
+    </message>
+    <message>
+        <source>Add Page %1 to Palette %2</source>
+        <translation>Adicionar a página % 1 à paleta % 2</translation>
+    </message>
+    <message>
+        <source>Delete Page %1 from Palette %2</source>
+        <translation>Excluir a página % 1 da paleta % 2</translation>
+    </message>
+    <message>
+        <source>Load Color Model %1  to Palette %2</source>
+        <translation>Carregar o Modelo de Cores % 1 na Paleta % 2</translation>
+    </message>
+    <message>
+        <source>Move Page</source>
+        <translation>Mover página</translation>
+    </message>
+    <message>
+        <source>Rename Page  %1 &gt; %2</source>
+        <translation>Renomear página %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Rename Style#%1 in Palette%2  : %3 &gt; %4</source>
+        <translation>Renomear o estilo#%1 na paleta%2: %3 &gt; %4</translation>
+    </message>
+    <message>
+        <source>Add Fx  : </source>
+        <translation>Adicionar FX:</translation>
+    </message>
+    <message>
+        <source>Insert Fx  : </source>
+        <translation>Inserir FX:</translation>
+    </message>
+    <message>
+        <source>Create Linked Fx  : %1</source>
+        <translation>Criar câmbio vinculado: %1</translation>
+    </message>
+    <message>
+        <source>Replace Fx  : </source>
+        <translation>Substitua FX:</translation>
+    </message>
+    <message>
+        <source>Unlink Fx  : %1 - - %2</source>
+        <translation>Desvincular FX: %1 - - %2</translation>
+    </message>
+    <message>
+        <source>Make Macro Fx  : %1</source>
+        <translation>Fazer Macro FX: % 1</translation>
+    </message>
+    <message>
+        <source>Explode Macro Fx  : %1</source>
+        <translation>Explodir Macro FX:% 1</translation>
+    </message>
+    <message>
+        <source>Create Output Fx</source>
+        <translation>Criar efeitos de saída</translation>
+    </message>
+    <message>
+        <source>Connect to Xsheet  : </source>
+        <translation>Conecte-se ao Xsheet:</translation>
+    </message>
+    <message>
+        <source>Disconnect from Xsheet  : </source>
+        <translation>Desconectar do Xsheet:</translation>
+    </message>
+    <message>
+        <source>Delete Link</source>
+        <translation>Excluir link</translation>
+    </message>
+    <message>
+        <source>Delete Fx Node : %1</source>
+        <translation>Excluir nó FX:% 1</translation>
+    </message>
+    <message>
+        <source>Paste Fx  :  </source>
+        <translation>Colar FX:</translation>
+    </message>
+    <message>
+        <source>Disconnect Fx</source>
+        <translation>Desconectar FX</translation>
+    </message>
+    <message>
+        <source>Connect Fx : %1 - %2</source>
+        <translation>Conectar FX: %1 - %2</translation>
+    </message>
+    <message>
+        <source>Rename Fx : %1 &gt; %2</source>
+        <translation>Renomear FX: %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Group Fx</source>
+        <translation>Grupo FX</translation>
+    </message>
+    <message>
+        <source>Ungroup Fx</source>
+        <translation>Desagrupar FX</translation>
+    </message>
+    <message>
+        <source>Rename Group  : %1 &gt; %2</source>
+        <translation>Renomear Grupo: %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Set Keyframe</source>
+        <translation>Definir quadro-chave</translation>
+    </message>
+    <message>
+        <source>Remove Keyframe</source>
+        <translation>Remover quadro-chave</translation>
+    </message>
+    <message>
+        <source>Cycle</source>
+        <translation>Ciclo</translation>
+    </message>
+    <message>
+        <source>Move</source>
+        <translation>Mover</translation>
+    </message>
+    <message>
+        <source>Edit Rotation</source>
+        <translation>Editar rotação</translation>
+    </message>
+    <message>
+        <source>Move X</source>
+        <translation>Mover X</translation>
+    </message>
+    <message>
+        <source>Move Y</source>
+        <translation>Mover Y</translation>
+    </message>
+    <message>
+        <source>Move Z</source>
+        <translation>Mover Z</translation>
+    </message>
+    <message>
+        <source>Edit Stack Order</source>
+        <translation>Editar ordem de pilha</translation>
+    </message>
+    <message>
+        <source>Edit Scale W</source>
+        <translation>Editar escala W</translation>
+    </message>
+    <message>
+        <source>Edit Scale H</source>
+        <translation>Editar escala H</translation>
+    </message>
+    <message>
+        <source>Edit Scale</source>
+        <translation>Editar escala</translation>
+    </message>
+    <message>
+        <source>Edit PosPath</source>
+        <translation>Editar PosPath</translation>
+    </message>
+    <message>
+        <source>Edit Shear X</source>
+        <translation>Editar cisalhamento X</translation>
+    </message>
+    <message>
+        <source>Edit Shear Y</source>
+        <translation>Editar cisalhamento Y</translation>
+    </message>
+    <message>
+        <source>%1  %2  Frame : %3</source>
+        <translation>% 1 % 2 Quadro: % 3</translation>
+    </message>
+    <message>
+        <source>Set Keyframe   %1 at frame %2</source>
+        <translation>Definir o quadro-chave % 1 no quadro % 2</translation>
+    </message>
+    <message>
+        <source>Remove Keyframe   %1 at frame %2</source>
+        <translation>Remover o quadro-chave % 1 do quadro % 2</translation>
+    </message>
+    <message>
+        <source>Move Center   %1  Frame %2</source>
+        <translation>Mover Centro % 1 Quadro % 2</translation>
+    </message>
+    <message>
+        <source>color model</source>
+        <translation>modelo de cor</translation>
+    </message>
+    <message>
+        <source>Set Picked Position of Style#%1 in Palette%2 : %3,%4</source>
+        <translation>Definir posição escolhida do estilo#%1 na paleta%2: %3,%4</translation>
+    </message>
+    <message>
+        <source>Update Colors by Using Picked Positions in Palette %1</source>
+        <translation>Actualizar as Cores Utilizando as Posições Seleccionadas na Paleta % 1</translation>
+    </message>
+    <message>
+        <source>Can't save</source>
+        <translation>Não é possível salvar</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation>Vermelho</translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation>Verde</translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation>Azul</translation>
+    </message>
+    <message>
+        <source>DarkYellow</source>
+        <translation>Amarelo escuro</translation>
+    </message>
+    <message>
+        <source>DarkCyan</source>
+        <translation>Ciano Escuro</translation>
+    </message>
+    <message>
+        <source>DarkMagenta</source>
+        <translation>Magenta Escuro</translation>
+    </message>
+    <message>
+        <source>Brightness</source>
+        <translation>Brilho</translation>
+    </message>
+    <message>
+        <source>Contrast</source>
+        <translation>Contraste</translation>
+    </message>
+    <message>
+        <source>HRange</source>
+        <translation>Faixa H</translation>
+    </message>
+    <message>
+        <source>Line Width</source>
+        <translation>Largura da linha</translation>
+    </message>
+    <message>
+        <source>ColorThres</source>
+        <translation>ColorThres</translation>
+    </message>
+    <message>
+        <source>WhiteThres</source>
+        <translation>BrancoThres</translation>
+    </message>
+    <message>
+        <source>Toggle Autopaint Option  Palette : %1  Style#%2</source>
+        <translation>Alternar paleta de opções de pintura automática: %1 Estilo#%2</translation>
+    </message>
+    <message>
+        <source>Can't undo rename palette</source>
+        <translation>Não é possível desfazer a renomeação da paleta</translation>
+    </message>
+    <message>
+        <source>Can't undo move palette</source>
+        <translation>Não é possível desfazer a movimentação da paleta</translation>
+    </message>
+    <message>
+        <source>Can't redo rename palette</source>
+        <translation>Não é possível refazer, renomear a paleta</translation>
+    </message>
+    <message>
+        <source>Can't redo move palette</source>
+        <translation>Não é possível refazer a movimentação da paleta</translation>
+    </message>
+    <message>
+        <source>Rename Studio Palette : %1 &gt; %2</source>
+        <translation>Renomear paleta do Studio: %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Xsheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <translation>Linha do Tempo</translation>
+    </message>
+    <message>
+        <source>Failed to save the following resources:
+</source>
+        <translation>Falha ao salvar os seguintes recursos:</translation>
+    </message>
+    <message>
+        <source>Failed to save palette.</source>
+        <translation>Falha ao salvar a paleta.</translation>
+    </message>
+    <message>
+        <source>and %1 more item(s).</source>
+        <translation>e mais %1 item(s).</translation>
+    </message>
+    <message>
+        <source>Orange</source>
+        <translation>Laranja</translation>
+    </message>
+    <message>
+        <source>Yellow</source>
+        <translation>Amarelo</translation>
+    </message>
+    <message>
+        <source>Light Green</source>
+        <translation>Verde claro</translation>
+    </message>
+    <message>
+        <source>Light Blue</source>
+        <translation>Azul claro</translation>
+    </message>
+    <message>
+        <source>Dark Blue</source>
+        <translation>Azul escuro</translation>
+    </message>
+    <message>
+        <source>Purple</source>
+        <translation>Roxo</translation>
+    </message>
+    <message>
+        <source>Pink</source>
+        <translation>Rosa</translation>
+    </message>
+    <message>
+        <source>Dark Pink</source>
+        <translation>Rosa Escuro</translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation>Branco</translation>
+    </message>
+    <message>
+        <source>Custom Texture</source>
+        <comment>TextureStyleChooserPage</comment>
+        <translation>Textura Personalizada</translation>
+    </message>
+    <message>
+        <source>Set Current Style from #%1 to %2</source>
+        <translation>Definir o estilo atual de #%1 a %2</translation>
+    </message>
+    <message>
+        <source>%1 is not a valid color (valid color names are 'red', 'transparent', '#FF8800', etc.)</source>
+        <translation>%1 não é uma cor válida (os nomes de cores válidos são 'vermelho', 'transparente', '#FF8800', etc.)</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::CenterlineVectorizer</name>
+    <message>
+        <source>Can't vectorize a %1 level</source>
+        <translation>Não é possível vetorizar um nível % 1</translation>
+    </message>
+    <message>
+        <source>Can't vectorize a level with no frames</source>
+        <translation>Não é possível vetorizar um nível sem quadros</translation>
+    </message>
+    <message>
+        <source>Can't vectorize a %1 image</source>
+        <translation>Não é possível vetorizar uma imagem % 1</translation>
+    </message>
+    <message>
+        <source>Bad argument (%1): should be an Image or a Level</source>
+        <translation>Argumento incorreto (%1): deveria ser uma imagem ou um nível</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::FilePath</name>
+    <message>
+        <source>"%1"</source>
+        <translation>"%1"</translation>
+    </message>
+    <message>
+        <source>can't concatenate an absolute path : %1</source>
+        <translation>não é possível concatenar um caminho absoluto:% 1</translation>
+    </message>
+    <message>
+        <source>%1 is not a directory</source>
+        <translation>% 1 não é um diretório</translation>
+    </message>
+    <message>
+        <source>can't read directory %1</source>
+        <translation>não consigo ler a pasta % 1</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::Image</name>
+    <message>
+        <source>File %1 doesn't exist</source>
+        <translation>O arquivo % 1 não existe</translation>
+    </message>
+    <message>
+        <source>Loaded first frame of %1</source>
+        <translation>Carregou o primeiro quadro de % 1</translation>
+    </message>
+    <message>
+        <source>Unexpected error while reading image</source>
+        <translation>Erro inesperado ao ler a imagem</translation>
+    </message>
+    <message>
+        <source>Unrecognized file type :</source>
+        <translation>Tipo de arquivo não reconhecido:</translation>
+    </message>
+    <message>
+        <source>Can't save a %1 image to this file type : %2</source>
+        <translation>Não é possível salvar uma imagem % 1 neste tipo de arquivo: % 2</translation>
+    </message>
+    <message>
+        <source>Unexpected error while writing image</source>
+        <translation>Erro inesperado ao gravar imagem</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::ImageBuilder</name>
+    <message>
+        <source>Bad argument (%1): should be 'Raster' or ToonzRaster'</source>
+        <translation>Argumento incorreto (%1): deveria ser 'Raster' ou ToonzRaster'</translation>
+    </message>
+    <message>
+        <source>ImageBuilder(%1 image)</source>
+        <translation>Construtor de imagens(%1 imagem)</translation>
+    </message>
+    <message>
+        <source>%1 : %2</source>
+        <translation>% 1: % 2</translation>
+    </message>
+    <message>
+        <source>Bad argument (%1): should be a Transformation</source>
+        <translation>Argumento incorreto (%1): deveria ser uma transformação</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::Level</name>
+    <message>
+        <source>%1 frames</source>
+        <translation>%1 quadros</translation>
+    </message>
+    <message>
+        <source>Bad argument (%1). It should be FilePath or string</source>
+        <translation>Argumento incorreto (%1). Deve ser FilePath ou string</translation>
+    </message>
+    <message>
+        <source>Exception loading level (%1)</source>
+        <translation>Nível de carregamento de exceção (%1)</translation>
+    </message>
+    <message>
+        <source>File %1 doesn't exist</source>
+        <translation>O arquivo % 1 não existe</translation>
+    </message>
+    <message>
+        <source>File %1 is unsupported</source>
+        <translation>O arquivo % 1 não é suportado</translation>
+    </message>
+    <message>
+        <source>Exception reading %1</source>
+        <translation>Leitura de excepção % 1</translation>
+    </message>
+    <message>
+        <source>Can't save an empty level</source>
+        <translation>Não é possível salvar um nível vazio</translation>
+    </message>
+    <message>
+        <source>Unrecognized file type :</source>
+        <translation>Tipo de arquivo não reconhecido:</translation>
+    </message>
+    <message>
+        <source>Can't save a %1 level to this file type : %2</source>
+        <translation>Não é possível salvar um nível %1 neste tipo de arquivo: %2</translation>
+    </message>
+    <message>
+        <source>Exception writing %1</source>
+        <translation>Escrita de excepção % 1</translation>
+    </message>
+    <message>
+        <source>frame index (%1) must be a number</source>
+        <translation>índice de quadros (%1) deve ser um número</translation>
+    </message>
+    <message>
+        <source>frame index (%1) is out of range (0-%2)</source>
+        <translation>índice de quadros (%1) está fora do intervalo (0-%2)</translation>
+    </message>
+    <message>
+        <source>second argument (%1) is not an image</source>
+        <translation>o segundo argumento (% 1) não é uma imagem</translation>
+    </message>
+    <message>
+        <source>can not insert a %1 image into a level</source>
+        <translation>nãoépossível inserir uma imagem % 1 num nível</translation>
+    </message>
+    <message>
+        <source>can not insert a %1 image to a %2 level</source>
+        <translation>nãoépossível inserir uma imagem % 1 num nível % 2</translation>
+    </message>
+    <message>
+        <source>Cannot set path on empty level</source>
+        <translation>Não é possível definir o caminho no nível vazio</translation>
+    </message>
+    <message>
+        <source>Unrecognized file type: %1</source>
+        <translation>Tipo de arquivo não reconhecido:% 1</translation>
+    </message>
+    <message>
+        <source>Can't save a %1 level to this file type: %2</source>
+        <translation>Não é possível salvar um nível %1 neste tipo de arquivo: %2</translation>
+    </message>
+    <message>
+        <source>cannot insert a %1 image into a level</source>
+        <translation>não é possível inserir uma imagem % 1 num nível</translation>
+    </message>
+    <message>
+        <source>cannot insert a %1 image to a %2 level</source>
+        <translation>não é possível inserir uma imagem % 1 no nível % 2</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::OutlineVectorizer</name>
+    <message>
+        <source>Can't vectorize a %1 level</source>
+        <translation>Não é possível vetorizar um nível % 1</translation>
+    </message>
+    <message>
+        <source>Can't vectorize a level with no frames</source>
+        <translation>Não é possível vetorizar um nível sem quadros</translation>
+    </message>
+    <message>
+        <source>Can't vectorize a %1 image</source>
+        <translation>Não é possível vetorizar uma imagem % 1</translation>
+    </message>
+    <message>
+        <source>Bad argument (%1): should be an Image or a Level</source>
+        <translation>Argumento incorreto (%1): deveria ser uma imagem ou um nível</translation>
+    </message>
+    <message>
+        <source>Invalid color : </source>
+        <translation>Cor inválida:</translation>
+    </message>
+    <message>
+        <source>Invalid color: %1</source>
+        <translation>Cor inválida: %1</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::Rasterizer</name>
+    <message>
+        <source>Expected a vector image: %1</source>
+        <translation>Esperava uma imagem vetorial: % 1</translation>
+    </message>
+    <message>
+        <source>Expected a vector level: %1</source>
+        <translation>Nível de vetor esperado: % 1</translation>
+    </message>
+    <message>
+        <source>Argument must be a vector level or image : </source>
+        <translation>O argumento deve ser um nível vetorial ou imagem:</translation>
+    </message>
+    <message>
+        <source>%1 has no palette</source>
+        <translation>% 1 não tem nenhuma paleta</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::Scene</name>
+    <message>
+        <source>File %1 doesn't exist</source>
+        <translation>O arquivo % 1 não existe</translation>
+    </message>
+    <message>
+        <source>Exception reading %1</source>
+        <translation>Leitura de excepção % 1</translation>
+    </message>
+    <message>
+        <source>Exception writing %1</source>
+        <translation>Escrita de excepção % 1</translation>
+    </message>
+    <message>
+        <source>Bad level type (%1): must be Vector,Raster or ToonzRaster</source>
+        <translation>Tipo de nível inválido (%1): deve ser Vetor,Raster ou ToonzRaster</translation>
+    </message>
+    <message>
+        <source>Can't add the level: name(%1) is already used</source>
+        <translation>Não é possível adicionar o nível: name(%1) já está em uso</translation>
+    </message>
+    <message>
+        <source>Can't load this kind of file as a level : %1</source>
+        <translation>Não é possível carregar este tipo de arquivo como nível: %1</translation>
+    </message>
+    <message>
+        <source>Could not load level %1</source>
+        <translation>Não foi possível carregar o nível % 1</translation>
+    </message>
+    <message>
+        <source>Level is not included in the scene : %1</source>
+        <translation>O nível não está incluído na cena: %1</translation>
+    </message>
+    <message>
+        <source>%1 : Expected a Level instance or a level name</source>
+        <translation>% 1: Esperava-se uma instância de Nível ou um nome de nível</translation>
+    </message>
+    <message>
+        <source>Level '%1' is not included in the scene</source>
+        <translation>O nível '%1' não está incluído na cena</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::ToonzRasterConverter</name>
+    <message>
+        <source>Can't convert a %1 level</source>
+        <translation>Não é possível converter um nível %1</translation>
+    </message>
+    <message>
+        <source>Can't convert a level with no frames</source>
+        <translation>Não é possível converter um nível sem quadros</translation>
+    </message>
+    <message>
+        <source>Can't convert a %1 image</source>
+        <translation>Não foi possível converter uma imagem % 1</translation>
+    </message>
+    <message>
+        <source>Bad argument (%1): should be a raster Level or a raster Image</source>
+        <translation>Argumento incorreto (%1): deve ser um nível raster ou uma imagem raster</translation>
+    </message>
+</context>
+<context>
+    <name>TScriptBinding::Transform</name>
+    <message>
+        <source>Identity</source>
+        <translation>Identidade</translation>
+    </message>
+    <message>
+        <source>Translation(%1,%2)</source>
+        <translation>Tradução(%1,%2)</translation>
+    </message>
+    <message>
+        <source>Rotation(%1)</source>
+        <translation>Rotação(%1)</translation>
+    </message>
+    <message>
+        <source>Scale(%1%)</source>
+        <translation>Escala(%1%)</translation>
+    </message>
+    <message>
+        <source>Scale(%1%, %2%)</source>
+        <translation>Escala(%1%,%2%)</translation>
+    </message>
+    <message>
+        <source>Transform(%1, %2, %3;  %4, %5, %6)</source>
+        <translation>Transformar(%1,%2,%3;%4,%5,%6)</translation>
+    </message>
+</context>
+</TS>

--- a/toonz/sources/translations/portuguese_brazil/toonzqt.ts
+++ b/toonz/sources/translations/portuguese_brazil/toonzqt.ts
@@ -1,0 +1,3460 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR" sourcelanguage="en">
+<context>
+    <name>AddFxContextMenu</name>
+    <message>
+        <source>Insert FX</source>
+        <translation>Inserir FX</translation>
+    </message>
+    <message>
+        <source>Add FX</source>
+        <translation>Adicionar FX</translation>
+    </message>
+    <message>
+        <source>Replace FX</source>
+        <translation>Substituir FX</translation>
+    </message>
+    <message>
+        <source>Insert </source>
+        <translation>Inserir</translation>
+    </message>
+    <message>
+        <source>Add </source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Replace </source>
+        <translation>Substituir</translation>
+    </message>
+</context>
+<context>
+    <name>AddWordButton</name>
+    <message>
+        <source>Character</source>
+        <translation>Personagem</translation>
+    </message>
+    <message>
+        <source>Part</source>
+        <translation>Papel</translation>
+    </message>
+    <message>
+        <source>Suffix</source>
+        <translation>Sufixo</translation>
+    </message>
+    <message>
+        <source>New</source>
+        <translation>Novo</translation>
+    </message>
+    <message>
+        <source>Add New Word for %1</source>
+        <translation>Adicionar Nova Palavra para % 1</translation>
+    </message>
+</context>
+<context>
+    <name>AdjustPaletteDialog</name>
+    <message>
+        <source>Adjust Current Level to This Palette</source>
+        <translation>Ajustar o nível atual para esta paleta</translation>
+    </message>
+    <message>
+        <source>Tolerance</source>
+        <translation>Tolerância</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>CameraPainter</name>
+    <message>
+        <source>&amp;Reset Center</source>
+        <translation>&amp;Redefinir Central</translation>
+    </message>
+    <message>
+        <source>&amp;Activate</source>
+        <translation>&amp;Ativar</translation>
+    </message>
+</context>
+<context>
+    <name>CameraSettingsWidget</name>
+    <message>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <source>XPx:</source>
+        <translation>XPx:</translation>
+    </message>
+    <message>
+        <source>YPx:</source>
+        <translation>YPx:</translation>
+    </message>
+    <message>
+        <source>XDpi:</source>
+        <translation>XDpi:</translation>
+    </message>
+    <message>
+        <source>YDpi:</source>
+        <translation>YDpi:</translation>
+    </message>
+    <message>
+        <source>Use Current Level Settings</source>
+        <translation>Usar configurações de nível atual</translation>
+    </message>
+    <message>
+        <source>Bad camera preset</source>
+        <translation>Predefinição de câmera ruim</translation>
+    </message>
+    <message>
+        <source>'%1' doesn't seem a well formed camera preset. 
+Possibly the preset file has been corrupted</source>
+        <translation>'%1' não parece ser uma predefinição de câmera bem formada. 
+Possivelmente o arquivo predefinido foi corrompido</translation>
+    </message>
+    <message>
+        <source>Preset name</source>
+        <translation>Nome predefinido</translation>
+    </message>
+    <message>
+        <source>Enter the name for %1</source>
+        <translation>Introduza o nome para % 1</translation>
+    </message>
+    <message>
+        <source>AR:</source>
+        <translation>RA:</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+    <message>
+        <source>Force Squared Pixel</source>
+        <translation>Forçar Pixel Quadrado</translation>
+    </message>
+    <message>
+        <source>Error : Preset Name is Invalid</source>
+        <translation>Erro: o nome predefinido é inválido</translation>
+    </message>
+    <message>
+        <source>The preset name must not use ','(comma).</source>
+        <translation>O nome predefinido não deve usar ','(vírgula).</translation>
+    </message>
+    <message>
+        <source>DPI</source>
+        <translation>DPI</translation>
+    </message>
+    <message>
+        <source>Pixels</source>
+        <translation>Pixels</translation>
+    </message>
+    <message>
+        <source>x</source>
+        <translation>x</translation>
+    </message>
+    <message>
+        <source>A/R</source>
+        <translation>Contas a receber</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>cm</source>
+        <translation>cm</translation>
+    </message>
+    <message>
+        <source>mm</source>
+        <translation>milímetros</translation>
+    </message>
+    <message>
+        <source>inch</source>
+        <translation>polegada</translation>
+    </message>
+    <message>
+        <source>field</source>
+        <translation>campo</translation>
+    </message>
+    <message>
+        <source>pixel</source>
+        <translation>pixel</translation>
+    </message>
+    <message>
+        <source>Deleting "%1".
+Are you sure?</source>
+        <translation>Excluindo "%1".
+Tem certeza?</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>ChannelHisto</name>
+    <message>
+        <source>Red</source>
+        <translation>Vermelho</translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation>Verde</translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation>Azul</translation>
+    </message>
+    <message>
+        <source>Alpha</source>
+        <translation>Alfa</translation>
+    </message>
+    <message>
+        <source>RGBA</source>
+        <translation>RGBA</translation>
+    </message>
+    <message>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+</context>
+<context>
+    <name>CleanupCameraSettingsWidget</name>
+    <message>
+        <source>Closest:</source>
+        <translation>Mais próximo:</translation>
+    </message>
+    <message>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <source>Y:</source>
+        <translation>E:</translation>
+    </message>
+    <message>
+        <source>DPI:</source>
+        <translation>DPI:</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>Nome:</translation>
+    </message>
+    <message>
+        <source>Path:</source>
+        <translation>Caminho:</translation>
+    </message>
+    <message>
+        <source>Field settings</source>
+        <translation>Configurações de campo</translation>
+    </message>
+    <message>
+        <source>XPx:</source>
+        <translation>XPx:</translation>
+    </message>
+    <message>
+        <source>YPx:</source>
+        <translation>YPx:</translation>
+    </message>
+    <message>
+        <source>Resulting Level Info</source>
+        <translation>Informações do nível resultante</translation>
+    </message>
+    <message>
+        <source>Y</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+</context>
+<context>
+    <name>ColumnPainter</name>
+    <message>
+        <source>&amp;Reset Center</source>
+        <translation>&amp;Redefinir Central</translation>
+    </message>
+    <message>
+        <source>&amp;Open Subxsheet</source>
+        <translation>&amp;Abrir subxplanilha</translation>
+    </message>
+</context>
+<context>
+    <name>ComboHistoRGBLabel</name>
+    <message>
+        <source>R:%1 G:%2 B:%3</source>
+        <translation>R:%1 G:%2 B:%3</translation>
+    </message>
+    <message>
+        <source> A:%1</source>
+        <translation>R:% 1</translation>
+    </message>
+    <message>
+        <source>A:%1</source>
+        <translation>R:% 1</translation>
+    </message>
+</context>
+<context>
+    <name>ComboHistogram</name>
+    <message>
+        <source>Picked Color</source>
+        <translation>Cor escolhida</translation>
+    </message>
+    <message>
+        <source>Average Color (Ctrl + Drag)</source>
+        <translation>Cor média (Ctrl + Arrastar)</translation>
+    </message>
+    <message>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <source>Y:</source>
+        <translation>E:</translation>
+    </message>
+    <message>
+        <source>8bit (0-255)</source>
+        <translation>8 bits (0-255)</translation>
+    </message>
+    <message>
+        <source>16bit (0-65535)</source>
+        <translation>16 bits (0-65535)</translation>
+    </message>
+    <message>
+        <source>0.0-1.0</source>
+        <translation>0,0-1,0</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui</name>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::CleanupColorField</name>
+    <message>
+        <source>Brightness:</source>
+        <translation>Brilho:</translation>
+    </message>
+    <message>
+        <source>Contrast:</source>
+        <translation>Contraste:</translation>
+    </message>
+    <message>
+        <source>Color Threshold</source>
+        <translation>Limite de cor</translation>
+    </message>
+    <message>
+        <source>White Threshold</source>
+        <translation>Limiar Branco</translation>
+    </message>
+    <message>
+        <source>H Range</source>
+        <translation>Faixa H</translation>
+    </message>
+    <message>
+        <source>Line Width</source>
+        <translation>Largura da linha</translation>
+    </message>
+    <message>
+        <source>Color Thres</source>
+        <translation>Cor Tres</translation>
+    </message>
+    <message>
+        <source>White Thres</source>
+        <translation>Tres Brancos</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::ColorField</name>
+    <message>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <source>G:</source>
+        <translation>G:</translation>
+    </message>
+    <message>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <source>A:</source>
+        <translation>UM:</translation>
+    </message>
+    <message>
+        <source>Paste Color</source>
+        <translation>Colar cor</translation>
+    </message>
+    <message>
+        <source>Paste Color of %1</source>
+        <translation>Colar a cor de % 1</translation>
+    </message>
+    <message>
+        <source>Copy Color</source>
+        <translation>Copiar cor</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::DvTextEdit</name>
+    <message>
+        <source>Bold</source>
+        <translation>Audacioso</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation>itálico</translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation>Sublinhado</translation>
+    </message>
+    <message>
+        <source>Align Left</source>
+        <translation>Alinhar à esquerda</translation>
+    </message>
+    <message>
+        <source>Align Center</source>
+        <translation>Alinhar Centro</translation>
+    </message>
+    <message>
+        <source>Align Right</source>
+        <translation>Alinhar à direita</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::FileField</name>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::HexColorNamesEditor</name>
+    <message>
+        <source>Hex Color Names Editor</source>
+        <translation>Editor de nomes de cores hexadecimais</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+    <message>
+        <source>Unselect</source>
+        <translation>Desmarcar</translation>
+    </message>
+    <message>
+        <source>Add Color</source>
+        <translation>Adicionar cor</translation>
+    </message>
+    <message>
+        <source>Delete Color</source>
+        <translation>Excluir cor</translation>
+    </message>
+    <message>
+        <source>User Defined Colors</source>
+        <translation>Cores definidas pelo usuário</translation>
+    </message>
+    <message>
+        <source>Default Main Colors</source>
+        <translation>Cores principais padrão</translation>
+    </message>
+    <message>
+        <source>Enable Auto-Complete</source>
+        <translation>Ativar preenchimento automático</translation>
+    </message>
+    <message>
+        <source>Import</source>
+        <translation>Importar</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>Exportar</translation>
+    </message>
+    <message>
+        <source>Open Color Names</source>
+        <translation>Abrir nomes de cores</translation>
+    </message>
+    <message>
+        <source>Text or XML (*.txt *.xml);;Text files (*.txt);;XML files (*.xml)</source>
+        <translation>Texto ou XML (*.txt *.xml);;Arquivos de texto (*.txt);;Arquivos XML (*.xml)</translation>
+    </message>
+    <message>
+        <source>Hex Color Names Import</source>
+        <translation>Importação de nomes de cores hexadecimais</translation>
+    </message>
+    <message>
+        <source>Do you want to merge with existing entries?</source>
+        <translation>Você deseja mesclar com entradas existentes?</translation>
+    </message>
+    <message>
+        <source>Error importing color names XML</source>
+        <translation>Erro ao importar nomes de cores XML</translation>
+    </message>
+    <message>
+        <source>Save Color Names</source>
+        <translation>Salvar nomes de cores</translation>
+    </message>
+    <message>
+        <source>XML files (*.xml);;Text files (*.txt)</source>
+        <translation>Arquivos XML (*.xml);;Arquivos de texto (*.txt)</translation>
+    </message>
+    <message>
+        <source>Error exporting color names XML</source>
+        <translation>Erro ao exportar nomes de cores XML</translation>
+    </message>
+    <message>
+        <source>Color name is not valid.
+The following characters cannot be used: \ # &lt; &gt; " '</source>
+        <translation>O nome da cor não é válido.
+Os seguintes caracteres não podem ser usados: \ # &lt; &gt; " '</translation>
+    </message>
+    <message>
+        <source>Color name already exists.
+Please use another name.</source>
+        <translation>O nome da cor já existe.
+Por favor, use outro nome.</translation>
+    </message>
+    <message>
+        <source>Invalid hex color format.</source>
+        <translation>Formato de cor hexadecimal inválido.</translation>
+    </message>
+    <message>
+        <source>Error importing color names XML:
+File not found or invalid format</source>
+        <translation>Erro ao importar nomes de cores XML:
+Arquivo não encontrado ou formato inválido</translation>
+    </message>
+    <message>
+        <source>Error importing color names XML:
+The file may be corrupt or have invalid format.</source>
+        <translation>Erro ao importar nomes de cores XML:
+O arquivo pode estar corrompido ou ter formato inválido.</translation>
+    </message>
+    <message>
+        <source>An unexpected error occurred while importing colors.</source>
+        <translation>Ocorreu um erro inesperado ao importar cores.</translation>
+    </message>
+    <message>
+        <source>Failed to save user color names file.</source>
+        <translation>Falha ao salvar o arquivo de nomes de cores do usuário.</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::LineEdit</name>
+    <message>
+        <source>A file name cannot contains any of the following chracters: /\:*?"&lt;&gt;|.</source>
+        <translation>Um nome de arquivo não pode conter nenhum dos seguintes caracteres: /\:*?"&lt;&gt;|.</translation>
+    </message>
+    <message>
+        <source>A file name cannot contains any of the following characters: /\:*?"&lt;&gt;|.</source>
+        <translation>Um nome de arquivo não pode conter nenhum dos seguintes caracteres: /\:*?"&lt;&gt;|.</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::ProgressDialog</name>
+    <message>
+        <source>Toonz</source>
+        <translation>Toonz</translation>
+    </message>
+    <message>
+        <source>OpenToonz</source>
+        <translation>OpenToonz</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::RadioButtonDialog</name>
+    <message>
+        <source>Toonz</source>
+        <translation>Toonz</translation>
+    </message>
+    <message>
+        <source>OpenToonz</source>
+        <translation>OpenToonz</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::StyleIndexLineEdit</name>
+    <message>
+        <source>current</source>
+        <translation>atual</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::ToneCurveField</name>
+    <message>
+        <source>Channel:</source>
+        <translation>Canal:</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation>Faixa:</translation>
+    </message>
+    <message>
+        <source>Output:</source>
+        <translation>Saída:</translation>
+    </message>
+    <message>
+        <source>Input:</source>
+        <translation>Entrada:</translation>
+    </message>
+</context>
+<context>
+    <name>DVGui::ValidatedChoiceDialog</name>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Apply to All</source>
+        <translation>Aplicar a todos</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>DvTextEdit</name>
+    <message>
+        <source>Bold</source>
+        <translation>Audacioso</translation>
+    </message>
+    <message>
+        <source>Italic</source>
+        <translation>itálico</translation>
+    </message>
+    <message>
+        <source>Underline</source>
+        <translation>Sublinhado</translation>
+    </message>
+    <message>
+        <source>Align Left</source>
+        <translation>Alinhar à esquerda</translation>
+    </message>
+    <message>
+        <source>Align Center</source>
+        <translation>Alinhar Centro</translation>
+    </message>
+    <message>
+        <source>Align Right</source>
+        <translation>Alinhar à direita</translation>
+    </message>
+</context>
+<context>
+    <name>EaseInOutSegmentPage</name>
+    <message>
+        <source>Ease In:</source>
+        <translation>Facilidade de entrada:</translation>
+    </message>
+    <message>
+        <source>Ease Out:</source>
+        <translation>Facilite:</translation>
+    </message>
+</context>
+<context>
+    <name>EasyInputArea</name>
+    <message>
+        <source>Warning</source>
+        <translation>Aviso</translation>
+    </message>
+    <message>
+        <source>%1 is already registered</source>
+        <translation>% 1 já está registado</translation>
+    </message>
+</context>
+<context>
+    <name>FileField</name>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+</context>
+<context>
+    <name>FileSegmentPage</name>
+    <message>
+        <source>File Path:</source>
+        <translation>Caminho do arquivo:</translation>
+    </message>
+    <message>
+        <source>Column:</source>
+        <translation>Coluna:</translation>
+    </message>
+    <message>
+        <source>Unit:</source>
+        <translation>Unidade:</translation>
+    </message>
+</context>
+<context>
+    <name>FlipConsole</name>
+    <message>
+        <source> FPS </source>
+        <translation>FPS</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Snapshot</source>
+        <translation>Instantâneo</translation>
+    </message>
+    <message>
+        <source>Define Sub-camera</source>
+        <translation>Definir subcâmera</translation>
+    </message>
+    <message>
+        <source>Background Colors</source>
+        <translation>Cores de fundo</translation>
+    </message>
+    <message>
+        <source>Framerate</source>
+        <translation>Taxa de quadros</translation>
+    </message>
+    <message>
+        <source>Playback Controls</source>
+        <translation>Controles de reprodução</translation>
+    </message>
+    <message>
+        <source>Color Channels</source>
+        <translation>Canais de cores</translation>
+    </message>
+    <message>
+        <source>Set Key</source>
+        <translation>Definir chave</translation>
+    </message>
+    <message>
+        <source>Histogram</source>
+        <translation>Histograma</translation>
+    </message>
+    <message>
+        <source>&amp;Save Images</source>
+        <translation>&amp;Salvar imagens</translation>
+    </message>
+    <message>
+        <source>&amp;Snapshot</source>
+        <translation>&amp;Instantâneo</translation>
+    </message>
+    <message>
+        <source>&amp;Compare to Snapshot</source>
+        <translation>&amp;Comparar com instantâneo</translation>
+    </message>
+    <message>
+        <source>&amp;Define Sub-camera</source>
+        <translation>&amp;Definir subcâmera</translation>
+    </message>
+    <message>
+        <source>&amp;White Background</source>
+        <translation>&amp;Fundo branco</translation>
+    </message>
+    <message>
+        <source>&amp;Black Background</source>
+        <translation>&amp;Fundo preto</translation>
+    </message>
+    <message>
+        <source>&amp;Checkered Background</source>
+        <translation>&amp;Fundo xadrez</translation>
+    </message>
+    <message>
+        <source>Set the playback frame rate</source>
+        <translation>Defina a taxa de quadros de reprodução</translation>
+    </message>
+    <message>
+        <source>&amp;First Frame</source>
+        <translation>&amp;Primeiro quadro</translation>
+    </message>
+    <message>
+        <source>&amp;Previous Frame</source>
+        <translation>&amp;Quadro Anterior</translation>
+    </message>
+    <message>
+        <source>Pause</source>
+        <translation>Pausa</translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation>Jogar</translation>
+    </message>
+    <message>
+        <source>Loop</source>
+        <translation>Laço</translation>
+    </message>
+    <message>
+        <source>&amp;Next frame</source>
+        <translation>&amp;Próximo quadro</translation>
+    </message>
+    <message>
+        <source>&amp;Last Frame</source>
+        <translation>&amp;Último quadro</translation>
+    </message>
+    <message>
+        <source>Red Channel</source>
+        <translation>Canal Vermelho</translation>
+    </message>
+    <message>
+        <source>Red Channel in Grayscale</source>
+        <translation>Canal Vermelho em Tons de Cinza</translation>
+    </message>
+    <message>
+        <source>Green Channel</source>
+        <translation>Canal Verde</translation>
+    </message>
+    <message>
+        <source>Green Channel in Grayscale</source>
+        <translation>Canal Verde em Tons de Cinza</translation>
+    </message>
+    <message>
+        <source>Blue Channel</source>
+        <translation>Canal Azul</translation>
+    </message>
+    <message>
+        <source>Blue Channel in Grayscale</source>
+        <translation>Canal Azul em Escala de Cinza</translation>
+    </message>
+    <message>
+        <source>Alpha Channel</source>
+        <translation>Canal Alfa</translation>
+    </message>
+    <message>
+        <source>&amp;Soundtrack </source>
+        <translation>&amp;Trilha sonora</translation>
+    </message>
+    <message>
+        <source>&amp;Histogram</source>
+        <translation>&amp;Histograma</translation>
+    </message>
+    <message>
+        <source> FPS	</source>
+        <translation>FPS</translation>
+    </message>
+    <message>
+        <source> Frame  </source>
+        <translation>Quadro</translation>
+    </message>
+    <message>
+        <source>Set the current frame</source>
+        <translation>Defina o quadro atual</translation>
+    </message>
+    <message>
+        <source>Drag to play the animation</source>
+        <translation>Arraste para reproduzir a animação</translation>
+    </message>
+    <message>
+        <source>Define Loading Box</source>
+        <translation>Definir caixa de carregamento</translation>
+    </message>
+    <message>
+        <source>Use Loading Box</source>
+        <translation>Usar caixa de carregamento</translation>
+    </message>
+    <message>
+        <source>&amp;Define Loading Box</source>
+        <translation>&amp;Definir caixa de carregamento</translation>
+    </message>
+    <message>
+        <source>&amp;Use Loading Box</source>
+        <translation>&amp;Usar caixa de carregamento</translation>
+    </message>
+    <message>
+        <source>Display Areas as Filled</source>
+        <translation>Exibir áreas como preenchidas</translation>
+    </message>
+    <message>
+        <source>&amp;Display Areas as Filled</source>
+        <translation>&amp;Exibir áreas preenchidas</translation>
+    </message>
+    <message>
+        <source>&amp;Locator</source>
+        <translation>&amp;Localizador</translation>
+    </message>
+    <message>
+        <source>Viewer Controls</source>
+        <translation>Controles do visualizador</translation>
+    </message>
+    <message>
+        <source>&amp;Zoom In</source>
+        <translation>&amp;Ampliar</translation>
+    </message>
+    <message>
+        <source>&amp;Zoom Out</source>
+        <translation>&amp;Diminuir zoom</translation>
+    </message>
+    <message>
+        <source>&amp;Flip Horizontally</source>
+        <translation>&amp;Virar horizontalmente</translation>
+    </message>
+    <message>
+        <source>&amp;Flip Vertically</source>
+        <translation>&amp;Virar verticalmente</translation>
+    </message>
+    <message>
+        <source>&amp;Reset View</source>
+        <translation>&amp;Redefinir visualização</translation>
+    </message>
+    <message>
+        <source>Sound</source>
+        <translation>Som</translation>
+    </message>
+    <message>
+        <source>Locator</source>
+        <translation>Localizador</translation>
+    </message>
+    <message>
+        <source>&amp;Next Frame</source>
+        <translation>&amp;Próximo quadro</translation>
+    </message>
+    <message>
+        <source>Gain Controls</source>
+        <translation>Controles de ganho</translation>
+    </message>
+    <message>
+        <source>&amp;Reduce gain 1/2 stop (divide by sqrt(2))</source>
+        <translation>&amp;Reduzir ganho 1/2 ponto (dividir por sqrt(2))</translation>
+    </message>
+    <message>
+        <source>Toggle gain between 1 and the previous setting.
+Gain is shown as an f-stop and the "neutral" or 1.0 gain f-stop is f/8.</source>
+        <translation>Alterne o ganho entre 1 e a configuração anterior.
+O ganho é mostrado como um f-stop e o f-stop "neutro" ou ganho de 1,0 é f/8.</translation>
+    </message>
+    <message>
+        <source>&amp;Increase gain 1/2 stop (multiply by sqrt(2))</source>
+        <translation>&amp;Aumentar o ganho 1/2 ponto (multiplicar por sqrt(2))</translation>
+    </message>
+    <message>
+        <source> (gain %1)</source>
+        <translation>(ganho% 1)</translation>
+    </message>
+    <message>
+        <source>&amp;Rotate Left</source>
+        <translation>&amp;Girar para a esquerda</translation>
+    </message>
+    <message>
+        <source>&amp;Rotate Right</source>
+        <translation>&amp;Girar para a direita</translation>
+    </message>
+</context>
+<context>
+    <name>FontParamField</name>
+    <message>
+        <source>Style:</source>
+        <translation>Estilo:</translation>
+    </message>
+    <message>
+        <source>Size:</source>
+        <translation>Tamanho:</translation>
+    </message>
+</context>
+<context>
+    <name>FrameNavigator</name>
+    <message>
+        <source>Previous Frame</source>
+        <translation>Quadro Anterior</translation>
+    </message>
+    <message>
+        <source>Next Frame</source>
+        <translation>Próximo quadro</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionExpressionSegmentPage</name>
+    <message>
+        <source>Expression:</source>
+        <translation>Expressão:</translation>
+    </message>
+    <message>
+        <source>Unit:</source>
+        <translation>Unidade:</translation>
+    </message>
+    <message>
+        <source>There is a circular reference in the definition of the interpolation.</source>
+        <translation>Há uma referência circular na definição da interpolação.</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionPanel</name>
+    <message>
+        <source>Link Handles</source>
+        <translation>Alças de link</translation>
+    </message>
+    <message>
+        <source>Unlink Handles</source>
+        <translation>Desvincular alças</translation>
+    </message>
+    <message>
+        <source>Reset Handles</source>
+        <translation>Redefinir alças</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Set Key</source>
+        <translation>Definir chave</translation>
+    </message>
+    <message>
+        <source>Activate Cycle</source>
+        <translation>Ativar Ciclo</translation>
+    </message>
+    <message>
+        <source>Deactivate Cycle</source>
+        <translation>Desativar Ciclo</translation>
+    </message>
+    <message>
+        <source>Linear Interpolation</source>
+        <translation>Interpolação Linear</translation>
+    </message>
+    <message>
+        <source>Speed In / Speed Out Interpolation</source>
+        <translation>Interpolação de entrada/saída de velocidade</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out Interpolation</source>
+        <translation>Interpolação de entrada/saída facilitada</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out (%) Interpolation</source>
+        <translation>Interpolação de entrada/saída facilitada (%)</translation>
+    </message>
+    <message>
+        <source>Exponential Interpolation</source>
+        <translation>Interpolação Exponencial</translation>
+    </message>
+    <message>
+        <source>Expression Interpolation</source>
+        <translation>Interpolação de Expressão</translation>
+    </message>
+    <message>
+        <source>File Interpolation</source>
+        <translation>Interpolação de arquivos</translation>
+    </message>
+    <message>
+        <source>Constant Interpolation</source>
+        <translation>Interpolação Constante</translation>
+    </message>
+    <message>
+        <source>Fit Selection</source>
+        <translation>Seleção de ajuste</translation>
+    </message>
+    <message>
+        <source>Fit</source>
+        <translation>Ajustar</translation>
+    </message>
+    <message>
+        <source>Similar Shape Interpolation</source>
+        <translation>Interpolação de forma semelhante</translation>
+    </message>
+    <message>
+        <source>Step 1</source>
+        <translation>Passo 1</translation>
+    </message>
+    <message>
+        <source>Step 2</source>
+        <translation>Etapa 2</translation>
+    </message>
+    <message>
+        <source>Step 3</source>
+        <translation>Etapa 3</translation>
+    </message>
+    <message>
+        <source>Step 4</source>
+        <translation>Etapa 4</translation>
+    </message>
+    <message>
+        <source>Function Curves</source>
+        <translation>Curvas de Função</translation>
+    </message>
+    <message>
+        <source>Smooth</source>
+        <translation>Suave</translation>
+    </message>
+    <message>
+        <source>Frame Based</source>
+        <translation>Baseado em quadro</translation>
+    </message>
+    <message>
+        <source>Curve Shape</source>
+        <translation>Forma de curva</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionSegmentViewer</name>
+    <message>
+        <source>Linear</source>
+        <translation>Linear</translation>
+    </message>
+    <message>
+        <source>Speed In / Speed Out</source>
+        <translation>Velocidade de entrada/saída</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out</source>
+        <translation>Facilidade de entrada/facilidade</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out %</source>
+        <translation>Facilidade de entrada/facilidade %</translation>
+    </message>
+    <message>
+        <source>Exponential</source>
+        <translation>Exponencial</translation>
+    </message>
+    <message>
+        <source>Expression</source>
+        <translation>Expressão</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Arquivo</translation>
+    </message>
+    <message>
+        <source>Constant</source>
+        <translation>Constante</translation>
+    </message>
+    <message>
+        <source>Range:</source>
+        <translation>Faixa:</translation>
+    </message>
+    <message>
+        <source>Interpolation:</source>
+        <translation>Interpolação:</translation>
+    </message>
+    <message>
+        <source>Step:</source>
+        <translation>Etapa:</translation>
+    </message>
+    <message>
+        <source>Similar Shape</source>
+        <translation>Forma semelhante</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>&lt; </source>
+        <translation>&lt; </translation>
+    </message>
+    <message>
+        <source> &gt;</source>
+        <translation> &gt;</translation>
+    </message>
+    <message>
+        <source>Speed</source>
+        <translation>Velocidade</translation>
+    </message>
+    <message>
+        <source>Ease</source>
+        <translation>Facilidade</translation>
+    </message>
+    <message>
+        <source>Ease%</source>
+        <translation>Facilidade%</translation>
+    </message>
+    <message>
+        <source>Expo</source>
+        <translation>Expo</translation>
+    </message>
+    <message>
+        <source>Expr</source>
+        <translation>Exp.</translation>
+    </message>
+    <message>
+        <source>Const</source>
+        <translation>Const.</translation>
+    </message>
+    <message>
+        <source>Similar</source>
+        <translation>Semelhante</translation>
+    </message>
+    <message>
+        <source>????</source>
+        <translation>????</translation>
+    </message>
+    <message>
+        <source>From</source>
+        <translation>De</translation>
+    </message>
+    <message>
+        <source>To</source>
+        <translation>Para</translation>
+    </message>
+    <message>
+        <source>Step</source>
+        <translation>Etapa</translation>
+    </message>
+    <message>
+        <source>Link/Unlink Handles</source>
+        <translation>Vincular/desvincular alças</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionSelection</name>
+    <message>
+        <source>There is a circular reference in the definition of the interpolation.</source>
+        <translation>Há uma referência circular na definição da interpolação.</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionSheet</name>
+    <message>
+        <source>Function Editor</source>
+        <translation>Editor de funções</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionSheetButtonArea</name>
+    <message>
+        <source>Toggle synchronizing zoom with xsheet</source>
+        <translation>Alternar sincronização de zoom com xsheet</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionSheetCellViewer</name>
+    <message>
+        <source>Delete Key</source>
+        <translation>Excluir chave</translation>
+    </message>
+    <message>
+        <source>Set Key</source>
+        <translation>Definir chave</translation>
+    </message>
+    <message>
+        <source>Linear Interpolation</source>
+        <translation>Interpolação Linear</translation>
+    </message>
+    <message>
+        <source>Speed In / Speed Out Interpolation</source>
+        <translation>Interpolação de entrada/saída de velocidade</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out Interpolation</source>
+        <translation>Interpolação de entrada/saída facilitada</translation>
+    </message>
+    <message>
+        <source>Ease In / Ease Out (%) Interpolation</source>
+        <translation>Interpolação de entrada/saída facilitada (%)</translation>
+    </message>
+    <message>
+        <source>Expression Interpolation</source>
+        <translation>Interpolação de Expressão</translation>
+    </message>
+    <message>
+        <source>File Interpolation</source>
+        <translation>Interpolação de arquivos</translation>
+    </message>
+    <message>
+        <source>Constant Interpolation</source>
+        <translation>Interpolação Constante</translation>
+    </message>
+    <message>
+        <source>Exponential Interpolation</source>
+        <translation>Interpolação Exponencial</translation>
+    </message>
+    <message>
+        <source>Step 1</source>
+        <translation>Passo 1</translation>
+    </message>
+    <message>
+        <source>Step 2</source>
+        <translation>Etapa 2</translation>
+    </message>
+    <message>
+        <source>Step 3</source>
+        <translation>Etapa 3</translation>
+    </message>
+    <message>
+        <source>Step 4</source>
+        <translation>Etapa 4</translation>
+    </message>
+    <message>
+        <source>Activate Cycle</source>
+        <translation>Ativar Ciclo</translation>
+    </message>
+    <message>
+        <source>Deactivate Cycle</source>
+        <translation>Desativar Ciclo</translation>
+    </message>
+    <message>
+        <source>Show Inbetween Values</source>
+        <translation>Mostrar valores intermediários</translation>
+    </message>
+    <message>
+        <source>Hide Inbetween Values</source>
+        <translation>Ocultar valores intermediários</translation>
+    </message>
+    <message>
+        <source>Change Interpolation</source>
+        <translation>Alterar interpolação</translation>
+    </message>
+    <message>
+        <source>Change Step</source>
+        <translation>Alterar etapa</translation>
+    </message>
+    <message>
+        <source>Similar Shape Interpolation</source>
+        <translation>Interpolação de forma semelhante</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionSheetColumnHeadViewer</name>
+    <message>
+        <source>Some key(s) in this parameter loses original reference in expression.
+Manually changing any keyframe will clear the warning.</source>
+        <translation>Algumas chaves neste parâmetro perdem a referência original na expressão.
+Alterar manualmente qualquer quadro-chave limpará o aviso.</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionToolbar</name>
+    <message>
+        <source>Value</source>
+        <translation>Valor</translation>
+    </message>
+    <message>
+        <source>&amp;Function Editor Toggle</source>
+        <translation>Alternar Editor de &amp;Funções</translation>
+    </message>
+    <message>
+        <source>&amp;Open Function Curve Editor</source>
+        <translation>&amp;Abrir editor de curva de função</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionTreeModel</name>
+    <message>
+        <source>Stage</source>
+        <translation>Estágio</translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <translation>FX</translation>
+    </message>
+    <message>
+        <source>Plastic Skeleton</source>
+        <translation>Esqueleto de Plástico</translation>
+    </message>
+    <message>
+        <source>Some key(s) in this parameter loses original reference in expression.
+Manually changing any keyframe will clear the warning.</source>
+        <translation>Algumas chaves neste parâmetro perdem a referência original na expressão.
+Alterar manualmente qualquer quadro-chave limpará o aviso.</translation>
+    </message>
+</context>
+<context>
+    <name>FunctionTreeView</name>
+    <message>
+        <source>Save Curve</source>
+        <translation>Salvar curva</translation>
+    </message>
+    <message>
+        <source>Load Curve</source>
+        <translation>Curva de Carga</translation>
+    </message>
+    <message>
+        <source>Export Data</source>
+        <translation>Exportar dados</translation>
+    </message>
+    <message>
+        <source>Show Animated Only</source>
+        <translation>Mostrar apenas animação</translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation>Mostrar tudo</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Mesa de animação</translation>
+    </message>
+    <message>
+        <source>Hide Selected</source>
+        <translation>Ocultar selecionado</translation>
+    </message>
+</context>
+<context>
+    <name>FxColumnPainter</name>
+    <message>
+        <source>&amp;Disconnect from Xsheet</source>
+        <translation>&amp;Desconectar do Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Connect to Xsheet</source>
+        <translation>&amp;Conectar ao Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Add</source>
+        <translation>&amp;Colar Adicionar</translation>
+    </message>
+    <message>
+        <source>&amp;Preview</source>
+        <translation>&amp;Visualizar</translation>
+    </message>
+    <message>
+        <source>&amp;Open Subxsheet</source>
+        <translation>&amp;Abrir subxplanilha</translation>
+    </message>
+    <message>
+        <source>&amp;Uncache Fx</source>
+        <translation>&amp;Descache FX</translation>
+    </message>
+    <message>
+        <source>&amp;Cache FX</source>
+        <translation>&amp;Cache FX</translation>
+    </message>
+</context>
+<context>
+    <name>FxOutputPainter</name>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Excluir</translation>
+    </message>
+    <message>
+        <source>&amp;Activate</source>
+        <translation>&amp;Ativar</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>Saída</translation>
+    </message>
+    <message>
+        <source>Out</source>
+        <translation>Fora</translation>
+    </message>
+</context>
+<context>
+    <name>FxPainter</name>
+    <message>
+        <source>&amp;Open Group</source>
+        <translation>&amp;Abrir grupo</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Replace</source>
+        <translation>&amp;Colar Substituir</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Add</source>
+        <translation>&amp;Colar Adicionar</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Excluir</translation>
+    </message>
+    <message>
+        <source>&amp;Disconnect from Xsheet</source>
+        <translation>&amp;Desconectar do Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Connect to Xsheet</source>
+        <translation>&amp;Conectar ao Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Create Linked FX</source>
+        <translation>&amp;Criar FX vinculado</translation>
+    </message>
+    <message>
+        <source>&amp;Unlink</source>
+        <translation>&amp;Desvincular</translation>
+    </message>
+    <message>
+        <source>&amp;Make Macro FX</source>
+        <translation>&amp;Fazer Macro FX</translation>
+    </message>
+    <message>
+        <source>&amp;Explode Macro FX</source>
+        <translation>&amp;Explodir Macro FX</translation>
+    </message>
+    <message>
+        <source>&amp;Open Macro FX</source>
+        <translation>&amp;Abrir macro FX</translation>
+    </message>
+    <message>
+        <source>&amp;Save As Preset...</source>
+        <translation>&amp;Salvar como predefinição...</translation>
+    </message>
+    <message>
+        <source>&amp;Preview</source>
+        <translation>&amp;Visualizar</translation>
+    </message>
+    <message>
+        <source>&amp;Uncache FX</source>
+        <translation>&amp;Descache FX</translation>
+    </message>
+    <message>
+        <source>&amp;Cache FX</source>
+        <translation>&amp;Cache FX</translation>
+    </message>
+</context>
+<context>
+    <name>FxPalettePainter</name>
+    <message>
+        <source>&amp;Disconnect from Xsheet</source>
+        <translation>&amp;Desconectar do Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Connect to Xsheet</source>
+        <translation>&amp;Conectar ao Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Preview</source>
+        <translation>&amp;Visualizar</translation>
+    </message>
+</context>
+<context>
+    <name>FxPassThroughPainter</name>
+    <message>
+        <source>&amp;Paste Add</source>
+        <translation>&amp;Colar Adicionar</translation>
+    </message>
+    <message>
+        <source>&amp;Preview</source>
+        <translation>&amp;Visualizar</translation>
+    </message>
+</context>
+<context>
+    <name>FxSchematicLink</name>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Excluir</translation>
+    </message>
+    <message>
+        <source>&amp;Paste Insert</source>
+        <translation>&amp;Colar Inserir</translation>
+    </message>
+</context>
+<context>
+    <name>FxSchematicOutputNode</name>
+    <message>
+        <source>Output</source>
+        <translation>Saída</translation>
+    </message>
+</context>
+<context>
+    <name>FxSchematicPassThroughNode</name>
+    <message>
+        <source> (Pass Through)</source>
+        <translation>(Passar)</translation>
+    </message>
+</context>
+<context>
+    <name>FxSchematicPort</name>
+    <message>
+        <source>&amp;Disconnect from Xsheet</source>
+        <translation>&amp;Desconectar do Xsheet</translation>
+    </message>
+    <message>
+        <source>&amp;Connect to Xsheet</source>
+        <translation>&amp;Conectar ao Xsheet</translation>
+    </message>
+</context>
+<context>
+    <name>FxSchematicScene</name>
+    <message>
+        <source>Cannot Paste Insert a selection of unconnected FX nodes.
+Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
+        <translation>Não é possível colar Insira uma seleção de nós FX não conectados.
+Selecione nós FX e links relacionados antes de copiar ou recortar a seleção que deseja colar.</translation>
+    </message>
+    <message>
+        <source>Cannot Paste Add a selection of unconnected FX nodes.
+Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
+        <translation>Não é possível colar Adicione uma seleção de nós FX não conectados.
+Selecione nós FX e links relacionados antes de copiar ou recortar a seleção que deseja colar.</translation>
+    </message>
+    <message>
+        <source>Cannot Paste Replace a selection of unconnected FX nodes.
+Select FX nodes and related links before copying or cutting the selection you want to paste.</source>
+        <translation>Não é possível colar Substitua uma seleção de nós FX não conectados.
+Selecione nós FX e links relacionados antes de copiar ou recortar a seleção que deseja colar.</translation>
+    </message>
+</context>
+<context>
+    <name>FxSchematicXSheetNode</name>
+    <message>
+        <source>XSheet</source>
+        <translation>Planilha X</translation>
+    </message>
+</context>
+<context>
+    <name>FxSettings</name>
+    <message>
+        <source>&amp;Camera Preview</source>
+        <translation>&amp;Visualização da câmera</translation>
+    </message>
+    <message>
+        <source>&amp;Preview</source>
+        <translation>&amp;Visualizar</translation>
+    </message>
+    <message>
+        <source>&amp;White Background</source>
+        <translation>&amp;Fundo branco</translation>
+    </message>
+    <message>
+        <source>&amp;Black Background</source>
+        <translation>&amp;Fundo preto</translation>
+    </message>
+    <message>
+        <source>&amp;Checkered Background</source>
+        <translation>&amp;Fundo xadrez</translation>
+    </message>
+    <message>
+        <source> : </source>
+        <translation> : </translation>
+    </message>
+    <message>
+        <source>Fx Settings</source>
+        <translation>Configurações de câmbio</translation>
+    </message>
+</context>
+<context>
+    <name>FxXSheetPainter</name>
+    <message>
+        <source>&amp;Paste Add</source>
+        <translation>&amp;Colar Adicionar</translation>
+    </message>
+    <message>
+        <source>&amp;Preview</source>
+        <translation>&amp;Visualizar</translation>
+    </message>
+    <message>
+        <source>XSheet</source>
+        <translation>Planilha X</translation>
+    </message>
+    <message>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+</context>
+<context>
+    <name>GroupPainter</name>
+    <message>
+        <source>&amp;Open Group</source>
+        <translation>&amp;Abrir grupo</translation>
+    </message>
+</context>
+<context>
+    <name>Histogram</name>
+    <message>
+        <source>Logarithmic Scale</source>
+        <translation>Escala Logarítmica</translation>
+    </message>
+    <message>
+        <source>Value</source>
+        <translation>Valor</translation>
+    </message>
+    <message>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <source>Red</source>
+        <translation>Vermelho</translation>
+    </message>
+    <message>
+        <source>Green</source>
+        <translation>Verde</translation>
+    </message>
+    <message>
+        <source>Blue</source>
+        <translation>Azul</translation>
+    </message>
+    <message>
+        <source>Alpha</source>
+        <translation>Alfa</translation>
+    </message>
+</context>
+<context>
+    <name>InfoViewer</name>
+    <message>
+        <source>File Info</source>
+        <translation>Informações do arquivo</translation>
+    </message>
+</context>
+<context>
+    <name>KeyframeNavigator</name>
+    <message>
+        <source>Previous Key</source>
+        <translation>Chave Anterior</translation>
+    </message>
+    <message>
+        <source>Set Key</source>
+        <translation>Definir chave</translation>
+    </message>
+    <message>
+        <source>Next Key</source>
+        <translation>Próxima chave</translation>
+    </message>
+</context>
+<context>
+    <name>LineEdit</name>
+    <message>
+        <source>A file name cannot contains any of the following chracters: /\:*?"&lt;&gt;|.</source>
+        <translation>Um nome de arquivo não pode conter nenhum dos seguintes caracteres: /\:*?"&lt;&gt;|.</translation>
+    </message>
+</context>
+<context>
+    <name>MyPaintBrushStyleChooserPage</name>
+    <message>
+        <source>Plain color</source>
+        <translation>Cor lisa</translation>
+    </message>
+</context>
+<context>
+    <name>NewWordDialog</name>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Enter new word</source>
+        <translation>Digite uma nova palavra</translation>
+    </message>
+</context>
+<context>
+    <name>PageViewer</name>
+    <message>
+        <source>Toggle Link to Studio Palette</source>
+        <translation>Alternar link para a paleta Studio</translation>
+    </message>
+    <message>
+        <source>Remove Reference to Studio Palette</source>
+        <translation>Remover referência à paleta Studio</translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation>Novo estilo</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation>Nova página</translation>
+    </message>
+</context>
+<context>
+    <name>PaletteViewer</name>
+    <message>
+        <source>&amp;Save Palette As</source>
+        <translation>&amp;Salvar paleta como</translation>
+    </message>
+    <message>
+        <source>&amp;Save Palette</source>
+        <translation>&amp;Salvar paleta</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Opções</translation>
+    </message>
+    <message>
+        <source>&amp;Small Thumbnails View</source>
+        <translation>&amp;Visualização de miniaturas pequenas</translation>
+    </message>
+    <message>
+        <source>&amp;Large Thumbnails View</source>
+        <translation>&amp;Visualização de miniaturas grandes</translation>
+    </message>
+    <message>
+        <source>&amp;List View</source>
+        <translation>&amp;Visualização de lista</translation>
+    </message>
+    <message>
+        <source>&amp;New Page</source>
+        <translation>&amp;Nova página</translation>
+    </message>
+    <message>
+        <source>&amp;New Style</source>
+        <translation>&amp;Novo estilo</translation>
+    </message>
+    <message>
+        <source>&amp;Move Palette</source>
+        <translation>&amp;Mover paleta</translation>
+    </message>
+    <message>
+        <source>Color Model: </source>
+        <translation>Modelo de cores:</translation>
+    </message>
+    <message>
+        <source>&amp;Palette Gizmo</source>
+        <translation>&amp;Paleta Gizmo</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation>Nova página</translation>
+    </message>
+    <message>
+        <source>Delete Page</source>
+        <translation>Excluir página</translation>
+    </message>
+    <message>
+        <source>Palette</source>
+        <translation>Paleta</translation>
+    </message>
+    <message>
+        <source>Level Palette: </source>
+        <translation>Paleta de níveis:</translation>
+    </message>
+    <message>
+        <source>Cleanup Palette</source>
+        <translation>Paleta de limpeza</translation>
+    </message>
+    <message>
+        <source>Studio Palette</source>
+        <translation>Paleta de estúdio</translation>
+    </message>
+    <message>
+        <source>&amp;Small Thumbnails With Name View</source>
+        <translation>&amp;Miniaturas pequenas com visualização de nome</translation>
+    </message>
+    <message>
+        <source>Lock Palette</source>
+        <translation>Paleta de bloqueio</translation>
+    </message>
+    <message>
+        <source>&amp;Lock Palette</source>
+        <translation>Paleta &amp;Bloquear</translation>
+    </message>
+    <message>
+        <source>&amp;Medium Thumbnails View</source>
+        <translation>Visualização de miniaturas &amp;médias</translation>
+    </message>
+    <message>
+        <source>Style Name</source>
+        <translation>Nome do estilo</translation>
+    </message>
+    <message>
+        <source>StudioPalette Name</source>
+        <translation>Nome da paleta Studio</translation>
+    </message>
+    <message>
+        <source>Both Names</source>
+        <translation>Ambos os nomes</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Don't Overwrite</source>
+        <translation>Não sobrescreva</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation>Atualizar</translation>
+    </message>
+    <message>
+        <source>Don't Update</source>
+        <translation>Não atualize</translation>
+    </message>
+    <message>
+        <source>     (Color Model: </source>
+        <translation>(Modelo de cor:</translation>
+    </message>
+    <message>
+        <source>)</source>
+        <translation>)</translation>
+    </message>
+    <message>
+        <source>Hide New Style Button</source>
+        <translation>Ocultar botão de novo estilo</translation>
+    </message>
+    <message>
+        <source>Show New Style Button</source>
+        <translation>Mostrar botão de novo estilo</translation>
+    </message>
+    <message>
+        <source>Failed to save palette.</source>
+        <translation>Falha ao salvar a paleta.</translation>
+    </message>
+    <message>
+        <source>Set Toolbar Below Styles</source>
+        <translation>Definir barra de ferramentas abaixo dos estilos</translation>
+    </message>
+    <message>
+        <source>Set Toolbar Above Styles</source>
+        <translation>Definir barra de ferramentas acima dos estilos</translation>
+    </message>
+    <message>
+        <source>Auto Adjust Panel Width</source>
+        <translation>Largura do painel de ajuste automático</translation>
+    </message>
+    <message>
+        <source>Visible Toolbar Buttons</source>
+        <translation>Botões visíveis da barra de ferramentas</translation>
+    </message>
+    <message>
+        <source>KeyFrame</source>
+        <translation>Quadro-chave</translation>
+    </message>
+    <message>
+        <source>New Style/Page</source>
+        <translation>Novo estilo/página</translation>
+    </message>
+    <message>
+        <source>Palette Gizmo</source>
+        <translation>Paleta Gizmo</translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation>Editor de nomes</translation>
+    </message>
+</context>
+<context>
+    <name>PaletteViewerGUI::PageViewer</name>
+    <message>
+        <source>- No Styles -</source>
+        <translation>- Sem estilos -</translation>
+    </message>
+    <message>
+        <source>Remove Links</source>
+        <translation>Remover links</translation>
+    </message>
+    <message>
+        <source>New Style</source>
+        <translation>Novo estilo</translation>
+    </message>
+    <message>
+        <source>New Page</source>
+        <translation>Nova página</translation>
+    </message>
+    <message>
+        <source>Name Editor</source>
+        <translation>Editor de nomes</translation>
+    </message>
+    <message>
+        <source> + </source>
+        <translation> + </translation>
+    </message>
+</context>
+<context>
+    <name>PalettesScanPopup</name>
+    <message>
+        <source>Search for Palettes</source>
+        <translation>Pesquisar paletas</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>&lt;files&gt;</source>
+        <translation>&lt;arquivos&gt;</translation>
+    </message>
+    <message>
+        <source>Failed to import palette.</source>
+        <translation>Falha ao importar a paleta.</translation>
+    </message>
+</context>
+<context>
+    <name>ParamViewer</name>
+    <message>
+        <source>Swatch Viewer</source>
+        <translation>Visualizador de amostras</translation>
+    </message>
+</context>
+<context>
+    <name>ParamsPageSet</name>
+    <message>
+        <source>Fx Help</source>
+        <translation>Ajuda cambial</translation>
+    </message>
+    <message>
+        <source>View help page</source>
+        <translation>Ver página de ajuda</translation>
+    </message>
+    <message>
+        <source>This Fx does not support rendering in floating point channel width (32bit).
+The output pixel values from this fx will be clamped to 0.0 - 1.0
+and tone may be slightly discretized.</source>
+        <translation>Este Fx não suporta renderização em largura de canal de ponto flutuante (32 bits).
+Os valores de pixel de saída deste fx serão fixados em 0,0 - 1,0
+e o tom pode ser ligeiramente discretizado.</translation>
+    </message>
+</context>
+<context>
+    <name>PegbarPainter</name>
+    <message>
+        <source>&amp;Reset Center</source>
+        <translation>&amp;Redefinir Central</translation>
+    </message>
+</context>
+<context>
+    <name>PlaneViewer</name>
+    <message>
+        <source>Reset View</source>
+        <translation>Redefinir visualização</translation>
+    </message>
+    <message>
+        <source>Fit To Window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+</context>
+<context>
+    <name>PointParamField</name>
+    <message>
+        <source>Y:</source>
+        <translation>E:</translation>
+    </message>
+    <message>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+</context>
+<context>
+    <name>ProgressDialog</name>
+    <message>
+        <source>Toonz</source>
+        <translation>Toonz</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Information</source>
+        <translation>Informação</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Aviso</translation>
+    </message>
+    <message>
+        <source>Critical</source>
+        <translation>Crítico</translation>
+    </message>
+    <message>
+        <source>Question</source>
+        <translation>Pergunta</translation>
+    </message>
+    <message>
+        <source>Styles you are going to delete are used to paint lines and areas in the animation level.
+</source>
+        <translation>Os estilos que você irá excluir são usados ​​para pintar linhas e áreas no nível de animação.</translation>
+    </message>
+    <message>
+        <source>How do you want to proceed?</source>
+        <translation>Como você deseja proceder?</translation>
+    </message>
+    <message>
+        <source>Delete Styles Only</source>
+        <translation>Excluir apenas estilos</translation>
+    </message>
+    <message>
+        <source>Delete Styles, Lines and Areas</source>
+        <translation>Excluir estilos, linhas e áreas</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Cannot premultiply the selected file.</source>
+        <translation>Não é possível pré-multiplicar o arquivo selecionado.</translation>
+    </message>
+    <message>
+        <source>Cannot premultiply a vector-based level.</source>
+        <translation>Não é possível pré-multiplicar um nível baseado em vetor.</translation>
+    </message>
+    <message>
+        <source>Level %1 premultiplied.</source>
+        <translation>Nível %1 pré-multiplicado.</translation>
+    </message>
+    <message>
+        <source>Frame %1 : conversion failed!</source>
+        <translation>Quadro %1: falha na conversão!</translation>
+    </message>
+    <message>
+        <source>Palette</source>
+        <translation>Paleta</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Discard</source>
+        <translation>Descartar</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Stage Schematic</source>
+        <translation>Esquema de Estágio</translation>
+    </message>
+    <message>
+        <source>FX Schematic</source>
+        <translation>Esquema FX</translation>
+    </message>
+    <message>
+        <source>Fx Schematic</source>
+        <translation>Esquema FX</translation>
+    </message>
+    <message>
+        <source>Save Motion Path</source>
+        <translation>Salvar caminho de movimento</translation>
+    </message>
+    <message>
+        <source>Motion Path files (*.mpath)</source>
+        <translation>Arquivos de caminho de movimento (*.mpath)</translation>
+    </message>
+    <message>
+        <source>Load Motion Path</source>
+        <translation>Carregar caminho de movimento</translation>
+    </message>
+    <message>
+        <source>Can't paste styles there</source>
+        <translation>Não é possível colar estilos lá</translation>
+    </message>
+    <message>
+        <source>Can't modify color #0</source>
+        <translation>Não é possível modificar a cor #0</translation>
+    </message>
+    <message>
+        <source>There are more cut/copied styles than selected. Paste anyway (adding styles)?</source>
+        <translation>Existem mais estilos recortados/copiados do que os selecionados. Colar mesmo assim (adicionando estilos)?</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation>Colar</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>For further information visit </source>
+        <translation>Para mais informações visite</translation>
+    </message>
+    <message>
+        <source>Fullpath:     </source>
+        <translation>Caminho completo:</translation>
+    </message>
+    <message>
+        <source>File Type:    </source>
+        <translation>Tipo de arquivo:</translation>
+    </message>
+    <message>
+        <source>Frames:       </source>
+        <translation>Quadros:</translation>
+    </message>
+    <message>
+        <source>Owner:        </source>
+        <translation>Proprietário:</translation>
+    </message>
+    <message>
+        <source>Size:         </source>
+        <translation>Tamanho:</translation>
+    </message>
+    <message>
+        <source>Created:      </source>
+        <translation>Criado:</translation>
+    </message>
+    <message>
+        <source>Modified:     </source>
+        <translation>Modificado:</translation>
+    </message>
+    <message>
+        <source>Last Access:  </source>
+        <translation>Último acesso:</translation>
+    </message>
+    <message>
+        <source>Image Size:   </source>
+        <translation>Tamanho da imagem:</translation>
+    </message>
+    <message>
+        <source>SaveBox:      </source>
+        <translation>Salvar caixa:</translation>
+    </message>
+    <message>
+        <source>Bits/Sample:  </source>
+        <translation>Bits/amostra:</translation>
+    </message>
+    <message>
+        <source>Sample/Pixel: </source>
+        <translation>Amostra/Pixel:</translation>
+    </message>
+    <message>
+        <source>Dpi:          </source>
+        <translation>Dpi:</translation>
+    </message>
+    <message>
+        <source>Orientation:  </source>
+        <translation>Orientação:</translation>
+    </message>
+    <message>
+        <source>Compression:  </source>
+        <translation>Compressão:</translation>
+    </message>
+    <message>
+        <source>Quality:      </source>
+        <translation>Qualidade:</translation>
+    </message>
+    <message>
+        <source>Smoothing:    </source>
+        <translation>Suavização:</translation>
+    </message>
+    <message>
+        <source>Codec:        </source>
+        <translation>Codec:</translation>
+    </message>
+    <message>
+        <source>Alpha Channel:</source>
+        <translation>Canal Alfa:</translation>
+    </message>
+    <message>
+        <source>Byte Ordering:</source>
+        <translation>Ordenação de bytes:</translation>
+    </message>
+    <message>
+        <source>H Pos:</source>
+        <translation>Posição H:</translation>
+    </message>
+    <message>
+        <source>Palette Pages:</source>
+        <translation>Páginas da paleta:</translation>
+    </message>
+    <message>
+        <source>Palette Styles:</source>
+        <translation>Estilos de paleta:</translation>
+    </message>
+    <message>
+        <source>Camera Size:      </source>
+        <translation>Tamanho da câmera:</translation>
+    </message>
+    <message>
+        <source>Camera Dpi:       </source>
+        <translation>Dpi da câmera:</translation>
+    </message>
+    <message>
+        <source>Number of Frames: </source>
+        <translation>Número de quadros:</translation>
+    </message>
+    <message>
+        <source>Number of Levels: </source>
+        <translation>Número de níveis:</translation>
+    </message>
+    <message>
+        <source>Output Path:      </source>
+        <translation>Caminho de saída:</translation>
+    </message>
+    <message>
+        <source>Endianness:      </source>
+        <translation>Endianismo:</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete the style #</source>
+        <translation>Não é possível deletar o estilo #</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete styles #0 and #1.</source>
+        <translation>Não é possível excluir os estilos #0 e #1.</translation>
+    </message>
+    <message>
+        <source>&lt;custom&gt;</source>
+        <translation>&lt;personalizado&gt;</translation>
+    </message>
+    <message>
+        <source>It is not possible to find the %1 level.</source>
+        <translation>Não é possível encontrar o nível %1.</translation>
+    </message>
+    <message>
+        <source>There was an error copying %1</source>
+        <translation>Ocorreu um erro ao copiar % 1</translation>
+    </message>
+    <message>
+        <source>It is not possible to find the level %1</source>
+        <translation>Nãoépossível encontrar o nível % 1</translation>
+    </message>
+    <message>
+        <source>Length:       </source>
+        <translation>Comprimento:</translation>
+    </message>
+    <message>
+        <source>Channels: </source>
+        <translation>Canais:</translation>
+    </message>
+    <message>
+        <source>Sample Rate: </source>
+        <translation>Taxa de amostragem:</translation>
+    </message>
+    <message>
+        <source>Sample Size:      </source>
+        <translation>Tamanho da amostra:</translation>
+    </message>
+    <message>
+        <source>The file %1 does not exist.</source>
+        <translation>O arquivo %1 não existe.</translation>
+    </message>
+    <message>
+        <source>It is not possible to assing a shortcut with modifiers to the visualization commands.</source>
+        <translation>Não é possível atribuir um atalho com modificadores aos comandos de visualização.</translation>
+    </message>
+    <message>
+        <source>It is not possible to save the motion path.</source>
+        <translation>Não é possível salvar o caminho do movimento.</translation>
+    </message>
+    <message>
+        <source>It is not possible to load the motion path.</source>
+        <translation>Não é possível carregar o caminho de movimento.</translation>
+    </message>
+    <message>
+        <source>Toonz 7.1</source>
+        <translation>Toonz 7.1</translation>
+    </message>
+    <message>
+        <source>The file name cannot be empty or contain any of the following characters: (new line) \ / : * ? " |</source>
+        <translation>O nome do arquivo não pode estar vazio nem conter nenhum dos seguintes caracteres: (nova linha) \ / : * ? " |</translation>
+    </message>
+    <message>
+        <source>The source image seems not suitable for this kind of conversion</source>
+        <translation>A imagem de origem parece não ser adequada para este tipo de conversão</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Deletion of Lines and Areas from raster-based levels is not undoable.
+Are you sure?</source>
+        <translation>A exclusão de linhas e áreas de níveis baseados em raster não é reversível.
+Tem certeza?</translation>
+    </message>
+    <message>
+        <source>Deleting "%1".
+Are you sure?</source>
+        <translation>Excluindo "%1".
+Tem certeza?</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Paste Style  in Palette : %1</source>
+        <translation>Colar estilo na paleta: %1</translation>
+    </message>
+    <message>
+        <source>Delete Style  from Palette : %1</source>
+        <translation>Excluir estilo da paleta:% 1</translation>
+    </message>
+    <message>
+        <source>Cut Style  from Palette : %1</source>
+        <translation>Cortar estilo da paleta: %1</translation>
+    </message>
+    <message>
+        <source>  to Palette : %1</source>
+        <translation>para a Paleta:% 1</translation>
+    </message>
+    <message>
+        <source>Paste Color &amp;&amp; Name%1</source>
+        <translation>Colar Cor &amp;&amp; Nome% 1</translation>
+    </message>
+    <message>
+        <source>Paste Name%1</source>
+        <translation>Colar o Nome% 1</translation>
+    </message>
+    <message>
+        <source>Paste Color%1</source>
+        <translation>Colar Cor% 1</translation>
+    </message>
+    <message>
+        <source>Paste%1</source>
+        <translation>Colar% 1</translation>
+    </message>
+    <message>
+        <source>Blend Colors  in Palette : %1</source>
+        <translation>Misturar Cores na Paleta: %1</translation>
+    </message>
+    <message>
+        <source>Toggle Link  in Palette : %1</source>
+        <translation>Alternar link na paleta: %1</translation>
+    </message>
+    <message>
+        <source>Remove Link  in Palette : %1</source>
+        <translation>Remover link na paleta: %1</translation>
+    </message>
+    <message>
+        <source>Get Color from Studio Palette</source>
+        <translation>Obtenha cores da paleta Studio</translation>
+    </message>
+    <message>
+        <source>Paste Object  </source>
+        <translation>Colar objeto</translation>
+    </message>
+    <message>
+        <source>Copy Keyframe</source>
+        <translation>Copiar quadro-chave</translation>
+    </message>
+    <message>
+        <source>Paste Keyframe  at Frame : %1</source>
+        <translation>Colar o quadro-chave no quadro:% 1</translation>
+    </message>
+    <message>
+        <source>Delete Keyframe</source>
+        <translation>Excluir quadro-chave</translation>
+    </message>
+    <message>
+        <source>Move Keyframe</source>
+        <translation>Mover quadro-chave</translation>
+    </message>
+    <message>
+        <source>Change Style   Palette : %1  Style#%2  [R%3 G%4 B%5] -&gt; [R%6 G%7 B%8]</source>
+        <translation>Alterar paleta de estilo: %1 Estilo#%2 [R%3 G%4 B%5] -&gt; [R%6 G%7 B%8]</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Modify Fx Param : %1</source>
+        <translation>Modificar Parâmetro FX: %1</translation>
+    </message>
+    <message>
+        <source>Modify Fx Param : %1 : %2 -&gt; %3</source>
+        <translation>Modificar parâmetro Fx: %1 : %2 -&gt; %3</translation>
+    </message>
+    <message>
+        <source>Modify Fx Param : </source>
+        <translation>Modificar parâmetro Fx:</translation>
+    </message>
+    <message>
+        <source>ON : %1</source>
+        <translation>ATIVADO:% 1</translation>
+    </message>
+    <message>
+        <source>OFF : %1</source>
+        <translation>DESATIVADO:% 1</translation>
+    </message>
+    <message>
+        <source>Modify Fx Param : %1 : %2 Key</source>
+        <translation>Modificar Parâmetro Fx: %1: Chave %2</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Remover</translation>
+    </message>
+    <message>
+        <source>Modify Fx Param : %1 : %2 Point</source>
+        <translation>Modificar Parâmetro Fx: %1: %2 Ponto</translation>
+    </message>
+    <message>
+        <source>%1 : Linear ON</source>
+        <translation>% 1: Linear LIGADO</translation>
+    </message>
+    <message>
+        <source>%1 : Linear OFF</source>
+        <translation>% 1: Linear DESLIGADO</translation>
+    </message>
+    <message>
+        <source>Overwrite</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Don't Overwrite</source>
+        <translation>Não sobrescreva</translation>
+    </message>
+    <message>
+        <source>Modify Fx Param : %1 Key : %2  Frame %3</source>
+        <translation>Modificar Parâmetro Fx: %1 Chave: %2 Quadro %3</translation>
+    </message>
+    <message>
+        <source>Set</source>
+        <translation>Definir</translation>
+    </message>
+    <message>
+        <source>OpenToonz 1.1</source>
+        <translation>OpenToonz 1.1</translation>
+    </message>
+    <message>
+        <source>Remove Reference  in Palette : %1</source>
+        <translation>Remover referência na paleta: %1</translation>
+    </message>
+    <message>
+        <source>It is not possible to assign a shortcut with modifiers to the visualization commands.</source>
+        <translation>Não é possível atribuir um atalho com modificadores aos comandos de visualização.</translation>
+    </message>
+    <message>
+        <source>Failed to compile m_textureShader.vert.</source>
+        <comment>gl</comment>
+        <translation>Falha ao compilar m_textureShader.vert.</translation>
+    </message>
+    <message>
+        <source>Failed to compile m_shader.frag.</source>
+        <comment>gl</comment>
+        <translation>Falha ao compilar m_shader.frag.</translation>
+    </message>
+    <message>
+        <source>Failed to add m_shader.vert.</source>
+        <comment>gl</comment>
+        <translation>Falha ao adicionar m_shader.vert.</translation>
+    </message>
+    <message>
+        <source>Failed to add m_shader.frag.</source>
+        <comment>gl</comment>
+        <translation>Falha ao adicionar m_shader.frag.</translation>
+    </message>
+    <message>
+        <source>Failed to link simple shader: %1</source>
+        <comment>gl</comment>
+        <translation>Falha ao vincular o shader simples:% 1</translation>
+    </message>
+    <message>
+        <source>Failed to get attribute location of %1</source>
+        <comment>gl</comment>
+        <translation>Não foi possível obter a localização do atributo % 1</translation>
+    </message>
+    <message>
+        <source>Failed to get uniform location of %1</source>
+        <comment>gl</comment>
+        <translation>Não foi possível obter a localização uniforme de % 1</translation>
+    </message>
+    <message>
+        <source>Failed to Open 3DLUT File.</source>
+        <translation>Falha ao abrir o arquivo 3DLUT.</translation>
+    </message>
+    <message>
+        <source>Failed to Load 3DLUT File.
+It should start with "3DMESH" keyword.</source>
+        <translation>Falha ao carregar o arquivo 3DLUT.
+Deve começar com a palavra-chave "3DMESH".</translation>
+    </message>
+    <message>
+        <source>Failed to Load 3DLUT File.
+The second line should be "Mesh [Input bit depth] [Output bit depth]"</source>
+        <translation>Falha ao carregar o arquivo 3DLUT.
+A segunda linha deve ser "Mesh [Profundidade de bits de entrada] [Profundidade de bits de saída]"</translation>
+    </message>
+    <message>
+        <source>Failed to Load 3DLUT File.</source>
+        <translation>Falha ao carregar o arquivo 3DLUT.</translation>
+    </message>
+    <message>
+        <source>OpenToonz 1.2</source>
+        <translation>OpenToonz 1.2</translation>
+    </message>
+    <message>
+        <source>Custom Texture</source>
+        <comment>TextureStyleChooserPage</comment>
+        <translation>Textura Personalizada</translation>
+    </message>
+    <message>
+        <source>Current Frame: </source>
+        <translation>Quadro Atual:</translation>
+    </message>
+    <message>
+        <source>File History</source>
+        <translation>Histórico de arquivos</translation>
+    </message>
+    <message>
+        <source>OpenToonz 1.3</source>
+        <translation>OpenToonz 1.3</translation>
+    </message>
+    <message>
+        <source>Plain color</source>
+        <comment>VectorBrushStyleChooserPage</comment>
+        <translation>Cor lisa</translation>
+    </message>
+    <message>
+        <source>Plain color</source>
+        <comment>MyPaintBrushStyleChooserPage</comment>
+        <translation>Cor lisa</translation>
+    </message>
+    <message>
+        <source>Plain color</source>
+        <comment>SpecialStyleChooserPage</comment>
+        <translation>Cor lisa</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>That is a reserved file name and cannot be used.</source>
+        <translation>Esse é um nome de arquivo reservado e não pode ser usado.</translation>
+    </message>
+    <message>
+        <source>There are no unused styles.</source>
+        <translation>Não há estilos não utilizados.</translation>
+    </message>
+    <message>
+        <source>and %1 more styles.</source>
+        <translation>e mais %1 estilos.</translation>
+    </message>
+    <message>
+        <source>Erasing unused styles with following indices. Are you sure?
+
+%1</source>
+        <translation>Apagando estilos não utilizados com os seguintes índices. Tem certeza?
+
+% 1</translation>
+    </message>
+    <message>
+        <source>Erase</source>
+        <translation>Apagar</translation>
+    </message>
+    <message>
+        <source>Click &amp; Drag Palette into Studio Palette</source>
+        <translation>Clique e arraste a paleta para a paleta do Studio</translation>
+    </message>
+    <message>
+        <source>Plain color</source>
+        <comment>TextureStyleChooserPage</comment>
+        <translation>Cor lisa</translation>
+    </message>
+    <message>
+        <source>Sample Type: </source>
+        <translation>Tipo de amostra:</translation>
+    </message>
+    <message>
+        <source>It is not possible to delete style #</source>
+        <translation>Não é possível excluir o estilo #</translation>
+    </message>
+    <message>
+        <source>Paste Style to Palette: %1</source>
+        <translation>Colar estilo na paleta: %1</translation>
+    </message>
+    <message>
+        <source>Delete Style from Palette: %1</source>
+        <translation>Excluir estilo da paleta: %1</translation>
+    </message>
+    <message>
+        <source>Cut Style from Palette: %1</source>
+        <translation>Cortar estilo da paleta: %1</translation>
+    </message>
+    <message>
+        <source> to Palette: %1</source>
+        <translation>para a Paleta: %1</translation>
+    </message>
+    <message>
+        <source>Blend Colors in Palette: %1</source>
+        <translation>Misturar Cores na Paleta: %1</translation>
+    </message>
+    <message>
+        <source>Toggle Link in Palette: %1</source>
+        <translation>Alternar link na paleta: %1</translation>
+    </message>
+    <message>
+        <source>Remove Reference in Palette: %1</source>
+        <translation>Remover Referência na Paleta: %1</translation>
+    </message>
+    <message>
+        <source>Set As...</source>
+        <translation>Definir como...</translation>
+    </message>
+    <message>
+        <source>Delete Lines and Areas</source>
+        <translation>Excluir linhas e áreas</translation>
+    </message>
+</context>
+<context>
+    <name>QPushButton</name>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+</context>
+<context>
+    <name>RadioButtonDialog</name>
+    <message>
+        <source>Toonz</source>
+        <translation>Toonz</translation>
+    </message>
+</context>
+<context>
+    <name>RgbLinkButtons</name>
+    <message>
+        <source>Copy RGB : %1 &gt; %2</source>
+        <translation>Copiar RGB: %1 &gt; %2</translation>
+    </message>
+    <message>
+        <source>Swap %1 and %2</source>
+        <translation>Trocar % 1 e % 2</translation>
+    </message>
+</context>
+<context>
+    <name>SchematicName</name>
+    <message>
+        <source>Cu&amp;t</source>
+        <translation>Com&amp;t</translation>
+    </message>
+    <message>
+        <source>&amp;Copy</source>
+        <translation>&amp;Cópia</translation>
+    </message>
+    <message>
+        <source>&amp;Paste</source>
+        <translation>&amp;Colar</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Excluir</translation>
+    </message>
+    <message>
+        <source>Select &amp;All</source>
+        <translation>Selecionar &amp;Todos</translation>
+    </message>
+</context>
+<context>
+    <name>SchematicViewer</name>
+    <message>
+        <source>&amp;Fit to Window</source>
+        <translation>&amp;Ajustar à janela</translation>
+    </message>
+    <message>
+        <source>&amp;Focus on Current</source>
+        <translation>&amp;Foco no atual</translation>
+    </message>
+    <message>
+        <source>&amp;Reorder Nodes</source>
+        <translation>&amp;Reordenar nós</translation>
+    </message>
+    <message>
+        <source>&amp;Reset Size</source>
+        <translation>&amp;Redefinir tamanho</translation>
+    </message>
+    <message>
+        <source>&amp;Minimize Nodes</source>
+        <translation>&amp;Minimizar nós</translation>
+    </message>
+    <message>
+        <source>&amp;Maximize Nodes</source>
+        <translation>&amp;Maximizar nós</translation>
+    </message>
+    <message>
+        <source>&amp;New Pegbar</source>
+        <translation>&amp;Novo Pegbar</translation>
+    </message>
+    <message>
+        <source>&amp;New Camera</source>
+        <translation>&amp;Nova câmera</translation>
+    </message>
+    <message>
+        <source>&amp;New Motion Path</source>
+        <translation>&amp;Novo caminho de movimento</translation>
+    </message>
+    <message>
+        <source>&amp;Schematic Toggle</source>
+        <translation>&amp;Alternar esquema</translation>
+    </message>
+    <message>
+        <source>&amp;Swtich output port display mode</source>
+        <translation>&amp;Alternar modo de exibição da porta de saída</translation>
+    </message>
+    <message>
+        <source>&amp;Toggle node icons</source>
+        <translation>&amp;Alternar ícones de nós</translation>
+    </message>
+    <message>
+        <source>&amp;Selection Mode</source>
+        <translation>&amp;Modo de seleção</translation>
+    </message>
+    <message>
+        <source>&amp;Zoom Mode</source>
+        <translation>Modo &amp;Zoom</translation>
+    </message>
+    <message>
+        <source>&amp;Hand Mode</source>
+        <translation>&amp;Modo Manual</translation>
+    </message>
+    <message>
+        <source>&amp;Switch output port display mode</source>
+        <translation>&amp;Mudar o modo de exibição da porta de saída</translation>
+    </message>
+</context>
+<context>
+    <name>SchematicWindowEditor</name>
+    <message>
+        <source>&amp;Close Editor</source>
+        <translation>&amp;Fechar Editor</translation>
+    </message>
+</context>
+<context>
+    <name>SeeThroughWindowPopup</name>
+    <message>
+        <source>See Through Mode (Main Window)</source>
+        <translation>Modo transparente (janela principal)</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>Opacidade</translation>
+    </message>
+    <message>
+        <source>Quickly toggle main window semi-transparency and full opacity.</source>
+        <translation>Alterne rapidamente a semitransparência e a opacidade total da janela principal.</translation>
+    </message>
+    <message>
+        <source>Hold ALT while clicking to use full transparency instead.</source>
+        <translation>Segure ALT enquanto clica para usar transparência total.</translation>
+    </message>
+    <message>
+        <source>When slider is at 100% it acts as ALT is held.</source>
+        <translation>Quando o controle deslizante está em 100%, ele atua enquanto ALT é pressionado.</translation>
+    </message>
+    <message>
+        <source>Close</source>
+        <translation>Fechar</translation>
+    </message>
+</context>
+<context>
+    <name>SimilarShapeSegmentPage</name>
+    <message>
+        <source>Reference Curve:</source>
+        <translation>Curva de referência:</translation>
+    </message>
+    <message>
+        <source>Frame Offset:</source>
+        <translation>Deslocamento do quadro:</translation>
+    </message>
+    <message>
+        <source>There is a syntax error in the definition of the interpolation.</source>
+        <translation>Há um erro de sintaxe na definição da interpolação.</translation>
+    </message>
+    <message>
+        <source>There is a circular reference in the definition of the interpolation.</source>
+        <translation>Há uma referência circular na definição da interpolação.</translation>
+    </message>
+</context>
+<context>
+    <name>SpecialStyleChooserPage</name>
+    <message>
+        <source>Plain color</source>
+        <translation>Cor lisa</translation>
+    </message>
+</context>
+<context>
+    <name>SpeedInOutSegmentPage</name>
+    <message>
+        <source>Speed in:</source>
+        <translation>Velocidade em:</translation>
+    </message>
+    <message>
+        <source>Speed out:</source>
+        <translation>Acelere:</translation>
+    </message>
+    <message>
+        <source>First Speed:</source>
+        <translation>Primeira velocidade:</translation>
+    </message>
+    <message>
+        <source>Handle:</source>
+        <translation>Lidar:</translation>
+    </message>
+    <message>
+        <source>/</source>
+        <translation>/</translation>
+    </message>
+    <message>
+        <source>Last Speed:</source>
+        <translation>Última velocidade:</translation>
+    </message>
+    <message>
+        <source>---</source>
+        <translation>---</translation>
+    </message>
+</context>
+<context>
+    <name>SplinePainter</name>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Excluir</translation>
+    </message>
+    <message>
+        <source>&amp;Save Motion Path...</source>
+        <translation>&amp;Salvar caminho de movimento...</translation>
+    </message>
+    <message>
+        <source>&amp;Load Motion Path...</source>
+        <translation>&amp;Carregar caminho de movimento...</translation>
+    </message>
+</context>
+<context>
+    <name>StageSchematicNode</name>
+    <message>
+        <source>Toggle Autorotate Along Motion Path</source>
+        <translation>Alternar rotação automática ao longo do caminho de movimento</translation>
+    </message>
+    <message>
+        <source>Toggle Link Motion Path to Control Points</source>
+        <translation>Alternar caminho de movimento de link para pontos de controle</translation>
+    </message>
+</context>
+<context>
+    <name>StageSchematicScene</name>
+    <message>
+        <source>&amp;New Pegbar</source>
+        <translation>&amp;Novo Pegbar</translation>
+    </message>
+    <message>
+        <source>&amp;New Motion Path</source>
+        <translation>&amp;Novo caminho de movimento</translation>
+    </message>
+    <message>
+        <source>&amp;New Camera</source>
+        <translation>&amp;Nova câmera</translation>
+    </message>
+</context>
+<context>
+    <name>StudioPaletteTreeViewer</name>
+    <message>
+        <source>This folder is not empty. Delete anyway?</source>
+        <translation>Esta pasta não está vazia. Excluir mesmo assim?</translation>
+    </message>
+    <message>
+        <source>New Palette</source>
+        <translation>Nova paleta</translation>
+    </message>
+    <message>
+        <source>New Folder</source>
+        <translation>Nova pasta</translation>
+    </message>
+    <message>
+        <source>Delete Folder</source>
+        <translation>Excluir pasta</translation>
+    </message>
+    <message>
+        <source>Load into Current Palette</source>
+        <translation>Carregar na paleta atual</translation>
+    </message>
+    <message>
+        <source>Merge to Current Palette</source>
+        <translation>Mesclar com a paleta atual</translation>
+    </message>
+    <message>
+        <source>Replace with Current Palette</source>
+        <translation>Substituir pela paleta atual</translation>
+    </message>
+    <message>
+        <source>Delete Palette</source>
+        <translation>Excluir paleta</translation>
+    </message>
+    <message>
+        <source>Search for Palettes</source>
+        <translation>Pesquisar paletas</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Adjust Current Level to This Palette</source>
+        <translation>Ajustar o nível atual para esta paleta</translation>
+    </message>
+    <message>
+        <source>Convert to Studio Palette and Overwrite</source>
+        <translation>Converter para paleta Studio e substituir</translation>
+    </message>
+    <message>
+        <source>the palette "%1"</source>
+        <translation>a paleta "%1"</translation>
+    </message>
+    <message>
+        <source>the selected palettes</source>
+        <translation>as paletas selecionadas</translation>
+    </message>
+    <message>
+        <source>Move %1 to "%2". Are you sure ?</source>
+        <translation>Mova %1 para "%2". Tem certeza ?</translation>
+    </message>
+    <message>
+        <source>Move</source>
+        <translation>Mover</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>The current palette %1
+in the studio palette has been modified. Do you want to save your changes?</source>
+        <translation>A paleta actual % 1
+na paleta do estúdio foi modificado. Quer salvar suas alterações?</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <source>Discard</source>
+        <translation>Descartar</translation>
+    </message>
+    <message>
+        <source>Convert %1 to Studio Palette and Overwrite. 
+Are you sure ?</source>
+        <translation>Converta %1 para Studio Palette e sobrescreva. 
+Tem certeza ?</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Sim</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <source>Replacing all selected palettes with the palette "%1". 
+Are you sure ?</source>
+        <translation>Substituindo todas as paletas selecionadas pela paleta "%1". 
+Tem certeza ?</translation>
+    </message>
+    <message>
+        <source>Replacing the palette "%1" with the palette "%2". 
+Are you sure ?</source>
+        <translation>Substituindo a paleta "%1" pela paleta "%2". 
+Tem certeza ?</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <source>Convert</source>
+        <translation>Converter</translation>
+    </message>
+    <message>
+        <source>Failed to save palette.</source>
+        <translation>Falha ao salvar a paleta.</translation>
+    </message>
+    <message>
+        <source>Set As...</source>
+        <translation>Definir como...</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>Atualizar</translation>
+    </message>
+</context>
+<context>
+    <name>StudioPaletteViewer</name>
+    <message>
+        <source>&amp;New Folder</source>
+        <translation>&amp;Nova pasta</translation>
+    </message>
+    <message>
+        <source>&amp;New Palette</source>
+        <translation>&amp;Nova paleta</translation>
+    </message>
+    <message>
+        <source>&amp;Search for Palettes</source>
+        <translation>&amp;Pesquisar paletas</translation>
+    </message>
+    <message>
+        <source>&amp;Delete</source>
+        <translation>&amp;Excluir</translation>
+    </message>
+</context>
+<context>
+    <name>StyleEditor</name>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Apply changes to current style</source>
+        <translation>Aplicar alterações ao estilo atual</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation>Auto</translation>
+    </message>
+    <message>
+        <source>Automatically update style changes</source>
+        <translation>Atualizar automaticamente as alterações de estilo</translation>
+    </message>
+    <message>
+        <source>Return To Previous Style</source>
+        <translation>Retornar ao estilo anterior</translation>
+    </message>
+    <message>
+        <source>Current Style</source>
+        <translation>Estilo Atual</translation>
+    </message>
+    <message>
+        <source>Plain</source>
+        <translation>Simples</translation>
+    </message>
+    <message>
+        <source>Texture</source>
+        <translation>Textura</translation>
+    </message>
+    <message>
+        <source>Special</source>
+        <translation>Especial</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>Personalizado</translation>
+    </message>
+    <message>
+        <source>Vector Brush</source>
+        <translation>Pincel vetorial</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>Configurações</translation>
+    </message>
+    <message>
+        <source>Auto  
+Apply</source>
+        <translation>Automático  
+Aplicar</translation>
+    </message>
+    <message>
+        <source>MyPaint Brush</source>
+        <translation>Pincel MyPaint</translation>
+    </message>
+    <message>
+        <source>- Style not Selected -</source>
+        <translation>- Estilo não selecionado -</translation>
+    </message>
+    <message>
+        <source>[CLEANUP]  </source>
+        <translation>[LIMPAR]</translation>
+    </message>
+    <message>
+        <source>[STUDIO]  </source>
+        <translation>[ESTÚDIO]</translation>
+    </message>
+    <message>
+        <source>[LEVEL]  </source>
+        <translation>[NÍVEL]</translation>
+    </message>
+    <message>
+        <source>- Style is Not Valid -</source>
+        <translation>- O estilo não é válido -</translation>
+    </message>
+    <message>
+        <source>Generated</source>
+        <translation>Gerado</translation>
+    </message>
+    <message>
+        <source>Trail</source>
+        <translation>Trilha</translation>
+    </message>
+    <message>
+        <source>Color</source>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <source>Vector</source>
+        <translation>Vetor</translation>
+    </message>
+    <message>
+        <source>Raster</source>
+        <translation>Raster</translation>
+    </message>
+    <message>
+        <source>Show or hide parts of the Color Page.</source>
+        <translation>Mostre ou oculte partes da página colorida.</translation>
+    </message>
+    <message>
+        <source>Toggle orientation of the Color Page.</source>
+        <translation>Alternar a orientação da página colorida.</translation>
+    </message>
+    <message>
+        <source>No Style Selected</source>
+        <translation>Nenhum estilo selecionado</translation>
+    </message>
+    <message>
+        <source>Style Editor - No Valid Style Selected</source>
+        <translation>Editor de estilo - Nenhum estilo válido selecionado</translation>
+    </message>
+    <message>
+        <source>Wheel</source>
+        <translation>Roda</translation>
+    </message>
+    <message>
+        <source>HSV</source>
+        <translation>HSV</translation>
+    </message>
+    <message>
+        <source>Alpha</source>
+        <translation>Alfa</translation>
+    </message>
+    <message>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <source>Palette</source>
+        <translation>Paleta</translation>
+    </message>
+    <message>
+        <source>Cleanup </source>
+        <translation>Limpar</translation>
+    </message>
+    <message>
+        <source>Studio </source>
+        <translation>Estúdio</translation>
+    </message>
+    <message>
+        <source>Level </source>
+        <translation>Nível</translation>
+    </message>
+    <message>
+        <source>Hex</source>
+        <translation>Feitiço</translation>
+    </message>
+    <message>
+        <source>Relative colored + Triangle handle</source>
+        <translation>Cor relativa + alça triangular</translation>
+    </message>
+    <message>
+        <source>Absolute colored + Line handle</source>
+        <translation>Cor absoluta + alça de linha</translation>
+    </message>
+    <message>
+        <source>Slider Appearance</source>
+        <translation>Aparência do controle deslizante</translation>
+    </message>
+    <message>
+        <source>Toggle Orientation</source>
+        <translation>Alternar orientação</translation>
+    </message>
+    <message>
+        <source>Hex Color Names...</source>
+        <translation>Nomes de cores hexadecimais...</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>Procurar</translation>
+    </message>
+    <message>
+        <source>Clear Search</source>
+        <translation>Limpar pesquisa</translation>
+    </message>
+</context>
+<context>
+    <name>StyleEditorGUI::ColorChannelControl</name>
+    <message>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation>G</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation>B</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <translation>UM</translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation>H</translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation>V</translation>
+    </message>
+</context>
+<context>
+    <name>StyleEditorGUI::PlainColorPage</name>
+    <message>
+        <source>Wheel</source>
+        <translation>Roda</translation>
+    </message>
+    <message>
+        <source>HSV</source>
+        <translation>HSV</translation>
+    </message>
+    <message>
+        <source>Matte</source>
+        <translation>Fosco</translation>
+    </message>
+    <message>
+        <source>RGB</source>
+        <translation>RGB</translation>
+    </message>
+    <message>
+        <source>Alpha</source>
+        <translation>Alfa</translation>
+    </message>
+</context>
+<context>
+    <name>StyleEditorGUI::SettingsPage</name>
+    <message>
+        <source>Autopaint for Lines</source>
+        <translation>Pintura automática para linhas</translation>
+    </message>
+    <message>
+        <source>Reset to default</source>
+        <translation>Redefinir para o padrão</translation>
+    </message>
+</context>
+<context>
+    <name>StyleEditorGUI::StyleChooserPage</name>
+    <message>
+        <source>Pin To Top</source>
+        <translation>Fixar no topo</translation>
+    </message>
+    <message>
+        <source>Set Pins To Top</source>
+        <translation>Definir alfinetes no topo</translation>
+    </message>
+    <message>
+        <source>Clear Pins To Top</source>
+        <translation>Limpar alfinetes para o topo</translation>
+    </message>
+</context>
+<context>
+    <name>StyleNameEditor</name>
+    <message>
+        <source>Name Editor</source>
+        <translation>Editor de nomes</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+    <message>
+        <source>Style Name</source>
+        <translation>Nome do estilo</translation>
+    </message>
+    <message>
+        <source>Name Editor: # %1</source>
+        <translation>Editor de Nome: # %1</translation>
+    </message>
+    <message>
+        <source>Apply and Next</source>
+        <translation>Aplicar e próximo</translation>
+    </message>
+    <message>
+        <source>Easy Inputs</source>
+        <translation>Entradas fáceis</translation>
+    </message>
+</context>
+<context>
+    <name>SwatchViewer</name>
+    <message>
+        <source>Reset View</source>
+        <translation>Redefinir visualização</translation>
+    </message>
+    <message>
+        <source>Fit To Window</source>
+        <translation>Ajustar à janela</translation>
+    </message>
+</context>
+<context>
+    <name>TMessageViewer</name>
+    <message>
+        <source>Errors</source>
+        <translation>Erros</translation>
+    </message>
+    <message>
+        <source>Warnings</source>
+        <translation>Avisos</translation>
+    </message>
+    <message>
+        <source>Infos</source>
+        <translation>Informações</translation>
+    </message>
+    <message>
+        <source> Clear </source>
+        <translation>Claro</translation>
+    </message>
+    <message>
+        <source>Display:  </source>
+        <translation>Mostrar:</translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <translation>Informações</translation>
+    </message>
+</context>
+<context>
+    <name>TablePainter</name>
+    <message>
+        <source>&amp;Reset Center</source>
+        <translation>&amp;Redefinir Central</translation>
+    </message>
+    <message>
+        <source>Table</source>
+        <translation>Mesa de animação</translation>
+    </message>
+</context>
+<context>
+    <name>ToneCurveField</name>
+    <message>
+        <source>Channel:</source>
+        <translation>Canal:</translation>
+    </message>
+</context>
+<context>
+    <name>VectorBrushStyleChooserPage</name>
+    <message>
+        <source>Plain color</source>
+        <translation>Cor lisa</translation>
+    </message>
+</context>
+<context>
+    <name>WordButton</name>
+    <message>
+        <source>Remove %1</source>
+        <translation>Remover % 1</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
### Description
This PR introduces the official Brazilian Portuguese (pt_BR) localization for OpenToonz.

As OpenToonz has a growing community of animators in Brazil, having the software localized to `pt_BR` is a highly requested feature to improve accessibility for local artists and students.

### What was done
- Added `portuguese_brazil` to `LANG_CODES` and `LANG_DISPLAY_NAMES` in `toonz/sources/CMakeLists.txt` so the language is properly compiled by Qt and displayed in the user's Preferences menu.
- Translated `.ts` files for the core modules: `colorfx.ts`, `image.ts`, `tnzcore.ts`, `tnztools.ts`, `toonz.ts`, `toonzlib.ts`, `toonzqt.ts` (totaling over 6,200 strings).
- Applied industry-standard 2D animation terminology used by Brazilian artists instead of literal translations (e.g., *Frame* -> Quadro, *Pegbar* -> Barra de pinos, *Onion Skin* -> Casca de Cebola).

### Note on Accuracy
This is the initial version (V1) of the localization. While the translation was extensively reviewed to match standard animation terminology and UI patterns, there might be a few context-specific strings that will need minor adjustments as the community starts using it in their daily workflow. Feedback and future minor translation fixes from the community are expected and welcome!