### PR TITLE
Add Palette Convert submenu for lines and areas

### DIFF
--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -23,6 +23,8 @@
 
 #define MI_BlendColors "MI_BlendColors"
 #define MI_EraseUnusedStyles "MI_EraseUnusedStyles"
+#define MI_ConvertLinesToAreas "MI_ConvertLinesToAreas"
+#define MI_ConvertAreasToLines "MI_ConvertAreasToLines"
 
 #define MI_Group "MI_Group"
 #define MI_Ungroup "MI_Ungroup"

--- a/toonz/sources/toonz/CMakeLists.txt
+++ b/toonz/sources/toonz/CMakeLists.txt
@@ -276,6 +276,7 @@ set(SOURCES
     addfilmstripframespopup.cpp
     camerasettingspopup.cpp
     convertpopup.cpp
+    convertlinestoareascommand.cpp
     crashhandler.cpp
     duplicatepopup.cpp
     dvdirtreeview.cpp

--- a/toonz/sources/toonz/convertlinestoareascommand.cpp
+++ b/toonz/sources/toonz/convertlinestoareascommand.cpp
@@ -1,0 +1,249 @@
+#include "convertlinestoareascommand.h"
+
+#include "tapp.h"
+#include "menubarcommandids.h"
+#include "tools/toolutils.h"
+#include "toonz/tcolumnhandle.h"
+#include "toonz/tframehandle.h"
+#include "toonz/ttilesaver.h"
+#include "toonz/ttileset.h"
+#include "toonz/txshcell.h"
+#include "toonz/txshcolumn.h"
+#include "toonz/txsheet.h"
+#include "toonz/txsheethandle.h"
+#include "toonz/txshlevelhandle.h"
+#include "toonz/txshleveltypes.h"
+#include "toonz/txshsimplelevel.h"
+#include "toonzqt/menubarcommand.h"
+#include "toonzqt/styleselection.h"
+#include "toonzqt/tselectionhandle.h"
+#include "ttoonzimage.h"
+
+#include <QTimer>
+
+#include <bitset>
+#include <memory>
+
+namespace {
+
+using StyleMask = std::bitset<4096>;
+
+enum class ConversionDirection { LineToArea, AreaToLine };
+
+// Conversion can leave paint underneath solid ink to prevent antialiasing
+// gaps (see Naa2TlvConverter::makeTlv). Test coverage in either direction.
+bool convertPixel(TPixelCM32 &pixel, const StyleMask &styles,
+                  ConversionDirection direction) {
+  const bool toArea     = direction == ConversionDirection::LineToArea;
+  const int source      = toArea ? pixel.getInk() : pixel.getPaint();
+  const int destination = toArea ? pixel.getPaint() : pixel.getInk();
+  const int maxTone     = TPixelCM32::getMaxTone();
+  int coverage          = toArea ? maxTone - pixel.getTone() : pixel.getTone();
+  if (source == 0 || !styles[source] || coverage == 0) return false;
+
+  if (coverage == maxTone || destination == source) {
+    // Hidden destination data contributes nothing. Matching style IDs combine
+    // to full coverage while retaining the style's own opacity.
+    coverage = maxTone;
+  } else if (destination != 0) {
+    // Two different contributing styles cannot share one destination slot.
+    return false;
+  }
+
+  // Retain fractional coverage against transparency, including antialiased
+  // edges.
+  pixel = toArea ? TPixelCM32(0, source, coverage)
+                 : TPixelCM32(source, 0, maxTone - coverage);
+  return true;
+}
+
+void convertLineArea(const TRasterCM32P &ras, const StyleMask &styles,
+                     ConversionDirection direction,
+                     TTileSaverCM32 *saver = nullptr) {
+  ras->lock();
+  for (int y = 0; y < ras->getLy(); ++y) {
+    TPixelCM32 *row = ras->pixels(y);
+    for (int x = 0; x < ras->getLx(); ++x) {
+      TPixelCM32 converted = row[x];
+      if (!convertPixel(converted, styles, direction)) continue;
+      if (saver) saver->save(TPoint(x, y));
+      row[x] = converted;
+    }
+  }
+  ras->unlock();
+}
+
+bool getTarget(TXshCell &cell, StyleMask &styles) {
+  TApp *app = TApp::instance();
+  if (app->getCurrentFrame()->isPlaying()) return false;
+
+  cell                = TTool::getImageCell();
+  TXshSimpleLevel *sl = cell.getSimpleLevel();
+  if (!sl || sl->getType() != TZP_XSHLEVEL || sl->isReadOnly() ||
+      !sl->isFid(cell.getFrameId()) || sl->isFrameReadOnly(cell.getFrameId()))
+    return false;
+
+  if (!app->getCurrentFrame()->isEditingLevel()) {
+    TXsheet *xsheet = app->getCurrentXsheet()->getXsheet();
+    TXshColumn *column =
+        xsheet->getColumn(app->getCurrentColumn()->getColumnIndex());
+    if (!column || column->isLocked()) return false;
+  }
+
+  TPaletteHandle *handle = app->getCurrentPalette();
+  TPalette *palette      = handle->getPalette();
+  if (!palette || palette != sl->getPalette() || palette->isCleanupPalette())
+    return false;
+
+  const auto addStyle = [&](int id) {
+    if (id > 0 && id < palette->getStyleCount() &&
+        id <= TPixelCM32::getMaxInk())
+      styles.set(id);
+  };
+  TStyleSelection *selection = dynamic_cast<TStyleSelection *>(
+      app->getCurrentSelection()->getSelection());
+  if (selection && !selection->isEmpty()) {
+    if (!selection->getPaletteHandle() || selection->getPalette() != palette)
+      return false;
+    const int pageIndex = selection->getPageIndex();
+    if (pageIndex < 0 || pageIndex >= palette->getPageCount()) return false;
+    TPalette::Page *page = palette->getPage(pageIndex);
+    for (int index : selection->getIndicesInPage()) {
+      if (index >= 0 && index < page->getStyleCount())
+        addStyle(page->getStyleId(index));
+    }
+  } else {
+    // A shortcut used from the viewer acts on the current drawing style.
+    addStyle(handle->getStyleIndex());
+  }
+  return styles.any();
+}
+
+class ConvertLineAreaUndo final : public ToolUtils::TRasterUndo {
+  StyleMask m_styles;
+  ConversionDirection m_direction;
+
+public:
+  ConvertLineAreaUndo(TTileSetCM32 *tiles, TXshSimpleLevel *sl,
+                      const TFrameId &fid, const StyleMask &styles,
+                      ConversionDirection direction)
+      : TRasterUndo(tiles, sl, fid, false, false, nullptr, false)
+      , m_styles(styles)
+      , m_direction(direction) {}
+
+  void notify() const {
+    m_level->touchFrame(m_frameId);
+    notifyImageChanged();
+    TApp::instance()->getCurrentLevel()->notifyLevelChange();
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  void undo() const override {
+    if (!getImage()) return;
+    TRasterUndo::undo();
+    notify();
+  }
+
+  void redo() const override {
+    TToonzImageP image = getImage();
+    if (!image || !image->getRaster()) return;
+    convertLineArea(image->getRaster(), m_styles, m_direction);
+    notify();
+  }
+
+  int getSize() const override {
+    return TRasterUndo::getSize() + sizeof(m_styles) + sizeof(m_direction);
+  }
+
+  QString getToolName() override {
+    return m_direction == ConversionDirection::LineToArea
+               ? QObject::tr("Convert Lines to Areas")
+               : QObject::tr("Convert Areas to Lines");
+  }
+};
+
+class ConvertLineAreaCommand final : public MenuItemHandler {
+  ConversionDirection m_direction;
+
+public:
+  ConvertLineAreaCommand(CommandId id, ConversionDirection direction)
+      : MenuItemHandler(id), m_direction(direction) {}
+
+  void execute() override {
+    TXshCell cell;
+    StyleMask styles;
+    if (!getTarget(cell, styles)) return;
+
+    TToonzImageP image = cell.getImage(true);
+    if (!image || !image->getRaster()) return;
+    TRasterCM32P ras = image->getRaster();
+    auto tiles       = std::make_unique<TTileSetCM32>(ras->getSize());
+    TTileSaverCM32 saver(ras, tiles.get());
+    convertLineArea(ras, styles, m_direction, &saver);
+    if (tiles->getTileCount() == 0) return;
+
+    auto undo = std::make_unique<ConvertLineAreaUndo>(
+        tiles.release(), cell.getSimpleLevel(), cell.getFrameId(), styles,
+        m_direction);
+    undo->notify();
+    TUndoManager::manager()->add(undo.release());
+  }
+};
+
+ConvertLineAreaCommand convertLinesToAreasCommand(
+    MI_ConvertLinesToAreas, ConversionDirection::LineToArea);
+ConvertLineAreaCommand convertAreasToLinesCommand(
+    MI_ConvertAreasToLines, ConversionDirection::AreaToLine);
+
+}  // namespace
+
+void initConvertLineAreaCommands(QAction *action, QAction *reverseAction) {
+  TApp *app = TApp::instance();
+  action->setToolTip(QObject::tr(
+      "Convert selected styles' lines (ink) to areas (paint) in the current "
+      "Toonz Raster drawing, preserving antialiasing and transparency. Mixed "
+      "edge pixels with a different area style are left unchanged."));
+  reverseAction->setToolTip(QObject::tr(
+      "Convert selected styles' areas (paint) to lines (ink) in the current "
+      "Toonz Raster drawing, preserving antialiasing and transparency. Mixed "
+      "edge pixels with a different line style are left unchanged."));
+  // Palette clicks update the style and selection in separate steps. Refresh
+  // after both changes so Ctrl/Shift selections are evaluated together.
+  const auto update = []() {
+    TXshCell cell;
+    StyleMask styles;
+    const bool enabled = getTarget(cell, styles);
+    CommandManager::instance()->enable(MI_ConvertLinesToAreas, enabled);
+    CommandManager::instance()->enable(MI_ConvertAreasToLines, enabled);
+  };
+  const auto scheduleUpdate = [action, update]() {
+    QTimer::singleShot(0, action, update);
+  };
+  QObject::connect(app->getCurrentSelection(),
+                   &TSelectionHandle::selectionSwitched, action,
+                   scheduleUpdate);
+  QObject::connect(app->getCurrentSelection(),
+                   &TSelectionHandle::selectionChanged, action, scheduleUpdate);
+  QObject::connect(app->getCurrentLevel(), &TXshLevelHandle::xshLevelSwitched,
+                   action, scheduleUpdate);
+  QObject::connect(app->getCurrentFrame(), &TFrameHandle::frameSwitched, action,
+                   scheduleUpdate);
+  QObject::connect(app->getCurrentFrame(),
+                   &TFrameHandle::isPlayingStatusChanged, action,
+                   scheduleUpdate);
+  QObject::connect(app->getCurrentXsheet(), &TXsheetHandle::xsheetChanged,
+                   action, scheduleUpdate);
+  QObject::connect(app->getCurrentPalette(), &TPaletteHandle::paletteSwitched,
+                   action, scheduleUpdate);
+  QObject::connect(app->getCurrentPalette(),
+                   &TPaletteHandle::colorStyleSwitched, action, scheduleUpdate);
+  QObject::connect(app->getCurrentLevel(), &TXshLevelHandle::xshLevelChanged,
+                   action, scheduleUpdate);
+  QObject::connect(app->getCurrentColumn(), &TColumnHandle::columnIndexSwitched,
+                   action, scheduleUpdate);
+  QObject::connect(app->getCurrentFrame(), &TFrameHandle::frameTypeChanged,
+                   action, scheduleUpdate);
+  QObject::connect(app->getCurrentXsheet(), &TXsheetHandle::xsheetSwitched,
+                   action, scheduleUpdate);
+  update();
+}

--- a/toonz/sources/toonz/convertlinestoareascommand.h
+++ b/toonz/sources/toonz/convertlinestoareascommand.h
@@ -1,0 +1,5 @@
+#pragma once
+
+class QAction;
+
+void initConvertLineAreaCommands(QAction *action, QAction *reverseAction);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1,6 +1,7 @@
 
 
 #include "mainwindow.h"
+#include "convertlinestoareascommand.h"
 #include "customhelplink.h"
 
 // Tnz6 includes
@@ -2643,6 +2644,11 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_EraseUnusedStyles,
                              QT_TR_NOOP("&Delete Unused Styles"), "",
                              "delete_unused_styles");
+  initConvertLineAreaCommands(
+      createRightClickMenuAction(MI_ConvertLinesToAreas,
+                                 QT_TR_NOOP("Convert Lines to Areas"), ""),
+      createRightClickMenuAction(MI_ConvertAreasToLines,
+                                 QT_TR_NOOP("Convert Areas to Lines"), ""));
 
   // Menu - View
 

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -31,6 +31,7 @@
 #include <QPainter>
 #include <QMouseEvent>
 #include <QKeyEvent>
+#include <QKeySequence>
 #include <QMenuBar>
 #include <QToolTip>
 #include <QDrag>
@@ -1003,6 +1004,11 @@ void PageViewer::mousePressEvent(QMouseEvent *event) {
 
   if (event->button() == Qt::RightButton) {
     m_styleSelection->makeCurrent();
+    // Opening the level palette menu beside the chips must preserve this
+    // page's selected styles for batch commands such as Convert.
+    const bool keepSelection =
+        m_viewType == LEVEL_PALETTE && !m_styleSelection->isEmpty() &&
+        m_styleSelection->isPageSelected(pageIndex);
     // if you are clicking on the color chip
     if (0 <= indexInPage && indexInPage < getChipCount()) {
       // Se pageIndex non e' selezionato lo seleziono
@@ -1012,7 +1018,7 @@ void PageViewer::mousePressEvent(QMouseEvent *event) {
       }
       // Cambio l'indice corrente
       setCurrentStyleIndex(m_page->getStyleId(indexInPage));
-    } else {
+    } else if (!keepSelection) {
       m_styleSelection->selectNone();
       m_styleSelection->select(pageIndex);
     }
@@ -1180,6 +1186,28 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   if (m_viewType == LEVEL_PALETTE) {
     QAction *openPltGizmoAct = cmd->getAction("MI_OpenPltGizmo");
     menu.addAction(openPltGizmoAct);
+    QMenu *convertMenu = menu.addMenu(tr("Convert"));
+    const auto addConversion = [&](CommandId id, const QString &label) {
+      QAction *command = cmd->getAction(id);
+      if (!command) return;
+      QAction *item = convertMenu->addAction(label);
+      const auto sync = [command, item, label]() {
+        const QString shortcut =
+            command->shortcut().toString(QKeySequence::NativeText);
+        // Display the assigned shortcut without registering it a second time.
+        item->setText(shortcut.isEmpty() ? label : label + "\t" + shortcut);
+        item->setIcon(command->icon());
+        item->setToolTip(command->toolTip());
+        item->setEnabled(command->isEnabled());
+      };
+      connect(command, &QAction::changed, item, sync);
+      connect(item, &QAction::triggered, command, &QAction::trigger);
+      sync();
+    };
+    //: "Line" means Toonz Raster ink; "Area" means Toonz Raster paint.
+    addConversion(MI_ConvertLinesToAreas, tr("Line to Area"));
+    //: "Area" means Toonz Raster paint; "Line" means Toonz Raster ink.
+    addConversion(MI_ConvertAreasToLines, tr("Area to Line"));
   }
   QAction *openStyleControlAct = cmd->getAction("MI_OpenStyleControl");
   menu.addAction(openStyleControlAct);

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -1006,9 +1006,9 @@ void PageViewer::mousePressEvent(QMouseEvent *event) {
     m_styleSelection->makeCurrent();
     // Opening the level palette menu beside the chips must preserve this
     // page's selected styles for batch commands such as Convert.
-    const bool keepSelection =
-        m_viewType == LEVEL_PALETTE && !m_styleSelection->isEmpty() &&
-        m_styleSelection->isPageSelected(pageIndex);
+    const bool keepSelection = m_viewType == LEVEL_PALETTE &&
+                               !m_styleSelection->isEmpty() &&
+                               m_styleSelection->isPageSelected(pageIndex);
     // if you are clicking on the color chip
     if (0 <= indexInPage && indexInPage < getChipCount()) {
       // Se pageIndex non e' selezionato lo seleziono
@@ -1186,11 +1186,11 @@ void PageViewer::contextMenuEvent(QContextMenuEvent *event) {
   if (m_viewType == LEVEL_PALETTE) {
     QAction *openPltGizmoAct = cmd->getAction("MI_OpenPltGizmo");
     menu.addAction(openPltGizmoAct);
-    QMenu *convertMenu = menu.addMenu(tr("Convert"));
+    QMenu *convertMenu       = menu.addMenu(tr("Convert"));
     const auto addConversion = [&](CommandId id, const QString &label) {
       QAction *command = cmd->getAction(id);
       if (!command) return;
-      QAction *item = convertMenu->addAction(label);
+      QAction *item   = convertMenu->addAction(label);
       const auto sync = [command, item, label]() {
         const QString shortcut =
             command->shortcut().toString(QKeySequence::NativeText);


### PR DESCRIPTION
Adds Palette > Convert > Line to Area and Area to Line for selected styles in the current editable Toonz Raster drawing.

Supports multi-style palette selections, preserves antialiased coverage against transparency, leaves true two-style edge pixels unchanged, and provides one Undo/Redo operation per conversion.

Core problem addressed
Conversion from raster to TLV can result in pixels being assigned as line whereas they need to be assigned as areas.  This PR does not attempt to resolve that problem which must be considered at the conversion stage.  It instead provides a means of targeting parts of TLV images assigned as lines to transform them into areas (and vice versa).

Workflow
Use of Paint Check view during conversion allows the user to quickly see and fully control what pixels are assigned as paint/area

Multiple styles can be selected at the same time and each will still retain control over the appropriate pixels.

A separate PR to Reduce Colors provides a means to combine styles together without loss of pixel coverage.
  
Additional inspiration for troubleshooting stray pixels:
The antialiased edge handling of this process follows a review of https://github.com/opentoonz/opentoonz/pull/7104 and its converter path: Naa2TlvConverter::makeTlv extends paint underneath solid ink to prevent antialiasing gaps. The conversion checks that data's coverage rather than rejecting any nonzero destination style. Undo restores the original pixel data, including hidden style IDs.  This helps in understanding how to treat the TLV format's specific requirements.

Chat GPT 6.0 was used in the development, processing, testing and documentation of this feature.
