### PR TITLE
Fix restored room layout sizing

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -441,7 +441,7 @@ void Room::showEvent(QShowEvent *event) {
     DockLayout::State savedState = m_pendingLayoutState;
     DockLayout *layout           = dockLayout();
     QTimer::singleShot(0, this, [layout, savedState]() {
-      layout->restoreState(savedState);
+      if (layout->restoreState(savedState)) layout->redistribute();
     });
   }
 }


### PR DESCRIPTION
Redistributes the deferred room layout after restoration so saved panel sizes fit the current room dimensions, avoiding gaps or clipping after window-size, resolution, or DPI changes.

A revert is unnecessary: https://github.com/opentoonz/opentoonz/pull/6975 deferred timing and viewer-state persistence remain correct; only the final layout fit was missing.