### PR TITLE
(Proposal) Set Brush as default tool at startup (Do not Merge)

### DIFF
--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -793,7 +793,7 @@ int main(int argc, char *argv[]) {
   // Show floating panels only after the main window has been shown
   w.startupFloatingPanels();
 
-  CommandManager::instance()->execute(T_Hand);
+  CommandManager::instance()->execute(T_Brush);
   if (!loadFilePath.isEmpty()) {
     splash.showMessage(
         QString("Loading file '") + loadFilePath.getQString() + "'...",


### PR DESCRIPTION
OpenToonz will now select the Brush Tool instead of the Hand Tool at startup.

**Note:** This is 1 of 2 related PRs changing the default from the Hand Tool to the Brush Tool.

The rationale for splitting the change into two PRs is that changing defaults can interfere with established workflows, particularly for studio personnel who do not use OpenToonz primarily for drawing. It may therefore be preferable to retain the Hand Tool at program startup while selecting the Brush Tool when a new scene is created.

Both PRs change existing default behavior, but keeping the changes separate allows either behavior to be easily reverted or modified based on feedback.

Original author: AHL (@Ahl76)

Authored with assistance from Cursor
(Processed with assistance from ChatGPT 5.6)
