### PR TITLE
Fix enabling color calibration without a LUT

### DIFF
--- a/toonz/sources/toonzqt/lutcalibrator.cpp
+++ b/toonz/sources/toonzqt/lutcalibrator.cpp
@@ -892,9 +892,9 @@ void LutManager::update() {
     // obtain 3dlut path associated to the monitor name
     QString lutPath =
         Preferences::instance()->getColorCalibrationLutPath(monitorName);
-    if (m_currentLutPath == lutPath)
+    if (!lutPath.isEmpty() && m_currentLutPath == lutPath && m_lut.data)
       m_isValid = true;
-    else if (loadLutFile(lutPath)) {
+    else if (!lutPath.isEmpty() && loadLutFile(lutPath)) {
       m_isValid        = true;
       m_currentLutPath = lutPath;
       textureChanged   = true;


### PR DESCRIPTION
Fixes a crash when enabling LUT color calibration without selecting a LUT file. 

Empty paths are no longer mistaken for a loaded LUT, so calibration remains inactive until valid LUT data is available.
