### PR TITLE
fix(stopmotion): handle JPEG load failures safely

### DIFF
--- a/toonz/sources/stopmotion/jpgconverter.cpp
+++ b/toonz/sources/stopmotion/jpgconverter.cpp
@@ -120,29 +120,32 @@ void JpgConverter::saveJpg(TRaster32P image, TFilePath path) {
 //-----------------------------------------------------------------------------
 
 bool JpgConverter::loadJpg(TFilePath path, TRaster32P& image) {
-  long size;
-  int inSubsamp, inColorspace, width, height;
+  long size = 0;
+  int inSubsamp, inColorspace, width = 0, height = 0;
   unsigned long jpegSize;
-  unsigned char* jpegBuf;
-  FILE* jpegFile;
-  QString qPath      = path.getQString();
-  QByteArray ba      = qPath.toLocal8Bit();
-  const char* c_path = ba.data();
-  bool success       = true;
-  tjhandle tjInstance;
+  unsigned char* jpegBuf = NULL;
+  FILE* jpegFile         = NULL;
+  QString qPath          = path.getQString();
+  QByteArray ba          = qPath.toLocal8Bit();
+  const char* c_path     = ba.data();
+  bool success           = true;
+  tjhandle tjInstance    = NULL;
 
   /* Read the JPEG file into memory. */
   if ((jpegFile = fopen(c_path, "rb")) == NULL) success = false;
-  if (success && fseek(jpegFile, 0, SEEK_END) < 0 ||
-      ((size = ftell(jpegFile)) < 0) || fseek(jpegFile, 0, SEEK_SET) < 0)
+  if (success &&
+      (fseek(jpegFile, 0, SEEK_END) < 0 || (size = ftell(jpegFile)) < 0 ||
+       fseek(jpegFile, 0, SEEK_SET) < 0))
     success = false;
   if (success && size == 0) success = false;
   jpegSize = (unsigned long)size;
   if (success && (jpegBuf = (unsigned char*)tjAlloc(jpegSize)) == NULL)
     success = false;
   if (success && fread(jpegBuf, jpegSize, 1, jpegFile) < 1) success = false;
-  fclose(jpegFile);
-  jpegFile = NULL;
+  if (jpegFile) {
+    fclose(jpegFile);
+    jpegFile = NULL;
+  }
 
   if (success && (tjInstance = tjInitDecompress()) == NULL) success = false;
 
@@ -161,19 +164,28 @@ bool JpgConverter::loadJpg(TFilePath path, TRaster32P& image) {
   if (success && tjDecompress2(tjInstance, jpegBuf, jpegSize, imgBuf, width, 0,
                                height, pixelFormat, flags) < 0)
     success = false;
-  tjFree(jpegBuf);
-  jpegBuf = NULL;
-  tjDestroy(tjInstance);
-  tjInstance = NULL;
+  if (jpegBuf) {
+    tjFree(jpegBuf);
+    jpegBuf = NULL;
+  }
+  if (tjInstance) {
+    tjDestroy(tjInstance);
+    tjInstance = NULL;
+  }
 
-  image = TRaster32P(width, height);
-  image->lock();
-  uchar* rawData = image->getRawData();
-  memcpy(rawData, imgBuf, width * height * tjPixelSize[pixelFormat]);
-  image->unlock();
+  // width/height and imgBuf are only meaningful once decoding succeeded
+  if (success) {
+    image = TRaster32P(width, height);
+    image->lock();
+    uchar* rawData = image->getRawData();
+    memcpy(rawData, imgBuf, width * height * tjPixelSize[pixelFormat]);
+    image->unlock();
+  }
 
-  tjFree(imgBuf);
-  imgBuf = NULL;
+  if (imgBuf) {
+    tjFree(imgBuf);
+    imgBuf = NULL;
+  }
 
   return success;
 }

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -366,8 +366,12 @@ bool StopMotion::buildLiveViewMap(TXshSimpleLevel *sl) {
     int frameNumber = id.getNumber();
     if (TSystem::doesExistFileOrLevel(liveViewFp.withFrame(frameNumber))) {
       TRaster32P image;
-      JpgConverter::loadJpg(liveViewFp.withFrame(frameNumber), image);
-      m_liveViewImageMap.insert(std::pair<int, TRaster32P>(frameNumber, image));
+      // a failed load leaves image null, and loadLiveViewImage() treats any
+      // cached entry as a success, so caching it hands out a null raster
+      if (JpgConverter::loadJpg(liveViewFp.withFrame(frameNumber), image)) {
+        m_liveViewImageMap.insert(
+            std::pair<int, TRaster32P>(frameNumber, image));
+      }
     }
   }
 


### PR DESCRIPTION
> ⚠️ **AI-assisted PR — created with Claude Opus 4.8 (Claude Code).** Please review as you would any human-written change; approach/prompt details are below, per opentoonz/opentoonz#6937.

## The bug

`JpgConverter::loadJpg()` dereferences a null `FILE*` whenever `fopen()` fails. The guard

```cpp
if (success && fseek(jpegFile, 0, SEEK_END) < 0 ||
    ((size = ftell(jpegFile)) < 0) || fseek(jpegFile, 0, SEEK_SET) < 0)
```

parses as

```cpp
(success && fseek(...) < 0) || (ftell(...) < 0) || (fseek(...) < 0)
```

so `success` short-circuits only the **first** operand. With `jpegFile == NULL`, the `ftell()` and second `fseek()` still execute and the process dies.

Reachable from the stop motion live view (`stopmotion.cpp` calls `loadJpg` on captured frame paths) whenever the file is missing or unreadable.

## Why the fix is more than the parentheses

Correcting only the parenthesisation would **move** the crash, because the rest of the function assumes the happy path:

| Code | Problem on a failure path |
|---|---|
| `fclose(jpegFile)` | unconditional → `fclose(NULL)` after a failed `fopen` |
| `tjFree(jpegBuf)` | `jpegBuf` is uninitialised unless its allocation ran |
| `tjDestroy(tjInstance)` | `tjInstance` is uninitialised unless init ran |
| `image = TRaster32P(width, height)` | `width`/`height` uninitialised, and this runs even when `success == false` |
| `memcpy(rawData, imgBuf, …)` | `imgBuf` may be NULL |

So this initialises the pointers and sizes, guards the cleanup calls, and only builds the raster once decoding actually succeeded.

## How it was found

Building with `-Wparentheses`, which reports exactly this condition:

```
warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
```

The build currently enables only `-Wmissing-declarations`, `-Wundef` and `-Wwrite-strings`, so it was never surfaced. (A follow-up enabling `-Wparentheses` is worth considering — I checked the whole tree and the only other 14 hits are benign unparenthesised bit-field writes and intentional `&&`/`||` nesting, so the flag is cheap to turn on. This same class of mistake also caused the crash fixed in #7000.)

## Verification

A standalone program reproducing the original control flow:

```
fopen failed, success=0, f=(nil)
about to evaluate the original condition...
Segmentation fault (core dumped)   -> exit 139
```

and the corrected form:

```
handled cleanly, success=0        -> exit 0
```

The tree also builds clean with the change.

**Limitation, stated plainly:** I could not unit test `loadJpg` itself — it is compiled into the `OpenToonz` executable and the tree has no wired-up test harness (`ttest.cpp` exists but is not in CI). The verification above demonstrates the mechanism, not the function. A manual check via stop motion live view with a missing frame file would confirm it end to end.

## AI-assistance details (re: #6937)

- **Approach / intent given to the model:** rather than auditing code by hand, enable a compiler warning across the whole tree and investigate what it reports. All 15 hits were classified; 14 were confirmed benign by checking operator precedence empirically, and this one was traced to a null dereference and reproduced.