### PR TITLE
Turn docked panels into tabs

### DIFF
--- a/stuff/config/qss/Blue/Blue.qss
+++ b/stuff/config/qss/Blue/Blue.qss
@@ -12,6 +12,7 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #43464d;
+  -hl-color: #4f7bc7;
   -icon-base-opacity: 0.8;
   -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;

--- a/stuff/config/qss/Clay/Clay.qss
+++ b/stuff/config/qss/Clay/Clay.qss
@@ -12,6 +12,7 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #514d4c;
+  -hl-color: #c26350;
   -icon-base-opacity: 0.8;
   -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;

--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -12,6 +12,7 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #303030;
+  -hl-color: #4f7bc7;
   -icon-base-opacity: 0.8;
   -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;

--- a/stuff/config/qss/Default-Green/Default-Green.qss
+++ b/stuff/config/qss/Default-Green/Default-Green.qss
@@ -12,6 +12,7 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #484848;
+  -hl-color: #278d44;
   -icon-base-opacity: 0.8;
   -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;

--- a/stuff/config/qss/Default/Default.qss
+++ b/stuff/config/qss/Default/Default.qss
@@ -12,6 +12,7 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #484848;
+  -hl-color: #4f7bc7;
   -icon-base-opacity: 0.8;
   -icon-disabled-opacity: 0.3;
   -icon-base-color: #dfdfdf;

--- a/stuff/config/qss/Default/less/layouts/_mainwindow.less
+++ b/stuff/config/qss/Default/less/layouts/_mainwindow.less
@@ -16,6 +16,7 @@ QToolBar * {
 
 :TOONZCOLORS {
   -bg-color: @bg-color;
+  -hl-color: @hl-color;
 
   // Opacity
   -icon-base-opacity: @icon-base-opacity;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -12,6 +12,7 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #d1d1d1;
+  -hl-color: #7098f0;
   -icon-base-opacity: 0.8;
   -icon-disabled-opacity: 0.3;
   -icon-base-color: black;

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -12,6 +12,7 @@ QToolBar * {
 }
 :TOONZCOLORS {
   -bg-color: #808080;
+  -hl-color: #dddddd;
   -icon-base-opacity: 0.8;
   -icon-disabled-opacity: 0.3;
   -icon-base-color: black;

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -798,11 +798,11 @@ void TPanelTitleBar::paintEvent(QPaintEvent *) {
         dw->windowTitle(), Qt::ElideRight, rect.width() - 50);
 
     painter.setBrush(Qt::NoBrush);
-    // Title text attenuation is reserved for inactive tabs within a
-    // hover-join tab group (see DockTabStrip::updateTabTextColors); a
-    // standalone or floating panel's own title bar always stays fully
-    // opaque, regardless of focus.
-    painter.setPen(m_activeTitleColor);
+    // Native focus-based title dimming for standalone/floating panels. This
+    // is unrelated to hover-join tab attenuation (see
+    // DockTabStrip::updateTabTextColors), which only dims inactive tabs
+    // inside a merged tab group and must not affect this path.
+    painter.setPen(isPanelActive ? m_activeTitleColor : m_titleColor);
     painter.drawText(QPointF(8, 13), titleText);
   }
 

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -798,10 +798,6 @@ void TPanelTitleBar::paintEvent(QPaintEvent *) {
         dw->windowTitle(), Qt::ElideRight, rect.width() - 50);
 
     painter.setBrush(Qt::NoBrush);
-    // Native focus-based title dimming for standalone/floating panels. This
-    // is unrelated to hover-join tab attenuation (see
-    // DockTabStrip::updateTabTextColors), which only dims inactive tabs
-    // inside a merged tab group and must not affect this path.
     painter.setPen(isPanelActive ? m_activeTitleColor : m_titleColor);
     painter.drawText(QPointF(8, 13), titleText);
   }

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -798,7 +798,11 @@ void TPanelTitleBar::paintEvent(QPaintEvent *) {
         dw->windowTitle(), Qt::ElideRight, rect.width() - 50);
 
     painter.setBrush(Qt::NoBrush);
-    painter.setPen(isPanelActive ? m_activeTitleColor : m_titleColor);
+    // Title text attenuation is reserved for inactive tabs within a
+    // hover-join tab group (see DockTabStrip::updateTabTextColors); a
+    // standalone or floating panel's own title bar always stays fully
+    // opaque, regardless of focus.
+    painter.setPen(m_activeTitleColor);
     painter.drawText(QPointF(8, 13), titleText);
   }
 

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -788,11 +788,11 @@ void TPanelTitleBar::paintEvent(QPaintEvent *) {
         dw->windowTitle(), Qt::ElideRight, rect.width() - 50);
 
     painter.setBrush(Qt::NoBrush);
-    // Title text attenuation is reserved for inactive tabs within a
-    // hover-join tab group (see DockTabStrip::updateTabTextColors); a
-    // standalone or floating panel's own title bar always stays fully
-    // opaque, regardless of focus.
-    painter.setPen(m_activeTitleColor);
+    // Native focus-based title dimming for standalone/floating panels. This
+    // is unrelated to hover-join tab attenuation (see
+    // DockTabStrip::updateTabTextColors), which only dims inactive tabs
+    // inside a merged tab group and must not affect this path.
+    painter.setPen(isPanelActive ? m_activeTitleColor : m_titleColor);
     painter.drawText(QPointF(8, 13), titleText);
   }
 

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -788,7 +788,11 @@ void TPanelTitleBar::paintEvent(QPaintEvent *) {
         dw->windowTitle(), Qt::ElideRight, rect.width() - 50);
 
     painter.setBrush(Qt::NoBrush);
-    painter.setPen(isPanelActive ? m_activeTitleColor : m_titleColor);
+    // Title text attenuation is reserved for inactive tabs within a
+    // hover-join tab group (see DockTabStrip::updateTabTextColors); a
+    // standalone or floating panel's own title bar always stays fully
+    // opaque, regardless of focus.
+    painter.setPen(m_activeTitleColor);
     painter.drawText(QPointF(8, 13), titleText);
   }
 

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -983,6 +983,8 @@ public:
     panel->setFixWidthMode(TPanel::fixed);
     panel->setWidget(toolbar);
     panel->setIsMaximizable(false);
+    // A tab strip would not fit this bar (see DockLayout::supportsTabGrouping)
+    panel->setProperty("canJoinDockTabs", false);
     // panel->setAllowedAreas(Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea);
     panel->setFixedWidth(44);  // 35
     toolbar->setFixedWidth(34);
@@ -1009,6 +1011,8 @@ public:
   TPanel *createPanel(QWidget *parent) override {
     TPanel *panel = new CommandBarPanel(parent);
     panel->setObjectName(getPanelType());
+    // A tab strip would not fit this bar (see DockLayout::supportsTabGrouping)
+    panel->setProperty("canJoinDockTabs", false);
     return panel;
   }
   void initialize(TPanel *panel) override {}
@@ -1047,6 +1051,8 @@ public:
     panel->setObjectName(getPanelType());
     panel->setWindowTitle(getPanelType());
     panel->resize(600, panel->height());
+    // A tab strip would not fit this bar (see DockLayout::supportsTabGrouping)
+    panel->setProperty("canJoinDockTabs", false);
     return panel;
   }
   void initialize(TPanel *panel) override { assert(0); }

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -3,6 +3,7 @@ set(MOC_HEADERS
     pluginhost.h
     stageobjectselection.h
     tdockwindows.h
+    docktabstrip.h
     ../include/toonzqt/addfxcontextmenu.h
     ../include/toonzqt/camerasettingswidget.h
     ../include/toonzqt/checkbox.h
@@ -110,6 +111,7 @@ set(SOURCES
     checkbox.cpp
     colorfield.cpp
     docklayout.cpp
+    docktabstrip.cpp
     dockwidget.cpp
     doublefield.cpp
     doublepairfield.cpp

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -665,11 +665,10 @@ void Region::setTabGroup(const std::vector<DockWidget *> &panels,
     return;
   }
 
-  m_tabItems       = panels;
-  m_activeTabIndex = (activeIndex >= 0 && activeIndex < (int)panels.size())
-                         ? activeIndex
-                         : 0;
-  m_item           = activeTab();
+  m_tabItems = panels;
+  m_activeTabIndex =
+      (activeIndex >= 0 && activeIndex < (int)panels.size()) ? activeIndex : 0;
+  m_item = activeTab();
 }
 
 //------------------------------------------------------

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -8,7 +8,7 @@
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QMouseEvent>
-#include <QTimer>
+#include <QVariant>
 
 #include <assert.h>
 #include <math.h>
@@ -86,15 +86,15 @@ inline QRect toRect(const QRectF &rect) {
 DockLayout::DockLayout()
     : m_maximizedDock(0)
     , m_decoAllocator(new DockDecoAllocator())
-    , m_joinHighlight(0)
-    , m_joinHighlightRegion(0) {}
+    , m_tabMergePreview(0)
+    , m_tabMergeTargetRegion(0) {}
 
 //-------------------------------------
 
 DockLayout::~DockLayout() {
-  clearJoinHighlight();
-  delete m_joinHighlight;
-  m_joinHighlight = 0;
+  hideTabMergePreview();
+  delete m_tabMergePreview;
+  m_tabMergePreview = 0;
 
   // Dock widgets may outlive this layout during application shutdown. Clear
   // their back-pointer so ~DockWidget does not call into a destroyed layout.
@@ -230,12 +230,12 @@ QWidget *DockLayout::containerOf(QPoint point) const {
   for (i = m_regions.size() - 1; i >= 0; --i) {
     Region *currRegion = m_regions[i];
 
-    if (currRegion->isTabbed() && currRegion->tabStripContainer() &&
+    if (currRegion->hasTabGroup() && currRegion->tabStripContainer() &&
         currRegion->tabStripContainer()->geometry().contains(point))
       return currRegion->tabStripContainer();
 
     DockWidget *item = currRegion->getItem();
-    if (!item && currRegion->isTabbed()) item = currRegion->activeTab();
+    if (!item && currRegion->hasTabGroup()) item = currRegion->activeTab();
 
     // First check if item contains it
     if (item && item->geometry().contains(point)) return item;
@@ -276,12 +276,8 @@ void DockLayout::setMaximized(DockWidget *item, bool state) {
         item->m_maximized = true;
         m_maximizedDock   = item;
 
-        // If item is (or was) the active tab of a merged group, its own
-        // title bar is normally hidden in favor of the tab strip - which
-        // stays behind at the group's old, now-covered location. Without
-        // its own title bar shown while maximized, there is no visible/
-        // clickable spot left to double-click back to normal size (see
-        // the matching restore below).
+        // A maximized panel covers the tab strip of the group it belongs to,
+        // so it needs its own title bar back to stay double-clickable.
         restorePanelTitleBar(item);
 
         // Hide all the other docked widgets (no need to update them. Moreover,
@@ -302,19 +298,11 @@ void DockLayout::setMaximized(DockWidget *item, bool state) {
       m_maximizedDock->m_maximized = false;
       m_maximizedDock              = 0;
 
-      // Show docked widgets again, but keep inactive tabs in tab groups hidden.
-      DockWidget *currWidget;
-      for (int i = 0; i < count(); ++i) {
-        currWidget = (DockWidget *)itemAt(i)->widget();
-        if (currWidget != item && !currWidget->isFloating()) currWidget->show();
-      }
-      refreshTabbedRegionsVisibility();
+      restoreDockedWidgetVisibility(item);
 
-      // If the un-maximized item still belongs to a merged tab group, hand
-      // its title bar back to being hidden in favor of the tab strip (see
-      // the matching show-on-maximize above) instead of leaving both
-      // visible on top of each other.
-      if (r && r->isTabbed()) updateTabVisibility(r);
+      // The title bar shown while maximized goes back to being hidden when
+      // the panel returns into a tab group.
+      if (r && r->hasTabGroup()) updateTabVisibility(r);
     }
   }
 }
@@ -340,7 +328,7 @@ void DockLayout::updateSeparatorCursors() {
   int jInt, k;
   for (i = 0; i < m_regions.size(); ++i) {
     r = m_regions[i];
-    if (r->isTabbed()) continue;
+    if (r->hasTabGroup()) continue;
 
     const int childCount     = static_cast<int>(r->getChildList().size());
     const int separatorCount = static_cast<int>(r->separators().size());
@@ -406,7 +394,7 @@ void DockLayout::applyGeometry() {
     const std::deque<Region *> &childList = r->getChildList();
     std::deque<DockSeparator *> &sepList  = r->m_separators;
 
-    if (r->isTabbed()) {
+    if (r->hasTabGroup()) {
       QRect regionRect = toRect(r->getGeometry());
       if (r->tabStripContainer()) {
         r->tabStripContainer()->setGeometry(
@@ -462,8 +450,22 @@ void DockLayout::applyGeometry() {
   // Finally, update separator cursors.
   updateSeparatorCursors();
 
-  if (m_joinHighlight && m_joinHighlightRegion)
-    updateJoinHighlightGeometry();
+  if (m_tabMergePreview && m_tabMergeTargetRegion)
+    updateTabMergePreviewGeometry();
+}
+
+//------------------------------------------------------
+
+//! Single commit point for dock operations: helpers mutate the region tree,
+//! then the public operation asks for the geometry work to be done once.
+void DockLayout::finishLayoutChange(LayoutUpdate update) {
+  if (update == LayoutUpdate::Full)
+    redistribute();  // applies geometry itself
+  else
+    applyGeometry();
+
+  if (update != LayoutUpdate::Geometry && parentWidget())
+    parentWidget()->repaint();
 }
 
 //------------------------------------------------------
@@ -600,12 +602,164 @@ void DockLayout::redistribute() {
 //=============================
 
 Region::~Region() {
-  delete m_tabStripContainer;
-  m_tabStrip         = 0;
-  m_tabStripContainer = 0;
+  if (m_owner) m_owner->destroyTabStrip(this, StripDeletion::Immediate);
+
   // Delete separators
   unsigned int i;
   for (i = 0; i < m_separators.size(); ++i) delete m_separators[i];
+}
+
+//------------------------------------------------------
+
+Region::Content Region::content() const {
+  if (hasTabGroup()) return Content::TabGroup;
+  if (hasChildren()) return Content::Split;
+  if (m_item) return Content::SinglePanel;
+  return Content::Empty;
+}
+
+//------------------------------------------------------
+
+DockTabStrip *Region::tabStrip() const { return m_tabStrip; }
+
+//------------------------------------------------------
+
+TabBarContainter *Region::tabStripContainer() const {
+  return m_tabStripContainer;
+}
+
+//------------------------------------------------------
+
+bool Region::containsPanel(const DockWidget *panel) const {
+  if (!panel) return false;
+  if (m_item == panel) return true;
+  return std::find(m_tabItems.begin(), m_tabItems.end(), panel) !=
+         m_tabItems.end();
+}
+
+//------------------------------------------------------
+
+DockWidget *Region::activeTab() const {
+  if (hasTabGroup()) {
+    if (m_activeTabIndex >= 0 && m_activeTabIndex < (int)m_tabItems.size())
+      return m_tabItems[m_activeTabIndex];
+    return m_tabItems.front();
+  }
+  return m_item;
+}
+
+//------------------------------------------------------
+
+void Region::setSinglePanel(DockWidget *panel) {
+  m_tabItems.clear();
+  m_activeTabIndex = 0;
+  m_item           = panel;
+}
+
+//------------------------------------------------------
+
+void Region::setTabGroup(const std::vector<DockWidget *> &panels,
+                         int activeIndex) {
+  if (panels.size() < 2) {
+    setSinglePanel(panels.empty() ? 0 : panels.front());
+    return;
+  }
+
+  m_tabItems       = panels;
+  m_activeTabIndex = (activeIndex >= 0 && activeIndex < (int)panels.size())
+                         ? activeIndex
+                         : 0;
+  m_item           = activeTab();
+}
+
+//------------------------------------------------------
+
+void Region::appendTab(DockWidget *panel) {
+  if (!panel) return;
+
+  std::vector<DockWidget *> panels = m_tabItems;
+  if (panels.empty() && m_item) panels.push_back(m_item);
+  panels.push_back(panel);
+
+  setTabGroup(panels, (int)panels.size() - 1);
+}
+
+//------------------------------------------------------
+
+int Region::removeTab(DockWidget *panel) {
+  auto it = std::find(m_tabItems.begin(), m_tabItems.end(), panel);
+  if (it == m_tabItems.end()) return -1;
+
+  const int removedIndex = (int)(it - m_tabItems.begin());
+
+  std::vector<DockWidget *> panels = m_tabItems;
+  panels.erase(panels.begin() + removedIndex);
+
+  int activeIndex = m_activeTabIndex;
+  if (activeIndex > removedIndex) --activeIndex;
+
+  setTabGroup(panels, activeIndex);
+  return removedIndex;
+}
+
+//------------------------------------------------------
+
+void Region::moveTab(int fromIndex, int toIndex) {
+  const int tabCount = (int)m_tabItems.size();
+  if (fromIndex < 0 || toIndex < 0 || fromIndex >= tabCount ||
+      toIndex >= tabCount || fromIndex == toIndex)
+    return;
+
+  DockWidget *active = activeTab();
+
+  DockWidget *moved = m_tabItems[fromIndex];
+  m_tabItems.erase(m_tabItems.begin() + fromIndex);
+  m_tabItems.insert(m_tabItems.begin() + toIndex, moved);
+
+  auto it = std::find(m_tabItems.begin(), m_tabItems.end(), active);
+  m_activeTabIndex =
+      (it == m_tabItems.end()) ? 0 : (int)(it - m_tabItems.begin());
+  m_item = activeTab();
+}
+
+//------------------------------------------------------
+
+void Region::setActiveTabIndex(int index) {
+  if (index < 0 || index >= (int)m_tabItems.size()) return;
+  m_activeTabIndex = index;
+  m_item           = activeTab();
+}
+
+//------------------------------------------------------
+
+void Region::adoptTabGroupFrom(Region *source) {
+  if (!source || source == this) return;
+
+  const std::vector<DockWidget *> panels = source->m_tabItems;
+  const int activeIndex                  = source->m_activeTabIndex;
+  TabBarContainter *container            = source->m_tabStripContainer;
+  DockTabStrip *strip                    = source->m_tabStrip;
+
+  source->detachTabStrip();
+  source->setSinglePanel(0);
+
+  setTabGroup(panels, activeIndex);
+  attachTabStrip(container, strip);
+}
+
+//------------------------------------------------------
+
+void Region::attachTabStrip(TabBarContainter *container, DockTabStrip *strip) {
+  m_tabStripContainer = container;
+  m_tabStrip          = strip;
+  if (m_tabStrip) m_tabStrip->rebindRegion(this);
+}
+
+//------------------------------------------------------
+
+void Region::detachTabStrip() {
+  m_tabStripContainer = 0;
+  m_tabStrip          = 0;
 }
 
 //------------------------------------------------------
@@ -662,7 +816,7 @@ Region *DockLayout::find(DockWidget *item) const {
     Region *r = m_regions[i];
     if (r->getItem() == item) return r;
 
-    if (r->isTabbed()) {
+    if (r->hasTabGroup()) {
       const std::vector<DockWidget *> &tabs = r->tabItems();
       for (j = 0; j < tabs.size(); ++j)
         if (tabs[j] == item) return r;
@@ -678,39 +832,28 @@ int DockLayout::tabStripHeight() const { return DockTabStrip::kHeight; }
 
 //------------------------------------------------------
 
-bool DockLayout::canParticipateInTabGroup(const DockWidget *widget) {
+bool DockLayout::supportsTabGrouping(const DockWidget *widget) {
   if (!widget) return false;
 
-  const QString name = widget->objectName();
-  if (name == QLatin1String("ToolBar") ||
-      name == QLatin1String("CommandBar") ||
-      name == QLatin1String("ToolOptions"))
-    return false;
+  const QVariant optOut = widget->property("canJoinDockTabs");
+  if (optOut.isValid()) return optOut.toBool();
 
   if (widget->getFixWidthMode() == DockWidget::fixed) return false;
 
-  // Thin vertical strips that cannot be resized (e.g. main toolbar).
+  // Fallback for panels that predate the property: bars too thin to hold a
+  // tab strip are excluded by their own fixed extent.
+  const int maxJoinableBarWidth  = 60;
+  const int maxJoinableBarHeight = 48;
+
   if (widget->minimumWidth() == widget->maximumWidth() &&
-      widget->maximumWidth() <= 60)
+      widget->maximumWidth() <= maxJoinableBarWidth)
     return false;
 
-  // Thin horizontal bars that cannot be resized (command / tool option bars).
   if (widget->minimumHeight() == widget->maximumHeight() &&
-      widget->maximumHeight() <= 48)
+      widget->maximumHeight() <= maxJoinableBarHeight)
     return false;
 
   return true;
-}
-
-//------------------------------------------------------
-
-DockWidget *Region::activeTab() const {
-  if (isTabbed()) {
-    if (m_activeTabIndex >= 0 && m_activeTabIndex < (int)m_tabItems.size())
-      return m_tabItems[m_activeTabIndex];
-    return m_tabItems.empty() ? 0 : m_tabItems.front();
-  }
-  return m_item;
 }
 
 //------------------------------------------------------
@@ -719,32 +862,44 @@ void DockLayout::ensureTabStrip(Region *region) {
   if (!region || !parentWidget()) return;
 
   if (!region->m_tabStripContainer) {
-    region->m_tabStripContainer = new TabBarContainter(parentWidget());
+    TabBarContainter *container = new TabBarContainter(parentWidget());
     // Reuse the Style Editor / Palette tab styling from the active theme.
-    region->m_tabStripContainer->setObjectName("TabBarContainer");
+    container->setObjectName("TabBarContainer");
 
-    QHBoxLayout *tabLayout = new QHBoxLayout(region->m_tabStripContainer);
+    QHBoxLayout *tabLayout = new QHBoxLayout(container);
     tabLayout->setContentsMargins(6, 0, 0, 0);
     tabLayout->setSpacing(0);
 
-    region->m_tabStrip =
-        new DockTabStrip(this, region, region->m_tabStripContainer);
+    DockTabStrip *strip = new DockTabStrip(this, region, container);
     // Let the strip fill the container so expanding tabs share width equally.
-    tabLayout->addWidget(region->m_tabStrip, 1);
+    tabLayout->addWidget(strip, 1);
 
-    region->m_tabStripContainer->setFixedHeight(tabStripHeight());
-    region->m_tabStripContainer->hide();
+    container->setFixedHeight(tabStripHeight());
+    container->hide();
+
+    region->attachTabStrip(container, strip);
   }
   region->m_tabStrip->syncFromRegion();
 }
 
 //------------------------------------------------------
 
-void DockLayout::destroyTabStrip(Region *region) {
-  if (!region || !region->m_tabStripContainer) return;
-  delete region->m_tabStripContainer;
-  region->m_tabStripContainer = 0;
-  region->m_tabStrip          = 0;
+//! Deletes the tab strip of \b region, if any. Deferred deletion is required
+//! whenever the strip may be the widget currently dispatching the event that
+//! led here (a tab dragged out of its own group).
+void DockLayout::destroyTabStrip(Region *region, StripDeletion deletion) {
+  if (!region) return;
+
+  TabBarContainter *container = region->m_tabStripContainer;
+  region->detachTabStrip();
+  if (!container) return;
+
+  if (deletion == StripDeletion::Deferred) {
+    container->hide();
+    container->deleteLater();
+  } else {
+    delete container;
+  }
 }
 
 //------------------------------------------------------
@@ -752,7 +907,7 @@ void DockLayout::destroyTabStrip(Region *region) {
 void DockLayout::updateTabVisibility(Region *region) {
   if (!region) return;
 
-  const bool tabbed = region->isTabbed();
+  const bool tabbed                     = region->hasTabGroup();
   const std::vector<DockWidget *> &tabs = region->tabItems();
   DockWidget *active                    = region->activeTab();
 
@@ -764,101 +919,77 @@ void DockLayout::updateTabVisibility(Region *region) {
     if (tdw && tdw->titleBarWidget())
       tdw->titleBarWidget()->setVisible(!tabbed);
 
-    if (tabs[i] == active) {
-      if (tabbed) {
-        tabs[i]->show();
-        tabs[i]->raise();
-      }
-    } else if (tabbed) {
-      tabs[i]->hide();
+    if (!tabbed) continue;
+
+    if (tab == active) {
+      tab->show();
+      tab->raise();
+    } else {
+      tab->hide();
     }
   }
 
   if (tabbed)
     ensureTabStrip(region);
   else
-    destroyTabStrip(region);
+    destroyTabStrip(region, StripDeletion::Immediate);
 }
 
 //------------------------------------------------------
 
 void DockLayout::setActiveTab(Region *region, int index) {
-  if (!region || !region->isTabbed()) return;
-  if (index < 0 || index >= (int)region->tabItems().size()) return;
+  if (!region || !region->hasTabGroup()) return;
 
-  region->m_activeTabIndex = index;
-  region->m_item           = region->activeTab();
+  region->setActiveTabIndex(index);
   updateTabVisibility(region);
-  applyGeometry();
-  parentWidget()->repaint();
+  finishLayoutChange(LayoutUpdate::GeometryAndRepaint);
 }
 
 //------------------------------------------------------
 
-void DockLayout::moveTab(Region *region, int fromIndex, int toIndex) {
-  if (!region || !region->isTabbed()) return;
+void DockLayout::reorderTab(Region *region, int fromIndex, int toIndex) {
+  if (!region || !region->hasTabGroup()) return;
 
-  std::vector<DockWidget *> &tabs = region->m_tabItems;
-  if (fromIndex < 0 || toIndex < 0 || fromIndex >= (int)tabs.size() ||
-      toIndex >= (int)tabs.size() || fromIndex == toIndex)
-    return;
-
-  DockWidget *moved = tabs[fromIndex];
-  tabs.erase(tabs.begin() + fromIndex);
-  tabs.insert(tabs.begin() + toIndex, moved);
-
-  if (region->m_activeTabIndex == fromIndex)
-    region->m_activeTabIndex = toIndex;
-  else if (fromIndex < region->m_activeTabIndex &&
-           toIndex >= region->m_activeTabIndex)
-    region->m_activeTabIndex--;
-  else if (fromIndex > region->m_activeTabIndex &&
-           toIndex <= region->m_activeTabIndex)
-    region->m_activeTabIndex++;
-
-  region->m_item = region->activeTab();
+  region->moveTab(fromIndex, toIndex);
   if (region->m_tabStrip) region->m_tabStrip->syncFromRegion();
   updateTabVisibility(region);
-  applyGeometry();
+  finishLayoutChange(LayoutUpdate::Geometry);
 }
 
 //------------------------------------------------------
 
-void DockLayout::setJoinHighlight(Region *region) {
+void DockLayout::showTabMergePreview(Region *region) {
   if (!parentWidget() || !region) return;
 
-  m_joinHighlightRegion = region;
-  if (!m_joinHighlight) {
+  m_tabMergeTargetRegion = region;
+  if (!m_tabMergePreview) {
     // Tool overlay so the frame paints above SubWindow dock panels.
-    m_joinHighlight =
-        new DockJoinHighlight(parentWidget());
+    m_tabMergePreview = new DockTabMergePreview(parentWidget());
   }
 
-  updateJoinHighlightGeometry();
-  m_joinHighlight->show();
-  m_joinHighlight->raise();
-  m_joinHighlight->update();
+  updateTabMergePreviewGeometry();
+  m_tabMergePreview->show();
+  m_tabMergePreview->raise();
+  m_tabMergePreview->update();
 }
 
 //------------------------------------------------------
 
-void DockLayout::clearJoinHighlight() {
-  m_joinHighlightRegion = 0;
-  if (m_joinHighlight) m_joinHighlight->hide();
+void DockLayout::hideTabMergePreview() {
+  m_tabMergeTargetRegion = 0;
+  if (m_tabMergePreview) m_tabMergePreview->hide();
 }
 
 //------------------------------------------------------
 
-void DockLayout::updateJoinHighlightGeometry() {
-  if (!m_joinHighlight || !m_joinHighlightRegion || !parentWidget()) return;
+//! The preview outlines the whole region the panel would join, whereas the
+//! placeholder it is triggered by only covers the title / tab strip band so
+//! that it never overlaps the classic split drop zones.
+void DockLayout::updateTabMergePreviewGeometry() {
+  if (!m_tabMergePreview || !m_tabMergeTargetRegion || !parentWidget()) return;
 
-  // Show the full panel/region size that will actually result from the
-  // merge (matches the pre-tabify behavior), while the underlying hit-test
-  // placeholder (see DockPlaceholder::buildGeometry, tabify case) stays a
-  // narrow title/tab-strip band so it never overlaps the classic split
-  // drop zones. Only this visual frame is enlarged.
-  const QRect local = toRect(m_joinHighlightRegion->getGeometry());
-  m_joinHighlight->setGeometry(
+  const QRect local = toRect(m_tabMergeTargetRegion->getGeometry());
+  m_tabMergePreview->setGeometry(
       QRect(parentWidget()->mapToGlobal(local.topLeft()), local.size()));
 }
 
@@ -875,7 +1006,17 @@ void DockLayout::restorePanelTitleBar(DockWidget *item) {
 
 //------------------------------------------------------
 
-void DockLayout::restoreSingleDockedPanel(DockWidget *item) {
+void DockLayout::restoreDetachedPanelAppearance(DockWidget *item) {
+  if (!item) return;
+
+  restorePanelTitleBar(item);
+  item->setDockedAppearance();
+  item->show();
+}
+
+//------------------------------------------------------
+
+void DockLayout::normalizeSingleDockedPanel(DockWidget *item) {
   if (!item) return;
 
   item->setWindowFlags(Qt::SubWindow);
@@ -894,69 +1035,59 @@ void DockLayout::restoreSingleDockedPanel(DockWidget *item) {
 
 //------------------------------------------------------
 
-void DockLayout::refreshTabbedRegionsVisibility() {
-  for (unsigned int i = 0; i < m_regions.size(); ++i) {
-    if (m_regions[i]->isTabbed()) updateTabVisibility(m_regions[i]);
+void DockLayout::normalizeTabGroupAppearance(Region *region) {
+  if (!region) return;
+
+  const std::vector<DockWidget *> &tabs = region->tabItems();
+  for (unsigned int t = 0; t < tabs.size(); ++t) {
+    tabs[t]->setDockedAppearance();
+    TDockWidget *tdw = qobject_cast<TDockWidget *>(tabs[t]);
+    if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(false);
   }
+}
+
+//------------------------------------------------------
+
+void DockLayout::restoreDockedWidgetVisibility(DockWidget *keptVisible) {
+  for (int i = 0; i < count(); ++i) {
+    DockWidget *currWidget = (DockWidget *)itemAt(i)->widget();
+    if (currWidget != keptVisible && !currWidget->isFloating())
+      currWidget->show();
+  }
+
+  // Inactive members of a tab group must go back to being hidden.
+  for (unsigned int i = 0; i < m_regions.size(); ++i)
+    if (m_regions[i]->hasTabGroup()) updateTabVisibility(m_regions[i]);
+
   applyGeometry();
 }
 
 //------------------------------------------------------
 
 bool DockLayout::removeFromTabGroup(DockWidget *item, Region *region,
-                                    bool deferStripDestroy) {
-  if (!region || !region->isTabbed()) return false;
+                                    StripDeletion deletion) {
+  if (!region || !region->hasTabGroup()) return false;
+  if (region->removeTab(item) < 0) return false;
 
-  std::vector<DockWidget *> &tabs = region->m_tabItems;
-  auto it = std::find(tabs.begin(), tabs.end(), item);
-  if (it == tabs.end()) return false;
+  restoreDetachedPanelAppearance(item);
 
-  int removedIndex = static_cast<int>(it - tabs.begin());
-  tabs.erase(it);
-
-  // Always restore the removed panel's title bar; only undockFromTabGroup
-  // used to do this, leaving orphaned panels without a drag grip.
-  restorePanelTitleBar(item);
-  item->setDockedAppearance();
-  item->show();
-
-  if (tabs.size() <= 1) {
-    DockWidget *remaining = tabs.empty() ? 0 : tabs.front();
-    tabs.clear();
-    region->m_activeTabIndex = 0;
-    region->setItem(remaining);
-    if (deferStripDestroy) {
-      if (region->m_tabStripContainer) region->m_tabStripContainer->hide();
-    } else {
-      destroyTabStrip(region);
-    }
-    if (remaining) restoreSingleDockedPanel(remaining);
-    applyGeometry();
-    if (parentWidget()) parentWidget()->repaint();
-    return true;
+  if (!region->hasTabGroup()) {
+    destroyTabStrip(region, deletion);
+    if (DockWidget *remaining = region->getItem())
+      normalizeSingleDockedPanel(remaining);
+  } else {
+    if (region->m_tabStrip) region->m_tabStrip->syncFromRegion();
+    updateTabVisibility(region);
   }
 
-  if (region->m_activeTabIndex > removedIndex)
-    region->m_activeTabIndex--;
-  if (region->m_activeTabIndex >= (int)tabs.size())
-    region->m_activeTabIndex = tabs.size() - 1;
-  if (region->m_activeTabIndex < 0) region->m_activeTabIndex = 0;
-
-  region->m_item = region->activeTab();
-  if (region->m_tabStrip) region->m_tabStrip->syncFromRegion();
-  updateTabVisibility(region);
-  applyGeometry();
-  if (parentWidget()) parentWidget()->repaint();
   return true;
 }
 
 //------------------------------------------------------
 
 bool DockLayout::undockFromTabGroup(DockWidget *item, Region *region,
-                                    bool deferStripDestroy) {
-  if (!removeFromTabGroup(item, region, deferStripDestroy)) return false;
-
-  restorePanelTitleBar(item);
+                                    StripDeletion deletion) {
+  if (!removeFromTabGroup(item, region, deletion)) return false;
 
   item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
   item->setFloatingAppearance();
@@ -966,19 +1097,17 @@ bool DockLayout::undockFromTabGroup(DockWidget *item, Region *region,
   restorePanelTitleBar(item);
 
   setMaximized(item, false);
-  redistribute();
-  applyGeometry();
-  if (parentWidget()) parentWidget()->repaint();
+  finishLayoutChange(LayoutUpdate::Full);
   return true;
 }
 
 //------------------------------------------------------
 
-bool DockLayout::beginTabDragOut(DockWidget *item, Region *region,
-                                 const QPoint &globalPos,
-                                 const QPoint &grabOffsetInTab) {
+bool DockLayout::detachTabForDrag(DockWidget *item, Region *region,
+                                  const QPoint &globalPos,
+                                  const QPoint &grabOffsetInTab) {
   if (!item || !region || !parentWidget()) return false;
-  if (!region->isTabbed()) return false;
+  if (!region->hasTabGroup()) return false;
 
   for (int i = 0; i < (int)region->tabItems().size(); ++i) {
     if (region->tabItems()[i] == item && region->activeTabIndex() != i) {
@@ -987,47 +1116,22 @@ bool DockLayout::beginTabDragOut(DockWidget *item, Region *region,
     }
   }
 
-  if (!undockFromTabGroup(item, region, true)) return false;
+  // The tab strip is the widget dispatching the mouse event that led here,
+  // so it may only be deleted once that handler has returned.
+  if (!undockFromTabGroup(item, region, StripDeletion::Deferred)) return false;
 
-  clearJoinHighlight();
-
-  // Destroy the hidden tab strip after this mouse handler returns. Detach
-  // ownership from the region first so Region::~Region and a late timer
-  // callback cannot both delete the same widget.
-  if (!region->isTabbed() && region->m_tabStripContainer) {
-    TabBarContainter *stripContainer = region->m_tabStripContainer;
-    region->m_tabStripContainer      = 0;
-    region->m_tabStrip                 = 0;
-    stripContainer->hide();
-
-    QWidget *host = parentWidget();
-    if (host) {
-      QTimer::singleShot(0, host, [stripContainer]() { delete stripContainer; });
-    } else {
-      delete stripContainer;
-    }
-  }
+  hideTabMergePreview();
 
   item->show();
   item->raise();
 
-  // The panel's floating appearance (custom title bar + frame margin) is
-  // only fully in place once its layout has been activated. Read the drag
-  // grip's *actual*, current position afterwards - rather than assuming a
-  // fixed margin - so the point grabbed on the tab lands under the cursor
-  // with no drift, however the appearance transition shifted things.
-  if (QLayout *l = item->layout()) l->activate();
-  QWidget *grip = item;
-  if (TDockWidget *tdw = qobject_cast<TDockWidget *>(item))
-    if (QWidget *titleBar = tdw->titleBarWidget()) grip = titleBar;
-  const QPoint gripOffsetInWidget =
-      grip->mapToGlobal(QPoint(0, 0)) - item->mapToGlobal(QPoint(0, 0));
-
-  // Hand off to DockWidget's native floating drag (same as title-bar undock).
+  // Hand off to DockWidget's native floating drag (same as title-bar undock),
+  // keeping the point grabbed on the tab under the cursor.
   item->m_undocking           = false;
   item->m_dragging            = true;
   item->m_dragMouseInitialPos = globalPos;
-  item->m_dragInitialPos = globalPos - grabOffsetInTab - gripOffsetInWidget;
+  item->m_dragInitialPos =
+      globalPos - grabOffsetInTab - item->settledDragGripOffset();
   item->move(item->m_dragInitialPos);
   item->grabMouse();
 
@@ -1039,16 +1143,17 @@ bool DockLayout::beginTabDragOut(DockWidget *item, Region *region,
 
 //------------------------------------------------------
 
-void DockLayout::tabifyItem(DockWidget *item, Region *region) {
+void DockLayout::addPanelToTabGroup(DockWidget *item, Region *region) {
   if (!item || !region) return;
-  if (!canParticipateInTabGroup(item)) return;
+  if (!supportsTabGrouping(item)) return;
+
+  DockWidget *existing = region->hasTabGroup() ? 0 : region->getItem();
 
   // Validate before mutating window flags / appearance so a failed join
   // cannot leave the panel without a title bar or docked margins.
-  if (!region->isTabbed()) {
-    DockWidget *existing = region->getItem();
+  if (!region->hasTabGroup()) {
     if (!existing || existing == item) return;
-    if (!canParticipateInTabGroup(existing)) return;
+    if (!supportsTabGrouping(existing)) return;
   }
 
   item->onDock(true);
@@ -1057,94 +1162,87 @@ void DockLayout::tabifyItem(DockWidget *item, Region *region) {
   item->m_wasFloating = true;
   item->setWindowFlags(Qt::SubWindow);
 
-  if (region->isTabbed()) {
-    region->m_tabItems.push_back(item);
-    region->m_activeTabIndex = region->m_tabItems.size() - 1;
-  } else {
-    DockWidget *existing = region->getItem();
+  if (existing) {
     existing->setDockedAppearance();
     existing->setWindowFlags(Qt::SubWindow);
     existing->m_floating = false;
-
-    region->m_tabItems.push_back(existing);
-    region->m_tabItems.push_back(item);
-    region->m_activeTabIndex = 1;
-    region->setItem(0);
   }
 
-  // Hide title bars and normalize appearance for every member so switching
-  // tabs does not jump between top/bottom content offsets.
-  for (unsigned int t = 0; t < region->m_tabItems.size(); ++t) {
-    DockWidget *tab = region->m_tabItems[t];
-    tab->setDockedAppearance();
-    TDockWidget *tdw = qobject_cast<TDockWidget *>(tab);
-    if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(false);
-  }
+  region->appendTab(item);
+  normalizeTabGroupAppearance(region);
 
-  region->m_item = region->activeTab();
   ensureTabStrip(region);
   updateTabVisibility(region);
-  applyGeometry();
   item->show();
 }
 
 //------------------------------------------------------
 
-void DockLayout::tabifyWithTarget(DockWidget *item, DockWidget *target) {
-  if (!item || !target || item == target) return;
-  if (!canParticipateInTabGroup(item) || !canParticipateInTabGroup(target))
-    return;
+bool DockLayout::canMergeAsTabs(DockWidget *item, DockWidget *target) const {
+  if (!item || !target || item == target) return false;
+  return supportsTabGrouping(item) && supportsTabGrouping(target);
+}
 
-  Region *region = find(target);
+//------------------------------------------------------
 
-  // When the target is still floating, dock it beside the panel under its center.
-  if (!region && target->isFloating()) {
-    QPoint layoutPt =
-        parentWidget()->mapFromGlobal(target->geometry().center());
-    DockWidget *anchor = dynamic_cast<DockWidget *>(containerOf(layoutPt));
-    if (anchor && anchor != target) {
-      region = find(anchor);
-      if (region) {
-        if (find(target)) undockItem(target);
-        else {
-          target->onDock(true);
-          target->setDockedAppearance();
-          target->m_floating    = false;
-          target->m_wasFloating = true;
-          target->setWindowFlags(Qt::SubWindow);
-        }
-        tabifyItem(target, region);
-        region = find(target);
-      }
-    }
+//! Returns the region holding \b target, docking it first if it is still
+//! floating: a merge target must be part of the region tree.
+Region *DockLayout::ensureDockedRegionForTarget(DockWidget *target) {
+  if (Region *region = find(target)) return region;
+  if (!target->isFloating() || !parentWidget()) return 0;
 
-    if (!region) {
-      dockItemPrivate(target, 0, 0);
-      region = find(target);
+  // Dock the target next to whichever panel sits under its center.
+  const QPoint layoutPt =
+      parentWidget()->mapFromGlobal(target->geometry().center());
+  DockWidget *anchor = dynamic_cast<DockWidget *>(containerOf(layoutPt));
+
+  if (anchor && anchor != target) {
+    if (Region *anchorRegion = find(anchor)) {
+      addPanelToTabGroup(target, anchorRegion);
+      if (Region *region = find(target)) return region;
     }
   }
 
-  if (!region) return;
+  dockItemPrivate(target, 0, 0);
+  return find(target);
+}
 
+//------------------------------------------------------
+
+//! Takes \b item out of whatever holds it now, so that it can be appended to
+//! \b destination. Returns false when the panel already belongs there.
+bool DockLayout::detachPanelFromCurrentRegion(DockWidget *item,
+                                              Region *destination) {
   Region *itemRegion = find(item);
-  if (itemRegion == region) {
-    const std::vector<DockWidget *> &tabs = region->tabItems();
-    for (unsigned int t = 0; t < tabs.size(); ++t)
-      if (tabs[t] == item) return;
-  }
+  if (!itemRegion) return true;
+  if (itemRegion == destination) return false;
 
-  if (itemRegion) {
-    if (itemRegion->isTabbed())
-      removeFromTabGroup(item, itemRegion);
-    else if (itemRegion != region)
-      undockItem(item);
-  }
+  if (itemRegion->hasTabGroup())
+    removeFromTabGroup(item, itemRegion, StripDeletion::Immediate);
+  else
+    undockItem(item);
 
-  tabifyItem(item, region);
-  clearJoinHighlight();
-  redistribute();
-  applyGeometry();
-  if (parentWidget()) parentWidget()->repaint();
+  return true;
+}
+
+//------------------------------------------------------
+
+void DockLayout::mergePanelsAsTabs(DockWidget *item, DockWidget *target) {
+  if (!canMergeAsTabs(item, target)) return;
+
+  Region *targetRegion = ensureDockedRegionForTarget(target);
+  if (!targetRegion || targetRegion->containsPanel(item)) return;
+
+  if (!detachPanelFromCurrentRegion(item, targetRegion)) return;
+
+  // Undocking the panel may have collapsed and rebuilt part of the region
+  // tree, so the target's region has to be looked up again.
+  targetRegion = find(target);
+  if (!targetRegion) return;
+
+  addPanelToTabGroup(item, targetRegion);
+  hideTabMergePreview();
+  finishLayoutChange(LayoutUpdate::Full);
 }
 
 //------------------------------------------------------
@@ -1154,7 +1252,7 @@ DockWidget *DockLayout::dockWidgetTitleBarAt(const QPoint &globalPos) const {
 
   for (int i = count() - 1; i >= 0; --i) {
     DockWidget *dw = static_cast<DockWidget *>(itemAt(i)->widget());
-    if (!dw || !canParticipateInTabGroup(dw)) continue;
+    if (!dw || !supportsTabGrouping(dw)) continue;
 
     QPoint localPos = dw->mapFromGlobal(globalPos);
     if (dw->rect().contains(localPos) && dw->isDragGrip(localPos)) return dw;
@@ -1179,10 +1277,7 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
   // If the DockLayout's owner widget is hidden, avoid
   if (!parentWidget()->isVisible()) return;
 
-  // Drop stale region references before deleting placeholder widgets.
-  for (unsigned int ri = 0; ri < m_regions.size(); ++ri)
-    m_regions[ri]->m_placeholders.clear();
-
+  clearRegionPlaceholderReferences();
   item->clearDockPlaceholders();
 
   if (!m_regions.size()) {
@@ -1262,34 +1357,23 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
     }
   }
 
-  // Hover-join placeholders on leaf regions (title bar / tab strip targets).
-  for (i = 0; i < m_regions.size(); ++i) {
+  addTabJoinTargets(item);
+}
+
+//------------------------------------------------------
+
+void DockLayout::addTabJoinTargets(DockWidget *item) {
+  if (!supportsTabGrouping(item)) return;
+
+  for (unsigned int i = 0; i < m_regions.size(); ++i) {
     Region *r = m_regions[i];
-    if (!r->getChildList().empty()) continue;
-    if (!r->getItem() && !r->isTabbed()) continue;
-    if (r->getItem() == item) continue;
-
-    DockWidget *targetWidget =
-        r->isTabbed() ? r->activeTab() : r->getItem();
-    if (!canParticipateInTabGroup(item) ||
-        !canParticipateInTabGroup(targetWidget))
-      continue;
-
-    bool alreadyMember = false;
-    if (r->isTabbed()) {
-      const std::vector<DockWidget *> &tabs = r->tabItems();
-      for (unsigned int t = 0; t < tabs.size(); ++t)
-        if (tabs[t] == item) alreadyMember = true;
-    }
-    if (alreadyMember) continue;
+    if (r->hasChildren() || r->content() == Region::Content::Empty) continue;
+    if (r->containsPanel(item)) continue;
+    if (!supportsTabGrouping(r->activeTab())) continue;
 
     item->m_placeholders.push_back(item->m_decoAllocator->newPlaceBuilt(
-        item, r, 0, DockPlaceholder::tabify));
+        item, r, 0, DockPlaceholder::tabJoinTarget));
   }
-
-  // Disable all placeholders
-  // for(i=0; i<item->m_placeholders.size(); ++i)
-  //  item->m_placeholders[i]->setDisabled(true);
 }
 
 //------------------------------------------------------
@@ -1302,17 +1386,15 @@ void DockLayout::dockItem(DockWidget *item, DockPlaceholder *place) {
   place->hide();
   item->hide();
 
-  if (place->getAttribute() == DockPlaceholder::tabify) {
-    Region *region = place->getParentRegion();
-    DockWidget *target =
-        region ? (region->isTabbed() ? region->activeTab() : region->getItem())
-               : 0;
-    clearJoinHighlight();
-    if (target) tabifyWithTarget(item, target);
+  if (place->getAttribute() == DockPlaceholder::tabJoinTarget) {
+    Region *region     = place->getParentRegion();
+    DockWidget *target = region ? region->activeTab() : 0;
+    hideTabMergePreview();
+    if (target) mergePanelsAsTabs(item, target);
   } else {
     dockItemPrivate(item, place->m_region, place->m_idx);
     redistribute();
-    clearJoinHighlight();
+    hideTabMergePreview();
     item->setWindowFlags(Qt::SubWindow);
     item->show();
   }
@@ -1363,23 +1445,20 @@ Region *DockLayout::dockItem(DockWidget *item, Region *r, int idx) {
 
 //------------------------------------------------------
 
+void DockLayout::clearRegionPlaceholderReferences() {
+  for (unsigned int i = 0; i < m_regions.size(); ++i)
+    m_regions[i]->m_placeholders.clear();
+}
+
+//------------------------------------------------------
+
+//! Moves the whole tab group of \b region into a new child region, so that
+//! the group can be split-docked against as a single unit.
 Region *DockLayout::detachTabGroupAsSubRegion(Region *region) {
-  if (!region || !region->isTabbed()) return 0;
+  if (!region || !region->hasTabGroup()) return 0;
 
   Region *child = new Region(this);
-  child->m_tabItems.swap(region->m_tabItems);
-  child->m_activeTabIndex    = region->m_activeTabIndex;
-  child->m_tabStrip          = region->m_tabStrip;
-  child->m_tabStripContainer = region->m_tabStripContainer;
-  child->m_item              = child->activeTab();
-
-  region->m_tabItems.clear();
-  region->m_activeTabIndex    = 0;
-  region->m_tabStrip          = 0;
-  region->m_tabStripContainer = 0;
-  region->m_item              = 0;
-
-  if (child->m_tabStrip) child->m_tabStrip->rebindRegion(child);
+  child->adoptTabGroupFrom(region);
 
   return child;
 }
@@ -1414,10 +1493,7 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
     newRoot->insertSubRegion(m_regions[1], 0);
 
     r = newRoot;
-  } else if (r->isTabbed()) {
-    // Split-dock beside/above a tab group: move the whole group as one unit,
-    // not just the active tab (which would orphan the other tabs and corrupt
-    // the region tree).
+  } else if (r->hasTabGroup()) {
     Region *regionForTabs = detachTabGroupAsSubRegion(r);
     regionForTabs->setSize(toRect(r->getGeometry()).size());
     r->insertSubRegion(regionForTabs, 0);
@@ -1447,7 +1523,7 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
 
 //! A region is empty, if contains no item and no children.
 static bool isEmptyRegion(Region *r) {
-  if (r->isTabbed()) return false;
+  if (r->hasTabGroup()) return false;
   if ((!r->getItem()) && (r->getChildList().size() == 0)) {
     delete r;  // Well, it's a bit improper, but it works...
     return true;
@@ -1475,25 +1551,8 @@ void Region::removeItem(DockWidget *item) {
         if (parent) {
           Region *remainingSon = m_childList[0];
           if (!remainingSon->m_childList.size()) {
-            if (remainingSon->isTabbed()) {
-              // remainingSon is itself a tab group, not a plain single-item
-              // leaf: absorb its whole tab-group state into `this` instead
-              // of just grabbing its active tab. Otherwise the other tabs
-              // and the live tab strip widget become an orphaned "zombie"
-              // Region that keeps lingering in DockLayout::m_regions (seen
-              // as a ghost duplicate/empty tab strip, vanished separators,
-              // and dangling pointers on further docking manipulation).
-              m_tabItems          = remainingSon->m_tabItems;
-              m_activeTabIndex    = remainingSon->m_activeTabIndex;
-              m_tabStrip          = remainingSon->m_tabStrip;
-              m_tabStripContainer = remainingSon->m_tabStripContainer;
-              m_item              = activeTab();
-              if (m_tabStrip) m_tabStrip->rebindRegion(this);
-
-              remainingSon->m_tabItems.clear();
-              remainingSon->m_tabStrip          = 0;
-              remainingSon->m_tabStripContainer = 0;
-              remainingSon->setItem(0);
+            if (remainingSon->hasTabGroup()) {
+              adoptTabGroupFrom(remainingSon);
             } else {
               // remainingSon is a plain leaf: better keep this and move
               // son's item and childList
@@ -1549,7 +1608,8 @@ bool DockLayout::undockItem(DockWidget *item) {
   Region *itemCarrier = find(item);
   if (!itemCarrier) return false;
 
-  if (itemCarrier->isTabbed()) return undockFromTabGroup(item, itemCarrier);
+  if (itemCarrier->hasTabGroup())
+    return undockFromTabGroup(item, itemCarrier, StripDeletion::Immediate);
 
   Region *parent = itemCarrier->getParent();
   if (parent) {
@@ -1748,7 +1808,7 @@ void Region::calculateExtremalSizes() {
 int Region::calculateMinimumSize(bool direction, bool recalcChildren) {
   int sumMinSizes = 0, maxMinSizes = 0;
 
-  if (isTabbed()) {
+  if (hasTabGroup()) {
     unsigned int t;
     int tabBarExtra = (direction == vertical) ? m_owner->tabStripHeight() : 0;
     for (t = 0; t < m_tabItems.size(); ++t) {
@@ -1800,7 +1860,7 @@ int Region::calculateMaximumSize(bool direction, bool recalcChildren) {
 
   int sumMaxSizes = 0, minMaxSizes = inf;
 
-  if (isTabbed()) {
+  if (hasTabGroup()) {
     unsigned int t;
     int tabBarExtra = (direction == vertical) ? m_owner->tabStripHeight() : 0;
     for (t = 0; t < m_tabItems.size(); ++t) {
@@ -2099,8 +2159,49 @@ DockLayout::State DockLayout::saveState() {
 
 //------------------------------------------------------
 
+//! Reads the body of a tab group - the tokens after '{' up to '}' - into
+//! \b region, starting at \b pos. Groups left with a single valid member are
+//! normalized into a plain single-panel region by Region::setTabGroup().
+bool DockLayout::parseTabGroup(const QStringList &tokens, int &pos,
+                               Region *region,
+                               std::vector<bool> &alreadyRestored) const {
+  std::vector<DockWidget *> panels;
+  int activeIndex = 0;
+  bool closed     = false;
+
+  for (; pos < tokens.size(); ++pos) {
+    const QString &token = tokens[pos];
+    if (token == "}") {
+      closed = true;
+      break;
+    }
+
+    bool tokenIsOk = false;
+    if (token.startsWith(QLatin1Char('@'))) {
+      activeIndex = token.mid(1).toInt(&tokenIsOk);
+      if (!tokenIsOk) return false;
+      continue;
+    }
+
+    const int panelIndex = token.toInt(&tokenIsOk);
+    if (!tokenIsOk || panelIndex < 0 || panelIndex >= (int)m_items.size() ||
+        alreadyRestored[panelIndex])
+      return false;
+
+    alreadyRestored[panelIndex] = true;
+    panels.push_back(static_cast<DockWidget *>(m_items[panelIndex]->widget()));
+  }
+
+  if (!closed || panels.empty()) return false;
+
+  region->setTabGroup(panels, activeIndex);
+  return true;
+}
+
+//------------------------------------------------------
+
 void DockLayout::writeRegion(Region *r, QString &hierarchy) {
-  if (r->isTabbed()) {
+  if (r->hasTabGroup()) {
     hierarchy.append("{ ");
     const std::vector<DockWidget *> &tabs = r->tabItems();
     for (unsigned int t = 0; t < tabs.size(); ++t)
@@ -2143,79 +2244,91 @@ void DockLayout::writeRegion(Region *r, QString &hierarchy) {
 //! identity of the items involved, assuming that the set of dock
 //! widget has ever been left unchanged or completely restored
 //! as it were when saved. In particular, their ordering must be preserved.
+
+//! Hierarchy string grammar:
+//!   state    := maximizedIndex rootOrientation region
+//!   region   := panelIndex | '[' region+ ']' | tabGroup
+//!   tabGroup := '{' panelIndex panelIndex+ '@'activeIndex '}'
+//! Panel indices refer to m_items and may each appear only once. Anything
+//! that does not parse leaves the current layout untouched.
 bool DockLayout::restoreState(const State &state) {
-  QStringList vars = state.second.split(" ", Qt::SkipEmptyParts);
-  if (vars.size() < 1) return 0;
+  const QStringList tokens = state.second.split(" ", Qt::SkipEmptyParts);
+  if (tokens.isEmpty()) return false;
 
   // Check number of items
-  unsigned int count = state.first.size();
+  if (m_items.size() != state.first.size()) return false;
 
-  if (m_items.size() != count) return false;  // Items list is not coherent
+  const int itemCount     = (int)m_items.size();
+  bool maximizedIndexIsOk = false;
+  const int maximizedItem = tokens[0].toInt(&maximizedIndexIsOk);
+  if (!maximizedIndexIsOk || maximizedItem < -1 || maximizedItem >= itemCount)
+    return false;
+
+  // A panel may only be restored into one region.
+  std::vector<bool> alreadyRestored(itemCount, false);
 
   // Initialize new Regions hierarchy
   std::deque<Region *> newHierarchy;
+  const bool expectsHierarchy = tokens.size() > 1;
+  bool malformed              = false;
 
-  // Load it
-  int maximizedItem = vars[0].toInt();
-
-  if (vars.size() > 1) {
+  if (expectsHierarchy) {
     // Scan hierarchy
-    Region *r       = 0, *newRegion;
-    int orientation = !vars[1].toInt();
+    Region *r             = 0;
+    const int orientation = !tokens[1].toInt();
 
-    int i;
-    for (i = 2; i < vars.size(); ++i) {
-      if (vars[i] == "]") {
+    for (int i = 2; i < tokens.size(); ++i) {
+      const QString &token = tokens[i];
+
+      if (token == "]") {
         // End region and get parent
+        if (!r) {
+          malformed = true;
+          break;
+        }
         r = r->getParent();
-      } else if (vars[i] == "{") {
-        newRegion = new Region(this);
-        newHierarchy.push_back(newRegion);
-        newRegion->m_orientation = !orientation;
-        if (r) r->insertSubRegion(newRegion, r->getChildList().size());
+        continue;
+      }
 
-        std::vector<int> tabIndices;
-        int activeTab = 0;
+      Region *newRegion = new Region(this);
+      newHierarchy.push_back(newRegion);
+      newRegion->m_orientation = !orientation;
+      if (r) r->insertSubRegion(newRegion, r->getChildList().size());
+
+      if (token == "{") {
         ++i;
-        while (i < vars.size() && vars[i] != "}") {
-          if (vars[i].startsWith(QLatin1Char('@')))
-            activeTab = vars[i].mid(1).toInt();
-          else
-            tabIndices.push_back(vars[i].toInt());
-          ++i;
+        if (!parseTabGroup(tokens, i, newRegion, alreadyRestored)) {
+          malformed = true;
+          break;
         }
-
-        for (unsigned int t = 0; t < tabIndices.size(); ++t) {
-          DockWidget *tabItem = static_cast<DockWidget *>(
-              m_items[tabIndices[t]]->widget());
-          newRegion->m_tabItems.push_back(tabItem);
-        }
-        newRegion->m_activeTabIndex = activeTab;
-        if (newRegion->m_activeTabIndex >= (int)newRegion->m_tabItems.size())
-          newRegion->m_activeTabIndex = 0;
-        newRegion->m_item = newRegion->activeTab();
+      } else if (token == "[") {
+        // Current region has children
+        r = newRegion;
       } else {
-        // Allocate new Region
-        newRegion = new Region(this);
-        newHierarchy.push_back(newRegion);
-        newRegion->m_orientation = !orientation;
-
-        if (r) r->insertSubRegion(newRegion, r->getChildList().size());
-
-        if (vars[i] == "[") {
-          // Current region has children
-          r = newRegion;
-        } else {
-          // newRegion has item
-          newRegion->m_item =
-              static_cast<DockWidget *>(m_items[vars[i].toInt()]->widget());
+        bool indexIsOk       = false;
+        const int panelIndex = token.toInt(&indexIsOk);
+        if (!indexIsOk || panelIndex < 0 || panelIndex >= itemCount ||
+            alreadyRestored[panelIndex]) {
+          malformed = true;
+          break;
         }
+        alreadyRestored[panelIndex] = true;
+        newRegion->setSinglePanel(
+            static_cast<DockWidget *>(m_items[panelIndex]->widget()));
       }
     }
 
-    // Check if size constraints are satisfied
-    newHierarchy[0]->calculateExtremalSizes();
+    if (r) malformed = true;  // unterminated '['
   }
+
+  if (malformed || (expectsHierarchy && newHierarchy.empty())) {
+    for (unsigned int j = 0; j < newHierarchy.size(); ++j)
+      delete newHierarchy[j];
+    return false;
+  }
+
+  // Check if size constraints are satisfied
+  if (!newHierarchy.empty()) newHierarchy[0]->calculateExtremalSizes();
 
   unsigned int j;
   for (j = 0; j < newHierarchy.size(); ++j) {
@@ -2259,7 +2372,7 @@ bool DockLayout::restoreState(const State &state) {
   // Docked widgets are found in hierarchy
   for (j = 0; j < m_regions.size(); ++j) {
     Region *region = m_regions[j];
-    if (region->isTabbed()) {
+    if (region->hasTabGroup()) {
       const std::vector<DockWidget *> &tabs = region->tabItems();
       for (unsigned int t = 0; t < tabs.size(); ++t) {
         item = tabs[t];
@@ -2304,18 +2417,7 @@ bool DockLayout::restoreState(const State &state) {
     }
   }
 
-  // Hidden tabs may have been saved with stale geometries from before they
-  // were merged. Align every tab in a group to the active tab before the
-  // region tree is rebuilt from leaf widget rects.
-  for (j = 0; j < m_regions.size(); ++j) {
-    Region *region = m_regions[j];
-    if (!region->isTabbed()) continue;
-    DockWidget *active = region->activeTab();
-    if (!active) continue;
-    const QRect ref                       = active->geometry();
-    const std::vector<DockWidget *> &tabs = region->tabItems();
-    for (unsigned int t = 0; t < tabs.size(); ++t) tabs[t]->setGeometry(ref);
-  }
+  normalizeRestoredTabGeometries();
 
   // Calculate regions' geometry starting from leaves (items)
   if (m_regions.size()) m_regions[0]->restoreGeometry();
@@ -2354,6 +2456,26 @@ bool DockLayout::restoreState(const State &state) {
 
 //------------------------------------------------------
 
+//! Hidden tabs may have been saved with stale geometries from before they
+//! were merged; align every member of a group on its active tab before the
+//! region tree is rebuilt from leaf widget rects.
+void DockLayout::normalizeRestoredTabGeometries() {
+  for (unsigned int i = 0; i < m_regions.size(); ++i) {
+    Region *region = m_regions[i];
+    if (!region->hasTabGroup()) continue;
+
+    DockWidget *active = region->activeTab();
+    if (!active) continue;
+
+    const QRect reference                 = active->geometry();
+    const std::vector<DockWidget *> &tabs = region->tabItems();
+    for (unsigned int t = 0; t < tabs.size(); ++t)
+      tabs[t]->setGeometry(reference);
+  }
+}
+
+//------------------------------------------------------
+
 //! Recalculates the geometry of \b this Region and of its branches,
 //! assuming those of 'leaf items' are correct.
 
@@ -2364,7 +2486,7 @@ bool DockLayout::restoreState(const State &state) {
 void Region::restoreGeometry() {
   // Applying a head-recursive algorithm to update the geometry of a Region
   // after those of its children have been updated
-  if (isTabbed()) {
+  if (hasTabGroup()) {
     DockWidget *active = activeTab();
     if (!active) return;
 

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -276,6 +276,14 @@ void DockLayout::setMaximized(DockWidget *item, bool state) {
         item->m_maximized = true;
         m_maximizedDock   = item;
 
+        // If item is (or was) the active tab of a merged group, its own
+        // title bar is normally hidden in favor of the tab strip - which
+        // stays behind at the group's old, now-covered location. Without
+        // its own title bar shown while maximized, there is no visible/
+        // clickable spot left to double-click back to normal size (see
+        // the matching restore below).
+        restorePanelTitleBar(item);
+
         // Hide all the other docked widgets (no need to update them. Moreover,
         // doing so
         // could eventually result in painting over the newly maximized widget)
@@ -294,12 +302,19 @@ void DockLayout::setMaximized(DockWidget *item, bool state) {
       m_maximizedDock->m_maximized = false;
       m_maximizedDock              = 0;
 
-      // Show all other docked widgets
+      // Show docked widgets again, but keep inactive tabs in tab groups hidden.
       DockWidget *currWidget;
       for (int i = 0; i < count(); ++i) {
         currWidget = (DockWidget *)itemAt(i)->widget();
         if (currWidget != item && !currWidget->isFloating()) currWidget->show();
       }
+      refreshTabbedRegionsVisibility();
+
+      // If the un-maximized item still belongs to a merged tab group, hand
+      // its title bar back to being hidden in favor of the tab strip (see
+      // the matching show-on-maximize above) instead of leaving both
+      // visible on top of each other.
+      if (r && r->isTabbed()) updateTabVisibility(r);
     }
   }
 }
@@ -714,8 +729,8 @@ void DockLayout::ensureTabStrip(Region *region) {
 
     region->m_tabStrip =
         new DockTabStrip(this, region, region->m_tabStripContainer);
-    tabLayout->addWidget(region->m_tabStrip, 0);
-    tabLayout->addStretch(1);
+    // Let the strip fill the container so expanding tabs share width equally.
+    tabLayout->addWidget(region->m_tabStrip, 1);
 
     region->m_tabStripContainer->setFixedHeight(tabStripHeight());
     region->m_tabStripContainer->hide();
@@ -742,12 +757,18 @@ void DockLayout::updateTabVisibility(Region *region) {
   DockWidget *active                    = region->activeTab();
 
   for (unsigned int i = 0; i < tabs.size(); ++i) {
-    TDockWidget *tdw = qobject_cast<TDockWidget *>(tabs[i]);
+    DockWidget *tab = tabs[i];
+    tab->setDockedAppearance();
+
+    TDockWidget *tdw = qobject_cast<TDockWidget *>(tab);
     if (tdw && tdw->titleBarWidget())
       tdw->titleBarWidget()->setVisible(!tabbed);
 
     if (tabs[i] == active) {
-      if (tabbed) tabs[i]->show();
+      if (tabbed) {
+        tabs[i]->show();
+        tabs[i]->raise();
+      }
     } else if (tabbed) {
       tabs[i]->hide();
     }
@@ -830,6 +851,12 @@ void DockLayout::clearJoinHighlight() {
 
 void DockLayout::updateJoinHighlightGeometry() {
   if (!m_joinHighlight || !m_joinHighlightRegion || !parentWidget()) return;
+
+  // Show the full panel/region size that will actually result from the
+  // merge (matches the pre-tabify behavior), while the underlying hit-test
+  // placeholder (see DockPlaceholder::buildGeometry, tabify case) stays a
+  // narrow title/tab-strip band so it never overlaps the classic split
+  // drop zones. Only this visual frame is enlarged.
   const QRect local = toRect(m_joinHighlightRegion->getGeometry());
   m_joinHighlight->setGeometry(
       QRect(parentWidget()->mapToGlobal(local.topLeft()), local.size()));
@@ -837,18 +864,41 @@ void DockLayout::updateJoinHighlightGeometry() {
 
 //------------------------------------------------------
 
+void DockLayout::restorePanelTitleBar(DockWidget *item) {
+  if (!item) return;
+  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
+  if (tdw && tdw->titleBarWidget()) {
+    tdw->titleBarWidget()->setVisible(true);
+    tdw->titleBarWidget()->raise();
+  }
+}
+
+//------------------------------------------------------
+
 void DockLayout::restoreSingleDockedPanel(DockWidget *item) {
   if (!item) return;
-
-  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
-  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
 
   item->setWindowFlags(Qt::SubWindow);
   item->setDockedAppearance();
   item->m_floating = false;
   item->onDock(true);
+
+  // setWindowFlags can re-hide children on Windows; restore title last and
+  // force a visible, raised docked panel so it never stays grey/inert.
+  restorePanelTitleBar(item);
+  if (QLayout *l = item->layout()) l->activate();
   item->show();
+  item->raise();
   item->update();
+}
+
+//------------------------------------------------------
+
+void DockLayout::refreshTabbedRegionsVisibility() {
+  for (unsigned int i = 0; i < m_regions.size(); ++i) {
+    if (m_regions[i]->isTabbed()) updateTabVisibility(m_regions[i]);
+  }
+  applyGeometry();
 }
 
 //------------------------------------------------------
@@ -863,6 +913,12 @@ bool DockLayout::removeFromTabGroup(DockWidget *item, Region *region,
 
   int removedIndex = static_cast<int>(it - tabs.begin());
   tabs.erase(it);
+
+  // Always restore the removed panel's title bar; only undockFromTabGroup
+  // used to do this, leaving orphaned panels without a drag grip.
+  restorePanelTitleBar(item);
+  item->setDockedAppearance();
+  item->show();
 
   if (tabs.size() <= 1) {
     DockWidget *remaining = tabs.empty() ? 0 : tabs.front();
@@ -900,13 +956,15 @@ bool DockLayout::undockFromTabGroup(DockWidget *item, Region *region,
                                     bool deferStripDestroy) {
   if (!removeFromTabGroup(item, region, deferStripDestroy)) return false;
 
-  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
-  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
+  restorePanelTitleBar(item);
 
   item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
   item->setFloatingAppearance();
   item->m_floating = true;
   item->onDock(false);
+  // Title bar can be reset by setWindowFlags on Windows.
+  restorePanelTitleBar(item);
+
   setMaximized(item, false);
   redistribute();
   applyGeometry();
@@ -985,10 +1043,18 @@ void DockLayout::tabifyItem(DockWidget *item, Region *region) {
   if (!item || !region) return;
   if (!canParticipateInTabGroup(item)) return;
 
+  // Validate before mutating window flags / appearance so a failed join
+  // cannot leave the panel without a title bar or docked margins.
+  if (!region->isTabbed()) {
+    DockWidget *existing = region->getItem();
+    if (!existing || existing == item) return;
+    if (!canParticipateInTabGroup(existing)) return;
+  }
+
   item->onDock(true);
   item->setDockedAppearance();
-  item->m_floating     = false;
-  item->m_wasFloating  = true;
+  item->m_floating    = false;
+  item->m_wasFloating = true;
   item->setWindowFlags(Qt::SubWindow);
 
   if (region->isTabbed()) {
@@ -996,8 +1062,9 @@ void DockLayout::tabifyItem(DockWidget *item, Region *region) {
     region->m_activeTabIndex = region->m_tabItems.size() - 1;
   } else {
     DockWidget *existing = region->getItem();
-    if (!existing || existing == item) return;
-    if (!canParticipateInTabGroup(existing)) return;
+    existing->setDockedAppearance();
+    existing->setWindowFlags(Qt::SubWindow);
+    existing->m_floating = false;
 
     region->m_tabItems.push_back(existing);
     region->m_tabItems.push_back(item);
@@ -1005,9 +1072,19 @@ void DockLayout::tabifyItem(DockWidget *item, Region *region) {
     region->setItem(0);
   }
 
+  // Hide title bars and normalize appearance for every member so switching
+  // tabs does not jump between top/bottom content offsets.
+  for (unsigned int t = 0; t < region->m_tabItems.size(); ++t) {
+    DockWidget *tab = region->m_tabItems[t];
+    tab->setDockedAppearance();
+    TDockWidget *tdw = qobject_cast<TDockWidget *>(tab);
+    if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(false);
+  }
+
   region->m_item = region->activeTab();
   ensureTabStrip(region);
   updateTabVisibility(region);
+  applyGeometry();
   item->show();
 }
 
@@ -1064,8 +1141,10 @@ void DockLayout::tabifyWithTarget(DockWidget *item, DockWidget *target) {
   }
 
   tabifyItem(item, region);
+  clearJoinHighlight();
   redistribute();
-  parentWidget()->repaint();
+  applyGeometry();
+  if (parentWidget()) parentWidget()->repaint();
 }
 
 //------------------------------------------------------
@@ -1228,6 +1307,7 @@ void DockLayout::dockItem(DockWidget *item, DockPlaceholder *place) {
     DockWidget *target =
         region ? (region->isTabbed() ? region->activeTab() : region->getItem())
                : 0;
+    clearJoinHighlight();
     if (target) tabifyWithTarget(item, target);
   } else {
     dockItemPrivate(item, place->m_region, place->m_idx);
@@ -1395,10 +1475,31 @@ void Region::removeItem(DockWidget *item) {
         if (parent) {
           Region *remainingSon = m_childList[0];
           if (!remainingSon->m_childList.size()) {
-            // remainingSon is a leaf: better keep this and move son's item and
-            // childList
-            setItem(remainingSon->getItem());
-            remainingSon->setItem(0);
+            if (remainingSon->isTabbed()) {
+              // remainingSon is itself a tab group, not a plain single-item
+              // leaf: absorb its whole tab-group state into `this` instead
+              // of just grabbing its active tab. Otherwise the other tabs
+              // and the live tab strip widget become an orphaned "zombie"
+              // Region that keeps lingering in DockLayout::m_regions (seen
+              // as a ghost duplicate/empty tab strip, vanished separators,
+              // and dangling pointers on further docking manipulation).
+              m_tabItems          = remainingSon->m_tabItems;
+              m_activeTabIndex    = remainingSon->m_activeTabIndex;
+              m_tabStrip          = remainingSon->m_tabStrip;
+              m_tabStripContainer = remainingSon->m_tabStripContainer;
+              m_item              = activeTab();
+              if (m_tabStrip) m_tabStrip->rebindRegion(this);
+
+              remainingSon->m_tabItems.clear();
+              remainingSon->m_tabStrip          = 0;
+              remainingSon->m_tabStripContainer = 0;
+              remainingSon->setItem(0);
+            } else {
+              // remainingSon is a plain leaf: better keep this and move
+              // son's item and childList
+              setItem(remainingSon->getItem());
+              remainingSon->setItem(0);
+            }
           } else {
             // remainingSon is a branch: append remainingSon childList to parent
             // one and sign this and remainingSon nodes for destruction.
@@ -2175,6 +2276,7 @@ bool DockLayout::restoreState(const State &state) {
       item->setDockedAppearance();
       item->m_floating  = false;
       item->m_saveIndex = -1;
+      restorePanelTitleBar(item);
       item->show();
     }
   }
@@ -2187,7 +2289,7 @@ bool DockLayout::restoreState(const State &state) {
   for (j = 0; j < m_items.size(); ++j) {
     item = static_cast<DockWidget *>(m_items[j]->widget());
 
-    if (item->m_saveIndex > 0) {
+    if (item->m_saveIndex >= 0) {
       // Ensure that floating panels are not placed in
       // unavailable positions
       if ((geoms[j] & QApplication::desktop()->availableGeometry(item))
@@ -2198,6 +2300,7 @@ bool DockLayout::restoreState(const State &state) {
       item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
       item->setFloatingAppearance();
       item->m_floating = true;
+      restorePanelTitleBar(item);
     }
   }
 

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -1,6 +1,14 @@
 
 
 #include "docklayout.h"
+#include "docktabstrip.h"
+#include "tdockwindows.h"
+#include "toonzqt/gutil.h"
+
+#include <QApplication>
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QTimer>
 
 #include <assert.h>
 #include <math.h>
@@ -76,11 +84,17 @@ inline QRect toRect(const QRectF &rect) {
 //-----------------
 
 DockLayout::DockLayout()
-    : m_maximizedDock(0), m_decoAllocator(new DockDecoAllocator()) {}
+    : m_maximizedDock(0)
+    , m_decoAllocator(new DockDecoAllocator())
+    , m_joinHighlight(0)
+    , m_joinHighlightRegion(0) {}
 
 //-------------------------------------
 
 DockLayout::~DockLayout() {
+  clearJoinHighlight();
+  delete m_joinHighlight;
+
   // Deleting Regions (separators are Widgets with parent, so they are
   // recursively deleted)
   unsigned int i;
@@ -207,10 +221,16 @@ QWidget *DockLayout::containerOf(QPoint point) const {
   unsigned int j;
   for (i = m_regions.size() - 1; i >= 0; --i) {
     Region *currRegion = m_regions[i];
-    DockWidget *item   = currRegion->getItem();
+
+    if (currRegion->isTabbed() && currRegion->tabStripContainer() &&
+        currRegion->tabStripContainer()->geometry().contains(point))
+      return currRegion->tabStripContainer();
+
+    DockWidget *item = currRegion->getItem();
+    if (!item && currRegion->isTabbed()) item = currRegion->activeTab();
 
     // First check if item contains it
-    if (item && item->geometry().contains(point)) return currRegion->getItem();
+    if (item && item->geometry().contains(point)) return item;
 
     // Then, search among separators
     for (j = 0; j < currRegion->separators().size(); ++j)
@@ -359,14 +379,37 @@ void DockLayout::updateSeparatorCursors() {
 
 //! Applies Regions geometry to dock widgets and separators.
 void DockLayout::applyGeometry() {
-  // Update docked window's geometries
   unsigned int i, j;
+  const int stripHeight = tabStripHeight();
   for (i = 0; i < m_regions.size(); ++i) {
     Region *r                             = m_regions[i];
     const std::deque<Region *> &childList = r->getChildList();
     std::deque<DockSeparator *> &sepList  = r->m_separators;
 
-    if (m_regions[i]->getItem()) {
+    if (r->isTabbed()) {
+      QRect regionRect = toRect(r->getGeometry());
+      if (r->tabStripContainer()) {
+        r->tabStripContainer()->setGeometry(
+            QRect(regionRect.left(), regionRect.top(), regionRect.width(),
+                  stripHeight));
+        r->tabStripContainer()->show();
+        r->tabStripContainer()->raise();
+      }
+
+      QRect contentRect = regionRect;
+      contentRect.setTop(regionRect.top() + stripHeight);
+
+      const std::vector<DockWidget *> &tabs = r->tabItems();
+      DockWidget *active                    = r->activeTab();
+      for (j = 0; j < tabs.size(); ++j) {
+        if (tabs[j] == active) {
+          tabs[j]->setGeometry(contentRect);
+          tabs[j]->show();
+        } else {
+          tabs[j]->hide();
+        }
+      }
+    } else if (m_regions[i]->getItem()) {
       m_regions[i]->getItem()->setGeometry(toRect(m_regions[i]->getGeometry()));
     } else {
       for (j = 0; j < sepList.size(); ++j) {
@@ -395,6 +438,9 @@ void DockLayout::applyGeometry() {
 
   // Finally, update separator cursors.
   updateSeparatorCursors();
+
+  if (m_joinHighlight && m_joinHighlightRegion)
+    updateJoinHighlightGeometry();
 }
 
 //------------------------------------------------------
@@ -531,6 +577,9 @@ void DockLayout::redistribute() {
 //=============================
 
 Region::~Region() {
+  delete m_tabStripContainer;
+  m_tabStrip         = 0;
+  m_tabStripContainer = 0;
   // Delete separators
   unsigned int i;
   for (i = 0; i < m_separators.size(); ++i) delete m_separators[i];
@@ -584,10 +633,436 @@ unsigned int Region::find(const Region *subRegion) const {
 //------------------------------------------------------
 
 Region *DockLayout::find(DockWidget *item) const {
-  unsigned int i;
+  unsigned int i, j;
 
-  for (i = 0; i < m_regions.size(); ++i)
-    if (m_regions[i]->getItem() == item) return m_regions[i];
+  for (i = 0; i < m_regions.size(); ++i) {
+    Region *r = m_regions[i];
+    if (r->getItem() == item) return r;
+
+    if (r->isTabbed()) {
+      const std::vector<DockWidget *> &tabs = r->tabItems();
+      for (j = 0; j < tabs.size(); ++j)
+        if (tabs[j] == item) return r;
+    }
+  }
+
+  return 0;
+}
+
+//------------------------------------------------------
+
+int DockLayout::tabStripHeight() const { return DockTabStrip::kHeight; }
+
+//------------------------------------------------------
+
+bool DockLayout::canParticipateInTabGroup(const DockWidget *widget) {
+  if (!widget) return false;
+
+  const QString name = widget->objectName();
+  if (name == QLatin1String("ToolBar") ||
+      name == QLatin1String("CommandBar") ||
+      name == QLatin1String("ToolOptions"))
+    return false;
+
+  if (widget->getFixWidthMode() == DockWidget::fixed) return false;
+
+  // Thin vertical strips that cannot be resized (e.g. main toolbar).
+  if (widget->minimumWidth() == widget->maximumWidth() &&
+      widget->maximumWidth() <= 60)
+    return false;
+
+  // Thin horizontal bars that cannot be resized (command / tool option bars).
+  if (widget->minimumHeight() == widget->maximumHeight() &&
+      widget->maximumHeight() <= 48)
+    return false;
+
+  return true;
+}
+
+//------------------------------------------------------
+
+DockWidget *Region::activeTab() const {
+  if (isTabbed()) {
+    if (m_activeTabIndex >= 0 && m_activeTabIndex < (int)m_tabItems.size())
+      return m_tabItems[m_activeTabIndex];
+    return m_tabItems.empty() ? 0 : m_tabItems.front();
+  }
+  return m_item;
+}
+
+//------------------------------------------------------
+
+void DockLayout::ensureTabStrip(Region *region) {
+  if (!region || !parentWidget()) return;
+
+  if (!region->m_tabStripContainer) {
+    region->m_tabStripContainer = new TabBarContainter(parentWidget());
+    // Reuse the Style Editor / Palette tab styling from the active theme.
+    region->m_tabStripContainer->setObjectName("TabBarContainer");
+
+    QHBoxLayout *tabLayout = new QHBoxLayout(region->m_tabStripContainer);
+    tabLayout->setContentsMargins(6, 0, 0, 0);
+    tabLayout->setSpacing(0);
+
+    region->m_tabStrip =
+        new DockTabStrip(this, region, region->m_tabStripContainer);
+    tabLayout->addWidget(region->m_tabStrip, 0);
+    tabLayout->addStretch(1);
+
+    region->m_tabStripContainer->setFixedHeight(tabStripHeight());
+    region->m_tabStripContainer->hide();
+  }
+  region->m_tabStrip->syncFromRegion();
+}
+
+//------------------------------------------------------
+
+void DockLayout::destroyTabStrip(Region *region) {
+  if (!region || !region->m_tabStripContainer) return;
+  delete region->m_tabStripContainer;
+  region->m_tabStripContainer = 0;
+  region->m_tabStrip          = 0;
+}
+
+//------------------------------------------------------
+
+void DockLayout::updateTabVisibility(Region *region) {
+  if (!region) return;
+
+  const bool tabbed = region->isTabbed();
+  const std::vector<DockWidget *> &tabs = region->tabItems();
+  DockWidget *active                    = region->activeTab();
+
+  for (unsigned int i = 0; i < tabs.size(); ++i) {
+    TDockWidget *tdw = qobject_cast<TDockWidget *>(tabs[i]);
+    if (tdw && tdw->titleBarWidget())
+      tdw->titleBarWidget()->setVisible(!tabbed);
+
+    if (tabs[i] == active) {
+      if (tabbed) tabs[i]->show();
+    } else if (tabbed) {
+      tabs[i]->hide();
+    }
+  }
+
+  if (tabbed)
+    ensureTabStrip(region);
+  else
+    destroyTabStrip(region);
+}
+
+//------------------------------------------------------
+
+void DockLayout::setActiveTab(Region *region, int index) {
+  if (!region || !region->isTabbed()) return;
+  if (index < 0 || index >= (int)region->tabItems().size()) return;
+
+  region->m_activeTabIndex = index;
+  region->m_item           = region->activeTab();
+  updateTabVisibility(region);
+  applyGeometry();
+  parentWidget()->repaint();
+}
+
+//------------------------------------------------------
+
+void DockLayout::moveTab(Region *region, int fromIndex, int toIndex) {
+  if (!region || !region->isTabbed()) return;
+
+  std::vector<DockWidget *> &tabs = region->m_tabItems;
+  if (fromIndex < 0 || toIndex < 0 || fromIndex >= (int)tabs.size() ||
+      toIndex >= (int)tabs.size() || fromIndex == toIndex)
+    return;
+
+  DockWidget *moved = tabs[fromIndex];
+  tabs.erase(tabs.begin() + fromIndex);
+  tabs.insert(tabs.begin() + toIndex, moved);
+
+  if (region->m_activeTabIndex == fromIndex)
+    region->m_activeTabIndex = toIndex;
+  else if (fromIndex < region->m_activeTabIndex &&
+           toIndex >= region->m_activeTabIndex)
+    region->m_activeTabIndex--;
+  else if (fromIndex > region->m_activeTabIndex &&
+           toIndex <= region->m_activeTabIndex)
+    region->m_activeTabIndex++;
+
+  region->m_item = region->activeTab();
+  if (region->m_tabStrip) region->m_tabStrip->syncFromRegion();
+  updateTabVisibility(region);
+  applyGeometry();
+}
+
+//------------------------------------------------------
+
+void DockLayout::setJoinHighlight(Region *region) {
+  if (!parentWidget() || !region) return;
+
+  m_joinHighlightRegion = region;
+  if (!m_joinHighlight) {
+    // Tool overlay so the frame paints above SubWindow dock panels.
+    m_joinHighlight =
+        new DockJoinHighlight(parentWidget());
+  }
+
+  updateJoinHighlightGeometry();
+  m_joinHighlight->show();
+  m_joinHighlight->raise();
+  m_joinHighlight->update();
+}
+
+//------------------------------------------------------
+
+void DockLayout::clearJoinHighlight() {
+  m_joinHighlightRegion = 0;
+  if (m_joinHighlight) m_joinHighlight->hide();
+}
+
+//------------------------------------------------------
+
+void DockLayout::updateJoinHighlightGeometry() {
+  if (!m_joinHighlight || !m_joinHighlightRegion || !parentWidget()) return;
+  const QRect local = toRect(m_joinHighlightRegion->getGeometry());
+  m_joinHighlight->setGeometry(
+      QRect(parentWidget()->mapToGlobal(local.topLeft()), local.size()));
+}
+
+//------------------------------------------------------
+
+void DockLayout::restoreSingleDockedPanel(DockWidget *item) {
+  if (!item) return;
+
+  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
+  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
+
+  item->setWindowFlags(Qt::SubWindow);
+  item->setDockedAppearance();
+  item->m_floating = false;
+  item->onDock(true);
+  item->show();
+  item->update();
+}
+
+//------------------------------------------------------
+
+bool DockLayout::removeFromTabGroup(DockWidget *item, Region *region,
+                                    bool deferStripDestroy) {
+  if (!region || !region->isTabbed()) return false;
+
+  std::vector<DockWidget *> &tabs = region->m_tabItems;
+  auto it = std::find(tabs.begin(), tabs.end(), item);
+  if (it == tabs.end()) return false;
+
+  int removedIndex = static_cast<int>(it - tabs.begin());
+  tabs.erase(it);
+
+  if (tabs.size() <= 1) {
+    DockWidget *remaining = tabs.empty() ? 0 : tabs.front();
+    tabs.clear();
+    region->m_activeTabIndex = 0;
+    region->setItem(remaining);
+    if (deferStripDestroy) {
+      if (region->m_tabStripContainer) region->m_tabStripContainer->hide();
+    } else {
+      destroyTabStrip(region);
+    }
+    if (remaining) restoreSingleDockedPanel(remaining);
+    applyGeometry();
+    if (parentWidget()) parentWidget()->repaint();
+    return true;
+  }
+
+  if (region->m_activeTabIndex > removedIndex)
+    region->m_activeTabIndex--;
+  if (region->m_activeTabIndex >= (int)tabs.size())
+    region->m_activeTabIndex = tabs.size() - 1;
+  if (region->m_activeTabIndex < 0) region->m_activeTabIndex = 0;
+
+  region->m_item = region->activeTab();
+  if (region->m_tabStrip) region->m_tabStrip->syncFromRegion();
+  updateTabVisibility(region);
+  applyGeometry();
+  if (parentWidget()) parentWidget()->repaint();
+  return true;
+}
+
+//------------------------------------------------------
+
+bool DockLayout::undockFromTabGroup(DockWidget *item, Region *region,
+                                    bool deferStripDestroy) {
+  if (!removeFromTabGroup(item, region, deferStripDestroy)) return false;
+
+  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
+  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
+
+  item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
+  item->setFloatingAppearance();
+  item->m_floating = true;
+  item->onDock(false);
+  setMaximized(item, false);
+  redistribute();
+  applyGeometry();
+  if (parentWidget()) parentWidget()->repaint();
+  return true;
+}
+
+//------------------------------------------------------
+
+bool DockLayout::beginTabDragOut(DockWidget *item, Region *region,
+                                 const QPoint &globalPos,
+                                 const QPoint &grabOffsetInTab) {
+  if (!item || !region || !parentWidget()) return false;
+  if (!region->isTabbed()) return false;
+
+  for (int i = 0; i < (int)region->tabItems().size(); ++i) {
+    if (region->tabItems()[i] == item && region->activeTabIndex() != i) {
+      setActiveTab(region, i);
+      break;
+    }
+  }
+
+  if (!undockFromTabGroup(item, region, true)) return false;
+
+  clearJoinHighlight();
+
+  // Destroy the hidden tab strip after this mouse handler returns.
+  if (!region->isTabbed() && region->m_tabStripContainer) {
+    Region *r = region;
+    QTimer::singleShot(0, [this, r]() {
+      if (!r->isTabbed() && r->m_tabStripContainer) destroyTabStrip(r);
+    });
+  }
+
+  item->show();
+  item->raise();
+
+  // The panel's floating appearance (custom title bar + frame margin) is
+  // only fully in place once its layout has been activated. Read the drag
+  // grip's *actual*, current position afterwards - rather than assuming a
+  // fixed margin - so the point grabbed on the tab lands under the cursor
+  // with no drift, however the appearance transition shifted things.
+  if (QLayout *l = item->layout()) l->activate();
+  QWidget *grip = item;
+  if (TDockWidget *tdw = qobject_cast<TDockWidget *>(item))
+    if (QWidget *titleBar = tdw->titleBarWidget()) grip = titleBar;
+  const QPoint gripOffsetInWidget =
+      grip->mapToGlobal(QPoint(0, 0)) - item->mapToGlobal(QPoint(0, 0));
+
+  // Hand off to DockWidget's native floating drag (same as title-bar undock).
+  item->m_undocking           = false;
+  item->m_dragging            = true;
+  item->m_dragMouseInitialPos = globalPos;
+  item->m_dragInitialPos = globalPos - grabOffsetInTab - gripOffsetInWidget;
+  item->move(item->m_dragInitialPos);
+  item->grabMouse();
+
+  if (!getMaximized() && !DockingCheck::instance()->isEnabled())
+    calculateDockPlaceholders(item);
+
+  return true;
+}
+
+//------------------------------------------------------
+
+void DockLayout::tabifyItem(DockWidget *item, Region *region) {
+  if (!item || !region) return;
+  if (!canParticipateInTabGroup(item)) return;
+
+  item->onDock(true);
+  item->setDockedAppearance();
+  item->m_floating     = false;
+  item->m_wasFloating  = true;
+  item->setWindowFlags(Qt::SubWindow);
+
+  if (region->isTabbed()) {
+    region->m_tabItems.push_back(item);
+    region->m_activeTabIndex = region->m_tabItems.size() - 1;
+  } else {
+    DockWidget *existing = region->getItem();
+    if (!existing || existing == item) return;
+    if (!canParticipateInTabGroup(existing)) return;
+
+    region->m_tabItems.push_back(existing);
+    region->m_tabItems.push_back(item);
+    region->m_activeTabIndex = 1;
+    region->setItem(0);
+  }
+
+  region->m_item = region->activeTab();
+  ensureTabStrip(region);
+  updateTabVisibility(region);
+  item->show();
+}
+
+//------------------------------------------------------
+
+void DockLayout::tabifyWithTarget(DockWidget *item, DockWidget *target) {
+  if (!item || !target || item == target) return;
+  if (!canParticipateInTabGroup(item) || !canParticipateInTabGroup(target))
+    return;
+
+  Region *region = find(target);
+
+  // When the target is still floating, dock it beside the panel under its center.
+  if (!region && target->isFloating()) {
+    QPoint layoutPt =
+        parentWidget()->mapFromGlobal(target->geometry().center());
+    DockWidget *anchor = dynamic_cast<DockWidget *>(containerOf(layoutPt));
+    if (anchor && anchor != target) {
+      region = find(anchor);
+      if (region) {
+        if (find(target)) undockItem(target);
+        else {
+          target->onDock(true);
+          target->setDockedAppearance();
+          target->m_floating    = false;
+          target->m_wasFloating = true;
+          target->setWindowFlags(Qt::SubWindow);
+        }
+        tabifyItem(target, region);
+        region = find(target);
+      }
+    }
+
+    if (!region) {
+      dockItemPrivate(target, 0, 0);
+      region = find(target);
+    }
+  }
+
+  if (!region) return;
+
+  Region *itemRegion = find(item);
+  if (itemRegion == region) {
+    const std::vector<DockWidget *> &tabs = region->tabItems();
+    for (unsigned int t = 0; t < tabs.size(); ++t)
+      if (tabs[t] == item) return;
+  }
+
+  if (itemRegion) {
+    if (itemRegion->isTabbed())
+      removeFromTabGroup(item, itemRegion);
+    else if (itemRegion != region)
+      undockItem(item);
+  }
+
+  tabifyItem(item, region);
+  redistribute();
+  parentWidget()->repaint();
+}
+
+//------------------------------------------------------
+
+DockWidget *DockLayout::dockWidgetTitleBarAt(const QPoint &globalPos) const {
+  if (!parentWidget()) return 0;
+
+  for (int i = count() - 1; i >= 0; --i) {
+    DockWidget *dw = static_cast<DockWidget *>(itemAt(i)->widget());
+    if (!dw || !canParticipateInTabGroup(dw)) continue;
+
+    QPoint localPos = dw->mapFromGlobal(globalPos);
+    if (dw->rect().contains(localPos) && dw->isDragGrip(localPos)) return dw;
+  }
 
   return 0;
 }
@@ -685,6 +1160,31 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
     }
   }
 
+  // Hover-join placeholders on leaf regions (title bar / tab strip targets).
+  for (i = 0; i < m_regions.size(); ++i) {
+    Region *r = m_regions[i];
+    if (!r->getChildList().empty()) continue;
+    if (!r->getItem() && !r->isTabbed()) continue;
+    if (r->getItem() == item) continue;
+
+    DockWidget *targetWidget =
+        r->isTabbed() ? r->activeTab() : r->getItem();
+    if (!canParticipateInTabGroup(item) ||
+        !canParticipateInTabGroup(targetWidget))
+      continue;
+
+    bool alreadyMember = false;
+    if (r->isTabbed()) {
+      const std::vector<DockWidget *> &tabs = r->tabItems();
+      for (unsigned int t = 0; t < tabs.size(); ++t)
+        if (tabs[t] == item) alreadyMember = true;
+    }
+    if (alreadyMember) continue;
+
+    item->m_placeholders.push_back(item->m_decoAllocator->newPlaceBuilt(
+        item, r, 0, DockPlaceholder::tabify));
+  }
+
   // Disable all placeholders
   // for(i=0; i<item->m_placeholders.size(); ++i)
   //  item->m_placeholders[i]->setDisabled(true);
@@ -699,11 +1199,21 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
 void DockLayout::dockItem(DockWidget *item, DockPlaceholder *place) {
   place->hide();
   item->hide();
-  dockItemPrivate(item, place->m_region, place->m_idx);
-  redistribute();
+
+  if (place->getAttribute() == DockPlaceholder::tabify) {
+    Region *region = place->getParentRegion();
+    DockWidget *target =
+        region ? (region->isTabbed() ? region->activeTab() : region->getItem())
+               : 0;
+    if (target) tabifyWithTarget(item, target);
+  } else {
+    dockItemPrivate(item, place->m_region, place->m_idx);
+    redistribute();
+    item->setWindowFlags(Qt::SubWindow);
+    item->show();
+  }
+
   parentWidget()->repaint();
-  item->setWindowFlags(Qt::SubWindow);
-  item->show();
 }
 
 //------------------------------------------------------
@@ -802,6 +1312,7 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
 
 //! A region is empty, if contains no item and no children.
 static bool isEmptyRegion(Region *r) {
+  if (r->isTabbed()) return false;
   if ((!r->getItem()) && (r->getChildList().size() == 0)) {
     delete r;  // Well, it's a bit improper, but it works...
     return true;
@@ -880,6 +1391,9 @@ void Region::removeItem(DockWidget *item) {
 bool DockLayout::undockItem(DockWidget *item) {
   // Find item's region index in m_regions
   Region *itemCarrier = find(item);
+  if (!itemCarrier) return false;
+
+  if (itemCarrier->isTabbed()) return undockFromTabGroup(item, itemCarrier);
 
   Region *parent = itemCarrier->getParent();
   if (parent) {
@@ -1078,7 +1592,17 @@ void Region::calculateExtremalSizes() {
 int Region::calculateMinimumSize(bool direction, bool recalcChildren) {
   int sumMinSizes = 0, maxMinSizes = 0;
 
-  if (m_item) {
+  if (isTabbed()) {
+    unsigned int t;
+    int tabBarExtra = (direction == vertical) ? m_owner->tabStripHeight() : 0;
+    for (t = 0; t < m_tabItems.size(); ++t) {
+      int w = m_tabItems[t]->minimumSize().width();
+      int h = m_tabItems[t]->minimumSize().height();
+      if (maxMinSizes < (direction == horizontal ? w : h))
+        maxMinSizes = (direction == horizontal ? w : h);
+    }
+    sumMinSizes = maxMinSizes + tabBarExtra;
+  } else if (m_item) {
     sumMinSizes = maxMinSizes = (direction == horizontal)
                                     ? m_item->minimumSize().width()
                                     : m_item->minimumSize().height();
@@ -1120,7 +1644,17 @@ int Region::calculateMaximumSize(bool direction, bool recalcChildren) {
 
   int sumMaxSizes = 0, minMaxSizes = inf;
 
-  if (m_item) {
+  if (isTabbed()) {
+    unsigned int t;
+    int tabBarExtra = (direction == vertical) ? m_owner->tabStripHeight() : 0;
+    for (t = 0; t < m_tabItems.size(); ++t) {
+      int w = m_tabItems[t]->maximumSize().width();
+      int h = m_tabItems[t]->maximumSize().height();
+      if (minMaxSizes > (direction == horizontal ? w : h))
+        minMaxSizes = (direction == horizontal ? w : h);
+    }
+    sumMaxSizes = minMaxSizes + tabBarExtra;
+  } else if (m_item) {
     sumMaxSizes = minMaxSizes = (direction == horizontal)
                                     ? m_item->maximumSize().width()
                                     : m_item->maximumSize().height();
@@ -1410,6 +1944,16 @@ DockLayout::State DockLayout::saveState() {
 //------------------------------------------------------
 
 void DockLayout::writeRegion(Region *r, QString &hierarchy) {
+  if (r->isTabbed()) {
+    hierarchy.append("{ ");
+    const std::vector<DockWidget *> &tabs = r->tabItems();
+    for (unsigned int t = 0; t < tabs.size(); ++t)
+      hierarchy.append(QString::number(tabs[t]->m_saveIndex) + " ");
+    hierarchy.append("@" + QString::number(r->activeTabIndex()) + " ");
+    hierarchy.append("} ");
+    return;
+  }
+
   DockWidget *item = static_cast<DockWidget *>(r->getItem());
 
   // If Region has item, write it.
@@ -1468,6 +2012,32 @@ bool DockLayout::restoreState(const State &state) {
       if (vars[i] == "]") {
         // End region and get parent
         r = r->getParent();
+      } else if (vars[i] == "{") {
+        newRegion = new Region(this);
+        newHierarchy.push_back(newRegion);
+        newRegion->m_orientation = !orientation;
+        if (r) r->insertSubRegion(newRegion, r->getChildList().size());
+
+        std::vector<int> tabIndices;
+        int activeTab = 0;
+        ++i;
+        while (i < vars.size() && vars[i] != "}") {
+          if (vars[i].startsWith(QLatin1Char('@')))
+            activeTab = vars[i].mid(1).toInt();
+          else
+            tabIndices.push_back(vars[i].toInt());
+          ++i;
+        }
+
+        for (unsigned int t = 0; t < tabIndices.size(); ++t) {
+          DockWidget *tabItem = static_cast<DockWidget *>(
+              m_items[tabIndices[t]]->widget());
+          newRegion->m_tabItems.push_back(tabItem);
+        }
+        newRegion->m_activeTabIndex = activeTab;
+        if (newRegion->m_activeTabIndex >= (int)newRegion->m_tabItems.size())
+          newRegion->m_activeTabIndex = 0;
+        newRegion->m_item = newRegion->activeTab();
       } else {
         // Allocate new Region
         newRegion = new Region(this);
@@ -1531,14 +2101,28 @@ bool DockLayout::restoreState(const State &state) {
   }
 
   // Docked widgets are found in hierarchy
-  for (j = 0; j < m_regions.size(); ++j)
-    if ((item = m_regions[j]->m_item)) {
+  for (j = 0; j < m_regions.size(); ++j) {
+    Region *region = m_regions[j];
+    if (region->isTabbed()) {
+      const std::vector<DockWidget *> &tabs = region->tabItems();
+      for (unsigned int t = 0; t < tabs.size(); ++t) {
+        item = tabs[t];
+        item->setWindowFlags(Qt::SubWindow);
+        item->setDockedAppearance();
+        item->m_floating  = false;
+        item->m_saveIndex = -1;
+        item->show();
+      }
+      ensureTabStrip(region);
+      updateTabVisibility(region);
+    } else if ((item = region->m_item)) {
       item->setWindowFlags(Qt::SubWindow);
       item->setDockedAppearance();
       item->m_floating  = false;
       item->m_saveIndex = -1;
       item->show();
     }
+  }
 
   // Recover available geometry infos
   // QRect availableRect= QApplication::desktop()->availableGeometry();

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -1024,8 +1024,8 @@ void DockLayout::normalizeSingleDockedPanel(DockWidget *item) {
   item->m_floating = false;
   item->onDock(true);
 
-  // setWindowFlags can re-hide children on Windows; restore title last and
-  // force a visible, raised docked panel so it never stays grey/inert.
+  // setWindowFlags can re-hide children on Windows, so restore the title bar
+  // last and show the panel explicitly.
   restorePanelTitleBar(item);
   if (QLayout *l = item->layout()) l->activate();
   item->show();
@@ -1185,30 +1185,6 @@ bool DockLayout::canMergeAsTabs(DockWidget *item, DockWidget *target) const {
 
 //------------------------------------------------------
 
-//! Returns the region holding \b target, docking it first if it is still
-//! floating: a merge target must be part of the region tree.
-Region *DockLayout::ensureDockedRegionForTarget(DockWidget *target) {
-  if (Region *region = find(target)) return region;
-  if (!target->isFloating() || !parentWidget()) return 0;
-
-  // Dock the target next to whichever panel sits under its center.
-  const QPoint layoutPt =
-      parentWidget()->mapFromGlobal(target->geometry().center());
-  DockWidget *anchor = dynamic_cast<DockWidget *>(containerOf(layoutPt));
-
-  if (anchor && anchor != target) {
-    if (Region *anchorRegion = find(anchor)) {
-      addPanelToTabGroup(target, anchorRegion);
-      if (Region *region = find(target)) return region;
-    }
-  }
-
-  dockItemPrivate(target, 0, 0);
-  return find(target);
-}
-
-//------------------------------------------------------
-
 //! Takes \b item out of whatever holds it now, so that it can be appended to
 //! \b destination. Returns false when the panel already belongs there.
 bool DockLayout::detachPanelFromCurrentRegion(DockWidget *item,
@@ -1230,7 +1206,7 @@ bool DockLayout::detachPanelFromCurrentRegion(DockWidget *item,
 void DockLayout::mergePanelsAsTabs(DockWidget *item, DockWidget *target) {
   if (!canMergeAsTabs(item, target)) return;
 
-  Region *targetRegion = ensureDockedRegionForTarget(target);
+  Region *targetRegion = find(target);
   if (!targetRegion || targetRegion->containsPanel(item)) return;
 
   if (!detachPanelFromCurrentRegion(item, targetRegion)) return;
@@ -1247,12 +1223,14 @@ void DockLayout::mergePanelsAsTabs(DockWidget *item, DockWidget *target) {
 
 //------------------------------------------------------
 
+//! Returns the docked panel whose drag grip lies under \b globalPos.
+//! Floating panels are not merge targets.
 DockWidget *DockLayout::dockWidgetTitleBarAt(const QPoint &globalPos) const {
   if (!parentWidget()) return 0;
 
   for (int i = count() - 1; i >= 0; --i) {
     DockWidget *dw = static_cast<DockWidget *>(itemAt(i)->widget());
-    if (!dw || !supportsTabGrouping(dw)) continue;
+    if (!dw || dw->isFloating() || !supportsTabGrouping(dw)) continue;
 
     QPoint localPos = dw->mapFromGlobal(globalPos);
     if (dw->rect().contains(localPos) && dw->isDragGrip(localPos)) return dw;
@@ -2160,13 +2138,13 @@ DockLayout::State DockLayout::saveState() {
 //------------------------------------------------------
 
 //! Reads the body of a tab group - the tokens after '{' up to '}' - into
-//! \b region, starting at \b pos. Groups left with a single valid member are
-//! normalized into a plain single-panel region by Region::setTabGroup().
+//! \b region, starting at \b pos. Input that does not match the grammar is
+//! rejected, not repaired.
 bool DockLayout::parseTabGroup(const QStringList &tokens, int &pos,
                                Region *region,
                                std::vector<bool> &alreadyRestored) const {
   std::vector<DockWidget *> panels;
-  int activeIndex = 0;
+  int activeIndex = -1;
   bool closed     = false;
 
   for (; pos < tokens.size(); ++pos) {
@@ -2178,8 +2156,9 @@ bool DockLayout::parseTabGroup(const QStringList &tokens, int &pos,
 
     bool tokenIsOk = false;
     if (token.startsWith(QLatin1Char('@'))) {
+      if (activeIndex >= 0) return false;
       activeIndex = token.mid(1).toInt(&tokenIsOk);
-      if (!tokenIsOk) return false;
+      if (!tokenIsOk || activeIndex < 0) return false;
       continue;
     }
 
@@ -2192,7 +2171,8 @@ bool DockLayout::parseTabGroup(const QStringList &tokens, int &pos,
     panels.push_back(static_cast<DockWidget *>(m_items[panelIndex]->widget()));
   }
 
-  if (!closed || panels.empty()) return false;
+  if (!closed || panels.size() < 2) return false;
+  if (activeIndex < 0 || activeIndex >= (int)panels.size()) return false;
 
   region->setTabGroup(panels, activeIndex);
   return true;
@@ -2274,8 +2254,12 @@ bool DockLayout::restoreState(const State &state) {
 
   if (expectsHierarchy) {
     // Scan hierarchy
-    Region *r             = 0;
-    const int orientation = !tokens[1].toInt();
+    Region *r                  = 0;
+    bool orientationIsOk       = false;
+    const int savedOrientation = tokens[1].toInt(&orientationIsOk);
+    if (!orientationIsOk || (savedOrientation != 0 && savedOrientation != 1))
+      return false;
+    const int orientation = !savedOrientation;
 
     for (int i = 2; i < tokens.size(); ++i) {
       const QString &token = tokens[i];
@@ -2288,6 +2272,12 @@ bool DockLayout::restoreState(const State &state) {
         }
         r = r->getParent();
         continue;
+      }
+
+      // The grammar allows a single root region.
+      if (!r && !newHierarchy.empty()) {
+        malformed = true;
+        break;
       }
 
       Region *newRegion = new Region(this);
@@ -2456,9 +2446,8 @@ bool DockLayout::restoreState(const State &state) {
 
 //------------------------------------------------------
 
-//! Hidden tabs may have been saved with stale geometries from before they
-//! were merged; align every member of a group on its active tab before the
-//! region tree is rebuilt from leaf widget rects.
+//! Hidden tabs may have been saved with geometries from before they were
+//! merged, so align every member of a group on its active tab.
 void DockLayout::normalizeRestoredTabGeometries() {
   for (unsigned int i = 0; i < m_regions.size(); ++i) {
     Region *region = m_regions[i];
@@ -2490,10 +2479,8 @@ void Region::restoreGeometry() {
     DockWidget *active = activeTab();
     if (!active) return;
 
-    // applyGeometry() stores panel widgets below the tab strip. Saved
-    // geometries therefore describe the content rect, not the full region.
-    // Expand upward so restore + applyGeometry land the strip and panels
-    // where they were when the layout was saved.
+    // Panels sit below the tab strip, so a saved panel rect describes the
+    // content area rather than the region. Expand upward to get the region.
     QRect g = active->geometry();
     g.setTop(g.top() - m_owner->tabStripHeight());
     setGeometry(g);

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -94,6 +94,14 @@ DockLayout::DockLayout()
 DockLayout::~DockLayout() {
   clearJoinHighlight();
   delete m_joinHighlight;
+  m_joinHighlight = 0;
+
+  // Dock widgets may outlive this layout during application shutdown. Clear
+  // their back-pointer so ~DockWidget does not call into a destroyed layout.
+  for (unsigned int i = 0; i < m_items.size(); ++i) {
+    if (DockWidget *dw = static_cast<DockWidget *>(m_items[i]->widget()))
+      dw->m_parentLayout = 0;
+  }
 
   // Deleting Regions (separators are Widgets with parent, so they are
   // recursively deleted)
@@ -314,9 +322,10 @@ void DockLayout::updateSeparatorCursors() {
   Region *r, *child;
 
   unsigned int i, j;
-  int k, jInt;
+  int jInt, k;
   for (i = 0; i < m_regions.size(); ++i) {
     r = m_regions[i];
+    if (r->isTabbed()) continue;
 
     const int childCount     = static_cast<int>(r->getChildList().size());
     const int separatorCount = static_cast<int>(r->separators().size());
@@ -325,8 +334,6 @@ void DockLayout::updateSeparatorCursors() {
     bool orientation = r->getOrientation();
 
     // If region geometry is minimal or maximal, its separators are blocked
-    // NOTE: If this update follows only from a dock/undock, this should be
-    // disabled 'til 'Otherwise'
     QSize size = toRect(r->getGeometry()).size();
     bool isExtremeSize =
         (orientation == Region::horizontal)
@@ -335,12 +342,10 @@ void DockLayout::updateSeparatorCursors() {
             : size.height() == r->getMinimumSize(Region::vertical) ||
                   size.height() == r->getMaximumSize(Region::vertical);
     if (isExtremeSize) {
-      for (j = 0; j < r->separators().size(); ++j)
+      for (j = 0; j < static_cast<unsigned int>(separatorCount); ++j)
         r->separator(j)->setCursor(Qt::ArrowCursor);
       continue;
     }
-
-    // Otherwise...
 
     // Arrowize all separators as long as the preceding region has equal
     // maximum and minimum sizes
@@ -354,7 +359,7 @@ void DockLayout::updateSeparatorCursors() {
         break;
     }
 
-    jInt = j;
+    jInt = static_cast<int>(j);
     // The same as above in reverse order
     k = std::min(childCount - 1, separatorCount);
     for (; k > jInt; --k) {
@@ -406,6 +411,9 @@ void DockLayout::applyGeometry() {
           tabs[j]->setGeometry(contentRect);
           tabs[j]->show();
         } else {
+          // Keep hidden tabs aligned so switching tabs after restore does not
+          // jump, and saveState sees a consistent geometry next time.
+          tabs[j]->setGeometry(contentRect);
           tabs[j]->hide();
         }
       }
@@ -925,12 +933,21 @@ bool DockLayout::beginTabDragOut(DockWidget *item, Region *region,
 
   clearJoinHighlight();
 
-  // Destroy the hidden tab strip after this mouse handler returns.
+  // Destroy the hidden tab strip after this mouse handler returns. Detach
+  // ownership from the region first so Region::~Region and a late timer
+  // callback cannot both delete the same widget.
   if (!region->isTabbed() && region->m_tabStripContainer) {
-    Region *r = region;
-    QTimer::singleShot(0, [this, r]() {
-      if (!r->isTabbed() && r->m_tabStripContainer) destroyTabStrip(r);
-    });
+    TabBarContainter *stripContainer = region->m_tabStripContainer;
+    region->m_tabStripContainer      = 0;
+    region->m_tabStrip                 = 0;
+    stripContainer->hide();
+
+    QWidget *host = parentWidget();
+    if (host) {
+      QTimer::singleShot(0, host, [stripContainer]() { delete stripContainer; });
+    } else {
+      delete stripContainer;
+    }
   }
 
   item->show();
@@ -1083,6 +1100,12 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
   // If the DockLayout's owner widget is hidden, avoid
   if (!parentWidget()->isVisible()) return;
 
+  // Drop stale region references before deleting placeholder widgets.
+  for (unsigned int ri = 0; ri < m_regions.size(); ++ri)
+    m_regions[ri]->m_placeholders.clear();
+
+  item->clearDockPlaceholders();
+
   if (!m_regions.size()) {
     if (isPossibleInsertion(item, 0, 0)) {
       // Then insert a root placeholder only
@@ -1209,6 +1232,7 @@ void DockLayout::dockItem(DockWidget *item, DockPlaceholder *place) {
   } else {
     dockItemPrivate(item, place->m_region, place->m_idx);
     redistribute();
+    clearJoinHighlight();
     item->setWindowFlags(Qt::SubWindow);
     item->show();
   }
@@ -1259,6 +1283,29 @@ Region *DockLayout::dockItem(DockWidget *item, Region *r, int idx) {
 
 //------------------------------------------------------
 
+Region *DockLayout::detachTabGroupAsSubRegion(Region *region) {
+  if (!region || !region->isTabbed()) return 0;
+
+  Region *child = new Region(this);
+  child->m_tabItems.swap(region->m_tabItems);
+  child->m_activeTabIndex    = region->m_activeTabIndex;
+  child->m_tabStrip          = region->m_tabStrip;
+  child->m_tabStripContainer = region->m_tabStripContainer;
+  child->m_item              = child->activeTab();
+
+  region->m_tabItems.clear();
+  region->m_activeTabIndex    = 0;
+  region->m_tabStrip          = 0;
+  region->m_tabStripContainer = 0;
+  region->m_item              = 0;
+
+  if (child->m_tabStrip) child->m_tabStrip->rebindRegion(child);
+
+  return child;
+}
+
+//------------------------------------------------------
+
 // Internal docking function. Contains raw docking code, excluded reparenting
 // (setWindowFlags)  which may slow down a bit should be done only
 // after a redistribute() and a repaint() on real-time docking.
@@ -1287,6 +1334,14 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
     newRoot->insertSubRegion(m_regions[1], 0);
 
     r = newRoot;
+  } else if (r->isTabbed()) {
+    // Split-dock beside/above a tab group: move the whole group as one unit,
+    // not just the active tab (which would orphan the other tabs and corrupt
+    // the region tree).
+    Region *regionForTabs = detachTabGroupAsSubRegion(r);
+    regionForTabs->setSize(toRect(r->getGeometry()).size());
+    r->insertSubRegion(regionForTabs, 0);
+    m_regions.push_back(regionForTabs);
   } else if (r->getItem()) {
     // Then the Layout gets further subdived - r's item has to be moved
     Region *regionForOldItem = r->insertItem(r->getItem(), 0);
@@ -2146,6 +2201,19 @@ bool DockLayout::restoreState(const State &state) {
     }
   }
 
+  // Hidden tabs may have been saved with stale geometries from before they
+  // were merged. Align every tab in a group to the active tab before the
+  // region tree is rebuilt from leaf widget rects.
+  for (j = 0; j < m_regions.size(); ++j) {
+    Region *region = m_regions[j];
+    if (!region->isTabbed()) continue;
+    DockWidget *active = region->activeTab();
+    if (!active) continue;
+    const QRect ref                       = active->geometry();
+    const std::vector<DockWidget *> &tabs = region->tabItems();
+    for (unsigned int t = 0; t < tabs.size(); ++t) tabs[t]->setGeometry(ref);
+  }
+
   // Calculate regions' geometry starting from leaves (items)
   if (m_regions.size()) m_regions[0]->restoreGeometry();
 
@@ -2193,6 +2261,20 @@ bool DockLayout::restoreState(const State &state) {
 void Region::restoreGeometry() {
   // Applying a head-recursive algorithm to update the geometry of a Region
   // after those of its children have been updated
+  if (isTabbed()) {
+    DockWidget *active = activeTab();
+    if (!active) return;
+
+    // applyGeometry() stores panel widgets below the tab strip. Saved
+    // geometries therefore describe the content rect, not the full region.
+    // Expand upward so restore + applyGeometry land the strip and panels
+    // where they were when the layout was saved.
+    QRect g = active->geometry();
+    g.setTop(g.top() - m_owner->tabStripHeight());
+    setGeometry(g);
+    return;
+  }
+
   if (m_item) {
     // Place item's geometry
     setGeometry(m_item->geometry());

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -1,6 +1,14 @@
 
 
 #include "docklayout.h"
+#include "docktabstrip.h"
+#include "tdockwindows.h"
+#include "toonzqt/gutil.h"
+
+#include <QApplication>
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QTimer>
 
 #include <assert.h>
 #include <math.h>
@@ -76,11 +84,17 @@ inline QRect toRect(const QRectF &rect) {
 //-----------------
 
 DockLayout::DockLayout()
-    : m_maximizedDock(0), m_decoAllocator(new DockDecoAllocator()) {}
+    : m_maximizedDock(0)
+    , m_decoAllocator(new DockDecoAllocator())
+    , m_joinHighlight(0)
+    , m_joinHighlightRegion(0) {}
 
 //-------------------------------------
 
 DockLayout::~DockLayout() {
+  clearJoinHighlight();
+  delete m_joinHighlight;
+
   // Deleting Regions (separators are Widgets with parent, so they are
   // recursively deleted)
   unsigned int i;
@@ -207,10 +221,16 @@ QWidget *DockLayout::containerOf(QPoint point) const {
   unsigned int j;
   for (i = m_regions.size() - 1; i >= 0; --i) {
     Region *currRegion = m_regions[i];
-    DockWidget *item   = currRegion->getItem();
+
+    if (currRegion->isTabbed() && currRegion->tabStripContainer() &&
+        currRegion->tabStripContainer()->geometry().contains(point))
+      return currRegion->tabStripContainer();
+
+    DockWidget *item = currRegion->getItem();
+    if (!item && currRegion->isTabbed()) item = currRegion->activeTab();
 
     // First check if item contains it
-    if (item && item->geometry().contains(point)) return currRegion->getItem();
+    if (item && item->geometry().contains(point)) return item;
 
     // Then, search among separators
     for (j = 0; j < currRegion->separators().size(); ++j)
@@ -353,14 +373,37 @@ void DockLayout::updateSeparatorCursors() {
 
 //! Applies Regions geometry to dock widgets and separators.
 void DockLayout::applyGeometry() {
-  // Update docked window's geometries
   unsigned int i, j;
+  const int stripHeight = tabStripHeight();
   for (i = 0; i < m_regions.size(); ++i) {
     Region *r                             = m_regions[i];
     const std::deque<Region *> &childList = r->getChildList();
     std::deque<DockSeparator *> &sepList  = r->m_separators;
 
-    if (m_regions[i]->getItem()) {
+    if (r->isTabbed()) {
+      QRect regionRect = toRect(r->getGeometry());
+      if (r->tabStripContainer()) {
+        r->tabStripContainer()->setGeometry(
+            QRect(regionRect.left(), regionRect.top(), regionRect.width(),
+                  stripHeight));
+        r->tabStripContainer()->show();
+        r->tabStripContainer()->raise();
+      }
+
+      QRect contentRect = regionRect;
+      contentRect.setTop(regionRect.top() + stripHeight);
+
+      const std::vector<DockWidget *> &tabs = r->tabItems();
+      DockWidget *active                    = r->activeTab();
+      for (j = 0; j < tabs.size(); ++j) {
+        if (tabs[j] == active) {
+          tabs[j]->setGeometry(contentRect);
+          tabs[j]->show();
+        } else {
+          tabs[j]->hide();
+        }
+      }
+    } else if (m_regions[i]->getItem()) {
       m_regions[i]->getItem()->setGeometry(toRect(m_regions[i]->getGeometry()));
     } else {
       for (j = 0; j < sepList.size(); ++j) {
@@ -389,6 +432,9 @@ void DockLayout::applyGeometry() {
 
   // Finally, update separator cursors.
   updateSeparatorCursors();
+
+  if (m_joinHighlight && m_joinHighlightRegion)
+    updateJoinHighlightGeometry();
 }
 
 //------------------------------------------------------
@@ -525,6 +571,9 @@ void DockLayout::redistribute() {
 //=============================
 
 Region::~Region() {
+  delete m_tabStripContainer;
+  m_tabStrip         = 0;
+  m_tabStripContainer = 0;
   // Delete separators
   unsigned int i;
   for (i = 0; i < m_separators.size(); ++i) delete m_separators[i];
@@ -578,10 +627,436 @@ unsigned int Region::find(const Region *subRegion) const {
 //------------------------------------------------------
 
 Region *DockLayout::find(DockWidget *item) const {
-  unsigned int i;
+  unsigned int i, j;
 
-  for (i = 0; i < m_regions.size(); ++i)
-    if (m_regions[i]->getItem() == item) return m_regions[i];
+  for (i = 0; i < m_regions.size(); ++i) {
+    Region *r = m_regions[i];
+    if (r->getItem() == item) return r;
+
+    if (r->isTabbed()) {
+      const std::vector<DockWidget *> &tabs = r->tabItems();
+      for (j = 0; j < tabs.size(); ++j)
+        if (tabs[j] == item) return r;
+    }
+  }
+
+  return 0;
+}
+
+//------------------------------------------------------
+
+int DockLayout::tabStripHeight() const { return DockTabStrip::kHeight; }
+
+//------------------------------------------------------
+
+bool DockLayout::canParticipateInTabGroup(const DockWidget *widget) {
+  if (!widget) return false;
+
+  const QString name = widget->objectName();
+  if (name == QLatin1String("ToolBar") ||
+      name == QLatin1String("CommandBar") ||
+      name == QLatin1String("ToolOptions"))
+    return false;
+
+  if (widget->getFixWidthMode() == DockWidget::fixed) return false;
+
+  // Thin vertical strips that cannot be resized (e.g. main toolbar).
+  if (widget->minimumWidth() == widget->maximumWidth() &&
+      widget->maximumWidth() <= 60)
+    return false;
+
+  // Thin horizontal bars that cannot be resized (command / tool option bars).
+  if (widget->minimumHeight() == widget->maximumHeight() &&
+      widget->maximumHeight() <= 48)
+    return false;
+
+  return true;
+}
+
+//------------------------------------------------------
+
+DockWidget *Region::activeTab() const {
+  if (isTabbed()) {
+    if (m_activeTabIndex >= 0 && m_activeTabIndex < (int)m_tabItems.size())
+      return m_tabItems[m_activeTabIndex];
+    return m_tabItems.empty() ? 0 : m_tabItems.front();
+  }
+  return m_item;
+}
+
+//------------------------------------------------------
+
+void DockLayout::ensureTabStrip(Region *region) {
+  if (!region || !parentWidget()) return;
+
+  if (!region->m_tabStripContainer) {
+    region->m_tabStripContainer = new TabBarContainter(parentWidget());
+    // Reuse the Style Editor / Palette tab styling from the active theme.
+    region->m_tabStripContainer->setObjectName("TabBarContainer");
+
+    QHBoxLayout *tabLayout = new QHBoxLayout(region->m_tabStripContainer);
+    tabLayout->setContentsMargins(6, 0, 0, 0);
+    tabLayout->setSpacing(0);
+
+    region->m_tabStrip =
+        new DockTabStrip(this, region, region->m_tabStripContainer);
+    tabLayout->addWidget(region->m_tabStrip, 0);
+    tabLayout->addStretch(1);
+
+    region->m_tabStripContainer->setFixedHeight(tabStripHeight());
+    region->m_tabStripContainer->hide();
+  }
+  region->m_tabStrip->syncFromRegion();
+}
+
+//------------------------------------------------------
+
+void DockLayout::destroyTabStrip(Region *region) {
+  if (!region || !region->m_tabStripContainer) return;
+  delete region->m_tabStripContainer;
+  region->m_tabStripContainer = 0;
+  region->m_tabStrip          = 0;
+}
+
+//------------------------------------------------------
+
+void DockLayout::updateTabVisibility(Region *region) {
+  if (!region) return;
+
+  const bool tabbed = region->isTabbed();
+  const std::vector<DockWidget *> &tabs = region->tabItems();
+  DockWidget *active                    = region->activeTab();
+
+  for (unsigned int i = 0; i < tabs.size(); ++i) {
+    TDockWidget *tdw = qobject_cast<TDockWidget *>(tabs[i]);
+    if (tdw && tdw->titleBarWidget())
+      tdw->titleBarWidget()->setVisible(!tabbed);
+
+    if (tabs[i] == active) {
+      if (tabbed) tabs[i]->show();
+    } else if (tabbed) {
+      tabs[i]->hide();
+    }
+  }
+
+  if (tabbed)
+    ensureTabStrip(region);
+  else
+    destroyTabStrip(region);
+}
+
+//------------------------------------------------------
+
+void DockLayout::setActiveTab(Region *region, int index) {
+  if (!region || !region->isTabbed()) return;
+  if (index < 0 || index >= (int)region->tabItems().size()) return;
+
+  region->m_activeTabIndex = index;
+  region->m_item           = region->activeTab();
+  updateTabVisibility(region);
+  applyGeometry();
+  parentWidget()->repaint();
+}
+
+//------------------------------------------------------
+
+void DockLayout::moveTab(Region *region, int fromIndex, int toIndex) {
+  if (!region || !region->isTabbed()) return;
+
+  std::vector<DockWidget *> &tabs = region->m_tabItems;
+  if (fromIndex < 0 || toIndex < 0 || fromIndex >= (int)tabs.size() ||
+      toIndex >= (int)tabs.size() || fromIndex == toIndex)
+    return;
+
+  DockWidget *moved = tabs[fromIndex];
+  tabs.erase(tabs.begin() + fromIndex);
+  tabs.insert(tabs.begin() + toIndex, moved);
+
+  if (region->m_activeTabIndex == fromIndex)
+    region->m_activeTabIndex = toIndex;
+  else if (fromIndex < region->m_activeTabIndex &&
+           toIndex >= region->m_activeTabIndex)
+    region->m_activeTabIndex--;
+  else if (fromIndex > region->m_activeTabIndex &&
+           toIndex <= region->m_activeTabIndex)
+    region->m_activeTabIndex++;
+
+  region->m_item = region->activeTab();
+  if (region->m_tabStrip) region->m_tabStrip->syncFromRegion();
+  updateTabVisibility(region);
+  applyGeometry();
+}
+
+//------------------------------------------------------
+
+void DockLayout::setJoinHighlight(Region *region) {
+  if (!parentWidget() || !region) return;
+
+  m_joinHighlightRegion = region;
+  if (!m_joinHighlight) {
+    // Tool overlay so the frame paints above SubWindow dock panels.
+    m_joinHighlight =
+        new DockJoinHighlight(parentWidget());
+  }
+
+  updateJoinHighlightGeometry();
+  m_joinHighlight->show();
+  m_joinHighlight->raise();
+  m_joinHighlight->update();
+}
+
+//------------------------------------------------------
+
+void DockLayout::clearJoinHighlight() {
+  m_joinHighlightRegion = 0;
+  if (m_joinHighlight) m_joinHighlight->hide();
+}
+
+//------------------------------------------------------
+
+void DockLayout::updateJoinHighlightGeometry() {
+  if (!m_joinHighlight || !m_joinHighlightRegion || !parentWidget()) return;
+  const QRect local = toRect(m_joinHighlightRegion->getGeometry());
+  m_joinHighlight->setGeometry(
+      QRect(parentWidget()->mapToGlobal(local.topLeft()), local.size()));
+}
+
+//------------------------------------------------------
+
+void DockLayout::restoreSingleDockedPanel(DockWidget *item) {
+  if (!item) return;
+
+  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
+  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
+
+  item->setWindowFlags(Qt::SubWindow);
+  item->setDockedAppearance();
+  item->m_floating = false;
+  item->onDock(true);
+  item->show();
+  item->update();
+}
+
+//------------------------------------------------------
+
+bool DockLayout::removeFromTabGroup(DockWidget *item, Region *region,
+                                    bool deferStripDestroy) {
+  if (!region || !region->isTabbed()) return false;
+
+  std::vector<DockWidget *> &tabs = region->m_tabItems;
+  auto it = std::find(tabs.begin(), tabs.end(), item);
+  if (it == tabs.end()) return false;
+
+  int removedIndex = static_cast<int>(it - tabs.begin());
+  tabs.erase(it);
+
+  if (tabs.size() <= 1) {
+    DockWidget *remaining = tabs.empty() ? 0 : tabs.front();
+    tabs.clear();
+    region->m_activeTabIndex = 0;
+    region->setItem(remaining);
+    if (deferStripDestroy) {
+      if (region->m_tabStripContainer) region->m_tabStripContainer->hide();
+    } else {
+      destroyTabStrip(region);
+    }
+    if (remaining) restoreSingleDockedPanel(remaining);
+    applyGeometry();
+    if (parentWidget()) parentWidget()->repaint();
+    return true;
+  }
+
+  if (region->m_activeTabIndex > removedIndex)
+    region->m_activeTabIndex--;
+  if (region->m_activeTabIndex >= (int)tabs.size())
+    region->m_activeTabIndex = tabs.size() - 1;
+  if (region->m_activeTabIndex < 0) region->m_activeTabIndex = 0;
+
+  region->m_item = region->activeTab();
+  if (region->m_tabStrip) region->m_tabStrip->syncFromRegion();
+  updateTabVisibility(region);
+  applyGeometry();
+  if (parentWidget()) parentWidget()->repaint();
+  return true;
+}
+
+//------------------------------------------------------
+
+bool DockLayout::undockFromTabGroup(DockWidget *item, Region *region,
+                                    bool deferStripDestroy) {
+  if (!removeFromTabGroup(item, region, deferStripDestroy)) return false;
+
+  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
+  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
+
+  item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
+  item->setFloatingAppearance();
+  item->m_floating = true;
+  item->onDock(false);
+  setMaximized(item, false);
+  redistribute();
+  applyGeometry();
+  if (parentWidget()) parentWidget()->repaint();
+  return true;
+}
+
+//------------------------------------------------------
+
+bool DockLayout::beginTabDragOut(DockWidget *item, Region *region,
+                                 const QPoint &globalPos,
+                                 const QPoint &grabOffsetInTab) {
+  if (!item || !region || !parentWidget()) return false;
+  if (!region->isTabbed()) return false;
+
+  for (int i = 0; i < (int)region->tabItems().size(); ++i) {
+    if (region->tabItems()[i] == item && region->activeTabIndex() != i) {
+      setActiveTab(region, i);
+      break;
+    }
+  }
+
+  if (!undockFromTabGroup(item, region, true)) return false;
+
+  clearJoinHighlight();
+
+  // Destroy the hidden tab strip after this mouse handler returns.
+  if (!region->isTabbed() && region->m_tabStripContainer) {
+    Region *r = region;
+    QTimer::singleShot(0, [this, r]() {
+      if (!r->isTabbed() && r->m_tabStripContainer) destroyTabStrip(r);
+    });
+  }
+
+  item->show();
+  item->raise();
+
+  // The panel's floating appearance (custom title bar + frame margin) is
+  // only fully in place once its layout has been activated. Read the drag
+  // grip's *actual*, current position afterwards - rather than assuming a
+  // fixed margin - so the point grabbed on the tab lands under the cursor
+  // with no drift, however the appearance transition shifted things.
+  if (QLayout *l = item->layout()) l->activate();
+  QWidget *grip = item;
+  if (TDockWidget *tdw = qobject_cast<TDockWidget *>(item))
+    if (QWidget *titleBar = tdw->titleBarWidget()) grip = titleBar;
+  const QPoint gripOffsetInWidget =
+      grip->mapToGlobal(QPoint(0, 0)) - item->mapToGlobal(QPoint(0, 0));
+
+  // Hand off to DockWidget's native floating drag (same as title-bar undock).
+  item->m_undocking           = false;
+  item->m_dragging            = true;
+  item->m_dragMouseInitialPos = globalPos;
+  item->m_dragInitialPos = globalPos - grabOffsetInTab - gripOffsetInWidget;
+  item->move(item->m_dragInitialPos);
+  item->grabMouse();
+
+  if (!getMaximized() && !DockingCheck::instance()->isEnabled())
+    calculateDockPlaceholders(item);
+
+  return true;
+}
+
+//------------------------------------------------------
+
+void DockLayout::tabifyItem(DockWidget *item, Region *region) {
+  if (!item || !region) return;
+  if (!canParticipateInTabGroup(item)) return;
+
+  item->onDock(true);
+  item->setDockedAppearance();
+  item->m_floating     = false;
+  item->m_wasFloating  = true;
+  item->setWindowFlags(Qt::SubWindow);
+
+  if (region->isTabbed()) {
+    region->m_tabItems.push_back(item);
+    region->m_activeTabIndex = region->m_tabItems.size() - 1;
+  } else {
+    DockWidget *existing = region->getItem();
+    if (!existing || existing == item) return;
+    if (!canParticipateInTabGroup(existing)) return;
+
+    region->m_tabItems.push_back(existing);
+    region->m_tabItems.push_back(item);
+    region->m_activeTabIndex = 1;
+    region->setItem(0);
+  }
+
+  region->m_item = region->activeTab();
+  ensureTabStrip(region);
+  updateTabVisibility(region);
+  item->show();
+}
+
+//------------------------------------------------------
+
+void DockLayout::tabifyWithTarget(DockWidget *item, DockWidget *target) {
+  if (!item || !target || item == target) return;
+  if (!canParticipateInTabGroup(item) || !canParticipateInTabGroup(target))
+    return;
+
+  Region *region = find(target);
+
+  // When the target is still floating, dock it beside the panel under its center.
+  if (!region && target->isFloating()) {
+    QPoint layoutPt =
+        parentWidget()->mapFromGlobal(target->geometry().center());
+    DockWidget *anchor = dynamic_cast<DockWidget *>(containerOf(layoutPt));
+    if (anchor && anchor != target) {
+      region = find(anchor);
+      if (region) {
+        if (find(target)) undockItem(target);
+        else {
+          target->onDock(true);
+          target->setDockedAppearance();
+          target->m_floating    = false;
+          target->m_wasFloating = true;
+          target->setWindowFlags(Qt::SubWindow);
+        }
+        tabifyItem(target, region);
+        region = find(target);
+      }
+    }
+
+    if (!region) {
+      dockItemPrivate(target, 0, 0);
+      region = find(target);
+    }
+  }
+
+  if (!region) return;
+
+  Region *itemRegion = find(item);
+  if (itemRegion == region) {
+    const std::vector<DockWidget *> &tabs = region->tabItems();
+    for (unsigned int t = 0; t < tabs.size(); ++t)
+      if (tabs[t] == item) return;
+  }
+
+  if (itemRegion) {
+    if (itemRegion->isTabbed())
+      removeFromTabGroup(item, itemRegion);
+    else if (itemRegion != region)
+      undockItem(item);
+  }
+
+  tabifyItem(item, region);
+  redistribute();
+  parentWidget()->repaint();
+}
+
+//------------------------------------------------------
+
+DockWidget *DockLayout::dockWidgetTitleBarAt(const QPoint &globalPos) const {
+  if (!parentWidget()) return 0;
+
+  for (int i = count() - 1; i >= 0; --i) {
+    DockWidget *dw = static_cast<DockWidget *>(itemAt(i)->widget());
+    if (!dw || !canParticipateInTabGroup(dw)) continue;
+
+    QPoint localPos = dw->mapFromGlobal(globalPos);
+    if (dw->rect().contains(localPos) && dw->isDragGrip(localPos)) return dw;
+  }
 
   return 0;
 }
@@ -679,6 +1154,31 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
     }
   }
 
+  // Hover-join placeholders on leaf regions (title bar / tab strip targets).
+  for (i = 0; i < m_regions.size(); ++i) {
+    Region *r = m_regions[i];
+    if (!r->getChildList().empty()) continue;
+    if (!r->getItem() && !r->isTabbed()) continue;
+    if (r->getItem() == item) continue;
+
+    DockWidget *targetWidget =
+        r->isTabbed() ? r->activeTab() : r->getItem();
+    if (!canParticipateInTabGroup(item) ||
+        !canParticipateInTabGroup(targetWidget))
+      continue;
+
+    bool alreadyMember = false;
+    if (r->isTabbed()) {
+      const std::vector<DockWidget *> &tabs = r->tabItems();
+      for (unsigned int t = 0; t < tabs.size(); ++t)
+        if (tabs[t] == item) alreadyMember = true;
+    }
+    if (alreadyMember) continue;
+
+    item->m_placeholders.push_back(item->m_decoAllocator->newPlaceBuilt(
+        item, r, 0, DockPlaceholder::tabify));
+  }
+
   // Disable all placeholders
   // for(i=0; i<item->m_placeholders.size(); ++i)
   //  item->m_placeholders[i]->setDisabled(true);
@@ -693,11 +1193,21 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
 void DockLayout::dockItem(DockWidget *item, DockPlaceholder *place) {
   place->hide();
   item->hide();
-  dockItemPrivate(item, place->m_region, place->m_idx);
-  redistribute();
+
+  if (place->getAttribute() == DockPlaceholder::tabify) {
+    Region *region = place->getParentRegion();
+    DockWidget *target =
+        region ? (region->isTabbed() ? region->activeTab() : region->getItem())
+               : 0;
+    if (target) tabifyWithTarget(item, target);
+  } else {
+    dockItemPrivate(item, place->m_region, place->m_idx);
+    redistribute();
+    item->setWindowFlags(Qt::SubWindow);
+    item->show();
+  }
+
   parentWidget()->repaint();
-  item->setWindowFlags(Qt::SubWindow);
-  item->show();
 }
 
 //------------------------------------------------------
@@ -796,6 +1306,7 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
 
 //! A region is empty, if contains no item and no children.
 static bool isEmptyRegion(Region *r) {
+  if (r->isTabbed()) return false;
   if ((!r->getItem()) && (r->getChildList().size() == 0)) {
     delete r;  // Well, it's a bit improper, but it works...
     return true;
@@ -874,6 +1385,9 @@ void Region::removeItem(DockWidget *item) {
 bool DockLayout::undockItem(DockWidget *item) {
   // Find item's region index in m_regions
   Region *itemCarrier = find(item);
+  if (!itemCarrier) return false;
+
+  if (itemCarrier->isTabbed()) return undockFromTabGroup(item, itemCarrier);
 
   Region *parent = itemCarrier->getParent();
   if (parent) {
@@ -1072,7 +1586,17 @@ void Region::calculateExtremalSizes() {
 int Region::calculateMinimumSize(bool direction, bool recalcChildren) {
   int sumMinSizes = 0, maxMinSizes = 0;
 
-  if (m_item) {
+  if (isTabbed()) {
+    unsigned int t;
+    int tabBarExtra = (direction == vertical) ? m_owner->tabStripHeight() : 0;
+    for (t = 0; t < m_tabItems.size(); ++t) {
+      int w = m_tabItems[t]->minimumSize().width();
+      int h = m_tabItems[t]->minimumSize().height();
+      if (maxMinSizes < (direction == horizontal ? w : h))
+        maxMinSizes = (direction == horizontal ? w : h);
+    }
+    sumMinSizes = maxMinSizes + tabBarExtra;
+  } else if (m_item) {
     sumMinSizes = maxMinSizes = (direction == horizontal)
                                     ? m_item->minimumSize().width()
                                     : m_item->minimumSize().height();
@@ -1114,7 +1638,17 @@ int Region::calculateMaximumSize(bool direction, bool recalcChildren) {
 
   int sumMaxSizes = 0, minMaxSizes = inf;
 
-  if (m_item) {
+  if (isTabbed()) {
+    unsigned int t;
+    int tabBarExtra = (direction == vertical) ? m_owner->tabStripHeight() : 0;
+    for (t = 0; t < m_tabItems.size(); ++t) {
+      int w = m_tabItems[t]->maximumSize().width();
+      int h = m_tabItems[t]->maximumSize().height();
+      if (minMaxSizes > (direction == horizontal ? w : h))
+        minMaxSizes = (direction == horizontal ? w : h);
+    }
+    sumMaxSizes = minMaxSizes + tabBarExtra;
+  } else if (m_item) {
     sumMaxSizes = minMaxSizes = (direction == horizontal)
                                     ? m_item->maximumSize().width()
                                     : m_item->maximumSize().height();
@@ -1404,6 +1938,16 @@ DockLayout::State DockLayout::saveState() {
 //------------------------------------------------------
 
 void DockLayout::writeRegion(Region *r, QString &hierarchy) {
+  if (r->isTabbed()) {
+    hierarchy.append("{ ");
+    const std::vector<DockWidget *> &tabs = r->tabItems();
+    for (unsigned int t = 0; t < tabs.size(); ++t)
+      hierarchy.append(QString::number(tabs[t]->m_saveIndex) + " ");
+    hierarchy.append("@" + QString::number(r->activeTabIndex()) + " ");
+    hierarchy.append("} ");
+    return;
+  }
+
   DockWidget *item = static_cast<DockWidget *>(r->getItem());
 
   // If Region has item, write it.
@@ -1462,6 +2006,32 @@ bool DockLayout::restoreState(const State &state) {
       if (vars[i] == "]") {
         // End region and get parent
         r = r->getParent();
+      } else if (vars[i] == "{") {
+        newRegion = new Region(this);
+        newHierarchy.push_back(newRegion);
+        newRegion->m_orientation = !orientation;
+        if (r) r->insertSubRegion(newRegion, r->getChildList().size());
+
+        std::vector<int> tabIndices;
+        int activeTab = 0;
+        ++i;
+        while (i < vars.size() && vars[i] != "}") {
+          if (vars[i].startsWith(QLatin1Char('@')))
+            activeTab = vars[i].mid(1).toInt();
+          else
+            tabIndices.push_back(vars[i].toInt());
+          ++i;
+        }
+
+        for (unsigned int t = 0; t < tabIndices.size(); ++t) {
+          DockWidget *tabItem = static_cast<DockWidget *>(
+              m_items[tabIndices[t]]->widget());
+          newRegion->m_tabItems.push_back(tabItem);
+        }
+        newRegion->m_activeTabIndex = activeTab;
+        if (newRegion->m_activeTabIndex >= (int)newRegion->m_tabItems.size())
+          newRegion->m_activeTabIndex = 0;
+        newRegion->m_item = newRegion->activeTab();
       } else {
         // Allocate new Region
         newRegion = new Region(this);
@@ -1514,14 +2084,28 @@ bool DockLayout::restoreState(const State &state) {
   }
 
   // Docked widgets are found in hierarchy
-  for (j = 0; j < m_regions.size(); ++j)
-    if ((item = m_regions[j]->m_item)) {
+  for (j = 0; j < m_regions.size(); ++j) {
+    Region *region = m_regions[j];
+    if (region->isTabbed()) {
+      const std::vector<DockWidget *> &tabs = region->tabItems();
+      for (unsigned int t = 0; t < tabs.size(); ++t) {
+        item = tabs[t];
+        item->setWindowFlags(Qt::SubWindow);
+        item->setDockedAppearance();
+        item->m_floating  = false;
+        item->m_saveIndex = -1;
+        item->show();
+      }
+      ensureTabStrip(region);
+      updateTabVisibility(region);
+    } else if ((item = region->m_item)) {
       item->setWindowFlags(Qt::SubWindow);
       item->setDockedAppearance();
       item->m_floating  = false;
       item->m_saveIndex = -1;
       item->show();
     }
+  }
 
   // Recover available geometry infos
   // QRect availableRect= QApplication::desktop()->availableGeometry();

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -276,6 +276,14 @@ void DockLayout::setMaximized(DockWidget *item, bool state) {
         item->m_maximized = true;
         m_maximizedDock   = item;
 
+        // If item is (or was) the active tab of a merged group, its own
+        // title bar is normally hidden in favor of the tab strip - which
+        // stays behind at the group's old, now-covered location. Without
+        // its own title bar shown while maximized, there is no visible/
+        // clickable spot left to double-click back to normal size (see
+        // the matching restore below).
+        restorePanelTitleBar(item);
+
         // Hide all the other docked widgets (no need to update them. Moreover,
         // doing so
         // could eventually result in painting over the newly maximized widget)
@@ -294,12 +302,19 @@ void DockLayout::setMaximized(DockWidget *item, bool state) {
       m_maximizedDock->m_maximized = false;
       m_maximizedDock              = 0;
 
-      // Show all other docked widgets
+      // Show docked widgets again, but keep inactive tabs in tab groups hidden.
       DockWidget *currWidget;
       for (int i = 0; i < count(); ++i) {
         currWidget = (DockWidget *)itemAt(i)->widget();
         if (currWidget != item && !currWidget->isFloating()) currWidget->show();
       }
+      refreshTabbedRegionsVisibility();
+
+      // If the un-maximized item still belongs to a merged tab group, hand
+      // its title bar back to being hidden in favor of the tab strip (see
+      // the matching show-on-maximize above) instead of leaving both
+      // visible on top of each other.
+      if (r && r->isTabbed()) updateTabVisibility(r);
     }
   }
 }
@@ -718,8 +733,8 @@ void DockLayout::ensureTabStrip(Region *region) {
 
     region->m_tabStrip =
         new DockTabStrip(this, region, region->m_tabStripContainer);
-    tabLayout->addWidget(region->m_tabStrip, 0);
-    tabLayout->addStretch(1);
+    // Let the strip fill the container so expanding tabs share width equally.
+    tabLayout->addWidget(region->m_tabStrip, 1);
 
     region->m_tabStripContainer->setFixedHeight(tabStripHeight());
     region->m_tabStripContainer->hide();
@@ -746,12 +761,18 @@ void DockLayout::updateTabVisibility(Region *region) {
   DockWidget *active                    = region->activeTab();
 
   for (unsigned int i = 0; i < tabs.size(); ++i) {
-    TDockWidget *tdw = qobject_cast<TDockWidget *>(tabs[i]);
+    DockWidget *tab = tabs[i];
+    tab->setDockedAppearance();
+
+    TDockWidget *tdw = qobject_cast<TDockWidget *>(tab);
     if (tdw && tdw->titleBarWidget())
       tdw->titleBarWidget()->setVisible(!tabbed);
 
     if (tabs[i] == active) {
-      if (tabbed) tabs[i]->show();
+      if (tabbed) {
+        tabs[i]->show();
+        tabs[i]->raise();
+      }
     } else if (tabbed) {
       tabs[i]->hide();
     }
@@ -834,6 +855,12 @@ void DockLayout::clearJoinHighlight() {
 
 void DockLayout::updateJoinHighlightGeometry() {
   if (!m_joinHighlight || !m_joinHighlightRegion || !parentWidget()) return;
+
+  // Show the full panel/region size that will actually result from the
+  // merge (matches the pre-tabify behavior), while the underlying hit-test
+  // placeholder (see DockPlaceholder::buildGeometry, tabify case) stays a
+  // narrow title/tab-strip band so it never overlaps the classic split
+  // drop zones. Only this visual frame is enlarged.
   const QRect local = toRect(m_joinHighlightRegion->getGeometry());
   m_joinHighlight->setGeometry(
       QRect(parentWidget()->mapToGlobal(local.topLeft()), local.size()));
@@ -841,18 +868,41 @@ void DockLayout::updateJoinHighlightGeometry() {
 
 //------------------------------------------------------
 
+void DockLayout::restorePanelTitleBar(DockWidget *item) {
+  if (!item) return;
+  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
+  if (tdw && tdw->titleBarWidget()) {
+    tdw->titleBarWidget()->setVisible(true);
+    tdw->titleBarWidget()->raise();
+  }
+}
+
+//------------------------------------------------------
+
 void DockLayout::restoreSingleDockedPanel(DockWidget *item) {
   if (!item) return;
-
-  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
-  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
 
   item->setWindowFlags(Qt::SubWindow);
   item->setDockedAppearance();
   item->m_floating = false;
   item->onDock(true);
+
+  // setWindowFlags can re-hide children on Windows; restore title last and
+  // force a visible, raised docked panel so it never stays grey/inert.
+  restorePanelTitleBar(item);
+  if (QLayout *l = item->layout()) l->activate();
   item->show();
+  item->raise();
   item->update();
+}
+
+//------------------------------------------------------
+
+void DockLayout::refreshTabbedRegionsVisibility() {
+  for (unsigned int i = 0; i < m_regions.size(); ++i) {
+    if (m_regions[i]->isTabbed()) updateTabVisibility(m_regions[i]);
+  }
+  applyGeometry();
 }
 
 //------------------------------------------------------
@@ -867,6 +917,12 @@ bool DockLayout::removeFromTabGroup(DockWidget *item, Region *region,
 
   int removedIndex = static_cast<int>(it - tabs.begin());
   tabs.erase(it);
+
+  // Always restore the removed panel's title bar; only undockFromTabGroup
+  // used to do this, leaving orphaned panels without a drag grip.
+  restorePanelTitleBar(item);
+  item->setDockedAppearance();
+  item->show();
 
   if (tabs.size() <= 1) {
     DockWidget *remaining = tabs.empty() ? 0 : tabs.front();
@@ -904,13 +960,15 @@ bool DockLayout::undockFromTabGroup(DockWidget *item, Region *region,
                                     bool deferStripDestroy) {
   if (!removeFromTabGroup(item, region, deferStripDestroy)) return false;
 
-  TDockWidget *tdw = qobject_cast<TDockWidget *>(item);
-  if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(true);
+  restorePanelTitleBar(item);
 
   item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
   item->setFloatingAppearance();
   item->m_floating = true;
   item->onDock(false);
+  // Title bar can be reset by setWindowFlags on Windows.
+  restorePanelTitleBar(item);
+
   setMaximized(item, false);
   redistribute();
   applyGeometry();
@@ -989,10 +1047,18 @@ void DockLayout::tabifyItem(DockWidget *item, Region *region) {
   if (!item || !region) return;
   if (!canParticipateInTabGroup(item)) return;
 
+  // Validate before mutating window flags / appearance so a failed join
+  // cannot leave the panel without a title bar or docked margins.
+  if (!region->isTabbed()) {
+    DockWidget *existing = region->getItem();
+    if (!existing || existing == item) return;
+    if (!canParticipateInTabGroup(existing)) return;
+  }
+
   item->onDock(true);
   item->setDockedAppearance();
-  item->m_floating     = false;
-  item->m_wasFloating  = true;
+  item->m_floating    = false;
+  item->m_wasFloating = true;
   item->setWindowFlags(Qt::SubWindow);
 
   if (region->isTabbed()) {
@@ -1000,8 +1066,9 @@ void DockLayout::tabifyItem(DockWidget *item, Region *region) {
     region->m_activeTabIndex = region->m_tabItems.size() - 1;
   } else {
     DockWidget *existing = region->getItem();
-    if (!existing || existing == item) return;
-    if (!canParticipateInTabGroup(existing)) return;
+    existing->setDockedAppearance();
+    existing->setWindowFlags(Qt::SubWindow);
+    existing->m_floating = false;
 
     region->m_tabItems.push_back(existing);
     region->m_tabItems.push_back(item);
@@ -1009,9 +1076,19 @@ void DockLayout::tabifyItem(DockWidget *item, Region *region) {
     region->setItem(0);
   }
 
+  // Hide title bars and normalize appearance for every member so switching
+  // tabs does not jump between top/bottom content offsets.
+  for (unsigned int t = 0; t < region->m_tabItems.size(); ++t) {
+    DockWidget *tab = region->m_tabItems[t];
+    tab->setDockedAppearance();
+    TDockWidget *tdw = qobject_cast<TDockWidget *>(tab);
+    if (tdw && tdw->titleBarWidget()) tdw->titleBarWidget()->setVisible(false);
+  }
+
   region->m_item = region->activeTab();
   ensureTabStrip(region);
   updateTabVisibility(region);
+  applyGeometry();
   item->show();
 }
 
@@ -1068,8 +1145,10 @@ void DockLayout::tabifyWithTarget(DockWidget *item, DockWidget *target) {
   }
 
   tabifyItem(item, region);
+  clearJoinHighlight();
   redistribute();
-  parentWidget()->repaint();
+  applyGeometry();
+  if (parentWidget()) parentWidget()->repaint();
 }
 
 //------------------------------------------------------
@@ -1232,6 +1311,7 @@ void DockLayout::dockItem(DockWidget *item, DockPlaceholder *place) {
     DockWidget *target =
         region ? (region->isTabbed() ? region->activeTab() : region->getItem())
                : 0;
+    clearJoinHighlight();
     if (target) tabifyWithTarget(item, target);
   } else {
     dockItemPrivate(item, place->m_region, place->m_idx);
@@ -1399,10 +1479,31 @@ void Region::removeItem(DockWidget *item) {
         if (parent) {
           Region *remainingSon = m_childList[0];
           if (!remainingSon->m_childList.size()) {
-            // remainingSon is a leaf: better keep this and move son's item and
-            // childList
-            setItem(remainingSon->getItem());
-            remainingSon->setItem(0);
+            if (remainingSon->isTabbed()) {
+              // remainingSon is itself a tab group, not a plain single-item
+              // leaf: absorb its whole tab-group state into `this` instead
+              // of just grabbing its active tab. Otherwise the other tabs
+              // and the live tab strip widget become an orphaned "zombie"
+              // Region that keeps lingering in DockLayout::m_regions (seen
+              // as a ghost duplicate/empty tab strip, vanished separators,
+              // and dangling pointers on further docking manipulation).
+              m_tabItems          = remainingSon->m_tabItems;
+              m_activeTabIndex    = remainingSon->m_activeTabIndex;
+              m_tabStrip          = remainingSon->m_tabStrip;
+              m_tabStripContainer = remainingSon->m_tabStripContainer;
+              m_item              = activeTab();
+              if (m_tabStrip) m_tabStrip->rebindRegion(this);
+
+              remainingSon->m_tabItems.clear();
+              remainingSon->m_tabStrip          = 0;
+              remainingSon->m_tabStripContainer = 0;
+              remainingSon->setItem(0);
+            } else {
+              // remainingSon is a plain leaf: better keep this and move
+              // son's item and childList
+              setItem(remainingSon->getItem());
+              remainingSon->setItem(0);
+            }
           } else {
             // remainingSon is a branch: append remainingSon childList to parent
             // one and sign this and remainingSon nodes for destruction.
@@ -2168,6 +2269,7 @@ bool DockLayout::restoreState(const State &state) {
       item->setDockedAppearance();
       item->m_floating  = false;
       item->m_saveIndex = -1;
+      restorePanelTitleBar(item);
       item->show();
     }
   }
@@ -2180,7 +2282,7 @@ bool DockLayout::restoreState(const State &state) {
   for (j = 0; j < m_items.size(); ++j) {
     item = static_cast<DockWidget *>(m_items[j]->widget());
 
-    if (item->m_saveIndex > 0) {
+    if (item->m_saveIndex >= 0) {
       // Ensure that floating panels are not placed in
       // unavailable positions
       if ((geoms[j] & QApplication::desktop()->availableGeometry(item))
@@ -2191,6 +2293,7 @@ bool DockLayout::restoreState(const State &state) {
       item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
       item->setFloatingAppearance();
       item->m_floating = true;
+      restorePanelTitleBar(item);
     }
   }
 

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -94,6 +94,14 @@ DockLayout::DockLayout()
 DockLayout::~DockLayout() {
   clearJoinHighlight();
   delete m_joinHighlight;
+  m_joinHighlight = 0;
+
+  // Dock widgets may outlive this layout during application shutdown. Clear
+  // their back-pointer so ~DockWidget does not call into a destroyed layout.
+  for (unsigned int i = 0; i < m_items.size(); ++i) {
+    if (DockWidget *dw = static_cast<DockWidget *>(m_items[i]->widget()))
+      dw->m_parentLayout = 0;
+  }
 
   // Deleting Regions (separators are Widgets with parent, so they are
   // recursively deleted)
@@ -314,14 +322,18 @@ void DockLayout::updateSeparatorCursors() {
   Region *r, *child;
 
   unsigned int i, j;
-  int k, jInt;
+  int jInt, k;
   for (i = 0; i < m_regions.size(); ++i) {
-    r                = m_regions[i];
+    r = m_regions[i];
+    if (r->isTabbed()) continue;
+
+    const unsigned int childCount = r->getChildList().size();
+    const unsigned int sepCount   = r->separators().size();
+    if (!childCount || !sepCount) continue;
+
     bool orientation = r->getOrientation();
 
     // If region geometry is minimal or maximal, its separators are blocked
-    // NOTE: If this update follows only from a dock/undock, this should be
-    // disabled 'til 'Otherwise'
     QSize size = toRect(r->getGeometry()).size();
     bool isExtremeSize =
         (orientation == Region::horizontal)
@@ -330,34 +342,34 @@ void DockLayout::updateSeparatorCursors() {
             : size.height() == r->getMinimumSize(Region::vertical) ||
                   size.height() == r->getMaximumSize(Region::vertical);
     if (isExtremeSize) {
-      for (j = 0; j < r->separators().size(); ++j)
-        r->separator(j)->setCursor(Qt::ArrowCursor);
+      for (j = 0; j < sepCount; ++j) r->separator(j)->setCursor(Qt::ArrowCursor);
       continue;
     }
 
-    // Otherwise...
-
     // Arrowize all separators as long as the preceding region has equal
     // maximum and minimum sizes
-    for (j = 0; j < r->getChildList().size(); ++j) {
+    for (j = 0; j < childCount; ++j) {
       child = r->childRegion(j);
 
       if (child->getMaximumSize(orientation) ==
-          child->getMinimumSize(orientation))
-        r->separator(j)->setCursor(Qt::ArrowCursor);
-      else
+          child->getMinimumSize(orientation)) {
+        if (j < sepCount) r->separator(j)->setCursor(Qt::ArrowCursor);
+      } else
         break;
     }
 
-    jInt = j;
+    jInt = static_cast<int>(j);
     // The same as above in reverse order
-    for (k = r->getChildList().size() - 1; k > jInt; --k) {
+    k = static_cast<int>(childCount) - 1;
+    for (; k > jInt; --k) {
       child = r->childRegion(k);
 
       if (child->getMaximumSize(orientation) ==
-          child->getMinimumSize(orientation))
-        r->separator(k - 1)->setCursor(Qt::ArrowCursor);
-      else
+          child->getMinimumSize(orientation)) {
+        const int sepIdx = k - 1;
+        if (sepIdx >= 0 && static_cast<unsigned int>(sepIdx) < sepCount)
+          r->separator(sepIdx)->setCursor(Qt::ArrowCursor);
+      } else
         break;
     }
 
@@ -365,7 +377,10 @@ void DockLayout::updateSeparatorCursors() {
     Qt::CursorShape shape = (orientation == Region::horizontal)
                                 ? Qt::SplitHCursor
                                 : Qt::SplitVCursor;
-    for (; jInt < k; ++jInt) r->separator(jInt)->setCursor(shape);
+    for (; jInt < k; ++jInt) {
+      if (static_cast<unsigned int>(jInt) < sepCount)
+        r->separator(jInt)->setCursor(shape);
+    }
   }
 }
 
@@ -400,6 +415,9 @@ void DockLayout::applyGeometry() {
           tabs[j]->setGeometry(contentRect);
           tabs[j]->show();
         } else {
+          // Keep hidden tabs aligned so switching tabs after restore does not
+          // jump, and saveState sees a consistent geometry next time.
+          tabs[j]->setGeometry(contentRect);
           tabs[j]->hide();
         }
       }
@@ -919,12 +937,21 @@ bool DockLayout::beginTabDragOut(DockWidget *item, Region *region,
 
   clearJoinHighlight();
 
-  // Destroy the hidden tab strip after this mouse handler returns.
+  // Destroy the hidden tab strip after this mouse handler returns. Detach
+  // ownership from the region first so Region::~Region and a late timer
+  // callback cannot both delete the same widget.
   if (!region->isTabbed() && region->m_tabStripContainer) {
-    Region *r = region;
-    QTimer::singleShot(0, [this, r]() {
-      if (!r->isTabbed() && r->m_tabStripContainer) destroyTabStrip(r);
-    });
+    TabBarContainter *stripContainer = region->m_tabStripContainer;
+    region->m_tabStripContainer      = 0;
+    region->m_tabStrip                 = 0;
+    stripContainer->hide();
+
+    QWidget *host = parentWidget();
+    if (host) {
+      QTimer::singleShot(0, host, [stripContainer]() { delete stripContainer; });
+    } else {
+      delete stripContainer;
+    }
   }
 
   item->show();
@@ -1077,6 +1104,12 @@ void DockLayout::calculateDockPlaceholders(DockWidget *item) {
   // If the DockLayout's owner widget is hidden, avoid
   if (!parentWidget()->isVisible()) return;
 
+  // Drop stale region references before deleting placeholder widgets.
+  for (unsigned int ri = 0; ri < m_regions.size(); ++ri)
+    m_regions[ri]->m_placeholders.clear();
+
+  item->clearDockPlaceholders();
+
   if (!m_regions.size()) {
     if (isPossibleInsertion(item, 0, 0)) {
       // Then insert a root placeholder only
@@ -1203,6 +1236,7 @@ void DockLayout::dockItem(DockWidget *item, DockPlaceholder *place) {
   } else {
     dockItemPrivate(item, place->m_region, place->m_idx);
     redistribute();
+    clearJoinHighlight();
     item->setWindowFlags(Qt::SubWindow);
     item->show();
   }
@@ -1253,6 +1287,29 @@ Region *DockLayout::dockItem(DockWidget *item, Region *r, int idx) {
 
 //------------------------------------------------------
 
+Region *DockLayout::detachTabGroupAsSubRegion(Region *region) {
+  if (!region || !region->isTabbed()) return 0;
+
+  Region *child = new Region(this);
+  child->m_tabItems.swap(region->m_tabItems);
+  child->m_activeTabIndex    = region->m_activeTabIndex;
+  child->m_tabStrip          = region->m_tabStrip;
+  child->m_tabStripContainer = region->m_tabStripContainer;
+  child->m_item              = child->activeTab();
+
+  region->m_tabItems.clear();
+  region->m_activeTabIndex    = 0;
+  region->m_tabStrip          = 0;
+  region->m_tabStripContainer = 0;
+  region->m_item              = 0;
+
+  if (child->m_tabStrip) child->m_tabStrip->rebindRegion(child);
+
+  return child;
+}
+
+//------------------------------------------------------
+
 // Internal docking function. Contains raw docking code, excluded reparenting
 // (setWindowFlags)  which may slow down a bit should be done only
 // after a redistribute() and a repaint() on real-time docking.
@@ -1281,6 +1338,14 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
     newRoot->insertSubRegion(m_regions[1], 0);
 
     r = newRoot;
+  } else if (r->isTabbed()) {
+    // Split-dock beside/above a tab group: move the whole group as one unit,
+    // not just the active tab (which would orphan the other tabs and corrupt
+    // the region tree).
+    Region *regionForTabs = detachTabGroupAsSubRegion(r);
+    regionForTabs->setSize(toRect(r->getGeometry()).size());
+    r->insertSubRegion(regionForTabs, 0);
+    m_regions.push_back(regionForTabs);
   } else if (r->getItem()) {
     // Then the Layout gets further subdived - r's item has to be moved
     Region *regionForOldItem = r->insertItem(r->getItem(), 0);
@@ -2139,6 +2204,19 @@ bool DockLayout::restoreState(const State &state) {
     }
   }
 
+  // Hidden tabs may have been saved with stale geometries from before they
+  // were merged. Align every tab in a group to the active tab before the
+  // region tree is rebuilt from leaf widget rects.
+  for (j = 0; j < m_regions.size(); ++j) {
+    Region *region = m_regions[j];
+    if (!region->isTabbed()) continue;
+    DockWidget *active = region->activeTab();
+    if (!active) continue;
+    const QRect ref = active->geometry();
+    const std::vector<DockWidget *> &tabs = region->tabItems();
+    for (unsigned int t = 0; t < tabs.size(); ++t) tabs[t]->setGeometry(ref);
+  }
+
   // Calculate regions' geometry starting from leaves (items)
   if (m_regions.size()) m_regions[0]->restoreGeometry();
 
@@ -2186,6 +2264,20 @@ bool DockLayout::restoreState(const State &state) {
 void Region::restoreGeometry() {
   // Applying a head-recursive algorithm to update the geometry of a Region
   // after those of its children have been updated
+  if (isTabbed()) {
+    DockWidget *active = activeTab();
+    if (!active) return;
+
+    // applyGeometry() stores panel widgets below the tab strip. Saved
+    // geometries therefore describe the content rect, not the full region.
+    // Expand upward so restore + applyGeometry land the strip and panels
+    // where they were when the layout was saved.
+    QRect g = active->geometry();
+    g.setTop(g.top() - m_owner->tabStripHeight());
+    setGeometry(g);
+    return;
+  }
+
   if (m_item) {
     // Place item's geometry
     setGeometry(m_item->geometry());

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -143,8 +143,7 @@ public:
   void setActiveTab(Region *region, int index);
   void reorderTab(Region *region, int fromIndex, int toIndex);
   bool detachTabForDrag(DockWidget *item, Region *region,
-                        const QPoint &globalPos,
-                        const QPoint &grabOffsetInTab);
+                        const QPoint &globalPos, const QPoint &grabOffsetInTab);
   void showTabMergePreview(Region *region);
   void hideTabMergePreview();
   DockWidget *dockWidgetTitleBarAt(const QPoint &globalPos) const;

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -7,6 +7,7 @@
 
 #include <QWidget>
 #include <QAction>
+#include <QPointer>
 
 #include <deque>
 #include <vector>
@@ -34,10 +35,22 @@ class DockPlaceholder;
 class DockSeparator;
 class DockDecoAllocator;
 class DockTabStrip;
-class DockJoinHighlight;
+class DockTabMergePreview;
 class TabBarContainter;
 
 class Region;
+
+//! Whether a tab strip widget can be destroyed right away, or only once the
+//! current event handler has returned (it may be the sender of that event).
+enum class StripDeletion { Immediate, Deferred };
+
+//! How much of the layout has to be recomputed once a dock operation has
+//! finished mutating the region tree.
+enum class LayoutUpdate {
+  Geometry,            //!< Re-apply known region geometries.
+  GeometryAndRepaint,  //!< ... and repaint the layout's parent widget.
+  Full                 //!< Recompute the partition, then apply and repaint.
+};
 
 //========================================================================
 
@@ -74,6 +87,8 @@ public:
   \sa DockWidget and DockSeparator classes.
 */
 class DVAPI DockLayout final : public QLayout {
+  friend class Region;  // Region routes tab strip deletion back to the layout
+
   std::vector<QLayoutItem *> m_items;
   std::deque<Region *> m_regions;
 
@@ -83,14 +98,16 @@ class DVAPI DockLayout final : public QLayout {
   // Decoration-related allocator (separators)
   DockDecoAllocator *m_decoAllocator;
 
-  DockJoinHighlight *m_joinHighlight;
-  Region *m_joinHighlightRegion;
+  DockTabMergePreview *m_tabMergePreview;
+  Region *m_tabMergeTargetRegion;
 
 public:
   DockLayout();
   virtual ~DockLayout();
 
-  static bool canParticipateInTabGroup(const DockWidget *widget);
+  //! Whether \b widget may be merged into a tab group. Panels can opt out
+  //! explicitly through the "canJoinDockTabs" property.
+  static bool supportsTabGrouping(const DockWidget *widget);
 
   // QLayout item handling (see Qt reference)
   int count(void) const override;
@@ -121,16 +138,15 @@ public:
   bool undockItem(DockWidget *item);
   void calculateDockPlaceholders(DockWidget *item);
 
-  // Hover-join (tabify) support
-  void tabifyItem(DockWidget *item, Region *region);
-  void tabifyWithTarget(DockWidget *item, DockWidget *target);
+  // Hover-join (tab group) support
+  void mergePanelsAsTabs(DockWidget *item, DockWidget *target);
   void setActiveTab(Region *region, int index);
-  void moveTab(Region *region, int fromIndex, int toIndex);
-  bool beginTabDragOut(DockWidget *item, Region *region,
-                       const QPoint &globalPos,
-                       const QPoint &grabOffsetInTab);
-  void setJoinHighlight(Region *region);
-  void clearJoinHighlight();
+  void reorderTab(Region *region, int fromIndex, int toIndex);
+  bool detachTabForDrag(DockWidget *item, Region *region,
+                        const QPoint &globalPos,
+                        const QPoint &grabOffsetInTab);
+  void showTabMergePreview(Region *region);
+  void hideTabMergePreview();
   DockWidget *dockWidgetTitleBarAt(const QPoint &globalPos) const;
   int tabStripHeight() const;
 
@@ -154,21 +170,35 @@ public:
 
 private:
   void applyGeometry();
+  void finishLayoutChange(LayoutUpdate update);
   inline void updateSeparatorCursors();
   Region *dockItemPrivate(DockWidget *item, Region *r, int idx);
 
   void ensureTabStrip(Region *region);
-  void destroyTabStrip(Region *region);
+  void destroyTabStrip(Region *region, StripDeletion deletion);
   void updateTabVisibility(Region *region);
-  void updateJoinHighlightGeometry();
+  void updateTabMergePreviewGeometry();
   void restorePanelTitleBar(DockWidget *item);
-  void restoreSingleDockedPanel(DockWidget *item);
-  void refreshTabbedRegionsVisibility();
+  void restoreDetachedPanelAppearance(DockWidget *item);
+  void normalizeSingleDockedPanel(DockWidget *item);
+  void normalizeTabGroupAppearance(Region *region);
+  void restoreDockedWidgetVisibility(DockWidget *keptVisible);
   Region *detachTabGroupAsSubRegion(Region *region);
   bool removeFromTabGroup(DockWidget *item, Region *region,
-                          bool deferStripDestroy = false);
+                          StripDeletion deletion);
   bool undockFromTabGroup(DockWidget *item, Region *region,
-                          bool deferStripDestroy = false);
+                          StripDeletion deletion);
+
+  // Steps of mergePanelsAsTabs(). These only mutate the region tree; the
+  // public operation performs the single closing layout update.
+  bool canMergeAsTabs(DockWidget *item, DockWidget *target) const;
+  Region *ensureDockedRegionForTarget(DockWidget *target);
+  bool detachPanelFromCurrentRegion(DockWidget *item, Region *destination);
+  void addPanelToTabGroup(DockWidget *item, Region *region);
+
+  // Placeholder helpers - called by calculateDockPlaceholders
+  void clearRegionPlaceholderReferences();
+  void addTabJoinTargets(DockWidget *item);
 
   // Insertion and removal check - called internally by dock/undockItem
   bool isPossibleInsertion(DockWidget *item, Region *parentRegion,
@@ -176,8 +206,11 @@ private:
   bool isPossibleRemoval(DockWidget *item, Region *parentRegion,
                          int removalIdx);
 
-  // Internal save function
+  // Internal save/restore functions
   void writeRegion(Region *r, QString &hierarchy);
+  bool parseTabGroup(const QStringList &tokens, int &pos, Region *region,
+                     std::vector<bool> &alreadyRestored) const;
+  void normalizeRestoredTabGeometries();
 };
 
 //========================================================================
@@ -240,11 +273,8 @@ protected:
 private:
   QPoint m_dragInitialPos;
   QPoint m_dragMouseInitialPos;
-  // Click offset relative to the title bar's (or drag grip's) own top-left,
-  // captured at press time. Used to re-anchor the panel precisely under the
-  // cursor right after a docked->floating transition, whose layout may shift
-  // the grip widget (e.g. a frame margin appearing around custom title
-  // bars).
+  // Click offset within the drag grip, captured at press time and used to
+  // re-anchor the panel under the cursor after a docked/floating transition.
   QPoint m_dragGripPressOffset;
 
   // Widget and Layout links
@@ -320,7 +350,7 @@ public:
 
   // Placeholders-related methods
   virtual void selectDockPlaceholder(QMouseEvent *me);
-  DockPlaceholder *tabifyPlaceholderAt(const QPoint &globalPos) const;
+  DockPlaceholder *tabJoinTargetAt(const QPoint &globalPos) const;
   void clearDockPlaceholders();
 
   // Decorations allocator
@@ -330,6 +360,9 @@ public:
   virtual void onDock(bool docked) {}
 
 private:
+  QWidget *dragGrip();
+  QPoint settledDragGripOffset();
+
   // Event handling
   // Basic events
   bool event(QEvent *e) override;
@@ -487,7 +520,9 @@ public:
     sepHor  = 4,
     sepVert = 5,
     root    = 6,
-    tabify  = 7
+    //! Hit area over a panel's title bar / tab strip, where a dragged panel
+    //! is merged as a tab instead of splitting the region.
+    tabJoinTarget = 7
   };
   int getAttribute() const { return m_attributes; }
   void setAttribute(int attribute) { m_attributes = attribute; }
@@ -554,11 +589,17 @@ class Region {
 
   int m_saveIndex;
 
-  // Tab group state (hover-join). Empty when the region hosts a single panel.
+  // Tab group membership. A group always holds at least two panels: a
+  // shorter list is normalized into a single-panel region by setTabGroup().
+  // Invariant: m_item is either the region's only panel, or - for a tab
+  // group - a mirror of the active tab, so that code walking leaf regions
+  // keeps seeing the panel that is actually on screen.
   std::vector<DockWidget *> m_tabItems;
   int m_activeTabIndex;
-  DockTabStrip *m_tabStrip;
-  TabBarContainter *m_tabStripContainer;
+  // The tab strip is a child widget of the layout's parent; the region only
+  // points at it. Deletion always goes through DockLayout::destroyTabStrip().
+  QPointer<DockTabStrip> m_tabStrip;
+  QPointer<TabBarContainter> m_tabStripContainer;
 
 public:
   Region(DockLayout *owner, DockWidget *item = 0)
@@ -566,14 +607,16 @@ public:
       , m_item(item)
       , m_parent(0)
       , m_orientation(0)
-      , m_activeTabIndex(0)
-      , m_tabStrip(0)
-      , m_tabStripContainer(0) {}
+      , m_activeTabIndex(0) {}
   ~Region();
 
   enum { inf = 1000000 };
   enum { horizontal = 0, vertical = 1 };
   enum { left = 0x1, right = 0x2, top = 0x4, bottom = 0x8 };
+
+  //! What a region holds. Transitions between these are performed only by
+  //! the setters below, so that the members backing them stay consistent.
+  enum class Content { Empty, SinglePanel, TabGroup, Split };
 
   // Getters - public
   bool getOrientation() const { return m_orientation; }
@@ -582,12 +625,17 @@ public:
   Region *getParent() const { return m_parent; }
   DockWidget *getItem() const { return m_item; }
 
-  bool isTabbed() const { return m_tabItems.size() > 1; }
+  Content content() const;
+  bool hasSinglePanel() const { return m_item && m_tabItems.empty(); }
+  bool hasTabGroup() const { return m_tabItems.size() > 1; }
+  bool hasChildren() const { return !m_childList.empty(); }
+
   const std::vector<DockWidget *> &tabItems() const { return m_tabItems; }
   int activeTabIndex() const { return m_activeTabIndex; }
   DockWidget *activeTab() const;
-  DockTabStrip *tabStrip() const { return m_tabStrip; }
-  TabBarContainter *tabStripContainer() const { return m_tabStripContainer; }
+  bool containsPanel(const DockWidget *panel) const;
+  DockTabStrip *tabStrip() const;
+  TabBarContainter *tabStripContainer() const;
 
   const std::deque<Region *> &getChildList() const { return m_childList; }
   Region *childRegion(int i) const { return m_childList[i]; }
@@ -610,6 +658,22 @@ private:
   void setSize(const QSizeF &size) { m_rect.setSize(size); }
   void setParent(Region *parent) { m_parent = parent; }
   void setItem(DockWidget *item) { m_item = item; }
+
+  // Tab group transitions. These are the only places where membership, the
+  // active index and the m_item mirror are updated together.
+  void setSinglePanel(DockWidget *panel);
+  void setTabGroup(const std::vector<DockWidget *> &panels, int activeIndex);
+  void appendTab(DockWidget *panel);
+  //! Returns the index the panel was removed from, or -1 if it was not a
+  //! member. The region falls back to a single panel when one tab is left.
+  int removeTab(DockWidget *panel);
+  void moveTab(int fromIndex, int toIndex);
+  void setActiveTabIndex(int index);
+  //! Moves membership, active tab and tab strip from \b source to \b this.
+  void adoptTabGroupFrom(Region *source);
+  void attachTabStrip(TabBarContainter *container, DockTabStrip *strip);
+  //! Gives up the tab strip without deleting it (see destroyTabStrip()).
+  void detachTabStrip();
 
   // Insertion and removal methods
   void insertSubRegion(Region *subregion, int idx);

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -162,6 +162,7 @@ private:
   void updateTabVisibility(Region *region);
   void updateJoinHighlightGeometry();
   void restoreSingleDockedPanel(DockWidget *item);
+  Region *detachTabGroupAsSubRegion(Region *region);
   bool removeFromTabGroup(DockWidget *item, Region *region,
                           bool deferStripDestroy = false);
   bool undockFromTabGroup(DockWidget *item, Region *region,

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -192,7 +192,6 @@ private:
   // Steps of mergePanelsAsTabs(). These only mutate the region tree; the
   // public operation performs the single closing layout update.
   bool canMergeAsTabs(DockWidget *item, DockWidget *target) const;
-  Region *ensureDockedRegionForTarget(DockWidget *target);
   bool detachPanelFromCurrentRegion(DockWidget *item, Region *destination);
   void addPanelToTabGroup(DockWidget *item, Region *region);
 
@@ -589,11 +588,9 @@ class Region {
 
   int m_saveIndex;
 
-  // Tab group membership. A group always holds at least two panels: a
-  // shorter list is normalized into a single-panel region by setTabGroup().
-  // Invariant: m_item is either the region's only panel, or - for a tab
-  // group - a mirror of the active tab, so that code walking leaf regions
-  // keeps seeing the panel that is actually on screen.
+  // A tab group holds at least two panels; setTabGroup() normalizes shorter
+  // lists into a single-panel region. Invariant: m_item mirrors the active
+  // tab, so code walking leaf regions still sees the panel on screen.
   std::vector<DockWidget *> m_tabItems;
   int m_activeTabIndex;
   // The tab strip is a child widget of the layout's parent; the region only

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -33,6 +33,9 @@ class DockWidget;
 class DockPlaceholder;
 class DockSeparator;
 class DockDecoAllocator;
+class DockTabStrip;
+class DockJoinHighlight;
+class TabBarContainter;
 
 class Region;
 
@@ -80,9 +83,14 @@ class DVAPI DockLayout final : public QLayout {
   // Decoration-related allocator (separators)
   DockDecoAllocator *m_decoAllocator;
 
+  DockJoinHighlight *m_joinHighlight;
+  Region *m_joinHighlightRegion;
+
 public:
   DockLayout();
   virtual ~DockLayout();
+
+  static bool canParticipateInTabGroup(const DockWidget *widget);
 
   // QLayout item handling (see Qt reference)
   int count(void) const override;
@@ -113,6 +121,19 @@ public:
   bool undockItem(DockWidget *item);
   void calculateDockPlaceholders(DockWidget *item);
 
+  // Hover-join (tabify) support
+  void tabifyItem(DockWidget *item, Region *region);
+  void tabifyWithTarget(DockWidget *item, DockWidget *target);
+  void setActiveTab(Region *region, int index);
+  void moveTab(Region *region, int fromIndex, int toIndex);
+  bool beginTabDragOut(DockWidget *item, Region *region,
+                       const QPoint &globalPos,
+                       const QPoint &grabOffsetInTab);
+  void setJoinHighlight(Region *region);
+  void clearJoinHighlight();
+  DockWidget *dockWidgetTitleBarAt(const QPoint &globalPos) const;
+  int tabStripHeight() const;
+
   // Query methods
   Region *rootRegion() const {
     return m_regions.size() ? m_regions.front() : 0;
@@ -135,6 +156,16 @@ private:
   void applyGeometry();
   inline void updateSeparatorCursors();
   Region *dockItemPrivate(DockWidget *item, Region *r, int idx);
+
+  void ensureTabStrip(Region *region);
+  void destroyTabStrip(Region *region);
+  void updateTabVisibility(Region *region);
+  void updateJoinHighlightGeometry();
+  void restoreSingleDockedPanel(DockWidget *item);
+  bool removeFromTabGroup(DockWidget *item, Region *region,
+                          bool deferStripDestroy = false);
+  bool undockFromTabGroup(DockWidget *item, Region *region,
+                          bool deferStripDestroy = false);
 
   // Insertion and removal check - called internally by dock/undockItem
   bool isPossibleInsertion(DockWidget *item, Region *parentRegion,
@@ -176,7 +207,7 @@ public:
       fixed = 1,     // to be used with setFixedWidth()
       sizeable = 2   // allow panel to be sizeable but doesn't auto resize
   };
-  int getFixWidthMode() { return m_modeFixWidth; }
+  int getFixWidthMode() const { return m_modeFixWidth; }
   void setFixWidthMode(int fixedmode) { m_modeFixWidth = fixedmode; }
 
 protected:
@@ -206,6 +237,12 @@ protected:
 private:
   QPoint m_dragInitialPos;
   QPoint m_dragMouseInitialPos;
+  // Click offset relative to the title bar's (or drag grip's) own top-left,
+  // captured at press time. Used to re-anchor the panel precisely under the
+  // cursor right after a docked->floating transition, whose layout may shift
+  // the grip widget (e.g. a frame margin appearing around custom title
+  // bars).
+  QPoint m_dragGripPressOffset;
 
   // Widget and Layout links
   DockLayout *m_parentLayout;
@@ -280,6 +317,7 @@ public:
 
   // Placeholders-related methods
   virtual void selectDockPlaceholder(QMouseEvent *me);
+  DockPlaceholder *tabifyPlaceholderAt(const QPoint &globalPos) const;
   void clearDockPlaceholders();
 
   // Decorations allocator
@@ -445,7 +483,8 @@ public:
     bottom  = 3,
     sepHor  = 4,
     sepVert = 5,
-    root    = 6
+    root    = 6,
+    tabify  = 7
   };
   int getAttribute() const { return m_attributes; }
   void setAttribute(int attribute) { m_attributes = attribute; }
@@ -495,7 +534,6 @@ class Region {
   friend class DockLayout;     // Layout is the main operating class over
                                // rectangular regions - need full access
   friend class DockSeparator;  // Separators need access to extremal sizes
-                               // methods when moving themselves
 
   DockLayout *m_owner;
   DockWidget *m_item;
@@ -513,9 +551,21 @@ class Region {
 
   int m_saveIndex;
 
+  // Tab group state (hover-join). Empty when the region hosts a single panel.
+  std::vector<DockWidget *> m_tabItems;
+  int m_activeTabIndex;
+  DockTabStrip *m_tabStrip;
+  TabBarContainter *m_tabStripContainer;
+
 public:
   Region(DockLayout *owner, DockWidget *item = 0)
-      : m_owner(owner), m_item(item), m_parent(0), m_orientation(0) {}
+      : m_owner(owner)
+      , m_item(item)
+      , m_parent(0)
+      , m_orientation(0)
+      , m_activeTabIndex(0)
+      , m_tabStrip(0)
+      , m_tabStripContainer(0) {}
   ~Region();
 
   enum { inf = 1000000 };
@@ -528,6 +578,13 @@ public:
   QSizeF getSize() const { return QSizeF(m_rect.width(), m_rect.height()); }
   Region *getParent() const { return m_parent; }
   DockWidget *getItem() const { return m_item; }
+
+  bool isTabbed() const { return m_tabItems.size() > 1; }
+  const std::vector<DockWidget *> &tabItems() const { return m_tabItems; }
+  int activeTabIndex() const { return m_activeTabIndex; }
+  DockWidget *activeTab() const;
+  DockTabStrip *tabStrip() const { return m_tabStrip; }
+  TabBarContainter *tabStripContainer() const { return m_tabStripContainer; }
 
   const std::deque<Region *> &getChildList() const { return m_childList; }
   Region *childRegion(int i) const { return m_childList[i]; }

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -161,7 +161,9 @@ private:
   void destroyTabStrip(Region *region);
   void updateTabVisibility(Region *region);
   void updateJoinHighlightGeometry();
+  void restorePanelTitleBar(DockWidget *item);
   void restoreSingleDockedPanel(DockWidget *item);
+  void refreshTabbedRegionsVisibility();
   Region *detachTabGroupAsSubRegion(Region *region);
   bool removeFromTabGroup(DockWidget *item, Region *region,
                           bool deferStripDestroy = false);

--- a/toonz/sources/toonzqt/docktabstrip.cpp
+++ b/toonz/sources/toonzqt/docktabstrip.cpp
@@ -323,8 +323,9 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
 //-------------------------------------
 
 void DockTabStrip::mouseReleaseEvent(QMouseEvent *event) {
-  const bool wasReorder = m_reordering && !m_dragOutStarted && m_pressIndex >= 0;
-  const bool wasClick   = !m_dragOutStarted && !m_reordering &&
+  const bool wasReorder =
+      m_reordering && !m_dragOutStarted && m_pressIndex >= 0;
+  const bool wasClick = !m_dragOutStarted && !m_reordering &&
                         m_pressIndex >= 0 && m_pressIndex < count();
 
   if (wasReorder) commitTabReorder();

--- a/toonz/sources/toonzqt/docktabstrip.cpp
+++ b/toonz/sources/toonzqt/docktabstrip.cpp
@@ -214,6 +214,7 @@ DockTabStrip::DockTabStrip(DockLayout *layout, Region *region, QWidget *parent)
     , m_pressIndex(-1)
     , m_dragOutStarted(false)
     , m_reordering(false)
+    , m_dropGapIndex(-1)
     , m_dimInactiveTabs(false) {
   setObjectName("DockTabStrip");
   setDrawBase(false);
@@ -321,18 +322,33 @@ void DockTabStrip::mouseDoubleClickEvent(QMouseEvent *event) {
 // text loses some contrast without any theme-specific color being assumed.
 void DockTabStrip::paintEvent(QPaintEvent *event) {
   QTabBar::paintEvent(event);
-  if (!m_dimInactiveTabs || !m_dimWashColor.isValid()) return;
 
   QPainter painter(this);
-  QColor wash = m_dimWashColor;
-  wash.setAlphaF(0.45);
-  const int current = currentIndex();
-  for (int i = 0; i < count(); ++i) {
-    if (i == current) continue;
-    QRect r = tabRect(i);
-    if (!r.isValid()) continue;
-    r.adjust(1, 1, -1, -1);
-    painter.fillRect(r, wash);
+  if (m_dimInactiveTabs && m_dimWashColor.isValid()) {
+    QColor wash = m_dimWashColor;
+    wash.setAlphaF(0.45);
+    const int current = currentIndex();
+    for (int i = 0; i < count(); ++i) {
+      if (i == current) continue;
+      QRect r = tabRect(i);
+      if (!r.isValid()) continue;
+      r.adjust(1, 1, -1, -1);
+      painter.fillRect(r, wash);
+    }
+  }
+
+  // Vertical insertion mark while reordering (gap before tab i, or after last).
+  if (m_reordering && m_dropGapIndex >= 0 && m_dropGapIndex <= count() &&
+      count() > 0) {
+    int x = 0;
+    if (m_dropGapIndex < count())
+      x = tabRect(m_dropGapIndex).left();
+    else
+      x = tabRect(count() - 1).right();
+
+    const int barW = 3;
+    QRect bar(x - barW / 2, 2, barW, height() - 4);
+    painter.fillRect(bar, dockThemeAccentColor());
   }
 }
 
@@ -360,6 +376,8 @@ void DockTabStrip::tryBeginDragOut(const QPoint &globalPos) {
   // once the panel shows its own title bar instead of the tab.
   const QPoint grabOffsetInTab = m_pressPos - tabRect(m_pressIndex).topLeft();
 
+  clearDropIndicator();
+  m_reordering     = false;
   m_dragOutStarted = true;
   releaseMouse();
 
@@ -371,13 +389,63 @@ void DockTabStrip::tryBeginDragOut(const QPoint &globalPos) {
 
 //-------------------------------------
 
+// Gap index under the cursor: 0 = before first tab, count() = after last.
+int DockTabStrip::dropGapAt(const QPoint &pos) const {
+  const int n = count();
+  if (n <= 0) return -1;
+
+  if (pos.x() < tabRect(0).center().x()) return 0;
+  for (int i = 0; i < n; ++i) {
+    const QRect r = tabRect(i);
+    if (!r.isValid()) continue;
+    if (pos.x() < r.center().x()) return i;
+  }
+  return n;
+}
+
+//-------------------------------------
+
+void DockTabStrip::setDropGapIndex(int gap) {
+  if (gap == m_dropGapIndex) return;
+  m_dropGapIndex = gap;
+  update();
+}
+
+//-------------------------------------
+
+void DockTabStrip::clearDropIndicator() {
+  if (m_dropGapIndex < 0) return;
+  m_dropGapIndex = -1;
+  update();
+}
+
+//-------------------------------------
+
+void DockTabStrip::commitTabReorder() {
+  if (!m_layout || !m_region || !m_reordering) return;
+  if (m_pressIndex < 0 || m_pressIndex >= count()) return;
+  if (m_dropGapIndex < 0 || m_dropGapIndex > count()) return;
+
+  // Dropping in the gaps immediately before/after the source is a no-op.
+  if (m_dropGapIndex == m_pressIndex || m_dropGapIndex == m_pressIndex + 1)
+    return;
+
+  // Convert insertion gap → destination index for moveTab (erase then insert).
+  int toIndex = m_dropGapIndex;
+  if (toIndex > m_pressIndex) --toIndex;
+  m_layout->moveTab(m_region, m_pressIndex, toIndex);
+}
+
+//-------------------------------------
+
 void DockTabStrip::mousePressEvent(QMouseEvent *event) {
   if (event->button() == Qt::LeftButton) {
-    m_pressIndex      = tabAt(event->pos());
-    m_pressPos        = event->pos();
-    m_globalPressPos  = event->globalPos();
-    m_dragOutStarted  = false;
-    m_reordering      = false;
+    m_pressIndex     = tabAt(event->pos());
+    m_pressPos       = event->pos();
+    m_globalPressPos = event->globalPos();
+    m_dragOutStarted = false;
+    m_reordering     = false;
+    clearDropIndicator();
 
     if (m_pressIndex >= 0) {
       grabMouse();
@@ -408,7 +476,7 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
         std::abs(delta.y()) > std::abs(delta.x());
 
     // Same spirit as docked title-bar undock: any significant move can detach.
-    // Horizontal moves inside the strip reorder tabs instead.
+    // Horizontal moves inside the strip preview a reorder instead.
     if (outsideStrip || verticalIntent) {
       tryBeginDragOut(event->globalPos());
       event->accept();
@@ -425,19 +493,17 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
       return;
     }
 
-    int srcIndex = m_pressIndex;
-    if (srcIndex < 0 || srcIndex >= count()) {
+    if (m_pressIndex < 0 || m_pressIndex >= count()) {
       QTabBar::mouseMoveEvent(event);
       return;
     }
 
-    int dstIndex = tabAt(event->pos());
-    if (dstIndex >= 0 && dstIndex < count() && dstIndex != srcIndex) {
-      QRect srcRect = tabRect(srcIndex);
-      int x         = event->pos().x();
-      if (x < srcRect.left() || x > srcRect.right())
-        m_layout->moveTab(m_region, srcIndex, dstIndex);
-    }
+    // Preview only: update the insertion bar, commit on mouse release.
+    const int gap = dropGapAt(event->pos());
+    if (gap == m_pressIndex || gap == m_pressIndex + 1)
+      clearDropIndicator();
+    else
+      setDropGapIndex(gap);
   }
 
   event->accept();
@@ -446,13 +512,18 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
 //-------------------------------------
 
 void DockTabStrip::mouseReleaseEvent(QMouseEvent *event) {
-  const bool wasClick =
-      !m_dragOutStarted && m_pressIndex >= 0 && m_pressIndex < count();
+  const bool wasReorder =
+      m_reordering && !m_dragOutStarted && m_pressIndex >= 0;
+  const bool wasClick = !m_dragOutStarted && !m_reordering &&
+                        m_pressIndex >= 0 && m_pressIndex < count();
+
+  if (wasReorder) commitTabReorder();
 
   releaseMouse();
 
   if (wasClick) setCurrentIndex(m_pressIndex);
 
+  clearDropIndicator();
   m_pressIndex     = -1;
   m_dragOutStarted = false;
   m_reordering     = false;

--- a/toonz/sources/toonzqt/docktabstrip.cpp
+++ b/toonz/sources/toonzqt/docktabstrip.cpp
@@ -3,12 +3,15 @@
 #include "docktabstrip.h"
 
 #include "docklayout.h"
+#include "toonzqt/gutil.h"
 
+#include <QApplication>
 #include <QImage>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPixmap>
 #include <QStyle>
+#include <QStyleOptionTab>
 #include <QStyleOptionToolButton>
 #include <QToolButton>
 #include <algorithm>
@@ -54,6 +57,123 @@ QColor dockThemeAccentColor() {
   return kFallback;
 }
 
+// QTabBar::initStyleOption() is protected; this tiny subclass exposes it
+// so the probe functions below can build a QStyleOptionTab that exactly
+// matches what the real tab bar would hand to the style/stylesheet.
+class ProbeTabBar final : public QTabBar {
+public:
+  using QTabBar::QTabBar;
+  void initOption(QStyleOptionTab *opt, int index) const {
+    initStyleOption(opt, index);
+  }
+};
+
+// Renders a single tab's text label through the live style/stylesheet onto
+// a transparent surface (CE_TabBarTabLabel paints only the label, not the
+// tab background), so the returned color is whatever the active theme
+// actually resolves for that state - no theme is ever assumed or hardcoded.
+QColor probeTabTextColor(ProbeTabBar &probe, int index) {
+  QStyleOptionTab opt;
+  probe.initOption(&opt, index);
+
+  QImage img(opt.rect.size(), QImage::Format_ARGB32_Premultiplied);
+  img.fill(Qt::transparent);
+  QPainter painter(&img);
+  painter.translate(-opt.rect.topLeft());
+  probe.style()->drawControl(QStyle::CE_TabBarTabLabel, &opt, &painter,
+                             &probe);
+  painter.end();
+
+  long long r = 0, g = 0, b = 0, n = 0;
+  for (int y = 0; y < img.height(); ++y) {
+    for (int x = 0; x < img.width(); ++x) {
+      const QColor c = img.pixelColor(x, y);
+      if (c.alpha() < 40) continue;  // skip anti-aliased/background pixels.
+      r += c.red();
+      g += c.green();
+      b += c.blue();
+      ++n;
+    }
+  }
+  if (n == 0) return QColor();
+  return QColor(int(r / n), int(g / n), int(b / n));
+}
+
+// Renders just a tab's background/border (CE_TabBarTabShape, no label)
+// through the live style, then samples a corner pixel far from any text -
+// this is the true background tone that theme paints for that tab, used as
+// the fallback wash color instead of any assumed/hardcoded value.
+QColor probeTabBackgroundColor(ProbeTabBar &probe, int index) {
+  QStyleOptionTab opt;
+  probe.initOption(&opt, index);
+
+  QImage img(opt.rect.size(), QImage::Format_ARGB32_Premultiplied);
+  img.fill(Qt::transparent);
+  QPainter painter(&img);
+  painter.translate(-opt.rect.topLeft());
+  probe.style()->drawControl(QStyle::CE_TabBarTabShape, &opt, &painter,
+                             &probe);
+  painter.end();
+
+  const int x = std::min(4, img.width() - 1);
+  const int y = std::max(img.height() - 4, 0);
+  const QColor sampled = img.pixelColor(x, y);
+  return sampled.alpha() > 0 ? sampled : QColor(Qt::transparent);
+}
+
+// Measures - by actually rendering through the live stylesheet, not by
+// assuming anything about any particular theme - whether the current theme
+// already gives a selected tab's text a visibly different color from an
+// unselected one. Bundled themes mostly do (dimmed alpha vs. opaque), but a
+// couple leave both states identical; this only kicks in for those, using a
+// wash color sampled from that same theme rather than a fixed hardcoded hue.
+struct TabTextContrast {
+  bool needsWash = false;
+  QColor washColor;
+};
+
+const TabTextContrast &dockTabTextContrast() {
+  static QString cachedStyleSheet;
+  static TabTextContrast cached;
+
+  const QString liveStyleSheet = qApp ? qApp->styleSheet() : QString();
+  if (!cachedStyleSheet.isNull() && liveStyleSheet == cachedStyleSheet)
+    return cached;
+  cachedStyleSheet = liveStyleSheet;
+
+  TabBarContainter container;
+  container.setAttribute(Qt::WA_DontShowOnScreen);
+  container.resize(160, 28);
+
+  ProbeTabBar probe(&container);
+  probe.setDrawBase(false);
+  probe.setDocumentMode(true);
+  probe.addTab(QStringLiteral("Ag"));
+  probe.addTab(QStringLiteral("Ag"));
+  probe.resize(160, 28);
+  probe.setCurrentIndex(0);  // Tab 0 selected, tab 1 is the plain state.
+  container.ensurePolished();
+  probe.ensurePolished();
+
+  const QColor selectedColor   = probeTabTextColor(probe, 0);
+  const QColor unselectedColor = probeTabTextColor(probe, 1);
+
+  if (!selectedColor.isValid() || !unselectedColor.isValid()) {
+    cached.needsWash = false;
+  } else {
+    const int distance = std::abs(selectedColor.red() - unselectedColor.red()) +
+                         std::abs(selectedColor.green() - unselectedColor.green()) +
+                         std::abs(selectedColor.blue() - unselectedColor.blue());
+    cached.needsWash = distance < 24;  // near-identical: theme doesn't dim.
+  }
+  // Wash toward the tab's own (unselected) background tone, sampled live,
+  // so the fallback still adapts to whatever theme triggered it.
+  const QColor bg = probeTabBackgroundColor(probe, 1);
+  cached.washColor = bg.alpha() > 0 ? bg : container.palette().color(QPalette::Window);
+
+  return cached;
+}
+
 }  // namespace
 
 const int DockTabStrip::kHeight              = 26;
@@ -93,12 +213,13 @@ DockTabStrip::DockTabStrip(DockLayout *layout, Region *region, QWidget *parent)
     , m_region(region)
     , m_pressIndex(-1)
     , m_dragOutStarted(false)
-    , m_reordering(false) {
+    , m_reordering(false)
+    , m_dimInactiveTabs(false) {
   setObjectName("DockTabStrip");
   setDrawBase(false);
   setDocumentMode(true);
   setMovable(false);
-  setExpanding(false);
+  setExpanding(true);
   setUsesScrollButtons(true);
   setElideMode(Qt::ElideRight);
 
@@ -136,21 +257,22 @@ void DockTabStrip::syncFromRegion() {
 
 //-------------------------------------
 
-// Dims inactive tab titles so the active tab (left at full theme opacity)
-// stands out clearly. Only the inactive color is overridden here, so the
-// active tab keeps whatever accent color the current theme's QSS assigns
-// to QTabBar::tab:selected (which may vary per theme).
+// Dim inactive tab titles with an opaque blend so Light/Neutral themes
+// (whose QSS forces solid black) still show a clear contrast. Alpha alone
+// is often ignored or invisible against light tab backgrounds.
 void DockTabStrip::updateTabTextColors() {
-  const int current = currentIndex();
-  for (int i = 0; i < count(); ++i) {
-    if (i == current) {
-      setTabTextColor(i, QColor());  // Reset override: use theme's :selected color.
-      continue;
-    }
-    QColor dimmed = palette().color(QPalette::WindowText);
-    dimmed.setAlphaF(0.6);
-    setTabTextColor(i, dimmed);
-  }
+  // The active theme's stylesheet always wins over setTabTextColor() for a
+  // styled #TabBarContainer QTabBar::tab, so this never fights the theme:
+  // it only measures (see dockTabTextContrast()) whether that theme's own
+  // :selected rule is actually visible, and if not, remembers a wash color
+  // - sampled from that same theme - for paintEvent() to apply as a subtle
+  // fallback. Themes that already differentiate are left untouched.
+  const TabTextContrast &contrast = dockTabTextContrast();
+  m_dimInactiveTabs                = contrast.needsWash;
+  m_dimWashColor                   = contrast.washColor;
+
+  for (int i = 0; i < count(); ++i) setTabTextColor(i, QColor());
+  update();
 }
 
 //-------------------------------------
@@ -159,6 +281,59 @@ void DockTabStrip::onCurrentChanged(int index) {
   updateTabTextColors();
   if (!m_layout || !m_region || index < 0 || m_dragOutStarted) return;
   m_layout->setActiveTab(m_region, index);
+}
+
+//-------------------------------------
+
+// Force every tab to share the strip's width equally (Qt's setExpanding
+// only scales sizeHint-based widths, which keeps long titles wide and short
+// ones squeezed). A floor keeps many tabs readable and lets the strip's
+// scroll buttons take over instead of shrinking tabs further.
+QSize DockTabStrip::tabSizeHint(int index) const {
+  QSize hint          = QTabBar::tabSizeHint(index);
+  const int tabCount  = count();
+  const int stripWidth = width();
+  if (tabCount > 0 && stripWidth > 0) {
+    const int minTabWidth = 60;
+    hint.setWidth(std::max(minTabWidth, stripWidth / tabCount));
+  }
+  return hint;
+}
+
+//-------------------------------------
+
+// Mirrors the standalone-panel title-bar double-click-to-maximize behavior
+// (see DockWidget::mouseDoubleClickEvent), since a tabbed panel's own title
+// bar is hidden and replaced by this strip.
+void DockTabStrip::mouseDoubleClickEvent(QMouseEvent *event) {
+  if (m_layout && m_region) {
+    if (DockWidget *active = m_region->activeTab())
+      m_layout->setMaximized(active, !active->isMaximized());
+  }
+  event->accept();
+}
+
+//-------------------------------------
+
+// Fallback for themes whose stylesheet does not itself distinguish a
+// selected tab's text from an unselected one (see dockTabTextContrast());
+// washes inactive tabs toward their own sampled background tone so their
+// text loses some contrast without any theme-specific color being assumed.
+void DockTabStrip::paintEvent(QPaintEvent *event) {
+  QTabBar::paintEvent(event);
+  if (!m_dimInactiveTabs || !m_dimWashColor.isValid()) return;
+
+  QPainter painter(this);
+  QColor wash = m_dimWashColor;
+  wash.setAlphaF(0.45);
+  const int current = currentIndex();
+  for (int i = 0; i < count(); ++i) {
+    if (i == current) continue;
+    QRect r = tabRect(i);
+    if (!r.isValid()) continue;
+    r.adjust(1, 1, -1, -1);
+    painter.fillRect(r, wash);
+  }
 }
 
 //-------------------------------------

--- a/toonz/sources/toonzqt/docktabstrip.cpp
+++ b/toonz/sources/toonzqt/docktabstrip.cpp
@@ -15,10 +15,8 @@ const int DockTabStrip::kUndockDragThreshold = 8;
 
 namespace {
 
-//! Accent color published by the active theme in its :TOONZCOLORS block, the
-//! same channel the icon colors go through. ThemeManager re-reads it whenever
-//! the stylesheet changes, so switching themes needs no restart. The fallback
-//! only ever applies to third-party themes written before the property.
+//! Accent color published by the active theme in its :TOONZCOLORS block,
+//! like the icon colors. The fallback covers themes that predate it.
 QColor themeAccentColor() {
   static const QColor fallback(0x4f, 0x7b, 0xc7);
   return ThemeManager::getInstance().getCustomPropertyColor("hl-color",
@@ -121,10 +119,8 @@ void DockTabStrip::onCurrentChanged(int index) {
 
 //-------------------------------------
 
-// Force every tab to share the strip's width equally (Qt's setExpanding
-// only scales sizeHint-based widths, which keeps long titles wide and short
-// ones squeezed). A floor keeps many tabs readable and lets the strip's
-// scroll buttons take over instead of shrinking tabs further.
+// Equal widths, which setExpanding() does not give: it scales the sizeHint,
+// so long titles stay wide. Below the floor the strip scrolls instead.
 QSize DockTabStrip::tabSizeHint(int index) const {
   QSize hint           = QTabBar::tabSizeHint(index);
   const int tabCount   = count();
@@ -291,7 +287,7 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
     const bool outsideStrip   = isOutsideTabStrip(event->globalPos());
     const bool verticalIntent = std::abs(delta.y()) > std::abs(delta.x());
 
-    // Same spirit as docked title-bar undock: any significant move can detach.
+    // Matches docked title-bar undock: any significant move detaches.
     // Horizontal moves inside the strip preview a reorder instead.
     if (outsideStrip || verticalIntent) {
       tryBeginDragOut(event->globalPos());

--- a/toonz/sources/toonzqt/docktabstrip.cpp
+++ b/toonz/sources/toonzqt/docktabstrip.cpp
@@ -5,187 +5,35 @@
 #include "docklayout.h"
 #include "toonzqt/gutil.h"
 
-#include <QApplication>
-#include <QImage>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QPixmap>
-#include <QStyle>
-#include <QStyleOptionTab>
-#include <QStyleOptionToolButton>
-#include <QToolButton>
 #include <algorithm>
 #include <cmath>
-
-namespace {
-
-// Samples the actual color the active theme paints for a checked/selected
-// tool button (e.g. the selected tool in the toolbar, or a selected preset
-// in the Brush Presets panel) so the hover-join frame always matches the
-// current theme's accent, whatever it is.
-QColor dockThemeAccentColor() {
-  static const QColor kFallback(0x7f, 0xdb, 0xfc);
-
-  static QToolButton *probe = 0;
-  if (!probe) {
-    probe = new QToolButton();
-    probe->setAttribute(Qt::WA_DontShowOnScreen);
-    probe->setCheckable(true);
-    probe->setChecked(true);
-    probe->setAutoRaise(false);
-    probe->resize(20, 20);
-  }
-
-  probe->style()->unpolish(probe);
-  probe->style()->polish(probe);
-  probe->ensurePolished();
-
-  QImage img(probe->size(), QImage::Format_ARGB32_Premultiplied);
-  img.fill(Qt::transparent);
-  QPainter painter(&img);
-  QStyleOptionToolButton opt;
-  opt.initFrom(probe);
-  opt.state |= QStyle::State_On | QStyle::State_Raised | QStyle::State_Enabled;
-  opt.rect = probe->rect();
-  probe->style()->drawComplexControl(QStyle::CC_ToolButton, &opt, &painter,
-                                     probe);
-  painter.end();
-
-  const QColor sampled = img.pixelColor(img.width() / 2, img.height() / 2);
-  if (sampled.alpha() > 0) return sampled;
-
-  return kFallback;
-}
-
-// QTabBar::initStyleOption() is protected; this tiny subclass exposes it
-// so the probe functions below can build a QStyleOptionTab that exactly
-// matches what the real tab bar would hand to the style/stylesheet.
-class ProbeTabBar final : public QTabBar {
-public:
-  using QTabBar::QTabBar;
-  void initOption(QStyleOptionTab *opt, int index) const {
-    initStyleOption(opt, index);
-  }
-};
-
-// Renders a single tab's text label through the live style/stylesheet onto
-// a transparent surface (CE_TabBarTabLabel paints only the label, not the
-// tab background), so the returned color is whatever the active theme
-// actually resolves for that state - no theme is ever assumed or hardcoded.
-QColor probeTabTextColor(ProbeTabBar &probe, int index) {
-  QStyleOptionTab opt;
-  probe.initOption(&opt, index);
-
-  QImage img(opt.rect.size(), QImage::Format_ARGB32_Premultiplied);
-  img.fill(Qt::transparent);
-  QPainter painter(&img);
-  painter.translate(-opt.rect.topLeft());
-  probe.style()->drawControl(QStyle::CE_TabBarTabLabel, &opt, &painter,
-                             &probe);
-  painter.end();
-
-  long long r = 0, g = 0, b = 0, n = 0;
-  for (int y = 0; y < img.height(); ++y) {
-    for (int x = 0; x < img.width(); ++x) {
-      const QColor c = img.pixelColor(x, y);
-      if (c.alpha() < 40) continue;  // skip anti-aliased/background pixels.
-      r += c.red();
-      g += c.green();
-      b += c.blue();
-      ++n;
-    }
-  }
-  if (n == 0) return QColor();
-  return QColor(int(r / n), int(g / n), int(b / n));
-}
-
-// Renders just a tab's background/border (CE_TabBarTabShape, no label)
-// through the live style, then samples a corner pixel far from any text -
-// this is the true background tone that theme paints for that tab, used as
-// the fallback wash color instead of any assumed/hardcoded value.
-QColor probeTabBackgroundColor(ProbeTabBar &probe, int index) {
-  QStyleOptionTab opt;
-  probe.initOption(&opt, index);
-
-  QImage img(opt.rect.size(), QImage::Format_ARGB32_Premultiplied);
-  img.fill(Qt::transparent);
-  QPainter painter(&img);
-  painter.translate(-opt.rect.topLeft());
-  probe.style()->drawControl(QStyle::CE_TabBarTabShape, &opt, &painter,
-                             &probe);
-  painter.end();
-
-  const int x = std::min(4, img.width() - 1);
-  const int y = std::max(img.height() - 4, 0);
-  const QColor sampled = img.pixelColor(x, y);
-  return sampled.alpha() > 0 ? sampled : QColor(Qt::transparent);
-}
-
-// Measures - by actually rendering through the live stylesheet, not by
-// assuming anything about any particular theme - whether the current theme
-// already gives a selected tab's text a visibly different color from an
-// unselected one. Bundled themes mostly do (dimmed alpha vs. opaque), but a
-// couple leave both states identical; this only kicks in for those, using a
-// wash color sampled from that same theme rather than a fixed hardcoded hue.
-struct TabTextContrast {
-  bool needsWash = false;
-  QColor washColor;
-};
-
-const TabTextContrast &dockTabTextContrast() {
-  static QString cachedStyleSheet;
-  static TabTextContrast cached;
-
-  const QString liveStyleSheet = qApp ? qApp->styleSheet() : QString();
-  if (!cachedStyleSheet.isNull() && liveStyleSheet == cachedStyleSheet)
-    return cached;
-  cachedStyleSheet = liveStyleSheet;
-
-  TabBarContainter container;
-  container.setAttribute(Qt::WA_DontShowOnScreen);
-  container.resize(160, 28);
-
-  ProbeTabBar probe(&container);
-  probe.setDrawBase(false);
-  probe.setDocumentMode(true);
-  probe.addTab(QStringLiteral("Ag"));
-  probe.addTab(QStringLiteral("Ag"));
-  probe.resize(160, 28);
-  probe.setCurrentIndex(0);  // Tab 0 selected, tab 1 is the plain state.
-  container.ensurePolished();
-  probe.ensurePolished();
-
-  const QColor selectedColor   = probeTabTextColor(probe, 0);
-  const QColor unselectedColor = probeTabTextColor(probe, 1);
-
-  if (!selectedColor.isValid() || !unselectedColor.isValid()) {
-    cached.needsWash = false;
-  } else {
-    const int distance = std::abs(selectedColor.red() - unselectedColor.red()) +
-                         std::abs(selectedColor.green() - unselectedColor.green()) +
-                         std::abs(selectedColor.blue() - unselectedColor.blue());
-    cached.needsWash = distance < 24;  // near-identical: theme doesn't dim.
-  }
-  // Wash toward the tab's own (unselected) background tone, sampled live,
-  // so the fallback still adapts to whatever theme triggered it.
-  const QColor bg = probeTabBackgroundColor(probe, 1);
-  cached.washColor = bg.alpha() > 0 ? bg : container.palette().color(QPalette::Window);
-
-  return cached;
-}
-
-}  // namespace
 
 const int DockTabStrip::kHeight              = 26;
 const int DockTabStrip::kUndockDragThreshold = 8;
 
+namespace {
+
+//! Accent color published by the active theme in its :TOONZCOLORS block, the
+//! same channel the icon colors go through. ThemeManager re-reads it whenever
+//! the stylesheet changes, so switching themes needs no restart. The fallback
+//! only ever applies to third-party themes written before the property.
+QColor themeAccentColor() {
+  static const QColor fallback(0x4f, 0x7b, 0xc7);
+  return ThemeManager::getInstance().getCustomPropertyColor("hl-color",
+                                                            fallback);
+}
+
+}  // namespace
+
 //========================================================
 
-DockJoinHighlight::DockJoinHighlight(QWidget *parent)
+DockTabMergePreview::DockTabMergePreview(QWidget *parent)
     : QWidget(parent, Qt::Tool | Qt::FramelessWindowHint |
                           Qt::WindowTransparentForInput |
                           Qt::WindowDoesNotAcceptFocus) {
-  setObjectName("DockJoinHighlight");
+  setObjectName("DockTabMergePreview");
   setAttribute(Qt::WA_TranslucentBackground);
   setAttribute(Qt::WA_ShowWithoutActivating);
   setAutoFillBackground(false);
@@ -193,14 +41,18 @@ DockJoinHighlight::DockJoinHighlight(QWidget *parent)
 
 //-------------------------------------
 
-void DockJoinHighlight::paintEvent(QPaintEvent *event) {
+QColor DockTabMergePreview::frameColor() const {
+  return m_frameColor.isValid() ? m_frameColor : themeAccentColor();
+}
+
+//-------------------------------------
+
+void DockTabMergePreview::paintEvent(QPaintEvent *event) {
   Q_UNUSED(event);
 
   QPainter painter(this);
   painter.setRenderHint(QPainter::Antialiasing);
-
-  QPen pen(dockThemeAccentColor(), 2);
-  painter.setPen(pen);
+  painter.setPen(QPen(frameColor(), 2));
   painter.setBrush(Qt::NoBrush);
   painter.drawRect(rect().adjusted(1, 1, -2, -2));
 }
@@ -214,8 +66,7 @@ DockTabStrip::DockTabStrip(DockLayout *layout, Region *region, QWidget *parent)
     , m_pressIndex(-1)
     , m_dragOutStarted(false)
     , m_reordering(false)
-    , m_dropGapIndex(-1)
-    , m_dimInactiveTabs(false) {
+    , m_insertionGapIndex(-1) {
   setObjectName("DockTabStrip");
   setDrawBase(false);
   setDocumentMode(true);
@@ -234,11 +85,18 @@ DockTabStrip::DockTabStrip(DockLayout *layout, Region *region, QWidget *parent)
 
 //-------------------------------------
 
+QColor DockTabStrip::insertionMarkerColor() const {
+  return m_insertionMarkerColor.isValid() ? m_insertionMarkerColor
+                                          : themeAccentColor();
+}
+
+//-------------------------------------
+
 void DockTabStrip::syncFromRegion() {
   blockSignals(true);
   while (count()) removeTab(0);
 
-  if (!m_region || !m_region->isTabbed()) {
+  if (!m_region || !m_region->hasTabGroup()) {
     blockSignals(false);
     return;
   }
@@ -252,34 +110,11 @@ void DockTabStrip::syncFromRegion() {
 
   setCurrentIndex(m_region->activeTabIndex());
   blockSignals(false);
-
-  updateTabTextColors();
-}
-
-//-------------------------------------
-
-// Dim inactive tab titles with an opaque blend so Light/Neutral themes
-// (whose QSS forces solid black) still show a clear contrast. Alpha alone
-// is often ignored or invisible against light tab backgrounds.
-void DockTabStrip::updateTabTextColors() {
-  // The active theme's stylesheet always wins over setTabTextColor() for a
-  // styled #TabBarContainer QTabBar::tab, so this never fights the theme:
-  // it only measures (see dockTabTextContrast()) whether that theme's own
-  // :selected rule is actually visible, and if not, remembers a wash color
-  // - sampled from that same theme - for paintEvent() to apply as a subtle
-  // fallback. Themes that already differentiate are left untouched.
-  const TabTextContrast &contrast = dockTabTextContrast();
-  m_dimInactiveTabs                = contrast.needsWash;
-  m_dimWashColor                   = contrast.washColor;
-
-  for (int i = 0; i < count(); ++i) setTabTextColor(i, QColor());
-  update();
 }
 
 //-------------------------------------
 
 void DockTabStrip::onCurrentChanged(int index) {
-  updateTabTextColors();
   if (!m_layout || !m_region || index < 0 || m_dragOutStarted) return;
   m_layout->setActiveTab(m_region, index);
 }
@@ -291,8 +126,8 @@ void DockTabStrip::onCurrentChanged(int index) {
 // ones squeezed). A floor keeps many tabs readable and lets the strip's
 // scroll buttons take over instead of shrinking tabs further.
 QSize DockTabStrip::tabSizeHint(int index) const {
-  QSize hint          = QTabBar::tabSizeHint(index);
-  const int tabCount  = count();
+  QSize hint           = QTabBar::tabSizeHint(index);
+  const int tabCount   = count();
   const int stripWidth = width();
   if (tabCount > 0 && stripWidth > 0) {
     const int minTabWidth = 60;
@@ -316,40 +151,28 @@ void DockTabStrip::mouseDoubleClickEvent(QMouseEvent *event) {
 
 //-------------------------------------
 
-// Fallback for themes whose stylesheet does not itself distinguish a
-// selected tab's text from an unselected one (see dockTabTextContrast());
-// washes inactive tabs toward their own sampled background tone so their
-// text loses some contrast without any theme-specific color being assumed.
 void DockTabStrip::paintEvent(QPaintEvent *event) {
   QTabBar::paintEvent(event);
 
+  if (!m_reordering) return;
+
   QPainter painter(this);
-  if (m_dimInactiveTabs && m_dimWashColor.isValid()) {
-    QColor wash = m_dimWashColor;
-    wash.setAlphaF(0.45);
-    const int current = currentIndex();
-    for (int i = 0; i < count(); ++i) {
-      if (i == current) continue;
-      QRect r = tabRect(i);
-      if (!r.isValid()) continue;
-      r.adjust(1, 1, -1, -1);
-      painter.fillRect(r, wash);
-    }
-  }
+  paintReorderInsertionMarker(painter);
+}
 
-  // Vertical insertion mark while reordering (gap before tab i, or after last).
-  if (m_reordering && m_dropGapIndex >= 0 && m_dropGapIndex <= count() &&
-      count() > 0) {
-    int x = 0;
-    if (m_dropGapIndex < count())
-      x = tabRect(m_dropGapIndex).left();
-    else
-      x = tabRect(count() - 1).right();
+//-------------------------------------
 
-    const int barW = 3;
-    QRect bar(x - barW / 2, 2, barW, height() - 4);
-    painter.fillRect(bar, dockThemeAccentColor());
-  }
+void DockTabStrip::paintReorderInsertionMarker(QPainter &painter) const {
+  if (m_insertionGapIndex < 0 || m_insertionGapIndex > count() || !count())
+    return;
+
+  const int x = m_insertionGapIndex < count()
+                    ? tabRect(m_insertionGapIndex).left()
+                    : tabRect(count() - 1).right();
+
+  const int markerWidth = 3;
+  painter.fillRect(QRect(x - markerWidth / 2, 2, markerWidth, height() - 4),
+                   insertionMarkerColor());
 }
 
 //-------------------------------------
@@ -376,12 +199,12 @@ void DockTabStrip::tryBeginDragOut(const QPoint &globalPos) {
   // once the panel shows its own title bar instead of the tab.
   const QPoint grabOffsetInTab = m_pressPos - tabRect(m_pressIndex).topLeft();
 
-  clearDropIndicator();
+  clearInsertionMarker();
   m_reordering     = false;
   m_dragOutStarted = true;
   releaseMouse();
 
-  if (m_layout->beginTabDragOut(item, region, globalPos, grabOffsetInTab))
+  if (m_layout->detachTabForDrag(item, region, globalPos, grabOffsetInTab))
     return;
 
   m_dragOutStarted = false;
@@ -389,12 +212,10 @@ void DockTabStrip::tryBeginDragOut(const QPoint &globalPos) {
 
 //-------------------------------------
 
-// Gap index under the cursor: 0 = before first tab, count() = after last.
-int DockTabStrip::dropGapAt(const QPoint &pos) const {
+int DockTabStrip::insertionGapAt(const QPoint &pos) const {
   const int n = count();
   if (n <= 0) return -1;
 
-  if (pos.x() < tabRect(0).center().x()) return 0;
   for (int i = 0; i < n; ++i) {
     const QRect r = tabRect(i);
     if (!r.isValid()) continue;
@@ -405,35 +226,32 @@ int DockTabStrip::dropGapAt(const QPoint &pos) const {
 
 //-------------------------------------
 
-void DockTabStrip::setDropGapIndex(int gap) {
-  if (gap == m_dropGapIndex) return;
-  m_dropGapIndex = gap;
+void DockTabStrip::setInsertionGapIndex(int gap) {
+  if (gap == m_insertionGapIndex) return;
+  m_insertionGapIndex = gap;
   update();
 }
 
 //-------------------------------------
 
-void DockTabStrip::clearDropIndicator() {
-  if (m_dropGapIndex < 0) return;
-  m_dropGapIndex = -1;
-  update();
-}
+void DockTabStrip::clearInsertionMarker() { setInsertionGapIndex(-1); }
 
 //-------------------------------------
 
 void DockTabStrip::commitTabReorder() {
   if (!m_layout || !m_region || !m_reordering) return;
   if (m_pressIndex < 0 || m_pressIndex >= count()) return;
-  if (m_dropGapIndex < 0 || m_dropGapIndex > count()) return;
+  if (m_insertionGapIndex < 0 || m_insertionGapIndex > count()) return;
 
   // Dropping in the gaps immediately before/after the source is a no-op.
-  if (m_dropGapIndex == m_pressIndex || m_dropGapIndex == m_pressIndex + 1)
+  if (m_insertionGapIndex == m_pressIndex ||
+      m_insertionGapIndex == m_pressIndex + 1)
     return;
 
-  // Convert insertion gap → destination index for moveTab (erase then insert).
-  int toIndex = m_dropGapIndex;
+  // Convert insertion gap into a destination index (erase, then insert).
+  int toIndex = m_insertionGapIndex;
   if (toIndex > m_pressIndex) --toIndex;
-  m_layout->moveTab(m_region, m_pressIndex, toIndex);
+  m_layout->reorderTab(m_region, m_pressIndex, toIndex);
 }
 
 //-------------------------------------
@@ -445,7 +263,7 @@ void DockTabStrip::mousePressEvent(QMouseEvent *event) {
     m_globalPressPos = event->globalPos();
     m_dragOutStarted = false;
     m_reordering     = false;
-    clearDropIndicator();
+    clearInsertionMarker();
 
     if (m_pressIndex >= 0) {
       grabMouse();
@@ -467,13 +285,11 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
   }
 
   const QPoint delta = event->globalPos() - m_globalPressPos;
-  const int distance =
-      std::max(std::abs(delta.x()), std::abs(delta.y()));
+  const int distance = std::max(std::abs(delta.x()), std::abs(delta.y()));
 
   if (distance >= kUndockDragThreshold) {
-    const bool outsideStrip = isOutsideTabStrip(event->globalPos());
-    const bool verticalIntent =
-        std::abs(delta.y()) > std::abs(delta.x());
+    const bool outsideStrip   = isOutsideTabStrip(event->globalPos());
+    const bool verticalIntent = std::abs(delta.y()) > std::abs(delta.x());
 
     // Same spirit as docked title-bar undock: any significant move can detach.
     // Horizontal moves inside the strip preview a reorder instead.
@@ -493,17 +309,16 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
       return;
     }
 
-    if (m_pressIndex < 0 || m_pressIndex >= count()) {
+    if (m_pressIndex >= count()) {
       QTabBar::mouseMoveEvent(event);
       return;
     }
 
-    // Preview only: update the insertion bar, commit on mouse release.
-    const int gap = dropGapAt(event->pos());
+    const int gap = insertionGapAt(event->pos());
     if (gap == m_pressIndex || gap == m_pressIndex + 1)
-      clearDropIndicator();
+      clearInsertionMarker();
     else
-      setDropGapIndex(gap);
+      setInsertionGapIndex(gap);
   }
 
   event->accept();
@@ -512,9 +327,8 @@ void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
 //-------------------------------------
 
 void DockTabStrip::mouseReleaseEvent(QMouseEvent *event) {
-  const bool wasReorder =
-      m_reordering && !m_dragOutStarted && m_pressIndex >= 0;
-  const bool wasClick = !m_dragOutStarted && !m_reordering &&
+  const bool wasReorder = m_reordering && !m_dragOutStarted && m_pressIndex >= 0;
+  const bool wasClick   = !m_dragOutStarted && !m_reordering &&
                         m_pressIndex >= 0 && m_pressIndex < count();
 
   if (wasReorder) commitTabReorder();
@@ -523,7 +337,7 @@ void DockTabStrip::mouseReleaseEvent(QMouseEvent *event) {
 
   if (wasClick) setCurrentIndex(m_pressIndex);
 
-  clearDropIndicator();
+  clearInsertionMarker();
   m_pressIndex     = -1;
   m_dragOutStarted = false;
   m_reordering     = false;

--- a/toonz/sources/toonzqt/docktabstrip.cpp
+++ b/toonz/sources/toonzqt/docktabstrip.cpp
@@ -1,0 +1,286 @@
+
+
+#include "docktabstrip.h"
+
+#include "docklayout.h"
+
+#include <QImage>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPixmap>
+#include <QStyle>
+#include <QStyleOptionToolButton>
+#include <QToolButton>
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+// Samples the actual color the active theme paints for a checked/selected
+// tool button (e.g. the selected tool in the toolbar, or a selected preset
+// in the Brush Presets panel) so the hover-join frame always matches the
+// current theme's accent, whatever it is.
+QColor dockThemeAccentColor() {
+  static const QColor kFallback(0x7f, 0xdb, 0xfc);
+
+  static QToolButton *probe = 0;
+  if (!probe) {
+    probe = new QToolButton();
+    probe->setAttribute(Qt::WA_DontShowOnScreen);
+    probe->setCheckable(true);
+    probe->setChecked(true);
+    probe->setAutoRaise(false);
+    probe->resize(20, 20);
+  }
+
+  probe->style()->unpolish(probe);
+  probe->style()->polish(probe);
+  probe->ensurePolished();
+
+  QImage img(probe->size(), QImage::Format_ARGB32_Premultiplied);
+  img.fill(Qt::transparent);
+  QPainter painter(&img);
+  QStyleOptionToolButton opt;
+  opt.initFrom(probe);
+  opt.state |= QStyle::State_On | QStyle::State_Raised | QStyle::State_Enabled;
+  opt.rect = probe->rect();
+  probe->style()->drawComplexControl(QStyle::CC_ToolButton, &opt, &painter,
+                                     probe);
+  painter.end();
+
+  const QColor sampled = img.pixelColor(img.width() / 2, img.height() / 2);
+  if (sampled.alpha() > 0) return sampled;
+
+  return kFallback;
+}
+
+}  // namespace
+
+const int DockTabStrip::kHeight              = 26;
+const int DockTabStrip::kUndockDragThreshold = 8;
+
+//========================================================
+
+DockJoinHighlight::DockJoinHighlight(QWidget *parent)
+    : QWidget(parent, Qt::Tool | Qt::FramelessWindowHint |
+                          Qt::WindowTransparentForInput |
+                          Qt::WindowDoesNotAcceptFocus) {
+  setObjectName("DockJoinHighlight");
+  setAttribute(Qt::WA_TranslucentBackground);
+  setAttribute(Qt::WA_ShowWithoutActivating);
+  setAutoFillBackground(false);
+}
+
+//-------------------------------------
+
+void DockJoinHighlight::paintEvent(QPaintEvent *event) {
+  Q_UNUSED(event);
+
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing);
+
+  QPen pen(dockThemeAccentColor(), 2);
+  painter.setPen(pen);
+  painter.setBrush(Qt::NoBrush);
+  painter.drawRect(rect().adjusted(1, 1, -2, -2));
+}
+
+//========================================================
+
+DockTabStrip::DockTabStrip(DockLayout *layout, Region *region, QWidget *parent)
+    : QTabBar(parent)
+    , m_layout(layout)
+    , m_region(region)
+    , m_pressIndex(-1)
+    , m_dragOutStarted(false)
+    , m_reordering(false) {
+  setObjectName("DockTabStrip");
+  setDrawBase(false);
+  setDocumentMode(true);
+  setMovable(false);
+  setExpanding(false);
+  setUsesScrollButtons(true);
+  setElideMode(Qt::ElideRight);
+
+  QFont tabFont = font();
+  tabFont.setBold(true);
+  setFont(tabFont);
+
+  connect(this, &QTabBar::currentChanged, this,
+          &DockTabStrip::onCurrentChanged);
+}
+
+//-------------------------------------
+
+void DockTabStrip::syncFromRegion() {
+  blockSignals(true);
+  while (count()) removeTab(0);
+
+  if (!m_region || !m_region->isTabbed()) {
+    blockSignals(false);
+    return;
+  }
+
+  const std::vector<DockWidget *> &tabs = m_region->tabItems();
+  for (unsigned int i = 0; i < tabs.size(); ++i) {
+    QString title = tabs[i]->windowTitle();
+    if (title.isEmpty()) title = tabs[i]->objectName();
+    addTab(title);
+  }
+
+  setCurrentIndex(m_region->activeTabIndex());
+  blockSignals(false);
+
+  updateTabTextColors();
+}
+
+//-------------------------------------
+
+// Dims inactive tab titles so the active tab (left at full theme opacity)
+// stands out clearly. Only the inactive color is overridden here, so the
+// active tab keeps whatever accent color the current theme's QSS assigns
+// to QTabBar::tab:selected (which may vary per theme).
+void DockTabStrip::updateTabTextColors() {
+  const int current = currentIndex();
+  for (int i = 0; i < count(); ++i) {
+    if (i == current) {
+      setTabTextColor(i, QColor());  // Reset override: use theme's :selected color.
+      continue;
+    }
+    QColor dimmed = palette().color(QPalette::WindowText);
+    dimmed.setAlphaF(0.6);
+    setTabTextColor(i, dimmed);
+  }
+}
+
+//-------------------------------------
+
+void DockTabStrip::onCurrentChanged(int index) {
+  updateTabTextColors();
+  if (!m_layout || !m_region || index < 0 || m_dragOutStarted) return;
+  m_layout->setActiveTab(m_region, index);
+}
+
+//-------------------------------------
+
+bool DockTabStrip::isOutsideTabStrip(const QPoint &globalPos) const {
+  QWidget *stripHost =
+      parentWidget() ? parentWidget() : const_cast<DockTabStrip *>(this);
+  const QRect hostRect(stripHost->mapToGlobal(QPoint(0, 0)), stripHost->size());
+  return !hostRect.contains(globalPos);
+}
+
+//-------------------------------------
+
+void DockTabStrip::tryBeginDragOut(const QPoint &globalPos) {
+  if (m_dragOutStarted || !m_layout || !m_region || m_pressIndex < 0 ||
+      m_pressIndex >= (int)m_region->tabItems().size())
+    return;
+
+  DockWidget *item = m_region->tabItems()[m_pressIndex];
+  Region *region   = m_region;
+
+  // Offset of the original click relative to the pressed tab's own
+  // top-left; reused after undock to keep the same relative grab point
+  // once the panel shows its own title bar instead of the tab.
+  const QPoint grabOffsetInTab = m_pressPos - tabRect(m_pressIndex).topLeft();
+
+  m_dragOutStarted = true;
+  releaseMouse();
+
+  if (m_layout->beginTabDragOut(item, region, globalPos, grabOffsetInTab))
+    return;
+
+  m_dragOutStarted = false;
+}
+
+//-------------------------------------
+
+void DockTabStrip::mousePressEvent(QMouseEvent *event) {
+  if (event->button() == Qt::LeftButton) {
+    m_pressIndex      = tabAt(event->pos());
+    m_pressPos        = event->pos();
+    m_globalPressPos  = event->globalPos();
+    m_dragOutStarted  = false;
+    m_reordering      = false;
+
+    if (m_pressIndex >= 0) {
+      grabMouse();
+      event->accept();
+      return;
+    }
+  }
+
+  QTabBar::mousePressEvent(event);
+}
+
+//-------------------------------------
+
+void DockTabStrip::mouseMoveEvent(QMouseEvent *event) {
+  if (!(event->buttons() & Qt::LeftButton) || m_pressIndex < 0 ||
+      m_dragOutStarted) {
+    QTabBar::mouseMoveEvent(event);
+    return;
+  }
+
+  const QPoint delta = event->globalPos() - m_globalPressPos;
+  const int distance =
+      std::max(std::abs(delta.x()), std::abs(delta.y()));
+
+  if (distance >= kUndockDragThreshold) {
+    const bool outsideStrip = isOutsideTabStrip(event->globalPos());
+    const bool verticalIntent =
+        std::abs(delta.y()) > std::abs(delta.x());
+
+    // Same spirit as docked title-bar undock: any significant move can detach.
+    // Horizontal moves inside the strip reorder tabs instead.
+    if (outsideStrip || verticalIntent) {
+      tryBeginDragOut(event->globalPos());
+      event->accept();
+      return;
+    }
+
+    if (!m_reordering) m_reordering = true;
+  }
+
+  if (m_reordering && !m_dragOutStarted) {
+    if (isOutsideTabStrip(event->globalPos())) {
+      tryBeginDragOut(event->globalPos());
+      event->accept();
+      return;
+    }
+
+    int srcIndex = m_pressIndex;
+    if (srcIndex < 0 || srcIndex >= count()) {
+      QTabBar::mouseMoveEvent(event);
+      return;
+    }
+
+    int dstIndex = tabAt(event->pos());
+    if (dstIndex >= 0 && dstIndex < count() && dstIndex != srcIndex) {
+      QRect srcRect = tabRect(srcIndex);
+      int x         = event->pos().x();
+      if (x < srcRect.left() || x > srcRect.right())
+        m_layout->moveTab(m_region, srcIndex, dstIndex);
+    }
+  }
+
+  event->accept();
+}
+
+//-------------------------------------
+
+void DockTabStrip::mouseReleaseEvent(QMouseEvent *event) {
+  const bool wasClick =
+      !m_dragOutStarted && m_pressIndex >= 0 && m_pressIndex < count();
+
+  releaseMouse();
+
+  if (wasClick) setCurrentIndex(m_pressIndex);
+
+  m_pressIndex     = -1;
+  m_dragOutStarted = false;
+  m_reordering     = false;
+
+  QTabBar::mouseReleaseEvent(event);
+}

--- a/toonz/sources/toonzqt/docktabstrip.h
+++ b/toonz/sources/toonzqt/docktabstrip.h
@@ -54,6 +54,7 @@ public:
 
   DockTabStrip(DockLayout *layout, Region *region, QWidget *parent);
   void syncFromRegion();
+  void rebindRegion(Region *region) { m_region = region; }
 
 public slots:
   void onCurrentChanged(int index);

--- a/toonz/sources/toonzqt/docktabstrip.h
+++ b/toonz/sources/toonzqt/docktabstrip.h
@@ -43,6 +43,12 @@ class DVAPI DockTabStrip final : public QTabBar {
   QPoint m_globalPressPos;
   bool m_dragOutStarted;
   bool m_reordering;
+  // Whether the active theme's own stylesheet fails to visually
+  // distinguish a selected tab's text from an unselected one (measured at
+  // runtime, see updateTabTextColors()), and if so, the tab's own sampled
+  // background tone used to wash its text down a bit.
+  bool m_dimInactiveTabs;
+  QColor m_dimWashColor;
 
   bool isOutsideTabStrip(const QPoint &globalPos) const;
   void tryBeginDragOut(const QPoint &globalPos);
@@ -63,6 +69,9 @@ protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
+  void mouseDoubleClickEvent(QMouseEvent *event) override;
+  void paintEvent(QPaintEvent *event) override;
+  QSize tabSizeHint(int index) const override;
 };
 
 #endif  // DOCKTABSTRIP_H

--- a/toonz/sources/toonzqt/docktabstrip.h
+++ b/toonz/sources/toonzqt/docktabstrip.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#ifndef DOCKTABSTRIP_H
+#define DOCKTABSTRIP_H
+
+#include "tcommon.h"
+
+#include <QTabBar>
+#include <QWidget>
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZQT_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+
+class DockLayout;
+class Region;
+class DockWidget;
+
+//! Frame drawn around a panel targeted by hover-join (theme accent color).
+class DVAPI DockJoinHighlight final : public QWidget {
+public:
+  explicit DockJoinHighlight(QWidget *parent);
+
+protected:
+  void paintEvent(QPaintEvent *event) override;
+};
+
+//! Tab bar shown above docked panels that have been merged via hover-join.
+//! Supports tab reordering (horizontal drag) and drag-out to float a panel.
+class DVAPI DockTabStrip final : public QTabBar {
+  Q_OBJECT
+
+  DockLayout *m_layout;
+  Region *m_region;
+  int m_pressIndex;
+  QPoint m_pressPos;
+  QPoint m_globalPressPos;
+  bool m_dragOutStarted;
+  bool m_reordering;
+
+  bool isOutsideTabStrip(const QPoint &globalPos) const;
+  void tryBeginDragOut(const QPoint &globalPos);
+  void updateTabTextColors();
+
+public:
+  static const int kHeight;
+  static const int kUndockDragThreshold;
+
+  DockTabStrip(DockLayout *layout, Region *region, QWidget *parent);
+  void syncFromRegion();
+
+public slots:
+  void onCurrentChanged(int index);
+
+protected:
+  void mousePressEvent(QMouseEvent *event) override;
+  void mouseMoveEvent(QMouseEvent *event) override;
+  void mouseReleaseEvent(QMouseEvent *event) override;
+};
+
+#endif  // DOCKTABSTRIP_H

--- a/toonz/sources/toonzqt/docktabstrip.h
+++ b/toonz/sources/toonzqt/docktabstrip.h
@@ -43,6 +43,9 @@ class DVAPI DockTabStrip final : public QTabBar {
   QPoint m_globalPressPos;
   bool m_dragOutStarted;
   bool m_reordering;
+  // Insertion gap while reordering: 0 .. count() (gap after last tab).
+  // -1 means no drop target / indicator hidden.
+  int m_dropGapIndex;
   // Whether the active theme's own stylesheet fails to visually
   // distinguish a selected tab's text from an unselected one (measured at
   // runtime, see updateTabTextColors()), and if so, the tab's own sampled
@@ -53,6 +56,10 @@ class DVAPI DockTabStrip final : public QTabBar {
   bool isOutsideTabStrip(const QPoint &globalPos) const;
   void tryBeginDragOut(const QPoint &globalPos);
   void updateTabTextColors();
+  int dropGapAt(const QPoint &pos) const;
+  void setDropGapIndex(int gap);
+  void clearDropIndicator();
+  void commitTabReorder();
 
 public:
   static const int kHeight;

--- a/toonz/sources/toonzqt/docktabstrip.h
+++ b/toonz/sources/toonzqt/docktabstrip.h
@@ -5,8 +5,11 @@
 
 #include "tcommon.h"
 
+#include <QColor>
 #include <QTabBar>
 #include <QWidget>
+
+class QPainter;
 
 #undef DVAPI
 #undef DVVAR
@@ -22,19 +25,32 @@ class DockLayout;
 class Region;
 class DockWidget;
 
-//! Frame drawn around a panel targeted by hover-join (theme accent color).
-class DVAPI DockJoinHighlight final : public QWidget {
+//! Frame previewing the region a dragged panel would be merged into as a
+//! tab. It defaults to the theme's accent color and can be overridden per
+//! theme through the "frameColor" stylesheet property.
+class DVAPI DockTabMergePreview final : public QWidget {
+  Q_OBJECT
+  Q_PROPERTY(QColor frameColor READ frameColor WRITE setFrameColor)
+
+  QColor m_frameColor;
+
 public:
-  explicit DockJoinHighlight(QWidget *parent);
+  explicit DockTabMergePreview(QWidget *parent);
+
+  QColor frameColor() const;
+  void setFrameColor(const QColor &color) { m_frameColor = color; }
 
 protected:
   void paintEvent(QPaintEvent *event) override;
 };
 
-//! Tab bar shown above docked panels that have been merged via hover-join.
-//! Supports tab reordering (horizontal drag) and drag-out to float a panel.
+//! Tab bar shown above docked panels that have been merged into a tab
+//! group. Supports tab reordering (horizontal drag) and drag-out to float a
+//! panel.
 class DVAPI DockTabStrip final : public QTabBar {
   Q_OBJECT
+  Q_PROPERTY(QColor insertionMarkerColor READ insertionMarkerColor WRITE
+                 setInsertionMarkerColor)
 
   DockLayout *m_layout;
   Region *m_region;
@@ -44,21 +60,16 @@ class DVAPI DockTabStrip final : public QTabBar {
   bool m_dragOutStarted;
   bool m_reordering;
   // Insertion gap while reordering: 0 .. count() (gap after last tab).
-  // -1 means no drop target / indicator hidden.
-  int m_dropGapIndex;
-  // Whether the active theme's own stylesheet fails to visually
-  // distinguish a selected tab's text from an unselected one (measured at
-  // runtime, see updateTabTextColors()), and if so, the tab's own sampled
-  // background tone used to wash its text down a bit.
-  bool m_dimInactiveTabs;
-  QColor m_dimWashColor;
+  // -1 means no drop target / marker hidden.
+  int m_insertionGapIndex;
+  QColor m_insertionMarkerColor;
 
   bool isOutsideTabStrip(const QPoint &globalPos) const;
   void tryBeginDragOut(const QPoint &globalPos);
-  void updateTabTextColors();
-  int dropGapAt(const QPoint &pos) const;
-  void setDropGapIndex(int gap);
-  void clearDropIndicator();
+  int insertionGapAt(const QPoint &pos) const;
+  void setInsertionGapIndex(int gap);
+  void clearInsertionMarker();
+  void paintReorderInsertionMarker(QPainter &painter) const;
   void commitTabReorder();
 
 public:
@@ -68,6 +79,11 @@ public:
   DockTabStrip(DockLayout *layout, Region *region, QWidget *parent);
   void syncFromRegion();
   void rebindRegion(Region *region) { m_region = region; }
+
+  QColor insertionMarkerColor() const;
+  void setInsertionMarkerColor(const QColor &color) {
+    m_insertionMarkerColor = color;
+  }
 
 public slots:
   void onCurrentChanged(int index);

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -150,10 +150,15 @@ DockWidget::~DockWidget() {
 //! Clears dock placeholders for this dockwidget. This is automatically called
 //! at drag ends.
 void DockWidget::clearDockPlaceholders() {
+  // Layout may already have been destroyed during application shutdown.
   if (m_parentLayout) m_parentLayout->clearJoinHighlight();
 
-  unsigned int i;
-  for (i = 0; i < m_placeholders.size(); ++i) delete m_placeholders[i];
+  // Placeholders are child widgets; hide first so a partially torn-down
+  // parent does not touch them again while we delete.
+  for (unsigned int i = 0; i < m_placeholders.size(); ++i) {
+    if (m_placeholders[i]) m_placeholders[i]->hide();
+  }
+  for (unsigned int i = 0; i < m_placeholders.size(); ++i) delete m_placeholders[i];
   m_placeholders.clear();
 }
 

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -151,7 +151,7 @@ DockWidget::~DockWidget() {
 //! at drag ends.
 void DockWidget::clearDockPlaceholders() {
   // Layout may already have been destroyed during application shutdown.
-  if (m_parentLayout) m_parentLayout->clearJoinHighlight();
+  if (m_parentLayout) m_parentLayout->hideTabMergePreview();
 
   // Placeholders are child widgets; hide first so a partially torn-down
   // parent does not touch them again while we delete.
@@ -295,18 +295,30 @@ void DockWidget::mousePressEvent(QMouseEvent *me) {
       // docked panel's screen position now so undock keeps the grab point.
       m_dragInitialPos = parentWidget()->mapToGlobal(m_dragInitialPos);
 
-      // Also remember the click offset relative to the drag grip's (title
-      // bar's) own top-left. Once undocked, the appearance transition may
-      // shift the grip within the panel (e.g. a frame margin appears around
-      // custom title bars); recomputing the anchor from this offset - using
-      // the grip's *actual* position right after the transition - keeps the
-      // exact clicked pixel glued to the cursor with no drift.
-      QWidget *grip = this;
-      if (TDockWidget *tdw = qobject_cast<TDockWidget *>(this))
-        if (QWidget *titleBar = tdw->titleBarWidget()) grip = titleBar;
-      m_dragGripPressOffset = me->globalPos() - grip->mapToGlobal(QPoint(0, 0));
+      m_dragGripPressOffset =
+          me->globalPos() - dragGrip()->mapToGlobal(QPoint(0, 0));
     }
   }
+}
+
+//-------------------------------------
+
+QWidget *DockWidget::dragGrip() {
+  if (TDockWidget *tdw = qobject_cast<TDockWidget *>(this))
+    if (QWidget *titleBar = tdw->titleBarWidget()) return titleBar;
+  return this;
+}
+
+//-------------------------------------
+
+//! Offset of the drag grip inside the panel, measured once the pending
+//! docked/floating appearance change has actually been laid out: the custom
+//! title bar may end up shifted by a frame margin that only exists in one of
+//! the two states, and assuming a fixed margin makes the panel jump under
+//! the cursor.
+QPoint DockWidget::settledDragGripOffset() {
+  if (QLayout *l = layout()) l->activate();
+  return dragGrip()->mapToGlobal(QPoint(0, 0)) - mapToGlobal(QPoint(0, 0));
 }
 
 //-------------------------------------
@@ -360,21 +372,8 @@ void DockWidget::mouseMoveEvent(QMouseEvent *me) {
         // NOTE: mouse *must* be grabbed only when visible - see Qt manual.
         grabMouse();
 
-        // The panel's floating appearance (custom title bar + frame margin)
-        // is only fully in place once its layout has been activated. Read
-        // the drag grip's *actual*, current position afterwards - rather
-        // than assuming a fixed margin - so the pixel grabbed at press time
-        // lands right back under the cursor, however the transition shifted
-        // things.
-        if (QLayout *l = layout()) l->activate();
-        QWidget *grip = this;
-        if (TDockWidget *tdw = qobject_cast<TDockWidget *>(this))
-          if (QWidget *titleBar = tdw->titleBarWidget()) grip = titleBar;
-        const QPoint gripOffsetInWidget =
-            grip->mapToGlobal(QPoint(0, 0)) - mapToGlobal(QPoint(0, 0));
-
-        m_dragInitialPos =
-            correctedGlobalPos - m_dragGripPressOffset - gripOffsetInWidget;
+        m_dragInitialPos = correctedGlobalPos - m_dragGripPressOffset -
+                           settledDragGripOffset();
         m_dragMouseInitialPos = correctedGlobalPos;
         move(m_dragInitialPos);
 
@@ -397,12 +396,10 @@ void DockWidget::mouseReleaseEvent(QMouseEvent *me) {
     m_dragging = false;
 
     if (m_floating && m_selectedPlace) {
-      if (m_selectedPlace->getAttribute() == DockPlaceholder::tabify) {
+      if (m_selectedPlace->getAttribute() == DockPlaceholder::tabJoinTarget) {
         Region *region = m_selectedPlace->getParentRegion();
-        DockWidget *target =
-            region ? (region->isTabbed() ? region->activeTab() : region->getItem())
-                   : 0;
-        if (target) m_parentLayout->tabifyWithTarget(this, target);
+        DockWidget *target = region ? region->activeTab() : 0;
+        if (target) m_parentLayout->mergePanelsAsTabs(this, target);
       } else {
         m_parentLayout->dockItem(this, m_selectedPlace);
       }
@@ -410,7 +407,7 @@ void DockWidget::mouseReleaseEvent(QMouseEvent *me) {
       DockWidget *titleTarget =
           m_parentLayout->dockWidgetTitleBarAt(me->globalPos());
       if (titleTarget && titleTarget != this)
-        m_parentLayout->tabifyWithTarget(this, titleTarget);
+        m_parentLayout->mergePanelsAsTabs(this, titleTarget);
     }
 
     // Clear dock placeholders
@@ -535,34 +532,33 @@ DockPlaceholder *DockWidget::placeOfSeparator(DockSeparator *sep) {
 void DockWidget::selectDockPlaceholder(QMouseEvent *me) {
   DockPlaceholder *selected = 0;
 
-  // Classic split docking has priority over hover-join (top/bottom/left/right).
+  // Classic split docking takes precedence: its drop zones are what users
+  // expect from the borders of a panel, tab joining only fills the gap.
   unsigned int i;
   for (i = 0; i < m_placeholders.size(); ++i) {
-    if (m_placeholders[i]->getAttribute() == DockPlaceholder::tabify) continue;
-    if (m_placeholders[i]->geometry().contains(me->globalPos())) {
+    if (m_placeholders[i]->getAttribute() == DockPlaceholder::tabJoinTarget)
+      continue;
+    if (m_placeholders[i]->geometry().contains(me->globalPos()))
       selected = m_placeholders[i];
-    }
   }
 
-  if (!selected) selected = tabifyPlaceholderAt(me->globalPos());
+  const bool joining = !selected;
+  if (joining) selected = tabJoinTargetAt(me->globalPos());
 
-  // Never show a split deco and a join highlight at the same time.
   if (m_selectedPlace != selected) {
     if (m_selectedPlace) m_selectedPlace->hide();
-    if (selected && selected->getAttribute() != DockPlaceholder::tabify)
-      selected->show();
+    if (selected && !joining) selected->show();
   }
 
   if (m_parentLayout) {
-    if (selected && selected->getAttribute() == DockPlaceholder::tabify) {
-      // Hide any leftover visible split deco before drawing the join band.
+    if (joining && selected) {
       for (i = 0; i < m_placeholders.size(); ++i) {
-        if (m_placeholders[i]->getAttribute() != DockPlaceholder::tabify)
+        if (m_placeholders[i]->getAttribute() != DockPlaceholder::tabJoinTarget)
           m_placeholders[i]->hide();
       }
-      m_parentLayout->setJoinHighlight(selected->getParentRegion());
+      m_parentLayout->showTabMergePreview(selected->getParentRegion());
     } else {
-      m_parentLayout->clearJoinHighlight();
+      m_parentLayout->hideTabMergePreview();
     }
   }
 
@@ -571,11 +567,10 @@ void DockWidget::selectDockPlaceholder(QMouseEvent *me) {
 
 //-------------------------------------
 
-DockPlaceholder *DockWidget::tabifyPlaceholderAt(
-    const QPoint &globalPos) const {
-  unsigned int i;
-  for (i = 0; i < m_placeholders.size(); ++i) {
-    if (m_placeholders[i]->getAttribute() != DockPlaceholder::tabify) continue;
+DockPlaceholder *DockWidget::tabJoinTargetAt(const QPoint &globalPos) const {
+  for (unsigned int i = 0; i < m_placeholders.size(); ++i) {
+    if (m_placeholders[i]->getAttribute() != DockPlaceholder::tabJoinTarget)
+      continue;
     if (m_placeholders[i]->geometry().contains(globalPos))
       return m_placeholders[i];
   }
@@ -622,14 +617,14 @@ inline void DockPlaceholder::buildGeometry() {
       // QPoint center= parentRect.center();
       // relativeToMainRect= QRect(center - QPoint(50,50), center +
       // QPoint(50,50));
-    } else if (getAttribute() == tabify) {
+    } else if (getAttribute() == tabJoinTarget) {
       Region *region = getParentRegion();
-      int top         = parentRect.top();
-      int left        = parentRect.left();
-      int width       = parentRect.width();
-      int height      = 24;
+      int top        = parentRect.top();
+      int left       = parentRect.left();
+      int width      = parentRect.width();
+      int height     = 24;
 
-      if (region && region->isTabbed()) {
+      if (region && region->hasTabGroup()) {
         height = m_owner->parentLayout()->tabStripHeight();
       } else {
         TDockWidget *target =

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -158,7 +158,8 @@ void DockWidget::clearDockPlaceholders() {
   for (unsigned int i = 0; i < m_placeholders.size(); ++i) {
     if (m_placeholders[i]) m_placeholders[i]->hide();
   }
-  for (unsigned int i = 0; i < m_placeholders.size(); ++i) delete m_placeholders[i];
+  for (unsigned int i = 0; i < m_placeholders.size(); ++i)
+    delete m_placeholders[i];
   m_placeholders.clear();
 }
 
@@ -395,7 +396,7 @@ void DockWidget::mouseReleaseEvent(QMouseEvent *me) {
 
     if (m_floating && m_selectedPlace) {
       if (m_selectedPlace->getAttribute() == DockPlaceholder::tabJoinTarget) {
-        Region *region = m_selectedPlace->getParentRegion();
+        Region *region     = m_selectedPlace->getParentRegion();
         DockWidget *target = region ? region->activeTab() : 0;
         if (target) m_parentLayout->mergePanelsAsTabs(this, target);
       } else {

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -3,6 +3,7 @@
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
 #include "docklayout.h"
+#include "tdockwindows.h"
 
 // Qt includes
 #include <QEvent>
@@ -149,6 +150,8 @@ DockWidget::~DockWidget() {
 //! Clears dock placeholders for this dockwidget. This is automatically called
 //! at drag ends.
 void DockWidget::clearDockPlaceholders() {
+  if (m_parentLayout) m_parentLayout->clearJoinHighlight();
+
   unsigned int i;
   for (i = 0; i < m_placeholders.size(); ++i) delete m_placeholders[i];
   m_placeholders.clear();
@@ -283,7 +286,20 @@ void DockWidget::mousePressEvent(QMouseEvent *me) {
         m_parentLayout->calculateDockPlaceholders(this);
     } else {
       if (!lock->isEnabled()) m_undocking = true;
+      // Floating Tool windows use screen coords for pos()/move(); capture the
+      // docked panel's screen position now so undock keeps the grab point.
       m_dragInitialPos = parentWidget()->mapToGlobal(m_dragInitialPos);
+
+      // Also remember the click offset relative to the drag grip's (title
+      // bar's) own top-left. Once undocked, the appearance transition may
+      // shift the grip within the panel (e.g. a frame margin appears around
+      // custom title bars); recomputing the anchor from this offset - using
+      // the grip's *actual* position right after the transition - keeps the
+      // exact clicked pixel glued to the cursor with no drift.
+      QWidget *grip = this;
+      if (TDockWidget *tdw = qobject_cast<TDockWidget *>(this))
+        if (QWidget *titleBar = tdw->titleBarWidget()) grip = titleBar;
+      m_dragGripPressOffset = me->globalPos() - grip->mapToGlobal(QPoint(0, 0));
     }
   }
 }
@@ -319,6 +335,8 @@ void DockWidget::mouseMoveEvent(QMouseEvent *me) {
 
     m_dragMouseInitialPos = correctedGlobalPos;
   } else if (m_dragging) {
+    // Qt::Tool floating panels: pos()/move() are in screen coordinates.
+    // Do not map through parentWidget() — that caused the title-bar grab jump.
     move(m_dragInitialPos + correctedGlobalPos - m_dragMouseInitialPos);
     selectDockPlaceholder(me);
   } else if (m_undocking) {
@@ -330,15 +348,30 @@ void DockWidget::mouseMoveEvent(QMouseEvent *me) {
       if (m_parentLayout->undockItem(this)) {
         m_dragging = true;
 
-        // Then, move dock widget under cursor, as if drag actually begun at
-        // button press.
-        move(m_dragInitialPos + correctedGlobalPos - m_dragMouseInitialPos);
         show();  // Dock widget is not automatically shown after undock.
 
         // Re-grab mouse inputs. Seems that making the window float (i.e.:
         // reparenting) breaks old grab.
         // NOTE: mouse *must* be grabbed only when visible - see Qt manual.
         grabMouse();
+
+        // The panel's floating appearance (custom title bar + frame margin)
+        // is only fully in place once its layout has been activated. Read
+        // the drag grip's *actual*, current position afterwards - rather
+        // than assuming a fixed margin - so the pixel grabbed at press time
+        // lands right back under the cursor, however the transition shifted
+        // things.
+        if (QLayout *l = layout()) l->activate();
+        QWidget *grip = this;
+        if (TDockWidget *tdw = qobject_cast<TDockWidget *>(this))
+          if (QWidget *titleBar = tdw->titleBarWidget()) grip = titleBar;
+        const QPoint gripOffsetInWidget =
+            grip->mapToGlobal(QPoint(0, 0)) - mapToGlobal(QPoint(0, 0));
+
+        m_dragInitialPos =
+            correctedGlobalPos - m_dragGripPressOffset - gripOffsetInWidget;
+        m_dragMouseInitialPos = correctedGlobalPos;
+        move(m_dragInitialPos);
 
         // After undocking takes place, docking possibilities have to be
         // recalculated
@@ -359,9 +392,20 @@ void DockWidget::mouseReleaseEvent(QMouseEvent *me) {
     m_dragging = false;
 
     if (m_floating && m_selectedPlace) {
-      m_parentLayout->dockItem(this, m_selectedPlace);
-    } else {
-      // qDebug("Dock failed");
+      if (m_selectedPlace->getAttribute() == DockPlaceholder::tabify) {
+        Region *region = m_selectedPlace->getParentRegion();
+        DockWidget *target =
+            region ? (region->isTabbed() ? region->activeTab() : region->getItem())
+                   : 0;
+        if (target) m_parentLayout->tabifyWithTarget(this, target);
+      } else {
+        m_parentLayout->dockItem(this, m_selectedPlace);
+      }
+    } else if (m_floating && m_parentLayout) {
+      DockWidget *titleTarget =
+          m_parentLayout->dockWidgetTitleBarAt(me->globalPos());
+      if (titleTarget && titleTarget != this)
+        m_parentLayout->tabifyWithTarget(this, titleTarget);
     }
 
     // Clear dock placeholders
@@ -484,24 +528,47 @@ DockPlaceholder *DockWidget::placeOfSeparator(DockSeparator *sep) {
 //! respect to the
 //! other (or these are kept hidden) according to the body of this function.
 void DockWidget::selectDockPlaceholder(QMouseEvent *me) {
-  // const int inf= 1000000;
   DockPlaceholder *selected = 0;
 
-  // Search placeholders containing mouse position
+  // Classic split docking has priority over hover-join (top/bottom/left/right).
   unsigned int i;
   for (i = 0; i < m_placeholders.size(); ++i) {
+    if (m_placeholders[i]->getAttribute() == DockPlaceholder::tabify) continue;
     if (m_placeholders[i]->geometry().contains(me->globalPos())) {
       selected = m_placeholders[i];
     }
   }
 
+  if (!selected) selected = tabifyPlaceholderAt(me->globalPos());
+
   // In order to avoid flickering
   if (m_selectedPlace != selected) {
     if (m_selectedPlace) m_selectedPlace->hide();
-    if (selected) selected->show();
+    if (selected && selected->getAttribute() != DockPlaceholder::tabify)
+      selected->show();
+  }
+
+  if (m_parentLayout) {
+    if (selected && selected->getAttribute() == DockPlaceholder::tabify)
+      m_parentLayout->setJoinHighlight(selected->getParentRegion());
+    else
+      m_parentLayout->clearJoinHighlight();
   }
 
   m_selectedPlace = selected;
+}
+
+//-------------------------------------
+
+DockPlaceholder *DockWidget::tabifyPlaceholderAt(
+    const QPoint &globalPos) const {
+  unsigned int i;
+  for (i = 0; i < m_placeholders.size(); ++i) {
+    if (m_placeholders[i]->getAttribute() != DockPlaceholder::tabify) continue;
+    if (m_placeholders[i]->geometry().contains(globalPos))
+      return m_placeholders[i];
+  }
+  return 0;
 }
 
 //========================================================
@@ -544,6 +611,27 @@ inline void DockPlaceholder::buildGeometry() {
       // QPoint center= parentRect.center();
       // relativeToMainRect= QRect(center - QPoint(50,50), center +
       // QPoint(50,50));
+    } else if (getAttribute() == tabify) {
+      Region *region = getParentRegion();
+      int top         = parentRect.top();
+      int left        = parentRect.left();
+      int width       = parentRect.width();
+      int height      = 24;
+
+      if (region && region->isTabbed()) {
+        height = m_owner->parentLayout()->tabStripHeight();
+      } else {
+        TDockWidget *target =
+            qobject_cast<TDockWidget *>(region ? region->getItem() : 0);
+        if (target && target->titleBarWidget())
+          height = std::max(24, target->titleBarWidget()->height());
+      }
+
+      // Restrict hover-join to the title/tab strip center band so that
+      // top/bottom/left/right split placeholders keep working as before.
+      const int hMargin = std::max(12, width / 5);
+      relativeToMainRect =
+          QRect(left + hMargin, top + 2, width - 2 * hMargin, height - 2);
     } else if (getParentRegion() == 0 ||
                getParentRegion() == layout->rootRegion()) {
       // Outer insertion case

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -546,7 +546,7 @@ void DockWidget::selectDockPlaceholder(QMouseEvent *me) {
 
   if (!selected) selected = tabifyPlaceholderAt(me->globalPos());
 
-  // In order to avoid flickering
+  // Never show a split deco and a join highlight at the same time.
   if (m_selectedPlace != selected) {
     if (m_selectedPlace) m_selectedPlace->hide();
     if (selected && selected->getAttribute() != DockPlaceholder::tabify)
@@ -554,10 +554,16 @@ void DockWidget::selectDockPlaceholder(QMouseEvent *me) {
   }
 
   if (m_parentLayout) {
-    if (selected && selected->getAttribute() == DockPlaceholder::tabify)
+    if (selected && selected->getAttribute() == DockPlaceholder::tabify) {
+      // Hide any leftover visible split deco before drawing the join band.
+      for (i = 0; i < m_placeholders.size(); ++i) {
+        if (m_placeholders[i]->getAttribute() != DockPlaceholder::tabify)
+          m_placeholders[i]->hide();
+      }
       m_parentLayout->setJoinHighlight(selected->getParentRegion());
-    else
+    } else {
       m_parentLayout->clearJoinHighlight();
+    }
   }
 
   m_selectedPlace = selected;
@@ -632,11 +638,13 @@ inline void DockPlaceholder::buildGeometry() {
           height = std::max(24, target->titleBarWidget()->height());
       }
 
-      // Restrict hover-join to the title/tab strip center band so that
-      // top/bottom/left/right split placeholders keep working as before.
-      const int hMargin = std::max(12, width / 5);
+      // Start below the top split band (sepWidth) so classic top docking and
+      // hover-join never share the same hit pixels / preview frames.
+      const int topInset = sepWidth + 2;
+      const int hMargin  = std::max(12, width / 5);
       relativeToMainRect =
-          QRect(left + hMargin, top + 2, width - 2 * hMargin, height - 2);
+          QRect(left + hMargin, top + topInset, width - 2 * hMargin,
+                std::max(12, height - topInset));
     } else if (getParentRegion() == 0 ||
                getParentRegion() == layout->rootRegion()) {
       // Outer insertion case

--- a/toonz/sources/toonzqt/dockwidget.cpp
+++ b/toonz/sources/toonzqt/dockwidget.cpp
@@ -311,11 +311,9 @@ QWidget *DockWidget::dragGrip() {
 
 //-------------------------------------
 
-//! Offset of the drag grip inside the panel, measured once the pending
-//! docked/floating appearance change has actually been laid out: the custom
-//! title bar may end up shifted by a frame margin that only exists in one of
-//! the two states, and assuming a fixed margin makes the panel jump under
-//! the cursor.
+//! Offset of the drag grip inside the panel, measured after the pending
+//! docked/floating transition has been laid out: the grip may shift by a
+//! frame margin that only exists in one of the two states.
 QPoint DockWidget::settledDragGripOffset() {
   if (QLayout *l = layout()) l->activate();
   return dragGrip()->mapToGlobal(QPoint(0, 0)) - mapToGlobal(QPoint(0, 0));
@@ -352,8 +350,8 @@ void DockWidget::mouseMoveEvent(QMouseEvent *me) {
 
     m_dragMouseInitialPos = correctedGlobalPos;
   } else if (m_dragging) {
-    // Qt::Tool floating panels: pos()/move() are in screen coordinates.
-    // Do not map through parentWidget() — that caused the title-bar grab jump.
+    // Qt::Tool floating panels: pos()/move() are in screen coordinates, so
+    // mapping through parentWidget() would offset the grab point.
     move(m_dragInitialPos + correctedGlobalPos - m_dragMouseInitialPos);
     selectDockPlaceholder(me);
   } else if (m_undocking) {
@@ -532,8 +530,8 @@ DockPlaceholder *DockWidget::placeOfSeparator(DockSeparator *sep) {
 void DockWidget::selectDockPlaceholder(QMouseEvent *me) {
   DockPlaceholder *selected = 0;
 
-  // Classic split docking takes precedence: its drop zones are what users
-  // expect from the borders of a panel, tab joining only fills the gap.
+  // Classic split docking takes precedence; tab joining is only tested where
+  // no split drop zone applies.
   unsigned int i;
   for (i = 0; i < m_placeholders.size(); ++i) {
     if (m_placeholders[i]->getAttribute() == DockPlaceholder::tabJoinTarget)

--- a/toonz/sources/toonzqt/tdockwindows.cpp
+++ b/toonz/sources/toonzqt/tdockwindows.cpp
@@ -232,9 +232,8 @@ bool TDockWidget::isDragGrip(QPoint p) {
 
   if (m_titlebar->isVisible()) return m_titlebar->geometry().contains(p);
 
-  // Recovery path: a tab-group bug may leave the title bar hidden on a
-  // standalone / floating panel. Keep the top strip draggable so the panel
-  // is not permanently stuck without a grip.
+  // Fallback while the title bar is hidden, so a panel can never end up
+  // with no draggable area at all.
   return QRect(0, 0, width(), 18).contains(p);
 }
 

--- a/toonz/sources/toonzqt/tdockwindows.cpp
+++ b/toonz/sources/toonzqt/tdockwindows.cpp
@@ -361,13 +361,13 @@ TDockPlaceholder::TDockPlaceholder(DockWidget *owner, Region *r, int idx,
     : DockPlaceholder(owner, r, idx, attributes) {
   setAutoFillBackground(true);
 
-  if (attributes == DockPlaceholder::tabify)
-    setObjectName("TDockTabifyPlaceholder");
-  else
-    setObjectName("TDockPlaceholder");
+  const bool isTabJoinTarget = attributes == DockPlaceholder::tabJoinTarget;
 
-  // Tabify targets are highlighted on the panel itself; keep hit area invisible.
-  setWindowOpacity(attributes == DockPlaceholder::tabify ? 0.0 : 0.8);
+  setObjectName(isTabJoinTarget ? "TDockTabJoinTarget" : "TDockPlaceholder");
+
+  // The merge preview is drawn around the target region itself, so the hit
+  // area stays invisible.
+  setWindowOpacity(isTabJoinTarget ? 0.0 : 0.8);
 }
 
 //----------------------------------------
@@ -484,7 +484,7 @@ void TDockWidget::selectDockPlaceholder(QMouseEvent *me) {
       if (selected) selected->show();
     }
 
-    if (parentLayout()) parentLayout()->clearJoinHighlight();
+    if (parentLayout()) parentLayout()->hideTabMergePreview();
 
     m_selectedPlace = selected;
   } else

--- a/toonz/sources/toonzqt/tdockwindows.cpp
+++ b/toonz/sources/toonzqt/tdockwindows.cpp
@@ -356,9 +356,13 @@ TDockPlaceholder::TDockPlaceholder(DockWidget *owner, Region *r, int idx,
     : DockPlaceholder(owner, r, idx, attributes) {
   setAutoFillBackground(true);
 
-  setObjectName("TDockPlaceholder");
+  if (attributes == DockPlaceholder::tabify)
+    setObjectName("TDockTabifyPlaceholder");
+  else
+    setObjectName("TDockPlaceholder");
 
-  setWindowOpacity(0.8);
+  // Tabify targets are highlighted on the panel itself; keep hit area invisible.
+  setWindowOpacity(attributes == DockPlaceholder::tabify ? 0.0 : 0.8);
 }
 
 //----------------------------------------
@@ -474,6 +478,8 @@ void TDockWidget::selectDockPlaceholder(QMouseEvent *me) {
       if (m_selectedPlace) m_selectedPlace->hide();
       if (selected) selected->show();
     }
+
+    if (parentLayout()) parentLayout()->clearJoinHighlight();
 
     m_selectedPlace = selected;
   } else

--- a/toonz/sources/toonzqt/tdockwindows.cpp
+++ b/toonz/sources/toonzqt/tdockwindows.cpp
@@ -230,7 +230,12 @@ void TDockWidget::setDockedAppearance() {
 bool TDockWidget::isDragGrip(QPoint p) {
   if (!m_titlebar) return DockWidget::isDragGrip(p);
 
-  return m_titlebar->geometry().contains(p);
+  if (m_titlebar->isVisible()) return m_titlebar->geometry().contains(p);
+
+  // Recovery path: a tab-group bug may leave the title bar hidden on a
+  // standalone / floating panel. Keep the top strip draggable so the panel
+  // is not permanently stuck without a grip.
+  return QRect(0, 0, width(), 18).contains(p);
 }
 
 //----------------------------------------


### PR DESCRIPTION
**_This is an experimental UI/workspace feature intended for nightly testing. Please report tabbed panel docking, layout restore, undocking, and multi monitor issues with platform and workspace details._**

**Description**

Problem

OpenToonz’s interface can fill up quickly. With many panels open, especially on smaller screens, the workspace becomes crowded and could be harder to organize.

**Proposal**

Allow docked panels to be grouped into tabs, so users can save space and arrange their workspace more flexibly.

Drag a panel onto another panel’s title bar to merge them into a tab group. A visual cue appears to show that the panels can be joined. Hold and drag a tab’s title area to pull that panel out of the group again. While reordering tabs, an insertion marker shows where the tab will land, and the new order is applied when you release the mouse. 
**Notes**

This feature was developed with Cursor’s AI models. If this PR suits you, the session layout persistence PR #6975 will need to be merged before this one.