### PR TITLE
Stabilize macOS Homebrew dependencies

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -50,6 +50,8 @@ jobs:
           brew link --overwrite --force python@3.14 || true
 
       - name: Install libraries
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           checkPkgAndInstall() {
             for pkg in "$@"; do
@@ -60,8 +62,6 @@ jobs:
               fi
             done
           }
-
-          brew update
 
           checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv@4 openjph openexr
 


### PR DESCRIPTION
Prevents the macOS CI build from updating Homebrew immediately before installing build dependencies.

The current workflow can pick up dependency changes newer than the GitHub runner image. This caused `opencv@4` to pull a VTK dependency for which no bottle was available on the `macos-15-intel` runner, causing the build to fail before OpenToonz compilation began.

Use the Homebrew package snapshot provided with the runner instead by disabling automatic updates during dependency installation.

No OpenToonz source code is changed.
