### PR TITLE
Add ZIP option to new project and standalone scene export

### DIFF
--- a/toonz/sources/toonz/exportscenepopup.cpp
+++ b/toonz/sources/toonz/exportscenepopup.cpp
@@ -32,6 +32,11 @@
 #include <QApplication>
 #include <QMainWindow>
 #include <QStandardPaths>
+#include <QCheckBox>
+#include <QDirIterator>
+#include <QFileInfo>
+
+#include "simplezipwriter.h"
 
 #include <vector>
 
@@ -101,6 +106,56 @@ void decodeLevelsPath(ToonzScene &scene) {
       sl->setPath(absolutePath);
     }
   }
+}
+
+bool zipDirectory(const TFilePath &sourceFolder, const TFilePath &archivePath,
+                  QString &errorMessage) {
+  QDir sourceDir(sourceFolder.getQString());
+  if (!sourceDir.exists()) {
+    errorMessage = QObject::tr("The exported folder does not exist.");
+    return false;
+  }
+
+  SimpleZipWriter writer(archivePath.getQString());
+  if (!writer.isOpen()) {
+    errorMessage = writer.errorString();
+    return false;
+  }
+
+  const QString rootName = QFileInfo(sourceDir.absolutePath()).fileName();
+  if (!writer.addDirectory(rootName)) {
+    errorMessage = writer.errorString();
+    return false;
+  }
+
+  QDirIterator iterator(sourceDir.absolutePath(),
+                        QDir::AllEntries | QDir::NoDotAndDotDot |
+                            QDir::Hidden | QDir::System,
+                        QDirIterator::Subdirectories);
+  while (iterator.hasNext()) {
+    iterator.next();
+    const QFileInfo info = iterator.fileInfo();
+    const QString relativePath =
+        sourceDir.relativeFilePath(info.absoluteFilePath());
+    const QString archiveEntry = rootName + "/" + relativePath;
+
+    bool added = true;
+    if (info.isDir())
+      added = writer.addDirectory(archiveEntry);
+    else if (info.isFile())
+      added = writer.addFile(archiveEntry, info.absoluteFilePath());
+
+    if (!added) {
+      errorMessage = writer.errorString();
+      return false;
+    }
+  }
+
+  if (!writer.close()) {
+    errorMessage = writer.errorString();
+    return false;
+  }
+  return true;
 }
 }  // namespace
 //------------------------------------------------------------------------
@@ -614,6 +669,13 @@ ExportScenePopup::ExportScenePopup(std::vector<TFilePath> scenes)
   lonelyProjectWidget->setLayout(lonelyProjectLayout);
   layout->addWidget(lonelyProjectWidget);
 
+  m_createZipCheckBox =
+      new QCheckBox(tr("Create ZIP archive of exported folder"), this);
+  m_createZipCheckBox->setToolTip(
+      tr("Create a ZIP archive after exporting a new project or "
+         "standalone scene while keeping the exported folder."));
+  layout->addWidget(m_createZipCheckBox);
+
   ret = ret &&
         connect(group, SIGNAL(buttonClicked(int)), this, SLOT(switchMode(int)));
 
@@ -639,6 +701,7 @@ ExportScenePopup::ExportScenePopup(std::vector<TFilePath> scenes)
 void ExportScenePopup::switchMode(int id) {
   assert(id < 3);
   m_mode = id;
+  m_createZipCheckBox->setEnabled(id != 0);
   // m_projectTreeView->setEnabled(true);
 }
 
@@ -735,11 +798,36 @@ void ExportScenePopup::onExport() {
       scene.save(newScenePath);
       Preferences::instance()->setValue(PreferencesItemId::pathAliasPriority,
                                         oldPriority, false);
+
+      if (m_createZipCheckBox->isChecked()) {
+        TFilePath archivePath(newSceneFolder.getWideString() + L".zip");
+        QString zipError;
+        if (!zipDirectory(newSceneFolder, archivePath, zipError)) {
+          DVGui::warning(
+              tr("The scene was exported, but the ZIP archive could not be "
+                 "created.\n%1")
+                  .arg(zipError));
+          success = false;
+        }
+      }
     }
     progressBar.setValue(i + 1);
   }
   progressBar.hide();
   pm->setCurrentProjectPath(oldProjectPath);
+
+  if (success && m_mode == 1 && m_createZipCheckBox->isChecked()) {
+    TFilePath projectFolder = projectPath.getParentDir();
+    TFilePath archivePath(projectFolder.getWideString() + L".zip");
+    QString zipError;
+    if (!zipDirectory(projectFolder, archivePath, zipError)) {
+      DVGui::warning(
+          tr("The project was exported, but the ZIP archive could not be "
+             "created.\n%1")
+              .arg(zipError));
+      success = false;
+    }
+  }
 
   QApplication::restoreOverrideCursor();
   if (!success) return;

--- a/toonz/sources/toonz/exportscenepopup.h
+++ b/toonz/sources/toonz/exportscenepopup.h
@@ -17,6 +17,7 @@
 class QLabel;
 class ExportSceneTreeView;
 class QRadioButton;
+class QCheckBox;
 
 //=============================================================================
 // ExportSceneDvDirModelFileFolderNode
@@ -173,6 +174,7 @@ class ExportScenePopup final : public DVGui::Dialog {
   QRadioButton *m_lonelyModeButton;
   QLabel *m_lonelyModePathLabel;
   DVGui::FileField *m_lonelyModePathFld;
+  QCheckBox *m_createZipCheckBox;
 
 public:
   ExportScenePopup(std::vector<TFilePath> scenes);

--- a/toonz/sources/toonz/simplezipwriter.h
+++ b/toonz/sources/toonz/simplezipwriter.h
@@ -1,0 +1,214 @@
+#pragma once
+
+#include <QByteArray>
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+#include <QVector>
+
+#include <limits>
+
+// Minimal streaming ZIP writer used for non-destructive scene packaging.
+// Entries use the ZIP "store" method so no additional compression library is
+// required. The resulting archive is a standard ZIP readable by common tools.
+class SimpleZipWriter {
+  struct Entry {
+    QByteArray name;
+    quint32 crc = 0;
+    quint32 size = 0;
+    quint32 offset = 0;
+    bool directory = false;
+  };
+
+  QFile m_output;
+  QVector<Entry> m_entries;
+  QString m_error;
+  bool m_closed = false;
+
+  static void append16(QByteArray &data, quint16 value) {
+    data.append(char(value & 0xff));
+    data.append(char((value >> 8) & 0xff));
+  }
+
+  static void append32(QByteArray &data, quint32 value) {
+    data.append(char(value & 0xff));
+    data.append(char((value >> 8) & 0xff));
+    data.append(char((value >> 16) & 0xff));
+    data.append(char((value >> 24) & 0xff));
+  }
+
+  static quint32 updateCrc32(quint32 crc, const QByteArray &data) {
+    crc = ~crc;
+    for (unsigned char byte : data) {
+      crc ^= byte;
+      for (int bit = 0; bit < 8; ++bit)
+        crc = (crc >> 1) ^ (0xedb88320u & (0u - (crc & 1u)));
+    }
+    return ~crc;
+  }
+
+  bool writeBytes(const QByteArray &data) {
+    if (m_output.write(data) != data.size()) {
+      m_error = m_output.errorString();
+      return false;
+    }
+    return true;
+  }
+
+  bool beginEntry(Entry &entry) {
+    const qint64 offset = m_output.pos();
+    if (offset < 0 || offset > std::numeric_limits<quint32>::max()) {
+      m_error = QStringLiteral("The ZIP archive exceeds the supported 4 GB size.");
+      return false;
+    }
+    entry.offset = quint32(offset);
+
+    QByteArray header;
+    append32(header, 0x04034b50u);
+    append16(header, 20);       // version needed
+    append16(header, 0x0808);   // UTF-8 name + data descriptor
+    append16(header, 0);        // store method
+    append16(header, 0);        // time
+    append16(header, 0);        // date
+    append32(header, 0);        // crc follows in descriptor
+    append32(header, 0);        // compressed size
+    append32(header, 0);        // uncompressed size
+    append16(header, quint16(entry.name.size()));
+    append16(header, 0);        // extra length
+    header.append(entry.name);
+    return writeBytes(header);
+  }
+
+  bool finishEntry(const Entry &entry) {
+    QByteArray descriptor;
+    append32(descriptor, 0x08074b50u);
+    append32(descriptor, entry.crc);
+    append32(descriptor, entry.size);
+    append32(descriptor, entry.size);
+    return writeBytes(descriptor);
+  }
+
+public:
+  explicit SimpleZipWriter(const QString &fileName) : m_output(fileName) {
+    if (!m_output.open(QIODevice::WriteOnly | QIODevice::Truncate))
+      m_error = m_output.errorString();
+  }
+
+  ~SimpleZipWriter() {
+    if (m_output.isOpen() && !m_closed) m_output.close();
+  }
+
+  bool isOpen() const { return m_output.isOpen(); }
+  QString errorString() const { return m_error; }
+
+  bool addDirectory(QString archiveName) {
+    if (!archiveName.endsWith('/')) archiveName.append('/');
+    Entry entry;
+    entry.name = archiveName.toUtf8();
+    entry.directory = true;
+    if (entry.name.size() > std::numeric_limits<quint16>::max()) {
+      m_error = QStringLiteral("A ZIP entry name is too long.");
+      return false;
+    }
+    if (!beginEntry(entry) || !finishEntry(entry)) return false;
+    m_entries.append(entry);
+    return true;
+  }
+
+  bool addFile(const QString &archiveName, const QString &sourceFile) {
+    QFile input(sourceFile);
+    if (!input.open(QIODevice::ReadOnly)) {
+      m_error = input.errorString();
+      return false;
+    }
+
+    const qint64 fileSize = input.size();
+    if (fileSize < 0 || fileSize > std::numeric_limits<quint32>::max()) {
+      m_error = QStringLiteral("A file exceeds the supported 4 GB ZIP entry size: %1")
+                    .arg(sourceFile);
+      return false;
+    }
+
+    Entry entry;
+    entry.name = archiveName.toUtf8();
+    if (entry.name.size() > std::numeric_limits<quint16>::max()) {
+      m_error = QStringLiteral("A ZIP entry name is too long.");
+      return false;
+    }
+    if (!beginEntry(entry)) return false;
+
+    while (!input.atEnd()) {
+      const QByteArray block = input.read(1024 * 1024);
+      if (block.isEmpty() && input.error() != QFile::NoError) {
+        m_error = input.errorString();
+        return false;
+      }
+      entry.crc = updateCrc32(entry.crc, block);
+      entry.size += quint32(block.size());
+      if (!writeBytes(block)) return false;
+    }
+
+    if (!finishEntry(entry)) return false;
+    m_entries.append(entry);
+    return true;
+  }
+
+  bool close() {
+    if (m_closed) return m_error.isEmpty();
+    if (!m_output.isOpen()) return false;
+
+    const qint64 centralOffset64 = m_output.pos();
+    if (centralOffset64 < 0 ||
+        centralOffset64 > std::numeric_limits<quint32>::max()) {
+      m_error = QStringLiteral("The ZIP archive exceeds the supported 4 GB size.");
+      return false;
+    }
+    const quint32 centralOffset = quint32(centralOffset64);
+
+    for (const Entry &entry : m_entries) {
+      QByteArray record;
+      append32(record, 0x02014b50u);
+      append16(record, 20);      // made by
+      append16(record, 20);      // version needed
+      append16(record, 0x0808);  // UTF-8 + descriptor
+      append16(record, 0);       // store method
+      append16(record, 0);
+      append16(record, 0);
+      append32(record, entry.crc);
+      append32(record, entry.size);
+      append32(record, entry.size);
+      append16(record, quint16(entry.name.size()));
+      append16(record, 0);       // extra
+      append16(record, 0);       // comment
+      append16(record, 0);       // disk
+      append16(record, 0);       // internal attributes
+      append32(record, entry.directory ? 0x10u : 0u);
+      append32(record, entry.offset);
+      record.append(entry.name);
+      if (!writeBytes(record)) return false;
+    }
+
+    const qint64 centralEnd64 = m_output.pos();
+    const qint64 centralSize64 = centralEnd64 - centralOffset64;
+    if (m_entries.size() > std::numeric_limits<quint16>::max() ||
+        centralSize64 > std::numeric_limits<quint32>::max()) {
+      m_error = QStringLiteral("The ZIP archive has too many entries or is too large.");
+      return false;
+    }
+
+    QByteArray end;
+    append32(end, 0x06054b50u);
+    append16(end, 0);
+    append16(end, 0);
+    append16(end, quint16(m_entries.size()));
+    append16(end, quint16(m_entries.size()));
+    append32(end, quint32(centralSize64));
+    append32(end, centralOffset);
+    append16(end, 0);
+    if (!writeBytes(end)) return false;
+
+    m_output.close();
+    m_closed = true;
+    return true;
+  }
+};


### PR DESCRIPTION
Summary
Adds an optional, (intentionally) non destructive ZIP packaging step to File > Export > Export Scene for both Create New Project and Export as Standalone Scene.

- Places the Create ZIP archive of exported folder option in the shared export dialog
- Enables it for Create New Project and Export as Standalone Scene
- Disables it for Choose Existing Project so unrelated existing project contents are not archived
- Keeps every exported directory after ZIP creation
- Includes the exported project or scene folder itself as the archive root
- Reports ZIP creation errors without undoing or deleting the completed export

After all selected scenes and resources export successfully the complete newly created project directory is written to an adjacent <project-name>.zip.

Export as Standalone Scene
Each successfully exported standalone scene folder is written to an adjacent <scene-folder>.zip.

Choose Existing Project
The ZIP option is disabled when Chosing Existing Project. Existing projects may contain unrelated files that should not be included automatically.

Implementation
The ZIP writer creates standards compatible archives using stored entries and streams files in chunks, avoiding an additional archive dependency. ZIP64 is not included, so individual files and archives remain subject to the classic ZIP 4 GB range.

Background
This advances the request to consolidate exported resources into a portable ZIP package:
https://github.com/opentoonz/opentoonz/discussions/6456

Testing
Build on Windows, macOS, and Linux
Create a new project with ZIP disabled and verify existing behavior is unchanged
Create a new project with ZIP enabled and verify:
the complete project folder remains
an adjacent <project-name>.zip is created
the archive contains the project folder as its root
all selected scenes and project resource folders are present
Export a standalone scene with ZIP enabled and verify existing adjacent scene folder ZIP behavior
Switch to Choose Existing Project and verify the ZIP option is disabled
Extract both archive types and open the exported scene/project
Verify nested folders, Unicode filenames, empty directories, and missing/unreadable file error handling

Implements #373 