### PR TITLE
Fix crash extending square Xsheet selections with Smart Tab

### DIFF
--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -715,7 +715,7 @@ public:
     int row = pos.frame(), col = pos.layer();
     if (!m_invert) {
       // Allow the negative drag
-      if (row == m_r0 && m_colCount == m_rowCount == 1) {
+      if (row == m_r0 && m_colCount == 1 && m_rowCount == 1) {
         int r0, c0, r1, c1;
         getViewer()->getCellSelection()->getSelectedCells(r0, c0, r1, c1);
         TXsheet *xsh = getViewer()->getXsheet();


### PR DESCRIPTION
> ⚠️ **AI-assisted PR — created with Claude Opus 4.8 (Claude Code).** Please review as you would any human-written change; approach/prompt details are below, per opentoonz/opentoonz#6937.

## The bug

`LevelExtenderTool::onDrag()` in `xsheetdragtool.cpp` guards the negative-drag special case with:

```cpp
if (row == m_r0 && m_colCount == m_rowCount == 1) {
```

That does **not** mean "both are 1". C++ evaluates it left to right as `(m_colCount == m_rowCount) == 1`, so it is true for *any* square selection — 2×2, 3×3, and so on:

```
1x1 selection -> branch taken: true   | intended: true
2x2 selection -> branch taken: true   | intended: false
3x3 selection -> branch taken: true   | intended: false
```

## Why that crashes

`onClick()` fills `m_columns` with exactly `m_colCount` entries (one `CellBuilder` per selected column). The mis-firing branch then rebuilds it with a **single** entry while leaving `m_colCount` unchanged:

```cpp
m_columns.clear();
m_columns.push_back(CellBuilder(xsh, r0, c0, m_rowCount, m_invert));
```

and the extend path in `onCellChange()` still indexes over the original range:

```cpp
for (int c = 0; c < m_colCount; c++)
    ... m_columns[c].generate(r) ...
```

So on an N×N selection with N ≥ 2, `m_columns` holds one element while the loop reads `m_columns[1 … N-1]` — an out-of-bounds `std::vector::operator[]`, i.e. undefined behaviour, typically a crash.

The surrounding logic is single-column by nature in any case: when walking backwards it only ever inspects column `m_c0`.

## Reproduction

1. Select a square block of cells spanning ≥ 2 columns and the same number of rows, with content (e.g. 2 columns × 2 rows).
2. Drag the smart tab at the bottom of the selection up to the selection's top row — the branch fires and shrinks `m_columns` to one entry.
3. Drag back down to extend → `onCellChange()` dereferences `m_columns[1]` on a one-element vector.

## The fix

One line — write the condition that was clearly intended:

```cpp
if (row == m_r0 && m_colCount == 1 && m_rowCount == 1) {
```

## Notes for reviewers

- **Honest limitation:** this is a static analysis. I verified the parsing behaviour with a standalone program and traced `m_columns` sizing against `m_colCount` through `onClick` / `onDrag` / `onCellChange`, and confirmed the tree builds — but I did **not** reproduce the crash interactively, as I have no way to drive xsheet drag gestures here. Worth a manual check against the repro steps above.
- The line dates from *"Refactor the negative drag of smart tab"* and was later touched by *"fix crash on dragging camera column cells + undo"* (`e3378a9f1`), which reformatted it without changing the condition.
- Out of scope but worth noting: `-Wparentheses` catches exactly this pattern ("suggest parentheses around comparison in operand of `==`"), but the build enables only `-Wmissing-declarations`, `-Wundef` and `-Wwrite-strings`, so the compiler never reported it. Enabling `-Wparentheses` would be a natural follow-up alongside the recent `-Werror=return-type` work in #6998.

## AI-assistance details (re: #6937)

- **Approach / intent given to the model:** find genuine stability bugs in the codebase, then fix the highest-impact one. This was located during a broader audit; the chained-comparison semantics were confirmed by compiling a minimal test case rather than assumed, and the out-of-bounds consequence was traced through the actual vector sizing and indexing in this class.