### PR TITLE
Add Animate Tool arrow key nudging

### DIFF
--- a/toonz/sources/tnztools/edittool.cpp
+++ b/toonz/sources/tnztools/edittool.cpp
@@ -1000,6 +1000,48 @@ void EditTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 }
 
 //-----------------------------------------------------------------------------
+
+bool EditTool::keyDown(QKeyEvent *event) {
+  if (!event || !doesApply() || m_dragTool || getSpline() ||
+      (m_activeAxis.getValue() != L"Position" &&
+       m_activeAxis.getValue() != L"All"))
+    return false;
+
+  TPointD delta;
+  switch (event->key()) {
+  case Qt::Key_Up:
+    delta.y = 1.0;
+    break;
+  case Qt::Key_Down:
+    delta.y = -1.0;
+    break;
+  case Qt::Key_Left:
+    delta.x = -1.0;
+    break;
+  case Qt::Key_Right:
+    delta.x = 1.0;
+    break;
+  default:
+    return false;
+  }
+
+  if (event->modifiers() & Qt::ShiftModifier) delta *= 10.0;
+
+  TMouseEvent mouseEvent;
+  DragPositionTool dragTool(m_lockPositionX.getValue(),
+                            m_lockPositionY.getValue(),
+                            m_globalKeyframes.getValue());
+  TUndoManager::manager()->beginBlock();
+  dragTool.leftButtonDown(TPointD(), mouseEvent);
+  dragTool.leftButtonDrag(delta, mouseEvent);
+  dragTool.leftButtonUp();
+  TUndoManager::manager()->endBlock();
+  TTool::getApplication()->getCurrentObject()->notifyObjectIdChanged(false);
+  invalidate();
+  return true;
+}
+
+//-----------------------------------------------------------------------------
 namespace {
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/tnztools/edittool.h
+++ b/toonz/sources/tnztools/edittool.h
@@ -111,6 +111,7 @@ public:
   void leftButtonDown(const TPointD& pos, const TMouseEvent&) override;
   void leftButtonDrag(const TPointD& pos, const TMouseEvent&) override;
   void leftButtonUp(const TPointD& pos, const TMouseEvent&) override;
+  bool keyDown(QKeyEvent* event) override;
 
   void mouseMove(const TPointD&, const TMouseEvent& e) override;
 


### PR DESCRIPTION
## Summary
- Move the selected Animate Tool object one logical pixel with each arrow key
- Use Shift + arrow for a ten-pixel nudge
- Reuse existing position locks, keyframe creation, undo handling, and object refresh behavior

## Credits
Originally implemented by @doangelshavewings in closed PR https://github.com/opentoonz/opentoonz/pull/7034 (Discussion #6550).

This re-opens the focused change as a standalone PR for review.

## Testing
- Compiled `edittool.cpp` (as noted in the original PR)
- Change is small and reuses the existing `DragPositionTool` path