### PR TITLE
[Idea #6764] Write scene-origin anchor into sprite sheet text file

### DIFF
--- a/toonz/sources/image/sprite/tiio_sprite.cpp
+++ b/toonz/sources/image/sprite/tiio_sprite.cpp
@@ -99,6 +99,15 @@ TLevelWriterSprite::~TLevelWriterSprite() {
   int totalHorizPadding = 0;
   int spriteSheetWidth;
   int spriteSheetHeight;
+  // Scene origin inside one frame cell, in pixels from the cell's top-left
+  // corner. A level pivot is not reachable here: the writer is handed only
+  // images, with no scene, column or stage object. What it does know is that
+  // every frame is a rendered camera raster whose centre is the scene origin,
+  // so the trim box, scale and padding place that origin inside the cell.
+  QString anchorX = QString::number(
+      (m_lx / 2.0 - m_left) * m_scale / 100.0 + m_leftPadding, 'f', 2);
+  QString anchorY = QString::number(
+      (m_ly / 2.0 - m_top) * m_scale / 100.0 + m_topPadding, 'f', 2);
   if (m_format == "Grid") {
     // Calculate Grid Size
     while (horizDim * horizDim < m_imagesResized.size()) horizDim++;
@@ -138,6 +147,28 @@ TLevelWriterSprite::~TLevelWriterSprite() {
       paddingPainter.end();
       padded.save(path, "PNG", -1);
     }
+    // The sheet formats have always written a companion text file describing
+    // their layout. Individual frames wrote none, so a script consuming them
+    // had no way to learn the cell geometry or the anchor.
+    QString textPath = m_path.getQString();
+    textPath         = textPath.replace(".spritesheet", ".txt");
+    QFile file(textPath);
+    file.open(QIODevice::WriteOnly | QIODevice::Text);
+    QTextStream out(&file);
+    out << "Total Images: " << m_imagesResized.size() << "\n";
+    out << "Individual Image Width: " << resizedWidth << "\n";
+    out << "Individual Image Height: " << resizedHeight << "\n";
+    out << "Individual Image Width with Padding: " << resizedWidth + horizPadding
+        << "\n";
+    out << "Individual Image Height with Padding: "
+        << resizedHeight + vertPadding << "\n";
+    out << "Top Padding: " << m_topPadding << "\n";
+    out << "Bottom Padding: " << m_bottomPadding << "\n";
+    out << "Left Padding: " << m_leftPadding << "\n";
+    out << "Right Padding: " << m_rightPadding << "\n";
+    out << "Anchor X: " << anchorX << "\n";
+    out << "Anchor Y: " << anchorY << "\n";
+    file.close();
   }
   if (m_format != "Individual") {
     QImage spriteSheet = QImage(spriteSheetWidth, spriteSheetHeight,
@@ -191,6 +222,8 @@ TLevelWriterSprite::~TLevelWriterSprite() {
     out << "Right Padding: " << m_rightPadding << "\n";
     out << "Horizontal Space Between Images: " << horizPadding << "\n";
     out << "Vertical Space Between Images: " << vertPadding << "\n";
+    out << "Anchor X: " << anchorX << "\n";
+    out << "Anchor Y: " << anchorY << "\n";
 
     file.close();
   }

--- a/toonz/sources/image/sprite/tiio_sprite.cpp
+++ b/toonz/sources/image/sprite/tiio_sprite.cpp
@@ -125,7 +125,18 @@ TLevelWriterSprite::~TLevelWriterSprite() {
       QString path      = m_path.getQString();
       QString newEnding = "_" + QString::number(i) + ".png";
       path              = path.replace(".spritesheet", newEnding);
-      m_imagesResized[i].save(path, "PNG", -1);
+      if (horizPadding == 0 && vertPadding == 0) {
+        m_imagesResized[i].save(path, "PNG", -1);
+        continue;
+      }
+      QImage padded(m_imagesResized[i].width() + horizPadding,
+                    m_imagesResized[i].height() + vertPadding,
+                    QImage::Format_ARGB32_Premultiplied);
+      padded.fill(qRgba(0, 0, 0, 0));
+      QPainter paddingPainter(&padded);
+      paddingPainter.drawImage(m_leftPadding, m_topPadding, m_imagesResized[i]);
+      paddingPainter.end();
+      padded.save(path, "PNG", -1);
     }
   }
   if (m_format != "Individual") {


### PR DESCRIPTION
## Depends on #7037
This branch is stacked on `idea/6471-individual-frame-padding` and currently shows that commit too. Merge #7037 first; this branch will then reduce to its own commit. The dependency is real rather than cosmetic: the anchor includes the padding offset, which is only applied to individual frames once #7037 lands.

## Summary
- Append `Anchor X` and `Anchor Y` to the sprite sheet text file, giving the scene origin in pixels from the top-left of one frame cell.
- Emit a text file for the `Individual` format, which previously wrote none, describing its cell geometry, padding and anchor.
- Every existing line keeps its wording and position, so current parsers are unaffected; the change is append-only.

The discussion asks for "pivot point data". A true level pivot is not reachable here: `TLevelWriter` is handed images with no scene, column, stage object or hooks, and reaching one would mean widening a shared I/O interface used by every format. The writer also crops every frame with one global union trim box, so a per-frame pivot would emit the same value repeated.

What the writer *can* derive is the scene origin. Each frame is a rendered camera raster whose centre is that origin, and the trim box, scale and padding place it inside the cell. That is the value needed to put a trimmed sprite back where it sat in the camera, which is what the requester is currently recovering by hand in another application.

Discussion: https://github.com/opentoonz/opentoonz/discussions/6764

## Testing
- Compiled `tiio_sprite.cpp` with the project compile command; no new warnings.
- Full `OpenToonz.app` target builds and links on macOS arm64.
- Ran a harness over the anchor formula: it is the raster centre when untrimmed, unscaled and unpadded; it shifts by the trim origin; it tracks Scale at 25%, 50% and 200%; padding adds absolute pixels on top of the scaled position; and the origin round-trips for several combinations of trim, scale and padding.
- `clang-format` reports no violations on the changed lines.
- `git diff --check` passed.