### PR TITLE
Fix Darker theme pressed text contrast

### DIFF
--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -474,7 +474,7 @@ QPushButton:hover {
 QPushButton:pressed {
   background-color: #424c61;
   border-color: #495368;
-  color: #424c61;
+  color: #d3d3d3;
 }
 QPushButton:checked {
   background-color: #242424;
@@ -515,7 +515,7 @@ QPushButton:disabled {
 #CustomPanelButton:pressed {
   background-color: #424c61;
   border-color: #495368;
-  color: #424c61;
+  color: #d3d3d3;
 }
 #CustomPanelButton:checked {
   background-color: #242424;
@@ -558,7 +558,7 @@ QComboBox:checked {
 QComboBox:pressed {
   background-color: #424c61;
   border-color: #6378a6;
-  color: #424c61;
+  color: #d3d3d3;
 }
 QComboBox:pressed:focus {
   background-color: #424c61;
@@ -1857,7 +1857,7 @@ PaletteViewer QToolBar #keyFrameNavigator #KeyTotal {
 #WordButton:pressed {
   background-color: #424c61;
   border-color: #495368;
-  color: #424c61;
+  color: #d3d3d3;
 }
 #WordButton:checked {
   background-color: #242424;
@@ -1966,7 +1966,7 @@ QDialog #dialogButtonFrame QPushButton:focus:hover {
 QDialog #dialogButtonFrame QPushButton:focus:pressed {
   background-color: #424c61;
   border-color: #495368;
-  color: #424c61;
+  color: #d3d3d3;
 }
 /* -----------------------------------------------------------------------------
    Scene Settings
@@ -2099,7 +2099,7 @@ ProjectPopup QLabel {
 #toolOptionsPanel QPushButton:pressed {
   background-color: #424c61;
   border-color: #495368;
-  color: #424c61;
+  color: #d3d3d3;
 }
 #toolOptionsPanel QPushButton:checked {
   background-color: #242424;
@@ -2572,7 +2572,7 @@ Ruler {
 #enableBlankFrameButton:pressed {
   background-color: #424c61;
   border-color: #495368;
-  color: #424c61;
+  color: #d3d3d3;
 }
 #enableBlankFrameButton:checked {
   background-color: #242424;

--- a/stuff/config/qss/Default/less/themes/others/darker-theme.less
+++ b/stuff/config/qss/Default/less/themes/others/darker-theme.less
@@ -74,7 +74,7 @@
 @button-border-color-hover: #050202;
 @button-bg-color-focus-hover: @hl-color;
 
-@button-text-color-pressed: @dark-color-2;
+@button-text-color-pressed: @text-color;
 @button-border-color-pressed: @darker-muted-accent-color;
 
 @button-text-color-checked: #d6d6d6;


### PR DESCRIPTION
The Darker theme used the same color for pressed control text and its background, causing text in tool option fields and combo boxes to disappear.

This changes the pressed text color to the theme’s standard light text color in the LESS source and updates the generated QSS accordingly. No layouts or other themes are changed.

ChatGPT 6.0 was used in the processing of this adjustment.