### PR TITLE
Add responsive level strip thumbnails option

### DIFF
--- a/toonz/sources/include/toonzqt/icongenerator.h
+++ b/toonz/sources/include/toonzqt/icongenerator.h
@@ -113,6 +113,8 @@ public:
                   bool onDemand = false);
   QPixmap getSizedIcon(TXshLevel *sl, const TFrameId &fid, std::string newId,
                        TDimension dim = TDimension(0, 0));
+  QPixmap getResponsiveIcon(TXshLevel *sl, const TFrameId &fid,
+                            const TDimension &dim);
   void invalidate(TXshLevel *sl, const TFrameId &fid,
                   bool onlyFilmStrip = false);
   void remove(TXshLevel *sl, const TFrameId &fid, bool onlyFilmStrip = false);

--- a/toonz/sources/include/toonzqt/icongenerator.h
+++ b/toonz/sources/include/toonzqt/icongenerator.h
@@ -101,7 +101,7 @@ public:
 
   TDimension getIconSize() const;
 
-  TOfflineGL *getOfflineGLContext();
+  TOfflineGL *getOfflineGLContext(const TDimension &minSize = TDimension());
 
   // icons from splines
   QPixmap getIcon(TStageObjectSpline *spline);

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -249,8 +249,8 @@ void FilmstripFrames::commitResponsiveRenderSize() {
     m_renderIconSize = m_prefIconSize;
     return;
   }
-  const QSize next = quantizeResponsiveRenderSize(m_iconSize, m_prefIconSize,
-                                                  m_isVertical);
+  const QSize next =
+      quantizeResponsiveRenderSize(m_iconSize, m_prefIconSize, m_isVertical);
   if (next == m_renderIconSize) return;
   m_renderIconSize = next;
   update();
@@ -266,12 +266,12 @@ void FilmstripFrames::updateIconLayout() {
     QWidget *vp = m_scrollArea->viewport();
     if (vp && m_prefIconSize.width() > 0 && m_prefIconSize.height() > 0) {
       if (m_isVertical) {
-        const int availW = vp->width() - fs_leftMargin - fs_rightMargin -
-                           fs_iconMarginLR * 2;
+        const int availW =
+            vp->width() - fs_leftMargin - fs_rightMargin - fs_iconMarginLR * 2;
         if (availW > 0) {
           const int w = availW;
-          const int h = std::max(
-              1, w * m_prefIconSize.height() / m_prefIconSize.width());
+          const int h =
+              std::max(1, w * m_prefIconSize.height() / m_prefIconSize.width());
           effective = QSize(w, h);
         }
       } else {
@@ -279,8 +279,8 @@ void FilmstripFrames::updateIconLayout() {
                            fs_iconMarginBottom;
         if (availH > 0) {
           const int h = availH;
-          const int w = std::max(
-              1, h * m_prefIconSize.width() / m_prefIconSize.height());
+          const int w =
+              std::max(1, h * m_prefIconSize.width() / m_prefIconSize.height());
           effective = QSize(w, h);
         }
       }
@@ -942,8 +942,7 @@ void FilmstripFrames::drawFrameIcon(QPainter &p, const QRect &r, int index,
         (m_renderIconSize.width() > m_prefIconSize.width() ||
          m_renderIconSize.height() > m_prefIconSize.height());
     if (needNativeSize) {
-      const TDimension dim(m_renderIconSize.width(),
-                           m_renderIconSize.height());
+      const TDimension dim(m_renderIconSize.width(), m_renderIconSize.height());
       pm = IconGenerator::instance()->getSizedIcon(
           xl, fid, responsiveIconCacheSuffix(m_renderIconSize), dim);
     }
@@ -1475,8 +1474,7 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   QAction *hideComboBox = panelMenu->addAction(tr("Show/Hide Drop Down Menu"));
   QAction *hideNavigator =
       panelMenu->addAction(tr("Show/Hide Level Navigator"));
-  QAction *responsiveThumbs =
-      panelMenu->addAction(tr("Responsive Thumbnails"));
+  QAction *responsiveThumbs = panelMenu->addAction(tr("Responsive Thumbnails"));
   hideComboBox->setCheckable(true);
   hideComboBox->setChecked(m_showComboBox);
   hideNavigator->setCheckable(true);
@@ -2175,8 +2173,8 @@ void Filmstrip::load(QSettings &settings) {
   }
   m_frames->setComboBox(m_showComboBox);
 
-  UINT responsive         = settings.value("responsiveThumbnails", 0).toUInt();
-  m_responsiveThumbnails  = responsive == 1;
+  UINT responsive        = settings.value("responsiveThumbnails", 0).toUInt();
+  m_responsiveThumbnails = responsive == 1;
   m_frames->setResponsiveThumbnails(m_responsiveThumbnails);
 }
 

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -49,6 +49,9 @@
 #include <QMainWindow>
 #include <QMimeData>
 #include <QDrag>
+#include <QTimer>
+#include <algorithm>
+#include <string>
 
 namespace {
 QString fidToFrameNumberWithLetter(int f) {
@@ -88,6 +91,30 @@ QString fidToFrameNumberWithLetter(int f) {
   }
   return str;
 }
+
+class StripViewportResizeFilter final : public QObject {
+  FilmstripFrames *m_frames;
+  bool m_busy = false;
+
+public:
+  StripViewportResizeFilter(FilmstripFrames *frames, QObject *viewport)
+      : QObject(viewport), m_frames(frames) {
+    viewport->installEventFilter(this);
+  }
+
+  bool eventFilter(QObject *watched, QEvent *event) override {
+    if (event->type() == QEvent::Resize && m_frames &&
+        m_frames->isResponsiveThumbnails() && !m_busy) {
+      m_busy = true;
+      m_frames->updateIconLayout();
+      m_busy = false;
+    }
+    return QObject::eventFilter(watched, event);
+  }
+};
+
+const int kResponsiveIconQuantStep    = 16;
+const int kResponsiveRenderDebounceMs = 120;
 }  // namespace
 
 //=============================================================================
@@ -101,7 +128,9 @@ FilmstripFrames::FilmstripFrames(QScrollArea *parent, Qt::WindowFlags flags)
     , m_frameHeadGadget(0)
     , m_inbetweenDialog(0)
     , m_pos(0, 0)
-    , m_iconSize(dimension2QSize(IconGenerator::instance()->getIconSize()))
+    , m_prefIconSize(dimension2QSize(IconGenerator::instance()->getIconSize()))
+    , m_iconSize(m_prefIconSize)
+    , m_renderIconSize(m_prefIconSize)
     , m_frameLabelWidth(11)
     , m_selectingRange(0, 0)
     , m_scrollSpeed(0)
@@ -115,12 +144,10 @@ FilmstripFrames::FilmstripFrames(QScrollArea *parent, Qt::WindowFlags flags)
   setFrameStyle(QFrame::StyledPanel);
 
   setFocusPolicy(Qt::StrongFocus);
+  applyCrossAxisDimension();
   if (m_isVertical) {
-    setFixedWidth(m_iconSize.width() + fs_leftMargin + fs_rightMargin +
-                  fs_iconMarginLR * 2);
     setFixedHeight(parentWidget()->height());
   } else {
-    setFixedHeight(parentWidget()->height());
     setFixedWidth(parentWidget()->width());
   }
 
@@ -133,6 +160,13 @@ FilmstripFrames::FilmstripFrames(QScrollArea *parent, Qt::WindowFlags flags)
   setMouseTracking(true);
 
   m_viewer = NULL;
+
+  m_responsiveRenderTimer = new QTimer(this);
+  m_responsiveRenderTimer->setSingleShot(true);
+  connect(m_responsiveRenderTimer, SIGNAL(timeout()), this,
+          SLOT(commitResponsiveRenderSize()));
+
+  new StripViewportResizeFilter(this, m_scrollArea->viewport());
 }
 
 //-----------------------------------------------------------------------------
@@ -147,6 +181,137 @@ FilmstripFrames::~FilmstripFrames() {
 TXshSimpleLevel *FilmstripFrames::getLevel() const {
   TXshLevel *xl = TApp::instance()->getCurrentLevel()->getLevel();
   return xl ? xl->getSimpleLevel() : 0;
+}
+
+//-----------------------------------------------------------------------------
+
+std::string FilmstripFrames::responsiveIconCacheSuffix(const QSize &size) {
+  return "_r_" + std::to_string(size.width()) + "x" +
+         std::to_string(size.height());
+}
+
+//-----------------------------------------------------------------------------
+
+QSize FilmstripFrames::quantizeResponsiveRenderSize(const QSize &layout,
+                                                    const QSize &pref,
+                                                    bool vertical) {
+  if (layout.width() <= 0 || layout.height() <= 0) return pref;
+  if (pref.width() <= 0 || pref.height() <= 0) return layout;
+
+  auto quantize = [](int v) {
+    if (v <= 0) return 1;
+    const int q =
+        ((v + kResponsiveIconQuantStep / 2) / kResponsiveIconQuantStep) *
+        kResponsiveIconQuantStep;
+    return std::max(kResponsiveIconQuantStep, q);
+  };
+
+  if (vertical) {
+    const int w = quantize(layout.width());
+    const int h = std::max(1, w * pref.height() / pref.width());
+    return QSize(w, h);
+  }
+  const int h = quantize(layout.height());
+  const int w = std::max(1, h * pref.width() / pref.height());
+  return QSize(w, h);
+}
+
+//-----------------------------------------------------------------------------
+
+void FilmstripFrames::applyCrossAxisDimension() {
+  if (!m_scrollArea) return;
+  QWidget *vp = m_scrollArea->viewport();
+  if (!vp) return;
+  if (m_responsiveThumbnails) {
+    if (m_isVertical)
+      setFixedWidth(std::max(1, vp->width()));
+    else
+      setFixedHeight(std::max(1, vp->height()));
+  } else if (m_isVertical) {
+    setFixedWidth(m_iconSize.width() + fs_leftMargin + fs_rightMargin +
+                  fs_iconMarginLR * 2);
+  } else {
+    setFixedHeight(getOneFrameHeight());
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void FilmstripFrames::scheduleResponsiveRenderCommit() {
+  if (!m_responsiveRenderTimer) return;
+  m_responsiveRenderTimer->start(kResponsiveRenderDebounceMs);
+}
+
+//-----------------------------------------------------------------------------
+
+void FilmstripFrames::commitResponsiveRenderSize() {
+  if (!m_responsiveThumbnails) {
+    m_renderIconSize = m_prefIconSize;
+    return;
+  }
+  const QSize next = quantizeResponsiveRenderSize(m_iconSize, m_prefIconSize,
+                                                  m_isVertical);
+  if (next == m_renderIconSize) return;
+  m_renderIconSize = next;
+  update();
+}
+
+//-----------------------------------------------------------------------------
+
+void FilmstripFrames::updateIconLayout() {
+  m_prefIconSize = dimension2QSize(IconGenerator::instance()->getIconSize());
+
+  QSize effective = m_prefIconSize;
+  if (m_responsiveThumbnails && m_scrollArea) {
+    QWidget *vp = m_scrollArea->viewport();
+    if (vp && m_prefIconSize.width() > 0 && m_prefIconSize.height() > 0) {
+      if (m_isVertical) {
+        const int availW = vp->width() - fs_leftMargin - fs_rightMargin -
+                           fs_iconMarginLR * 2;
+        if (availW > 0) {
+          const int w = availW;
+          const int h = std::max(
+              1, w * m_prefIconSize.height() / m_prefIconSize.width());
+          effective = QSize(w, h);
+        }
+      } else {
+        const int availH = vp->height() - fs_frameSpacing - fs_iconMarginTop -
+                           fs_iconMarginBottom;
+        if (availH > 0) {
+          const int h = availH;
+          const int w = std::max(
+              1, h * m_prefIconSize.width() / m_prefIconSize.height());
+          effective = QSize(w, h);
+        }
+      }
+    }
+  }
+
+  m_iconSize = effective;
+
+  applyCrossAxisDimension();
+  if (m_frameHeadGadget) m_frameHeadGadget->updateFrameMetrics();
+  if (m_isVertical)
+    updateContentHeight();
+  else
+    updateContentWidth();
+
+  if (m_responsiveThumbnails)
+    scheduleResponsiveRenderCommit();
+  else {
+    if (m_responsiveRenderTimer) m_responsiveRenderTimer->stop();
+    m_renderIconSize = m_prefIconSize;
+  }
+  update();
+}
+
+//-----------------------------------------------------------------------------
+
+void FilmstripFrames::setResponsiveThumbnails(bool responsive) {
+  if (m_responsiveThumbnails == responsive) return;
+  m_responsiveThumbnails = responsive;
+  updateIconLayout();
+  if (responsive) commitResponsiveRenderSize();
 }
 
 //-----------------------------------------------------------------------------
@@ -770,11 +935,30 @@ void FilmstripFrames::drawFrameIcon(QPainter &p, const QRect &r, int index,
                                     const TFrameId &fid, int flags) {
   QPixmap pm;
   TXshSimpleLevel *sl = getLevel();
-  if (sl) {
-    pm = IconGenerator::instance()->getIcon(sl, fid);
+  TXshLevel *xl       = TApp::instance()->getCurrentLevel()->getLevel();
+  if (sl && xl) {
+    const bool needNativeSize =
+        m_responsiveThumbnails &&
+        (m_renderIconSize.width() > m_prefIconSize.width() ||
+         m_renderIconSize.height() > m_prefIconSize.height());
+    if (needNativeSize) {
+      const TDimension dim(m_renderIconSize.width(),
+                           m_renderIconSize.height());
+      pm = IconGenerator::instance()->getSizedIcon(
+          xl, fid, responsiveIconCacheSuffix(m_renderIconSize), dim);
+    }
+    if (pm.isNull()) pm = IconGenerator::instance()->getIcon(xl, fid);
   }
   if (!pm.isNull()) {
-    p.drawPixmap(r.left(), r.top(), pm);
+    if (pm.size() == r.size()) {
+      p.drawPixmap(r.topLeft(), pm);
+    } else {
+      const QPixmap scaled =
+          pm.scaled(r.size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+      QRect dest(scaled.rect());
+      dest.moveCenter(r.center());
+      p.drawPixmap(dest.topLeft(), scaled);
+    }
 
     if (sl && sl->getType() == PLI_XSHLEVEL && flags & F_INBETWEEN_RANGE) {
       if (m_isVertical) {
@@ -1291,16 +1475,22 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
   QAction *hideComboBox = panelMenu->addAction(tr("Show/Hide Drop Down Menu"));
   QAction *hideNavigator =
       panelMenu->addAction(tr("Show/Hide Level Navigator"));
+  QAction *responsiveThumbs =
+      panelMenu->addAction(tr("Responsive Thumbnails"));
   hideComboBox->setCheckable(true);
   hideComboBox->setChecked(m_showComboBox);
   hideNavigator->setCheckable(true);
   hideNavigator->setChecked(m_showNavigator);
+  responsiveThumbs->setCheckable(true);
+  responsiveThumbs->setChecked(m_responsiveThumbnails);
   connect(toggleOrientation, SIGNAL(triggered(bool)), this,
           SLOT(orientationToggled(bool)));
   connect(hideComboBox, SIGNAL(triggered(bool)), this,
           SLOT(comboBoxToggled(bool)));
   connect(hideNavigator, SIGNAL(triggered(bool)), this,
           SLOT(navigatorToggled(bool)));
+  connect(responsiveThumbs, SIGNAL(triggered(bool)), this,
+          SLOT(responsiveThumbnailsToggled(bool)));
 
   menu->exec(event->globalPos());
 }
@@ -1356,6 +1546,12 @@ void FilmstripFrames::navigatorToggled(bool ignore) {
 
 //-----------------------------------------------------------------------------
 
+void FilmstripFrames::responsiveThumbnailsToggled(bool ignore) {
+  emit(responsiveThumbnailsToggledSignal());
+}
+
+//-----------------------------------------------------------------------------
+
 void FilmstripFrames::orientationToggled(bool ignore) {
   m_isVertical = !m_isVertical;
   emit(orientationToggledSignal(m_isVertical));
@@ -1365,18 +1561,7 @@ void FilmstripFrames::orientationToggled(bool ignore) {
 
 void FilmstripFrames::setOrientation(bool isVertical) {
   m_isVertical = isVertical;
-  if (m_isVertical) {
-    setFixedWidth(m_iconSize.width() + fs_leftMargin + fs_rightMargin +
-                  fs_iconMarginLR * 2);
-    setFixedHeight(parentWidget()->height());
-  } else {
-    setFixedHeight(parentWidget()->height());
-    setFixedWidth(parentWidget()->width());
-  }
-  if (m_isVertical)
-    updateContentHeight();
-  else
-    updateContentWidth();
+  updateIconLayout();
   TApp *app        = TApp::instance();
   TFrameHandle *fh = app->getCurrentFrame();
   TFrameId fid     = getCurrentFrameId();
@@ -1564,8 +1749,12 @@ Filmstrip::Filmstrip(QWidget *parent, Qt::WindowFlags flags) : QWidget(parent) {
           SLOT(comboBoxToggled()));
   connect(m_frames, SIGNAL(navigatorToggledSignal()), this,
           SLOT(navigatorToggled()));
+  connect(m_frames, SIGNAL(responsiveThumbnailsToggledSignal()), this,
+          SLOT(responsiveThumbnailsToggled()));
   connect(m_frames, SIGNAL(levelSelectedSignal(int)), this,
           SLOT(onChooseLevelComboChanged(int)));
+
+  m_frames->setResponsiveThumbnails(m_responsiveThumbnails);
 }
 
 //-----------------------------------------------------------------------------
@@ -1798,6 +1987,7 @@ void Filmstrip::hideEvent(QHideEvent *) {
 //-----------------------------------------------------------------------------
 
 void Filmstrip::resizeEvent(QResizeEvent *e) {
+  if (m_frames->isResponsiveThumbnails()) m_frames->updateIconLayout();
   if (m_isVertical) {
     m_frames->updateContentHeight();
     m_frameArea->verticalScrollBar()->setSingleStep(
@@ -1926,6 +2116,13 @@ void Filmstrip::navigatorToggled() {
 
 //-----------------------------------------------------------------------------
 
+void Filmstrip::responsiveThumbnailsToggled() {
+  m_responsiveThumbnails = !m_responsiveThumbnails;
+  m_frames->setResponsiveThumbnails(m_responsiveThumbnails);
+}
+
+//-----------------------------------------------------------------------------
+
 void Filmstrip::setOrientation(bool isVertical) {
   m_isVertical = isVertical;
   if (isVertical) {
@@ -1955,6 +2152,9 @@ void Filmstrip::save(QSettings &settings) const {
   UINT navigator = 0;
   navigator      = m_showNavigator ? 1 : 0;
   settings.setValue("navigator", navigator);
+
+  UINT responsive = m_responsiveThumbnails ? 1 : 0;
+  settings.setValue("responsiveThumbnails", responsive);
 }
 
 void Filmstrip::load(QSettings &settings) {
@@ -1974,6 +2174,10 @@ void Filmstrip::load(QSettings &settings) {
     m_chooseLevelCombo->hide();
   }
   m_frames->setComboBox(m_showComboBox);
+
+  UINT responsive         = settings.value("responsiveThumbnails", 0).toUInt();
+  m_responsiveThumbnails  = responsive == 1;
+  m_frames->setResponsiveThumbnails(m_responsiveThumbnails);
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -51,7 +51,6 @@
 #include <QDrag>
 #include <QTimer>
 #include <algorithm>
-#include <string>
 
 namespace {
 QString fidToFrameNumberWithLetter(int f) {
@@ -144,7 +143,7 @@ FilmstripFrames::FilmstripFrames(QScrollArea *parent, Qt::WindowFlags flags)
   setFrameStyle(QFrame::StyledPanel);
 
   setFocusPolicy(Qt::StrongFocus);
-  applyCrossAxisDimension();
+  updateContentConstraints();
   if (m_isVertical) {
     setFixedHeight(parentWidget()->height());
   } else {
@@ -185,13 +184,6 @@ TXshSimpleLevel *FilmstripFrames::getLevel() const {
 
 //-----------------------------------------------------------------------------
 
-std::string FilmstripFrames::responsiveIconCacheSuffix(const QSize &size) {
-  return "_r_" + std::to_string(size.width()) + "x" +
-         std::to_string(size.height());
-}
-
-//-----------------------------------------------------------------------------
-
 QSize FilmstripFrames::quantizeResponsiveRenderSize(const QSize &layout,
                                                     const QSize &pref,
                                                     bool vertical) {
@@ -218,20 +210,32 @@ QSize FilmstripFrames::quantizeResponsiveRenderSize(const QSize &layout,
 
 //-----------------------------------------------------------------------------
 
-void FilmstripFrames::applyCrossAxisDimension() {
+void FilmstripFrames::updateContentConstraints() {
   if (!m_scrollArea) return;
-  QWidget *vp = m_scrollArea->viewport();
-  if (!vp) return;
   if (m_responsiveThumbnails) {
-    if (m_isVertical)
-      setFixedWidth(std::max(1, vp->width()));
-    else
-      setFixedHeight(std::max(1, vp->height()));
+    m_scrollArea->setWidgetResizable(true);
+    if (m_isVertical) {
+      setMinimumWidth(0);
+      setMaximumWidth(QWIDGETSIZE_MAX);
+      setMinimumHeight(getFramesHeight());
+      setMaximumHeight(QWIDGETSIZE_MAX);
+    } else {
+      setMinimumHeight(0);
+      setMaximumHeight(QWIDGETSIZE_MAX);
+      setMinimumWidth(getFramesWidth());
+      setMaximumWidth(QWIDGETSIZE_MAX);
+    }
   } else if (m_isVertical) {
+    m_scrollArea->setWidgetResizable(false);
     setFixedWidth(m_iconSize.width() + fs_leftMargin + fs_rightMargin +
                   fs_iconMarginLR * 2);
+    setMinimumHeight(0);
+    setMaximumHeight(QWIDGETSIZE_MAX);
   } else {
+    m_scrollArea->setWidgetResizable(false);
     setFixedHeight(getOneFrameHeight());
+    setMinimumWidth(0);
+    setMaximumWidth(QWIDGETSIZE_MAX);
   }
 }
 
@@ -289,7 +293,7 @@ void FilmstripFrames::updateIconLayout() {
 
   m_iconSize = effective;
 
-  applyCrossAxisDimension();
+  updateContentConstraints();
   if (m_frameHeadGadget) m_frameHeadGadget->updateFrameMetrics();
   if (m_isVertical)
     updateContentHeight();
@@ -395,14 +399,14 @@ int FilmstripFrames::getFramesWidth() const {
 
 //-----------------------------------------------------------------------------
 
-int FilmstripFrames::getOneFrameHeight() {
+int FilmstripFrames::getOneFrameHeight() const {
   return m_iconSize.height() + fs_frameSpacing + fs_iconMarginTop +
          fs_iconMarginBottom;
 }
 
 //-----------------------------------------------------------------------------
 
-int FilmstripFrames::getOneFrameWidth() {
+int FilmstripFrames::getOneFrameWidth() const {
   return m_iconSize.width() + fs_frameSpacing + fs_leftMargin +
          fs_iconMarginLR + fs_rightMargin;
 }
@@ -415,41 +419,58 @@ void FilmstripFrames::updateContentHeight(int minimumHeight) {
   if (contentHeight < minimumHeight) contentHeight = minimumHeight;
   int parentHeight = parentWidget()->height();
   if (contentHeight < parentHeight) contentHeight = parentHeight;
-  if (contentHeight != height()) setFixedHeight(contentHeight);
+  if (m_responsiveThumbnails) {
+    setMinimumHeight(contentHeight);
+  } else if (contentHeight != height()) {
+    setFixedHeight(contentHeight);
+  }
 }
 
 //-----------------------------------------------------------------------------
 void FilmstripFrames::updateContentWidth(int minimumWidth) {
-  setFixedHeight(getOneFrameHeight());
+  if (!m_responsiveThumbnails) setFixedHeight(getOneFrameHeight());
   if (minimumWidth < 0) minimumWidth = visibleRegion().boundingRect().right();
   int contentWidth = getFramesWidth();
   if (contentWidth < minimumWidth) contentWidth = minimumWidth;
   int parentWidth = parentWidget()->width();
   if (contentWidth < parentWidth) contentWidth = parentWidth;
-  if (contentWidth != width()) setFixedWidth(contentWidth);
+  if (m_responsiveThumbnails) {
+    setMinimumWidth(contentWidth);
+  } else if (contentWidth != width()) {
+    setFixedWidth(contentWidth);
+  }
 }
 
 //-----------------------------------------------------------------------------
 
 void FilmstripFrames::showFrame(int index) {
   TXshSimpleLevel *level = getLevel();
+  if (!level) return;
   if (m_isVertical) {
     if (!level->isFid(index2fid(index))) {
       if (!level->isFid(index2fid(index))) return;
     }
     int y0 = index2y(index);
-    int y1 = y0 + m_iconSize.height() + fs_frameSpacing + fs_iconMarginTop +
-             fs_iconMarginBottom;
-    if (y1 > height()) setFixedHeight(y1);
+    int y1 = y0 + getOneFrameHeight();
+    if (y1 > height()) {
+      if (m_responsiveThumbnails)
+        setMinimumHeight(y1);
+      else
+        setFixedHeight(y1);
+    }
     m_scrollArea->ensureVisible(0, (y0 + y1) / 2, 50, (y1 - y0) / 2);
   } else {
     if (!level->isFid(index2fid(index))) {
       if (!level->isFid(index2fid(index - 1))) return;
     }
     int x0 = index2x(index);
-    int x1 = x0 + m_iconSize.width() + fs_frameSpacing + fs_leftMargin +
-             fs_rightMargin + fs_iconMarginLR;
-    if (x1 > width()) setFixedWidth(x1);
+    int x1 = x0 + getOneFrameWidth();
+    if (x1 > width()) {
+      if (m_responsiveThumbnails)
+        setMinimumWidth(x1);
+      else
+        setFixedWidth(x1);
+    }
     m_scrollArea->ensureVisible((x0 + x1) / 2, 0, (x1 - x0) / 2, 50);
   }
 }
@@ -943,8 +964,7 @@ void FilmstripFrames::drawFrameIcon(QPainter &p, const QRect &r, int index,
          m_renderIconSize.height() > m_prefIconSize.height());
     if (needNativeSize) {
       const TDimension dim(m_renderIconSize.width(), m_renderIconSize.height());
-      pm = IconGenerator::instance()->getSizedIcon(
-          xl, fid, responsiveIconCacheSuffix(m_renderIconSize), dim);
+      pm = IconGenerator::instance()->getResponsiveIcon(xl, fid, dim);
     }
     if (pm.isNull()) pm = IconGenerator::instance()->getIcon(xl, fid);
   }
@@ -1544,8 +1564,8 @@ void FilmstripFrames::navigatorToggled(bool ignore) {
 
 //-----------------------------------------------------------------------------
 
-void FilmstripFrames::responsiveThumbnailsToggled(bool ignore) {
-  emit(responsiveThumbnailsToggledSignal());
+void FilmstripFrames::responsiveThumbnailsToggled(bool responsive) {
+  emit(responsiveThumbnailsToggledSignal(responsive));
 }
 
 //-----------------------------------------------------------------------------
@@ -1747,8 +1767,8 @@ Filmstrip::Filmstrip(QWidget *parent, Qt::WindowFlags flags) : QWidget(parent) {
           SLOT(comboBoxToggled()));
   connect(m_frames, SIGNAL(navigatorToggledSignal()), this,
           SLOT(navigatorToggled()));
-  connect(m_frames, SIGNAL(responsiveThumbnailsToggledSignal()), this,
-          SLOT(responsiveThumbnailsToggled()));
+  connect(m_frames, SIGNAL(responsiveThumbnailsToggledSignal(bool)), this,
+          SLOT(responsiveThumbnailsToggled(bool)));
   connect(m_frames, SIGNAL(levelSelectedSignal(int)), this,
           SLOT(onChooseLevelComboChanged(int)));
 
@@ -1985,7 +2005,6 @@ void Filmstrip::hideEvent(QHideEvent *) {
 //-----------------------------------------------------------------------------
 
 void Filmstrip::resizeEvent(QResizeEvent *e) {
-  if (m_frames->isResponsiveThumbnails()) m_frames->updateIconLayout();
   if (m_isVertical) {
     m_frames->updateContentHeight();
     m_frameArea->verticalScrollBar()->setSingleStep(
@@ -2049,10 +2068,8 @@ void Filmstrip::onLevelSwitched(TXshLevel *oldLevel) {
 //-----------------------------------------------------------------------------
 
 void Filmstrip::onSliderMoved(int val) {
-  int oneFrameHeight = m_frames->getIconSize().height() + fs_frameSpacing +
-                       fs_iconMarginTop + fs_iconMarginBottom;
-  int oneFrameWidth =
-      m_frames->getIconSize().width() + fs_frameSpacing + fs_iconMarginLR;
+  int oneFrameHeight = m_frames->getOneFrameHeight();
+  int oneFrameWidth  = m_frames->getOneFrameWidth();
   if (m_isVertical) {
     int tmpVal =
         (int)((float)val / (float)oneFrameHeight + 0.5f) * oneFrameHeight;
@@ -2114,9 +2131,9 @@ void Filmstrip::navigatorToggled() {
 
 //-----------------------------------------------------------------------------
 
-void Filmstrip::responsiveThumbnailsToggled() {
-  m_responsiveThumbnails = !m_responsiveThumbnails;
-  m_frames->setResponsiveThumbnails(m_responsiveThumbnails);
+void Filmstrip::responsiveThumbnailsToggled(bool responsive) {
+  m_responsiveThumbnails = responsive;
+  m_frames->setResponsiveThumbnails(responsive);
 }
 
 //-----------------------------------------------------------------------------
@@ -2173,7 +2190,7 @@ void Filmstrip::load(QSettings &settings) {
   }
   m_frames->setComboBox(m_showComboBox);
 
-  UINT responsive        = settings.value("responsiveThumbnails", 0).toUInt();
+  UINT responsive        = settings.value("responsiveThumbnails", 1).toUInt();
   m_responsiveThumbnails = responsive == 1;
   m_frames->setResponsiveThumbnails(m_responsiveThumbnails);
 }

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -15,7 +15,6 @@
 // STD includes
 #include <vector>
 #include <map>
-#include <string>
 
 // forward declaration
 class TFrameId;
@@ -51,7 +50,7 @@ public:
   bool m_isVertical           = true;
   bool m_showNavigator        = true;
   bool m_showComboBox         = true;
-  bool m_responsiveThumbnails = false;
+  bool m_responsiveThumbnails = true;
 
   void setBGColor(const QColor &color) { m_bgColor = color; }
   QColor getBGColor() const { return m_bgColor; }
@@ -120,8 +119,8 @@ public:
   };
   void select(int index, SelectionMode mode = SIMPLE_SELECT);
 
-  int getOneFrameHeight();
-  int getOneFrameWidth();
+  int getOneFrameHeight() const;
+  int getOneFrameWidth() const;
   void setOrientation(bool isVertical);
   void setNavigator(bool showNavigator);
   void setComboBox(bool showComboBox);
@@ -133,7 +132,7 @@ signals:
   void orientationToggledSignal(bool);
   void comboBoxToggledSignal();
   void navigatorToggledSignal();
-  void responsiveThumbnailsToggledSignal();
+  void responsiveThumbnailsToggledSignal(bool responsive);
   void levelSelectedSignal(int);
 
 protected:
@@ -217,9 +216,8 @@ private:
 
   QTimer *m_responsiveRenderTimer = nullptr;
 
-  void applyCrossAxisDimension();
+  void updateContentConstraints();
   void scheduleResponsiveRenderCommit();
-  static std::string responsiveIconCacheSuffix(const QSize &size);
   static QSize quantizeResponsiveRenderSize(const QSize &layout,
                                             const QSize &pref, bool vertical);
 
@@ -255,7 +253,7 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
   bool m_isVertical           = true;
   bool m_showNavigator        = true;
   bool m_showComboBox         = true;
-  bool m_responsiveThumbnails = false;
+  bool m_responsiveThumbnails = true;
 
 public:
   Filmstrip(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
@@ -291,7 +289,7 @@ public slots:
   void orientationToggled(bool);
   void comboBoxToggled();
   void navigatorToggled();
-  void responsiveThumbnailsToggled();
+  void responsiveThumbnailsToggled(bool responsive);
 
 private:
   void updateWindowTitle();

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -15,6 +15,7 @@
 // STD includes
 #include <vector>
 #include <map>
+#include <string>
 
 // forward declaration
 class TFrameId;
@@ -22,6 +23,7 @@ class TFilmstripSelection;
 class FilmstripFrameHeadGadget;
 class TXshSimpleLevel;
 class QComboBox;
+class QTimer;
 class InbetweenDialog;
 class TXshLevel;
 class SceneViewer;
@@ -46,9 +48,10 @@ public:
                   Qt::WindowFlags flags = Qt::WindowFlags());
   ~FilmstripFrames();
 
-  bool m_isVertical    = true;
-  bool m_showNavigator = true;
-  bool m_showComboBox  = true;
+  bool m_isVertical           = true;
+  bool m_showNavigator        = true;
+  bool m_showComboBox         = true;
+  bool m_responsiveThumbnails = false;
 
   void setBGColor(const QColor &color) { m_bgColor = color; }
   QColor getBGColor() const { return m_bgColor; }
@@ -122,11 +125,15 @@ public:
   void setOrientation(bool isVertical);
   void setNavigator(bool showNavigator);
   void setComboBox(bool showComboBox);
+  void setResponsiveThumbnails(bool responsive);
+  bool isResponsiveThumbnails() const { return m_responsiveThumbnails; }
+  void updateIconLayout();
 
 signals:
   void orientationToggledSignal(bool);
   void comboBoxToggledSignal();
   void navigatorToggledSignal();
+  void responsiveThumbnailsToggledSignal();
   void levelSelectedSignal(int);
 
 protected:
@@ -170,8 +177,10 @@ protected slots:
   void orientationToggled(bool);
   void comboBoxToggled(bool);
   void navigatorToggled(bool);
+  void responsiveThumbnailsToggled(bool);
   void levelSelected(int);
   void onViewerAboutToBeDestroyed();
+  void commitResponsiveRenderSize();
 
 private:
   // QSS Properties
@@ -201,8 +210,18 @@ private:
 
   QPoint m_pos;  //!< Last mouse position.
 
-  const QSize m_iconSize;
+  QSize m_prefIconSize;
+  QSize m_iconSize;
+  QSize m_renderIconSize;
   const int m_frameLabelWidth;
+
+  QTimer *m_responsiveRenderTimer = nullptr;
+
+  void applyCrossAxisDimension();
+  void scheduleResponsiveRenderCommit();
+  static std::string responsiveIconCacheSuffix(const QSize &size);
+  static QSize quantizeResponsiveRenderSize(const QSize &layout,
+                                            const QSize &pref, bool vertical);
 
   std::pair<int, int> m_selectingRange;
 
@@ -233,9 +252,10 @@ class Filmstrip final : public QWidget, public SaveLoadQSettings {
 
   std::vector<TXshSimpleLevel *> m_levels;
   std::map<TXshSimpleLevel *, TFrameId> m_workingFrames;
-  bool m_isVertical    = true;
-  bool m_showNavigator = true;
-  bool m_showComboBox  = true;
+  bool m_isVertical           = true;
+  bool m_showNavigator        = true;
+  bool m_showComboBox         = true;
+  bool m_responsiveThumbnails = false;
 
 public:
   Filmstrip(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags());
@@ -271,6 +291,7 @@ public slots:
   void orientationToggled(bool);
   void comboBoxToggled();
   void navigatorToggled();
+  void responsiveThumbnailsToggled();
 
 private:
   void updateWindowTitle();

--- a/toonz/sources/toonz/frameheadgadget.cpp
+++ b/toonz/sources/toonz/frameheadgadget.cpp
@@ -329,10 +329,8 @@ int FilmstripFrameHeadGadget::getCurrentFrame() const {
 //-----------------------------------------------------------------------------
 
 void FilmstripFrameHeadGadget::updateFrameMetrics() {
-  m_dy = m_filmstrip->getIconSize().height() + fs_frameSpacing +
-         fs_iconMarginTop + fs_iconMarginBottom;
-  m_dx = m_filmstrip->getIconSize().width() + fs_frameSpacing + fs_leftMargin +
-         fs_rightMargin + fs_iconMarginLR;
+  m_dy = m_filmstrip->getOneFrameHeight();
+  m_dx = m_filmstrip->getOneFrameWidth();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/frameheadgadget.cpp
+++ b/toonz/sources/toonz/frameheadgadget.cpp
@@ -328,6 +328,15 @@ int FilmstripFrameHeadGadget::getCurrentFrame() const {
 
 //-----------------------------------------------------------------------------
 
+void FilmstripFrameHeadGadget::updateFrameMetrics() {
+  m_dy = m_filmstrip->getIconSize().height() + fs_frameSpacing +
+         fs_iconMarginTop + fs_iconMarginBottom;
+  m_dx = m_filmstrip->getIconSize().width() + fs_frameSpacing + fs_leftMargin +
+         fs_rightMargin + fs_iconMarginLR;
+}
+
+//-----------------------------------------------------------------------------
+
 void FilmstripFrameHeadGadget::drawOnionSkinSelection(QPainter &p,
                                                       const QColor &lightColor,
                                                       const QColor &darkColor) {

--- a/toonz/sources/toonz/frameheadgadget.h
+++ b/toonz/sources/toonz/frameheadgadget.h
@@ -94,6 +94,8 @@ public:
   void setCurrentFrame(int index) const override;
   int getCurrentFrame() const override;
 
+  void updateFrameMetrics();
+
   bool eventFilter(QObject *obj, QEvent *event) override;
   bool shiftTraceEventFilter(QObject *obj, QEvent *event);
 };

--- a/toonz/sources/toonzqt/icongenerator.cpp
+++ b/toonz/sources/toonzqt/icongenerator.cpp
@@ -47,6 +47,9 @@
 #include "toonzqt/icongenerator.h"
 
 #include <QCoreApplication>
+#include <algorithm>
+#include <deque>
+#include <map>
 #include <vector>
 
 //=============================================================================
@@ -64,6 +67,8 @@ TDimension FilmstripIconSize(0, 0);
 // Access name-based storage
 std::set<std::string> iconsMap;
 typedef std::set<std::string>::iterator IconIterator;
+std::map<std::string, std::deque<std::string>> responsiveIconKeys;
+const int kMaxResponsiveIconSizes = 3;
 
 //-----------------------------------------------------------------------------
 
@@ -166,15 +171,40 @@ void removeIcon(const std::string &iconName) {
 
 //-----------------------------------------------------------------------------
 
-void removeResponsiveSizedIcons(const std::string &baseId) {
-  const std::string prefix = baseId + "_r_";
-  std::vector<std::string> toRemove;
-  for (IconIterator it = iconsMap.lower_bound(prefix);
-       it != iconsMap.end() && it->compare(0, prefix.size(), prefix) == 0;
-       ++it) {
-    toRemove.push_back(*it);
+std::string responsiveIconKey(const std::string &baseId,
+                              const TDimension &size) {
+  return baseId + "_r_" + std::to_string(size.lx) + "x" +
+         std::to_string(size.ly);
+}
+
+std::string filmstripIconBaseId(TXshSimpleLevel *sl, const TFrameId &fid) {
+  const int status = sl->getFrameStatus(fid);
+  if (sl->getType() == TZP_XSHLEVEL &&
+      status & TXshSimpleLevel::CleanupPreview) {
+    sl->setFrameStatus(fid, status & ~TXshSimpleLevel::CleanupPreview);
+    std::string id = sl->getIconId(fid);
+    sl->setFrameStatus(fid, status);
+    return id;
   }
-  for (const std::string &key : toRemove) removeIcon(key);
+  return sl->getIconId(fid);
+}
+
+void removeResponsiveSizedIcons(const std::string &baseId) {
+  auto it = responsiveIconKeys.find(baseId);
+  if (it == responsiveIconKeys.end()) return;
+  for (const std::string &key : it->second) removeIcon(key);
+  responsiveIconKeys.erase(it);
+}
+
+void retainResponsiveIcon(const std::string &baseId, const std::string &key) {
+  std::deque<std::string> &keys = responsiveIconKeys[baseId];
+  auto found                    = std::find(keys.begin(), keys.end(), key);
+  if (found != keys.end()) keys.erase(found);
+  keys.push_back(key);
+  while ((int)keys.size() > kMaxResponsiveIconSizes) {
+    removeIcon(keys.front());
+    keys.pop_front();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1601,13 +1631,27 @@ QPixmap IconGenerator::getSizedIcon(TXshLevel *xl, const TFrameId &fid,
 
 //-----------------------------------------------------------------------------
 
+QPixmap IconGenerator::getResponsiveIcon(TXshLevel *xl, const TFrameId &fid,
+                                         const TDimension &dim) {
+  if (!xl) return QPixmap();
+  TXshSimpleLevel *sl = xl->getSimpleLevel();
+  if (!sl) return QPixmap();
+
+  const std::string baseId = filmstripIconBaseId(sl, fid);
+  const std::string key    = responsiveIconKey(baseId, dim);
+  retainResponsiveIcon(baseId, key);
+  return getSizedIcon(xl, fid, key.substr(baseId.size()), dim);
+}
+
+//-----------------------------------------------------------------------------
+
 void IconGenerator::invalidate(TXshLevel *xl, const TFrameId &fid,
                                bool onlyFilmStrip) {
   if (!xl) return;
 
   if (TXshSimpleLevel *sl = xl->getSimpleLevel()) {
     std::string id = sl->getIconId(fid);
-    removeResponsiveSizedIcons(id);
+    removeResponsiveSizedIcons(filmstripIconBaseId(sl, fid));
 
     int type = sl->getType();
 
@@ -1695,7 +1739,7 @@ void IconGenerator::remove(TXshLevel *xl, const TFrameId &fid,
     std::string id(sl->getIconId(fid));
 
     removeIcon(id);
-    removeResponsiveSizedIcons(id);
+    removeResponsiveSizedIcons(filmstripIconBaseId(sl, fid));
     if (!onlyFilmStrip) removeIcon(id + "_small");
   } else {
     TXshChildLevel *cl = xl->getChildLevel();

--- a/toonz/sources/toonzqt/icongenerator.cpp
+++ b/toonz/sources/toonzqt/icongenerator.cpp
@@ -47,6 +47,7 @@
 #include "toonzqt/icongenerator.h"
 
 #include <QCoreApplication>
+#include <vector>
 
 //=============================================================================
 
@@ -165,6 +166,19 @@ void removeIcon(const std::string &iconName) {
 
 //-----------------------------------------------------------------------------
 
+void removeResponsiveSizedIcons(const std::string &baseId) {
+  const std::string prefix = baseId + "_r_";
+  std::vector<std::string> toRemove;
+  for (IconIterator it = iconsMap.lower_bound(prefix);
+       it != iconsMap.end() && it->compare(0, prefix.size(), prefix) == 0;
+       ++it) {
+    toRemove.push_back(*it);
+  }
+  for (const std::string &key : toRemove) removeIcon(key);
+}
+
+//-----------------------------------------------------------------------------
+
 bool isUnpremultiplied(const TRaster32P &r) {
   int lx = r->getLx();
   int y  = r->getLy();
@@ -225,7 +239,8 @@ TRaster32P convertToIcon(TVectorImageP vimage, int frame,
   if (!plt) return TRaster32P();
   plt->setFrame(frame);
 
-  TOfflineGL *glContext = IconGenerator::instance()->getOfflineGLContext();
+  TOfflineGL *glContext =
+      IconGenerator::instance()->getOfflineGLContext(iconSize);
 
   // Image bounding box with a small margin to prevent issues with empty images
   TRectD imageBox;
@@ -387,8 +402,9 @@ TRaster32P convertToIcon(TMeshImageP mi, int frame, const TDimension &iconSize,
                          const IconGenerator::Settings &settings) {
   if (!mi) return TRaster32P();
 
-  TOfflineGL *glContext = IconGenerator::instance()->getOfflineGLContext();
-  TRectD imageBox       = mi->getBBox().enlarge(.1);
+  TOfflineGL *glContext =
+      IconGenerator::instance()->getOfflineGLContext(iconSize);
+  TRectD imageBox = mi->getBBox().enlarge(.1);
   TPointD imageCenter(0.5 * (imageBox.getP00() + imageBox.getP11()));
 
   const int margin = 10;
@@ -616,7 +632,8 @@ public:
 TRaster32P SplineIconRenderer::generateRaster(
     const TDimension &iconSize) const {
   // get the glContext
-  TOfflineGL *glContext = IconGenerator::instance()->getOfflineGLContext();
+  TOfflineGL *glContext =
+      IconGenerator::instance()->getOfflineGLContext(iconSize);
   glContext->makeCurrent();
   glContext->clear(TPixel32::White);
 
@@ -1381,23 +1398,22 @@ TDimension IconGenerator::getIconSize() const { return FilmstripIconSize; }
 
 //-----------------------------------------------------------------------------
 
-TOfflineGL *IconGenerator::getOfflineGLContext() {
+TOfflineGL *IconGenerator::getOfflineGLContext(const TDimension &minSize) {
+  const TDimension requiredSize(
+      std::max(minSize.lx, std::max(FilmstripIconSize.lx, IconSize.lx)),
+      std::max(minSize.ly, std::max(FilmstripIconSize.ly, IconSize.ly)));
+
   TOfflineGL *context = m_contexts.localData();
   // One context per rendering thread
   if (!context) {
-    context =
-        new TOfflineGL(TDimension(std::max(FilmstripIconSize.lx, IconSize.lx),
-                                  std::max(FilmstripIconSize.ly, IconSize.ly)));
+    context = new TOfflineGL(requiredSize);
     m_contexts.setLocalData(context);
     return context;
   }
-  TDimension requiredSize(std::max(FilmstripIconSize.lx, IconSize.lx),
-                          std::max(FilmstripIconSize.ly, IconSize.ly));
-  TDimension actualSize = context->getSize();
 
+  const TDimension actualSize = context->getSize();
   if (actualSize.lx < requiredSize.lx || actualSize.ly < requiredSize.ly) {
     context = new TOfflineGL(requiredSize);
-
     m_contexts.setLocalData(context);
   }
 
@@ -1591,6 +1607,7 @@ void IconGenerator::invalidate(TXshLevel *xl, const TFrameId &fid,
 
   if (TXshSimpleLevel *sl = xl->getSimpleLevel()) {
     std::string id = sl->getIconId(fid);
+    removeResponsiveSizedIcons(id);
 
     int type = sl->getType();
 
@@ -1678,6 +1695,7 @@ void IconGenerator::remove(TXshLevel *xl, const TFrameId &fid,
     std::string id(sl->getIconId(fid));
 
     removeIcon(id);
+    removeResponsiveSizedIcons(id);
     if (!onlyFilmStrip) removeIcon(id + "_small");
   } else {
     TXshChildLevel *cl = xl->getChildLevel();


### PR DESCRIPTION
**The problem**

Level Strip thumbnails stay at the fixed size from Preferences, even when the panel is much wider or taller. On a large strip you end up with small previews and a lot of empty space. Making them bigger only through Preferences is clumsy if you just want to use the room you already have.

**Porposal**

<img width="816" height="1076" alt="responsive thumbnail" src="https://github.com/user-attachments/assets/3d371118-4a27-45b8-afd7-8488c62b34c6" />

This PR adds a responsive Thumbnails option in the Level Strip panel settings.It's an optional way to make Level Strip thumbnails use the free space in the panel, so you can see larger previews without changing the Preferences size every time. You can leave it off if it does not fit how you work.

When it is on, thumbnails grow to use the free space in the panel (across the strip in vertical layout, along the strip height in horizontal layout), while keeping the same proportions as the Preferen

ces thumbnail size. When it is off, behaviour is unchanged: Preferences size only.

In practice this feels like a quick zoom on the strip, handy when you want to check details without leaving the Level Strip. It should also work well with the frame marks support I plan to propose next. It can open up new ways of working with the strip, depending on how you arrange your room.

The setting is saved with the panel layout, like the other Level Strip options.

While you resize the panel, previews stay usable; once you stop, they refresh at a sharper size. Works for raster, Toonz Raster, vector and mesh levels.

**Notes**

Off by default. Existing layouts keep the classic fixed size until you turn it on.

**Limitations**

Adjacent panels may change size or position when the strip grows.


This feature was developed with Cursor’s AI models