### PR TITLE
Set Default Startup and New Scene Tool

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -375,6 +375,12 @@ public:
   TPixel32 getAnimateToolColor() const {
     return getColorValue(animateToolColor);
   }
+  QString getDefaultStartupTool() const {
+    return getStringValue(defaultStartupTool);
+  }
+  QString getDefaultNewSceneTool() const {
+    return getStringValue(defaultNewSceneTool);
+  }
 
   // Xsheet  tab
   QString getXsheetLayoutPreference() const {

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -130,6 +130,8 @@ enum PreferencesItemId {
   tempToolSwitchTimer,
   animateToolHandleSize,
   animateToolColor,
+  defaultStartupTool,
+  defaultNewSceneTool,
 
   //----------
   // Xsheet

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -29,6 +29,7 @@
 
 // TnzTools includes
 #include "tools/toolhandle.h"
+#include "tools/toolcommandids.h"
 
 // ToonzQt includes
 #include "toonzqt/gutil.h"
@@ -39,6 +40,7 @@
 #include "toonzqt/imageutils.h"
 
 // ToonzLib includes
+#include "toonz/preferences.h"
 #include "toonz/palettecontroller.h"
 #include "toonz/tscenehandle.h"
 #include "toonz/tobjecthandle.h"
@@ -86,6 +88,7 @@
 // Qt includes
 #include <QLabel>
 #include <QApplication>
+#include <QByteArray>
 #include <QClipboard>
 #include <QDirIterator>
 
@@ -1378,7 +1381,12 @@ void IoCmd::newScene() {
   ToolHandle *toolH = TApp::instance()->getCurrentTool();
   if (toolH && toolH->getTool()) toolH->getTool()->reset();
 
-  CommandManager::instance()->execute("T_Hand");
+  const QByteArray defaultNewSceneTool =
+      Preferences::instance()->getDefaultNewSceneTool().toLatin1();
+  if (CommandManager::instance()->getAction(defaultNewSceneTool.constData()))
+    CommandManager::instance()->execute(defaultNewSceneTool.constData());
+  else
+    CommandManager::instance()->execute(T_Hand);
 
   CommandManager::instance()->enable(MI_SaveSubxsheetAs, false);
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -74,6 +74,7 @@
 #include <QApplication>
 #include <QAbstractEventDispatcher>
 #include <QAbstractNativeEventFilter>
+#include <QByteArray>
 #include <QSplashScreen>
 #include <QGLPixelBuffer>
 #include <QTranslator>
@@ -793,7 +794,12 @@ int main(int argc, char *argv[]) {
   // Show floating panels only after the main window has been shown
   w.startupFloatingPanels();
 
-  CommandManager::instance()->execute(T_Hand);
+  const QByteArray defaultStartupTool =
+      Preferences::instance()->getDefaultStartupTool().toLatin1();
+  if (CommandManager::instance()->getAction(defaultStartupTool.constData()))
+    CommandManager::instance()->execute(defaultStartupTool.constData());
+  else
+    CommandManager::instance()->execute(T_Hand);
   if (!loadFilePath.isEmpty()) {
     splash.showMessage(
         QString("Loading file '") + loadFilePath.getQString() + "'...",

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -40,6 +40,7 @@
 
 // TnzTools includes
 #include "tools/toolhandle.h"
+#include "tools/toolcommandids.h"
 
 #include "kis_tablet_support_win8.h"
 
@@ -734,6 +735,13 @@ void PreferencesPopup::onLevelBasedToolsDisplayChanged() {
 
 //-----------------------------------------------------------------------------
 
+void PreferencesPopup::onDefaultStartupToolChanged() {
+  m_pref->setValue(defaultNewSceneTool,
+                   m_pref->getStringValue(defaultStartupTool));
+}
+
+//-----------------------------------------------------------------------------
+
 void PreferencesPopup::onShowKeyframesOnCellAreaChanged() {
   TApp::instance()->getCurrentScene()->notifyPreferenceChanged("XsheetCamera");
 }
@@ -1391,6 +1399,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
        tr("Switch Tool Temporarily Keypress Length (ms):")},
       {animateToolHandleSize, tr("Handle Size (%):")},
       {animateToolColor, tr("Handle Color:")},
+      {defaultStartupTool, tr("Default Startup and New Scene Tool:")},
 
       // Xsheet
       {xsheetLayoutPreference, tr("Column Header Layout*:")},
@@ -1575,6 +1584,35 @@ QList<ComboBoxItem> PreferencesPopup::getComboItemList(
        {{tr("Default"), 0},
         {tr("Enable Tools For Level Only"), 1},
         {tr("Show Tools For Level Only"), 2}}},
+      {defaultStartupTool,
+       {{tr("Edit Tool"), T_Edit},
+        {tr("Selection Tool"), T_Selection},
+        {tr("Brush Tool"), T_Brush},
+        {tr("Geometric Tool"), T_Geometric},
+        {tr("Type Tool"), T_Type},
+        {tr("Fill Tool"), T_Fill},
+        {tr("Paint Brush Tool"), T_PaintBrush},
+        {tr("Eraser Tool"), T_Eraser},
+        {tr("Tape Tool"), T_Tape},
+        {tr("Style Picker Tool"), T_StylePicker},
+        {tr("RGB Picker Tool"), T_RGBPicker},
+        {tr("Control Point Editor Tool"), T_ControlPointEditor},
+        {tr("Pinch Tool"), T_Pinch},
+        {tr("Pump Tool"), T_Pump},
+        {tr("Magnet Tool"), T_Magnet},
+        {tr("Bender Tool"), T_Bender},
+        {tr("Iron Tool"), T_Iron},
+        {tr("Cutter Tool"), T_Cutter},
+        {tr("Hook Tool"), T_Hook},
+        {tr("Skeleton Tool"), T_Skeleton},
+        {tr("Tracker Tool"), T_Tracker},
+        {tr("Plastic Tool"), T_Plastic},
+        {tr("Zoom Tool"), T_Zoom},
+        {tr("Rotate Tool"), T_Rotate},
+        {tr("Hand Tool"), T_Hand},
+        {tr("Ruler Tool"), T_Ruler},
+        {tr("Finger Tool"), T_Finger},
+        {tr("Edit Assistants Tool"), T_EditAssistants}}},
       {xsheetLayoutPreference,
        {{tr("Classic"), "Classic"},
         {tr("Classic-revised"), "Classic-revised"},
@@ -2164,6 +2202,15 @@ QWidget* PreferencesPopup::createToolsPage() {
   //         getComboItemList(dropdownShortcutsCycleOptions));
   insertUI(levelBasedToolsDisplay, lay,
            getComboItemList(levelBasedToolsDisplay));
+  insertUI(defaultStartupTool, lay, getComboItemList(defaultStartupTool));
+  QComboBox* defaultToolCombo = getUI<QComboBox*>(defaultStartupTool);
+  defaultToolCombo->setToolTip(
+      tr("This menu sets both events. To set them independently, edit "
+         "preferences.ini and use:\n"
+         "defaultStartupTool=T_Hand\n"
+         "defaultNewSceneTool=T_Brush"));
+  m_onEditedFuncMap.insert(defaultStartupTool,
+                           &PreferencesPopup::onDefaultStartupToolChanged);
   QGridLayout* fillToolOptionsLay =
       insertGroupBox(tr("Fill Tool Options (Toonz Raster Level)"), lay);
   {

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -139,6 +139,7 @@ private:
   void onUseNumpadForSwitchingStylesClicked();
   // Tools
   void onLevelBasedToolsDisplayChanged();
+  void onDefaultStartupToolChanged();
   // Xsheet
   void onShowKeyframesOnCellAreaChanged();
   void onShowXSheetToolbarClicked();

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -577,6 +577,12 @@ void Preferences::definePreferenceItems() {
          1.0, 5.0);
   define(animateToolColor, "animateToolColor", QMetaType::QColor,
          QColor(250, 127, 240));
+  // The Preferences dialog updates both keys together. Advanced users may set
+  // these command IDs independently in preferences.ini.
+  define(defaultStartupTool, "defaultStartupTool", QMetaType::QString,
+         "T_Hand");
+  define(defaultNewSceneTool, "defaultNewSceneTool", QMetaType::QString,
+         "T_Hand");
 
   // Xsheet
   define(xsheetLayoutPreference, "xsheetLayoutPreference", QMetaType::QString,


### PR DESCRIPTION
Replaces opentoonz/opentoonz#7101 and opentoonz/opentoonz#7102 with an opt-in tool preference.

- Adds **Preferences > Tools > Default Startup and New Scene Tool**.
- Keeps the Hand Tool as the default.
- Applies the selected tool at application startup and when creating a new scene.
- Stores stable tool command IDs and falls back to Hand if a manually entered ID is invalid.
- Documents the advanced `preferences.ini` override in the preference tooltip:
  - `defaultStartupTool=T_Hand`
  - `defaultNewSceneTool=T_Brush`

While the Preferences control writes both values together; the two INI keys may be set independently for workflows that need different startup and new-scene tools.

Co-authored-by: Ahl76 <145405932+Ahl76@users.noreply.github.com>

There is future work to do with regard to preferences.ini and its undocumented options.
This is important given current development policy regarding maintaining historical and keeping changes that might interfere with classical useage optional.