### PR TITLE
[Idea #6773] Add tcomposer output width and height options

### DIFF
--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -604,6 +604,8 @@ int main(int argc, char *argv[]) {
   RangeQualifier range;
   IntQualifier stepOpt("-step n", "Step");
   IntQualifier shrinkOpt("-shrink n", "Shrink");
+  IntQualifier widthOpt("-width n", "Output width in pixels");
+  IntQualifier heightOpt("-height n", "Output height in pixels");
   IntQualifier multimedia("-multimedia n", "Multimedia rendering mode");
   StringQualifier farmData("-farm data", "TFarm Controller");
   StringQualifier idq("-id n", "id");
@@ -611,8 +613,9 @@ int main(int argc, char *argv[]) {
   StringQualifier tileSize("-maxtilesize n",
                            "Enable tile rendering of max n MB per tile");
   StringQualifier tmsg("-tmsg val", "only internal use");
-  usageLine = srcName + dstName + range + stepOpt + shrinkOpt + multimedia +
-              farmData + idq + nthreads + tileSize + tmsg;
+  usageLine = srcName + dstName + range + stepOpt + shrinkOpt + widthOpt +
+              heightOpt + multimedia + farmData + idq + nthreads + tileSize +
+              tmsg;
 
   // system path qualifiers
   std::map<QString, std::unique_ptr<TCli::QualifierT<TFilePath>>>
@@ -920,6 +923,37 @@ int main(int argc, char *argv[]) {
       shrink = shrinkOpt.getValue();
     else
       shrink = scene_shrink;
+
+    if (widthOpt.isSelected() || heightOpt.isSelected()) {
+      int outWidth  = widthOpt.isSelected() ? widthOpt.getValue() : 0;
+      int outHeight = heightOpt.isSelected() ? heightOpt.getValue() : 0;
+      if (outWidth < 0 || outHeight < 0 ||
+          (widthOpt.isSelected() && outWidth == 0) ||
+          (heightOpt.isSelected() && outHeight == 0)) {
+        cout << "Qualifier 'width'/'height': size must be positive" << endl;
+        exit(1);
+      }
+      TCamera *camera     = scene->getCurrentCamera();
+      TDimension sceneRes = camera->getRes();
+      if (sceneRes.lx <= 0 || sceneRes.ly <= 0) {
+        cout << "The scene camera has no usable resolution" << endl;
+        exit(1);
+      }
+      if (outWidth == 0)
+        outWidth = (int)(outHeight * (double)sceneRes.lx / sceneRes.ly + 0.5);
+      if (outHeight == 0)
+        outHeight = (int)(outWidth * (double)sceneRes.ly / sceneRes.lx + 0.5);
+      outWidth  = std::max(1, outWidth);
+      outHeight = std::max(1, outHeight);
+      camera->setRes(TDimension(outWidth, outHeight));
+      if (shrink != 1) {
+        m_userLog->info("Shrink ignored because -width or -height was given");
+        shrink = 1;
+      }
+      m_userLog->info("Output resolution: " + std::to_string(outWidth) + "x" +
+                      std::to_string(outHeight));
+    }
+
     if (multimedia.isSelected())
       scene->getProperties()->getOutputProperties()->setMultimediaRendering(
           multimedia.getValue());


### PR DESCRIPTION
## Summary
- Add `-width n` and `-height n` to `tcomposer`, setting the render resolution directly via `TCamera::setRes`.
- Either may be given alone, in which case the other follows the camera aspect ratio.
- They take precedence over `-shrink`, which would otherwise scale the result a second time; the substitution is reported in the render log.
- Non-positive values are rejected with a usage error. Behaviour is unchanged when neither option is given.

`-shrink` was the only way to change render resolution from the command line. It divides the camera resolution by an integer and is marked obsolete, so arbitrary output sizes required editing the scene. This matters for automated pipelines that render at reduced resolution during production and full resolution for finals.

Discussion: https://github.com/opentoonz/opentoonz/discussions/6773

## Testing
- Built `tcomposer` and the full `OpenToonz.app` target on macOS arm64.
- Confirmed `[ -width n ] [ -height n ]` now appear in the usage line, in the expected position, and are absent from a build of unmodified `master`.
- `clang-format` reports no violations on the changed lines.
- `git diff --check` passed.
- End-to-end render at a forced resolution still needs a real scene file; none ship in `stuff/`.