### PR TITLE
style: parenthesise expressions flagged by -Wparentheses

### DIFF
--- a/toonz/sources/image/tzp/toonzrle.cpp
+++ b/toonz/sources/image/tzp/toonzrle.cpp
@@ -202,25 +202,25 @@ start_from_in0:
       break;
 
     case 0xA:
-      outval = outval & not_colmask | GET_IN0 << col_offs;
+      outval = (outval & not_colmask) | (GET_IN0 << col_offs);
       goto start_from_in1;
 
       break;
 
     case 0xB:
-      outval = outval & not_penmask | GET_IN0 << pen_offs;
+      outval = (outval & not_penmask) | (GET_IN0 << pen_offs);
       goto start_from_in1;
 
       break;
 
     case 0xC:
-      outval = outval & not_colmask | *in++ << col_offs;
+      outval = (outval & not_colmask) | (*in++ << col_offs);
       goto start_from_in0;
 
       break;
 
     case 0xD:
-      outval = outval & not_penmask | *in++ << pen_offs;
+      outval = (outval & not_penmask) | (*in++ << pen_offs);
       goto start_from_in0;
 
       break;
@@ -334,27 +334,27 @@ start_from_in1:
       break;
 
     case 0xA:
-      outval = outval & not_colmask | in1 << col_offs;
+      outval = (outval & not_colmask) | (in1 << col_offs);
       goto start_from_in0;
 
       break;
 
     case 0xB:
-      outval = outval & not_penmask | in1 << pen_offs;
+      outval = (outval & not_penmask) | (in1 << pen_offs);
       goto start_from_in0;
 
       break;
 
     case 0xC:
       tmp    = in1 << 4;
-      outval = outval & not_colmask | (tmp | GET_IN0) << col_offs;
+      outval = (outval & not_colmask) | ((tmp | GET_IN0) << col_offs);
       goto start_from_in1;
 
       break;
 
     case 0xD:
       tmp    = in1 << 4;
-      outval = outval & not_penmask | (tmp | GET_IN0) << pen_offs;
+      outval = (outval & not_penmask) | ((tmp | GET_IN0) << pen_offs);
       goto start_from_in1;
 
       break;
@@ -423,7 +423,7 @@ static int tif_toonz1_decode_cm24(UCHAR* buf_in, int* buf_in_len,
     inval = *in++;
     switch (inval) {
     case 0xF6:
-      outval = outval & not_xubmask | *in++ << xub_offs;
+      outval = (outval & not_xubmask) | (*in++ << xub_offs);
 
       break;
 
@@ -459,12 +459,12 @@ static int tif_toonz1_decode_cm24(UCHAR* buf_in, int* buf_in_len,
       break;
 
     case 0xFC:
-      outval = outval & not_colmask | *in++ << col_offs;
+      outval = (outval & not_colmask) | (*in++ << col_offs);
 
       break;
 
     case 0xFD:
-      outval = outval & not_penmask | *in++ << pen_offs;
+      outval = (outval & not_penmask) | (*in++ << pen_offs);
 
       break;
 

--- a/toonz/sources/toonz/xshcellmover.cpp
+++ b/toonz/sources/toonz/xshcellmover.cpp
@@ -560,11 +560,11 @@ void LevelMoverTool::onClick(const QMouseEvent *e) {
     m_qualifiers |= CellsMover::eCopyCells;
   if (e->modifiers() & Qt::ShiftModifier ||
       // Or Dragging the Frame Cell
-      Preferences::instance()->isAlwaysDragFrameCell() &&
-          (r0 == r1 && c0 == c1) &&
-          xsh->getCell(row, col) != xsh->getCell(row - 1, col) &&
-          !(xsh->getCell(row + 1, col).isEmpty() &&
-            xsh->getCell(row - 1, col).isEmpty()))
+      (Preferences::instance()->isAlwaysDragFrameCell() &&
+       (r0 == r1 && c0 == c1) &&
+       xsh->getCell(row, col) != xsh->getCell(row - 1, col) &&
+       !(xsh->getCell(row + 1, col).isEmpty() &&
+         xsh->getCell(row - 1, col).isEmpty())))
     m_qualifiers |= CellsMover::eInsertCells;
   if (e->modifiers() & Qt::AltModifier)
     m_qualifiers |= CellsMover::eOverwriteCells;

--- a/toonz/sources/toonzlib/fill.cpp
+++ b/toonz/sources/toonzlib/fill.cpp
@@ -575,7 +575,7 @@ bool extendNormalFill(const TRasterCM32P &r, const TPoint &p, bool right,
     bool toneDown = false;
     int pixPaint  = pixel->getPaint();
     while (tone != 0 && (pixPaint == paintAtClickedPos ||
-                         pixPaint == paint && !DEF_REGION_WITH_PAINT)) {
+                         (pixPaint == paint && !DEF_REGION_WITH_PAINT))) {
       points.push_back(TPoint(x, y));
       ++pixelCount;
       if (pixel->isPurePaint()) ++rowPixelCount;

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -1028,8 +1028,8 @@ bool ShortcutZoomer::exec(QKeyEvent *event) {
   if (key == Qt::Key_Control || key == Qt::Key_Shift || key == Qt::Key_Alt)
     return false;
 
-  key = key | event->modifiers() &
-                  (~0xf0000000);  // Ignore if the key is a numpad key
+  key = key | (event->modifiers() &
+               (~0xf0000000));  // Ignore if the key is a numpad key
 
   return (key == showHideFullScreenKey) ? toggleFullScreen()
          : (key == Qt::Key_Escape)      ? toggleFullScreen(true)


### PR DESCRIPTION
> ⚠️ **AI-assisted PR — created with Claude Opus 4.8 (Claude Code).** Please review as you would any human-written change; approach/prompt details are below, per opentoonz/opentoonz#6937.

## What and why

Building the tree with `-Wparentheses` reports 15 sites. **One was a real null-pointer dereference** — fixed separately in #7008. The other **14 are correct as written**, but rely on the reader knowing the relative precedence of `<<`, `&`, `|` and `&&`/`||`.

This makes the grouping explicit so the flag can be enabled — the flag being what surfaced that crash in the first place.

| File | Count | Pattern |
|---|---|---|
| `image/tzp/toonzrle.cpp` | 11 | `outval = outval & mask \| value << offs;` → `(outval & mask) \| (value << offs)` |
| `toonzqt/imageutils.cpp` | 1 | `key \| (modifiers & ~0xf0000000)` |
| `toonzlib/fill.cpp` | 1 | `&&` nested in `\|\|` |
| `toonz/xshcellmover.cpp` | 1 | `&&` nested in `\|\|` (matches its own "Or Dragging the Frame Cell" comment) |

## No behaviour change — verified, not assumed

The parentheses were chosen to match how the compiler already parses these expressions. To confirm rather than trust that:

- Operator precedence was checked with a standalone program (`outval & mask | val << offs` does equal `(outval & mask) | (val << offs)`).
- `toonzrle.cpp` was compiled before and after, and the disassembly of the resulting object files compared: **byte-identical machine code**.

## Result

With this PR and #7008, the tree builds clean under `-Wparentheses` (verified by a full build — the only remaining warning is the one #7008 fixes). That makes it possible to enable the flag afterwards.

## Notes for reviewers

- This is deliberately *only* the mechanical part. Enabling the flag is a separate step, and would naturally fold into #6999, which already adds `-Werror=return-type` to the Fedora job — putting both flags on one line avoids two PRs touching the same `cmake` invocation.
- Suggested order: #7008 and this one, then the flag in #6999.
- If you'd rather not carry cosmetic churn in the RLE codec, the alternative is to leave `-Wparentheses` off and accept that this class of bug stays invisible — I'd argue against that given it just produced a crash, but it's your call.

## AI-assistance details (re: #6937)

- **Approach / intent given to the model:** enable a compiler warning across the tree, classify every hit rather than assuming, fix the real bug separately, and make the remaining benign ones explicit. Each classification was checked against the code's intent, and the no-op claim was verified by comparing compiled output.