### PR TITLE
Modify Transparency Check + Inks Only Behavior

### DIFF
--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -595,7 +595,8 @@ void RasterPainter::flushRasterImages() {
           std::set<int> autoPaints;
           if (autocloseSettings.m_ignoreAPInks) {
             for (int styleIdx = 0; styleIdx < plt->getStyleCount(); ++styleIdx)
-              if (plt->getStyle(styleIdx)->getFlags() != 0) autoPaints.insert(styleIdx);
+              if (plt->getStyle(styleIdx)->getFlags() != 0)
+                autoPaints.insert(styleIdx);
           }
           TAutocloser ac(srcCm, gapCheckIndex, autocloseSettings,
                          std::move(autoPaints));
@@ -671,10 +672,12 @@ void RasterPainter::flushRasterImages() {
         // ==============================================================
         // Transparency Check: (see helper above)
         // Apply high-tone empty pixel fix
+        // When "Inks Only" check is ON, the high-tone modification will not be
+        // applied
         // ==============================================================
         TRasterCM32P rasterToUse = srcCm;
 
-        if (settings.m_transparencyCheck) {
+        if (settings.m_transparencyCheck && !settings.m_inksOnly) {
           const int threshold = 80;  // Minimum tone for "false" high antialias
 
           // Clone and adjust high-tone empty pixels


### PR DESCRIPTION
This PR is related to #6329.

Regarding the behavior of Transparency Check, when it is simultaneously enabled with “Inks Only,” the pixel correction implemented in #6329 will not be performed. Instead, just like in previous versions, all semi-transparent areas of the inks will be visually emphasized.

This feature is necessary for detecting and removing faint ink noise that occurs when scanning and cleaning up hand-drawn animations on paper.

Since the change in #6329 was made to make it easier to find areas where paint was missed, I believe there will be no negative impact from the behavior changing when used in conjunction with the “Inks Only” option.