### PR TITLE
(Proposal) Set Brush as default tool for new scenes (Do not Merge)

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1378,7 +1378,7 @@ void IoCmd::newScene() {
   ToolHandle *toolH = TApp::instance()->getCurrentTool();
   if (toolH && toolH->getTool()) toolH->getTool()->reset();
 
-  CommandManager::instance()->execute("T_Hand");
+  CommandManager::instance()->execute("T_Brush");
 
   CommandManager::instance()->enable(MI_SaveSubxsheetAs, false);
 


### PR DESCRIPTION
Select the Brush tool instead of the Hand tool when a new scene is created.

Note: This is 2 of 2 related PRs changing the default from the Hand Tool to the Brush Tool.
See also:  #7101

Changes the default tool selected when OpenToonz starts from the Hand Tool to the Brush Tool.
This reduces the step between launching OpenToonz and beginning to draw while otherwise leaving tool behavior unchanged.

Because this changes a longstanding default, feedback is welcome particularly from anyone who believes the Hand Tool, or another tool, should remain the default at startup.

Original author: **AHL (@Ahl76)**.

Authored with assistance from Cursor
(Processed with assistance from ChatGPT 5.6)
Based on OpenAnimationLibrary/opentoonz-dev#70.