### PR TITLE
[Idea #6971] Add Schematic reroute insertion

### DIFF
--- a/toonz/sources/include/toonzqt/fxschematicscene.h
+++ b/toonz/sources/include/toonzqt/fxschematicscene.h
@@ -112,6 +112,7 @@ public:
   void updateScene() override;
   QGraphicsItem *getCurrentNode() override;
   void reorderScene() override;
+  void insertReroute(SchematicLink *link, const QPointF &position) override;
   TXsheet *getXsheet();
 
   void setApplication(TApplication *app);

--- a/toonz/sources/include/toonzqt/schematicnode.h
+++ b/toonz/sources/include/toonzqt/schematicnode.h
@@ -302,6 +302,7 @@ public:
 protected:
   void mousePressEvent(QGraphicsSceneMouseEvent *me) override;
   void mouseReleaseEvent(QGraphicsSceneMouseEvent *me) override;
+  void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *me) override;
 };
 
 //========================================================

--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -84,6 +84,7 @@ public:
   virtual QGraphicsItem *getCurrentNode() { return 0; }
   virtual void reorderScene() = 0;
   virtual void updateScene()  = 0;
+  virtual void insertReroute(SchematicLink *, const QPointF &) {}
 
   QPointF mousePos() { return m_mousePos; }
   void setMousePos(QPointF pos) { m_mousePos = pos; }

--- a/toonz/sources/include/toonzqt/stageschematicscene.h
+++ b/toonz/sources/include/toonzqt/stageschematicscene.h
@@ -115,6 +115,7 @@ public:
 
   //! Replace all nodes in the scene.
   void reorderScene() override;
+  void insertReroute(SchematicLink *link, const QPointF &position) override;
   TXsheet *getXsheet();
   TXsheetHandle *getXsheetHandle() { return m_xshHandle; }
 

--- a/toonz/sources/toonzlib/tstageobjectcmd.cpp
+++ b/toonz/sources/toonzlib/tstageobjectcmd.cpp
@@ -398,6 +398,7 @@ class RemovePegbarNodeUndo final : public TUndo {
   TXshColumnP m_column;
   TStageObjectParams *m_params;
   QList<TStageObjectId> m_linkedObj;
+  QList<std::string> m_linkedParentHandles;
   TXsheetHandle *m_xshHandle;
 
 public:
@@ -412,8 +413,10 @@ public:
 
   ~RemovePegbarNodeUndo() { delete m_params; }
 
-  void setLinkedObjects(const QList<TStageObjectId> &linkedObj) {
+  void setLinkedObjects(const QList<TStageObjectId> &linkedObj,
+                        const QList<std::string> &linkedParentHandles) {
     m_linkedObj = linkedObj;
+    m_linkedParentHandles = linkedParentHandles;
   }
 
   void undo() const override {
@@ -430,6 +433,7 @@ public:
       TStageObject *linkedObj = xsh->getStageObject(m_linkedObj[i]);
       assert(linkedObj);
       linkedObj->setParent(m_objId);
+      linkedObj->setParentHandle(m_linkedParentHandles[i]);
     }
     m_xshHandle->notifyXsheetChanged();
     xsh->notifyStageObjectAdded(m_objId);
@@ -437,13 +441,17 @@ public:
 
   void redo() const override {
     TXsheet *xsh     = m_xshHandle->getXsheet();
+    TStageObject *obj = xsh->getStageObject(m_objId);
+    std::string parentHandle = obj->getParentHandle();
     int pegbarsCount = xsh->getStageObjectTree()->getStageObjectCount();
     int i;
     for (i = 0; i < pegbarsCount; ++i) {
       TStageObject *other = xsh->getStageObjectTree()->getStageObject(i);
       if (other->getId() == m_objId) continue;
-      if (other->getParent() == m_objId)
+      if (other->getParent() == m_objId) {
         other->setParent(xsh->getStageObjectParent(m_objId));
+        other->setParentHandle(parentHandle);
+      }
     }
     if (m_objId.isColumn())
       xsh->removeColumn(m_objId.getIndex());
@@ -800,13 +808,17 @@ void removeStageObjectNode(const TStageObjectId &id, TXsheetHandle *xshHandle,
 
   // stacco tutti i figli e li attacco al padre
   QList<TStageObjectId> linkedObjects;
+  QList<std::string> linkedParentHandles;
+  std::string parentHandle = pegbar->getParentHandle();
   int pegbarsCount = xsh->getStageObjectTree()->getStageObjectCount();
   int i;
   for (i = 0; i < pegbarsCount; ++i) {
     TStageObject *other = xsh->getStageObjectTree()->getStageObject(i);
     if (other == pegbar) continue;
     if (other->getParent() == id) {
+      linkedParentHandles.push_back(other->getParentHandle());
       other->setParent(pegbar->getParent());
+      other->setParentHandle(parentHandle);
       linkedObjects.push_back(other->getId());
     }
   }
@@ -814,7 +826,7 @@ void removeStageObjectNode(const TStageObjectId &id, TXsheetHandle *xshHandle,
     objHandle->setObjectId(TStageObjectId::TableId);
 
   RemovePegbarNodeUndo *undo = new RemovePegbarNodeUndo(id, xshHandle);
-  undo->setLinkedObjects(linkedObjects);
+  undo->setLinkedObjects(linkedObjects, linkedParentHandles);
   if (id.isColumn())
     xsh->removeColumn(id.getIndex());
   else

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -1296,6 +1296,28 @@ void FxSchematicScene::reorderScene() {
 
 //------------------------------------------------------------------
 
+void FxSchematicScene::insertReroute(SchematicLink *link,
+                                     const QPointF &position) {
+  if (!link || !m_app || !m_columnHandle || !m_frameHandle) return;
+
+  TFxCommand::Link boundingFxs = m_selection->getBoundingFxs(link);
+  if (!boundingFxs.m_inputFx || !boundingFxs.m_outputFx ||
+      boundingFxs.m_index < 0)
+    return;
+
+  std::unique_ptr<TFx> passThrough(TFx::create("nothingFx"));
+  if (!passThrough) return;
+
+  passThrough->getAttributes()->setDagNodePos(
+      TPointD(position.x(), position.y()));
+  TFxCommand::insertFx(passThrough.release(), QList<TFxP>(),
+                       QList<TFxCommand::Link>() << boundingFxs, m_app,
+                       m_columnHandle->getColumnIndex(),
+                       m_frameHandle->getFrameIndex());
+}
+
+//------------------------------------------------------------------
+
 void FxSchematicScene::removeRetroLinks(TFx *fx, double &maxX) {
   if (!fx) return;
   for (int i = 0; i < fx->getInputPortCount(); i++) {

--- a/toonz/sources/toonzqt/schematicnode.cpp
+++ b/toonz/sources/toonzqt/schematicnode.cpp
@@ -796,6 +796,24 @@ void SchematicLink::mouseReleaseEvent(QGraphicsSceneMouseEvent *me) {
     QGraphicsItem::mouseReleaseEvent(me);
 }
 
+//--------------------------------------------------------
+
+void SchematicLink::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *me) {
+  if (me->button() != Qt::LeftButton) {
+    me->ignore();
+    return;
+  }
+
+  SchematicScene *schematicScene = dynamic_cast<SchematicScene *>(scene());
+  if (!schematicScene) {
+    me->ignore();
+    return;
+  }
+
+  schematicScene->insertReroute(this, me->scenePos());
+  me->accept();
+}
+
 //========================================================
 //
 // class SchematicPort

--- a/toonz/sources/toonzqt/stageschematicnode.cpp
+++ b/toonz/sources/toonzqt/stageschematicnode.cpp
@@ -404,10 +404,14 @@ void PegbarPainter::paint(QPainter *painter,
       painter->setPen(viewer->getSelectedNodeTextColor());
     else
       painter->setPen(viewer->getTextColor());
-    // Draw the name
-    QRectF rect(18, 0, 54, 18);
-    QString elidedName = elideText(m_name, painter->font(), rect.width());
-    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+    if (m_name == "Reroute") {
+      painter->drawText(QRectF(0, 0, m_width, m_height), Qt::AlignCenter,
+                        "R");
+    } else {
+      QRectF rect(18, 0, 54, 18);
+      QString elidedName = elideText(m_name, painter->font(), rect.width());
+      painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
+    }
   }
 }
 
@@ -1584,7 +1588,8 @@ void StageSchematicNode::onHandleReleased() {
 
 StageSchematicPegbarNode::StageSchematicPegbarNode(StageSchematicScene *scene,
                                                    TStageObject *pegbar)
-    : StageSchematicNode(scene, pegbar, 90, 18) {
+    : StageSchematicNode(scene, pegbar,
+                         pegbar->getName() == "Reroute" ? 30 : 90, 18) {
   SchematicViewer *viewer = scene->getSchematicViewer();
   std::string name        = m_stageObject->getFullName();
   std::string id          = m_stageObject->getId().toString();

--- a/toonz/sources/toonzqt/stageschematicscene.cpp
+++ b/toonz/sources/toonzqt/stageschematicscene.cpp
@@ -31,6 +31,7 @@
 #include "tsystem.h"
 #include "tstream.h"
 #include "tstroke.h"
+#include "tundo.h"
 #include "tenv.h"
 
 // Qt includes
@@ -663,6 +664,59 @@ QGraphicsItem *StageSchematicScene::getCurrentNode() {
 //------------------------------------------------------------------
 
 void StageSchematicScene::reorderScene() { placeNodes(); }
+
+//------------------------------------------------------------------
+
+void StageSchematicScene::insertReroute(SchematicLink *link,
+                                        const QPointF &position) {
+  if (!link || !m_xshHandle || !m_objHandle) return;
+
+  StageSchematicNodePort *firstPort =
+      dynamic_cast<StageSchematicNodePort *>(link->getStartPort());
+  StageSchematicNodePort *secondPort =
+      dynamic_cast<StageSchematicNodePort *>(link->getEndPort());
+  if (!firstPort || !secondPort) return;
+
+  StageSchematicNodePort *childPort =
+      firstPort->getType() == eStageParentPort ? firstPort : secondPort;
+  StageSchematicNodePort *parentPort =
+      firstPort->getType() == eStageChildPort ? firstPort : secondPort;
+  if (childPort->getType() != eStageParentPort ||
+      parentPort->getType() != eStageChildPort)
+    return;
+
+  StageSchematicNode *childNode =
+      dynamic_cast<StageSchematicNode *>(childPort->getNode());
+  StageSchematicNode *parentNode =
+      dynamic_cast<StageSchematicNode *>(parentPort->getNode());
+  if (!childNode || !parentNode) return;
+
+  TStageObject *childObject  = childNode->getStageObject();
+  TStageObject *parentObject = parentNode->getStageObject();
+  if (!childObject || !parentObject || childObject->isGrouped() ||
+      parentObject->isGrouped() ||
+      childObject->getParent() != parentObject->getId())
+    return;
+
+  TUndoManager::manager()->beginBlock();
+  TStageObjectTree *tree = m_xshHandle->getXsheet()->getStageObjectTree();
+  int rerouteIndex       = 0;
+  while (tree->getStageObject(TStageObjectId::PegbarId(rerouteIndex), false))
+    ++rerouteIndex;
+  TStageObjectId rerouteId = TStageObjectId::PegbarId(rerouteIndex);
+  TStageObjectCmd::addNewPegbar(m_xshHandle, m_objHandle, position);
+  TStageObject *rerouteObject =
+      m_xshHandle->getXsheet()->getStageObject(rerouteId);
+  assert(rerouteObject);
+  rerouteObject->setDagNodePos(TPointD(position.x(), position.y()));
+  TStageObjectCmd::rename(rerouteId, "Reroute", m_xshHandle);
+  TStageObjectCmd::setParent(rerouteId, parentObject->getId(),
+                             childObject->getParentHandle(), m_xshHandle);
+  TStageObjectCmd::setParent(childObject->getId(), rerouteId, "B",
+                             m_xshHandle);
+  TUndoManager::manager()->endBlock();
+  m_xshHandle->notifyXsheetChanged();
+}
 
 //------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- insert the existing FX Pass Through node by double-clicking an FX Schematic link
- insert a persistent identity Pegbar routing point by double-clicking a Stage Schematic link
- preserve Stage parent handles when deleting or undoing intermediate Stage objects

## Testing
- compiled schematicnode.cpp, fxschematicscene.cpp, stageschematicscene.cpp, stageschematicnode.cpp, tstageobjectcmd.cpp, and generated Qt metadata with the configured CMake compile commands