### PR TITLE
[Idea #6533] Open Level Settings from schematic nodes

### DIFF
--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -73,6 +73,29 @@ bool isAInnerMacroFx(TFx *fx, TXsheet *xsh) {
 
 //-----------------------------------------------------
 
+bool hasLevelSettingsAtCurrentFrame(FxSchematicScene *scene, int column) {
+  if (!scene || column < 0) return false;
+
+  TXsheet *xsheet = scene->getXsheet();
+  if (!xsheet) return false;
+
+  TFrameHandle *frameHandle = scene->getFrameHandle();
+  if (!frameHandle) return false;
+
+  int frame       = frameHandle->getFrame();
+  if (frame < 0) return false;
+  TXshLevel *level = xsheet->getCell(frame, column).m_level.getPointer();
+  if (!level && frame > 0)
+    level = xsheet->getCell(frame - 1, column).m_level.getPointer();
+
+  if (!level) return false;
+
+  int type = level->getType();
+  return type == OVL_XSHLEVEL || type == TZP_XSHLEVEL || type == PLI_XSHLEVEL;
+}
+
+//-----------------------------------------------------
+
 // Draw a cached FX flap indicator
 void drawCachedFxFlap(QPainter *painter, const QPointF &pos) {
   painter->save();
@@ -3369,13 +3392,13 @@ void FxSchematicColumnNode::mouseDoubleClickEvent(
     m_nameItem->show();
     m_nameItem->setFocus();
     setFlag(QGraphicsItem::ItemIsSelectable, false);
-  } else {
-    QAction *fxEditorPopup =
-        CommandManager::instance()->getAction(MI_FxParamEditor);
-    fxEditorPopup->trigger();
-    // this signal cause the update the contents of the FxSettings
-    emit fxNodeDoubleClicked();
+    return;
   }
+
+  FxSchematicScene *fxScene = dynamic_cast<FxSchematicScene *>(scene());
+  if (!hasLevelSettingsAtCurrentFrame(fxScene, m_columnIndex)) return;
+
+  CommandManager::instance()->getAction(MI_LevelSettings)->trigger();
 }
 
 //-----------------------------------------------------

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -49,7 +49,32 @@
 
 #include "toonzqt/stageschematicnode.h"
 
+#include "../toonz/menubarcommandids.h"
+
 namespace {
+bool hasLevelSettingsAtCurrentFrame(StageSchematicScene *scene, int column) {
+  if (!scene || column < 0) return false;
+
+  TXsheet *xsheet = scene->getXsheet();
+  if (!xsheet) return false;
+
+  TFrameHandle *frameHandle = scene->getFrameHandle();
+  if (!frameHandle) return false;
+
+  int frame       = frameHandle->getFrame();
+  if (frame < 0) return false;
+  TXshLevel *level = xsheet->getCell(frame, column).m_level.getPointer();
+  if (!level && frame > 0)
+    level = xsheet->getCell(frame - 1, column).m_level.getPointer();
+
+  if (!level) return false;
+
+  int type = level->getType();
+  return type == OVL_XSHLEVEL || type == TZP_XSHLEVEL || type == PLI_XSHLEVEL;
+}
+
+//--------------------------------------------------------
+
 void drawCamera(QPainter *painter, const QColor &color, const QPen &pen,
                 double width, double height) {
   QPointF points[3];
@@ -1960,7 +1985,8 @@ void StageSchematicColumnNode::mouseDoubleClickEvent(
       dynamic_cast<StageSchematicScene *>(scene());
   if (!stageScene) return;
   QRectF nameArea(14, 0, m_width - 15, 14);
-  if (nameArea.contains(me->pos())) {
+  if (nameArea.contains(me->pos()) &&
+      me->modifiers() == Qt::ControlModifier) {
     std::string name = m_stageObject->getName();
 
     TStageObjectId id  = m_stageObject->getId();
@@ -1977,7 +2003,13 @@ void StageSchematicColumnNode::mouseDoubleClickEvent(
     m_nameItem->show();
     m_nameItem->setFocus();
     setFlag(QGraphicsItem::ItemIsSelectable, false);
+    return;
   }
+
+  int column = m_stageObject->getId().getIndex();
+  if (!hasLevelSettingsAtCurrentFrame(stageScene, column)) return;
+
+  CommandManager::instance()->getAction(MI_LevelSettings)->trigger();
 }
 
 //--------------------------------------------------------


### PR DESCRIPTION
## Summary
- open Level Settings when an eligible level-column node is double-clicked in the FX or Stage Schematic
- keep node renaming available with Ctrl+double-click on its name
- leave empty, unsupported, and non-level columns unchanged

## Testing
- compiled fxschematicnode.cpp and stageschematicnode.cpp with the configured CMake compile commands