### PR TITLE
Check clang-format on changed PR source files

### DIFF
--- a/.github/workflows/workflow_clang_format.yml
+++ b/.github/workflows/workflow_clang_format.yml
@@ -1,0 +1,63 @@
+name: clang-format Check
+
+on:
+  pull_request:
+    paths:
+      - "toonz/sources/**/*.c"
+      - "toonz/sources/**/*.cc"
+      - "toonz/sources/**/*.cpp"
+      - "toonz/sources/**/*.cxx"
+      - "toonz/sources/**/*.h"
+      - "toonz/sources/**/*.hh"
+      - "toonz/sources/**/*.hpp"
+      - "toonz/sources/**/*.hxx"
+      - "toonz/sources/.clang-format"
+      - ".github/workflows/workflow_clang_format.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-14
+
+      - name: Check formatting of changed C/C++ files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          files=()
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              toonz/sources/*.c|toonz/sources/*.cc|toonz/sources/*.cpp|toonz/sources/*.cxx|\
+              toonz/sources/*.h|toonz/sources/*.hh|toonz/sources/*.hpp|toonz/sources/*.hxx)
+                files+=("$file")
+                ;;
+            esac
+          done < <(
+            git diff --name-only --diff-filter=ACMR -z \
+              "$BASE_SHA" "$HEAD_SHA"
+          )
+
+          if (( ${#files[@]} == 0 )); then
+            echo "No changed C/C++ files to check."
+            exit 0
+          fi
+
+          printf 'Checking %s\n' "${files[@]}"
+          clang-format-14 --dry-run --Werror -style=file "${files[@]}"


### PR DESCRIPTION
# Check clang-format only on changed PR source files

This PR adds a clang-format CI check for C/C++ files changed by a pull request.

OpenToonz already defines its formatting policy in `toonz/sources/.clang-format`, based on Google style with project specific override.  Its existing beautification scripts operate on files changed relative to the base branch. This PR keeps that structure intact and brings the CI behavior into line with it.

Workflow:

* runs only when relevant C/C++ source files, `.clang-format`, or the workflow itself changes;
* checks only files changed by the pull request;
* ignores deleted files;
* uses the existing `toonz/sources/.clang-format` through clang-format's normal `-style=file` lookup;
* verifies formatting with `--dry-run --Werror` rather than modifying contributor branches;
* grants only `contents: read` permission.

The intent is to enforce the current formatting standard on code being introduced or modified without requiring unrelated legacy source files to be reformatted or causing pull requests to fail because of formatting outside their scope.

This supersedes the implementation approach explored in #5615 while preserving the underlying concern raised there: linting and formatting checks should remain aligned with the actual scope of a pull request.  There is the question remaining however about how best to lint legacy code.
