### PR TITLE
Add select parent column command

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2865,6 +2865,8 @@ void MainWindow::defineActions() {
                false, RightClickMenuCommandType);
   createRightClickMenuAction(MI_ToggleCurrentTimeIndicator,
                              QT_TR_NOOP("Toggle Current Time Indicator"), "");
+  createRightClickMenuAction(MI_SelectParentColumn,
+                             QT_TR_NOOP("Select Parent Column"), "");
   createRightClickMenuAction(MI_DuplicateFile, QT_TR_NOOP("Duplicate"), "",
                              "duplicate");
   createRightClickMenuAction(MI_ShowFolderContents,

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -321,6 +321,7 @@
 #define MI_FoldColumns "MI_FoldColumns"
 #define MI_ToggleXsheetCameraColumn "MI_ToggleXsheetCameraColumn"
 #define MI_ToggleCurrentTimeIndicator "MI_ToggleCurrentTimeIndicator"
+#define MI_SelectParentColumn "MI_SelectParentColumn"
 
 #define MI_LoadIntoCurrentPalette "MI_LoadIntoCurrentPalette"
 #define MI_AdjustCurrentLevelToPalette "MI_AdjustCurrentLevelToPalette"

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -3027,6 +3027,7 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
         menu.addAction(cmdManager->getAction(MI_CloneChild));
         menu.addAction(cmdManager->getAction(MI_ExplodeChild));
       }
+      menu.addAction(cmdManager->getAction(MI_SelectParentColumn));
       menu.addSeparator();
     }
     menu.addAction(cmdManager->getAction(MI_FoldColumns));

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -232,6 +232,37 @@ public:
 
 //=============================================================================
 
+class SelectParentColumnCommand final : public MenuItemHandler {
+public:
+  SelectParentColumnCommand() : MenuItemHandler(MI_SelectParentColumn) {}
+
+  void execute() override {
+    TApp *app  = TApp::instance();
+    int column = app->getCurrentColumn()->getColumnIndex();
+    if (column < 0) return;
+
+    TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+    TStageObjectId parent =
+        xsh->getStageObjectParent(TStageObjectId::ColumnId(column));
+    if (!parent.isColumn()) return;
+
+    XsheetViewer *viewer = app->getCurrentXsheetViewer();
+    if (!viewer) {
+      app->getCurrentColumn()->setColumnIndex(parent.getIndex());
+      return;
+    }
+
+    viewer->setCurrentColumn(parent.getIndex());
+    TColumnSelection *selection = viewer->getColumnSelection();
+    selection->selectNone();
+    selection->selectColumn(parent.getIndex(), true);
+    selection->makeCurrent();
+    viewer->update();
+  }
+} selectParentColumnCommand;
+
+//=============================================================================
+
 class InsertSceneFrameCommand final : public MenuItemHandler {
 public:
   InsertSceneFrameCommand() : MenuItemHandler(MI_InsertSceneFrame) {}


### PR DESCRIPTION
## Summary\n- add a configurable command to select the current column's parent column\n- update the active column and Timeline selection together\n- expose the command in the column-header context menu\n\n## Testing\n- compiled xsheetcmd.cpp with warnings treated as errors\n- compiled xshcolumnviewer.cpp with warnings treated as errors\n- compiled mainwindow.cpp with warnings treated as errors