### PR TITLE
Preserve Tape Stroke Direction

### DIFF
--- a/toonz/sources/common/tvectorimage/tvectorimage.cpp
+++ b/toonz/sources/common/tvectorimage/tvectorimage.cpp
@@ -2001,7 +2001,7 @@ assert(m_strokes[strokeIndex-wSize+1]->m_edgeList.empty());*/
 //-----------------------------------------------------------------------------
 
 static void computeEdgeList(TStroke *newS, const std::list<TEdge *> &edgeList1,
-                            bool join1AtBegin,
+                            bool join1AtBegin, bool stroke1isFlipped,
                             const std::list<TEdge *> &edgeList2,
                             bool join2AtBegin, std::list<TEdge *> &edgeList) {
   std::list<TEdge *>::const_iterator it;
@@ -2009,11 +2009,17 @@ static void computeEdgeList(TStroke *newS, const std::list<TEdge *> &edgeList1,
   if (!edgeList1.empty()) {
     TStroke *s1    = edgeList1.front()->m_s;
     double length1 = s1->getLength();
-    ;
+
+    double offset = newS->getLength(newS->getW(s1->getPoint(0.0)));
 
     for (it = edgeList1.begin(); it != edgeList1.end(); ++it) {
       double l0 = s1->getLength((*it)->m_w0), l1 = s1->getLength((*it)->m_w1);
-      if (join1AtBegin) l0 = length1 - l0, l1 = length1 - l1;
+      if (join1AtBegin) {
+        if (stroke1isFlipped)
+          l0 = length1 - l0, l1 = length1 - l1;
+        else
+          l0 = offset + l0, l1 = offset + l1;
+      }
 
       TEdge *e         = new TEdge();
       e->m_toBeDeleted = true;
@@ -2132,12 +2138,13 @@ VIStroke *TVectorImage::Imp::extendStrokeSmoothly(int index,
   for (int i = 0; i < cpCount - 1; i++)
     points[i] = stroke->getControlPoint((cpIndex == 0) ? cpCount - i - 1 : i);
   points[cpCount - 1] = pos;
+  if (cpIndex == 0) std::reverse(points.begin(), points.end());
 
   TStroke *newStroke = new TStroke(points);
   newStroke->setStyle(styleId);
   newStroke->outlineOptions() = stroke->outlineOptions();
   std::list<TEdge *> oldEdgeList, emptyList;
-  computeEdgeList(newStroke, m_strokes[index]->m_edgeList, cpIndex == 0,
+  computeEdgeList(newStroke, m_strokes[index]->m_edgeList, cpIndex == 0, false,
                   emptyList, 0, oldEdgeList);
 
   std::vector<int> toBeDeleted;
@@ -2169,6 +2176,7 @@ VIStroke *TVectorImage::Imp::extendStroke(int index, const TThickPoint &p,
   TThickPoint tp(p, points[count - 1].thick);
   points[count++] = 0.5 * (stroke->getControlPoint(cpIndex) + tp);
   points[count++] = tp;
+  if (cpIndex == 0) std::reverse(points.begin(), points.end());
 
   TStroke *newStroke = new TStroke(points);
   newStroke->setStyle(stroke->getStyle());
@@ -2178,7 +2186,7 @@ VIStroke *TVectorImage::Imp::extendStroke(int index, const TThickPoint &p,
 
   if (m_computedAlmostOnce)
     computeEdgeList(newStroke, m_strokes[index]->m_edgeList, cpIndex == 0,
-                    emptyList, false, oldEdgeList);
+                    false, emptyList, false, oldEdgeList);
 
   std::vector<int> toBeDeleted;
   toBeDeleted.push_back(index);
@@ -2246,7 +2254,7 @@ VIStroke *TVectorImage::Imp::joinStroke(int index1, int index2, int cpIndex1,
   std::list<TEdge *> oldEdgeList, emptyList;
 
   computeEdgeList(
-      newStroke, m_strokes[index1]->m_edgeList, cpIndex1 == 0,
+      newStroke, m_strokes[index1]->m_edgeList, cpIndex1 == 0, cpIndex1 == 0,
       (index1 != index2) ? m_strokes[index2]->m_edgeList : emptyList,
       cpIndex2 == 0, oldEdgeList);
 
@@ -2332,7 +2340,7 @@ VIStroke *TVectorImage::Imp::joinStrokeSmoothly(int index1, int index2,
   if (stroke1 == stroke2) {
     std::list<TEdge *> oldEdgeList, emptyList;
     computeEdgeList(stroke1, m_strokes[index1]->m_edgeList, cpIndex1 == 0,
-                    emptyList, false, oldEdgeList);
+                    cpIndex1 == 0, emptyList, false, oldEdgeList);
     eraseIntersection(index1);
     m_strokes[index1]->m_isNewForFill = true;
     stroke1->setSelfLoop();
@@ -2376,7 +2384,8 @@ VIStroke *TVectorImage::Imp::joinStrokeSmoothly(int index1, int index2,
   // m_imp->m_strokes[index2]->m_edgeList);
 
   computeEdgeList(newStroke, m_strokes[index1]->m_edgeList, cpIndex1 == 0,
-                  m_strokes[index2]->m_edgeList, cpIndex2 == 0, oldEdgeList);
+                  cpIndex1 == 0, m_strokes[index2]->m_edgeList, cpIndex2 == 0,
+                  oldEdgeList);
   // printEdges(os, "****edgelist", getPalette(), oldEdgeList);
 
   std::vector<int> toBeDeleted;

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -237,6 +237,9 @@ enum PreferencesItemId {
   // LineTestFpsCapture,
   // guidedDrawingType,
 
+  // Tape Tool confirmation (stored only; no Preferences popup control)
+  tapeToolFillRiskPolicy,
+
   PreferencesItemCount
 };
 

--- a/toonz/sources/tnztools/vectortapetool.cpp
+++ b/toonz/sources/tnztools/vectortapetool.cpp
@@ -11,7 +11,9 @@
 #include "tproperty.h"
 
 #include "toonzqt/imageutils.h"
+#include "toonzqt/dvdialog.h"
 
+#include "toonz/preferences.h"
 #include "toonz/tframehandle.h"
 #include "toonz/tcolumnhandle.h"
 #include "toonz/txshlevelhandle.h"
@@ -23,6 +25,9 @@
 #include "tenv.h"
 // For Qt translation support
 #include <QCoreApplication>
+#include <QCursor>
+#include <QToolTip>
+#include <memory>
 
 using namespace ToolUtils;
 
@@ -38,6 +43,17 @@ TEnv::IntVar TapeJoinStrokes("InknpaintTapeJoinStrokes", 0);
 TEnv::StringVar TapeType("InknpaintTapeType1", "Normal");
 TEnv::DoubleVar AutocloseFactor("InknpaintAutocloseFactor", 4.0);
 namespace {
+
+enum class TapeFillRiskPolicy { Ask = 0, Continue = 1, Cancel = 2 };
+
+bool hasFilledRegion(TRegion *region) {
+  if (region->getStyle() != 0) return true;
+  for (UINT i = 0; i < region->getSubregionCount(); ++i)
+    if (hasFilledRegion(region->getSubregion(i))) return true;
+  return false;
+}
+
+bool isEndpoint(double w) { return w == 0.0 || w == 1.0; }
 
 class UndoAutoclose final : public ToolUtils::TToolUndo {
   int m_oldStrokeId1;
@@ -601,19 +617,27 @@ public:
 #define l2p 3
 #define l2l 4
 
-  void tapeRect(const TVectorImageP &vi, const TRectD &rect) {
-    std::vector<TFilledRegionInf> *fillInformation =
-        new std::vector<TFilledRegionInf>;
-    ImageUtils::getFillingInformationOverlappingArea(vi, *fillInformation,
-                                                     rect);
-
-    bool initUndoBlock = false;
-
+  bool tapeRect(TVectorImageP vi, TRectD rect) {
     std::vector<std::pair<int, double>> startPoints, endPoints;
     getClosingPoints(rect, m_autocloseFactor.getValue(), vi, startPoints,
                      endPoints);
 
     assert(startPoints.size() == endPoints.size());
+    if (startPoints.empty()) return false;
+
+    bool joinsExistingStrokes = false;
+    for (size_t i = 0; i < startPoints.size(); ++i)
+      if (isEndpoint(startPoints[i].second) || isEndpoint(endPoints[i].second))
+        joinsExistingStrokes = true;
+    // Ask once, before any connection, writable image request, or undo block.
+    if (!confirmTape(vi, joinsExistingStrokes)) return false;
+    vi = TVectorImageP(getImage(true));
+    if (!vi) return false;
+    QMutexLocker lock(vi->getMutex());
+    std::vector<TFilledRegionInf> *fillInformation =
+        new std::vector<TFilledRegionInf>;
+    ImageUtils::getFillingInformationOverlappingArea(vi, *fillInformation,
+                                                     rect);
 
     std::vector<TPointD> startP(startPoints.size()), endP(startPoints.size());
 
@@ -650,6 +674,7 @@ public:
       }
     }
     if (!startPoints.empty()) TUndoManager::manager()->endBlock();
+    return true;
   }
 
   int doTape(const TVectorImageP &vi,
@@ -686,24 +711,78 @@ public:
   }
   //-------------------------------------------------------------------------------
 
+  bool confirmTape(const TVectorImageP &vi, bool joinsExistingStrokes) {
+    if (!m_joinStrokes.getValue() || !joinsExistingStrokes) return true;
+    bool hasFills = false;
+    {
+      QMutexLocker lock(vi->getMutex());
+      vi->findRegions();  // Includes fills whose region data was not yet
+                          // computed.
+      for (UINT i = 0; i < vi->getRegionCount() && !hasFills; ++i)
+        hasFills = hasFilledRegion(vi->getRegion(i));
+    }
+    if (!hasFills) return true;
+
+    Preferences *preferences = Preferences::instance();
+    const int policy         = preferences->getIntValue(tapeToolFillRiskPolicy);
+    if (policy == int(TapeFillRiskPolicy::Continue)) return true;
+    if (policy == int(TapeFillRiskPolicy::Cancel)) {
+      QToolTip::showText(
+          QCursor::pos(),
+          tr("Tape operation canceled by your remembered choice."), nullptr,
+          QRect(), 3000);
+      return false;
+    }
+
+    // A precaution for filled work; do not hold the image lock while asking.
+    std::unique_ptr<DVGui::MessageAndCheckboxDialog> dialog(
+        DVGui::createMsgandCheckbox(
+            DVGui::WARNING,
+            tr("Editing vector strokes may change or remove existing color "
+               "fills.\n"
+               "Do you want to continue?"),
+            tr("Remember my choice"),
+            QStringList() << tr("Cancel") << tr("Continue"), 0, Qt::Unchecked));
+    dialog->setWindowTitle(tr("Tape Tool"));
+    const int result = dialog->exec();
+    // Escape/close cancel this operation only, even if the checkbox was
+    // checked.
+    if ((result == 1 || result == 2) && dialog->getChecked())
+      preferences->setValue(tapeToolFillRiskPolicy,
+                            int(result == 2 ? TapeFillRiskPolicy::Continue
+                                            : TapeFillRiskPolicy::Cancel));
+    return result == 2 &&
+           TVectorImageP(getImage(false)).getPointer() == vi.getPointer();
+  }
+
+  void resetGesture() {
+    m_strokeIndex1 = m_strokeIndex2 = -1;
+    m_w1 = m_w2     = -1.0;
+    m_secondPoint   = false;
+    m_selectionRect = TRectD();
+    m_startRect     = TPointD();
+    invalidate();
+  }
+
   void leftButtonUp(const TPointD &, const TMouseEvent &) override {
-    TVectorImageP vi(getImage(true));
+    TVectorImageP vi(getImage(false));
 
     if (vi && m_type.getValue() == RECT) {
-      tapeRect(vi, m_selectionRect);
-      m_selectionRect = TRectD();
-      m_startRect     = TPointD();
-      notifyImageChanged();
-      invalidate();
+      if (tapeRect(vi, m_selectionRect)) notifyImageChanged();
+      resetGesture();
       return;
     }
 
-    if (!vi || m_strokeIndex1 == -1 || !m_secondPoint || m_strokeIndex2 == -1) {
-      m_strokeIndex1 = -1;
-      m_strokeIndex2 = -1;
-      m_w1           = -1.0;
-      m_w2           = -1.0;
-      m_secondPoint  = false;
+    if (!vi || m_strokeIndex1 < 0 || !m_secondPoint || m_strokeIndex2 < 0 ||
+        m_strokeIndex1 >= int(vi->getStrokeCount()) ||
+        m_strokeIndex2 >= int(vi->getStrokeCount()) ||
+        !confirmTape(vi, isEndpoint(m_w1) || isEndpoint(m_w2))) {
+      resetGesture();
+      return;
+    }
+    vi = TVectorImageP(getImage(true));
+    if (!vi) {
+      resetGesture();
       return;
     }
     QMutexLocker lock(vi->getMutex());
@@ -717,11 +796,7 @@ public:
 
     doTape(vi, fillInformation, m_joinStrokes.getValue());
 
-    invalidate();
-
-    m_strokeIndex2 = -1;
-    m_w1           = -1.0;
-    m_w2           = -1.0;
+    resetGesture();
   }
 
   //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -702,6 +702,8 @@ void Preferences::definePreferenceItems() {
   define(useQtNativeWinInk, "useQtNativeWinInk", QMetaType::Bool, false);
 
   // Others (not appearing in the popup)
+  // Tape Tool: 0 = ask, 1 = continue, 2 = cancel.
+  define(tapeToolFillRiskPolicy, "tapeToolFillRiskPolicy", QMetaType::Int, 0);
   // Shortcut popup settings
   define(shortcutPreset, "shortcutPreset", QMetaType::QString, "defopentoonz");
   // Viewer context menu


### PR DESCRIPTION
Fixes #2347

Preserve vector orientation when Tape extends a stroke at its beginning, with Smooth on or off, and adjust fill edge mapping for that orientation. 

Includes a precautionary confirmation before joining or extending strokes in filled drawings. 
Cancel is the default, and an optional remembered choice is stored silently in preferences.ini without a Preferences window entry. Rectangular gestures ask once before making changes.

Adapted from Shun Iwasawa's original fix in opentoonz/opentoonz#2355 (94e1643c8aa044438f65735b224346739a49f400).

Implementation and review assisted by ChatGPT (Codex).