### PR TITLE
ci(linux): don't fail the AppImage build on a transient AppStream check

### DIFF
--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -99,6 +99,10 @@ jobs:
         chmod 755 apprun.sh
 
         export LD_LIBRARY_PATH='appdir/usr/lib/opentoonz'
+        # appimagetool's AppStream check fetches URLs from the .appdata.xml
+        # (e.g. the issue tracker link) to confirm they're reachable; a
+        # transient network error there fails the whole build. Skip it.
+        export LDAI_NO_APPSTREAM=1
         ./linuxdeploy-x86_64.AppImage --appdir=appdir --plugin=qt --output=appimage --custom-apprun=apprun.sh \
         --executable=appdir/usr/bin/lzocompress \
         --executable=appdir/usr/bin/lzodecompress \


### PR DESCRIPTION
> ⚠️ **AI-assisted PR — created with Claude Sonnet 5 (Claude Code).** Please review as you would any human-written change; approach/prompt details are below, per opentoonz/opentoonz#6937.

## What this fixes

`appimagetool` validates `io.github.OpenToonz.appdata.xml` with `appstreamcli`, which includes checking that URLs referenced in the file (e.g. the issue tracker link) are actually reachable over the network at build time. A transient failure there fails validation, which fails `appimagetool`, which fails the whole Linux Build job — even though nothing about the build itself was wrong.

Observed on a real run:

```
[appimage/stdout]   W: io.github.OpenToonz:23: url-not-reachable
[appimage/stdout]        https://github.com/opentoonz/opentoonz/issues - Unexpected status code: 504
[appimage/stdout]
[appimage/stdout] ✘ Validation failed: warnings: 1, infos: 3, pedantic: 2
[appimage/stdout] run_external: subprocess exited with status 3ERROR: Failed to run plugin: appimage (exit code: 1)
Error: Process completed with exit code 1.
```

That `url-not-reachable` warning (a transient `504` from GitHub, not anything wrong with the file) was the only failing check — every other finding was `info`/`pedantic` level, which don't fail validation on their own. Because the `[gcc, clang]` matrix defaults to `fail-fast: true`, that single network hiccup on the `gcc` leg's `Create Artifact` step also cancelled the in-progress `clang` leg, so one flaky external request took down the entire Linux CI run.

## The fix

Set `LDAI_NO_APPSTREAM=1` before invoking `linuxdeploy`, a variable documented by `linuxdeploy-plugin-appimage` specifically to skip the AppStream metadata check.

## Scope

4 lines, one step (`Create Artifact`), no logic changes elsewhere. `.github/workflows/workflow_linux.yml` only.

## Testing

- YAML validated; CI is green on my fork with this change applied (both `Ubuntu (gcc)` and `Ubuntu (clang)` legs).

## Notes for reviewers

- This trades away *all* AppStream linting, not just the flaky network check — `appstreamcli` bundles both into one pass/fail, and I didn't find an option to disable only the reachability probe. I think that's the right call since the failure mode is "the build breaks because GitHub was briefly unavailable," which is worse than not catching a metadata nit in CI. Happy to look further if you'd rather keep AppStream validation partially active.
- Separately (out of scope here): `strategy.fail-fast` defaulting to `true` on the `[gcc, clang]` matrix means any one leg's flake currently cancels the other. Flagging in case a `fail-fast: false` is wanted as its own follow-up.

## AI-assistance details (re: #6937)

- **Approach / intent given to the model:** diagnose a real CI failure log from the `gcc` leg's `Create Artifact` step. The `504`/AppStream root cause and the `LDAI_NO_APPSTREAM` fix were identified from that log plus `linuxdeploy-plugin-appimage`'s own README, not written from memory.
- No source code is touched; this is CI configuration only.