### PR TITLE
Persist viewer view and room panel layout across sessions

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -238,6 +238,9 @@ public:
   bool isViewerIndicatorEnabled() const {
     return getBoolValue(viewerIndicatorEnabled);
   }
+  bool isRestoreViewerViewFromLastSessionEnabled() const {
+    return getBoolValue(restoreViewerViewFromLastSession);
+  }
 
   // Visualization  tab
   bool getShow0ThickLines() const { return getBoolValue(show0ThickLines); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -43,6 +43,7 @@ enum PreferencesItemId {
   showRoomBindButtons,
   displayIn30bit,
   viewerIndicatorEnabled,
+  restoreViewerViewFromLastSession,
 
   //----------
   // Visualization

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -58,6 +58,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QMessageBox>
+#include <QTimer>
 #ifdef _WIN32
 #include <QtPlatformHeaders/QWindowsWindowFunctions>
 #endif
@@ -418,7 +419,28 @@ void Room::load(const TFilePath &fp, RoomLoadParams &params) {
 
   layout->restoreState(state);
 
+  // Store layout state for deferred re-apply after the first show.
+  // Without this, TMainWindow::resizeEvent → redistribute() recalculates
+  // panel sizes before the window has reached its final geometry.
+  m_pendingLayoutState        = state;
+  m_hasPendingLayoutRestore   = true;
+
   m_initialized = true;
+}
+
+//-----------------------------------------------------------------------------
+
+void Room::showEvent(QShowEvent *event) {
+  TMainWindow::showEvent(event);
+
+  if (m_hasPendingLayoutRestore) {
+    m_hasPendingLayoutRestore = false;
+    DockLayout::State savedState = m_pendingLayoutState;
+    DockLayout *layout           = dockLayout();
+    QTimer::singleShot(0, this, [layout, savedState]() {
+      layout->restoreState(savedState);
+    });
+  }
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -33,6 +33,11 @@ class Room final : public TMainWindow {
   // For lazy loading
   bool m_initialized;
 
+  // Deferred layout restore: saved state re-applied after the first show
+  // to counteract redistribute() overwriting panel sizes.
+  bool m_hasPendingLayoutRestore = false;
+  DockLayout::State m_pendingLayoutState;
+
 public:
   Room(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags())
       : TMainWindow(parent, flags)
@@ -63,6 +68,9 @@ public:
     params.forceBuildGui = true;
     load(m_path, params);
   }
+
+protected:
+  void showEvent(QShowEvent *event) override;
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -748,6 +748,16 @@ void TPanelTitleBarButtonSet::select(TPanelTitleBarButton *button) {
   emit selected(button->getId());
 }
 
+bool TPanelTitleBarButtonSet::select(int id) {
+  for (auto *btn : m_buttons) {
+    if (btn->getId() == id) {
+      select(btn);
+      return true;
+    }
+  }
+  return false;
+}
+
 //=============================================================================
 // PaneTitleBar
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -161,6 +161,7 @@ public:
 
   void add(TPanelTitleBarButton *button);
   void select(TPanelTitleBarButton *button);
+  bool select(int id);
 
 signals:
   //! emitted when the current button changes. id is the button identifier

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1244,6 +1244,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {showIconsInMenu, tr("Show Icons In Menu*")},
       {showRoomBindButtons, tr("Show Room Bind Buttons*")},
       {viewerIndicatorEnabled, tr("Show Viewer Indicators")},
+      {restoreViewerViewFromLastSession,
+       tr("Restore Viewer Zoom and Pan from Last Session")},
 
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
@@ -2276,6 +2278,7 @@ QWidget* PreferencesPopup::createPreviewPage() {
     insertUI(actualPixelViewOnSceneEditingMode, viewerLay);
     insertUI(showRasterImagesDarkenBlendedInViewer, viewerLay);
     insertUI(viewerIndicatorEnabled, viewerLay);
+    insertUI(restoreViewerViewFromLastSession, viewerLay);
   }
   QGridLayout* palyControlLay = insertGroupBox(tr("Play Control"), lay);
   {

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2466,6 +2466,34 @@ void SceneViewer::setViewMatrix(const TAffine &aff, int viewMode) {
 
 //-----------------------------------------------------------------------------
 
+void SceneViewer::setViewZoomPan(int viewMode, const TAffine &aff) {
+  if (viewMode < 0 || viewMode >= (int)m_viewAff.size()) return;
+  m_viewAff[viewMode]       = aff;
+  m_rotationAngle[viewMode] = 0.0;
+  if (m_isFlippedX || m_isFlippedY) {
+    m_isFlippedX = false;
+    m_isFlippedY = false;
+    emit onFlipHChanged(false);
+    emit onFlipVChanged(false);
+  }
+  if (m_previewMode != NO_PREVIEW) requestTimedRefresh();
+  emit onZoomChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+void SceneViewer::setCamera3DViewState(const TPointD &pan, double zoom,
+                                       double phi, double theta) {
+  m_pan3D       = pan;
+  m_zoomScale3D = zoom;
+  m_phi3D       = (float)tcrop(phi, -90.0, 90.0);
+  m_theta3D     = (float)tcrop(theta, 0.0, 90.0);
+  invalidateAll();
+  emit onZoomChanged();
+}
+
+//-----------------------------------------------------------------------------
+
 bool SceneViewer::is3DView() const {
   bool isCameraTest = CameraTestCheck::instance()->isEnabled();
   return (m_referenceMode == CAMERA3D_REFERENCE && !isCameraTest);

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -259,10 +259,16 @@ public:
 
   TPointD getPan3D() const { return m_pan3D; }
   double getZoomScale3D() const { return m_zoomScale3D; }
+  double getPhi3D() const { return m_phi3D; }
+  double getTheta3D() const { return m_theta3D; }
 
-  // Accessors for session state persistence
   TAffine getViewAffine(int viewMode) const { return m_viewAff[viewMode]; }
   int getReferenceMode() const { return m_referenceMode; }
+
+  //! Restores zoom/pan only: clears rotation and flips for that view mode.
+  void setViewZoomPan(int viewMode, const TAffine &aff);
+  void setCamera3DViewState(const TPointD &pan, double zoom, double phi,
+                            double theta);
 
   double projectToZ(const TPointD &delta) override;
 

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -260,6 +260,10 @@ public:
   TPointD getPan3D() const { return m_pan3D; }
   double getZoomScale3D() const { return m_zoomScale3D; }
 
+  // Accessors for session state persistence
+  TAffine getViewAffine(int viewMode) const { return m_viewAff[viewMode]; }
+  int getReferenceMode() const { return m_referenceMode; }
+
   double projectToZ(const TPointD &delta) override;
 
   TPointD getDpiScale() const override { return m_dpiScale; }

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -81,6 +81,19 @@ enum OldV_Parts {
   OldVPARTS_ALL         = OldVPARTS_PLAYBAR | OldVPARTS_FRAMESLIDER
 };
 
+namespace {
+
+//! Keeps the view center and zoom, drops rotation and reflection.
+TAffine zoomPanOnly(const TAffine &aff) {
+  const double det = aff.det();
+  if (std::abs(det) < 1e-12) return TAffine();
+  const TPointD center = aff.inv() * TPointD(0, 0);
+  const double scale   = std::sqrt(std::abs(det));
+  return TScale(scale) * TTranslation(-center.x, -center.y);
+}
+
+}  // namespace
+
 //=============================================================================
 //
 // BaseViewerPanel
@@ -358,18 +371,9 @@ void BaseViewerPanel::showEvent(QShowEvent *event) {
   onSceneChanged();
   changeWindowTitle();
 
-  // Deferred restore of saved session view state. singleShot(0) ensures this
-  // runs after SceneViewer::showEvent() has called fitToCamera().
-  if (m_hasPendingViewRestore) {
-    m_hasPendingViewRestore = false;
-    std::array<TAffine, 2> affs = m_pendingViewAffs;
-    int refMode                 = m_pendingReferenceMode;
-    SceneViewer *sv             = m_sceneViewer;
-    QTimer::singleShot(0, this, [sv, affs, refMode]() {
-      for (int m = 0; m < 2; ++m)
-        sv->setViewMatrix(affs[m], m);
-      if (refMode >= 0) sv->setReferenceMode(refMode);
-    });
+  if (m_pendingViewState.valid) {
+    m_pendingViewState.valid = false;
+    QTimer::singleShot(0, this, [this]() { applyPendingViewState(); });
   }
 }
 
@@ -869,13 +873,40 @@ void BaseViewerPanel::setVisiblePartsFlag(UINT flag) {
   updateShowHide();
 }
 
+void BaseViewerPanel::applyReferenceMode(int mode) {
+  if (!m_sceneViewer) return;
+  if (m_referenceModeBs && m_referenceModeBs->select(mode)) return;
+  m_sceneViewer->setReferenceMode(mode);
+}
+
+//-----------------------------------------------------------------------------
+
+void BaseViewerPanel::applyPendingViewState() {
+  if (!m_sceneViewer) return;
+
+  for (int m = 0; m < 2; ++m)
+    m_sceneViewer->setViewZoomPan(m, m_pendingViewState.viewAffs[m]);
+
+  if (m_pendingViewState.hasCamera3D) {
+    m_sceneViewer->setCamera3DViewState(
+        m_pendingViewState.pan3D, m_pendingViewState.zoomScale3D,
+        m_pendingViewState.phi3D, m_pendingViewState.theta3D);
+  }
+
+  if (m_pendingViewState.referenceMode >= 0)
+    applyReferenceMode(m_pendingViewState.referenceMode);
+
+  m_sceneViewer->invalidateAll();
+}
+
+//-----------------------------------------------------------------------------
+
 // SaveLoadQSettings
 void BaseViewerPanel::save(QSettings &settings) const {
   settings.setValue("viewerVisibleParts", m_visiblePartsFlag);
 
-  // Save both view matrices (scene mode and level mode)
   for (int m = 0; m < 2; ++m) {
-    TAffine a = m_sceneViewer->getViewAffine(m);
+    TAffine a = zoomPanOnly(m_sceneViewer->getViewAffine(m));
     settings.beginGroup(QString("viewAff%1").arg(m));
     settings.setValue("a11", a.a11);
     settings.setValue("a12", a.a12);
@@ -886,8 +917,15 @@ void BaseViewerPanel::save(QSettings &settings) const {
     settings.endGroup();
   }
 
-  // Reference mode (Normal / Camera / Camera3D)
   settings.setValue("referenceMode", m_sceneViewer->getReferenceMode());
+
+  settings.beginGroup(QStringLiteral("camera3D"));
+  settings.setValue("panX", m_sceneViewer->getPan3D().x);
+  settings.setValue("panY", m_sceneViewer->getPan3D().y);
+  settings.setValue("zoom", m_sceneViewer->getZoomScale3D());
+  settings.setValue("phi", m_sceneViewer->getPhi3D());
+  settings.setValue("theta", m_sceneViewer->getTheta3D());
+  settings.endGroup();
 }
 
 void BaseViewerPanel::load(QSettings &settings) {
@@ -896,30 +934,45 @@ void BaseViewerPanel::load(QSettings &settings) {
       settings.value("viewerVisibleParts", m_visiblePartsFlag).toUInt();
   updateShowHide();
 
-  // Store view matrices for deferred restore (applied after the first
-  // sceneSwitched signal resets the viewer via resetSceneViewer())
+  if (!Preferences::instance()->isRestoreViewerViewFromLastSessionEnabled())
+    return;
+
+  PendingViewState pending;
   for (int m = 0; m < 2; ++m) {
     QString groupKey = QString("viewAff%1").arg(m);
-    if (settings.childGroups().contains(groupKey)) {
-      settings.beginGroup(groupKey);
-      TAffine a;
-      a.a11 = settings.value("a11", 1.0).toDouble();
-      a.a12 = settings.value("a12", 0.0).toDouble();
-      a.a13 = settings.value("a13", 0.0).toDouble();
-      a.a21 = settings.value("a21", 0.0).toDouble();
-      a.a22 = settings.value("a22", 1.0).toDouble();
-      a.a23 = settings.value("a23", 0.0).toDouble();
-      settings.endGroup();
-      m_pendingViewAffs[m]     = a;
-      m_hasPendingViewRestore  = true;
-    }
+    if (!settings.childGroups().contains(groupKey)) continue;
+    settings.beginGroup(groupKey);
+    TAffine a;
+    a.a11 = settings.value("a11", 1.0).toDouble();
+    a.a12 = settings.value("a12", 0.0).toDouble();
+    a.a13 = settings.value("a13", 0.0).toDouble();
+    a.a21 = settings.value("a21", 0.0).toDouble();
+    a.a22 = settings.value("a22", 1.0).toDouble();
+    a.a23 = settings.value("a23", 0.0).toDouble();
+    settings.endGroup();
+    pending.viewAffs[m] = zoomPanOnly(a);
+    pending.valid       = true;
   }
 
-  // Reference mode
   if (settings.contains("referenceMode")) {
-    m_pendingReferenceMode  = settings.value("referenceMode").toInt();
-    m_hasPendingViewRestore = true;
+    pending.referenceMode = settings.value("referenceMode").toInt();
+    pending.valid         = true;
   }
+
+  if (settings.childGroups().contains(QStringLiteral("camera3D"))) {
+    settings.beginGroup(QStringLiteral("camera3D"));
+    pending.pan3D =
+        TPointD(settings.value("panX", 0.0).toDouble(),
+                settings.value("panY", 0.0).toDouble());
+    pending.zoomScale3D = settings.value("zoom", 1.0).toDouble();
+    pending.phi3D       = settings.value("phi", 30.0).toDouble();
+    pending.theta3D     = settings.value("theta", 20.0).toDouble();
+    settings.endGroup();
+    pending.hasCamera3D = true;
+    pending.valid       = true;
+  }
+
+  if (pending.valid) m_pendingViewState = pending;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -64,6 +64,7 @@
 #include <QToolBar>
 #include <QMainWindow>
 #include <QSettings>
+#include <QTimer>
 
 #include "viewerpane.h"
 
@@ -356,6 +357,20 @@ void BaseViewerPanel::showEvent(QShowEvent *event) {
   // refresh
   onSceneChanged();
   changeWindowTitle();
+
+  // Deferred restore of saved session view state. singleShot(0) ensures this
+  // runs after SceneViewer::showEvent() has called fitToCamera().
+  if (m_hasPendingViewRestore) {
+    m_hasPendingViewRestore = false;
+    std::array<TAffine, 2> affs = m_pendingViewAffs;
+    int refMode                 = m_pendingReferenceMode;
+    SceneViewer *sv             = m_sceneViewer;
+    QTimer::singleShot(0, this, [sv, affs, refMode]() {
+      for (int m = 0; m < 2; ++m)
+        sv->setViewMatrix(affs[m], m);
+      if (refMode >= 0) sv->setReferenceMode(refMode);
+    });
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -736,6 +751,7 @@ void BaseViewerPanel::onSceneSwitched() {
                                   ->getFrameRate());
   m_sceneViewer->setEditPreviewSubcamera(false);
   onSceneChanged();
+
 }
 
 //-----------------------------------------------------------------------------
@@ -856,6 +872,22 @@ void BaseViewerPanel::setVisiblePartsFlag(UINT flag) {
 // SaveLoadQSettings
 void BaseViewerPanel::save(QSettings &settings) const {
   settings.setValue("viewerVisibleParts", m_visiblePartsFlag);
+
+  // Save both view matrices (scene mode and level mode)
+  for (int m = 0; m < 2; ++m) {
+    TAffine a = m_sceneViewer->getViewAffine(m);
+    settings.beginGroup(QString("viewAff%1").arg(m));
+    settings.setValue("a11", a.a11);
+    settings.setValue("a12", a.a12);
+    settings.setValue("a13", a.a13);
+    settings.setValue("a21", a.a21);
+    settings.setValue("a22", a.a22);
+    settings.setValue("a23", a.a23);
+    settings.endGroup();
+  }
+
+  // Reference mode (Normal / Camera / Camera3D)
+  settings.setValue("referenceMode", m_sceneViewer->getReferenceMode());
 }
 
 void BaseViewerPanel::load(QSettings &settings) {
@@ -863,6 +895,31 @@ void BaseViewerPanel::load(QSettings &settings) {
   m_visiblePartsFlag =
       settings.value("viewerVisibleParts", m_visiblePartsFlag).toUInt();
   updateShowHide();
+
+  // Store view matrices for deferred restore (applied after the first
+  // sceneSwitched signal resets the viewer via resetSceneViewer())
+  for (int m = 0; m < 2; ++m) {
+    QString groupKey = QString("viewAff%1").arg(m);
+    if (settings.childGroups().contains(groupKey)) {
+      settings.beginGroup(groupKey);
+      TAffine a;
+      a.a11 = settings.value("a11", 1.0).toDouble();
+      a.a12 = settings.value("a12", 0.0).toDouble();
+      a.a13 = settings.value("a13", 0.0).toDouble();
+      a.a21 = settings.value("a21", 0.0).toDouble();
+      a.a22 = settings.value("a22", 1.0).toDouble();
+      a.a23 = settings.value("a23", 0.0).toDouble();
+      settings.endGroup();
+      m_pendingViewAffs[m]     = a;
+      m_hasPendingViewRestore  = true;
+    }
+  }
+
+  // Reference mode
+  if (settings.contains("referenceMode")) {
+    m_pendingReferenceMode  = settings.value("referenceMode").toInt();
+    m_hasPendingViewRestore = true;
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -68,10 +68,20 @@ protected:
 
   bool m_isActive = false;
 
-  // Deferred view restore after first sceneSwitched (session persistence)
-  bool m_hasPendingViewRestore        = false;
-  std::array<TAffine, 2> m_pendingViewAffs = {TAffine(), TAffine()};
-  int m_pendingReferenceMode          = -1;
+  struct PendingViewState {
+    bool valid                              = false;
+    std::array<TAffine, 2> viewAffs         = {TAffine(), TAffine()};
+    int referenceMode                       = -1;
+    bool hasCamera3D                        = false;
+    TPointD pan3D;
+    double zoomScale3D                      = 1.0;
+    double phi3D                            = 30.0;
+    double theta3D                          = 20.0;
+  };
+  PendingViewState m_pendingViewState;
+
+  void applyReferenceMode(int mode);
+  void applyPendingViewState();
 
 public:
   BaseViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -10,11 +10,7 @@
 #include "saveloadqsettings.h"
 
 #include <QFrame>
-<<<<<<< HEAD
-=======
-#include <QContextMenuEvent>
 #include <array>
->>>>>>> 37c40d2d3 (feat: persist viewer zoom/pan and reference mode across sessions)
 
 class SceneViewer;
 class QPoint;

--- a/toonz/sources/toonz/viewerpane.h
+++ b/toonz/sources/toonz/viewerpane.h
@@ -10,6 +10,11 @@
 #include "saveloadqsettings.h"
 
 #include <QFrame>
+<<<<<<< HEAD
+=======
+#include <QContextMenuEvent>
+#include <array>
+>>>>>>> 37c40d2d3 (feat: persist viewer zoom/pan and reference mode across sessions)
 
 class SceneViewer;
 class QPoint;
@@ -66,6 +71,11 @@ protected:
   TSoundTrack *m_sound = NULL;
 
   bool m_isActive = false;
+
+  // Deferred view restore after first sceneSwitched (session persistence)
+  bool m_hasPendingViewRestore        = false;
+  std::array<TAffine, 2> m_pendingViewAffs = {TAffine(), TAffine()};
+  int m_pendingReferenceMode          = -1;
 
 public:
   BaseViewerPanel(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -462,6 +462,8 @@ void Preferences::definePreferenceItems() {
 
   define(viewerIndicatorEnabled, "viewerIndicatorEnabled", QMetaType::Bool,
          true);
+  define(restoreViewerViewFromLastSession, "restoreViewerViewFromLastSession",
+         QMetaType::Bool, false);
 
   // Visualization
   define(show0ThickLines, "show0ThickLines", QMetaType::Bool, true);


### PR DESCRIPTION
Goal : Keep viewer zoom, pan, and room panel layout between sessions

**Problem**

When reopening OpenToonz, the viewer often returned to a default zoom and pan, and the size of panels in the room could change on startup. Users lost the view and workspace layout they had set up in the previous session.

**Proposal**

Keep the last viewer view and room panel layout between sessions, and restore them only once the window is ready, so startup no longer resets what the user had arranged.

The viewer comes back with the same zoom, pan, and reference mode as before. Panel sizes in the room are kept as you left them after closing and reopening OpenToonz.

**Notes**

This feature was developed with Cursor’s AI models.
