### PR TITLE
Remember the Style Editor tab between sessions

### DIFF
--- a/toonz/sources/include/toonz/palettecontroller.h
+++ b/toonz/sources/include/toonz/palettecontroller.h
@@ -25,6 +25,7 @@
 //    Forward declarations
 
 class TPaletteHandle;
+class TPalette;
 
 //=====================================================
 
@@ -63,6 +64,9 @@ public:
   TPaletteHandle *getCurrentPalette() const { return m_currentPalette; }
 
   void setCurrentPalette(TPaletteHandle *paletteHandle);
+
+  // Load cleanup without selecting it.
+  void assignCleanupPalette(TPalette *palette);
 
   // centralized handling of color auto-apply. see StyleEditor.
   // when ColorAutoApply is disabled then changes should made on the ColorSample

--- a/toonz/sources/include/toonz/palettecontroller.h
+++ b/toonz/sources/include/toonz/palettecontroller.h
@@ -50,6 +50,7 @@ class DVAPI PaletteController final : public QObject {
   //!  the last setCurrentPalette() invocation.
   TPixel32 m_colorSample;
   bool m_colorAutoApplyEnabled;
+  bool m_skipCleanupEdit;
 
 public:
   PaletteController();

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -241,6 +241,9 @@ public:
   bool isRestoreViewerViewFromLastSessionEnabled() const {
     return getBoolValue(restoreViewerViewFromLastSession);
   }
+  bool isRestoreStyleEditorTabEnabled() const {
+    return getBoolValue(RestoreStyleEditorTab);
+  }
 
   // Visualization  tab
   bool getShow0ThickLines() const { return getBoolValue(show0ThickLines); }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -44,6 +44,7 @@ enum PreferencesItemId {
   displayIn30bit,
   viewerIndicatorEnabled,
   restoreViewerViewFromLastSession,
+  RestoreStyleEditorTab,
 
   //----------
   // Visualization

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -920,6 +920,9 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
   QPushButton *m_textureSearchClear;
   QPushButton *m_vectorsSearchClear;
   QPushButton *m_mypaintSearchClear;
+  QPushButton *m_specialButton     = nullptr;
+  QPushButton *m_customButton      = nullptr;
+  QPushButton *m_vectorBrushButton = nullptr;
 
   TColorStyleP
       m_oldStyle;  //!< A copy of current style \a before the last change.
@@ -931,6 +934,7 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
   bool m_enabledOnlyFirstTab;
   bool m_enabledFirstAndLastTab;
   bool m_colorPageIsVertical = true;
+  int m_currentPageIndex     = 0;
 
 public:
   StyleEditor(PaletteController *, QWidget *parent = 0);
@@ -1051,6 +1055,9 @@ private:
   QFrame *createVectorPage();
   QFrame *createMyPaintPage();
   void updateTabBar();
+  int tabIndexForPage(int page) const;
+  void rememberPage(int page);
+  void applySavedPage();
 
   void copyEditedStyleToPalette(bool isDragging);
 };

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -931,6 +931,8 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
   bool m_enabledOnlyFirstTab;
   bool m_enabledFirstAndLastTab;
   bool m_colorPageIsVertical = true;
+  int m_pendingPageIndex     = -1;
+  int m_currentPageIndex     = 0;
 
 public:
   StyleEditor(PaletteController *, QWidget *parent = 0);

--- a/toonz/sources/toonz/cleanupsettingsmodel.cpp
+++ b/toonz/sources/toonz/cleanupsettingsmodel.cpp
@@ -467,10 +467,8 @@ void CleanupSettingsModel::onSceneSwitched() {
 
   // Make sure that the current cleanup palette is set to currentParams' palette
   // This might refresh the StyleEditor
-  TApp::instance()
-      ->getPaletteController()
-      ->getCurrentCleanupPalette()
-      ->setPalette(params->m_cleanupPalette.getPointer());
+  TApp::instance()->getPaletteController()->assignCleanupPalette(
+      params->m_cleanupPalette.getPointer());
 
   m_clnPath = TFilePath();  // This Path won't be stored in scene or project
   m_backupParams.assign(params, false);

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1365,7 +1365,7 @@ void IoCmd::newScene() {
                           ->getCleanupParameters()
                           ->m_cleanupPalette.getPointer();
   PaletteController *paletteController = app->getPaletteController();
-  paletteController->getCurrentCleanupPalette()->setPalette(palette, -1);
+  paletteController->assignCleanupPalette(palette);
 
   TFilePath scenePath = scene->getScenePath();
   DvDirModel::instance()->refreshFolder(scenePath.getParentDir());

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1292,6 +1292,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {viewerIndicatorEnabled, tr("Show Viewer Indicators")},
       {restoreViewerViewFromLastSession,
        tr("Restore Viewer Zoom and Pan from Last Session")},
+      {RestoreStyleEditorTab, tr("Remember Style Editor Tab")},
 
       // Visualization
       {show0ThickLines, tr("Show Lines with Thickness 0")},
@@ -1869,6 +1870,7 @@ QWidget* PreferencesPopup::createInterfacePage() {
   lay->addWidget(check30bitBtn, row - 1, 2, Qt::AlignRight);
   insertUI(showIconsInMenu, lay);
   insertUI(showRoomBindButtons, lay);
+  insertUI(RestoreStyleEditorTab, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonzlib/palettecontroller.cpp
+++ b/toonz/sources/toonzlib/palettecontroller.cpp
@@ -6,6 +6,7 @@
 #include "toonz/tscenehandle.h"
 #include "toonz/txshlevelhandle.h"
 #include "toonz/txshlevel.h"
+#include "toonz/preferences.h"
 
 // TnzBase includes
 #include "tenv.h"
@@ -98,6 +99,25 @@ void PaletteController::editLevelPalette() {
 
 void PaletteController::editCleanupPalette() {
   setCurrentPalette(m_currentCleanupPalette);
+}
+
+//-----------------------------------------------------------------------------
+
+void PaletteController::assignCleanupPalette(TPalette *palette) {
+  if (!Preferences::instance()->isRestoreStyleEditorTabEnabled()) {
+    m_currentCleanupPalette->setPalette(palette);
+    return;
+  }
+
+  const bool editingCleanup =
+      (m_originalCurrentPalette == m_currentCleanupPalette);
+  m_currentCleanupPalette->blockSignals(true);
+  m_currentCleanupPalette->setPalette(palette);
+  m_currentCleanupPalette->blockSignals(false);
+  if (editingCleanup)
+    editCleanupPalette();
+  else if (!m_originalCurrentPalette)
+    editLevelPalette();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/palettecontroller.cpp
+++ b/toonz/sources/toonzlib/palettecontroller.cpp
@@ -23,7 +23,8 @@ PaletteController::PaletteController()
     , m_originalCurrentPalette(0)
     , m_currentPalette(0)
     , m_colorAutoApplyEnabled(PaletteControllerAutoApplyState != 0)
-    , m_colorSample() {
+    , m_colorSample()
+    , m_skipCleanupEdit(false) {
   m_currentLevelPalette   = new TPaletteHandle;
   m_currentCleanupPalette = new TPaletteHandle;
   m_currentPalette        = new TPaletteHandle;
@@ -98,6 +99,7 @@ void PaletteController::editLevelPalette() {
 //-----------------------------------------------------------------------------
 
 void PaletteController::editCleanupPalette() {
+  if (m_skipCleanupEdit) return;
   setCurrentPalette(m_currentCleanupPalette);
 }
 
@@ -111,9 +113,9 @@ void PaletteController::assignCleanupPalette(TPalette *palette) {
 
   const bool editingCleanup =
       (m_originalCurrentPalette == m_currentCleanupPalette);
-  m_currentCleanupPalette->blockSignals(true);
+  m_skipCleanupEdit = true;
   m_currentCleanupPalette->setPalette(palette);
-  m_currentCleanupPalette->blockSignals(false);
+  m_skipCleanupEdit = false;
   if (editingCleanup)
     editCleanupPalette();
   else if (!m_originalCurrentPalette)

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -464,6 +464,7 @@ void Preferences::definePreferenceItems() {
          true);
   define(restoreViewerViewFromLastSession, "restoreViewerViewFromLastSession",
          QMetaType::Bool, false);
+  define(RestoreStyleEditorTab, "RestoreStyleEditorTab", QMetaType::Bool, true);
 
   // Visualization
   define(show0ThickLines, "show0ThickLines", QMetaType::Bool, true);

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -3585,6 +3585,12 @@ void StyleEditor::onStyleSwitched() {
     m_colorParameterSelector->clear();
     m_oldStyle    = TColorStyleP();
     m_editedStyle = TColorStyleP();
+    m_settingsPage->setStyle(TColorStyleP());
+    TSolidColorStyle emptyStyle(TPixel32::Transparent);
+    m_plainColorPage->setColor(emptyStyle, 0);
+    m_oldColor->setColor(TPixel32::Transparent);
+    m_newColor->setColor(TPixel32::Transparent);
+    m_hexLineEdit->setStyle(emptyStyle, 0);
     m_parent->setWindowTitle(tr("No Style Selected"));
     if (Preferences::instance()->isRestoreStyleEditorTabEnabled()) {
       enable(true, false, false);
@@ -3787,6 +3793,14 @@ void StyleEditor::enable(bool enabled, bool enabledOnlyFirstTab,
   bool flagsChanged =
       m_enabled != enabled || m_enabledOnlyFirstTab != enabledOnlyFirstTab ||
       m_enabledFirstAndLastTab != enabledFirstAndLastTab;
+  bool rememberTabs =
+      Preferences::instance()->isRestoreStyleEditorTabEnabled();
+  bool alreadyFullTabs =
+      m_enabled && !m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab;
+  bool enteringFullTabs =
+      enabled && !enabledOnlyFirstTab && !enabledFirstAndLastTab;
+  if (!rememberTabs && enteringFullTabs && !alreadyFullTabs)
+    m_currentPageIndex = 0;
   if (flagsChanged) {
     m_enabled                = enabled;
     m_enabledOnlyFirstTab    = enabledOnlyFirstTab;
@@ -4101,13 +4115,15 @@ void StyleEditor::save(QSettings &settings) const {
   if (m_searchAction->isChecked()) visibleParts |= 0x20;
   settings.setValue("visibleParts", visibleParts);
   settings.setValue("splitterState", m_plainColorPage->getSplitterState());
-  settings.setValue("currentPage", m_currentPageIndex);
-  if (m_specialButton) {
-    int vectorParts = 0;
-    if (m_specialButton->isChecked()) vectorParts |= 0x01;
-    if (m_customButton->isChecked()) vectorParts |= 0x02;
-    if (m_vectorBrushButton->isChecked()) vectorParts |= 0x04;
-    settings.setValue("vectorParts", vectorParts);
+  if (Preferences::instance()->isRestoreStyleEditorTabEnabled()) {
+    settings.setValue("currentPage", m_currentPageIndex);
+    if (m_specialButton) {
+      int vectorParts = 0;
+      if (m_specialButton->isChecked()) vectorParts |= 0x01;
+      if (m_customButton->isChecked()) vectorParts |= 0x02;
+      if (m_vectorBrushButton->isChecked()) vectorParts |= 0x04;
+      settings.setValue("vectorParts", vectorParts);
+    }
   }
 }
 void StyleEditor::load(QSettings &settings) {
@@ -4148,20 +4164,22 @@ void StyleEditor::load(QSettings &settings) {
   QVariant splitterState = settings.value("splitterState");
   if (splitterState.canConvert(QVariant::ByteArray))
     m_plainColorPage->setSplitterState(splitterState.toByteArray());
-  QVariant currentPage = settings.value("currentPage");
-  if (currentPage.canConvert(QVariant::Int)) {
-    int page = currentPage.toInt();
-    if (page >= 0 && page < m_styleChooser->count() - 1)
-      m_currentPageIndex = page;
+  if (Preferences::instance()->isRestoreStyleEditorTabEnabled()) {
+    QVariant currentPage = settings.value("currentPage");
+    if (currentPage.canConvert(QVariant::Int)) {
+      int page = currentPage.toInt();
+      if (page >= 0 && page < m_styleChooser->count() - 1)
+        m_currentPageIndex = page;
+    }
+    QVariant vectorParts = settings.value("vectorParts");
+    if (vectorParts.canConvert(QVariant::Int) && m_specialButton) {
+      int v = vectorParts.toInt();
+      m_specialButton->setChecked(v & 0x01);
+      m_customButton->setChecked(v & 0x02);
+      m_vectorBrushButton->setChecked(v & 0x04);
+    }
+    applySavedPage();
   }
-  QVariant vectorParts = settings.value("vectorParts");
-  if (vectorParts.canConvert(QVariant::Int) && m_specialButton) {
-    int v = vectorParts.toInt();
-    m_specialButton->setChecked(v & 0x01);
-    m_customButton->setChecked(v & 0x02);
-    m_vectorBrushButton->setChecked(v & 0x04);
-  }
-  applySavedPage();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -1911,6 +1911,7 @@ void StyleChooserPage::applyFilter(const QString text) {
 //-----------------------------------------------------------------------------
 
 void StyleChooserPage::paintEvent(QPaintEvent *) {
+  if (!parentWidget()) return;
   if (loadIfNeeded() || m_pinsToTopDirty) {
     m_pinsToTopDirty = false;
     applyFilter();
@@ -2178,6 +2179,7 @@ void CustomStyleChooserPage::onSelect(int index) {
 //-----------------------------------------------------------------------------
 
 bool CustomStyleChooserPage::isSameStyle(const TColorStyleP style, int index) {
+  if (!style) return false;
   return style->getBrushIdHash() == m_manager->getData(index).hash;
 }
 
@@ -2227,6 +2229,7 @@ void VectorBrushStyleChooserPage::onSelect(int index) {
 
 bool VectorBrushStyleChooserPage::isSameStyle(const TColorStyleP style,
                                               int index) {
+  if (!style) return false;
   if (index > 0) {
     auto &data = m_manager->getData(index - 1);
     if (!data.isVector) return false;  // must be Vector
@@ -2281,6 +2284,7 @@ void TextureStyleChooserPage::onSelect(int index) {
 //-----------------------------------------------------------------------------
 
 bool TextureStyleChooserPage::isSameStyle(const TColorStyleP style, int index) {
+  if (!style) return false;
   if (index > 0)
     return style->getBrushIdHash() == m_manager->getData(index - 1).hash;
   else
@@ -2330,6 +2334,7 @@ void MyPaintBrushStyleChooserPage::onSelect(int index) {
 
 bool MyPaintBrushStyleChooserPage::isSameStyle(const TColorStyleP style,
                                                int index) {
+  if (!style) return false;
   if (index > 0)
     return style->getBrushIdHash() == getBrush(index - 1).getBrushIdHash();
   else
@@ -2381,6 +2386,7 @@ void SpecialStyleChooserPage::onSelect(int index) {
 //-----------------------------------------------------------------------------
 
 bool SpecialStyleChooserPage::isSameStyle(const TColorStyleP style, int index) {
+  if (!style) return false;
   if (index > 0)
     return style->getBrushIdHash() == m_manager->getData(index - 1).hash;
   else
@@ -3247,9 +3253,9 @@ QFrame *StyleEditor::createVectorPage() {
   QFrame *vectorOutsideFrame = new QFrame();
   vectorOutsideFrame->setMinimumWidth(50);
 
-  QPushButton *specialButton     = new QPushButton(tr("Generated"));
-  QPushButton *customButton      = new QPushButton(tr("Trail"));
-  QPushButton *vectorBrushButton = new QPushButton(tr("Vector Brush"));
+  m_specialButton     = new QPushButton(tr("Generated"));
+  m_customButton      = new QPushButton(tr("Trail"));
+  m_vectorBrushButton = new QPushButton(tr("Vector Brush"));
 
   m_vectorsSearchFrame = new QFrame();
   m_vectorsSearchText  = new QLineEdit();
@@ -3258,12 +3264,12 @@ QFrame *StyleEditor::createVectorPage() {
   m_vectorsSearchClear->setSizePolicy(QSizePolicy::Minimum,
                                       QSizePolicy::Preferred);
 
-  specialButton->setCheckable(true);
-  customButton->setCheckable(true);
-  vectorBrushButton->setCheckable(true);
-  specialButton->setChecked(true);
-  customButton->setChecked(true);
-  vectorBrushButton->setChecked(true);
+  m_specialButton->setCheckable(true);
+  m_customButton->setCheckable(true);
+  m_vectorBrushButton->setCheckable(true);
+  m_specialButton->setChecked(true);
+  m_customButton->setChecked(true);
+  m_vectorBrushButton->setChecked(true);
 
   /* ------ layout ------ */
   QVBoxLayout *vectorOutsideLayout = new QVBoxLayout();
@@ -3274,9 +3280,9 @@ QFrame *StyleEditor::createVectorPage() {
     QHBoxLayout *vectorButtonLayout = new QHBoxLayout();
     vectorButtonLayout->setSizeConstraint(QLayout::SetNoConstraint);
     {
-      vectorButtonLayout->addWidget(specialButton);
-      vectorButtonLayout->addWidget(customButton);
-      vectorButtonLayout->addWidget(vectorBrushButton);
+      vectorButtonLayout->addWidget(m_specialButton);
+      vectorButtonLayout->addWidget(m_customButton);
+      vectorButtonLayout->addWidget(m_vectorBrushButton);
     }
     vectorOutsideLayout->addLayout(vectorButtonLayout);
 
@@ -3311,11 +3317,11 @@ QFrame *StyleEditor::createVectorPage() {
 
   /* ------ signal-slot connections ------ */
   bool ret = true;
-  ret      = ret && connect(specialButton, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_specialButton, SIGNAL(toggled(bool)), this,
                             SLOT(onSpecialButtonToggled(bool)));
-  ret      = ret && connect(customButton, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_customButton, SIGNAL(toggled(bool)), this,
                             SLOT(onCustomButtonToggled(bool)));
-  ret      = ret && connect(vectorBrushButton, SIGNAL(toggled(bool)), this,
+  ret      = ret && connect(m_vectorBrushButton, SIGNAL(toggled(bool)), this,
                             SLOT(onVectorBrushButtonToggled(bool)));
   ret =
       ret && connect(m_vectorsSearchText, SIGNAL(textChanged(const QString &)),
@@ -3434,7 +3440,48 @@ void StyleEditor::onMyPaintClearSearch() {
 
 //-----------------------------------------------------------------------------
 
+int StyleEditor::tabIndexForPage(int page) const {
+  if (!m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab)
+    return (page >= 0 && page <= 4) ? page : -1;
+  if (m_enabledFirstAndLastTab) {
+    if (page == 0) return 0;
+    return (page == m_styleChooser->count() - 2) ? 1 : -1;
+  }
+  return (page == 0) ? 0 : -1;
+}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::rememberPage(int page) {
+  if (page < 0 || page >= m_styleChooser->count() - 1) return;
+
+  // Do not replace the stored page.
+  bool fullTabSet = !m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab;
+  if (!fullTabSet && page != m_styleChooser->count() - 2) return;
+
+  m_currentPageIndex = page;
+}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::applySavedPage() {
+  if (!m_enabled) return;
+  int tab = tabIndexForPage(m_currentPageIndex);
+  if (tab < 0) return;
+  if (m_styleChooser->currentIndex() == m_currentPageIndex &&
+      m_styleBar->currentIndex() == tab)
+    return;
+
+  m_styleBar->blockSignals(true);
+  m_styleBar->setCurrentIndex(tab);
+  m_styleBar->blockSignals(false);
+  m_styleChooser->setCurrentIndex(m_currentPageIndex);
+}
+
+//-----------------------------------------------------------------------------
+
 void StyleEditor::updateTabBar() {
+  m_styleBar->blockSignals(true);
   m_styleBar->clearTabBar();
   if (m_enabled && !m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab) {
     m_styleBar->addSimpleTab(tr("Color"));
@@ -3442,24 +3489,34 @@ void StyleEditor::updateTabBar() {
     m_styleBar->addSimpleTab(tr("Vector"));
     m_styleBar->addSimpleTab(tr("Raster"));
     m_styleBar->addSimpleTab(tr("Settings"));
-  } else if (m_enabled && m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab)
+  } else if (m_enabled && m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab) {
     m_styleBar->addSimpleTab(tr("Color"));
-  else if (m_enabled && !m_enabledOnlyFirstTab && m_enabledFirstAndLastTab) {
+  } else if (m_enabled && !m_enabledOnlyFirstTab && m_enabledFirstAndLastTab) {
     m_styleBar->addSimpleTab(tr("Color"));
     m_styleBar->addSimpleTab(tr("Settings"));
   } else {
+    m_styleBar->blockSignals(false);
     m_styleChooser->setCurrentIndex(m_styleChooser->count() - 1);
     return;
   }
   m_tabBarContainer->layout()->update();
-  m_styleChooser->setCurrentIndex(0);
+
+  int tab = tabIndexForPage(m_currentPageIndex);
+  if (tab < 0) {
+    m_styleBar->setCurrentIndex(0);
+    m_styleBar->blockSignals(false);
+    m_styleChooser->setCurrentIndex(0);
+    return;
+  }
+
+  m_styleBar->blockSignals(false);
+  applySavedPage();
 }
 
 //-----------------------------------------------------------------------------
 
 void StyleEditor::showEvent(QShowEvent *) {
   m_autoButton->setChecked(m_paletteController->isColorAutoApplyEnabled());
-  onStyleSwitched();
   bool ret = true;
   ret      = ret && connect(m_paletteHandle, SIGNAL(colorStyleSwitched()),
                             SLOT(onStyleSwitched()));
@@ -3487,6 +3544,7 @@ void StyleEditor::showEvent(QShowEvent *) {
   onSearchVisible(m_searchAction->isChecked());
   updateOrientationButton();
   assert(ret);
+  QMetaObject::invokeMethod(this, "onStyleSwitched", Qt::QueuedConnection);
 }
 
 //-----------------------------------------------------------------------------
@@ -3524,14 +3582,21 @@ void StyleEditor::onStyleSwitched() {
   TPalette *palette = getPalette();
 
   if (!palette) {
-    // set the current page to empty
-    m_styleChooser->setCurrentIndex(m_styleChooser->count() - 1);
-    enable(false);
     m_colorParameterSelector->clear();
     m_oldStyle    = TColorStyleP();
     m_editedStyle = TColorStyleP();
-
     m_parent->setWindowTitle(tr("No Style Selected"));
+    if (Preferences::instance()->isRestoreStyleEditorTabEnabled()) {
+      enable(true, false, false);
+      m_autoButton->setEnabled(false);
+      m_applyButton->setEnabled(false);
+      m_oldColor->setEnable(false);
+      m_newColor->setEnable(false);
+      m_hexLineEdit->setEnabled(false);
+    } else {
+      m_styleChooser->setCurrentIndex(m_styleChooser->count() - 1);
+      enable(false);
+    }
     return;
   }
 
@@ -3719,8 +3784,10 @@ void StyleEditor::onColorChanged(const ColorModel &color, bool isDragging) {
 
 void StyleEditor::enable(bool enabled, bool enabledOnlyFirstTab,
                          bool enabledFirstAndLastTab) {
-  if (m_enabled != enabled || m_enabledOnlyFirstTab != enabledOnlyFirstTab ||
-      m_enabledFirstAndLastTab != enabledFirstAndLastTab) {
+  bool flagsChanged =
+      m_enabled != enabled || m_enabledOnlyFirstTab != enabledOnlyFirstTab ||
+      m_enabledFirstAndLastTab != enabledFirstAndLastTab;
+  if (flagsChanged) {
     m_enabled                = enabled;
     m_enabledOnlyFirstTab    = enabledOnlyFirstTab;
     m_enabledFirstAndLastTab = enabledFirstAndLastTab;
@@ -3734,6 +3801,8 @@ void StyleEditor::enable(bool enabled, bool enabledOnlyFirstTab,
       m_oldColor->setColor(TPixel32::Transparent);
       m_newColor->setColor(TPixel32::Transparent);
     }
+  } else if (m_enabled) {
+    applySavedPage();
   }
 
   // lock button behavior
@@ -3778,6 +3847,7 @@ void StyleEditor::onNewStyleClicked() { applyButtonClicked(); }
 void StyleEditor::setPage(int index) {
   if (!m_enabledFirstAndLastTab) {
     m_styleChooser->setCurrentIndex(index);
+    rememberPage(index);
     return;
   }
 
@@ -3787,6 +3857,7 @@ void StyleEditor::setPage(int index) {
     index = m_styleChooser->count() -
             2;  // 2 because at the end there is a blank page.
   m_styleChooser->setCurrentIndex(index);
+  rememberPage(index);
 }
 
 //-----------------------------------------------------------------------------
@@ -4030,6 +4101,14 @@ void StyleEditor::save(QSettings &settings) const {
   if (m_searchAction->isChecked()) visibleParts |= 0x20;
   settings.setValue("visibleParts", visibleParts);
   settings.setValue("splitterState", m_plainColorPage->getSplitterState());
+  settings.setValue("currentPage", m_currentPageIndex);
+  if (m_specialButton) {
+    int vectorParts = 0;
+    if (m_specialButton->isChecked()) vectorParts |= 0x01;
+    if (m_customButton->isChecked()) vectorParts |= 0x02;
+    if (m_vectorBrushButton->isChecked()) vectorParts |= 0x04;
+    settings.setValue("vectorParts", vectorParts);
+  }
 }
 void StyleEditor::load(QSettings &settings) {
   QVariant isVertical = settings.value("isVertical");
@@ -4069,6 +4148,20 @@ void StyleEditor::load(QSettings &settings) {
   QVariant splitterState = settings.value("splitterState");
   if (splitterState.canConvert(QVariant::ByteArray))
     m_plainColorPage->setSplitterState(splitterState.toByteArray());
+  QVariant currentPage = settings.value("currentPage");
+  if (currentPage.canConvert(QVariant::Int)) {
+    int page = currentPage.toInt();
+    if (page >= 0 && page < m_styleChooser->count() - 1)
+      m_currentPageIndex = page;
+  }
+  QVariant vectorParts = settings.value("vectorParts");
+  if (vectorParts.canConvert(QVariant::Int) && m_specialButton) {
+    int v = vectorParts.toInt();
+    m_specialButton->setChecked(v & 0x01);
+    m_customButton->setChecked(v & 0x02);
+    m_vectorBrushButton->setChecked(v & 0x04);
+  }
+  applySavedPage();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -3790,11 +3790,10 @@ void StyleEditor::onColorChanged(const ColorModel &color, bool isDragging) {
 
 void StyleEditor::enable(bool enabled, bool enabledOnlyFirstTab,
                          bool enabledFirstAndLastTab) {
-  bool flagsChanged =
-      m_enabled != enabled || m_enabledOnlyFirstTab != enabledOnlyFirstTab ||
-      m_enabledFirstAndLastTab != enabledFirstAndLastTab;
-  bool rememberTabs =
-      Preferences::instance()->isRestoreStyleEditorTabEnabled();
+  bool flagsChanged = m_enabled != enabled ||
+                      m_enabledOnlyFirstTab != enabledOnlyFirstTab ||
+                      m_enabledFirstAndLastTab != enabledFirstAndLastTab;
+  bool rememberTabs = Preferences::instance()->isRestoreStyleEditorTabEnabled();
   bool alreadyFullTabs =
       m_enabled && !m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab;
   bool enteringFullTabs =

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -3435,6 +3435,7 @@ void StyleEditor::onMyPaintClearSearch() {
 //-----------------------------------------------------------------------------
 
 void StyleEditor::updateTabBar() {
+  m_styleBar->blockSignals(true);
   m_styleBar->clearTabBar();
   if (m_enabled && !m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab) {
     m_styleBar->addSimpleTab(tr("Color"));
@@ -3442,17 +3443,55 @@ void StyleEditor::updateTabBar() {
     m_styleBar->addSimpleTab(tr("Vector"));
     m_styleBar->addSimpleTab(tr("Raster"));
     m_styleBar->addSimpleTab(tr("Settings"));
-  } else if (m_enabled && m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab)
+  } else if (m_enabled && m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab) {
     m_styleBar->addSimpleTab(tr("Color"));
-  else if (m_enabled && !m_enabledOnlyFirstTab && m_enabledFirstAndLastTab) {
+  } else if (m_enabled && !m_enabledOnlyFirstTab && m_enabledFirstAndLastTab) {
     m_styleBar->addSimpleTab(tr("Color"));
     m_styleBar->addSimpleTab(tr("Settings"));
   } else {
+    m_styleBar->blockSignals(false);
     m_styleChooser->setCurrentIndex(m_styleChooser->count() - 1);
     return;
   }
   m_tabBarContainer->layout()->update();
-  m_styleChooser->setCurrentIndex(0);
+
+  // Determine target page: prefer pending (from load()), else keep last known page.
+  int targetPage = m_currentPageIndex;
+  if (m_pendingPageIndex >= 0) targetPage = m_pendingPageIndex;
+
+  // Map stacked-widget page index to tab-bar index for the current mode.
+  // Full (5 tabs): direct 0-4.  Color+Settings: 0→0, 4→1.  Color only: 0→0.
+  int tabIndex = -1;
+  if (!m_enabledOnlyFirstTab && !m_enabledFirstAndLastTab) {
+    if (targetPage >= 0 && targetPage <= 4) tabIndex = targetPage;
+  } else if (m_enabledFirstAndLastTab) {
+    if (targetPage == 0)
+      tabIndex = 0;
+    else if (targetPage == 4)
+      tabIndex = 1;
+  } else {
+    if (targetPage == 0) tabIndex = 0;
+  }
+
+  // Only consume pending when the page was actually mapped; if the page is
+  // unavailable in the current (possibly restricted) mode, keep pending alive
+  // so it can be applied later when the full tab set becomes available.
+  if (tabIndex >= 0 && m_pendingPageIndex >= 0) m_pendingPageIndex = -1;
+
+  bool isFallback = (tabIndex < 0);
+  if (tabIndex < 0) tabIndex = 0;
+
+  m_styleBar->setCurrentIndex(tabIndex);
+  m_styleBar->blockSignals(false);
+
+  if (!isFallback) {
+    setPage(tabIndex);
+  } else {
+    // Restricted mode can't show the saved page; display Color temporarily
+    // but preserve m_currentPageIndex so it is restored when the full tab
+    // set becomes available (e.g. after a room switch or palette change).
+    m_styleChooser->setCurrentIndex(0);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -3571,6 +3610,17 @@ void StyleEditor::onStyleSwitched() {
   } else {
     m_parent->setWindowTitle(tr("Style Editor - No Valid Style Selected"));
   }
+  // When the saved or current page requires full-mode tabs
+  // (Texture / Vector / Raster), suppress palette-driven restrictions so the
+  // user's chosen tab stays visible across room switches and startup.
+  // The override lifts naturally when the user selects Color (0) or
+  // Settings (4), which are available in every restricted mode.
+  if ((m_pendingPageIndex >= 1 && m_pendingPageIndex <= 3) ||
+      (m_currentPageIndex >= 1 && m_currentPageIndex <= 3)) {
+    isColorInField   = false;
+    isCleanUpPalette = false;
+  }
+
   enable(!isStyleNull && isValidIndex, isColorInField, isCleanUpPalette);
 
   updateStylePages();
@@ -3778,6 +3828,9 @@ void StyleEditor::onNewStyleClicked() { applyButtonClicked(); }
 void StyleEditor::setPage(int index) {
   if (!m_enabledFirstAndLastTab) {
     m_styleChooser->setCurrentIndex(index);
+    if (index >= 0 && index < m_styleChooser->count() - 1) {
+      m_currentPageIndex = index;
+    }
     return;
   }
 
@@ -3787,6 +3840,9 @@ void StyleEditor::setPage(int index) {
     index = m_styleChooser->count() -
             2;  // 2 because at the end there is a blank page.
   m_styleChooser->setCurrentIndex(index);
+  if (index >= 0 && index < m_styleChooser->count() - 1) {
+    m_currentPageIndex = index;
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -4030,6 +4086,7 @@ void StyleEditor::save(QSettings &settings) const {
   if (m_searchAction->isChecked()) visibleParts |= 0x20;
   settings.setValue("visibleParts", visibleParts);
   settings.setValue("splitterState", m_plainColorPage->getSplitterState());
+  settings.setValue("currentPage", m_currentPageIndex);
 }
 void StyleEditor::load(QSettings &settings) {
   QVariant isVertical = settings.value("isVertical");
@@ -4069,6 +4126,13 @@ void StyleEditor::load(QSettings &settings) {
   QVariant splitterState = settings.value("splitterState");
   if (splitterState.canConvert(QVariant::ByteArray))
     m_plainColorPage->setSplitterState(splitterState.toByteArray());
+  QVariant currentPage = settings.value("currentPage");
+  if (currentPage.canConvert(QVariant::Int)) {
+    int page = currentPage.toInt();
+    if (page >= 0 && page < m_styleChooser->count() - 1) {
+      m_pendingPageIndex = page;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
**Problem**

After closing OpenToonz or switching rooms, the Style Editor always came back on the Color tab. If you were working on Texture, Vector, or Raster, you had to open that tab again each time.

**Proposal**

Remember the last Style Editor tab and reopen on it after a restart or a room switch. The Style Editor returns to the tab you were using (Color, Texture, Vector, Raster, or Settings).

When Remember Style Editor Tab is on, the Vector page filters (Generated, Trail, and Vector Brush) are remembered as well. When it is off, that persistence is not saved or restored.

**Notes**

This feature was developed with Cursor’s AI models.