### PR TITLE
[Idea #6573] Allow extra FFmpeg encoding arguments

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_apng.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_apng.cpp
@@ -55,6 +55,12 @@ TLevelWriterAPng::TLevelWriterAPng(const TFilePath &path, TPropertyGroup *winfo)
 
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
 
@@ -215,14 +221,17 @@ TImageP TLevelReaderAPng::load(int frameIndex) {
 Tiio::APngWriterProperties::APngWriterProperties()
     : m_scale("Scale", 1, 100, 100)
     , m_looping("Looping", true)
-    , m_extPng("ExtPng", false) {
+    , m_extPng("ExtPng", false)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
   bind(m_scale);
   bind(m_looping);
   bind(m_extPng);
+  bind(m_extraArgs);
 }
 
 void Tiio::APngWriterProperties::updateTranslation() {
   m_scale.setQStringName(tr("Scale"));
   m_looping.setQStringName(tr("Looping"));
   m_extPng.setQStringName(tr("Write as .png"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }

--- a/toonz/sources/image/ffmpeg/tiio_apng.h
+++ b/toonz/sources/image/ffmpeg/tiio_apng.h
@@ -75,6 +75,7 @@ public:
   TIntProperty m_scale;
   TBoolProperty m_looping;
   TBoolProperty m_extPng;
+  TStringProperty m_extraArgs;
   APngWriterProperties();
   void updateTranslation() override;
 };

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -189,6 +189,54 @@ void Ffmpeg::createIntermediateImage(const TImageP &img, int frameIndex) {
   m_cleanUpList.push_back(tempPath);
 }
 
+namespace {
+
+bool tokenizeFfmpegArgs(const QString &args, QStringList &tokens) {
+  QString current;
+  bool inQuotes = false;
+  bool started  = false;
+  for (const QChar &c : args) {
+    if (c == '"') {
+      inQuotes = !inQuotes;
+      started  = true;
+    } else if (c.isSpace() && !inQuotes) {
+      if (started) tokens << current;
+      current.clear();
+      started = false;
+    } else {
+      current += c;
+      started = true;
+    }
+  }
+  if (inQuotes) return false;
+  if (started) tokens << current;
+  return true;
+}
+
+}  // namespace
+
+bool Ffmpeg::setExtraArgs(const QString &args) {
+  QStringList tokens;
+  if (!tokenizeFfmpegArgs(args, tokens)) {
+    DVGui::warning(QObject::tr("Extra FFmpeg Args has an unmatched quote."));
+    return false;
+  }
+
+  static const QStringList reserved = {"-i", "-y", "-n"};
+  for (const QString &token : tokens) {
+    if (reserved.contains(token)) {
+      QString message = QObject::tr(
+                            "The FFmpeg argument '%1' is reserved by OpenToonz "
+                            "and cannot be overridden. It was ignored.")
+                            .arg(token);
+      DVGui::warning(message);
+      return false;
+    }
+  }
+  m_extraArgs = tokens;
+  return true;
+}
+
 void Ffmpeg::runFfmpeg(const QStringList &preInputArgs,
                        const QStringList &postInputArgs, bool inputPathIncluded,
                        bool outputPathIncluded, bool overwrite,
@@ -209,6 +257,7 @@ void Ffmpeg::runFfmpeg(const QStringList &preInputArgs,
 
   if (m_hasSoundTrack) args.append(m_audioArgs);
   args.append(postInputArgs);
+  args.append(m_extraArgs);
 
   if (overwrite && !outputPathIncluded) args << "-y";
 

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -70,6 +70,8 @@ public:
   void setFrameRate(double fps);
   void setPath(const TFilePath &path);
 
+  bool setExtraArgs(const QString &args);
+
   void saveSoundTrack(TSoundTrack *soundTrack);
 
   bool checkFilesExist() const;
@@ -96,6 +98,7 @@ private:
   QString m_audioPath;
   QString m_audioFormat;
   QStringList m_audioArgs;
+  QStringList m_extraArgs;
 
   // Mutable members for caching inside const functions
   mutable double m_frameRate = 0.0;

--- a/toonz/sources/image/ffmpeg/tiio_gif.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_gif.cpp
@@ -55,6 +55,12 @@ TLevelWriterGif::TLevelWriterGif(const TFilePath &path, TPropertyGroup *winfo)
 
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   // m_frameCount = 0;
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
@@ -306,7 +312,8 @@ Tiio::GifWriterProperties::GifWriterProperties()
     , m_looping("Looping", true)
     , m_palette("Generate Palette", true)
     , m_mode("Mode")
-    , m_maxcolors("Max Colors", 2, 256, 256) {
+    , m_maxcolors("Max Colors", 2, 256, 256)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
 
   // Set values for mode
   m_mode.addValue(L"GLOBAL0");
@@ -346,6 +353,7 @@ Tiio::GifWriterProperties::GifWriterProperties()
   bind(m_palette);
   bind(m_mode);
   bind(m_maxcolors);
+  bind(m_extraArgs);
 }
 
 void Tiio::GifWriterProperties::updateTranslation() {
@@ -353,6 +361,7 @@ void Tiio::GifWriterProperties::updateTranslation() {
   m_looping.setQStringName(tr("Looping"));
   m_mode.setQStringName(tr("Mode"));
   m_maxcolors.setQStringName(tr("Max Colors"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }
 
 // Tiio::Reader* Tiio::makeGifReader(){ return nullptr; }

--- a/toonz/sources/image/ffmpeg/tiio_gif.h
+++ b/toonz/sources/image/ffmpeg/tiio_gif.h
@@ -86,6 +86,7 @@ public:
   TEnumProperty m_mode;
   TIntProperty m_maxcolors;
 
+  TStringProperty m_extraArgs;
   GifWriterProperties();
 
   void updateTranslation() override;

--- a/toonz/sources/image/ffmpeg/tiio_mp4.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.cpp
@@ -51,6 +51,12 @@ TLevelWriterMp4::TLevelWriterMp4(const TFilePath &path, TPropertyGroup *winfo)
   }
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
 
@@ -225,14 +231,18 @@ TImageP TLevelReaderMp4::load(int frameIndex) {
 }
 
 Tiio::Mp4WriterProperties::Mp4WriterProperties()
-    : m_vidQuality("Quality", 1, 100, 90), m_scale("Scale", 1, 100, 100) {
+    : m_vidQuality("Quality", 1, 100, 90)
+    , m_scale("Scale", 1, 100, 100)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
   bind(m_vidQuality);
   bind(m_scale);
+  bind(m_extraArgs);
 }
 
 void Tiio::Mp4WriterProperties::updateTranslation() {
   m_vidQuality.setQStringName(tr("Quality"));
   m_scale.setQStringName(tr("Scale"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }
 
 // Tiio::Reader* Tiio::makeMp4Reader(){ return nullptr; }

--- a/toonz/sources/image/ffmpeg/tiio_mp4.h
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.h
@@ -79,6 +79,7 @@ public:
   // TBoolProperty m_matte;
   TIntProperty m_vidQuality;
   TIntProperty m_scale;
+  TStringProperty m_extraArgs;
   Mp4WriterProperties();
   void updateTranslation() override;
 };

--- a/toonz/sources/image/ffmpeg/tiio_webm.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_webm.cpp
@@ -60,6 +60,12 @@ TLevelWriterWebm::TLevelWriterWebm(const TFilePath &path, TPropertyGroup *winfo)
 
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
 
@@ -297,7 +303,9 @@ Tiio::WebmWriterProperties::WebmWriterProperties()
     , m_speed("Encoding Speed")
     , m_kf("Keyframe Interval")
     , m_preserveAlpha("Preserve Alpha", true)
-    , m_lossless("Lossless", false) {
+    , m_lossless("Lossless", false)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
+  bind(m_extraArgs);
   bind(m_scale);
   bind(m_speed);
   bind(m_kf);
@@ -333,6 +341,7 @@ void Tiio::WebmWriterProperties::updateTranslation() {
   m_kf.setQStringName(tr("Keyframe Interval"));
   m_preserveAlpha.setQStringName(tr("Preserve Alpha"));
   m_lossless.setQStringName(tr("Lossless"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }
 
 // Tiio::Reader* Tiio::makeWebmReader(){ return nullptr; }

--- a/toonz/sources/image/ffmpeg/tiio_webm.h
+++ b/toonz/sources/image/ffmpeg/tiio_webm.h
@@ -90,6 +90,7 @@ public:
   TBoolProperty m_preserveAlpha;
   TBoolProperty m_lossless;
 
+  TStringProperty m_extraArgs;
   WebmWriterProperties();
   void updateTranslation() override;
 };


### PR DESCRIPTION
## Summary
- Add an `Extra FFmpeg Args` format property to the MP4, WebM, GIF and APNG writers.
- Stored in the existing format property group, so it saves with the scene and with output presets.
- Arguments are appended after the arguments the writer builds and before the output path.
- An empty field produces exactly the command line built today.

Safety:
- Arguments are split on whitespace, honouring double quotes, and passed to `QProcess` as a list, so no shell is involved. This is consistent with the hardening in #6903 and #6904.
- The tokens `-i`, `-y` and `-n` are rejected with a warning: they would retarget the process rather than configure the encode, and the writer owns the input pattern, the overwrite flag and the output path.

This is deliberately the smaller of the two designs discussed. The external-instruction-file prototype from the thread is not implemented; a plain per-format field keeps the failure mode legible.

Discussion: https://github.com/opentoonz/opentoonz/discussions/6573

## Testing
- Compiled all five changed files with the project compile command; no new warnings.
- Full `OpenToonz.app` target builds and links on macOS arm64.
- Ran a harness over the tokenizer and deny list: empty and whitespace-only input yield no arguments; flag/value pairs, codec selectors and hardware-acceleration flags pass through; quoted values survive as one token including colons; extra whitespace collapses; `-i`, `-y` and `-n` are rejected anywhere in the list; and `-i` inside a quoted metadata value is correctly not rejected.
- `clang-format` reports no violations on the changed lines.
- `git diff --check` passed.