### PR TITLE
Convert NAAimage to TLV: Added BG Color Option

### DIFF
--- a/toonz/sources/include/toonz/Naa2TlvConverter.h
+++ b/toonz/sources/include/toonz/Naa2TlvConverter.h
@@ -108,6 +108,7 @@ public:
   double m_inkThickness;
   TPalette *m_palette;
   bool m_valid;
+  bool m_allowOnlyWhiteBG;
 
   Naa2TlvConverter();
   ~Naa2TlvConverter();
@@ -154,6 +155,8 @@ public:
   TVectorImageP vectorize();
 
   void removeUnusedStyles(const QList<int> &styleIds);
+
+  void setAllowOnlyWhiteBG(bool on) { m_allowOnlyWhiteBG = on; }
 };
 
 #endif

--- a/toonz/sources/include/toonzqt/imageutils.h
+++ b/toonz/sources/include/toonzqt/imageutils.h
@@ -119,7 +119,8 @@ void DVAPI convertNaa2Tlv(
         0,  //!< Special conversion function from an antialiased level to tlv.
             //!  \sa  Function ImageUtils::convert().
     bool removeUnusedStyles = false,
-    double dpi = 0.0);  //! Remove unused styles from input palette.
+    double dpi              = 0.0,  //! Remove unused styles from input palette.
+    bool allowOnlyWhiteBG   = false);
 
 // convert old levels (tzp / tzu) to tlv
 void DVAPI convertOldLevel2Tlv(

--- a/toonz/sources/toonz/convertpopup.cpp
+++ b/toonz/sources/toonz/convertpopup.cpp
@@ -63,6 +63,8 @@ TEnv::IntVar ConvertPopupRemoveUnusedStyles("ConvertPopupRemoveUnusedStyles",
 TEnv::IntVar ConvertPopupDpiMode("ConvertPopupDpiMode", 2);  // Custom DPI
 TEnv::DoubleVar ConvertPopupDpiValue("ConvertPopupDpiValue", 72.0);
 
+TEnv::IntVar ConvertPopupAllowOnlyWhiteBG("ConvertPopupAllowOnlyWhiteBG", 0);
+
 //=============================================================================
 // convertPopup
 //-----------------------------------------------------------------------------
@@ -215,7 +217,8 @@ void ConvertPopup::Converter::convertLevel(
       ImageUtils::convertNaa2Tlv(sourceFileFullPath, dstFileFullPath, from, to,
                                  m_parent->m_notifier, palette.getPointer(),
                                  m_parent->m_removeUnusedStyles->isChecked(),
-                                 m_parent->m_dpiFld->getValue());
+                                 m_parent->m_dpiFld->getValue(),
+                                 m_parent->m_allowOnlyWhiteBG->isChecked());
     } else {
       // other 3 cases
       convertLevelWithConvert2Tlv(sourceFileFullPath);
@@ -590,6 +593,9 @@ QFrame *ConvertPopup::createTlvSettings() {
   m_dpiMode = new QComboBox();
   m_dpiFld  = new DVGui::DoubleLineEdit();
 
+  m_allowOnlyWhiteBG = new QCheckBox(tr(
+      "Only white or transparent pixels can be identified as the background"));
+
   m_unpaintedFolder->setFileMode(
       QFileDialog::Directory);  // implies ShowDirsOnly
   m_unpaintedSuffix->setMaximumWidth(40);
@@ -607,7 +613,8 @@ QFrame *ConvertPopup::createTlvSettings() {
 
   m_appendDefaultPalette->setToolTip(
       tr("When activated, styles of the default "
-         "palette\n($TOONZSTUDIOPALETTE\\Global Palettes\\Default Palettes\\Cleanup_Palette.tpl) will \nbe "
+         "palette\n($TOONZSTUDIOPALETTE\\Global Palettes\\Default "
+         "Palettes\\Cleanup_Palette.tpl) will \nbe "
          "appended to the palette after conversion in \norder to save the "
          "effort of creating styles \nbefore color designing."));
 
@@ -626,6 +633,13 @@ QFrame *ConvertPopup::createTlvSettings() {
       "used.\n"));
   m_dpiMode->setCurrentIndex(ConvertPopupDpiMode);
   m_dpiFld->setValue(ConvertPopupDpiValue);
+
+  m_allowOnlyWhiteBG->setToolTip(tr(
+      "When activated, only fully white or transparent pixels are \n"
+      "identified as the background. When deactivated, the brightest \n"
+      "or most transparent color in the image is identified as a candidate \n"
+      "for the background color."));
+  m_allowOnlyWhiteBG->setChecked(ConvertPopupAllowOnlyWhiteBG != 0);
 
   QGridLayout *gridLay = new QGridLayout();
   {
@@ -661,6 +675,8 @@ QFrame *ConvertPopup::createTlvSettings() {
                        Qt::AlignRight | Qt::AlignVCenter);
     gridLay->addWidget(m_dpiMode, 8, 1);
     gridLay->addWidget(m_dpiFld, 8, 2);
+
+    gridLay->addWidget(m_allowOnlyWhiteBG, 9, 1, 1, 3);
   }
   gridLay->setColumnStretch(0, 0);
   gridLay->setColumnStretch(1, 1);
@@ -713,7 +729,7 @@ void ConvertPopup::onAntialiasSelected(int index) {
 void ConvertPopup::onFileInChanged() {
   assert(m_convertFileFld);
   std::vector<TFilePath> fps;
-  auto project = TProjectManager::instance()->getCurrentProject();
+  auto project      = TProjectManager::instance()->getCurrentProject();
   ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
   fps.push_back(scene->decodeFilePath(
       TFilePath(m_convertFileFld->getPath().toStdString())));
@@ -739,6 +755,7 @@ void ConvertPopup::onTlvModeSelected(const QString &tlvMode) {
                                        CreateNewPalette);
 
   m_saveBackupToNopaint->setEnabled(TlvMode_Unpainted == tlvMode);
+  m_allowOnlyWhiteBG->setEnabled(TlvMode_PaintedFromNonAA == tlvMode);
 }
 
 //-------------------------------------------------
@@ -766,6 +783,8 @@ void ConvertPopup::onFormatSelected(const QString &format) {
 
     m_saveBackupToNopaint->setEnabled(m_tlvMode->currentText() ==
                                       TlvMode_Unpainted);
+    m_allowOnlyWhiteBG->setEnabled(m_tlvMode->currentText() ==
+                                   TlvMode_PaintedFromNonAA);
   }
   // For unknown reasons, calling adjustSize twice is needed to
   // prevent the dialog from remaining large size when the current
@@ -836,7 +855,7 @@ void ConvertPopup::setFiles(const std::vector<TFilePath> &fps) {
 
   if (m_srcFilePaths.size() == 1) {
     setWindowTitle(tr("Convert 1 Level : %1")
-        .arg(QString::fromStdString(fps[0].getName())));
+                       .arg(QString::fromStdString(fps[0].getName())));
     m_fileNameFld->setEnabled(true);
 
     m_fromFld->setEnabled(false);
@@ -888,9 +907,9 @@ void ConvertPopup::setFiles(const std::vector<TFilePath> &fps) {
   // m_fileFormat->setCurrentIndex(areFullcolor?0:m_fileFormat->findText("tif"));
 }
 
-void ConvertPopup::setFormat(QString format){
-    m_fileFormat->setDisabled(true);
-    m_fileFormat->setCurrentIndex(m_fileFormat->findText(format));
+void ConvertPopup::setFormat(QString format) {
+  m_fileFormat->setDisabled(true);
+  m_fileFormat->setCurrentIndex(m_fileFormat->findText(format));
 }
 
 //-------------------------------------------------------------------
@@ -1192,6 +1211,8 @@ void ConvertPopup::apply() {
   if (m_dpiMode->currentIndex() == 2)  // In the case of Custom DPI
     ConvertPopupDpiValue = m_dpiFld->getValue();
 
+  ConvertPopupAllowOnlyWhiteBG = m_allowOnlyWhiteBG->isChecked() ? 1 : 0;
+
   // parameters are ok: close the dialog first
   close();
 
@@ -1267,7 +1288,6 @@ QString::number(m_srcFilePaths.size()-skipped)).arg(QString::number(m_srcFilePat
 
 void ConvertPopup::onLevelConverted(const TFilePath &fullPath) {
   IconGenerator::instance()->invalidate(fullPath);
-  
 }
 
 //-------------------------------------------------------------------

--- a/toonz/sources/toonz/convertpopup.h
+++ b/toonz/sources/toonz/convertpopup.h
@@ -36,7 +36,7 @@ class ColorField;
 class ProgressDialog;
 class CheckBox;
 class DoubleLineEdit;
-}
+}  // namespace DVGui
 
 namespace ImageUtils {
 class FrameTaskNotifier;
@@ -54,7 +54,7 @@ class FrameTaskNotifier;
 */
 
 class ConvertPopup : public DVGui::Dialog {
-    Q_OBJECT
+  Q_OBJECT
 
 public:
   ConvertPopup(bool specifyInput = false);
@@ -65,8 +65,9 @@ public:
   bool isConverting() const { return m_isConverting; }
 
   void convertToTlv(bool toPainted);
-  TFilePath getConvertedPath(TFilePath path) 
-  {return m_convertedFileMap[path];};
+  TFilePath getConvertedPath(TFilePath path) {
+    return m_convertedFileMap[path];
+  };
   QString getDestinationType() const;
   QString getTlvMode() const;
   QString TlvMode_Unpainted;
@@ -110,7 +111,8 @@ private:
   DVGui::ColorField *m_bgColorField;
   QFrame *m_tlvFrame;
   QCheckBox *m_applyAutoclose, *m_removeDotBeforeFrameNumber,
-      *m_saveBackupToNopaint, *m_appendDefaultPalette, *m_removeUnusedStyles;
+      *m_saveBackupToNopaint, *m_appendDefaultPalette, *m_removeUnusedStyles,
+      *m_allowOnlyWhiteBG;
   DVGui::CheckBox *m_skip;
   QComboBox *m_antialias, *m_tlvMode, *m_fileFormat;
   QLabel *m_bgColorLabel, *m_suffixLabel, *m_unpaintedFolderLabel,

--- a/toonz/sources/toonzlib/Naa2TlvConverter.cpp
+++ b/toonz/sources/toonzlib/Naa2TlvConverter.cpp
@@ -48,8 +48,7 @@ Naa2TlvConverter::Naa2TlvConverter()
     , m_inkThickness(0)
     , m_palette(0)
     , m_valid(false)
-
-{}
+    , m_allowOnlyWhiteBG(false) {}
 
 Naa2TlvConverter::~Naa2TlvConverter() {
   delete m_regionRas;
@@ -343,8 +342,10 @@ void Naa2TlvConverter::findBackgroundRegions() {
   int maxV         = 0;
   for (int i = 0; i < m_colors.count(); i++) {
     TPixel color = m_colors.at(i);
-    int v        = color.r + color.g + color.b;
-    int a        = std::min({color.r, color.g, color.b});
+    if (m_allowOnlyWhiteBG && color != TPixel::White) continue;
+
+    int v = color.r + color.g + color.b;
+    int a = std::min({color.r, color.g, color.b});
     if (a < 230) continue;
     if (v > maxV) {
       bgColorIndex = i;
@@ -547,7 +548,8 @@ void Naa2TlvConverter::findThinInks() {
   if (!m_regionRas || !m_borderRas || m_regions.empty()) return;
   for (int i = 0; i < m_regions.count(); i++) {
     RegionInfo &region = m_regions[i];
-    if (region.type != RegionInfo::Unknown) continue; // Skip already classified regions
+    if (region.type != RegionInfo::Unknown)
+      continue;  // Skip already classified regions
 
     QList<int> &bs = region.boundaries;
 
@@ -555,19 +557,21 @@ void Naa2TlvConverter::findThinInks() {
       // If there are exactly 2 boundaries, classify as ThinInk
       region.type = RegionInfo::ThinInk;
     } else if (bs.count() == 3) {
-      // If there are exactly 3 boundaries, classify as ThinInk if bs[2] is small compared to bs[1]
+      // If there are exactly 3 boundaries, classify as ThinInk if bs[2] is
+      // small compared to bs[1]
       if (bs[2] * 5 < bs[1]) {
         region.type = RegionInfo::ThinInk;
       }
     } else {
-      // For other cases, calculate a threshold and classify as ThinInk if conditions are met
+      // For other cases, calculate a threshold and classify as ThinInk if
+      // conditions are met
       int k = 1;
       int s = 0;
       while (k < bs.count() && s * 100 < region.pixelCount * 90) {
         s += bs[k++];
       }
       if (region.pixelCount > 100 && k <= 3) {
-        region.type = RegionInfo::ThinInk; // was Ink for some reason
+        region.type = RegionInfo::ThinInk;  // was Ink for some reason
       }
     }
   }

--- a/toonz/sources/toonzqt/imageutils.cpp
+++ b/toonz/sources/toonzqt/imageutils.cpp
@@ -727,9 +727,9 @@ bool isPaintedImage(TFilePath path) {
 
   std::vector<uint8_t> visited(totalPixels, 0);
   std::vector<uint32_t> stack;
-  stack.reserve(totalPixels / 4);  
+  stack.reserve(totalPixels / 4);
 
-  uint32_t outerBackgroundCount = 0;  
+  uint32_t outerBackgroundCount = 0;
 
   auto tryPush = [&](uint16_t x, uint16_t y) {
     uint32_t idx = y * width + x;
@@ -758,7 +758,7 @@ bool isPaintedImage(TFilePath path) {
     uint16_t x   = packed & 0xFFFF;
     uint32_t idx = y * width + x;
 
-    if (y > 0) {  
+    if (y > 0) {
       uint32_t nidx = idx - width;
       if (!visited[nidx] && imgData[nidx] == backgroundColor) {
         visited[nidx] = 1;
@@ -766,7 +766,7 @@ bool isPaintedImage(TFilePath path) {
         stack.push_back((static_cast<uint32_t>(y - 1) << 16) | x);
       }
     }
-    if (y < height - 1) {  
+    if (y < height - 1) {
       uint32_t nidx = idx + width;
       if (!visited[nidx] && imgData[nidx] == backgroundColor) {
         visited[nidx] = 1;
@@ -774,7 +774,7 @@ bool isPaintedImage(TFilePath path) {
         stack.push_back((static_cast<uint32_t>(y + 1) << 16) | x);
       }
     }
-    if (x > 0) {  
+    if (x > 0) {
       uint32_t nidx = idx - 1;
       if (!visited[nidx] && imgData[nidx] == backgroundColor) {
         visited[nidx] = 1;
@@ -782,7 +782,7 @@ bool isPaintedImage(TFilePath path) {
         stack.push_back((static_cast<uint32_t>(y) << 16) | (x - 1));
       }
     }
-    if (x < width - 1) {  
+    if (x < width - 1) {
       uint32_t nidx = idx + 1;
       if (!visited[nidx] && imgData[nidx] == backgroundColor) {
         visited[nidx] = 1;
@@ -792,9 +792,8 @@ bool isPaintedImage(TFilePath path) {
     }
   }
 
-  uint32_t objectColorCount = totalPixels - maxCount;
-  uint32_t innerBackgroundCount =
-      maxCount - outerBackgroundCount;
+  uint32_t objectColorCount     = totalPixels - maxCount;
+  uint32_t innerBackgroundCount = maxCount - outerBackgroundCount;
 
   if (objectColorCount == 0) return 0.0;
 
@@ -807,7 +806,8 @@ bool isPaintedImage(TFilePath path) {
 void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
                     const TFrameId &from, const TFrameId &to,
                     FrameTaskNotifier *frameNotifier, TPalette *palette,
-                    bool removeUnusedStyles, double dpi) {
+                    bool removeUnusedStyles, double dpi,
+                    bool allowOnlyWhiteBG) {
   // std::string dstExt = dest.getType(), srcExt = source.getType();
   if (TSystem::doesExistFileOrLevel(dest.withType("tpl")))
     TSystem::deleteFile(dest.withType("tpl"));
@@ -827,6 +827,7 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
 
   Naa2TlvConverter converter;
   converter.setPalette(palette);
+  converter.setAllowOnlyWhiteBG(allowOnlyWhiteBG);
 
   QList<int> usedStyleIds({0});
 
@@ -869,7 +870,7 @@ void convertNaa2Tlv(const TFilePath &source, const TFilePath &dest,
     } catch (...) {
     }
 
-    frameNotifier->notifyFrameCompleted(f+1);
+    frameNotifier->notifyFrameCompleted(f + 1);
   }
 
   if (removeUnusedStyles) converter.removeUnusedStyles(usedStyleIds);


### PR DESCRIPTION
This PR adds a new checkbox to ConvertDialog that is enabled only when converting to TLV with the `“Painted tlv from non-AA source”` mode.

New option: `Only white or transparent pixels can be identified as the background`

Under the conventional specification, the color identified as the background pixel (StyleId = 0) was “the brightest color in the image, where the value of each channel is 230 or higher.”

In most cases, the color that met this condition was pure white, so it wasn’t a particular issue. However, especially in scenes with animation BG (背景動画), when converting images where the entire frame is filled with color, a problem occurs where parts of the image are unintentionally converted to transparent (i.e., the background style).

Therefore, we have added an option to limit the colors identified as the background to pure white or transparent.