### PR TITLE
fix(stylepicker): return a value on all paths in onPropertyChanged

### DIFF
--- a/toonz/sources/tnztools/stylepickertool.cpp
+++ b/toonz/sources/tnztools/stylepickertool.cpp
@@ -319,8 +319,8 @@ bool StylePickerTool::onPropertyChanged(std::string propertyName) {
           IconGenerator::instance()->invalidate(xl, fid);
       }
     }
-    return true;
   }
+  return true;
 }
 
 /* Check if the organizing operation is available */


### PR DESCRIPTION
`StylePickerTool::onPropertyChanged()` is declared `bool` but can fall off the end without returning a value: both `m_organizePalette` success branches, and — the common case — any property name other than the two that are handled (`Mode:`, `Passive Pick`), since there was no final `return`.

This is only a warning in a normal build, because OpenToonz sets no `-Werror` of its own. RPM builds inject `-Werror=return-type` through the distro `%optflags`, which turns it into a hard error and breaks packaging of 1.8.0 and master:

```
stylepickertool.cpp:324:1: error: control reaches end of non-void function [-Werror=return-type]
```

It is not a gcc 15 regression — the flag is what differs, not the compiler.

## Fix

Move the existing `return true;` out of the `else if` branch to the end of the function, so every path returns, rather than adding a second `return`.

This matches the convention in the sibling tools — `RGBPickerTool::onPropertyChanged()` returns `true` unconditionally — and no caller uses the return value (`toolpropertiespanel.cpp`, `brushpresetpanel.cpp`, `tooloptionsshortcutinvoker.cpp` all discard it), so behavior is unchanged.

Introduced in e79af2f2d ("Feat(StylePicker): Add Replace Style Option"). Reported by @AlexanderShad in #6940, who also proposed this fix.

## Verification

Compiled the translation unit with the project's normal flags plus `-Werror=return-type` on gcc 16.1.1:

| | result |
|---|---|
| before | `stylepickertool.cpp:324:1: error: control reaches end of non-void function` — exit 1 |
| after | compiles clean, object produced — exit 0 |

Note that `-fsyntax-only` does **not** reproduce this: the diagnostic comes from GCC's middle end, so verifying it requires a real compile. Worth keeping in mind if we ever add a `-Werror=return-type` guard to the Fedora CI job added in #6986 — which, as configured today, would not have caught this.

Fixes #6940

🤖 Generated with [Claude Code](https://claude.com/claude-code)