### PR TITLE
Use theme colors for numeric roller controls

### DIFF
--- a/toonz/sources/toonzqt/intfield.cpp
+++ b/toonz/sources/toonzqt/intfield.cpp
@@ -64,13 +64,13 @@ void RollerField::getRange(double &minValue, double &maxValue) {
 
 void RollerField::paintEvent(QPaintEvent *e) {
   QPainter p(this);
+  const QColor color = palette().color(QPalette::WindowText);
 
   int w = width();
 
-  drawArrow(p, QPointF(3, 3), QPointF(5, 5), QPointF(5, 1), true, Qt::black,
-            Qt::black);
+  drawArrow(p, QPointF(3, 3), QPointF(5, 5), QPointF(5, 1), true, color, color);
   drawArrow(p, QPointF(w - 4, 3), QPointF(w - 6, 5), QPointF(w - 6, 1), true,
-            Qt::black, Qt::black);
+            color, color);
 
   p.drawLine(QPoint(3, 3), QPoint(w - 4, 3));
 }


### PR DESCRIPTION
The arrow-and-line controls beneath numeric FX fields were always painted black,
making them difficult to see in dark themes. Draw both arrows and the connecting
line with the widget's WindowText palette color. In Darker they become silver
(#d3d3d3); Light and Neutral retain black controls. Disabled controls use the
theme's disabled text color.

Validation: compiled the changed source with Qt 5.15.19, checked rendered enabled
and disabled controls against the palette in all eight bundled themes, and
confirmed the same check fails against the original black-painting implementation.
Visually inspected Darker and Light renders. Changed lines pass clang-format 14
and git diff --check. Full OpenToonz application testing on Windows is still pending.

Feedback from Soda-Popz JP following #7080. AI-assisted implementation and
validation using Codex.
