### PR TITLE
Add hold cell creation toggle command

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2436,6 +2436,9 @@ void MainWindow::defineActions() {
                          "scene_settings");
   createMenuXsheetAction(MI_CameraSettings, QT_TR_NOOP("&Camera Settings..."),
                          "", "camera_settings");
+  createMenuXsheetAction(MI_ToggleCreationInHoldCells,
+                         QT_TR_NOOP("Toggle Creation in Hold Cells"),
+                         "Caps Lock");
   createMenuXsheetAction(MI_OpenChild, QT_TR_NOOP("&Open Sub-Xsheet"), "",
                          "sub_enter");
   createMenuXsheetAction(MI_CloseChild, QT_TR_NOOP("&Close Sub-Xsheet"), "",

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -321,6 +321,7 @@
 #define MI_FoldColumns "MI_FoldColumns"
 #define MI_ToggleXsheetCameraColumn "MI_ToggleXsheetCameraColumn"
 #define MI_ToggleCurrentTimeIndicator "MI_ToggleCurrentTimeIndicator"
+#define MI_ToggleCreationInHoldCells "MI_ToggleCreationInHoldCells"
 
 #define MI_LoadIntoCurrentPalette "MI_LoadIntoCurrentPalette"
 #define MI_AdjustCurrentLevelToPalette "MI_AdjustCurrentLevelToPalette"

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -232,6 +232,20 @@ public:
 
 //=============================================================================
 
+class ToggleCreationInHoldCellsCommand final : public MenuItemHandler {
+public:
+  ToggleCreationInHoldCellsCommand()
+      : MenuItemHandler(MI_ToggleCreationInHoldCells) {}
+
+  void execute() override {
+    Preferences *preferences = Preferences::instance();
+    preferences->setValue(EnableCreationInHoldCells,
+                          !preferences->isCreationInHoldCellsEnabled());
+  }
+} toggleCreationInHoldCellsCommand;
+
+//=============================================================================
+
 class InsertSceneFrameCommand final : public MenuItemHandler {
 public:
   InsertSceneFrameCommand() : MenuItemHandler(MI_InsertSceneFrame) {}


### PR DESCRIPTION
## Summary\n- add a configurable Xsheet command to toggle creation in hold cells\n- assign Caps Lock as the default shortcut while allowing users to change it\n- reuse the existing preference without changing the creation behavior\n\n## Testing\n- compiled xsheetcmd.cpp with warnings treated as errors\n- compiled mainwindow.cpp with warnings treated as errors