### PR TITLE
Fix startup crash in dock layout restore

### DIFF
--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -296,7 +296,12 @@ void DockLayout::updateSeparatorCursors() {
   unsigned int i, j;
   int k, jInt;
   for (i = 0; i < m_regions.size(); ++i) {
-    r                = m_regions[i];
+    r = m_regions[i];
+
+    const int childCount     = static_cast<int>(r->getChildList().size());
+    const int separatorCount = static_cast<int>(r->separators().size());
+    if (childCount == 0 || separatorCount == 0) continue;
+
     bool orientation = r->getOrientation();
 
     // If region geometry is minimal or maximal, its separators are blocked
@@ -319,7 +324,7 @@ void DockLayout::updateSeparatorCursors() {
 
     // Arrowize all separators as long as the preceding region has equal
     // maximum and minimum sizes
-    for (j = 0; j < r->getChildList().size(); ++j) {
+    for (j = 0; j < static_cast<unsigned int>(separatorCount); ++j) {
       child = r->childRegion(j);
 
       if (child->getMaximumSize(orientation) ==
@@ -331,7 +336,8 @@ void DockLayout::updateSeparatorCursors() {
 
     jInt = j;
     // The same as above in reverse order
-    for (k = r->getChildList().size() - 1; k > jInt; --k) {
+    k = std::min(childCount - 1, separatorCount);
+    for (; k > jInt; --k) {
       child = r->childRegion(k);
 
       if (child->getMaximumSize(orientation) ==
@@ -1513,6 +1519,17 @@ bool DockLayout::restoreState(const State &state) {
     item->m_saveIndex = j;
   }
 
+  // Allocate region separators before showing docked widgets. Showing a widget
+  // can synchronously activate the layout and reach updateSeparatorCursors().
+  unsigned int k;
+  for (j = 0; j < m_regions.size(); ++j) {
+    Region *r = m_regions[j];
+    for (k = 1; k < r->m_childList.size(); ++k) {
+      r->insertSeparator(
+          m_decoAllocator->newSeparator(this, r->getOrientation(), r));
+    }
+  }
+
   // Docked widgets are found in hierarchy
   for (j = 0; j < m_regions.size(); ++j)
     if ((item = m_regions[j]->m_item)) {
@@ -1542,16 +1559,6 @@ bool DockLayout::restoreState(const State &state) {
       item->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
       item->setFloatingAppearance();
       item->m_floating = true;
-    }
-  }
-
-  // Allocate region separators
-  unsigned int k;
-  for (j = 0; j < m_regions.size(); ++j) {
-    Region *r = m_regions[j];
-    for (k = 1; k < r->m_childList.size(); ++k) {
-      r->insertSeparator(
-          m_decoAllocator->newSeparator(this, r->getOrientation(), r));
     }
   }
 
@@ -1659,8 +1666,8 @@ DockPlaceholder *DockDecoAllocator::newPlaceBuilt(DockWidget *owner, Region *r,
 
 //------------------------------------------------------
 
-//! Sets current deco allocator to decoAllocator. A default deco allocator
-//! is already provided at construction.
+//! Sets current deco allocator to decoAllocator. A default deco allocator is
+//! already provided at construction.
 
 //!\b NOTE: DockLayout takes ownership of the allocator.
 void DockLayout::setDecoAllocator(DockDecoAllocator *decoAllocator) {
@@ -1673,8 +1680,8 @@ void DockLayout::setDecoAllocator(DockDecoAllocator *decoAllocator) {
 
 //------------------------------------------------------
 
-//! Sets current deco allocator to decoAllocator. A default deco allocator
-//! is already provided at construction.
+//! Sets current deco allocator to decoAllocator. A default deco allocator is
+//! already provided at construction.
 
 //!\b NOTE: DockWidget takes ownership of the allocator.
 void DockWidget::setDecoAllocator(DockDecoAllocator *decoAllocator) {


### PR DESCRIPTION
Addresses two concrete causes of the reported startup / room-restore crash in `DockLayout`:

1. `updateSeparatorCursors()` can index separators using child-region traversal even though a split region with N children owns only N - 1 separators. The forward loop can therefore read past the separator list.
2. `restoreState()` shows restored dock widgets before allocating separators. `show()` can synchronously activate Qt layout processing and re-enter `redistribute()` / `updateSeparatorCursors()` while the restored hierarchy is only partially constructed.

This fix:
- bounds separator cursor updates by the actual separator count;
- safely skips cursor work when no separators exist;
- allocates restored region separators before any restored dock widget is shown.

Background
The crash report identifies `DockLayout::updateSeparatorCursors` as the faulting frame and `DockLayout::restoreState` as the restore path. Source analysis distinguishes the latent N / N-1 separator indexing defect from the restore-time empty-separator condition.

PR #6975 is not considered the likely origin of the invalid indexing, but its room-layout persistence changes may have made this older latent defect easier to expose by restoring more exact panel dimensions.

Open PR #6976 also touches this code and contains related separator-count defenses; it should be reconciled with this focused fix afterward.

Testing focus:
- repeated room switching, particularly layouts with fixed-width or otherwise constrained panels;
- close and relaunch with those rooms active to exercise startup restore;
- resize restored rooms and verify separator cursors remain correct.

Staged from OT-Dev PR #130 with research and processing assisted by Chat GPT 5.6

NOTE:  I personally have not been able to reproduce this crash but others reliably can.

Fixes #7105