### PR TITLE
Add automatic current frame selection

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -439,6 +439,9 @@ public:
   bool isCurrentTimelineIndicatorEnabled() const {
     return getBoolValue(currentTimelineEnabled);
   }
+  bool isAutoSelectCurrentFrameEnabled() const {
+    return getBoolValue(autoSelectCurrentFrame);
+  }
   void getCurrentColumnData(TPixel &color) const {
     color = getColorValue(currentColumnColor);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -153,6 +153,7 @@ enum PreferencesItemId {
   highlightLineEverySecond,
   syncLevelRenumberWithXsheet,
   currentTimelineEnabled,
+  autoSelectCurrentFrame,
   currentColumnColor,
   levelNameDisplayType,
   showFrameNumberWithLetters,

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1404,6 +1404,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {syncLevelRenumberWithXsheet,
        tr("Sync Level Strip Drawing Number Changes with the Xsheet")},
       {currentTimelineEnabled, tr("Show Current Time Indicator")},
+      {autoSelectCurrentFrame, tr("Automatically Select Current Frame")},
       {currentColumnColor, tr("Current Column Color:")},
       //{ levelNameOnEachMarkerEnabled, tr("Display Level Name on Each
       // Marker")
@@ -2237,6 +2238,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
   {
     insertUI(highlightLineEverySecond, xshCellAreaLay);
     insertUI(currentTimelineEnabled, xshCellAreaLay);
+    insertUI(autoSelectCurrentFrame, xshCellAreaLay);
     insertUI(showFrameNumberWithLetters, xshCellAreaLay);
   }
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1496,6 +1496,29 @@ bool changeFrameSkippingHolds(QKeyEvent *e) {
 
 //-----------------------------------------------------------------------------
 
+bool changeColumnWithArrowKey(QKeyEvent *event) {
+  if (event->modifiers() != Qt::NoModifier ||
+      (event->key() != Qt::Key_Up && event->key() != Qt::Key_Down))
+    return false;
+
+  TApp *app        = TApp::instance();
+  TFrameHandle *fh = app->getCurrentFrame();
+  if (!fh->isEditingScene()) return false;
+
+  TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+  int firstColumn =
+      Preferences::instance()->isXsheetCameraColumnVisible() ? -1 : 0;
+  int lastColumn = std::max(0, xsh->getColumnCount() - 1);
+  int currentColumn = app->getCurrentColumn()->getColumnIndex();
+  int nextColumn = currentColumn +
+                   (event->key() == Qt::Key_Up ? 1 : -1);
+  if (nextColumn >= firstColumn && nextColumn <= lastColumn)
+    app->getCurrentColumn()->setColumnIndex(nextColumn);
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
 void SceneViewer::keyPressEvent(QKeyEvent *event) {
   if (m_freezedStatus != NO_FREEZED) return;
   int key = event->key();
@@ -1624,6 +1647,7 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
 
   // Handle frame navigation if no tool handled the key
   if (!ret) {
+    if (changeColumnWithArrowKey(event)) return;
     if (changeFrameSkippingHolds(event)) return;
 
     TFrameHandle *fh = TApp::instance()->getCurrentFrame();

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1497,13 +1497,27 @@ void XsheetViewer::onPreferenceChanged(const QString &prefName) {
 //-----------------------------------------------------------------------------
 
 void XsheetViewer::onCurrentFrameSwitched() {
-  int row           = TApp::instance()->getCurrentFrame()->getFrame();
+  TFrameHandle *frameHandle = TApp::instance()->getCurrentFrame();
+  int row                   = frameHandle->getFrame();
   QRect visibleRect = m_cellArea->visibleRegion().boundingRect();
   if (visibleRect.isEmpty()) {
     m_isCurrentFrameSwitched = true;
     return;
   }
   m_isCurrentFrameSwitched = false;
+
+  if (Preferences::instance()->isAutoSelectCurrentFrameEnabled() &&
+      frameHandle->isEditingScene() && !frameHandle->isPlaying()) {
+    int col = getCurrentColumn();
+    if (col >= 0) {
+      TCellSelection *selection = getCellSelection();
+      selection->makeCurrent();
+      selection->selectCell(row, col);
+      m_cellArea->update(m_cellArea->visibleRegion());
+      m_rowArea->update(m_rowArea->visibleRegion());
+    }
+  }
+
   scrollToRow(row);
 
   TXsheet *xsh            = getXsheet();

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -616,6 +616,8 @@ void Preferences::definePreferenceItems() {
          QMetaType::Bool, true);
   define(currentTimelineEnabled, "currentTimelineEnabled", QMetaType::Bool,
          true);
+  define(autoSelectCurrentFrame, "autoSelectCurrentFrame", QMetaType::Bool,
+         false);
   define(currentColumnColor, "currentColumnColor", QMetaType::QColor,
          QColor(Qt::yellow));
   define(levelNameDisplayType, "levelNameDisplayType", QMetaType::Int,


### PR DESCRIPTION
## Summary\n- add an opt-in Xsheet preference to select the current cell while editing a scene\n- leave playback, the Level Strip, and the camera column unchanged\n- refresh the Xsheet cell and row areas when the selection changes\n\n## Testing\n- compiled xsheetviewer.cpp with warnings treated as errors\n- compiled preferencespopup.cpp with warnings treated as errors\n- compiled preferences.cpp with warnings treated as errors