### PR TITLE
ci(linux): add a Fedora compile check

### DIFF
--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -116,3 +116,42 @@ jobs:
       with:
         name: Opentoonz-${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
         path: toonz/build/Opentoonz-${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}.tar.gz
+
+  # Compile-only: catches Fedora-specific breakage (package renames, newer
+  # GCC/Qt) that the Ubuntu job cannot. Deliberately builds no AppImage.
+  Fedora:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+    - name: Install prerequisites
+      # actions/checkout needs git and tar, absent from the base image
+      run: dnf install -y git tar gzip
+
+    - uses: actions/checkout@v6
+
+    - name: Install libraries
+      run: |
+        dnf install -y gcc gcc-c++ automake libtool make git cmake ninja-build \
+          boost boost-devel SuperLU SuperLU-devel lz4-devel xz-devel \
+          libusb1-devel lzo-devel libjpeg-turbo-devel turbojpeg-devel \
+          glew glew-devel freeglut freeglut-devel freetype-devel libpng-devel \
+          blas blas-devel json-c-devel opencv-devel libmypaint-devel \
+          qt5-qtbase-devel qt5-qtsvg qt5-qtsvg-devel qt5-qtscript qt5-qtscript-devel \
+          qt5-qttools qt5-qttools-devel qt5-qttools-static qt5-qtmultimedia \
+          qt5-qtmultimedia-devel qt5-qtserialport-devel qt5-qtwayland \
+          pkgconf-pkg-config
+
+    - name: Build libtiff
+      run: |
+        cd thirdparty/tiff-4.0.3
+        CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./configure --disable-jbig
+        make -j $(nproc)
+
+    - name: Build
+      run: |
+        cd toonz
+        mkdir build
+        cd build
+        cmake ../sources -G Ninja -DWITH_TRANSLATION=OFF
+        ninja


### PR DESCRIPTION
> ⚠️ **AI-assisted PR — created with Claude Opus 4.8 (Claude Code).** Please review as you would any human-written change; approach/prompt details are below, per opentoonz/opentoonz#6937.

Split out of #6967 as @RodneyBaker suggested, so the Fedora compile coverage can be reviewed on its own. The Linux release-packaging and publication half will follow as a separate PR once the AppImage `stuff` question raised in #6966 / #6967 is resolved.

## What this does

Adds a **compile-only** `Fedora` job to `workflow_linux.yml`.

CI previously only built on Ubuntu, so Fedora-specific breakage — package renames, newer GCC/Qt versions — went unnoticed even though OpenToonz builds and runs on Fedora. This job runs in a `fedora:latest` container, installs the equivalent `dnf` dependency set, builds `thirdparty/tiff-4.0.3`, then builds the full tree with Ninja.

It deliberately **does not** build an AppImage or publish anything, and requires no additional token permissions — its only purpose is catching build regressions on a modern non-Ubuntu distro.

## Scope

- One new job appended to `.github/workflows/workflow_linux.yml` (+39 lines, purely additive).
- The existing `Ubuntu` job is **not** modified.
- No permission changes.

## Testing

- The `dnf` dependency list was confirmed to resolve and install cleanly in the current `fedora:latest` image (Fedora 44).
- The full tree was built successfully on Fedora 44 with this exact dependency set: GCC 16, CMake 4.3, Qt 5.15.18.
- YAML validated, and this branch's CI is green on my fork (Ubuntu gcc/clang + Fedora, all passing).

Caveat worth stating plainly: a workflow can only be fully proven by GitHub Actions actually running it, so the CI run on this PR is the real test.

## Notes for reviewers

- `fedora:latest` is used intentionally so the job tracks the current release (that is the point of the check). Happy to pin it to a specific version (e.g. `fedora:41`) if you would prefer reproducibility over currency.
- The job runs on both `push` and `pull_request`, consistent with the existing `Ubuntu` job. Easy to restrict to one if preferred.
- `git`/`tar` are installed before `actions/checkout` because the Fedora base image does not ship them.

## AI-assistance details (re: #6937)

- **Approach / intent given to the model:** add Fedora coverage to Linux CI, since OpenToonz builds on Fedora but only Ubuntu was tested; then, after review feedback, split that work out of #6967 into this single-topic PR and reduce in-code commentary. The dependency list was derived empirically — built from source on Fedora 44, then re-verified inside a `fedora:latest` container — rather than written from memory.
- No source code is changed by this PR; it is CI configuration only.