### PR TITLE
Update CI actions for Node 24 (Github deprecation of Node 20)

### DIFF
--- a/.github/workflows/workflow_clang_format.yml
+++ b/.github/workflows/workflow_clang_format.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -88,7 +88,7 @@ jobs:
 
       # Add msbuild to PATH for build process
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       # CMake configuration step
       - name: CMake configuration


### PR DESCRIPTION
Summary
Updates the remaining GitHub Actions that depend on Node.js 20.

- Updates actions/checkout from v4 to v6 in the clang-format workflow.
- Updates microsoft/setup-msbuild from v2 to v3 in the Windows workflow.
- Preserves existing workflow behavior while preparing for GitHub’s removal of Node.js 20 on September 23, 2026.

Checkout v6 also improves credential isolation by storing authentication data outside .git/config. No build or formatting requirements are changed.

Research, testing and validation via ChatGPT 5.6

REF:  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/?utm_source=chatgpt.com

clang-format (testing) note:  This change only edits YAML workflow files which are not processed by OpenToonz’s clang-format check. There are no C/C++ changes to format so the check should pass without reporting formatting differences. (Edit:  Passed easily and quickly)