### PR TITLE
Fix vector palette order persistence

### DIFF
--- a/toonz/sources/image/pli/tiio_pli.cpp
+++ b/toonz/sources/image/pli/tiio_pli.cpp
@@ -173,24 +173,26 @@ pli->m_idWrittenColorsArray[i]=false;
 pli->m_idWrittenColorsArray[0]=true;
 */
 
-  for (i = 1; i < (unsigned)vPalette->getStyleCount(); i++) {
-    TColorStyle *style   = vPalette->getStyle(i);
-    TPalette::Page *page = vPalette->getStylePage(i);
-    if (!page) continue;
-    int pageIndex = 65535;
-    // if (page)
-    pageIndex = page->getIndex();
+  // Write styles in displayed page order. PLI stores page index but not
+// position within a page. The reader reconstructs it from style tag order.
+for (int pageIndex = 0; pageIndex < vPalette->getPageCount(); pageIndex++) {
+  TPalette::Page *page = vPalette->getPage(pageIndex);
+  for (int styleIndex = 0; styleIndex < page->getStyleCount();
+       styleIndex++) {
+    int styleId = page->getStyleId(styleIndex);
+    if (styleId <= 0) continue;
 
-    // TColorStyle*style = tempVecImg->getPalette()->getStyle(styleId);
+    TColorStyle *style = vPalette->getStyle(styleId);
     std::vector<TStyleParam> stream;
     PliOutputStream chan(&stream);
     style->save(chan);  // viene riempito lo stream;
 
     assert(pageIndex >= 0 && pageIndex <= 65535);
-    StyleTag *styleTag =
-        new StyleTag(i, pageIndex, stream.size(), stream.data());
+    StyleTag *styleTag = new StyleTag(
+        styleId, pageIndex, stream.size(), stream.data());
     pli->m_palette_tags.push_back((PliObjectTag *)styleTag);
   }
+}
 
   if (vPalette->isAnimated()) {
     std::set<int> keyFrames;


### PR DESCRIPTION
Write embedded PLI palette styles in displayed page order so custom vector palette ordering is restored after reload.

Verified using the reproduction steps from opentoonz/opentoonz#2758:
- create a new vector level
- add several styles
- Ctrl-drag the styles out of order
- save and revert the scene

Fixes opentoonz/opentoonz#2758

ChatGPT 5.6 was used to research and assist in processing this PR.