### PR TITLE
Select keys in selected cells

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2908,6 +2908,8 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_SelectFollowingKeysInRow,
                              QT_TR_NOOP("Select Following Keys in this Frame"),
                              "");
+  createRightClickMenuAction(MI_SelectKeyframesInSelectedCells,
+                             QT_TR_NOOP("Select Keys in Selected Cells"), "");
   createRightClickMenuAction(MI_InvertKeyframeSelection,
                              QT_TR_NOOP("Invert Key Selection"), "");
   createRightClickMenuAction(MI_SetAcceleration, QT_TR_NOOP("Set Acceleration"),

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -279,6 +279,7 @@
 #define MI_SelectFollowingKeysInColumn "MI_SelectFollowingKeysInColumn"
 #define MI_SelectPreviousKeysInRow "MI_SelectPreviousKeysInRow"
 #define MI_SelectFollowingKeysInRow "MI_SelectFollowingKeysInRow"
+#define MI_SelectKeyframesInSelectedCells "MI_SelectKeyframesInSelectedCells"
 #define MI_InvertKeyframeSelection "MI_InvertKeyframeSelection"
 
 #define MI_ShiftKeyframesDown "MI_ShiftKeyframesDown"

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -3952,6 +3952,7 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
       }
 
       if (!soundCellsSelected && !soundTextCellsSelected) {
+        menu.addAction(cmdManager->getAction(MI_SelectKeyframesInSelectedCells));
         if (selectionContainTlvImage(m_viewer->getCellSelection(),
                                      m_viewer->getXsheet()))
           replaceLevelMenu->addAction(
@@ -4145,6 +4146,7 @@ void CellArea::createKeyMenu(QMenu &menu) {
   menu.addAction(cmdManager->getAction(MI_SelectFollowingKeysInColumn));
   menu.addAction(cmdManager->getAction(MI_SelectPreviousKeysInRow));
   menu.addAction(cmdManager->getAction(MI_SelectFollowingKeysInRow));
+  menu.addAction(cmdManager->getAction(MI_SelectKeyframesInSelectedCells));
   menu.addAction(cmdManager->getAction(MI_InvertKeyframeSelection));
   menu.addSeparator();
   menu.addAction(cmdManager->getAction(MI_Cut));

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -1085,6 +1085,40 @@ public:
 //    Selection  commands
 //*****************************************************************************
 
+class SelectKeyframesInSelectedCellsCommand final : public MenuItemHandler {
+public:
+  SelectKeyframesInSelectedCellsCommand()
+      : MenuItemHandler(MI_SelectKeyframesInSelectedCells) {}
+
+  void execute() override {
+    TApp *app = TApp::instance();
+    TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(
+        app->getCurrentSelection()->getSelection());
+    XsheetViewer *viewer = app->getCurrentXsheetViewer();
+    if (!cellSelection || cellSelection->isEmpty() || !viewer) return;
+
+    TCellSelection::Range range = cellSelection->getSelectedCells();
+    TXsheet *xsh                = app->getCurrentXsheet()->getXsheet();
+    TKeyframeSelection *selection = viewer->getKeyframeSelection();
+    cellSelection->selectNone();
+    selection->selectNone();
+    viewer->getCellKeyframeSelection()->makeCurrent();
+
+    int firstColumn = std::max(0, range.m_c0);
+    int lastColumn = std::min(range.m_c1, xsh->getColumnCount() - 1);
+    for (int col = firstColumn; col <= lastColumn; ++col) {
+      TStageObject *object =
+          xsh->getStageObject(TStageObjectId::ColumnId(col));
+      for (int row = std::max(0, range.m_r0); row <= range.m_r1; ++row) {
+        if (object->isKeyframe(row)) selection->select(row, col);
+      }
+    }
+    app->getCurrentXsheet()->notifyXsheetChanged();
+  }
+} selectKeyframesInSelectedCellsCommand;
+
+//-----------------------------------------------------------------------------
+
 class SelectRowKeyframesCommand final : public MenuItemHandler {
 public:
   SelectRowKeyframesCommand() : MenuItemHandler(MI_SelectRowKeyframes) {}


### PR DESCRIPTION
## Summary\n- add a configurable command to select keyframes within a selected cell range\n- replace the cell selection with the resulting keyframe selection\n- expose the command in the cell and keyframe context menus\n\n## Testing\n- compiled xsheetcmd.cpp with warnings treated as errors\n- compiled xshcellviewer.cpp with warnings treated as errors\n- compiled mainwindow.cpp with warnings treated as errors