### PR TITLE
Fix crash when changing frame with arrows

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -34,6 +34,7 @@
 #include "toonz/imagestyles.h"
 #include "toonz/preferences.h"
 #include "toonz/toonzfolders.h"
+#include "toonz/txshsimplelevel.h"
 
 // TnzCore includes
 #include "tgl.h"
@@ -142,7 +143,8 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
     , m_notifier(0)
     , m_presetsLoaded(false)
     , m_firstTime(true)
-    , m_started(false) {
+    , m_started(false)
+    , m_strokeFrameId() {
   bind(TTool::RasterImage | TTool::EmptyTarget);
   m_thickness.setNonLinearSlider();
 
@@ -272,6 +274,7 @@ void FullColorBrushTool::updateWorkAndBackupRasters(const TRect &rect) {
   if (!ri) return;
 
   TRasterP ras = ri->getRaster();
+  if (!ras || !m_workRaster || !m_backUpRas) return;
 
   const int denominator = 8;
   TRect enlargedRect    = rect + m_lastRect;
@@ -317,6 +320,7 @@ bool FullColorBrushTool::askRead(const TRect &rect) { return askWrite(rect); }
 
 bool FullColorBrushTool::askWrite(const TRect &rect) {
   if (rect.isEmpty()) return true;
+  if (!m_tileSaver || !m_workRaster) return false;
   m_strokeRect += rect;
   m_strokeSegmentRect += rect;
   updateWorkAndBackupRasters(rect);
@@ -368,6 +372,13 @@ bool FullColorBrushTool::preLeftButtonDown() {
 void FullColorBrushTool::handleMouseEvent(MouseEventType type,
                                           const TPointD &pos,
                                           const TMouseEvent &e) {
+  if (m_skipStrokeUntilDown) {
+    if (type == ME_DOWN)
+      m_skipStrokeUntilDown = false;
+    else if (type != ME_MOVE)
+      return;
+  }
+
   TTimerTicks t = TToolTimer::ticks();
   bool alt      = e.getModifiersMask() & TMouseEvent::ALT_KEY;
   bool shift    = e.getModifiersMask() & TMouseEvent::SHIFT_KEY;
@@ -396,7 +407,8 @@ void FullColorBrushTool::handleMouseEvent(MouseEventType type,
     THoverList hovers(1, pos);
     m_inputmanager.hoverEvent(hovers);
   } else {
-    bool   isMyPaint   = getApplication()->getCurrentLevelStyle()->getTagId() == 4001;
+    TColorStyle *levelStyle = getApplication()->getCurrentLevelStyle();
+    bool isMyPaint          = levelStyle && levelStyle->getTagId() == 4001;
     int    deviceId    = e.isTablet() ? 1 : 0;
     double defPressure = isMyPaint ? 0.5 : 1.0;
     bool   hasPressure = e.isTablet();
@@ -496,44 +508,27 @@ void FullColorBrushTool::inputMouseMove(const TPointD &position,
 //-------------------------------------------------------------------------------------------------------------
 
 void FullColorBrushTool::inputSetBusy(bool busy) {
+  if (m_skipStrokeUntilDown && busy) return;
   if (m_started == busy) return;
   if (busy) {
     // begin paint
     TRasterImageP ri = (TRasterImageP)getImage(true);
     if (!ri) return;// ri = (TRasterImageP)touchImage(); touch in preLeftButtonDown
     TRasterP ras = ri->getRaster();
+    if (!ras) return;
 
     if (!(m_workRaster && m_backUpRas)) setWorkAndBackupImages();
+    if (!m_workRaster) return;
     m_workRaster->lock();
-    m_tileSet   = new TTileSetFullColor(ras->getSize());
-    m_tileSaver = new TTileSaverFullColor(ras, m_tileSet);
+    m_tileSet       = new TTileSetFullColor(ras->getSize());
+    m_tileSaver     = new TTileSaverFullColor(ras, m_tileSet);
+    m_strokeFrameId = getCurrentFid();
 
     // update color here since the current style might be switched
     // with numpad shortcut keys
     updateCurrentStyle();
   } else {
-    // end paint
-    if (TRasterImageP ri = (TRasterImageP)getImage(true)) {
-      TRasterP ras = ri->getRaster();
-
-      m_lastRect.empty();
-      m_workRaster->unlock();
-
-      if (m_tileSet->getTileCount() > 0) {
-        delete m_tileSaver;
-        TTool::Application *app   = TTool::getApplication();
-        TXshLevel *level          = app->getCurrentLevel()->getLevel();
-        TXshSimpleLevelP simLevel = level->getSimpleLevel();
-        TFrameId frameId          = getCurrentFid();
-        TRasterP subras           = ras->extract(m_strokeRect)->clone();
-        TUndoManager::manager()->add(new FullColorBrushUndo(
-            m_tileSet, simLevel.getPointer(), frameId, m_isFrameCreated, subras,
-            m_strokeRect.getP00()));
-      }
-
-      notifyImageChanged();
-      m_strokeRect.empty();
-    }
+    commitStroke();
   }
   m_started = busy;
 }
@@ -551,7 +546,8 @@ void FullColorBrushTool::inputPaintTrackPoint(const TTrackPoint &point,
   
   TRasterImageP ri = (TRasterImageP)getImage(true);
   if (!ri) return;
-  TRasterP ras      = ri->getRaster();
+  TRasterP ras = ri->getRaster();
+  if (!ras) return;
   TPointD rasCenter = ras->getCenterD();
 
   // init brush
@@ -566,7 +562,8 @@ void FullColorBrushTool::inputPaintTrackPoint(const TTrackPoint &point,
   handler = dynamic_cast<TrackHandler *>(track.handler.getPointer());
   if (!handler) return;
 
-  bool   isMyPaint   = getApplication()->getCurrentLevelStyle()->getTagId() == 4001;
+  TColorStyle *levelStyle = getApplication()->getCurrentLevelStyle();
+  bool isMyPaint          = levelStyle && levelStyle->getTagId() == 4001;
   double defPressure = isMyPaint ? 0.5 : 1.0;
   double pressure    = m_enabledPressure ? point.pressure : defPressure;
   
@@ -607,6 +604,7 @@ void FullColorBrushTool::draw() {
     if (!Preferences::instance()->isCursorOutlineEnabled()) return;
 
     TRasterP ras = ri->getRaster();
+    if (!ras) return;
 
     double alpha       = 1.0;
     double alphaRadius = 3.0;
@@ -660,7 +658,57 @@ TPropertyGroup *FullColorBrushTool::getProperties(int targetType) {
 
 //----------------------------------------------------------------------------------------------------------
 
-void FullColorBrushTool::onImageChanged() { setWorkAndBackupImages(); }
+void FullColorBrushTool::commitStroke() {
+  if (!m_started) return;
+
+  TFrameId frameId =
+      m_strokeFrameId.isEmptyFrame() ? getCurrentFid() : m_strokeFrameId;
+
+  TRasterImageP ri;
+  TXshSimpleLevel *sl     = 0;
+  TTool::Application *app = TTool::getApplication();
+  if (app && app->getCurrentLevel()) {
+    TXshLevel *level = app->getCurrentLevel()->getLevel();
+    sl               = level ? level->getSimpleLevel() : 0;
+    if (sl) ri = TRasterImageP(sl->getFrame(frameId, true));
+  }
+  if (!ri) ri = (TRasterImageP)getImage(true);
+  TRasterP ras = ri ? ri->getRaster() : TRasterP();
+
+  m_lastRect.empty();
+  if (m_workRaster) m_workRaster->unlock();
+
+  if (ras && sl && m_tileSet && m_tileSet->getTileCount() > 0) {
+    delete m_tileSaver;
+    m_tileSaver     = 0;
+    TRasterP subras = ras->extract(m_strokeRect)->clone();
+    TUndoManager::manager()->add(
+        new FullColorBrushUndo(m_tileSet, sl, frameId, m_isFrameCreated, subras,
+                               m_strokeRect.getP00()));
+    m_tileSet = 0;
+  } else {
+    delete m_tileSaver;
+    m_tileSaver = 0;
+    delete m_tileSet;
+    m_tileSet = 0;
+  }
+
+  m_started       = false;
+  m_strokeFrameId = TFrameId();
+  m_strokeRect.empty();
+  if (ras) notifyImageChanged(frameId);
+}
+
+//----------------------------------------------------------------------------------------------------------
+
+void FullColorBrushTool::onImageChanged() {
+  m_inputmanager.reset();
+  if (m_started) {
+    commitStroke();
+    m_skipStrokeUntilDown = true;
+  }
+  setWorkAndBackupImages();
+}
 
 //----------------------------------------------------------------------------------------------------------
 
@@ -668,7 +716,8 @@ void FullColorBrushTool::setWorkAndBackupImages() {
   TRasterImageP ri = (TRasterImageP)getImage(false, 1);
   if (!ri) return;
 
-  TRasterP ras   = ri->getRaster();
+  TRasterP ras = ri->getRaster();
+  if (!ras) return;
   TDimension dim = ras->getSize();
 
   if (!m_workRaster || m_workRaster->getLx() != dim.lx ||

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -144,7 +144,8 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
     , m_presetsLoaded(false)
     , m_firstTime(true)
     , m_started(false)
-    , m_strokeFrameId() {
+    , m_strokeFrameId()
+    , m_strokeLevel() {
   bind(TTool::RasterImage | TTool::EmptyTarget);
   m_thickness.setNonLinearSlider();
 
@@ -525,6 +526,13 @@ void FullColorBrushTool::inputSetBusy(bool busy) {
     m_tileSet       = new TTileSetFullColor(ras->getSize());
     m_tileSaver     = new TTileSaverFullColor(ras, m_tileSet);
     m_strokeFrameId = getCurrentFid();
+    m_strokeLevel   = TXshSimpleLevelP();
+    if (TTool::Application *app = TTool::getApplication()) {
+      if (TXshLevelHandle *lh = app->getCurrentLevel()) {
+        if (TXshLevel *xl = lh->getLevel())
+          m_strokeLevel = xl->getSimpleLevel();
+      }
+    }
 
     // update color here since the current style might be switched
     // with numpad shortcut keys
@@ -665,15 +673,10 @@ void FullColorBrushTool::commitStroke() {
 
   TFrameId frameId =
       m_strokeFrameId.isEmptyFrame() ? getCurrentFid() : m_strokeFrameId;
+  TXshSimpleLevel *sl = m_strokeLevel.getPointer();
 
-  TRasterImageP ri;
-  TXshSimpleLevel *sl     = 0;
-  TTool::Application *app = TTool::getApplication();
-  if (app && app->getCurrentLevel()) {
-    TXshLevel *level = app->getCurrentLevel()->getLevel();
-    sl               = level ? level->getSimpleLevel() : 0;
-    if (sl) ri = TRasterImageP(sl->getFrame(frameId, true));
-  }
+  TRasterImageP ri =
+      sl ? TRasterImageP(sl->getFrame(frameId, true)) : TRasterImageP();
   TRasterP ras = ri ? ri->getRaster() : TRasterP();
 
   m_lastRect.empty();
@@ -696,8 +699,9 @@ void FullColorBrushTool::commitStroke() {
 
   m_started       = false;
   m_strokeFrameId = TFrameId();
+  m_strokeLevel   = TXshSimpleLevelP();
   m_strokeRect.empty();
-  if (ras) notifyImageChanged(frameId);
+  if (ras && sl) notifyImageChanged(frameId, sl);
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -253,6 +253,7 @@ void FullColorBrushTool::onActivate() {
   setWorkAndBackupImages();
   onColorStyleChanged();
   updateModifiers();
+  m_skipStrokeUntilDown = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -261,8 +262,9 @@ void FullColorBrushTool::onDeactivate() {
   if (m_notifier) m_notifier->onDeactivate();
 
   m_inputmanager.finishTracks();
-  m_workRaster = TRaster32P();
-  m_backUpRas  = TRasterP();
+  m_workRaster          = TRaster32P();
+  m_backUpRas           = TRasterP();
+  m_skipStrokeUntilDown = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -372,13 +374,6 @@ bool FullColorBrushTool::preLeftButtonDown() {
 void FullColorBrushTool::handleMouseEvent(MouseEventType type,
                                           const TPointD &pos,
                                           const TMouseEvent &e) {
-  if (m_skipStrokeUntilDown) {
-    if (type == ME_DOWN)
-      m_skipStrokeUntilDown = false;
-    else if (type != ME_MOVE)
-      return;
-  }
-
   TTimerTicks t = TToolTimer::ticks();
   bool alt      = e.getModifiersMask() & TMouseEvent::ALT_KEY;
   bool shift    = e.getModifiersMask() & TMouseEvent::SHIFT_KEY;
@@ -402,6 +397,13 @@ void FullColorBrushTool::handleMouseEvent(MouseEventType type,
     m_inputmanager.keyEvent(shift, TKey::shift, t, nullptr);
   if (control != m_inputmanager.state.isKeyPressed(TKey::control))
     m_inputmanager.keyEvent(control, TKey::control, t, nullptr);
+
+  if (m_skipStrokeUntilDown) {
+    if (type == ME_DOWN)
+      m_skipStrokeUntilDown = false;
+    else if (type != ME_MOVE)
+      return;
+  }
 
   if (type == ME_MOVE) {
     THoverList hovers(1, pos);
@@ -672,7 +674,6 @@ void FullColorBrushTool::commitStroke() {
     sl               = level ? level->getSimpleLevel() : 0;
     if (sl) ri = TRasterImageP(sl->getFrame(frameId, true));
   }
-  if (!ri) ri = (TRasterImageP)getImage(true);
   TRasterP ras = ri ? ri->getRaster() : TRasterP();
 
   m_lastRect.empty();

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -115,7 +115,8 @@ public:
 
 private:
   void updateModifiers();
-  
+  void commitStroke();
+
   enum MouseEventType { ME_DOWN, ME_DRAG, ME_UP, ME_MOVE };
   void handleMouseEvent(MouseEventType type, const TPointD &pos,
                         const TMouseEvent &e);
@@ -167,8 +168,10 @@ protected:
   bool m_firstTime;
 
   bool m_started;
+  TFrameId m_strokeFrameId;
 
-  bool m_propertyUpdating = false;
+  bool m_propertyUpdating    = false;
+  bool m_skipStrokeUntilDown = false;
 };
 
 //------------------------------------------------------------

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -169,6 +169,7 @@ protected:
 
   bool m_started;
   TFrameId m_strokeFrameId;
+  TXshSimpleLevelP m_strokeLevel;
 
   bool m_propertyUpdating    = false;
   bool m_skipStrokeUntilDown = false;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1220,6 +1220,11 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
     }
 
     m_painting.frameId = getFrameId();
+    m_painting.level   = TXshSimpleLevelP();
+    if (TXshLevelHandle *lh = app->getCurrentLevel()) {
+      if (TXshLevel *xl = lh->getLevel())
+        m_painting.level = xl->getSimpleLevel();
+    }
 
     TToonzImageP ri(getImage(true));
     TRasterCM32P ras = ri ? ri->getRaster() : TRasterCM32P();
@@ -1578,15 +1583,10 @@ void ToonzRasterBrushTool::commitPainting() {
 
   TFrameId frameId =
       m_painting.frameId.isEmptyFrame() ? getCurrentFid() : m_painting.frameId;
-  TXshSimpleLevel *sl     = 0;
-  TTool::Application *app = TTool::getApplication();
-  if (app && app->getCurrentLevel()) {
-    TXshLevel *level = app->getCurrentLevel()->getLevel();
-    sl               = level ? level->getSimpleLevel() : 0;
-  }
+  TXshSimpleLevel *sl = m_painting.level.getPointer();
 
-  TToonzImageP ti  = sl ? TToonzImageP(sl->getFrame(frameId, true))
-                        : TToonzImageP(getImage(true));
+  TToonzImageP ti =
+      sl ? TToonzImageP(sl->getFrame(frameId, true)) : TToonzImageP();
   TRasterCM32P ras = ti ? ti->getRaster() : TRasterCM32P();
 
   if (m_painting.tileSet && m_painting.tileSet->getTileCount() > 0 && ras &&
@@ -1604,12 +1604,13 @@ void ToonzRasterBrushTool::commitPainting() {
   if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();
 
   m_painting.frameId          = TFrameId();
+  m_painting.level            = TXshSimpleLevelP();
   m_painting.myPaint.isActive = false;
   m_painting.pencil.isActive  = false;
   m_painting.blured.isActive  = false;
   m_painting.active           = false;
 
-  notifyImageChanged(frameId);
+  if (sl) notifyImageChanged(frameId, sl);
   ToolUtils::updateSaveBox();
 }
 

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1113,6 +1113,13 @@ bool ToonzRasterBrushTool::preLeftButtonDown() {
 void ToonzRasterBrushTool::handleMouseEvent(MouseEventType type,
                                             const TPointD &pos,
                                             const TMouseEvent &e) {
+  if (m_skipStrokeUntilDown) {
+    if (type == ME_DOWN)
+      m_skipStrokeUntilDown = false;
+    else if (type != ME_MOVE)
+      return;
+  }
+
   TTimerTicks t    = TToolTimer::ticks();
   bool alt         = e.getModifiersMask() & TMouseEvent::ALT_KEY;
   bool shift       = e.getModifiersMask() & TMouseEvent::SHIFT_KEY;
@@ -1178,6 +1185,7 @@ void ToonzRasterBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 //--------------------------------------------------------------------------------------------------
 
 void ToonzRasterBrushTool::inputSetBusy(bool busy) {
+  if (m_skipStrokeUntilDown && busy) return;
   if (m_painting.active == busy) return;
 
   if (busy) {
@@ -1211,9 +1219,8 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
 
     m_painting.frameId = getFrameId();
 
-    TImageP img = getImage(true);
-    TToonzImageP ri(img);
-    TRasterCM32P ras = ri->getRaster();
+    TToonzImageP ri(getImage(true));
+    TRasterCM32P ras = ri ? ri->getRaster() : TRasterCM32P();
     if (!ras) {
       m_painting.active = false;
       return;
@@ -1255,51 +1262,7 @@ void ToonzRasterBrushTool::inputSetBusy(bool busy) {
     }
 
   } else {
-    // finish painting
-
-    if (m_painting.myPaint.isActive) {
-      // finish myPaint drawing
-      m_workRas->unlock();
-    }
-
-    delete m_painting.tileSaver;
-    m_painting.tileSaver = nullptr;
-
-    // add undo record
-    TFrameId frameId = m_painting.frameId.isEmptyFrame() ? getCurrentFid()
-                                                         : m_painting.frameId;
-    if (m_painting.tileSet->getTileCount() > 0) {
-      TTool::Application *app   = TTool::getApplication();
-      TXshLevel *level          = app->getCurrentLevel()->getLevel();
-      TXshSimpleLevelP simLevel = level->getSimpleLevel();
-      TRasterCM32P ras          = TToonzImageP(getImage(true))->getRaster();
-      TRasterCM32P subras = ras->extract(m_painting.affectedRect)->clone();
-      TUndoManager::manager()->add(new MyPaintBrushUndo(
-          m_painting.tileSet, simLevel.getPointer(), frameId, m_isFrameCreated,
-          m_isLevelCreated, subras, m_painting.affectedRect.getP00()));
-      // MyPaintBrushUndo will delete tileSet by it self
-    } else {
-      // delete tileSet here because MyPaintBrushUndo will not do it
-      delete m_painting.tileSet;
-    }
-    m_painting.tileSet = nullptr;
-
-    // Restore gap/autoclose Fill Check
-    int tc = ToonzCheck::instance()->getChecks();
-    if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();
-
-    /*-- 作業中のフレームをリセット --*/
-    m_painting.frameId = TFrameId();
-
-    m_painting.myPaint.isActive = false;
-    m_painting.pencil.isActive  = false;
-    m_painting.blured.isActive  = false;
-    m_painting.active           = false;
-
-    /*-- FIdを指定して、描画中にフレームが動いても、
-      描画開始時のFidのサムネイルが更新されるようにする。--*/
-    notifyImageChanged(frameId);
-    ToolUtils::updateSaveBox();
+    commitPainting();
   }
 }
 
@@ -1310,9 +1273,8 @@ void ToonzRasterBrushTool::inputPaintTrackPoint(const TTrackPoint &point,
                                                 bool firstTrack, bool preview) {
   if (!m_painting.active || preview) return;
 
-  TImageP img = getImage(true);
-  TToonzImageP ri(img);
-  TRasterCM32P ras = ri->getRaster();
+  TToonzImageP ri(getImage(true));
+  TRasterCM32P ras = ri ? ri->getRaster() : TRasterCM32P();
   if (!ras) return;
   TPointD rasCenter     = convert(ras->getCenter());
   TPointD fixedPosition = getCenteredCursorPos(point.position);
@@ -1562,6 +1524,7 @@ void ToonzRasterBrushTool::draw() {
 
   if (TToonzImageP ti = img) {
     TRasterP ras = ti->getRaster();
+    if (!ras) return;
     int lx       = ras->getLx();
     int ly       = ras->getLy();
     drawEmptyCircle(m_brushPos, tround(m_minThick), lx % 2 == 0, ly % 2 == 0,
@@ -1603,7 +1566,59 @@ TPropertyGroup *ToonzRasterBrushTool::getProperties(int idx) {
 
 //----------------------------------------------------------------------------------------------------------
 
+void ToonzRasterBrushTool::commitPainting() {
+  if (!m_painting.active) return;
+
+  if (m_painting.myPaint.isActive && m_workRas) m_workRas->unlock();
+
+  delete m_painting.tileSaver;
+  m_painting.tileSaver = nullptr;
+
+  TFrameId frameId =
+      m_painting.frameId.isEmptyFrame() ? getCurrentFid() : m_painting.frameId;
+  TXshSimpleLevel *sl     = 0;
+  TTool::Application *app = TTool::getApplication();
+  if (app && app->getCurrentLevel()) {
+    TXshLevel *level = app->getCurrentLevel()->getLevel();
+    sl               = level ? level->getSimpleLevel() : 0;
+  }
+
+  TToonzImageP ti  = sl ? TToonzImageP(sl->getFrame(frameId, true))
+                        : TToonzImageP(getImage(true));
+  TRasterCM32P ras = ti ? ti->getRaster() : TRasterCM32P();
+
+  if (m_painting.tileSet && m_painting.tileSet->getTileCount() > 0 && ras &&
+      sl) {
+    TRasterCM32P subras = ras->extract(m_painting.affectedRect)->clone();
+    TUndoManager::manager()->add(new MyPaintBrushUndo(
+        m_painting.tileSet, sl, frameId, m_isFrameCreated, m_isLevelCreated,
+        subras, m_painting.affectedRect.getP00()));
+  } else {
+    delete m_painting.tileSet;
+  }
+  m_painting.tileSet = nullptr;
+
+  int tc = ToonzCheck::instance()->getChecks();
+  if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();
+
+  m_painting.frameId          = TFrameId();
+  m_painting.myPaint.isActive = false;
+  m_painting.pencil.isActive  = false;
+  m_painting.blured.isActive  = false;
+  m_painting.active           = false;
+
+  notifyImageChanged(frameId);
+  ToolUtils::updateSaveBox();
+}
+
+//----------------------------------------------------------------------------------------------------------
+
 void ToonzRasterBrushTool::onImageChanged() {
+  m_inputmanager.reset();
+  if (m_painting.active) {
+    commitPainting();
+    m_skipStrokeUntilDown = true;
+  }
   if (!isEnabled()) return;
   setWorkAndBackupImages();
 }
@@ -1613,7 +1628,8 @@ void ToonzRasterBrushTool::onImageChanged() {
 void ToonzRasterBrushTool::setWorkAndBackupImages() {
   TToonzImageP ti = (TToonzImageP)getImage(false, 1);
   if (!ti) return;
-  TRasterP ras   = ti->getRaster();
+  TRasterP ras = ti->getRaster();
+  if (!ras) return;
   TDimension dim = ras->getSize();
 
   if (!m_workRas || m_workRas->getLx() < dim.lx || m_workRas->getLy() < dim.ly)

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1034,6 +1034,7 @@ void ToonzRasterBrushTool::onActivate() {
 
   updateModifiers();
   m_brushTimer.start();
+  m_skipStrokeUntilDown = false;
   // TODO:app->editImageOrSpline();
 }
 
@@ -1041,9 +1042,10 @@ void ToonzRasterBrushTool::onActivate() {
 
 void ToonzRasterBrushTool::onDeactivate() {
   m_inputmanager.finishTracks();
-  m_enabled   = false;
-  m_workRas   = TRaster32P();
-  m_backupRas = TRasterCM32P();
+  m_enabled             = false;
+  m_workRas             = TRaster32P();
+  m_backupRas           = TRasterCM32P();
+  m_skipStrokeUntilDown = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1113,13 +1115,6 @@ bool ToonzRasterBrushTool::preLeftButtonDown() {
 void ToonzRasterBrushTool::handleMouseEvent(MouseEventType type,
                                             const TPointD &pos,
                                             const TMouseEvent &e) {
-  if (m_skipStrokeUntilDown) {
-    if (type == ME_DOWN)
-      m_skipStrokeUntilDown = false;
-    else if (type != ME_MOVE)
-      return;
-  }
-
   TTimerTicks t    = TToolTimer::ticks();
   bool alt         = e.getModifiersMask() & TMouseEvent::ALT_KEY;
   bool shift       = e.getModifiersMask() & TMouseEvent::SHIFT_KEY;
@@ -1148,6 +1143,13 @@ void ToonzRasterBrushTool::handleMouseEvent(MouseEventType type,
     m_inputmanager.keyEvent(shift, TKey::shift, t, nullptr);
   if (control != m_inputmanager.state.isKeyPressed(TKey::control))
     m_inputmanager.keyEvent(control, TKey::control, t, nullptr);
+
+  if (m_skipStrokeUntilDown) {
+    if (type == ME_DOWN)
+      m_skipStrokeUntilDown = false;
+    else if (type != ME_MOVE)
+      return;
+  }
 
   if (type == ME_MOVE) {
     THoverList hovers(1, fixedPos);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -11,6 +11,7 @@
 #include <toonz/strokegenerator.h>
 #include <toonz/rasterstrokegenerator.h>
 #include "toonz/preferences.h"
+#include "toonz/txshsimplelevel.h"
 #include <tools/tool.h>
 #include <tools/cursors.h>
 
@@ -254,6 +255,7 @@ protected:
     // 作業中のFrameIdをクリック時に保存し、マウスリリース時（Undoの登録時）に別のフレームに
     // 移動していたときの不具合を修正する。
     TFrameId frameId;
+    TXshSimpleLevelP level;
 
     // common variables
     TTileSetCM32 *tileSet     = nullptr;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -196,6 +196,7 @@ public:
 
 private:
   void updateModifiers();
+  void commitPainting();
 
   enum MouseEventType { ME_DOWN, ME_DRAG, ME_UP, ME_MOVE };
   void handleMouseEvent(MouseEventType type, const TPointD &pos,
@@ -314,7 +315,8 @@ protected:
   QElapsedTimer m_brushTimer;
   int m_minCursorThick, m_maxCursorThick;
 
-  bool m_propertyUpdating = false;
+  bool m_propertyUpdating    = false;
+  bool m_skipStrokeUntilDown = false;
 
 protected:
   static void drawLine(const TPointD &point, const TPointD &centre,

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -729,6 +729,14 @@ void ToonzVectorBrushTool::onActivate() {
 
 //--------------------------------------------------------------------------------------------------
 
+void ToonzVectorBrushTool::onImageChanged() {
+  m_inputmanager.reset();
+  m_active = false;
+  m_tracks.clear();
+}
+
+//-----------------------------------------------------------------------------
+
 void ToonzVectorBrushTool::onDeactivate() {
   /*---
    * ドラッグ中にツールが切り替わった場合に備え、onDeactivateにもMouseReleaseと同じ処理を行う
@@ -899,6 +907,7 @@ void ToonzVectorBrushTool::inputSetBusy(bool busy) {
     TStroke *stroke = m_tracks.front().makeStroke(error);
 
     TVectorImageP vi = getImage(true);
+    if (!vi) return;
 
     if (!isJustCreatedSpline(vi.getPointer())) {
       m_currentColor = TPixel32::Green;
@@ -927,6 +936,7 @@ void ToonzVectorBrushTool::inputSetBusy(bool busy) {
   // paint regular strokes
   
   TVectorImageP vi = getImage(true);
+  if (!vi) return;
   QMutexLocker lock(vi->getMutex());
   TTool::Application *app = TTool::getApplication();
   

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -724,12 +724,14 @@ void ToonzVectorBrushTool::onActivate() {
   }
   resetFrameRange();
   updateModifiers();
+  m_skipStrokeUntilDown = false;
   // TODO:app->editImageOrSpline();
 }
 
 //--------------------------------------------------------------------------------------------------
 
 void ToonzVectorBrushTool::onImageChanged() {
+  if (m_active) m_skipStrokeUntilDown = true;
   m_inputmanager.reset();
   m_active = false;
   m_tracks.clear();
@@ -745,6 +747,7 @@ void ToonzVectorBrushTool::onDeactivate() {
   // End current stroke.
   m_inputmanager.finishTracks();
   resetFrameRange();
+  m_skipStrokeUntilDown = false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1197,6 +1200,13 @@ void ToonzVectorBrushTool::handleMouseEvent(MouseEventType type,
   if (control != m_inputmanager.state.isKeyPressed(TKey::control))
     m_inputmanager.keyEvent(control, TKey::control, t, nullptr);
 
+  if (m_skipStrokeUntilDown) {
+    if (type == ME_DOWN)
+      m_skipStrokeUntilDown = false;
+    else if (type != ME_MOVE)
+      return;
+  }
+
   TPointD snappedPos = pos;
   bool pickerMode = getViewer() && getViewer()->getGuidedStrokePickerMode();
   bool snapInvert = alt && (!control || type == ME_MOVE || type == ME_DOWN);
@@ -1557,7 +1567,20 @@ void ToonzVectorBrushTool::snap(const TPointD &pos, bool snapEnabled, bool withS
 void ToonzVectorBrushTool::draw() {
   m_pixelSize = getPixelSize();
   m_inputmanager.draw();
-  
+
+  for (TrackList::iterator i = m_rangeTracks.begin(); i != m_rangeTracks.end();
+       ++i) {
+    if (i->isEmpty()) continue;
+    TPointD offset1 = TPointD(5, 5);
+    TPointD offset2 = TPointD(-offset1.x, offset1.y);
+    TPointD point   = i->getFirstPoint();
+    glColor3d(1.0, 0.0, 0.0);
+    i->drawAllFragments();
+    glColor3d(0.0, 0.6, 0.0);
+    tglDrawSegment(point - offset1, point + offset1);
+    tglDrawSegment(point - offset2, point + offset2);
+  }
+
   /*--ショートカットでのツール切り替え時に赤点が描かれるのを防止する--*/
   if (m_minThick == 0 && m_maxThick == 0 &&
       !Preferences::instance()->getShow0ThickLines())
@@ -1577,19 +1600,6 @@ void ToonzVectorBrushTool::draw() {
   if (m_snappedSelf) {
     tglColor(TPixelD(0.9, 0.9, 0.1));
     tglDrawCircle(m_snapPointSelf, snapMarkRadius);
-  }
-
-  // frame range
-  for(TrackList::iterator i = m_rangeTracks.begin(); i != m_rangeTracks.end(); ++i) {
-    if (i->isEmpty()) continue;
-    TPointD offset1 = TPointD(5, 5);
-    TPointD offset2 = TPointD(-offset1.x, offset1.y);
-    TPointD point = i->getFirstPoint();
-    glColor3d(1.0, 0.0, 0.0);
-    i->drawAllFragments();
-    glColor3d(0.0, 0.6, 0.0);
-    tglDrawSegment(point - offset1, point + offset1);
-    tglDrawSegment(point - offset2, point + offset2);
   }
 
   if (getApplication()->getCurrentObject()->isSpline()) return;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -135,6 +135,7 @@ public:
 
   void onActivate() override;
   void onDeactivate() override;
+  void onImageChanged() override;
 
   bool preLeftButtonDown() override;
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;

--- a/toonz/sources/tnztools/toonzvectorbrushtool.h
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.h
@@ -261,6 +261,7 @@ protected:
       m_presetsManager;  //!< Manager for presets of this tool instance
 
   bool m_active, m_firstTime, m_isPath, m_presetsLoaded, m_firstFrameRange;
+  bool m_skipStrokeUntilDown = false;
 
   bool m_propertyUpdating;
   double m_cameraDpi;


### PR DESCRIPTION
I first hit this while testing #7098. It is not caused by that option: the same crash happens on the nightly build, without it. This is the separate fix.

Vector: drop the in-progress stroke when the frame changes. Do not use a missing image.

Toonz Raster and Raster: finish the interrupted stroke on the frame where it started, with its undo. Toonz Raster no longer creates a cell on the leftover mouse release; it matches Raster. Do not use a missing image.

Vector drops the stroke because after a frame change the current image is gone or is another drawing. Raster can finish on the start frame because those pixels live there. Switching tools already commits via finishTracks(); changing frame with the arrows is not the same case for Vector.



This feature was developed with Cursor’s AI models