### PR TITLE
Make Shift Origin toggle hide references

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -431,6 +431,8 @@ public:
       //     cm->getAction(MI_NoShift)->setChecked(false);
       TApp::instance()->getCurrentOnionSkin()->notifyOnionSkinMaskChanged();
     } else if (std::string(m_cmdId) == MI_EditShift) {
+      QAction *showShiftOrigin = cm->getAction(MI_ShowShiftOrigin);
+      if (showShiftOrigin) showShiftOrigin->setChecked(checked);
       if (checked) {
         QAction *noShiftAction =
             CommandManager::instance()->getAction(MI_NoShift);

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -499,7 +499,7 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         if (m_onionSkinMask.getShiftTraceStatus() !=
             OnionSkinMask::ENABLED_WITHOUT_GHOST_MOVEMENTS) {
           if (m_shiftTraceGhostId == FIRST_GHOST) {
-            if (m_editingShift || m_showShiftOrigin) {
+            if (m_showShiftOrigin) {
               player.m_opacity = 30;
               players.push_back(player);
             }
@@ -508,7 +508,7 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
             player.m_placement =
                 m_onionSkinMask.getShiftTraceGhostAff(0) * player.m_placement;
           } else if (m_shiftTraceGhostId == SECOND_GHOST) {
-            if (m_editingShift || m_showShiftOrigin) {
+            if (m_showShiftOrigin) {
               player.m_opacity = 30;
               players.push_back(player);
             }
@@ -792,8 +792,10 @@ void StageBuilder::addSimpleLevelFrame(PlayerSet &players,
     player.m_bingoOrder = 10;
     if (m_onionSkinMask.getShiftTraceStatus() !=
         OnionSkinMask::ENABLED_WITHOUT_GHOST_MOVEMENTS) {
-      player.m_opacity = 30;
-      players.push_back(player);
+      if (m_onionSkinMask.isShowShiftOrigin()) {
+        player.m_opacity = 30;
+        players.push_back(player);
+      }
       player.m_opacity           = opacity;
       player.m_onionSkinDistance = (ghostIndex == 0) ? -1 : 1;
       player.m_placement = m_onionSkinMask.getShiftTraceGhostAff(ghostIndex) *


### PR DESCRIPTION
## Summary\n- make Show Shift Origin control unshifted Shift and Trace references\n- preserve original Edit Shift behavior by enabling the control when Edit Shift starts\n- apply the same visibility behavior in scene and Level Strip rendering\n\n## Testing\n- compiled stage.cpp with warnings treated as errors\n- compiled sceneviewer.cpp with warnings treated as errors