### PR TITLE
Fix fast strokes becoming angular

### DIFF
--- a/toonz/sources/include/tools/tool.h
+++ b/toonz/sources/include/tools/tool.h
@@ -9,6 +9,7 @@
 #include "toonz/imagepainter.h"
 #include "toonz/tapplication.h"
 #include "tools/cursors.h"
+#include "tools/tooltimer.h"
 
 // TnzCore includes
 #include "tcommon.h"
@@ -101,6 +102,8 @@ public:
   Qt::MouseButton m_button;
   QPointF m_mousePos;  // mouse position obtained with QMouseEvent::pos() or
                        // QTabletEvent::pos()
+  TTimerTicks m_time;  // Source event time mapped to TToolTimer ticks,
+                       // preserving tablet input timing when events are batched.
   bool m_isTablet;
   bool m_isHighFrequent;
 
@@ -110,6 +113,7 @@ public:
       , m_modifiersMask(NO_KEY)
       , m_buttons(Qt::NoButton)
       , m_button(Qt::NoButton)
+      , m_time(0)
       , m_isTablet(false)
       , m_isHighFrequent(false) {}
 
@@ -121,6 +125,7 @@ public:
   Qt::MouseButtons buttons() const { return m_buttons; }
   Qt::MouseButton button() const { return m_button; }
   QPointF mousePos() const { return m_mousePos; }
+  TTimerTicks time() const { return m_time; }
   bool isTablet() const { return m_isTablet; }
   bool isHighFrequent() const { return m_isHighFrequent; }
 

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -368,7 +368,7 @@ bool FullColorBrushTool::preLeftButtonDown() {
 void FullColorBrushTool::handleMouseEvent(MouseEventType type,
                                           const TPointD &pos,
                                           const TMouseEvent &e) {
-  TTimerTicks t = TToolTimer::ticks();
+  TTimerTicks t = e.time() > 0 ? e.time() : TToolTimer::ticks();
   bool alt      = e.getModifiersMask() & TMouseEvent::ALT_KEY;
   bool shift    = e.getModifiersMask() & TMouseEvent::SHIFT_KEY;
   bool control  = e.getModifiersMask() & TMouseEvent::CTRL_KEY;

--- a/toonz/sources/tnztools/modifiers/modifiertangents.cpp
+++ b/toonz/sources/tnztools/modifiers/modifiertangents.cpp
@@ -97,14 +97,18 @@ TModifierTangents::modifyTrack(
   int start = track.size() - track.pointsAdded;
   if (start < 0) start = 0;
   
-  // update tangents
+  // --- update tangents
   int tangentStart = start - 1;
   if (tangentStart < 0) tangentStart = 0;
   intr->tangents.resize(tangentStart);
   for(int i = tangentStart; i < track.size(); ++i)
     intr->tangents.push_back(calcTangent(track, i));
 
-  // update subTrack
+  // --- update subTrack
+  // Re-emit the preceding point because its newly calculated tangent also
+  // changes the segment leading into it.
+  if (start > 1) --start;
+  
   subTrack.truncate(start);
   for(int i = start; i < track.size(); ++i)
     subTrack.push_back(subTrack.pointFromOriginal(i), false);

--- a/toonz/sources/tnztools/mypainttoonzbrush.cpp
+++ b/toonz/sources/tnztools/mypainttoonzbrush.cpp
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <cmath>
 
 #include "mypainttoonzbrush.h"
 #include "tropcm.h"
@@ -9,6 +10,8 @@
 #include <QColor>
 
 namespace {
+constexpr double minMyPaintDtime = 0.001;  // Qt source time: ms.
+
 void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
                    bool lockAlpha) {
   if (!out.getPointer() || !in.getPointer()) return;
@@ -159,6 +162,10 @@ void MyPaintToonzBrush::strokeTo(const TPointD &position, double pressure,
     m_brush.setState(MYPAINT_BRUSH_STATE_ACTUAL_Y, m_current.y);
     return;
   }
+
+  // Reject ordering-only deltas.
+  if (!std::isfinite(dtime) || dtime < minMyPaintDtime)
+    dtime = minMyPaintDtime;
 
   if (m_interpolation) {
     next.time = m_current.time + dtime;

--- a/toonz/sources/tnztools/mypainttoonzbrush.cpp
+++ b/toonz/sources/tnztools/mypainttoonzbrush.cpp
@@ -1,6 +1,5 @@
 
 #include <algorithm>
-#include <cmath>
 
 #include "mypainttoonzbrush.h"
 #include "tropcm.h"
@@ -10,8 +9,6 @@
 #include <QColor>
 
 namespace {
-constexpr double minMyPaintDtime = 0.001;  // Qt source time: ms.
-
 void putOnRasterCM(const TRasterCM32P &out, const TRaster32P &in, int styleId,
                    bool lockAlpha) {
   if (!out.getPointer() || !in.getPointer()) return;
@@ -162,10 +159,6 @@ void MyPaintToonzBrush::strokeTo(const TPointD &position, double pressure,
     m_brush.setState(MYPAINT_BRUSH_STATE_ACTUAL_Y, m_current.y);
     return;
   }
-
-  // Reject ordering-only deltas.
-  if (!std::isfinite(dtime) || dtime < minMyPaintDtime)
-    dtime = minMyPaintDtime;
 
   if (m_interpolation) {
     next.time = m_current.time + dtime;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1113,7 +1113,7 @@ bool ToonzRasterBrushTool::preLeftButtonDown() {
 void ToonzRasterBrushTool::handleMouseEvent(MouseEventType type,
                                             const TPointD &pos,
                                             const TMouseEvent &e) {
-  TTimerTicks t    = TToolTimer::ticks();
+  TTimerTicks t    = e.time() > 0 ? e.time() : TToolTimer::ticks();
   bool alt         = e.getModifiersMask() & TMouseEvent::ALT_KEY;
   bool shift       = e.getModifiersMask() & TMouseEvent::SHIFT_KEY;
   bool control     = e.getModifiersMask() & TMouseEvent::CTRL_KEY;

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -180,12 +180,9 @@ class SceneViewer final : public TToolViewer, public Previewer::Listener {
   bool m_isStyleShortcutSwitchable;
 
   bool m_isBusyOnTabletMove;
-  qint64 m_tabletTimestampAnchor = -1;  // First source tablet timestamp in the
-                                        // current stroke
-  TTimerTicks m_tabletTickAnchor = 0;   // TToolTimer time corresponding to the
-                                        // source timestamp anchor.
-  TTimerTicks m_lastTabletTime = 0;     // Last mapped time, used to keep tablet
-                                        // event times increasing.
+  qint64 m_tabletTimestampAnchor = -1;  // Stroke source clock.
+  TTimerTicks m_tabletTickAnchor = 0;   // Mapped clock anchor.
+  TTimerTicks m_lastTabletTime   = 0;   // Last mapped time.
 
   QMatrix4x4 m_projectionMatrix;
 

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -180,6 +180,12 @@ class SceneViewer final : public TToolViewer, public Previewer::Listener {
   bool m_isStyleShortcutSwitchable;
 
   bool m_isBusyOnTabletMove;
+  qint64 m_tabletTimestampAnchor = -1;  // First source tablet timestamp in the
+                                        // current stroke
+  TTimerTicks m_tabletTickAnchor = 0;   // TToolTimer time corresponding to the
+                                        // source timestamp anchor.
+  TTimerTicks m_lastTabletTime = 0;     // Last mapped time, used to keep tablet
+                                        // event times increasing.
 
   QMatrix4x4 m_projectionMatrix;
 

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -78,8 +78,13 @@ void mapTabletTimestamp(TMouseEvent &event, qint64 sourceTimestamp,
                         qint64 &sourceAnchor, TTimerTicks &tickAnchor,
                         TTimerTicks &lastTime) {
   const TTimerTicks dispatchTime = event.m_time;
-  if (sourceTimestamp < 0) {
+  // QTabletEvent timestamps are unsigned ms counters. Zero means the tablet
+  // backend did not provide usable source timing. Use the local monotonic
+  // dispatch time for this event and clear the source anchor. The next valid
+  // tablet timestamp will establish a new tablet-to-application clock mapping.
+  if (sourceTimestamp <= 0) {
     sourceAnchor = -1;
+    event.m_time = dispatchTime;
     lastTime     = dispatchTime;
     return;
   }
@@ -98,7 +103,18 @@ void mapTabletTimestamp(TMouseEvent &event, qint64 sourceTimestamp,
     tickAnchor -= mapped - dispatchTime;
     mapped = dispatchTime;
   }
-  if (mapped < lastTime) mapped = lastTime;
+  if (mapped <= lastTime) {
+    // Tablet timestamps have millisecond resolution, so consecutive samples
+    // may map to the same time. Event delivery can also make source time
+    // fall behind the last accepted sample. Brush times must remain strictly
+    // increasing, prefer the dispatch time when it has advanced, otherwise
+    // move ahead one nanosecond. Apply the same correction to the anchor so
+    // following samples continue from the adjusted timeline.
+    const TTimerTicks fallback =
+        dispatchTime > lastTime ? dispatchTime : lastTime + 1;
+    tickAnchor += fallback - mapped;
+    mapped = fallback;
+  }
 
   event.m_time = mapped;
   lastTime     = mapped;

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -77,17 +77,29 @@ namespace {
 void mapTabletTimestamp(TMouseEvent &event, qint64 sourceTimestamp,
                         qint64 &sourceAnchor, TTimerTicks &tickAnchor,
                         TTimerTicks &lastTime) {
-  if (sourceTimestamp < 0) return;
+  const TTimerTicks dispatchTime = event.m_time;
+  if (sourceTimestamp < 0) {
+    sourceAnchor = -1;
+    lastTime     = dispatchTime;
+    return;
+  }
 
   if (sourceAnchor < 0 || sourceTimestamp < sourceAnchor ||
       sourceTimestamp - sourceAnchor > 60000) {
     sourceAnchor = sourceTimestamp;
-    tickAnchor   = event.m_time;
+    tickAnchor   = dispatchTime;
   }
 
   TTimerTicks mapped =
       tickAnchor + (sourceTimestamp - sourceAnchor) * 1000000;
-  if (mapped <= lastTime) mapped = lastTime + 1;
+
+  // Source time: spacing only, never future.
+  if (mapped > dispatchTime) {
+    tickAnchor -= mapped - dispatchTime;
+    mapped = dispatchTime;
+  }
+  if (mapped < lastTime) mapped = lastTime;
+
   event.m_time = mapped;
   lastTime     = mapped;
 }

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -74,12 +74,33 @@ extern QString updateToolEnableStatus(TTool *tool);
 namespace {
 //-----------------------------------------------------------------------------
 
+void mapTabletTimestamp(TMouseEvent &event, qint64 sourceTimestamp,
+                        qint64 &sourceAnchor, TTimerTicks &tickAnchor,
+                        TTimerTicks &lastTime) {
+  if (sourceTimestamp < 0) return;
+
+  if (sourceAnchor < 0 || sourceTimestamp < sourceAnchor ||
+      sourceTimestamp - sourceAnchor > 60000) {
+    sourceAnchor = sourceTimestamp;
+    tickAnchor   = event.m_time;
+  }
+
+  TTimerTicks mapped =
+      tickAnchor + (sourceTimestamp - sourceAnchor) * 1000000;
+  if (mapped <= lastTime) mapped = lastTime + 1;
+  event.m_time = mapped;
+  lastTime     = mapped;
+}
+
+//-----------------------------------------------------------------------------
+
 void initToonzEvent(TMouseEvent &toonzEvent, QMouseEvent *event,
                     int widgetHeight, double pressure, int devPixRatio) {
   toonzEvent.m_pos      = TPointD(event->pos().x() * devPixRatio,
                                   widgetHeight - 1 - event->pos().y() * devPixRatio);
   toonzEvent.m_mousePos = event->pos();
   toonzEvent.m_pressure = 1.0;
+  toonzEvent.m_time     = TToolTimer::ticks();
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
@@ -100,6 +121,7 @@ void initToonzEvent(TMouseEvent &toonzEvent, QTabletEvent *event,
       (float)widgetHeight - 1.0f - event->posF().y() * (float)devPixRatio);
   toonzEvent.m_mousePos = event->posF();
   toonzEvent.m_pressure = pressure;
+  toonzEvent.m_time     = TToolTimer::ticks();
 
   toonzEvent.setModifiers(event->modifiers() & Qt::ShiftModifier,
                           event->modifiers() & Qt::AltModifier,
@@ -280,6 +302,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
   }
   switch (e->type()) {
   case QEvent::TabletPress: {
+    m_tabletTimestampAnchor = -1;
+    m_lastTabletTime        = 0;
 #ifdef MACOSX
     // In OSX tablet action may cause only tabletEvent, not followed by
     // mousePressEvent.
@@ -287,6 +311,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
     if (e->button() == Qt::LeftButton) m_tabletState = Touched;
     TMouseEvent mouseEvent;
     initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+    mapTabletTimestamp(mouseEvent, e->timestamp(), m_tabletTimestampAnchor,
+                       m_tabletTickAnchor, m_lastTabletTime);
     onPress(mouseEvent);
 
     // create context menu on right click here
@@ -308,6 +334,10 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       if (m_tabletState == Released || m_tabletState == None) {
         TMouseEvent mouseEvent;
         initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+        // Preserve the tablet event's source time so batched events retain their
+        // original timing.
+        mapTabletTimestamp(mouseEvent, e->timestamp(), m_tabletTimestampAnchor,
+                           m_tabletTickAnchor, m_lastTabletTime);
         m_tabletState = Touched;
         onPress(mouseEvent);
       } else if (m_tabletState == Touched) {
@@ -334,6 +364,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
 
     TMouseEvent mouseEvent;
     initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+    mapTabletTimestamp(mouseEvent, e->timestamp(), m_tabletTimestampAnchor,
+                       m_tabletTickAnchor, m_lastTabletTime);
     onRelease(mouseEvent);
 
     if (TApp::instance()->getCurrentTool()->isToolBusy())
@@ -343,6 +375,8 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       m_tabletState = Released;
       TMouseEvent mouseEvent;
       initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
+      mapTabletTimestamp(mouseEvent, e->timestamp(), m_tabletTimestampAnchor,
+                         m_tabletTickAnchor, m_lastTabletTime);
       onRelease(mouseEvent);
     } else
       m_tabletEvent = false;
@@ -390,6 +424,9 @@ void SceneViewer::tabletEvent(QTabletEvent *e) {
       initToonzEvent(mouseEvent, e, height(), m_pressure, getDevPixRatio());
       QTimer::singleShot(20, this, SLOT(releaseBusyOnTabletMove()));
 #endif
+
+      mapTabletTimestamp(mouseEvent, e->timestamp(), m_tabletTimestampAnchor,
+                         m_tabletTickAnchor, m_lastTabletTime);
 
       // cancel stroke to prevent drawing while floating
       // 23/1/2018 There is a case that the pressure becomes zero at the start


### PR DESCRIPTION
A longstanding issue has been fast drawn curves like arcs, circles etc. become angular, circles can end up looking hexagonal. Not everyone experiences this and it hasn't been established why yet.

This should fix the issue in some part by resolving two areas:
- Tangent recalculation now invalidates and regenerates the preceding segment instead of retaining geometry generated with a provisional endpoint tanget: This fixes the issue with basic brushes (non-MyPaint)
- Tablet source timestamps are now preserved and mapped to `TToolTimer` (prevent coalesced event dispatch timing from producing random artificial velocity spikes found during profiling: Fixes the issue for MyPaint brushes. This seem to have been removed during inclusion of Assistants tool.

Anyone who experienced the issue, please give it a test. It may still produce issues on WinInk, my test target was WinTab devices (Wacom) first.

**Example of the issue (left):**

<img width="1008" height="603" alt="image" src="https://github.com/user-attachments/assets/4d057d0d-18a8-4469-926c-ef0d676b72af" />