### PR TITLE
Rendering, export and interchange improvements

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -261,6 +261,7 @@
         <command>MI_Render</command>
         <separator/>
         <command>MI_FastRender</command>
+        <command>MI_FastRenderFrame</command>
     </menu>
     <menu title="View">
         <command>MI_ViewTable</command>

--- a/toonz/sources/image/ffmpeg/tiio_apng.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_apng.cpp
@@ -55,6 +55,12 @@ TLevelWriterAPng::TLevelWriterAPng(const TFilePath &path, TPropertyGroup *winfo)
 
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
 
@@ -215,14 +221,17 @@ TImageP TLevelReaderAPng::load(int frameIndex) {
 Tiio::APngWriterProperties::APngWriterProperties()
     : m_scale("Scale", 1, 100, 100)
     , m_looping("Looping", true)
-    , m_extPng("ExtPng", false) {
+    , m_extPng("ExtPng", false)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
   bind(m_scale);
   bind(m_looping);
   bind(m_extPng);
+  bind(m_extraArgs);
 }
 
 void Tiio::APngWriterProperties::updateTranslation() {
   m_scale.setQStringName(tr("Scale"));
   m_looping.setQStringName(tr("Looping"));
   m_extPng.setQStringName(tr("Write as .png"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }

--- a/toonz/sources/image/ffmpeg/tiio_apng.h
+++ b/toonz/sources/image/ffmpeg/tiio_apng.h
@@ -75,6 +75,7 @@ public:
   TIntProperty m_scale;
   TBoolProperty m_looping;
   TBoolProperty m_extPng;
+  TStringProperty m_extraArgs;
   APngWriterProperties();
   void updateTranslation() override;
 };

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -189,6 +189,54 @@ void Ffmpeg::createIntermediateImage(const TImageP &img, int frameIndex) {
   m_cleanUpList.push_back(tempPath);
 }
 
+namespace {
+
+bool tokenizeFfmpegArgs(const QString &args, QStringList &tokens) {
+  QString current;
+  bool inQuotes = false;
+  bool started  = false;
+  for (const QChar &c : args) {
+    if (c == '"') {
+      inQuotes = !inQuotes;
+      started  = true;
+    } else if (c.isSpace() && !inQuotes) {
+      if (started) tokens << current;
+      current.clear();
+      started = false;
+    } else {
+      current += c;
+      started = true;
+    }
+  }
+  if (inQuotes) return false;
+  if (started) tokens << current;
+  return true;
+}
+
+}  // namespace
+
+bool Ffmpeg::setExtraArgs(const QString &args) {
+  QStringList tokens;
+  if (!tokenizeFfmpegArgs(args, tokens)) {
+    DVGui::warning(QObject::tr("Extra FFmpeg Args has an unmatched quote."));
+    return false;
+  }
+
+  static const QStringList reserved = {"-i", "-y", "-n"};
+  for (const QString &token : tokens) {
+    if (reserved.contains(token)) {
+      QString message = QObject::tr(
+                            "The FFmpeg argument '%1' is reserved by OpenToonz "
+                            "and cannot be overridden. It was ignored.")
+                            .arg(token);
+      DVGui::warning(message);
+      return false;
+    }
+  }
+  m_extraArgs = tokens;
+  return true;
+}
+
 void Ffmpeg::runFfmpeg(const QStringList &preInputArgs,
                        const QStringList &postInputArgs, bool inputPathIncluded,
                        bool outputPathIncluded, bool overwrite,
@@ -209,6 +257,7 @@ void Ffmpeg::runFfmpeg(const QStringList &preInputArgs,
 
   if (m_hasSoundTrack) args.append(m_audioArgs);
   args.append(postInputArgs);
+  args.append(m_extraArgs);
 
   if (overwrite && !outputPathIncluded) args << "-y";
 

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.h
@@ -70,6 +70,8 @@ public:
   void setFrameRate(double fps);
   void setPath(const TFilePath &path);
 
+  bool setExtraArgs(const QString &args);
+
   void saveSoundTrack(TSoundTrack *soundTrack);
 
   bool checkFilesExist() const;
@@ -96,6 +98,7 @@ private:
   QString m_audioPath;
   QString m_audioFormat;
   QStringList m_audioArgs;
+  QStringList m_extraArgs;
 
   // Mutable members for caching inside const functions
   mutable double m_frameRate = 0.0;

--- a/toonz/sources/image/ffmpeg/tiio_gif.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_gif.cpp
@@ -55,6 +55,12 @@ TLevelWriterGif::TLevelWriterGif(const TFilePath &path, TPropertyGroup *winfo)
 
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   // m_frameCount = 0;
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
@@ -306,7 +312,8 @@ Tiio::GifWriterProperties::GifWriterProperties()
     , m_looping("Looping", true)
     , m_palette("Generate Palette", true)
     , m_mode("Mode")
-    , m_maxcolors("Max Colors", 2, 256, 256) {
+    , m_maxcolors("Max Colors", 2, 256, 256)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
 
   // Set values for mode
   m_mode.addValue(L"GLOBAL0");
@@ -346,6 +353,7 @@ Tiio::GifWriterProperties::GifWriterProperties()
   bind(m_palette);
   bind(m_mode);
   bind(m_maxcolors);
+  bind(m_extraArgs);
 }
 
 void Tiio::GifWriterProperties::updateTranslation() {
@@ -353,6 +361,7 @@ void Tiio::GifWriterProperties::updateTranslation() {
   m_looping.setQStringName(tr("Looping"));
   m_mode.setQStringName(tr("Mode"));
   m_maxcolors.setQStringName(tr("Max Colors"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }
 
 // Tiio::Reader* Tiio::makeGifReader(){ return nullptr; }

--- a/toonz/sources/image/ffmpeg/tiio_gif.h
+++ b/toonz/sources/image/ffmpeg/tiio_gif.h
@@ -86,6 +86,7 @@ public:
   TEnumProperty m_mode;
   TIntProperty m_maxcolors;
 
+  TStringProperty m_extraArgs;
   GifWriterProperties();
 
   void updateTranslation() override;

--- a/toonz/sources/image/ffmpeg/tiio_mp4.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.cpp
@@ -51,6 +51,12 @@ TLevelWriterMp4::TLevelWriterMp4(const TFilePath &path, TPropertyGroup *winfo)
   }
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
 
@@ -225,14 +231,18 @@ TImageP TLevelReaderMp4::load(int frameIndex) {
 }
 
 Tiio::Mp4WriterProperties::Mp4WriterProperties()
-    : m_vidQuality("Quality", 1, 100, 90), m_scale("Scale", 1, 100, 100) {
+    : m_vidQuality("Quality", 1, 100, 90)
+    , m_scale("Scale", 1, 100, 100)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
   bind(m_vidQuality);
   bind(m_scale);
+  bind(m_extraArgs);
 }
 
 void Tiio::Mp4WriterProperties::updateTranslation() {
   m_vidQuality.setQStringName(tr("Quality"));
   m_scale.setQStringName(tr("Scale"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }
 
 // Tiio::Reader* Tiio::makeMp4Reader(){ return nullptr; }

--- a/toonz/sources/image/ffmpeg/tiio_mp4.h
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.h
@@ -79,6 +79,7 @@ public:
   // TBoolProperty m_matte;
   TIntProperty m_vidQuality;
   TIntProperty m_scale;
+  TStringProperty m_extraArgs;
   Mp4WriterProperties();
   void updateTranslation() override;
 };

--- a/toonz/sources/image/ffmpeg/tiio_webm.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_webm.cpp
@@ -60,6 +60,12 @@ TLevelWriterWebm::TLevelWriterWebm(const TFilePath &path, TPropertyGroup *winfo)
 
   ffmpegWriter = new Ffmpeg();
   ffmpegWriter->setPath(m_path);
+  {
+    TProperty *extraProp = m_properties->getProperty("Extra FFmpeg Args");
+    if (extraProp)
+      ffmpegWriter->setExtraArgs(
+          QString::fromStdString(extraProp->getValueAsString()));
+  }
   if (TSystem::doesExistFileOrLevel(m_path)) TSystem::deleteFile(m_path);
 }
 
@@ -297,7 +303,9 @@ Tiio::WebmWriterProperties::WebmWriterProperties()
     , m_speed("Encoding Speed")
     , m_kf("Keyframe Interval")
     , m_preserveAlpha("Preserve Alpha", true)
-    , m_lossless("Lossless", false) {
+    , m_lossless("Lossless", false)
+    , m_extraArgs("Extra FFmpeg Args", L"") {
+  bind(m_extraArgs);
   bind(m_scale);
   bind(m_speed);
   bind(m_kf);
@@ -333,6 +341,7 @@ void Tiio::WebmWriterProperties::updateTranslation() {
   m_kf.setQStringName(tr("Keyframe Interval"));
   m_preserveAlpha.setQStringName(tr("Preserve Alpha"));
   m_lossless.setQStringName(tr("Lossless"));
+  m_extraArgs.setQStringName(tr("Extra FFmpeg Args"));
 }
 
 // Tiio::Reader* Tiio::makeWebmReader(){ return nullptr; }

--- a/toonz/sources/image/ffmpeg/tiio_webm.h
+++ b/toonz/sources/image/ffmpeg/tiio_webm.h
@@ -90,6 +90,7 @@ public:
   TBoolProperty m_preserveAlpha;
   TBoolProperty m_lossless;
 
+  TStringProperty m_extraArgs;
   WebmWriterProperties();
   void updateTranslation() override;
 };

--- a/toonz/sources/image/sprite/tiio_sprite.cpp
+++ b/toonz/sources/image/sprite/tiio_sprite.cpp
@@ -99,6 +99,15 @@ TLevelWriterSprite::~TLevelWriterSprite() {
   int totalHorizPadding = 0;
   int spriteSheetWidth;
   int spriteSheetHeight;
+  // Scene origin inside one frame cell, in pixels from the cell's top-left
+  // corner. A level pivot is not reachable here: the writer is handed only
+  // images, with no scene, column or stage object. What it does know is that
+  // every frame is a rendered camera raster whose centre is the scene origin,
+  // so the trim box, scale and padding place that origin inside the cell.
+  QString anchorX = QString::number(
+      (m_lx / 2.0 - m_left) * m_scale / 100.0 + m_leftPadding, 'f', 2);
+  QString anchorY = QString::number(
+      (m_ly / 2.0 - m_top) * m_scale / 100.0 + m_topPadding, 'f', 2);
   if (m_format == "Grid") {
     // Calculate Grid Size
     while (horizDim * horizDim < m_imagesResized.size()) horizDim++;
@@ -138,6 +147,28 @@ TLevelWriterSprite::~TLevelWriterSprite() {
       paddingPainter.end();
       padded.save(path, "PNG", -1);
     }
+    // The sheet formats have always written a companion text file describing
+    // their layout. Individual frames wrote none, so a script consuming them
+    // had no way to learn the cell geometry or the anchor.
+    QString textPath = m_path.getQString();
+    textPath         = textPath.replace(".spritesheet", ".txt");
+    QFile file(textPath);
+    file.open(QIODevice::WriteOnly | QIODevice::Text);
+    QTextStream out(&file);
+    out << "Total Images: " << m_imagesResized.size() << "\n";
+    out << "Individual Image Width: " << resizedWidth << "\n";
+    out << "Individual Image Height: " << resizedHeight << "\n";
+    out << "Individual Image Width with Padding: " << resizedWidth + horizPadding
+        << "\n";
+    out << "Individual Image Height with Padding: "
+        << resizedHeight + vertPadding << "\n";
+    out << "Top Padding: " << m_topPadding << "\n";
+    out << "Bottom Padding: " << m_bottomPadding << "\n";
+    out << "Left Padding: " << m_leftPadding << "\n";
+    out << "Right Padding: " << m_rightPadding << "\n";
+    out << "Anchor X: " << anchorX << "\n";
+    out << "Anchor Y: " << anchorY << "\n";
+    file.close();
   }
   if (m_format != "Individual") {
     QImage spriteSheet = QImage(spriteSheetWidth, spriteSheetHeight,
@@ -191,6 +222,8 @@ TLevelWriterSprite::~TLevelWriterSprite() {
     out << "Right Padding: " << m_rightPadding << "\n";
     out << "Horizontal Space Between Images: " << horizPadding << "\n";
     out << "Vertical Space Between Images: " << vertPadding << "\n";
+    out << "Anchor X: " << anchorX << "\n";
+    out << "Anchor Y: " << anchorY << "\n";
 
     file.close();
   }

--- a/toonz/sources/image/sprite/tiio_sprite.cpp
+++ b/toonz/sources/image/sprite/tiio_sprite.cpp
@@ -125,7 +125,18 @@ TLevelWriterSprite::~TLevelWriterSprite() {
       QString path      = m_path.getQString();
       QString newEnding = "_" + QString::number(i) + ".png";
       path              = path.replace(".spritesheet", newEnding);
-      m_imagesResized[i].save(path, "PNG", -1);
+      if (horizPadding == 0 && vertPadding == 0) {
+        m_imagesResized[i].save(path, "PNG", -1);
+        continue;
+      }
+      QImage padded(m_imagesResized[i].width() + horizPadding,
+                    m_imagesResized[i].height() + vertPadding,
+                    QImage::Format_ARGB32_Premultiplied);
+      padded.fill(qRgba(0, 0, 0, 0));
+      QPainter paddingPainter(&padded);
+      paddingPainter.drawImage(m_leftPadding, m_topPadding, m_imagesResized[i]);
+      paddingPainter.end();
+      padded.save(path, "PNG", -1);
     }
   }
   if (m_format != "Individual") {

--- a/toonz/sources/include/toutputproperties.h
+++ b/toonz/sources/include/toutputproperties.h
@@ -5,6 +5,10 @@
 
 #include "tfilepath.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #undef DVAPI
 #undef DVVAR
 #ifdef TOONZLIB_EXPORTS
@@ -82,6 +86,9 @@ private:
   double m_frameRate;
 
   int m_from, m_to;
+  /*-- Optional non-contiguous selection. Empty means "use m_from/m_to",
+   * which keeps existing scenes and presets byte-identical. --*/
+  std::vector<std::pair<int, int>> m_frameRanges;
   int m_whichLevels;
   int m_offset, m_step;
 
@@ -173,6 +180,30 @@ Set first frame to \b r0, last frame to \b r1, step to \b step.
 \sa getRange()
 */
   void setRange(int r0, int r1, int step);
+
+  /*!
+Non-contiguous output selection, as a list of inclusive [from, to] pairs in
+the same zero-based space as getRange(). An empty list means the single
+range held by getRange() is authoritative.
+*/
+  const std::vector<std::pair<int, int>> &getFrameRanges() const {
+    return m_frameRanges;
+  }
+  void setFrameRanges(const std::vector<std::pair<int, int>> &ranges);
+  void clearFrameRanges() { m_frameRanges.clear(); }
+
+  //! Expands the selection into ascending frame numbers, honouring step.
+  std::vector<int> getFrameList(int sceneLength) const;
+
+  /*! Parses a printer-style list such as "1-3, 5, 8-10". Frame numbers are
+one-based, matching what the user types. Returns false and fills \b error
+when the text is malformed; \b ranges is then left untouched. */
+  static bool parseFrameRanges(const std::string &text,
+                               std::vector<std::pair<int, int>> &ranges,
+                               std::string *error = 0);
+  //! Inverse of parseFrameRanges(), producing one-based text.
+  static std::string formatFrameRanges(
+      const std::vector<std::pair<int, int>> &ranges);
 
   /*!
 Set output frame rate.

--- a/toonz/sources/tcomposer/tcomposer.cpp
+++ b/toonz/sources/tcomposer/tcomposer.cpp
@@ -604,6 +604,8 @@ int main(int argc, char *argv[]) {
   RangeQualifier range;
   IntQualifier stepOpt("-step n", "Step");
   IntQualifier shrinkOpt("-shrink n", "Shrink");
+  IntQualifier widthOpt("-width n", "Output width in pixels");
+  IntQualifier heightOpt("-height n", "Output height in pixels");
   IntQualifier multimedia("-multimedia n", "Multimedia rendering mode");
   StringQualifier farmData("-farm data", "TFarm Controller");
   StringQualifier idq("-id n", "id");
@@ -611,8 +613,9 @@ int main(int argc, char *argv[]) {
   StringQualifier tileSize("-maxtilesize n",
                            "Enable tile rendering of max n MB per tile");
   StringQualifier tmsg("-tmsg val", "only internal use");
-  usageLine = srcName + dstName + range + stepOpt + shrinkOpt + multimedia +
-              farmData + idq + nthreads + tileSize + tmsg;
+  usageLine = srcName + dstName + range + stepOpt + shrinkOpt + widthOpt +
+              heightOpt + multimedia + farmData + idq + nthreads + tileSize +
+              tmsg;
 
   // system path qualifiers
   std::map<QString, std::unique_ptr<TCli::QualifierT<TFilePath>>>
@@ -920,6 +923,37 @@ int main(int argc, char *argv[]) {
       shrink = shrinkOpt.getValue();
     else
       shrink = scene_shrink;
+
+    if (widthOpt.isSelected() || heightOpt.isSelected()) {
+      int outWidth  = widthOpt.isSelected() ? widthOpt.getValue() : 0;
+      int outHeight = heightOpt.isSelected() ? heightOpt.getValue() : 0;
+      if (outWidth < 0 || outHeight < 0 ||
+          (widthOpt.isSelected() && outWidth == 0) ||
+          (heightOpt.isSelected() && outHeight == 0)) {
+        cout << "Qualifier 'width'/'height': size must be positive" << endl;
+        exit(1);
+      }
+      TCamera *camera     = scene->getCurrentCamera();
+      TDimension sceneRes = camera->getRes();
+      if (sceneRes.lx <= 0 || sceneRes.ly <= 0) {
+        cout << "The scene camera has no usable resolution" << endl;
+        exit(1);
+      }
+      if (outWidth == 0)
+        outWidth = (int)(outHeight * (double)sceneRes.lx / sceneRes.ly + 0.5);
+      if (outHeight == 0)
+        outHeight = (int)(outWidth * (double)sceneRes.ly / sceneRes.lx + 0.5);
+      outWidth  = std::max(1, outWidth);
+      outHeight = std::max(1, outHeight);
+      camera->setRes(TDimension(outWidth, outHeight));
+      if (shrink != 1) {
+        m_userLog->info("Shrink ignored because -width or -height was given");
+        shrink = 1;
+      }
+      m_userLog->info("Output resolution: " + std::to_string(outWidth) + "x" +
+                      std::to_string(outHeight));
+    }
+
     if (multimedia.isSelected())
       scene->getProperties()->getOutputProperties()->setMultimediaRendering(
           multimedia.getValue());

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2600,6 +2600,9 @@ void MainWindow::defineActions() {
                          "render");
   createMenuRenderAction(MI_FastRender, QT_TR_NOOP("&Fast Render to MP4"),
                          "Alt+R", "fast_render_mp4");
+  createMenuRenderAction(MI_FastRenderFrame,
+                         QT_TR_NOOP("Fast Render &Current Frame to PNG"), "",
+                         "fast_render_png");
   createMenuRenderAction(MI_Preview, QT_TR_NOOP("&Preview"), "Ctrl+R",
                          "preview");
   createMenuRenderAction(MI_SavePreviewedFrames,

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -49,6 +49,7 @@
 #define MI_PreviewSettings "MI_PreviewSettings"
 #define MI_Render "MI_Render"
 #define MI_FastRender "MI_FastRender"
+#define MI_FastRenderFrame "MI_FastRenderFrame"
 #define MI_Preview "MI_Preview"
 #define MI_SoundTrack "MI_SoundTrack"
 #define MI_RegeneratePreview "MI_RegeneratePreview"

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -367,7 +367,11 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   // Output Camera
   m_outputCameraOm = new QComboBox();
   // Frame Start-End
-  m_startFld = new DVGui::IntLineEdit(this);
+  m_startFld        = new DVGui::IntLineEdit(this);
+  m_frameRangesFld  = new DVGui::LineEdit(this);
+  m_frameRangesFld->setToolTip(
+      tr("Render only these frames, for example 1-3, 5, 8-10.\n"
+         "Leave empty to use Frame Start and End."));
   m_endFld   = new DVGui::IntLineEdit(this);
   // Step-Shrink
   m_stepFld   = new DVGui::IntLineEdit(this);
@@ -437,6 +441,10 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
                                 Qt::AlignRight | Qt::AlignVCenter);
       frameShrinkLay->addWidget(m_stepFld, 0, 7);
 
+      frameShrinkLay->addWidget(new QLabel(tr("Frames:"), this), 2, 0,
+                                Qt::AlignRight | Qt::AlignVCenter);
+      frameShrinkLay->addWidget(m_frameRangesFld, 2, 1, 1, 7);
+
       frameShrinkLay->addWidget(new QLabel(tr("Shrink:"), this), 1, 0,
                                 Qt::AlignRight | Qt::AlignVCenter);
       frameShrinkLay->addWidget(m_shrinkFld, 1, 1);
@@ -457,6 +465,8 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   ret      = ret &&
         connect(m_outputCameraOm, SIGNAL(currentIndexChanged(const QString &)),
                 SLOT(onCameraChanged(const QString &)));
+  ret = ret && connect(m_frameRangesFld, SIGNAL(editingFinished()), this,
+                       SLOT(onFrameRangesEditFinished()));
   ret = ret && connect(m_startFld, SIGNAL(editingFinished()),
                        SLOT(onFrameFldEditFinished()));
   ret = ret && connect(m_endFld, SIGNAL(editingFinished()),
@@ -1004,6 +1014,8 @@ void OutputSettingsPopup::updateField() {
   }
   m_startFld->setValue(r0 + 1);
   m_endFld->setValue(r1 + 1);
+  m_frameRangesFld->setText(QString::fromStdString(
+      TOutputProperties::formatFrameRanges(prop->getFrameRanges())));
   m_stepFld->setValue(step);
   m_shrinkFld->setValue(renderSettings.m_shrinkX);
   if (m_applyShrinkChk)
@@ -1319,6 +1331,42 @@ void OutputSettingsPopup::onSyncColorSettingsChecked(int state) {
 }
 
 //----------------------------------------------
+
+/*-- An empty field clears the selection and hands control back to Frame Start
+ * and End. Anything else must parse completely or nothing is applied. --*/
+void OutputSettingsPopup::onFrameRangesEditFinished() {
+  ToonzScene *scene = getCurrentScene();
+  if (!scene) return;
+  TOutputProperties *prop = getProperties();
+
+  QString text = m_frameRangesFld->text().trimmed();
+  if (text.isEmpty()) {
+    if (!prop->getFrameRanges().empty()) {
+      prop->clearFrameRanges();
+      TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+    }
+    return;
+  }
+
+  std::vector<std::pair<int, int>> ranges;
+  std::string error;
+  if (!TOutputProperties::parseFrameRanges(text.toStdString(), ranges,
+                                           &error)) {
+    DVGui::warning(tr("Invalid frame list: %1")
+                       .arg(QString::fromStdString(error)));
+    m_frameRangesFld->setText(QString::fromStdString(
+        TOutputProperties::formatFrameRanges(prop->getFrameRanges())));
+    return;
+  }
+
+  prop->setFrameRanges(ranges);
+  /*-- Echo the normalised form so the user can see merges and reordering. --*/
+  m_frameRangesFld->setText(
+      QString::fromStdString(TOutputProperties::formatFrameRanges(ranges)));
+  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+}
+
+//-----------------------------------------------------------------------------
 
 void OutputSettingsPopup::onFrameFldEditFinished() {
   ToonzScene *scene = getCurrentScene();

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -54,6 +54,7 @@ class OutputSettingsPopup : public DVGui::Dialog {
   QComboBox *m_fileFormat;
   QComboBox *m_outputCameraOm;
   DVGui::IntLineEdit *m_startFld, *m_endFld;
+  DVGui::LineEdit *m_frameRangesFld;
   DVGui::IntLineEdit *m_stepFld, *m_shrinkFld;
   QComboBox *m_multimediaOm;
   QComboBox *m_resampleBalanceOm;
@@ -116,6 +117,7 @@ protected slots:
   void openSettingsPopup();
   void onCameraChanged(const QString &str);
   void onFrameFldEditFinished();
+  void onFrameRangesEditFinished();
   void onResampleChanged(int type);
   void onChannelWidthChanged(int type);
   void onLinearColorSpaceClicked(bool checked);

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -18,6 +18,7 @@
 #include "toonz/preferences.h"
 #include "toonz/toonzscene.h"
 #include "toonz/tscenehandle.h"
+#include "toonz/tframehandle.h"
 #include "toonz/txsheet.h"
 #include "toonz/txsheethandle.h"
 #include "toonz/fxdag.h"
@@ -214,6 +215,8 @@ public:
       , m_multimediaRender(0) {
     setCommandHandler("MI_Render", this, &RenderCommand::onRender);
     setCommandHandler("MI_FastRender", this, &RenderCommand::onFastRender);
+    setCommandHandler("MI_FastRenderFrame", this,
+                      &RenderCommand::onFastRenderFrame);
     setCommandHandler("MI_Preview", this, &RenderCommand::onPreview);
   }
 
@@ -222,6 +225,7 @@ public:
   void multimediaRender();
   void onRender();
   void onFastRender();
+  void onFastRenderFrame();
   void onPreview();
   static void resetBgColor();
   void doRender(bool isPreview);
@@ -818,6 +822,55 @@ void RenderCommand::onFastRender() {
   }
   prop->setPath(path);
   doRender(false);
+  prop->setPath(currPath);
+}
+
+//---------------------------------------------------------
+
+void RenderCommand::onFastRenderFrame() {
+  TApp *app               = TApp::instance();
+  TFrameHandle *frameHandle = app->getCurrentFrame();
+  if (!frameHandle->isEditingScene()) {
+    DVGui::warning(
+        QObject::tr("Fast Render Current Frame is available in scene mode."));
+    return;
+  }
+
+  ToonzScene *scene       = app->getCurrentScene()->getScene();
+  TOutputProperties *prop = scene->getProperties()->getOutputProperties();
+
+  QStringList formats;
+  TImageWriter::getSupportedFormats(formats, true);
+  TLevelWriter::getSupportedFormats(formats, true);
+  Tiio::Writer::getSupportedFormats(formats, true);
+  if (!formats.contains("png")) {
+    DVGui::warning(QObject::tr("The PNG format is not available."));
+    return;
+  }
+
+  int frame = frameHandle->getFrame();
+  if (frame < 0 || frame >= scene->getFrameCount()) {
+    DVGui::warning(
+        QObject::tr("The current frame is outside the scene frame range."));
+    return;
+  }
+
+  QString sceneName = QString::fromStdWString(scene->getSceneName());
+  QString location  = Preferences::instance()->getFastRenderPath();
+  if (location == "desktop" || location == "Desktop") {
+    location =
+        QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+  }
+  TFilePath path = TFilePath(location) + TFilePath(sceneName + ".png");
+
+  TFilePath currPath = prop->getPath();
+  int currR0, currR1, currStep;
+  prop->getRange(currR0, currR1, currStep);
+
+  prop->setPath(path);
+  prop->setRange(frame, frame, 1);
+  doRender(false);
+  prop->setRange(currR0, currR1, currStep);
   prop->setPath(currPath);
 }
 

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -201,6 +201,9 @@ class RenderCommand {
   double m_timeStretchFactor;
 
   int m_multimediaRender;
+  /*-- Frames to render, in order. Always populated, so the render loop has
+   * a single path whether or not a non-contiguous selection is in use. --*/
+  std::vector<double> m_frames;
 
 public:
   RenderCommand()
@@ -341,6 +344,30 @@ sprop->getOutputProperties()->setRenderSettings(rso);*/
 
   m_r         = stretchedR0 / m_timeStretchFactor;
   m_numFrames = (stretchedR1 - stretchedR0) / m_step + 1;
+
+  /*-- Expand the frames to render. A non-contiguous selection is only honoured
+   * at 1:1 time stretch: stretching resamples the timeline, so an arbitrary
+   * frame list has no well-defined meaning there and the contiguous range
+   * stays authoritative. --*/
+  m_frames.clear();
+  const std::vector<std::pair<int, int>> &ranges =
+      outputSettings.getFrameRanges();
+  if (!ranges.empty() && areAlmostEqual(m_timeStretchFactor, 1.0)) {
+    std::vector<int> frameList =
+        outputSettings.getFrameList(scene->getFrameCount());
+    for (int i = 0; i < (int)frameList.size(); i++)
+      m_frames.push_back((double)frameList[i]);
+    m_numFrames = (int)m_frames.size();
+    if (m_numFrames == 0) {
+      DVGui::warning(QObject::tr(
+          "The selected frames are outside the scene. Nothing to render."));
+      return false;
+    }
+    m_r = m_frames.front();
+  } else {
+    for (int i = 0; i < m_numFrames; i++)
+      m_frames.push_back(m_r + i * m_stepd);
+  }
 
   // Update the multimedia render switch
   m_multimediaRender = outputSettings.getMultimediaRendering();
@@ -564,7 +591,8 @@ void RenderCommand::rasterRender(bool isPreview) {
       QObject::tr("Building Schematic...", "RenderCommand"));
   buildSceneProgressBar->show();
 
-  for (int i = 0; i < m_numFrames; ++i, m_r += m_stepd) {
+  for (int i = 0; i < m_numFrames; ++i) {
+    m_r = m_frames[i];
     buildSceneProgressBar->setValue(i);
 
     if (rs.m_stereoscopic) scene->shiftCameraX(-rs.m_stereoscopicShift / 2);
@@ -776,8 +804,10 @@ void RenderCommand::multimediaRender() {
   multimediaRenderer.setDpi(cameraDpi.x, cameraDpi.y);
   multimediaRenderer.enablePrecomputing(true);
 
-  for (int i = 0; i < m_numFrames; ++i, m_r += m_stepd)
+  for (int i = 0; i < m_numFrames; ++i) {
+    m_r = m_frames[i];
     multimediaRenderer.addFrame(m_r);
+  }
 
   MultimediaProgressBar *listener =
       new MultimediaProgressBar(&multimediaRenderer);

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -1,5 +1,8 @@
 
 
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include "toutputproperties.h"
 
 // TnzLib includes
@@ -55,6 +58,7 @@ TOutputProperties::TOutputProperties(const TOutputProperties &src)
     , m_formatProperties(src.m_formatProperties)
     , m_renderSettings(new TRenderSettings(*src.m_renderSettings))
     , m_frameRate(src.m_frameRate)
+    , m_frameRanges(src.m_frameRanges)
     , m_from(src.m_from)
     , m_to(src.m_to)
     , m_whichLevels(src.m_whichLevels)
@@ -88,6 +92,7 @@ TOutputProperties::~TOutputProperties() {
 
 TOutputProperties &TOutputProperties::operator=(const TOutputProperties &src) {
   m_path        = src.m_path;
+  m_frameRanges = src.m_frameRanges;
   m_from        = src.m_from;
   m_to          = src.m_to;
   m_frameRate   = src.m_frameRate;
@@ -130,6 +135,137 @@ void TOutputProperties::setPath(const TFilePath &fp) { m_path = fp; }
 //-------------------------------------------------------------------
 
 void TOutputProperties::setOffset(int off) { m_offset = off; }
+
+//-----------------------------------------------------------------------------
+
+void TOutputProperties::setFrameRanges(
+    const std::vector<std::pair<int, int>> &ranges) {
+  m_frameRanges = ranges;
+}
+
+//-----------------------------------------------------------------------------
+
+/*-- Expand the selection into ascending, de-duplicated frame numbers. Step is
+ * applied across the whole selection rather than restarting per range, so a
+ * step of 2 over "1-4, 7-10" behaves like a single strided pass. --*/
+std::vector<int> TOutputProperties::getFrameList(int sceneLength) const {
+  std::vector<int> frames;
+  std::vector<std::pair<int, int>> ranges = m_frameRanges;
+  if (ranges.empty()) {
+    int r0, r1, step;
+    if (!getRange(r0, r1, step)) {
+      r0 = 0;
+      r1 = sceneLength - 1;
+    }
+    ranges.push_back(std::make_pair(r0, r1));
+  }
+
+  int step = m_step > 0 ? m_step : 1;
+  std::vector<int> expanded;
+  for (int i = 0; i < (int)ranges.size(); i++) {
+    int from = std::max(0, ranges[i].first);
+    int to   = std::min(sceneLength - 1, ranges[i].second);
+    for (int f = from; f <= to; f++) expanded.push_back(f);
+  }
+  std::sort(expanded.begin(), expanded.end());
+  expanded.erase(std::unique(expanded.begin(), expanded.end()),
+                 expanded.end());
+
+  for (int i = 0; i < (int)expanded.size(); i += step)
+    frames.push_back(expanded[i]);
+  return frames;
+}
+
+//-----------------------------------------------------------------------------
+
+/*-- Frame numbers in the text are one-based because that is what the Output
+ * Settings fields show; the stored pairs are zero-based like getRange(). --*/
+bool TOutputProperties::parseFrameRanges(
+    const std::string &text, std::vector<std::pair<int, int>> &ranges,
+    std::string *error) {
+  std::vector<std::pair<int, int>> parsed;
+  std::string token;
+  std::vector<std::string> tokens;
+  for (size_t i = 0; i <= text.size(); i++) {
+    if (i == text.size() || text[i] == ',') {
+      tokens.push_back(token);
+      token.clear();
+    } else if (!isspace((unsigned char)text[i]))
+      token += text[i];
+  }
+
+  bool anyContent = false;
+  for (size_t i = 0; i < tokens.size(); i++) {
+    const std::string &tk = tokens[i];
+    if (tk.empty()) continue;
+    anyContent = true;
+
+    size_t dash = tk.find('-');
+    std::string fromStr =
+        (dash == std::string::npos) ? tk : tk.substr(0, dash);
+    std::string toStr =
+        (dash == std::string::npos) ? tk : tk.substr(dash + 1);
+    if (fromStr.empty() || toStr.empty()) {
+      if (error) *error = "Incomplete frame range: " + tk;
+      return false;
+    }
+    for (size_t c = 0; c < fromStr.size(); c++)
+      if (!isdigit((unsigned char)fromStr[c])) {
+        if (error) *error = "Frame numbers must be positive integers: " + tk;
+        return false;
+      }
+    for (size_t c = 0; c < toStr.size(); c++)
+      if (!isdigit((unsigned char)toStr[c])) {
+        if (error) *error = "Frame numbers must be positive integers: " + tk;
+        return false;
+      }
+
+    int from = std::atoi(fromStr.c_str());
+    int to   = std::atoi(toStr.c_str());
+    if (from < 1 || to < 1) {
+      if (error) *error = "Frame numbers start at 1: " + tk;
+      return false;
+    }
+    if (from > to) {
+      if (error) *error = "Range start is after its end: " + tk;
+      return false;
+    }
+    parsed.push_back(std::make_pair(from - 1, to - 1));
+  }
+
+  if (!anyContent) {
+    if (error) *error = "No frames were specified.";
+    return false;
+  }
+
+  /*-- Normalise so overlapping and unordered input still describes exactly one
+   * ascending selection. --*/
+  std::sort(parsed.begin(), parsed.end());
+  std::vector<std::pair<int, int>> merged;
+  for (size_t i = 0; i < parsed.size(); i++) {
+    if (!merged.empty() && parsed[i].first <= merged.back().second + 1)
+      merged.back().second = std::max(merged.back().second, parsed[i].second);
+    else
+      merged.push_back(parsed[i]);
+  }
+
+  ranges = merged;
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+std::string TOutputProperties::formatFrameRanges(
+    const std::vector<std::pair<int, int>> &ranges) {
+  std::string text;
+  for (size_t i = 0; i < ranges.size(); i++) {
+    if (i > 0) text += ", ";
+    text += std::to_string(ranges[i].first + 1);
+    if (ranges[i].second != ranges[i].first)
+      text += "-" + std::to_string(ranges[i].second + 1);
+  }
+  return text;
+}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -249,6 +249,11 @@ void TSceneProperties::saveData(TOStream &os) const {
     out.getRange(from, to, step);
     os.child("range") << from << to;
     os.child("step") << step;
+    /*-- Written only when a non-contiguous selection exists, so scenes that use
+     * a single range keep their previous byte-for-byte output. --*/
+    if (!out.getFrameRanges().empty())
+      os.child("frameRanges")
+          << TOutputProperties::formatFrameRanges(out.getFrameRanges());
     os.child("shrink") << rs.m_shrinkX;
     os.child("applyShrinkToViewer") << (rs.m_applyShrinkToViewer ? 1 : 0);
     os.child("fps") << out.getFrameRate();
@@ -562,6 +567,14 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
               is >> step;
               out.getRange(from, to, dummy);
               out.setRange(from, to, step);
+            } else if (tagName == "frameRanges") {
+              std::string text;
+              is >> text;
+              std::vector<std::pair<int, int>> ranges;
+              /*-- A malformed or stale list must not stop the scene loading;
+               * fall back to the single range that is always present. --*/
+              if (TOutputProperties::parseFrameRanges(text, ranges))
+                out.setFrameRanges(ranges);
             } else if (tagName == "shrink") {
               int shrink;
               is >> shrink;


### PR DESCRIPTION
Six independent improvements to the rendering and export path, each kept as its own commit so they can be reviewed, and if necessary reverted, separately. Each addresses a specific feature request; the discussion is linked per item below.

Supersedes #7037, #7038, #7039, #7040, #7043 and #7044, which are closed in favour of this branch.

---

### 1. Apply sprite sheet padding to individual frames
Discussion: https://github.com/opentoonz/opentoonz/discussions/6471

Top, Bottom, Left and Right Padding were honoured only by the Grid, Vertical and Horizontal layouts. The `Individual` format saved each trimmed frame directly, so padding was silently dropped — which is the option users need when sprites are too large for one sheet. Disabling Trim Empty Space is not a workaround; the reported case requires it enabled.

Each frame is now drawn onto a transparent canvas expanded by the configured padding. When every padding value is zero the original image is saved unchanged, so existing output is byte-identical. The change is confined to the `Individual` branch; the three sheet layouts are untouched.

### 2. Write scene-origin anchor into the sprite sheet text file
Discussion: https://github.com/opentoonz/opentoonz/discussions/6764

`Anchor X` and `Anchor Y` are appended to the sprite sheet text file, giving the scene origin in pixels from the top-left of one frame cell. The `Individual` format, which wrote no text file at all, now writes one describing its cell geometry, padding and anchor. Every existing line keeps its wording and position, so current parsers are unaffected.

The request asks for "pivot point data". A true level pivot is not reachable here: `TLevelWriter` is handed images with no scene, column, stage object or hooks, and reaching one would mean widening a shared I/O interface used by every format. The writer also crops every frame with one global union trim box, so a per-frame pivot would emit the same value repeated. The scene origin *is* derivable — each frame is a rendered camera raster whose centre is that origin — and it is the value needed to place a trimmed sprite back where it sat in the camera.

Depends on item 1: the anchor includes the padding offset.

### 3. Add tcomposer output width and height options
Discussion: https://github.com/opentoonz/opentoonz/discussions/6773

`-shrink` was the only way to change render resolution from the command line. It divides the camera resolution by an integer and is marked obsolete, so arbitrary output sizes required editing the scene. This matters for automated pipelines that render reduced during production and full for finals.

`-width n` and `-height n` set the resolution directly via `TCamera::setRes`. Either may be given alone, in which case the other follows the camera aspect ratio. They take precedence over `-shrink`, which would otherwise scale a second time, and the substitution is reported in the render log. Non-positive values are rejected. Behaviour is unchanged when neither is given.

### 4. Add Fast Render Current Frame to PNG
Discussion: https://github.com/opentoonz/opentoonz/discussions/6552

Exporting one frame at render resolution meant opening Output Settings, switching format to PNG, narrowing the range, rendering, then putting all three back. `MI_FastRender` already establishes the pattern of a one-click render that bypasses Output Settings; this is its single-frame counterpart.

It saves and restores both the output path and the frame range, so Output Settings is left exactly as the user had it. Because it uses the normal render path rather than grabbing the viewport, camera box and other overlays are absent and the result is full render resolution. No default shortcut.

Note: the discussion was closed on the grounds that the result is already achievable. That is true — this closes the workflow gap, not a capability gap.

### 5. Allow extra FFmpeg encoding arguments
Discussion: https://github.com/opentoonz/opentoonz/discussions/6573

The FFmpeg-backed writers built a fixed argument list, so options the UI does not expose — hardware acceleration being the motivating example — were unreachable without editing the source.

MP4, WebM, GIF and APNG each gain an `Extra FFmpeg Args` format property, stored in the existing property group so it saves with the scene and with output presets. Arguments are appended after the writer's own and before the output path. They are split on whitespace honouring double quotes and passed to `QProcess` as a list, so no shell is involved, consistent with the hardening in #6903 and #6904. The tokens `-i`, `-y` and `-n` are rejected with a warning: they would retarget the process rather than configure the encode. An empty field produces exactly the command line built today.

This is deliberately the smaller of the two designs discussed; the external-instruction-file prototype is not implemented.

### 6. Render non-contiguous frame ranges
Discussion: https://github.com/opentoonz/opentoonz/discussions/6535

Output Settings could describe only one contiguous range, so rendering frames 1-3 and 8-10 meant two renders and reconciling the output numbering by hand. This matters most for sprite sheets, where duplicate frames are skipped but the rest must keep their relative order.

A `Frames` field accepts a printer-style list such as `1-3, 5, 8-10`, one-based to match the existing Frame Start and End fields. Overlapping and unordered input is normalised into one ascending selection and echoed back so merges are visible; malformed input is rejected and nothing is applied.

Compatibility: the list is written to the scene only when non-empty, so scenes and presets using a single range serialize exactly as before, and a stale or malformed stored list falls back to the single range rather than failing the load. The render loop now iterates an explicit frame vector which, when no list is set, is populated with the previous arithmetic. The selection is honoured only at 1:1 time stretch, since stretching resamples the timeline and an arbitrary frame list has no well-defined meaning there.

Overlap note: opentoonz-dev #34 edits the same four files; if it lands first this needs a rebase.

---

## Testing

- Full `OpenToonz.app` target builds and links on macOS arm64 with all six commits applied: **1595/1595, zero errors**. Also built and linked at each individual commit.
- `clang-format` reports no violations on any changed line. The files carry pre-existing violations under newer clang-format versions (pointer alignment); those were left alone rather than reformatted.
- `git diff --check` passes.
- Focused harnesses were run against the logic that can be exercised in isolation:
  - **Sprite padding** — zero padding is byte-identical to current output; padded canvas size, content offset, transparent margins on all four sides, asymmetric values not symmetrised, absolute under Scale, and a fully transparent frame all verified.
  - **Anchor** — raster centre when untrimmed/unscaled/unpadded; shifts by the trim origin; tracks Scale at 25/50/200%; padding adds absolute pixels; origin round-trips across several trim/scale/padding combinations.
  - **FFmpeg arguments** — flag/value pairs, codec selectors and hardware-acceleration flags pass; quoted values survive as one token; `-i`, `-y`, `-n` rejected anywhere in the list; `-i` inside a quoted metadata value correctly not rejected.
  - **Frame ranges** — the discussion's own example round-trips; adjacent singles and overlapping/unordered ranges merge; empty text, frame 0, reversed ranges, dangling dashes and non-numeric input rejected; expansion yields exactly the listed frames; step strides across the whole selection; frames past the scene end are clipped.
- `tcomposer` was built and `-width`/`-height` confirmed present in the usage line and absent from an unmodified `master` build.
- Not covered locally: end-to-end renders needing a real scene file, since none ship in `stuff/`.

## Build note

Building natively on Apple Silicon currently fails to link because `thirdparty/superlu/libsuperlu_4.1.a` is a fat i386/x86_64 archive with no arm64 slice. The SuperLU 4.1 source already ships in the repo and builds clean for arm64 with `-Wno-implicit-function-declaration` (clang 15+ rejects the C89 style). Regenerating that one archive is enough to make the full target link — relevant to #6882.