### PR TITLE
Ideas: Scripting, Installation and Developer Architecture

### DIFF
--- a/toonz/sources/toonz/scriptconsolepanel.cpp
+++ b/toonz/sources/toonz/scriptconsolepanel.cpp
@@ -74,6 +74,27 @@ static QScriptValue dummyFun(QScriptContext *context, QScriptEngine *engine) {
   return QScriptValue(engine, 0);
 }
 
+static QScriptValue getProjectFolderFun(QScriptContext *context,
+                                        QScriptEngine *engine) {
+  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+  if (!scene || !scene->getProject())
+    return context->throwError("No current project is available");
+
+  return QScriptValue(engine, scene->getProject()->getProjectFolder().getQString());
+}
+
+static QScriptValue getSceneFolderFun(QScriptContext *context,
+                                      QScriptEngine *engine) {
+  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+  if (!scene || !scene->getProject())
+    return context->throwError("No current scene is available");
+
+  TFilePath scenePath = scene->getScenePath();
+  TFilePath folder = scene->isUntitled() ? scene->getProject()->getScenesPath()
+                                         : scenePath.getParentDir();
+  return QScriptValue(engine, folder.getQString());
+}
+
 static QScriptValue viewFun(QScriptContext *context, QScriptEngine *engine) {
   TScriptBinding::Image *image = 0;
   TScriptBinding::Level *level = 0;
@@ -141,6 +162,8 @@ def(teng, "loadLevel", loadLevelFun);
 
   def(teng, "view", viewFun);
   def(teng, "dummy", dummyFun);
+  def(teng, "getProjectFolder", getProjectFolderFun);
+  def(teng, "getSceneFolder", getSceneFolderFun);
 
   // teng->getQScriptEngine()->evaluate("console={version:'1.0'};function
   // version() {print('Toonz '+toonz.version+'\nscript '+script.version);};");


### PR DESCRIPTION
This draft collects the implementation work for scripting, installation, and developer-architecture ideas. Each item is added as a separate focused commit and this description is updated as work lands.

Implemented

- [#6849 Script APIs for project/scene-relative paths](https://github.com/opentoonz/opentoonz/discussions/6849): adds `getProjectFolder()` and `getSceneFolder()` to the Script Console. Untitled scenes use the current project Scenes folder.

Pending

- [#6345 Remove private libtiff API usage](https://github.com/opentoonz/opentoonz/discussions/6345)
- [#6358 Replace GLEW with libepoxy or GLAD](https://github.com/opentoonz/opentoonz/discussions/6358)
- [#6375 ToonzScript JSON and plain-text I/O](https://github.com/opentoonz/opentoonz/discussions/6375)
- [#6746 TLV I/O cleanup and testable rewrite](https://github.com/opentoonz/opentoonz/discussions/6746)

Verification for #6849: compiled `scriptconsolepanel.cpp` with warnings treated as errors.