### PR TITLE
Add option to hide palette style indexes (Tahoma2D port)

### DIFF
--- a/toonz/sources/include/toonzqt/paletteviewergui.h
+++ b/toonz/sources/include/toonzqt/paletteviewergui.h
@@ -153,6 +153,8 @@ public:
   NameDisplayMode getNameDisplayMode() const { return m_nameDisplayMode; }
   void setNameDisplayMode(NameDisplayMode mode);
 
+  void setShowStyleIndex(bool showStyleIndex);
+  bool getShowStyleIndex() const;
   PaletteViewerGUI::PaletteViewType getViewType() const { return m_viewType; }
 
   int posToIndex(const QPoint &pos) const;

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -43,6 +43,7 @@
 #include <QApplication>
 #include <QLabel>
 #include <QDrag>
+#include <QSignalBlocker>
 
 TEnv::IntVar ShowNewStyleButton("ShowNewStyleButton", 1);
 using namespace PaletteViewerGUI;
@@ -517,6 +518,20 @@ void PaletteViewer::createPaletteToolBar() {
   addNameDisplayAction(tr("Style Name"), PageViewer::Style);
   addNameDisplayAction(tr("StudioPalette Name"), PageViewer::Original);
   addNameDisplayAction(tr("Both Names"), PageViewer::StyleAndOriginal);
+
+  QAction *showStyleIndexesAction =
+      new QAction(tr("Show Style Indexes"), viewMode);
+  showStyleIndexesAction->setCheckable(true);
+  showStyleIndexesAction->setChecked(m_pageViewer->getShowStyleIndex());
+  connect(showStyleIndexesAction, &QAction::toggled, this,
+          [this](bool checked) { m_pageViewer->setShowStyleIndex(checked); });
+  connect(viewMode, &QMenu::aboutToShow, this,
+          [this, showStyleIndexesAction]() {
+            QSignalBlocker blocker(showStyleIndexesAction);
+            showStyleIndexesAction->setChecked(
+                m_pageViewer->getShowStyleIndex());
+          });
+  viewMode->addAction(showStyleIndexesAction);
 
   viewMode->addSeparator();
 

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -42,7 +42,7 @@ TEnv::IntVar EnvSoftwareCurrentFontSize_StyleName(
     "SoftwareCurrentFontSize_StyleName", 11);
 extern TEnv::IntVar ShowNewStyleButton;
 
-TEnv::IntVar ShowStyleIndex("ShowStyleIndex", 0);
+TEnv::IntVar ShowStyleIndex("ShowStyleIndex", 1);
 
 using namespace PaletteViewerGUI;
 using namespace DVGui;

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -42,6 +42,8 @@ TEnv::IntVar EnvSoftwareCurrentFontSize_StyleName(
     "SoftwareCurrentFontSize_StyleName", 11);
 extern TEnv::IntVar ShowNewStyleButton;
 
+TEnv::IntVar ShowStyleIndex("ShowStyleIndex", 0);
+
 using namespace PaletteViewerGUI;
 using namespace DVGui;
 
@@ -228,6 +230,20 @@ int PageViewer::getCurrentStyleIndex() const {
 }
 
 //-----------------------------------------------------------------------------
+
+void PageViewer::setShowStyleIndex(bool showStyleIndex) {
+  if (getShowStyleIndex() == showStyleIndex) return;
+
+  ShowStyleIndex = showStyleIndex ? 1 : 0;
+  update();
+}
+
+//-----------------------------------------------------------------------------
+
+bool PageViewer::getShowStyleIndex() const { return ShowStyleIndex != 0; }
+
+//-----------------------------------------------------------------------------
+
 /*! Set current page to \b page and update view.
  */
 void PageViewer::setPage(TPalette::Page *page) {
@@ -852,19 +868,23 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       tmpFont.setPointSize(9);
       tmpFont.setItalic(false);
       p.setFont(tmpFont);
-      int indexWidth =
-          fontMetrics().horizontalAdvance(QString().setNum(styleIndex)) + 4;
-      QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
-                      chipRect.bottomRight());
-      p.setPen(Qt::black);
-      p.setBrush(Qt::white);
-      p.drawRect(indexRect);
-      p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
+      if (getShowStyleIndex()) {
+        int indexWidth =
+            fontMetrics().horizontalAdvance(QString().setNum(styleIndex)) + 4;
+        QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
+                        chipRect.bottomRight());
+        p.setPen(Qt::black);
+        p.setBrush(Qt::white);
+        p.drawRect(indexRect);
+        p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
+      }
 
       // draw "Autopaint for lines" indicator
       int offset = 0;
       if (style->getFlags() != 0) {
         QRect aflRect(chipRect.bottomLeft() + QPoint(0, -14), QSize(12, 15));
+        p.setPen(Qt::black);
+        p.fillRect(aflRect, QBrush(Qt::white));
         p.drawRect(aflRect);
         p.drawText(aflRect, Qt::AlignCenter, "A");
         offset += 12;
@@ -875,6 +895,7 @@ void PageViewer::paintEvent(QPaintEvent *e) {
           m_viewMode != SmallChips) {
         QRect ppRect(chipRect.bottomLeft() + QPoint(offset, -14),
                      QSize(12, 15));
+        p.fillRect(ppRect, QBrush(Qt::white));
         p.drawRect(ppRect);
         QPoint markPos = ppRect.center() + QPoint(1, 0);
         p.drawEllipse(markPos, 3, 3);


### PR DESCRIPTION
## Summary

Adds a Palette Viewer option to show or hide style number indexes.

Style indexes appear by default, and the preference is retained between sessions.
Turn the indexes on/off via the burger menu option.

## Authorship

This pull request is submitted by OpenAnimationLibrary on behalf of:

- @JParks123
- @motionmonster
- @abdullah

All three contributors are credited in the single consolidated commit
through `Co-authored-by` trailers.

## Review history

This supersedes #6992 and carries forward the reviewed result from
OpenAnimationLibrary/opentoonz-dev#17.

## Scope

Only the following three files are changed:

- `toonz/sources/include/toonzqt/paletteviewergui.h`
- `toonz/sources/toonzqt/paletteviewer.cpp`
- `toonz/sources/toonzqt/paletteviewergui.cpp`

The branch contains one commit based directly on the current `master`.