### PR TITLE
docs(linux): fix and verify the Fedora dependency list

### DIFF
--- a/doc/how_to_build_linux.md
+++ b/doc/how_to_build_linux.md
@@ -34,17 +34,16 @@ Notes:
 * For Qt, MyPaint and OpenCV, you can alternatively build and install from source.
 
 ### Installing Dependencies on Fedora
-(it may include some useless packages)
+
+This is the same dependency set used by the `Fedora` job in
+`.github/workflows/workflow_linux.yml`, so it is verified on every push.
 
 ```
-$ sudo dnf install gcc gcc-c++ automake git cmake boost boost-devel SuperLU SuperLU-devel lz4-devel lzma libusb-devel lzo-devel libjpeg-turbo-devel libGLEW glew-devel freeglut-devel freeglut freetype-devel libpng-devel qt5-qtbase-devel qt5-qtsvg qt5-qtsvg-devel qt5-qtscript qt5-qtscript-devel qt5-qttools qt5-qttools-devel qt5-qtmultimedia-devel blas blas-devel json-c-devel libtool intltool make qt5-qtmultimedia turbojpeg-devel opencv-devel qt5-qttools-static qt5-qtserialport-devel
+$ sudo dnf install gcc gcc-c++ automake libtool make git cmake ninja-build boost boost-devel SuperLU SuperLU-devel lz4-devel xz-devel libusb1-devel lzo-devel libjpeg-turbo-devel turbojpeg-devel glew glew-devel freeglut freeglut-devel freetype-devel libpng-devel blas blas-devel json-c-devel opencv-devel libmypaint-devel qt5-qtbase-devel qt5-qtsvg qt5-qtsvg-devel qt5-qtscript qt5-qtscript-devel qt5-qttools qt5-qttools-devel qt5-qttools-static qt5-qtmultimedia qt5-qtmultimedia-devel qt5-qtserialport-devel qt5-qtwayland pkgconf-pkg-config
 ```
 
-For newest versions of OS you may install libmypaint from repository and don't need to build it from source:
-
-```
-$ sudo dnf install libmypaint-devel
-```
+`libmypaint-devel` is included above, so there is no need to build libmypaint
+from source on Fedora.
 
 
 ### Installing Dependencies on ArchLinux
@@ -135,14 +134,14 @@ $ cmake ../sources
 $ make -j$(nproc)
 ```
 
-The build takes a lot of time, be patient. CMake may not pick up all the required dependencies. On Fedora 30, it can be helpful to use 
+The build takes a lot of time, be patient.
+
+CMake may not pick up all the required dependencies. If SuperLU is not found,
+point CMake at it explicitly:
 ```
-$cmake ../sources/ -DSUPERLU_INCLUDE_DIR=/usr/include/SuperLU
+$ cmake ../sources/ -DSUPERLU_INCLUDE_DIR=/usr/include/SuperLU
 ```
-instead of just
-```
-$cmake ../sources/
-```
+On current Fedora this is not needed; SuperLU is detected automatically.
 
 ### Troubleshooting Build Errors
 


### PR DESCRIPTION
> ⚠️ **AI-assisted PR — created with Claude Opus 4.8 (Claude Code).** Please review as you would any human-written change; approach/prompt details are below, per opentoonz/opentoonz#6937.

Follow-up to #6986, addressing @RodneyBaker's suggestion there:

> Update the Fedora build documentation to match the dependency list verified by this workflow.

## The bug this fixes

Two package names in the documented `dnf` command no longer exist on current Fedora:

| Documented | Actual name |
|---|---|
| `libusb-devel` | `libusb1-devel` |
| `lzma` | `xz-devel` |

This is not merely cosmetic. `dnf` aborts the **entire** transaction when given an unknown argument, so someone following the documentation today installs *nothing*:

```
Failed to resolve the transaction:
No match for argument: libusb-devel
```

## What changed

Replaced the list with the one used by the `Fedora` job in `workflow_linux.yml`, so the docs and CI can no longer drift apart.

Beyond the two corrections above, this also:
- **adds** `ninja-build`, `pkgconf-pkg-config`, `qt5-qtwayland` (needed to run on Wayland), `glew`, `libmypaint-devel`
- **drops** `libGLEW` and `intltool`, which aren't needed
- **folds in** the separate "install libmypaint from repository" note, now redundant since `libmypaint-devel` is in the main list
- **generalises** the stale *"On Fedora 30"* SuperLU hint — the workaround is still documented for anyone who needs it, but is no longer presented as version-specific, and it notes that current Fedora detects SuperLU automatically (as the CI job demonstrates)

Also removed the `(it may include some useless packages)` caveat, since the list is now CI-verified.

## Testing

- The **exact command in this file** was run in a current `fedora:latest` container (Fedora 44): installs cleanly, `Complete!`, exit 0.
- Confirmed the package list is byte-for-byte identical to the one CI exercises on every push (diffed programmatically, no differences).
- Confirmed `libusb-devel` and `lzma` genuinely fail to resolve on Fedora 44, and that `dnf` aborts the whole transaction as a result.
- Confirmed the packages this PR adds and removes all resolve as expected.

## Notes for reviewers

- Documentation only; no code, CI, or packaging changes.
- The Ubuntu, ArchLinux and openSUSE sections are deliberately untouched — I only verified Fedora, so I didn't want to make claims about distros I haven't tested.
- Tying the docs to the CI list is the point here: with #6986 merged, any future breakage in this list now fails CI rather than silently rotting in the documentation.

## AI-assistance details (re: #6937)

- **Approach / intent given to the model:** act on the review suggestion from #6986 to bring the Fedora documentation in line with the CI-verified dependency set. The stale package names were found by programmatically diffing the documented list against the workflow's list, then each difference was checked against a real `fedora:latest` container rather than assumed.