### PR TITLE
ci(linux): build the AppImage on Ubuntu 22.04 for glibc compatibility

### DIFF
--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -24,7 +24,11 @@ on:
 
 jobs:
   Ubuntu:
-    runs-on: ubuntu-24.04
+    # Build on the oldest supported LTS: glibc/libstdc++ symbol versioning is
+    # backward compatible only, so an AppImage built on 24.04 requires
+    # GLIBC_2.38 / GLIBCXX_3.4.32 and will not start on 22.04 (see #7001).
+    # Modern-toolchain coverage comes from the Fedora job below.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         compiler: [gcc, clang]


### PR DESCRIPTION
> ⚠️ **AI-assisted PR — created with Claude Opus 4.8 (Claude Code).** Please review as you would any human-written change; approach/prompt details are below, per opentoonz/opentoonz#6937.

Fixes #7001.

## The problem

The AppImage produced by CI does not start on Ubuntu 22.04 LTS:

```
libstdc++.so.6: version `GLIBCXX_3.4.32' not found
libc.so.6: version `GLIBC_2.38' not found
```

glibc and libstdc++ symbol versioning is **backward compatible only** — a binary built against a newer runtime records minimum version requirements that older systems cannot satisfy.

| | glibc | libstdc++ |
|---|---|---|
| Build host `ubuntu-24.04` | 2.39 → binary needs `GLIBC_2.38` | GCC 13 → needs `GLIBCXX_3.4.32` |
| Ubuntu 22.04 LTS (supported to **April 2027**) | 2.35 ❌ | 3.4.30 ❌ |

## The fix

Build on the oldest LTS we intend to support, which is the usual practice for AppImages.

Nothing is lost in compiler coverage: the Fedora job added in #6986 already builds with a current toolchain (GCC 16), so the two jobs now span **both ends** of the supported range instead of two recent releases.

## Verification

Run in `ubuntu:22.04` containers using the workflow's own dependency list:

| Check | Result |
|---|---|
| Dependency list installs on 22.04 | ✅ |
| GCC 11.4.0 builds the tree | ✅ |
| Clang 14.0.0 builds the tree | ✅ |
| Binary's max glibc requirement | **GLIBC_2.34** (22.04 provides 2.35) ✅ |
| Binary's max libstdc++ requirement | **GLIBCXX_3.4.29** (22.04 provides 3.4.30) ✅ |

Both matrix legs were checked, not just gcc.

## Notes for reviewers

- **This is a treadmill, not a permanent solution.** GitHub retired the `ubuntu-20.04` runner in 2025 and `ubuntu-22.04` will follow eventually; the comment in the workflow is there so the reason isn't lost when someone later bumps the version. Conveniently, 22.04's EOL (April 2027) is roughly when this will need revisiting.
- **@alexb3d's suggestion in #7001 is the more thorough answer.** Tools like `sharun` / the AnyLinux AppImages bundle the C library so the result is genuinely distro-agnostic rather than pinned to whatever the runner happens to ship. That is a larger change and a third-party dependency, so this PR is the pragmatic one-liner that unblocks 22.04 users now — but it's worth considering if you want to stop tracking runner images altogether.
- An alternative shape, if you'd rather keep testing on 24.04: leave the matrix on 24.04 and add a separate 22.04 job that only produces the AppImage. That costs a second full build in CI, which is why I didn't propose it as the default.

## AI-assistance details (re: #6937)

- **Approach / intent given to the model:** investigate the reported issue, identify the root cause, and verify a fix empirically rather than by reasoning alone. The glibc/libstdc++ requirement figures above come from actually building the tree in `ubuntu:22.04` containers and inspecting the resulting binary with `objdump -T`, not from assumption.