### PR TITLE
Native arm64 MacOS builds

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -63,7 +63,7 @@ jobs:
             done
           }
 
-          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv@4 openjph openexr
+          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv@4 openjph openexr superlu
 
           brew list --formula | grep '^qt' | grep -v '@5' | xargs -n1 brew unlink || true
 

--- a/doc/how_to_build_macosx.md
+++ b/doc/how_to_build_macosx.md
@@ -33,7 +33,7 @@ Check site for any changes in installation instructions, but they will probably 
 
 In a Terminal window, execute the following statements:
 ```sh
-brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt@5 boost jpeg-turbo opencv
+brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt@5 boost jpeg-turbo opencv@4 superlu
 git lfs install
 ```
 
@@ -41,11 +41,19 @@ NOTE: This will install the latest version of QT v5.x which may not be compatibl
 
 If you cannot use the most recent version, download the online installer from https://www.qt.io/download and install the appropriate `macOS` version (min 5.15).  If installing via this method, be sure to install the `Qt Script (Deprecated)` libraries.
 
+### Apple Silicon and Intel
+
+The build is native to the machine it runs on: arm64 on Apple Silicon, x86_64 on Intel. There is no universal binary.
+
+Homebrew lives in `/opt/homebrew` on Apple Silicon and `/usr/local` on Intel. The commands below use `$(brew --prefix ...)` so they work on both.
+
+SuperLU comes from Homebrew (`superlu` in the install line above). The archive bundled in `thirdparty/superlu` is Intel-only and is no longer used on macOS.
+
 ### Remove incompatible symbolic directory
 Check to see if this symbolic glew directory exists. If so, remove it:
 ```sh
-ls -l /usr/local/lib/cmake/glew
-rm /usr/local/lib/cmake/glew
+ls -l $(brew --prefix)/lib/cmake/glew
+rm $(brew --prefix)/lib/cmake/glew
 ```
 
 ### Set up OpenToonz repository
@@ -80,14 +88,14 @@ cd build
 2. Include libjpeg-turbo path to PKG_CONFIG_PATH
 
 ```sh
-export PKG_CONFIG_PATH="/opt/homebrew/opt/jpeg-turbo/lib/pkgconfig:$PKG_CONFIG_PATH"
+export PKG_CONFIG_PATH="$(brew --prefix jpeg-turbo)/lib/pkgconfig:$PKG_CONFIG_PATH"
 ```
 
 3. Set up build environment
 
 To build from command line, do the following:
 ```sh
-cmake ../sources -DQT_PATH='/opt/homebrew/opt/qt@5/lib'  #replace QT path with your installed QT version#
+cmake ../sources -DQT_PATH="$(brew --prefix qt@5)/lib" -DOpenCV_DIR="$(brew --prefix opencv@4)/lib/cmake/opencv4"  #replace QT path with your installed QT version#
 make
 ```
 - If you downloaded the QT installer and installed to `/Users/yourlogin/Qt` instead of by using homebrew, your lib path may look something like this: `~/Qt/5.12.2/clang_64/lib` or `~/Qt/5.12.2/clang_32/lib`
@@ -95,7 +103,7 @@ make
 To build using Xcode, do the following:
 ```sh
 sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-cmake -G Xcode ../sources -B. -DQT_PATH='/opt/homebrew/opt/qt@5/lib' -DWITH_TRANSLATION=OFF   #replace QT path with your installed QT version#
+cmake -G Xcode ../sources -B. -DQT_PATH="$(brew --prefix qt@5)/lib" -DOpenCV_DIR="$(brew --prefix opencv@4)/lib/cmake/opencv4" -DWITH_TRANSLATION=OFF   #replace QT path with your installed QT version#
 ```
 - Note that the option `-DWITH_TRANSLATION=OFF` is needed to avoid error when using XCode 12+ which does not allow to add the same source to multiple targets.
 - Open Xcode app and open project /Users/yourlogin/Documents/opentoonz/toonz/build/OpenToonz.xcodeproj

--- a/doc/how_to_build_macosx_ja.md
+++ b/doc/how_to_build_macosx_ja.md
@@ -24,7 +24,7 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/
 ### brew で必要なパッケージをインストール
 
 ```
-$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt boost
+$ brew install glew lz4 libjpeg libpng lzo pkg-config libusb cmake git-lfs libmypaint qt boost superlu
 $ git lfs install
 ```
 

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -213,6 +213,8 @@ elseif(BUILD_ENV_APPLE)
 
     add_definitions(
         -DMACOSX
+        # not an architecture flag: tmachine.h uses i386 to pick the little-endian
+        # channel order on macOS, which is also correct on arm64. Keep it.
         -Di386
         -D__MACOS__
       )

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -93,7 +93,8 @@ if(BUILD_ENV_MSVC)
     set(_init_SYSTEM_SUPERLU                 OFF)
 elseif(BUILD_ENV_APPLE)
     set(_init_SYSTEM_LZO                     OFF)
-    set(_init_SYSTEM_SUPERLU                 OFF)
+    # the bundled libsuperlu_4.1.a is i386/x86_64 only; use Homebrew's superlu
+    set(_init_SYSTEM_SUPERLU                 ON)
 elseif(BUILD_ENV_UNIXLIKE)
     set(_init_SYSTEM_LZO                     ON)
     set(_init_SYSTEM_SUPERLU                 ON)
@@ -416,7 +417,10 @@ elseif(BUILD_ENV_APPLE)
     find_package(GLEW)
 
     find_package(SuperLU REQUIRED)
-    set(SUPERLU_INCLUDE_DIR ${SUPERLU_INCLUDE_DIR}/superlu)
+    if(NOT WITH_SYSTEM_SUPERLU)
+        # vendored SuperLU 4.1 layout; Homebrew installs flat headers
+        set(SUPERLU_INCLUDE_DIR ${SUPERLU_INCLUDE_DIR}/superlu)
+    endif()
     set(SUPERLU_LIB ${SUPERLU_LIBRARY})
     message("SuperLU:" ${SUPERLU_INCLUDE_DIR})
 

--- a/toonz/sources/common/tsystem/cpuextensions.cpp
+++ b/toonz/sources/common/tsystem/cpuextensions.cpp
@@ -9,14 +9,14 @@
 
 using namespace TSystem;
 
-#ifdef x64
+#if defined(x64) && (defined(_M_X64) || defined(__x86_64__))
 long TSystem::getCPUExtensions() {
   return TSystem::CpuSupportsSse |
          TSystem::CpuSupportsSse2;  // TSystem::CPUExtensionsNone
 }
 
 #else
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || defined(x64)
 long TSystem::getCPUExtensions() { return TSystem::CPUExtensionsNone; }
 #else
 namespace {

--- a/toonz/sources/tnzext/CMakeLists.txt
+++ b/toonz/sources/tnzext/CMakeLists.txt
@@ -95,17 +95,16 @@ if(BUILD_ENV_APPLE)
     find_library(ACCE_LIB Accelerate)
 endif()
 
-if(BUILD_ENV_MSVC OR BUILD_ENV_APPLE)
-    # Warning, this looks wrong,
-    # should _only_ use SUPERLU_INCLUDE_DIR, for now do this with Linux.
-    include_directories(
-        SYSTEM
-        ${SDKROOT}/superlu/SuperLU_4.1/SRC
-    )
-else()
+if(WITH_SYSTEM_SUPERLU)
     include_directories(
         SYSTEM
         ${SUPERLU_INCLUDE_DIR}
+    )
+else()
+    # vendored SuperLU 4.1 headers (Windows, or -DWITH_SYSTEM_SUPERLU=OFF)
+    include_directories(
+        SYSTEM
+        ${SDKROOT}/superlu/SuperLU_4.1/SRC
     )
 endif()
 


### PR DESCRIPTION
The purpose of our change is to enable/allow proper arm64 Apple Sillicon builds on M-series Mac machines. In 2027 MacOS will end support for Rosetta 2[^1], and M-series mac machines are pretty prevalent nowadays so I would say this is a safe change!

The main changes seem to just be using Superlu from homebrew, rather than the vendored version. Linux uses the system version of Superlu so I am assuming this will be an okay change to make. 

This PR does NOT touch any of the Github Runners. I wanted to keep this PR scope small, but I can modify the runners if needed.

I have read through the AI-Assisted Development Checklist, and will disclose that I used Claude Code, Fable 5.1 xhigh, and I will include the full chat log as well. 
I probably didn't need to use Fable, but it was default from another side project I was working on. 

Ran with plan mode, approved with auto mode.

<details>
<summary>Claude Code session transcript - CC-BY (click to expand) </summary>

### ❯ Let's implement Arm64 / Apple Sillicon native builds for our project

⏺ I'll plan out native ARM64/Apple Silicon builds for OpenToonz. First I need to understand the current macOS build setup: CMake config, third-party libraries, CI workflows, and any x86-specific code (SSE intrinsics, etc.).

*Read 3 files, listed 1 directory, ran 1 shell command (ctrl+o to expand)*

⏺ 2 background agents launched (↓ to manage)

```text
├ Find x86-specific code in OpenToonz
└ Survey macOS build deps and thirdparty
```

⏺ I'll check the SuperLU archive's architecture, whether clang accepts -m64 on arm64, the installed brew packages, and any existing upstream ARM64 work while the explore agents run in parallel. · summarized

*Listed 1 directory, ran 4 shell commands (ctrl+o to expand)*

⏺ The vendored SuperLU static library only supports i386/x86_64, though clang on arm64 accepts -m64 and all brew dependencies are already installed here. I'll dig into the historical arm64 SuperLU commits and check for an existing local build. · summarized

*Ran 4 shell commands (ctrl+o to expand)*

⏺ I found an arm64 OpenToonz binary from Feb 2025 linked to a hand-built SuperLU in /usr/local/lib. Now I'll check that library, the historical arm64 SuperLU commit, the wrapper, i386 macro sites, and relevant upstream issue discussion. · summarized

*Searched for 1 pattern, read 1 file, ran 5 shell commands (ctrl+o to expand)*

⏺ I'll check upstream PR #6882 for the Intel runner deprecation, along with the vendored SuperLU 4.1 build leftovers, tnzext link setup, and dgstrf API usage. · summarized

*Ran 4 shell commands (ctrl+o to expand)*

⏺ Still gathering facts: checking the brew SuperLU formula's header layout, what the hand-built SuperLU actually was, and whether the vendored libtiff 4.0.3 configure script handles arm64.

*Ran 4 shell commands (ctrl+o to expand)*

⏺ Homebrew's SuperLU install includes flat headers, a shared library, and pkg-config support, so the existing FindSuperLU module should work once system-SuperLU is enabled on Apple. I'll check the bundle plist template next while the explore agents wrap up. · summarized

*Read 1 file (ctrl+o to expand)*

⏺ I have enough to draft the plan while the two explore agents finish their inventories. Writing the initial plan file now.

⏺ Updated plan

> ⎿ /plan to preview

⏺ Agent "Find x86-specific code in OpenToonz" finished · 6m 11s

⏺ Found that SSE2 paths are dead on macOS since they're gated behind Windows/x64, but spotted a latent bug where getCPUExtensions() wrongly reports SSE2 support on arm64. I'll check that file directly to confirm. · summarized

*Read 1 file (ctrl+o to expand)*

⏺ Updated plan

> ⎿ /plan to preview

⏺ Two decisions shape the plan, and they don't depend on the remaining inventory, so I'll ask now.

⏺ User answered Claude's questions:

- How should the macOS CI workflow handle architectures? → Local build only, no CI changes
- The vendored SuperLU archive is x86-only. Homebrew's superlu (7.0.1) has arm64 and Intel bottles. Should Intel Macs switch to it too? → Homebrew SuperLU on all macOS (Recommended)

⏺ Agent "Survey macOS build deps and thirdparty" finished · 8m 5s

⏺ The second inventory backs up the earlier findings and raises a claim worth testing: that install_name_tool invalidates the ad-hoc signature on arm64. I'll check the signature state of the Feb 2025 arm64 binary in toonz/build, since it went through that exact step. · summarized

*Ran 3 shell commands (ctrl+o to expand)*

⏺ I'll verify whether CMake already searches /opt/homebrew by default, since that determines whether the THIRDPARTY_LIBS_HINTS edit is even needed. · summarized

*Searched for 1 pattern (ctrl+o to expand)*

⏺ Since CMake's Darwin platform module already prepends the Homebrew prefix to the search path, the THIRDPARTY_LIBS_HINTS edit isn't needed, so I'm dropping it. Now I'll write the final plan, scoped to local builds as you specified. · summarized

⏺ Updated plan

> ⎿ /plan to preview

⏺ Plan is written. Requesting approval now.

⏺ User approved Claude's plan

> ⎿ Plan saved to: ~/.claude/plans/let-s-implement-arm64-radiant-stallman.md · /plan to edit

<details>
<summary>Native ARM64 / Apple Silicon builds for OpenToonz</summary>

#### Context

The macOS build is x86_64-only in practice: CI runs on `macos-15-intel` and a fresh Apple
Silicon checkout cannot link. Apple ends Rosetta after macOS 27 and GitHub retires the Intel
runner in Aug 2027 (upstream issues #6624, #6132). The only upstream attempt, PR #6882,
replaces the toolchain with Nix + mise and is unmerged.

The source tree is already arch-clean. Every SSE2 kernel in `toonz/sources/common/trop/` is
behind `defined(_WIN32) && defined(x64)`, endianness comes from CMake's `test_big_endian`,
vendored `kiss_fft`/`tinyexr` have no x86 dependency in the paths OpenToonz compiles, and an
arm64 `OpenToonz.app` was built on this machine in Feb 2025 (leftover in `toonz/build`).
What blocks a reproducible native build is one library and one default:

- `thirdparty/superlu/libsuperlu_4.1.a` is an i386/x86_64 fat archive with no arm64 slice.
  `toonz/cmake/FindSuperLU.cmake` falls back to it whenever no Homebrew SuperLU is present.
- Even when a newer SuperLU is found, macOS compiles against the vendored 4.1 headers
  (`tnzext/CMakeLists.txt:98-104`). SuperLU 5.0 added a `GlobalLU_t*` parameter to `dgstrf`,
  so the Feb 2025 build (SuperLU 6.0 lib + 4.1 headers) has an ABI mismatch inside the
  Plastic tool's solver.

Decisions taken with the user:
- Scope is the local developer build plus docs. No CI runner/matrix changes.
- SuperLU comes from Homebrew on all macOS (arm64 and Intel), matching how Linux already uses
  the system SuperLU. The wrapper `tnzext/tlin/tlin_superlu_wrap.cpp:312` already handles
  `SUPERLU_MAJOR_VERSION >= 5`, and Linux CI builds against 5.x/7.x today.

Non-goals: universal binaries (Homebrew ships no universal Qt/libs), deployment target,
code signing, CI runner migration.

#### Changes

##### 1. SuperLU from Homebrew on macOS

Homebrew `superlu` 7.0.1 (arm64 and Intel bottles) installs flat headers in
`$(brew --prefix)/include`, `lib/libsuperlu.dylib` (linked to OpenBLAS) and `superlu.pc`.
CMake's Darwin platform module already prepends `brew --prefix` to
`CMAKE_SYSTEM_PREFIX_PATH` (verified in CMake 4.4's `Platform/Darwin.cmake:245-253`), and
`FindSuperLU.cmake` additionally hints `/opt/homebrew` then `/usr/local` on Apple and lists
`libsuperlu.dylib` before the vendored `.a`. So only three edits are needed:

- `toonz/sources/CMakeLists.txt:94-96`: in the `BUILD_ENV_APPLE` block set
  `_init_SYSTEM_SUPERLU ON` (leave `_init_SYSTEM_LZO OFF`). With `WITH_SYSTEM_SUPERLU=ON`
  the Find module's header suffixes become `superlu`/`SuperLU`, and `find_path` also checks
  the hint dir itself, so `$(brew --prefix)/include/slu_Cnames.h` resolves.
- `toonz/sources/CMakeLists.txt:418-421`: wrap the
  `set(SUPERLU_INCLUDE_DIR ${SUPERLU_INCLUDE_DIR}/superlu)` line in
  `if(NOT WITH_SYSTEM_SUPERLU)`. Homebrew headers are flat; the append currently produces a
  nonexistent directory.
- `toonz/sources/tnzext/CMakeLists.txt:98-110`: select the include dir by
  `WITH_SYSTEM_SUPERLU` instead of by platform: ON uses `${SUPERLU_INCLUDE_DIR}`, OFF uses the
  vendored `${SDKROOT}/superlu/SuperLU_4.1/SRC`. Windows (OFF) and Linux (ON) keep exactly
  their current behavior.

The vendored archive and 4.1 headers stay in the tree for `-DWITH_SYSTEM_SUPERLU=OFF`.
Global `include_directories(SYSTEM ... ${SUPERLU_INCLUDE_DIR})` at line 611 will now add
`$(brew --prefix)/include`, which `PNG_INCLUDE_DIRS` already adds (with `BEFORE`), so include
ordering versus the vendored libtiff headers is unchanged.

##### 2. Stop reporting SSE2 on arm64

`toonz/sources/common/tsystem/cpuextensions.cpp:12`: `x64` is defined for every 64-bit build
(`CMakeLists.txt:622`), so `TSystem::getCPUExtensions()` returns
`CpuSupportsSse | CpuSupportsSse2` on Apple Silicon. Change the guard to

```c
#if defined(x64) && (defined(_M_X64) || defined(__x86_64__))
```

x86_64 on every OS keeps its current answer; arm64 falls through to the existing
`#ifndef _MSC_VER` branch returning `CPUExtensionsNone`. Nothing consumes the value outside
`USE_SSE2` blocks today, so this is a correctness fix with no behavior change.

##### 3. Document why `-Di386` stays

`toonz/sources/CMakeLists.txt:213-217`: keep `-Di386`, add a one-line comment. It is not an
architecture flag here: `toonz/sources/include/tmachine.h:6` and `tscannerepson.cpp:33` use
it to mean "little-endian channel order on macOS" (selects `TNZ_MACHINE_CHANNEL_ORDER_BGRM`,
119 uses across the renderer, GL upload and PNG I/O). arm64 is little-endian, so the
behavior is correct; removing the define would silently flip pixel layout.

Also unchanged on purpose: `-m64` (Apple clang 21 accepts it for arm64, verified) and
`pli_io.cpp:19`'s `<architecture/i386/io.h>` (still in the macOS 26 SDK, two typedefs).

##### 4. Docs

`doc/how_to_build_macosx.md`:
- Add `superlu` to the brew install line (line 36).
- Short "Apple Silicon" note: the build is native to the host arch (arm64 on Apple Silicon,
  x86_64 on Intel), `brew --prefix` is `/opt/homebrew` vs `/usr/local`, and SuperLU now comes
  from Homebrew (`-DWITH_SYSTEM_SUPERLU=OFF` restores the Intel-only vendored archive).
- Replace the two hard-coded `/opt/homebrew/...` examples (lines 83, 90, 98) with
  `$(brew --prefix jpeg-turbo)` / `$(brew --prefix qt@5)` so they work on both prefixes.
- Fix the glew symlink lines 47-48 to use `$(brew --prefix)/lib/cmake/glew`.

`doc/how_to_build_macosx_ja.md`: add `superlu` to its brew line (line 27) only. The rest of
that file is already stale (unversioned `qt`, `/usr/local/opt/qt/lib`) and is out of scope.

##### 5. One-word workflow change (flagged)

`.github/workflows/workflow_macos.yml:66`: add `superlu` to the `checkPkgAndInstall` list.
This is the only CI edit. It is required, not optional: with `WITH_SYSTEM_SUPERLU=ON` the
Find module drops the `superlu` path suffix, so the existing Intel job would stop finding
the vendored archive and fail. Runner, cache and packaging steps are untouched.

#### Noticed, not touched

- `workflow_macos.yml` hard-codes `/usr/local/opt/...` (Intel prefix) in four places and its
  ccache dir is likely a no-op (`CCACHE_DIR` unset). Needed only when CI moves to arm64.
- Dead conditions `if(GLEW-NOTFOUND)` (`CMakeLists.txt:427`), `if(LZ4_STATIC-FOUND)` (440),
  the malformed `if()` inside `find_path` in `toonz/cmake/FindTIFF.cmake:12-16`, and the
  `SupperLU_4.1` typo in `toonz/sources/tnztools/CMakeLists.txt:188`.
- `thirdparty/superlu/SuperLU_4.1/build/` and `/usr/local/lib/libsuperlu.a` on this machine
  are leftovers of a manual SuperLU 6.0 build; gitignored, but they mask the bug locally.

#### Verification

On this Apple Silicon machine (Homebrew at `/opt/homebrew`, Qt 5.15 arm64 and all other
deps already installed; `brew install superlu` is the only new package):

```sh
brew install superlu
cd thirdparty/tiff-4.0.3 && ./configure --disable-lzma && make -j$(sysctl -n hw.ncpu)
cd ../../toonz && rm -rf build-arm64 && mkdir build-arm64 && cd build-arm64
export PKG_CONFIG_PATH="$(brew --prefix jpeg-turbo)/lib/pkgconfig:$PKG_CONFIG_PATH"
cmake ../sources -G Ninja \
  -DQT_PATH=$(brew --prefix qt@5)/lib \
  -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
  -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 \
  -DOpenCV_DIR=$(brew --prefix opencv@4)/lib/cmake/opencv4 \
  -DWITH_TRANSLATION=OFF
ninja -j$(sysctl -n hw.ncpu)
```

Checks:
- Configure log shows `SuperLU Header path: /opt/homebrew/include` and
  `SuperLU Library path: /opt/homebrew/lib/libsuperlu.dylib`; `WITH_SYSTEM_SUPERLU:BOOL=ON`
  in the cache.
- `lipo -info toonz/OpenToonz.app/Contents/MacOS/OpenToonz` reports `arm64`;
  `otool -L toonz/OpenToonz.app/Contents/MacOS/libtnzext.dylib` lists Homebrew's
  `libsuperlu.7.dylib` plus `Accelerate.framework`.
- `codesign -dv` on the executable still shows `adhoc,linker-signed` after the post-build
  `install_name_tool -add_rpath` (confirmed on the Feb 2025 build; the tool re-signs).
- `open toonz/OpenToonz.app` (stuff dir per the doc), then use the Plastic tool: create a
  mesh on a level, add a couple of skeleton vertices and drag one. This is the only code path
  that calls into SuperLU, and is what the header/library mismatch would corrupt.
- Regression on the OFF path: `cmake ... -DWITH_SYSTEM_SUPERLU=OFF` on arm64 must still fail
  at link with `fat file missing arch 'arm64'` (expected), and on an Intel Mac must still
  resolve to the vendored archive and 4.1 headers as before. Windows and Linux CMake logic is
  untouched; a Linux build (`WITH_SYSTEM_SUPERLU=ON`) exercises the same tnzext branch.

</details>

⏺ Plan approved. I'll branch off the detached HEAD, install Homebrew SuperLU, and apply the six edits, then kick off the native build.

*Ran 3 shell commands (ctrl+o to expand)*

⏺ All edits are in and SuperLU 7.0.1 (arm64) is installed. Now configuring a fresh arm64 build directory to confirm SuperLU resolves to Homebrew before starting the long compile.

*Ran 1 shell command (ctrl+o to expand)*

⏺ Configure stopped at the OpenCV lookup, which is before any SuperLU logic. Let me read the exact error and check whether OpenCV is actually installed.

*Ran 1 shell command (ctrl+o to expand)*

⏺ OpenCV is not installed on this machine (it was when the Feb 2025 build ran). Installing it from Homebrew, then re-running configure.

*Ran 1 shell command (ctrl+o to expand)*

⏺ Homebrew's default opencv is now version 5.0, which doesn't satisfy the project's find_package(OpenCV 4.1) requirement, so I'll install opencv@4 instead and update the docs to match what CI already uses. · summarized

*Ran 2 shell commands (ctrl+o to expand)*

⏺ opencv@4 is keg-only, so the doc's cmake examples need an OpenCV_DIR hint just like CI passes. Adding that to the doc and re-running configure in parallel.

*Ran 2 shell commands (ctrl+o to expand)*

⏺ Configure now resolves SuperLU to Homebrew's arm64 dylib with matching 7.x headers, and OpenCV 4.14. Starting the full native build in the background and reviewing the diff while it compiles.

*Ran 2 shell commands (ctrl+o to expand)*

⏺ The diff matches the plan, but I noticed the CPU-extensions guard would misroute non-x86 64-bit MSVC builds (e.g. Windows on ARM) into the 32-bit inline-asm path. I'll make the fallback explicit so those builds return "no extensions," then check build progress. · summarized

*Ran 1 shell command (ctrl+o to expand)*

⏺ Build is progressing cleanly with only pre-existing OpenGL warnings. While it finishes, I'll prep post-build checks: reviewing the SuperLU wrapper API to write a solver test for dgstrf, checking how the app locates its stuff directory for a launch test, and saving a memory note on macOS environment gotchas. · summarized

*Searched for 2 patterns, listed 1 directory, ran 3 shell commands (ctrl+o to expand)*

⏺ The build is two-thirds done with no errors, and the SuperLU wrapper compiled cleanly. Since tnzext, tnzcore, and tnzbase are already linked, I'll compile and run the solver test against them now instead of waiting for the full app link. · summarized

*Ran 1 shell command (ctrl+o to expand)*

⏺ The tnzext dylib links Homebrew's arm64 libsuperlu.7.dylib plus Accelerate as intended. The test just needs the Boost include path; recompiling and running it.

*Ran 1 shell command (ctrl+o to expand)*

⏺ The solver test passes on both paths: the factorize path (dgstrf with the SuperLU 5+ GlobalLU_t argument, then dgstrs) and the direct dgssv path both return the exact expected solutions through the arm64 libtnzext.dylib linked against Homebrew SuperLU 7.0.1. That confirms the headers and library now match.

The full build is at step 1391 of 1596, linking the main app next. When it finishes I'll rebuild once more to pick up the second CPU-extensions tweak, then run the bundle checks and a launch test.

*✻ Cooked for 18m 0s · done Wednesday 2:00 PM*

⏺ Background command "Run full arm64 ninja build in the background, logging to build.log" completed (exit code 0)

⏺ The build finished with exit 0. Rebuilding incrementally to pick up the second CPU-extensions edit, then running the bundle checks.

*Ran 1 shell command (ctrl+o to expand)*

⏺ Incremental rebuild done (18 steps, all links clean). Now the bundle checks and a launch test in parallel.

*Ran 2 shell commands (ctrl+o to expand)*

⏺ All binaries are arm64 with intact ad-hoc signatures, and tnzext correctly links Homebrew SuperLU 7 plus Accelerate. Once the launch test finishes, I'll verify the runtime CPU-extensions value on arm64 and confirm the vendored SuperLU archive is still selected when -DWITH_SYSTEM_SUPERLU=OFF. · summarized

*Ran 2 shell commands (ctrl+o to expand)*

⏺ I found that with WITH_SYSTEM_SUPERLU=OFF, the Find module still prefers a Homebrew SuperLU if installed, so the doc's claim that OFF always restores the vendored archive isn't accurate. I'll remove that sentence instead of documenting a footgun. · summarized

*Searched for 1 pattern, ran 1 shell command (ctrl+o to expand)*

⏺ Background command "Launch the arm64 app with portablestuff, verify it stays running, then stop it" completed (exit code 0)

⏺ The process only reached 3 MB resident size, suggesting it stalled before Qt fully initialized, likely due to launching without a GUI session. I'll relaunch it through LaunchServices, sample the main thread's stack to check if it reached the Qt event loop, and look for crash reports. · summarized

*Listed 1 directory, ran 1 shell command (ctrl+o to expand)*

⏺ No crash reports were written. The second launch test is running in the background (about 50 seconds); I'll report once it returns.

*✻ Churned for 2m 7s · done Wednesday 2:02 PM*

⏺ Background command "Launch the app via LaunchServices, sample its main thread, then quit it" completed (exit code 0)

*Searched for 1 pattern, ran 1 shell command (ctrl+o to expand)*

⏺ Native arm64 builds work. The changes are uncommitted on a new branch, feature/arm64-native-build, cut from master.

**What changed (6 files, about 30 lines):**

- toonz/sources/CMakeLists.txt: macOS now defaults to WITH_SYSTEM_SUPERLU=ON, the /superlu header-path suffix is only applied for the vendored layout, and a comment explains why -Di386 must stay.
- toonz/sources/tnzext/CMakeLists.txt: the SuperLU include dir follows WITH_SYSTEM_SUPERLU instead of the platform. Windows and Linux keep their existing paths.
- toonz/sources/common/tsystem/cpuextensions.cpp: the SSE2 stub is now limited to x86_64. Any other 64-bit target returns "no extensions".
- doc/how_to_build_macosx.md: superlu and opencv@4 in the brew line, an Apple Silicon note, and $(brew --prefix ...) forms so the commands work on both Homebrew prefixes. The Japanese doc only gains superlu.
- .github/workflows/workflow_macos.yml: one word, superlu added to the brew list, so the existing Intel job keeps working with the new default. Nothing else in CI changed.

**Verification on this machine**

- Fresh configure resolved SuperLU to Homebrew's arm64 libsuperlu.dylib with matching 7.0.1 headers, and the full 1596-step ninja build completed with zero errors.
- Every executable and dylib in OpenToonz.app is arm64, and the main binary keeps its linker-signed ad-hoc signature after the post-build rpath step.
- A small test program linked against the built libtnzext.dylib ran both solver paths the Plastic tool uses (dgstrf/dgstrs and dgssv) and returned exact solutions. This is the path the old header/library mismatch would have corrupted.
- getCPUExtensions() returns 0 at runtime on arm64.
- The app launched through LaunchServices, loaded Qt, tnzext and SuperLU, reached 110 MB resident, and quit cleanly on an Apple event. No crash reports were written. I could not drive the Plastic tool through the UI, so the solver test stands in for that.

**Side effects on your machine**

- Installed via brew: superlu (needed) and opencv@4 (needed, keg-only). I also installed unversioned opencv, which is now 5.0 and unusable here. That was a mistake on my part; brew uninstall opencv removes it if you want.
- New build directory toonz/build-arm64 with portablestuff copied in. The old toonz/build is a Feb 2025 build with the SuperLU mismatch and can be deleted.

**Noticed, not touched**

- FindSuperLU.cmake prefers a Homebrew SuperLU even when WITH_SYSTEM_SUPERLU=OFF, so OFF only restores the vendored archive on a Mac without brew superlu. Pre-existing, and now moot by default.
- The workflow still hard-codes Intel /usr/local/opt paths and runs on the Intel runner. Those need changing when CI moves to an arm64 image.

I did not commit. Say the word and I'll commit it as a single line on this branch.

*✻ Cogitated for 40s · done Wednesday 2:03 PM*

*※ recap: Native arm64 OpenToonz builds now work locally: CMake, source, and doc changes are done, built, and verified on this Mac, uncommitted on branch feature/arm64-native-build. Next action is your call on committing them. *

</details>


[^1]: https://arstechnica.com/gadgets/2025/06/apple-details-the-end-of-intel-mac-support-and-a-phaseout-for-rosetta-2/
