### PR TITLE
Fix macOS build with Homebrew OpenCV 4

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -59,7 +59,7 @@ jobs:
 
           brew update
 
-          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv openjph openexr
+          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv@4 openjph openexr
 
           brew list --formula | grep '^qt' | grep -v '@5' | xargs -n1 brew unlink || true
 
@@ -95,6 +95,7 @@ jobs:
             -DQT_PATH=$(brew --prefix qt@5)/lib \
             -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
             -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 \
+            -DOpenCV_DIR=$(brew --prefix opencv@4)/lib/cmake/opencv4 \
             -DWITH_TRANSLATION=OFF
           ninja -j $(sysctl -n hw.ncpu)
       - name: Introduce Libraries and Stuff


### PR DESCRIPTION
Homebrew’s unversioned `opencv` formula now installs OpenCV 5, which is incompatible with OpenToonz’s OpenCV 4 requirement. This updates the macOS workflow to install `opencv@4` and explicitly directs CMake to its configuration directory.

This should bring macOS github action builds back online.
I don't think this will address similar issue with nightly builds. 
