### PR TITLE
Add Quicklink

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -342,6 +342,7 @@
     <menu title="Help">
         <command>MI_OpenOnlineManual</command>
         <command>MI_OpenWhatsNew</command>
+        <command>MI_Quicklink</command>
         <command>MI_OpenCommunityForum</command>
         <separator/>
         <command>MI_OpenReportABug</command>

--- a/stuff/profiles/layouts/shortcuts/defopentoonz.ini
+++ b/stuff/profiles/layouts/shortcuts/defopentoonz.ini
@@ -279,6 +279,7 @@ MI_PrevStep=
 MI_Print=Ctrl+P
 MI_PrintXsheet=
 MI_ProjectSettings=
+MI_Quicklink=
 MI_Quit=Ctrl+Q
 MI_Random=
 MI_RasterizePli=

--- a/stuff/profiles/layouts/shortcuts/otadobe.ini
+++ b/stuff/profiles/layouts/shortcuts/otadobe.ini
@@ -267,6 +267,7 @@ MI_PrevStep=
 MI_Print=
 MI_PrintXsheet=
 MI_ProjectSettings=
+MI_Quicklink=
 MI_Quit=Ctrl+Q
 MI_Random=
 MI_RasterizePli=

--- a/stuff/profiles/layouts/shortcuts/otharmony.ini
+++ b/stuff/profiles/layouts/shortcuts/otharmony.ini
@@ -267,6 +267,7 @@ MI_PrevStep=
 MI_Print=
 MI_PrintXsheet=
 MI_ProjectSettings=
+MI_Quicklink=
 MI_Quit=Ctrl+Q
 MI_Random=
 MI_RasterizePli=

--- a/stuff/profiles/layouts/shortcuts/otretas.ini
+++ b/stuff/profiles/layouts/shortcuts/otretas.ini
@@ -267,6 +267,7 @@ MI_PrevStep=
 MI_Print=
 MI_PrintXsheet=
 MI_ProjectSettings=
+MI_Quicklink=
 MI_Quit=Ctrl+Q
 MI_Random=
 MI_RasterizePli=

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -41,6 +41,7 @@ enum PreferencesItemId {
   colorCalibrationLutPaths,
   showIconsInMenu,
   showRoomBindButtons,
+  customHelpLink,
   displayIn30bit,
   viewerIndicatorEnabled,
   restoreViewerViewFromLastSession,

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -172,6 +172,7 @@ set(HEADERS
     cellselection.h
     columncommand.h
     columnselection.h
+    customhelplink.h
     curveio.h
     drawingdata.h
     exportlevelcommand.h
@@ -226,6 +227,7 @@ set(SOURCES
     loadfolderpopup.cpp
     main.cpp
     mainwindow.cpp
+    customhelplink.cpp
     matchline.cpp
     menubar.cpp
     menubarpopup.cpp

--- a/toonz/sources/toonz/customhelplink.cpp
+++ b/toonz/sources/toonz/customhelplink.cpp
@@ -1,0 +1,95 @@
+#include "customhelplink.h"
+
+// TnzQt includes
+#include "toonzqt/dvdialog.h"
+
+// TnzLib includes
+#include "toonz/preferences.h"
+
+// TnzBase includes
+#include "tenv.h"
+
+// TnzCore includes
+#include "tsystem.h"
+
+// Qt includes
+#include <QCoreApplication>
+#include <QDesktopServices>
+#include <QFileInfo>
+#include <QUrl>
+
+namespace {
+
+const QString DefaultCustomHelpLink = QStringLiteral("index.html");
+
+QUrl resolveHelpLink(const QString &link) {
+  QUrl url(link);
+  // QUrl("C:/docs/help.html") reports "c" as a one-character scheme.
+  if (url.isValid() && url.scheme().length() > 1) return url;
+
+  // A PDF page is expressed as a URL fragment (for example #page=12). Keep
+  // the fragment out of local filesystem resolution, then restore it on the
+  // resulting file URL.
+  QString localPath = link;
+  QString fragment;
+  int fragmentIndex = localPath.indexOf('#');
+  if (fragmentIndex >= 0) {
+    fragment  = localPath.mid(fragmentIndex + 1);
+    localPath = localPath.left(fragmentIndex);
+  }
+
+  QFileInfo fileInfo(localPath);
+  if (fileInfo.isAbsolute()) {
+    url = QUrl::fromLocalFile(fileInfo.absoluteFilePath());
+    url.setFragment(fragment);
+    return url;
+  }
+
+  std::string lang =
+      Preferences::instance()->getCurrentLanguage().toStdString();
+  TFilePath base = TEnv::getStuffDir() + "doc";
+  TFilePath relativePath(localPath.toStdWString());
+  TFilePath fp = base + lang + relativePath;
+  if (!TFileStatus(fp).doesExist()) fp = base + relativePath;
+
+  url = QUrl::fromLocalFile(QString::fromStdWString(fp.getWideString()));
+  url.setFragment(fragment);
+  return url;
+}
+
+}  // namespace
+
+namespace CustomHelpLink {
+
+QString current() {
+  QString link =
+      Preferences::instance()->getStringValue(customHelpLink).trimmed();
+  return link.isEmpty() ? DefaultCustomHelpLink : link;
+}
+
+void set(const QString &link) {
+  Preferences::instance()->setValue(customHelpLink, link.trimmed());
+}
+
+void open() {
+  const QString link = current();
+  QUrl url           = resolveHelpLink(link);
+  if (!url.isValid()) {
+    DVGui::warning(QCoreApplication::translate(
+        "MainWindow", "The Quicklink URL is not valid."));
+    return;
+  }
+
+  if (url.isLocalFile() && !QFileInfo::exists(url.toLocalFile())) {
+    DVGui::warning(QCoreApplication::translate(
+                       "MainWindow", "Could not find the help file \"%1\".")
+                       .arg(link));
+    return;
+  }
+
+  if (!QDesktopServices::openUrl(url))
+    DVGui::warning(QCoreApplication::translate(
+        "MainWindow", "Could not open the Quicklink URL."));
+}
+
+}  // namespace CustomHelpLink

--- a/toonz/sources/toonz/customhelplink.h
+++ b/toonz/sources/toonz/customhelplink.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <QString>
+
+namespace CustomHelpLink {
+
+QString current();
+void set(const QString &link);
+void open();
+
+}  // namespace CustomHelpLink

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1,6 +1,7 @@
 
 
 #include "mainwindow.h"
+#include "customhelplink.h"
 
 // Tnz6 includes
 #include "menubar.h"
@@ -533,6 +534,7 @@ centralWidget->setLayout(centralWidgetLayout);*/
   setCommandHandler(MI_About, this, &MainWindow::onAbout);
   setCommandHandler(MI_OpenOnlineManual, this, &MainWindow::onOpenOnlineManual);
   setCommandHandler(MI_OpenWhatsNew, this, &MainWindow::onOpenWhatsNew);
+  setCommandHandler(MI_Quicklink, this, &MainWindow::onOpenQuicklink);
   setCommandHandler(MI_OpenCommunityForum, this,
                     &MainWindow::onOpenCommunityForum);
   setCommandHandler(MI_OpenReportABug, this, &MainWindow::onOpenReportABug);
@@ -1136,6 +1138,10 @@ void MainWindow::onOpenWhatsNew() {
   QDesktopServices::openUrl(
       QUrl(tr("https://github.com/opentoonz/opentoonz/releases/latest")));
 }
+
+//-----------------------------------------------------------------------------
+
+void MainWindow::onOpenQuicklink() { CustomHelpLink::open(); }
 
 //-----------------------------------------------------------------------------
 
@@ -2819,6 +2825,7 @@ void MainWindow::defineActions() {
                        "F1", "manual");
   createMenuHelpAction(MI_OpenWhatsNew, QT_TR_NOOP("&What's New..."), "",
                        "web");
+  createMenuHelpAction(MI_Quicklink, QT_TR_NOOP("&Quicklink"), "", "web");
   createMenuHelpAction(MI_OpenCommunityForum, QT_TR_NOOP("&Community Forum..."),
                        "", "web");
   createMenuHelpAction(MI_OpenReportABug, QT_TR_NOOP("&Report a Bug..."), "",

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -119,6 +119,7 @@ public:
   void onAbout();
   void onOpenOnlineManual();
   void onOpenWhatsNew();
+  void onOpenQuicklink();
   void onOpenCommunityForum();
   void onOpenReportABug();
   void checkForUpdates();

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1,6 +1,7 @@
 
 
 #include "menubar.h"
+#include "customhelplink.h"
 
 // Tnz6 includes
 #include "menubarcommandids.h"
@@ -35,6 +36,7 @@
 #include "tsystem.h"
 
 // Qt includes
+#include <QCoreApplication>
 #include <QIcon>
 #include <QPainter>
 #include <QMouseEvent>
@@ -52,6 +54,67 @@ UrlOpener dvHome(QUrl("http://www.toonz.com/"));
 UrlOpener manual(QUrl("file:///C:/gmt/butta/M&C in EU.pdf"));
 
 TEnv::IntVar LockRoomTabToggle("LockRoomTabToggle", 0);
+
+namespace {
+
+void ensureQuicklinkAction(QMenu *helpMenu) {
+  QAction *quicklink = CommandManager::instance()->getAction(MI_Quicklink);
+  if (!quicklink || helpMenu->actions().contains(quicklink)) return;
+
+  const QList<QAction *> actions = helpMenu->actions();
+  QAction *whatsNew = CommandManager::instance()->getAction(MI_OpenWhatsNew);
+  int whatsNewIndex = actions.indexOf(whatsNew);
+  if (whatsNewIndex >= 0) {
+    QAction *before = whatsNewIndex + 1 < actions.size()
+                          ? actions.at(whatsNewIndex + 1)
+                          : nullptr;
+    if (before)
+      helpMenu->insertAction(before, quicklink);
+    else
+      helpMenu->addAction(quicklink);
+    return;
+  }
+
+  QAction *about = CommandManager::instance()->getAction(MI_About);
+  if (actions.contains(about))
+    helpMenu->insertAction(about, quicklink);
+  else
+    helpMenu->addAction(quicklink);
+}
+
+void enableQuicklinkEditing(QMenu *helpMenu) {
+  const char *propertyName = "quicklinkEditingEnabled";
+  if (helpMenu->property(propertyName).toBool()) return;
+  helpMenu->setProperty(propertyName, true);
+  helpMenu->setContextMenuPolicy(Qt::CustomContextMenu);
+
+  QObject::connect(
+      helpMenu, &QWidget::customContextMenuRequested, helpMenu,
+      [helpMenu](const QPoint &pos) {
+        QAction *quicklink =
+            CommandManager::instance()->getAction(MI_Quicklink);
+        if (helpMenu->actionAt(pos) != quicklink) return;
+
+        QMenu editMenu(helpMenu);
+        QAction *editLink = editMenu.addAction(
+            QCoreApplication::translate("MainWindow", "Edit Link..."));
+        if (editMenu.exec(helpMenu->mapToGlobal(pos)) != editLink) return;
+
+        bool ok      = false;
+        QString link = DVGui::getText(
+            QCoreApplication::translate("MainWindow", "Edit Quicklink"),
+            QCoreApplication::translate("MainWindow", "Link:"),
+            CustomHelpLink::current(), &ok);
+        if (ok) CustomHelpLink::set(link);
+      });
+}
+
+void ensureHelpActions(QMenu *helpMenu) {
+  ensureQuicklinkAction(helpMenu);
+  enableQuicklinkEditing(helpMenu);
+}
+
+}  // namespace
 
 //=============================================================================
 // RoomTabWidget
@@ -280,9 +343,12 @@ QMenuBar *StackedMenuBar::loadMenuBar(const TFilePath &fp) {
            * translation file -*/
           QMenu *menu = new QMenu(tr(title.toStdString().c_str()));
           menu->setToolTipsVisible(true);
-          if (readMenuRecursive(reader, menu))
+          if (readMenuRecursive(reader, menu)) {
+            // Older Windows profiles keep private menu XML files. Add the new
+            // built-in command without replacing the user's customized menu.
+            if (title == QStringLiteral("Help")) ensureHelpActions(menu);
             menuBar->addMenu(menu);
-          else {
+          } else {
             reader.raiseError(tr("Failed to load menu %1").arg(title));
             delete menu;
           }
@@ -500,6 +566,7 @@ QMenuBar *StackedMenuBar::createCleanupMenuBar() {
   //----Help Menu
   QMenu *helpMenu = addMenu(tr("Help"), cleanupMenuBar);
   addMenuItem(helpMenu, MI_About);
+  ensureHelpActions(helpMenu);
 
   return cleanupMenuBar;
 }
@@ -670,6 +737,7 @@ QMenuBar *StackedMenuBar::createPltEditMenuBar() {
   //---Help Menu
   QMenu *helpMenu = addMenu(tr("Help"), pltEditMenuBar);
   addMenuItem(helpMenu, MI_About);
+  ensureHelpActions(helpMenu);
 
   return pltEditMenuBar;
 }
@@ -850,6 +918,7 @@ QMenuBar *StackedMenuBar::createInknPaintMenuBar() {
   //---Help Menu
   QMenu *helpMenu = addMenu(tr("Help"), inknPaintMenuBar);
   addMenuItem(helpMenu, MI_About);
+  ensureHelpActions(helpMenu);
 
   return inknPaintMenuBar;
 }
@@ -1037,6 +1106,7 @@ QMenuBar *StackedMenuBar::createXsheetMenuBar() {
   //---Help Menu
   QMenu *helpMenu = addMenu(tr("Help"), xsheetMenuBar);
   addMenuItem(helpMenu, MI_About);
+  ensureHelpActions(helpMenu);
 
   return xsheetMenuBar;
 }
@@ -1073,6 +1143,7 @@ QMenuBar *StackedMenuBar::createBatchesMenuBar() {
   //---Help Menu
   QMenu *helpMenu = addMenu(tr("Help"), batchesMenuBar);
   addMenuItem(helpMenu, MI_About);
+  ensureHelpActions(helpMenu);
 
   return batchesMenuBar;
 }
@@ -1110,6 +1181,7 @@ QMenuBar *StackedMenuBar::createBrowserMenuBar() {
   //---Help Menu
   QMenu *helpMenu = addMenu(tr("Help"), browserMenuBar);
   addMenuItem(helpMenu, MI_About);
+  ensureHelpActions(helpMenu);
 
   return browserMenuBar;
 }
@@ -1499,11 +1571,13 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   QMenu *helpMenu = addMenu(tr("Help"), fullMenuBar);
   addMenuItem(helpMenu, MI_OpenOnlineManual);
   addMenuItem(helpMenu, MI_OpenWhatsNew);
+  addMenuItem(helpMenu, MI_Quicklink);
   addMenuItem(helpMenu, MI_OpenCommunityForum);
   helpMenu->addSeparator();
   addMenuItem(helpMenu, MI_OpenReportABug);
   helpMenu->addSeparator();
   addMenuItem(helpMenu, MI_About);
+  enableQuicklinkEditing(helpMenu);
 
 // addMenuItem(fileMenu, MI_TestAnimation);
 // fileMenu->addSeparator();

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -472,6 +472,7 @@
 
 #define MI_OpenOnlineManual "MI_OpenOnlineManual"
 #define MI_OpenWhatsNew "MI_OpenWhatsNew"
+#define MI_Quicklink "MI_Quicklink"
 #define MI_OpenCommunityForum "MI_OpenCommunityForum"
 #define MI_OpenReportABug "MI_OpenReportABug"
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1071,6 +1071,16 @@ QWidget* PreferencesPopup::createUI(PreferencesItemId id,
           combo, &QFontComboBox::currentFontChanged, this,
           [this](const QFont& font) { onInterfaceFontChanged(font.family()); });
       widget = combo;
+    } else if (id == customHelpLink) {
+      DVGui::FileField* field =
+          new DVGui::FileField(this, item.value.toString());
+      field->setFileMode(QFileDialog::ExistingFile);
+      field->setFilters(QStringList() << "html"
+                                      << "htm"
+                                      << "pdf");
+      connect(field, &FileField::pathChanged, this,
+              &PreferencesPopup::onChange);
+      widget = field;
     } else if (!comboItems.isEmpty()) {  // create QComboBox
       QComboBox* combo = new QComboBox(this);
       for (const ComboBoxItem& item : comboItems)
@@ -1289,6 +1299,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {displayIn30bit, tr("30bit Display*")},
       {showIconsInMenu, tr("Show Icons In Menu*")},
       {showRoomBindButtons, tr("Show Room Bind Buttons*")},
+      {customHelpLink, tr("Quicklink URL:")},
       {viewerIndicatorEnabled, tr("Show Viewer Indicators")},
       {restoreViewerViewFromLastSession,
        tr("Restore Viewer Zoom and Pan from Last Session")},
@@ -1869,6 +1880,11 @@ QWidget* PreferencesPopup::createInterfacePage() {
   lay->addWidget(check30bitBtn, row - 1, 2, Qt::AlignRight);
   insertUI(showIconsInMenu, lay);
   insertUI(showRoomBindButtons, lay);
+  insertUI(customHelpLink, lay);
+  getUI<FileField*>(customHelpLink)
+      ->setToolTip(
+          tr("Leave blank to use the local OpenToonz documentation index. "
+             "To open a PDF at a specific page, append #page=12."));
 
   lay->setRowStretch(lay->rowCount(), 1);
   insertFootNote(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -455,6 +455,7 @@ void Preferences::definePreferenceItems() {
 #endif
   define(showIconsInMenu, "showIconsInMenu", QMetaType::Bool, defIconsVisible);
   define(showRoomBindButtons, "showRoomBindButtons", QMetaType::Bool, true);
+  define(customHelpLink, "customHelpLink", QMetaType::QString, "");
 
   setCallBack(pixelsOnly, &Preferences::setPixelsOnly);
   setCallBack(linearUnits, &Preferences::setUnits);


### PR DESCRIPTION
Adds a configurable Help menu Quicklink with local and web target support. Defaults to the local documentation index at stuff/doc/index.html.

The link can be set by the user either via Right Click on the menu or via Preferences.

Processed with assistance from ChatGPT 5.6.