### PR TITLE
[Idea #6549] Add Texture FX preserve-source mode

### DIFF
--- a/toonz/sources/stdfx/texturefx.cpp
+++ b/toonz/sources/stdfx/texturefx.cpp
@@ -43,6 +43,7 @@ public:
     m_mode->addItem(MULTIPLY, "Multiply");
     m_mode->addItem(LIGHTEN, "Lighten");
     m_mode->addItem(DARKEN, "Darken");
+    m_mode->addItem(OVER_SOURCE, "Over Source");
   }
 
   ~TextureFx(){};
@@ -206,6 +207,10 @@ TRasterP appRas = tile.getRaster()->create(dim.lx,dim.ly);
       myOver32(tile.getRaster(), textureTile.getRaster(),
                &textureLighten<TPixel32>, v);
       break;
+    case OVER_SOURCE:
+      myOver32(tile.getRaster(), textureTile.getRaster(),
+               &textureOverSource<TPixel32>, v);
+      break;
     default:
       assert(0);
       break;
@@ -246,6 +251,10 @@ TRasterP appRas = tile.getRaster()->create(dim.lx,dim.ly);
     case LIGHTEN:
       myOver64(tile.getRaster(), textureTile.getRaster(),
                &textureLighten<TPixel64>, v);
+      break;
+    case OVER_SOURCE:
+      myOver64(tile.getRaster(), textureTile.getRaster(),
+               &textureOverSource<TPixel64>, v);
       break;
     default:
       assert(0);

--- a/toonz/sources/stdfx/texturefxP.h
+++ b/toonz/sources/stdfx/texturefxP.h
@@ -4,7 +4,16 @@
 
 namespace {
 
-enum { SUBSTITUTE, PATTERNTYPE, ADD, SUBTRACT, MULTIPLY, LIGHTEN, DARKEN };
+enum {
+  SUBSTITUTE,
+  PATTERNTYPE,
+  ADD,
+  SUBTRACT,
+  MULTIPLY,
+  LIGHTEN,
+  DARKEN,
+  OVER_SOURCE
+};
 
 typedef void (*func32)(TPixel32 &pixmask, const TPixel32 &pixtext, double v);
 typedef void (*func64)(TPixel64 &pixmask, const TPixel64 &pixtext, double v);
@@ -41,6 +50,25 @@ inline void substitute(T &pixout, const T &pixin, double v) {
   pixout.g = k * pixin.g;
   pixout.b = k * pixin.b;
   pixout.m = k * pixin.m;
+}
+
+//-----------------------------------------------------------------------------
+
+//! Composites the texture inside the source alpha, retaining the source alpha.
+//! This makes transparent texture pixels reveal the original source without
+//! extending the source's antialiased edge.
+template <class T>
+inline void textureOverSource(T &pixout, const T &pixin, double v) {
+  const double sourceAlpha  = pixout.m / (double)T::maxChannelValue;
+  const double textureAlpha = pixin.m / (double)T::maxChannelValue;
+  const double opacity      = textureAlpha * v / 100.0;
+
+  pixout.r = troundp(pixout.r * (1.0 - opacity) +
+                     pixin.r * sourceAlpha * v / 100.0);
+  pixout.g = troundp(pixout.g * (1.0 - opacity) +
+                     pixin.g * sourceAlpha * v / 100.0);
+  pixout.b = troundp(pixout.b * (1.0 - opacity) +
+                     pixin.b * sourceAlpha * v / 100.0);
 }
 
 //---------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add an appended Over Source mode to Texture FX
- retain the source beneath transparent texture pixels
- preserve source alpha at antialiased edges

## Testing

- compiled texturefx.cpp from the configured OpenToonz build