### PR TITLE
Fix scientific notation in expression tokenizer

### DIFF
--- a/toonz/sources/common/expressions/ttokenizer.cpp
+++ b/toonz/sources/common/expressions/ttokenizer.cpp
@@ -81,15 +81,17 @@ void Tokenizer::setBuffer(std::string buffer) {
         token.append(1, s[i++]);
 
         while (isascii(s[i]) && isdigit(s[i])) token.append(1, s[i++]);
+      }
 
-        if ((s[i] == 'e' || s[i] == 'E') &&
-            (((isascii(s[i + 1]) && isdigit(s[i + 1])) ||
-             s[i + 1] == '-' || s[i + 1] == '+') && isascii(s[i + 2]) &&
-                 isdigit(s[i + 2]))) {
-          token.append(1, s[i++]);
+      if (token != "." && (s[i] == 'e' || s[i] == 'E')) {
+        // Only consume the exponent if its optional sign is followed by a
+        // digit.
+        int exponent = i + 1;
+        if (s[exponent] == '-' || s[exponent] == '+') ++exponent;
 
-          if (s[i] == '-' || s[i] == '+') token.append(1, s[i++]);
-
+        if (isascii(s[exponent]) && isdigit(s[exponent])) {
+          token.append(s + i, exponent - i);
+          i = exponent;
           while (isascii(s[i]) && isdigit(s[i])) token.append(1, s[i++]);
         }
       }


### PR DESCRIPTION
Fixes #7112.

Expression literals such as `1.0e2` and `1e+2` were split into multiple tokens, while `1.0e+2` worked. Scan the exponent independently of the decimal point, allow an optional sign, and require a digit before consuming the exponent. A bare decimal point cannot serve as the mantissa.

This PR changes only `toonz/sources/common/expressions/ttokenizer.cpp`.

Validation: the original 10-case reproduction now passes; a local 34-case regression harness covering numeric values, incomplete exponents, token positions, and surrounding expression tokens passes. The same harness detects failures against the original source. AddressSanitizer, UndefinedBehaviorSanitizer, and LeakSanitizer checks pass. Test harnesses remain local and are not included in this PR. Formatting checked with clang-format 18; CI uses clang-format 14. The full application and GUI were not tested.
