### PR TITLE
Harden undo history for rapid draw undo workflows

### DIFF
--- a/toonz/sources/common/tcore/tundo.cpp
+++ b/toonz/sources/common/tcore/tundo.cpp
@@ -111,17 +111,20 @@ struct TUndoManager::TUndoManagerImp {
   UndoList m_undoList;
   UndoListIterator m_current;
   bool m_skipped;
+  bool m_inUndoRedo;
   int m_undoMemorySize;  // in bytes
 
   std::vector<TUndoBlock *> m_blockStack;
 
 public:
-  TUndoManagerImp() : m_skipped(false), m_undoMemorySize(0) {
+  TUndoManagerImp()
+      : m_skipped(false), m_inUndoRedo(false), m_undoMemorySize(0) {
     m_current = m_undoList.end();
   }
   ~TUndoManagerImp() {}
 
   void add(TUndo *undo);
+  void discardRedoHistory();
 
 public:
   static struct ManagerPtr {
@@ -179,11 +182,26 @@ void TUndoManager::TUndoManagerImp::add(TUndo *undo) {
 
 //-----------------------------------------------------------------------------
 
+void TUndoManager::TUndoManagerImp::discardRedoHistory() {
+  if (m_current == m_undoList.end()) return;
+
+  // Move the abandoned redo branch out of the live history before deleting it.
+  // Destructors for individual undo items may release sizeable drawing data or
+  // trigger other cleanup. Keeping the manager's iterator state consistent
+  // first makes rapid "draw -> undo -> draw" workflows less vulnerable to
+  // re-entrant observers seeing a half-pruned history list.
+  UndoList discarded;
+  discarded.insert(discarded.end(), m_current, m_undoList.end());
+  m_undoList.erase(m_current, m_undoList.end());
+  m_current = m_undoList.end();
+
+  std::for_each(discarded.begin(), discarded.end(), deleteUndo);
+}
+
+//-----------------------------------------------------------------------------
+
 void TUndoManager::TUndoManagerImp::doAdd(TUndo *undo) {
-  if (m_current != m_undoList.end()) {
-    std::for_each(m_current, m_undoList.end(), deleteUndo);
-    m_undoList.erase(m_current, m_undoList.end());
-  }
+  discardRedoHistory();
 
   int i, memorySize = 0, count = m_undoList.size();
   for (i = 0; i < count; i++) memorySize += m_undoList[i]->getSize();
@@ -207,10 +225,7 @@ void TUndoManager::TUndoManagerImp::doAdd(TUndo *undo) {
 //-----------------------------------------------------------------------------
 
 void TUndoManager::beginBlock() {
-  if (m_imp->m_current != m_imp->m_undoList.end()) {
-    std::for_each(m_imp->m_current, m_imp->m_undoList.end(), deleteUndo);
-    m_imp->m_undoList.erase(m_imp->m_current, m_imp->m_undoList.end());
-  }
+  m_imp->discardRedoHistory();
 
   TUndoBlock *undoBlock = new TUndoBlock;
   m_imp->m_blockStack.push_back(undoBlock);
@@ -238,38 +253,48 @@ void TUndoManager::endBlock() {
 
 bool TUndoManager::undo() {
   assert(m_imp->m_blockStack.empty());
-  UndoListIterator &it = m_imp->m_current;
-  if (it != m_imp->m_undoList.begin()) {
+  if (m_imp->m_inUndoRedo) return false;
+
+  m_imp->m_inUndoRedo = true;
+  bool changed        = false;
+
+  while (m_imp->m_current != m_imp->m_undoList.begin()) {
     m_imp->m_skipped = false;
-    --it;
-    (*it)->undo();
+    --m_imp->m_current;
+    (*m_imp->m_current)->undo();
+    changed = true;
     emit historyChanged();
-    if (m_imp->m_skipped) {
-      m_imp->m_skipped = false;
-      return undo();
-    }
-    return true;
-  } else
-    return false;
+
+    if (!m_imp->m_skipped) break;
+  }
+
+  m_imp->m_skipped    = false;
+  m_imp->m_inUndoRedo = false;
+  return changed;
 }
 
 //-----------------------------------------------------------------------------
 
 bool TUndoManager::redo() {
   assert(m_imp->m_blockStack.empty());
-  UndoListIterator &it = m_imp->m_current;
-  if (it != m_imp->m_undoList.end()) {
+  if (m_imp->m_inUndoRedo) return false;
+
+  m_imp->m_inUndoRedo = true;
+  bool changed        = false;
+
+  while (m_imp->m_current != m_imp->m_undoList.end()) {
     m_imp->m_skipped = false;
-    (*it)->redo();
-    ++it;
+    (*m_imp->m_current)->redo();
+    ++m_imp->m_current;
+    changed = true;
     emit historyChanged();
-    if (m_imp->m_skipped) {
-      m_imp->m_skipped = false;
-      return redo();
-    }
-    return true;
-  } else
-    return false;
+
+    if (!m_imp->m_skipped) break;
+  }
+
+  m_imp->m_skipped    = false;
+  m_imp->m_inUndoRedo = false;
+  return changed;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
With apologies for the wall of text!

## PURPOSE

Harden the shared Undo manager for rapid exploratory workflows:

`draw → Undo → draw replacement → Undo → draw replacement`

This is common drawing practice. Undo is used not only to repair mistakes, but to test one stroke, reject it, and immediately try another.

Related to [OpenToonz #6947](https://github.com/opentoonz/opentoonz/issues/6947).

## CHANGE

- Centralize removal of the abandoned Redo branch.
- Remove abandoned entries from live history before running their destructors.
- Restore the history iterator to a stable state before cleanup.
- Replace recursive `skip()` processing with iteration.
- Reject nested Undo/Redo calls while an Undo or Redo command is already executing.

The change is limited to `toonz/sources/common/tcore/tundo.cpp`.

## REASON

After Undo, adding a new action invalidates every later Redo entry. Previously, those objects were destroyed while they were still associated with the live history container and its current iterator.

That is normally harmless when an Undo object has passive cleanup. Drawing Undo objects may own substantial image, stroke, frame, cache, or level state. Their destruction may also trigger cleanup or observers. Removing the abandoned branch first gives those destructors a stable manager state.

Recursive `skip()` handling also caused one manager invocation to call another. Iteration preserves the intended sequence without accumulating nested Undo/Redo calls.

## REPORTS

The following reports identify workflows worth testing. A link here means **potentially related**, not **fixed by this PR**. Several reports were operation-specific and have already received separate fixes.

### Direct drawing and Undo reports

| Report | Observed pattern | Status / distinction |
| --- | --- | --- |
| [OpenToonz #6947](https://github.com/opentoonz/opentoonz/issues/6947) | Continuous drawing and repeated Undo followed by an access-violation crash. | Primary report. The supplied trace does not reliably identify `TUndoManager` as the crash site. |
| [OpenToonz #3613](https://github.com/opentoonz/opentoonz/issues/3613) | Rapid drawing and Undo while creating or replacing drawings caused reproducible crashes. | Fixed separately by [PR #3783](https://github.com/opentoonz/opentoonz/pull/3783); the identified cause was image-cache remapping. Retained as a regression pattern. |
| [OpenToonz #3618](https://github.com/opentoonz/opentoonz/issues/3618) | Random closure while drawing and pressing Ctrl+Z repeatedly. | Closed as likely resolved; insufficient reproduction information. |
| [OpenToonz #4940](https://github.com/opentoonz/opentoonz/issues/4940) | Repeated Undo during frame-by-frame drawing reportedly produced missing/red exposures before a crash. | Closed after the immediate problem stopped occurring; no stable reproduction. |
| [Tahoma2D #808](https://github.com/tahoma2d/tahoma2d/issues/808) | Undo issued while a drawing operation was still active corrupted later Undo results. | Open. Shared architectural lineage, but this PR does not block Undo during a live stroke. |
| [Tahoma2D #1332](https://github.com/tahoma2d/tahoma2d/issues/1332) | Drawing, unexpected history order, Undo, autosave, and a crash occurred together. | Open. Autosave coordination is outside this PR. |
| [Tahoma2D #1313](https://github.com/tahoma2d/tahoma2d/issues/1313) | Paste a frame, draw, then Undo caused a crash with `TUndoManager::undo()` in the trace. | Open. The deeper failure appears tied to frame removal and renumbering. |

### History integrity reports

| Report | Observed pattern | Status / distinction |
| --- | --- | --- |
| [OpenToonz #4964](https://github.com/opentoonz/opentoonz/issues/4964) | After sustained Raster/MyPaint drawing, History stopped recording the newest strokes and Undo targeted older work. | Closed pending clearer reproduction. Autosave and mixed editing contexts were also implicated. |
| [OpenToonz #4907](https://github.com/opentoonz/opentoonz/issues/4907) | Undo/Redo affected older strokes, other frames, or unexpected drawing regions. | Closed after related fixes; retained as a history-integrity reference. |
| [OpenToonz #4910](https://github.com/opentoonz/opentoonz/issues/4910) | Pasting a Raster selection into a new drawing stopped that and later actions from entering History. | Fixed separately by [PR #4951](https://github.com/opentoonz/opentoonz/pull/4951), which restored a missing `endBlock()` call. |
| [OpenToonz #5536](https://github.com/opentoonz/opentoonz/issues/5536) | Repeated Raster selection pastes broke Undo ordering and occasionally preceded a crash. | Closed as likely covered by newer Undo fixes, including the #4910 path. |
| [OpenToonz #6876](https://github.com/opentoonz/opentoonz/issues/6876) | Ctrl+Z removed frames instead of strokes and could crash after restarting a Raster-based project. | Reported resolved by the OpenToonz 1.8 release candidate. |

### Historical operation-specific reports

| Report | Observed pattern | Status / distinction |
| --- | --- | --- |
| [OpenToonz #1758](https://github.com/opentoonz/opentoonz/issues/1758) | Undoing Vector Brush Frame Range work crashed or targeted an older action. | Closed historical report. |
| [OpenToonz #1821](https://github.com/opentoonz/opentoonz/issues/1821) | Undo—or merely opening History—after a Freehand Raster erase caused a crash. | Fixed specifically by [PR #1823](https://github.com/opentoonz/opentoonz/pull/1823). |
| [OpenToonz #2166](https://github.com/opentoonz/opentoonz/issues/2166) | Repeatedly alternating Undo and Redo after merging levels eventually crashed. | Fixed specifically by [PR #2183](https://github.com/opentoonz/opentoonz/pull/2183). |
| [OpenToonz #4352](https://github.com/opentoonz/opentoonz/issues/4352) | Undoing Vector-tool edits reached an assertion in `UndoModifyStrokeAndPaint`. | Closed as old and no longer reproducible. |
| [OpenToonz #5288](https://github.com/opentoonz/opentoonz/issues/5288) | Undo remained disabled after tablet drawing because the tool-busy state remained set. | Fixed through [PR #5302](https://github.com/opentoonz/opentoonz/pull/5302). This is relevant precedent for guarding Undo around active tools, but it is outside the manager change here. |

## CLAIM BOUNDARY

This PR hardens generic history bookkeeping. It does **not** claim to:

- Prove that `TUndoManager` caused the crash in #6947.
- Repair operation-specific Undo objects.
- Serialize Undo with autosave.
- Prevent Undo while a brush stroke or other tool operation is active.
- Resolve every linked report.

The linked reports establish recurring stress patterns for review and testing.

## TESTING

### Core cycle

- Draw a stroke.
- Undo it.
- Draw a replacement, invalidating the Redo branch.
- Repeat rapidly for several hundred cycles.
- Test Raster, Toonz Raster, and Vector levels.

### History

- Repeat with the History panel open and closed.
- Confirm the newest action remains the next Undo target.
- Confirm drawing after Undo removes the abandoned Redo branch.
- Begin an Undo block after Undo and confirm the Redo branch is discarded correctly.
- Exercise commands using `TUndoManager::skip()`.

### Stress and boundaries

- Test near the configured Undo memory limit.
- Test with autosave enabled and disabled.
- Create and replace drawings while onion skin is active.
- Paste Raster selections into new drawings, then draw, Undo, and draw again.
- Attempt Undo during an active stroke as a boundary test; unchanged corruption here would remain outside this PR’s claim.
- Confirm normal Undo, Redo, History, and multi-step behavior remain unchanged.

The OT-Dev source head passed CI and Translation Validation. Interactive stress testing remains required because automated builds do not exercise drawing/Undo timing.

## SCOPE

- One file.
- One shared subsystem.
- No public API change.
- No brush-rendering change.
- No stroke-generation change.
- No autosave or scene-saving change.

Developed and reviewed in [OpenAnimationLibrary/opentoonz-dev#95](https://github.com/OpenAnimationLibrary/opentoonz-dev/pull/95).

## AI ASSISTANCE

ChatGPT Work/Codex assisted investigation, implementation drafting, report comparison, and review. Human review, testing, and responsibility remain required.
