### PR TITLE
Fix: Recognize Tahoma2D project files

### DIFF
--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -38,6 +38,7 @@ using namespace std;
 const std::wstring prjSuffix[4] = {L"_otprj", L"_prj63ml", L"_prj6", L"_prj"};
 const std::wstring xmlExt       = L".xml";
 const int prjSuffixCount        = 4;
+const std::wstring tahomaProjectFileName = L"tahomaproject.xml";
 
 //===================================================================
 /*! Default inputs folder: is used to save all scanned immage.*/
@@ -137,6 +138,13 @@ TFilePath getProjectFile(const TFilePath &fp) {
     if (prjfiles.size()) return fp + TFilePath(prjfiles[0]);
   }
 
+  // Tahoma2D stores otherwise-compatible project metadata in a fixed
+  // tahomaproject.xml file. Keep OpenToonz project files as the preferred
+  // discovery result when both formats are present, but accept a Tahoma2D
+  // project in place when it is the available project descriptor.
+  TFilePath tahomaProjectPath = fp + tahomaProjectFileName;
+  if (TFileStatus(tahomaProjectPath).doesExist()) return tahomaProjectPath;
+
   return TFilePath();
 }
 
@@ -214,7 +222,6 @@ void hideOlderProjectFiles(const TFilePath &folderPath) {
 //
 // TProject
 //
-
 //-------------------------------------------------------------------
 
 /*! \class TProject tproject.h
@@ -710,6 +717,7 @@ void TProject::load(const TFilePath &projectPath) {
 bool TProject::isAProjectPath(const TFilePath &fp) {
   if (fp.isAbsolute() && fp.getType() == "xml") {
     const std::wstring &fpName = fp.getWideName();
+    if (fpName == L"tahomaproject") return true;
     for (int i = 0; i < prjSuffixCount; ++i)
       if (fpName.find(prjSuffix[i]) != std::wstring::npos) return true;
   }


### PR DESCRIPTION
### Problem
This is designated a fix but addresses an external problem introduced in Tahoma2D.
OpenToonz scenes stored in a Tahoma2D project can fail to open even when the .tnz scene itself is otherwise compatible or even the same files.  This unnecessaryly creates incompatibility with the Opentoonz .tnz file extension and confusion on the part of users.

Background
Tahoma2D uses the fixed project descriptor name tahomaproject.xml, while OpenToonz currently recognizes only its historical *_otprj.xml, *_prj63ml.xml, *_prj6.xml, and *_prj.xml naming conventions.

This fixed proejct descriptor change introduced an incompatiblity requiring users to manually rename the tahomaproject.xml with the proper suffix before otherwise compatible projects can be opened in OpenToonz.

### Changes
`getProjectFile()` now explicitly recognizes tahomaproject.xml when no standard OpenToonz project descriptor is found.
`TProject::isAProjectPath() ` accepts the exact tahomaproject.xml filename so the discovered project is allowed through the normal loading path.

Existing OpenToonz project naming and discovery remain unchanged.

This PR is intentionally limited to project discovery compatibility. Specific .tnz scene additions (in Tahoma2D or otherwise) are separate from this fix.

A forward looking consideration might be for programs to maintain Opentoonz compatibility by  generating both the unique file and the original form recognized by Opentoonz.  This duplicate intially might be trivial as the files are currently the same except for the filename.  Should the files diverge in content in the future, maintaining both files could supply program specific data not recognized by other programs and be used to assist with targeted conversion.

Note:  There will always be outliers concerning compatibility needing to be addressed and once identified those can also be addressed.  Recommend reviewing those incompatiblities at their source before changing any code.  If unable to resolve the problem at the source other remedies can be explored. 

(Only change from from original PR is squashed commits)