### PR TITLE
[Idea #6535] Render non-contiguous frame ranges

### DIFF
--- a/toonz/sources/include/toutputproperties.h
+++ b/toonz/sources/include/toutputproperties.h
@@ -5,6 +5,10 @@
 
 #include "tfilepath.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #undef DVAPI
 #undef DVVAR
 #ifdef TOONZLIB_EXPORTS
@@ -82,6 +86,9 @@ private:
   double m_frameRate;
 
   int m_from, m_to;
+  /*-- Optional non-contiguous selection. Empty means "use m_from/m_to",
+   * which keeps existing scenes and presets byte-identical. --*/
+  std::vector<std::pair<int, int>> m_frameRanges;
   int m_whichLevels;
   int m_offset, m_step;
 
@@ -173,6 +180,30 @@ Set first frame to \b r0, last frame to \b r1, step to \b step.
 \sa getRange()
 */
   void setRange(int r0, int r1, int step);
+
+  /*!
+Non-contiguous output selection, as a list of inclusive [from, to] pairs in
+the same zero-based space as getRange(). An empty list means the single
+range held by getRange() is authoritative.
+*/
+  const std::vector<std::pair<int, int>> &getFrameRanges() const {
+    return m_frameRanges;
+  }
+  void setFrameRanges(const std::vector<std::pair<int, int>> &ranges);
+  void clearFrameRanges() { m_frameRanges.clear(); }
+
+  //! Expands the selection into ascending frame numbers, honouring step.
+  std::vector<int> getFrameList(int sceneLength) const;
+
+  /*! Parses a printer-style list such as "1-3, 5, 8-10". Frame numbers are
+one-based, matching what the user types. Returns false and fills \b error
+when the text is malformed; \b ranges is then left untouched. */
+  static bool parseFrameRanges(const std::string &text,
+                               std::vector<std::pair<int, int>> &ranges,
+                               std::string *error = 0);
+  //! Inverse of parseFrameRanges(), producing one-based text.
+  static std::string formatFrameRanges(
+      const std::vector<std::pair<int, int>> &ranges);
 
   /*!
 Set output frame rate.

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -367,7 +367,11 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   // Output Camera
   m_outputCameraOm = new QComboBox();
   // Frame Start-End
-  m_startFld = new DVGui::IntLineEdit(this);
+  m_startFld        = new DVGui::IntLineEdit(this);
+  m_frameRangesFld  = new DVGui::LineEdit(this);
+  m_frameRangesFld->setToolTip(
+      tr("Render only these frames, for example 1-3, 5, 8-10.\n"
+         "Leave empty to use Frame Start and End."));
   m_endFld   = new DVGui::IntLineEdit(this);
   // Step-Shrink
   m_stepFld   = new DVGui::IntLineEdit(this);
@@ -437,6 +441,10 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
                                 Qt::AlignRight | Qt::AlignVCenter);
       frameShrinkLay->addWidget(m_stepFld, 0, 7);
 
+      frameShrinkLay->addWidget(new QLabel(tr("Frames:"), this), 2, 0,
+                                Qt::AlignRight | Qt::AlignVCenter);
+      frameShrinkLay->addWidget(m_frameRangesFld, 2, 1, 1, 7);
+
       frameShrinkLay->addWidget(new QLabel(tr("Shrink:"), this), 1, 0,
                                 Qt::AlignRight | Qt::AlignVCenter);
       frameShrinkLay->addWidget(m_shrinkFld, 1, 1);
@@ -457,6 +465,8 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   ret      = ret &&
         connect(m_outputCameraOm, SIGNAL(currentIndexChanged(const QString &)),
                 SLOT(onCameraChanged(const QString &)));
+  ret = ret && connect(m_frameRangesFld, SIGNAL(editingFinished()), this,
+                       SLOT(onFrameRangesEditFinished()));
   ret = ret && connect(m_startFld, SIGNAL(editingFinished()),
                        SLOT(onFrameFldEditFinished()));
   ret = ret && connect(m_endFld, SIGNAL(editingFinished()),
@@ -1004,6 +1014,8 @@ void OutputSettingsPopup::updateField() {
   }
   m_startFld->setValue(r0 + 1);
   m_endFld->setValue(r1 + 1);
+  m_frameRangesFld->setText(QString::fromStdString(
+      TOutputProperties::formatFrameRanges(prop->getFrameRanges())));
   m_stepFld->setValue(step);
   m_shrinkFld->setValue(renderSettings.m_shrinkX);
   if (m_applyShrinkChk)
@@ -1319,6 +1331,42 @@ void OutputSettingsPopup::onSyncColorSettingsChecked(int state) {
 }
 
 //----------------------------------------------
+
+/*-- An empty field clears the selection and hands control back to Frame Start
+ * and End. Anything else must parse completely or nothing is applied. --*/
+void OutputSettingsPopup::onFrameRangesEditFinished() {
+  ToonzScene *scene = getCurrentScene();
+  if (!scene) return;
+  TOutputProperties *prop = getProperties();
+
+  QString text = m_frameRangesFld->text().trimmed();
+  if (text.isEmpty()) {
+    if (!prop->getFrameRanges().empty()) {
+      prop->clearFrameRanges();
+      TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    }
+    return;
+  }
+
+  std::vector<std::pair<int, int>> ranges;
+  std::string error;
+  if (!TOutputProperties::parseFrameRanges(text.toStdString(), ranges,
+                                           &error)) {
+    DVGui::warning(tr("Invalid frame list: %1")
+                       .arg(QString::fromStdString(error)));
+    m_frameRangesFld->setText(QString::fromStdString(
+        TOutputProperties::formatFrameRanges(prop->getFrameRanges())));
+    return;
+  }
+
+  prop->setFrameRanges(ranges);
+  /*-- Echo the normalised form so the user can see merges and reordering. --*/
+  m_frameRangesFld->setText(
+      QString::fromStdString(TOutputProperties::formatFrameRanges(ranges)));
+  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+}
+
+//-----------------------------------------------------------------------------
 
 void OutputSettingsPopup::onFrameFldEditFinished() {
   ToonzScene *scene = getCurrentScene();

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -54,6 +54,7 @@ class OutputSettingsPopup : public DVGui::Dialog {
   QComboBox *m_fileFormat;
   QComboBox *m_outputCameraOm;
   DVGui::IntLineEdit *m_startFld, *m_endFld;
+  DVGui::LineEdit *m_frameRangesFld;
   DVGui::IntLineEdit *m_stepFld, *m_shrinkFld;
   QComboBox *m_multimediaOm;
   QComboBox *m_resampleBalanceOm;
@@ -116,6 +117,7 @@ protected slots:
   void openSettingsPopup();
   void onCameraChanged(const QString &str);
   void onFrameFldEditFinished();
+  void onFrameRangesEditFinished();
   void onResampleChanged(int type);
   void onChannelWidthChanged(int type);
   void onLinearColorSpaceClicked(bool checked);

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -200,6 +200,9 @@ class RenderCommand {
   double m_timeStretchFactor;
 
   int m_multimediaRender;
+  /*-- Frames to render, in order. Always populated, so the render loop has
+   * a single path whether or not a non-contiguous selection is in use. --*/
+  std::vector<double> m_frames;
 
 public:
   RenderCommand()
@@ -337,6 +340,30 @@ sprop->getOutputProperties()->setRenderSettings(rso);*/
 
   m_r         = stretchedR0 / m_timeStretchFactor;
   m_numFrames = (stretchedR1 - stretchedR0) / m_step + 1;
+
+  /*-- Expand the frames to render. A non-contiguous selection is only honoured
+   * at 1:1 time stretch: stretching resamples the timeline, so an arbitrary
+   * frame list has no well-defined meaning there and the contiguous range
+   * stays authoritative. --*/
+  m_frames.clear();
+  const std::vector<std::pair<int, int>> &ranges =
+      outputSettings.getFrameRanges();
+  if (!ranges.empty() && areAlmostEqual(m_timeStretchFactor, 1.0)) {
+    std::vector<int> frameList =
+        outputSettings.getFrameList(scene->getFrameCount());
+    for (int i = 0; i < (int)frameList.size(); i++)
+      m_frames.push_back((double)frameList[i]);
+    m_numFrames = (int)m_frames.size();
+    if (m_numFrames == 0) {
+      DVGui::warning(QObject::tr(
+          "The selected frames are outside the scene. Nothing to render."));
+      return false;
+    }
+    m_r = m_frames.front();
+  } else {
+    for (int i = 0; i < m_numFrames; i++)
+      m_frames.push_back(m_r + i * m_stepd);
+  }
 
   // Update the multimedia render switch
   m_multimediaRender = outputSettings.getMultimediaRendering();
@@ -560,7 +587,8 @@ void RenderCommand::rasterRender(bool isPreview) {
       QObject::tr("Building Schematic...", "RenderCommand"));
   buildSceneProgressBar->show();
 
-  for (int i = 0; i < m_numFrames; ++i, m_r += m_stepd) {
+  for (int i = 0; i < m_numFrames; ++i) {
+    m_r = m_frames[i];
     buildSceneProgressBar->setValue(i);
 
     if (rs.m_stereoscopic) scene->shiftCameraX(-rs.m_stereoscopicShift / 2);
@@ -772,8 +800,10 @@ void RenderCommand::multimediaRender() {
   multimediaRenderer.setDpi(cameraDpi.x, cameraDpi.y);
   multimediaRenderer.enablePrecomputing(true);
 
-  for (int i = 0; i < m_numFrames; ++i, m_r += m_stepd)
+  for (int i = 0; i < m_numFrames; ++i) {
+    m_r = m_frames[i];
     multimediaRenderer.addFrame(m_r);
+  }
 
   MultimediaProgressBar *listener =
       new MultimediaProgressBar(&multimediaRenderer);

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -1,5 +1,8 @@
 
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include "toutputproperties.h"
 
 // TnzLib includes
@@ -55,6 +58,7 @@ TOutputProperties::TOutputProperties(const TOutputProperties &src)
     , m_formatProperties(src.m_formatProperties)
     , m_renderSettings(new TRenderSettings(*src.m_renderSettings))
     , m_frameRate(src.m_frameRate)
+    , m_frameRanges(src.m_frameRanges)
     , m_from(src.m_from)
     , m_to(src.m_to)
     , m_whichLevels(src.m_whichLevels)
@@ -88,6 +92,7 @@ TOutputProperties::~TOutputProperties() {
 
 TOutputProperties &TOutputProperties::operator=(const TOutputProperties &src) {
   m_path        = src.m_path;
+  m_frameRanges = src.m_frameRanges;
   m_from        = src.m_from;
   m_to          = src.m_to;
   m_frameRate   = src.m_frameRate;
@@ -130,6 +135,137 @@ void TOutputProperties::setPath(const TFilePath &fp) { m_path = fp; }
 //-------------------------------------------------------------------
 
 void TOutputProperties::setOffset(int off) { m_offset = off; }
+
+//-----------------------------------------------------------------------------
+
+void TOutputProperties::setFrameRanges(
+    const std::vector<std::pair<int, int>> &ranges) {
+  m_frameRanges = ranges;
+}
+
+//-----------------------------------------------------------------------------
+
+/*-- Expand the selection into ascending, de-duplicated frame numbers. Step is
+ * applied across the whole selection rather than restarting per range, so a
+ * step of 2 over "1-4, 7-10" behaves like a single strided pass. --*/
+std::vector<int> TOutputProperties::getFrameList(int sceneLength) const {
+  std::vector<int> frames;
+  std::vector<std::pair<int, int>> ranges = m_frameRanges;
+  if (ranges.empty()) {
+    int r0, r1, step;
+    if (!getRange(r0, r1, step)) {
+      r0 = 0;
+      r1 = sceneLength - 1;
+    }
+    ranges.push_back(std::make_pair(r0, r1));
+  }
+
+  int step = m_step > 0 ? m_step : 1;
+  std::vector<int> expanded;
+  for (int i = 0; i < (int)ranges.size(); i++) {
+    int from = std::max(0, ranges[i].first);
+    int to   = std::min(sceneLength - 1, ranges[i].second);
+    for (int f = from; f <= to; f++) expanded.push_back(f);
+  }
+  std::sort(expanded.begin(), expanded.end());
+  expanded.erase(std::unique(expanded.begin(), expanded.end()),
+                 expanded.end());
+
+  for (int i = 0; i < (int)expanded.size(); i += step)
+    frames.push_back(expanded[i]);
+  return frames;
+}
+
+//-----------------------------------------------------------------------------
+
+/*-- Frame numbers in the text are one-based because that is what the Output
+ * Settings fields show; the stored pairs are zero-based like getRange(). --*/
+bool TOutputProperties::parseFrameRanges(
+    const std::string &text, std::vector<std::pair<int, int>> &ranges,
+    std::string *error) {
+  std::vector<std::pair<int, int>> parsed;
+  std::string token;
+  std::vector<std::string> tokens;
+  for (size_t i = 0; i <= text.size(); i++) {
+    if (i == text.size() || text[i] == ',') {
+      tokens.push_back(token);
+      token.clear();
+    } else if (!isspace((unsigned char)text[i]))
+      token += text[i];
+  }
+
+  bool anyContent = false;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    const std::string &tk = tokens[i];
+    if (tk.empty()) continue;
+    anyContent = true;
+
+    size_t dash = tk.find('-');
+    std::string fromStr =
+        (dash == std::string::npos) ? tk : tk.substr(0, dash);
+    std::string toStr =
+        (dash == std::string::npos) ? tk : tk.substr(dash + 1);
+    if (fromStr.empty() || toStr.empty()) {
+      if (error) *error = "Incomplete frame range: " + tk;
+      return false;
+    }
+    for (size_t c = 0; c < fromStr.size(); c++)
+      if (!isdigit((unsigned char)fromStr[c])) {
+        if (error) *error = "Frame numbers must be positive integers: " + tk;
+        return false;
+      }
+    for (size_t c = 0; c < toStr.size(); c++)
+      if (!isdigit((unsigned char)toStr[c])) {
+        if (error) *error = "Frame numbers must be positive integers: " + tk;
+        return false;
+      }
+
+    int from = std::atoi(fromStr.c_str());
+    int to   = std::atoi(toStr.c_str());
+    if (from < 1 || to < 1) {
+      if (error) *error = "Frame numbers start at 1: " + tk;
+      return false;
+    }
+    if (from > to) {
+      if (error) *error = "Range start is after its end: " + tk;
+      return false;
+    }
+    parsed.push_back(std::make_pair(from - 1, to - 1));
+  }
+
+  if (!anyContent) {
+    if (error) *error = "No frames were specified.";
+    return false;
+  }
+
+  /*-- Normalise so overlapping and unordered input still describes exactly one
+   * ascending selection. --*/
+  std::sort(parsed.begin(), parsed.end());
+  std::vector<std::pair<int, int>> merged;
+  for (size_t i = 0; i < parsed.size(); i++) {
+    if (!merged.empty() && parsed[i].first <= merged.back().second + 1)
+      merged.back().second = std::max(merged.back().second, parsed[i].second);
+    else
+      merged.push_back(parsed[i]);
+  }
+
+  ranges = merged;
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+std::string TOutputProperties::formatFrameRanges(
+    const std::vector<std::pair<int, int>> &ranges) {
+  std::string text;
+  for (size_t i = 0; i < ranges.size(); i++) {
+    if (i > 0) text += ", ";
+    text += std::to_string(ranges[i].first + 1);
+    if (ranges[i].second != ranges[i].first)
+      text += "-" + std::to_string(ranges[i].second + 1);
+  }
+  return text;
+}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -249,6 +249,11 @@ void TSceneProperties::saveData(TOStream &os) const {
     out.getRange(from, to, step);
     os.child("range") << from << to;
     os.child("step") << step;
+    /*-- Written only when a non-contiguous selection exists, so scenes that use
+     * a single range keep their previous byte-for-byte output. --*/
+    if (!out.getFrameRanges().empty())
+      os.child("frameRanges")
+          << TOutputProperties::formatFrameRanges(out.getFrameRanges());
     os.child("shrink") << rs.m_shrinkX;
     os.child("applyShrinkToViewer") << (rs.m_applyShrinkToViewer ? 1 : 0);
     os.child("fps") << out.getFrameRate();
@@ -562,6 +567,14 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
               is >> step;
               out.getRange(from, to, dummy);
               out.setRange(from, to, step);
+            } else if (tagName == "frameRanges") {
+              std::string text;
+              is >> text;
+              std::vector<std::pair<int, int>> ranges;
+              /*-- A malformed or stale list must not stop the scene loading;
+               * fall back to the single range that is always present. --*/
+              if (TOutputProperties::parseFrameRanges(text, ranges))
+                out.setFrameRanges(ranges);
             } else if (tagName == "shrink") {
               int shrink;
               is >> shrink;


### PR DESCRIPTION
## Summary
- Add a `Frames` field to Output Settings accepting a printer-style list such as `1-3, 5, 8-10`.
- Frame numbers are one-based, matching the existing Frame Start and End fields.
- Overlapping and unordered input is normalised into one ascending selection and echoed back, so merges are visible.
- Malformed input is rejected with a message and nothing is applied.
- An empty field leaves Frame Start and End authoritative.

Compatibility is the main design constraint:
- The list is written to the scene only when non-empty, so scenes and output presets using a single range serialize exactly as before.
- A stale or malformed stored list falls back to the single range rather than failing the load.
- The selection is honoured only at 1:1 time stretch. Stretching resamples the timeline, so an arbitrary frame list has no well-defined meaning there and the contiguous range stays authoritative.

The render loop now iterates an explicit frame vector. When no list is set that vector is populated with the previous arithmetic, so the contiguous path is unchanged.

Discussion: https://github.com/opentoonz/opentoonz/discussions/6535

## Testing
- Full `OpenToonz.app` target builds and links on macOS arm64 (1595/1595, no errors), so the new slot's moc is regenerated and the connection resolves.
- Ran a harness over the parser, formatter and frame expansion: the discussion's own example round-trips; adjacent singles merge; overlapping and unordered ranges merge; whitespace is tolerated; empty text, frame 0, reversed ranges, dangling dashes and non-numeric input are all rejected; expansion yields exactly the listed frames; step strides across the whole selection; frames past the scene end are clipped.
- `clang-format` reports no violations on the changed lines.
- `git diff --check` passed.

## Note on overlap
opentoonz-dev #34 edits `toutputproperties.h`, `outputproperties.cpp`, `sceneproperties.cpp` and `outputsettingspopup.cpp`. If that lands first this branch should be rebased onto it.