### PR TITLE
Fix Camera Capture interval and onion skin controls

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1714,14 +1714,12 @@ PencilTestPopup::PencilTestPopup()
   m_onionSkinGBox->setChecked(false);
   m_onionOpacityFld->setRange(1, 100);
   m_onionOpacityFld->setValue(50);
-  m_onionOpacityFld->setDisabled(true);
 
   m_timerGBox->setObjectName("CleanupSettingsFrame");
   m_timerGBox->setCheckable(true);
   m_timerGBox->setChecked(false);
   m_timerIntervalFld->setRange(0, 60);
   m_timerIntervalFld->setValue(10);
-  m_timerIntervalFld->setDisabled(true);
   // Make the interval timer single-shot. When the capture finished, restart
   // timer for next frame.
   // This is because capturing and saving the image needs some time.


### PR DESCRIPTION
Fixes the Camera Capture Interval Timer and Onion Skin opacity controls remaining disabled after their sections are enabled.

While researching and testing #7066 I discovered a regression introduced in #4250, when the separate checkboxes were replaced with checkable QGroupBox controls. The old explicit setDisabled(true) calls remained, preventing the group boxes from re-enabling their child fields.

This removes those two obsolete disables so the group boxes control their child fields as intended.