### PR TITLE
Fixed foldername casing for versioncontrol

### DIFF
--- a/toonz/sources/toonz/versioncontroltimeline.cpp
+++ b/toonz/sources/toonz/versioncontroltimeline.cpp
@@ -297,7 +297,7 @@ void SVNTimeline::onLogDone(const QString &xmlResponse) {
         // Create the sceneIcons folder
         QDir d(QDir::tempPath());
         d.mkdir("sceneIcons");
-        QString tmpFileName = QDir::tempPath() + QString("/sceneicons/") +
+        QString tmpFileName = QDir::tempPath() + QString("/sceneIcons/") +
                               "svn_temp_img_" + QString::number(i) + " .png";
         m_auxTempFiles.append(new QTemporaryFile());
         m_auxTempFiles.at(m_auxTempFiles.size() - 1)->setFileName(tmpFileName);


### PR DESCRIPTION
When trying to use "Get Revision..." from the version control menu on a scene opentoonz would give an error wherein is stated that '/tmp/sceneicons' is a non existing folder.
This is because throughout the code 'sceneIcons' is used to create the tmp directory.
I've changed the '/tmp/sceneicons' to now use the uppercase variant.

Afterwards the functionality has been tested and it is working correctly now.