### PR TITLE
Add Button to Save MyPaint Brushes with Modified Settings

### DIFF
--- a/toonz/sources/include/toonz/mypaintbrushstyle.h
+++ b/toonz/sources/include/toonz/mypaintbrushstyle.h
@@ -96,6 +96,7 @@ public:
 
   void setBaseValue(MyPaintBrushSetting id, bool enable, float value);
   void resetBaseValues();
+  bool saveBrushAs(const TFilePath &path, QString &errorMessage) const;
 
   void setBaseValue(MyPaintBrushSetting id, float value) {
     setBaseValue(id, true, value);

--- a/toonz/sources/include/toonzqt/styleeditor.h
+++ b/toonz/sources/include/toonzqt/styleeditor.h
@@ -761,6 +761,11 @@ public:
       return false;
   }
 
+  void reloadItems() {
+    m_manager->loadItems();
+    patternAdded();
+  }
+
   TMyPaintBrushStyle &getBrush(int index) {
     return m_mypManager->getBrush(index);
   }
@@ -818,6 +823,7 @@ class SettingsPage final : public QScrollArea {
   QGridLayout *m_paramsLayout;
 
   QCheckBox *m_autoFillCheckBox;
+  QPushButton *m_saveMyPaintButton;
 
   TColorStyleP m_editedStyle;  //!< A copy of the current style being edited by
                                //! the Style Editor.
@@ -840,12 +846,14 @@ signals:
 
   void paramStyleChanged(
       bool isDragging);  //!< Signals that the edited style has changed.
+  void myPaintBrushSaved();
 
 private slots:
 
   void onAutofillChanged();
   void onValueChanged(bool isDragging = false);
   void onValueReset();
+  void onMyPaintSaveAs();
 };
 
 //=============================================================================
@@ -1023,6 +1031,7 @@ protected slots:
   void onColorParamChanged();
 
   void onParamStyleChanged(bool isDragging);
+  void onMyPaintBrushSaved();
 
   void onHexChanged();
   void onHexEditor();

--- a/toonz/sources/toonzlib/mypaintbrushstyle.cpp
+++ b/toonz/sources/toonzlib/mypaintbrushstyle.cpp
@@ -325,8 +325,8 @@ bool TMyPaintBrushStyle::saveBrushAs(const TFilePath &path,
   const QFileInfo sourceInfo(m_fullpath.getQString());
   const QFileInfo destinationInfo(path.getQString());
   const QString sourcePath      = sourceInfo.canonicalFilePath().isEmpty()
-                                 ? sourceInfo.absoluteFilePath()
-                                 : sourceInfo.canonicalFilePath();
+                                      ? sourceInfo.absoluteFilePath()
+                                      : sourceInfo.canonicalFilePath();
   const QString destinationPath = destinationInfo.canonicalFilePath().isEmpty()
                                       ? destinationInfo.absoluteFilePath()
                                       : destinationInfo.canonicalFilePath();

--- a/toonz/sources/toonzlib/mypaintbrushstyle.cpp
+++ b/toonz/sources/toonzlib/mypaintbrushstyle.cpp
@@ -324,7 +324,7 @@ bool TMyPaintBrushStyle::saveBrushAs(const TFilePath &path,
                                      QString &errorMessage) const {
   const QFileInfo sourceInfo(m_fullpath.getQString());
   const QFileInfo destinationInfo(path.getQString());
-  const QString sourcePath = sourceInfo.canonicalFilePath().isEmpty()
+  const QString sourcePath      = sourceInfo.canonicalFilePath().isEmpty()
                                  ? sourceInfo.absoluteFilePath()
                                  : sourceInfo.canonicalFilePath();
   const QString destinationPath = destinationInfo.canonicalFilePath().isEmpty()
@@ -363,7 +363,7 @@ bool TMyPaintBrushStyle::saveBrushAs(const TFilePath &path,
     return false;
   }
 
-  QJsonObject root = document.object();
+  QJsonObject root     = document.object();
   QJsonObject settings = root.value("settings").toObject();
   for (const auto &entry : m_baseValues) {
     const QString key =
@@ -377,8 +377,9 @@ bool TMyPaintBrushStyle::saveBrushAs(const TFilePath &path,
   root.insert("version", 3);
 
   if (!TSystem::touchParentDir(path)) {
-    errorMessage = QObject::tr("The destination folder could not be created: %1")
-                       .arg(path.getParentDir().getQString());
+    errorMessage =
+        QObject::tr("The destination folder could not be created: %1")
+            .arg(path.getParentDir().getQString());
     return false;
   }
 

--- a/toonz/sources/toonzlib/mypaintbrushstyle.cpp
+++ b/toonz/sources/toonzlib/mypaintbrushstyle.cpp
@@ -1,6 +1,12 @@
 
 #include <streambuf>
 
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSaveFile>
+
 #include <QStandardPaths>
 
 #include "tfilepath_io.h"
@@ -310,6 +316,95 @@ void TMyPaintBrushStyle::loadBrush(const TFilePath &path) {
   TImageReader::load(preview_path, m_preview);
 
   invalidateIcon();
+}
+
+//-----------------------------------------------------------------------------
+
+bool TMyPaintBrushStyle::saveBrushAs(const TFilePath &path,
+                                     QString &errorMessage) const {
+  const QFileInfo sourceInfo(m_fullpath.getQString());
+  const QFileInfo destinationInfo(path.getQString());
+  const QString sourcePath = sourceInfo.canonicalFilePath().isEmpty()
+                                 ? sourceInfo.absoluteFilePath()
+                                 : sourceInfo.canonicalFilePath();
+  const QString destinationPath = destinationInfo.canonicalFilePath().isEmpty()
+                                      ? destinationInfo.absoluteFilePath()
+                                      : destinationInfo.canonicalFilePath();
+#ifdef _WIN32
+  const Qt::CaseSensitivity pathCaseSensitivity = Qt::CaseInsensitive;
+#else
+  const Qt::CaseSensitivity pathCaseSensitivity = Qt::CaseSensitive;
+#endif
+  if (QString::compare(sourcePath, destinationPath, pathCaseSensitivity) == 0) {
+    errorMessage = QObject::tr(
+        "Save As cannot replace the source MyPaint brush. Choose a new name "
+        "or location.");
+    return false;
+  }
+
+  QFile source(sourcePath);
+  if (!source.open(QIODevice::ReadOnly)) {
+    errorMessage = QObject::tr("The source MyPaint brush could not be read: %1")
+                       .arg(m_fullpath.getQString());
+    return false;
+  }
+
+  const QByteArray data = source.readAll();
+  std::string brushData(data.constData(), data.size());
+  if (brushData.find("version 2") != std::string::npos)
+    brushData = mybToVersion3(brushData);
+
+  QJsonParseError parseError;
+  QJsonDocument document = QJsonDocument::fromJson(
+      QByteArray::fromStdString(brushData), &parseError);
+  if (document.isNull() || !document.isObject()) {
+    errorMessage = QObject::tr("The source MyPaint brush is not valid JSON: %1")
+                       .arg(parseError.errorString());
+    return false;
+  }
+
+  QJsonObject root = document.object();
+  QJsonObject settings = root.value("settings").toObject();
+  for (const auto &entry : m_baseValues) {
+    const QString key =
+        QString::fromStdString(mypaint::Setting::byId(entry.first).key);
+    QJsonObject setting = settings.value(key).toObject();
+    setting.insert("base_value", static_cast<double>(entry.second));
+    settings.insert(key, setting);
+  }
+  root.insert("settings", settings);
+  root.insert("parent_brush_name", m_path.withType("").getQString());
+  root.insert("version", 3);
+
+  if (!TSystem::touchParentDir(path)) {
+    errorMessage = QObject::tr("The destination folder could not be created: %1")
+                       .arg(path.getParentDir().getQString());
+    return false;
+  }
+
+  QSaveFile output(destinationInfo.absoluteFilePath());
+  if (!output.open(QIODevice::WriteOnly)) {
+    errorMessage = QObject::tr("The MyPaint brush could not be written: %1")
+                       .arg(path.getQString());
+    return false;
+  }
+  output.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+  if (!output.commit()) {
+    errorMessage = QObject::tr("The MyPaint brush could not be saved: %1")
+                       .arg(path.getQString());
+    return false;
+  }
+
+  const TFilePath sourcePreview =
+      m_fullpath.getParentDir() + (m_fullpath.getWideName() + L"_prev.png");
+  const TFilePath destinationPreview =
+      path.getParentDir() + (path.getWideName() + L"_prev.png");
+  if (TFileStatus(sourcePreview).doesExist()) {
+    QFile::remove(destinationPreview.getQString());
+    QFile::copy(sourcePreview.getQString(), destinationPreview.getQString());
+  }
+
+  return true;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -43,6 +43,8 @@
 #include <QGridLayout>
 #include <QPainter>
 #include <QButtonGroup>
+#include <QDir>
+#include <QFileDialog>
 #include <QMouseEvent>
 #include <QLabel>
 #include <QCheckBox>
@@ -55,6 +57,7 @@
 #include <QToolTip>
 #include <QSplitter>
 #include <QMenu>
+#include <QMessageBox>
 #include <QOpenGLFramebufferObject>
 
 namespace {
@@ -2528,6 +2531,15 @@ SettingsPage::SettingsPage(QWidget *parent)
   paramsContainerLayout->addLayout(m_paramsLayout);
 
   paramsContainerLayout->addStretch(1);
+
+  m_saveMyPaintButton = new QPushButton(tr("Save As..."), this);
+  m_saveMyPaintButton->hide();
+  paramsContainerLayout->addWidget(m_saveMyPaintButton, 0, Qt::AlignRight);
+
+  ret = connect(m_saveMyPaintButton, SIGNAL(clicked(bool)), this,
+                SLOT(onMyPaintSaveAs())) &&
+        ret;
+  assert(ret);
 }
 
 //-----------------------------------------------------------------------------
@@ -2564,6 +2576,8 @@ void SettingsPage::setStyle(const TColorStyleP &editedStyle) {
       !(m_editedStyle && typeid(*m_editedStyle) == typeid(*editedStyle));
 
   m_editedStyle = editedStyle;
+  m_saveMyPaintButton->setVisible(
+      dynamic_cast<TMyPaintBrushStyle *>(m_editedStyle.getPointer()));
 
   if (clearLayout) locals::clearLayout(m_paramsLayout);
 
@@ -2799,6 +2813,46 @@ void SettingsPage::onValueReset() {
 
 //-----------------------------------------------------------------------------
 
+void SettingsPage::onMyPaintSaveAs() {
+  TMyPaintBrushStyle *myPaintStyle =
+      dynamic_cast<TMyPaintBrushStyle *>(m_editedStyle.getPointer());
+  assert(myPaintStyle);
+
+  const TFilePath customDir =
+      ToonzFolder::getLibraryFolder() + "mypaint brushes" + "Custom";
+  if (!QDir().mkpath(customDir.getQString())) {
+    QMessageBox::warning(
+        this, tr("Save MyPaint Brush As"),
+        tr("The Custom MyPaint brush folder could not be created: %1")
+            .arg(customDir.getQString()));
+    return;
+  }
+
+  QString brushName = QString::fromStdString(myPaintStyle->getPath().getName());
+  if (brushName.isEmpty()) brushName = tr("Custom Brush");
+  QFileDialog saveDialog(this, tr("Save MyPaint Brush As"),
+                         customDir.getQString(), tr("MyPaint Brush (*.myb)"));
+  saveDialog.setAcceptMode(QFileDialog::AcceptSave);
+  saveDialog.setFileMode(QFileDialog::AnyFile);
+  saveDialog.setDefaultSuffix("myb");
+  saveDialog.selectFile(brushName + " Copy.myb");
+  if (saveDialog.exec() != QDialog::Accepted) return;
+
+  const QStringList selectedFiles = saveDialog.selectedFiles();
+  if (selectedFiles.isEmpty()) return;
+
+  QString errorMessage;
+  if (!myPaintStyle->saveBrushAs(TFilePath(selectedFiles.front()),
+                                 errorMessage)) {
+    QMessageBox::warning(this, tr("Save MyPaint Brush As"), errorMessage);
+    return;
+  }
+
+  emit myPaintBrushSaved();
+}
+
+//-----------------------------------------------------------------------------
+
 void SettingsPage::onValueChanged(bool isDragging) {
   assert(m_editedStyle);
 
@@ -2980,6 +3034,8 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
                        SLOT(selectStyle(const TColorStyle &)));
   ret = ret && connect(m_settingsPage, SIGNAL(paramStyleChanged(bool)), this,
                        SLOT(onParamStyleChanged(bool)));
+  ret = ret && connect(m_settingsPage, SIGNAL(myPaintBrushSaved()), this,
+                       SLOT(onMyPaintBrushSaved()));
   ret = ret && connect(m_plainColorPage,
                        SIGNAL(colorChanged(const ColorModel &, bool)), this,
                        SLOT(onColorChanged(const ColorModel &, bool)));
@@ -2993,6 +3049,16 @@ StyleEditor::StyleEditor(PaletteController *paletteController, QWidget *parent)
 //-----------------------------------------------------------------------------
 
 StyleEditor::~StyleEditor() {}
+
+//-----------------------------------------------------------------------------
+
+void StyleEditor::onMyPaintBrushSaved() {
+  static_cast<MyPaintBrushStyleChooserPage *>(m_mypaintBrushesStylePage)
+      ->reloadItems();
+}
+
+//-----------------------------------------------------------------------------
+
 
 //-----------------------------------------------------------------------------
 /*

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -3059,7 +3059,6 @@ void StyleEditor::onMyPaintBrushSaved() {
 
 //-----------------------------------------------------------------------------
 
-
 //-----------------------------------------------------------------------------
 /*
 void StyleEditor::setPaletteHandle(TPaletteHandle* paletteHandle)


### PR DESCRIPTION
Problem:  Users cannot save/restore brushes with the modifications they have made.

This change adds Save As… button to MyPaint brush Settings so modified brush settings can be saved as a new reusable .myb brush without altering the original.

The default location for saving new brushes is a custom directory in the Library's MyPaint brush directory.  This helps prevent accidental overwriting of source brushes and allows private sets of brushes to be collected together.  An error also tells users to choose a different brush name or location if they try to replace the source brush.

Chat GPT 6.0 was used in creation and processing.