### PR TITLE
Add exposed Macro FX properties

### DIFF
--- a/toonz/sources/common/tfx/tmacrofx.cpp
+++ b/toonz/sources/common/tfx/tmacrofx.cpp
@@ -88,6 +88,13 @@ void collectParams(TMacroFx *macroFx) {
   }
 }
 
+bool isMemberFx(const TMacroFx *macroFx, const TFx *fx) {
+  const std::vector<TFxP> &fxs = macroFx->getFxs();
+  return std::find_if(fxs.begin(), fxs.end(), [fx](const TFxP &candidate) {
+           return candidate.getPointer() == fx;
+         }) != fxs.end();
+}
+
 }  // anonymous namespace
 
 //--------------------------------------------------
@@ -254,6 +261,7 @@ TFx *TMacroFx::clone(bool recursive) const {
   TMacroFx *clone = TMacroFx::create(clones);
   clone->setName(getName());
   clone->setFxId(getFxId());
+  clone->m_exposedParams = m_exposedParams;
 
   // Copy the index of the passive cache manager.
   clone->getAttributes()->passiveCacheDataIdx() =
@@ -334,6 +342,62 @@ std::string TMacroFx::getMacroFxType() const {
       name += m_fxs[i]->getFxType();
   }
   return name + ")";
+}
+
+//--------------------------------------------------
+
+const std::vector<TMacroFx::ExposedParam> &TMacroFx::getExposedParams() const {
+  return m_exposedParams;
+}
+
+//--------------------------------------------------
+
+bool TMacroFx::isParamExposed(const TFx *fx,
+                               const std::string &paramName) const {
+  if (!fx) return false;
+
+  return std::find_if(m_exposedParams.begin(), m_exposedParams.end(),
+                      [fx, &paramName](const ExposedParam &param) {
+                        return param.m_fxId == fx->getFxId() &&
+                               param.m_paramName == paramName;
+                      }) != m_exposedParams.end();
+}
+
+//--------------------------------------------------
+
+void TMacroFx::setParamExposed(const TFx *fx, const std::string &paramName,
+                                bool exposed) {
+  if (!fx || !isMemberFx(this, fx) || !fx->getParams()->getParam(paramName))
+    return;
+
+  std::vector<ExposedParam>::iterator found =
+      std::find_if(m_exposedParams.begin(), m_exposedParams.end(),
+                   [fx, &paramName](const ExposedParam &param) {
+                     return param.m_fxId == fx->getFxId() &&
+                            param.m_paramName == paramName;
+                   });
+  if (exposed) {
+    if (found == m_exposedParams.end())
+      m_exposedParams.push_back({fx->getFxId(), paramName});
+  } else if (found != m_exposedParams.end()) {
+    m_exposedParams.erase(found);
+  }
+}
+
+//--------------------------------------------------
+
+std::string TMacroFx::getExposedParamKey() const {
+  std::string key;
+  for (const ExposedParam &param : m_exposedParams) {
+    std::vector<TFxP>::const_iterator found =
+        std::find_if(m_fxs.begin(), m_fxs.end(), [&param](const TFxP &fx) {
+          return fx->getFxId() == param.m_fxId;
+        });
+    if (found == m_fxs.end()) continue;
+    key += std::to_string(std::distance(m_fxs.begin(), found));
+    key += ':' + param.m_paramName + ';';
+  }
+  return key;
 }
 
 //--------------------------------------------------
@@ -540,6 +604,14 @@ void TMacroFx::loadData(TIStream &is) {
         } else
           throw TException("unexpected tag " + tagName);
       }
+    } else if (tagName == "exposedparams") {
+      while (is.matchTag(tagName)) {
+        if (tagName != "param") throw TException("unexpected tag " + tagName);
+        const std::string fxId = is.getTagAttribute("fx_id");
+        const std::string paramName = is.getTagAttribute("name");
+        if (TFx *fx = getFxById(::to_wstring(fxId)))
+          setParamExposed(fx, paramName, true);
+      }
     } else if (tagName == "super") {
       TRasterFx::loadData(is);
     } else
@@ -571,6 +643,16 @@ void TMacroFx::saveData(TOStream &os) {
     os.openCloseChild("port", attr);
   }
   os.closeChild();
+  if (!m_exposedParams.empty()) {
+    os.openChild("exposedparams");
+    for (const ExposedParam &param : m_exposedParams) {
+      std::map<std::string, std::string> attr;
+      attr["fx_id"] = ::to_string(param.m_fxId);
+      attr["name"]  = param.m_paramName;
+      os.openCloseChild("param", attr);
+    }
+    os.closeChild();
+  }
   os.openChild("super");
   TRasterFx::saveData(os);
   os.closeChild();

--- a/toonz/sources/include/tmacrofx.h
+++ b/toonz/sources/include/tmacrofx.h
@@ -24,8 +24,15 @@
 class DVAPI TMacroFx final : public TRasterFx {
   FX_DECLARATION(TMacroFx)
 
+public:
+  struct ExposedParam {
+    std::wstring m_fxId;
+    std::string m_paramName;
+  };
+
   TRasterFxP m_root;
   std::vector<TFxP> m_fxs;
+  std::vector<ExposedParam> m_exposedParams;
   bool m_isEditing;
 
   bool isaLeaf(TFx *fx) const;
@@ -65,6 +72,12 @@ public:
   // restituisce un riferimento al vettore contenente gli effetti contenuti nel
   // macroFx
   const std::vector<TFxP> &getFxs() const;
+
+  const std::vector<ExposedParam> &getExposedParams() const;
+  bool isParamExposed(const TFx *fx, const std::string &paramName) const;
+  void setParamExposed(const TFx *fx, const std::string &paramName,
+                       bool exposed);
+  std::string getExposedParamKey() const;
 
   std::string getMacroFxType() const;
 

--- a/toonz/sources/include/toonzqt/fxsettings.h
+++ b/toonz/sources/include/toonzqt/fxsettings.h
@@ -14,6 +14,8 @@
 #include <QMap>
 #include <QGroupBox>
 
+#include <map>
+
 #include "tcommon.h"
 #include "tfx.h"
 #include "tabbar.h"
@@ -50,6 +52,7 @@ class TSceneHandle;
 class TXshLevelHandle;
 class TObjectHandle;
 class ToonzScene;
+class TMacroFx;
 
 //=============================================================================
 /*! \brief ParamsPage. View a page with fx params.
@@ -72,6 +75,12 @@ class DVAPI ParamsPage final : public QFrame {
   FxHistogramRender *m_fxHistogramRender;
 
   ParamViewer *m_paramViewer;
+  struct ExposedParamTarget {
+    int m_fxIndex;
+    std::string m_paramName;
+  };
+  std::vector<std::pair<ParamField *, std::string>> m_pageParams;
+  std::map<ParamField *, ExposedParamTarget> m_exposedParamTargets;
 
 public:
   ParamsPage(QWidget *parent = 0, ParamViewer *paramViewer = 0);
@@ -87,6 +96,10 @@ public:
 
   void update(int frame);
   void setPointValue(int index, const TPointD &p);
+
+  void addExposedParam(int fxIndex, const TFxP &fx,
+                       const std::string &paramName);
+  void addMacroExposureControls(TMacroFx *macroFx, TFx *memberFx);
 
   FxHistogramRender *getFxHistogramRender() const {
     return m_fxHistogramRender;
@@ -168,7 +181,8 @@ public:
 
   void updatePage(int frame, bool onlyParam);
   /*! Create a page reading xml file relating to \b fx. */
-  void createControls(const TFxP &fx, int index = -1);
+  void createControls(const TFxP &fx, int index = -1,
+                      TMacroFx *macroFx = nullptr);
 
   ParamsPage *getCurrentParamsPage() const;
   ParamsPage *getParamsPage(int index) const;
@@ -182,7 +196,8 @@ public:
   void updateWarnings(const TFxP &currentFx, bool isFloat);
 
 protected:
-  void createPage(TIStream &is, const TFxP &fx, int index);
+  void createPage(TIStream &is, const TFxP &fx, int index,
+                  TMacroFx *macroFx);
 
 protected slots:
   void setPage(int);

--- a/toonz/sources/include/toonzqt/paramfield.h
+++ b/toonz/sources/include/toonzqt/paramfield.h
@@ -94,6 +94,7 @@ public:
   virtual QSize getPreferredSize() { return QSize(200, 28); }
 
   static void setFxHandle(TFxHandle *fxHandle);
+  static TFxHandle *getFxHandle() { return m_fxHandleStat; }
 
   virtual void setPrecision(int precision) {}
 signals:

--- a/toonz/sources/toonzqt/fxsettings.cpp
+++ b/toonz/sources/toonzqt/fxsettings.cpp
@@ -13,6 +13,7 @@
 #include "tspectrumparam.h"
 #include "tfxattributes.h"
 #include "toutputproperties.h"
+#include "tundo.h"
 #include "pluginhost.h"
 #include "tenv.h"
 #include "tsystem.h"
@@ -65,6 +66,43 @@ bool hasEmptyInputPort(const TFxP &currentFx) {
   if (currentFx->getInputPortCount() == 0) return false;
   return hasEmptyInputPort(currentFx->getInputPort(0)->getFx());
 }
+
+class MacroParamExposureUndo final : public TUndo {
+  TFxP m_macroFx;
+  std::wstring m_fxId;
+  std::string m_paramName;
+  bool m_oldValue;
+  bool m_newValue;
+
+  void setValue(bool value) const {
+    TMacroFx *macroFx = dynamic_cast<TMacroFx *>(m_macroFx.getPointer());
+    if (!macroFx) return;
+    TFx *fx = macroFx->getFxById(m_fxId);
+    if (!fx) return;
+    macroFx->setParamExposed(fx, m_paramName, value);
+    if (TFxHandle *fxHandle = ParamField::getFxHandle()) {
+      fxHandle->notifyFxChanged();
+      fxHandle->onFxNodeDoubleClicked();
+    }
+  }
+
+public:
+  MacroParamExposureUndo(const TFxP &macroFx, const std::wstring &fxId,
+                         const std::string &paramName, bool oldValue,
+                         bool newValue)
+      : m_macroFx(macroFx)
+      , m_fxId(fxId)
+      , m_paramName(paramName)
+      , m_oldValue(oldValue)
+      , m_newValue(newValue) {}
+
+  int getSize() const override { return sizeof(*this) + m_paramName.size(); }
+  void undo() const override { setValue(m_oldValue); }
+  void redo() const override { setValue(m_newValue); }
+  QString getHistoryString() override {
+    return QObject::tr("Modify Macro Fx Properties");
+  }
+};
 
 // find the field by parameter name and register the field and its label widget
 bool findItemByParamName(QLayout *layout, std::string name,
@@ -168,6 +206,7 @@ void ParamsPage::setPageField(TIStream &is, const TFxP &fx, bool isVertical) {
         if (field) {
           if (decimals >= 0) field->setPrecision(decimals);
           m_fields.push_back(field);
+          m_pageParams.emplace_back(field, name);
           /*-- hboxタグに挟まれているとき --*/
           if (isVertical == false) {
             assert(m_horizontalLayout);
@@ -518,6 +557,7 @@ void ParamsPage::addWidget(QWidget *field, bool isVertical) {
     ParamField *field = MAKE(this, paramName, param);                          \
     if (!field) return NULL;                                                   \
     m_fields.push_back(field);                                                 \
+    m_pageParams.emplace_back(field, name);                                    \
     connect(field, SIGNAL(currentParamChanged()), m_paramViewer,               \
             SIGNAL(currentFxParamChanged()));                                  \
     connect(field, SIGNAL(actualParamChanged()), m_paramViewer,                \
@@ -544,6 +584,26 @@ void ParamsPage::setFx(const TFxP &currentFx, const TFxP &actualFx, int frame) {
   assert(actualFx);
   for (int i = 0; i < (int)m_fields.size(); i++) {
     ParamField *field = m_fields[i];
+    std::map<ParamField *, ExposedParamTarget>::const_iterator exposed =
+        m_exposedParamTargets.find(field);
+    if (exposed != m_exposedParamTargets.end()) {
+      TMacroFx *currentMacro =
+          dynamic_cast<TMacroFx *>(currentFx.getPointer());
+      TMacroFx *actualMacro = dynamic_cast<TMacroFx *>(actualFx.getPointer());
+      if (!currentMacro || !actualMacro) continue;
+      const std::vector<TFxP> &currentFxs = currentMacro->getFxs();
+      const std::vector<TFxP> &actualFxs  = actualMacro->getFxs();
+      const int fxIndex                    = exposed->second.m_fxIndex;
+      if (fxIndex < 0 || fxIndex >= (int)currentFxs.size() ||
+          fxIndex >= (int)actualFxs.size())
+        continue;
+      TParamP currentParam =
+          currentFxs[fxIndex]->getParams()->getParam(exposed->second.m_paramName);
+      TParamP actualParam =
+          actualFxs[fxIndex]->getParams()->getParam(exposed->second.m_paramName);
+      if (currentParam && actualParam) field->setParam(currentParam, actualParam, frame);
+      continue;
+    }
     QString fieldName = field->getParamName();
     TFxP fx           = getCurrentFx(currentFx, actualFx->getFxId());
     assert(fx.getPointer());
@@ -558,6 +618,80 @@ void ParamsPage::setFx(const TFxP &currentFx, const TFxP &actualFx, int frame) {
   if (actualFx->getInputPortCount() > 0)
     m_fxHistogramRender->computeHistogram(actualFx->getInputPort(0)->getFx(),
                                           frame);
+}
+
+//-----------------------------------------------------------------------------
+
+void ParamsPage::addExposedParam(int fxIndex, const TFxP &fx,
+                                 const std::string &paramName) {
+  TParamP param = fx->getParams()->getParam(paramName);
+  if (!param) return;
+
+  QString label = QString::fromStdString(fx->getFxType()) + ": " +
+                  (param->hasUILabel()
+                       ? QString::fromStdString(param->getUILabel())
+                       : QString::fromStdString(paramName));
+  ParamField *field = ParamField::create(this, label, param);
+  if (!field) return;
+
+  m_fields.push_back(field);
+  m_exposedParamTargets[field] = {fxIndex, paramName};
+  connect(field, SIGNAL(currentParamChanged()), m_paramViewer,
+          SIGNAL(currentFxParamChanged()));
+  connect(field, SIGNAL(actualParamChanged()), m_paramViewer,
+          SIGNAL(actualFxParamChanged()));
+  connect(field, SIGNAL(paramKeyToggle()), m_paramViewer,
+          SIGNAL(paramKeyChanged()));
+
+  const int row = m_mainLayout->rowCount();
+  QLabel *nameLabel = new QLabel(label, this);
+  nameLabel->setObjectName("FxSettingsLabel");
+  m_mainLayout->addWidget(nameLabel, row, 0, Qt::AlignRight | Qt::AlignVCenter);
+  m_mainLayout->addWidget(field, row, 1);
+}
+
+//-----------------------------------------------------------------------------
+
+void ParamsPage::addMacroExposureControls(TMacroFx *macroFx, TFx *memberFx) {
+  if (!macroFx || !memberFx || m_pageParams.empty()) return;
+
+  QGroupBox *group = new QGroupBox(tr("Exposed in Macro"), this);
+  QVBoxLayout *layout = new QVBoxLayout(group);
+  layout->setContentsMargins(8, 6, 8, 6);
+
+  for (const auto &pageParam : m_pageParams) {
+    ParamField *field            = pageParam.first;
+    const std::string &paramName = pageParam.second;
+    if (!memberFx->getParams()->getParam(paramName)) continue;
+
+    QCheckBox *checkBox = new QCheckBox(field->getUIName(), group);
+    checkBox->setChecked(macroFx->isParamExposed(memberFx, paramName));
+    layout->addWidget(checkBox);
+    connect(checkBox, &QCheckBox::toggled, this,
+            [this, macro = TFxP(macroFx), fxId = memberFx->getFxId(),
+             paramName](bool exposed) {
+              TMacroFx *currentMacro =
+                  dynamic_cast<TMacroFx *>(macro.getPointer());
+              if (!currentMacro) return;
+              TFx *member = currentMacro->getFxById(fxId);
+              if (!member) return;
+              const bool oldValue =
+                  currentMacro->isParamExposed(member, paramName);
+              if (oldValue == exposed) return;
+              currentMacro->setParamExposed(member, paramName, exposed);
+              TUndoManager::manager()->add(new MacroParamExposureUndo(
+                  macro, fxId, paramName, oldValue, exposed));
+              emit m_paramViewer->actualFxParamChanged();
+              if (TFxHandle *fxHandle = ParamField::getFxHandle())
+                fxHandle->onFxNodeDoubleClicked();
+            });
+  }
+
+  if (layout->count() == 0) {
+    delete group;
+    return;
+  }
+  m_mainLayout->addWidget(group, m_mainLayout->rowCount(), 0, 1, 2);
 }
 
 //-----------------------------------------------------------------------------
@@ -780,8 +914,12 @@ void ParamsPageSet::setFx(const TFxP &currentFx, const TFxP &actualFx,
     assert(currentFxMacroFxs.size() == actualFxMacroFxs.size());
     for (int i = 0; i < m_pagesList->count(); i++) {
       ParamsPage *page = getParamsPage(i);
-      if (!page || !m_pageFxIndexTable.contains(page)) continue;
-      int index = m_pageFxIndexTable[page];
+      if (!page) continue;
+      if (!m_pageFxIndexTable.contains(page)) {
+        page->setFx(currentFx, actualFx, frame);
+        continue;
+      }
+      const int index = m_pageFxIndexTable[page];
       page->setFx(currentFxMacroFxs[index], actualFxMacroFxs[index], frame);
     }
   } else {
@@ -855,10 +993,38 @@ void ParamsPageSet::addParamsPage(ParamsPage *page, const char *name) {
 
 //-----------------------------------------------------------------------------
 
-void ParamsPageSet::createControls(const TFxP &fx, int index) {
+void ParamsPageSet::createControls(const TFxP &fx, int index,
+                                   TMacroFx *owningMacro) {
   if (TMacroFx *macroFx = dynamic_cast<TMacroFx *>(fx.getPointer())) {
+    if (!macroFx->getExposedParams().empty()) {
+      ParamsPage *page = createParamsPage();
+      const std::vector<TFxP> &fxs = macroFx->getFxs();
+      bool hasExposedParam = false;
+      for (const TMacroFx::ExposedParam &param : macroFx->getExposedParams()) {
+        TFx *memberFx = macroFx->getFxById(param.m_fxId);
+        if (!memberFx || !memberFx->getParams()->getParam(param.m_paramName))
+          continue;
+        const std::vector<TFxP>::const_iterator found =
+            std::find_if(fxs.begin(), fxs.end(), [memberFx](const TFxP &fx) {
+              return fx.getPointer() == memberFx;
+            });
+        if (found != fxs.end()) {
+          page->addExposedParam(std::distance(fxs.begin(), found), memberFx,
+                                param.m_paramName);
+          hasExposedParam = true;
+        }
+      }
+      if (!hasExposedParam)
+        delete page;
+      else {
+        page->setPageSpace();
+        const QByteArray tabName = tr("Exposed").toUtf8();
+        addParamsPage(page, tabName.constData());
+      }
+    }
     const std::vector<TFxP> &fxs = macroFx->getFxs();
-    for (int i = 0; i < (int)fxs.size(); i++) createControls(fxs[i], i);
+    for (int i = 0; i < (int)fxs.size(); i++)
+      createControls(fxs[i], i, macroFx);
     return;
   }
   if (RasterFxPluginHost *plugin =
@@ -894,7 +1060,7 @@ void ParamsPageSet::createControls(const TFxP &fx, int index) {
         m_helpCommand = is.getTagAttribute("help_command");
       }
 
-      while (!is.matchEndTag()) createPage(is, fx, index);
+      while (!is.matchEndTag()) createPage(is, fx, index, owningMacro);
     } catch (TException const &) {
     }
   }
@@ -921,7 +1087,8 @@ ParamsPage *ParamsPageSet::getParamsPage(int index) const {
 
 //-----------------------------------------------------------------------------
 
-void ParamsPageSet::createPage(TIStream &is, const TFxP &fx, int index) {
+void ParamsPageSet::createPage(TIStream &is, const TFxP &fx, int index,
+                               TMacroFx *macroFx) {
   std::string tagName;
   if (!is.matchTag(tagName) || tagName != "page")
     throw TException("expected <page>");
@@ -937,6 +1104,7 @@ void ParamsPageSet::createPage(TIStream &is, const TFxP &fx, int index) {
     isFirstPageOfFx = !(m_pageFxIndexTable.values().contains(index));
 
   paramsPage->setPage(is, fx, isFirstPageOfFx);
+  if (macroFx) paramsPage->addMacroExposureControls(macroFx, fx.getPointer());
 
   connect(paramsPage, SIGNAL(preferredPageSizeChanged()), this,
           SLOT(recomputePreferredSize()));
@@ -1115,7 +1283,8 @@ void ParamViewer::setFx(const TFxP &currentFx, const TFxP &actualFx, int frame,
   std::string name = actualFx->getFxType();
   if (name == "macroFx") {
     TMacroFx *macroFx = dynamic_cast<TMacroFx *>(currentFx.getPointer());
-    if (macroFx) name = macroFx->getMacroFxType();
+    if (macroFx)
+      name = macroFx->getMacroFxType() + "[" + macroFx->getExposedParamKey() + "]";
   } else {
     name += std::to_string(actualFx->getFxVersion());
   }


### PR DESCRIPTION
## Summary\n- add per-property Macro FX exposure controls alongside the existing full nested FX controls\n- add an Exposed tab that edits only selected nested properties\n- persist exposure selections in Macro FX data and preserve them through cloning and undo\n\n## Testing\n- compile tmacrofx.cpp and fxsettings.cpp with the project commands and -Werror\n- ninja -C /private/tmp/opentoonz-6370-build toonzqt (blocked at the pre-existing arm64-incompatible bundled SuperLU archive before toonzqt links)