### PR TITLE
Add Pencil Test interval countdown sound

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -85,6 +85,7 @@
 #include <QKeyEvent>
 #include <QCommonStyle>
 #include <QTimer>
+#include <QApplication>
 #include <QIntValidator>
 #include <QRegularExpressionValidator>
 
@@ -1584,6 +1585,7 @@ PencilTestPopup::PencilTestPopup()
     , m_currentCamera(NULL)
     , m_captureWhiteBGCue(false)
     , m_captureCue(false)
+    , m_lastCountdownSecond(-1)
     , m_useMjpg(CamCapUseMjpg != 0)
 #ifdef _WIN32
     , m_useDirectShow(CamCapUseDirectShow != 0)
@@ -1641,6 +1643,7 @@ PencilTestPopup::PencilTestPopup()
 
   m_timerGBox        = new QGroupBox(tr("Interval timer"), this);
   m_timerIntervalFld = new IntField(this);
+  m_timerSoundCB     = new QCheckBox(tr("Play countdown sound"), this);
   m_captureTimer     = new QTimer(this);
   m_countdownTimer   = new QTimer(this);
   m_timer            = new QTimer(this);
@@ -1722,6 +1725,8 @@ PencilTestPopup::PencilTestPopup()
   m_timerIntervalFld->setRange(0, 60);
   m_timerIntervalFld->setValue(10);
   m_timerIntervalFld->setDisabled(true);
+  m_timerSoundCB->setChecked(false);
+  m_timerSoundCB->setDisabled(true);
   // Make the interval timer single-shot. When the capture finished, restart
   // timer for next frame.
   // This is because capturing and saving the image needs some time.
@@ -1962,6 +1967,7 @@ PencilTestPopup::PencilTestPopup()
           timerLay->addWidget(new QLabel(tr("Interval(sec):"), this), 0,
                               Qt::AlignRight);
           timerLay->addWidget(m_timerIntervalFld, 1);
+          timerLay->addWidget(m_timerSoundCB);
         }
         m_timerGBox->setLayout(timerLay);
         rightLay->addWidget(m_timerGBox);
@@ -2994,6 +3000,7 @@ void PencilTestPopup::onOnionOpacityFldEdited() {
 //-----------------------------------------------------------------------------
 
 void PencilTestPopup::onTimerCBToggled(bool on) {
+  m_timerSoundCB->setEnabled(on);
   m_captureButton->setCheckable(on);
   if (on)
     m_captureButton->setText(tr("Start Capturing\n[Return key]"));
@@ -3007,9 +3014,11 @@ void PencilTestPopup::onCaptureButtonClicked(bool on) {
   if (m_timerGBox->isChecked()) {
     m_timerGBox->setDisabled(on);
     m_timerIntervalFld->setDisabled(on);
+    m_timerSoundCB->setDisabled(on);
     // Start interval capturing
     if (on) {
       m_captureButton->setText(tr("Stop Capturing\n[Return key]"));
+      m_lastCountdownSecond = -1;
       m_captureTimer->start(m_timerIntervalFld->getValue() * 1000);
       if (m_timerIntervalFld->getValue() != 0) m_countdownTimer->start(100);
     }
@@ -3018,6 +3027,7 @@ void PencilTestPopup::onCaptureButtonClicked(bool on) {
       m_captureButton->setText(tr("Start Capturing\n[Return key]"));
       m_captureTimer->stop();
       m_countdownTimer->stop();
+      m_lastCountdownSecond = -1;
       // Hide the count down text
       m_videoWidget->showCountDownTime(0);
     }
@@ -3029,13 +3039,25 @@ void PencilTestPopup::onCaptureButtonClicked(bool on) {
 
 //-----------------------------------------------------------------------------
 
-void PencilTestPopup::onCaptureTimerTimeout() { m_captureCue = true; }
+void PencilTestPopup::onCaptureTimerTimeout() {
+  if (m_timerSoundCB->isChecked()) QApplication::beep();
+  m_lastCountdownSecond = -1;
+  m_captureCue          = true;
+}
 
 //-----------------------------------------------------------------------------
 
 void PencilTestPopup::onCountDown() {
-  m_videoWidget->showCountDownTime(
-      m_captureTimer->isActive() ? m_captureTimer->remainingTime() : 0);
+  int remainingTime =
+      m_captureTimer->isActive() ? m_captureTimer->remainingTime() : 0;
+  m_videoWidget->showCountDownTime(remainingTime);
+  if (!m_timerSoundCB->isChecked() || remainingTime <= 0) return;
+
+  int remainingSecond = (remainingTime + 999) / 1000;
+  if (remainingSecond == m_lastCountdownSecond) return;
+
+  m_lastCountdownSecond = remainingSecond;
+  QApplication::beep();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -268,7 +268,7 @@ class PencilTestPopup : public DVGui::Dialog {
   QComboBox *m_cameraListCombo, *m_resolutionCombo, *m_fileTypeCombo,
       *m_colorTypeCombo;
   LevelNameLineEdit* m_levelNameEdit;
-  QCheckBox *m_upsideDownCB, *m_saveOnCaptureCB;
+  QCheckBox *m_upsideDownCB, *m_saveOnCaptureCB, *m_timerSoundCB;
   QGroupBox *m_onionSkinGBox, *m_timerGBox;
   QPushButton *m_fileFormatOptionButton, *m_captureWhiteBGButton,
       *m_captureButton, *m_loadImageButton, *m_saveImgAdjustDefaultButton;
@@ -298,6 +298,7 @@ class PencilTestPopup : public DVGui::Dialog {
 
   bool m_captureWhiteBGCue;
   bool m_captureCue;
+  int m_lastCountdownSecond;
   bool m_alwaysOverwrite = false;
   bool m_useMjpg;
 #ifdef _WIN32

--- a/toonz/sources/toonz/penciltestpopup_qt.cpp
+++ b/toonz/sources/toonz/penciltestpopup_qt.cpp
@@ -70,6 +70,7 @@
 #include <QKeyEvent>
 #include <QCommonStyle>
 #include <QTimer>
+#include <QApplication>
 #include <QIntValidator>
 #include <QRegExpValidator>
 
@@ -1474,6 +1475,7 @@ PencilTestPopup::PencilTestPopup()
     : Dialog(0, false, false, "PencilTest")
     , m_currentCamera(NULL)
     , m_captureWhiteBGCue(false)
+    , m_lastCountdownSecond(-1)
     , m_captureCue(false) {
   setWindowTitle(tr("Camera Capture"));
 
@@ -1527,6 +1529,7 @@ PencilTestPopup::PencilTestPopup()
   QGroupBox* timerFrame = new QGroupBox(tr("Interval timer"), this);
   m_timerCB             = new QCheckBox(tr("Use interval timer"), this);
   m_timerIntervalFld    = new IntField(this);
+  m_timerSoundCB        = new QCheckBox(tr("Play countdown sound"), this);
   m_captureTimer        = new QTimer(this);
   m_countdownTimer      = new QTimer(this);
 
@@ -1585,6 +1588,8 @@ PencilTestPopup::PencilTestPopup()
   m_timerIntervalFld->setRange(0, 60);
   m_timerIntervalFld->setValue(10);
   m_timerIntervalFld->setDisabled(true);
+  m_timerSoundCB->setChecked(false);
+  m_timerSoundCB->setDisabled(true);
   // Make the interval timer single-shot. When the capture finished, restart
   // timer for next frame.
   // This is because capturing and saving the image needs some time.
@@ -1778,6 +1783,7 @@ PencilTestPopup::PencilTestPopup()
           timerLay->addWidget(new QLabel(tr("Interval(sec):"), this), 1, 0,
                               Qt::AlignRight);
           timerLay->addWidget(m_timerIntervalFld, 1, 1);
+          timerLay->addWidget(m_timerSoundCB, 2, 0, 1, 2);
         }
         timerLay->setColumnStretch(0, 0);
         timerLay->setColumnStretch(1, 1);
@@ -2468,6 +2474,7 @@ void PencilTestPopup::onOnionOpacityFldEdited() {
 
 void PencilTestPopup::onTimerCBToggled(bool on) {
   m_timerIntervalFld->setEnabled(on);
+  m_timerSoundCB->setEnabled(on);
   m_captureButton->setCheckable(on);
   if (on)
     m_captureButton->setText(tr("Start Capturing\n[Return key]"));
@@ -2481,9 +2488,11 @@ void PencilTestPopup::onCaptureButtonClicked(bool on) {
   if (m_timerCB->isChecked()) {
     m_timerCB->setDisabled(on);
     m_timerIntervalFld->setDisabled(on);
+    m_timerSoundCB->setDisabled(on);
     // start interval capturing
     if (on) {
       m_captureButton->setText(tr("Stop Capturing\n[Return key]"));
+      m_lastCountdownSecond = -1;
       m_captureTimer->start(m_timerIntervalFld->getValue() * 1000);
       if (m_timerIntervalFld->getValue() != 0) m_countdownTimer->start(100);
     }
@@ -2492,6 +2501,7 @@ void PencilTestPopup::onCaptureButtonClicked(bool on) {
       m_captureButton->setText(tr("Start Capturing\n[Return key]"));
       m_captureTimer->stop();
       m_countdownTimer->stop();
+      m_lastCountdownSecond = -1;
       // hide the count down text
       m_videoWidget->showCountDownTime(0);
     }
@@ -2503,13 +2513,25 @@ void PencilTestPopup::onCaptureButtonClicked(bool on) {
 
 //-----------------------------------------------------------------------------
 
-void PencilTestPopup::onCaptureTimerTimeout() { m_captureCue = true; }
+void PencilTestPopup::onCaptureTimerTimeout() {
+  if (m_timerSoundCB->isChecked()) QApplication::beep();
+  m_lastCountdownSecond = -1;
+  m_captureCue          = true;
+}
 
 //-----------------------------------------------------------------------------
 
 void PencilTestPopup::onCountDown() {
-  m_videoWidget->showCountDownTime(
-      m_captureTimer->isActive() ? m_captureTimer->remainingTime() : 0);
+  int remainingTime =
+      m_captureTimer->isActive() ? m_captureTimer->remainingTime() : 0;
+  m_videoWidget->showCountDownTime(remainingTime);
+  if (!m_timerSoundCB->isChecked() || remainingTime <= 0) return;
+
+  int remainingSecond = (remainingTime + 999) / 1000;
+  if (remainingSecond == m_lastCountdownSecond) return;
+
+  m_lastCountdownSecond = remainingSecond;
+  QApplication::beep();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/penciltestpopup_qt.h
+++ b/toonz/sources/toonz/penciltestpopup_qt.h
@@ -296,7 +296,8 @@ class PencilTestPopup : public DVGui::Dialog {
   QComboBox *m_cameraListCombo, *m_resolutionCombo, *m_fileTypeCombo,
       *m_colorTypeCombo;
   LevelNameLineEdit* m_levelNameEdit;
-  QCheckBox *m_upsideDownCB, *m_onionSkinCB, *m_saveOnCaptureCB, *m_timerCB;
+  QCheckBox *m_upsideDownCB, *m_onionSkinCB, *m_saveOnCaptureCB, *m_timerCB,
+      *m_timerSoundCB;
   QPushButton *m_fileFormatOptionButton, *m_captureWhiteBGButton,
       *m_captureButton, *m_loadImageButton;
   DVGui::FileField* m_saveInFileFld;
@@ -323,6 +324,7 @@ class PencilTestPopup : public DVGui::Dialog {
   QSize m_allowedCameraSize;
 
   bool m_captureWhiteBGCue;
+  int m_lastCountdownSecond;
   bool m_captureCue;
   bool m_alwaysOverwrite = false;
 


### PR DESCRIPTION
Adds an optional countdown sound for Camera Capture interval captures.

- Adds a disabled-by-default Play countdown sound option.
- Plays one sound per displayed countdown second and when capture begins.
- Keeps the control unavailable while an interval capture is active.

Tested by compiling penciltestpopup.cpp with warnings treated as errors.