### PR TITLE
Add optional Camera Capture sound

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -85,6 +85,7 @@
 #include <QKeyEvent>
 #include <QCommonStyle>
 #include <QTimer>
+#include <QSound>
 #include <QIntValidator>
 #include <QRegularExpressionValidator>
 
@@ -127,6 +128,7 @@ TEnv::RectVar CamCapSubCameraRect("CamCapSubCameraRect", TRect());
 TEnv::IntVar CamCapDoAutoDpi("CamCapDoAutoDpi", 1);
 TEnv::DoubleVar CamCapCustomDpi("CamCapDpiForNewLevel", 120.0);
 TEnv::StringVar CamCapFileType("CamCapFileType", "jpg");
+TEnv::IntVar CamCapPlayCaptureSound("CamCapPlayCaptureSound", 0);
 
 namespace {
 
@@ -1624,6 +1626,8 @@ PencilTestPopup::PencilTestPopup()
 
   m_saveOnCaptureCB =
       new QCheckBox(tr("Save images as they are captured"), this);
+  QCheckBox* playCaptureSoundCB =
+      new QCheckBox(tr("Play Sound on Capture"), this);
 
   QGroupBox* imageFrame        = new QGroupBox(tr("Image adjust"), this);
   m_colorTypeCombo             = new QComboBox(this);
@@ -1693,6 +1697,7 @@ PencilTestPopup::PencilTestPopup()
   m_previousLevelButton->setArrowType(Qt::LeftArrow);
   m_previousLevelButton->setToolTip(tr("Previous Level"));
   m_saveOnCaptureCB->setChecked(true);
+  playCaptureSoundCB->setChecked(CamCapPlayCaptureSound != 0);
 
   imageFrame->setObjectName("CleanupSettingsFrame");
   m_colorTypeCombo->addItems(
@@ -1888,6 +1893,7 @@ PencilTestPopup::PencilTestPopup()
           fileLay->addLayout(fileTypeLay, 0);
 
           fileLay->addWidget(m_saveOnCaptureCB, 0);
+          fileLay->addWidget(playCaptureSoundCB, 0);
         }
         fileFrame->setLayout(fileLay);
         rightLay->addWidget(fileFrame, 0);
@@ -2006,6 +2012,9 @@ PencilTestPopup::PencilTestPopup()
 
   connect(m_saveImgAdjustDefaultButton, &QPushButton::pressed, this,
           &PencilTestPopup::saveImageAdjustDefault);
+
+  connect(playCaptureSoundCB, &QCheckBox::toggled,
+          [](bool checked) { CamCapPlayCaptureSound = checked ? 1 : 0; });
 
   connect(m_captureWhiteBGButton, &QPushButton::pressed, this,
           &PencilTestPopup::onCaptureWhiteBGButtonPressed);
@@ -2660,6 +2669,8 @@ void PencilTestPopup::onFrameCaptured(cv::Mat& image) {
     m_captureCue = false;
 
     if (importImage(qimg)) {
+      if (CamCapPlayCaptureSound != 0)
+        QSound::play(":Resources/camera_snap.wav");
       m_videoWidget->setPreviousImage(qimg.copy());
       if (Preferences::instance()->isShowFrameNumberWithLettersEnabled()) {
         TFrameId fId = m_frameNumberEdit->getValue();

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1626,8 +1626,6 @@ PencilTestPopup::PencilTestPopup()
 
   m_saveOnCaptureCB =
       new QCheckBox(tr("Save images as they are captured"), this);
-  QCheckBox* playCaptureSoundCB =
-      new QCheckBox(tr("Play Sound on Capture"), this);
 
   QGroupBox* imageFrame        = new QGroupBox(tr("Image adjust"), this);
   m_colorTypeCombo             = new QComboBox(this);
@@ -1652,8 +1650,9 @@ PencilTestPopup::PencilTestPopup()
   m_captureButton          = new QPushButton(tr("Capture\n[Return key]"), this);
   QPushButton* closeButton = new QPushButton(tr("Close"), this);
 
+  QPushButton* captureOptionsButton = new QPushButton(this);
 #ifdef WIN32
-  m_captureFilterSettingsBtn = new QPushButton(this);
+  m_captureFilterSettingsBtn = captureOptionsButton;
 #else
   m_captureFilterSettingsBtn = nullptr;
 #endif
@@ -1697,7 +1696,6 @@ PencilTestPopup::PencilTestPopup()
   m_previousLevelButton->setArrowType(Qt::LeftArrow);
   m_previousLevelButton->setToolTip(tr("Previous Level"));
   m_saveOnCaptureCB->setChecked(true);
-  playCaptureSoundCB->setChecked(CamCapPlayCaptureSound != 0);
 
   imageFrame->setObjectName("CleanupSettingsFrame");
   m_colorTypeCombo->addItems(
@@ -1737,14 +1735,12 @@ PencilTestPopup::PencilTestPopup()
   QCommonStyle style;
   m_captureButton->setIcon(style.standardIcon(QStyle::SP_DialogOkButton));
   m_captureButton->setIconSize(QSize(30, 30));
-  if (m_captureFilterSettingsBtn) {
-    m_captureFilterSettingsBtn->setObjectName("GearButton");
-    m_captureFilterSettingsBtn->setFixedSize(24, 24);
-    m_captureFilterSettingsBtn->setIconSize(QSize(16, 16));
-    m_captureFilterSettingsBtn->setIcon(createQIcon("gear"));
-    m_captureFilterSettingsBtn->setToolTip(tr("Options"));
-    m_captureFilterSettingsBtn->setMenu(createOptionsMenu());
-  }
+  captureOptionsButton->setObjectName("GearButton");
+  captureOptionsButton->setFixedSize(24, 24);
+  captureOptionsButton->setIconSize(QSize(16, 16));
+  captureOptionsButton->setIcon(createQIcon("gear"));
+  captureOptionsButton->setToolTip(tr("Options"));
+  captureOptionsButton->setMenu(createOptionsMenu());
 
   subfolderButton->setObjectName("SubfolderButton");
   subfolderButton->setIconSize(QSize(16, 16));
@@ -1792,10 +1788,8 @@ PencilTestPopup::PencilTestPopup()
       camLay->addWidget(new QLabel(tr("Resolution:"), this), 0);
       camLay->addWidget(m_resolutionCombo, 1);
 
-      if (m_captureFilterSettingsBtn) {
-        camLay->addSpacing(10);
-        camLay->addWidget(m_captureFilterSettingsBtn);
-      }
+      camLay->addSpacing(10);
+      camLay->addWidget(captureOptionsButton);
 
       camLay->addSpacing(10);
       camLay->addWidget(m_subcameraButton, 0);
@@ -1893,7 +1887,6 @@ PencilTestPopup::PencilTestPopup()
           fileLay->addLayout(fileTypeLay, 0);
 
           fileLay->addWidget(m_saveOnCaptureCB, 0);
-          fileLay->addWidget(playCaptureSoundCB, 0);
         }
         fileFrame->setLayout(fileLay);
         rightLay->addWidget(fileFrame, 0);
@@ -2012,9 +2005,6 @@ PencilTestPopup::PencilTestPopup()
 
   connect(m_saveImgAdjustDefaultButton, &QPushButton::pressed, this,
           &PencilTestPopup::saveImageAdjustDefault);
-
-  connect(playCaptureSoundCB, &QCheckBox::toggled,
-          [](bool checked) { CamCapPlayCaptureSound = checked ? 1 : 0; });
 
   connect(m_captureWhiteBGButton, &QPushButton::pressed, this,
           &PencilTestPopup::onCaptureWhiteBGButtonPressed);
@@ -2209,6 +2199,15 @@ QMenu* PencilTestPopup::createOptionsMenu() {
     m_useMjpg     = checked;
     CamCapUseMjpg = checked;
     m_timer->start(40);
+  });
+
+  menu->addSeparator();
+
+  QAction* playSoundAct = menu->addAction(tr("Play Sound on Capture"));
+  playSoundAct->setCheckable(true);
+  playSoundAct->setChecked(CamCapPlayCaptureSound != 0);
+  connect(playSoundAct, &QAction::toggled, [](bool checked) {
+    CamCapPlayCaptureSound = checked ? 1 : 0;
   });
 
   return menu;

--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1650,7 +1650,11 @@ PencilTestPopup::PencilTestPopup()
   m_captureButton          = new QPushButton(tr("Capture\n[Return key]"), this);
   QPushButton* closeButton = new QPushButton(tr("Close"), this);
 
+#if defined(WIN32) || defined(MACOSX)
   QPushButton* captureOptionsButton = new QPushButton(this);
+#else
+  QPushButton* captureOptionsButton = nullptr;
+#endif
 #ifdef WIN32
   m_captureFilterSettingsBtn = captureOptionsButton;
 #else
@@ -1735,12 +1739,14 @@ PencilTestPopup::PencilTestPopup()
   QCommonStyle style;
   m_captureButton->setIcon(style.standardIcon(QStyle::SP_DialogOkButton));
   m_captureButton->setIconSize(QSize(30, 30));
-  captureOptionsButton->setObjectName("GearButton");
-  captureOptionsButton->setFixedSize(24, 24);
-  captureOptionsButton->setIconSize(QSize(16, 16));
-  captureOptionsButton->setIcon(createQIcon("gear"));
-  captureOptionsButton->setToolTip(tr("Options"));
-  captureOptionsButton->setMenu(createOptionsMenu());
+  if (captureOptionsButton) {
+    captureOptionsButton->setObjectName("GearButton");
+    captureOptionsButton->setFixedSize(24, 24);
+    captureOptionsButton->setIconSize(QSize(16, 16));
+    captureOptionsButton->setIcon(createQIcon("gear"));
+    captureOptionsButton->setToolTip(tr("Options"));
+    captureOptionsButton->setMenu(createOptionsMenu());
+  }
 
   subfolderButton->setObjectName("SubfolderButton");
   subfolderButton->setIconSize(QSize(16, 16));
@@ -1788,8 +1794,10 @@ PencilTestPopup::PencilTestPopup()
       camLay->addWidget(new QLabel(tr("Resolution:"), this), 0);
       camLay->addWidget(m_resolutionCombo, 1);
 
-      camLay->addSpacing(10);
-      camLay->addWidget(captureOptionsButton);
+      if (captureOptionsButton) {
+        camLay->addSpacing(10);
+        camLay->addWidget(captureOptionsButton);
+      }
 
       camLay->addSpacing(10);
       camLay->addWidget(m_subcameraButton, 0);
@@ -2168,8 +2176,8 @@ PencilTestPopup::~PencilTestPopup() { m_cvWebcam.release(); }
 
 QMenu* PencilTestPopup::createOptionsMenu() {
   QMenu* menu = new QMenu();
-  bool ret    = true;
 #ifdef _WIN32
+  bool ret = true;
   auto* settingsAct = menu->addAction(tr("Video Capture Filter Settings..."));
   connect(settingsAct, &QAction::triggered, this,
           &PencilTestPopup::onCaptureFilterSettingsBtnPressed);
@@ -2186,7 +2194,7 @@ QMenu* PencilTestPopup::createOptionsMenu() {
           CamCapUseDirectShow = checked;
           m_timer->start(40);
         });
-#endif
+
   QAction* useMjpgAct = menu->addAction(tr("Use MJPG with Webcam"));
   useMjpgAct->setCheckable(true);
   useMjpgAct->setChecked(m_useMjpg);
@@ -2202,6 +2210,7 @@ QMenu* PencilTestPopup::createOptionsMenu() {
   });
 
   menu->addSeparator();
+#endif
 
   QAction* playSoundAct = menu->addAction(tr("Play Sound on Capture"));
   playSoundAct->setCheckable(true);


### PR DESCRIPTION
Implements:  https://github.com/opentoonz/opentoonz/discussions/6480

Adds an option for sound after a successful Camera Capture in the Camera Capture window.

Uses the existing camera_snap.wav sound supplied by the similar feature in Stopmotion Control.

Functional testing:

Open Camera Capture and confirm Play Sound on Capture appears and defaults off.
Enable option. Take a normal capture:  one shutter sound should occur after successful capture.
Enable the interval timer:  each successfully captured frame should produce one sound.
Disable the option: captures should be silent.
Cancel/fail an overwrite or other capture:  no success sound should be produced.
Close and reopen Camera Capture: the sound setting should persist.

Tested successfully in opentoonz-dev.
ChatGPT 5.6 used for research, testing and processing of code.