### PR TITLE
Fix Ctrl+Alt brush resizing across level types

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -478,7 +478,12 @@ void FullColorBrushTool::inputMouseMove(const TPointD &position,
     }
   } locals = {this};
 
-  if (state.isKeyPressed(TKey::control) && state.isKeyPressed(TKey::alt)) {
+  const bool resizeBrush =
+      Preferences::instance()->useCtrlAltToResizeBrushEnabled() &&
+      state.isKeyPressed(TKey::control) && state.isKeyPressed(TKey::alt) &&
+      !state.isKeyPressed(TKey::shift);
+
+  if (resizeBrush) {
     const TPointD &diff = position - m_mousePos;
     if (getBrushStyle()) {
       locals.add(m_modifierSize, 0.01 * diff.x);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1466,12 +1466,15 @@ void ToonzRasterBrushTool::inputMouseMove(const TPointD &position,
   struct Locals {
     ToonzRasterBrushTool *m_this;
 
+    void notify(TProperty &prop) {
+      m_this->onPropertyChanged(prop.getName());
+      TTool::getApplication()->getCurrentTool()->notifyToolChanged();
+    }
+
     void setValue(TDoublePairProperty &prop,
                   const TDoublePairProperty::Value &value) {
       prop.setValue(value);
-
-      m_this->onPropertyChanged(prop.getName());
-      TTool::getApplication()->getCurrentTool()->notifyToolChanged();
+      notify(prop);
     }
 
     void addMinMax(TDoublePairProperty &prop, double min, double max) {
@@ -1487,6 +1490,14 @@ void ToonzRasterBrushTool::inputMouseMove(const TPointD &position,
 
       setValue(prop, value);
     }
+
+    void add(TDoubleProperty &prop, double amount) {
+      if (amount == 0.0) return;
+      const TDoubleProperty::Range &range = prop.getRange();
+      prop.setValue(
+          tcrop<double>(prop.getValue() + amount, range.first, range.second));
+      notify(prop);
+    }
   } locals = {this};
 
   double thickness =
@@ -1494,25 +1505,31 @@ void ToonzRasterBrushTool::inputMouseMove(const TPointD &position,
   TPointD halfThick(thickness * 0.5, thickness * 0.5);
   TRectD invalidateRect(m_brushPos - halfThick, m_brushPos + halfThick);
 
-  if (Preferences::instance()->useCtrlAltToResizeBrushEnabled() &&
+  const bool resizeBrush =
+      Preferences::instance()->useCtrlAltToResizeBrushEnabled() &&
       state.isKeyPressed(TKey::control) && state.isKeyPressed(TKey::alt) &&
-      !state.isKeyPressed(TKey::shift)) {
+      !state.isKeyPressed(TKey::shift);
+
+  if (resizeBrush) {
     // Resize the brush if CTRL+ALT is pressed and the preference is enabled.
     const TPointD &diff = position - m_mousePos;
-    double max          = diff.x / 2;
-    double min          = diff.y / 2;
-
-    locals.addMinMax(m_rasThickness, min, max);
-
-    double radius = m_rasThickness.getValue().second * 0.5;
+    double radius;
+    if (m_isMyPaintStyleSelected) {
+      locals.add(m_modifierSize, 0.01 * diff.x);
+      radius = (m_maxCursorThick + 1) * 0.5;
+    } else {
+      locals.addMinMax(m_rasThickness, diff.y / 2, diff.x / 2);
+      radius = m_rasThickness.getValue().second * 0.5;
+    }
     invalidateRect += TRectD(m_brushPos - TPointD(radius, radius),
                              m_brushPos + TPointD(radius, radius));
-
   } else {
-    m_brushPos = m_mousePos = position;
+    m_brushPos = position;
 
     invalidateRect += TRectD(position - halfThick, position + halfThick);
   }
+
+  m_mousePos = position;
 
   invalidate(invalidateRect.enlarge(20));
 
@@ -1699,6 +1716,8 @@ bool ToonzRasterBrushTool::onPropertyChanged(std::string propertyName) {
   RasterBrushModifierSize  = m_modifierSize.getValue();
   BrushLockAlpha           = m_modifierLockAlpha.getValue();
   RasterBrushAssistants    = m_assistants.getValue();
+
+  if (propertyName == m_modifierSize.getName()) updateCurrentStyle();
 
   // Recalculate/reset based on changed settings
   if (propertyName == m_rasThickness.getName()) {

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -771,29 +771,32 @@ void ToonzVectorBrushTool::inputMouseMove(
 
   } locals = {this};
 
-  TPointD halfThick(m_maxThick * 0.5, m_maxThick * 0.5);
+  const double pixelToStage = Stage::inch / m_cameraDpi;
+  TPointD halfThick(m_maxThick * 0.5 * pixelToStage,
+                    m_maxThick * 0.5 * pixelToStage);
   TRectD invalidateRect(m_brushPos - halfThick, m_brushPos + halfThick);
 
-  bool alt     = state.isKeyPressed(TInputState::Key::alt);
-  bool shift   = state.isKeyPressed(TInputState::Key::shift);
-  bool control = state.isKeyPressed(TInputState::Key::control);
-  
-  if ( alt && control && !shift
-    && Preferences::instance()->useCtrlAltToResizeBrushEnabled() )
-  {
+  const bool resizeBrush =
+      Preferences::instance()->useCtrlAltToResizeBrushEnabled() &&
+      state.isKeyPressed(TKey::control) && state.isKeyPressed(TKey::alt) &&
+      !state.isKeyPressed(TKey::shift);
+
+  if (resizeBrush) {
     // Resize the brush if CTRL+ALT is pressed and the preference is enabled.
     const TPointD &diff = position - m_mousePos;
-    double max          = diff.x / 2;
-    double min          = diff.y / 2;
+    double max          = diff.x / (2.0 * pixelToStage);
+    double min          = diff.y / (2.0 * pixelToStage);
 
     locals.addMinMax(m_thickness, min, max);
 
-    double radius = m_thickness.getValue().second * 0.5;
+    double radius = m_thickness.getValue().second * 0.5 * pixelToStage;
     halfThick = TPointD(radius, radius);
   } else {
-    m_brushPos = m_mousePos = position;
+    m_brushPos = position;
   }
-  
+
+  m_mousePos = position;
+
   invalidateRect += TRectD(m_brushPos - halfThick, m_brushPos + halfThick);
 
   if (m_minThick == 0 && m_maxThick == 0) {


### PR DESCRIPTION
Fixes #7126.

Updates Ctrl+Alt resizing for MyPaint brushes on Toonz Raster levels and makes the shortcut consistent across Raster, Toonz Raster, and Vector brushes. Vector resizing is normalized to camera DPI for matching on-canvas response.

While this fixes the initial problem from #7126 it goes a little farther to standardize consistence across all level types.  As such it needs additional testing and confirmation.

ChatGPT was used in the implementation and processing of this change.