### PR TITLE
[Idea #6471] Apply sprite sheet padding to individual frames

### DIFF
--- a/toonz/sources/image/sprite/tiio_sprite.cpp
+++ b/toonz/sources/image/sprite/tiio_sprite.cpp
@@ -125,7 +125,18 @@ TLevelWriterSprite::~TLevelWriterSprite() {
       QString path      = m_path.getQString();
       QString newEnding = "_" + QString::number(i) + ".png";
       path              = path.replace(".spritesheet", newEnding);
-      m_imagesResized[i].save(path, "PNG", -1);
+      if (horizPadding == 0 && vertPadding == 0) {
+        m_imagesResized[i].save(path, "PNG", -1);
+        continue;
+      }
+      QImage padded(m_imagesResized[i].width() + horizPadding,
+                    m_imagesResized[i].height() + vertPadding,
+                    QImage::Format_ARGB32_Premultiplied);
+      padded.fill(qRgba(0, 0, 0, 0));
+      QPainter paddingPainter(&padded);
+      paddingPainter.drawImage(m_leftPadding, m_topPadding, m_imagesResized[i]);
+      paddingPainter.end();
+      padded.save(path, "PNG", -1);
     }
   }
   if (m_format != "Individual") {


### PR DESCRIPTION
## Summary
- Honour Top, Bottom, Left and Right Padding in the `Individual` sprite sheet format, which previously ignored them.
- Draw each frame onto a transparent canvas expanded by the configured padding.
- Short-circuit to the original save call when every padding value is zero, so existing output is byte-identical.
- Grid, Vertical and Horizontal layouts are untouched: the change is confined to the `Individual` branch.

Padding worked for the sheet layouts but was silently dropped for individual frames, which is the option users need when sprites are too large for a single sheet. Disabling Trim Empty Space is not a workaround, since the reported use case requires it enabled.

Discussion: https://github.com/opentoonz/opentoonz/discussions/6471

## Testing
- Compiled `tiio_sprite.cpp` with the project compile command; no new warnings.
- Full `OpenToonz.app` target builds and links on macOS arm64.
- Ran a harness replicating the pre- and post-change code paths: zero padding is byte-identical to current output; the padded canvas is content plus left/right and top/bottom; content lands at (leftPadding, topPadding); all four margins are fully transparent; asymmetric padding is not symmetrised; padding stays absolute under Scale; a fully transparent frame still gets a correctly sized canvas.
- `clang-format` reports no violations on the changed lines.
- `git diff --check` passed.