### PR TITLE
Fix macOS Preferences window hierarchy

### DIFF
--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1682,9 +1682,6 @@ PreferencesPopup::PreferencesPopup()
   }
   setLayout(mainLayout);
 
-#ifdef MACOSX
-  setWindowFlags(Qt::Tool);
-#endif
 
   connect(categoryList, &QListWidget::currentRowChanged, stackedWidget,
           &QStackedWidget::setCurrentIndex);


### PR DESCRIPTION
## Summary

Removes the macOS only `Qt::Tool` override from Preferences. 
Preferences remains a `QDialog` parented to the OpenToonz main window, preserving the normal application window hierarchy.

Addresses the Preferences case reported in #1846 without changing shared dialog behavior.

ChatGPT 5.6 was used to research and proccess this fix.
