### PR TITLE
Style Editor color wheels

### DIFF
--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -872,6 +872,8 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
 
   DVGui::TabBar *m_styleBar;
   QStackedWidget *m_styleChooser;
+  QSplitter *m_mainSplitter;
+  QFrame *m_bottomWidget;
 
   DVGui::StyleSample
       *m_newColor;  //!< New style viewer (lower-right panel side).
@@ -908,6 +910,7 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
   QAction *m_rgbAction;
   QAction *m_hexAction;
   QAction *m_searchAction;
+  QAction *m_bottomBarAction;
   QActionGroup *m_sliderAppearanceAG;
   QAction *m_hexEditorAction;
 
@@ -930,7 +933,8 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
   bool m_enabled;
   bool m_enabledOnlyFirstTab;
   bool m_enabledFirstAndLastTab;
-  bool m_colorPageIsVertical = true;
+  bool m_colorPageIsVertical   = true;
+  bool m_bottomInitialized     = false;
 
 public:
   StyleEditor(PaletteController *, QWidget *parent = 0);
@@ -1035,6 +1039,8 @@ protected slots:
 
   void onSliderAppearanceSelected(QAction *);
   void onPopupMenuAboutToShow();
+  void onBottomBarToggled(bool visible);
+  void onMainSplitterMoved(int pos, int index);
 
   void onTextureSearch(const QString &);
   void onTextureClearSearch();

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -933,8 +933,7 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
   bool m_enabled;
   bool m_enabledOnlyFirstTab;
   bool m_enabledFirstAndLastTab;
-  bool m_colorPageIsVertical   = true;
-  bool m_bottomInitialized     = false;
+  bool m_colorPageIsVertical = true;
 
 public:
   StyleEditor(PaletteController *, QWidget *parent = 0);
@@ -996,6 +995,8 @@ protected:
 protected:
   void showEvent(QShowEvent *) override;
   void hideEvent(QHideEvent *) override;
+  void resizeEvent(QResizeEvent *) override;
+  bool eventFilter(QObject *watched, QEvent *event) override;
 
 protected slots:
 
@@ -1057,6 +1058,10 @@ private:
   QFrame *createVectorPage();
   QFrame *createMyPaintPage();
   void updateTabBar();
+  // Restore the pre-collapsible bottom-bar height (min 60 + QSS content).
+  void restoreBottomBarExpandedSize();
+  int bottomBarNaturalHeight() const;
+  void setBottomBarExpandedConstraints(bool expanded);
 
   void copyEditedStyleToPalette(bool isDragging);
 };

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -135,6 +135,12 @@ public:
 
 enum CurrentWheel { none, leftWheel, rightTriangle };
 
+enum ColorWheelDisplayMode {
+  ClassicWheelDisplay,
+  CompactNestedWheelDisplay,
+  ExtendedCorrectedWheelDisplay
+};
+
 class DVAPI HexagonalColorWheel final : public GLWidgetForHighDpi {
   Q_OBJECT
 
@@ -147,7 +153,15 @@ class DVAPI HexagonalColorWheel final : public GLWidgetForHighDpi {
   float m_triEdgeLen;
   float m_triHeight;
   QPointF m_wp[7], m_leftp[3];
+  QPointF m_innerWp[7];
+  QPointF m_circleCenter;
+  float m_hexEdgeLen;
+  float m_hexTriHeight;
+  float m_outerRadius;
+  float m_innerRadius;
+  float m_ringInnerScale = 0.72f;
 
+  ColorWheelDisplayMode m_displayMode = ClassicWheelDisplay;
   CurrentWheel m_currentWheel;
 
   // used for color calibration with 3DLUT
@@ -158,9 +172,36 @@ class DVAPI HexagonalColorWheel final : public GLWidgetForHighDpi {
   bool m_cuedCalibrationUpdate = false;
 
 private:
+  void computeHexVertices();
+  void computeInnerHexVertices();
+  void computeClassicLayout(int w, int h);
+  void computeCompactLayout(int w, int h);
+  void computeExtendedLayout(int w, int h);
+  void updateLayout(int w, int h);
+  void drawClassicHexWheel(float v);
+  void drawHueRing();
+  void drawCircularHueRing();
+  void drawInnerHexBackground();
+  void drawSatValueTriangle();
   void drawCurrentColorMark();
+  void drawHueRingBaton(int hue, float innerDist, float outerDist,
+                        const QPointF &center);
+  void computeCompactSVTriangle();
+  QPointF svTriangleMarkerPos(float s, float v) const;
+  static bool svTriangleBarycentric(const QPointF &p, const QPointF &hueV,
+                                    const QPointF &blackV,
+                                    const QPointF &whiteV, float &wHue,
+                                    float &wBlack, float &wWhite);
+  void svFromTrianglePoint(const QPointF &localPos, int &s, int &v) const;
   void clickLeftWheel(const QPoint &pos);
+  void clickHueRing(const QPoint &pos);
   void clickRightTriangle(const QPoint &pos);
+  bool isInHueRing(const QPoint &pos) const;
+  bool isInCircularHueRing(const QPoint &pos) const;
+  bool isInClassicWheel(const QPoint &pos) const;
+  bool isInTriangle(const QPoint &pos) const;
+  static void hexCornerColor(int cornerIndex, float v, float &r, float &g,
+                             float &b);
 
 public:
   HexagonalColorWheel(QWidget *parent);
@@ -170,6 +211,9 @@ public:
 
   void setBGColor(const QColor &color) { m_bgColor = color; }
   QColor getBGColor() const { return m_bgColor; }
+
+  void setDisplayMode(ColorWheelDisplayMode mode);
+  ColorWheelDisplayMode displayMode() const { return m_displayMode; }
 
   void updateColorCalibration();
   void cueCalibrationUpdate() { m_cuedCalibrationUpdate = true; }
@@ -496,6 +540,7 @@ public:
   void setSplitterState(QByteArray state);
 
   void updateColorCalibration();
+  void setColorWheelDisplayMode(ColorWheelDisplayMode mode);
 
 protected:
   void resizeEvent(QResizeEvent *) override;
@@ -912,6 +957,7 @@ class DVAPI StyleEditor final : public QWidget, public SaveLoadQSettings {
   QAction *m_searchAction;
   QAction *m_bottomBarAction;
   QActionGroup *m_sliderAppearanceAG;
+  QActionGroup *m_colorWheelDisplayModeAG;
   QAction *m_hexEditorAction;
 
   QFrame *m_textureSearchFrame;
@@ -1039,6 +1085,7 @@ protected slots:
   void onVectorBrushButtonToggled(bool on);
 
   void onSliderAppearanceSelected(QAction *);
+  void onColorWheelDisplayModeSelected(QAction *);
   void onPopupMenuAboutToShow();
   void onBottomBarToggled(bool visible);
   void onMainSplitterMoved(int pos, int index);

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -67,6 +67,7 @@ class QPushButton;
 class QTabWidget;
 class QToolBar;
 class QOpenGLFramebufferObject;
+class QMenu;
 
 class ColorSquaredWheel;
 class TabBarContainter;
@@ -231,6 +232,7 @@ protected:
   void showEvent(QShowEvent *) override;
 signals:
   void colorChanged(const ColorModel &color, bool isDragging);
+  void contextMenuRequested(const QPoint &globalPos);
 
 public slots:
   void onContextAboutToBeDestroyed();
@@ -541,6 +543,7 @@ public:
 
   void updateColorCalibration();
   void setColorWheelDisplayMode(ColorWheelDisplayMode mode);
+  bool connectWheelContextMenu(const QObject *receiver, const char *member);
 
 protected:
   void resizeEvent(QResizeEvent *) override;
@@ -1012,6 +1015,9 @@ public:
 
   void updateColorCalibration();
 
+signals:
+  void wheelContextMenuAboutToShow(QMenu *menu);
+
 protected:
   /*! Return false if style is linked and style must be set to null.*/
   bool setStyle(TColorStyle *currentStyle);
@@ -1086,6 +1092,7 @@ protected slots:
 
   void onSliderAppearanceSelected(QAction *);
   void onColorWheelDisplayModeSelected(QAction *);
+  void onWheelContextMenu(const QPoint &globalPos);
   void onPopupMenuAboutToShow();
   void onBottomBarToggled(bool visible);
   void onMainSplitterMoved(int pos, int index);

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -121,9 +121,16 @@ void TPanel::onCloseButtonPressed() {
 
 void TPanel::onCustomContextMenuRequested(const QPoint &pos) {
   QMenu menu(this);
+  appendRoomBindMenuAction(&menu);
+  menu.exec(mapToGlobal(pos));
+}
 
-  // Add "Bind to Current Room" option
-  QAction *bindAction = menu.addAction(tr("Bind to Current Room"));
+//-----------------------------------------------------------------------------
+
+void TPanel::appendRoomBindMenuAction(QMenu *menu) {
+  if (!menu) return;
+
+  QAction *bindAction = menu->addAction(tr("Bind to Current Room"));
   bindAction->setCheckable(true);
   bindAction->setChecked(m_isRoomBound);
 
@@ -134,23 +141,15 @@ void TPanel::onCustomContextMenuRequested(const QPoint &pos) {
     Room *currentRoom = mw->getCurrentRoom();
     if (!currentRoom) return;
 
-    // Update binding state
     setRoomBound(checked);
     if (checked) {
-      // Bind panel to current room
       setBoundRoomName(currentRoom->getName());
-      // Update visibility immediately for all bound panels
       mw->updatePanelVisibility();
     } else {
-      // Unbind panel from room
       setBoundRoomName(QString());
-      // Show panel if it was hidden
       if (isHidden()) show();
     }
   });
-
-  menu.exec(mapToGlobal(pos));
-  // menu is automatically deleted by unique_ptr
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -17,6 +17,7 @@
 class TPanelTitleBarButtonSet;
 class TPanelTitleBarButton;
 class Room;
+class QMenu;
 
 //-----------------------------------------------------------------------------
 //! icon buttons placed on the panel titlebar (cfr. viewerpane.h)
@@ -307,6 +308,7 @@ public:
   // Add room binding toggle button to the title bar
   // This enables the "Bind to Room" feature for any panel
   void addRoomBindButton();
+  void appendRoomBindMenuAction(QMenu *menu);
 
   // Virtuals that may be overridden
   virtual void reset() {}

--- a/toonz/sources/toonz/tpanels.cpp
+++ b/toonz/sources/toonz/tpanels.cpp
@@ -257,7 +257,7 @@ void SchematicScenePanel::onDeleteStageObjects(
     return;
 
   TApp *app = TApp::instance();
-  // Safe conversion QList → std::vector (avoids std::length_error crash)
+  // Safe conversion QList ? std::vector (avoids std::length_error crash)
   const QList<TStageObjectId> objList = selection->getObjects();
   std::vector<TStageObjectId> objects(objList.begin(), objList.end());
 
@@ -931,6 +931,8 @@ StyleEditorPanel::StyleEditorPanel(QWidget *parent) : TPanel(parent) {
   setWidget(m_styleEditor);
 
   m_styleEditor->setLevelHandle(TApp::instance()->getCurrentLevel());
+  connect(m_styleEditor, SIGNAL(wheelContextMenuAboutToShow(QMenu *)), this,
+          SLOT(onWheelContextMenuAboutToShow(QMenu *)));
   setMinimumWidth(200);
   resize(340, 630);
 }
@@ -952,6 +954,13 @@ void StyleEditorPanel::hideEvent(QHideEvent *) {
 void StyleEditorPanel::onPreferenceChanged(const QString &prefName) {
   if (prefName == "ColorCalibration") m_styleEditor->updateColorCalibration();
 }
+
+//-----------------------------------------------------------------------------
+
+void StyleEditorPanel::onWheelContextMenuAboutToShow(QMenu *menu) {
+  appendRoomBindMenuAction(menu);
+}
+
 //-----------------------------------------------------------------------------
 
 class StyleEditorFactory final : public TPanelFactory {

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -111,6 +111,7 @@ protected:
   void hideEvent(QHideEvent *) override;
 protected slots:
   void onPreferenceChanged(const QString &prefName);
+  void onWheelContextMenuAboutToShow(QMenu *menu);
 };
 
 //=========================================================

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -1182,6 +1182,10 @@ bool HexagonalColorWheel::isInTriangle(const QPoint &pos) const {
 //-----------------------------------------------------------------------------
 
 void HexagonalColorWheel::mousePressEvent(QMouseEvent *event) {
+  if (event->button() == Qt::RightButton) {
+    emit contextMenuRequested(event->globalPos());
+    return;
+  }
   if (~event->buttons() & Qt::LeftButton) return;
 
   QPoint curPos = event->pos() * getDevPixRatio();
@@ -2176,6 +2180,14 @@ void PlainColorPage::updateColorCalibration() {
 
 void PlainColorPage::setColorWheelDisplayMode(ColorWheelDisplayMode mode) {
   m_hexagonalColorWheel->setDisplayMode(mode);
+}
+
+//-----------------------------------------------------------------------------
+
+bool PlainColorPage::connectWheelContextMenu(const QObject *receiver,
+                                             const char *member) {
+  return connect(m_hexagonalColorWheel, SIGNAL(contextMenuRequested(QPoint)),
+                 receiver, member);
 }
 
 //-----------------------------------------------------------------------------
@@ -3391,6 +3403,8 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
   ret = ret && connect(m_plainColorPage,
                        SIGNAL(colorChanged(const ColorModel &, bool)), this,
                        SLOT(onColorChanged(const ColorModel &, bool)));
+  ret = ret && m_plainColorPage->connectWheelContextMenu(
+                       this, SLOT(onWheelContextMenu(QPoint)));
   assert(ret);
   /* ------- initial conditions ------- */
   enable(false, false, false);
@@ -4718,6 +4732,29 @@ void StyleEditor::onColorWheelDisplayModeSelected(QAction *action) {
   if (displayId == (int)StyleEditorColorWheelDisplayMode) return;
   StyleEditorColorWheelDisplayMode = displayId;
   m_plainColorPage->setColorWheelDisplayMode((ColorWheelDisplayMode)displayId);
+}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::onWheelContextMenu(const QPoint &globalPos) {
+  if (!m_colorWheelDisplayModeAG || !m_bottomBarAction) return;
+
+  for (auto action : m_colorWheelDisplayModeAG->actions()) {
+    bool ok         = true;
+    int displayId = action->data().toInt(&ok);
+    if (ok && displayId == (int)StyleEditorColorWheelDisplayMode)
+      action->setChecked(true);
+  }
+
+  QMenu menu(this);
+  QMenu *wheelShapeMenu = menu.addMenu(tr("Wheel Shape"));
+  for (auto action : m_colorWheelDisplayModeAG->actions())
+    wheelShapeMenu->addAction(action);
+  menu.addSeparator();
+  menu.addAction(m_bottomBarAction);
+  menu.addSeparator();
+  emit wheelContextMenuAboutToShow(&menu);
+  menu.exec(globalPos);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -650,7 +650,8 @@ void HexagonalColorWheel::initializeGL() {
   if (m_firstInitialized)
     m_firstInitialized = false;
   else {
-    resizeGL(width(), height());
+    // Logical size: resizeGL multiplies by DPR once.
+    resizeGL(QOpenGLWidget::width(), QOpenGLWidget::height());
     update();
   }
 }
@@ -826,9 +827,16 @@ void HexagonalColorWheel::updateLayout(int w, int h) {
 void HexagonalColorWheel::setDisplayMode(ColorWheelDisplayMode mode) {
   if (m_displayMode == mode) return;
   m_displayMode = mode;
-  int lw = width() * getDevPixRatio();
-  int lh = height() * getDevPixRatio();
-  if (lw > 0 && lh > 0) updateLayout(lw, lh);
+  // GLWidgetForHighDpi::width()/height() already include the device pixel
+  // ratio. Pass the logical QOpenGLWidget size into resizeGL so DPR is
+  // applied only once (same contract as Qt's resizeGL callback).
+  const int logicalW = QOpenGLWidget::width();
+  const int logicalH = QOpenGLWidget::height();
+  if (logicalW > 0 && logicalH > 0 && isValid()) {
+    makeCurrent();
+    resizeGL(logicalW, logicalH);
+    doneCurrent();
+  }
   update();
 }
 

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -54,9 +54,13 @@
 #include <QStyleOptionSlider>
 #include <QToolTip>
 #include <QSplitter>
+#include <QSplitterHandle>
 #include <QTimer>
 #include <QMenu>
 #include <QOpenGLFramebufferObject>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QResizeEvent>
 
 namespace {
 enum ColorSliderAppearance {
@@ -2886,6 +2890,8 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
     , m_hexColorNamesEditor(0)
     , m_editedStyle(0) {
   setFocusPolicy(Qt::NoFocus);
+  // Needed for QSS rules like "#StyleEditor #bottomWidget QPushButton".
+  setObjectName("StyleEditor");
   // Remove
   TFilePath libraryPath = ToonzFolder::getLibraryFolder();
   setRootPath(libraryPath);
@@ -2962,6 +2968,10 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
     m_mainSplitter->setStretchFactor(1, 0);
     m_mainSplitter->setCollapsible(0, false);
     m_mainSplitter->setCollapsible(1, true);
+    // Allow temporarily lowering the bottom min-height while the user drags
+    // the handle (see eventFilter); otherwise window resize would thin it.
+    if (QSplitterHandle *handle = m_mainSplitter->handle(1))
+      handle->installEventFilter(this);
 
     mainLayout->addWidget(m_tabBarContainer);
     mainLayout->addWidget(m_mainSplitter, 1);
@@ -3030,6 +3040,8 @@ QFrame *StyleEditor::createBottomWidget() {
   bottomWidget->setFrameStyle(QFrame::StyledPanel);
   bottomWidget->setObjectName("bottomWidget");
   bottomWidget->setContentsMargins(0, 0, 0, 0);
+  // Allow full collapse via the splitter; expanded size is enforced in
+  // restoreBottomBarExpandedSize() (original floor was 60px).
   bottomWidget->setMinimumHeight(0);
   m_applyButton->setToolTip(tr("Apply changes to current style"));
   m_applyButton->setDisabled(m_paletteController->isColorAutoApplyEnabled());
@@ -3207,12 +3219,78 @@ QFrame *StyleEditor::createBottomWidget() {
                        SLOT(onPopupMenuAboutToShow()));
   assert(ret);
 
-  // Cap the maximum height to the widget's natural size so the bottom section
-  // can only collapse (0) or sit at its original height — never grow via drag.
-  int naturalH = bottomWidget->sizeHint().height();
-  if (naturalH > 0) bottomWidget->setMaximumHeight(naturalH);
-
   return bottomWidget;
+}
+
+//-----------------------------------------------------------------------------
+
+int StyleEditor::bottomBarNaturalHeight() const {
+  static const int kOriginalMinH = 60;
+  if (!m_bottomWidget) return kOriginalMinH;
+
+  // Measure without the expanded min=max lock, otherwise sizeHint just
+  // echoes the previous locked height.
+  QFrame *w          = m_bottomWidget;
+  const int savedMin = w->minimumHeight();
+  const int savedMax = w->maximumHeight();
+  w->setMinimumHeight(0);
+  w->setMaximumHeight(QWIDGETSIZE_MAX);
+
+  w->ensurePolished();
+  if (m_autoButton) m_autoButton->ensurePolished();
+  if (m_applyButton) m_applyButton->ensurePolished();
+  if (QLayout *l = w->layout()) l->activate();
+
+  int h = w->sizeHint().height();
+  h     = std::max(h, w->minimumSizeHint().height());
+  h     = std::max(h, kOriginalMinH);
+
+  w->setMinimumHeight(savedMin);
+  w->setMaximumHeight(savedMax);
+  return h;
+}
+
+//-----------------------------------------------------------------------------
+
+// Expanded: lock min=max=natural height so a window resize cannot thin
+// Auto/Apply (pre-collapsible behavior). Collapsed: min=0 so the leaf can
+// stay shut; max stays at natural so drag-to-reopen still works.
+void StyleEditor::setBottomBarExpandedConstraints(bool expanded) {
+  if (!m_bottomWidget) return;
+  const int naturalH = bottomBarNaturalHeight();
+  if (expanded) {
+    m_bottomWidget->setMinimumHeight(naturalH);
+    m_bottomWidget->setMaximumHeight(naturalH);
+  } else {
+    m_bottomWidget->setMinimumHeight(0);
+    m_bottomWidget->setMaximumHeight(naturalH);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::restoreBottomBarExpandedSize() {
+  if (!m_mainSplitter || !m_bottomWidget) return;
+
+  const bool expanded =
+      !m_bottomBarAction || m_bottomBarAction->isChecked();
+
+  QList<int> sizes = m_mainSplitter->sizes();
+  int total        = (sizes.size() >= 2) ? (sizes[0] + sizes[1]) : 0;
+  if (total <= 0) total = m_mainSplitter->height();
+
+  const int naturalH = bottomBarNaturalHeight();
+  setBottomBarExpandedConstraints(expanded);
+
+  if (!expanded) {
+    if (total > 0) m_mainSplitter->setSizes({total, 0});
+    return;
+  }
+
+  if (total <= 0) return;
+
+  const int bottomH = std::min(naturalH, total);
+  m_mainSplitter->setSizes({std::max(0, total - bottomH), bottomH});
 }
 
 //-----------------------------------------------------------------------------
@@ -3517,17 +3595,19 @@ void StyleEditor::showEvent(QShowEvent *) {
   updateOrientationButton();
   assert(ret);
 
-  if (!m_bottomInitialized && m_mainSplitter) {
-    m_bottomInitialized = true;
-    QTimer::singleShot(0, this, [this]() {
-      int total    = m_mainSplitter->height();
-      if (total <= 0) return;
-      bool visible = m_bottomBarAction && m_bottomBarAction->isChecked();
-      int naturalH = visible ? m_bottomWidget->sizeHint().height() : 0;
-      naturalH     = qBound(0, naturalH, total - 40);
-      m_mainSplitter->setSizes({total - naturalH, naturalH});
-    });
+  // Handle may not exist until the splitter is shown.
+  if (m_mainSplitter) {
+    if (QSplitterHandle *handle = m_mainSplitter->handle(1))
+      handle->installEventFilter(this);
   }
+
+  // After the widget is shown and styles are applied, pin the bottom bar
+  // back to its original content height (floating panels often open with a
+  // zero/thin splitter size inherited from a saved state).
+  QTimer::singleShot(0, this, [this]() {
+    restoreBottomBarExpandedSize();
+    QTimer::singleShot(50, this, [this]() { restoreBottomBarExpandedSize(); });
+  });
 }
 
 //-----------------------------------------------------------------------------
@@ -3536,6 +3616,54 @@ void StyleEditor::hideEvent(QHideEvent *) {
   disconnect(m_paletteHandle, 0, this, 0);
   if (m_cleanupPaletteHandle) disconnect(m_cleanupPaletteHandle, 0, this, 0);
   disconnect(m_paletteController, 0, this, 0);
+}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::resizeEvent(QResizeEvent *event) {
+  QWidget::resizeEvent(event);
+  if (!m_mainSplitter || !m_bottomWidget) return;
+  if (m_bottomBarAction && !m_bottomBarAction->isChecked()) return;
+
+  // Window resize (not splitter-handle drag): keep the bottom bar at its
+  // natural height like the original non-splitter layout, and let the
+  // color page absorb the shrink.
+  QList<int> sizes = m_mainSplitter->sizes();
+  if (sizes.size() < 2 || sizes[1] <= 2) return;
+
+  const int naturalH = bottomBarNaturalHeight();
+  const int total    = m_mainSplitter->height();
+  if (total <= 0 || sizes[1] == naturalH) return;
+
+  setBottomBarExpandedConstraints(true);
+  const int bottomH = std::min(naturalH, total);
+  m_mainSplitter->setSizes({std::max(0, total - bottomH), bottomH});
+}
+
+//-----------------------------------------------------------------------------
+
+bool StyleEditor::eventFilter(QObject *watched, QEvent *event) {
+  if (m_mainSplitter && m_bottomWidget &&
+      watched == m_mainSplitter->handle(1)) {
+    if (event->type() == QEvent::MouseButtonPress) {
+      // Temporarily unlock min-height so the user can drag-collapse.
+      m_bottomWidget->setMinimumHeight(0);
+      m_bottomWidget->setMaximumHeight(bottomBarNaturalHeight());
+    } else if (event->type() == QEvent::MouseButtonRelease) {
+      QList<int> sizes = m_mainSplitter->sizes();
+      const bool expanded = sizes.size() >= 2 && sizes[1] > 2;
+      if (m_bottomBarAction) {
+        bool blocked = m_bottomBarAction->blockSignals(true);
+        m_bottomBarAction->setChecked(expanded);
+        m_bottomBarAction->blockSignals(blocked);
+      }
+      if (expanded)
+        restoreBottomBarExpandedSize();
+      else
+        setBottomBarExpandedConstraints(false);
+    }
+  }
+  return QWidget::eventFilter(watched, event);
 }
 
 //-----------------------------------------------------------------------------
@@ -4072,8 +4200,10 @@ void StyleEditor::save(QSettings &settings) const {
   if (m_bottomBarAction && m_bottomBarAction->isChecked()) visibleParts |= 0x40;
   settings.setValue("visibleParts", visibleParts);
   settings.setValue("splitterState", m_plainColorPage->getSplitterState());
-  if (m_mainSplitter)
+  if (m_mainSplitter) {
+    const_cast<StyleEditor *>(this)->restoreBottomBarExpandedSize();
     settings.setValue("bottomSplitterState", m_mainSplitter->saveState());
+  }
 }
 void StyleEditor::load(QSettings &settings) {
   QVariant isVertical = settings.value("isVertical");
@@ -4120,22 +4250,15 @@ void StyleEditor::load(QSettings &settings) {
   QVariant bottomState = settings.value("bottomSplitterState");
   if (m_mainSplitter && bottomState.canConvert(QVariant::ByteArray))
     m_mainSplitter->restoreState(bottomState.toByteArray());
+  // Ignore a thinned saved height; always re-pin to original dimensions.
+  QTimer::singleShot(0, this, [this]() { restoreBottomBarExpandedSize(); });
 }
 
 //-----------------------------------------------------------------------------
 
 void StyleEditor::onBottomBarToggled(bool visible) {
-  if (!m_mainSplitter) return;
-  QList<int> sizes = m_mainSplitter->sizes();
-  if (sizes.size() < 2) return;
-  int total = sizes[0] + sizes[1];
-  if (visible) {
-    int naturalH = m_bottomWidget->sizeHint().height();
-    naturalH     = qBound(naturalH / 2, naturalH, total - 40);
-    m_mainSplitter->setSizes({total - naturalH, naturalH});
-  } else {
-    m_mainSplitter->setSizes({total, 0});
-  }
+  Q_UNUSED(visible);
+  restoreBottomBarExpandedSize();
 }
 
 //-----------------------------------------------------------------------------
@@ -4144,7 +4267,7 @@ void StyleEditor::onMainSplitterMoved(int, int) {
   if (!m_mainSplitter || !m_bottomBarAction) return;
   QList<int> sizes = m_mainSplitter->sizes();
   if (sizes.size() < 2) return;
-  bool collapsed = sizes[1] == 0;
+  bool collapsed = sizes[1] <= 2;
   bool blocked   = m_bottomBarAction->blockSignals(true);
   m_bottomBarAction->setChecked(!collapsed);
   m_bottomBarAction->blockSignals(blocked);

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -54,6 +54,7 @@
 #include <QStyleOptionSlider>
 #include <QToolTip>
 #include <QSplitter>
+#include <QTimer>
 #include <QMenu>
 #include <QOpenGLFramebufferObject>
 
@@ -2874,6 +2875,9 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
     , m_paletteHandle(paletteController->getCurrentPalette())
     , m_cleanupPaletteHandle(paletteController->getCurrentCleanupPalette())
     , m_toolBar(0)
+    , m_mainSplitter(0)
+    , m_bottomWidget(0)
+    , m_bottomBarAction(0)
     , m_enabled(false)
     , m_enabledOnlyFirstTab(false)
     , m_enabledFirstAndLastTab(false)
@@ -2931,9 +2935,9 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
   m_styleChooser->addWidget(makeChooserPageWithoutScrollBar(emptyPage));
   m_styleChooser->setFocusPolicy(Qt::NoFocus);
 
-  QFrame *bottomWidget = createBottomWidget();
+  createBottomWidget();
   /* ------- layout ------- */
-  QGridLayout *mainLayout = new QGridLayout;
+  QVBoxLayout *mainLayout = new QVBoxLayout;
   mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->setSpacing(0);
   {
@@ -2946,19 +2950,29 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
     }
     m_tabBarContainer->setLayout(hLayout);
 
-    mainLayout->addWidget(m_tabBarContainer, 0, 0, 1, 2);
-    mainLayout->addWidget(m_styleChooser, 1, 0, 1, 2);
-    mainLayout->addWidget(bottomWidget, 2, 0, 1, 2);
-    // mainLayout->addWidget(m_toolBar, 3, 0);
-    // mainLayout->addWidget(displayToolbar, 3, 1);
+    m_mainSplitter = new QSplitter(Qt::Vertical, this);
+    m_mainSplitter->setFocusPolicy(Qt::NoFocus);
+    // setHandleWidth(2): any value > 0 overrides the global QSS
+    // "QSplitter::handle { height: 4 }" (Qt falls back to QSS only when
+    // handleWidth == 0). 2px gives a thin but draggable handle.
+    m_mainSplitter->setHandleWidth(2);
+    m_mainSplitter->addWidget(m_styleChooser);
+    m_mainSplitter->addWidget(m_bottomWidget);
+    m_mainSplitter->setStretchFactor(0, 1);
+    m_mainSplitter->setStretchFactor(1, 0);
+    m_mainSplitter->setCollapsible(0, false);
+    m_mainSplitter->setCollapsible(1, true);
+
+    mainLayout->addWidget(m_tabBarContainer);
+    mainLayout->addWidget(m_mainSplitter, 1);
   }
-  mainLayout->setColumnStretch(0, 1);
-  mainLayout->setRowStretch(1, 1);
   setLayout(mainLayout);
 
   /* ------- signal-slot connections ------- */
 
   bool ret = true;
+  ret      = ret && connect(m_mainSplitter, SIGNAL(splitterMoved(int, int)), this,
+                            SLOT(onMainSplitterMoved(int, int)));
   ret      = ret && connect(m_styleBar, SIGNAL(currentChanged(int)), this,
                             SLOT(setPage(int)));
   ret = ret && connect(m_colorParameterSelector, SIGNAL(colorParamChanged()),
@@ -3006,7 +3020,8 @@ void StyleEditor::setPaletteHandle(TPaletteHandle* paletteHandle)
 //-----------------------------------------------------------------------------
 
 QFrame *StyleEditor::createBottomWidget() {
-  QFrame *bottomWidget = new QFrame(this);
+  m_bottomWidget       = new QFrame(this);
+  QFrame *bottomWidget = m_bottomWidget;
   m_autoButton         = new QPushButton(tr("Auto"));
   m_oldColor           = new DVGui::StyleSample(this, 42, 24);
   m_newColor           = new DVGui::StyleSample(this, 42, 24);
@@ -3015,7 +3030,7 @@ QFrame *StyleEditor::createBottomWidget() {
   bottomWidget->setFrameStyle(QFrame::StyledPanel);
   bottomWidget->setObjectName("bottomWidget");
   bottomWidget->setContentsMargins(0, 0, 0, 0);
-  bottomWidget->setMinimumHeight(60);
+  bottomWidget->setMinimumHeight(0);
   m_applyButton->setToolTip(tr("Apply changes to current style"));
   m_applyButton->setDisabled(m_paletteController->isColorAutoApplyEnabled());
   m_applyButton->setFocusPolicy(Qt::NoFocus);
@@ -3048,7 +3063,8 @@ QFrame *StyleEditor::createBottomWidget() {
   m_alphaAction  = new QAction(tr("Alpha"), this);
   m_rgbAction    = new QAction(tr("RGB"), this);
   m_hexAction    = new QAction(tr("Hex"), this);
-  m_searchAction = new QAction(tr("Search"), this);
+  m_searchAction    = new QAction(tr("Search"), this);
+  m_bottomBarAction = new QAction(tr("Bottom Bar"), this);
 
   m_wheelAction->setCheckable(true);
   m_hsvAction->setCheckable(true);
@@ -3056,18 +3072,24 @@ QFrame *StyleEditor::createBottomWidget() {
   m_rgbAction->setCheckable(true);
   m_hexAction->setCheckable(true);
   m_searchAction->setCheckable(true);
+  m_bottomBarAction->setCheckable(true);
+  m_bottomBarAction->setToolTip(
+      tr("Show or hide the bottom bar (Apply, Auto, controls)."));
   m_wheelAction->setChecked(true);
   m_hsvAction->setChecked(true);
   m_alphaAction->setChecked(true);
   m_rgbAction->setChecked(true);
   m_hexAction->setChecked(false);
   m_searchAction->setChecked(false);
+  m_bottomBarAction->setChecked(true);
   menu->addAction(m_wheelAction);
   menu->addAction(m_hsvAction);
   menu->addAction(m_alphaAction);
   menu->addAction(m_rgbAction);
   menu->addAction(m_hexAction);
   menu->addAction(m_searchAction);
+  menu->addSeparator();
+  menu->addAction(m_bottomBarAction);
 
   m_sliderAppearanceAG = new QActionGroup(this);
   QAction *relColorAct =
@@ -3169,6 +3191,8 @@ QFrame *StyleEditor::createBottomWidget() {
                        SLOT(setVisible(bool)));
   ret = ret && connect(m_searchAction, SIGNAL(toggled(bool)), this,
                        SLOT(onSearchVisible(bool)));
+  ret = ret && connect(m_bottomBarAction, SIGNAL(toggled(bool)), this,
+                       SLOT(onBottomBarToggled(bool)));
   ret = ret && connect(m_hexLineEdit, SIGNAL(editingFinished()), this,
                        SLOT(onHexChanged()));
   ret = ret && connect(m_hexEditorAction, SIGNAL(triggered()), this,
@@ -3182,6 +3206,11 @@ QFrame *StyleEditor::createBottomWidget() {
   ret = ret && connect(menu, SIGNAL(aboutToShow()), this,
                        SLOT(onPopupMenuAboutToShow()));
   assert(ret);
+
+  // Cap the maximum height to the widget's natural size so the bottom section
+  // can only collapse (0) or sit at its original height — never grow via drag.
+  int naturalH = bottomWidget->sizeHint().height();
+  if (naturalH > 0) bottomWidget->setMaximumHeight(naturalH);
 
   return bottomWidget;
 }
@@ -3487,6 +3516,18 @@ void StyleEditor::showEvent(QShowEvent *) {
   onSearchVisible(m_searchAction->isChecked());
   updateOrientationButton();
   assert(ret);
+
+  if (!m_bottomInitialized && m_mainSplitter) {
+    m_bottomInitialized = true;
+    QTimer::singleShot(0, this, [this]() {
+      int total    = m_mainSplitter->height();
+      if (total <= 0) return;
+      bool visible = m_bottomBarAction && m_bottomBarAction->isChecked();
+      int naturalH = visible ? m_bottomWidget->sizeHint().height() : 0;
+      naturalH     = qBound(0, naturalH, total - 40);
+      m_mainSplitter->setSizes({total - naturalH, naturalH});
+    });
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -4028,8 +4069,11 @@ void StyleEditor::save(QSettings &settings) const {
   if (m_rgbAction->isChecked()) visibleParts |= 0x08;
   if (m_hexAction->isChecked()) visibleParts |= 0x10;
   if (m_searchAction->isChecked()) visibleParts |= 0x20;
+  if (m_bottomBarAction && m_bottomBarAction->isChecked()) visibleParts |= 0x40;
   settings.setValue("visibleParts", visibleParts);
   settings.setValue("splitterState", m_plainColorPage->getSplitterState());
+  if (m_mainSplitter)
+    settings.setValue("bottomSplitterState", m_mainSplitter->saveState());
 }
 void StyleEditor::load(QSettings &settings) {
   QVariant isVertical = settings.value("isVertical");
@@ -4065,10 +4109,45 @@ void StyleEditor::load(QSettings &settings) {
       m_searchAction->setChecked(true);
     else
       m_searchAction->setChecked(false);
+    if (m_bottomBarAction) {
+      bool bottomVisible = (visiblePartsInt & 0x40) != 0;
+      m_bottomBarAction->setChecked(bottomVisible);
+    }
   }
   QVariant splitterState = settings.value("splitterState");
   if (splitterState.canConvert(QVariant::ByteArray))
     m_plainColorPage->setSplitterState(splitterState.toByteArray());
+  QVariant bottomState = settings.value("bottomSplitterState");
+  if (m_mainSplitter && bottomState.canConvert(QVariant::ByteArray))
+    m_mainSplitter->restoreState(bottomState.toByteArray());
+}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::onBottomBarToggled(bool visible) {
+  if (!m_mainSplitter) return;
+  QList<int> sizes = m_mainSplitter->sizes();
+  if (sizes.size() < 2) return;
+  int total = sizes[0] + sizes[1];
+  if (visible) {
+    int naturalH = m_bottomWidget->sizeHint().height();
+    naturalH     = qBound(naturalH / 2, naturalH, total - 40);
+    m_mainSplitter->setSizes({total - naturalH, naturalH});
+  } else {
+    m_mainSplitter->setSizes({total, 0});
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::onMainSplitterMoved(int, int) {
+  if (!m_mainSplitter || !m_bottomBarAction) return;
+  QList<int> sizes = m_mainSplitter->sizes();
+  if (sizes.size() < 2) return;
+  bool collapsed = sizes[1] == 0;
+  bool blocked   = m_bottomBarAction->blockSignals(true);
+  m_bottomBarAction->setChecked(!collapsed);
+  m_bottomBarAction->blockSignals(blocked);
 }
 
 //-----------------------------------------------------------------------------
@@ -4100,3 +4179,6 @@ void StyleEditor::onPopupMenuAboutToShow() {
       action->setChecked(true);
   }
 }
+
+//-----------------------------------------------------------------------------
+

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -70,6 +70,8 @@ enum ColorSliderAppearance {
 }
 TEnv::IntVar StyleEditorColorSliderAppearance(
     "StyleEditorColorSliderAppearance", RelativeColoredTriangleHandle);
+TEnv::IntVar StyleEditorColorWheelDisplayMode(
+    "StyleEditorColorWheelDisplayMode", ClassicWheelDisplay);
 
 using namespace StyleEditorGUI;
 
@@ -581,6 +583,8 @@ HexagonalColorWheel::HexagonalColorWheel(QWidget *parent)
   setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   setFocusPolicy(Qt::NoFocus);
   m_currentWheel = none;
+  m_displayMode =
+      (ColorWheelDisplayMode)(int)StyleEditorColorWheelDisplayMode;
   if (Preferences::instance()->isColorCalibrationEnabled())
     m_lutCalibrator = new LutCalibrator();
 }
@@ -653,9 +657,80 @@ void HexagonalColorWheel::initializeGL() {
 
 //-----------------------------------------------------------------------------
 
-void HexagonalColorWheel::resizeGL(int w, int h) {
-  w *= getDevPixRatio();
-  h *= getDevPixRatio();
+void HexagonalColorWheel::hexCornerColor(int cornerIndex, float v, float &r,
+                                         float &g, float &b) {
+  switch (cornerIndex) {
+  case 1:
+    r = 0.0f;
+    g = v;
+    b = 0.0f;
+    break;
+  case 2:
+    r = 0.0f;
+    g = v;
+    b = v;
+    break;
+  case 3:
+    r = 0.0f;
+    g = 0.0f;
+    b = v;
+    break;
+  case 4:
+    r = v;
+    g = 0.0f;
+    b = v;
+    break;
+  case 5:
+    r = v;
+    g = 0.0f;
+    b = 0.0f;
+    break;
+  case 6:
+    r = v;
+    g = v;
+    b = 0.0f;
+    break;
+  default:
+    r = g = b = v;
+    break;
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::computeHexVertices() {
+  m_hexTriHeight = m_hexEdgeLen * 0.866f;
+  m_wp[0].setX(m_hexEdgeLen);
+  m_wp[0].setY(m_hexTriHeight);
+  m_wp[1].setX(m_hexEdgeLen * 0.5f);
+  m_wp[1].setY(0.0f);
+  m_wp[2].setX(0.0f);
+  m_wp[2].setY(m_hexTriHeight);
+  m_wp[3].setX(m_hexEdgeLen * 0.5f);
+  m_wp[3].setY(m_hexTriHeight * 2.0f);
+  m_wp[4].setX(m_hexEdgeLen * 1.5f);
+  m_wp[4].setY(m_hexTriHeight * 2.0f);
+  m_wp[5].setX(m_hexEdgeLen * 2.0f);
+  m_wp[5].setY(m_hexTriHeight);
+  m_wp[6].setX(m_hexEdgeLen * 1.5f);
+  m_wp[6].setY(0.0f);
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::computeInnerHexVertices() {
+  for (int i = 0; i < 7; ++i) {
+    if (i == 0) {
+      m_innerWp[0] = m_wp[0];
+      continue;
+    }
+    m_innerWp[i] = m_wp[0] + (m_wp[i] - m_wp[0]) * m_ringInnerScale;
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::computeClassicLayout(int w, int h) {
   float d                 = (w - 5.0f) / 2.5f;
   bool isHorizontallyLong = ((d * 1.732f) < h) ? false : true;
 
@@ -671,21 +746,8 @@ void HexagonalColorWheel::resizeGL(int w, int h) {
     m_wheelPosition.setY(((float)h - (m_triHeight * 2.0f)) / 2.0f);
   }
 
-  // set all vertices positions
-  m_wp[0].setX(m_triEdgeLen);
-  m_wp[0].setY(m_triHeight);
-  m_wp[1].setX(m_triEdgeLen * 0.5f);
-  m_wp[1].setY(0.0f);
-  m_wp[2].setX(0.0f);
-  m_wp[2].setY(m_triHeight);
-  m_wp[3].setX(m_triEdgeLen * 0.5f);
-  m_wp[3].setY(m_triHeight * 2.0f);
-  m_wp[4].setX(m_triEdgeLen * 1.5f);
-  m_wp[4].setY(m_triHeight * 2.0f);
-  m_wp[5].setX(m_triEdgeLen * 2.0f);
-  m_wp[5].setY(m_triHeight);
-  m_wp[6].setX(m_triEdgeLen * 1.5f);
-  m_wp[6].setY(0.0f);
+  m_hexEdgeLen = m_triEdgeLen;
+  computeHexVertices();
 
   m_leftp[0].setX(m_wp[6].x() + 5.0f);
   m_leftp[0].setY(0.0f);
@@ -693,6 +755,90 @@ void HexagonalColorWheel::resizeGL(int w, int h) {
   m_leftp[1].setY(m_triHeight * 2.0f);
   m_leftp[2].setX(m_leftp[1].x());
   m_leftp[2].setY(0.0f);
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::computeCompactSVTriangle() {
+  float R  = m_innerRadius;
+  float cx = m_circleCenter.x();
+  float cy = m_circleCenter.y();
+  auto onCircle = [&](float deg) {
+    float rad = deg / 180.0f * 3.1415f;
+    return QPointF(cx + R * cosf(rad), cy - R * sinf(rad));
+  };
+  // OpenToonz SV corners on the inner circle, symmetric equilateral layout:
+  // hue top-left, white top-right, black bottom (like AdvancedColorSelector)
+  m_leftp[0] = onCircle(150.0f);
+  m_leftp[2] = onCircle(30.0f);
+  m_leftp[1] = onCircle(270.0f);
+  m_triEdgeLen = (float)QLineF(m_leftp[0], m_leftp[2]).length();
+  m_triHeight  = (float)QLineF(m_leftp[1], m_circleCenter).length();
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::computeCompactLayout(int w, int h) {
+  float avail = std::min((float)w, (float)h);
+  float margin = avail * 0.03f;
+  m_outerRadius = (avail - margin * 2.0f) * 0.5f;
+  // ring band ~15% of outer radius
+  m_innerRadius = m_outerRadius * 0.85f;
+
+  float localSize = m_outerRadius * 2.0f;
+  m_wheelPosition.setX((w - localSize) * 0.5f);
+  m_wheelPosition.setY((h - localSize) * 0.5f);
+
+  m_circleCenter.setX(m_outerRadius);
+  m_circleCenter.setY(m_outerRadius);
+  m_wp[0] = m_circleCenter;
+
+  computeCompactSVTriangle();
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::computeExtendedLayout(int w, int h) {
+  computeClassicLayout(w, h);
+  m_ringInnerScale = 0.72f;
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::updateLayout(int w, int h) {
+  switch (m_displayMode) {
+  case CompactNestedWheelDisplay:
+    computeCompactLayout(w, h);
+    break;
+  case ExtendedCorrectedWheelDisplay:
+    computeExtendedLayout(w, h);
+    computeInnerHexVertices();
+    break;
+  case ClassicWheelDisplay:
+  default:
+    computeClassicLayout(w, h);
+    break;
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::setDisplayMode(ColorWheelDisplayMode mode) {
+  if (m_displayMode == mode) return;
+  m_displayMode = mode;
+  int lw = width() * getDevPixRatio();
+  int lh = height() * getDevPixRatio();
+  if (lw > 0 && lh > 0) updateLayout(lw, lh);
+  update();
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::resizeGL(int w, int h) {
+  w *= getDevPixRatio();
+  h *= getDevPixRatio();
+
+  updateLayout(w, h);
 
   // GL settings
   glViewport(0, 0, w, h);
@@ -705,6 +851,100 @@ void HexagonalColorWheel::resizeGL(int w, int h) {
     if (m_fbo) delete m_fbo;
     m_fbo = new QOpenGLFramebufferObject(w, h);
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::drawClassicHexWheel(float v) {
+  glBegin(GL_TRIANGLE_FAN);
+  glColor3f(v, v, v);
+  glVertex2f(m_wp[0].x(), m_wp[0].y());
+
+  for (int i = 1; i <= 6; ++i) {
+    float r, g, b;
+    hexCornerColor(i, v, r, g, b);
+    glColor3f(r, g, b);
+    glVertex2f(m_wp[i].x(), m_wp[i].y());
+  }
+  float r, g, b;
+  hexCornerColor(1, v, r, g, b);
+  glColor3f(r, g, b);
+  glVertex2f(m_wp[1].x(), m_wp[1].y());
+  glEnd();
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::drawCircularHueRing() {
+  const int segs = 120;
+  float cx = m_circleCenter.x();
+  float cy = m_circleCenter.y();
+  for (int i = 0; i < segs; ++i) {
+    float a0 = (float)i / (float)segs * 360.0f;
+    float a1 = (float)(i + 1) / (float)segs * 360.0f;
+    QColor c0 = QColor::fromHsv((int)a0 % 360, 255, 255);
+    QColor c1 = QColor::fromHsv((int)a1 % 360, 255, 255);
+    float r0 = a0 / 180.0f * 3.1415f;
+    float r1 = a1 / 180.0f * 3.1415f;
+    glBegin(GL_QUADS);
+    glColor3f(c0.redF(), c0.greenF(), c0.blueF());
+    glVertex2f(cx + m_outerRadius * cosf(r0), cy - m_outerRadius * sinf(r0));
+    glColor3f(c1.redF(), c1.greenF(), c1.blueF());
+    glVertex2f(cx + m_outerRadius * cosf(r1), cy - m_outerRadius * sinf(r1));
+    glColor3f(c1.redF(), c1.greenF(), c1.blueF());
+    glVertex2f(cx + m_innerRadius * cosf(r1), cy - m_innerRadius * sinf(r1));
+    glColor3f(c0.redF(), c0.greenF(), c0.blueF());
+    glVertex2f(cx + m_innerRadius * cosf(r0), cy - m_innerRadius * sinf(r0));
+    glEnd();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::drawHueRing() {
+  for (int i = 1; i <= 6; ++i) {
+    int next = (i == 6) ? 1 : i + 1;
+    float r0, g0, b0, r1, g1, b1;
+    hexCornerColor(i, 1.0f, r0, g0, b0);
+    hexCornerColor(next, 1.0f, r1, g1, b1);
+    glBegin(GL_QUADS);
+    glColor3f(r0, g0, b0);
+    glVertex2f(m_wp[i].x(), m_wp[i].y());
+    glColor3f(r1, g1, b1);
+    glVertex2f(m_wp[next].x(), m_wp[next].y());
+    glColor3f(r1, g1, b1);
+    glVertex2f(m_innerWp[next].x(), m_innerWp[next].y());
+    glColor3f(r0, g0, b0);
+    glVertex2f(m_innerWp[i].x(), m_innerWp[i].y());
+    glEnd();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::drawInnerHexBackground() {
+  QColor const color = getBGColor();
+  glColor4f(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+  glBegin(GL_TRIANGLE_FAN);
+  glVertex2f(m_innerWp[0].x(), m_innerWp[0].y());
+  for (int i = 1; i <= 6; ++i)
+    glVertex2f(m_innerWp[i].x(), m_innerWp[i].y());
+  glVertex2f(m_innerWp[1].x(), m_innerWp[1].y());
+  glEnd();
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::drawSatValueTriangle() {
+  QColor hueCol = QColor().fromHsv(m_color.getValue(eHue), 255, 255);
+  glBegin(GL_TRIANGLES);
+  glColor3f(hueCol.redF(), hueCol.greenF(), hueCol.blueF());
+  glVertex2f(m_leftp[0].x(), m_leftp[0].y());
+  glColor3f(0.0f, 0.0f, 0.0f);
+  glVertex2f(m_leftp[1].x(), m_leftp[1].y());
+  glColor3f(1.0f, 1.0f, 1.0f);
+  glVertex2f(m_leftp[2].x(), m_leftp[2].y());
+  glEnd();
 }
 
 //-----------------------------------------------------------------------------
@@ -724,48 +964,107 @@ void HexagonalColorWheel::paintGL() {
   float v = (float)m_color.getValue(eValue) / 100.0f;
 
   glPushMatrix();
-
-  // draw hexagonal color wheel
   glTranslatef(m_wheelPosition.rx(), m_wheelPosition.ry(), 0.0f);
-  glBegin(GL_TRIANGLE_FAN);
-  glColor3f(v, v, v);
-  glVertex2f(m_wp[0].x(), m_wp[0].y());
 
-  glColor3f(0.0f, v, 0.0f);
-  glVertex2f(m_wp[1].x(), m_wp[1].y());
-  glColor3f(0.0f, v, v);
-  glVertex2f(m_wp[2].x(), m_wp[2].y());
-  glColor3f(0.0f, 0.0f, v);
-  glVertex2f(m_wp[3].x(), m_wp[3].y());
-  glColor3f(v, 0.0f, v);
-  glVertex2f(m_wp[4].x(), m_wp[4].y());
-  glColor3f(v, 0.0f, 0.0f);
-  glVertex2f(m_wp[5].x(), m_wp[5].y());
-  glColor3f(v, v, 0.0f);
-  glVertex2f(m_wp[6].x(), m_wp[6].y());
-  glColor3f(0.0f, v, 0.0f);
-  glVertex2f(m_wp[1].x(), m_wp[1].y());
-  glEnd();
+  switch (m_displayMode) {
+  case CompactNestedWheelDisplay:
+    drawCircularHueRing();
+    drawSatValueTriangle();
+    break;
+  case ExtendedCorrectedWheelDisplay:
+    drawHueRing();
+    drawInnerHexBackground();
+    drawSatValueTriangle();
+    break;
+  case ClassicWheelDisplay:
+  default:
+    drawClassicHexWheel(v);
+    drawSatValueTriangle();
+    break;
+  }
 
-  QColor leftCol = QColor().fromHsv(m_color.getValue(eHue), 255, 255);
-
-  // draw triangle color picker
-  glBegin(GL_TRIANGLES);
-  glColor3f(leftCol.redF(), leftCol.greenF(), leftCol.blueF());
-  glVertex2f(m_leftp[0].x(), m_leftp[0].y());
-  glColor3f(0.0f, 0.0f, 0.0f);
-  glVertex2f(m_leftp[1].x(), m_leftp[1].y());
-  glColor3f(1.0f, 1.0f, 1.0f);
-  glVertex2f(m_leftp[2].x(), m_leftp[2].y());
-  glEnd();
-
-  // draw small quad at current color position
   drawCurrentColorMark();
-
   glPopMatrix();
 
   if (m_lutCalibrator && m_lutCalibrator->isValid())
     m_lutCalibrator->onEndDraw(m_fbo);
+}
+
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+
+bool HexagonalColorWheel::svTriangleBarycentric(const QPointF &p,
+                                                const QPointF &hueV,
+                                                const QPointF &blackV,
+                                                const QPointF &whiteV,
+                                                float &wHue, float &wBlack,
+                                                float &wWhite) {
+  QPointF v0 = whiteV - hueV;
+  QPointF v1 = blackV - hueV;
+  QPointF v2 = p - hueV;
+  float dot00 = QPointF::dotProduct(v0, v0);
+  float dot01 = QPointF::dotProduct(v0, v1);
+  float dot02 = QPointF::dotProduct(v0, v2);
+  float dot11 = QPointF::dotProduct(v1, v1);
+  float dot12 = QPointF::dotProduct(v1, v2);
+  float denom = dot00 * dot11 - dot01 * dot01;
+  if (fabs(denom) < 1e-6f) return false;
+  float invDenom = 1.0f / denom;
+  wWhite         = (dot11 * dot02 - dot01 * dot12) * invDenom;
+  wBlack         = (dot00 * dot12 - dot01 * dot02) * invDenom;
+  wHue           = 1.0f - wWhite - wBlack;
+  return wHue >= -0.02f && wBlack >= -0.02f && wWhite >= -0.02f;
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::svFromTrianglePoint(const QPointF &localPos, int &s,
+                                              int &v) const {
+  float wHue, wBlack, wWhite;
+  if (!svTriangleBarycentric(localPos, m_leftp[0], m_leftp[1], m_leftp[2], wHue,
+                             wBlack, wWhite)) {
+    wHue = wBlack = wWhite = 0.0f;
+  }
+  wHue   = std::max(0.0f, wHue);
+  wBlack = std::max(0.0f, wBlack);
+  wWhite = std::max(0.0f, wWhite);
+  float sum = wHue + wBlack + wWhite;
+  if (sum > 0.0f) {
+    wHue /= sum;
+    wBlack /= sum;
+    wWhite /= sum;
+  }
+  s = (int)(std::min(std::max(wHue, 0.0f), 1.0f) * 100.0f + 0.5f);
+  v = (int)(std::min(std::max(wHue + wWhite, 0.0f), 1.0f) * 100.0f + 0.5f);
+}
+
+//-----------------------------------------------------------------------------
+
+QPointF HexagonalColorWheel::svTriangleMarkerPos(float s, float v) const {
+  float wHue   = s / 100.0f;
+  float wWhite = std::max(0.0f, v / 100.0f - wHue);
+  float wBlack = std::max(0.0f, 1.0f - wHue - wWhite);
+  return wHue * m_leftp[0] + wBlack * m_leftp[1] + wWhite * m_leftp[2];
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::drawHueRingBaton(int hue, float innerDist,
+                                           float outerDist,
+                                           const QPointF &center) {
+  float rad       = (float)hue / 180.0f * 3.1415f;
+  float halfAngle = 2.2f / std::max(outerDist, 1.0f);
+  float r0        = rad - halfAngle;
+  float r1        = rad + halfAngle;
+  float cx        = center.x();
+  float cy        = center.y();
+  glBegin(GL_LINE_LOOP);
+  glVertex2f(cx + innerDist * cosf(r0), cy - innerDist * sinf(r0));
+  glVertex2f(cx + outerDist * cosf(r0), cy - outerDist * sinf(r0));
+  glVertex2f(cx + outerDist * cosf(r1), cy - outerDist * sinf(r1));
+  glVertex2f(cx + innerDist * cosf(r1), cy - innerDist * sinf(r1));
+  glEnd();
 }
 
 //-----------------------------------------------------------------------------
@@ -780,35 +1079,53 @@ void HexagonalColorWheel::drawCurrentColorMark() {
   s = (float)m_color.getValue(eSaturation) / 100.0f;
   v = (float)m_color.getValue(eValue) / 100.0f;
 
-  // d is a distance from a center of the wheel
-  float d, phi;
-  phi = (float)(h % 60 - 30) / 180.0f * 3.1415f;
-  d   = s * m_triHeight / cosf(phi);
-
-  // set marker color
   if (v > 0.4f)
     glColor3f(0.0f, 0.0f, 0.0f);
   else
     glColor3f(1.0f, 1.0f, 1.0f);
 
-  // draw marker (in the wheel)
-  glPushMatrix();
-  glTranslatef(m_wp[0].x(), m_wp[0].y(), 0.1f);
-  glRotatef(h, 0.0, 0.0, 1.0);
-  glTranslatef(d, 0.0f, 0.0f);
-  glRotatef(-h, 0.0, 0.0, 1.0);
-  glBegin(GL_LINE_LOOP);
-  glVertex2f(-3, -3);
-  glVertex2f(3, -3);
-  glVertex2f(3, 3);
-  glVertex2f(-3, 3);
-  glEnd();
-  glPopMatrix();
+  int hue = m_color.getValue(eHue);
+
+  // draw marker (in the wheel or hue ring)
+  if (m_displayMode == ClassicWheelDisplay) {
+    glPushMatrix();
+    float phi = (float)(h % 60 - 30) / 180.0f * 3.1415f;
+    float d   = s * m_hexTriHeight / cosf(phi);
+    glTranslatef(m_wp[0].x(), m_wp[0].y(), 0.1f);
+    glRotatef(h, 0.0, 0.0, 1.0);
+    glTranslatef(d, 0.0f, 0.0f);
+    glRotatef(-h, 0.0, 0.0, 1.0);
+    glBegin(GL_LINE_LOOP);
+    glVertex2f(-3, -3);
+    glVertex2f(3, -3);
+    glVertex2f(3, 3);
+    glVertex2f(-3, 3);
+    glEnd();
+    glPopMatrix();
+  } else if (m_displayMode == CompactNestedWheelDisplay) {
+    drawHueRingBaton(hue, m_innerRadius, m_outerRadius, m_circleCenter);
+  } else {
+    float phi    = (float)(h % 60 - 30) / 180.0f * 3.1415f;
+    float outerD = m_hexTriHeight / cosf(phi);
+    float innerD = outerD * m_ringInnerScale;
+    glPushMatrix();
+    glTranslatef(m_wp[0].x(), m_wp[0].y(), 0.1f);
+    glRotatef(h, 0.0, 0.0, 1.0);
+    glBegin(GL_LINE_LOOP);
+    glVertex2f(innerD, -3.5f);
+    glVertex2f(outerD, -3.5f);
+    glVertex2f(outerD, 3.5f);
+    glVertex2f(innerD, 3.5f);
+    glEnd();
+    glPopMatrix();
+  }
 
   // draw marker (in the triangle)
+  QPointF marker =
+      svTriangleMarkerPos((float)m_color.getValue(eSaturation),
+                          (float)m_color.getValue(eValue));
   glPushMatrix();
-  glTranslatef(m_leftp[1].x(), m_leftp[1].y(), 0.1f);
-  glTranslatef(-m_triEdgeLen * v * s, -m_triHeight * v * 2.0f, 0.0f);
+  glTranslatef(marker.x(), marker.y(), 0.1f);
   glBegin(GL_LINE_LOOP);
   glVertex2f(-3, -3);
   glVertex2f(3, -3);
@@ -820,35 +1137,73 @@ void HexagonalColorWheel::drawCurrentColorMark() {
 
 //-----------------------------------------------------------------------------
 
-void HexagonalColorWheel::mousePressEvent(QMouseEvent *event) {
-  if (~event->buttons() & Qt::LeftButton) return;
-
-  // check whether the mouse cursor is in the wheel or in the triangle (or
-  // nothing).
-  QPoint curPos = event->pos() * getDevPixRatio();
-
+bool HexagonalColorWheel::isInClassicWheel(const QPoint &pos) const {
   QPolygonF wheelPolygon;
-  // in the case of the wheel
   wheelPolygon << m_wp[1] << m_wp[2] << m_wp[3] << m_wp[4] << m_wp[5]
                << m_wp[6];
   wheelPolygon.translate(m_wheelPosition);
-  if (wheelPolygon.toPolygon().containsPoint(curPos, Qt::OddEvenFill)) {
-    m_currentWheel = leftWheel;
-    clickLeftWheel(curPos);
-    return;
-  }
+  return wheelPolygon.toPolygon().containsPoint(pos, Qt::OddEvenFill);
+}
 
-  wheelPolygon.clear();
-  // in the case of the triangle
-  wheelPolygon << m_leftp[0] << m_leftp[1] << m_leftp[2];
-  wheelPolygon.translate(m_wheelPosition);
-  if (wheelPolygon.toPolygon().containsPoint(curPos, Qt::OddEvenFill)) {
+//-----------------------------------------------------------------------------
+
+bool HexagonalColorWheel::isInCircularHueRing(const QPoint &pos) const {
+  QPointF local = QPointF(pos) - m_wheelPosition;
+  float dist    = QLineF(m_circleCenter, local).length();
+  return dist >= m_innerRadius && dist <= m_outerRadius;
+}
+
+//-----------------------------------------------------------------------------
+
+bool HexagonalColorWheel::isInHueRing(const QPoint &pos) const {
+  if (isInTriangle(pos)) return false;
+  if (m_displayMode == CompactNestedWheelDisplay)
+    return isInCircularHueRing(pos);
+  if (m_displayMode == ClassicWheelDisplay) return isInClassicWheel(pos);
+
+  if (!isInClassicWheel(pos)) return false;
+
+  QPolygonF innerPolygon;
+  innerPolygon << m_innerWp[1] << m_innerWp[2] << m_innerWp[3] << m_innerWp[4]
+               << m_innerWp[5] << m_innerWp[6];
+  innerPolygon.translate(m_wheelPosition);
+  return !innerPolygon.toPolygon().containsPoint(pos, Qt::OddEvenFill);
+}
+
+//-----------------------------------------------------------------------------
+
+bool HexagonalColorWheel::isInTriangle(const QPoint &pos) const {
+  QPolygonF triPolygon;
+  triPolygon << m_leftp[0] << m_leftp[1] << m_leftp[2];
+  triPolygon.translate(m_wheelPosition);
+  return triPolygon.toPolygon().containsPoint(pos, Qt::OddEvenFill);
+}
+
+//-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::mousePressEvent(QMouseEvent *event) {
+  if (~event->buttons() & Qt::LeftButton) return;
+
+  QPoint curPos = event->pos() * getDevPixRatio();
+
+  if (isInTriangle(curPos)) {
     m_currentWheel = rightTriangle;
     clickRightTriangle(curPos);
     return;
   }
 
-  //... or, in the case of nothing
+  if (m_displayMode == ClassicWheelDisplay) {
+    if (isInClassicWheel(curPos)) {
+      m_currentWheel = leftWheel;
+      clickLeftWheel(curPos);
+      return;
+    }
+  } else if (isInHueRing(curPos)) {
+    m_currentWheel = leftWheel;
+    clickHueRing(curPos);
+    return;
+  }
+
   m_currentWheel = none;
 }
 
@@ -860,7 +1215,10 @@ void HexagonalColorWheel::mouseMoveEvent(QMouseEvent *event) {
   case none:
     break;
   case leftWheel:
-    clickLeftWheel(event->pos() * getDevPixRatio());
+    if (m_displayMode == ClassicWheelDisplay)
+      clickLeftWheel(event->pos() * getDevPixRatio());
+    else
+      clickHueRing(event->pos() * getDevPixRatio());
     break;
   case rightTriangle:
     clickRightTriangle(event->pos() * getDevPixRatio());
@@ -876,6 +1234,33 @@ void HexagonalColorWheel::mouseReleaseEvent(QMouseEvent *event) {
 }
 
 //-----------------------------------------------------------------------------
+
+void HexagonalColorWheel::clickHueRing(const QPoint &pos) {
+  QPointF center = (m_displayMode == CompactNestedWheelDisplay)
+                       ? m_circleCenter + m_wheelPosition
+                       : m_wp[0] + m_wheelPosition;
+
+  int hue;
+  if (m_displayMode == CompactNestedWheelDisplay) {
+    QPointF d = QPointF(pos) - center;
+    float theta = atan2f(-d.y(), d.x()) * 180.0f / 3.1415f;
+    if (theta < 0.0f) theta += 360.0f;
+    hue = (int)(theta + 0.5f);
+  } else {
+    QLineF p(center, QPointF(pos));
+    QLineF horizontal(0, 0, 1, 0);
+    float theta =
+        (p.dy() >= 0) ? horizontal.angleTo(p) : 360 - p.angleTo(horizontal);
+    hue = (int)theta;
+  }
+  if (hue > 359) hue = 359;
+
+  m_color.setValue(eHue, hue);
+  emit colorChanged(m_color, true);
+}
+
+//-----------------------------------------------------------------------------
+
 /*! compute hue and saturation position. saturation value must be clamped
  */
 void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
@@ -887,7 +1272,7 @@ void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
   while (phi >= 60.0f) phi -= 60.0f;
   phi -= 30.0f;
   // d is a length from center to edge of the wheel when saturation = 100
-  float d = m_triHeight / cosf(phi / 180.0f * 3.1415f);
+  float d = m_hexTriHeight / cosf(phi / 180.0f * 3.1415f);
 
   int h = (int)theta;
   if (h > 359) h = 359;
@@ -902,18 +1287,11 @@ void HexagonalColorWheel::clickLeftWheel(const QPoint &pos) {
 //-----------------------------------------------------------------------------
 
 void HexagonalColorWheel::clickRightTriangle(const QPoint &pos) {
+  QPointF local = QPointF(pos) - m_wheelPosition;
   int s, v;
-  QPointF p = m_leftp[1] + m_wheelPosition - QPointF(pos);
-  if (p.ry() <= 0.0f) {
-    s = 0;
-    v = 0;
-  } else {
-    float v_ratio = std::min((float)(p.ry() / (m_triHeight * 2.0f)), 1.0f);
-    float s_f     = p.rx() / (m_triEdgeLen * v_ratio);
-    v             = (int)(v_ratio * 100.0f);
-    s             = (int)(std::min(std::max(s_f, 0.0f), 1.0f) * 100.0f);
-  }
-  m_color.setValues(eHue, s, v);
+  svFromTrianglePoint(local, s, v);
+  m_color.setValue(eSaturation, s);
+  m_color.setValue(eValue, v);
   emit colorChanged(m_color, true);
 }
 
@@ -1792,6 +2170,12 @@ void PlainColorPage::updateColorCalibration() {
     m_hexagonalColorWheel->updateColorCalibration();
   else
     m_hexagonalColorWheel->cueCalibrationUpdate();
+}
+
+//-----------------------------------------------------------------------------
+
+void PlainColorPage::setColorWheelDisplayMode(ColorWheelDisplayMode mode) {
+  m_hexagonalColorWheel->setDisplayMode(mode);
 }
 
 //-----------------------------------------------------------------------------
@@ -3124,6 +3508,38 @@ QFrame *StyleEditor::createBottomWidget() {
   appearanceSubMenu->addAction(relColorAct);
   appearanceSubMenu->addAction(absColorAct);
 
+  m_colorWheelDisplayModeAG = new QActionGroup(this);
+  QAction *classicWheelAct = new QAction(tr("Classic"), this);
+  QAction *compactWheelAct = new QAction(tr("Round"), this);
+  QAction *extendedWheelAct = new QAction(tr("Hexagonal"), this);
+  classicWheelAct->setData(ClassicWheelDisplay);
+  compactWheelAct->setData(CompactNestedWheelDisplay);
+  extendedWheelAct->setData(ExtendedCorrectedWheelDisplay);
+  classicWheelAct->setCheckable(true);
+  compactWheelAct->setCheckable(true);
+  extendedWheelAct->setCheckable(true);
+  switch ((ColorWheelDisplayMode)(int)StyleEditorColorWheelDisplayMode) {
+  case CompactNestedWheelDisplay:
+    compactWheelAct->setChecked(true);
+    break;
+  case ExtendedCorrectedWheelDisplay:
+    extendedWheelAct->setChecked(true);
+    break;
+  case ClassicWheelDisplay:
+  default:
+    classicWheelAct->setChecked(true);
+    break;
+  }
+  m_colorWheelDisplayModeAG->addAction(classicWheelAct);
+  m_colorWheelDisplayModeAG->addAction(compactWheelAct);
+  m_colorWheelDisplayModeAG->addAction(extendedWheelAct);
+  m_colorWheelDisplayModeAG->setExclusive(true);
+  menu->addSeparator();
+  QMenu *wheelDisplaySubMenu = menu->addMenu(tr("Wheel Shape"));
+  wheelDisplaySubMenu->addAction(classicWheelAct);
+  wheelDisplaySubMenu->addAction(compactWheelAct);
+  wheelDisplaySubMenu->addAction(extendedWheelAct);
+
   m_toggleOrientationAction =
       new QAction(createQIcon("orientation_h"), tr("Toggle Orientation"), this);
   menu->addAction(m_toggleOrientationAction);
@@ -3215,6 +3631,8 @@ QFrame *StyleEditor::createBottomWidget() {
                        SLOT(updateOrientationButton()));
   ret = ret && connect(m_sliderAppearanceAG, SIGNAL(triggered(QAction *)), this,
                        SLOT(onSliderAppearanceSelected(QAction *)));
+  ret = ret && connect(m_colorWheelDisplayModeAG, SIGNAL(triggered(QAction *)),
+                       this, SLOT(onColorWheelDisplayModeSelected(QAction *)));
   ret = ret && connect(menu, SIGNAL(aboutToShow()), this,
                        SLOT(onPopupMenuAboutToShow()));
   assert(ret);
@@ -4293,12 +4711,29 @@ void StyleEditor::onSliderAppearanceSelected(QAction *action) {
 
 //-----------------------------------------------------------------------------
 
+void StyleEditor::onColorWheelDisplayModeSelected(QAction *action) {
+  bool ok       = true;
+  int displayId = action->data().toInt(&ok);
+  if (!ok) return;
+  if (displayId == (int)StyleEditorColorWheelDisplayMode) return;
+  StyleEditorColorWheelDisplayMode = displayId;
+  m_plainColorPage->setColorWheelDisplayMode((ColorWheelDisplayMode)displayId);
+}
+
+//-----------------------------------------------------------------------------
+
 void StyleEditor::onPopupMenuAboutToShow() {
   // sync radio button state to the current user env settings
   for (auto action : m_sliderAppearanceAG->actions()) {
     bool ok          = true;
     int appearanceId = action->data().toInt(&ok);
     if (ok && appearanceId == StyleEditorColorSliderAppearance)
+      action->setChecked(true);
+  }
+  for (auto action : m_colorWheelDisplayModeAG->actions()) {
+    bool ok       = true;
+    int displayId = action->data().toInt(&ok);
+    if (ok && displayId == (int)StyleEditorColorWheelDisplayMode)
       action->setChecked(true);
   }
 }


### PR DESCRIPTION
**Proposal**

This PR adds new chromatic wheel styles to the Style Editor , Round and Hexagonal , alongside the classic layout. It gives more visual choice when picking colors.

You can switch the shape from the hamburger menu (Wheel Shape) or by right-clicking the wheel. The chosen style is remembered between sessions. A HiDPI fix is included so the wheel scales correctly when switching shapes. The right-click menu also exposes Bottom Bar and Bind to Current Room.

**Notes**

Depends on the collapsible Style Editor bottom bar PR #6979 (should be merged first).  

This feature was developed with Cursor’s AI models.