### PR TITLE
Fix vector thumbnails after offline GL resize

### DIFF
--- a/toonz/sources/toonzqt/icongenerator.cpp
+++ b/toonz/sources/toonzqt/icongenerator.cpp
@@ -1443,6 +1443,8 @@ TOfflineGL *IconGenerator::getOfflineGLContext(const TDimension &minSize) {
 
   const TDimension actualSize = context->getSize();
   if (actualSize.lx < requiredSize.lx || actualSize.ly < requiredSize.ly) {
+    // Destroy the old FBO before the replacement context becomes current.
+    m_contexts.setLocalData(nullptr);
     context = new TOfflineGL(requiredSize);
     m_contexts.setLocalData(context);
   }


### PR DESCRIPTION
Fix Linux vector thumbnails after offline GL resize

Fixes #7122.

Destroy the previous offline GL renderer before creating its replacement. 
This prevents vector thumbnails from rendering blank on Linux after the framebuffer is resized.

Validated on Linux virtual machine with adiditional test to ensure the Windows build was not adversely effected.

Various releases of ChatGPT were used to process and test this fix.
