### PR TITLE
fix(tzl): reject invalid frame buffer sizes in legacy .tlv loaders

### DIFF
--- a/toonz/sources/image/tzl/tiio_tzl.cpp
+++ b/toonz/sources/image/tzl/tiio_tzl.cpp
@@ -1638,14 +1638,16 @@ m_lrp->m_frameIndex = m_frameIndex;*/
     reverse((char *)&ydpi, sizeof(double));
 #endif
 
+    delete[] imgBuff;
+    imgBuff = 0;
+
     imgBuffSize = m_lx * m_ly * sizeof(TPixelCM32);
     assert(actualBuffSize <= imgBuffSize);
+    if (actualBuffSize <= 0 || actualBuffSize > imgBuffSize)
+      throw TException("Loading tlv: buffer size error");
 
-    delete[] imgBuff;
     imgBuff = new UCHAR[imgBuffSize];
-    // int ret =
     fread(imgBuff, actualBuffSize, 1, chan);
-    // assert(ret==1);
   }
 
   Header *header = (Header *)imgBuff;
@@ -1762,11 +1764,11 @@ m_lrp->m_frameIndex = m_frameIndex;*/
 
   imgBuffSize = m_lx * m_ly * sizeof(TPixelCM32);
   assert(actualBuffSize <= imgBuffSize);
+  if (actualBuffSize <= 0 || actualBuffSize > imgBuffSize)
+    throw TException("Loading tlv: buffer size error");
 
   imgBuff = new UCHAR[imgBuffSize];
-  // int ret =
   fread(imgBuff, actualBuffSize, 1, chan);
-  // assert(ret==1);
 
   Header *header = (Header *)imgBuff;
 
@@ -1796,8 +1798,6 @@ m_lrp->m_frameIndex = m_frameIndex;*/
     }
     ras->unlock();
   }
-
-// codec.compress(ras, 1, &imgBuff, actualBuffSize);
 #endif
 
   TRect savebox(TPoint(sbx0, sby0), TDimension(sblx, sbly));
@@ -1815,18 +1815,9 @@ m_lrp->m_frameIndex = m_frameIndex;*/
 
   delete[] imgBuff;
 
-  // codec.decompress(m_compressedBuffer, m_compressedBufferSize, ras);
-
-  // assert(0);
-  // TToonzImageP ti; //  = new
-  // TToonzImage(m_lx,m_ly,savebox,imgBuff,actualBuffSize);
   TToonzImageP ti(ras, savebox);
-  // if(dpiflag)
   ti->setDpi(xdpi, ydpi);
-  // m_lrp->m_level->setFrame(TFrameId(m_frameIndex+1), ti);
   ti->setPalette(m_lrp->m_level->getPalette());
-  // delete [] imgBuff;
-  // imgBuff = 0;
   return ti;
 
   // ToonzImageUtils::updateRas32(ti);
@@ -1882,7 +1873,9 @@ TImageP TImageReaderTzl::load13() {
     fread(&actualBuffSize, sizeof(TINT32), 1, chan);
 
     imgBuffSize = (iconLx * iconLy * sizeof(TPixelCM32));
-    imgBuff     = new UCHAR[imgBuffSize];
+    if (actualBuffSize <= 0 || actualBuffSize > imgBuffSize)
+      throw TException("Loading tlv: icon buffer size error.");
+    imgBuff = new UCHAR[imgBuffSize];
     fread(imgBuff, actualBuffSize, 1, chan);
 
 #if !TNZ_LITTLE_ENDIAN
@@ -1956,17 +1949,14 @@ TImageP TImageReaderTzl::load13() {
     return ti;
   }
 
+  if (actualBuffSize <= 0 ||
+      actualBuffSize > (int)(m_lx * m_ly * sizeof(TPixelCM32)))
+    throw TException("Loading tlv: buffer size error");
+
   TRasterCM32P raux = TRasterCM32P(m_lx, m_ly);
   raux->lock();
-  imgBuff = (UCHAR *)raux->getRawData();  // new UCHAR[imgBuffSize];
-  // imgBuff = new UCHAR[imgBuffSize];
-  // imgBuffSize = m_lx*m_ly*sizeof(TPixelCM32);
-  // assert(actualBuffSize <= imgBuffSize);
-
-  // imgBuff = new UCHAR[imgBuffSize];
-  // int ret =
+  imgBuff = (UCHAR *)raux->getRawData();
   fread(imgBuff, actualBuffSize, 1, chan);
-  // assert(ret==1);
 
   Header *header = (Header *)imgBuff;
 
@@ -2467,9 +2457,14 @@ const TImageInfo *TImageReaderTzl::getImageInfo10() const {
     reverse((char *)&ydpi, sizeof(double));
 #endif
 
+    delete[] imgBuff;
+    imgBuff = 0;
+
     imgBuffSize = m_lx * m_ly * sizeof(TPixelCM32);
     assert(actualBuffSize <= imgBuffSize);
-    delete[] imgBuff;
+    if (actualBuffSize <= 0 || actualBuffSize > imgBuffSize)
+      throw TException("Loading tlv: buffer size error");
+
     imgBuff = new UCHAR[imgBuffSize];
     fread(imgBuff, actualBuffSize, 1, chan);
   }


### PR DESCRIPTION
> This change was created by Claude Sonnet 5 and requires proper code review by a maintainer before merging.

**Problem**
- Old `.tlv` level files (format versions 10, 11, 13) store a "how many bytes is this frame" number in the file itself.
- The loader trusts that number completely and copies that many bytes into a fixed-size buffer, with no real check — only a debug assert that does nothing in a normal build.
- If that number is wrong (corrupt file, truncated/failed save, etc.), the copy overflows the buffer and crashes the app.
- This is what's happening in #7070: a failed save leaves a broken `.tlv` behind, and the next save attempt reads that broken file and crashes.
- The current file format (version 14) was already fixed for this exact issue at some point — the older formats were just never updated to match.

**Solution**
- Added the same size check the current format already uses to the four places still missing it: `load10()`, `load11()`, `load13()`, `getImageInfo10()`.
- If the file's stated size doesn't make sense, it's now rejected with a normal, catchable error instead of overflowing memory.
- Tested with a deliberately broken `.tlv` file: old code crashes (confirmed segfault), new code fails cleanly with an error message.
- Tested with a normal, correctly-sized file to make sure valid levels still load exactly as before.