### PR TITLE
[Idea #6707] Unify Schematic selection and navigation

### DIFF
--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -61,7 +61,7 @@ class SnapTargetItem;
 
 //====================================================
 namespace {
-enum CursorMode { Select, Zoom, Hand };
+enum CursorMode { Select, Zoom };
 }
 
 //==================================================================
@@ -624,7 +624,6 @@ protected slots:
 
   void selectModeEnabled();
   void zoomModeEnabled();
-  void handModeEnabled();
 
   void deleteFxs();
   void deleteStageObjects();
@@ -639,7 +638,7 @@ private:
   QToolBar *m_stageToolbar, *m_commonToolbar, *m_fxToolbar, *m_swapToolbar;
 
   QAction *m_fitSchematic, *m_centerOn, *m_reorder, *m_normalize, *m_nodeSize,
-      *m_changeScene, *m_selectMode, *m_zoomMode, *m_handMode;
+      *m_changeScene, *m_selectMode, *m_zoomMode;
 
   bool m_fullSchematic, m_maximizedNode;
 

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -340,32 +340,36 @@ void SchematicSceneViewer::mousePressEvent(QMouseEvent *me) {
       m_zoomPoint = me->pos();
       m_zooming   = true;
       return;
-    } else if (m_cursorMode == CursorMode::Hand) {
-      m_mousePanPoint = m_touchDevice == QTouchDevice::TouchScreen
-                            ? mapToScene(me->pos())
-                            : me->pos() * getDevicePixelRatio(this);
-      m_panning       = true;
-      return;
     }
   } else if (m_buttonState == Qt::MiddleButton) {
     m_mousePanPoint = m_touchDevice == QTouchDevice::TouchScreen
                           ? mapToScene(me->pos())
                           : me->pos() * getDevicePixelRatio(this);
   }
-  bool drawRect                       = true;
+  bool isEmptyBackground              = true;
   QList<QGraphicsItem *> pointedItems = items(me->pos());
   int i;
   for (i = 0; i < pointedItems.size(); i++) {
     SchematicWindowEditor *editor =
         dynamic_cast<SchematicWindowEditor *>(pointedItems[i]);
     if (!editor) {
-      drawRect = false;
+      isEmptyBackground = false;
       break;
     }
   }
 
-  if (m_buttonState == Qt::LeftButton && drawRect)
-    setDragMode(QGraphicsView::RubberBandDrag);
+  if (m_buttonState == Qt::LeftButton && isEmptyBackground) {
+    if (me->modifiers() & Qt::ShiftModifier) {
+      setDragMode(QGraphicsView::RubberBandDrag);
+    } else {
+      m_mousePanPoint = m_touchDevice == QTouchDevice::TouchScreen
+                            ? mapToScene(me->pos())
+                            : me->pos() * getDevicePixelRatio(this);
+      m_panning       = true;
+      return;
+    }
+  }
+
   QGraphicsView::mousePressEvent(me);
 }
 
@@ -382,8 +386,7 @@ void SchematicSceneViewer::mouseMoveEvent(QMouseEvent *me) {
 
   QPoint currWinPos    = me->pos();
   QPointF currScenePos = mapToScene(currWinPos);
-  if ((m_cursorMode == CursorMode::Hand && m_panning) ||
-      m_buttonState == Qt::MiddleButton) {
+  if (m_panning || m_buttonState == Qt::MiddleButton) {
     QPointF usePos     = m_touchDevice == QTouchDevice::TouchScreen
                              ? mapToScene(me->pos())
                              : me->pos() * getDevicePixelRatio(this);
@@ -604,9 +607,6 @@ void SchematicSceneViewer::showEvent(QShowEvent *se) {
 
 void SchematicSceneViewer::enterEvent(QEvent *e) {
   switch (m_cursorMode) {
-  case CursorMode::Hand:
-    setToolCursor(this, ToolCursor::PanCursor);
-    break;
   case CursorMode::Zoom:
     setToolCursor(this, ToolCursor::ZoomCursor);
     break;
@@ -1051,11 +1051,6 @@ void SchematicViewer::createActions() {
     m_zoomMode->setCheckable(true);
     connect(m_zoomMode, SIGNAL(triggered()), this, SLOT(zoomModeEnabled()));
 
-    QIcon handModeIcon = createQIcon("hand_schematic");
-    m_handMode = new QAction(handModeIcon, tr("&Hand Mode"), m_commonToolbar);
-    m_handMode->setCheckable(true);
-    connect(m_handMode, SIGNAL(triggered()), this, SLOT(handModeEnabled()));
-
     setCursorMode(m_cursorMode);
 
     if (m_fullSchematic) {
@@ -1131,7 +1126,6 @@ void SchematicViewer::createActions() {
   m_commonToolbar->addAction(m_centerOn);
   m_commonToolbar->addAction(m_fitSchematic);
   m_commonToolbar->addSeparator();
-  m_commonToolbar->addAction(m_handMode);
   m_commonToolbar->addAction(m_zoomMode);
   m_commonToolbar->addAction(m_selectMode);
 
@@ -1297,7 +1291,6 @@ void SchematicViewer::setCursorMode(CursorMode cursorMode) {
 
   m_selectMode->setChecked((m_cursorMode == CursorMode::Select));
   m_zoomMode->setChecked((m_cursorMode == CursorMode::Zoom));
-  m_handMode->setChecked((m_cursorMode == CursorMode::Hand));
 }
 
 //------------------------------------------------------------------
@@ -1307,10 +1300,6 @@ void SchematicViewer::selectModeEnabled() { setCursorMode(CursorMode::Select); }
 //------------------------------------------------------------------
 
 void SchematicViewer::zoomModeEnabled() { setCursorMode(CursorMode::Zoom); }
-
-//------------------------------------------------------------------
-
-void SchematicViewer::handModeEnabled() { setCursorMode(CursorMode::Hand); }
 
 //------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- pan the schematic by dragging empty background in Select mode
- preserve Shift-drag rubber-band selection and middle-button panning
- remove the redundant Hand mode after its navigation behavior is reachable from Select mode

## Testing
- compiled schematicviewer.cpp and generated Qt metadata with the configured CMake compile commands