### PR TITLE
[Idea #6740] Add FX Schematic node display options

### DIFF
--- a/toonz/sources/include/toonzqt/fxschematicscene.h
+++ b/toonz/sources/include/toonzqt/fxschematicscene.h
@@ -253,8 +253,16 @@ protected slots:
   void onEditGroup();
 
   void onIconifyNodesToggled(bool iconified);
+  void onCompactNodesToggled(bool compact);
+  void onLargeNodeTextToggled(bool largeText);
+  void onShowFxIdsToggled(bool showFxIds);
 
   void onNodeChangedSize();
+
+public:
+  bool isCompactNodeView() const;
+  bool usesLargeNodeText() const;
+  bool shouldShowFxIds() const;
 
 private:
   void setEnableCache(bool toggle);

--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -639,7 +639,8 @@ private:
   QToolBar *m_stageToolbar, *m_commonToolbar, *m_fxToolbar, *m_swapToolbar;
 
   QAction *m_fitSchematic, *m_centerOn, *m_reorder, *m_normalize, *m_nodeSize,
-      *m_changeScene, *m_selectMode, *m_zoomMode, *m_handMode;
+      *m_changeScene, *m_selectMode, *m_zoomMode, *m_handMode,
+      *m_compactNodes, *m_largeNodeText, *m_showFxIds;
 
   bool m_fullSchematic, m_maximizedNode;
 

--- a/toonz/sources/toonzqt/fxschematicnode.cpp
+++ b/toonz/sources/toonzqt/fxschematicnode.cpp
@@ -674,7 +674,10 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
   }
 
   QFont columnFont(painter->font());
-  columnFont.setPixelSize(columnFont.pixelSize() - 1);
+  const int pixelSize = columnFont.pixelSize();
+  if (pixelSize > 0)
+    columnFont.setPixelSize(
+        pixelSize + (sceneFx->usesLargeNodeText() ? 1 : -1));
   painter->setFont(columnFont);
 
   // draw fxId in the bottom part
@@ -694,7 +697,9 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
       label = QString::fromStdWString(m_parent->getFx()->getFxId());
   }
 
-  if (label != m_name) {
+  const bool showFxId = sceneFx->shouldShowFxIds() &&
+                        !sceneFx->isCompactNodeView();
+  if (showFxId && label != m_name) {
     label = elideText(label, painter->font(), m_width - 21);
     painter->drawText(QRectF(3, 16, m_width - 21, 14),
                       Qt::AlignLeft | Qt::AlignVCenter, label);
@@ -707,14 +712,13 @@ void FxPainter::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
     if (!sceneFx) return;
     if (sceneFx->getCurrentFx() == m_parent->getFx())
       painter->setPen(viewer->getSelectedNodeTextColor());
-    QRectF rect(3, 2, m_width - 21, 14);
+    QRectF rect(3, 2, m_width - 21, showFxId ? 14 : m_height - 4);
     int w = rect.width();
-    if (label == m_name) {
-      rect.adjust(0, 0, 0, 14);
+    if (!showFxId || label == m_name) {
       w *= 2;
     }
     QString elidedName = elideText(m_name, painter->font(), w);
-    painter->drawText(rect, Qt::TextWrapAnywhere, elidedName);
+    painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, elidedName);
   }
 }
 
@@ -2023,8 +2027,11 @@ FxSchematicNode::FxSchematicNode(FxSchematicScene *scene, TFx *fx, qreal width,
     m_actualFx           = zfx ? zfx->getZeraryFx() : m_fx;
   }
 
-  setWidth(width);
-  setHeight(height);
+  const bool compactFxNode =
+      m_isNormalIconView && scene->isCompactNodeView() &&
+      (m_type == eNormalFx || m_type == eZeraryFx || m_type == eGroupedFx);
+  setWidth(compactFxNode ? 140 : width);
+  setHeight(compactFxNode ? 18 : height);
 }
 
 //-----------------------------------------------------
@@ -2614,9 +2621,9 @@ FxSchematicNormalFxNode::FxSchematicNormalFxNode(FxSchematicScene *scene,
 
   if (m_isNormalIconView) {
     m_nameItem->setPos(1, -1);
-    m_outDock->setPos(72, 14);
-    m_linkDock->setPos(72, 7);
-    m_renderToggle->setPos(72, 0);
+    m_outDock->setPos(m_width - 18, 14);
+    m_linkDock->setPos(m_width - 18, 7);
+    m_renderToggle->setPos(m_width - 18, 0);
   } else {
     QFont fnt = m_nameItem->font();
     fnt.setPixelSize(fnt.pixelSize() * 2);
@@ -2895,10 +2902,10 @@ FxSchematicZeraryNode::FxSchematicZeraryNode(FxSchematicScene *scene,
   // define positions
   if (m_isNormalIconView) {
     m_nameItem->setPos(1, -1);
-    m_outDock->setPos(72, 14);
-    m_linkDock->setPos(72, m_height);
-    m_renderToggle->setPos(72, 0);
-    m_cameraStandToggle->setPos(72, 7);
+    m_outDock->setPos(m_width - 18, 14);
+    m_linkDock->setPos(m_width - 18, m_height);
+    m_renderToggle->setPos(m_width - 18, 0);
+    m_cameraStandToggle->setPos(m_width - 18, 7);
 
   } else {
     QFont fnt = m_nameItem->font();
@@ -3643,8 +3650,8 @@ FxGroupNode::FxGroupNode(FxSchematicScene *scene, const QList<TFxP> &groupedFx,
   // set geometry
   if (m_isNormalIconView) {
     m_nameItem->setPos(1, -1);
-    m_renderToggle->setPos(72, 0);
-    m_outDock->setPos(72, 14);
+    m_renderToggle->setPos(m_width - 18, 0);
+    m_outDock->setPos(m_width - 18, 14);
     inDock->setPos(0, m_height);
   } else {
     QFont fnt = m_nameItem->font();

--- a/toonz/sources/toonzqt/fxschematicscene.cpp
+++ b/toonz/sources/toonzqt/fxschematicscene.cpp
@@ -47,6 +47,9 @@
 #include <QStack>
 
 TEnv::IntVar IconifyFxSchematicNodes("IconifyFxSchematicNodes", 0);
+TEnv::IntVar CompactFxSchematicNodes("CompactFxSchematicNodes", 0);
+TEnv::IntVar LargeFxSchematicNodeText("LargeFxSchematicNodeText", 0);
+TEnv::IntVar ShowFxSchematicNodeIds("ShowFxSchematicNodeIds", 1);
 
 namespace {
 
@@ -1590,6 +1593,45 @@ void FxSchematicScene::onIconifyNodesToggled(bool iconified) {
   m_isNormalIconView      = !iconified;
   IconifyFxSchematicNodes = (iconified) ? 1 : 0;
   updateScene();
+}
+
+//------------------------------------------------------------------
+
+void FxSchematicScene::onCompactNodesToggled(bool compact) {
+  CompactFxSchematicNodes = compact ? 1 : 0;
+  updateScene();
+}
+
+//------------------------------------------------------------------
+
+void FxSchematicScene::onLargeNodeTextToggled(bool largeText) {
+  LargeFxSchematicNodeText = largeText ? 1 : 0;
+  updateScene();
+}
+
+//------------------------------------------------------------------
+
+void FxSchematicScene::onShowFxIdsToggled(bool showFxIds) {
+  ShowFxSchematicNodeIds = showFxIds ? 1 : 0;
+  updateScene();
+}
+
+//------------------------------------------------------------------
+
+bool FxSchematicScene::isCompactNodeView() const {
+  return CompactFxSchematicNodes != 0;
+}
+
+//------------------------------------------------------------------
+
+bool FxSchematicScene::usesLargeNodeText() const {
+  return LargeFxSchematicNodeText != 0;
+}
+
+//------------------------------------------------------------------
+
+bool FxSchematicScene::shouldShowFxIds() const {
+  return ShowFxSchematicNodeIds != 0;
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/toonzqt/schematicviewer.cpp
+++ b/toonz/sources/toonzqt/schematicviewer.cpp
@@ -1109,6 +1109,28 @@ void SchematicViewer::createActions() {
       connect(iconifyNodes, SIGNAL(toggled(bool)), m_fxScene,
               SLOT(onIconifyNodesToggled(bool)));
 
+      m_compactNodes = new QAction(tr("&Compact Wide Nodes"), m_fxToolbar);
+      m_compactNodes->setCheckable(true);
+      m_compactNodes->setChecked(m_fxScene->isCompactNodeView());
+      connect(m_compactNodes, SIGNAL(toggled(bool)), m_fxScene,
+              SLOT(onCompactNodesToggled(bool)));
+
+      m_largeNodeText = new QAction(tr("&Larger Node Text"), m_fxToolbar);
+      m_largeNodeText->setCheckable(true);
+      m_largeNodeText->setChecked(m_fxScene->usesLargeNodeText());
+      connect(m_largeNodeText, SIGNAL(toggled(bool)), m_fxScene,
+              SLOT(onLargeNodeTextToggled(bool)));
+
+      m_showFxIds = new QAction(tr("Show &FX IDs"), m_fxToolbar);
+      m_showFxIds->setCheckable(true);
+      m_showFxIds->setChecked(m_fxScene->shouldShowFxIds());
+      m_showFxIds->setEnabled(!m_compactNodes->isChecked());
+      connect(m_showFxIds, SIGNAL(toggled(bool)), m_fxScene,
+              SLOT(onShowFxIdsToggled(bool)));
+      connect(m_compactNodes, &QAction::toggled, this, [this](bool compact) {
+        m_showFxIds->setEnabled(!compact);
+      });
+
       // Swap fx/stage schematic
       QIcon changeSchematicIcon = createQIcon("swap");
       m_changeScene =
@@ -1143,6 +1165,10 @@ void SchematicViewer::createActions() {
     m_stageToolbar->addAction(addCamera);
     m_stageToolbar->addAction(addPegbar);
 
+    m_fxToolbar->addSeparator();
+    m_fxToolbar->addAction(m_showFxIds);
+    m_fxToolbar->addAction(m_largeNodeText);
+    m_fxToolbar->addAction(m_compactNodes);
     m_fxToolbar->addSeparator();
     m_fxToolbar->addAction(iconifyNodes);
     m_fxToolbar->addSeparator();


### PR DESCRIPTION
Adds persisted FX Schematic display controls for compact wide nodes, larger node text, and optional FX IDs.\n\nThe compact layout widens normal, Zerary, and group nodes while reducing their title-box height and keeping their controls on the outer edge. Display changes refresh the schematic immediately without changing the stored graph.