### PR TITLE
[Idea #6552] Add Fast Render Current Frame to PNG

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -261,6 +261,7 @@
         <command>MI_Render</command>
         <separator/>
         <command>MI_FastRender</command>
+        <command>MI_FastRenderFrame</command>
     </menu>
     <menu title="View">
         <command>MI_ViewTable</command>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2600,6 +2600,9 @@ void MainWindow::defineActions() {
                          "render");
   createMenuRenderAction(MI_FastRender, QT_TR_NOOP("&Fast Render to MP4"),
                          "Alt+R", "fast_render_mp4");
+  createMenuRenderAction(MI_FastRenderFrame,
+                         QT_TR_NOOP("Fast Render &Current Frame to PNG"), "",
+                         "fast_render_png");
   createMenuRenderAction(MI_Preview, QT_TR_NOOP("&Preview"), "Ctrl+R",
                          "preview");
   createMenuRenderAction(MI_SavePreviewedFrames,

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -49,6 +49,7 @@
 #define MI_PreviewSettings "MI_PreviewSettings"
 #define MI_Render "MI_Render"
 #define MI_FastRender "MI_FastRender"
+#define MI_FastRenderFrame "MI_FastRenderFrame"
 #define MI_Preview "MI_Preview"
 #define MI_SoundTrack "MI_SoundTrack"
 #define MI_RegeneratePreview "MI_RegeneratePreview"

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -18,6 +18,7 @@
 #include "toonz/preferences.h"
 #include "toonz/toonzscene.h"
 #include "toonz/tscenehandle.h"
+#include "toonz/tframehandle.h"
 #include "toonz/txsheet.h"
 #include "toonz/txsheethandle.h"
 #include "toonz/fxdag.h"
@@ -214,6 +215,8 @@ public:
       , m_multimediaRender(0) {
     setCommandHandler("MI_Render", this, &RenderCommand::onRender);
     setCommandHandler("MI_FastRender", this, &RenderCommand::onFastRender);
+    setCommandHandler("MI_FastRenderFrame", this,
+                      &RenderCommand::onFastRenderFrame);
     setCommandHandler("MI_Preview", this, &RenderCommand::onPreview);
   }
 
@@ -222,6 +225,7 @@ public:
   void multimediaRender();
   void onRender();
   void onFastRender();
+  void onFastRenderFrame();
   void onPreview();
   static void resetBgColor();
   void doRender(bool isPreview);
@@ -818,6 +822,55 @@ void RenderCommand::onFastRender() {
   }
   prop->setPath(path);
   doRender(false);
+  prop->setPath(currPath);
+}
+
+//---------------------------------------------------------
+
+void RenderCommand::onFastRenderFrame() {
+  TApp *app               = TApp::instance();
+  TFrameHandle *frameHandle = app->getCurrentFrame();
+  if (!frameHandle->isEditingScene()) {
+    DVGui::warning(
+        QObject::tr("Fast Render Current Frame is available in scene mode."));
+    return;
+  }
+
+  ToonzScene *scene       = app->getCurrentScene()->getScene();
+  TOutputProperties *prop = scene->getProperties()->getOutputProperties();
+
+  QStringList formats;
+  TImageWriter::getSupportedFormats(formats, true);
+  TLevelWriter::getSupportedFormats(formats, true);
+  Tiio::Writer::getSupportedFormats(formats, true);
+  if (!formats.contains("png")) {
+    DVGui::warning(QObject::tr("The PNG format is not available."));
+    return;
+  }
+
+  int frame = frameHandle->getFrame();
+  if (frame < 0 || frame >= scene->getFrameCount()) {
+    DVGui::warning(
+        QObject::tr("The current frame is outside the scene frame range."));
+    return;
+  }
+
+  QString sceneName = QString::fromStdWString(scene->getSceneName());
+  QString location  = Preferences::instance()->getFastRenderPath();
+  if (location == "desktop" || location == "Desktop") {
+    location =
+        QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+  }
+  TFilePath path = TFilePath(location) + TFilePath(sceneName + ".png");
+
+  TFilePath currPath = prop->getPath();
+  int currR0, currR1, currStep;
+  prop->getRange(currR0, currR1, currStep);
+
+  prop->setPath(path);
+  prop->setRange(frame, frame, 1);
+  doRender(false);
+  prop->setRange(currR0, currR1, currStep);
   prop->setPath(currPath);
 }
 


### PR DESCRIPTION
## Summary
- Add a `Fast Render Current Frame to PNG` command that renders only the current frame to the existing Fast Render path.
- It saves and restores both the output path and the frame range, so Output Settings is left exactly as the user had it.
- Because it goes through the normal render path rather than grabbing the viewport, camera box and other overlays are absent and the result is full render resolution.
- No default shortcut. Clear messages when PNG is unavailable or the current frame lies outside the scene.

This mirrors the existing `MI_FastRender`, which already establishes the pattern of a one-click render that bypasses Output Settings. The gap it closes is workflow rather than capability: exporting one frame previously meant opening Output Settings, switching format to PNG, narrowing the range, rendering, then putting all three back.

Discussion: https://github.com/opentoonz/opentoonz/discussions/6552 (closed on the grounds that the result is already achievable; this adds the one-click path, not a new capability)

## Testing
- Compiled `rendercommand.cpp` and `mainwindow.cpp` with the project compile command; no new warnings.
- Full `OpenToonz.app` target builds and links on macOS arm64.
- `clang-format` reports no violations on the changed lines.
- `git diff --check` passed.