### PR TITLE
[Idea #6457] Focus Schematic on selected nodes

### DIFF
--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -13,6 +13,7 @@
 // Qt includes
 #include <QGraphicsScene>
 #include <QGraphicsView>
+#include <QHash>
 #include <QTouchDevice>
 
 #include <QIcon>
@@ -74,6 +75,8 @@ class DVAPI SchematicScene : public QGraphicsScene {
   Q_OBJECT
 
   QPointF m_mousePos, m_clickedPos;
+  bool m_showingSelectedNodesOnly;
+  QHash<QGraphicsItem *, bool> m_filteredItemVisibility;
 
 public:
   SchematicScene(QWidget *parent);
@@ -84,6 +87,12 @@ public:
   virtual QGraphicsItem *getCurrentNode() { return 0; }
   virtual void reorderScene() = 0;
   virtual void updateScene()  = 0;
+
+  void showSelectedNodesOnly();
+  void showAllNodes();
+  bool isShowingSelectedNodesOnly() const {
+    return m_showingSelectedNodesOnly;
+  }
 
   QPointF mousePos() { return m_mousePos; }
   void setMousePos(QPointF pos) { m_mousePos = pos; }
@@ -117,6 +126,7 @@ protected:
 protected slots:
 
   virtual void onSelectionSwitched(TSelection *, TSelection *) {}
+  void onSceneSelectionChanged();
 };
 
 //==================================================================

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -1019,6 +1019,14 @@ void FxSchematicScene::contextMenuEvent(QGraphicsSceneContextMenuEvent *cme) {
   menu.addAction(copy);
   menu.addAction(cut);
   menu.addAction(paste);
+  menu.addSeparator();
+  QAction *showSelectedNodes =
+      menu.addAction(tr("Show Selected Nodes Only"));
+  connect(showSelectedNodes, &QAction::triggered, this,
+          &SchematicScene::showSelectedNodesOnly);
+  QAction *showAllNodes = menu.addAction(tr("Show All Nodes"));
+  connect(showAllNodes, &QAction::triggered, this,
+          &SchematicScene::showAllNodes);
   m_selection->setPastePosition(TPointD(scenePos.x(), scenePos.y()));
   menu.exec(cme->screenPos());
   m_selection->setPastePosition(TConst::nowhere);

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -40,8 +40,10 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QMouseEvent>
 #include <QGraphicsItem>
+#include <QCursor>
 #include <QToolBar>
 #include <QToolButton>
+#include <QToolTip>
 #include <QMenu>
 #include <QIcon>
 #include <QAction>
@@ -87,9 +89,12 @@ int SchematicScene::snapVInterval = 75;
 //
 //==================================================================
 
-SchematicScene::SchematicScene(QWidget *parent) : QGraphicsScene(parent) {
+SchematicScene::SchematicScene(QWidget *parent)
+    : QGraphicsScene(parent), m_showingSelectedNodesOnly(false) {
   setSceneRect(0, 0, 50000, 50000);
   setItemIndexMethod(NoIndex);
+  connect(this, &QGraphicsScene::selectionChanged, this,
+          &SchematicScene::onSceneSelectionChanged);
 }
 
 //------------------------------------------------------------------
@@ -119,6 +124,7 @@ void SchematicScene::hideEvent(QHideEvent *se) {
  */
 
 void SchematicScene::clearAllItems() {
+  showAllNodes();
   clearSelection();
   m_highlightedLinks.clear();
   QList<SchematicWindowEditor *> editors;
@@ -160,6 +166,79 @@ void SchematicScene::clearAllItems() {
     delete node;
   }
   assert(items().size() == 0);
+}
+
+//------------------------------------------------------------------
+
+void SchematicScene::showSelectedNodesOnly() {
+  QList<SchematicNode *> selectedNodes;
+  for (QGraphicsItem *item : selectedItems()) {
+    SchematicNode *node = dynamic_cast<SchematicNode *>(item);
+    if (node) selectedNodes.append(node);
+  }
+
+  if (selectedNodes.isEmpty()) {
+    if (!views().isEmpty())
+      QToolTip::showText(QCursor::pos(), tr("Select one or more nodes first."),
+                         views().front());
+    return;
+  }
+
+  showAllNodes();
+  m_showingSelectedNodesOnly = true;
+
+  QRectF visibleBounds;
+  for (QGraphicsItem *item : items()) {
+    SchematicNode *node = dynamic_cast<SchematicNode *>(item);
+    if (!node) continue;
+
+    m_filteredItemVisibility.insert(node, node->isVisible());
+    bool isSelected = selectedNodes.contains(node);
+    node->setVisible(isSelected);
+    if (isSelected) visibleBounds |= node->sceneBoundingRect();
+  }
+
+  for (QGraphicsItem *item : items()) {
+    SchematicLink *link = dynamic_cast<SchematicLink *>(item);
+    if (!link) continue;
+
+    m_filteredItemVisibility.insert(link, link->isVisible());
+    SchematicPort *startPort = link->getStartPort();
+    SchematicPort *endPort   = link->getEndPort();
+    bool isVisible = startPort && endPort && startPort->getNode()->isVisible() &&
+                     endPort->getNode()->isVisible();
+    link->setVisible(link->isVisible() && isVisible);
+  }
+
+  if (!views().isEmpty() && visibleBounds.isValid())
+    views().front()->fitInView(visibleBounds.adjusted(-30, -30, 30, 30),
+                               Qt::KeepAspectRatio);
+}
+
+//------------------------------------------------------------------
+
+void SchematicScene::showAllNodes() {
+  if (!m_showingSelectedNodesOnly) return;
+
+  for (auto it = m_filteredItemVisibility.cbegin();
+       it != m_filteredItemVisibility.cend(); ++it) {
+    QGraphicsItem *item = it.key();
+    if (item && item->scene() == this) item->setVisible(it.value());
+  }
+
+  m_filteredItemVisibility.clear();
+  m_showingSelectedNodesOnly = false;
+}
+
+//------------------------------------------------------------------
+
+void SchematicScene::onSceneSelectionChanged() {
+  if (!m_showingSelectedNodesOnly) return;
+
+  for (QGraphicsItem *item : selectedItems())
+    if (dynamic_cast<SchematicNode *>(item)) return;
+
+  showAllNodes();
 }
 
 //------------------------------------------------------------------
@@ -445,6 +524,16 @@ void SchematicSceneViewer::mouseDoubleClickEvent(QMouseEvent *event) {
 //------------------------------------------------------------------
 
 void SchematicSceneViewer::keyPressEvent(QKeyEvent *ke) {
+  if (ke->key() == Qt::Key_Escape) {
+    SchematicScene *schematicScene =
+        dynamic_cast<SchematicScene *>(scene());
+    if (schematicScene && schematicScene->isShowingSelectedNodesOnly()) {
+      schematicScene->showAllNodes();
+      ke->accept();
+      return;
+    }
+  }
+
   ke->ignore();
   QGraphicsView::keyPressEvent(ke);
   if (!ke->isAccepted()) SchematicZoomer(this).exec(ke);

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -1156,6 +1156,14 @@ void StageSchematicScene::contextMenuEvent(
 
   menu.addSeparator();
   menu.addAction(paste);
+  menu.addSeparator();
+  QAction *showSelectedNodes =
+      menu.addAction(tr("Show Selected Nodes Only"));
+  connect(showSelectedNodes, &QAction::triggered, this,
+          &SchematicScene::showSelectedNodesOnly);
+  QAction *showAllNodes = menu.addAction(tr("Show All Nodes"));
+  connect(showAllNodes, &QAction::triggered, this,
+          &SchematicScene::showAllNodes);
   m_selection->setPastePosition(TPointD(scenePos.x(), scenePos.y()));
   menu.exec(cme->screenPos());
 }


### PR DESCRIPTION
## Summary
- add Show Selected Nodes Only and Show All Nodes to FX and Stage Schematic context menus
- keep the filter view-only, preserving scene data and render visibility
- restore the prior view with Show All Nodes, Escape, or when the filtered selection disappears

## Testing
- compiled schematicviewer.cpp, fxschematicscene.cpp, stageschematicscene.cpp, and generated Qt metadata with the configured CMake compile commands